### PR TITLE
mobile: screenshot every screen, and fix the layout bugs it found

### DIFF
--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -80,6 +80,33 @@ read the comment at the top of `metro.config.js` before changing any of it.
   sets `coverageProvider: 'v8'` and keeps `coverageThreshold.global` below the measured numbers
   so the gate is honest and enforceable; raise it as coverage grows.
 
+## Screenshotting every screen
+
+`scripts/screenshot-screens.mjs` drives the **Expo web** build with Playwright and
+captures one PNG per screen, walking the deep-link paths in
+`navigation/linking.ts`. It's how layout regressions get caught without a device.
+
+```bash
+npm run dev:server                                   # repo root: API on :7777
+npm --prefix mobile run web                          # Expo web on :8081
+node mobile/scripts/screenshot-screens.mjs --out ./mobile-shots
+node mobile/scripts/screenshot-screens.mjs --width 320   # narrow-phone pass
+```
+
+Two things to know:
+
+- **Auth**: `App.tsx` treats an unconfigured Supabase as logged in
+  (`isSupabaseConfigured`), so temporarily drop `extra.supabaseUrl` /
+  `extra.supabaseAnonKey` from `app.json` — otherwise every route lands on the
+  login wall. Restore it afterwards.
+- **Parameterized routes** (a document, an asset, a job) need real ids; pass them
+  with `--ids ids.json` (keys: `workflowId`, `threadId`, `applicationId`,
+  `assetId`, `jobId`, `scriptId`, `storyboardId`, `timelineId`, `sketchId`,
+  `noteId`). Routes whose id is missing are skipped, so a partial seed still runs.
+
+The emitted `report.json` flags any screen whose document scrolls horizontally —
+a reliable signal that a row is clipped off the right edge on a phone.
+
 ## Rules
 
 - TypeScript strict, no `any`; throw `Error` objects, not strings.

--- a/mobile/scripts/screenshot-screens.mjs
+++ b/mobile/scripts/screenshot-screens.mjs
@@ -59,6 +59,7 @@ const ROUTES = [
   { name: 'asset-viewer', path: (v) => `asset/${v}`, needs: 'assetId' },
   { name: 'jobs', path: 'jobs' },
   { name: 'job-detail', path: (v) => `job/${v}`, needs: 'jobId' },
+  { name: 'job-detail-failed', path: (v) => `job/${v}`, needs: 'failedJobId' },
   { name: 'triggers', path: 'triggers' },
   { name: 'collections', path: 'collections' },
   { name: 'settings', path: 'settings' },

--- a/mobile/scripts/screenshot-screens.mjs
+++ b/mobile/scripts/screenshot-screens.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Screenshot every mobile screen through the Expo web build.
+ *
+ * Prerequisites (the script checks both and exits with instructions if missing):
+ *   1. A NodeTool API server on http://localhost:7777  (`npm run dev:server`)
+ *   2. The Expo web dev server on http://localhost:8081 (`npm --prefix mobile run web`)
+ *
+ * Auth: `App.tsx` treats an unconfigured Supabase as "logged in" (see
+ * `isSupabaseConfigured`), so run the web server with `extra.supabaseUrl` /
+ * `extra.supabaseAnonKey` absent from app.json to reach the real screens
+ * instead of the login wall.
+ *
+ * Screens are reached by their deep-link paths from `src/navigation/linking.ts`.
+ * Routes with parameters read their ids from a seed file (`--ids <file.json>`)
+ * so the shots show populated screens; without it those routes are skipped.
+ *
+ *   node mobile/scripts/screenshot-screens.mjs --out ./mobile-shots
+ *   node mobile/scripts/screenshot-screens.mjs --ids seed-ids.json --width 320
+ */
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const argv = process.argv.slice(2);
+const flag = (name, fallback) => {
+  const i = argv.indexOf(`--${name}`);
+  return i === -1 ? fallback : argv[i + 1];
+};
+
+const OUT = path.resolve(flag('out', 'mobile-shots'));
+const WEB = flag('url', 'http://localhost:8081');
+const API = flag('api', 'http://localhost:7777');
+const WIDTH = Number(flag('width', 390));
+const HEIGHT = Number(flag('height', 844));
+const IDS_FILE = flag('ids', null);
+const ONLY = flag('only', null);
+const SETTLE_MS = Number(flag('settle', 3500));
+
+const ids = IDS_FILE && fs.existsSync(IDS_FILE)
+  ? JSON.parse(fs.readFileSync(IDS_FILE, 'utf8'))
+  : {};
+
+/**
+ * name → deep-link path. `needs` names a key in the ids file; the route is
+ * skipped when it is missing so a partial seed still produces a full run.
+ */
+const ROUTES = [
+  { name: 'workflows-list', path: '' },
+  { name: 'threads', path: 'threads' },
+  { name: 'chat-new', path: 'chat' },
+  { name: 'chat-thread', path: (v) => `chat/${v}`, needs: 'threadId' },
+  { name: 'documents', path: 'documents' },
+  { name: 'apps', path: 'apps' },
+  { name: 'app', path: (v) => `app/${v}`, needs: 'applicationId' },
+  // Metro's dev server owns `/assets/*`, so this one is reached by tapping the
+  // header button instead of by URL.
+  { name: 'assets', path: '', click: 'Open assets' },
+  { name: 'asset-viewer', path: (v) => `asset/${v}`, needs: 'assetId' },
+  { name: 'jobs', path: 'jobs' },
+  { name: 'job-detail', path: (v) => `job/${v}`, needs: 'jobId' },
+  { name: 'triggers', path: 'triggers' },
+  { name: 'collections', path: 'collections' },
+  { name: 'settings', path: 'settings' },
+  { name: 'secrets', path: 'settings/secrets' },
+  { name: 'model-selection', path: 'settings/models' },
+  { name: 'graph-editor', path: (v) => `workflow/${v}`, needs: 'workflowId' },
+  { name: 'script-editor', path: (v) => `document/script/${v}`, needs: 'scriptId' },
+  { name: 'storyboard-editor', path: (v) => `document/storyboard/${v}`, needs: 'storyboardId' },
+  { name: 'timeline-viewer', path: (v) => `document/timeline/${v}`, needs: 'timelineId' },
+  { name: 'sketch-viewer', path: (v) => `document/sketch/${v}`, needs: 'sketchId' },
+  { name: 'document-viewer', path: (v) => `document/note/${v}`, needs: 'noteId' },
+];
+
+async function assertUp(url, hint) {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  } catch (err) {
+    console.error(`Not reachable: ${url} (${err.message})\n  → ${hint}`);
+    process.exit(1);
+  }
+}
+
+await assertUp(`${API}/health`, 'start the API with: npm run dev:server');
+await assertUp(WEB, 'start the web build with: npm --prefix mobile run web');
+
+fs.mkdirSync(OUT, { recursive: true });
+
+const browser = await chromium.launch({
+  // Set when the installed Chromium doesn't match this Playwright build's
+  // expected revision (e.g. a pre-provisioned browser in CI containers).
+  executablePath: process.env.PLAYWRIGHT_CHROMIUM_PATH || undefined,
+  args: ['--no-sandbox'],
+});
+const context = await browser.newContext({
+  viewport: { width: WIDTH, height: HEIGHT },
+  deviceScaleFactor: 2,
+  colorScheme: flag('theme', 'dark') === 'light' ? 'light' : 'dark',
+});
+const page = await context.newPage();
+
+const consoleErrors = [];
+page.on('console', (msg) => {
+  if (msg.type() === 'error') consoleErrors.push({ route: current, text: msg.text() });
+});
+page.on('pageerror', (err) => consoleErrors.push({ route: current, text: `pageerror: ${err.message}` }));
+
+let current = 'boot';
+// First load pays the Metro bundle cost; later navigations are client-side.
+await page.goto(`${WEB}/`, { waitUntil: 'load', timeout: 300_000 });
+await page.waitForTimeout(20_000);
+
+const results = [];
+let index = 0;
+for (const route of ROUTES) {
+  if (ONLY && !route.name.includes(ONLY)) continue;
+  if (route.needs && !ids[route.needs]) {
+    results.push({ name: route.name, skipped: `no ids.${route.needs}` });
+    continue;
+  }
+  const rel = typeof route.path === 'function' ? route.path(ids[route.needs]) : route.path;
+  current = route.name;
+  const file = `${String(++index).padStart(2, '0')}-${route.name}.png`;
+  await page.goto(`${WEB}/${rel}`, { waitUntil: 'load', timeout: 120_000 });
+  await page.waitForTimeout(SETTLE_MS);
+  if (route.click) {
+    await page.getByLabel(route.click).first().click({ timeout: 15_000 });
+    await page.waitForTimeout(SETTLE_MS);
+  }
+  await page.screenshot({ path: path.join(OUT, file) });
+  const text = await page.locator('body').innerText().catch(() => '');
+  // A horizontally scrollable body means something is wider than the viewport.
+  const overflow = await page.evaluate(() => {
+    const el = document.documentElement;
+    return { scrollWidth: el.scrollWidth, clientWidth: el.clientWidth };
+  });
+  results.push({
+    name: route.name,
+    url: `/${rel}`,
+    file,
+    overflowsX: overflow.scrollWidth > overflow.clientWidth + 1,
+    ...overflow,
+    text: text.slice(0, 600),
+  });
+  console.log(`${file}${overflow.scrollWidth > overflow.clientWidth + 1 ? '  ⚠ x-overflow' : ''}`);
+}
+
+fs.writeFileSync(
+  path.join(OUT, 'report.json'),
+  JSON.stringify({ width: WIDTH, height: HEIGHT, results, consoleErrors }, null, 2)
+);
+console.log(`\n${results.filter((r) => r.file).length} shots → ${OUT}`);
+if (consoleErrors.length) console.log(`${consoleErrors.length} console errors (see report.json)`);
+await browser.close();

--- a/mobile/src/components/OfflineBanner.test.tsx
+++ b/mobile/src/components/OfflineBanner.test.tsx
@@ -3,6 +3,10 @@ import { act, render, screen } from '@testing-library/react-native';
 import NetInfo, { type NetInfoState } from '@react-native-community/netinfo';
 import { OfflineBanner } from './OfflineBanner';
 
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 34, left: 0, right: 0 }),
+}));
+
 type Listener = (state: NetInfoState) => void;
 
 const addEventListener = NetInfo.addEventListener as jest.MockedFunction<

--- a/mobile/src/components/OfflineBanner.tsx
+++ b/mobile/src/components/OfflineBanner.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNetworkStatus } from '../hooks/useNetworkStatus';
 import { useTheme } from '../hooks/useTheme';
 
@@ -16,6 +17,7 @@ const OFFLINE_MESSAGE = 'No internet connection. Showing saved data.';
 export function OfflineBanner() {
   const { isOffline } = useNetworkStatus();
   const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
 
   useEffect(() => {
     if (isOffline) {
@@ -30,7 +32,12 @@ export function OfflineBanner() {
 
   return (
     <View
-      style={[styles.banner, { backgroundColor: colors.warning }]}
+      style={[
+        styles.banner,
+        // Mounted at the very bottom of the root column, so without the inset
+        // the whole banner sits inside the home-indicator band.
+        { backgroundColor: colors.warning, paddingBottom: insets.bottom + 6 },
+      ]}
       accessibilityRole="alert"
       accessibilityLiveRegion="polite"
       accessibilityLabel={OFFLINE_MESSAGE}

--- a/mobile/src/components/app_runtime/__tests__/widgetLayout.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/widgetLayout.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Layout invariants that a screenshot can't state and a device-only prop can't
+ * show: one shared width per table column, a shrinkable label next to a
+ * fixed-size control, and nested scrolling on the inner scrollers that sit
+ * inside the app's own ScrollView (Android needs the prop to deliver the pan).
+ */
+import React from "react";
+import { ScrollView, StyleSheet } from "react-native";
+import { render, screen } from "@testing-library/react-native";
+
+import {
+  parseApplicationDocument,
+  type ApplicationDocument,
+} from "@nodetool-ai/app-runtime";
+
+import type { Workflow } from "../../../types/workflow";
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock("../../../stores/WorkflowRunner", () => ({
+  useWorkflowRunner: () => ({
+    getState: () => ({
+      job_id: null,
+      run: jest.fn().mockResolvedValue(undefined),
+      cancel: jest.fn().mockResolvedValue(undefined),
+    }),
+    subscribe: () => () => {},
+  }),
+}));
+
+jest.mock("../../../services/WebSocketService", () => ({
+  webSocketService: { subscribe: () => () => {} },
+}));
+
+jest.mock("../../../services/api", () => ({
+  apiService: {
+    resolveUrl: (uri: string) => uri,
+    getApiHost: () => "http://localhost:7777",
+  },
+}));
+
+import ApplicationAppView from "../ApplicationAppView";
+
+const appDoc = (
+  widget: { type: string; props: Record<string, unknown> },
+  value: unknown
+) => ({
+  schemaVersion: 3,
+  ui: {
+    root: { props: { title: "Probe" } },
+    content: [{ type: widget.type, props: { binding: "var:v", ...widget.props } }],
+    zones: {},
+  },
+  operations: [
+    {
+      id: "main",
+      name: "Run",
+      workflowId: "wf-layout",
+      inputs: {},
+      outputs: {},
+      policy: "replace",
+    },
+  ],
+  resources: [],
+  variables: [
+    { id: "v", name: "v", scope: "instance", persist: false, default: value },
+  ],
+});
+
+const makeWorkflow = (id: string): Workflow =>
+  ({
+    id,
+    name: "Probe",
+    description: "",
+    graph: { nodes: [], edges: [] },
+  }) as unknown as Workflow;
+
+const renderApp = (
+  id: string,
+  widget: { type: string; props: Record<string, unknown> },
+  value: unknown
+) =>
+  render(
+    <ApplicationAppView
+      document={parseApplicationDocument(appDoc(widget, value)) as ApplicationDocument}
+      workflow={makeWorkflow(id)}
+    />
+  );
+
+const widthOf = (text: string): number | undefined => {
+  const style = StyleSheet.flatten(screen.getByText(text).props.style) as {
+    width?: number;
+  };
+  return style.width;
+};
+
+describe("widget layout invariants", () => {
+  it("gives a table column one width, shared by its header and its cells", async () => {
+    // The header is short where the data is long, and long where it is short:
+    // sized per cell, the two rows would settle at different widths.
+    renderApp("wf-widths", { type: "Table", props: { id: "t" } }, [
+      { id: "a-considerably-longer-cell-value", verbose_column_header: "x" },
+    ]);
+
+    await screen.findByText("id");
+    expect(widthOf("id")).toBe(widthOf("a-considerably-longer-cell-value"));
+    expect(widthOf("verbose_column_header")).toBe(widthOf("x"));
+    // Distinct content still yields distinct columns, not one uniform width.
+    expect(widthOf("id")).not.toBe(widthOf("verbose_column_header"));
+  });
+
+  it("lets a switch label shrink instead of pushing the control off the edge", async () => {
+    renderApp(
+      "wf-switch",
+      {
+        type: "Switch",
+        props: { id: "s", label: "Enable high-resolution upscaling" },
+      },
+      true
+    );
+
+    const label = await screen.findByText("Enable high-resolution upscaling");
+    const style = StyleSheet.flatten(label.props.style) as { flex?: number };
+    expect(style.flex).toBe(1);
+    expect(label.props.numberOfLines).toBe(2);
+  });
+
+  it("enables nested scrolling on the chat thread's inner scroller", async () => {
+    renderApp(
+      "wf-chat",
+      { type: "ChatThread", props: { id: "c", maxHeight: 360 } },
+      [{ role: "user", content: "hello" }]
+    );
+
+    await screen.findByText("hello");
+    const capped = screen.UNSAFE_getAllByType(ScrollView).filter((node) => {
+      const style = StyleSheet.flatten(node.props.style) as {
+        maxHeight?: number;
+      };
+      return style?.maxHeight === 360;
+    });
+    expect(capped).toHaveLength(1);
+    expect(capped[0].props.nestedScrollEnabled).toBe(true);
+  });
+});

--- a/mobile/src/components/app_runtime/widgets.tsx
+++ b/mobile/src/components/app_runtime/widgets.tsx
@@ -22,6 +22,8 @@ import {
   TextInput,
   TouchableOpacity,
   View,
+  type StyleProp,
+  type TextStyle,
 } from "react-native";
 import {
   composeUserMessage,
@@ -340,12 +342,53 @@ export const tableColumns = (rows: ReadonlyArray<unknown>): string[] => {
   return columns;
 };
 
+/**
+ * One explicit width per column, so the header row and the body rows lay their
+ * cells out on the same grid. Sizing each cell independently (a `minWidth` /
+ * `maxWidth` range) lets a column's header and its data settle at different
+ * widths, which shears the labels off their column and breaks the hairlines.
+ *
+ * The width is derived from the longest string in the column — a one-pass
+ * estimate at ~7.5pt per character for the 14pt cell font, clamped to the same
+ * 120–240 range the old per-cell style used. An estimate is enough here:
+ * correctness only needs header and body to agree, and `onLayout` measurement
+ * would cost a render round-trip per table.
+ */
+export const tableColumnWidths = (
+  headers: ReadonlyArray<string>,
+  rows: ReadonlyArray<ReadonlyArray<string>>,
+  charWidth = 7.5,
+  padding = 24,
+  min = 120,
+  max = 240
+): number[] =>
+  headers.map((header, index) => {
+    let longest = header.length;
+    for (const row of rows) {
+      longest = Math.max(longest, (row[index] ?? "").length);
+    }
+    return Math.min(max, Math.max(min, Math.round(longest * charWidth) + padding));
+  });
+
 /** Lays an array value out as rows — what a run that emits N results needs. */
 const TableWidget: React.FC<WidgetProps> = (widget) => {
   const { colors } = useTheme();
   const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
   const rows = asItems(value);
   const columns = useMemo(() => tableColumns(rows), [rows]);
+  const body = useMemo(
+    () =>
+      rows.map((row) =>
+        columns.length === 0
+          ? [cellText(row)]
+          : columns.map((column) => (isRow(row) ? cellText(row[column]) : ""))
+      ),
+    [columns, rows]
+  );
+  const widths = useMemo(
+    () => tableColumnWidths(columns.length === 0 ? [""] : columns, body),
+    [body, columns]
+  );
 
   if (rows.length === 0) {
     return (
@@ -356,28 +399,27 @@ const TableWidget: React.FC<WidgetProps> = (widget) => {
     );
   }
 
-  const cells = (row: unknown): string[] =>
-    columns.length === 0
-      ? [cellText(row)]
-      : columns.map((column) => (isRow(row) ? cellText(row[column]) : ""));
-
   return (
     <ScrollView horizontal showsHorizontalScrollIndicator={false}>
       <View style={[styles.table, { borderColor: colors.border }]}>
         {columns.length > 0 ? (
           <View style={[styles.tableRow, { backgroundColor: colors.inputBg }]}>
-            {columns.map((column) => (
+            {columns.map((column, columnIndex) => (
               <Text
                 key={column}
                 numberOfLines={1}
-                style={[styles.tableCell, styles.tableHeader, { color: colors.text }]}
+                style={[
+                  styles.tableCell,
+                  styles.tableHeader,
+                  { color: colors.text, width: widths[columnIndex] },
+                ]}
               >
                 {column}
               </Text>
             ))}
           </View>
         ) : null}
-        {rows.map((row, index) => (
+        {body.map((cells, index) => (
           <View
             key={index}
             style={[
@@ -387,11 +429,14 @@ const TableWidget: React.FC<WidgetProps> = (widget) => {
                 : null,
             ]}
           >
-            {cells(row).map((text, cellIndex) => (
+            {cells.map((text, cellIndex) => (
               <Text
                 key={cellIndex}
                 numberOfLines={3}
-                style={[styles.tableCell, { color: colors.textSecondary }]}
+                style={[
+                  styles.tableCell,
+                  { color: colors.textSecondary, width: widths[cellIndex] },
+                ]}
               >
                 {text}
               </Text>
@@ -447,12 +492,20 @@ const ProgressWidget: React.FC<WidgetProps> = (widget) => {
   );
 };
 
-const FieldLabel: React.FC<{ text: string; colors: ThemeColors }> = ({
-  text,
-  colors,
-}) =>
+const FieldLabel: React.FC<{
+  text: string;
+  colors: ThemeColors;
+  /** Set when the label shares a row with a control, so it can shrink. */
+  style?: StyleProp<TextStyle>;
+  numberOfLines?: number;
+}> = ({ text, colors, style, numberOfLines }) =>
   text ? (
-    <Text style={[styles.label, { color: colors.text }]}>{text}</Text>
+    <Text
+      numberOfLines={numberOfLines}
+      style={[styles.label, { color: colors.text }, style]}
+    >
+      {text}
+    </Text>
   ) : null;
 
 /** A bound value shown as a message. Empty binding renders nothing. */
@@ -896,8 +949,16 @@ const SliderWidget: React.FC<WidgetProps> = (widget) => {
   return (
     <View style={styles.field}>
       <View style={styles.row}>
-        <FieldLabel text={str(widget.props.label)} colors={colors} />
-        <Text style={[styles.label, { color: colors.textSecondary }]}>
+        <FieldLabel
+          text={str(widget.props.label)}
+          colors={colors}
+          style={styles.rowLabel}
+          numberOfLines={2}
+        />
+        <Text
+          numberOfLines={1}
+          style={[styles.label, styles.rowValue, { color: colors.textSecondary }]}
+        >
           {current}
         </Text>
       </View>
@@ -925,7 +986,12 @@ const SwitchWidget: React.FC<WidgetProps> = (widget) => {
   });
   return (
     <View style={[styles.field, styles.row]}>
-      <FieldLabel text={str(widget.props.label)} colors={colors} />
+      <FieldLabel
+        text={str(widget.props.label)}
+        colors={colors}
+        style={styles.rowLabel}
+        numberOfLines={2}
+      />
       <Switch
         value={value === true}
         disabled={widget.disabled}
@@ -1576,6 +1642,14 @@ const DataFrameInputWidget: React.FC<WidgetProps> = (widget) => {
   });
   const grid = useMemo(() => readGrid(value), [value]);
   const maxHeight = numOr(widget.props.maxHeight, 280);
+  const widths = useMemo(
+    () =>
+      tableColumnWidths(
+        grid.columns,
+        grid.rows.map((row) => row.map(cellText))
+      ),
+    [grid]
+  );
 
   const commit = useCallback(
     (rows: unknown[][]) => {
@@ -1604,11 +1678,15 @@ const DataFrameInputWidget: React.FC<WidgetProps> = (widget) => {
         <ScrollView style={{ maxHeight }} nestedScrollEnabled>
           <View style={[styles.table, { borderColor: colors.border }]}>
             <View style={[styles.tableRow, { backgroundColor: colors.inputBg }]}>
-              {grid.columns.map((column) => (
+              {grid.columns.map((column, columnIndex) => (
                 <Text
                   key={column}
                   numberOfLines={1}
-                  style={[styles.tableCell, styles.tableHeader, { color: colors.text }]}
+                  style={[
+                    styles.tableCell,
+                    styles.tableHeader,
+                    { color: colors.text, width: widths[columnIndex] },
+                  ]}
                 >
                   {column}
                 </Text>
@@ -1632,7 +1710,7 @@ const DataFrameInputWidget: React.FC<WidgetProps> = (widget) => {
                     style={[
                       styles.tableCell,
                       styles.cellInput,
-                      { color: colors.text },
+                      { color: colors.text, width: widths[cellIndex] },
                     ]}
                     editable={!widget.disabled}
                     value={cellText(row[cellIndex])}
@@ -1853,7 +1931,11 @@ const ChatThreadWidget: React.FC<WidgetProps> = (widget) => {
           colors={colors}
         />
       ) : (
-        <ScrollView style={{ maxHeight }} contentContainerStyle={styles.stack}>
+        <ScrollView
+          style={{ maxHeight }}
+          contentContainerStyle={styles.stack}
+          nestedScrollEnabled
+        >
           {messages.map((message, index) => (
             <View
               key={index}
@@ -2283,6 +2365,16 @@ const styles = StyleSheet.create({
   flex: {
     flex: 1,
   },
+  /**
+   * A label sharing `row` with a fixed-size control. RN's default flexShrink is
+   * 0, so without this a long label pushes the control off the trailing edge.
+   */
+  rowLabel: {
+    flex: 1,
+  },
+  rowValue: {
+    flexShrink: 0,
+  },
   heading: {
     fontWeight: "700",
     letterSpacing: -0.3,
@@ -2380,8 +2472,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
   },
   tableCell: {
-    minWidth: 120,
-    maxWidth: 240,
+    // Width comes from tableColumnWidths() so header and body share a grid.
     paddingHorizontal: 12,
     paddingVertical: 10,
     fontSize: 14,

--- a/mobile/src/components/chat/ChatComposer.test.tsx
+++ b/mobile/src/components/chat/ChatComposer.test.tsx
@@ -3,7 +3,15 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent, act, waitFor } from '@testing-library/react-native';
+import {
+  render as rtlRender,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+} from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import {
   ExpoSpeechRecognitionModule,
   useSpeechRecognitionEvent,
@@ -20,6 +28,23 @@ const speech = ExpoSpeechRecognitionModule as unknown as {
   abort: jest.Mock;
 };
 const eventHook = useSpeechRecognitionEvent as unknown as jest.Mock;
+
+/**
+ * The composer reads the real bottom inset, so every render needs a provider
+ * with metrics — a notched phone here, so the inset is non-zero.
+ */
+const SafeAreaWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <SafeAreaProvider
+    initialMetrics={{
+      frame: { x: 0, y: 0, width: 390, height: 844 },
+      insets: { top: 47, left: 0, right: 0, bottom: 34 },
+    }}
+  >
+    {children}
+  </SafeAreaProvider>
+);
+
+const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: SafeAreaWrapper });
 
 type Listener = (event: unknown) => void;
 let speechListeners: Record<string, Listener>;
@@ -47,6 +72,13 @@ describe('ChatComposer', () => {
   });
 
   describe('Rendering', () => {
+    it('pads the bottom by the real safe-area inset, not a hardcoded platform value', () => {
+      render(<ChatComposer status="connected" onSendMessage={mockOnSendMessage} />);
+
+      const container = screen.getByTestId('composer-container');
+      expect(StyleSheet.flatten(container.props.style).paddingBottom).toBe(34 + 8);
+    });
+
     it('renders input field', () => {
       render(
         <ChatComposer

--- a/mobile/src/components/chat/ChatComposer.tsx
+++ b/mobile/src/components/chat/ChatComposer.tsx
@@ -10,7 +10,6 @@ import {
   TouchableOpacity,
   StyleSheet,
   Keyboard,
-  Platform,
   ScrollView,
   Modal,
   Text,
@@ -18,6 +17,7 @@ import {
   AccessibilityInfo,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as ImagePicker from 'expo-image-picker';
 import * as DocumentPicker from 'expo-document-picker';
 import { MessageContent, ChatStatus } from '../../types';
@@ -70,6 +70,7 @@ export const ChatComposer: React.FC<ChatComposerProps> = ({
   const [showAttachmentMenu, setShowAttachmentMenu] = useState(false);
   const [showParamMenu, setShowParamMenu] = useState<string | null>(null);
   const { colors, shadows } = useTheme();
+  const insets = useSafeAreaInsets();
   const { droppedFiles, addDroppedFiles, removeFile, clearFiles, getFileContents } = useFileHandling();
 
   const mode = useMediaGenerationStore((s) => s.mode);
@@ -375,7 +376,17 @@ export const ChatComposer: React.FC<ChatComposerProps> = ({
   );
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.surfaceHeader, borderTopColor: colors.borderLight }]}>
+    <View
+      testID="composer-container"
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.surfaceHeader,
+          borderTopColor: colors.borderLight,
+          paddingBottom: insets.bottom + 8,
+        },
+      ]}
+    >
       {/* Mode selector tabs */}
       <View style={styles.modeRow}>
         {MODE_CONFIG.map(({ mode: m, icon, label }) => {
@@ -648,7 +659,13 @@ export const ChatComposer: React.FC<ChatComposerProps> = ({
             onPress={() => setShowAttachmentMenu(false)}
           />
 
-          <View style={[styles.attachmentMenu, shadows.large, { backgroundColor: colors.surface }]}>
+          <View
+            style={[
+              styles.attachmentMenu,
+              shadows.large,
+              { backgroundColor: colors.surface, paddingBottom: insets.bottom + 20 },
+            ]}
+          >
             <View style={[styles.menuHandle, { backgroundColor: colors.border }]} />
             <Text style={[styles.attachmentMenuTitle, { color: colors.text }]}>
               Add Attachment
@@ -716,7 +733,6 @@ const styles = StyleSheet.create({
   container: {
     paddingHorizontal: 12,
     paddingVertical: 8,
-    paddingBottom: Platform.OS === 'ios' ? 24 : 8,
     borderTopWidth: StyleSheet.hairlineWidth,
   },
   modeRow: {
@@ -893,7 +909,6 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 24,
     paddingTop: 12,
     paddingHorizontal: 16,
-    paddingBottom: Platform.OS === 'ios' ? 40 : 20,
   },
   menuHandle: {
     width: 36,

--- a/mobile/src/components/chat/ChatView.test.tsx
+++ b/mobile/src/components/chat/ChatView.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import { ChatView } from './ChatView';
 import { Message, ChatStatus } from '../../types';
@@ -120,6 +121,15 @@ describe('ChatView', () => {
       render(<ChatView {...defaultProps} error="Connection failed" />);
       
       expect(screen.getByText('Connection failed')).toBeTruthy();
+    });
+
+    it('lets a long error string wrap instead of overflowing the centred row', () => {
+      const longError = 'Network request failed: connect ECONNREFUSED 127.0.0.1:7777';
+      render(<ChatView {...defaultProps} error={longError} />);
+
+      const style = StyleSheet.flatten(screen.getByText(longError).props.style);
+      expect(style.flex).toBe(1);
+      expect(style.textAlign).toBe('center');
     });
 
     it('shows disconnected banner', () => {

--- a/mobile/src/components/chat/ChatView.tsx
+++ b/mobile/src/components/chat/ChatView.tsx
@@ -238,9 +238,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  // The row is centred, so without `flex` a long error string overflows and is
+  // clipped at both ends. Taking the leftover width lets it wrap instead.
   bannerText: {
+    flex: 1,
     fontSize: 13,
     fontWeight: '500',
+    textAlign: 'center',
   },
 });
 

--- a/mobile/src/components/chat/FilePreview.test.tsx
+++ b/mobile/src/components/chat/FilePreview.test.tsx
@@ -14,6 +14,21 @@ describe('FilePreview', () => {
     jest.clearAllMocks();
   });
 
+  describe('Remove button', () => {
+    it('gives the 20pt icon a 44pt effective touch target', () => {
+      const file: DroppedFile = {
+        dataUri: 'data:application/pdf;base64,pdf123',
+        type: 'application/pdf',
+        name: 'document.pdf',
+      };
+
+      render(<FilePreview file={file} onRemove={mockOnRemove} />);
+
+      const button = screen.getByLabelText('Remove file document.pdf');
+      expect(button.props.hitSlop).toEqual({ top: 12, bottom: 12, left: 12, right: 12 });
+    });
+  });
+
   describe('Image files', () => {
     it('shows file icon for image with invalid data URI format', () => {
       const invalidImageFile: DroppedFile = {

--- a/mobile/src/components/chat/FilePreview.tsx
+++ b/mobile/src/components/chat/FilePreview.tsx
@@ -72,6 +72,8 @@ export const FilePreview: React.FC<FilePreviewProps> = ({ file, onRemove }) => {
         onPress={onRemove}
         accessibilityLabel={`Remove file ${file.name}`}
         accessibilityRole="button"
+        // 20pt icon + 12pt slop on each side = a 44pt effective touch target.
+        hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
       >
         <Ionicons name="close-circle" size={20} color="#FF453A" />
       </TouchableOpacity>

--- a/mobile/src/components/chat/MessageContentRenderer.test.tsx
+++ b/mobile/src/components/chat/MessageContentRenderer.test.tsx
@@ -3,9 +3,18 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react-native';
+import { Dimensions, StyleSheet } from 'react-native';
+import { render, screen, act } from '@testing-library/react-native';
 import { MessageContentRenderer } from './MessageContentRenderer';
 import { MessageContent } from '../../types/ApiTypes';
+
+/** The content box MessageView's bubble gives a message at a given window width. */
+const bubbleContentWidth = (windowWidth: number) => (windowWidth - 28) * 0.85 - 28;
+
+const setWindowWidth = (width: number) => {
+  const metrics = { width, height: 800, scale: 2, fontScale: 1 };
+  Dimensions.set({ window: metrics, screen: metrics } as never);
+};
 
 describe('MessageContentRenderer', () => {
   const mockRenderTextContent = jest.fn((text: string, index: number) => {
@@ -93,6 +102,39 @@ describe('MessageContentRenderer', () => {
       expect(UNSAFE_root).toBeTruthy();
       // renderTextContent should not be called for images
       expect(mockRenderTextContent).not.toHaveBeenCalled();
+    });
+
+    it('keeps the image inside the bubble content box on a narrow phone', () => {
+      const original = Dimensions.get('window');
+      setWindowWidth(320);
+      const imageContent: MessageContent = {
+        type: 'image_url',
+        image: { type: 'image', uri: 'https://example.com/image.png' },
+      };
+
+      render(
+        <MessageContentRenderer
+          content={imageContent}
+          renderTextContent={mockRenderTextContent}
+          index={0}
+        />
+      );
+
+      const styleAt320 = StyleSheet.flatten(screen.getByLabelText('Image content').props.style);
+      expect(styleAt320.width).toBeLessThanOrEqual(bubbleContentWidth(320));
+      // Height follows the media's ratio instead of a fixed 200pt letterbox.
+      expect(styleAt320.height).toBeUndefined();
+      expect(styleAt320.aspectRatio).toBeGreaterThan(0);
+
+      // A width change (rotation, split view) is picked up without a re-mount —
+      // the old module-level Dimensions.get value never was.
+      act(() => setWindowWidth(720));
+
+      const styleAt720 = StyleSheet.flatten(screen.getByLabelText('Image content').props.style);
+      expect(styleAt720.width).toBeGreaterThan(styleAt320.width as number);
+      expect(styleAt720.width).toBeLessThanOrEqual(bubbleContentWidth(720));
+
+      act(() => setWindowWidth(original.width));
     });
 
     it('shows error message when image URI is missing', () => {

--- a/mobile/src/components/chat/MessageContentRenderer.test.tsx
+++ b/mobile/src/components/chat/MessageContentRenderer.test.tsx
@@ -123,8 +123,9 @@ describe('MessageContentRenderer', () => {
       const styleAt320 = StyleSheet.flatten(screen.getByLabelText('Image content').props.style);
       expect(styleAt320.width).toBeLessThanOrEqual(bubbleContentWidth(320));
       // Height follows the media's ratio instead of a fixed 200pt letterbox.
-      expect(styleAt320.height).toBeUndefined();
-      expect(styleAt320.aspectRatio).toBeGreaterThan(0);
+      const ratio = (styleAt320.width as number) / (styleAt320.height as number);
+      expect(ratio).toBeCloseTo(4 / 3);
+      expect(styleAt320.height as number).toBeLessThanOrEqual(360);
 
       // A width change (rotation, split view) is picked up without a re-mount —
       // the old module-level Dimensions.get value never was.

--- a/mobile/src/components/chat/MessageContentRenderer.tsx
+++ b/mobile/src/components/chat/MessageContentRenderer.tsx
@@ -3,7 +3,7 @@
  * Adapted from web/src/components/chat/message/MessageContentRenderer.tsx
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   View,
   Text,
@@ -69,8 +69,8 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
         return <Text style={[styles.errorText, { color: colors.textSecondary }]}>Unable to load image</Text>;
       }
       return (
-        <View style={[styles.mediaContainer, { width: mediaWidth }]}>
-          <MessageImage uri={imageUri} width={mediaWidth} />
+        <View style={[styles.mediaContainer, { maxWidth: mediaWidth }]}>
+          <MessageImage uri={imageUri} maxWidth={mediaWidth} />
         </View>
       );
     }
@@ -117,25 +117,42 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
 MessageContentRenderer.displayName = "MessageContentRenderer";
 
 /**
- * Image that keeps its natural aspect ratio inside whatever width the bubble
- * gives it. The ratio is only known once the source reports its dimensions, so
- * it starts on a landscape fallback and settles on load.
+ * Image sized to its own aspect ratio inside the width the bubble allows, with
+ * the height capped. Both edges are computed from the ratio, so a portrait image
+ * gets a portrait box instead of being letterboxed inside a landscape one. The
+ * ratio is only known once the source reports its dimensions, so it starts on a
+ * landscape fallback and settles on load.
  */
-const MessageImage: React.FC<{ uri: string; width: number }> = ({ uri, width }) => {
+const MessageImage: React.FC<{ uri: string; maxWidth: number }> = ({ uri, maxWidth }) => {
   const [aspectRatio, setAspectRatio] = useState(FALLBACK_ASPECT_RATIO);
+
+  useEffect(() => {
+    let cancelled = false;
+    Image.getSize(
+      uri,
+      (naturalWidth, naturalHeight) => {
+        if (!cancelled && naturalWidth > 0 && naturalHeight > 0) {
+          setAspectRatio(naturalWidth / naturalHeight);
+        }
+      },
+      // A source that cannot be measured keeps the fallback ratio; the <Image>
+      // below reports its own failure.
+      () => {}
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [uri]);
+
+  const width = Math.min(maxWidth, MAX_MEDIA_HEIGHT * aspectRatio);
+  const height = width / aspectRatio;
 
   return (
     <Image
       source={{ uri }}
-      style={[styles.image, { width, aspectRatio }]}
+      style={[styles.image, { width, height }]}
       resizeMode="contain"
       accessibilityLabel="Image content"
-      onLoad={(event) => {
-        const source = event.nativeEvent?.source;
-        if (source && source.width > 0 && source.height > 0) {
-          setAspectRatio(source.width / source.height);
-        }
-      }}
     />
   );
 };
@@ -233,8 +250,6 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   image: {
-    maxWidth: '100%',
-    maxHeight: MAX_MEDIA_HEIGHT,
     borderRadius: 8,
   },
   video: {

--- a/mobile/src/components/chat/MessageContentRenderer.tsx
+++ b/mobile/src/components/chat/MessageContentRenderer.tsx
@@ -3,14 +3,14 @@
  * Adapted from web/src/components/chat/message/MessageContentRenderer.tsx
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
   Image,
   StyleSheet,
-  Dimensions,
   TouchableOpacity,
+  useWindowDimensions,
 } from 'react-native';
 import { useAudioPlayer, useAudioPlayerStatus } from 'expo-audio';
 import { MediaPlayerView } from '../media/MediaPlayerView';
@@ -18,8 +18,29 @@ import { MessageContent } from '../../types/ApiTypes';
 import { useTheme } from '../../hooks/useTheme';
 import { apiService } from '../../services/api';
 
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
-const MAX_MEDIA_WIDTH = SCREEN_WIDTH * 0.7;
+/**
+ * Media is sized to the bubble's content box, derived from the live window width
+ * (`useWindowDimensions` re-renders on rotation and split view — a module-level
+ * `Dimensions.get` does not) using the same geometry MessageView lays the bubble
+ * out with: the row's horizontal padding, the bubble's 85% cap, and the bubble's
+ * own horizontal padding. The old `screenWidth * 0.7` ignored all three and was
+ * wider than the bubble's content box on narrow phones.
+ */
+const ROW_HORIZONTAL_PADDING = 28; // MessageView styles.container paddingHorizontal 14 * 2
+const BUBBLE_MAX_WIDTH_RATIO = 0.85; // MessageView styles.bubble maxWidth
+const BUBBLE_HORIZONTAL_PADDING = 28; // MessageView styles.bubble paddingHorizontal 14 * 2
+const MAX_MEDIA_HEIGHT = 360;
+const FALLBACK_ASPECT_RATIO = 4 / 3;
+const VIDEO_ASPECT_RATIO = 16 / 9;
+
+const mediaWidthFor = (windowWidth: number): number =>
+  Math.max(
+    120,
+    Math.floor(
+      (windowWidth - ROW_HORIZONTAL_PADDING) * BUBBLE_MAX_WIDTH_RATIO -
+        BUBBLE_HORIZONTAL_PADDING
+    )
+  );
 
 interface MessageContentRendererProps {
   content: MessageContent;
@@ -33,6 +54,8 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
   index,
 }) => {
   const { colors } = useTheme();
+  const { width: windowWidth } = useWindowDimensions();
+  const mediaWidth = mediaWidthFor(windowWidth);
 
   switch (content.type) {
     case 'text': {
@@ -46,13 +69,8 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
         return <Text style={[styles.errorText, { color: colors.textSecondary }]}>Unable to load image</Text>;
       }
       return (
-        <View style={styles.mediaContainer}>
-          <Image
-            source={{ uri: imageUri }}
-            style={styles.image}
-            resizeMode="contain"
-            accessibilityLabel="Image content"
-          />
+        <View style={[styles.mediaContainer, { width: mediaWidth }]}>
+          <MessageImage uri={imageUri} width={mediaWidth} />
         </View>
       );
     }
@@ -63,7 +81,7 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
         return <Text style={[styles.errorText, { color: colors.textSecondary }]}>Unable to load audio</Text>;
       }
       return (
-        <View style={[styles.audioContainer, { backgroundColor: colors.surface }]}>
+        <View style={[styles.audioContainer, { width: mediaWidth, backgroundColor: colors.surface }]}>
           <AudioPlayer uri={audioUri} colors={colors} />
         </View>
       );
@@ -75,8 +93,8 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
         return <Text style={[styles.errorText, { color: colors.textSecondary }]}>Unable to load video</Text>;
       }
       return (
-        <View style={styles.mediaContainer}>
-          <MediaPlayerView uri={videoUri} style={styles.video} />
+        <View style={[styles.mediaContainer, { width: mediaWidth }]}>
+          <MediaPlayerView uri={videoUri} style={[styles.video, { width: mediaWidth }]} />
         </View>
       );
     }
@@ -97,6 +115,30 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
 });
 
 MessageContentRenderer.displayName = "MessageContentRenderer";
+
+/**
+ * Image that keeps its natural aspect ratio inside whatever width the bubble
+ * gives it. The ratio is only known once the source reports its dimensions, so
+ * it starts on a landscape fallback and settles on load.
+ */
+const MessageImage: React.FC<{ uri: string; width: number }> = ({ uri, width }) => {
+  const [aspectRatio, setAspectRatio] = useState(FALLBACK_ASPECT_RATIO);
+
+  return (
+    <Image
+      source={{ uri }}
+      style={[styles.image, { width, aspectRatio }]}
+      resizeMode="contain"
+      accessibilityLabel="Image content"
+      onLoad={(event) => {
+        const source = event.nativeEvent?.source;
+        if (source && source.width > 0 && source.height > 0) {
+          setAspectRatio(source.width / source.height);
+        }
+      }}
+    />
+  );
+};
 
 /**
  * Simple audio player component
@@ -185,26 +227,27 @@ function getMediaUri(
 
 const styles = StyleSheet.create({
   mediaContainer: {
+    maxWidth: '100%',
     marginVertical: 8,
     borderRadius: 8,
     overflow: 'hidden',
-    maxWidth: MAX_MEDIA_WIDTH,
   },
   image: {
-    width: MAX_MEDIA_WIDTH,
-    height: 200,
+    maxWidth: '100%',
+    maxHeight: MAX_MEDIA_HEIGHT,
     borderRadius: 8,
   },
   video: {
-    width: MAX_MEDIA_WIDTH,
-    height: 200,
+    maxWidth: '100%',
+    aspectRatio: VIDEO_ASPECT_RATIO,
+    maxHeight: MAX_MEDIA_HEIGHT,
     borderRadius: 8,
   },
   audioContainer: {
+    maxWidth: '100%',
     marginVertical: 8,
     borderRadius: 8,
     padding: 12,
-    maxWidth: MAX_MEDIA_WIDTH,
   },
   audioPlayerContainer: {
     flexDirection: 'row',
@@ -238,10 +281,10 @@ const styles = StyleSheet.create({
     fontSize: 11,
   },
   documentContainer: {
+    maxWidth: '100%',
     marginVertical: 8,
     borderRadius: 8,
     padding: 12,
-    maxWidth: MAX_MEDIA_WIDTH,
   },
   documentText: {
     fontSize: 14,

--- a/mobile/src/components/graph_editor/ChainNodeCard.tsx
+++ b/mobile/src/components/graph_editor/ChainNodeCard.tsx
@@ -18,6 +18,7 @@ import {
   View,
   Text,
   TouchableOpacity,
+  ScrollView,
   StyleSheet,
   LayoutAnimation,
   Platform,
@@ -412,9 +413,16 @@ export const ChainNodeCard: React.FC<ChainNodeCardProps> = ({
 
       {/* Result preview (visible even when collapsed) */}
       {outputValue !== undefined && !isRunning && !isError && (
-        <View style={styles.resultPreview}>
+        // The cap has to sit on a scroller: as a plain View it clipped
+        // everything past 300pt with no way to reach the rest of the result.
+        <ScrollView
+          style={styles.resultPreview}
+          contentContainerStyle={styles.resultPreviewContent}
+          nestedScrollEnabled
+          showsVerticalScrollIndicator
+        >
           <OutputRenderer value={outputValue} />
-        </View>
+        </ScrollView>
       )}
 
       {/* Expanded content */}
@@ -547,11 +555,17 @@ const styles = StyleSheet.create({
   card: {
     borderRadius: 14,
     borderWidth: 1.5,
-    overflow: "hidden",
+    // No `overflow: hidden` here: on iOS masksToBounds also clips the layer's
+    // own shadow, so it would silently cancel `shadows.small`. The only child
+    // that reaches the card's edge is the progress track, which rounds its own
+    // top corners instead.
   },
   progressTrack: {
     height: 3,
     width: "100%",
+    // Card radius minus the 1.5 border.
+    borderTopLeftRadius: 12.5,
+    borderTopRightRadius: 12.5,
     overflow: "hidden",
   },
   progressFill: {
@@ -588,9 +602,11 @@ const styles = StyleSheet.create({
     lineHeight: 18,
   },
   resultPreview: {
+    maxHeight: 300,
+  },
+  resultPreviewContent: {
     paddingHorizontal: 14,
     paddingBottom: 12,
-    maxHeight: 300,
   },
   header: {
     flexDirection: "row",

--- a/mobile/src/components/graph_editor/FloatingToolbar.tsx
+++ b/mobile/src/components/graph_editor/FloatingToolbar.tsx
@@ -214,6 +214,7 @@ export const FloatingToolbar: React.FC<FloatingToolbarProps> = memo(
         <TouchableOpacity
           style={[
             styles.runButton,
+            isRunning && styles.runButtonRunning,
             {
               backgroundColor: isRunning ? colors.surface
                 : isPaused ? colors.surface
@@ -283,11 +284,18 @@ const styles = StyleSheet.create({
     marginHorizontal: 4,
   },
   runButton: {
-    width: 44,
+    // A circle when it holds a single icon, a pill once the running state adds
+    // an elapsed timer next to the spinner — a hard 44pt width made that row
+    // spill over the neighbouring Stop button.
+    minWidth: 44,
     height: 44,
     borderRadius: 22,
+    paddingHorizontal: 4,
     alignItems: "center",
     justifyContent: "center",
+  },
+  runButtonRunning: {
+    paddingHorizontal: 12,
   },
   runningContent: {
     flexDirection: "row",

--- a/mobile/src/components/outputs/OutputRenderer.tsx
+++ b/mobile/src/components/outputs/OutputRenderer.tsx
@@ -65,6 +65,31 @@ const resolveMediaUri = (
 };
 
 /**
+ * One explicit width per column so the header row and the body rows share a
+ * grid. Sizing each cell on its own (a `minWidth`/`maxWidth` range) lets a
+ * column's header and its data settle at different widths, which shears the
+ * labels off their column and breaks the per-cell hairlines.
+ *
+ * Derived in one pass from the longest string in the column at ~6.5pt per
+ * character for the 12pt cell font, clamped to the 80–160 range the old
+ * per-cell style used. An estimate suffices: correctness only needs header and
+ * body to agree, and `onLayout` measurement would cost a render round-trip.
+ */
+const tableColumnWidths = (
+  headers: ReadonlyArray<string>,
+  rows: ReadonlyArray<ReadonlyArray<string>>
+): number[] =>
+  headers.map((header, index) => {
+    let longest = header.length;
+    for (const row of rows) {
+      longest = Math.max(longest, (row[index] ?? "").length);
+    }
+    return Math.min(160, Math.max(80, Math.round(longest * 6.5) + 16));
+  });
+
+const cellString = (cell: unknown): string => (cell == null ? "" : String(cell));
+
+/**
  * Format a Datetime object (month is 1-indexed from the API).
  */
 const formatDatetime = (dt: {
@@ -401,32 +426,36 @@ export const OutputRenderer = ({ value }: OutputRendererProps) => {
       if (columns.length === 0 || data.length === 0) {
         return renderJSON(v, codeTheme, colors, mode, monoFont);
       }
+      const headers = columns.map((col) => {
+        const c = col as string | DataframeColumn;
+        return typeof c === "object" && c !== null ? String(c.name) : String(c);
+      });
+      const bodyRows = data.slice(0, 50).map((rawRow) => {
+        const row = rawRow as unknown[] | Record<string, unknown>;
+        return (Array.isArray(row) ? row : Object.values(row)).map(cellString);
+      });
+      const widths = tableColumnWidths(headers, bodyRows);
       return (
         <ScrollView horizontal showsHorizontalScrollIndicator>
           <View>
             {/* Header row */}
             <View style={[styles.tableRow, { backgroundColor: mode === "dark" ? "#2A2A2A" : "#E8E8E8" }]}>
-              {columns.map((col, i) => {
-                const c = col as string | DataframeColumn;
-                return (
+              {headers.map((header, i) => (
                 <Text
                   key={i}
                   style={[
                     styles.tableCell,
                     styles.tableHeader,
-                    { color: colors.text, borderColor: colors.border },
+                    { color: colors.text, borderColor: colors.border, width: widths[i] },
                   ]}
                   numberOfLines={1}
                 >
-                  {typeof c === "object" && c !== null ? String(c.name) : String(c)}
+                  {header}
                 </Text>
-                );
-              })}
+              ))}
             </View>
             {/* Data rows (limit to 50 for performance) */}
-            {data.slice(0, 50).map((rawRow, rowIdx) => {
-              const row = rawRow as unknown[] | Record<string, unknown>;
-              return (
+            {bodyRows.map((cells, rowIdx) => (
               <View
                 key={rowIdx}
                 style={[
@@ -436,18 +465,20 @@ export const OutputRenderer = ({ value }: OutputRendererProps) => {
                     : "transparent" },
                 ]}
               >
-                {(Array.isArray(row) ? row : Object.values(row)).map((cell: unknown, cellIdx: number) => (
+                {cells.map((cell: string, cellIdx: number) => (
                   <Text
                     key={cellIdx}
-                    style={[styles.tableCell, { color: colors.text, borderColor: colors.border }]}
+                    style={[
+                      styles.tableCell,
+                      { color: colors.text, borderColor: colors.border, width: widths[cellIdx] },
+                    ]}
                     numberOfLines={2}
                   >
-                    {cell == null ? "" : String(cell)}
+                    {cell}
                   </Text>
                 ))}
               </View>
-              );
-            })}
+            ))}
             {data.length > 50 && (
               <Text style={[styles.placeholder, { color: colors.textSecondary, padding: 8 }]}>
                 Showing 50 of {data.length} rows
@@ -617,6 +648,10 @@ export const OutputRenderer = ({ value }: OutputRendererProps) => {
         if (!first.type) {
           const keys = Object.keys(first);
           if (keys.length > 0) {
+            const objectRows = (arr as Record<string, unknown>[])
+              .slice(0, 50)
+              .map((row) => keys.map((k) => cellString(row[k])));
+            const objectWidths = tableColumnWidths(keys, objectRows);
             return (
               <ScrollView horizontal showsHorizontalScrollIndicator>
                 <View>
@@ -624,14 +659,18 @@ export const OutputRenderer = ({ value }: OutputRendererProps) => {
                     {keys.map((k, i) => (
                       <Text
                         key={i}
-                        style={[styles.tableCell, styles.tableHeader, { color: colors.text, borderColor: colors.border }]}
+                        style={[
+                          styles.tableCell,
+                          styles.tableHeader,
+                          { color: colors.text, borderColor: colors.border, width: objectWidths[i] },
+                        ]}
                         numberOfLines={1}
                       >
                         {k}
                       </Text>
                     ))}
                   </View>
-                  {(arr as Record<string, unknown>[]).slice(0, 50).map((row, rowIdx: number) => (
+                  {objectRows.map((cells, rowIdx: number) => (
                     <View
                       key={rowIdx}
                       style={[
@@ -641,13 +680,16 @@ export const OutputRenderer = ({ value }: OutputRendererProps) => {
                           : "transparent" },
                       ]}
                     >
-                      {keys.map((k, cellIdx) => (
+                      {cells.map((cell, cellIdx) => (
                         <Text
                           key={cellIdx}
-                          style={[styles.tableCell, { color: colors.text, borderColor: colors.border }]}
+                          style={[
+                            styles.tableCell,
+                            { color: colors.text, borderColor: colors.border, width: objectWidths[cellIdx] },
+                          ]}
                           numberOfLines={2}
                         >
-                          {row[k] == null ? "" : String(row[k])}
+                          {cell}
                         </Text>
                       ))}
                     </View>
@@ -742,23 +784,34 @@ function renderJSON(
         },
       ]}
     >
+      {/*
+        The cap lives on the inner vertical scroller, not on the block: a
+        maxHeight on the container alone just clips the tail of a long payload
+        with no way to reach it.
+      */}
       <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-        <SyntaxHighlighter
-          language="json"
-          highlighter="prism"
-          style={codeTheme}
-          customStyle={{
-            backgroundColor: "transparent",
-            padding: 0,
-            margin: 0,
-          }}
-          fontSize={12}
-          fontFamily={monoFont}
-          PreTag={View}
-          CodeTag={View}
+        <ScrollView
+          style={styles.codeBlockScroll}
+          nestedScrollEnabled
+          showsVerticalScrollIndicator
         >
-          {JSON.stringify(value, null, 2)}
-        </SyntaxHighlighter>
+          <SyntaxHighlighter
+            language="json"
+            highlighter="prism"
+            style={codeTheme}
+            customStyle={{
+              backgroundColor: "transparent",
+              padding: 0,
+              margin: 0,
+            }}
+            fontSize={12}
+            fontFamily={monoFont}
+            PreTag={View}
+            CodeTag={View}
+          >
+            {JSON.stringify(value, null, 2)}
+          </SyntaxHighlighter>
+        </ScrollView>
       </ScrollView>
     </View>
   );
@@ -819,9 +872,11 @@ const styles = StyleSheet.create({
   codeBlock: {
     padding: 12,
     borderRadius: 8,
-    maxHeight: 300,
     borderWidth: 1,
     marginVertical: 4,
+  },
+  codeBlockScroll: {
+    maxHeight: 300,
   },
   linkButton: {
     padding: 12,
@@ -896,8 +951,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
   },
   tableCell: {
-    minWidth: 80,
-    maxWidth: 160,
+    // Width comes from tableColumnWidths() so header and body share a grid.
     paddingHorizontal: 8,
     paddingVertical: 6,
     borderWidth: StyleSheet.hairlineWidth,

--- a/mobile/src/screens/AppsScreen.tsx
+++ b/mobile/src/screens/AppsScreen.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../hooks/useTheme';
@@ -31,7 +32,9 @@ type AppsScreenProps = {
 
 export default function AppsScreen({ navigation }: AppsScreenProps) {
   const { colors, shadows } = useTheme();
+  const insets = useSafeAreaInsets();
   const { data, isLoading, isRefetching, error, refetch } = useApplications();
+  const apps = data ?? [];
 
   const openApp = useCallback(
     (app: ApplicationListItem) => {
@@ -101,10 +104,14 @@ export default function AppsScreen({ navigation }: AppsScreenProps) {
         </View>
       ) : null}
       <FlatList
-        data={data ?? []}
+        data={apps}
         keyExtractor={(item) => item.id}
         renderItem={renderItem}
-        contentContainerStyle={styles.listContent}
+        contentContainerStyle={[
+          styles.listContent,
+          { paddingBottom: insets.bottom + 24 },
+          apps.length === 0 && styles.listContentEmpty,
+        ]}
         refreshControl={
           <RefreshControl
             refreshing={isRefetching}
@@ -132,6 +139,12 @@ const styles = StyleSheet.create({
   listContent: {
     padding: 16,
     gap: 10,
+  },
+  // A content container only grows to its content, so the empty block's
+  // `flex: 1` has nothing to fill. Let it take the list's height instead.
+  listContentEmpty: {
+    flexGrow: 1,
+    justifyContent: 'center',
   },
   center: {
     flex: 1,

--- a/mobile/src/screens/ChatScreen.test.tsx
+++ b/mobile/src/screens/ChatScreen.test.tsx
@@ -73,13 +73,17 @@ describe('ChatScreen', () => {
       expect(screen.getByTestId('chat-view')).toBeTruthy();
     });
 
-    it('renders SafeAreaView container', () => {
+    it('renders a safe-area-context SafeAreaView container', () => {
       const { UNSAFE_root } = render(
         <ChatScreen navigation={mockNavigation as any} route={{} as any} />
       );
-      
-      const safeAreaView = UNSAFE_root.findByType(require('react-native').SafeAreaView);
+
+      const safeAreaView = UNSAFE_root.findByType(
+        require('react-native-safe-area-context').SafeAreaView
+      );
       expect(safeAreaView).toBeTruthy();
+      // The header owns the top inset; the composer paints the bottom one.
+      expect(safeAreaView.props.edges).toEqual(['left', 'right']);
     });
   });
 

--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -9,9 +9,9 @@ import {
   StyleSheet,
   TouchableOpacity,
   Text,
-  SafeAreaView,
   StatusBar,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/types';
@@ -145,8 +145,13 @@ export default function ChatScreen({ navigation, route }: Props) {
     }
   }, [connect]);
 
+  // The navigator header owns the top inset and the composer paints its own
+  // bottom inset, so this only guards the horizontal (landscape notch) edges.
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      edges={['left', 'right']}
+    >
       <StatusBar barStyle={mode === 'dark' ? 'light-content' : 'dark-content'} backgroundColor={colors.background} />
       <ChatView
         status={status}

--- a/mobile/src/screens/DocumentViewerScreen.tsx
+++ b/mobile/src/screens/DocumentViewerScreen.tsx
@@ -209,6 +209,11 @@ export default function DocumentViewerScreen({
       ) : null}
 
       <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>JSON</Text>
+      {/*
+        The block is not height-capped: its only scroller is horizontal, so a
+        cap would put everything past it out of reach on the one screen whose
+        job is inspecting the document. The page scroller carries it instead.
+      */}
       <ScrollView
         horizontal
         style={[
@@ -328,7 +333,6 @@ const styles = StyleSheet.create({
     marginHorizontal: 16,
     borderRadius: 12,
     borderWidth: StyleSheet.hairlineWidth,
-    maxHeight: 420,
   },
   jsonContent: {
     padding: 12,

--- a/mobile/src/screens/DocumentsScreen.tsx
+++ b/mobile/src/screens/DocumentsScreen.tsx
@@ -321,6 +321,7 @@ export default function DocumentsScreen({ navigation }: DocumentsScreenProps) {
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
+        style={styles.chipScroll}
         contentContainerStyle={styles.chipRow}
       >
         <FilterChip
@@ -559,8 +560,17 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 13,
   },
+  // A horizontal ScrollView is still a flex child of the column above it: left
+  // to grow it takes the leftover vertical space and stretches every chip to
+  // its height. Pinning it to its content and centring the row keeps the chips
+  // at their natural height.
+  chipScroll: {
+    flexGrow: 0,
+    flexShrink: 0,
+  },
   chipRow: {
     flexDirection: 'row',
+    alignItems: 'center',
     gap: 8,
     paddingHorizontal: 16,
     paddingTop: 12,
@@ -581,6 +591,9 @@ const styles = StyleSheet.create({
   },
   createRow: {
     flexDirection: 'row',
+    // Two buttons already fill a 320pt screen, so let them wrap instead of
+    // spilling past the edge.
+    flexWrap: 'wrap',
     gap: 8,
     paddingHorizontal: 16,
     paddingTop: 10,

--- a/mobile/src/screens/JobsScreen.tsx
+++ b/mobile/src/screens/JobsScreen.tsx
@@ -284,7 +284,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  bannerText: { fontSize: 13, fontWeight: '500' },
+  bannerText: { fontSize: 13, fontWeight: '500', flexShrink: 1 },
   list: { padding: 16 },
   card: {
     borderRadius: 12,

--- a/mobile/src/screens/LanguageModelSelectionScreen.tsx
+++ b/mobile/src/screens/LanguageModelSelectionScreen.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { normalizeModels } from '../services/api';
 import { trpc } from '../trpc/client';
 import { useChatStore } from '../stores/ChatStore';
@@ -27,6 +28,7 @@ export default function LanguageModelSelectionScreen() {
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const { colors, shadows } = useTheme();
+  const insets = useSafeAreaInsets();
 
   const providersQuery = trpc.models.providers.useQuery(undefined, {
     select: (all) =>
@@ -214,7 +216,7 @@ export default function LanguageModelSelectionScreen() {
           data={filteredProviders}
           renderItem={renderProviderItem}
           keyExtractor={(item: Provider) => item.provider}
-          contentContainerStyle={styles.listContent}
+          contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + 24 }]}
           ListEmptyComponent={renderEmptyList('providers')}
         />
       ) : (
@@ -222,7 +224,7 @@ export default function LanguageModelSelectionScreen() {
           data={filteredModels}
           renderItem={renderModelItem}
           keyExtractor={(item: LanguageModel) => item.id}
-          contentContainerStyle={styles.listContent}
+          contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + 24 }]}
           ListEmptyComponent={renderEmptyList('models')}
         />
       )}

--- a/mobile/src/screens/LanguageModelSelectionScreen.tsx
+++ b/mobile/src/screens/LanguageModelSelectionScreen.tsx
@@ -127,7 +127,13 @@ export default function LanguageModelSelectionScreen() {
       <View style={[styles.itemIconWrap, { backgroundColor: colors.primaryMuted }]}>
         <Ionicons name="cloud-outline" size={18} color={colors.primary} />
       </View>
-      <Text style={[styles.itemText, { color: colors.text }]}>{item.provider}</Text>
+      <Text
+        style={[styles.itemText, styles.itemTextFill, { color: colors.text }]}
+        numberOfLines={1}
+        ellipsizeMode="tail"
+      >
+        {item.provider}
+      </Text>
       <View style={[styles.itemChevron, { backgroundColor: colors.primaryLight }]}>
         <Ionicons name="chevron-forward" size={16} color={colors.primary} />
       </View>
@@ -146,9 +152,13 @@ export default function LanguageModelSelectionScreen() {
         <Ionicons name="sparkles-outline" size={16} color={colors.accent} />
       </View>
       <View style={styles.modelInfo}>
-        <Text style={[styles.itemText, { color: colors.text }]}>{item.name}</Text>
+        <Text style={[styles.itemText, { color: colors.text }]} numberOfLines={1} ellipsizeMode="tail">
+          {item.name}
+        </Text>
         {item.id !== item.name && (
-          <Text style={[styles.subText, { color: colors.textTertiary }]}>{item.id}</Text>
+          <Text style={[styles.subText, { color: colors.textTertiary }]} numberOfLines={1} ellipsizeMode="tail">
+            {item.id}
+          </Text>
         )}
       </View>
       <Ionicons name="checkmark-circle-outline" size={20} color={colors.textTertiary} />
@@ -299,6 +309,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 12,
+    flexShrink: 0,
   },
   itemChevron: {
     width: 28,
@@ -306,6 +317,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     justifyContent: 'center',
     alignItems: 'center',
+    flexShrink: 0,
   },
   modelInfo: {
     flex: 1,
@@ -315,6 +327,12 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '500',
     letterSpacing: -0.2,
+  },
+  // Lets the label take the row's remaining width so the trailing chevron
+  // stays pinned to the right edge instead of hugging the text.
+  itemTextFill: {
+    flex: 1,
+    marginRight: 12,
   },
   subText: {
     fontSize: 12,

--- a/mobile/src/screens/ScriptEditorScreen.tsx
+++ b/mobile/src/screens/ScriptEditorScreen.tsx
@@ -22,12 +22,18 @@ import React, {
 } from 'react';
 import {
   ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
   View,
+  useWindowDimensions,
+  type NativeSyntheticEvent,
+  type TextInputContentSizeChangeEventData,
+  type TextInputProps,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { RouteProp, useFocusEffect } from '@react-navigation/native';
@@ -83,6 +89,43 @@ const STATUS_LABELS: Record<ScriptLineStatus, string> = {
   voiced: 'Voiced',
   stale: 'Stale',
 };
+
+/** 18pt icon + 10pt padding = 38pt; the slop lifts it to the 46pt touch target. */
+const ICON_HIT_SLOP = { top: 4, bottom: 4, left: 4, right: 4 };
+
+/**
+ * Width the title cannot have: the back button plus the actions (chat bubble,
+ * gap, Save) plus the gutters around them.
+ */
+const HEADER_RESERVED_WIDTH = 164;
+
+const MULTILINE_MIN_HEIGHT = 68;
+
+/**
+ * Multiline field that grows to fit its text.
+ *
+ * A plain multiline `TextInput` with a fixed height clips its own content — on
+ * web it is a `textarea` that never resizes — so a line long enough to wrap
+ * three times got cut through the middle of the third row. Following the
+ * content size keeps every wrapped row visible while typing.
+ */
+function GrowingTextInput({ style, ...rest }: TextInputProps) {
+  const [height, setHeight] = useState(MULTILINE_MIN_HEIGHT);
+  const onContentSizeChange = useCallback(
+    (event: NativeSyntheticEvent<TextInputContentSizeChangeEventData>) => {
+      setHeight(event.nativeEvent.contentSize.height);
+    },
+    []
+  );
+  return (
+    <TextInput
+      {...rest}
+      multiline
+      onContentSizeChange={onContentSizeChange}
+      style={[style, { height: Math.max(MULTILINE_MIN_HEIGHT, height) }]}
+    />
+  );
+}
 
 export default function ScriptEditorScreen({ navigation, route }: Props) {
   const { id, name: initialName } = route.params;
@@ -420,10 +463,27 @@ export default function ScriptEditorScreen({ navigation, route }: Props) {
     navigation.navigate('Chat');
   }, [navigation]);
 
+  // The header lays the title out at its natural width and never shrinks it, so
+  // a long script name runs under the actions and pushes Save off the screen.
+  // Cap the title instead, leaving room for the actions and the back button.
+  const { width: windowWidth } = useWindowDimensions();
+  const titleMaxWidth = Math.max(96, windowWidth - HEADER_RESERVED_WIDTH);
+
   useLayoutEffect(() => {
     const saving = status === 'saving';
     navigation.setOptions({
       title: name || initialName || 'Script',
+      headerTitle: ({ children, tintColor }) => (
+        <Text
+          numberOfLines={1}
+          style={[
+            styles.headerTitle,
+            { maxWidth: titleMaxWidth, color: tintColor ?? colors.text },
+          ]}
+        >
+          {children}
+        </Text>
+      ),
       headerRight: () => (
         <View style={styles.headerActions}>
           <TouchableOpacity
@@ -470,9 +530,11 @@ export default function ScriptEditorScreen({ navigation, route }: Props) {
     dirty,
     status,
     colors.primary,
+    colors.text,
     colors.textTertiary,
     handleSave,
     openChat,
+    titleMaxWidth,
   ]);
 
   // ── Local edits ──────────────────────────────────────────────────────────
@@ -631,7 +693,13 @@ export default function ScriptEditorScreen({ navigation, route }: Props) {
   const lineNumber = new Map(flat.map((entry) => [entry.line.id, entry.index]));
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    // Every line is a text field, so the keyboard would otherwise cover
+    // whichever one the user tapped in the lower half of the screen.
+    <KeyboardAvoidingView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 90 : 0}
+    >
       {status === 'conflict' && (
         <View
           style={[styles.banner, { backgroundColor: colors.warning + '22' }]}
@@ -713,6 +781,7 @@ export default function ScriptEditorScreen({ navigation, route }: Props) {
               accessibilityRole="button"
               accessibilityLabel={`Assign ${speaker.name} to the selected line`}
               accessibilityState={{ disabled: selectedLineId === null }}
+              hitSlop={ICON_HIT_SLOP}
               style={styles.iconButton}
             >
               <Ionicons
@@ -726,6 +795,7 @@ export default function ScriptEditorScreen({ navigation, route }: Props) {
               activeOpacity={0.7}
               accessibilityRole="button"
               accessibilityLabel={`Remove speaker ${index + 1}`}
+              hitSlop={ICON_HIT_SLOP}
               style={styles.iconButton}
             >
               <Ionicons name="trash-outline" size={18} color={colors.error} />
@@ -822,6 +892,7 @@ export default function ScriptEditorScreen({ navigation, route }: Props) {
                   activeOpacity={0.7}
                   accessibilityRole="button"
                   accessibilityLabel={`Delete section ${sectionIndex + 1}`}
+                  hitSlop={ICON_HIT_SLOP}
                   style={styles.iconButton}
                 >
                   <Ionicons name="trash-outline" size={18} color={colors.error} />
@@ -889,7 +960,7 @@ export default function ScriptEditorScreen({ navigation, route }: Props) {
                       </View>
                     </TouchableOpacity>
 
-                    <TextInput
+                    <GrowingTextInput
                       style={[
                         styles.input,
                         styles.inputMulti,
@@ -903,7 +974,6 @@ export default function ScriptEditorScreen({ navigation, route }: Props) {
                       onChangeText={(text) => patchLine(line.id, { text })}
                       placeholder="What is said"
                       placeholderTextColor={colors.textTertiary}
-                      multiline
                       accessibilityLabel={`Line ${index + 1} text`}
                     />
 
@@ -933,6 +1003,7 @@ export default function ScriptEditorScreen({ navigation, route }: Props) {
                         accessibilityRole="button"
                         accessibilityLabel={`Move line ${index + 1} up`}
                         accessibilityState={{ disabled: index === 0 }}
+                        hitSlop={ICON_HIT_SLOP}
                         style={styles.iconButton}
                       >
                         <Ionicons
@@ -948,6 +1019,7 @@ export default function ScriptEditorScreen({ navigation, route }: Props) {
                         accessibilityRole="button"
                         accessibilityLabel={`Move line ${index + 1} down`}
                         accessibilityState={{ disabled: index === flat.length - 1 }}
+                        hitSlop={ICON_HIT_SLOP}
                         style={styles.iconButton}
                       >
                         <Ionicons
@@ -966,6 +1038,7 @@ export default function ScriptEditorScreen({ navigation, route }: Props) {
                         activeOpacity={0.7}
                         accessibilityRole="button"
                         accessibilityLabel={`Delete line ${index + 1}`}
+                        hitSlop={ICON_HIT_SLOP}
                         style={styles.iconButton}
                       >
                         <Ionicons name="trash-outline" size={18} color={colors.error} />
@@ -995,7 +1068,7 @@ export default function ScriptEditorScreen({ navigation, route }: Props) {
           ))
         )}
       </ScrollView>
-    </View>
+    </KeyboardAvoidingView>
   );
 }
 
@@ -1054,7 +1127,14 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   centerText: { fontSize: 14, textAlign: 'center' },
-  headerActions: { flexDirection: 'row', alignItems: 'center', gap: 16 },
+  headerTitle: { fontSize: 17, fontWeight: '700' },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    // Native headers inset their own items; the web header does not.
+    paddingRight: Platform.OS === 'web' ? 12 : 0,
+  },
   saveText: { fontSize: 16, fontWeight: '600' },
   banner: {
     flexDirection: 'row',
@@ -1086,7 +1166,7 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     marginBottom: 8,
   },
-  inputMulti: { minHeight: 68, textAlignVertical: 'top' },
+  inputMulti: { minHeight: MULTILINE_MIN_HEIGHT, textAlignVertical: 'top' },
   castRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
   castInput: { flex: 1, marginBottom: 0 },
   colorChip: { width: 14, height: 14, borderRadius: 7 },
@@ -1120,6 +1200,6 @@ const styles = StyleSheet.create({
     gap: 8,
     marginTop: 2,
   },
-  iconButton: { padding: 6 },
+  iconButton: { padding: 10 },
   spacer: { flex: 1 },
 });

--- a/mobile/src/screens/ScriptEditorScreen.tsx
+++ b/mobile/src/screens/ScriptEditorScreen.tsx
@@ -1168,7 +1168,9 @@ const styles = StyleSheet.create({
   },
   inputMulti: { minHeight: MULTILINE_MIN_HEIGHT, textAlignVertical: 'top' },
   castRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  castInput: { flex: 1, marginBottom: 0 },
+  // `minWidth: 0` is what lets the field give way to the buttons beside it: a
+  // web text input will not shrink past its default intrinsic width otherwise.
+  castInput: { flex: 1, minWidth: 0, marginBottom: 0 },
   colorChip: { width: 14, height: 14, borderRadius: 7 },
   addButton: {
     flexDirection: 'row',
@@ -1183,7 +1185,7 @@ const styles = StyleSheet.create({
   primaryButtonText: { fontSize: 15, fontWeight: '600' },
   sectionBlock: { marginTop: 14 },
   sectionHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  sectionInput: { flex: 1, marginBottom: 0, fontWeight: '600' },
+  sectionInput: { flex: 1, minWidth: 0, marginBottom: 0, fontWeight: '600' },
   card: { borderRadius: 14, borderWidth: 1, padding: 12, marginTop: 10 },
   cardHeader: {
     flexDirection: 'row',

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -360,7 +360,7 @@ export default function SettingsScreen({ navigation }: SettingsScreenProps) {
         </TouchableOpacity>
 
         <TouchableOpacity
-          style={styles.aboutRow}
+          style={[styles.aboutRow, styles.aboutRowLast]}
           onPress={() => navigation.navigate('Triggers')}
           accessibilityRole="button"
           accessibilityLabel="View triggers"
@@ -383,7 +383,7 @@ export default function SettingsScreen({ navigation }: SettingsScreenProps) {
             <Text style={[styles.cardTitle, { color: colors.text }]}>Account</Text>
           </View>
 
-          <View style={[styles.aboutRow, { borderBottomColor: colors.borderLight }]}>
+          <View style={[styles.aboutRow, styles.aboutRowLast]}>
             <Text style={[styles.aboutLabel, { color: colors.textSecondary }]}>Signed in as</Text>
             <Text
               style={[styles.aboutValue, { color: colors.text, flexShrink: 1, marginLeft: 12 }]}
@@ -443,7 +443,7 @@ export default function SettingsScreen({ navigation }: SettingsScreenProps) {
           </View>
         </View>
         <TouchableOpacity
-          style={styles.aboutRow}
+          style={[styles.aboutRow, styles.aboutRowLast]}
           onPress={() => Linking.openURL('https://github.com/nodetool-ai/nodetool')}
           accessibilityRole="link"
           accessibilityLabel="Open NodeTool on GitHub"
@@ -556,6 +556,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: 12,
     borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  // Rows carry a hairline separator; the last row in a card must not, or the
+  // divider floats above the card's bottom padding.
+  aboutRowLast: {
+    borderBottomWidth: 0,
   },
   manageRowLeft: {
     flexDirection: 'row',

--- a/mobile/src/screens/StoryboardEditorScreen.tsx
+++ b/mobile/src/screens/StoryboardEditorScreen.tsx
@@ -15,12 +15,18 @@ import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from
 import {
   ActivityIndicator,
   Image,
+  KeyboardAvoidingView,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
   View,
+  useWindowDimensions,
+  type NativeSyntheticEvent,
+  type TextInputContentSizeChangeEventData,
+  type TextInputProps,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { RouteProp, useFocusEffect } from '@react-navigation/native';
@@ -64,6 +70,43 @@ const newShotId = (): string =>
 
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(Math.max(value, min), max);
+
+/** 18pt icon + 10pt padding = 38pt; the slop lifts it to the 46pt touch target. */
+const ICON_HIT_SLOP = { top: 4, bottom: 4, left: 4, right: 4 };
+
+/**
+ * Width the title cannot have: the back button plus the actions (chat bubble,
+ * gap, Save) plus the gutters around them.
+ */
+const HEADER_RESERVED_WIDTH = 164;
+
+const MULTILINE_MIN_HEIGHT = 68;
+
+/**
+ * Multiline field that grows to fit its text.
+ *
+ * A plain multiline `TextInput` with a fixed height clips its own content — on
+ * web it is a `textarea` that never resizes — so a brief long enough to wrap
+ * three times got cut through the middle of the third row. Following the
+ * content size keeps every wrapped row visible while typing.
+ */
+function GrowingTextInput({ style, ...rest }: TextInputProps) {
+  const [height, setHeight] = useState(MULTILINE_MIN_HEIGHT);
+  const onContentSizeChange = useCallback(
+    (event: NativeSyntheticEvent<TextInputContentSizeChangeEventData>) => {
+      setHeight(event.nativeEvent.contentSize.height);
+    },
+    []
+  );
+  return (
+    <TextInput
+      {...rest}
+      multiline
+      onContentSizeChange={onContentSizeChange}
+      style={[style, { height: Math.max(MULTILINE_MIN_HEIGHT, height) }]}
+    />
+  );
+}
 
 const STATUS_LABELS: Record<ShotStatus, string> = {
   planned: 'Planned',
@@ -294,10 +337,27 @@ export default function StoryboardEditorScreen({ navigation, route }: Props) {
     navigation.navigate('Chat');
   }, [navigation]);
 
+  // The header lays the title out at its natural width and never shrinks it, so
+  // a long board name runs under the actions and pushes Save off the screen.
+  // Cap the title instead, leaving room for the actions and the back button.
+  const { width: windowWidth } = useWindowDimensions();
+  const titleMaxWidth = Math.max(96, windowWidth - HEADER_RESERVED_WIDTH);
+
   useLayoutEffect(() => {
     const saving = status === 'saving';
     navigation.setOptions({
       title: name || initialName || 'Storyboard',
+      headerTitle: ({ children, tintColor }) => (
+        <Text
+          numberOfLines={1}
+          style={[
+            styles.headerTitle,
+            { maxWidth: titleMaxWidth, color: tintColor ?? colors.text },
+          ]}
+        >
+          {children}
+        </Text>
+      ),
       headerRight: () => (
         <View style={styles.headerActions}>
           <TouchableOpacity
@@ -340,9 +400,11 @@ export default function StoryboardEditorScreen({ navigation, route }: Props) {
     dirty,
     status,
     colors.primary,
+    colors.text,
     colors.textTertiary,
     handleSave,
     openChat,
+    titleMaxWidth,
   ]);
 
   // ── Local edits ──────────────────────────────────────────────────────────
@@ -432,7 +494,13 @@ export default function StoryboardEditorScreen({ navigation, route }: Props) {
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    // Brief, style, and every shot are text fields, so the keyboard would
+    // otherwise cover whichever one the user tapped in the lower half.
+    <KeyboardAvoidingView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 90 : 0}
+    >
       {status === 'conflict' && (
         <View
           style={[styles.banner, { backgroundColor: colors.warning + '22' }]}
@@ -479,7 +547,7 @@ export default function StoryboardEditorScreen({ navigation, route }: Props) {
         </View>
 
         <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Brief</Text>
-        <TextInput
+        <GrowingTextInput
           style={[
             styles.input,
             styles.inputMulti,
@@ -489,12 +557,11 @@ export default function StoryboardEditorScreen({ navigation, route }: Props) {
           onChangeText={(brief) => edit((board) => ({ ...board, brief }))}
           placeholder="What is this piece about?"
           placeholderTextColor={colors.textTertiary}
-          multiline
           accessibilityLabel="Board brief"
         />
 
         <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Style</Text>
-        <TextInput
+        <GrowingTextInput
           style={[
             styles.input,
             styles.inputMulti,
@@ -504,7 +571,6 @@ export default function StoryboardEditorScreen({ navigation, route }: Props) {
           onChangeText={(style) => edit((board) => ({ ...board, style }))}
           placeholder="Grainy 16mm, muted teal palette, low sun"
           placeholderTextColor={colors.textTertiary}
-          multiline
           accessibilityLabel="Board style"
         />
 
@@ -628,7 +694,7 @@ export default function StoryboardEditorScreen({ navigation, route }: Props) {
                   />
                 )}
 
-                <TextInput
+                <GrowingTextInput
                   style={[
                     styles.input,
                     styles.inputMulti,
@@ -642,7 +708,6 @@ export default function StoryboardEditorScreen({ navigation, route }: Props) {
                   onChangeText={(action) => patchShot(shot.id, { action })}
                   placeholder="What we see in this shot"
                   placeholderTextColor={colors.textTertiary}
-                  multiline
                   accessibilityLabel={`Shot ${index + 1} action`}
                 />
 
@@ -712,6 +777,7 @@ export default function StoryboardEditorScreen({ navigation, route }: Props) {
                     accessibilityRole="button"
                     accessibilityLabel={`Move shot ${index + 1} up`}
                     accessibilityState={{ disabled: index === 0 }}
+                    hitSlop={ICON_HIT_SLOP}
                     style={styles.iconButton}
                   >
                     <Ionicons
@@ -727,6 +793,7 @@ export default function StoryboardEditorScreen({ navigation, route }: Props) {
                     accessibilityRole="button"
                     accessibilityLabel={`Move shot ${index + 1} down`}
                     accessibilityState={{ disabled: index === doc.shots.length - 1 }}
+                    hitSlop={ICON_HIT_SLOP}
                     style={styles.iconButton}
                   >
                     <Ionicons
@@ -743,6 +810,7 @@ export default function StoryboardEditorScreen({ navigation, route }: Props) {
                     activeOpacity={0.7}
                     accessibilityRole="button"
                     accessibilityLabel={`Delete shot ${index + 1}`}
+                    hitSlop={ICON_HIT_SLOP}
                     style={styles.iconButton}
                   >
                     <Ionicons name="trash-outline" size={18} color={colors.error} />
@@ -753,7 +821,7 @@ export default function StoryboardEditorScreen({ navigation, route }: Props) {
           })
         )}
       </ScrollView>
-    </View>
+    </KeyboardAvoidingView>
   );
 }
 
@@ -761,7 +829,14 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, gap: 12 },
   centerText: { fontSize: 14, textAlign: 'center' },
-  headerActions: { flexDirection: 'row', alignItems: 'center', gap: 16 },
+  headerTitle: { fontSize: 17, fontWeight: '700' },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    // Native headers inset their own items; the web header does not.
+    paddingRight: Platform.OS === 'web' ? 12 : 0,
+  },
   saveText: { fontSize: 16, fontWeight: '600' },
   banner: {
     flexDirection: 'row',
@@ -801,7 +876,7 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     marginBottom: 8,
   },
-  inputMulti: { minHeight: 68, textAlignVertical: 'top' },
+  inputMulti: { minHeight: MULTILINE_MIN_HEIGHT, textAlignVertical: 'top' },
   addButton: { flexDirection: 'row', alignItems: 'center', gap: 4 },
   addButtonText: { fontSize: 15, fontWeight: '600' },
   empty: { alignItems: 'center', paddingVertical: 40, gap: 12 },
@@ -828,6 +903,6 @@ const styles = StyleSheet.create({
   statusPillText: { fontSize: 11, fontWeight: '600' },
   thumbnail: { width: '100%', height: 150, borderRadius: 10, marginBottom: 10 },
   cardActions: { flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 2 },
-  iconButton: { padding: 6 },
+  iconButton: { padding: 10 },
   spacer: { flex: 1 },
 });

--- a/mobile/src/screens/ThreadsScreen.tsx
+++ b/mobile/src/screens/ThreadsScreen.tsx
@@ -226,7 +226,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  bannerText: { fontSize: 13, fontWeight: '500' },
+  bannerText: { fontSize: 13, fontWeight: '500', flexShrink: 1 },
   list: { padding: 16, paddingTop: 4 },
   card: {
     borderRadius: 12,

--- a/mobile/src/screens/TimelineViewerScreen.tsx
+++ b/mobile/src/screens/TimelineViewerScreen.tsx
@@ -23,11 +23,13 @@ import React, {
 } from 'react';
 import {
   ActivityIndicator,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
+  useWindowDimensions,
   type GestureResponderEvent,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
@@ -74,6 +76,12 @@ const DEFAULT_PX_PER_SECOND = 20;
 const ZOOM_FACTOR = 2;
 /** Empty room after the last clip, so the sequence end is reachable. */
 const TAIL_MS = 2000;
+
+/**
+ * Width the title cannot have: the back button plus the actions (chat bubble,
+ * gap, Save) plus the gutters around them.
+ */
+const HEADER_RESERVED_WIDTH = 164;
 
 /** Tick spacings, coarsest that still leaves ~64px between labels wins. */
 const TICK_STEPS_MS = [
@@ -435,10 +443,27 @@ export default function TimelineViewerScreen({ navigation, route }: Props) {
   const openChat = useCallback(() => navigation.navigate('Chat'), [navigation]);
   const handleSave = useCallback(() => void runSave(), [runSave]);
 
+  // The header lays the title out at its natural width and never shrinks it, so
+  // a long sequence name runs under the actions and pushes Save off the screen.
+  // Cap the title instead, leaving room for the actions and the back button.
+  const { width: windowWidth } = useWindowDimensions();
+  const titleMaxWidth = Math.max(96, windowWidth - HEADER_RESERVED_WIDTH);
+
   useLayoutEffect(() => {
     const saving = status === 'saving';
     navigation.setOptions({
       title,
+      headerTitle: ({ children, tintColor }) => (
+        <Text
+          numberOfLines={1}
+          style={[
+            styles.headerTitle,
+            { maxWidth: titleMaxWidth, color: tintColor ?? colors.text },
+          ]}
+        >
+          {children}
+        </Text>
+      ),
       headerRight: () => (
         <View style={styles.headerActions}>
           <TouchableOpacity
@@ -484,6 +509,7 @@ export default function TimelineViewerScreen({ navigation, route }: Props) {
     openChat,
     status,
     title,
+    titleMaxWidth,
   ]);
 
   const msToPx = useCallback(
@@ -592,7 +618,10 @@ export default function TimelineViewerScreen({ navigation, route }: Props) {
       )}
 
       <View style={[styles.toolbar, { borderBottomColor: colors.borderLight }]}>
-        <Text style={[styles.toolbarText, { color: colors.textSecondary }]}>
+        <Text
+          style={[styles.toolbarText, { color: colors.textSecondary }]}
+          numberOfLines={1}
+        >
           {`${formatTime(durationMs)} · ${tracks.length} tracks · ${clips.length} clips`}
         </Text>
         <View style={styles.toolbarActions}>
@@ -868,10 +897,16 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
   },
+  headerTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+  },
   headerActions: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 16,
+    // Native headers inset their own items; the web header does not.
+    paddingRight: Platform.OS === 'web' ? 12 : 0,
   },
   saveText: {
     fontSize: 16,
@@ -922,11 +957,16 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
   toolbarText: {
+    // Shrinks and truncates so the zoom controls and the playhead readout keep
+    // their width on a narrow phone.
+    flexShrink: 1,
+    marginRight: 8,
     fontSize: 12,
   },
   toolbarActions: {
     flexDirection: 'row',
     alignItems: 'center',
+    flexShrink: 0,
     gap: 4,
   },
   playheadReadout: {

--- a/mobile/src/screens/WorkflowsListScreen.tsx
+++ b/mobile/src/screens/WorkflowsListScreen.tsx
@@ -267,7 +267,7 @@ export default function WorkflowsListScreen({ navigation }: WorkflowsListScreenP
             data={filteredWorkflows}
             renderItem={renderWorkflowItem}
             keyExtractor={(item: Workflow) => item.id}
-            contentContainerStyle={styles.listContent}
+            contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + 24 }]}
             refreshControl={
               <RefreshControl
                 refreshing={isRefetching}

--- a/mobile/src/screens/WorkflowsListScreen.tsx
+++ b/mobile/src/screens/WorkflowsListScreen.tsx
@@ -142,9 +142,9 @@ export default function WorkflowsListScreen({ navigation }: WorkflowsListScreenP
           paddingTop: insets.top + 12,
         }
       ]}>
-        <View>
-          <Text style={[styles.title, { color: colors.text }]}>Workflows</Text>
-          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+        <View style={styles.headerTitleBlock}>
+          <Text style={[styles.title, { color: colors.text }]} numberOfLines={1}>Workflows</Text>
+          <Text style={[styles.subtitle, { color: colors.textSecondary }]} numberOfLines={1}>
             {workflows.length > 0 ? `${workflows.length} available` : 'Your workflows'}
           </Text>
         </View>
@@ -305,21 +305,25 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: 24,
   },
+  // The six destinations don't fit beside the title on a narrow phone, so the
+  // header stacks: title row, then a nav rail whose buttons share the width.
   header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
     paddingHorizontal: 20,
     paddingBottom: 16,
     borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 12,
+  },
+  headerTitleBlock: {
+    alignSelf: 'flex-start',
+    maxWidth: '100%',
   },
   headerButtons: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 10,
+    gap: 8,
   },
   headerButton: {
-    width: 40,
+    flex: 1,
     height: 40,
     borderRadius: 12,
     justifyContent: 'center',


### PR DESCRIPTION
Nobody had actually looked at every mobile screen at once. This adds a harness that does, then fixes what it turned up.

## The harness

`mobile/scripts/screenshot-screens.mjs` drives the **Expo web** build with Playwright, walking the deep-link paths in `navigation/linking.ts` and writing one PNG per screen plus a `report.json` that flags any screen whose document scrolls horizontally — a reliable signal that a row is clipped off the right edge on a phone.

```bash
npm run dev:server                                       # API on :7777
npm --prefix mobile run web                              # Expo web on :8081
node mobile/scripts/screenshot-screens.mjs --out ./shots
node mobile/scripts/screenshot-screens.mjs --width 320   # narrow-phone pass
```

Two wrinkles documented in `mobile/AGENTS.md`: `App.tsx` treats an unconfigured Supabase as logged in, so `extra.supabaseUrl`/`supabaseAnonKey` come out of `app.json` for the run (otherwise every route lands on the login wall), and parameterized routes take real ids via `--ids ids.json` (missing ids are skipped, so a partial seed still runs).

22 screens were captured against a server seeded with real workflows, apps, documents, assets, jobs and triggers — including a deliberately 158-character document title.

## What was broken

Caught by the screenshots:

- **WorkflowsListScreen** — the title and six icon buttons shared one row, so the rail needed 330pt inside a 390pt screen. Chat and settings sat off the right edge, **unreachable**, and the page scrolled horizontally. The header now stacks the title above a rail whose buttons divide the width.
- **DocumentsScreen** — the kind-filter `ScrollView` had no `style`, so it grew into the column's leftover vertical space and, with the cross-axis default of `stretch`, blew every chip up to ~200pt tall.
- **Document screens** (script, storyboard, timeline) — the header laid the title out at its natural width and never shrank it, so a real document name ran under the chat action and pushed **Save off the screen**. The title is now capped and truncates.
- **StoryboardEditorScreen** — fixed-height multiline fields cut a line of text in half mid-glyph. They grow with their content now.
- **LanguageModelSelectionScreen** — the chevron rendered right after the label text instead of at the row's trailing edge.
- **SettingsScreen** — three cards drew a separator after their last row, leaving a divider floating above the card padding.
- **AppsScreen** — the empty block centred itself with `flex: 1` but the content container never grew, so "No apps yet" collapsed under the header while the same screen's loading state centred fine.

Found by auditing the layout code alongside the shots:

- **Tables** (Table widget, dataframe input, dataframe output) sized header cells and body cells independently, so any column whose header differed in length from its data drifted out from over its own column and the hairline grid broke. They now share one width per column.
- **Height-capped blocks** (document JSON, code output, node result preview) had only a *horizontal* scroller, so everything past the cap was unreachable.
- **The chat composer** used `react-native`'s `SafeAreaView` — a no-op on Android — plus a hardcoded iOS inset: the send row sat on Android's gesture bar and double-padded on iOS.
- **Three lists** (workflows, apps, model picker) padded their headers by `insets.top` but never padded the list bottom, so the last row scrolled under the home indicator. The offline banner sat entirely inside that band.
- Smaller ones: widget label rows pushed their switch off the edge; the run button's elapsed timer spilled out of its 44pt circle; chat media came from a stale module-level `Dimensions` read and letterboxed portrait images; error banners centred a `Text` with no `flexShrink` and clipped at both ends; nested scrollers lacked `nestedScrollEnabled` on Android; several icon buttons were 30pt targets.

## Verification

`npx tsc --noEmit` clean · `npm run lint` clean (one pre-existing `ChatStore.ts:242` warning, untouched) · `npx jest` 73 suites / 981 tests pass.

Final screenshot pass: **zero horizontal overflow on all 22 screens at both 390pt and 320pt.** Fixes that can't be seen in a browser — safe-area insets and `nestedScrollEnabled`, both no-ops under react-native-web — are covered by tests that mount a provider with a real notch inset, and the diff matches the sibling screens' existing pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2hWCkKYAhCt3WKE3z9xMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2hWCkKYAhCt3WKE3z9xMM)_