### PR TITLE
feat(agents): extend the QuickJS sandbox — crypto, binary I/O, formatting, progress, csv/html bridges, per-run limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54668,9 +54668,11 @@
         "@nodetool-ai/vectorstore": "*",
         "@sebastianwessel/quickjs": "^3.0.1",
         "@types/mailparser": "^3.4.6",
+        "cheerio": "^1.2.0",
         "imapflow": "^1.2.12",
         "js-tiktoken": "^1.0.18",
-        "mailparser": "^3.9.3"
+        "mailparser": "^3.9.3",
+        "papaparse": "^5.5.3"
       },
       "devDependencies": {
         "@stryker-mutator/core": "^9.6.1",

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -74,22 +74,36 @@ User-authored JS from `MiniJSAgentTool` and `nodetool.code.Code` runs in a
 in its own WASM heap, so runaway or malicious code can't corrupt the host V8
 heap the way it could under the previous `node:vm` implementation.
 
-Hard limits enforced by the runtime:
+Hard limits enforced by the runtime. Each row's default can be overridden per
+invocation via `RunSandboxOptions.limits`, clamped to the ceiling in the last
+column by `resolveSandboxLimits`:
 
-| Limit | Value | Configured by |
-|-------|-------|---------------|
-| Execution time | `timeoutMs` (default 30 s) | `setInterruptHandler` (CPU budget) + wall-clock race |
-| Guest heap | `GUEST_MEMORY_LIMIT` = 64 MB | `runtime.setMemoryLimit` |
-| Call stack | `GUEST_STACK_LIMIT` = 512 KB | `runtime.setMaxStackSize` |
-| Fetch calls | `MAX_FETCH_CALLS` = 20 per run | counter inside bridge |
-| Fetch body | `MAX_RESPONSE_BODY_SIZE` = 1 MB | truncation inside bridge |
-| Output | `MAX_OUTPUT_SIZE` = 100 KB | `serializeResult` truncation |
+| Limit | Default | Configured by | Ceiling |
+|-------|---------|---------------|---------|
+| Execution time | `timeoutMs` (30 s) | `setInterruptHandler` (CPU budget) + wall-clock race | — |
+| Guest heap | `GUEST_MEMORY_LIMIT` = 64 MB | `runtime.setMemoryLimit` (`limits.memoryLimitBytes`) | 512 MB |
+| Call stack | `GUEST_STACK_LIMIT` = 512 KB | `runtime.setMaxStackSize` (`limits.stackLimitBytes`) | 8 MB |
+| Fetch calls | `MAX_FETCH_CALLS` = 20 per run | counter inside bridge (`limits.maxFetchCalls`) | 100 |
+| Fetch body | `MAX_RESPONSE_BODY_SIZE` = 1 MB | truncation inside bridge (`limits.maxResponseBodyBytes`) | 50 MB |
+| Fetch timeout | `FETCH_TIMEOUT_MS` = 15 s | per-request `AbortController` (`limits.fetchTimeoutMs`) | 120 s |
+| Output | `MAX_OUTPUT_SIZE` = 100 KB | `serializeResult` truncation (`limits.maxOutputSize`) | 10 MB |
+| Random bytes | `MAX_RANDOM_BYTES` = 64 KB | `crypto.getRandomValues` clamp | — |
+
+QuickJS's memory limiter counts its own heap objects; string and typed-array
+payloads are not charged against it, so `memoryLimitBytes` bites on object
+allocation, not on `new Uint8Array(n)`.
 
 Exposed guest surface: `console`, `fetch`, `uuid`, `sleep`, `getSecret`,
-`workspace.{read,write,list}` (requires a `ProcessingContext`), and any
-caller-supplied `globals`. `eval` and `Function` are deleted at init so the
-user cannot re-enter dynamic code generation. Core JS (`JSON`, `Math`, `Date`,
-`Map`, `URL`, `TextEncoder`, etc.) is QuickJS's native implementation, not a
+`crypto.{randomUUID,getRandomValues,digest,hmac}` (WebCrypto-backed — `digest`
+and `hmac` take SHA-1/256/384/512 and accept string or `Uint8Array` input, both
+returning a `Uint8Array`), `workspace.{read,write,list,readBytes,writeBytes,
+stat,mkdir,remove}` (requires a `ProcessingContext`; `remove` deletes one file
+or one empty directory, never a tree), the pure guest-side helpers
+`toBase64`/`fromBase64`/`toHex`/`fromHex`/`utf8Encode`/`utf8Decode`, and any
+caller-supplied `globals`. `fetch` sends a `Uint8Array` body as raw bytes
+instead of JSON. `eval` and `Function` are deleted at init so the user cannot
+re-enter dynamic code generation. Core JS (`JSON`, `Math`, `Date`, `Map`,
+`URL`, `TextEncoder`, etc.) is QuickJS's native implementation, not a
 host-bridged version.
 
 **State sync-back**: object-typed globals are deep-replaced on the host after
@@ -104,6 +118,12 @@ Primitive globals pass by value (no sync).
   prelude rewraps into a real `throw`. Working around a known handle leak in
   `@sebastianwessel/quickjs@3.0.1` (tracked as `list_empty(&rt->gc_obj_list)`
   assertion on runtime dispose).
+- Binary crosses the boundary asymmetrically. Guest → host is handled by the
+  typed-array serializers (`addSerializer`), so a guest `Uint8Array` reaches a
+  bridge as a native one. Host → guest is not: a returned `Uint8Array` arrives
+  in the guest as a numeric-keyed plain object. Bridges that produce bytes
+  therefore return a base64 marker object and the guest prelude rebuilds a real
+  `Uint8Array` — the pattern to follow for any new binary bridge.
 
 ## Running Agents from CLI
 

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -89,6 +89,8 @@ column by `resolveSandboxLimits`:
 | Output | `MAX_OUTPUT_SIZE` = 100 KB | `serializeResult` truncation (`limits.maxOutputSize`) | 10 MB |
 | Random bytes | `MAX_RANDOM_BYTES` = 64 KB | `crypto.getRandomValues` clamp | — |
 | Progress reports | `MAX_PROGRESS_CALLS` = 1000 per run, one per `PROGRESS_MIN_INTERVAL_MS` = 100 ms | counter + timestamp inside the bridge | — |
+| `data.*` input | `MAX_DATA_INPUT_CHARS` = 5 MB of text | length check inside each bridge | — |
+| `data.selectHtml` matches | `DEFAULT_SELECT_HTML_LIMIT` = 100 | `options.limit` | `MAX_SELECT_HTML_LIMIT` = 1000 |
 
 QuickJS's memory limiter counts its own heap objects; string and typed-array
 payloads are not charged against it, so `memoryLimitBytes` bites on object
@@ -101,9 +103,9 @@ returning a `Uint8Array`), `workspace.{read,write,list,readBytes,writeBytes,
 stat,mkdir,remove}` (requires a `ProcessingContext`; `remove` deletes one file
 or one empty directory, never a tree), the pure guest-side helpers
 `toBase64`/`fromBase64`/`toHex`/`fromHex`/`utf8Encode`/`utf8Decode`,
-`progress(percent, message?)`, `format.{number,date,relativeTime,list}`, and any
-caller-supplied `globals`. `fetch` sends a `Uint8Array` body as raw bytes
-instead of JSON.
+`progress(percent, message?)`, `format.{number,date,relativeTime,list}`,
+`data.{parseCsv,selectHtml}`, and any caller-supplied `globals`. `fetch` sends a
+`Uint8Array` body as raw bytes instead of JSON.
 
 `progress` is fire-and-forget: it reports to
 `RunSandboxOptions.onProgress`, clamped to 0–100 with the message truncated to
@@ -111,6 +113,19 @@ instead of JSON.
 wires it to `context.postMessage({ type: "node_progress", … })`, the same
 channel the Python worker uses, so a long-running snippet drives the node's
 progress bar.
+
+`data` is the structured-parsing pair: `parseCsv(text, {delimiter, header})`
+returns records keyed by the header row (default) or raw string arrays with
+`header: false`, and `selectHtml(html, selector, {attr, limit})` runs a CSS
+selector and returns trimmed text — or the named attribute, skipping matches
+that lack it. Both are host bridges over papaparse and cheerio,
+`await import`ed on first use inside the bridge — lazily, so neither library
+sits in any entry graph, but visibly, so esbuild inlines them into the packaged
+backend's single-file `server.mjs` and Vite picks cheerio's `browser` build for
+the in-browser runner. CSV values stay strings (no `dynamicTyping`) so a column
+never changes shape between runs. The guest itself has no module loader —
+`import`/`require` do not exist — so a host bridge is the only way
+library-backed behaviour reaches user code.
 
 `format` exists because QuickJS ships no `Intl`: each member is a host bridge
 over `Intl.NumberFormat`, `Intl.DateTimeFormat`, `Intl.RelativeTimeFormat` and

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -88,6 +88,7 @@ column by `resolveSandboxLimits`:
 | Fetch timeout | `FETCH_TIMEOUT_MS` = 15 s | per-request `AbortController` (`limits.fetchTimeoutMs`) | 120 s |
 | Output | `MAX_OUTPUT_SIZE` = 100 KB | `serializeResult` truncation (`limits.maxOutputSize`) | 10 MB |
 | Random bytes | `MAX_RANDOM_BYTES` = 64 KB | `crypto.getRandomValues` clamp | — |
+| Progress reports | `MAX_PROGRESS_CALLS` = 1000 per run, one per `PROGRESS_MIN_INTERVAL_MS` = 100 ms | counter + timestamp inside the bridge | — |
 
 QuickJS's memory limiter counts its own heap objects; string and typed-array
 payloads are not charged against it, so `memoryLimitBytes` bites on object
@@ -99,9 +100,23 @@ and `hmac` take SHA-1/256/384/512 and accept string or `Uint8Array` input, both
 returning a `Uint8Array`), `workspace.{read,write,list,readBytes,writeBytes,
 stat,mkdir,remove}` (requires a `ProcessingContext`; `remove` deletes one file
 or one empty directory, never a tree), the pure guest-side helpers
-`toBase64`/`fromBase64`/`toHex`/`fromHex`/`utf8Encode`/`utf8Decode`, and any
+`toBase64`/`fromBase64`/`toHex`/`fromHex`/`utf8Encode`/`utf8Decode`,
+`progress(percent, message?)`, `format.{number,date,relativeTime,list}`, and any
 caller-supplied `globals`. `fetch` sends a `Uint8Array` body as raw bytes
-instead of JSON. `eval` and `Function` are deleted at init so the user cannot
+instead of JSON.
+
+`progress` is fire-and-forget: it reports to
+`RunSandboxOptions.onProgress`, clamped to 0–100 with the message truncated to
+500 chars, and is a no-op when the caller passes no sink. `nodetool.code.Code`
+wires it to `context.postMessage({ type: "node_progress", … })`, the same
+channel the Python worker uses, so a long-running snippet drives the node's
+progress bar.
+
+`format` exists because QuickJS ships no `Intl`: each member is a host bridge
+over `Intl.NumberFormat`, `Intl.DateTimeFormat`, `Intl.RelativeTimeFormat` and
+`Intl.ListFormat`, defaulting to locale `en-US`. All four are async (they follow
+the never-reject convention), so a bad locale or option arrives in the guest as
+a thrown `Error` carrying Intl's own message. `eval` and `Function` are deleted at init so the user cannot
 re-enter dynamic code generation. Core JS (`JSON`, `Math`, `Date`, `Map`,
 `URL`, `TextEncoder`, etc.) is QuickJS's native implementation, not a
 host-bridged version.

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -30,9 +30,11 @@
     "@nodetool-ai/vectorstore": "*",
     "@sebastianwessel/quickjs": "^3.0.1",
     "@types/mailparser": "^3.4.6",
+    "cheerio": "^1.2.0",
     "imapflow": "^1.2.12",
     "js-tiktoken": "^1.0.18",
-    "mailparser": "^3.9.3"
+    "mailparser": "^3.9.3",
+    "papaparse": "^5.5.3"
   },
   "devDependencies": {
     "@stryker-mutator/core": "^9.6.1",

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -290,7 +290,8 @@ export type {
   RunSandboxOptions,
   RunSandboxResult,
   SandboxLimits,
-  ResolvedSandboxLimits
+  ResolvedSandboxLimits,
+  SandboxProgressCallback
 } from "./js-sandbox.js";
 
 // Constants

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -280,8 +280,18 @@ export { LocalGetNodeInfoTool } from "./tools/local-get-node-info-tool.js";
 export { LocalListNodesTool } from "./tools/local-list-nodes-tool.js";
 
 // Shared JS sandbox engine
-export { buildSandbox, runInSandbox, serializeResult } from "./js-sandbox.js";
-export type { RunSandboxOptions, RunSandboxResult } from "./js-sandbox.js";
+export {
+  buildSandbox,
+  runInSandbox,
+  serializeResult,
+  resolveSandboxLimits
+} from "./js-sandbox.js";
+export type {
+  RunSandboxOptions,
+  RunSandboxResult,
+  SandboxLimits,
+  ResolvedSandboxLimits
+} from "./js-sandbox.js";
 
 // Constants
 export { MAX_TOOL_RESULT_CHARS, truncateToolResult } from "./constants.js";

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -8,12 +8,15 @@
  *
  * The exposed surface is a small curated one: vanilla JavaScript plus a handful
  * of bridge functions (`fetch`, `workspace`, `getSecret`, `uuid`, `sleep`,
- * `assetToSandbox`, `sandboxToAsset`, `crypto`, `console`) and a few pure
- * guest-side binary helpers (`toBase64`, `fromBase64`, `toHex`, `fromHex`,
- * `utf8Encode`, `utf8Decode`). `crypto` covers `randomUUID`,
- * `getRandomValues`, `digest`, and `hmac` (WebCrypto-backed);
- * `workspace` covers text and binary reads/writes plus `stat`, `mkdir`, and
- * `remove`. Every quantitative limit (fetch calls, response body, output size,
+ * `assetToSandbox`, `sandboxToAsset`, `crypto`, `console`, `progress`,
+ * `format`) and a few pure guest-side binary helpers (`toBase64`,
+ * `fromBase64`, `toHex`, `fromHex`, `utf8Encode`, `utf8Decode`). `crypto`
+ * covers `randomUUID`, `getRandomValues`, `digest`, and `hmac`
+ * (WebCrypto-backed); `workspace` covers text and binary reads/writes plus
+ * `stat`, `mkdir`, and `remove`; `progress` forwards a percentage and label to
+ * the host caller (rate-limited); `format` exposes host `Intl` number, date,
+ * relative-time and list formatting, which QuickJS itself does not ship.
+ * Every quantitative limit (fetch calls, response body, output size,
  * guest heap, stack, fetch timeout) is overridable per invocation through
  * `RunSandboxOptions.limits`, clamped to hard ceilings. Library-powered helpers
  * (lodash, dayjs, cheerio, csv-parse,
@@ -52,8 +55,22 @@ export const GUEST_MEMORY_LIMIT = 64 * 1024 * 1024;
 export const GUEST_STACK_LIMIT = 512 * 1024;
 /** Per-request wall-clock cap for the fetch bridge. */
 export const FETCH_TIMEOUT_MS = 15_000;
+/** Locale used by the `format` bridge when the caller names none. */
+export const DEFAULT_FORMAT_LOCALE = "en-US";
 /** Largest `crypto.getRandomValues` request the bridge will serve. */
 export const MAX_RANDOM_BYTES = 65_536;
+/** Progress reports forwarded to the host per run; further calls are dropped. */
+export const MAX_PROGRESS_CALLS = 1000;
+/** Minimum gap between two forwarded progress reports. */
+export const PROGRESS_MIN_INTERVAL_MS = 100;
+/** Longest progress message forwarded to the host. */
+export const MAX_PROGRESS_MESSAGE_CHARS = 500;
+
+/** Host sink for guest `progress()` calls. */
+export type SandboxProgressCallback = (
+  progress: number,
+  message?: string
+) => void;
 
 /**
  * Per-invocation limit overrides. Every field defaults to the module constant
@@ -642,11 +659,14 @@ export interface SandboxResult {
  *                 operations and makes `sleep` return immediately.
  * @param limits   Optional per-invocation limit overrides, clamped by
  *                 {@link resolveSandboxLimits}.
+ * @param onProgress Optional sink for guest `progress()` calls. Without one the
+ *                 guest function is a no-op.
  */
 export function buildSandbox(
   context?: ProcessingContext,
   signal?: AbortSignal,
-  limits?: SandboxLimits
+  limits?: SandboxLimits,
+  onProgress?: SandboxProgressCallback
 ): SandboxResult {
   const logs: string[] = [];
   const resolvedLimits = resolveSandboxLimits(limits);
@@ -995,6 +1015,116 @@ export function buildSandbox(
         throw new Error("sandboxToAsset is not available without a context");
       };
 
+  // Fire-and-forget progress reporting. Synchronous like console.log: it never
+  // throws, so it needs no never-reject wrapper. A guest that spams it cannot
+  // flood the host — reports closer together than PROGRESS_MIN_INTERVAL_MS are
+  // dropped, and the run has a lifetime cap.
+  let progressCalls = 0;
+  let lastProgressAt = 0;
+  const progress = (percent: number, message?: string): void => {
+    if (!onProgress || signal?.aborted) return;
+    if (progressCalls >= MAX_PROGRESS_CALLS) return;
+    const now = Date.now();
+    if (progressCalls > 0 && now - lastProgressAt < PROGRESS_MIN_INTERVAL_MS) {
+      return;
+    }
+    const raw = Number(percent);
+    const clamped = Number.isFinite(raw) ? Math.min(Math.max(raw, 0), 100) : 0;
+    const text =
+      message === undefined || message === null
+        ? undefined
+        : String(message).slice(0, MAX_PROGRESS_MESSAGE_CHARS);
+    progressCalls++;
+    lastProgressAt = now;
+    try {
+      onProgress(clamped, text);
+    } catch {
+      // A failing host sink must not take the guest run down with it.
+    }
+  };
+
+  // QuickJS ships no Intl, so locale-aware formatting has to come from the
+  // host. Async + never-reject like the other bridges: a bad locale or option
+  // surfaces in the guest as a thrown Error with Intl's own message.
+  const format = {
+    number: async (
+      value: number,
+      options?: Record<string, unknown>
+    ): Promise<string> => {
+      const num = Number(value);
+      if (!Number.isFinite(num)) {
+        throw new Error("format.number: value must be a finite number");
+      }
+      const opts = options ?? {};
+      return new Intl.NumberFormat(
+        (opts.locale as string) ?? DEFAULT_FORMAT_LOCALE,
+        {
+          style: opts.style as Intl.NumberFormatOptions["style"],
+          currency: opts.currency as string | undefined,
+          minimumFractionDigits: opts.minimumFractionDigits as
+            | number
+            | undefined,
+          maximumFractionDigits: opts.maximumFractionDigits as
+            | number
+            | undefined,
+          useGrouping: opts.useGrouping as boolean | undefined
+        }
+      ).format(num);
+    },
+    date: async (
+      epochMs: number,
+      options?: Record<string, unknown>
+    ): Promise<string> => {
+      const ms = Number(epochMs);
+      if (!Number.isFinite(ms)) {
+        throw new Error(
+          "format.date: epochMs must be a finite number of milliseconds"
+        );
+      }
+      const opts = options ?? {};
+      const dateStyle =
+        opts.dateStyle as Intl.DateTimeFormatOptions["dateStyle"];
+      const timeStyle =
+        opts.timeStyle as Intl.DateTimeFormatOptions["timeStyle"];
+      return new Intl.DateTimeFormat(
+        (opts.locale as string) ?? DEFAULT_FORMAT_LOCALE,
+        {
+          // Intl falls back to a date-only default when neither style is given.
+          dateStyle: dateStyle ?? (timeStyle ? undefined : "medium"),
+          timeStyle,
+          timeZone: opts.timeZone as string | undefined
+        }
+      ).format(new Date(ms));
+    },
+    relativeTime: async (
+      value: number,
+      unit: string,
+      options?: Record<string, unknown>
+    ): Promise<string> => {
+      const num = Number(value);
+      if (!Number.isFinite(num)) {
+        throw new Error("format.relativeTime: value must be a finite number");
+      }
+      const opts = options ?? {};
+      return new Intl.RelativeTimeFormat(
+        (opts.locale as string) ?? DEFAULT_FORMAT_LOCALE
+      ).format(num, unit as Intl.RelativeTimeFormatUnit);
+    },
+    list: async (
+      items: unknown,
+      options?: Record<string, unknown>
+    ): Promise<string> => {
+      if (!Array.isArray(items)) {
+        throw new Error("format.list: items must be an array of strings");
+      }
+      const opts = options ?? {};
+      return new Intl.ListFormat(
+        (opts.locale as string) ?? DEFAULT_FORMAT_LOCALE,
+        { type: opts.type as Intl.ListFormatOptions["type"] }
+      ).format(items.map((i) => String(i)));
+    }
+  };
+
   const sandbox: Record<string, unknown> = {
     // Core JS globals are native in QuickJS; we still reflect them in the
     // descriptor so callers that inspect `sandbox.JSON` / `sandbox.Math`
@@ -1047,6 +1177,8 @@ export function buildSandbox(
     workspace,
     assetToSandbox,
     sandboxToAsset,
+    progress,
+    format,
     __maxIter: MAX_LOOP_ITERATIONS
   };
 
@@ -1092,6 +1224,13 @@ export interface RunSandboxOptions {
    * caller can tune a limit but not disable a protection.
    */
   limits?: SandboxLimits;
+  /**
+   * Sink for guest `progress(percent, message?)` calls. Values are clamped to
+   * 0–100, messages truncated, and reports rate-limited to one per
+   * {@link PROGRESS_MIN_INTERVAL_MS} (at most {@link MAX_PROGRESS_CALLS} per
+   * run). Without a callback the guest function is a no-op.
+   */
+  onProgress?: SandboxProgressCallback;
 }
 
 export interface RunSandboxResult {
@@ -1134,6 +1273,8 @@ const RESERVED_SANDBOX_NAMES = new Set([
   "workspace",
   "assetToSandbox",
   "sandboxToAsset",
+  "progress",
+  "format",
   // Pure guest-side helpers defined by the prelude.
   "toBase64",
   "fromBase64",
@@ -1161,6 +1302,8 @@ const EXPOSED_BRIDGE_NAMES = [
   "workspace",
   "assetToSandbox",
   "sandboxToAsset",
+  "progress",
+  "format",
   "__maxIter"
 ] as const;
 
@@ -1179,7 +1322,8 @@ export async function runInSandbox(
     timeoutMs = DEFAULT_TIMEOUT_MS,
     globals,
     signal,
-    limits
+    limits,
+    onProgress
   } = options;
   const resolvedLimits = resolveSandboxLimits(limits);
 
@@ -1191,7 +1335,12 @@ export async function runInSandbox(
     return { success: false, error: "Execution cancelled", logs: [] };
   }
 
-  const { sandbox, getLogs } = buildSandbox(context, signal, resolvedLimits);
+  const { sandbox, getLogs } = buildSandbox(
+    context,
+    signal,
+    resolvedLimits,
+    onProgress
+  );
 
   // User-supplied globals (dynamic inputs from CodeNode etc.) layer on top of
   // the core surface, but must not clobber the bridge functions themselves.
@@ -1241,15 +1390,20 @@ export async function runInSandbox(
         bridges.getSecret = wrap(bridges.getSecret as never);
         bridges.assetToSandbox = wrap(bridges.assetToSandbox as never);
         bridges.sandboxToAsset = wrap(bridges.sandboxToAsset as never);
-        const ws = bridges.workspace as Record<
-          string,
-          (...a: never[]) => Promise<unknown>
-        >;
-        const wrappedWorkspace: Record<string, unknown> = {};
-        for (const [name, fn] of Object.entries(ws)) {
-          wrappedWorkspace[name] = wrap(fn as never);
-        }
-        bridges.workspace = wrappedWorkspace;
+        // Object bridges whose members are all async: wrap each member.
+        const wrapAllMembers = (bridge: unknown): Record<string, unknown> => {
+          const out: Record<string, unknown> = {};
+          const members = bridge as Record<
+            string,
+            (...a: never[]) => Promise<unknown>
+          >;
+          for (const [name, fn] of Object.entries(members)) {
+            out[name] = wrap(fn as never);
+          }
+          return out;
+        };
+        bridges.workspace = wrapAllMembers(bridges.workspace);
+        bridges.format = wrapAllMembers(bridges.format);
         const hostCrypto = bridges.crypto as {
           randomUUID: () => string;
           getRandomValues: (n: number) => Record<string, string>;
@@ -1377,6 +1531,13 @@ globalThis.workspace = {
   stat: __wrap(__ws.stat),
   mkdir: __wrap(__ws.mkdir),
   remove: __wrap(__ws.remove)
+};
+const __fmt = globalThis.format;
+globalThis.format = {
+  number: __wrap(__fmt.number),
+  date: __wrap(__fmt.date),
+  relativeTime: __wrap(__fmt.relativeTime),
+  list: __wrap(__fmt.list)
 };
 const __crypto = globalThis.crypto;
 globalThis.crypto = {

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -8,7 +8,14 @@
  *
  * The exposed surface is a small curated one: vanilla JavaScript plus a handful
  * of bridge functions (`fetch`, `workspace`, `getSecret`, `uuid`, `sleep`,
- * `assetToSandbox`, `sandboxToAsset`, `console`). Library-powered helpers
+ * `assetToSandbox`, `sandboxToAsset`, `crypto`, `console`) and a few pure
+ * guest-side binary helpers (`toBase64`, `fromBase64`, `toHex`, `fromHex`,
+ * `utf8Encode`, `utf8Decode`). `crypto` covers `randomUUID`,
+ * `getRandomValues`, `digest`, and `hmac` (WebCrypto-backed);
+ * `workspace` covers text and binary reads/writes plus `stat`, `mkdir`, and
+ * `remove`. Every quantitative limit (fetch calls, response body, output size,
+ * guest heap, stack, fetch timeout) is overridable per invocation through
+ * `RunSandboxOptions.limits`, clamped to hard ceilings. Library-powered helpers
  * (lodash, dayjs, cheerio, csv-parse,
  * validator) are intentionally NOT exposed here — use the dedicated workflow
  * nodes instead (lib.datetime.*, lib.html.*, lib.data.ParseCSV,
@@ -43,6 +50,75 @@ export const MAX_RESPONSE_BODY_SIZE = 1_000_000;
 export const GUEST_MEMORY_LIMIT = 64 * 1024 * 1024;
 /** Guest stack cap — protects against deeply recursive code. */
 export const GUEST_STACK_LIMIT = 512 * 1024;
+/** Per-request wall-clock cap for the fetch bridge. */
+export const FETCH_TIMEOUT_MS = 15_000;
+/** Largest `crypto.getRandomValues` request the bridge will serve. */
+export const MAX_RANDOM_BYTES = 65_536;
+
+/**
+ * Per-invocation limit overrides. Every field defaults to the module constant
+ * above and is clamped to a hard ceiling, so a caller can tighten a limit or
+ * raise it within bounds but never switch a protection off.
+ */
+export interface SandboxLimits {
+  maxFetchCalls?: number;
+  maxResponseBodyBytes?: number;
+  maxOutputSize?: number;
+  memoryLimitBytes?: number;
+  stackLimitBytes?: number;
+  fetchTimeoutMs?: number;
+}
+
+export type ResolvedSandboxLimits = Required<SandboxLimits>;
+
+function clampLimit(
+  value: number | undefined,
+  fallback: number,
+  min: number,
+  max: number
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.min(Math.max(Math.floor(value), min), max);
+}
+
+/** Apply defaults and ceilings to a caller-supplied {@link SandboxLimits}. */
+export function resolveSandboxLimits(
+  limits?: SandboxLimits
+): ResolvedSandboxLimits {
+  return {
+    maxFetchCalls: clampLimit(limits?.maxFetchCalls, MAX_FETCH_CALLS, 0, 100),
+    maxResponseBodyBytes: clampLimit(
+      limits?.maxResponseBodyBytes,
+      MAX_RESPONSE_BODY_SIZE,
+      1024,
+      50 * 1024 * 1024
+    ),
+    maxOutputSize: clampLimit(
+      limits?.maxOutputSize,
+      MAX_OUTPUT_SIZE,
+      1024,
+      10 * 1024 * 1024
+    ),
+    memoryLimitBytes: clampLimit(
+      limits?.memoryLimitBytes,
+      GUEST_MEMORY_LIMIT,
+      1024 * 1024,
+      512 * 1024 * 1024
+    ),
+    stackLimitBytes: clampLimit(
+      limits?.stackLimitBytes,
+      GUEST_STACK_LIMIT,
+      16 * 1024,
+      8 * 1024 * 1024
+    ),
+    fetchTimeoutMs: clampLimit(
+      limits?.fetchTimeoutMs,
+      FETCH_TIMEOUT_MS,
+      100,
+      120_000
+    )
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Engine bootstrap — one WASM module shared by every invocation.
@@ -105,6 +181,39 @@ function getEngine(): ReturnType<typeof loadQuickJs> {
  * behaviour (the user still gets a thrown Error with name + message).
  */
 const SANDBOX_ERROR_MARKER = "__nodetool_sandbox_error__";
+
+/**
+ * Marker key carrying base64 bytes from host to guest. Host→guest is the
+ * asymmetric direction: a guest `Uint8Array` reaches the host as a native one
+ * (see the typed-array serializers), but a host `Uint8Array` returned through
+ * `expose` arrives in the guest as a plain numeric-keyed object — indexable,
+ * yet not a real typed array. Bridges that produce binary therefore return
+ * `{ [SANDBOX_BYTES_MARKER]: "<base64>" }` and the guest prelude reconstructs a
+ * genuine `Uint8Array`, so the guest-visible API is binary all the way through.
+ */
+const SANDBOX_BYTES_MARKER = "__nodetool_sandbox_bytes__";
+
+const BASE64_ALPHABET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+function encodeBase64(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 3) {
+    const c =
+      (bytes[i] << 16) | ((bytes[i + 1] ?? 0) << 8) | (bytes[i + 2] ?? 0);
+    out +=
+      BASE64_ALPHABET[(c >> 18) & 63] +
+      BASE64_ALPHABET[(c >> 12) & 63] +
+      (i + 1 < bytes.length ? BASE64_ALPHABET[(c >> 6) & 63] : "=") +
+      (i + 2 < bytes.length ? BASE64_ALPHABET[c & 63] : "=");
+  }
+  return out;
+}
+
+/** Tag bytes for the guest prelude to turn back into a real `Uint8Array`. */
+function toGuestBytes(bytes: Uint8Array): Record<string, string> {
+  return { [SANDBOX_BYTES_MARKER]: encodeBase64(bytes) };
+}
 
 function neverReject<Args extends unknown[], R>(
   fn: (...args: Args) => Promise<R>
@@ -210,12 +319,30 @@ async function assertWorkspaceContained(
   if (await within(root, fullPath)) return;
   if (isWrite) {
     // Target may not exist yet — lstat detects a dangling symlink entry, and
-    // otherwise the containing directory must be inside the workspace.
+    // otherwise the nearest existing ancestor must be inside the workspace.
+    // Walking up covers writes and mkdirs that create several levels at once;
+    // path segments that don't exist yet cannot be symlinks, so nothing along
+    // the way can redirect the write.
     try {
       await fs.lstat(fullPath);
       // Exists (real file or symlink) but failed containment → outside root.
     } catch {
-      if (await within(root, nodePath.dirname(fullPath))) return;
+      let dir = nodePath.dirname(fullPath);
+      for (;;) {
+        let exists = true;
+        try {
+          await fs.lstat(dir);
+        } catch {
+          exists = false;
+        }
+        if (exists) {
+          if (await within(root, dir)) return;
+          break;
+        }
+        const parent = nodePath.dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+      }
     }
   }
   throw new Error(`workspace path resolves outside the workspace: ${fullPath}`);
@@ -348,7 +475,7 @@ function isTypedArray(value: unknown): boolean {
   );
 }
 
-function toNativeUint8Array(value: unknown): Uint8Array {
+function toNativeUint8Array(value: unknown): Uint8Array<ArrayBuffer> {
   const v = value as {
     length?: number;
     byteLength?: number;
@@ -360,11 +487,65 @@ function toNativeUint8Array(value: unknown): Uint8Array {
   return arr;
 }
 
+const DIGEST_ALGORITHMS: Record<string, string> = {
+  "SHA-1": "SHA-1",
+  SHA1: "SHA-1",
+  "SHA-256": "SHA-256",
+  SHA256: "SHA-256",
+  "SHA-384": "SHA-384",
+  SHA384: "SHA-384",
+  "SHA-512": "SHA-512",
+  SHA512: "SHA-512"
+};
+
+function normalizeDigestAlgorithm(algorithm: unknown): string {
+  const key = String(algorithm ?? "")
+    .trim()
+    .toUpperCase();
+  const resolved = DIGEST_ALGORITHMS[key];
+  if (!resolved) {
+    throw new Error(
+      `crypto: unsupported algorithm "${String(algorithm)}" (use SHA-1, SHA-256, SHA-384 or SHA-512)`
+    );
+  }
+  return resolved;
+}
+
+/** Accept a guest string or byte-like value as host bytes. */
+function coerceBytesInput(
+  value: unknown,
+  label: string
+): Uint8Array<ArrayBuffer> {
+  if (typeof value === "string") return new TextEncoder().encode(value);
+  if (value instanceof Uint8Array) return Uint8Array.from(value);
+  if (isTypedArray(value)) return toNativeUint8Array(value);
+  if (Array.isArray(value)) return Uint8Array.from(value.map(Number));
+  if (
+    value &&
+    typeof value === "object" &&
+    typeof (value as { length?: unknown }).length === "number"
+  ) {
+    return toNativeUint8Array(value);
+  }
+  throw new Error(`crypto: ${label} must be a string or Uint8Array`);
+}
+
+function webCryptoSubtle(): SubtleCrypto {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    throw new Error("crypto: WebCrypto (crypto.subtle) is not available");
+  }
+  return subtle;
+}
+
 /**
  * Recursively serialize a value returned from the sandbox, converting typed
  * arrays to native Uint8Array and enforcing output size limits.
  */
-export function serializeResult(result: unknown): unknown {
+export function serializeResult(
+  result: unknown,
+  maxOutputSize: number = MAX_OUTPUT_SIZE
+): unknown {
   if (result === undefined) return null;
   if (result === null) return null;
   if (
@@ -372,8 +553,8 @@ export function serializeResult(result: unknown): unknown {
     typeof result === "number" ||
     typeof result === "boolean"
   ) {
-    if (typeof result === "string" && result.length > MAX_OUTPUT_SIZE) {
-      return truncate(result, MAX_OUTPUT_SIZE);
+    if (typeof result === "string" && result.length > maxOutputSize) {
+      return truncate(result, maxOutputSize);
     }
     return result;
   }
@@ -405,8 +586,8 @@ export function serializeResult(result: unknown): unknown {
     }
     try {
       const json = JSON.stringify(result);
-      if (json.length > MAX_OUTPUT_SIZE) {
-        return truncate(json, MAX_OUTPUT_SIZE);
+      if (json.length > maxOutputSize) {
+        return truncate(json, maxOutputSize);
       }
       return JSON.parse(json);
     } catch {
@@ -459,12 +640,16 @@ export interface SandboxResult {
  *                 `workspace.*` and `getSecret()` APIs.
  * @param signal   Optional external cancellation. Aborts in-flight host
  *                 operations and makes `sleep` return immediately.
+ * @param limits   Optional per-invocation limit overrides, clamped by
+ *                 {@link resolveSandboxLimits}.
  */
 export function buildSandbox(
   context?: ProcessingContext,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  limits?: SandboxLimits
 ): SandboxResult {
   const logs: string[] = [];
+  const resolvedLimits = resolveSandboxLimits(limits);
   let fetchCount = 0;
 
   const console = {
@@ -487,9 +672,9 @@ export function buildSandbox(
     options?: Record<string, unknown>
   ): Promise<Record<string, unknown>> => {
     fetchCount++;
-    if (fetchCount > MAX_FETCH_CALLS) {
+    if (fetchCount > resolvedLimits.maxFetchCalls) {
       throw new Error(
-        `Fetch limit exceeded (max ${MAX_FETCH_CALLS} requests per execution)`
+        `Fetch limit exceeded (max ${resolvedLimits.maxFetchCalls} requests per execution)`
       );
     }
     if (typeof url !== "string" || !url) {
@@ -501,9 +686,12 @@ export function buildSandbox(
     assertFetchUrlAllowed(url);
 
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 15_000);
+    const timer = setTimeout(
+      () => controller.abort(),
+      resolvedLimits.fetchTimeoutMs
+    );
     // Cancelling the run kills an in-flight request rather than waiting out
-    // the 15s cap.
+    // the per-request timeout.
     const onExternalAbort = (): void => controller.abort();
     if (signal?.aborted) controller.abort();
     else signal?.addEventListener("abort", onExternalAbort, { once: true });
@@ -518,10 +706,17 @@ export function buildSandbox(
         fetchOptions.headers = options.headers as Record<string, string>;
       }
       if (options?.body !== undefined) {
-        fetchOptions.body =
-          typeof options.body === "string"
-            ? options.body
-            : JSON.stringify(options.body);
+        const body = options.body;
+        if (typeof body === "string") {
+          fetchOptions.body = body;
+        } else if (isTypedArray(body)) {
+          // Binary request body. A guest Uint8Array reaches the host as a
+          // native one via the typed-array serializers, but normalize anyway
+          // so a numeric-keyed object is sent as raw bytes, not as JSON.
+          fetchOptions.body = toNativeUint8Array(body) as unknown as BodyInit;
+        } else {
+          fetchOptions.body = JSON.stringify(body);
+        }
       }
 
       const response = await fetch(url, fetchOptions);
@@ -531,7 +726,7 @@ export function buildSandbox(
       const rawBytes = await readBodyCapped(
         response,
         controller,
-        MAX_RESPONSE_BODY_SIZE
+        resolvedLimits.maxResponseBodyBytes
       );
       const ok = response.ok;
       const status = response.status;
@@ -543,8 +738,9 @@ export function buildSandbox(
         if (cachedText === null) {
           const decoded = new TextDecoder().decode(rawBytes);
           cachedText =
-            decoded.length > MAX_RESPONSE_BODY_SIZE
-              ? decoded.slice(0, MAX_RESPONSE_BODY_SIZE) + "...[truncated]"
+            decoded.length > resolvedLimits.maxResponseBodyBytes
+              ? decoded.slice(0, resolvedLimits.maxResponseBodyBytes) +
+                "...[truncated]"
               : decoded;
         }
         return cachedText;
@@ -565,12 +761,10 @@ export function buildSandbox(
         body: getText(),
         json: parsedJson,
         text: async () => getText(),
-        arrayBuffer: async () =>
-          rawBytes.buffer.slice(
-            rawBytes.byteOffset,
-            rawBytes.byteOffset + rawBytes.byteLength
-          ),
-        bytes: async () => rawBytes
+        // Both binary accessors return the bytes marker; the guest prelude's
+        // fetch wrapper turns them back into a Uint8Array / ArrayBuffer.
+        arrayBuffer: async () => toGuestBytes(rawBytes),
+        bytes: async () => toGuestBytes(rawBytes)
       };
     } finally {
       clearTimeout(timer);
@@ -578,7 +772,52 @@ export function buildSandbox(
     }
   };
 
-  const uuid = () => crypto.randomUUID();
+  const uuid = () => globalThis.crypto.randomUUID();
+
+  // WebCrypto exists in both Node >= 20 and browsers, so no node:crypto import
+  // is needed and the sandbox stays browser-safe. `getRandomValues` is the one
+  // synchronous member: it clamps instead of throwing, since a host throw does
+  // not go through the never-reject convention.
+  const sandboxCrypto = {
+    randomUUID: (): string => globalThis.crypto.randomUUID(),
+    getRandomValues: (length: number): Record<string, string> => {
+      const requested = Number(length);
+      const size = Number.isFinite(requested)
+        ? Math.min(Math.max(Math.floor(requested), 0), MAX_RANDOM_BYTES)
+        : 0;
+      const bytes = new Uint8Array(size);
+      if (size > 0) globalThis.crypto.getRandomValues(bytes);
+      return toGuestBytes(bytes);
+    },
+    digest: async (
+      algorithm: string,
+      data: unknown
+    ): Promise<Record<string, string>> => {
+      const algo = normalizeDigestAlgorithm(algorithm);
+      const bytes = coerceBytesInput(data, "data");
+      const digest = await webCryptoSubtle().digest(algo, bytes);
+      return toGuestBytes(new Uint8Array(digest));
+    },
+    hmac: async (
+      algorithm: string,
+      key: unknown,
+      data: unknown
+    ): Promise<Record<string, string>> => {
+      const algo = normalizeDigestAlgorithm(algorithm);
+      const keyBytes = coerceBytesInput(key, "key");
+      const dataBytes = coerceBytesInput(data, "data");
+      const subtle = webCryptoSubtle();
+      const cryptoKey = await subtle.importKey(
+        "raw",
+        keyBytes,
+        { name: "HMAC", hash: algo },
+        false,
+        ["sign"]
+      );
+      const signature = await subtle.sign("HMAC", cryptoKey, dataBytes);
+      return toGuestBytes(new Uint8Array(signature));
+    }
+  };
 
   const getSecret = context
     ? async (name: string): Promise<string | undefined> => {
@@ -623,6 +862,71 @@ export function buildSandbox(
             false
           );
           return fs.readdir(fullPath);
+        },
+        readBytes: async (path: string): Promise<Record<string, string>> => {
+          const fullPath = context.resolveWorkspacePath(path);
+          const fs = await loadFsPromises();
+          const nodePath = await loadNodePath();
+          await assertWorkspaceContained(
+            context,
+            fs,
+            nodePath,
+            fullPath,
+            false
+          );
+          return toGuestBytes(new Uint8Array(await fs.readFile(fullPath)));
+        },
+        writeBytes: async (path: string, data: unknown): Promise<void> => {
+          const fullPath = context.resolveWorkspacePath(path);
+          const bytes =
+            data instanceof Uint8Array ? data : toNativeUint8Array(data);
+          const fs = await loadFsPromises();
+          const nodePath = await loadNodePath();
+          await assertWorkspaceContained(context, fs, nodePath, fullPath, true);
+          await fs.mkdir(nodePath.dirname(fullPath), { recursive: true });
+          await fs.writeFile(fullPath, bytes);
+        },
+        stat: async (path: string): Promise<Record<string, unknown>> => {
+          const fullPath = context.resolveWorkspacePath(path);
+          const fs = await loadFsPromises();
+          const nodePath = await loadNodePath();
+          await assertWorkspaceContained(
+            context,
+            fs,
+            nodePath,
+            fullPath,
+            false
+          );
+          const info = await fs.stat(fullPath);
+          return {
+            size: info.size,
+            isDirectory: info.isDirectory(),
+            isFile: info.isFile(),
+            modifiedMs: info.mtimeMs
+          };
+        },
+        mkdir: async (path: string): Promise<void> => {
+          const fullPath = context.resolveWorkspacePath(path);
+          const fs = await loadFsPromises();
+          const nodePath = await loadNodePath();
+          await assertWorkspaceContained(context, fs, nodePath, fullPath, true);
+          await fs.mkdir(fullPath, { recursive: true });
+        },
+        remove: async (path: string): Promise<void> => {
+          const fullPath = context.resolveWorkspacePath(path);
+          const fs = await loadFsPromises();
+          const nodePath = await loadNodePath();
+          // Treated as a write for containment. `recursive: false` keeps this
+          // to one file or one empty directory — guest code cannot delete a
+          // whole workspace subtree in a single call.
+          await assertWorkspaceContained(context, fs, nodePath, fullPath, true);
+          const info = await fs.lstat(fullPath);
+          if (info.isDirectory()) {
+            // rmdir refuses a non-empty directory, which is the point.
+            await fs.rmdir(fullPath);
+          } else {
+            await fs.rm(fullPath, { recursive: false });
+          }
         }
       }
     : {
@@ -634,6 +938,25 @@ export function buildSandbox(
         },
         list: async (_path: string): Promise<string[]> => {
           throw new Error("workspace.list is not available without a context");
+        },
+        readBytes: async (_path: string): Promise<Record<string, string>> => {
+          throw new Error(
+            "workspace.readBytes is not available without a context"
+          );
+        },
+        writeBytes: async (_path: string, _data: unknown): Promise<void> => {
+          throw new Error(
+            "workspace.writeBytes is not available without a context"
+          );
+        },
+        stat: async (_path: string): Promise<Record<string, unknown>> => {
+          throw new Error("workspace.stat is not available without a context");
+        },
+        mkdir: async (_path: string): Promise<void> => {
+          throw new Error("workspace.mkdir is not available without a context");
+        },
+        remove: async (_path: string): Promise<void> => {
+          throw new Error("workspace.remove is not available without a context");
         }
       };
 
@@ -717,6 +1040,7 @@ export function buildSandbox(
     setInterval: undefined,
     // Bridge functions — the only non-native surface the sandbox exposes.
     fetch: sandboxedFetch,
+    crypto: sandboxCrypto,
     uuid,
     sleep,
     getSecret,
@@ -762,6 +1086,12 @@ export interface RunSandboxOptions {
    * for it.
    */
   signal?: AbortSignal;
+  /**
+   * Per-invocation limit overrides (fetch calls, response body, output size,
+   * guest heap, stack, fetch timeout). Each is clamped to a hard ceiling, so a
+   * caller can tune a limit but not disable a protection.
+   */
+  limits?: SandboxLimits;
 }
 
 export interface RunSandboxResult {
@@ -797,12 +1127,20 @@ function replaceInPlace(target: unknown, source: unknown): void {
 const RESERVED_SANDBOX_NAMES = new Set([
   "console",
   "fetch",
+  "crypto",
   "uuid",
   "sleep",
   "getSecret",
   "workspace",
   "assetToSandbox",
   "sandboxToAsset",
+  // Pure guest-side helpers defined by the prelude.
+  "toBase64",
+  "fromBase64",
+  "toHex",
+  "fromHex",
+  "utf8Encode",
+  "utf8Decode",
   "__maxIter"
 ]);
 
@@ -816,6 +1154,7 @@ const RESERVED_SANDBOX_NAMES = new Set([
 const EXPOSED_BRIDGE_NAMES = [
   "console",
   "fetch",
+  "crypto",
   "uuid",
   "sleep",
   "getSecret",
@@ -839,8 +1178,10 @@ export async function runInSandbox(
     context,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     globals,
-    signal
+    signal,
+    limits
   } = options;
+  const resolvedLimits = resolveSandboxLimits(limits);
 
   if (!code.trim()) {
     return { success: false, error: "No code provided", logs: [] };
@@ -850,7 +1191,7 @@ export async function runInSandbox(
     return { success: false, error: "Execution cancelled", logs: [] };
   }
 
-  const { sandbox, getLogs } = buildSandbox(context, signal);
+  const { sandbox, getLogs } = buildSandbox(context, signal, resolvedLimits);
 
   // User-supplied globals (dynamic inputs from CodeNode etc.) layer on top of
   // the core surface, but must not clobber the bridge functions themselves.
@@ -900,15 +1241,28 @@ export async function runInSandbox(
         bridges.getSecret = wrap(bridges.getSecret as never);
         bridges.assetToSandbox = wrap(bridges.assetToSandbox as never);
         bridges.sandboxToAsset = wrap(bridges.sandboxToAsset as never);
-        const ws = bridges.workspace as {
-          read: (p: string) => Promise<string>;
-          write: (p: string, c: string) => Promise<void>;
-          list: (p: string) => Promise<string[]>;
+        const ws = bridges.workspace as Record<
+          string,
+          (...a: never[]) => Promise<unknown>
+        >;
+        const wrappedWorkspace: Record<string, unknown> = {};
+        for (const [name, fn] of Object.entries(ws)) {
+          wrappedWorkspace[name] = wrap(fn as never);
+        }
+        bridges.workspace = wrappedWorkspace;
+        const hostCrypto = bridges.crypto as {
+          randomUUID: () => string;
+          getRandomValues: (n: number) => Record<string, string>;
+          digest: (...a: never[]) => Promise<unknown>;
+          hmac: (...a: never[]) => Promise<unknown>;
         };
-        bridges.workspace = {
-          read: wrap(ws.read),
-          write: wrap(ws.write),
-          list: wrap(ws.list)
+        bridges.crypto = {
+          // randomUUID/getRandomValues are synchronous and never throw, so they
+          // stay unwrapped; the async pair follows the never-reject convention.
+          randomUUID: hostCrypto.randomUUID,
+          getRandomValues: hostCrypto.getRandomValues,
+          digest: wrap(hostCrypto.digest),
+          hmac: wrap(hostCrypto.hmac)
         };
         // Caller-injected globals (ScriptRunner's __runAgent/__log/…) are host
         // functions too — guard the async ones or a cancelled script keeps
@@ -935,6 +1289,61 @@ export async function runInSandbox(
         // throws ReferenceError — same for `Function`.
         await evalCode(
           `const __marker = "${SANDBOX_ERROR_MARKER}";
+const __bytesMarker = "${SANDBOX_BYTES_MARKER}";
+const __b64chars = "${BASE64_ALPHABET}";
+const __hasTE = typeof TextEncoder === "function";
+globalThis.utf8Encode = (s) => {
+  if (__hasTE) return new TextEncoder().encode(String(s));
+  const esc = encodeURIComponent(String(s));
+  const out = [];
+  for (let i = 0; i < esc.length; i++) {
+    if (esc[i] === "%") { out.push(parseInt(esc.substr(i + 1, 2), 16)); i += 2; }
+    else out.push(esc.charCodeAt(i));
+  }
+  return new Uint8Array(out);
+};
+globalThis.utf8Decode = (b) => {
+  if (__hasTE) return new TextDecoder().decode(b instanceof Uint8Array ? b : Uint8Array.from(b));
+  let esc = "";
+  for (let i = 0; i < b.length; i++) esc += "%" + (b[i] < 16 ? "0" : "") + b[i].toString(16);
+  return decodeURIComponent(esc);
+};
+globalThis.toBase64 = (input) => {
+  const b = typeof input === "string" ? globalThis.utf8Encode(input) : input;
+  let out = "";
+  for (let i = 0; i < b.length; i += 3) {
+    const c = (b[i] << 16) | ((b[i + 1] || 0) << 8) | (b[i + 2] || 0);
+    out += __b64chars[(c >> 18) & 63] + __b64chars[(c >> 12) & 63] +
+      (i + 1 < b.length ? __b64chars[(c >> 6) & 63] : "=") +
+      (i + 2 < b.length ? __b64chars[c & 63] : "=");
+  }
+  return out;
+};
+globalThis.fromBase64 = (s) => {
+  const clean = String(s).replace(/-/g, "+").replace(/_/g, "/").replace(/[^A-Za-z0-9+/]/g, "");
+  const out = new Uint8Array((clean.length * 6) >> 3);
+  let acc = 0, bits = 0, o = 0;
+  for (let i = 0; i < clean.length; i++) {
+    acc = (acc << 6) | __b64chars.indexOf(clean[i]);
+    bits += 6;
+    if (bits >= 8) { bits -= 8; out[o++] = (acc >> bits) & 255; }
+  }
+  return out;
+};
+globalThis.toHex = (b) => {
+  let s = "";
+  for (let i = 0; i < b.length; i++) s += (b[i] < 16 ? "0" : "") + b[i].toString(16);
+  return s;
+};
+globalThis.fromHex = (s) => {
+  const t = String(s).replace(/[^0-9a-fA-F]/g, "");
+  const out = new Uint8Array(t.length >> 1);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(t.substr(i * 2, 2), 16);
+  return out;
+};
+const __revive = (v) => (v && typeof v === "object" && typeof v[__bytesMarker] === "string")
+  ? globalThis.fromBase64(v[__bytesMarker])
+  : v;
 const __wrap = (fn) => async (...args) => {
   const r = await fn(...args);
   if (r && r[__marker]) {
@@ -942,9 +1351,18 @@ const __wrap = (fn) => async (...args) => {
     e.name = r.name;
     throw e;
   }
+  return __revive(r);
+};
+const __rawFetch = __wrap(globalThis.fetch);
+globalThis.fetch = async (...args) => {
+  const r = await __rawFetch(...args);
+  if (r && typeof r === "object") {
+    const rb = r.bytes, rab = r.arrayBuffer;
+    if (typeof rb === "function") r.bytes = async () => __revive(await rb());
+    if (typeof rab === "function") r.arrayBuffer = async () => __revive(await rab()).buffer;
+  }
   return r;
 };
-globalThis.fetch = __wrap(globalThis.fetch);
 globalThis.sleep = __wrap(globalThis.sleep);
 globalThis.getSecret = __wrap(globalThis.getSecret);
 globalThis.assetToSandbox = __wrap(globalThis.assetToSandbox);
@@ -953,7 +1371,25 @@ const __ws = globalThis.workspace;
 globalThis.workspace = {
   read: __wrap(__ws.read),
   write: __wrap(__ws.write),
-  list: __wrap(__ws.list)
+  list: __wrap(__ws.list),
+  readBytes: __wrap(__ws.readBytes),
+  writeBytes: __wrap(__ws.writeBytes),
+  stat: __wrap(__ws.stat),
+  mkdir: __wrap(__ws.mkdir),
+  remove: __wrap(__ws.remove)
+};
+const __crypto = globalThis.crypto;
+globalThis.crypto = {
+  randomUUID: () => __crypto.randomUUID(),
+  getRandomValues: (n) => {
+    const len = Number(n);
+    if (!Number.isFinite(len) || len < 0) {
+      throw new TypeError("crypto.getRandomValues: length must be a non-negative number");
+    }
+    return __revive(__crypto.getRandomValues(Math.floor(len)));
+  },
+  digest: __wrap(__crypto.digest),
+  hmac: __wrap(__crypto.hmac)
 };
 delete globalThis.eval;
 delete globalThis.Function;
@@ -1002,8 +1438,8 @@ export default true;`,
       },
       {
         executionTimeout: timeoutMs,
-        memoryLimit: GUEST_MEMORY_LIMIT,
-        maxStackSize: GUEST_STACK_LIMIT
+        memoryLimit: resolvedLimits.memoryLimitBytes,
+        maxStackSize: resolvedLimits.stackLimitBytes
       }
     );
 
@@ -1051,7 +1487,7 @@ export default true;`,
 
     return {
       success: true,
-      result: serializeResult(evalResponse.data),
+      result: serializeResult(evalResponse.data, resolvedLimits.maxOutputSize),
       logs: logs.length > 0 ? logs : undefined
     };
   } catch (e: unknown) {

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -9,7 +9,7 @@
  * The exposed surface is a small curated one: vanilla JavaScript plus a handful
  * of bridge functions (`fetch`, `workspace`, `getSecret`, `uuid`, `sleep`,
  * `assetToSandbox`, `sandboxToAsset`, `crypto`, `console`, `progress`,
- * `format`) and a few pure guest-side binary helpers (`toBase64`,
+ * `format`, `data`) and a few pure guest-side binary helpers (`toBase64`,
  * `fromBase64`, `toHex`, `fromHex`, `utf8Encode`, `utf8Decode`). `crypto`
  * covers `randomUUID`, `getRandomValues`, `digest`, and `hmac`
  * (WebCrypto-backed); `workspace` covers text and binary reads/writes plus
@@ -18,13 +18,16 @@
  * relative-time and list formatting, which QuickJS itself does not ship.
  * Every quantitative limit (fetch calls, response body, output size,
  * guest heap, stack, fetch timeout) is overridable per invocation through
- * `RunSandboxOptions.limits`, clamped to hard ceilings. Library-powered helpers
- * (lodash, dayjs, cheerio, csv-parse,
- * validator) are intentionally NOT exposed here — use the dedicated workflow
- * nodes instead (lib.datetime.*, lib.html.*, lib.data.ParseCSV,
- * lib.validate.*, etc.). Keeping the sandbox lib-free makes snippet behaviour
- * identical between dev and packaged Electron, and avoids shipping those
- * packages into the user-code surface.
+ * `RunSandboxOptions.limits`, clamped to hard ceilings.
+ *
+ * The guest itself stays module-free — there is no loader, so user code cannot
+ * `import`/`require` anything. Library-backed capabilities reach it only
+ * through narrow host bridges that take and return plain data:
+ * `data.parseCsv` (papaparse), `data.selectHtml` (cheerio), `format.*` (Intl)
+ * and `crypto.*` (WebCrypto). The libraries run host-side, are imported lazily
+ * on first use, and are never handed to the guest — so the snippet surface is
+ * the same string-in/plain-data-out contract in dev, in packaged Electron, and
+ * in the browser runner, which bundles this module too.
  */
 
 import { addSerializer, expose, loadQuickJs } from "@sebastianwessel/quickjs";
@@ -65,6 +68,12 @@ export const MAX_PROGRESS_CALLS = 1000;
 export const PROGRESS_MIN_INTERVAL_MS = 100;
 /** Longest progress message forwarded to the host. */
 export const MAX_PROGRESS_MESSAGE_CHARS = 500;
+/** Largest CSV/HTML payload the `data` bridges accept, in characters. */
+export const MAX_DATA_INPUT_CHARS = 5 * 1024 * 1024;
+/** Default number of `data.selectHtml` matches returned. */
+export const DEFAULT_SELECT_HTML_LIMIT = 100;
+/** Ceiling for `data.selectHtml`'s `limit` option. */
+export const MAX_SELECT_HTML_LIMIT = 1000;
 
 /** Host sink for guest `progress()` calls. */
 export type SandboxProgressCallback = (
@@ -363,6 +372,78 @@ async function assertWorkspaceContained(
     }
   }
   throw new Error(`workspace path resolves outside the workspace: ${fullPath}`);
+}
+
+/**
+ * Minimal structural views of papaparse and cheerio — only the members the
+ * `data` bridges call. Declaring them here keeps the packages out of the type
+ * graph, so a consumer that never installs them (the browser runner) still
+ * typechecks.
+ */
+interface PapaparseLike {
+  parse: (
+    input: string,
+    config: Record<string, unknown>
+  ) => { data?: unknown; errors?: { message?: string }[] };
+}
+
+interface CheerioSelection {
+  length: number;
+  eq: (index: number) => CheerioSelection;
+  text: () => string;
+  attr: (name: string) => string | undefined;
+}
+
+interface CheerioLike {
+  load: (html: string) => (selector: string) => CheerioSelection;
+}
+
+/**
+ * Resolve the module object a bridge needs from a lazily imported package,
+ * unwrapping a CJS `default` interop wrapper. Throws a bridge-named Error when
+ * the library isn't usable, which `neverReject` turns into a guest-side throw.
+ *
+ * The imports below are deliberately dynamic and inside the bridge functions:
+ * nothing is loaded until guest code calls one, and neither library reaches a
+ * bundle's entry graph. They are NOT hidden from the bundler (unlike
+ * `loadFsPromises`) — esbuild must inline them into the packaged backend's
+ * single-file `server.mjs`, and Vite must pick cheerio's `browser` build for
+ * the in-browser runner. Both packages resolve on every target we ship.
+ */
+function unwrapLibrary<T>(
+  mod: unknown,
+  bridge: string,
+  specifier: string,
+  isModule: (value: unknown) => boolean
+): T {
+  const candidate =
+    mod && !isModule(mod) ? (mod as { default?: unknown }).default : mod;
+  if (!isModule(candidate)) {
+    throw new Error(
+      `${bridge}: the "${specifier}" library is not available in this runtime`
+    );
+  }
+  return candidate as T;
+}
+
+async function loadPapaparse(): Promise<PapaparseLike> {
+  const mod: unknown = await import("papaparse");
+  return unwrapLibrary<PapaparseLike>(
+    mod,
+    "data.parseCsv",
+    "papaparse",
+    (v) => typeof (v as PapaparseLike | undefined)?.parse === "function"
+  );
+}
+
+async function loadCheerio(): Promise<CheerioLike> {
+  const mod: unknown = await import("cheerio");
+  return unwrapLibrary<CheerioLike>(
+    mod,
+    "data.selectHtml",
+    "cheerio",
+    (v) => typeof (v as CheerioLike | undefined)?.load === "function"
+  );
 }
 
 /** True if a literal IPv4/IPv6 host is loopback, link-local, or private. */
@@ -1125,6 +1206,98 @@ export function buildSandbox(
     }
   };
 
+  // Narrow structured-data bridges. The libraries stay host-side: the guest
+  // hands over text and gets plain arrays back, so nothing library-shaped
+  // crosses the boundary. Both are async and never-reject-wrapped like the
+  // rest, and both cap their input so a huge string can't pin the host heap.
+  const data = {
+    parseCsv: async (
+      text: string,
+      options?: Record<string, unknown>
+    ): Promise<unknown[]> => {
+      if (typeof text !== "string") {
+        throw new Error("data.parseCsv: text must be a string");
+      }
+      if (text.length > MAX_DATA_INPUT_CHARS) {
+        throw new Error(
+          `data.parseCsv: input exceeds the ${MAX_DATA_INPUT_CHARS} character limit`
+        );
+      }
+      const opts = options ?? {};
+      const header = opts.header === undefined ? true : Boolean(opts.header);
+      // papaparse treats "" as auto-detect.
+      const delimiter =
+        opts.delimiter === undefined || opts.delimiter === null
+          ? ""
+          : String(opts.delimiter);
+      if (delimiter.length > 1) {
+        throw new Error("data.parseCsv: delimiter must be a single character");
+      }
+      const papa = await loadPapaparse();
+      // Values stay strings so a column never changes shape between runs;
+      // guest code converts what it needs with Number()/Date.
+      const parsed = papa.parse(text, {
+        header,
+        delimiter,
+        dynamicTyping: false,
+        skipEmptyLines: true
+      });
+      const rows = Array.isArray(parsed.data) ? parsed.data : [];
+      return header
+        ? rows.filter((row) => row !== null && typeof row === "object")
+        : rows.filter((row) => Array.isArray(row));
+    },
+    selectHtml: async (
+      html: string,
+      selector: string,
+      options?: Record<string, unknown>
+    ): Promise<string[]> => {
+      if (typeof html !== "string") {
+        throw new Error("data.selectHtml: html must be a string");
+      }
+      if (html.length > MAX_DATA_INPUT_CHARS) {
+        throw new Error(
+          `data.selectHtml: input exceeds the ${MAX_DATA_INPUT_CHARS} character limit`
+        );
+      }
+      if (typeof selector !== "string" || !selector.trim()) {
+        throw new Error("data.selectHtml: selector must be a non-empty string");
+      }
+      const opts = options ?? {};
+      const attr =
+        opts.attr === undefined || opts.attr === null
+          ? undefined
+          : String(opts.attr);
+      const rawLimit = Number(opts.limit ?? DEFAULT_SELECT_HTML_LIMIT);
+      const limit = Number.isFinite(rawLimit)
+        ? Math.min(Math.max(Math.floor(rawLimit), 0), MAX_SELECT_HTML_LIMIT)
+        : DEFAULT_SELECT_HTML_LIMIT;
+      const cheerio = await loadCheerio();
+      const $ = cheerio.load(html);
+      let matches: CheerioSelection;
+      try {
+        matches = $(selector);
+      } catch (e) {
+        throw new Error(
+          `data.selectHtml: invalid selector "${selector}" (${
+            e instanceof Error ? e.message : String(e)
+          })`
+        );
+      }
+      const out: string[] = [];
+      for (let i = 0; i < matches.length && out.length < limit; i++) {
+        const el = matches.eq(i);
+        if (attr) {
+          const value = el.attr(attr);
+          if (value !== undefined && value !== null) out.push(String(value));
+        } else {
+          out.push(el.text().trim());
+        }
+      }
+      return out;
+    }
+  };
+
   const sandbox: Record<string, unknown> = {
     // Core JS globals are native in QuickJS; we still reflect them in the
     // descriptor so callers that inspect `sandbox.JSON` / `sandbox.Math`
@@ -1179,6 +1352,7 @@ export function buildSandbox(
     sandboxToAsset,
     progress,
     format,
+    data,
     __maxIter: MAX_LOOP_ITERATIONS
   };
 
@@ -1275,6 +1449,7 @@ const RESERVED_SANDBOX_NAMES = new Set([
   "sandboxToAsset",
   "progress",
   "format",
+  "data",
   // Pure guest-side helpers defined by the prelude.
   "toBase64",
   "fromBase64",
@@ -1304,6 +1479,7 @@ const EXPOSED_BRIDGE_NAMES = [
   "sandboxToAsset",
   "progress",
   "format",
+  "data",
   "__maxIter"
 ] as const;
 
@@ -1404,6 +1580,7 @@ export async function runInSandbox(
         };
         bridges.workspace = wrapAllMembers(bridges.workspace);
         bridges.format = wrapAllMembers(bridges.format);
+        bridges.data = wrapAllMembers(bridges.data);
         const hostCrypto = bridges.crypto as {
           randomUUID: () => string;
           getRandomValues: (n: number) => Record<string, string>;
@@ -1538,6 +1715,11 @@ globalThis.format = {
   date: __wrap(__fmt.date),
   relativeTime: __wrap(__fmt.relativeTime),
   list: __wrap(__fmt.list)
+};
+const __data = globalThis.data;
+globalThis.data = {
+  parseCsv: __wrap(__data.parseCsv),
+  selectHtml: __wrap(__data.selectHtml)
 };
 const __crypto = globalThis.crypto;
 globalThis.crypto = {

--- a/packages/agents/src/tools/code-tools.ts
+++ b/packages/agents/src/tools/code-tools.ts
@@ -20,7 +20,12 @@ interface RunCodeResult {
 export class RunCodeTool extends Tool {
   readonly name = "run_code";
   readonly description =
-    "Execute JavaScript code in a sandboxed QuickJS environment. Only javascript is supported.";
+    "Execute JavaScript code in a sandboxed QuickJS environment. Only javascript is supported. " +
+    "Vanilla JS plus bridges: fetch(), console.*, workspace.read/write/list/readBytes/writeBytes/" +
+    "stat/mkdir/remove(), getSecret(), uuid(), sleep(), progress(), crypto.randomUUID/" +
+    "getRandomValues/digest/hmac, format.number/date/relativeTime/list, " +
+    "data.parseCsv(text, {delimiter, header}), data.selectHtml(html, selector, {attr, limit}), " +
+    "toBase64/fromBase64/toHex/fromHex. No imports — there is no module loader.";
   readonly jsonSchema: Record<string, unknown> = {
     type: "object",
     properties: {

--- a/packages/agents/src/tools/js-code-tool.ts
+++ b/packages/agents/src/tools/js-code-tool.ts
@@ -26,8 +26,9 @@ Vanilla JavaScript with full syntax: variables, loops, conditionals, functions, 
 destructuring, spread, template literals, try/catch, async/await, Map, Set, RegExp, URL, \
 URLSearchParams, Date, Math, JSON, Array methods (map, filter, reduce, find, every, some, etc).
 
-Third-party helpers (lodash, dayjs, cheerio, csv-parse, validator) are NOT available. \
-Use vanilla JS equivalents, or call dedicated tools/nodes when richer behaviour is needed.
+There is no module loader — \`import\`/\`require\` do not exist and no third-party library is in \
+scope. Library-backed work reaches you only through the narrow bridges below (\`data\`, \`format\`, \
+\`crypto\`); for anything else use vanilla JS or a dedicated tool/node.
 
 ## Bridge APIs
 
@@ -42,7 +43,30 @@ const items = res.json.results;
 Output appears in the "logs" field of the result.
 
 ### workspace.read(path) / .write(path, content) / .list(path)
-Read/write files in the agent workspace.
+Read/write files in the agent workspace. Also .readBytes / .writeBytes (Uint8Array),
+.stat(path) → {size, isDirectory, isFile, modifiedMs}, .mkdir(path), .remove(path)
+(one file or one empty directory).
+
+### data.parseCsv(text, {delimiter?, header?}) → object[] | string[][]
+Parse CSV. \`header\` defaults to true (records keyed by the header row); with \`header: false\`
+you get arrays of strings. Values are always strings. Input capped at 5 MB.
+
+### data.selectHtml(html, selector, {attr?, limit?}) → string[]
+Run a CSS selector over HTML and get each match's trimmed text, or the named attribute's value
+when \`attr\` is set (matches without it are skipped). \`limit\` defaults to 100, max 1000.
+Input capped at 5 MB.
+
+### format.number(value, opts?) / .date(epochMs, opts?) / .relativeTime(value, unit, opts?) / .list(items, opts?)
+Locale-aware formatting (Intl-backed; defaults to en-US).
+
+### crypto.randomUUID() / .getRandomValues(n) / .digest(algo, data) / .hmac(algo, key, data)
+SHA-1/256/384/512. \`digest\` and \`hmac\` are async and return a Uint8Array.
+
+### toBase64(x) / fromBase64(s) / toHex(bytes) / fromHex(s) / utf8Encode(s) / utf8Decode(bytes)
+Binary and text conversion helpers (synchronous, guest-side).
+
+### progress(percent, message?)
+Report progress to the caller (0–100). Fire-and-forget.
 
 ### assetToSandbox(assetId, path)
 Copy a persistent platform asset into the sandbox workspace at the given path.

--- a/packages/agents/tests/js-sandbox.test.ts
+++ b/packages/agents/tests/js-sandbox.test.ts
@@ -16,7 +16,10 @@ import {
   truncate,
   cleanStack,
   wrapCode,
-  MAX_OUTPUT_SIZE
+  resolveSandboxLimits,
+  MAX_OUTPUT_SIZE,
+  MAX_FETCH_CALLS,
+  GUEST_MEMORY_LIMIT
 } from "../src/js-sandbox.js";
 
 // ---------------------------------------------------------------------------
@@ -824,5 +827,524 @@ describe("runInSandbox cancellation of CPU-bound guests", () => {
     await new Promise((r) => setTimeout(r, 300));
     expect(hostCalls).toBeLessThanOrEqual(callsAtCancel + 1);
     expect(hostCalls).toBeLessThan(12);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// crypto bridge
+// ---------------------------------------------------------------------------
+
+describe("runInSandbox crypto bridge", () => {
+  it("digests a string with the known SHA-256 vector for 'abc'", async () => {
+    const result = await runInSandbox({
+      code: `
+        const d = await crypto.digest("SHA-256", "abc");
+        return { hex: toHex(d), isBytes: d instanceof Uint8Array, len: d.length };
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      hex: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+      isBytes: true,
+      len: 32
+    });
+  });
+
+  it("digests a Uint8Array and matches the string form", async () => {
+    const result = await runInSandbox({
+      code: `
+        const a = await crypto.digest("SHA-1", "abc");
+        const b = await crypto.digest("sha1", utf8Encode("abc"));
+        return { a: toHex(a), b: toHex(b) };
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      a: "a9993e364706816aba3e25717850c26c9cd0d89d",
+      b: "a9993e364706816aba3e25717850c26c9cd0d89d"
+    });
+  });
+
+  it("supports SHA-384 and SHA-512", async () => {
+    const result = await runInSandbox({
+      code: `
+        const a = await crypto.digest("SHA-384", "abc");
+        const b = await crypto.digest("SHA-512", "abc");
+        return { a: a.length, b: b.length };
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ a: 48, b: 64 });
+  });
+
+  it("rejects an unsupported algorithm with a clear error", async () => {
+    const result = await runInSandbox({
+      code: `return await crypto.digest("MD5", "abc");`
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/unsupported algorithm/i);
+  });
+
+  it("rejects non-string, non-byte digest input", async () => {
+    const result = await runInSandbox({
+      code: `return await crypto.digest("SHA-256", 42);`
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/must be a string or Uint8Array/i);
+  });
+
+  it("computes the known HMAC-SHA256 vector", async () => {
+    const result = await runInSandbox({
+      code: `
+        const mac = await crypto.hmac(
+          "SHA-256",
+          "key",
+          "The quick brown fox jumps over the lazy dog"
+        );
+        return toHex(mac);
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(
+      "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8"
+    );
+  });
+
+  it("accepts binary keys and data for hmac", async () => {
+    const result = await runInSandbox({
+      code: `
+        const mac = await crypto.hmac("SHA-256", utf8Encode("key"), utf8Encode("msg"));
+        const mac2 = await crypto.hmac("SHA-256", "key", "msg");
+        return { same: toHex(mac) === toHex(mac2), len: mac.length };
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ same: true, len: 32 });
+  });
+
+  it("getRandomValues returns a real Uint8Array of the requested length", async () => {
+    const result = await runInSandbox({
+      code: `
+        const b = crypto.getRandomValues(16);
+        return { len: b.length, isBytes: b instanceof Uint8Array, allZero: b.every(v => v === 0) };
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatchObject({ len: 16, isBytes: true });
+    expect((result.result as { allZero: boolean }).allZero).toBe(false);
+  });
+
+  it("caps getRandomValues at 65536 bytes", async () => {
+    const result = await runInSandbox({
+      code: `return crypto.getRandomValues(200000).length;`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(65_536);
+  });
+
+  it("crypto.randomUUID returns a UUID", async () => {
+    const result = await runInSandbox({ code: `return crypto.randomUUID();` });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// base64 / hex / utf8 guest helpers
+// ---------------------------------------------------------------------------
+
+describe("runInSandbox binary helpers", () => {
+  it("round-trips base64", async () => {
+    const result = await runInSandbox({
+      code: `
+        const b64 = toBase64("hello world");
+        const back = fromBase64(b64);
+        return { b64, text: utf8Decode(back), isBytes: back instanceof Uint8Array };
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      b64: Buffer.from("hello world").toString("base64"),
+      text: "hello world",
+      isBytes: true
+    });
+  });
+
+  it("base64-encodes every byte value correctly", async () => {
+    const result = await runInSandbox({
+      code: `
+        const bytes = new Uint8Array(256);
+        for (let i = 0; i < 256; i++) bytes[i] = i;
+        const b64 = toBase64(bytes);
+        const back = fromBase64(b64);
+        let same = back.length === 256;
+        for (let i = 0; i < 256 && same; i++) same = back[i] === i;
+        return { b64, same };
+      `
+    });
+    expect(result.success).toBe(true);
+    const expected = Buffer.from(
+      Array.from({ length: 256 }, (_, i) => i)
+    ).toString("base64");
+    expect(result.result).toEqual({ b64: expected, same: true });
+  });
+
+  it("round-trips hex", async () => {
+    const result = await runInSandbox({
+      code: `
+        const hex = toHex(utf8Encode("nodetool"));
+        const back = fromHex(hex);
+        return { hex, text: utf8Decode(back) };
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      hex: Buffer.from("nodetool").toString("hex"),
+      text: "nodetool"
+    });
+  });
+
+  it("round-trips non-ASCII text through utf8Encode/utf8Decode", async () => {
+    const result = await runInSandbox({
+      code: `
+        const bytes = utf8Encode("héllo — 世界");
+        return { len: bytes.length, text: utf8Decode(bytes) };
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      len: Buffer.from("héllo — 世界").length,
+      text: "héllo — 世界"
+    });
+  });
+
+  it("accepts base64url input in fromBase64", async () => {
+    const result = await runInSandbox({
+      code: `return utf8Decode(fromBase64("aGVsbG8_d29ybGQ-"));`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(
+      Buffer.from("aGVsbG8/d29ybGQ+", "base64").toString("utf-8")
+    );
+  });
+
+  it("does not let a caller global clobber the helpers", async () => {
+    const result = await runInSandbox({
+      code: `return typeof toBase64;`,
+      globals: { toBase64: 5 }
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// workspace binary + metadata I/O
+// ---------------------------------------------------------------------------
+
+describe("runInSandbox workspace binary I/O", () => {
+  const withWorkspace = async (
+    fn: (ctx: import("@nodetool-ai/runtime").ProcessingContext, dir: string) => Promise<void>
+  ): Promise<void> => {
+    const { mkdtemp, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join, isAbsolute } = await import("node:path");
+    const dir = await mkdtemp(join(tmpdir(), "sbx-bin-"));
+    const context = {
+      resolveWorkspacePath: (p: string) => (isAbsolute(p) ? p : join(dir, p))
+    } as unknown as import("@nodetool-ai/runtime").ProcessingContext;
+    try {
+      await fn(context, dir);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  };
+
+  it("round-trips bytes through writeBytes/readBytes", async () => {
+    await withWorkspace(async (context, dir) => {
+      const result = await runInSandbox({
+        code: `
+          const data = new Uint8Array([0, 1, 2, 250, 255]);
+          await workspace.writeBytes("nested/blob.bin", data);
+          const back = await workspace.readBytes("nested/blob.bin");
+          return { isBytes: back instanceof Uint8Array, values: Array.from(back) };
+        `,
+        context
+      });
+      expect(result.success).toBe(true);
+      expect(result.result).toEqual({
+        isBytes: true,
+        values: [0, 1, 2, 250, 255]
+      });
+      const { readFile } = await import("node:fs/promises");
+      const { join } = await import("node:path");
+      const onDisk = await readFile(join(dir, "nested/blob.bin"));
+      expect(Array.from(onDisk)).toEqual([0, 1, 2, 250, 255]);
+    });
+  });
+
+  it("stats files and directories", async () => {
+    await withWorkspace(async (context) => {
+      const result = await runInSandbox({
+        code: `
+          await workspace.write("a.txt", "hello");
+          await workspace.mkdir("sub/dir");
+          const f = await workspace.stat("a.txt");
+          const d = await workspace.stat("sub/dir");
+          return {
+            size: f.size,
+            fileIsFile: f.isFile,
+            fileIsDir: f.isDirectory,
+            hasMtime: typeof f.modifiedMs === "number" && f.modifiedMs > 0,
+            dirIsDir: d.isDirectory
+          };
+        `,
+        context
+      });
+      expect(result.success).toBe(true);
+      expect(result.result).toEqual({
+        size: 5,
+        fileIsFile: true,
+        fileIsDir: false,
+        hasMtime: true,
+        dirIsDir: true
+      });
+    });
+  });
+
+  it("removes a file and an empty directory but not a populated tree", async () => {
+    await withWorkspace(async (context) => {
+      const result = await runInSandbox({
+        code: `
+          await workspace.write("gone.txt", "x");
+          await workspace.remove("gone.txt");
+          await workspace.mkdir("empty");
+          await workspace.remove("empty");
+          await workspace.write("tree/keep.txt", "x");
+          let treeError = null;
+          try { await workspace.remove("tree"); } catch (e) { treeError = e.message; }
+          return { after: await workspace.list("."), treeError: treeError !== null };
+        `,
+        context
+      });
+      expect(result.success).toBe(true);
+      expect(result.result).toMatchObject({ treeError: true });
+      expect((result.result as { after: string[] }).after).toEqual(["tree"]);
+    });
+  });
+
+  it("blocks binary writes through an escaping symlink", async () => {
+    const { mkdtemp, rm, writeFile, symlink, readFile } =
+      await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join, isAbsolute } = await import("node:path");
+    const ws = await mkdtemp(join(tmpdir(), "sbx-ws-"));
+    const outside = await mkdtemp(join(tmpdir(), "sbx-out-"));
+    try {
+      await writeFile(join(outside, "secret.bin"), "SECRET");
+      await symlink(join(outside, "secret.bin"), join(ws, "link.bin"));
+      const context = {
+        resolveWorkspacePath: (p: string) => (isAbsolute(p) ? p : join(ws, p))
+      } as never;
+      const { sandbox } = buildSandbox(context);
+      const workspace = sandbox.workspace as {
+        readBytes: (p: string) => Promise<unknown>;
+        writeBytes: (p: string, d: Uint8Array) => Promise<void>;
+        remove: (p: string) => Promise<void>;
+      };
+      await expect(workspace.readBytes("link.bin")).rejects.toThrow(
+        /outside the workspace/i
+      );
+      await expect(
+        workspace.writeBytes("link.bin", new Uint8Array([1]))
+      ).rejects.toThrow(/outside the workspace/i);
+      await expect(workspace.remove("link.bin")).rejects.toThrow(
+        /outside the workspace/i
+      );
+      expect(await readFile(join(outside, "secret.bin"), "utf-8")).toBe(
+        "SECRET"
+      );
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("new workspace members throw helpfully without a context", async () => {
+    const { sandbox } = buildSandbox();
+    const ws = sandbox.workspace as Record<
+      string,
+      (...a: never[]) => Promise<unknown>
+    >;
+    for (const name of ["readBytes", "writeBytes", "stat", "mkdir", "remove"]) {
+      await expect(ws[name]("x" as never)).rejects.toThrow(
+        "not available without a context"
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetch binary bodies + limits
+// ---------------------------------------------------------------------------
+
+describe("runInSandbox fetch binary bodies", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    (globalThis as { fetch: typeof originalFetch }).fetch = originalFetch;
+  });
+
+  it("sends a Uint8Array body as raw bytes, not JSON", async () => {
+    let sentBody: unknown;
+    (globalThis as { fetch: unknown }).fetch = vi.fn(
+      async (_u: string, init: RequestInit) => {
+        sentBody = init.body;
+        return new Response("ok", { status: 200 });
+      }
+    );
+    const result = await runInSandbox({
+      code: `
+        const r = await fetch("https://example.com", {
+          method: "POST",
+          body: new Uint8Array([1, 2, 3, 4])
+        });
+        return r.status;
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(sentBody).toBeInstanceOf(Uint8Array);
+    expect(Array.from(sentBody as Uint8Array)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("still JSON-encodes plain object bodies", async () => {
+    let sentBody: unknown;
+    (globalThis as { fetch: unknown }).fetch = vi.fn(
+      async (_u: string, init: RequestInit) => {
+        sentBody = init.body;
+        return new Response("ok", { status: 200 });
+      }
+    );
+    const result = await runInSandbox({
+      code: `return (await fetch("https://example.com", { method: "POST", body: { a: 1 } })).status;`
+    });
+    expect(result.success).toBe(true);
+    expect(sentBody).toBe('{"a":1}');
+  });
+
+  it("delivers bytes() and arrayBuffer() as real binary in the guest", async () => {
+    (globalThis as { fetch: unknown }).fetch = vi.fn(
+      async () => new Response(new Uint8Array([222, 173, 190, 239]))
+    );
+    const result = await runInSandbox({
+      code: `
+        const r = await fetch("https://example.com/bin");
+        const b = await r.bytes();
+        const ab = await r.arrayBuffer();
+        return {
+          isBytes: b instanceof Uint8Array,
+          hex: toHex(b),
+          abBytes: ab.byteLength
+        };
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      isBytes: true,
+      hex: "deadbeef",
+      abBytes: 4
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// configurable limits
+// ---------------------------------------------------------------------------
+
+describe("resolveSandboxLimits", () => {
+  it("defaults to the module constants", () => {
+    const limits = resolveSandboxLimits();
+    expect(limits.maxFetchCalls).toBe(MAX_FETCH_CALLS);
+    expect(limits.maxOutputSize).toBe(MAX_OUTPUT_SIZE);
+    expect(limits.memoryLimitBytes).toBe(GUEST_MEMORY_LIMIT);
+  });
+
+  it("clamps values above the hard ceilings", () => {
+    const limits = resolveSandboxLimits({
+      maxFetchCalls: 10_000,
+      maxResponseBodyBytes: 1024 ** 4,
+      maxOutputSize: 1024 ** 4,
+      memoryLimitBytes: 1024 ** 4,
+      stackLimitBytes: 1024 ** 4,
+      fetchTimeoutMs: 10 * 60_000
+    });
+    expect(limits.maxFetchCalls).toBe(100);
+    expect(limits.maxResponseBodyBytes).toBe(50 * 1024 * 1024);
+    expect(limits.maxOutputSize).toBe(10 * 1024 * 1024);
+    expect(limits.memoryLimitBytes).toBe(512 * 1024 * 1024);
+    expect(limits.stackLimitBytes).toBe(8 * 1024 * 1024);
+    expect(limits.fetchTimeoutMs).toBe(120_000);
+  });
+
+  it("ignores non-numeric overrides", () => {
+    const limits = resolveSandboxLimits({
+      maxFetchCalls: Number.NaN,
+      maxOutputSize: undefined
+    });
+    expect(limits.maxFetchCalls).toBe(MAX_FETCH_CALLS);
+    expect(limits.maxOutputSize).toBe(MAX_OUTPUT_SIZE);
+  });
+});
+
+describe("runInSandbox limits option", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    (globalThis as { fetch: typeof originalFetch }).fetch = originalFetch;
+  });
+
+  it("maxFetchCalls=1 blocks the second request", async () => {
+    (globalThis as { fetch: unknown }).fetch = vi.fn(
+      async () => new Response("{}", { status: 200 })
+    );
+    const result = await runInSandbox({
+      code: `
+        await fetch("https://example.com/1");
+        await fetch("https://example.com/2");
+        return "ok";
+      `,
+      limits: { maxFetchCalls: 1 }
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Fetch limit exceeded \(max 1 /i);
+  });
+
+  it("maxOutputSize truncates the returned value", async () => {
+    const result = await runInSandbox({
+      code: `return "x".repeat(20000);`,
+      limits: { maxOutputSize: 2000 }
+    });
+    expect(result.success).toBe(true);
+    expect((result.result as string).length).toBeLessThan(3000);
+    expect(result.result as string).toContain("[truncated]");
+  });
+
+  it("memoryLimitBytes override fails a large allocation", async () => {
+    // Allocate JS objects: QuickJS's memory limiter counts its own heap
+    // objects, not string or typed-array payloads.
+    const code = `
+      const items = [];
+      for (let i = 0; i < 200000; i++) items.push({ i });
+      return items.length;
+    `;
+    const tight = await runInSandbox({
+      code,
+      limits: { memoryLimitBytes: 2 * 1024 * 1024 }
+    });
+    expect(tight.success).toBe(false);
+    expect(tight.error).toMatch(/out of memory/i);
+    const roomy = await runInSandbox({ code, timeoutMs: 20_000 });
+    expect(roomy.success).toBe(true);
+    expect(roomy.result).toBe(200000);
   });
 });

--- a/packages/agents/tests/js-sandbox.test.ts
+++ b/packages/agents/tests/js-sandbox.test.ts
@@ -1348,3 +1348,178 @@ describe("runInSandbox limits option", () => {
     expect(roomy.result).toBe(200000);
   });
 });
+
+// ---------------------------------------------------------------------------
+// progress reporting
+// ---------------------------------------------------------------------------
+
+describe("progress bridge", () => {
+  it("forwards a report to the host callback", async () => {
+    const seen: Array<[number, string | undefined]> = [];
+    const result = await runInSandbox({
+      code: `progress(42, "halfway"); return "done";`,
+      onProgress: (p, m) => seen.push([p, m])
+    });
+    expect(result.success).toBe(true);
+    expect(seen).toEqual([[42, "halfway"]]);
+  });
+
+  it("clamps percentages to 0-100 and coerces non-finite to 0", () => {
+    const seen: number[] = [];
+    const { sandbox } = buildSandbox(undefined, undefined, undefined, (p) =>
+      seen.push(p)
+    );
+    const report = sandbox.progress as (p: number, m?: string) => void;
+    // Rate limiting drops reports inside the 100 ms window, so drive the host
+    // function directly with a wide enough gap between calls.
+    vi.useFakeTimers();
+    try {
+      report(-5);
+      vi.advanceTimersByTime(200);
+      report(150);
+      vi.advanceTimersByTime(200);
+      report(Number.NaN);
+      vi.advanceTimersByTime(200);
+      report(Number.POSITIVE_INFINITY);
+    } finally {
+      vi.useRealTimers();
+    }
+    // Infinity is not finite, so it coerces to 0 rather than clamping to 100.
+    expect(seen).toEqual([0, 100, 0, 0]);
+  });
+
+  it("truncates the message to 500 characters", () => {
+    const seen: Array<string | undefined> = [];
+    const { sandbox } = buildSandbox(undefined, undefined, undefined, (_p, m) =>
+      seen.push(m)
+    );
+    const report = sandbox.progress as (p: number, m?: string) => void;
+    report(1, "y".repeat(2000));
+    expect(seen[0]).toHaveLength(500);
+  });
+
+  it("rate-limits a tight loop of reports", async () => {
+    const seen: number[] = [];
+    const result = await runInSandbox({
+      code: `for (let i = 0; i < 200; i++) progress(i / 2); return "ok";`,
+      onProgress: (p) => seen.push(p)
+    });
+    expect(result.success).toBe(true);
+    // The loop runs well inside one 100 ms window, so only the first report
+    // (and at most a handful more on a very slow machine) gets through.
+    expect(seen.length).toBeGreaterThanOrEqual(1);
+    expect(seen.length).toBeLessThan(20);
+    expect(seen[0]).toBe(0);
+  });
+
+  it("stops forwarding once the run is cancelled", () => {
+    const seen: number[] = [];
+    const controller = new AbortController();
+    const { sandbox } = buildSandbox(
+      undefined,
+      controller.signal,
+      undefined,
+      (p) => seen.push(p)
+    );
+    const report = sandbox.progress as (p: number, m?: string) => void;
+    report(10);
+    controller.abort();
+    report(20);
+    expect(seen).toEqual([10]);
+  });
+
+  it("is a no-op without a callback", async () => {
+    const result = await runInSandbox({
+      code: `progress(10, "no sink"); return progress(20) === undefined;`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Intl-backed format bridge
+// ---------------------------------------------------------------------------
+
+describe("format bridge", () => {
+  it("formats numbers with grouping", async () => {
+    const result = await runInSandbox({
+      code: `return await format.number(1234.5, { locale: "en-US" });`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("1,234.5");
+  });
+
+  it("formats currency and percent", async () => {
+    const result = await runInSandbox({
+      code: `return {
+        usd: await format.number(12.5, { locale: "en-US", style: "currency", currency: "USD" }),
+        pct: await format.number(0.256, { locale: "en-US", style: "percent", maximumFractionDigits: 1 }),
+        plain: await format.number(1234.5, { locale: "en-US", useGrouping: false })
+      };`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      usd: "$12.50",
+      pct: "25.6%",
+      plain: "1234.5"
+    });
+  });
+
+  it("formats a date in a fixed time zone", async () => {
+    const result = await runInSandbox({
+      code: `return await format.date(0, {
+        locale: "en-US",
+        dateStyle: "medium",
+        timeZone: "UTC"
+      });`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("Jan 1, 1970");
+  });
+
+  it("rejects a non-finite epoch", async () => {
+    const result = await runInSandbox({
+      code: `try { await format.date(NaN); return "no throw"; }
+             catch (e) { return e.message; }`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatch(/epochMs must be a finite number/);
+  });
+
+  it("formats relative time", async () => {
+    const result = await runInSandbox({
+      code: `return await format.relativeTime(-1, "day", { locale: "en-US" });`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("1 day ago");
+  });
+
+  it("formats a list as a conjunction and a disjunction", async () => {
+    const result = await runInSandbox({
+      code: `return {
+        and: await format.list(["a", "b", "c"], { locale: "en-US" }),
+        or: await format.list(["a", "b"], { locale: "en-US", type: "disjunction" })
+      };`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ and: "a, b, and c", or: "a or b" });
+  });
+
+  it("surfaces an invalid locale as a guest-side Error", async () => {
+    const result = await runInSandbox({
+      code: `try { await format.number(1, { locale: "not a locale" }); return "no throw"; }
+             catch (e) { return e.message; }`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatch(/locale/i);
+  });
+
+  it("defaults to en-US when no locale is given", async () => {
+    const result = await runInSandbox({
+      code: `return await format.number(1234567.891);`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("1,234,567.891");
+  });
+});

--- a/packages/agents/tests/js-sandbox.test.ts
+++ b/packages/agents/tests/js-sandbox.test.ts
@@ -1523,3 +1523,147 @@ describe("format bridge", () => {
     expect(result.result).toBe("1,234,567.891");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Structured-data bridges (papaparse / cheerio, host-side)
+// ---------------------------------------------------------------------------
+
+describe("data.parseCsv bridge", () => {
+  it("parses to records keyed by the header row by default", async () => {
+    const result = await runInSandbox({
+      code: `return await data.parseCsv("name,age\\nada,36\\nlin,41");`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual([
+      { name: "ada", age: "36" },
+      { name: "lin", age: "41" }
+    ]);
+  });
+
+  it("returns string arrays with header: false", async () => {
+    const result = await runInSandbox({
+      code: `return await data.parseCsv("a,b\\n1,2", { header: false });`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual([
+      ["a", "b"],
+      ["1", "2"]
+    ]);
+  });
+
+  it("honours a custom delimiter", async () => {
+    const result = await runInSandbox({
+      code: `return await data.parseCsv("a;b\\n1;2", { delimiter: ";" });`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual([{ a: "1", b: "2" }]);
+  });
+
+  it("keeps quoted fields containing the delimiter and newlines intact", async () => {
+    const result = await runInSandbox({
+      code: `return await data.parseCsv('a,b\\n"x,y","line1\\nline2"');`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual([{ a: "x,y", b: "line1\nline2" }]);
+  });
+
+  it("rejects a multi-character delimiter", async () => {
+    const result = await runInSandbox({
+      code: `try { await data.parseCsv("a,b", { delimiter: "||" }); return "no throw"; }
+             catch (e) { return e.message; }`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatch(/single character/);
+  });
+
+  it("rejects a non-string input", async () => {
+    const result = await runInSandbox({
+      code: `try { await data.parseCsv(42); return "no throw"; }
+             catch (e) { return e.message; }`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatch(/text must be a string/);
+  });
+
+  it("rejects an oversized input", async () => {
+    const result = await runInSandbox({
+      code: `try { await data.parseCsv("x".repeat(5 * 1024 * 1024 + 1)); return "no throw"; }
+             catch (e) { return e.message; }`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatch(/exceeds the \d+ character limit/);
+  });
+});
+
+describe("data.selectHtml bridge", () => {
+  const HTML = `<ul>
+    <li class="item"> alpha </li>
+    <li class="item">beta</li>
+    <li class="item">gamma</li>
+  </ul>
+  <a href="https://example.com/a" id="first">A</a>
+  <a id="second">B</a>`;
+
+  it("extracts trimmed text for each match", async () => {
+    const result = await runInSandbox({
+      code: `return await data.selectHtml(html, "li.item");`,
+      globals: { html: HTML }
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("extracts an attribute and drops matches lacking it", async () => {
+    const result = await runInSandbox({
+      code: `return await data.selectHtml(html, "a", { attr: "href" });`,
+      globals: { html: HTML }
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual(["https://example.com/a"]);
+  });
+
+  it("caps the result count with limit", async () => {
+    const result = await runInSandbox({
+      code: `return await data.selectHtml(html, "li.item", { limit: 2 });`,
+      globals: { html: HTML }
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual(["alpha", "beta"]);
+  });
+
+  it("returns an empty array when nothing matches", async () => {
+    const result = await runInSandbox({
+      code: `return await data.selectHtml(html, "table td");`,
+      globals: { html: HTML }
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual([]);
+  });
+
+  it("rejects an empty selector", async () => {
+    const result = await runInSandbox({
+      code: `try { await data.selectHtml("<p>x</p>", "  "); return "no throw"; }
+             catch (e) { return e.message; }`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatch(/selector must be a non-empty string/);
+  });
+
+  it("surfaces an unparseable selector as a guest-side Error", async () => {
+    const result = await runInSandbox({
+      code: `try { await data.selectHtml("<p>x</p>", "li:::"); return "no throw"; }
+             catch (e) { return e.message; }`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatch(/invalid selector/);
+  });
+
+  it("rejects an oversized input", async () => {
+    const result = await runInSandbox({
+      code: `try { await data.selectHtml("x".repeat(5 * 1024 * 1024 + 1), "p"); return "no throw"; }
+             catch (e) { return e.message; }`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toMatch(/exceeds the \d+ character limit/);
+  });
+});

--- a/packages/code-nodes/src/nodes/code-node.ts
+++ b/packages/code-nodes/src/nodes/code-node.ts
@@ -3,7 +3,7 @@
  *
  * Runs user code in an isolated QuickJS WebAssembly guest (see
  * `@nodetool-ai/agents/js-sandbox`) with standard JavaScript plus fetch(),
- * workspace, getSecret(), uuid(), and sleep() APIs.
+ * workspace, getSecret(), uuid(), sleep(), progress() and format() APIs.
  * Dynamic inputs are injected as global variables in the sandbox.
  *
  * Example:
@@ -99,7 +99,7 @@ export class CodeNode extends BaseNode {
   static readonly title = "Code";
   static readonly description =
     "Execute vanilla JavaScript in a sandboxed environment. " +
-    "APIs: fetch(), workspace.read/write/list(), getSecret(), uuid(), sleep(). " +
+    "APIs: fetch(), workspace.read/write/list(), getSecret(), uuid(), sleep(), progress(). " +
     "Dynamic inputs become global variables; return an object to define outputs. " +
     "For date/HTML/CSV/validation work use the dedicated workflow nodes.\n    code, javascript, function, script, dynamic";
   static readonly inlineFields = ["code"];
@@ -117,7 +117,8 @@ export class CodeNode extends BaseNode {
     description:
       "JavaScript code to execute. " +
       "Dynamic inputs are available as variables. " +
-      "APIs: fetch(), workspace.read/write/list(), getSecret(), uuid(), sleep(). " +
+      "APIs: fetch(), workspace.read/write/list(), getSecret(), uuid(), sleep(), " +
+      "progress(percent, message). " +
       "A persistent `state` object survives across streaming invocations. " +
       "Return an object — its keys become output handles."
   })
@@ -133,6 +134,27 @@ export class CodeNode extends BaseNode {
 
   async initialize(): Promise<void> {
     this._state = {};
+  }
+
+  /**
+   * Forward guest `progress(percent, message)` calls to the kernel as
+   * `node_progress` messages — the same channel the Python worker and the
+   * ComfyUI node use, so the editor's node progress bar picks them up.
+   */
+  private progressSink(
+    context?: ProcessingContext
+  ): ((progress: number, message?: string) => void) | undefined {
+    if (!context || !this.__node_id) return undefined;
+    return (progress: number, message?: string) => {
+      context.postMessage({
+        type: "node_progress",
+        node_id: this.__node_id,
+        progress,
+        total: 100,
+        chunk: message,
+        workflow_id: context.workflowId
+      });
+    };
   }
 
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
@@ -157,7 +179,8 @@ export class CodeNode extends BaseNode {
       code: body,
       context,
       timeoutMs: timeout > 0 ? timeout * 1000 : undefined,
-      globals
+      globals,
+      onProgress: this.progressSink(context)
     });
 
     if (!sandboxResult.success) {
@@ -200,7 +223,8 @@ export class CodeNode extends BaseNode {
       code: wrappedBody,
       context,
       timeoutMs: timeout > 0 ? timeout * 1000 : undefined,
-      globals
+      globals,
+      onProgress: this.progressSink(context)
     });
 
     if (!sandboxResult.success) {

--- a/packages/code-nodes/src/nodes/code-node.ts
+++ b/packages/code-nodes/src/nodes/code-node.ts
@@ -2,9 +2,11 @@
  * Universal Code Node — sandboxed JavaScript execution via QuickJS WASM.
  *
  * Runs user code in an isolated QuickJS WebAssembly guest (see
- * `@nodetool-ai/agents/js-sandbox`) with standard JavaScript plus fetch(),
- * workspace, getSecret(), uuid(), sleep(), progress() and format() APIs.
- * Dynamic inputs are injected as global variables in the sandbox.
+ * `@nodetool-ai/agents/js-sandbox`) with standard JavaScript plus the bridge
+ * APIs: fetch(), workspace (text/bytes/stat/mkdir/remove), getSecret(), uuid(),
+ * sleep(), progress(), crypto, format, data (CSV/HTML parsing) and the
+ * base64/hex helpers. Dynamic inputs are injected as global variables in the
+ * sandbox.
  *
  * Example:
  *   // inputs: { x: 5, text: "hello" }
@@ -99,9 +101,12 @@ export class CodeNode extends BaseNode {
   static readonly title = "Code";
   static readonly description =
     "Execute vanilla JavaScript in a sandboxed environment. " +
-    "APIs: fetch(), workspace.read/write/list(), getSecret(), uuid(), sleep(), progress(). " +
-    "Dynamic inputs become global variables; return an object to define outputs. " +
-    "For date/HTML/CSV/validation work use the dedicated workflow nodes.\n    code, javascript, function, script, dynamic";
+    "APIs: fetch(), workspace.read/write/list/readBytes/writeBytes/stat/mkdir/remove(), " +
+    "getSecret(), uuid(), sleep(), progress(), crypto.digest/hmac/randomUUID/getRandomValues, " +
+    "format.number/date/relativeTime/list, data.parseCsv/selectHtml, " +
+    "toBase64/fromBase64/toHex/fromHex. " +
+    "Dynamic inputs become global variables; return an object to define outputs." +
+    "\n    code, javascript, function, script, dynamic";
   static readonly inlineFields = ["code"];
   static readonly inputFields = [];
   static readonly supportsDynamicInputs = true;
@@ -117,8 +122,13 @@ export class CodeNode extends BaseNode {
     description:
       "JavaScript code to execute. " +
       "Dynamic inputs are available as variables. " +
-      "APIs: fetch(), workspace.read/write/list(), getSecret(), uuid(), sleep(), " +
-      "progress(percent, message). " +
+      "APIs: fetch(url, options), workspace.read/write/list/readBytes/writeBytes/stat/mkdir/remove, " +
+      "getSecret(name), uuid(), sleep(ms), progress(percent, message), " +
+      "crypto.randomUUID/getRandomValues/digest/hmac, " +
+      "format.number/date/relativeTime/list, " +
+      "data.parseCsv(text, {delimiter, header}), data.selectHtml(html, selector, {attr, limit}), " +
+      "toBase64/fromBase64/toHex/fromHex. Await fetch, sleep, workspace, getSecret, format, " +
+      "data and crypto.digest/hmac; the rest are synchronous. " +
       "A persistent `state` object survives across streaming invocations. " +
       "Return an object — its keys become output handles."
   })


### PR DESCRIPTION
Extends the QuickJS JavaScript sandbox (`packages/agents/src/js-sandbox.ts`) — shared by `nodetool.code.Code`, `MiniJSAgentTool`/`RunCodeTool`, `ScriptRunner`, and the graph DSL evaluator — with eight approved capability additions, keeping the guest module-free and inside the existing `neverReject`/`guardAbort` bridge conventions.

## What's new in the guest

- **`crypto` bridge** — `randomUUID`, `getRandomValues` (≤64 KB), `digest`, `hmac` (SHA-1/256/384/512), backed by host WebCrypto (`globalThis.crypto`), so guest code can hash and sign without `node:crypto`.
- **Binary + richer workspace I/O** — `workspace.readBytes/writeBytes/stat/mkdir/remove`, all through the existing `resolveWorkspacePath` + symlink-containment guard; `remove` deletes one file or one empty directory, never a tree. The write-containment check now walks to the nearest existing ancestor so writes into new subdirectories work.
- **Base64/hex/utf8 helpers** — `toBase64`/`fromBase64` (base64url accepted)/`toHex`/`fromHex`/`utf8Encode`/`utf8Decode`, pure guest-side prelude code.
- **Fetch ergonomics** — `Uint8Array` request bodies sent as raw bytes (previously `JSON.stringify`'d); `bytes()`/`arrayBuffer()` now arrive in the guest as real binary; call cap and per-request timeout configurable.
- **Per-invocation limits** — `RunSandboxOptions.limits` (`maxFetchCalls`, `maxResponseBodyBytes`, `maxOutputSize`, `memoryLimitBytes`, `stackLimitBytes`, `fetchTimeoutMs`), clamped by `resolveSandboxLimits` to hard ceilings (512 MB heap, 10 MB output, 100 fetches, 50 MB body, 120 s fetch timeout) so callers can raise but not disable protection.
- **`progress(percent, message?)`** — clamped 0–100, message truncated to 500 chars, rate-limited to one forwarded call per 100 ms, ≤1000 per run. `CodeNode` forwards it to the kernel as `node_progress` messages, so long-running snippets show live progress in the UI.
- **`format` bridge** — `number`, `date`, `relativeTime`, `list`, backed by host `Intl` (QuickJS ships none); default locale `en-US`.
- **`data` bridge** — `parseCsv` (papaparse, header/no-header/custom delimiter, 5 MB cap) and `selectHtml` (cheerio, CSS selector → text or attribute values, limit 100 default / 1000 ceiling, 5 MB cap). Narrow host bridges rather than guest modules: the libraries never ship into the user-code surface.

## Host→guest binary convention

Probing showed a host `Uint8Array` returned through `expose` reaches the guest as a numeric-keyed plain object. Binary-producing bridges therefore return a tagged base64 object that the guest prelude revives into a real `Uint8Array` — now the documented pattern for any future binary bridge (and it fixes the pre-existing bug where `fetch(...).bytes()` wasn't a typed array in the guest).

## Bundling notes

papaparse and cheerio were already in the tree (`data-nodes`, `automation-nodes`); they're added as regular `packages/agents` dependencies and loaded via lazy `await import(...)` inside the bridges. esbuild inlines them into the packaged backend's `server.mjs` with correct nested resolution (staging cheerio into flat `_modules/` breaks on the `entities` major split — verified by `npm run backend:smoke`, which passes), and Vite puts cheerio's browser build in a lazy chunk so `selectHtml` also works in the browser runner.

## Docs

`js-sandbox.ts` header, `packages/agents/CLAUDE.md` § JavaScript Sandbox (surface + limits table), `CodeNode` description/prop docs, and the `js`/`run_code` tool descriptions all updated to the new surface.

## Testing

- `tests/js-sandbox.test.ts`: 62 → **120** (58 new, all pre-existing green)
- agents suite: **1705 passed** / 1 skipped (109 files); code-nodes: 247 passed / 6 skipped
- `turbo run build` for agents + code-nodes, `tsc --noEmit` both packages, web + electron typecheck, full web build (cheerio in a lazy chunk), `npm run backend:smoke` (packaged backend boots, `/health` OK), repo lint — all green. Mobile typecheck fails only on uninstalled Expo deps in this environment; the diff doesn't touch `mobile/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MKZcSUno1fke1D1XTodpq

---
_Generated by [Claude Code](https://claude.ai/code/session_012MKZcSUno1fke1D1XTodpq)_