### PR TITLE
Hide the Claude sign-in on hosted deployments; unblock the OAuth pop-up on mobile

### DIFF
--- a/web/src/components/menus/APIKeysTab.tsx
+++ b/web/src/components/menus/APIKeysTab.tsx
@@ -16,6 +16,7 @@ import ShieldIcon from "@mui/icons-material/Shield";
 import useSecretsStore from "../../stores/SecretsStore";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import { useOAuthConnection } from "../../hooks/useOAuthConnection";
+import { isElectron, isLocalhost } from "../../lib/env";
 import type { SecretResponse } from "../../stores/ApiTypes";
 import {
   FlexColumn,
@@ -90,9 +91,19 @@ interface ProviderMeta {
    * secret NodeTool persists.
    */
   oauthOnly?: boolean;
+  /**
+   * Connecting only works when the browser and the server share a machine —
+   * the flow finishes on the server's loopback listener and writes credentials
+   * to its filesystem. Hidden on hosted deployments, where it can't complete.
+   */
+  localOnly?: boolean;
   /** Multi-field credentials (e.g. login + password). Single-field providers omit this. */
   fields?: Array<{ key: string; label: string; secret?: boolean }>;
 }
+
+/** Hosted deployments can't finish a same-machine sign-in — hide those cards. */
+const isProviderAvailable = (meta: ProviderMeta): boolean =>
+  !meta.localOnly || isLocalhost || isElectron;
 
 const PROVIDER_META: ProviderMeta[] = [
   {
@@ -116,7 +127,8 @@ const PROVIDER_META: ProviderMeta[] = [
     mono: true,
     note: "Signs in through Claude Code and shares its credentials.",
     oauth: "claude",
-    oauthOnly: true
+    oauthOnly: true,
+    localOnly: true
   },
   {
     key: "ANTHROPIC_API_KEY",
@@ -1037,7 +1049,9 @@ export const APIKeysTabContent = memo(function APIKeysTabContent({
     for (const secret of safeSecrets) {
       // For multi-field providers, only process the parent
       const meta = getParentProviderMeta(secret.key);
-      if (!meta || processed.has(meta.key)) continue;
+      if (!meta || processed.has(meta.key) || !isProviderAvailable(meta)) {
+        continue;
+      }
 
       // If it's a multi-field provider, create a synthetic secret that represents all fields
       if (meta.fields) {
@@ -1078,6 +1092,7 @@ export const APIKeysTabContent = memo(function APIKeysTabContent({
   const unconfiguredMeta = useMemo(() => {
     return PROVIDER_META.filter(
       (p) =>
+        isProviderAvailable(p) &&
         !areAllFieldsConfigured(p, configuredKeys) &&
         (!lowerSearch ||
           p.name.toLowerCase().includes(lowerSearch) ||

--- a/web/src/components/menus/__tests__/APIKeysTabContent.test.tsx
+++ b/web/src/components/menus/__tests__/APIKeysTabContent.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+
+import { useOAuthConnection } from "../../../hooks/useOAuthConnection";
+
+// Hosted deployment: neither the browser nor the server is local.
+jest.mock("../../../lib/env", () => ({
+  isLocalhost: false,
+  isElectron: false
+}));
+jest.mock("../../../hooks/useOAuthConnection");
+jest.mock("../GoogleWorkspaceCard", () => () => null);
+jest.mock("../../../stores/SecretsStore", () => ({
+  __esModule: true,
+  default: (selector: (state: unknown) => unknown) =>
+    selector({
+      secrets: [],
+      updateSecret: jest.fn(),
+      deleteSecret: jest.fn()
+    })
+}));
+jest.mock("../../../stores/NotificationStore", () => ({
+  useNotificationStore: (selector: (state: unknown) => unknown) =>
+    selector({ addNotification: jest.fn() })
+}));
+
+// Imported after the mocks so the module picks up the hosted-env values.
+import { APIKeysTabContent } from "../APIKeysTab";
+
+describe("APIKeysTabContent on a hosted deployment", () => {
+  beforeEach(() => {
+    (useOAuthConnection as jest.MockedFunction<typeof useOAuthConnection>)
+      .mockReturnValue({
+        label: "",
+        isConnected: false,
+        isConnecting: false,
+        canDisconnect: false,
+        connect: jest.fn(),
+        disconnect: jest.fn()
+      });
+  });
+
+  it("hides the Claude subscription card, whose sign-in needs a local server", () => {
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <APIKeysTabContent />
+      </ThemeProvider>
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /sign in with claude/i })
+    ).not.toBeInTheDocument();
+    // The API-key providers are unaffected.
+    expect(screen.getByText("Anthropic")).toBeInTheDocument();
+    expect(screen.getByText("OpenAI")).toBeInTheDocument();
+  });
+});

--- a/web/src/hooks/__tests__/useOAuthConnection.test.tsx
+++ b/web/src/hooks/__tests__/useOAuthConnection.test.tsx
@@ -27,9 +27,19 @@ const createWrapper = () => {
   };
 };
 
+/** Stand-in for the window connect() claims in the click's own tick. */
+const fakeAuthWindow = () =>
+  ({
+    opener: {},
+    document: { title: "", body: null },
+    location: { replace: jest.fn() },
+    close: jest.fn()
+  }) as unknown as Window;
+
 describe("useOAuthConnection", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(window, "open").mockReturnValue(fakeAuthWindow());
     (useNotificationStore as unknown as jest.Mock).mockImplementation(
       (selector: (state: unknown) => unknown) =>
         selector({ addNotification: mockAddNotification })
@@ -42,6 +52,10 @@ describe("useOAuthConnection", () => {
       if (url.endsWith("/disconnect")) return jsonResponse({});
       return jsonResponse({});
     });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("stays inert and issues no request when provider is null", async () => {
@@ -76,10 +90,11 @@ describe("useOAuthConnection", () => {
     expect(result.current.canDisconnect).toBe(true);
   });
 
-  it("opens the auth URL when connect() is called", async () => {
-    const openSpy = jest
-      .spyOn(window, "open")
-      .mockReturnValue(null as unknown as Window);
+  it("claims a window before /start, then navigates it to the auth URL", async () => {
+    const authWindow = fakeAuthWindow();
+    (window.open as jest.MockedFunction<typeof window.open>).mockReturnValue(
+      authWindow
+    );
 
     const { result } = renderHook(() => useOAuthConnection("hf"), {
       wrapper: createWrapper()
@@ -89,13 +104,34 @@ describe("useOAuthConnection", () => {
       await result.current.connect();
     });
 
-    expect(mockRestFetch).toHaveBeenCalledWith("/api/oauth/hf/start");
-    expect(openSpy).toHaveBeenCalledWith(
-      "https://example.com/auth",
+    // Opened blank so the click's own tick pays for it — a window opened after
+    // the /start round-trip is blocked on mobile.
+    expect(window.open).toHaveBeenCalledWith(
+      "",
       "_blank",
-      expect.stringContaining("noopener")
+      "width=600,height=700"
     );
-    openSpy.mockRestore();
+    expect(mockRestFetch).toHaveBeenCalledWith("/api/oauth/hf/start");
+    expect(authWindow.location.replace).toHaveBeenCalledWith(
+      "https://example.com/auth"
+    );
+    expect(authWindow.opener).toBeNull();
+  });
+
+  it("falls back to a same-tab navigation when the pop-up is blocked", async () => {
+    const open = (
+      window.open as jest.MockedFunction<typeof window.open>
+    ).mockReturnValue(null);
+
+    const { result } = renderHook(() => useOAuthConnection("hf"), {
+      wrapper: createWrapper()
+    });
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(open).toHaveBeenCalledWith("https://example.com/auth", "_self");
   });
 
   it("calls the disconnect endpoint for a provider that supports it", async () => {

--- a/web/src/hooks/useOAuthConnection.ts
+++ b/web/src/hooks/useOAuthConnection.ts
@@ -23,6 +23,33 @@ interface TokensResponse {
   tokens: unknown[];
 }
 
+/**
+ * Claim a window synchronously so the browser credits it to the user's click,
+ * and show something while /start is in flight. Returns null when the pop-up
+ * was blocked. `noopener` is deliberately absent — it would null the handle we
+ * need to navigate — so the opener link is severed by hand instead.
+ */
+const openPlaceholderWindow = (label: string): Window | null => {
+  const authWindow = window.open("", "_blank", "width=600,height=700");
+  if (!authWindow) {
+    return null;
+  }
+  try {
+    authWindow.opener = null;
+    const doc = authWindow.document;
+    doc.title = `Connecting to ${label}…`;
+    if (doc.body) {
+      doc.body.style.font = "16px sans-serif";
+      doc.body.style.padding = "2rem";
+      doc.body.textContent = `Connecting to ${label}…`;
+    }
+  } catch {
+    // A browser that refuses to let us touch the blank document can still be
+    // navigated, which is all the flow actually needs.
+  }
+  return authWindow;
+};
+
 export interface OAuthConnection {
   /** Provider label for UI (e.g. "OpenAI"). */
   label: string;
@@ -102,6 +129,16 @@ export const useOAuthConnection = (
       return;
     }
     setIsConnecting(true);
+
+    // The auth URL only exists after a round-trip to /start, but a window
+    // opened after that await counts as gestureless and mobile browsers block
+    // it silently — the login page simply never appears. So claim the window
+    // now, in the click's own tick, and point it at the URL once it lands.
+    const useNativeBrowser = isElectron && !!window.api?.shell?.openExternal;
+    const authWindow = useNativeBrowser
+      ? null
+      : openPlaceholderWindow(config.label);
+
     try {
       const response = await restFetch(`/api/oauth/${provider}/start`);
       const body = (await response.json().catch(() => null)) as
@@ -113,16 +150,17 @@ export const useOAuthConnection = (
       }
 
       const authUrl = body.auth_url;
-      if (isElectron && window.api?.shell?.openExternal) {
-        await window.api.shell.openExternal(authUrl);
+      if (useNativeBrowser) {
+        await window.api?.shell?.openExternal(authUrl);
+      } else if (authWindow) {
+        authWindow.location.replace(authUrl);
       } else {
-        window.open(
-          authUrl,
-          "_blank",
-          "noopener,noreferrer,width=600,height=700"
-        );
+        // Pop-up blocked (the strict default on mobile Safari). Hand the whole
+        // tab to the provider instead; the poll picks the token up on return.
+        window.open(authUrl, "_self");
       }
     } catch (error) {
+      authWindow?.close();
       setIsConnecting(false);
       addNotification({
         content:


### PR DESCRIPTION
Two fixes to provider sign-in in the API Keys settings tab.

## Claude sign-in is hidden on hosted deployments

The Claude subscription card signs in through Claude Code and writes tokens to the server's `~/.claude/.credentials.json`, and the flow finishes on a loopback listener the server process binds. Both only line up when the browser and the server share a machine, so on `nodetool.fly.dev` / `api.nodetool.ai` the card offers a sign-in that cannot complete.

`ProviderMeta` gains a `localOnly` flag, set on the Claude entry, and both list builders in `APIKeysTabContent` filter on it. Local dev and the Electron app still show the card; nothing about the API-key providers changes.

## The OAuth pop-up now survives mobile pop-up blockers

`useOAuthConnection.connect()` called `window.open()` *after* awaiting `/api/oauth/<provider>/start`. That await costs the call its user-gesture credit, so mobile browsers block the window silently — clicking **Sign in with OpenAI** did nothing visible.

The window is now claimed synchronously in the click's own tick (showing "Connecting to …" while `/start` is in flight) and navigated once the auth URL arrives. `noopener` had to go, since it nulls the handle needed to navigate, so the opener reference is severed by hand instead. If the pop-up is blocked anyway, the flow falls back to a same-tab navigation. The Electron path (`shell.openExternal`) is unchanged and skips the placeholder window entirely.

## Testing

- `web/src/hooks/__tests__/useOAuthConnection.test.tsx` — rewrote the open-the-auth-URL case for the two-step window, added a blocked-pop-up fallback case.
- `web/src/components/menus/__tests__/APIKeysTabContent.test.tsx` (new) — renders the tab with a hosted env and asserts the Claude sign-in is absent while the API-key providers remain. Verified it fails when the env is flipped back to local.
- `npx jest src/hooks/__tests__/useOAuthConnection.test.tsx src/components/menus/__tests__` → 55 passed.
- eslint and tsc clean on the touched files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWTHYzZJoPf5etFKZNrbVA)_