### PR TITLE
fix: three defects that let a workflow fail or lie about succeeding

### DIFF
--- a/packages/base-nodes/nodetool/examples/nodetool-base/A Gradient Card as PNG.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/A Gradient Card as PNG.json
@@ -1,0 +1,178 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "A Gradient Card as PNG",
+  "tool_name": null,
+  "description": "Build vector art, then rasterise it. SVGToImage is the bridge: author resolution-independently, hand a PNG to anything that needs pixels.",
+  "tags": [
+    "image",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "g",
+        "type": "lib.svg.Gradient",
+        "data": {
+          "gradient_type": "linearGradient",
+          "x1": 0,
+          "y1": 0,
+          "x2": 100,
+          "y2": 100,
+          "color1": {
+            "type": "color",
+            "value": "#0ea5e9"
+          },
+          "color2": {
+            "type": "color",
+            "value": "#7c3aed"
+          }
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Gradient"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "r",
+        "type": "lib.svg.Rect",
+        "data": {
+          "x": 0,
+          "y": 0,
+          "width": 400,
+          "height": 240,
+          "fill": {
+            "type": "color",
+            "value": "#111827"
+          },
+          "stroke": {
+            "type": "color",
+            "value": "none"
+          },
+          "stroke_width": 1
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Card"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "l",
+        "type": "nodetool.constant.List",
+        "data": {
+          "value": []
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Collect"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "img",
+        "type": "lib.svg.SVGToImage",
+        "data": {
+          "elements": [],
+          "width": 400,
+          "height": 240,
+          "viewBox": "0 0 400 240",
+          "scale": 2
+        },
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Rasterise 2x"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "card"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "5  PNG"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "g",
+        "sourceHandle": "output",
+        "target": "l",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e2",
+        "source": "r",
+        "sourceHandle": "output",
+        "target": "l",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e3",
+        "source": "l",
+        "sourceHandle": "output",
+        "target": "img",
+        "targetHandle": "elements"
+      },
+      {
+        "id": "e4",
+        "source": "img",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Ad Creative Factory.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Ad Creative Factory.json
@@ -5,7 +5,7 @@
   "updated_at": "2026-07-01T00:00:00.000000",
   "name": "Ad Creative Factory",
   "tool_name": null,
-  "description": "Turn one product photo and one offer into a batch of ready-to-test vertical video ads. A strategist agent plans a persona × angle test matrix, a structured data generator emits one variant row per cell — persona, angle, and spoken hook as separate fields, not a prose blob — and every row's hook becomes a staged product scene, an animated 9:16 clip, and a voiceover mixed on top.",
+  "description": "Turn one product photo and one offer into a batch of ready-to-test vertical video ads. A strategist agent plans a persona \u00d7 angle test matrix, a structured data generator emits one variant row per cell \u2014 persona, angle, and spoken hook as separate fields, not a prose blob \u2014 and every row's hook becomes a staged product scene, an animated 9:16 clip, and a voiceover mixed on top.",
   "tags": [
     "marketing",
     "advertising",
@@ -288,7 +288,7 @@
         "id": "comment",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 🎯 Ad Creative Factory\n\nOne product photo and one offer become a batch of ready-to-test vertical video ads. A strategist agent builds a persona × angle test matrix, a structured data generator turns each matrix cell into a variant row — persona, angle, and spoken hook as three separate fields, not one prose blob — and every row's hook becomes a staged product scene, an animated 9:16 clip, and a voiceover mixed on top.\n\n**Pipeline:** Offer + Audience + Photo → Strategist → Variant rows (persona/angle/hook) → Product scenes → Image-to-Video → Voiceover → Finished ads\n\n**Try this:** pick the language, image, video, and TTS models, then raise the variant count or sharpen the audience — the test matrix adapts on the next run."
+          "comment": "# \ud83c\udfaf Ad Creative Factory\n\nOne product photo and one offer become a batch of ready-to-test vertical video ads. A strategist agent builds a persona \u00d7 angle test matrix, a structured data generator turns each matrix cell into a variant row \u2014 persona, angle, and spoken hook as three separate fields, not one prose blob \u2014 and every row's hook becomes a staged product scene, an animated 9:16 clip, and a voiceover mixed on top.\n\n**Pipeline:** Offer + Audience + Photo \u2192 Strategist \u2192 Variant rows (persona/angle/hook) \u2192 Product scenes \u2192 Image-to-Video \u2192 Voiceover \u2192 Finished ads\n\n**Try this:** pick the language, image, video, and TTS models, then raise the variant count or sharpen the audience \u2014 the test matrix adapts on the next run."
         },
         "ui_properties": {
           "position": {
@@ -309,7 +309,7 @@
         "type": "nodetool.input.StringInput",
         "data": {
           "name": "product_offer",
-          "value": "Aurora Trail smart fitness watch — launch-week offer: 20% off. GPS navigation, heart-rate analytics, adaptive coaching, water resistance.",
+          "value": "Aurora Trail smart fitness watch \u2014 launch-week offer: 20% off. GPS navigation, heart-rate analytics, adaptive coaching, water resistance.",
           "description": "The product and the offer the ads must sell"
         },
         "ui_properties": {
@@ -319,7 +319,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "1️⃣ Product & offer",
+          "title": "1\ufe0f\u20e3 Product & offer",
           "selectable": true,
           "bypassed": false
         },
@@ -341,7 +341,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "2️⃣ Audience",
+          "title": "2\ufe0f\u20e3 Audience",
           "selectable": true,
           "bypassed": false
         },
@@ -365,7 +365,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "3️⃣ Variant count",
+          "title": "3\ufe0f\u20e3 Variant count",
           "selectable": true,
           "bypassed": false
         },
@@ -384,7 +384,7 @@
             "data": null,
             "metadata": null
           },
-          "description": "One clean photo of the product — the same shot anchors every variant"
+          "description": "One clean photo of the product \u2014 the same shot anchors every variant"
         },
         "ui_properties": {
           "position": {
@@ -393,7 +393,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "4️⃣ Product photo",
+          "title": "4\ufe0f\u20e3 Product photo",
           "selectable": true,
           "bypassed": false
         },
@@ -404,7 +404,7 @@
         "id": "strategy_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "You are planning a paid-social creative test for the product in the attached photo.\n\nProduct and offer: {{ BRIEF }}\nAudience: {{ AUDIENCE }}\nVariants to produce: {{ COUNT }}\n\nReturn a creative test plan in Markdown, no commentary:\n\nPersonas: 2-3 buyer personas inside this audience — one line each on who they are and what they want.\nAngles: 3-4 message angles (pain point, bold claim, social proof, offer urgency) — one line each on why it could win.\nMatrix: the {{ COUNT }} strongest persona × angle pairings to test, one line each on what that ad must communicate.\nVisual world: 2-3 lines on settings, casting, and light that read native in a vertical feed — believable phone footage, not a studio ad."
+          "prompt": "You are planning a paid-social creative test for the product in the attached photo.\n\nProduct and offer: {{ BRIEF }}\nAudience: {{ AUDIENCE }}\nVariants to produce: {{ COUNT }}\n\nReturn a creative test plan in Markdown, no commentary:\n\nPersonas: 2-3 buyer personas inside this audience \u2014 one line each on who they are and what they want.\nAngles: 3-4 message angles (pain point, bold claim, social proof, offer urgency) \u2014 one line each on why it could win.\nMatrix: the {{ COUNT }} strongest persona \u00d7 angle pairings to test, one line each on what that ad must communicate.\nVisual world: 2-3 lines on settings, casting, and light that read native in a vertical feed \u2014 believable phone footage, not a studio ad."
         },
         "ui_properties": {
           "position": {
@@ -419,7 +419,7 @@
           "bypassed": false
         },
         "dynamic_properties": {
-          "BRIEF": "Aurora Trail smart fitness watch — launch-week offer: 20% off. GPS navigation, heart-rate analytics, adaptive coaching, water resistance.",
+          "BRIEF": "Aurora Trail smart fitness watch \u2014 launch-week offer: 20% off. GPS navigation, heart-rate analytics, adaptive coaching, water resistance.",
           "AUDIENCE": "active millennials who hike on weekends and scroll fitness content at night",
           "COUNT": "6"
         },
@@ -463,7 +463,7 @@
           "zIndex": 0,
           "width": 330,
           "height": 350,
-          "title": "5️⃣ Plan the test matrix",
+          "title": "5\ufe0f\u20e3 Plan the test matrix",
           "selectable": true,
           "bypassed": false
         },
@@ -474,7 +474,7 @@
         "id": "hooks_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "From this creative test plan, generate exactly {{ COUNT }} ad variant rows — one row per matrix pairing. Fill every field for every row:\n\n- persona: the buyer persona this variant targets, in 3-6 words (e.g. \"weekend trail hiker\").\n- angle: the message angle it plays — pain point, bold claim, social proof, or offer urgency — in 3-6 words.\n- hook: the spoken line for this variant. 18 words or fewer, written to be said aloud in the first three seconds of a vertical video ad. Plain spoken language for {{ AUDIENCE }}. No hashtags, no emoji, no brand-speak. Lands one concrete benefit or the offer — never a vague promise.\n\nPlan:\n{{ PLAN }}"
+          "prompt": "From this creative test plan, generate exactly {{ COUNT }} ad variant rows \u2014 one row per matrix pairing. Fill every field for every row:\n\n- persona: the buyer persona this variant targets, in 3-6 words (e.g. \"weekend trail hiker\").\n- angle: the message angle it plays \u2014 pain point, bold claim, social proof, or offer urgency \u2014 in 3-6 words.\n- hook: the spoken line for this variant. 18 words or fewer, written to be said aloud in the first three seconds of a vertical video ad. Plain spoken language for {{ AUDIENCE }}. No hashtags, no emoji, no brand-speak. Lands one concrete benefit or the offer \u2014 never a vague promise.\n\nPlan:\n{{ PLAN }}"
         },
         "ui_properties": {
           "position": {
@@ -537,7 +537,7 @@
           "zIndex": 0,
           "width": 330,
           "height": 260,
-          "title": "6️⃣ Generate variant rows",
+          "title": "6\ufe0f\u20e3 Generate variant rows",
           "selectable": true,
           "bypassed": false
         },
@@ -558,7 +558,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 200,
-          "title": "📋 Variant table (persona / angle / hook)",
+          "title": "\ud83d\udccb Variant table (persona / angle / hook)",
           "selectable": true,
           "bypassed": false
         },
@@ -607,7 +607,7 @@
         "id": "scene_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "One vertical 9:16 paid-social ad still, built from the input product photo.\n\nSpoken hook this scene must visualize: {{ HOOK }}\nProduct and offer: {{ BRIEF }}\nAudience: {{ AUDIENCE }}\n\nKeep the product from the input photo as the unmistakable hero, placed naturally in a real scene from the hook's world. Native UGC aesthetic: believable location, natural light, shallow depth of field, casual framing — shot-on-a-phone energy, not a studio render. Keep the upper third calm for caption text. No on-screen text, no logos, no watermarks, no distorted anatomy."
+          "prompt": "One vertical 9:16 paid-social ad still, built from the input product photo.\n\nSpoken hook this scene must visualize: {{ HOOK }}\nProduct and offer: {{ BRIEF }}\nAudience: {{ AUDIENCE }}\n\nKeep the product from the input photo as the unmistakable hero, placed naturally in a real scene from the hook's world. Native UGC aesthetic: believable location, natural light, shallow depth of field, casual framing \u2014 shot-on-a-phone energy, not a studio render. Keep the upper third calm for caption text. No on-screen text, no logos, no watermarks, no distorted anatomy."
         },
         "ui_properties": {
           "position": {
@@ -623,7 +623,7 @@
         },
         "dynamic_properties": {
           "HOOK": "",
-          "BRIEF": "Aurora Trail smart fitness watch — launch-week offer: 20% off. GPS navigation, heart-rate analytics, adaptive coaching, water resistance.",
+          "BRIEF": "Aurora Trail smart fitness watch \u2014 launch-week offer: 20% off. GPS navigation, heart-rate analytics, adaptive coaching, water resistance.",
           "AUDIENCE": "active millennials who hike on weekends and scroll fitness content at night"
         },
         "dynamic_outputs": {}
@@ -634,7 +634,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -654,7 +654,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 340,
-          "title": "7️⃣ Stage the product shot",
+          "title": "7\ufe0f\u20e3 Stage the product shot",
           "selectable": true,
           "bypassed": false
         },
@@ -665,7 +665,7 @@
         "id": "motion_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "Animate this product ad still as a short vertical video. The hook spoken over it: {{ HOOK }}\n\nOne subtle handheld push-in toward the product with gentle parallax and one small believable motion in the scene — steam, breeze, hands, passing light. Natural lighting shift, product stays sharp and centered. No cuts, no zoom bursts, no on-screen text, no morphing."
+          "prompt": "Animate this product ad still as a short vertical video. The hook spoken over it: {{ HOOK }}\n\nOne subtle handheld push-in toward the product with gentle parallax and one small believable motion in the scene \u2014 steam, breeze, hands, passing light. Natural lighting shift, product stays sharp and centered. No cuts, no zoom bursts, no on-screen text, no morphing."
         },
         "ui_properties": {
           "position": {
@@ -710,7 +710,7 @@
           "zIndex": 0,
           "width": 330,
           "height": 240,
-          "title": "8️⃣ Animate the ad",
+          "title": "8\ufe0f\u20e3 Animate the ad",
           "selectable": true,
           "bypassed": false
         },
@@ -747,7 +747,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 220,
-          "title": "9️⃣ Voice the hook",
+          "title": "9\ufe0f\u20e3 Voice the hook",
           "selectable": true,
           "bypassed": false
         },
@@ -769,7 +769,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 240,
-          "title": "🔊 Mix voiceover",
+          "title": "\ud83d\udd0a Mix voiceover",
           "selectable": true,
           "bypassed": false
         },
@@ -790,7 +790,7 @@
           "zIndex": 0,
           "width": 360,
           "height": 420,
-          "title": "🎯 Finished ads",
+          "title": "\ud83c\udfaf Finished ads",
           "selectable": true,
           "bypassed": false
         },

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Audio To Image.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Audio To Image.json
@@ -5,7 +5,7 @@
   "updated_at": "2026-06-22T12:00:00.000Z",
   "name": "Audio To Image",
   "tool_name": null,
-  "description": "Speak an image into existence: no keyboard needed. Whisper transcribes your audio, then FLUX renders the description as an image — the whole pipeline runs from a single voice note.",
+  "description": "Speak an image into existence: no keyboard needed. Whisper transcribes your audio, then FLUX renders the description as an image \u2014 the whole pipeline runs from a single voice note.",
   "tags": [
     "huggingface",
     "multimodal",
@@ -53,7 +53,7 @@
         "parent_id": null,
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 🎙️ Audio To Image\n\nSpeak a description and watch it become an image. Whisper transcribes your audio, then a text-to-image model renders it.\n\n**Pipeline:** Audio → Whisper → Text-to-Image\n\n**Try this:** swap the ASR or image model, or change aspect ratio / resolution."
+          "comment": "# \ud83c\udf99\ufe0f Audio To Image\n\nSpeak a description and watch it become an image. Whisper transcribes your audio, then a text-to-image model renders it.\n\n**Pipeline:** Audio \u2192 Whisper \u2192 Text-to-Image\n\n**Try this:** swap the ASR or image model, or change aspect ratio / resolution."
         },
         "ui_properties": {
           "selected": false,
@@ -82,7 +82,7 @@
           }
         },
         "ui_properties": {
-          "title": "1️⃣ Record audio",
+          "title": "1\ufe0f\u20e3 Record audio",
           "selected": false,
           "position": {
             "x": 65,
@@ -109,7 +109,7 @@
           }
         },
         "ui_properties": {
-          "title": "2️⃣ Transcribe",
+          "title": "2\ufe0f\u20e3 Transcribe",
           "selected": false,
           "position": {
             "x": 340,
@@ -129,7 +129,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -141,7 +141,7 @@
           "timeout_seconds": 0
         },
         "ui_properties": {
-          "title": "3️⃣ Generate image",
+          "title": "3\ufe0f\u20e3 Generate image",
           "selected": false,
           "position": {
             "x": 650,

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Brand Asset Generator.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Brand Asset Generator.json
@@ -5,7 +5,7 @@
   "updated_at": "2026-06-22T12:00:00.000Z",
   "name": "Brand Asset Generator",
   "tool_name": null,
-  "description": "Turn a brand name and vibe into a whole social kit in one run: the graph fans out to two branches at once — a streamed gallery of four on-brand, text-overlaid social images (Instagram, LinkedIn, X, product launch) and a one-page brand brief (voice, palette, tagline options). Differentiator: structured multi-asset outputs from a single fan-out graph. Uses fal-ai flux/schnell for images (paid) and gpt-5-mini for text.",
+  "description": "Turn a brand name and vibe into a whole social kit in one run: the graph fans out to two branches at once \u2014 a streamed gallery of four on-brand, text-overlaid social images (Instagram, LinkedIn, X, product launch) and a one-page brand brief (voice, palette, tagline options). Differentiator: structured multi-asset outputs from a single fan-out graph. Uses fal-ai flux/schnell for images (paid) and gpt-5-mini for text.",
   "tags": [
     "brand-asset",
     "branding",
@@ -135,7 +135,7 @@
         "id": "comment-intro",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 🏷️ Brand Asset Generator\n\nFrom a brand name + vibe, produce a full social kit in one run.\n\n**Two branches fan out from the same inputs:**\n- **Images** → an art director writes 4 prompts, each rendered, stamped with the brand name (in your color) and tagline, then collected into a gallery.\n- **Brief** → a strategist writes a one-page brand guideline (voice, palette, taglines).\n\n**Try this:** change the brand color or edit the two prompt templates to shift the whole kit."
+          "comment": "# \ud83c\udff7\ufe0f Brand Asset Generator\n\nFrom a brand name + vibe, produce a full social kit in one run.\n\n**Two branches fan out from the same inputs:**\n- **Images** \u2192 an art director writes 4 prompts, each rendered, stamped with the brand name (in your color) and tagline, then collected into a gallery.\n- **Brief** \u2192 a strategist writes a one-page brand guideline (voice, palette, taglines).\n\n**Try this:** change the brand color or edit the two prompt templates to shift the whole kit."
         },
         "ui_properties": {
           "selected": false,
@@ -169,7 +169,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "1️⃣ Brand name"
+          "title": "1\ufe0f\u20e3 Brand name"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -191,7 +191,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "2️⃣ Brand vibe"
+          "title": "2\ufe0f\u20e3 Brand vibe"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -213,7 +213,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "3️⃣ Tagline"
+          "title": "3\ufe0f\u20e3 Tagline"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -238,7 +238,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "4️⃣ Brand color"
+          "title": "4\ufe0f\u20e3 Brand color"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -258,7 +258,7 @@
           "width": 300,
           "selectable": true,
           "bypassed": false,
-          "title": "5️⃣ Write image prompts"
+          "title": "5\ufe0f\u20e3 Write image prompts"
         },
         "dynamic_properties": {
           "brand_name": "Aurora Labs",
@@ -290,7 +290,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "6️⃣ Split into 4 prompts"
+          "title": "6\ufe0f\u20e3 Split into 4 prompts"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -301,7 +301,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -324,7 +324,7 @@
           "width": 360,
           "selectable": true,
           "bypassed": false,
-          "title": "7️⃣ Render each image",
+          "title": "7\ufe0f\u20e3 Render each image",
           "height": 400
         },
         "dynamic_properties": {},
@@ -359,7 +359,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "8️⃣ Stamp brand name"
+          "title": "8\ufe0f\u20e3 Stamp brand name"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -393,7 +393,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "9️⃣ Overlay tagline"
+          "title": "9\ufe0f\u20e3 Overlay tagline"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -413,7 +413,7 @@
           "width": 240,
           "selectable": true,
           "bypassed": false,
-          "title": "🔟 Collect gallery"
+          "title": "\ud83d\udd1f Collect gallery"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -436,7 +436,7 @@
         "id": "prompt_brief",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "Write a one-page brand brief for the brand below.\n\nBRAND\nName: {{ brand_name }}\nPositioning: {{ brand_description }}\nWorking tagline: {{ tagline }}\n\nProduce Markdown with exactly these sections:\n- **Voice & tone** — 3 adjectives, then one sentence on how the brand speaks.\n- **Color palette** — a primary color plus 2 complementary colors as hex codes, each with a one-line usage note.\n- **Tagline options** — 3 alternatives to the working tagline, in the brand's voice.\n- **Do / Don't** — 2 bullets each, covering visuals and copy.\n\nKeep the whole brief under 200 words. Output only the Markdown, with no preamble."
+          "prompt": "Write a one-page brand brief for the brand below.\n\nBRAND\nName: {{ brand_name }}\nPositioning: {{ brand_description }}\nWorking tagline: {{ tagline }}\n\nProduce Markdown with exactly these sections:\n- **Voice & tone** \u2014 3 adjectives, then one sentence on how the brand speaks.\n- **Color palette** \u2014 a primary color plus 2 complementary colors as hex codes, each with a one-line usage note.\n- **Tagline options** \u2014 3 alternatives to the working tagline, in the brand's voice.\n- **Do / Don't** \u2014 2 bullets each, covering visuals and copy.\n\nKeep the whole brief under 200 words. Output only the Markdown, with no preamble."
         },
         "ui_properties": {
           "position": {
@@ -447,7 +447,7 @@
           "width": 300,
           "selectable": true,
           "bypassed": false,
-          "title": "5️⃣ Write brief prompt"
+          "title": "5\ufe0f\u20e3 Write brief prompt"
         },
         "dynamic_properties": {
           "brand_name": "Aurora Labs",
@@ -496,7 +496,7 @@
           "width": 300,
           "selectable": true,
           "bypassed": false,
-          "title": "6️⃣ Draft brand brief",
+          "title": "6\ufe0f\u20e3 Draft brand brief",
           "height": 300
         },
         "dynamic_properties": {},

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Circles and Lines.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Circles and Lines.json
@@ -1,0 +1,210 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Circles and Lines",
+  "tool_name": null,
+  "description": "The remaining SVG primitives in one document \u2014 circle, ellipse and line \u2014 so the shape vocabulary is visible in one place.",
+  "tags": [
+    "image",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "c",
+        "type": "lib.svg.Circle",
+        "data": {
+          "cx": 80,
+          "cy": 80,
+          "radius": 50,
+          "fill": {
+            "type": "color",
+            "value": "#ef4444"
+          },
+          "stroke": {
+            "type": "color",
+            "value": "none"
+          },
+          "stroke_width": 1
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Circle"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "e",
+        "type": "lib.svg.Ellipse",
+        "data": {
+          "cx": 220,
+          "cy": 80,
+          "rx": 70,
+          "ry": 40,
+          "fill": {
+            "type": "color",
+            "value": "#22c55e"
+          },
+          "stroke": {
+            "type": "color",
+            "value": "none"
+          },
+          "stroke_width": 1
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Ellipse"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "ln",
+        "type": "lib.svg.Line",
+        "data": {
+          "x1": 20,
+          "y1": 150,
+          "x2": 280,
+          "y2": 150,
+          "stroke": {
+            "type": "color",
+            "value": "#111827"
+          },
+          "stroke_width": 4
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Rule"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "l",
+        "type": "nodetool.constant.List",
+        "data": {
+          "value": []
+        },
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Collect"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "doc",
+        "type": "lib.svg.Document",
+        "data": {
+          "elements": [],
+          "width": 300,
+          "height": 180,
+          "viewBox": "0 0 300 180"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "5  Document"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "shapes"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "6  SVG"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "c",
+        "sourceHandle": "output",
+        "target": "l",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e2",
+        "source": "e",
+        "sourceHandle": "output",
+        "target": "l",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e3",
+        "source": "ln",
+        "sourceHandle": "output",
+        "target": "l",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e4",
+        "source": "l",
+        "sourceHandle": "output",
+        "target": "doc",
+        "targetHandle": "elements"
+      },
+      {
+        "id": "e5",
+        "source": "doc",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Concept Art Iteration Board.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Concept Art Iteration Board.json
@@ -128,7 +128,7 @@
         "id": "comment-intro",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 🖼️ Concept Art Iteration Board\n\nOne brief becomes a gallery of on-brief concept-art variations — the thing a single image prompt can't do.\n\n**Why the graph:** an agent first commits to a coherent art direction, so every variation shares one visual language instead of drifting. The list generator then writes N distinct prompts from that direction, and each one streams into the image node — so the output fills up as a variant gallery rather than a single picture.\n\n**Pipeline:** Brief + Style + Mood → Art-director agent → N prompts → Text-to-Image (one per prompt) → gallery\n\n**Try this:** change Style or Mood for a whole new look, or bump Variations to compare more options in one run."
+          "comment": "# \ud83d\uddbc\ufe0f Concept Art Iteration Board\n\nOne brief becomes a gallery of on-brief concept-art variations \u2014 the thing a single image prompt can't do.\n\n**Why the graph:** an agent first commits to a coherent art direction, so every variation shares one visual language instead of drifting. The list generator then writes N distinct prompts from that direction, and each one streams into the image node \u2014 so the output fills up as a variant gallery rather than a single picture.\n\n**Pipeline:** Brief + Style + Mood \u2192 Art-director agent \u2192 N prompts \u2192 Text-to-Image (one per prompt) \u2192 gallery\n\n**Try this:** change Style or Mood for a whole new look, or bump Variations to compare more options in one run."
         },
         "ui_properties": {
           "position": {
@@ -150,7 +150,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -172,7 +172,7 @@
           "zIndex": 0,
           "width": 461,
           "height": 489,
-          "title": "9️⃣ Render each variation",
+          "title": "9\ufe0f\u20e3 Render each variation",
           "selectable": true,
           "bypassed": false,
           "selected_generation": "8200a9c8-6d27-4298-9e02-19b2df7abfa0"
@@ -203,7 +203,7 @@
           "zIndex": 0,
           "width": 390,
           "height": 292,
-          "title": "8️⃣ Generate prompt list",
+          "title": "8\ufe0f\u20e3 Generate prompt list",
           "selectable": true,
           "bypassed": false
         },
@@ -222,7 +222,7 @@
             "path": null,
             "supported_tasks": []
           },
-          "system": "You are a senior concept-art director for games and film. You translate a creative brief into precise, evocative art direction a concept artist can execute immediately. Commit to concrete choices — name colors, framings, and shapes rather than hedging with vague adjectives. Keep the whole direction internally consistent so every downstream variation reads as one coherent world.",
+          "system": "You are a senior concept-art director for games and film. You translate a creative brief into precise, evocative art direction a concept artist can execute immediately. Commit to concrete choices \u2014 name colors, framings, and shapes rather than hedging with vague adjectives. Keep the whole direction internally consistent so every downstream variation reads as one coherent world.",
           "image": {
             "type": "image",
             "uri": "",
@@ -249,7 +249,7 @@
           "zIndex": 0,
           "width": 319,
           "height": 207,
-          "title": "6️⃣ Art-director agent",
+          "title": "6\ufe0f\u20e3 Art-director agent",
           "selectable": true,
           "bypassed": false
         },
@@ -272,7 +272,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "1️⃣ Brief",
+          "title": "1\ufe0f\u20e3 Brief",
           "selectable": true,
           "bypassed": false
         },
@@ -294,7 +294,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "2️⃣ Style",
+          "title": "2\ufe0f\u20e3 Style",
           "selectable": true,
           "bypassed": false
         },
@@ -316,7 +316,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "3️⃣ Mood",
+          "title": "3\ufe0f\u20e3 Mood",
           "selectable": true,
           "bypassed": false
         },
@@ -342,7 +342,7 @@
           "zIndex": 0,
           "width": 418,
           "height": 563,
-          "title": "7️⃣ Write variation prompts",
+          "title": "7\ufe0f\u20e3 Write variation prompts",
           "selectable": true,
           "bypassed": false
         },
@@ -356,7 +356,7 @@
         "id": "77560ab1-75f1-4208-aa4f-66732f56e22b",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "Creative brief: {{ brief }}\nArt style: {{ style }}\nMood: {{ mood }}\n\nTask: turn the brief above into a concrete art-direction brief a concept artist could execute without asking a single follow-up question. Interpret the brief — do not restate it.\n\nCover each of these, one tight paragraph each, in order:\n1. Composition and camera framing\n2. Color palette — name 4–6 specific colors and where they fall\n3. Key design elements, silhouette, and shape language\n4. Lighting and atmosphere that carry the mood\n\nWrite in vivid, specific visual language. No preamble, no headings beyond the four numbered points.",
+          "prompt": "Creative brief: {{ brief }}\nArt style: {{ style }}\nMood: {{ mood }}\n\nTask: turn the brief above into a concrete art-direction brief a concept artist could execute without asking a single follow-up question. Interpret the brief \u2014 do not restate it.\n\nCover each of these, one tight paragraph each, in order:\n1. Composition and camera framing\n2. Color palette \u2014 name 4\u20136 specific colors and where they fall\n3. Key design elements, silhouette, and shape language\n4. Lighting and atmosphere that carry the mood\n\nWrite in vivid, specific visual language. No preamble, no headings beyond the four numbered points.",
           "dynamic_properties": {
             "brief": "An ancient forest guardian: a towering tree-spirit, bark-skinned and moss-cloaked, watching over an enchanted grove. Fantasy RPG character concept.",
             "style": "Painterly digital concept art, dramatic cinematic lighting, rich saturated color, visible brushwork, AAA game key art",
@@ -372,7 +372,7 @@
           "zIndex": 0,
           "width": 377,
           "height": 571,
-          "title": "5️⃣ Build art-direction brief",
+          "title": "5\ufe0f\u20e3 Build art-direction brief",
           "selectable": true,
           "bypassed": false
         },
@@ -420,7 +420,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "4️⃣ Variations",
+          "title": "4\ufe0f\u20e3 Variations",
           "selectable": true,
           "bypassed": false
         },

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Directed Film to Timeline.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Directed Film to Timeline.json
@@ -114,7 +114,7 @@
         "id": "comment_main",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 🎬 Directed Film to Timeline\n\nA brief becomes an editable rough cut in one graph:\n\n**1. Direct** — the Director agent turns your brief into a typed screenplay (shots with action, camera, and a shared style bible).\n**2. Fan out** — Screenplay Shots streams one composed prompt per shot.\n**3. Storyboard** — each prompt renders a keyframe still.\n**4. Shoot** — each keyframe is animated into a clip.\n**5. Assemble** — clips are collected, appended to a timeline sequence, and rendered to a single video.\n\nThe rendered timeline is a real editable sequence — reopen it in the timeline editor to trim, reorder, or add audio."
+          "comment": "# \ud83c\udfac Directed Film to Timeline\n\nA brief becomes an editable rough cut in one graph:\n\n**1. Direct** \u2014 the Director agent turns your brief into a typed screenplay (shots with action, camera, and a shared style bible).\n**2. Fan out** \u2014 Screenplay Shots streams one composed prompt per shot.\n**3. Storyboard** \u2014 each prompt renders a keyframe still.\n**4. Shoot** \u2014 each keyframe is animated into a clip.\n**5. Assemble** \u2014 clips are collected, appended to a timeline sequence, and rendered to a single video.\n\nThe rendered timeline is a real editable sequence \u2014 reopen it in the timeline editor to trim, reorder, or add audio."
         },
         "ui_properties": {
           "position": {
@@ -135,7 +135,7 @@
         "type": "nodetool.input.StringInput",
         "data": {
           "name": "Brief",
-          "value": "A lighthouse keeper discovers the beam of her lamp has started bending toward something beneath the waves — and tonight it refuses to point anywhere else."
+          "value": "A lighthouse keeper discovers the beam of her lamp has started bending toward something beneath the waves \u2014 and tonight it refuses to point anywhere else."
         },
         "ui_properties": {
           "position": {
@@ -144,7 +144,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "1️⃣ Brief",
+          "title": "1\ufe0f\u20e3 Brief",
           "selectable": true,
           "bypassed": false
         },
@@ -177,7 +177,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 320,
-          "title": "2️⃣ Director — write the screenplay",
+          "title": "2\ufe0f\u20e3 Director \u2014 write the screenplay",
           "selectable": true,
           "bypassed": false
         },
@@ -196,7 +196,7 @@
           "zIndex": 0,
           "width": 280,
           "height": 200,
-          "title": "3️⃣ Fan out one prompt per shot",
+          "title": "3\ufe0f\u20e3 Fan out one prompt per shot",
           "selectable": true,
           "bypassed": false
         },
@@ -209,7 +209,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -229,7 +229,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 320,
-          "title": "4️⃣ Storyboard keyframes",
+          "title": "4\ufe0f\u20e3 Storyboard keyframes",
           "selectable": true,
           "bypassed": false
         },
@@ -263,7 +263,7 @@
           "zIndex": 0,
           "width": 330,
           "height": 240,
-          "title": "5️⃣ Animate each shot",
+          "title": "5\ufe0f\u20e3 Animate each shot",
           "selectable": true,
           "bypassed": false
         },
@@ -282,7 +282,7 @@
           "zIndex": 0,
           "width": 160,
           "height": 140,
-          "title": "6️⃣ Collect the clips",
+          "title": "6\ufe0f\u20e3 Collect the clips",
           "selectable": true,
           "bypassed": false
         },
@@ -309,7 +309,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 220,
-          "title": "7️⃣ Assemble into a timeline",
+          "title": "7\ufe0f\u20e3 Assemble into a timeline",
           "selectable": true,
           "bypassed": false
         },
@@ -335,7 +335,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 200,
-          "title": "8️⃣ Render the rough cut",
+          "title": "8\ufe0f\u20e3 Render the rough cut",
           "selectable": true,
           "bypassed": false
         },
@@ -353,7 +353,7 @@
             "x": 2830,
             "y": 180
           },
-          "title": "🎬 Rough cut",
+          "title": "\ud83c\udfac Rough cut",
           "selectable": true
         },
         "dynamic_properties": {},

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Does This Text Mention the Deadline.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Does This Text Mention the Deadline.json
@@ -1,0 +1,100 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Does This Text Mention the Deadline",
+  "tool_name": null,
+  "description": "A containment check returning a boolean \u2014 the branch condition for a workflow that routes on what a document says.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "s",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "Submissions close on the 14th; late entries are not reviewed."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Text"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "c",
+        "type": "nodetool.text.Contains",
+        "data": {
+          "text": "",
+          "substring": "close",
+          "case_sensitive": false
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Contains 'close'"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "mentions"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Boolean"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "s",
+        "sourceHandle": "output",
+        "target": "c",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "c",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Draw a Badge in SVG.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Draw a Badge in SVG.json
@@ -1,0 +1,174 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Draw a Badge in SVG",
+  "tool_name": null,
+  "description": "Compose a badge from primitives rather than generating one. Every shape is an element you can reposition or recolour later \u2014 no regeneration, no resampling.",
+  "tags": [
+    "image",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "r",
+        "type": "lib.svg.Rect",
+        "data": {
+          "x": 20,
+          "y": 20,
+          "width": 260,
+          "height": 120,
+          "fill": {
+            "type": "color",
+            "value": "#1d4ed8"
+          },
+          "stroke": {
+            "type": "color",
+            "value": "none"
+          },
+          "stroke_width": 1
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Plate"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "t",
+        "type": "lib.svg.Text",
+        "data": {
+          "text": "SHIPPED",
+          "x": 150,
+          "y": 95,
+          "font_family": "Arial",
+          "font_size": 42,
+          "fill": {
+            "type": "color",
+            "value": "#ffffff"
+          },
+          "text_anchor": "middle"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Label"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "l",
+        "type": "nodetool.constant.List",
+        "data": {
+          "value": []
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Collect"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "doc",
+        "type": "lib.svg.Document",
+        "data": {
+          "elements": [],
+          "width": 300,
+          "height": 160,
+          "viewBox": "0 0 300 160"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Document"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "badge"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "5  SVG"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "r",
+        "sourceHandle": "output",
+        "target": "l",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e2",
+        "source": "t",
+        "sourceHandle": "output",
+        "target": "l",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e3",
+        "source": "l",
+        "sourceHandle": "output",
+        "target": "doc",
+        "targetHandle": "elements"
+      },
+      {
+        "id": "e4",
+        "source": "doc",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Find Every Number in a Sentence.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Find Every Number in a Sentence.json
@@ -1,0 +1,99 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Find Every Number in a Sentence",
+  "tool_name": null,
+  "description": "FindAllRegex returns each match rather than the first, which is what you want when pulling figures out of a report.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "s",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "Revenue rose from 12 to 47 across 3 regions."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Sentence"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "fa",
+        "type": "nodetool.text.FindAllRegex",
+        "data": {
+          "text": "",
+          "regex": "\\d+"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Find all digits"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "numbers"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Matches"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "s",
+        "sourceHandle": "output",
+        "target": "fa",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "fa",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Generate then Upscale a Poster.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Generate then Upscale a Poster.json
@@ -1,0 +1,145 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Generate then Upscale a Poster",
+  "tool_name": null,
+  "description": "Generate small and cheap, then pay for resolution only on the frame you keep. Iterating at 1K and upscaling once at the end costs a fraction of generating every draft at full size.",
+  "tags": [
+    "image",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "p",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "a retro travel poster of a volcanic coastline, screenprint texture"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Prompt"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "gen",
+        "type": "nodetool.image.TextToImage",
+        "data": {
+          "model": {
+            "type": "image_model",
+            "provider": "fal_ai",
+            "id": "fal-ai/flux/schnell",
+            "name": "FLUX.1 Schnell",
+            "path": null,
+            "supported_tasks": []
+          },
+          "prompt": "",
+          "negative_prompt": "",
+          "entities": [],
+          "aspect_ratio": "3:4",
+          "resolution": "1K"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Draft"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "up",
+        "type": "nodetool.image.Upscale",
+        "data": {
+          "model": {
+            "type": "image_model",
+            "provider": "fal_ai",
+            "id": "fal-ai/clarity-upscaler",
+            "name": "Clarity Upscaler",
+            "path": null,
+            "supported_tasks": []
+          },
+          "scale": 2,
+          "prompt": ""
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Upscale 2x"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "poster"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Poster"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "p",
+        "sourceHandle": "output",
+        "target": "gen",
+        "targetHandle": "prompt"
+      },
+      {
+        "id": "e2",
+        "source": "gen",
+        "sourceHandle": "output",
+        "target": "up",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e3",
+        "source": "up",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Hook & Thumbnail Factory.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Hook & Thumbnail Factory.json
@@ -5,7 +5,7 @@
   "updated_at": "2026-07-17T12:00:00.000Z",
   "name": "Hook & Thumbnail Factory",
   "tool_name": null,
-  "description": "One video topic in, a full thumbnail pack out: scroll-stopping hook lines plus a color-graded, ready-to-post thumbnail for each. The differentiator is the fan-out — one hook stream drives a whole gallery of matching images in a single run. Uses fal-ai/flux/schnell (cheap, fast).",
+  "description": "One video topic in, a full thumbnail pack out: scroll-stopping hook lines plus a color-graded, ready-to-post thumbnail for each. The differentiator is the fan-out \u2014 one hook stream drives a whole gallery of matching images in a single run. Uses fal-ai/flux/schnell (cheap, fast).",
   "tags": [
     "image",
     "content",
@@ -155,7 +155,7 @@
         "id": "comment-intro",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 🎬 Hook & Thumbnail Factory\n\nGive a video topic and audience. The graph writes scroll-stopping hook lines and, for **each** hook, generates a matching thumbnail — color-graded for punch and collected into a gallery. A whole thumbnail pack from one run.\n\n**Why a graph, not a chat box:** the hook stream fans out. `List Generator` emits one hook at a time; each hook flows through its own prompt → image → color-grade branch, so N hooks become N finished thumbnails in parallel. A chat box can list hooks; it can't hand you the images.\n\n**Pipeline:** Topic + audience + count → hook brief → List Generator (streams hooks) → per-hook thumbnail prompt → Text-to-Image → color grade → collect gallery\n\n**Try this:** change the topic, audience, or number of hooks; tweak the thumbnail style in the prompt. Pick a text model on the List Generator and an image model on Text-to-Image first."
+          "comment": "# \ud83c\udfac Hook & Thumbnail Factory\n\nGive a video topic and audience. The graph writes scroll-stopping hook lines and, for **each** hook, generates a matching thumbnail \u2014 color-graded for punch and collected into a gallery. A whole thumbnail pack from one run.\n\n**Why a graph, not a chat box:** the hook stream fans out. `List Generator` emits one hook at a time; each hook flows through its own prompt \u2192 image \u2192 color-grade branch, so N hooks become N finished thumbnails in parallel. A chat box can list hooks; it can't hand you the images.\n\n**Pipeline:** Topic + audience + count \u2192 hook brief \u2192 List Generator (streams hooks) \u2192 per-hook thumbnail prompt \u2192 Text-to-Image \u2192 color grade \u2192 collect gallery\n\n**Try this:** change the topic, audience, or number of hooks; tweak the thumbnail style in the prompt. Pick a text model on the List Generator and an image model on Text-to-Image first."
         },
         "ui_properties": {
           "selected": false,
@@ -188,7 +188,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "1️⃣ Video topic",
+          "title": "1\ufe0f\u20e3 Video topic",
           "selectable": true,
           "bypassed": false
         },
@@ -200,7 +200,7 @@
         "type": "nodetool.input.StringInput",
         "data": {
           "name": "Target Audience",
-          "description": "Who you are making it for — shapes tone and references.",
+          "description": "Who you are making it for \u2014 shapes tone and references.",
           "value": "Gen Z just starting to invest"
         },
         "ui_properties": {
@@ -211,7 +211,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "2️⃣ Target audience",
+          "title": "2\ufe0f\u20e3 Target audience",
           "selectable": true,
           "bypassed": false
         },
@@ -236,7 +236,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "3️⃣ How many hooks",
+          "title": "3\ufe0f\u20e3 How many hooks",
           "selectable": true,
           "bypassed": false
         },
@@ -258,7 +258,7 @@
           "zIndex": 0,
           "width": 340,
           "height": 460,
-          "title": "4️⃣ Build hook brief",
+          "title": "4\ufe0f\u20e3 Build hook brief",
           "selectable": true,
           "bypassed": false
         },
@@ -292,7 +292,7 @@
           "zIndex": 0,
           "width": 360,
           "height": 420,
-          "title": "5️⃣ Stream hooks",
+          "title": "5\ufe0f\u20e3 Stream hooks",
           "selectable": true,
           "bypassed": false
         },
@@ -314,7 +314,7 @@
           "zIndex": 0,
           "width": 340,
           "height": 460,
-          "title": "6️⃣ Build thumbnail prompt",
+          "title": "6\ufe0f\u20e3 Build thumbnail prompt",
           "selectable": true,
           "bypassed": false
         },
@@ -330,7 +330,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -350,7 +350,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 360,
-          "title": "7️⃣ Generate thumbnail",
+          "title": "7\ufe0f\u20e3 Generate thumbnail",
           "selectable": true,
           "bypassed": false
         },
@@ -372,7 +372,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "8️⃣ Color grade for punch",
+          "title": "8\ufe0f\u20e3 Color grade for punch",
           "selectable": true,
           "bypassed": false
         },
@@ -393,7 +393,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "9️⃣ Collect gallery",
+          "title": "9\ufe0f\u20e3 Collect gallery",
           "selectable": true,
           "bypassed": false
         },
@@ -414,7 +414,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "🖼️ Thumbnail gallery",
+          "title": "\ud83d\uddbc\ufe0f Thumbnail gallery",
           "selectable": true,
           "bypassed": false
         },
@@ -436,7 +436,7 @@
           "zIndex": 0,
           "width": 360,
           "height": 300,
-          "title": "🪝 Hook ideas",
+          "title": "\ud83e\ude9d Hook ideas",
           "selectable": true,
           "bypassed": false
         },
@@ -458,7 +458,7 @@
           "zIndex": 0,
           "width": 360,
           "height": 320,
-          "title": "🖼️ Latest thumbnail",
+          "title": "\ud83d\uddbc\ufe0f Latest thumbnail",
           "selectable": true,
           "bypassed": false
         },

--- a/packages/base-nodes/nodetool/examples/nodetool-base/How Long Is This String.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/How Long Is This String.json
@@ -1,0 +1,98 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "How Long Is This String",
+  "tool_name": null,
+  "description": "Character length as a first-class value, so downstream nodes can branch on size without a code node.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "s",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "Measure twice."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Text"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "ln",
+        "type": "nodetool.text.Length",
+        "data": {
+          "text": ""
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Length"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "length"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Length"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "s",
+        "sourceHandle": "output",
+        "target": "ln",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "ln",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/How Long Is This Transcript.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/How Long Is This Transcript.json
@@ -1,0 +1,161 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "How Long Is This Transcript",
+  "tool_name": null,
+  "description": "Transcribe a clip and count the tokens. Worth knowing before you feed a transcript to a model that bills per token or caps context.",
+  "tags": [
+    "audio",
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "in",
+        "type": "nodetool.input.VideoInput",
+        "data": {
+          "name": "clip",
+          "value": null,
+          "description": "The clip to measure"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Clip"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "ex",
+        "type": "nodetool.video.ExtractAudio",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Extract audio"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "asr",
+        "type": "nodetool.text.AutomaticSpeechRecognition",
+        "data": {
+          "model": {
+            "type": "asr_model",
+            "provider": "openai",
+            "id": "gpt-4o-mini-transcribe",
+            "name": "GPT-4o Mini Transcribe",
+            "path": null
+          },
+          "language": "en",
+          "prompt": "",
+          "temperature": 0.0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Transcribe"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "ct",
+        "type": "nodetool.text.CountTokens",
+        "data": {
+          "text": "",
+          "encoding": "cl100k_base"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Count tokens"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "token_count"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "5  Count"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "in",
+        "sourceHandle": "output",
+        "target": "ex",
+        "targetHandle": "video"
+      },
+      {
+        "id": "e2",
+        "source": "ex",
+        "sourceHandle": "output",
+        "target": "asr",
+        "targetHandle": "audio"
+      },
+      {
+        "id": "e3",
+        "source": "asr",
+        "sourceHandle": "text",
+        "target": "ct",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e4",
+        "source": "ct",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Image to Video Animation.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Image to Video Animation.json
@@ -78,7 +78,7 @@
         "id": "comment-intro",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 🎬 Image to Video Animation\n\nGenerate a still from a scene prompt, then animate it into a short cinematic clip.\n\n**Pipeline:** scene prompt → Text-to-Image → build motion prompt → Image-to-Video\n\n**Try this:** edit the scene, motion, or duration prompts.\n\n**Cost note:** the animation step uses Veo 3.1, a paid per-second video model — each run costs noticeably more than an image-only template."
+          "comment": "# \ud83c\udfac Image to Video Animation\n\nGenerate a still from a scene prompt, then animate it into a short cinematic clip.\n\n**Pipeline:** scene prompt \u2192 Text-to-Image \u2192 build motion prompt \u2192 Image-to-Video\n\n**Try this:** edit the scene, motion, or duration prompts.\n\n**Cost note:** the animation step uses Veo 3.1, a paid per-second video model \u2014 each run costs noticeably more than an image-only template."
         },
         "ui_properties": {
           "selected": false,
@@ -122,7 +122,7 @@
           "width": 416,
           "selectable": true,
           "height": 360,
-          "title": "3️⃣ Animate to video"
+          "title": "3\ufe0f\u20e3 Animate to video"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -133,7 +133,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -156,7 +156,7 @@
           "width": 384,
           "selectable": true,
           "height": 400,
-          "title": "2️⃣ Generate still"
+          "title": "2\ufe0f\u20e3 Generate still"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -177,7 +177,7 @@
           "zIndex": 0,
           "width": 280,
           "selectable": true,
-          "title": "1️⃣ Scene prompt"
+          "title": "1\ufe0f\u20e3 Scene prompt"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Key Out a Green Screen.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Key Out a Green Screen.json
@@ -1,0 +1,105 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Key Out a Green Screen",
+  "tool_name": null,
+  "description": "Chroma key with the two dials that matter: similarity decides how much of the colour range goes transparent, blend softens the edge.",
+  "tags": [
+    "video",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "in",
+        "type": "nodetool.input.VideoInput",
+        "data": {
+          "name": "clip",
+          "value": null,
+          "description": "Green screen footage"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Footage"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "ck",
+        "type": "nodetool.video.ChromaKey",
+        "data": {
+          "key_color": {
+            "type": "color",
+            "value": "#00FF00"
+          },
+          "similarity": 0.3,
+          "blend": 0.1
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Key"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "keyed"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Result"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "in",
+        "sourceHandle": "output",
+        "target": "ck",
+        "targetHandle": "video"
+      },
+      {
+        "id": "e2",
+        "source": "ck",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Movie Posters.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Movie Posters.json
@@ -5,7 +5,7 @@
   "updated_at": "2026-06-21T22:36:58.355Z",
   "name": "Movie Posters",
   "tool_name": null,
-  "description": "Turn a title, genre, and visual style into finished theatrical one-sheet posters. An art-direction agent first writes a key-art brief (positioning, palette, typography), which drives every generated poster — the differentiator is the agent-authored creative strategy, not a raw prompt.",
+  "description": "Turn a title, genre, and visual style into finished theatrical one-sheet posters. An art-direction agent first writes a key-art brief (positioning, palette, typography), which drives every generated poster \u2014 the differentiator is the agent-authored creative strategy, not a raw prompt.",
   "tags": [
     "start",
     "image",
@@ -217,7 +217,7 @@
                       "format": 0,
                       "mode": "normal",
                       "style": "",
-                      "text": "🎬 Movie Posters",
+                      "text": "\ud83c\udfac Movie Posters",
                       "type": "text",
                       "version": 1
                     }
@@ -236,7 +236,7 @@
                       "format": 0,
                       "mode": "normal",
                       "style": "",
-                      "text": "From a title, genre, and visual style, design a batch of theatrical poster concepts. An art-direction agent writes the key-art brief — positioning, palette, typography — and that brief drives every poster the image model renders.",
+                      "text": "From a title, genre, and visual style, design a batch of theatrical poster concepts. An art-direction agent writes the key-art brief \u2014 positioning, palette, typography \u2014 and that brief drives every poster the image model renders.",
                       "type": "text",
                       "version": 1
                     }
@@ -265,7 +265,7 @@
                       "format": 0,
                       "mode": "normal",
                       "style": "",
-                      "text": " Title / Genre / Style → Art-direction agent → Poster concepts → Text-to-Image",
+                      "text": " Title / Genre / Style \u2192 Art-direction agent \u2192 Poster concepts \u2192 Text-to-Image",
                       "type": "text",
                       "version": 1
                     }
@@ -334,7 +334,7 @@
         "id": "strategy_prompt_formatter",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "You are the art director on a major studio's key-art team.\n\nFilm brief:\n- Title: {{ MOVIE_TITLE }}\n- Genre: {{ GENRE }}\n- Visual style: {{ STYLE }}\n\nDesign the theatrical one-sheet strategy. Commit to bold, specific choices that fit the genre and honor the requested visual style. Return only Markdown, no preamble, with exactly these sections:\n\nPositioning: one or two sentences on the promise the poster must make at a glance.\n\nAudience Insight: who is pulled toward this film and the emotional hook that lands them.\n\nCore Visual Concept: the single big-idea image the poster is built around — the hero subject, its symbolism, and the frozen moment.\n\nDesign:\n- Color Palette: up to 5 swatches, each as Name + #hex + the emotion it carries.\n- Imagery: hero focus, composition, and lighting.\n- Typography: title font family plus its texture and mood.\nKeep every design choice consistent with the {{ STYLE }} style."
+          "prompt": "You are the art director on a major studio's key-art team.\n\nFilm brief:\n- Title: {{ MOVIE_TITLE }}\n- Genre: {{ GENRE }}\n- Visual style: {{ STYLE }}\n\nDesign the theatrical one-sheet strategy. Commit to bold, specific choices that fit the genre and honor the requested visual style. Return only Markdown, no preamble, with exactly these sections:\n\nPositioning: one or two sentences on the promise the poster must make at a glance.\n\nAudience Insight: who is pulled toward this film and the emotional hook that lands them.\n\nCore Visual Concept: the single big-idea image the poster is built around \u2014 the hero subject, its symbolism, and the frozen moment.\n\nDesign:\n- Color Palette: up to 5 swatches, each as Name + #hex + the emotion it carries.\n- Imagery: hero focus, composition, and lighting.\n- Typography: title font family plus its texture and mood.\nKeep every design choice consistent with the {{ STYLE }} style."
         },
         "ui_properties": {
           "position": {
@@ -457,7 +457,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -516,7 +516,7 @@
         "id": "923fb0f1-8bd4-406a-ba73-9ec3137c20cd",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "You are pitching poster concepts for the film \"{{ title }}\" ({{ genre }}).\n\nPositioning: {{ positioning }}\nAudience insight: {{ audience_insight }}\n\nGenerate distinct theatrical poster concepts. Each concept is ONE self-contained line describing a single striking image: the hero subject, the setting, the framing, and the mood. Vary the ideas across the set — different angles, symbols, and emotional beats — while staying true to the genre and positioning. One concept per line, no numbering and no commentary."
+          "prompt": "You are pitching poster concepts for the film \"{{ title }}\" ({{ genre }}).\n\nPositioning: {{ positioning }}\nAudience insight: {{ audience_insight }}\n\nGenerate distinct theatrical poster concepts. Each concept is ONE self-contained line describing a single striking image: the hero subject, the setting, the framing, and the mood. Vary the ideas across the set \u2014 different angles, symbols, and emotional beats \u2014 while staying true to the genre and positioning. One concept per line, no numbering and no commentary."
         },
         "ui_properties": {
           "selected": false,
@@ -542,7 +542,7 @@
         "id": "04757c8a-dad6-48f3-a45f-459f54e26b7b",
         "type": "nodetool.generators.StructuredOutputGenerator",
         "data": {
-          "system_prompt": "You are a film key-art director turning a creative brief into structured fields.\n\nGoal\n- Read <INSTRUCTIONS> (the art-direction brief) and any <CONTEXT>, then produce a single JSON object matching <JSON_SCHEMA> exactly.\n\nOutput format (MANDATORY)\n- Output exactly ONE fenced code block labeled json containing ONLY the JSON object:\n\n  ```json\n  { ...single JSON object matching <JSON_SCHEMA>... }\n  ```\n- No prose before or after the block.\n\nGeneration rules\n- Fill every field with concrete, vivid, production-ready detail — no placeholders, no hedging.\n- Keep all fields internally consistent with the film's genre and visual style.\n- Honor every constraint in <JSON_SCHEMA> (types, enums, formats).\n\nValidation\n- Ensure the final JSON validates against <JSON_SCHEMA> exactly.",
+          "system_prompt": "You are a film key-art director turning a creative brief into structured fields.\n\nGoal\n- Read <INSTRUCTIONS> (the art-direction brief) and any <CONTEXT>, then produce a single JSON object matching <JSON_SCHEMA> exactly.\n\nOutput format (MANDATORY)\n- Output exactly ONE fenced code block labeled json containing ONLY the JSON object:\n\n  ```json\n  { ...single JSON object matching <JSON_SCHEMA>... }\n  ```\n- No prose before or after the block.\n\nGeneration rules\n- Fill every field with concrete, vivid, production-ready detail \u2014 no placeholders, no hedging.\n- Keep all fields internally consistent with the film's genre and visual style.\n- Honor every constraint in <JSON_SCHEMA> (types, enums, formats).\n\nValidation\n- Ensure the final JSON validates against <JSON_SCHEMA> exactly.",
           "model": {
             "type": "language_model",
             "provider": "openai",
@@ -563,7 +563,7 @@
           },
           "zIndex": 0,
           "width": 282,
-          "title": "Art-direction brief → fields",
+          "title": "Art-direction brief \u2192 fields",
           "selectable": true,
           "bypassed": false
         },

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Movie Trailer Generator.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Movie Trailer Generator.json
@@ -5,7 +5,7 @@
   "updated_at": "2026-06-27T13:33:47.316Z",
   "name": "Movie Trailer Generator",
   "tool_name": null,
-  "description": "Type a single logline and get back a cinematic teaser. Prompt nodes template the inputs into a treatment and turn each shot into full cinematic key art; the shots are animated and cut together into the final trailer. Cost note: each shot runs through Veo 3.1 image-to-video, which is metered per second of generated video and is the most expensive step in the pipeline — a 6-shot trailer makes 6 Veo calls.",
+  "description": "Type a single logline and get back a cinematic teaser. Prompt nodes template the inputs into a treatment and turn each shot into full cinematic key art; the shots are animated and cut together into the final trailer. Cost note: each shot runs through Veo 3.1 image-to-video, which is metered per second of generated video and is the most expensive step in the pipeline \u2014 a 6-shot trailer makes 6 Veo calls.",
   "tags": [
     "video",
     "generation",
@@ -187,7 +187,7 @@
         "id": "comment",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 🎬 Movie Trailer Generator\n\nType one logline and the canvas builds a cinematic teaser. Prompt nodes do the work: one templates the inputs into a trailer treatment, one turns each shot into full cinematic key art.\n\n**Pipeline:** Logline → Treatment → Shot prompts → Keyframes → Image-to-Video → Concat\n\n**Cost note:** the Image-to-Video step runs on Veo 3.1, billed per second of generated video — the most expensive node here. A 6-shot trailer fires 6 Veo calls, so raising Shot Count raises cost linearly.\n\n**Try this:** change the visual style or shot count, or swap the image / video model."
+          "comment": "# \ud83c\udfac Movie Trailer Generator\n\nType one logline and the canvas builds a cinematic teaser. Prompt nodes do the work: one templates the inputs into a trailer treatment, one turns each shot into full cinematic key art.\n\n**Pipeline:** Logline \u2192 Treatment \u2192 Shot prompts \u2192 Keyframes \u2192 Image-to-Video \u2192 Concat\n\n**Cost note:** the Image-to-Video step runs on Veo 3.1, billed per second of generated video \u2014 the most expensive node here. A 6-shot trailer fires 6 Veo calls, so raising Shot Count raises cost linearly.\n\n**Try this:** change the visual style or shot count, or swap the image / video model."
         },
         "ui_properties": {
           "position": {
@@ -208,7 +208,7 @@
         "type": "nodetool.input.StringInput",
         "data": {
           "name": "Logline",
-          "value": "A getaway driver speeds onto a bridge as it starts to collapse — and the only way out is to outrun the gap."
+          "value": "A getaway driver speeds onto a bridge as it starts to collapse \u2014 and the only way out is to outrun the gap."
         },
         "ui_properties": {
           "position": {
@@ -217,7 +217,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "1️⃣ Logline",
+          "title": "1\ufe0f\u20e3 Logline",
           "selectable": true,
           "bypassed": false
         },
@@ -238,7 +238,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "2️⃣ Visual style",
+          "title": "2\ufe0f\u20e3 Visual style",
           "selectable": true,
           "bypassed": false
         },
@@ -259,7 +259,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "3️⃣ Shot count",
+          "title": "3\ufe0f\u20e3 Shot count",
           "selectable": true,
           "bypassed": false
         },
@@ -285,7 +285,7 @@
           "bypassed": false
         },
         "dynamic_properties": {
-          "LOGLINE": "A getaway driver speeds onto a bridge as it starts to collapse — and the only way out is to outrun the gap.",
+          "LOGLINE": "A getaway driver speeds onto a bridge as it starts to collapse \u2014 and the only way out is to outrun the gap.",
           "STYLE": "high-contrast daylight, dust and sparks, handheld telephoto, motion blur, hard sun, blown-out sky, gritty",
           "COUNT": "6"
         },
@@ -314,7 +314,7 @@
           "zIndex": 0,
           "width": 332,
           "height": 353,
-          "title": "4️⃣ Write the treatment",
+          "title": "4\ufe0f\u20e3 Write the treatment",
           "selectable": true,
           "bypassed": false
         },
@@ -368,7 +368,7 @@
           "zIndex": 0,
           "width": 331,
           "height": 245,
-          "title": "5️⃣ Generate shot prompts",
+          "title": "5\ufe0f\u20e3 Generate shot prompts",
           "selectable": true,
           "bypassed": false
         },
@@ -405,7 +405,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -425,7 +425,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 342,
-          "title": "6️⃣ Render keyframes",
+          "title": "6\ufe0f\u20e3 Render keyframes",
           "selectable": true,
           "bypassed": false,
           "selected_generation": "133f0bef77d34f2bbb3cbc49a97b592b",
@@ -461,7 +461,7 @@
           "zIndex": 0,
           "width": 331,
           "height": 222,
-          "title": "7️⃣ Animate each keyframe (Veo, metered per second)",
+          "title": "7\ufe0f\u20e3 Animate each keyframe (Veo, metered per second)",
           "selectable": true,
           "bypassed": false,
           "selected_generation": "8fb0f284a8e54876858f8155aff3dd5d",
@@ -490,7 +490,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 280,
-          "title": "🎬 Final trailer",
+          "title": "\ud83c\udfac Final trailer",
           "selectable": true,
           "bypassed": false
         },
@@ -530,7 +530,7 @@
             "x": 3505,
             "y": 534
           },
-          "title": "8️⃣ Trailer output",
+          "title": "8\ufe0f\u20e3 Trailer output",
           "selectable": true
         }
       }

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Music Video Visualizer.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Music Video Visualizer.json
@@ -5,7 +5,7 @@
   "updated_at": "2026-07-08T10:44:38.859Z",
   "name": "Music Video Visualizer",
   "tool_name": null,
-  "description": "Turn any song into a mood-matched music video. Whisper transcribes the lyrics, an LLM creative director reads the emotional arc, writes one image prompt per frame, FLUX renders every frame, and they are stitched back to your original audio. Differentiator: a full transcribe → analyze → fan-out → render → reassemble media pipeline in a single graph — no chat box can do this. Cost note: generates one image per frame (default 8) plus a Whisper transcription, so a run costs several fal-ai calls.",
+  "description": "Turn any song into a mood-matched music video. Whisper transcribes the lyrics, an LLM creative director reads the emotional arc, writes one image prompt per frame, FLUX renders every frame, and they are stitched back to your original audio. Differentiator: a full transcribe \u2192 analyze \u2192 fan-out \u2192 render \u2192 reassemble media pipeline in a single graph \u2014 no chat box can do this. Cost note: generates one image per frame (default 8) plus a Whisper transcription, so a run costs several fal-ai calls.",
   "tags": [
     "video",
     "audio",
@@ -159,7 +159,7 @@
         "id": "comment-intro",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 🎵 Music Video Visualizer\n\nTurn a song into a music video. Whisper transcribes the lyrics, a creative-director agent reads the emotional arc, then we fan out one image prompt per frame, render each with FLUX, and stitch the frames back to your audio.\n\n**Why the graph branches:** the mood analysis fans out into N frame prompts (ListGenerator), each prompt is rendered in parallel (ForEach → TextToImage), then Collect + FrameToVideo re-assemble the sequence and AddAudio re-attaches the original track. That fan-out / re-assemble is the part a chat box can't do.\n\n**Pipeline:** Audio → Transcribe → Mood agent → Frame prompts → Images → Video + Audio\n\n**Try this:** change the visual style or genre, or raise the frame count for a longer clip."
+          "comment": "# \ud83c\udfb5 Music Video Visualizer\n\nTurn a song into a music video. Whisper transcribes the lyrics, a creative-director agent reads the emotional arc, then we fan out one image prompt per frame, render each with FLUX, and stitch the frames back to your audio.\n\n**Why the graph branches:** the mood analysis fans out into N frame prompts (ListGenerator), each prompt is rendered in parallel (ForEach \u2192 TextToImage), then Collect + FrameToVideo re-assemble the sequence and AddAudio re-attaches the original track. That fan-out / re-assemble is the part a chat box can't do.\n\n**Pipeline:** Audio \u2192 Transcribe \u2192 Mood agent \u2192 Frame prompts \u2192 Images \u2192 Video + Audio\n\n**Try this:** change the visual style or genre, or raise the frame count for a longer clip."
         },
         "ui_properties": {
           "position": {
@@ -193,7 +193,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "1️⃣ Song audio",
+          "title": "1\ufe0f\u20e3 Song audio",
           "selectable": true,
           "bypassed": false
         },
@@ -285,7 +285,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "2️⃣ Transcribe lyrics",
+          "title": "2\ufe0f\u20e3 Transcribe lyrics",
           "selectable": true,
           "bypassed": false
         },
@@ -328,7 +328,7 @@
             "path": null,
             "supported_tasks": []
           },
-          "system": "You are an award-winning music-video creative director. You translate how a song feels into concrete visual language — mood, energy, color, and motion. Answer with tight, evocative direction only; never restate or acknowledge the request, and never add headings or lists unless asked."
+          "system": "You are an award-winning music-video creative director. You translate how a song feels into concrete visual language \u2014 mood, energy, color, and motion. Answer with tight, evocative direction only; never restate or acknowledge the request, and never add headings or lists unless asked."
         },
         "ui_properties": {
           "position": {
@@ -337,7 +337,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "3️⃣ Analyze mood",
+          "title": "3\ufe0f\u20e3 Analyze mood",
           "selectable": true,
           "bypassed": false
         },
@@ -391,7 +391,7 @@
           "zIndex": 0,
           "width": 280,
           "height": 340,
-          "title": "4️⃣ Generate frame prompts",
+          "title": "4\ufe0f\u20e3 Generate frame prompts",
           "selectable": true,
           "bypassed": false
         },
@@ -421,7 +421,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -440,7 +440,7 @@
           "zIndex": 0,
           "width": 384,
           "height": 400,
-          "title": "5️⃣ Render frames",
+          "title": "5\ufe0f\u20e3 Render frames",
           "selectable": true,
           "bypassed": false
         },
@@ -478,7 +478,7 @@
           "zIndex": 0,
           "width": 416,
           "height": 360,
-          "title": "6️⃣ Frames to video",
+          "title": "6\ufe0f\u20e3 Frames to video",
           "selectable": true,
           "bypassed": false
         },
@@ -500,7 +500,7 @@
           "zIndex": 0,
           "width": 416,
           "height": 360,
-          "title": "7️⃣ Add audio",
+          "title": "7\ufe0f\u20e3 Add audio",
           "selectable": true,
           "bypassed": false
         },

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Name a File from Its Narration.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Name a File from Its Narration.json
@@ -1,0 +1,191 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Name a File from Its Narration",
+  "tool_name": null,
+  "description": "Transcribe a clip and turn the first words into a URL-safe slug. A small chain that shows speech becoming a filename rather than a document.",
+  "tags": [
+    "audio",
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "in",
+        "type": "nodetool.input.VideoInput",
+        "data": {
+          "name": "clip",
+          "value": null,
+          "description": "The clip to name"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Clip"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "ex",
+        "type": "nodetool.video.ExtractAudio",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Extract audio"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "asr",
+        "type": "nodetool.text.AutomaticSpeechRecognition",
+        "data": {
+          "model": {
+            "type": "asr_model",
+            "provider": "openai",
+            "id": "gpt-4o-mini-transcribe",
+            "name": "GPT-4o Mini Transcribe",
+            "path": null
+          },
+          "language": "en",
+          "prompt": "",
+          "temperature": 0.0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Transcribe"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "tr",
+        "type": "nodetool.text.TruncateText",
+        "data": {
+          "text": "",
+          "max_length": 60,
+          "ellipsis": ""
+        },
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  First 60 chars"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "sl",
+        "type": "nodetool.text.Slugify",
+        "data": {
+          "text": "",
+          "separator": "-",
+          "lowercase": true,
+          "allow_unicode": false
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "5  Slugify"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "slug"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "6  Slug"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "in",
+        "sourceHandle": "output",
+        "target": "ex",
+        "targetHandle": "video"
+      },
+      {
+        "id": "e2",
+        "source": "ex",
+        "sourceHandle": "output",
+        "target": "asr",
+        "targetHandle": "audio"
+      },
+      {
+        "id": "e3",
+        "source": "asr",
+        "sourceHandle": "text",
+        "target": "tr",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e4",
+        "source": "tr",
+        "sourceHandle": "output",
+        "target": "sl",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e5",
+        "source": "sl",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Photo Enhancement Suite.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Photo Enhancement Suite.json
@@ -5,7 +5,7 @@
   "updated_at": "2026-06-22T12:00:00.000Z",
   "name": "Photo Enhancement Suite",
   "tool_name": null,
-  "description": "Batch-enhance a list of photos through a fixed retouch chain — auto-contrast, color, sharpening, and an AI cinematic-grade pass — with no folder path required, just drop images in.",
+  "description": "Batch-enhance a list of photos through a fixed retouch chain \u2014 auto-contrast, color, sharpening, and an AI cinematic-grade pass \u2014 with no folder path required, just drop images in.",
   "tags": [
     "image",
     "photo",
@@ -19,7 +19,7 @@
         "id": "comment-intro",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 📷 Photo Enhancement Suite\n\nBatch-enhance a list of photos through a fixed retouch chain: auto-contrast, color, brightness, sharpening, and an AI polish pass.\n\n**Pipeline:** Photo list → Auto-contrast → Color/Brightness → Sharpen → AI enhance → Collect\n\n**Try this:** add a few photos and adjust the brightness and color factors to taste."
+          "comment": "# \ud83d\udcf7 Photo Enhancement Suite\n\nBatch-enhance a list of photos through a fixed retouch chain: auto-contrast, color, brightness, sharpening, and an AI polish pass.\n\n**Pipeline:** Photo list \u2192 Auto-contrast \u2192 Color/Brightness \u2192 Sharpen \u2192 AI enhance \u2192 Collect\n\n**Try this:** add a few photos and adjust the brightness and color factors to taste."
         },
         "ui_properties": {
           "selected": false,
@@ -44,7 +44,7 @@
           "input_item": []
         },
         "ui_properties": {
-          "title": "8️⃣ Collect enhanced batch"
+          "title": "8\ufe0f\u20e3 Collect enhanced batch"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -56,7 +56,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -83,7 +83,7 @@
         "ui_properties": {
           "width": 384,
           "height": 400,
-          "title": "7️⃣ AI enhance"
+          "title": "7\ufe0f\u20e3 AI enhance"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -104,7 +104,7 @@
           "threshold": 0.0117647
         },
         "ui_properties": {
-          "title": "6️⃣ Sharpen detail"
+          "title": "6\ufe0f\u20e3 Sharpen detail"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -124,7 +124,7 @@
           "amount": 1
         },
         "ui_properties": {
-          "title": "5️⃣ Sharpen"
+          "title": "5\ufe0f\u20e3 Sharpen"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -146,7 +146,7 @@
           "brightness": 1
         },
         "ui_properties": {
-          "title": "4️⃣ Adjust color"
+          "title": "4\ufe0f\u20e3 Adjust color"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -167,7 +167,7 @@
           "contrast": 1
         },
         "ui_properties": {
-          "title": "3️⃣ Brightness/Contrast"
+          "title": "3\ufe0f\u20e3 Brightness/Contrast"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -187,7 +187,7 @@
           "cutoff": 2
         },
         "ui_properties": {
-          "title": "2️⃣ Auto-contrast"
+          "title": "2\ufe0f\u20e3 Auto-contrast"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -201,7 +201,7 @@
           "limit": -1
         },
         "ui_properties": {
-          "title": "1️⃣ Iterate photos"
+          "title": "1\ufe0f\u20e3 Iterate photos"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -213,7 +213,7 @@
         "data": {
           "name": "photos",
           "value": [],
-          "description": "Photos to enhance. Add one or more images directly — no folder path or upload step required."
+          "description": "Photos to enhance. Add one or more images directly \u2014 no folder path or upload step required."
         },
         "ui_properties": {
           "title": "Photos to enhance"

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Podcast Repurposing Studio.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Podcast Repurposing Studio.json
@@ -244,7 +244,7 @@
         "id": "comment",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 🎙️ Podcast Repurposing Studio\n\nDrop in one episode and ship the whole content pack: titles and show notes, a newsletter edition, five social posts, and quote cards rendered as square images. The episode is transcribed once; four writer branches fan out from the transcript.\n\n**Pipeline:** Episode audio → Transcript → Show notes · Newsletter · Posts · Quotes → Quote cards\n\n**Try this:** pick the ASR, language, and image models, then tune each writer's prompt to your show's voice."
+          "comment": "# \ud83c\udf99\ufe0f Podcast Repurposing Studio\n\nDrop in one episode and ship the whole content pack: titles and show notes, a newsletter edition, five social posts, and quote cards rendered as square images. The episode is transcribed once; four writer branches fan out from the transcript.\n\n**Pipeline:** Episode audio \u2192 Transcript \u2192 Show notes \u00b7 Newsletter \u00b7 Posts \u00b7 Quotes \u2192 Quote cards\n\n**Try this:** pick the ASR, language, and image models, then tune each writer's prompt to your show's voice."
         },
         "ui_properties": {
           "position": {
@@ -278,7 +278,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "1️⃣ Episode audio",
+          "title": "1\ufe0f\u20e3 Episode audio",
           "selectable": true,
           "bypassed": false
         },
@@ -290,8 +290,8 @@
         "type": "nodetool.input.StringInput",
         "data": {
           "name": "show_context",
-          "value": "Trailhead — a weekly hiking and outdoor-gear podcast hosted by Maya. Voice: warm, practical, a little irreverent. CTA: subscribe and grab the free gear checklist at trailhead.fm",
-          "description": "Show name, host, voice, and call to action — every writer branch uses this"
+          "value": "Trailhead \u2014 a weekly hiking and outdoor-gear podcast hosted by Maya. Voice: warm, practical, a little irreverent. CTA: subscribe and grab the free gear checklist at trailhead.fm",
+          "description": "Show name, host, voice, and call to action \u2014 every writer branch uses this"
         },
         "ui_properties": {
           "position": {
@@ -300,7 +300,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "2️⃣ Show context",
+          "title": "2\ufe0f\u20e3 Show context",
           "selectable": true,
           "bypassed": false
         },
@@ -324,7 +324,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "3️⃣ Quote-card count",
+          "title": "3\ufe0f\u20e3 Quote-card count",
           "selectable": true,
           "bypassed": false
         },
@@ -351,7 +351,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 240,
-          "title": "4️⃣ Transcribe the episode",
+          "title": "4\ufe0f\u20e3 Transcribe the episode",
           "selectable": true,
           "bypassed": false
         },
@@ -362,7 +362,7 @@
         "id": "shownotes_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "You are producing the episode page for this podcast.\n\nShow: {{ SHOW }}\n\nFrom the transcript below, return Markdown, no commentary:\n\nTitles: 3 episode title options — specific, curiosity-driven, under 60 characters.\nSummary: one paragraph, 3-4 sentences, written for the episode page.\nShow notes: 6-10 bullet chapters in listening order — each a short phrase naming what gets discussed.\nResources: anything mentioned worth linking — books, tools, people, places.\nCTA: one closing line using the show's call to action.\n\nTranscript:\n{{ TRANSCRIPT }}"
+          "prompt": "You are producing the episode page for this podcast.\n\nShow: {{ SHOW }}\n\nFrom the transcript below, return Markdown, no commentary:\n\nTitles: 3 episode title options \u2014 specific, curiosity-driven, under 60 characters.\nSummary: one paragraph, 3-4 sentences, written for the episode page.\nShow notes: 6-10 bullet chapters in listening order \u2014 each a short phrase naming what gets discussed.\nResources: anything mentioned worth linking \u2014 books, tools, people, places.\nCTA: one closing line using the show's call to action.\n\nTranscript:\n{{ TRANSCRIPT }}"
         },
         "ui_properties": {
           "position": {
@@ -413,7 +413,7 @@
           "zIndex": 0,
           "width": 330,
           "height": 330,
-          "title": "5️⃣ Write show notes & titles",
+          "title": "5\ufe0f\u20e3 Write show notes & titles",
           "selectable": true,
           "bypassed": false
         },
@@ -434,7 +434,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 300,
-          "title": "📝 Show notes & titles",
+          "title": "\ud83d\udcdd Show notes & titles",
           "selectable": true,
           "bypassed": false
         },
@@ -445,7 +445,7 @@
         "id": "newsletter_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "Turn this podcast episode into the show's email newsletter edition.\n\nShow: {{ SHOW }}\n\nReturn Markdown, no commentary:\n\nSubject: 3 subject-line options under 50 characters.\nBody: 150-250 words in the host's voice — open on the episode's single most surprising idea, tease two more takeaways without spoiling them, close with the show's call to action and a listen-link placeholder.\n\nTranscript:\n{{ TRANSCRIPT }}"
+          "prompt": "Turn this podcast episode into the show's email newsletter edition.\n\nShow: {{ SHOW }}\n\nReturn Markdown, no commentary:\n\nSubject: 3 subject-line options under 50 characters.\nBody: 150-250 words in the host's voice \u2014 open on the episode's single most surprising idea, tease two more takeaways without spoiling them, close with the show's call to action and a listen-link placeholder.\n\nTranscript:\n{{ TRANSCRIPT }}"
         },
         "ui_properties": {
           "position": {
@@ -477,7 +477,7 @@
             "path": null,
             "supported_tasks": []
           },
-          "system": "You write email newsletters for podcasters. Short, personal, in the host's voice — the reader should feel the episode, not a summary of it.",
+          "system": "You write email newsletters for podcasters. Short, personal, in the host's voice \u2014 the reader should feel the episode, not a summary of it.",
           "audio": {
             "type": "audio",
             "uri": "",
@@ -496,7 +496,7 @@
           "zIndex": 0,
           "width": 330,
           "height": 330,
-          "title": "6️⃣ Draft the newsletter",
+          "title": "6\ufe0f\u20e3 Draft the newsletter",
           "selectable": true,
           "bypassed": false
         },
@@ -517,7 +517,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 300,
-          "title": "✉️ Newsletter edition",
+          "title": "\u2709\ufe0f Newsletter edition",
           "selectable": true,
           "bypassed": false
         },
@@ -528,7 +528,7 @@
         "id": "posts_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "From this podcast episode transcript, write exactly 5 social posts, one per line — no numbering, no labels, no hashtags unless they earn their place.\n\nRules:\n- Each post stands alone: one idea, claim, or moment from the episode, written to stop the scroll.\n- Mix formats across the five: a bold take, a question, a mini-story, a concrete stat or detail, a one-line lesson.\n- Plain language in the show's voice ({{ SHOW }}). 280 characters maximum each.\n\nTranscript:\n{{ TRANSCRIPT }}"
+          "prompt": "From this podcast episode transcript, write exactly 5 social posts, one per line \u2014 no numbering, no labels, no hashtags unless they earn their place.\n\nRules:\n- Each post stands alone: one idea, claim, or moment from the episode, written to stop the scroll.\n- Mix formats across the five: a bold take, a question, a mini-story, a concrete stat or detail, a one-line lesson.\n- Plain language in the show's voice ({{ SHOW }}). 280 characters maximum each.\n\nTranscript:\n{{ TRANSCRIPT }}"
         },
         "ui_properties": {
           "position": {
@@ -571,7 +571,7 @@
           "zIndex": 0,
           "width": 330,
           "height": 245,
-          "title": "7️⃣ Generate social posts",
+          "title": "7\ufe0f\u20e3 Generate social posts",
           "selectable": true,
           "bypassed": false
         },
@@ -592,7 +592,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 260,
-          "title": "📣 Social posts",
+          "title": "\ud83d\udce3 Social posts",
           "selectable": true,
           "bypassed": false
         },
@@ -603,7 +603,7 @@
         "id": "quotes_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "From this transcript, pick exactly {{ COUNT }} verbatim quotes worth putting on a quote card, one per line — no numbering, no attribution, no surrounding quotation marks.\n\nRules:\n- Verbatim from the transcript, lightly trimmed for readability only.\n- 8 to 25 words: punchy, self-contained, meaningful without context.\n- Prefer strong opinions, hard-won lessons, and vivid phrasing over pleasantries.\n\nTranscript:\n{{ TRANSCRIPT }}"
+          "prompt": "From this transcript, pick exactly {{ COUNT }} verbatim quotes worth putting on a quote card, one per line \u2014 no numbering, no attribution, no surrounding quotation marks.\n\nRules:\n- Verbatim from the transcript, lightly trimmed for readability only.\n- 8 to 25 words: punchy, self-contained, meaningful without context.\n- Prefer strong opinions, hard-won lessons, and vivid phrasing over pleasantries.\n\nTranscript:\n{{ TRANSCRIPT }}"
         },
         "ui_properties": {
           "position": {
@@ -646,7 +646,7 @@
           "zIndex": 0,
           "width": 330,
           "height": 245,
-          "title": "8️⃣ Pull the best quotes",
+          "title": "8\ufe0f\u20e3 Pull the best quotes",
           "selectable": true,
           "bypassed": false
         },
@@ -683,7 +683,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -702,7 +702,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 340,
-          "title": "9️⃣ Render quote cards",
+          "title": "9\ufe0f\u20e3 Render quote cards",
           "selectable": true,
           "bypassed": false
         },
@@ -723,7 +723,7 @@
           "zIndex": 0,
           "width": 360,
           "height": 380,
-          "title": "🖼️ Quote cards",
+          "title": "\ud83d\uddbc\ufe0f Quote cards",
           "selectable": true,
           "bypassed": false
         },

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Pokemon Maker.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Pokemon Maker.json
@@ -67,7 +67,7 @@
         "id": "comment-intro",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 🐲 Pokemon Maker\n\nName a few animals, pick an art style, and get a batch of four original collectible creatures — each one a believable fusion of the animals you chose, all rendered in the same style.\n\n**Pipeline:** Animals + Style → Design brief → Creature prompts → Render → Gallery\n\n**Try this:** mix an unlikely pair (axolotl + hummingbird) and switch the style to see the whole set restyle at once."
+          "comment": "# \ud83d\udc32 Pokemon Maker\n\nName a few animals, pick an art style, and get a batch of four original collectible creatures \u2014 each one a believable fusion of the animals you chose, all rendered in the same style.\n\n**Pipeline:** Animals + Style \u2192 Design brief \u2192 Creature prompts \u2192 Render \u2192 Gallery\n\n**Try this:** mix an unlikely pair (axolotl + hummingbird) and switch the style to see the whole set restyle at once."
         },
         "ui_properties": {
           "selected": false,
@@ -89,7 +89,7 @@
         "type": "nodetool.input.StringInput",
         "data": {
           "name": "animals",
-          "description": "Which real animals should the creatures be built from? List two or three, comma-separated — mixing distant species gives the most striking hybrids.",
+          "description": "Which real animals should the creatures be built from? List two or three, comma-separated \u2014 mixing distant species gives the most striking hybrids.",
           "value": "lion, eagle, koi fish"
         },
         "ui_properties": {
@@ -100,7 +100,7 @@
           },
           "zIndex": 0,
           "width": 220,
-          "title": "1️⃣ Animal inspiration",
+          "title": "1\ufe0f\u20e3 Animal inspiration",
           "selectable": true,
           "bypassed": false
         },
@@ -131,7 +131,7 @@
           },
           "zIndex": 0,
           "width": 220,
-          "title": "1️⃣ Art style",
+          "title": "1\ufe0f\u20e3 Art style",
           "selectable": true,
           "bypassed": false
         },
@@ -142,7 +142,7 @@
         "id": "464a17c1-c916-4b24-8e23-856160732293",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "You are a creature designer for an original monster-collecting game. Invent FOUR distinct collectible creatures, each a believable fusion of these real animals: {{animals}}.\n\nFor every creature, write ONE self-contained image-generation prompt — a single vivid paragraph, no title, no numbering, no creature name — that describes:\n- Body and silhouette: proportions, stance, and how the source animals fuse into one coherent form\n- Surface detail: dominant colors, patterns, and one or two standout features (horns, fins, glowing markings, plating)\n- Framing: the creature centered on a clean, uncluttered studio background so it reads clearly\n\nRender all four in this consistent art style: {{style}}.\n\nReturn exactly four prompts — one creature each, no two alike."
+          "prompt": "You are a creature designer for an original monster-collecting game. Invent FOUR distinct collectible creatures, each a believable fusion of these real animals: {{animals}}.\n\nFor every creature, write ONE self-contained image-generation prompt \u2014 a single vivid paragraph, no title, no numbering, no creature name \u2014 that describes:\n- Body and silhouette: proportions, stance, and how the source animals fuse into one coherent form\n- Surface detail: dominant colors, patterns, and one or two standout features (horns, fins, glowing markings, plating)\n- Framing: the creature centered on a clean, uncluttered studio background so it reads clearly\n\nRender all four in this consistent art style: {{style}}.\n\nReturn exactly four prompts \u2014 one creature each, no two alike."
         },
         "ui_properties": {
           "selected": false,
@@ -152,7 +152,7 @@
           },
           "zIndex": 0,
           "width": 351,
-          "title": "2️⃣ Build design brief",
+          "title": "2\ufe0f\u20e3 Build design brief",
           "selectable": true,
           "bypassed": false
         },
@@ -187,7 +187,7 @@
           "width": 291,
           "selectable": true,
           "bypassed": false,
-          "title": "3️⃣ Write four creature prompts"
+          "title": "3\ufe0f\u20e3 Write four creature prompts"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -198,7 +198,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -223,7 +223,7 @@
           "selectable": true,
           "bypassed": false,
           "height": 400,
-          "title": "4️⃣ Render each creature"
+          "title": "4\ufe0f\u20e3 Render each creature"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Product Mockup Generator.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Product Mockup Generator.json
@@ -5,7 +5,7 @@
   "updated_at": "2026-06-22T12:00:00.000Z",
   "name": "Product Mockup Generator",
   "tool_name": null,
-  "description": "Turn one product photo into a whole set of polished lifestyle mockups. An LLM art-director designs a varied shot list from your product description, then each scene is rendered with FLUX and finished with a brightness/contrast polish. Differentiator: the model invents the scenes, so a single input fans out into a coordinated mockup set — not one prompt, one image.",
+  "description": "Turn one product photo into a whole set of polished lifestyle mockups. An LLM art-director designs a varied shot list from your product description, then each scene is rendered with FLUX and finished with a brightness/contrast polish. Differentiator: the model invents the scenes, so a single input fans out into a coordinated mockup set \u2014 not one prompt, one image.",
   "tags": [
     "product-mockup",
     "mockup",
@@ -136,7 +136,7 @@
         "id": "comment-intro",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 🖼️ Product Mockup Generator\n\nOne product photo in, a coordinated set of lifestyle mockups out.\n\n**Why the extra stages:** a single image prompt gives you one look. Here an art-director agent first invents *distinct* scene concepts from the product brief (studio, lifestyle, flat-lay, outdoor…), a second prompt turns each concept into a photography-grade image prompt, and a list generator splits them so every scene renders in parallel.\n\n**Two outputs per scene:** a pure text-to-image render (the *scene*), and an image-to-image pass that composites your real product photo into it (the *mockup*), finished with a brightness/contrast polish.\n\n**Try this:** raise the scene count, or change the target audience to shift the whole shot list."
+          "comment": "# \ud83d\uddbc\ufe0f Product Mockup Generator\n\nOne product photo in, a coordinated set of lifestyle mockups out.\n\n**Why the extra stages:** a single image prompt gives you one look. Here an art-director agent first invents *distinct* scene concepts from the product brief (studio, lifestyle, flat-lay, outdoor\u2026), a second prompt turns each concept into a photography-grade image prompt, and a list generator splits them so every scene renders in parallel.\n\n**Two outputs per scene:** a pure text-to-image render (the *scene*), and an image-to-image pass that composites your real product photo into it (the *mockup*), finished with a brightness/contrast polish.\n\n**Try this:** raise the scene count, or change the target audience to shift the whole shot list."
         },
         "ui_properties": {
           "selected": false,
@@ -169,7 +169,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "©️ Final color adjust → mockup"
+          "title": "\u00a9\ufe0f Final color adjust \u2192 mockup"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -190,7 +190,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "🅱️ Brightness / contrast polish"
+          "title": "\ud83c\udd71\ufe0f Brightness / contrast polish"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -201,7 +201,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -227,7 +227,7 @@
           "selectable": true,
           "bypassed": false,
           "height": 400,
-          "title": "🅰️ Composite product into scene (image-to-image)"
+          "title": "\ud83c\udd70\ufe0f Composite product into scene (image-to-image)"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -255,7 +255,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "3️⃣ Product image"
+          "title": "3\ufe0f\u20e3 Product image"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -284,7 +284,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "9️⃣ Split into per-scene prompts"
+          "title": "9\ufe0f\u20e3 Split into per-scene prompts"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -304,7 +304,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "8️⃣ Build image prompt"
+          "title": "8\ufe0f\u20e3 Build image prompt"
         },
         "dynamic_properties": {
           "scenes": "Studio shot on a matte black surface with soft key lighting; lifestyle scene on a wooden desk beside a laptop",
@@ -325,7 +325,7 @@
             "path": null,
             "supported_tasks": []
           },
-          "system": "You are a professional product photographer and commercial art director.\n\nFrom a product brief you invent distinct, sales-ready photography scene concepts. Follow these rules:\n- Make every concept visibly different in setting, lighting, and mood — no two should read as the same shot.\n- Stay faithful to the product's real materials, colors, and features; never invent capabilities you were not given.\n- Ground each concept for the stated target audience.\n- Be concrete and shootable: name the environment, the light, the props, the camera angle, and the atmosphere.\n\nReturn only the scene concepts, one complete concept per line, no numbering or commentary.",
+          "system": "You are a professional product photographer and commercial art director.\n\nFrom a product brief you invent distinct, sales-ready photography scene concepts. Follow these rules:\n- Make every concept visibly different in setting, lighting, and mood \u2014 no two should read as the same shot.\n- Stay faithful to the product's real materials, colors, and features; never invent capabilities you were not given.\n- Ground each concept for the stated target audience.\n- Be concrete and shootable: name the environment, the light, the props, the camera angle, and the atmosphere.\n\nReturn only the scene concepts, one complete concept per line, no numbering or commentary.",
           "image": {
             "type": "image",
             "uri": "",
@@ -353,7 +353,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "7️⃣ Scene concept agent"
+          "title": "7\ufe0f\u20e3 Scene concept agent"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -373,7 +373,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "6️⃣ Build scene prompt"
+          "title": "6\ufe0f\u20e3 Build scene prompt"
         },
         "dynamic_properties": {
           "name": "Premium Wireless Headphones",
@@ -400,7 +400,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "1️⃣ Product name"
+          "title": "1\ufe0f\u20e3 Product name"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -422,7 +422,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "5️⃣ Product description"
+          "title": "5\ufe0f\u20e3 Product description"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -444,7 +444,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "4️⃣ Target audience"
+          "title": "4\ufe0f\u20e3 Target audience"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -468,7 +468,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "2️⃣ Scene count"
+          "title": "2\ufe0f\u20e3 Scene count"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -479,7 +479,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -503,7 +503,7 @@
           "selectable": true,
           "bypassed": false,
           "height": 400,
-          "title": "🔟 Render scene (text-to-image)"
+          "title": "\ud83d\udd1f Render scene (text-to-image)"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Pull a Field out of JSON Text.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Pull a Field out of JSON Text.json
@@ -1,0 +1,101 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Pull a Field out of JSON Text",
+  "tool_name": null,
+  "description": "Model output often arrives as JSON inside a string. ExtractJSON reaches into it by path so you do not have to parse it by hand downstream.",
+  "tags": [
+    "text",
+    "data",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "s",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "{\"user\":{\"name\":\"Ada\",\"role\":\"engineer\"},\"active\":true}"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  JSON text"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "ej",
+        "type": "nodetool.text.ExtractJSON",
+        "data": {
+          "text": "",
+          "json_path": "$.user.name",
+          "find_all": false
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Extract $.user.name"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "name"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Value"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "s",
+        "sourceHandle": "output",
+        "target": "ej",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "ej",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Put a Voice Over a Music Bed.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Put a Voice Over a Music Bed.json
@@ -1,0 +1,174 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Put a Voice Over a Music Bed",
+  "tool_name": null,
+  "description": "Generate a bed, synthesise a voice, and lay one over the other. Overlay mixes both signals rather than replacing one with the other.",
+  "tags": [
+    "audio",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "t",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "Built for people who would rather ship than configure."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Script"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "tts",
+        "type": "nodetool.audio.TextToSpeech",
+        "data": {
+          "model": {
+            "type": "tts_model",
+            "provider": "openai",
+            "id": "tts-1",
+            "name": "TTS 1",
+            "path": null,
+            "voices": [
+              "alloy",
+              "echo",
+              "fable",
+              "onyx",
+              "nova",
+              "shimmer"
+            ],
+            "selected_voice": "nova"
+          },
+          "text": "",
+          "speed": 1.0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Voice"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "mus",
+        "type": "nodetool.audio.TextToMusic",
+        "data": {
+          "model": {
+            "type": "music_model",
+            "provider": "replicate",
+            "id": "meta/musicgen",
+            "name": "MusicGen",
+            "path": null
+          },
+          "prompt": "calm ambient pad, no drums, soft and unobtrusive",
+          "lyrics": "",
+          "duration": 8.0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Music bed"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "ov",
+        "type": "nodetool.audio.OverlayAudio",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Overlay"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "spot"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "5  Spot"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "t",
+        "sourceHandle": "output",
+        "target": "tts",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "tts",
+        "sourceHandle": "audio",
+        "target": "ov",
+        "targetHandle": "a"
+      },
+      {
+        "id": "e3",
+        "source": "mus",
+        "sourceHandle": "audio",
+        "target": "ov",
+        "targetHandle": "b"
+      },
+      {
+        "id": "e4",
+        "source": "ov",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Read a Clip's Frame Rate.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Read a Clip's Frame Rate.json
@@ -1,0 +1,98 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Read a Clip's Frame Rate",
+  "tool_name": null,
+  "description": "Fps reads the rate off the header without decoding the video. Cheap enough to run before deciding whether a clip needs conforming.",
+  "tags": [
+    "video",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "in",
+        "type": "nodetool.input.VideoInput",
+        "data": {
+          "name": "clip",
+          "value": null,
+          "description": "The clip to inspect"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Clip"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "f",
+        "type": "nodetool.video.Fps",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Frame rate"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "fps"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  FPS"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "in",
+        "sourceHandle": "output",
+        "target": "f",
+        "targetHandle": "video"
+      },
+      {
+        "id": "e2",
+        "source": "f",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Redact Email Addresses.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Redact Email Addresses.json
@@ -1,0 +1,101 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Redact Email Addresses",
+  "tool_name": null,
+  "description": "A regex replace standing in for the everyday cleanup step \u2014 strip personal data out of text before it reaches a model or a log.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "s",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "Contact ada@example.com or grace@navy.mil before Friday."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Text"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "rr",
+        "type": "nodetool.text.RegexReplace",
+        "data": {
+          "text": "",
+          "pattern": "[\\w.+-]+@[\\w-]+\\.[\\w.]+",
+          "replacement": "[redacted]",
+          "count": 0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Redact"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "clean"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Result"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "s",
+        "sourceHandle": "output",
+        "target": "rr",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "rr",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Relight a Portrait.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Relight a Portrait.json
@@ -1,0 +1,109 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Relight a Portrait",
+  "tool_name": null,
+  "description": "Change where the light comes from after the shot. The subject and framing stay put while the lighting is re-rendered from a description.",
+  "tags": [
+    "image",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "in",
+        "type": "nodetool.input.ImageInput",
+        "data": {
+          "name": "picture",
+          "value": null,
+          "description": "The portrait to relight"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Portrait"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "rl",
+        "type": "nodetool.image.Relight",
+        "data": {
+          "model": {
+            "type": "image_model",
+            "provider": "fal_ai",
+            "id": "fal-ai/image-apps-v2/relighting",
+            "name": "Relight",
+            "path": null,
+            "supported_tasks": []
+          },
+          "prompt": "warm rim light from the back left, deep shadows, cinematic",
+          "negative_prompt": ""
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Relight"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "relit"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Result"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "in",
+        "sourceHandle": "output",
+        "target": "rl",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e2",
+        "source": "rl",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Restyle a Still with FLUX Dev.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Restyle a Still with FLUX Dev.json
@@ -1,0 +1,114 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Restyle a Still with FLUX Dev",
+  "tool_name": null,
+  "description": "Image-to-image at moderate strength: keep the composition, change the medium. Strength is the dial \u2014 low preserves the original, high redraws it.",
+  "tags": [
+    "image",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "in",
+        "type": "nodetool.input.ImageInput",
+        "data": {
+          "name": "picture",
+          "value": null,
+          "description": "The still to restyle"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Still"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "i2i",
+        "type": "nodetool.image.ImageToImage",
+        "data": {
+          "model": {
+            "type": "image_model",
+            "provider": "fal_ai",
+            "id": "fal-ai/flux/dev",
+            "name": "FLUX.1 Dev",
+            "path": null,
+            "supported_tasks": []
+          },
+          "image": [],
+          "prompt": "oil painting, visible brush strokes, muted palette",
+          "negative_prompt": "",
+          "entities": [],
+          "strength": 0.6,
+          "aspect_ratio": "1:1",
+          "resolution": "1K"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Restyle"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "restyled"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Result"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "in",
+        "sourceHandle": "output",
+        "target": "i2i",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e2",
+        "source": "i2i",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/SEO Content Engine.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/SEO Content Engine.json
@@ -5,7 +5,7 @@
   "updated_at": "2026-07-01T00:00:00.000000",
   "name": "SEO Content Engine",
   "tool_name": null,
-  "description": "One topic in, a keyword-targeted article batch out — each article lands as typed fields (title, meta description, keywords, body) instead of one markdown blob, ready to paste straight into a CMS. A strategist agent plans the topic cluster, a list generator turns it into briefs, and every brief becomes a full article with an editorial hero image.",
+  "description": "One topic in, a keyword-targeted article batch out \u2014 each article lands as typed fields (title, meta description, keywords, body) instead of one markdown blob, ready to paste straight into a CMS. A strategist agent plans the topic cluster, a list generator turns it into briefs, and every brief becomes a full article with an editorial hero image.",
   "tags": [
     "seo",
     "content",
@@ -222,7 +222,7 @@
         "id": "comment",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 📈 SEO Content Engine\n\nOne topic in, a keyword-targeted article batch out — each article comes back as separate title, meta description, keyword list, and body fields (not one markdown blob), ready to drop into a CMS. A strategist agent plans the topic cluster, a list generator turns it into briefs, and every brief becomes a full article with an editorial hero image.\n\n**Pipeline:** Business + Seed topics → Strategist → Briefs → Articles (typed fields) + Hero images\n\n**Try this:** pick the language and image models, then raise the article count or point the seed topics at the next cluster."
+          "comment": "# \ud83d\udcc8 SEO Content Engine\n\nOne topic in, a keyword-targeted article batch out \u2014 each article comes back as separate title, meta description, keyword list, and body fields (not one markdown blob), ready to drop into a CMS. A strategist agent plans the topic cluster, a list generator turns it into briefs, and every brief becomes a full article with an editorial hero image.\n\n**Pipeline:** Business + Seed topics \u2192 Strategist \u2192 Briefs \u2192 Articles (typed fields) + Hero images\n\n**Try this:** pick the language and image models, then raise the article count or point the seed topics at the next cluster."
         },
         "ui_properties": {
           "position": {
@@ -243,7 +243,7 @@
         "type": "nodetool.input.StringInput",
         "data": {
           "name": "business",
-          "value": "Aurora Gear — a DTC shop for ultralight hiking equipment. The blog lives at auroragear.example/guides and supports the trail-gear collection pages.",
+          "value": "Aurora Gear \u2014 a DTC shop for ultralight hiking equipment. The blog lives at auroragear.example/guides and supports the trail-gear collection pages.",
           "description": "Who is publishing, and which pages the articles should support"
         },
         "ui_properties": {
@@ -253,7 +253,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "1️⃣ Business & site",
+          "title": "1\ufe0f\u20e3 Business & site",
           "selectable": true,
           "bypassed": false
         },
@@ -275,7 +275,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "2️⃣ Audience & seed topics",
+          "title": "2\ufe0f\u20e3 Audience & seed topics",
           "selectable": true,
           "bypassed": false
         },
@@ -299,7 +299,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "3️⃣ Article count",
+          "title": "3\ufe0f\u20e3 Article count",
           "selectable": true,
           "bypassed": false
         },
@@ -310,7 +310,7 @@
         "id": "plan_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "You are planning organic-search content for this business.\n\nBusiness: {{ BUSINESS }}\nAudience and seed topics: {{ SEEDS }}\nArticles to produce: {{ COUNT }}\n\nReturn a content plan in Markdown, no commentary:\n\nCluster: the one topic cluster these articles should own, and the money pages they support.\nKeywords: {{ COUNT }} primary keywords — each a real phrase this audience searches, one line each with intent (informational, comparison, transactional) and the searcher's actual question.\nCoverage: how the {{ COUNT }} articles divide the cluster without competing with each other.\nVoice: 2-3 lines on the tone and point of view that make this business worth reading over the top-ten listicles."
+          "prompt": "You are planning organic-search content for this business.\n\nBusiness: {{ BUSINESS }}\nAudience and seed topics: {{ SEEDS }}\nArticles to produce: {{ COUNT }}\n\nReturn a content plan in Markdown, no commentary:\n\nCluster: the one topic cluster these articles should own, and the money pages they support.\nKeywords: {{ COUNT }} primary keywords \u2014 each a real phrase this audience searches, one line each with intent (informational, comparison, transactional) and the searcher's actual question.\nCoverage: how the {{ COUNT }} articles divide the cluster without competing with each other.\nVoice: 2-3 lines on the tone and point of view that make this business worth reading over the top-ten listicles."
         },
         "ui_properties": {
           "position": {
@@ -325,7 +325,7 @@
           "bypassed": false
         },
         "dynamic_properties": {
-          "BUSINESS": "Aurora Gear — a DTC shop for ultralight hiking equipment. The blog lives at auroragear.example/guides and supports the trail-gear collection pages.",
+          "BUSINESS": "Aurora Gear \u2014 a DTC shop for ultralight hiking equipment. The blog lives at auroragear.example/guides and supports the trail-gear collection pages.",
           "SEEDS": "beginner hikers researching their first serious gear; seed topics: ultralight backpacking basics, trail runners vs hiking boots, multi-day packing lists",
           "COUNT": "4"
         },
@@ -362,7 +362,7 @@
           "zIndex": 0,
           "width": 330,
           "height": 350,
-          "title": "4️⃣ Plan the keyword cluster",
+          "title": "4\ufe0f\u20e3 Plan the keyword cluster",
           "selectable": true,
           "bypassed": false
         },
@@ -383,7 +383,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 220,
-          "title": "🗺️ Content plan",
+          "title": "\ud83d\uddfa\ufe0f Content plan",
           "selectable": true,
           "bypassed": false
         },
@@ -394,7 +394,7 @@
         "id": "briefs_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "From this content plan, write exactly {{ COUNT }} article briefs, one per line — no numbering, no labels.\n\nEach line: working title | primary keyword | search intent | the 3-4 H2 sections the article needs | the one thing the reader must be able to do after reading.\n\nPlan:\n{{ PLAN }}"
+          "prompt": "From this content plan, write exactly {{ COUNT }} article briefs, one per line \u2014 no numbering, no labels.\n\nEach line: working title | primary keyword | search intent | the 3-4 H2 sections the article needs | the one thing the reader must be able to do after reading.\n\nPlan:\n{{ PLAN }}"
         },
         "ui_properties": {
           "position": {
@@ -437,7 +437,7 @@
           "zIndex": 0,
           "width": 330,
           "height": 245,
-          "title": "5️⃣ Generate article briefs",
+          "title": "5\ufe0f\u20e3 Generate article briefs",
           "selectable": true,
           "bypassed": false
         },
@@ -448,7 +448,7 @@
         "id": "article_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "Write the full article for this brief.\n\nBrief: {{ BRIEF }}\nPublishing business: {{ BUSINESS }}\n\nRules for the body:\n- 900-1200 words. Use the brief's H2 sections; add H3s where they help scanning.\n- Answer the searcher's question in the first two sentences, then earn the depth.\n- Concrete numbers, steps, and examples over generalities. First-hand point of view where credible.\n- The primary keyword appears where it belongs — write for the reader, not the crawler.\n- End with a short FAQ (3 questions) and one unforced call to action for the business."
+          "prompt": "Write the full article for this brief.\n\nBrief: {{ BRIEF }}\nPublishing business: {{ BUSINESS }}\n\nRules for the body:\n- 900-1200 words. Use the brief's H2 sections; add H3s where they help scanning.\n- Answer the searcher's question in the first two sentences, then earn the depth.\n- Concrete numbers, steps, and examples over generalities. First-hand point of view where credible.\n- The primary keyword appears where it belongs \u2014 write for the reader, not the crawler.\n- End with a short FAQ (3 questions) and one unforced call to action for the business."
         },
         "ui_properties": {
           "position": {
@@ -464,7 +464,7 @@
         },
         "dynamic_properties": {
           "BRIEF": "",
-          "BUSINESS": "Aurora Gear — a DTC shop for ultralight hiking equipment. The blog lives at auroragear.example/guides and supports the trail-gear collection pages."
+          "BUSINESS": "Aurora Gear \u2014 a DTC shop for ultralight hiking equipment. The blog lives at auroragear.example/guides and supports the trail-gear collection pages."
         },
         "dynamic_outputs": {}
       },
@@ -480,7 +480,7 @@
             "path": null,
             "supported_tasks": []
           },
-          "system": "You are a senior content writer for organic search. You write like an expert practitioner sharing what works, never like a content mill. Specific, useful, zero filler.\n\nOutput Format\n- Return a single JSON object matching the defined output schema — `title`, `meta_description`, `keywords`, and `body` are separate fields, never merged into one string.\n- `title`: the article's H1, plain text, no Markdown syntax, no surrounding quotes.\n- `meta_description`: a 150-160 character search-result snippet that earns the click, written in sentence case.\n- `keywords`: 3-6 keyword phrases as an array of strings, primary keyword first.\n- `body`: the full article body as Markdown, starting at H2 (no title line, no meta line, no keyword list) — follow the rules given in the brief.",
+          "system": "You are a senior content writer for organic search. You write like an expert practitioner sharing what works, never like a content mill. Specific, useful, zero filler.\n\nOutput Format\n- Return a single JSON object matching the defined output schema \u2014 `title`, `meta_description`, `keywords`, and `body` are separate fields, never merged into one string.\n- `title`: the article's H1, plain text, no Markdown syntax, no surrounding quotes.\n- `meta_description`: a 150-160 character search-result snippet that earns the click, written in sentence case.\n- `keywords`: 3-6 keyword phrases as an array of strings, primary keyword first.\n- `body`: the full article body as Markdown, starting at H2 (no title line, no meta line, no keyword list) \u2014 follow the rules given in the brief.",
           "audio": {
             "type": "audio",
             "uri": "",
@@ -499,7 +499,7 @@
           "zIndex": 0,
           "width": 330,
           "height": 350,
-          "title": "6️⃣ Write the articles",
+          "title": "6\ufe0f\u20e3 Write the articles",
           "selectable": true,
           "bypassed": false
         },
@@ -547,7 +547,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 110,
-          "title": "📌 Article titles",
+          "title": "\ud83d\udccc Article titles",
           "selectable": true,
           "bypassed": false
         },
@@ -568,7 +568,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 110,
-          "title": "🏷️ Meta descriptions",
+          "title": "\ud83c\udff7\ufe0f Meta descriptions",
           "selectable": true,
           "bypassed": false
         },
@@ -589,7 +589,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 140,
-          "title": "🔑 Keywords",
+          "title": "\ud83d\udd11 Keywords",
           "selectable": true,
           "bypassed": false
         },
@@ -610,7 +610,7 @@
           "zIndex": 0,
           "width": 380,
           "height": 420,
-          "title": "📄 Article bodies",
+          "title": "\ud83d\udcc4 Article bodies",
           "selectable": true,
           "bypassed": false
         },
@@ -621,7 +621,7 @@
         "id": "hero_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "Editorial hero image for a blog article, 16:9.\n\nArticle brief: {{ BRIEF }}\n\nOne clear photographic scene that shows the article's subject in the real world — natural light, believable setting, room on one side for a headline overlay. Magazine photo-essay quality. No on-screen text, no logos, no watermarks, no illustration style, no distorted anatomy."
+          "prompt": "Editorial hero image for a blog article, 16:9.\n\nArticle brief: {{ BRIEF }}\n\nOne clear photographic scene that shows the article's subject in the real world \u2014 natural light, believable setting, room on one side for a headline overlay. Magazine photo-essay quality. No on-screen text, no logos, no watermarks, no illustration style, no distorted anatomy."
         },
         "ui_properties": {
           "position": {
@@ -646,7 +646,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -665,7 +665,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 340,
-          "title": "7️⃣ Render hero images",
+          "title": "7\ufe0f\u20e3 Render hero images",
           "selectable": true,
           "bypassed": false
         },
@@ -686,7 +686,7 @@
           "zIndex": 0,
           "width": 360,
           "height": 380,
-          "title": "🖼️ Hero images",
+          "title": "\ud83d\uddbc\ufe0f Hero images",
           "selectable": true,
           "bypassed": false
         },

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Script to Screen.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Script to Screen.json
@@ -334,7 +334,7 @@
         "id": "comment_main",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 🎬 Script to Screen\n\nThe full production spine in one graph:\n\n**1. Direction** — a Director agent turns your brief into a direction document: characters with fixed descriptors, a style bible, a numbered shot list, narration, and music direction.\n**2. Storyboard** — a style frame anchors every keyframe (image-to-image), so characters and grade stay consistent. Keyframes cost cents; check them before the video spend.\n**3. Shoot** — each keyframe is animated with its shot's motion direction.\n**4. Post** — clips are cut together, then narration and music are mixed in.\n\n**Cost control:** bypass the Animate node (right-click → Bypass) to iterate on direction and storyboard cheaply. Re-enable it when the stills look right."
+          "comment": "# \ud83c\udfac Script to Screen\n\nThe full production spine in one graph:\n\n**1. Direction** \u2014 a Director agent turns your brief into a direction document: characters with fixed descriptors, a style bible, a numbered shot list, narration, and music direction.\n**2. Storyboard** \u2014 a style frame anchors every keyframe (image-to-image), so characters and grade stay consistent. Keyframes cost cents; check them before the video spend.\n**3. Shoot** \u2014 each keyframe is animated with its shot's motion direction.\n**4. Post** \u2014 clips are cut together, then narration and music are mixed in.\n\n**Cost control:** bypass the Animate node (right-click \u2192 Bypass) to iterate on direction and storyboard cheaply. Re-enable it when the stills look right."
         },
         "ui_properties": {
           "position": {
@@ -355,7 +355,7 @@
         "type": "nodetool.input.StringInput",
         "data": {
           "name": "Brief",
-          "value": "A lighthouse keeper discovers the beam of her lamp has started bending toward something beneath the waves — and tonight it refuses to point anywhere else."
+          "value": "A lighthouse keeper discovers the beam of her lamp has started bending toward something beneath the waves \u2014 and tonight it refuses to point anywhere else."
         },
         "ui_properties": {
           "position": {
@@ -364,7 +364,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "1️⃣ Brief",
+          "title": "1\ufe0f\u20e3 Brief",
           "selectable": true,
           "bypassed": false
         },
@@ -385,7 +385,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "2️⃣ Visual style",
+          "title": "2\ufe0f\u20e3 Visual style",
           "selectable": true,
           "bypassed": false
         },
@@ -406,7 +406,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "3️⃣ Shot count",
+          "title": "3\ufe0f\u20e3 Shot count",
           "selectable": true,
           "bypassed": false
         },
@@ -417,7 +417,7 @@
         "id": "director_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "You are directing a short film. Write a complete DIRECTION DOCUMENT for this brief.\n\nBrief: {{ BRIEF }}\nVisual style: {{ STYLE }}\nShot count: {{ COUNT }}\n\nReturn Markdown with exactly these sections:\n\n## TITLE\nOne evocative title.\n\n## LOGLINE\nOne sentence.\n\n## CHARACTERS\nEach recurring character or subject on its own line as `Name: <one fixed visual descriptor sentence>`. These exact descriptor sentences will be pasted into every shot prompt, so make them concrete: age, build, hair, wardrobe, distinguishing detail.\n\n## STYLE BIBLE\n3-4 lines: palette, light, lens, texture. Consistent with the visual style above.\n\n## SHOT LIST\nExactly {{ COUNT }} numbered shots. Each shot is one line: `N. VISUAL: <subject + setting, reusing the exact character descriptors> | CAMERA: <framing, lens, angle> | MOTION: <what moves in the shot, including camera movement>`.\n\n## NARRATION\nA voiceover script read over the whole film — about 2 seconds of speech per shot, written to land against the shot order. Plain sentences, no headings.\n\n## MUSIC\nOne line describing the score: genre, mood, instrumentation, tempo."
+          "prompt": "You are directing a short film. Write a complete DIRECTION DOCUMENT for this brief.\n\nBrief: {{ BRIEF }}\nVisual style: {{ STYLE }}\nShot count: {{ COUNT }}\n\nReturn Markdown with exactly these sections:\n\n## TITLE\nOne evocative title.\n\n## LOGLINE\nOne sentence.\n\n## CHARACTERS\nEach recurring character or subject on its own line as `Name: <one fixed visual descriptor sentence>`. These exact descriptor sentences will be pasted into every shot prompt, so make them concrete: age, build, hair, wardrobe, distinguishing detail.\n\n## STYLE BIBLE\n3-4 lines: palette, light, lens, texture. Consistent with the visual style above.\n\n## SHOT LIST\nExactly {{ COUNT }} numbered shots. Each shot is one line: `N. VISUAL: <subject + setting, reusing the exact character descriptors> | CAMERA: <framing, lens, angle> | MOTION: <what moves in the shot, including camera movement>`.\n\n## NARRATION\nA voiceover script read over the whole film \u2014 about 2 seconds of speech per shot, written to land against the shot order. Plain sentences, no headings.\n\n## MUSIC\nOne line describing the score: genre, mood, instrumentation, tempo."
         },
         "ui_properties": {
           "position": {
@@ -450,7 +450,7 @@
             "path": null,
             "supported_tasks": []
           },
-          "system": "You are a film director and screenwriter. You write tight, concrete direction documents. Every line is visual and specific — no vague adjectives, no meta commentary. You keep character descriptors identical wherever they recur.",
+          "system": "You are a film director and screenwriter. You write tight, concrete direction documents. Every line is visual and specific \u2014 no vague adjectives, no meta commentary. You keep character descriptors identical wherever they recur.",
           "max_tokens": 100000
         },
         "ui_properties": {
@@ -461,7 +461,7 @@
           "zIndex": 0,
           "width": 330,
           "height": 360,
-          "title": "4️⃣ Director — write the direction",
+          "title": "4\ufe0f\u20e3 Director \u2014 write the direction",
           "selectable": true,
           "bypassed": false
         },
@@ -479,7 +479,7 @@
             "x": 1160,
             "y": -60
           },
-          "title": "📋 Direction document",
+          "title": "\ud83d\udccb Direction document",
           "selectable": true
         },
         "dynamic_properties": {},
@@ -497,7 +497,7 @@
             "path": null,
             "supported_tasks": []
           },
-          "instructions": "The context is a film direction document. Extract three fields:\n- narration: the full NARRATION section verbatim, as one block of plain text with no headings.\n- music_prompt: the MUSIC line as a single music-generation prompt (genre, mood, instrumentation, tempo). Instrumental only — state 'instrumental, no vocals'.\n- style_frame_prompt: one text-to-image prompt for a single 16:9 master style frame that establishes the film's world: the main character (exact descriptor from CHARACTERS), the key location, and the STYLE BIBLE's palette and light. No text, no titles, no watermark.",
+          "instructions": "The context is a film direction document. Extract three fields:\n- narration: the full NARRATION section verbatim, as one block of plain text with no headings.\n- music_prompt: the MUSIC line as a single music-generation prompt (genre, mood, instrumentation, tempo). Instrumental only \u2014 state 'instrumental, no vocals'.\n- style_frame_prompt: one text-to-image prompt for a single 16:9 master style frame that establishes the film's world: the main character (exact descriptor from CHARACTERS), the key location, and the STYLE BIBLE's palette and light. No text, no titles, no watermark.",
           "context": "",
           "max_tokens": 4096
         },
@@ -509,7 +509,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 300,
-          "title": "5️⃣ Extract production data",
+          "title": "5\ufe0f\u20e3 Extract production data",
           "selectable": true,
           "bypassed": false
         },
@@ -538,7 +538,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -557,7 +557,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 320,
-          "title": "6️⃣ Master style frame",
+          "title": "6\ufe0f\u20e3 Master style frame",
           "selectable": true,
           "bypassed": false
         },
@@ -610,7 +610,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 240,
-          "title": "7️⃣ Stream the shots",
+          "title": "7\ufe0f\u20e3 Stream the shots",
           "selectable": true,
           "bypassed": false
         },
@@ -647,7 +647,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -667,7 +667,7 @@
           "zIndex": 0,
           "width": 320,
           "height": 340,
-          "title": "8️⃣ Storyboard keyframes (anchored to style frame)",
+          "title": "8\ufe0f\u20e3 Storyboard keyframes (anchored to style frame)",
           "selectable": true,
           "bypassed": false
         },
@@ -703,7 +703,7 @@
             "x": 2880,
             "y": 80
           },
-          "title": "🖼️ Storyboard — approve before video spend",
+          "title": "\ud83d\uddbc\ufe0f Storyboard \u2014 approve before video spend",
           "selectable": true
         },
         "dynamic_properties": {},
@@ -758,7 +758,7 @@
           "zIndex": 0,
           "width": 330,
           "height": 240,
-          "title": "9️⃣ Animate each shot (the expensive step)",
+          "title": "9\ufe0f\u20e3 Animate each shot (the expensive step)",
           "selectable": true,
           "bypassed": false
         },
@@ -795,7 +795,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 240,
-          "title": "🎞️ Cut the shots together",
+          "title": "\ud83c\udf9e\ufe0f Cut the shots together",
           "selectable": true,
           "bypassed": false
         },
@@ -834,7 +834,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 220,
-          "title": "🎙️ Narration",
+          "title": "\ud83c\udf99\ufe0f Narration",
           "selectable": true,
           "bypassed": false
         },
@@ -863,7 +863,7 @@
           "zIndex": 0,
           "width": 300,
           "height": 240,
-          "title": "🎵 Score",
+          "title": "\ud83c\udfb5 Score",
           "selectable": true,
           "bypassed": false
         },
@@ -925,7 +925,7 @@
             "x": 4350,
             "y": 560
           },
-          "title": "🎬 Final film",
+          "title": "\ud83c\udfac Final film",
           "selectable": true
         },
         "dynamic_properties": {},

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Social Media Calendar Filler.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Social Media Calendar Filler.json
@@ -5,7 +5,7 @@
   "updated_at": "2026-06-22T12:00:00.000Z",
   "name": "Social Media Calendar Filler",
   "tool_name": null,
-  "description": "Generate a month's worth of social media content as a structured calendar — one row per post with its own image prompt and ready-to-post caption — then render an image for every row.",
+  "description": "Generate a month's worth of social media content as a structured calendar \u2014 one row per post with its own image prompt and ready-to-post caption \u2014 then render an image for every row.",
   "tags": [
     "content",
     "social media",
@@ -135,7 +135,7 @@
         "id": "comment-intro",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# 📅 Social Media Calendar Filler\n\nTurn a brand brief into a month of posts: one agent call plans the whole calendar as structured rows (day, post type, image prompt, caption) — not a prose blob — then each row's image prompt renders an image and its caption ships as-is.\n\n**Pipeline:** Brand inputs → Plan calendar (structured dataframe) → Extract image prompts / captions per row → Image per post\n\n**Try this:** change posts-per-week or brand voice, or swap the image model. Open the calendar table output to see every row before images render."
+          "comment": "# \ud83d\udcc5 Social Media Calendar Filler\n\nTurn a brand brief into a month of posts: one agent call plans the whole calendar as structured rows (day, post type, image prompt, caption) \u2014 not a prose blob \u2014 then each row's image prompt renders an image and its caption ships as-is.\n\n**Pipeline:** Brand inputs \u2192 Plan calendar (structured dataframe) \u2192 Extract image prompts / captions per row \u2192 Image per post\n\n**Try this:** change posts-per-week or brand voice, or swap the image model. Open the calendar table output to see every row before images render."
         },
         "ui_properties": {
           "selected": false,
@@ -169,7 +169,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "1️⃣ Brand name"
+          "title": "1\ufe0f\u20e3 Brand name"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -191,7 +191,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "5️⃣ Monthly theme"
+          "title": "5\ufe0f\u20e3 Monthly theme"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -213,7 +213,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "4️⃣ Target audience"
+          "title": "4\ufe0f\u20e3 Target audience"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -235,7 +235,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "3️⃣ Brand voice"
+          "title": "3\ufe0f\u20e3 Brand voice"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -259,7 +259,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "2️⃣ Posts per week"
+          "title": "2\ufe0f\u20e3 Posts per week"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -268,7 +268,7 @@
         "id": "calendar_prompt",
         "type": "nodetool.text.Prompt",
         "data": {
-          "prompt": "You are a social media content planner for {{brand}}.\n\nBrand voice: {{voice}}\nTarget audience: {{audience}}\nMonthly theme: {{theme}}\nPosting frequency: {{frequency}} posts per week\n\nPlan a full 4-week content calendar — {{frequency}} posts per week times 4 weeks, one row per post. For every post decide:\n- day: the week and day it goes out, e.g. \"Week 1, Monday\"\n- post_type: the format, e.g. tip, behind-the-scenes, customer story, product feature, poll\n- image_prompt: a vivid, specific text-to-image prompt describing the visual — describe subject, scene, and style; no brand names or logos in the prompt\n- caption: the ready-to-post caption in the brand voice, tied to the monthly theme, ending with 3-5 relevant hashtags\n\nRules:\n- Vary post_type across the month; never repeat the same type on two consecutive posts.\n- Every image_prompt must be visually distinct from every other row.\n- Every caption must speak directly to {{audience}}.\n- No placeholder text, no commentary outside the rows."
+          "prompt": "You are a social media content planner for {{brand}}.\n\nBrand voice: {{voice}}\nTarget audience: {{audience}}\nMonthly theme: {{theme}}\nPosting frequency: {{frequency}} posts per week\n\nPlan a full 4-week content calendar \u2014 {{frequency}} posts per week times 4 weeks, one row per post. For every post decide:\n- day: the week and day it goes out, e.g. \"Week 1, Monday\"\n- post_type: the format, e.g. tip, behind-the-scenes, customer story, product feature, poll\n- image_prompt: a vivid, specific text-to-image prompt describing the visual \u2014 describe subject, scene, and style; no brand names or logos in the prompt\n- caption: the ready-to-post caption in the brand voice, tied to the monthly theme, ending with 3-5 relevant hashtags\n\nRules:\n- Vary post_type across the month; never repeat the same type on two consecutive posts.\n- Every image_prompt must be visually distinct from every other row.\n- Every caption must speak directly to {{audience}}.\n- No placeholder text, no commentary outside the rows."
         },
         "ui_properties": {
           "selected": false,
@@ -280,7 +280,7 @@
           "width": 300,
           "selectable": true,
           "bypassed": false,
-          "title": "6️⃣ Build calendar prompt"
+          "title": "6\ufe0f\u20e3 Build calendar prompt"
         },
         "dynamic_properties": {
           "brand": "TechStartup Pro",
@@ -340,7 +340,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "7️⃣ Plan calendar (structured rows)"
+          "title": "7\ufe0f\u20e3 Plan calendar (structured rows)"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -358,7 +358,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "8️⃣ View calendar table",
+          "title": "8\ufe0f\u20e3 View calendar table",
           "selectable": true,
           "bypassed": false
         },
@@ -380,7 +380,7 @@
           "width": 280,
           "selectable": true,
           "bypassed": false,
-          "title": "9️⃣ Extract image prompts"
+          "title": "9\ufe0f\u20e3 Extract image prompts"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
@@ -429,7 +429,7 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "huggingface_fal_ai",
+            "provider": "fal_ai",
             "id": "fal-ai/flux/schnell",
             "name": "FLUX.1 Schnell",
             "path": null,
@@ -450,7 +450,7 @@
           "selectable": true,
           "bypassed": false,
           "height": 400,
-          "title": "🔟 Generate post image"
+          "title": "\ud83d\udd1f Generate post image"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Speak a Line, Then Trim the Silence.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Speak a Line, Then Trim the Silence.json
@@ -1,0 +1,145 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Speak a Line, Then Trim the Silence",
+  "tool_name": null,
+  "description": "Synthesise speech and strip the dead air off both ends. TTS often leaves padding; RemoveSilence gives you a tight clip you can drop into a timeline.",
+  "tags": [
+    "audio",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "t",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "The package arrives on Thursday. Someone has to be home to sign for it."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Line"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "tts",
+        "type": "nodetool.audio.TextToSpeech",
+        "data": {
+          "model": {
+            "type": "tts_model",
+            "provider": "openai",
+            "id": "tts-1",
+            "name": "TTS 1",
+            "path": null,
+            "voices": [
+              "alloy",
+              "echo",
+              "fable",
+              "onyx",
+              "nova",
+              "shimmer"
+            ],
+            "selected_voice": "nova"
+          },
+          "text": "",
+          "speed": 1.0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Speak"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "rs",
+        "type": "nodetool.audio.RemoveSilence",
+        "data": {
+          "min_length": 200,
+          "threshold": -40,
+          "reduction_factor": 1.0,
+          "crossfade": 10,
+          "min_silence_between_parts": 100
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Trim silence"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "line"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Audio"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "t",
+        "sourceHandle": "output",
+        "target": "tts",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "tts",
+        "sourceHandle": "audio",
+        "target": "rs",
+        "targetHandle": "audio"
+      },
+      {
+        "id": "e3",
+        "source": "rs",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Split a Log into Records.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Split a Log into Records.json
@@ -1,0 +1,100 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Split a Log into Records",
+  "tool_name": null,
+  "description": "Regex split turns one blob into a list. The pattern is the record boundary, which is often more reliable than a fixed delimiter.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "s",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "2026-01-01 boot\n2026-01-02 sync\n2026-01-03 purge"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Log"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "rs",
+        "type": "nodetool.text.RegexSplit",
+        "data": {
+          "text": "",
+          "pattern": "\\n",
+          "maxsplit": 0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Split on newline"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "records"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Records"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "s",
+        "sourceHandle": "output",
+        "target": "rs",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "rs",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Strip Accents for a Search Key.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Strip Accents for a Search Key.json
@@ -1,0 +1,98 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Strip Accents for a Search Key",
+  "tool_name": null,
+  "description": "Fold accented characters down to ASCII so a lookup key matches regardless of how the name was typed.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "s",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "Caf\u00e9 Gr\u00f6\u00dfe \u00c5ngstr\u00f6m"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Text"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "sa",
+        "type": "nodetool.text.StripAccents",
+        "data": {
+          "text": ""
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Strip accents"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "ascii_key"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Key"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "s",
+        "sourceHandle": "output",
+        "target": "sa",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "sa",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Take the First Few Seconds of a Bed.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Take the First Few Seconds of a Bed.json
@@ -1,0 +1,108 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Take the First Few Seconds of a Bed",
+  "tool_name": null,
+  "description": "Generate music and slice a short section out of it. Cheaper than regenerating when you only need a sting rather than a full bed.",
+  "tags": [
+    "audio",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "mus",
+        "type": "nodetool.audio.TextToMusic",
+        "data": {
+          "model": {
+            "type": "music_model",
+            "provider": "replicate",
+            "id": "meta/musicgen",
+            "name": "MusicGen",
+            "path": null
+          },
+          "prompt": "bright synth arpeggio, upbeat, clean",
+          "lyrics": "",
+          "duration": 8.0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Generate bed"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "sl",
+        "type": "nodetool.audio.SliceAudio",
+        "data": {
+          "start": 0.0,
+          "end": 3.0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  First 3 s"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "sting"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Sting"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "mus",
+        "sourceHandle": "audio",
+        "target": "sl",
+        "targetHandle": "audio"
+      },
+      {
+        "id": "e2",
+        "source": "sl",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Tidy Up Messy Text.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Tidy Up Messy Text.json
@@ -1,0 +1,150 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Tidy Up Messy Text",
+  "tool_name": null,
+  "description": "Three cleanups in a row \u2014 collapse runs of whitespace, strip punctuation, then lowercase. The order matters, which is the point of showing it as a chain rather than one node.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "s",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "  The   QUICK, brown --- fox!!  "
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Messy"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "cw",
+        "type": "nodetool.text.CollapseWhitespace",
+        "data": {
+          "text": ""
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Collapse spaces"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "rp",
+        "type": "nodetool.text.RemovePunctuation",
+        "data": {
+          "text": ""
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Strip punctuation"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "lc",
+        "type": "nodetool.text.ToLowercase",
+        "data": {
+          "text": ""
+        },
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Lowercase"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "tidy"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "5  Result"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "s",
+        "sourceHandle": "output",
+        "target": "cw",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "cw",
+        "sourceHandle": "output",
+        "target": "rp",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e3",
+        "source": "rp",
+        "sourceHandle": "output",
+        "target": "lc",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e4",
+        "source": "lc",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Title Case a Heading.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Title Case a Heading.json
@@ -1,0 +1,98 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Title Case a Heading",
+  "tool_name": null,
+  "description": "Casing helpers, applied to a heading. Small, but these are the nodes you reach for constantly when formatting model output for display.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "s",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "the making of a visual workflow"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Heading"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "tc",
+        "type": "nodetool.text.ToTitlecase",
+        "data": {
+          "text": ""
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Title case"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "heading"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Heading"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "s",
+        "sourceHandle": "output",
+        "target": "tc",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "tc",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Trim a Blurb to Length.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Trim a Blurb to Length.json
@@ -1,0 +1,100 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Trim a Blurb to Length",
+  "tool_name": null,
+  "description": "Cap text at a character budget with an ellipsis. The everyday fix for a card or preview that must not overflow.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "s",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "A visual editor for building AI workflows that run locally on your own hardware or against cloud APIs, whichever suits the job."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Blurb"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "tr",
+        "type": "nodetool.text.TruncateText",
+        "data": {
+          "text": "",
+          "max_length": 60,
+          "ellipsis": "..."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Truncate to 60"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "blurb"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Result"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "s",
+        "sourceHandle": "output",
+        "target": "tr",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "tr",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Validate a Postcode Shape.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Validate a Postcode Shape.json
@@ -1,0 +1,99 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Validate a Postcode Shape",
+  "tool_name": null,
+  "description": "RegexValidate answers whether text matches a pattern \u2014 a guard to run before you trust user input or model output as structured data.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "s",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "SW1A 1AA"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Input"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "rv",
+        "type": "nodetool.text.RegexValidate",
+        "data": {
+          "text": "",
+          "pattern": "^[A-Z]{1,2}\\d[A-Z\\d]? \\d[A-Z]{2}$"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Validate"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "is_valid"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Valid?"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "s",
+        "sourceHandle": "output",
+        "target": "rv",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "rv",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Vectorize a Generated Logo.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Vectorize a Generated Logo.json
@@ -1,0 +1,143 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Vectorize a Generated Logo",
+  "tool_name": null,
+  "description": "Generate a flat mark, then trace it to true vector art. Raster generators cannot produce clean vectors, so the two steps are separate: FLUX draws the shape, Recraft converts it to SVG paths that scale without resampling.",
+  "tags": [
+    "image",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "p",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "a flat minimal fox head logo, two colors, thick shapes, solid white background"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Prompt"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "gen",
+        "type": "nodetool.image.TextToImage",
+        "data": {
+          "model": {
+            "type": "image_model",
+            "provider": "fal_ai",
+            "id": "fal-ai/flux/schnell",
+            "name": "FLUX.1 Schnell",
+            "path": null,
+            "supported_tasks": []
+          },
+          "prompt": "",
+          "negative_prompt": "",
+          "entities": [],
+          "aspect_ratio": "1:1",
+          "resolution": "1K"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Draw the mark"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "vec",
+        "type": "nodetool.image.Vectorize",
+        "data": {
+          "model": {
+            "type": "image_model",
+            "provider": "fal_ai",
+            "id": "fal-ai/recraft/vectorize",
+            "name": "Recraft Vectorize",
+            "path": null,
+            "supported_tasks": []
+          }
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Trace to SVG"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "logo_svg"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  SVG out"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "p",
+        "sourceHandle": "output",
+        "target": "gen",
+        "targetHandle": "prompt"
+      },
+      {
+        "id": "e2",
+        "source": "gen",
+        "sourceHandle": "output",
+        "target": "vec",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e3",
+        "source": "vec",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Vectorize a Photo You Provide.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Vectorize a Photo You Provide.json
@@ -1,0 +1,107 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Vectorize a Photo You Provide",
+  "tool_name": null,
+  "description": "Trace an image you supply into SVG paths. Useful for turning a scanned sketch or a flat render into artwork you can recolour and scale.",
+  "tags": [
+    "image",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "in",
+        "type": "nodetool.input.ImageInput",
+        "data": {
+          "name": "picture",
+          "value": null,
+          "description": "The image to trace"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Image"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "vec",
+        "type": "nodetool.image.Vectorize",
+        "data": {
+          "model": {
+            "type": "image_model",
+            "provider": "fal_ai",
+            "id": "fal-ai/recraft/vectorize",
+            "name": "Recraft Vectorize",
+            "path": null,
+            "supported_tasks": []
+          }
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Trace to SVG"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "traced_svg"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  SVG out"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "in",
+        "sourceHandle": "output",
+        "target": "vec",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e2",
+        "source": "vec",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Warm Up a Cold Clip.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Warm Up a Cold Clip.json
@@ -1,0 +1,102 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Warm Up a Cold Clip",
+  "tool_name": null,
+  "description": "Per-channel colour balance \u2014 lift red, drop blue. A grade you can apply without a GPU, since it runs through ffmpeg rather than a shader.",
+  "tags": [
+    "video",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "in",
+        "type": "nodetool.input.VideoInput",
+        "data": {
+          "name": "clip",
+          "value": null,
+          "description": "The clip to warm"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Clip"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "cb",
+        "type": "nodetool.video.ColorBalance",
+        "data": {
+          "red_adjust": 1.15,
+          "green_adjust": 1.0,
+          "blue_adjust": 0.85
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Warm grade"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "graded"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Result"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "in",
+        "sourceHandle": "output",
+        "target": "cb",
+        "targetHandle": "video"
+      },
+      {
+        "id": "e2",
+        "source": "cb",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Widen a Mono Voice.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Widen a Mono Voice.json
@@ -1,0 +1,139 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Widen a Mono Voice",
+  "tool_name": null,
+  "description": "Synthesise a mono voice and place it in a stereo field. Most TTS returns mono; anything mixed for stereo playback needs both channels.",
+  "tags": [
+    "audio",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "t",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "Stereo is not louder. It is wider."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Line"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "tts",
+        "type": "nodetool.audio.TextToSpeech",
+        "data": {
+          "model": {
+            "type": "tts_model",
+            "provider": "openai",
+            "id": "tts-1",
+            "name": "TTS 1",
+            "path": null,
+            "voices": [
+              "alloy",
+              "echo",
+              "fable",
+              "onyx",
+              "nova",
+              "shimmer"
+            ],
+            "selected_voice": "nova"
+          },
+          "text": "",
+          "speed": 1.0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Speak"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "ms",
+        "type": "nodetool.audio.MonoToStereo",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Mono to stereo"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "wide"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Audio"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "t",
+        "sourceHandle": "output",
+        "target": "tts",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "tts",
+        "sourceHandle": "audio",
+        "target": "ms",
+        "targetHandle": "audio"
+      },
+      {
+        "id": "e3",
+        "source": "ms",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Wrap a Value in Quotes.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Wrap a Value in Quotes.json
@@ -1,0 +1,100 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-07-30T12:00:00.000Z",
+  "updated_at": "2026-07-30T12:00:00.000Z",
+  "name": "Wrap a Value in Quotes",
+  "tool_name": null,
+  "description": "SurroundWith builds a fragment from a value \u2014 the small assembly step between a model's answer and a template that expects delimiters.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "s",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "shipped"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Value"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "sw",
+        "type": "nodetool.text.SurroundWith",
+        "data": {
+          "text": "",
+          "prefix": "\"",
+          "suffix": "\""
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Add quotes"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "out",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "quoted"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Result"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "s",
+        "sourceHandle": "output",
+        "target": "sw",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "sw",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -34,7 +34,10 @@ import { readCachedHfModels, searchCachedHfModels } from "@nodetool-ai/huggingfa
 import { initMasterKey } from "@nodetool-ai/security";
 import { getDefaultDbPath, getDefaultAssetsPath } from "@nodetool-ai/config";
 import { ExecutionSession } from "@nodetool-ai/execution";
-import { NodeRegistry } from "@nodetool-ai/node-sdk";
+import {
+  NodeRegistry,
+  createGraphNodeTypeResolver
+} from "@nodetool-ai/node-sdk";
 import { registerBaseNodes } from "@nodetool-ai/base-nodes";
 import { registerElevenLabsNodes } from "@nodetool-ai/elevenlabs-nodes";
 import { registerMinimaxNodes } from "@nodetool-ai/minimax-nodes";
@@ -731,6 +734,12 @@ workflows
         const session = await ExecutionSession.create({
           graph,
           registry,
+          // Registry alone hydrates node flags but not `propertyTypes`, and
+          // correlation analysis reads list-ness only from that map — so a
+          // saved workflow (which never carries it) had every list handle
+          // read as non-list, and legal fan-in into one was rejected before
+          // any node ran. The resolver fills it from node metadata.
+          resolveNodeType: createGraphNodeTypeResolver(registry).resolveNodeType,
           jobId,
           workflowId,
           params,

--- a/packages/cli/src/validate/index.ts
+++ b/packages/cli/src/validate/index.ts
@@ -5,6 +5,7 @@
  * unit-tested in node-sdk's graph-validation.test.ts.
  */
 import { validateGraph, type GraphValidationReport } from "@nodetool-ai/node-sdk";
+import { listRegisteredProviderIds } from "@nodetool-ai/runtime";
 import { buildFullRegistry } from "../node-registry.js";
 import { resolveTarget } from "../debug/index.js";
 import type { DebugGraph, DebugTargetInfo } from "../debug/types.js";
@@ -24,6 +25,14 @@ export async function runValidate(
 ): Promise<ValidateResult> {
   const resolved = await resolveTarget(ref, deps.loadFromDb);
   const registry = buildFullRegistry();
-  const report = validateGraph(resolved.graph, registry);
+  // Supplied here rather than on NodeRegistry itself: the registry also runs in
+  // the browser, which has no provider registry to reach and should not pull
+  // the runtime into its bundle for this.
+  const report = validateGraph(resolved.graph, {
+    has: (t) => registry.has(t),
+    getMetadata: (t) => registry.getMetadata(t),
+    validateNode: (d, h) => registry.validateNode(d, h),
+    listProviderIds: () => listRegisteredProviderIds()
+  });
   return { target: resolved.info, report };
 }

--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -1654,7 +1654,7 @@ export class TextToImageNode extends BaseNode {
     type: "image_model",
     default: {
       type: "image_model",
-      provider: "huggingface_fal_ai",
+      provider: "fal_ai",
       id: "fal-ai/flux/schnell",
       name: "FLUX.1 Schnell",
       path: null,
@@ -1761,7 +1761,7 @@ export class ImageToImageNode extends BaseNode {
     type: "image_model",
     default: {
       type: "image_model",
-      provider: "huggingface_fal_ai",
+      provider: "fal_ai",
       id: "fal-ai/flux/dev",
       name: "FLUX.1 Dev",
       path: null,

--- a/packages/node-sdk/src/base-node.ts
+++ b/packages/node-sdk/src/base-node.ts
@@ -34,6 +34,19 @@ export function coerceToDeclaredType(
   value: unknown,
   declaredType: string
 ): unknown {
+  // A URI string standing in for an asset ref. Callers reach for the plain
+  // string — `--params '{"clip":"file:///clip.mp4"}'`, a REST body, a webhook
+  // payload — and without this the ref stays empty, the node reads no bytes,
+  // and the run reports success carrying a zero-valued result. Only strings
+  // with a scheme convert, so a prompt or a caption is never mistaken for a
+  // location.
+  if (
+    typeof value === "string" &&
+    ASSET_REF_TYPES.has(declaredType) &&
+    URI_WITH_SCHEME.test(value)
+  ) {
+    return { type: declaredType, uri: value };
+  }
   if (
     value !== null &&
     value !== undefined &&
@@ -44,6 +57,22 @@ export function coerceToDeclaredType(
   }
   return value;
 }
+
+/**
+ * Declared types whose runtime value is an asset reference — a tagged object
+ * carrying `uri`/`asset_id`/`data` rather than a bare scalar.
+ */
+const ASSET_REF_TYPES = new Set([
+  "image",
+  "video",
+  "audio",
+  "document",
+  "folder",
+  "model_3d"
+]);
+
+/** `file://`, `https://`, `asset://`, `data:` and the like. */
+const URI_WITH_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
 
 /**
  * Coerce a value against a typed dynamic slot's declared type. Slots with no

--- a/packages/node-sdk/src/graph-validation.ts
+++ b/packages/node-sdk/src/graph-validation.ts
@@ -106,6 +106,12 @@ export interface GraphValidationRegistry {
     },
     connectedHandles?: ReadonlySet<string>
   ): NodePropertyValidationIssue[];
+  /**
+   * Provider ids the runtime can actually construct. Optional: a caller that
+   * cannot reach the provider registry (the browser) omits it and the
+   * provider check is skipped rather than guessing.
+   */
+  listProviderIds?(): readonly string[];
 }
 
 /**
@@ -198,6 +204,24 @@ function normalizeEdge(raw: GraphValidationEdge, index: number): NormEdge {
   };
 }
 
+/**
+ * Provider id of a model-reference property value, or undefined when the value
+ * is not one. Model refs are tagged objects whose `type` ends in `_model`
+ * (`image_model`, `asr_model`, `tts_model`, `language_model`, …), so keying on
+ * that suffix avoids reacting to any unrelated object that happens to carry a
+ * `provider` field. A blank provider is left to the existing unselected-model
+ * check rather than reported as unknown.
+ */
+function modelProviderOf(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const rec = value as Record<string, unknown>;
+  const kind = rec.type;
+  if (typeof kind !== "string" || !kind.endsWith("_model")) return undefined;
+  const provider = rec.provider;
+  if (typeof provider !== "string" || provider === "") return undefined;
+  return provider;
+}
+
 export function validateGraph(
   graph: GraphValidationInput,
   registry: GraphValidationRegistry
@@ -256,6 +280,12 @@ export function validateGraph(
     set.add(e.targetHandle);
   }
 
+  const providerIds = registry.listProviderIds?.();
+  // An empty list means the registry could not be reached, not that zero
+  // providers exist — checking against it would flag every model in the graph.
+  const knownProviders =
+    providerIds && providerIds.length > 0 ? new Set(providerIds) : null;
+
   for (const node of nodes) {
     const id = String(node.id ?? "");
     const type = String(node.type ?? "");
@@ -280,6 +310,31 @@ export function validateGraph(
         nodeType: type,
         message: pi.message
       });
+    }
+
+    // A model property naming a provider the runtime cannot construct fails
+    // only once the node runs — after the rest of the graph has already been
+    // paid for. The id is right there in the saved property, so check it here.
+    if (knownProviders) {
+      const props = (node.properties ?? node.data ?? {}) as Record<
+        string,
+        unknown
+      >;
+      for (const [propName, value] of Object.entries(props)) {
+        const provider = modelProviderOf(value);
+        if (provider === undefined || knownProviders.has(provider)) continue;
+        issues.push({
+          severity: "error",
+          code: "unknown_provider",
+          nodeId: id,
+          nodeType: type,
+          message:
+            `Property "${propName}" selects provider "${provider}", which is ` +
+            `not registered. Known providers: ${[...knownProviders]
+              .sort()
+              .join(", ")}`
+        });
+      }
     }
   }
 

--- a/packages/node-sdk/tests/base-node-props.test.ts
+++ b/packages/node-sdk/tests/base-node-props.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { BaseNode } from "../src/base-node.js";
+import { BaseNode, coerceToDeclaredType } from "../src/base-node.js";
 import { prop } from "../src/decorators.js";
 
 // --- Test node classes ---
@@ -188,5 +188,47 @@ describe("BaseNode — list-type coercion", () => {
     const node = new ListNode();
     node.assign({ images: null });
     expect(node.images).toBeNull();
+  });
+});
+
+describe("coerceToDeclaredType — asset refs from URI strings", () => {
+  it("wraps a URI string into a ref for an asset-typed property", () => {
+    expect(coerceToDeclaredType("file:///clip.mp4", "video")).toEqual({
+      type: "video",
+      uri: "file:///clip.mp4"
+    });
+  });
+
+  it("covers every asset kind", () => {
+    for (const t of ["image", "audio", "document", "folder", "model_3d"]) {
+      expect(coerceToDeclaredType(`https://x/y`, t)).toEqual({
+        type: t,
+        uri: "https://x/y"
+      });
+    }
+  });
+
+  // A prompt is a string on a str property; converting it would be nonsense.
+  it("leaves non-asset properties alone", () => {
+    expect(coerceToDeclaredType("file:///clip.mp4", "str")).toBe(
+      "file:///clip.mp4"
+    );
+  });
+
+  // Without a scheme it is prose, not a location — converting would turn a
+  // caption into a broken ref that silently reads no bytes.
+  it("ignores strings that carry no scheme", () => {
+    expect(coerceToDeclaredType("a photo of a fox", "image")).toBe(
+      "a photo of a fox"
+    );
+  });
+
+  it("passes an already-formed ref through untouched", () => {
+    const ref = { type: "image", uri: "file:///a.png", asset_id: "x" };
+    expect(coerceToDeclaredType(ref, "image")).toBe(ref);
+  });
+
+  it("still wraps a scalar for a list-typed property", () => {
+    expect(coerceToDeclaredType(3, "list[int]")).toEqual([3]);
   });
 });

--- a/packages/node-sdk/tests/graph-validation.test.ts
+++ b/packages/node-sdk/tests/graph-validation.test.ts
@@ -521,3 +521,58 @@ describe("validationHeadline", () => {
     ).toContain("2 error");
   });
 });
+
+describe("unknown_provider", () => {
+  const registry = {
+    has: () => true,
+    getMetadata: () => ({ properties: [], outputs: [] }) as never,
+    validateNode: () => [],
+    listProviderIds: () => ["fal_ai", "openai"]
+  };
+  const graphWith = (provider: string) => ({
+    nodes: [
+      {
+        id: "n",
+        type: "nodetool.image.TextToImage",
+        data: { model: { type: "image_model", provider, id: "x" } }
+      }
+    ],
+    edges: []
+  });
+
+  it("flags a provider the runtime cannot construct", () => {
+    const report = validateGraph(graphWith("huggingface_fal_ai"), registry);
+    const issue = report.issues.find((i) => i.code === "unknown_provider");
+    expect(issue?.message).toContain("huggingface_fal_ai");
+  });
+
+  it("accepts a registered provider", () => {
+    const report = validateGraph(graphWith("fal_ai"), registry);
+    expect(report.issues.some((i) => i.code === "unknown_provider")).toBe(false);
+  });
+
+  // Without the list there is nothing to check against; guessing would flag
+  // every model in the graph.
+  it("skips the check when the caller supplies no provider list", () => {
+    const { listProviderIds: _omit, ...noProviders } = registry;
+    const report = validateGraph(graphWith("huggingface_fal_ai"), noProviders);
+    expect(report.issues.some((i) => i.code === "unknown_provider")).toBe(false);
+  });
+
+  it("ignores non-model objects that carry a provider field", () => {
+    const report = validateGraph(
+      {
+        nodes: [
+          {
+            id: "n",
+            type: "x",
+            data: { cfg: { type: "settings", provider: "whatever" } }
+          }
+        ],
+        edges: []
+      },
+      registry
+    );
+    expect(report.issues.some((i) => i.code === "unknown_provider")).toBe(false);
+  });
+});


### PR DESCRIPTION
Found by running examples. A dead provider default, a silent wrong answer, and a legal graph the runner refused. The first is now also caught statically.

## A shipped default naming a provider that does not exist

`TextToImage` and `ImageToImage` shipped `provider: "huggingface_fal_ai"`. Nothing registers it — no alias maps it, and the string existed only at those two declarations. **Dragging either node onto a canvas and pressing run failed**, and 17 shipped examples inherited it: Pokemon Maker, Movie Posters, Script to Screen, SEO Content Engine, Podcast Repurposing Studio and more.

Now `fal_ai`, which is what the accompanying `fal-ai/flux/*` ids always meant.

### …and a check so the next one cannot ship unnoticed

`validate` gains `unknown_provider`:

```
error Property "model" selects provider "huggingface_fal_ai", which is not
registered. Known providers: aki, anthropic, … fal_ai, gemini, … (unknown_provider)
```

Model refs are tagged objects whose `type` ends in `_model`, so the check keys on that rather than reacting to any object carrying a `provider` field. The provider list arrives as an **optional** registry capability supplied by the CLI: `NodeRegistry` also runs in the browser, which has no provider registry to consult and should not pull the runtime into its bundle. No list means the check is skipped rather than guessing.

## A URI string silently became an empty asset

```
--params '{"clip":"file:///clip.mp4"}'          → {"out": [0]}   status: completed
--params '{"clip":{"type":"video","uri":"…"}}'  → {"out": [25]}  status: completed
```

The ref stayed empty, the node read no bytes, and the run **reported success carrying a zero**. Worse than failing, because nothing tells you. Callers reach for the plain string from the CLI, a REST body or a webhook, so `coerceToDeclaredType` now converts it. Only strings with a scheme convert, so a prompt or a caption is never mistaken for a location.

## Legal fan-in into a list input was rejected before any node ran

```
Handle "value" receives 2 edges but is not a list type;
this is invalid under correlation analysis.
```

Correlation analysis reads list-ness **only** from `propertyTypes` — a map saved workflows never carry. So every list handle read as non-list and legal fan-in was refused. `validate` was right all along; it resolves the type from the registry.

The CLI passed a `registry`, which hydrates node flags but not that map, where it needed a `resolveNodeType`. `createGraphNodeTypeResolver` already existed for exactly this; the run path simply never used it.

## Verification

- **Examples validating clean: 119/139 → 139/139**
- All three previously-failing SVG examples now run; `Generate then Upscale a Poster` produces **4.98 MB**
- `node-sdk` 677 passing (+10 new tests), `kernel` 933, `core-nodes` 237, `image-nodes` 227/227
- typecheck and lint clean

Two pre-existing environment failures are unrelated and verified against a stashed clean tree: `image-nodes` needs a Vulkan driver (`mesa-vulkan-drivers`, added to the image in #4607), and 4 Ruby tests need `ruby` on PATH.

Also adds 29 examples covering `lib.svg`, uncovered `nodetool.text` nodes, and paid capabilities (Recraft vectorize, Relight, Clarity upscale, OpenAI ASR/TTS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)