### PR TITLE
fix(runners,providers,gpu): four defects found by running example workflows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,18 @@ ENV NODE_ENV=production \
 #   pandoc            — document conversion nodes
 #   postgresql-client — psql/pg_dump for DATABASE_URL deployments
 #   jq/zip/unzip      — everyday shell plumbing for agents
+#   mesa-vulkan-drivers — lavapipe, a software Vulkan device. The image nodes
+#                     run their shaders on Dawn, which reaches the GPU only
+#                     through a Vulkan ICD and bundles no software fallback of
+#                     its own. With no ICD installed, `vkCreateInstance` fails
+#                     outright (VK_ERROR_INCOMPATIBLE_DRIVER) and every
+#                     nodetool.image.* node dies on "No WebGPU adapter
+#                     available" — crop and resize included. Containers have no
+#                     GPU, so lavapipe is what makes them runnable at all.
+#                     Pinned to bookworm-backports: bookworm ships Mesa 22.3,
+#                     whose lavapipe Dawn rejects with "Vulkan
+#                     shaderUniform*ArrayDynamicIndexing required" and still
+#                     hands back a null adapter. 25.0 satisfies it.
 #
 # The image doubles as the agent sandbox (see the sandbox entrypoint below),
 # so it also carries the sandbox desktop/browser stack:
@@ -99,7 +111,9 @@ ENV NODE_ENV=production \
 #   xdotool/scrot/xterm                  — desktop_* tools (input, screenshots)
 #   imagemagick/tesseract-ocr/weasyprint — screenshot post-processing, OCR, PDF
 #   tmux/wget                            — shell tool conveniences
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN echo 'deb http://deb.debian.org/debian bookworm-backports main' \
+      > /etc/apt/sources.list.d/backports.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl wget tmux \
     ffmpeg git jq zip unzip \
     poppler-utils qpdf pandoc \
@@ -111,6 +125,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
     libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
     libgbm1 libpango-1.0-0 libcairo2 libasound2 \
+    && apt-get install -y --no-install-recommends -t bookworm-backports \
+    mesa-vulkan-drivers \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /workspace \
     && chown node:node /workspace

--- a/packages/code-runners/src/python-runner.ts
+++ b/packages/code-runners/src/python-runner.ts
@@ -1,3 +1,5 @@
+import { delimiter, join } from "node:path";
+import { accessSync, constants } from "node:fs";
 import {
   StreamRunnerBase,
   type StreamRunnerOptions
@@ -26,6 +28,48 @@ export class PythonDockerRunner extends StreamRunnerBase {
     code += userCode;
     return ["python", "-c", code];
   }
+
+  /**
+   * Subprocess mode reuses `buildContainerCommand`, whose `python` is correct
+   * inside `python:3.11-slim` but not on a host. Debian, Ubuntu and macOS ship
+   * only `python3` — no unsuffixed shim — so the container name spawns ENOENT
+   * there. Called on the subprocess path only, so Docker keeps `python`.
+   */
+  override wrapSubprocessCommand(command: string[]): [string[], unknown] {
+    if (command[0] !== "python") return super.wrapSubprocessCommand(command);
+    return super.wrapSubprocessCommand([
+      resolvePythonExecutable(),
+      ...command.slice(1)
+    ]);
+  }
+}
+
+let cachedPythonExecutable: string | undefined;
+
+/**
+ * First of `python`/`python3` present on PATH, preferring the unsuffixed name
+ * so an explicit shim (pyenv, a venv, conda) still wins. Falls back to
+ * `python3` when neither resolves, which gives the clearer error of the two.
+ */
+function resolvePythonExecutable(): string {
+  if (cachedPythonExecutable !== undefined) return cachedPythonExecutable;
+  const dirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+  const suffixes = process.platform === "win32" ? [".exe", ".bat", ""] : [""];
+  for (const name of ["python", "python3"]) {
+    for (const dir of dirs) {
+      for (const suffix of suffixes) {
+        try {
+          accessSync(join(dir, name + suffix), constants.X_OK);
+          cachedPythonExecutable = name;
+          return name;
+        } catch {
+          // Not executable here — keep looking.
+        }
+      }
+    }
+  }
+  cachedPythonExecutable = "python3";
+  return cachedPythonExecutable;
 }
 
 /**

--- a/packages/code-runners/tests/language-runners.test.ts
+++ b/packages/code-runners/tests/language-runners.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { accessSync, constants } from "node:fs";
+import { delimiter, join } from "node:path";
 import { BashDockerRunner } from "../src/bash-runner.js";
 import { JavaScriptDockerRunner } from "../src/javascript-runner.js";
 import { PythonDockerRunner } from "../src/python-runner.js";
@@ -199,6 +201,34 @@ describe("PythonDockerRunner", () => {
   it("uses python:3.11-slim as default image", () => {
     const runner = new PythonDockerRunner();
     expect(runner.image).toBe("python:3.11-slim");
+  });
+
+  // Subprocess mode reuses buildContainerCommand, whose `python` exists in the
+  // image but not on a host that ships only `python3` — Debian, Ubuntu, macOS.
+  // That spawned ENOENT everywhere. Assert the invariant that actually matters
+  // (the interpreter resolves on this machine) rather than a literal name,
+  // which would just re-encode one platform's answer.
+  it("resolves a python that exists on PATH for subprocess mode", () => {
+    const runner = new PythonDockerRunner();
+    const [command] = runner.wrapSubprocessCommand(
+      runner.buildContainerCommand("pass", {})
+    );
+    const dirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+    const found = dirs.some((dir) => {
+      try {
+        accessSync(join(dir, command[0]), constants.X_OK);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    expect(["python", "python3"]).toContain(command[0]);
+    expect(found).toBe(true);
+  });
+
+  it("leaves the container command on `python` for Docker mode", () => {
+    const runner = new PythonDockerRunner();
+    expect(runner.buildContainerCommand("pass", {})[0]).toBe("python");
   });
 
   it("accepts a custom image", () => {

--- a/packages/gpu/src/node.ts
+++ b/packages/gpu/src/node.ts
@@ -93,9 +93,27 @@ export async function createNodeGPUDevice(): Promise<GPUDevice> {
   retainedDawnInstances.push(gpu);
   const adapter = await gpu.requestAdapter();
   if (!adapter) {
-    throw new Error("No WebGPU adapter available (Node/Dawn)");
+    throw new Error(
+      "No WebGPU adapter available (Node/Dawn). " + adapterHelpForPlatform()
+    );
   }
   return adapter.requestDevice();
+}
+
+/**
+ * Dawn reaches the GPU through a platform driver and ships no software
+ * fallback, so "no adapter" almost always means a missing driver rather than a
+ * missing GPU. On Linux that is a Vulkan ICD: with none installed the loader
+ * fails `vkCreateInstance` with `VK_ERROR_INCOMPATIBLE_DRIVER`, which surfaces
+ * here as a null adapter and says nothing about the cause. Name the fix.
+ */
+function adapterHelpForPlatform(): string {
+  return (
+    "On headless Linux this usually means no Vulkan driver (ICD) is installed — " +
+    "Dawn has no software fallback of its own. Install a software rasterizer " +
+    "with `apt-get install mesa-vulkan-drivers` (lavapipe), or point the loader " +
+    "at an existing one with VK_DRIVER_FILES=/path/to/icd.json."
+  );
 }
 
 /**

--- a/packages/runtime/src/providers/kie-provider.ts
+++ b/packages/runtime/src/providers/kie-provider.ts
@@ -1167,6 +1167,7 @@ export class KieProvider extends BaseProvider {
     log.debug("Kie textToImage", { model: modelId });
     const apiKey = this.requireApiKey();
     const { pollInterval, maxAttempts } = this.pollConfig(modelId);
+    this.applyRequiredDefaults(input, fields);
     const taskId = await submitTaskWithWebhook(apiKey, modelId, input);
     await waitForCompletion(apiKey, taskId, pollInterval, maxAttempts);
     return downloadResultBytes(apiKey, taskId);
@@ -1256,6 +1257,7 @@ export class KieProvider extends BaseProvider {
     log.debug("Kie imageToImage", { model: modelId, images: imageUrls.length });
 
     const { pollInterval, maxAttempts } = this.pollConfig(modelId);
+    this.applyRequiredDefaults(input, fields);
     const taskId = await submitTaskWithWebhook(apiKey, modelId, input);
     await waitForCompletion(apiKey, taskId, pollInterval, maxAttempts);
     return downloadResultBytes(apiKey, taskId);
@@ -1299,6 +1301,7 @@ export class KieProvider extends BaseProvider {
     log.debug("Kie inpaint", { model: modelId, images: imageUrls.length });
 
     const { pollInterval, maxAttempts } = this.pollConfig(modelId);
+    this.applyRequiredDefaults(input, fields);
     const taskId = await submitTaskWithWebhook(apiKey, modelId, input);
     await waitForCompletion(apiKey, taskId, pollInterval, maxAttempts);
     return downloadResultBytes(apiKey, taskId);

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -9,6 +9,14 @@ import { createLogger, importHidden } from "@nodetool-ai/config";
 import { BaseProvider, splitToolResultImages } from "./base-provider.js";
 import { hashSystemPrompt } from "./provider-session.js";
 import { sniffAudioMime } from "./audio-mime.js";
+
+/** Extension for each mime `sniffAudioMime` can return; anything else is mp3. */
+const AUDIO_MIME_EXT: Record<string, string> = {
+  "audio/wav": "wav",
+  "audio/ogg": "ogg",
+  "audio/flac": "flac",
+  "audio/mpeg": "mp3"
+};
 import {
   extractResponsesImages,
   extractResponsesText,
@@ -1987,11 +1995,17 @@ export class OpenAIProvider extends BaseProvider {
     const temperature = Math.max(0, Math.min(1, args.temperature ?? 0));
 
     const audioPart = new Uint8Array(args.audio);
+    // Label the upload with what the bytes actually are. Hardcoding audio/mpeg
+    // made OpenAI reject anything that was not MP3 with "400 Audio file might
+    // be corrupted or unsupported" — which is every clip coming through
+    // `nodetool.video.ExtractAudio`, since that writes PCM WAV.
+    const audioMime = sniffAudioMime(audioPart);
+    const audioName = `audio.${AUDIO_MIME_EXT[audioMime] ?? "mp3"}`;
     const fileLike =
       typeof File !== "undefined"
-        ? new File([audioPart], "audio.mp3", { type: "audio/mpeg" })
-        : Object.assign(new Blob([audioPart], { type: "audio/mpeg" }), {
-            name: "audio.mp3"
+        ? new File([audioPart], audioName, { type: audioMime })
+        : Object.assign(new Blob([audioPart], { type: audioMime }), {
+            name: audioName
           });
 
     const isDiarizationModel = args.model.startsWith(

--- a/packages/video-nodes/src/nodes/video.ts
+++ b/packages/video-nodes/src/nodes/video.ts
@@ -1789,7 +1789,20 @@ export class StabilizeVideoNode extends VideoTransformNode {
     const smoothing = Math.max(1, Number(this.smoothing ?? 10));
     const cropBlack = Boolean(this.crop_black ?? true);
 
-    const deshake = `deshake=smooth=${smoothing}`;
+    // ffmpeg's `deshake` filter has no `smooth` option. Passing one fails the
+    // whole filtergraph with "Error applying option 'smooth' to filter
+    // 'deshake': Option not found", so this node could never run. `smooth`
+    // belongs to vidstabtransform, which needs a libvidstab-enabled ffmpeg we
+    // cannot assume is present. Map the smoothing dial onto deshake's actual
+    // control — the rx/ry search range, which sets how much motion it can
+    // track between frames. deshake rejects a range that is not a multiple of
+    // 16 ("rx must be a multiple of 16"), so snap to the nearest legal step and
+    // keep at least one: rx=0 disables the search entirely.
+    const searchRange = Math.min(
+      64,
+      Math.max(16, Math.round(smoothing / 16) * 16)
+    );
+    const deshake = `deshake=rx=${searchRange}:ry=${searchRange}`;
 
     if (!cropBlack) {
       const transformed = await ffmpegTransform(bytes, [

--- a/packages/video-nodes/tests/regression-video.test.ts
+++ b/packages/video-nodes/tests/regression-video.test.ts
@@ -204,8 +204,15 @@ describe("DenoiseVideoNode — uses nlmeans filter with strength param", () => {
 
 // ─── 2. Stabilize ──────────────────────────────────────────────────────────────
 
-describe("StabilizeVideoNode — uses deshake with smooth param", () => {
-  it("constructs deshake filter with smooth parameter", async () => {
+// `deshake` has no `smooth` option — that belongs to `vidstabtransform`, which
+// needs a libvidstab build we can't assume. The node emitted `deshake=smooth=N`
+// and ffmpeg rejected every invocation with "Option not found". These tests
+// asserted that exact string, so they passed while the node could not run at
+// all: they string-matched the args and never executed ffmpeg. `smoothing` now
+// maps onto deshake's real control, rx/ry, which ffmpeg requires to be a
+// multiple of 16 in 0–64 (0 disables the search, so the floor is 16).
+describe("StabilizeVideoNode — maps smoothing onto deshake rx/ry", () => {
+  it("snaps smoothing to a legal rx/ry step", async () => {
     const node = new StabilizeVideoNode();
     node.assign({
       video: videoRef([1, 2, 3, 4]),
@@ -216,7 +223,23 @@ describe("StabilizeVideoNode — uses deshake with smooth param", () => {
 
     const args = ffmpegArgString();
     expect(args).toContain("deshake");
-    expect(args).toContain("smooth=15");
+    expect(args).toContain("rx=16");
+    expect(args).toContain("ry=16");
+    expect(args).not.toContain("smooth=");
+  });
+
+  it("clamps a large smoothing to the 64 ceiling", async () => {
+    const node = new StabilizeVideoNode();
+    node.assign({
+      video: videoRef([1, 2, 3, 4]),
+      smoothing: 200,
+      crop_black: false
+    });
+    await node.process().catch(() => undefined);
+
+    const args = ffmpegArgString();
+    expect(args).toContain("rx=64");
+    expect(args).toContain("ry=64");
   });
 
   it("includes cropdetect and crop when crop_black=true", async () => {
@@ -230,7 +253,7 @@ describe("StabilizeVideoNode — uses deshake with smooth param", () => {
 
     const args = ffmpegArgString();
     expect(args).toContain("deshake");
-    expect(args).toContain("smooth=10");
+    expect(args).toContain("rx=16");
     expect(args).toContain("cropdetect");
     expect(args).toContain("crop");
   });


### PR DESCRIPTION
Five fixes, each found by *running* workflows rather than validating them. None were catchable by `nodetool validate`.

## `ExecutePython` never worked in subprocess mode

Subprocess execution reuses `buildContainerCommand()`, so the `python` that is correct inside `python:3.11-slim` got spawned on the **host** — where Debian, Ubuntu and macOS ship only `python3`. Every run died on `spawn python ENOENT`.

JavaScript, Bash and Lua passed; only Python failed, because only Python has the version-suffix problem. **This affected our own runtime image too** — `node:22-slim` has `python3` and no `python`.

Fixed through `wrapSubprocessCommand`, an existing hook invoked on the subprocess path only, so Docker keeps `python` and cannot regress. Unsuffixed `python` still wins when present, leaving pyenv/venv/conda shims intact.

## `Stabilize` emitted a filtergraph ffmpeg rejects

```
Error applying option 'smooth' to filter 'deshake': Option not found
```

`deshake` has no `smooth` option — that belongs to `vidstabtransform`, which needs a libvidstab build we cannot assume. The node had been emitting an invalid filtergraph on every run since it was written.

`smoothing` now maps onto deshake's real control, `rx`/`ry`, snapped to the multiple of 16 ffmpeg requires (0–64; 0 disables the search, so the floor is 16).

**The regression test asserted the broken string and passed** — it matched args without ever invoking ffmpeg. That is precisely why the bug survived. It now asserts the corrected filter and guards `smooth=` from returning.

## Kie omitted required fields on image models

`applyRequiredDefaults` was wired into 2 of the 6 sites that load model fields, so the **image** paths still 500'd with `"This field is required"`. Now applied at every submit site. It only fills fields the manifest marks required *and* gives an explicit default, so it cannot invent a value the model never described.

## OpenAI transcription mislabelled every upload

Hardcoded `audio.mp3` / `audio/mpeg`, while `ExtractAudio` writes PCM WAV (`-acodec pcm_s16le`). OpenAI rejected the mismatch, so extract-then-transcribe could not work on any clip. The file already imported `sniffAudioMime`; the transcription path now uses it.

## Image nodes on machines without a GPU

```
vkCreateInstance: Found no drivers!  VK_ERROR_INCOMPATIBLE_DRIVER
```

The error says "no adapter", but Dawn never gets that far. It reaches the GPU only through a Vulkan ICD and bundles **no software fallback**, so with none installed every `nodetool.image.*` node fails — **crop and resize included**, not just shader-heavy colour work. `forceFallbackAdapter: true` does not help.

The runtime image now carries lavapipe, **pinned to bookworm-backports**: bookworm ships Mesa 22.3, which Dawn rejects with `shaderUniform*ArrayDynamicIndexing required` and still returns a null adapter. My first attempt used plain `mesa-vulkan-drivers` and would have shipped broken — caught by actually building the runtime layer and acquiring an adapter and device inside it.

The error message now names the cause and the remedy rather than only the symptom.

## Verification

- `packages/image-nodes`: **52 failures → 227/227** on a GPU-less machine. Those 52 fail identically on a stashed clean tree, so they predate this branch.
- `code-runners` 334/334 (+2 new), `gpu` 791/798 (7 skipped), `video-nodes` 171/171, `runtime` 2634/2634
- typecheck and lint clean
- All previously failing example workflows now run end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)