### PR TITLE
fix(kernel,websocket): acknowledge a run before it can fail validation

### DIFF
--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -540,6 +540,17 @@ export class WorkflowRunner {
         jobId: request.job_id,
         workflowId: request.workflow_id
       });
+
+      // Emit job_update: running before any validation. A run that dies in
+      // graph validation still gets the running acknowledgement first, so
+      // clients never see a terminal update for a job they were never told
+      // started.
+      this._emit({
+        type: "job_update",
+        status: "running",
+        job_id: request.job_id,
+        workflow_id: request.workflow_id ?? null
+      });
       // Rewrite the graph to route around nodes marked
       // `ui_properties.bypassed === true`. Each outgoing edge of a
       // bypassed node is re-attached to the matching upstream source
@@ -579,14 +590,6 @@ export class WorkflowRunner {
       // Pre-flight node validation: catch missing required fields and
       // unset model selections before spawning any actors.
       this._validateNodes();
-
-      // Emit job_update: running
-      this._emit({
-        type: "job_update",
-        status: "running",
-        job_id: request.job_id,
-        workflow_id: request.workflow_id ?? null
-      });
 
       // Detect multi-edge list inputs
       this._detectMultiEdgeListInputs();

--- a/packages/kernel/tests/runner.test.ts
+++ b/packages/kernel/tests/runner.test.ts
@@ -129,6 +129,30 @@ describe("WorkflowRunner – job status messages", () => {
     expect(jobMsgs.some((m) => m.status === "running")).toBe(true);
     expect(jobMsgs.some((m) => m.status === "completed")).toBe(true);
   });
+
+  it("emits running before failing graph validation", async () => {
+    const nodes: NodeDescriptor[] = [{ id: "loop", type: "test.Loop" }];
+    // Self-loop edges are rejected by Graph.validate(), which runs before any
+    // actor is spawned.
+    const edges: Edge[] = [
+      {
+        source: "loop",
+        sourceHandle: "value",
+        target: "loop",
+        targetHandle: "value"
+      }
+    ];
+
+    const runner = makeRunner({});
+    const result = await runner.run({ job_id: "j-validate" }, { nodes, edges });
+
+    expect(result.status).toBe("failed");
+
+    const statuses = (
+      result.messages.filter((m) => m.type === "job_update") as JobUpdate[]
+    ).map((m) => m.status);
+    expect(statuses).toEqual(["running", "failed"]);
+  });
 });
 
 describe("WorkflowRunner – error handling", () => {

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -149,6 +149,13 @@ import { handleSdkV1LifecycleRpc } from "./sdk/sdk-lifecycle-rpc-handler.js";
 const log = createLogger("nodetool.websocket.runner");
 const DATA_URI_PATTERN = /data:([^;,]+)?;base64,[A-Za-z0-9+/=\r\n]+/gi;
 const MAX_ERROR_TEXT_LENGTH = 4000;
+const TERMINAL_JOB_STATUSES = [
+  "completed",
+  "failed",
+  "cancelled",
+  "error",
+  "suspended"
+];
 
 /**
  * Largest binary (MsgPack) frame accepted from a client before deserialization.
@@ -3049,9 +3056,10 @@ export class UnifiedWebSocketRunner {
     // N-variant run does one query per node, not one per variant (RFC D8).
     const persistedIndexByNode = new Map<string, Set<number>>();
 
-    // The kernel emits the same running update once graph validation begins.
-    // Authoritative SDK runs can use that update and avoid an otherwise
-    // duplicate WebSocket frame. Legacy clients keep the eager acknowledgement.
+    // The kernel opens every run with the same running update. Authoritative
+    // SDK runs relay that one and avoid an otherwise duplicate WebSocket
+    // frame. Legacy clients keep the eager acknowledgement.
+    let runningSeen = false;
     if (!active.requireTerminalResult) {
       await this.sendMessage({
         type: "job_update",
@@ -3059,7 +3067,23 @@ export class UnifiedWebSocketRunner {
         job_id: active.jobId,
         workflow_id: active.workflowId
       });
+      runningSeen = true;
     }
+    // Guard the framing contract for authoritative runs: a terminal update
+    // must never be the first job_update a client sees. The kernel emits
+    // running before it can fail, but a run that dies before the kernel
+    // starts — or a future reordering there — must not silently drop the
+    // acknowledgement.
+    const ensureRunningFrame = async (): Promise<void> => {
+      if (runningSeen) return;
+      runningSeen = true;
+      await this.sendMessage({
+        type: "job_update",
+        status: "running",
+        job_id: active.jobId,
+        workflow_id: active.workflowId
+      });
+    };
 
     const executionSettled = executePromise
       .then((result) => {
@@ -3304,14 +3328,17 @@ export class UnifiedWebSocketRunner {
           status === "completed" &&
           outbound.result === undefined;
         if (!suppressProvisionalCompletion) {
+          if (outbound.type === "job_update") {
+            if (status === "running") {
+              runningSeen = true;
+            } else if (TERMINAL_JOB_STATUSES.includes(status)) {
+              await ensureRunningFrame();
+            }
+          }
           await this.sendMessage(outbound);
         }
         if (outbound.type === "job_update" && !suppressProvisionalCompletion) {
-          if (
-            ["completed", "failed", "cancelled", "error", "suspended"].includes(
-              status
-            )
-          ) {
+          if (TERMINAL_JOB_STATUSES.includes(status)) {
             terminalSeen = true;
             if (outbound.result !== undefined) {
               terminalWithResultSeen = true;
@@ -3345,6 +3372,7 @@ export class UnifiedWebSocketRunner {
       !terminalSeen ||
       (!terminalWithResultSeen && Object.keys(finalOutputs).length > 0)
     ) {
+      await ensureRunningFrame();
       await this.sendMessage({
         type: "job_update",
         status: active.status,

--- a/packages/websocket/tests/unified-websocket-runner-runjob-coverage.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner-runjob-coverage.test.ts
@@ -245,6 +245,37 @@ describe("UnifiedWebSocketRunner run_job — streamJobMessages relay", () => {
     expect(runningUpdates).toHaveLength(1);
   });
 
+  it("acknowledges an authoritative SDK run that fails before the kernel emits running", async () => {
+    // Graph validation can fail before the kernel's running update, leaving the
+    // failed job_update as the only kernel frame. The client must still see the
+    // run acknowledged before the terminal update.
+    const active = makeActive({
+      jobId: "J-SDK-INVALID",
+      workflowId: "wf-sdk-invalid",
+      messages: [
+        {
+          type: "job_update",
+          status: "failed",
+          error: "Correlation analysis failed",
+          validation_issues: [
+            { node_id: "n1", node_type: "test.Node", property: "", message: "x" }
+          ]
+        }
+      ],
+      requireTerminalResult: true
+    });
+
+    await streamTo(
+      runner,
+      active,
+      Promise.resolve({ status: "failed", error: "Correlation analysis failed" })
+    );
+
+    const jobUpdates = decodeAll(ws).filter((m) => m.type === "job_update");
+    expect(jobUpdates.map((m) => m.status)).toEqual(["running", "failed"]);
+    expect(jobUpdates[1]?.validation_issues).toBeDefined();
+  });
+
   it("waits for execution activity without scheduling a polling timer", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## What

Follow-up to #4576, which trimmed the websocket runner's eager `job_update: running`
frame for authoritative (`requireTerminalResult: true`) SDK runs on the grounds that
the kernel emits the same update. It does — but only *after* correlation analysis,
`graph.validate()`, and node pre-flight all pass. A run that fails any of them jumps
straight to the catch block, so its terminal `failed` update was the first job_update
the client ever saw. `requireTerminalResult` defaults to true for the SDK
(`packages/protocol/src/api-schemas/sdk-lifecycle-v1.ts`), so every SDK client lost
its run acknowledgement on a graph-validation failure.

Two changes:

1. **Kernel** (`packages/kernel/src/runner.ts`): `job_update: running` is emitted at
   the top of `run()`, before any validation. A validation failure now frames as
   `running` → `failed` (with `validation_issues`) instead of `failed` alone.
2. **WebSocket runner** (`packages/websocket/src/unified-websocket-runner.ts`): the
   relay tracks whether a running frame has gone out and injects one before relaying
   any terminal `job_update` — and before the synthesized terminal fallback — if none
   has. Dead code in the normal path now that the kernel emits early; it keeps the SDK
   lifecycle guarantee from depending on kernel ordering, and covers execution
   rejecting before the kernel emits anything at all. The terminal-status list is now
   a `TERMINAL_JOB_STATUSES` const shared by both call sites.

## Scope

Protocol framing for every client.

- Legacy (non-SDK) websocket clients: no change in frame count or order.
- SDK clients: gain a `running` frame on graph-validation failure, where they
  previously got none. No change on the success path.
- Non-websocket consumers (CLI, DSL runner, `nodetool debug`): also gain the `running`
  update on validation failure, where they previously got only `failed`.

## Tests

- `packages/kernel/tests/runner.test.ts` — a self-loop graph is rejected by
  `Graph.validate()` before any actor spawns; asserts the job_update sequence is
  exactly `["running", "failed"]`.
- `packages/websocket/tests/unified-websocket-runner-runjob-coverage.test.ts` — a
  `requireTerminalResult: true` run whose only kernel frame is the validation
  `failed`; asserts the client sees `running` then `failed` with `validation_issues`
  intact.

Full kernel suite passes (921). The websocket framing suites — runjob-coverage,
lifecycle-coverage, workflow-message-parity, job-stream-failure-bookkeeping — pass (86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
