### PR TITLE
fix(reliability,execution): make cancellation, goldens, diffs, and leak accounting real

### DIFF
--- a/docs/RELIABILITY_ARCHITECTURE.md
+++ b/docs/RELIABILITY_ARCHITECTURE.md
@@ -169,6 +169,13 @@ Rules that keep journeys trustworthy:
   not globally, because the actor model legitimately interleaves.
 - **Every journey states its invariant set explicitly** (§6) and the
   harness refuses a journey that asserts nothing beyond "completed".
+- **A declared golden decides the verdict.** `assertions.outputs` /
+  `assertions.streamShape` compare every surface's record against
+  `expected/` and fail the journey on a mismatch — invariants and the
+  cross-surface diff both pass when every surface returns the same wrong
+  answer. Faulted runs skip the comparison (and say so): a golden
+  describes the unfaulted contract. `nodetool reliability update-goldens
+  <journey>` recaptures the fixtures from an unfaulted kernel run.
 
 ## 5. Which workflows belong in the suite
 
@@ -234,7 +241,11 @@ the checks that convert today's advisory logging into failures:
 - Terminal precedence is exactly cancel > suspend > failed > completed
   (`runner.ts:625`) — asserted, not assumed.
 - Exactly one terminal `job_update` per run, and nothing follows it on
-  that job's stream.
+  that job's stream. A driver records repeated frames rather than
+  dropping them; a repeat its surface documents (the ws-server's eager
+  `running`/`cancelled` acks and its authoritative terminal snapshot) is
+  tagged `redundant` and discounted here and in the cross-surface diff.
+  Any other duplicate is untagged, and fails.
 
 **Cleanup and leaks.**
 - `_checkPendingInboxWork` finding pending work is a journey **failure**,
@@ -247,6 +258,11 @@ the checks that convert today's advisory logging into failures:
   repeated journey iterations (leak journeys run N=20 and compare).
 - Cancellation completes within a budget (e.g. 5 s) and `finalize()` ran
   for every started actor.
+- The counters above are **measured** — the kernel driver reads them off
+  `ExecutionSession.resourceCounters()`, the ws-server driver off the
+  runner's `slotCounters` once the connection is gone. A journey that
+  declares `cleanup-leaks` on a surface whose driver produces no post-run
+  snapshot fails on that: "nothing measured" must not read as "no leaks".
 
 **Determinism.**
 - Two runs of the same journey with the same cassettes produce identical

--- a/packages/cli/src/commands/reliability.ts
+++ b/packages/cli/src/commands/reliability.ts
@@ -71,6 +71,25 @@ export function registerReliabilityCommands(program: Command): void {
     });
 
   reliability
+    .command("update-goldens <journey>")
+    .description(
+      "Rewrite a journey's expected/ fixtures from a fresh unfaulted kernel run — " +
+        "for a golden that legitimately moved. Review the diff before committing"
+    )
+    .action(async (journeyName: string) => {
+      try {
+        const { updateJourneyGoldens } = await import(
+          "@nodetool-ai/reliability-harness"
+        );
+        const { written } = await updateJourneyGoldens(journeyName);
+        for (const file of written) console.log(`wrote ${file}`);
+      } catch (e) {
+        console.error(String(e));
+        process.exit(1);
+      }
+    });
+
+  reliability
     .command("list")
     .description("List the journeys under reliability/journeys/")
     .option("--json", "Print the full journey summaries as JSON")

--- a/packages/execution/README.md
+++ b/packages/execution/README.md
@@ -81,8 +81,14 @@ const session = await ExecutionSession.create({
   persistence: { onAccepted, onTerminal } | null,
   limits: { runTimeoutMs, bufferLimit },  // nodeTimeoutMs: not yet supported, see above
   requireTerminalResult: true,  // optional — output-name rewriting
+  captureMessages: true,        // optional — required to read `messages` below
 });
 
+// Only with `captureMessages: true`, and only if you actually drain it:
+// capture queues each message until a consumer pulls it, so a host that just
+// awaits `result` would hold the whole run's messages (audio chunks included)
+// for nothing. Reading `messages` without the flag throws; a consumer that
+// falls behind `limits.messageBufferLimit` makes the iterator throw.
 for await (const message of session.messages) { /* ProcessingMessage */ }
 
 await session.pushInput("input_name", value);

--- a/packages/execution/src/index.ts
+++ b/packages/execution/src/index.ts
@@ -3,6 +3,7 @@
  */
 export { ExecutionSession } from "./session.js";
 export { normalizeGraph } from "./normalize-graph.js";
+export { DEFAULT_MESSAGE_BUFFER_LIMIT } from "./message-stream.js";
 export type {
   BridgeFactory,
   Edge,

--- a/packages/execution/src/message-stream.ts
+++ b/packages/execution/src/message-stream.ts
@@ -3,18 +3,40 @@
  * `AsyncIterable<ProcessingMessage>`. Modeled on the queue/wake pattern in
  * `packages/workflow-runner/src/run.ts`'s `runWorkflow` generator — the one
  * other place in the repo already streams a kernel run as an async sequence.
+ *
+ * The queue is bounded. A caller that opts into capture (see
+ * `ExecutionSessionOptions.captureMessages`) but never iterates would
+ * otherwise retain every message of the run — including real-time audio
+ * chunks, which the kernel's own message retention deliberately avoids
+ * holding (roughly 25 MB/minute). Past the limit the stream stops queueing
+ * and the iterator throws, so a non-draining consumer fails loudly instead of
+ * growing until the run ends.
  */
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
+
+/** Queued messages allowed to pile up before the stream gives up. */
+export const DEFAULT_MESSAGE_BUFFER_LIMIT = 10_000;
 
 export class MessageStream implements AsyncIterable<ProcessingMessage> {
   private readonly queue: ProcessingMessage[] = [];
   private waiter: (() => void) | null = null;
   private closed = false;
+  private overflowedAt: number | null = null;
+  private readonly limit: number;
   private readonly unsubscribe: () => void;
 
-  constructor(context: ProcessingContext) {
+  /** `limit` of 0 (or a negative number) means unbounded. */
+  constructor(context: ProcessingContext, limit = DEFAULT_MESSAGE_BUFFER_LIMIT) {
+    this.limit = limit > 0 ? limit : Number.POSITIVE_INFINITY;
     this.unsubscribe = context.addMessageListener((message) => {
+      if (this.queue.length >= this.limit) {
+        if (this.overflowedAt === null) {
+          this.overflowedAt = this.queue.length;
+          this.unsubscribe();
+        }
+        return;
+      }
       this.queue.push(message);
       this.wake();
     });
@@ -38,6 +60,15 @@ export class MessageStream implements AsyncIterable<ProcessingMessage> {
     for (;;) {
       while (this.queue.length > 0) {
         yield this.queue.shift()!;
+      }
+      if (this.overflowedAt !== null) {
+        throw new Error(
+          `ExecutionSession message stream overflowed after ${this.overflowedAt} ` +
+            `queued messages (limit ${this.limit}) — the consumer fell behind, ` +
+            "so messages past that point were dropped rather than retained. " +
+            "Iterate `session.messages` as the run progresses, or raise " +
+            "`limits.messageBufferLimit`."
+        );
       }
       if (this.closed) return;
       await new Promise<void>((resolve) => {

--- a/packages/execution/src/session.ts
+++ b/packages/execution/src/session.ts
@@ -30,8 +30,10 @@ export class ExecutionSession {
   readonly graph: HydratedGraphData;
 
   private readonly runner: WorkflowRunner;
-  private readonly stream: MessageStream;
+  /** Null unless the caller opted into `captureMessages` (see options). */
+  private readonly stream: MessageStream | null;
   private readonly persistence: ExecutionSessionOptions["persistence"];
+  private readonly bridge: { pendingRequestCount?: number } | null;
   private readonly resultPromise: Promise<RunResult>;
   private runTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
   private _cancelReason: string | null = null;
@@ -45,15 +47,21 @@ export class ExecutionSession {
     persistence: ExecutionSessionOptions["persistence"];
     params: Record<string, unknown>;
     triggerEvent: ExecutionSessionOptions["triggerEvent"];
+    bridge: { pendingRequestCount?: number } | null;
     closeBridge: () => void;
     runTimeoutMs: number | undefined;
+    captureMessages: boolean;
+    messageBufferLimit: number | undefined;
   }) {
     this.jobId = init.jobId;
     this.workflowId = init.workflowId;
     this.graph = init.graph;
     this.runner = init.runner;
     this.persistence = init.persistence;
-    this.stream = new MessageStream(init.context);
+    this.bridge = init.bridge;
+    this.stream = init.captureMessages
+      ? new MessageStream(init.context, init.messageBufferLimit)
+      : null;
 
     if (init.runTimeoutMs && init.runTimeoutMs > 0) {
       this.runTimeoutHandle = setTimeout(() => {
@@ -80,7 +88,7 @@ export class ExecutionSession {
         // The terminal message was emitted synchronously before run()
         // resolved (ProcessingContext.emit() calls listeners inline), so the
         // stream can close now without dropping it.
-        this.stream.close();
+        this.stream?.close();
       });
 
     this.resultPromise
@@ -206,19 +214,59 @@ export class ExecutionSession {
       persistence: options.persistence ?? null,
       params: options.params ?? {},
       triggerEvent: options.triggerEvent ?? null,
+      bridge,
       closeBridge,
-      runTimeoutMs: options.limits?.runTimeoutMs
+      runTimeoutMs: options.limits?.runTimeoutMs,
+      captureMessages: options.captureMessages === true,
+      messageBufferLimit: options.limits?.messageBufferLimit
     });
   }
 
-  /** Validated, live message stream — closes once the run reaches a terminal state. */
+  /**
+   * Live message stream — closes once the run reaches a terminal state.
+   * Requires `captureMessages: true` at `create()`; without it nothing is
+   * queued (see that option) and reading this throws rather than handing back
+   * a stream that would silently yield nothing.
+   */
   get messages(): AsyncIterable<ProcessingMessage> {
+    if (!this.stream) {
+      throw new Error(
+        "ExecutionSession: `messages` requires `captureMessages: true` at " +
+          "create() — message capture is opt-in so a host that only awaits " +
+          "`result` never queues a run's messages unread."
+      );
+    }
     return this.stream;
   }
 
   /** The run's terminal result. Never rejects — kernel failures resolve as `status: "failed"`. */
   get result(): Promise<RunResult> {
     return this.resultPromise;
+  }
+
+  /**
+   * Live resource counts, for leak accounting: after a terminal result every
+   * one of these must be back to zero. Measured, not inferred — the
+   * reliability harness's `cleanup-leaks` invariant asserts against these
+   * numbers and reports a violation when a driver can't produce them.
+   */
+  resourceCounters(): {
+    liveActors: number;
+    pendingControlResponses: number;
+    pendingTimers: number;
+    pythonBridgePendingRequests: number;
+  } {
+    return {
+      liveActors: this.runner.liveActorCount,
+      pendingControlResponses: this.runner.pendingControlResponseCount,
+      // The session's own run-timeout timer is the only timer it owns; it is
+      // cleared when the run settles.
+      pendingTimers: this.runTimeoutHandle === null ? 0 : 1,
+      pythonBridgePendingRequests:
+        typeof this.bridge?.pendingRequestCount === "number"
+          ? this.bridge.pendingRequestCount
+          : 0
+    };
   }
 
   /** The reason passed to the most recent `cancel()` call, if any. */

--- a/packages/execution/src/types.ts
+++ b/packages/execution/src/types.ts
@@ -62,6 +62,14 @@ export interface ExecutionLimits {
   nodeTimeoutMs?: number;
   /** Forwarded to `WorkflowRunnerOptions.bufferLimit` (per-inbox cap). */
   bufferLimit?: number | null;
+  /**
+   * Cap on messages queued for an un-drained `session.messages` consumer
+   * (default {@link DEFAULT_MESSAGE_BUFFER_LIMIT}); `0` disables the cap. Only
+   * meaningful together with `captureMessages`. Past the cap the stream stops
+   * queueing and the iterator throws — a consumer that fell behind fails
+   * loudly instead of retaining the whole run's message history.
+   */
+  messageBufferLimit?: number;
 }
 
 export interface ExecutionSessionOptions {
@@ -144,6 +152,17 @@ export interface ExecutionSessionOptions {
    * surface and the one place strict mode is meant to be on by default.
    */
   strict?: boolean;
+  /**
+   * Capture every emitted message into `session.messages` (default `false`).
+   * Off by default because capture is retention: the queue holds each message
+   * until a consumer pulls it, and a host that only awaits `session.result`
+   * (every production caller today) would grow one unread queue per run — the
+   * kernel is explicit about not retaining real-time chunks for exactly that
+   * reason. Turn it on only when actually iterating the stream (the
+   * reliability harness's kernel driver does); see `limits.messageBufferLimit`
+   * for the cap that catches a consumer falling behind.
+   */
+  captureMessages?: boolean;
 }
 
 export type { NodeDescriptor, Edge, ProcessingMessage, RunResult };

--- a/packages/execution/tests/message-capture.test.ts
+++ b/packages/execution/tests/message-capture.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Message capture is opt-in and bounded: a host that only awaits
+ * `session.result` (every production caller) must not accumulate an unread
+ * queue of the run's messages, and a consumer that opts in but falls behind
+ * must fail loudly instead of retaining everything.
+ */
+import { describe, it, expect } from "vitest";
+import { ExecutionSession } from "../src/index.js";
+import { buildTestRegistry } from "./fixtures.js";
+
+const NO_BRIDGE = async () => null;
+
+const DOUBLE_GRAPH = {
+  nodes: [
+    { id: "v", type: "nodetool.input.Value", properties: {} },
+    { id: "double", type: "test.execution.Double", properties: {} }
+  ],
+  edges: [
+    { source: "v", sourceHandle: "output", target: "double", targetHandle: "value" }
+  ]
+};
+
+describe("ExecutionSession — message capture", () => {
+  it("queues nothing and refuses `messages` when capture is not requested", async () => {
+    const registry = buildTestRegistry();
+    const session = await ExecutionSession.create({
+      graph: DOUBLE_GRAPH,
+      registry,
+      bridgeFactory: NO_BRIDGE,
+      params: { v: 5 }
+    });
+
+    expect(() => session.messages).toThrow(/captureMessages/);
+    const result = await session.result;
+    expect(result.status).toBe("completed");
+  });
+
+  it("throws once an un-drained consumer exceeds the buffer limit", async () => {
+    const registry = buildTestRegistry();
+    const session = await ExecutionSession.create({
+      graph: {
+        nodes: [{ id: "loop", type: "test.execution.Loop", properties: {} }],
+        edges: []
+      },
+      registry,
+      bridgeFactory: NO_BRIDGE,
+      captureMessages: true,
+      limits: { runTimeoutMs: 500, messageBufferLimit: 3 }
+    });
+
+    // Let the run emit well past the limit before pulling anything.
+    await session.result;
+
+    const drain = async (): Promise<void> => {
+      for await (const _message of session.messages) {
+        // drain
+      }
+    };
+    await expect(drain()).rejects.toThrow(/overflowed/);
+  });
+});

--- a/packages/execution/tests/session-run.test.ts
+++ b/packages/execution/tests/session-run.test.ts
@@ -105,7 +105,8 @@ describe("ExecutionSession — messages", () => {
       },
       registry,
       bridgeFactory: NO_BRIDGE,
-      params: { v: 5 }
+      params: { v: 5 },
+      captureMessages: true
     });
 
     const seen: string[] = [];

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -291,6 +291,14 @@ export class WorkflowRunner {
   private _cancelled = false;
 
   /**
+   * Actors spawned and not yet finished (including their completion
+   * handling). Exposed via {@link liveActorCount} for leak accounting — after
+   * a run this must be back to zero, and a harness that can't measure it
+   * can't assert it.
+   */
+  private _liveActors = 0;
+
+  /**
    * Latch set by `cancel()` and never cleared by `_resetRunState`. A cancel
    * that lands between construction and `run()` would otherwise be dropped —
    * the reset clears `_cancelled` and swaps the AbortController. `_runImpl`
@@ -758,6 +766,20 @@ export class WorkflowRunner {
     this._correlation = undefined;
     this._eosSentEdges = new Set();
     this._suspend = undefined;
+  }
+
+  /** Actors spawned and not yet finished. Zero before and after a run. */
+  get liveActorCount(): number {
+    return this._liveActors;
+  }
+
+  /** Control-event responses still waiting on an actor, summed over nodes. */
+  get pendingControlResponseCount(): number {
+    let count = 0;
+    for (const queue of this._pendingControlResponses.values()) {
+      count += queue.length;
+    }
+    return count;
   }
 
   /**
@@ -1236,6 +1258,7 @@ export class WorkflowRunner {
       });
 
       actorNodeIds.push(node.id);
+      this._liveActors++;
       actorPromises.push(
         actor.run().then(async (result) => {
           // Nothing will read this inbox again. Wake any upstream actor parked
@@ -1304,6 +1327,12 @@ export class WorkflowRunner {
               }
             }
           }
+        })
+        // Counts the actor as live until its completion handling (EOS
+        // routing, output collection) is done too — that work can still emit
+        // messages, so an actor is not "gone" before it finishes.
+        .finally(() => {
+          this._liveActors--;
         })
       );
     }

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -156,6 +156,19 @@ export abstract class PythonBridgeBase
     this._options = options;
   }
 
+  /**
+   * Requests still awaiting a worker reply (plain, streaming, and Comfy event
+   * subscriptions). Exposed for leak accounting — a run that ended with
+   * pending requests left a promise nothing will ever settle.
+   */
+  get pendingRequestCount(): number {
+    return (
+      this._pending.size +
+      this._pendingStream.size +
+      this._pendingComfyEvents.size
+    );
+  }
+
   // ── Transport hooks (implemented by subclasses) ─────────────────────
 
   /** Open the underlying transport and become connected. */

--- a/packages/websocket/src/test-ui-server.ts
+++ b/packages/websocket/src/test-ui-server.ts
@@ -974,6 +974,12 @@ export interface TestUiServerOptions extends HttpApiOptions {
   resolveUnknownNodeType?: (
     nodeType: string
   ) => Promise<import("@nodetool-ai/kernel").ResolvedNodeType | null>;
+  /**
+   * Called with each per-connection `UnifiedWebSocketRunner` right after it is
+   * constructed. The runner is otherwise private to the upgrade handler; the
+   * reliability harness needs it to read `slotCounters` for leak accounting.
+   */
+  onRunnerCreated?: (runner: UnifiedWebSocketRunner) => void;
 }
 
 function detectMetadataRootsFromPip(): string[] {
@@ -1466,6 +1472,7 @@ export function createTestUiServer(options: TestUiServerOptions = {}) {
             ])),
         getNodeMetadata: (nodeType) => registry.getMetadata(nodeType)
       });
+      options.onRunnerCreated?.(runner);
       log.info("WebSocket client connected");
       void runner.run(new WsAdapter(ws)).catch((error) => {
         log.error(

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1794,6 +1794,14 @@ export class UnifiedWebSocketRunner {
    * can't both slip past `activeJobs.size` and exceed MAX_CONCURRENT_JOBS.
    */
   private startingJobs = 0;
+  /**
+   * WS slot accounting, for leak accounting: after every run finishes both
+   * must be back to zero. Read by the reliability harness's ws-server driver,
+   * whose `cleanup-leaks` invariant can only assert what it can measure.
+   */
+  get slotCounters(): { activeJobs: number; startingJobs: number } {
+    return { activeJobs: this.activeJobs.size, startingJobs: this.startingJobs };
+  }
   private currentTask: Promise<void> | null = null;
   private heartbeatTimer: NodeJS.Timeout | null = null;
   private statsTimer: NodeJS.Timeout | null = null;
@@ -2867,6 +2875,59 @@ export class UnifiedWebSocketRunner {
       );
     }
 
+    // Persistence runs BEFORE the session exists, because
+    // `ExecutionSession.create()` starts the kernel: a job cancelled while it
+    // sat in the queue must never execute, and the only way to guarantee that
+    // is to check before anything can run. (The DB-only cancel path — tRPC
+    // `jobs.cancel` — doesn't remove the job from `jobQueue`, so drainQueue
+    // can still hand us a cancelled job.)
+    phaseStartedAt = performance.now();
+    if (executionOptions.persistence === "job") {
+      try {
+        const existing = await Job.get(jobId);
+        if (existing) {
+          if (existing.status === "cancelled") {
+            log.info("Skipping start of cancelled job", { jobId });
+            // Nothing was registered in activeJobs yet — free the reserved
+            // slot and promote any queued run, matching every other slot
+            // release (streamJobMessages finally, the chat-run finally).
+            // Without it a cancelled-while-queued job leaves its slot idle
+            // and the next queued run stalls.
+            releaseSlot();
+            this.drainQueue();
+            this.sendDetached({
+              type: "job_update",
+              status: "cancelled",
+              job_id: jobId,
+              workflow_id: workflowId
+            });
+            return;
+          }
+          // Was persisted as "queued" while waiting for a slot — flip it to
+          // running now that it's actually starting.
+          if (existing.status !== "running") {
+            existing.markRunning();
+            await existing.save();
+          }
+        } else {
+          await Job.create({
+            id: jobId,
+            workflow_id: workflowId ?? "",
+            user_id: userId,
+            status: "running",
+            name: req.job_name ?? "",
+            started_at: new Date().toISOString(),
+            params: req.params ?? {},
+            graph
+          });
+        }
+      } catch (error) {
+        this.logError("runJob persistence failed", error);
+        // Persistence is best-effort in TS runtime mode.
+      }
+    }
+    const persistenceMs = performance.now() - phaseStartedAt;
+
     // A5 (docs/RELIABILITY_TASKS.md Track A): the facade replaces the direct
     // `new WorkflowRunner` + later `runner.run()` pair — `graph` is already
     // hydrated/output-name-rewritten above, so this call re-hydrates it
@@ -2906,8 +2967,8 @@ export class UnifiedWebSocketRunner {
         graphLoadedMs,
         graphHydratedMs,
         preRunMs,
-        persistenceMs: 0,
-        kernelStartedAt: 0
+        persistenceMs,
+        kernelStartedAt: performance.now()
       },
       applicationId: req.application_id ?? null
     };
@@ -2917,61 +2978,9 @@ export class UnifiedWebSocketRunner {
     releaseSlot();
     log.info("Job started", { jobId, workflowId });
 
-    phaseStartedAt = performance.now();
-    if (executionOptions.persistence === "job") {
-      try {
-        const existing = await Job.get(jobId);
-        if (existing) {
-          // The run may have been cancelled via the DB-only cancel path (tRPC
-          // `jobs.cancel`) while it was still sitting in the in-memory queue —
-          // that path doesn't remove it from `jobQueue`, so drainQueue can still
-          // hand it to us. Honor the cancellation instead of resurrecting it:
-          // undo the start, surface the cancelled status, and free the slot.
-          if (existing.status === "cancelled") {
-            log.info("Skipping start of cancelled job", { jobId });
-            this.activeJobs.delete(jobId);
-            // Freeing this slot must promote any queued run, matching every
-            // other activeJobs.delete site (streamJobMessages finally, the
-            // chat-run finally). Without it a cancelled-while-queued job leaves
-            // its slot idle and the next queued run stalls.
-            this.drainQueue();
-            this.sendDetached({
-              type: "job_update",
-              status: "cancelled",
-              job_id: jobId,
-              workflow_id: workflowId
-            });
-            return;
-          }
-          // Was persisted as "queued" while waiting for a slot — flip it to
-          // running now that it's actually starting.
-          if (existing.status !== "running") {
-            existing.markRunning();
-            await existing.save();
-          }
-        } else {
-          await Job.create({
-            id: jobId,
-            workflow_id: workflowId ?? "",
-            user_id: userId,
-            status: "running",
-            name: req.job_name ?? "",
-            started_at: new Date().toISOString(),
-            params: req.params ?? {},
-            graph
-          });
-        }
-      } catch (error) {
-        this.logError("runJob persistence failed", error);
-        // Persistence is best-effort in TS runtime mode.
-      }
-    }
-    active.timings.persistenceMs = performance.now() - phaseStartedAt;
-    active.timings.kernelStartedAt = performance.now();
-
     // The run itself already started inside `ExecutionSession.create()`
-    // above (before this persistence block) — `session.result` is the same
-    // never-rejecting terminal-result promise `runner.run()` used to return.
+    // above — `session.result` is the same never-rejecting terminal-result
+    // promise `runner.run()` used to return.
     const executePromise = session.result;
 
     // `streamJobMessages` handles its own failures, but nothing awaits this

--- a/packages/websocket/tests/unified-websocket-runner.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner.test.ts
@@ -729,6 +729,10 @@ describe("UnifiedWebSocketRunner", () => {
     // hand the still-queued request to startJob — the runner must honor the
     // cancellation rather than flip it back to running/completed. Regression
     // test for "cancel multiple, only one stays in the Cancelled lane".
+    //
+    // "Honor" means the workflow never executes: a DB row that still reads
+    // "cancelled" proves nothing on its own, since the kernel could have run
+    // (and performed side effects) before anything looked at the row.
     initTestDb();
     await Job.create({
       id: "cancelled-while-queued",
@@ -736,6 +740,16 @@ describe("UnifiedWebSocketRunner", () => {
       user_id: "1",
       status: "cancelled",
       name: "Cancelled run"
+    });
+
+    let executed = 0;
+    runner = new UnifiedWebSocketRunner({
+      resolveExecutor: () => ({
+        async process() {
+          executed++;
+          return {};
+        }
+      })
     });
 
     await runner.connect(ws);
@@ -758,6 +772,25 @@ describe("UnifiedWebSocketRunner", () => {
 
     const job = await Job.get<Job>("cancelled-while-queued");
     expect(job?.status).toBe("cancelled");
+    expect(executed).toBe(0);
+
+    const sent = ws.sentBytes.map((b) => unpack(b) as Record<string, unknown>);
+    expect(
+      sent.some(
+        (m) =>
+          m.type === "job_update" &&
+          m.job_id === "cancelled-while-queued" &&
+          m.status === "cancelled"
+      )
+    ).toBe(true);
+    expect(
+      sent.some(
+        (m) =>
+          m.type === "job_update" &&
+          m.job_id === "cancelled-while-queued" &&
+          m.status === "completed"
+      )
+    ).toBe(false);
 
     await runner.disconnect();
   });

--- a/reliability/harness/src/cli.ts
+++ b/reliability/harness/src/cli.ts
@@ -5,10 +5,11 @@
  * does the work, `commands/debug.ts` just parses flags and prints).
  */
 import { existsSync } from "node:fs";
-import { readdir } from "node:fs/promises";
+import { readdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadJourney, type Journey, type JourneyFault } from "./core/journey.js";
+import { streamShapeOf, terminalOutputsOf } from "./core/golden.js";
 import { compareJourney, formatCompareReport, type CompareDriver, type CompareReport } from "./compare.js";
 import { KernelDriver } from "./drivers/kernel.js";
 import { WsServerDriver } from "./drivers/ws-server.js";
@@ -199,6 +200,51 @@ export async function runJourney(
   const report = await compareJourney(journey, drivers, { faults });
 
   return report;
+}
+
+/**
+ * Rewrites a journey's `expected/` fixtures from a fresh, unfaulted oracle
+ * (kernel) run — the maintainer path for a golden that legitimately moved.
+ *
+ * Only writes the fixtures the journey declares, and refuses a run that
+ * didn't complete: a golden captured from a broken run bakes the breakage in.
+ * Review the diff — that is what makes the fixture an assertion rather than a
+ * transcript.
+ */
+export async function updateJourneyGoldens(
+  journeyName: string,
+  options: { journeysDir?: string } = {}
+): Promise<{ written: string[] }> {
+  const journeysDir = options.journeysDir ?? findJourneysDir();
+  const journey = await resolveJourney(journeyName, journeysDir);
+  const { assertions } = journey.manifest;
+  if (!assertions.outputs && !assertions.streamShape) {
+    throw new ReliabilityCliError(
+      `journey "${journeyName}" declares no golden assertions to update`
+    );
+  }
+
+  const record = await new KernelDriver().run(journey);
+  if (record.status !== "completed") {
+    throw new ReliabilityCliError(
+      `journey "${journeyName}" ended "${record.status}" (${record.error ?? "no error"}) — ` +
+        "refusing to capture goldens from a run that didn't complete"
+    );
+  }
+
+  const expectedDir = join(journeysDir, journeyName, "expected");
+  const written: string[] = [];
+  if (assertions.outputs) {
+    const file = join(expectedDir, "outputs.json");
+    await writeFile(file, `${JSON.stringify(terminalOutputsOf(record), null, 2)}\n`);
+    written.push(file);
+  }
+  if (assertions.streamShape) {
+    const file = join(expectedDir, "stream.shape.json");
+    await writeFile(file, `${JSON.stringify(streamShapeOf(record), null, 2)}\n`);
+    written.push(file);
+  }
+  return { written };
 }
 
 /** Every fault name a `FaultModule` is actually registered for right now —

--- a/reliability/harness/src/compare.ts
+++ b/reliability/harness/src/compare.ts
@@ -8,6 +8,7 @@
  */
 import type { Journey, JourneyFault } from "./core/journey.js";
 import { diffNormalizedRecords, formatStreamDiff, streamDiffIsEmpty, type StreamDiff } from "./core/diff.js";
+import { checkGoldens, type GoldenCheckResult } from "./core/golden.js";
 import { INVARIANT_CHECKS, type Violation } from "./core/invariants/index.js";
 import { normalizeRunRecord, type NormalizedRunRecord } from "./core/normalize.js";
 import type { RunRecord } from "./core/record.js";
@@ -39,6 +40,12 @@ export interface SurfaceCompareResult {
   error?: string | null;
   /** §6 invariant violations from the journey's declared `assertions.invariants`. */
   violations: Violation[];
+  /**
+   * Golden comparisons the journey declared (`assertions.outputs`,
+   * `assertions.streamShape`), one entry each. A skipped entry (faulted run)
+   * carries its reason — the fixtures are never silently ignored.
+   */
+  goldens: GoldenCheckResult[];
   /** Diff against the oracle's normalized `server_to_client` frames — `null`
    * for the oracle surface itself, or when the surface didn't run. */
   diffVsOracle: StreamDiff | null;
@@ -198,6 +205,7 @@ export async function compareJourney(
         ran: false,
         skipReason: "not applicable to this journey",
         violations: [],
+        goldens: [],
         diffVsOracle: null,
         diffVsOracleEmpty: true,
         notApplicable: true,
@@ -224,6 +232,7 @@ export async function compareJourney(
           ran: false,
           skipReason,
           violations: [],
+          goldens: [],
           diffVsOracle: null,
           diffVsOracleEmpty: false,
           notApplicable: false,
@@ -236,6 +245,11 @@ export async function compareJourney(
     }
 
     const violations = checks.flatMap((c) => c.check(record));
+    // §4's golden fixtures: the only assertion on what the run actually
+    // produced. Every surface is held to them, not just the oracle — a
+    // surface can agree with the oracle frame-for-frame and still be wrong.
+    const goldens = checkGoldens(journey, record, { faultsApplied });
+    const goldenFailures = goldens.flatMap((g) => g.failures);
 
     let diff: StreamDiff | null = null;
     let diffEmpty = true;
@@ -245,9 +259,15 @@ export async function compareJourney(
       diffEmpty = streamDiffIsEmpty(diff);
     }
 
-    const ok = violations.length === 0 && diffEmpty;
+    const ok = violations.length === 0 && diffEmpty && goldenFailures.length === 0;
     if (violations.length > 0) {
       issues.push(`${driver.name}: ${violations.length} invariant violation(s)`);
+    }
+    for (const golden of goldens) {
+      if (golden.failures.length === 0) continue;
+      issues.push(
+        `${driver.name}: ${golden.kind} golden mismatch (${golden.failures.length})`
+      );
     }
     if (!diffEmpty) {
       issues.push(`${driver.name}: diverges from ${oracleDriver.name}`);
@@ -259,6 +279,7 @@ export async function compareJourney(
       status: record.status,
       error: record.error,
       violations,
+      goldens,
       diffVsOracle: diff,
       diffVsOracleEmpty: diffEmpty,
       notApplicable: false,
@@ -304,6 +325,12 @@ export function formatCompareReport(
     if (s.error) bits.push(`error: ${s.error}`);
     if (s.faultsApplied.length > 0) bits.push(`faults: ${s.faultsApplied.join(", ")}`);
     if (s.violations.length > 0) bits.push(`${s.violations.length} violation(s)`);
+    for (const golden of s.goldens) {
+      if (!golden.checked) bits.push(`${golden.kind} golden skipped`);
+      else if (golden.failures.length > 0) {
+        bits.push(`${golden.kind} golden: ${golden.failures.length} mismatch(es)`);
+      }
+    }
     if (!s.diffVsOracleEmpty) {
       bits.push(
         showDiff ? `diverges from ${report.oracle}` : `diverges from ${report.oracle} (--diff for detail)`
@@ -312,6 +339,14 @@ export function formatCompareReport(
     lines.push(`  ${mark} ${s.surface}: ${bits.join(" — ")}`);
     for (const v of s.violations) {
       lines.push(`      [${v.invariant}] ${v.message}`);
+    }
+    for (const golden of s.goldens) {
+      if (!golden.checked && golden.skipReason) {
+        lines.push(`      [${golden.kind}] ${golden.skipReason}`);
+      }
+      for (const failure of golden.failures) {
+        lines.push(`      [${golden.kind}] ${failure}`);
+      }
     }
     if (showDiff && !s.diffVsOracleEmpty && s.diffVsOracle) {
       for (const line of formatStreamDiff(s.diffVsOracle).split("\n")) {

--- a/reliability/harness/src/core/diff.ts
+++ b/reliability/harness/src/core/diff.ts
@@ -12,6 +12,7 @@
  * so its own tests and callers stay green.
  */
 import type { NormalizedRunFrame, NormalizedRunRecord } from "./normalize.js";
+import { stableStringify } from "./stable-json.js";
 
 export interface ChannelDiffEntry {
   kind: "added" | "removed" | "changed" | "unchanged";
@@ -30,7 +31,7 @@ export interface StreamDiff {
 }
 
 function canonicalKey(message: Record<string, unknown>): string {
-  return JSON.stringify(message, Object.keys(message).sort());
+  return stableStringify(message);
 }
 
 function groupByChannel(

--- a/reliability/harness/src/core/golden.ts
+++ b/reliability/harness/src/core/golden.ts
@@ -1,0 +1,206 @@
+/**
+ * Golden-fixture assertions (§4): the `expected/outputs.json` and
+ * `expected/stream.shape.json` a journey opts into via
+ * `assertions.outputs` / `assertions.streamShape`.
+ *
+ * These are the only checks that pin down *what a run produced*. Invariants
+ * describe stream shape and lifecycle; the cross-surface diff only says the
+ * surfaces agree — both pass happily when every surface returns the same
+ * wrong answer. A journey that declares a golden must have it compared, or
+ * declaring it means nothing.
+ */
+import type { Journey } from "./journey.js";
+import type { RunRecord } from "./record.js";
+import { normalizeRunRecord, type NormalizedRunRecord } from "./normalize.js";
+import { stableStringify } from "./stable-json.js";
+
+/** One golden entry, matching `expected/stream.shape.json`'s element shape. */
+export interface StreamShapeEntry {
+  channel: string;
+  message: Record<string, unknown>;
+}
+
+export interface GoldenCheckResult {
+  kind: "outputs" | "streamShape";
+  /** False when the journey didn't declare it, or the run couldn't be compared. */
+  checked: boolean;
+  /** Why it wasn't checked. Only set when `!checked`. */
+  skipReason?: string;
+  /** Human-readable mismatches; empty when the golden matched. */
+  failures: string[];
+}
+
+/** Max mismatching stream-shape entries reported before truncating. */
+const MAX_REPORTED_ENTRIES = 10;
+
+/**
+ * A run's terminal outputs, keyed the way `expected/outputs.json` is: by an
+ * Output node's public `output_name`, last value wins (a node that streams
+ * several values ends on the one a client would display).
+ */
+export function terminalOutputsOf(record: RunRecord): Record<string, unknown> {
+  const outputs: Record<string, unknown> = {};
+  for (const frame of record.frames) {
+    if (frame.direction !== "server_to_client") continue;
+    const message = frame.message as Record<string, unknown>;
+    if (message["type"] !== "output_update") continue;
+    const name = message["output_name"];
+    if (typeof name !== "string") continue;
+    outputs[name] = message["value"];
+  }
+  return outputs;
+}
+
+/** A run's normalized `server_to_client` stream in golden-fixture shape. */
+export function streamShapeOf(
+  record: RunRecord,
+  normalized: NormalizedRunRecord = normalizeRunRecord(record)
+): StreamShapeEntry[] {
+  return normalized.frames
+    .filter((frame) => frame.direction === "server_to_client")
+    .map((frame) => ({ channel: frame.channel, message: frame.message }));
+}
+
+function compareOutputs(
+  expected: unknown,
+  record: RunRecord
+): string[] {
+  const actual = terminalOutputsOf(record);
+  const expectedRecord = (expected ?? {}) as Record<string, unknown>;
+  const failures: string[] = [];
+  const keys = new Set([
+    ...Object.keys(expectedRecord),
+    ...Object.keys(actual)
+  ]);
+  for (const key of Array.from(keys).sort()) {
+    const want = stableStringify(expectedRecord[key]);
+    const got = stableStringify(actual[key]);
+    if (want === got) continue;
+    if (!(key in expectedRecord)) {
+      failures.push(`unexpected output "${key}": ${got}`);
+    } else if (!(key in actual)) {
+      failures.push(`missing output "${key}" (expected ${want})`);
+    } else {
+      failures.push(`output "${key}": expected ${want}, got ${got}`);
+    }
+  }
+  return failures;
+}
+
+function byChannel(entries: readonly StreamShapeEntry[]): Map<string, string[]> {
+  const groups = new Map<string, string[]>();
+  for (const entry of entries) {
+    const serialized = stableStringify(entry.message);
+    const group = groups.get(entry.channel);
+    if (group) group.push(serialized);
+    else groups.set(entry.channel, [serialized]);
+  }
+  return groups;
+}
+
+/**
+ * Compared per node-channel, in channel order — the same rule the
+ * cross-surface diff uses (§4: "per-node-channel, not globally"). The actor
+ * model legitimately interleaves frames across nodes run to run, so a global
+ * index-wise comparison would flag reorderings that are not regressions;
+ * within one channel the order is the node's own and is asserted exactly.
+ *
+ * One limit is inherited from normalization: id placeholders are numbered by
+ * order of first sight (`IdMapper`), so a run where a *different* node emits
+ * first renumbers them and mismatches. The cross-surface diff has the same
+ * property; journeys whose node start order isn't structurally fixed should
+ * not declare `streamShape`.
+ */
+function compareStreamShape(
+  expected: unknown,
+  record: RunRecord,
+  normalized: NormalizedRunRecord
+): string[] {
+  if (!Array.isArray(expected)) {
+    return ["expected/stream.shape.json is not an array of {channel, message}"];
+  }
+  const golden = byChannel(expected as StreamShapeEntry[]);
+  const actual = byChannel(streamShapeOf(record, normalized));
+  const failures: string[] = [];
+
+  const channels = Array.from(
+    new Set([...golden.keys(), ...actual.keys()])
+  ).sort();
+
+  for (const channel of channels) {
+    const want = golden.get(channel) ?? [];
+    const got = actual.get(channel) ?? [];
+    for (let i = 0; i < Math.max(want.length, got.length); i++) {
+      if (failures.length >= MAX_REPORTED_ENTRIES) {
+        failures.push("… further mismatches not reported");
+        return failures;
+      }
+      if (want[i] === got[i]) continue;
+      if (want[i] === undefined) {
+        failures.push(`${channel}[${i}]: unexpected ${got[i]}`);
+      } else if (got[i] === undefined) {
+        failures.push(`${channel}[${i}]: missing ${want[i]}`);
+      } else {
+        failures.push(`${channel}[${i}]: expected ${want[i]}, got ${got[i]}`);
+      }
+    }
+  }
+  return failures;
+}
+
+/**
+ * Runs the golden comparisons a journey declared against one surface's record.
+ *
+ * Faulted runs are skipped rather than compared: a golden describes what the
+ * journey produces when nothing is broken, and every fault journey that opts
+ * into outputs (`host-disk-full-write`, `python-node-workflow`) declares its
+ * faults precisely because the run is *supposed* to fail under them. The skip
+ * is reported, never silent.
+ */
+export function checkGoldens(
+  journey: Journey,
+  record: RunRecord,
+  options: { faultsApplied?: readonly string[] } = {}
+): GoldenCheckResult[] {
+  const { assertions } = journey.manifest;
+  const faults = options.faultsApplied ?? [];
+  const results: GoldenCheckResult[] = [];
+
+  const skipReason =
+    faults.length > 0
+      ? `not compared under fault(s): ${faults.join(", ")}`
+      : undefined;
+
+  // Normalize once — both goldens read from the same view.
+  const normalized = assertions.streamShape ? normalizeRunRecord(record) : null;
+
+  if (assertions.outputs) {
+    results.push(
+      skipReason
+        ? { kind: "outputs", checked: false, skipReason, failures: [] }
+        : {
+            kind: "outputs",
+            checked: true,
+            failures: compareOutputs(journey.expected.outputs, record)
+          }
+    );
+  }
+
+  if (assertions.streamShape) {
+    results.push(
+      skipReason
+        ? { kind: "streamShape", checked: false, skipReason, failures: [] }
+        : {
+            kind: "streamShape",
+            checked: true,
+            failures: compareStreamShape(
+              journey.expected.streamShape,
+              record,
+              normalized!
+            )
+          }
+    );
+  }
+
+  return results;
+}

--- a/reliability/harness/src/core/invariants/leaks.ts
+++ b/reliability/harness/src/core/invariants/leaks.ts
@@ -7,10 +7,11 @@
  * iterations (leak journeys run N=20 and compare).
  *
  * Operates on `RunRecord.resourceCounters` (additive over C1's shape, see
- * `record.ts`) — a driver that doesn't instrument these counters produces no
- * snapshots, and this module reports no violations rather than treating
- * absence itself as a leak: it can only assert what a driver actually
- * measured.
+ * `record.ts`). A journey that declares this invariant but whose record
+ * carries no post-run snapshot fails on that: the check measured nothing, and
+ * "nothing measured" must not read as "no leaks". Drivers that can't
+ * instrument the counters should not declare `cleanup-leaks` for the surfaces
+ * they cover.
  */
 import type { ResourceCounterSnapshot, RunRecord } from "../record.js";
 import type { Violation } from "./types.js";
@@ -27,11 +28,23 @@ const COUNTER_FIELDS = [
 type CounterField = (typeof COUNTER_FIELDS)[number];
 
 export function checkLeaks(record: RunRecord): Violation[] {
-  const snapshots = record.resourceCounters;
-  if (!snapshots || snapshots.length === 0) return [];
-
+  const snapshots = record.resourceCounters ?? [];
   const violations: Violation[] = [];
   const afterSnapshots = snapshots.filter((s) => s.at === "after");
+
+  if (afterSnapshots.length === 0) {
+    return [
+      {
+        invariant: "leaks.not-instrumented",
+        message:
+          `surface "${record.surface}" produced no post-run resource-counter ` +
+          "snapshot, so the cleanup-leaks invariant asserted nothing — " +
+          "instrument the driver (RunRecord.resourceCounters) or stop " +
+          "declaring cleanup-leaks for this surface",
+        details: { surface: record.surface, snapshots: snapshots.length }
+      }
+    ];
+  }
 
   afterSnapshots.forEach((snapshot, snapshotIndex) => {
     for (const field of COUNTER_FIELDS) {

--- a/reliability/harness/src/core/invariants/terminal-uniqueness.ts
+++ b/reliability/harness/src/core/invariants/terminal-uniqueness.ts
@@ -9,6 +9,13 @@
  *
  * Split from `lifecycle.ts` (which covers the node-level running/terminal
  * pairing) so each §6 bullet stays independently attributable.
+ *
+ * Frames a driver tagged `redundant` (see `RunFrame.redundant`) are discounted
+ * here: they are that surface's documented client-convenience repeats (the
+ * ws-server's eager "running" ack and its authoritative terminal snapshot),
+ * recognized one-by-one by the driver that speaks the protocol. Every other
+ * duplicate is untagged and therefore still a violation — which is the point
+ * of recording repeats instead of dropping them at the driver.
  */
 import type { RunRecord } from "../record.js";
 import type { Violation } from "./types.js";
@@ -28,6 +35,7 @@ export function checkTerminalUniqueness(record: RunRecord): Violation[] {
 
   const terminalIndices: number[] = [];
   record.frames.forEach((frame, index) => {
+    if (frame.redundant !== undefined) return;
     const message = frame.message as Record<string, unknown>;
     if (asString(message, "type") !== "job_update") return;
     const status = asString(message, "status");
@@ -57,7 +65,9 @@ export function checkTerminalUniqueness(record: RunRecord): Violation[] {
   const framesAfter = record.frames
     .slice(firstTerminal + 1)
     .filter(
-      (frame) => asString(frame.message as Record<string, unknown>, "type") === "job_update"
+      (frame) =>
+        frame.redundant === undefined &&
+        asString(frame.message as Record<string, unknown>, "type") === "job_update"
     );
   if (framesAfter.length > 0) {
     violations.push({

--- a/reliability/harness/src/core/normalize.ts
+++ b/reliability/harness/src/core/normalize.ts
@@ -192,6 +192,11 @@ export function normalizeRunRecord(
   mapper: IdMapper = new IdMapper()
 ): NormalizedRunRecord {
   const frames: NormalizedRunFrame[] = record.frames
+    // Frames a driver tagged as its surface's own documented redundancy
+    // (`RunFrame.redundant`) have no counterpart on the kernel's raw stream,
+    // so they are dropped here — in the comparison view only. The record
+    // itself keeps them, and the invariants read the record.
+    .filter((frame) => frame.redundant === undefined)
     .filter((frame) => !isTrivialNodeFrame(frame.message as Record<string, unknown>))
     .map((frame) => ({
       seq: frame.seq,

--- a/reliability/harness/src/core/record.ts
+++ b/reliability/harness/src/core/record.ts
@@ -45,6 +45,21 @@ export interface RunFrame {
   /** The raw frame payload. A `ProcessingMessage` for server→client frames;
    * an untyped record for client→server control frames (run/cancel/…). */
   message: ProcessingMessage | Record<string, unknown>;
+  /**
+   * Set when a driver recognizes this frame as its own surface's *documented*
+   * redundancy — a repeat of information an earlier frame already carried,
+   * emitted for client convenience (the ws-server's eager "running" ack and
+   * its authoritative terminal snapshot; see `drivers/ws-server.ts`). The
+   * value is the reason tag.
+   *
+   * The frame is still recorded: dropping repeats outright, as this driver
+   * used to, makes "exactly one terminal job_update" unfalsifiable on the one
+   * surface that has a wire. Cross-surface normalization skips tagged frames
+   * (they have no kernel counterpart), and the invariants that assert
+   * uniqueness discount them — so an *undocumented* duplicate, which is never
+   * tagged, still fails both.
+   */
+  redundant?: string;
 }
 
 /**

--- a/reliability/harness/src/core/stable-json.ts
+++ b/reliability/harness/src/core/stable-json.ts
@@ -1,0 +1,26 @@
+/**
+ * Order-independent JSON serialization, recursive at every depth — the
+ * canonical form both the stream diff (`diff.ts`) and the golden comparisons
+ * (`golden.ts`) key messages by.
+ *
+ * `JSON.stringify(value, keyArray)` cannot do this: its array form is a key
+ * *whitelist* applied at every nesting level, so a top-level key list erases
+ * every nested object's contents — `{result: {output: "A"}}` and
+ * `{result: {output: "B"}}` both serialize to `{"result":{}}`, and output,
+ * metadata, and nested error divergences compare equal.
+ */
+export function stableStringify(value: unknown): string {
+  if (value === undefined) return "null";
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries
+    .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`)
+    .join(",")}}`;
+}

--- a/reliability/harness/src/drivers/kernel.ts
+++ b/reliability/harness/src/drivers/kernel.ts
@@ -32,7 +32,12 @@ import {
 import { createGraphNodeTypeResolver } from "@nodetool-ai/node-sdk";
 import { InMemoryStorageAdapter, ProcessingContext } from "@nodetool-ai/runtime";
 import type { Journey, JourneyInteraction } from "../core/journey.js";
-import { makeFrame, type RunFrame, type RunRecord } from "../core/record.js";
+import {
+  makeFrame,
+  type ResourceCounterSnapshot,
+  type RunFrame,
+  type RunRecord
+} from "../core/record.js";
 import { AnchorWaiter } from "./anchors.js";
 import { buildJourneyRegistry } from "./registry.js";
 import { journeyPythonBridgeFactory } from "./python-bridge.js";
@@ -147,7 +152,12 @@ export class KernelDriver implements RunDriver {
             // it" — the kernel driver is the oracle surface, so its advisory
             // checks (pending inbox work, pending control responses) are
             // always thrown violations, not log warnings.
-            strict: true
+            strict: true,
+            // This driver records the message stream frame by frame
+            // (`pumpMessages` below), so it's one of the few callers that
+            // actually drains `session.messages` — capture is opt-in exactly
+            // so hosts that only await `result` don't queue messages unread.
+            captureMessages: true
           };
           // Every kernel run gets a working (in-memory, hermetic) storage
           // adapter — `ExecutionSession`'s own default context wires none at
@@ -244,6 +254,17 @@ export class KernelDriver implements RunDriver {
     const result = await session.result;
     if (pump) await pump;
 
+    // §6 "Cleanup and leaks": measured from the session itself
+    // (`ExecutionSession.resourceCounters`), not inferred. The kernel driver
+    // owns no WS slots, so those two are structurally zero here — the
+    // ws-server driver is where they carry information.
+    const counters: ResourceCounterSnapshot = {
+      at: "after",
+      ...session.resourceCounters(),
+      activeJobs: 0,
+      startingJobs: 0
+    };
+
     return {
       journeyId: journey.manifest.name,
       surface: this.name,
@@ -255,7 +276,8 @@ export class KernelDriver implements RunDriver {
       status: result.status,
       error: result.error ?? null,
       params: journey.manifest.params,
-      frames
+      frames,
+      resourceCounters: [counters]
     };
   }
 }

--- a/reliability/harness/src/drivers/ws-server.ts
+++ b/reliability/harness/src/drivers/ws-server.ts
@@ -16,7 +16,8 @@ import { WebSocket } from "ws";
 import {
   createTestUiServer,
   packWebSocketMessage,
-  unpackWebSocketMessage
+  unpackWebSocketMessage,
+  type UnifiedWebSocketRunner
 } from "@nodetool-ai/websocket";
 import { NodeRegistry } from "@nodetool-ai/node-sdk";
 import { registerBaseNodes } from "@nodetool-ai/base-nodes";
@@ -25,7 +26,12 @@ import {
   type PythonBridgeBase
 } from "@nodetool-ai/runtime";
 import type { Journey, JourneyInteraction } from "../core/journey.js";
-import { makeFrame, type RunFrame, type RunRecord } from "../core/record.js";
+import {
+  makeFrame,
+  type ResourceCounterSnapshot,
+  type RunFrame,
+  type RunRecord
+} from "../core/record.js";
 import { AnchorWaiter } from "./anchors.js";
 import { registerFixtureNodes } from "./fixture-nodes.js";
 import { journeyPythonBridgeFactory } from "./python-bridge.js";
@@ -86,6 +92,55 @@ function stripRelayOnlyFields(message: Record<string, unknown>): Record<string, 
   return rest;
 }
 
+/** How long to let the server's post-disconnect cleanup settle before
+ * recording the slot counters as final. Cleanup is asynchronous (the runner
+ * finishes streaming, then frees the slot), so a snapshot taken the instant
+ * the socket closes would report a slot that is merely about to be freed. */
+const SLOT_SETTLE_TIMEOUT_MS = 2000;
+const SLOT_SETTLE_POLL_MS = 10;
+
+/**
+ * Post-run WS slot accounting (§6 "Cleanup and leaks"), summed over every
+ * connection this run opened. Polls until both counters reach zero or the
+ * settle window elapses, then reports whatever it measured — a genuine leak
+ * survives the wait and is recorded as non-zero.
+ */
+async function settledSlotCounters(
+  runners: readonly UnifiedWebSocketRunner[]
+): Promise<ResourceCounterSnapshot> {
+  const total = (): { activeJobs: number; startingJobs: number } =>
+    runners.reduce(
+      (acc, runner) => {
+        const slots = runner.slotCounters;
+        return {
+          activeJobs: acc.activeJobs + slots.activeJobs,
+          startingJobs: acc.startingJobs + slots.startingJobs
+        };
+      },
+      { activeJobs: 0, startingJobs: 0 }
+    );
+
+  const deadline = Date.now() + SLOT_SETTLE_TIMEOUT_MS;
+  let slots = total();
+  while ((slots.activeJobs > 0 || slots.startingJobs > 0) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, SLOT_SETTLE_POLL_MS));
+    slots = total();
+  }
+
+  return {
+    at: "after",
+    // Kernel-internal counters belong to the process the ws-server runs the
+    // kernel in; this driver reaches the server only over the wire, so it
+    // reports the accounting it can actually observe and leaves the rest at
+    // zero (the kernel driver is the surface that measures those).
+    liveActors: 0,
+    pendingControlResponses: 0,
+    pendingTimers: 0,
+    pythonBridgePendingRequests: 0,
+    ...slots
+  };
+}
+
 function requireJobId(jobId: string | null, journeyName: string, action: string): string {
   if (!jobId) {
     throw new Error(
@@ -120,9 +175,14 @@ export class WsServerDriver implements RunDriver {
     );
 
     let liveRegistry: NodeRegistry | null = null;
+    // §6 "Cleanup and leaks" needs the server's own WS slot accounting, which
+    // lives on the per-connection runner. `createTestUiServer` builds one per
+    // upgrade and keeps it private; this hook is the only way to read it.
+    const runners: UnifiedWebSocketRunner[] = [];
     const srv = createTestUiServer({
       host: "127.0.0.1",
       port: 0,
+      onRunnerCreated: (runner) => runners.push(runner),
       configureRegistry: (registry) => {
         registerFixtureNodes(registry);
         liveRegistry = registry;
@@ -192,6 +252,7 @@ export class WsServerDriver implements RunDriver {
     const port = wsFrontEnd ? wsFrontEnd.port : serverPort;
 
     const frames: RunFrame[] = [];
+    let counters: ResourceCounterSnapshot | null = null;
     let seq = 0;
     const waiter = new AnchorWaiter();
     let jobId: string | null = null;
@@ -205,11 +266,46 @@ export class WsServerDriver implements RunDriver {
     // `unified-websocket-runner.ts`), and, for any non-"completed" terminal
     // status, an "authoritative terminal snapshot" appended after the
     // relayed one because the kernel's own terminal frame never carries a
-    // `result` field. Recording only the first `job_update` this driver
-    // sees per status makes frame counts comparable to the kernel driver's
-    // single emission per status — the second is this wire protocol's own
-    // client-convenience redundancy, not new information.
-    const seenJobUpdateStatuses = new Set<string>();
+    // `result` field.
+    //
+    // Both are recorded, tagged `redundant` (see `RunFrame.redundant`) rather
+    // than dropped: dropping every repeat, as this driver used to, also drops
+    // the duplicates that would be real bugs, leaving "exactly one terminal
+    // job_update" with nothing to detect on the one surface that has a wire.
+    // The tag is narrow — a repeat only earns it by matching the documented
+    // shape below — so any other duplicate stays visible to the invariants
+    // and to the cross-surface diff.
+    const jobUpdateStatusCounts = new Map<string, number>();
+    const taggedReasons = new Set<string>();
+    let cancelRequested = false;
+
+    /** The reason tag for a repeated `job_update`, or undefined when this
+     * surface has no documented reason to have sent it twice. */
+    const documentedRedundancy = (
+      status: string,
+      message: Record<string, unknown>
+    ): string | undefined => {
+      const claim = (reason: string): string | undefined => {
+        // One repeat per documented reason. A third frame is not something
+        // the protocol documents, so it stays visible.
+        if (taggedReasons.has(reason)) return undefined;
+        taggedReasons.add(reason);
+        return reason;
+      };
+      if (status === "running") return claim("ws-eager-running-ack");
+      if (TERMINAL_JOB_STATUSES.has(status) && "result" in message) {
+        return claim("ws-authoritative-terminal-snapshot");
+      }
+      // `cancel_job` is acknowledged with a `cancelled` job_update right away
+      // (`unified-websocket-runner.ts`'s cancel handler: "the runner's own
+      // cleanup can lag"), which the kernel's own relayed terminal then
+      // repeats. Only ever allowed for a cancel this driver actually asked
+      // for.
+      if (status === "cancelled" && cancelRequested) {
+        return claim("ws-eager-cancel-ack");
+      }
+      return undefined;
+    };
     let resolveTerminal!: () => void;
     const terminalPromise = new Promise<void>((resolve) => {
       resolveTerminal = resolve;
@@ -239,16 +335,24 @@ export class WsServerDriver implements RunDriver {
 
       if (message["type"] === "job_update") {
         const status = String(message["status"]);
-        if (seenJobUpdateStatuses.has(status)) return;
-        seenJobUpdateStatuses.add(status);
-        if (TERMINAL_JOB_STATUSES.has(status)) {
+        const seenBefore = (jobUpdateStatusCounts.get(status) ?? 0) > 0;
+        jobUpdateStatusCounts.set(
+          status,
+          (jobUpdateStatusCounts.get(status) ?? 0) + 1
+        );
+        const redundant = seenBefore
+          ? documentedRedundancy(status, message)
+          : undefined;
+        const frame = makeFrame(seq++, "ws-server", "server_to_client", message);
+        frames.push(redundant === undefined ? frame : { ...frame, redundant });
+
+        if (!seenBefore && TERMINAL_JOB_STATUSES.has(status)) {
           terminalStatus = status;
           terminalError =
             typeof message["error"] === "string" ? (message["error"] as string) : null;
-          frames.push(makeFrame(seq++, "ws-server", "server_to_client", message));
           resolveTerminal();
-          return;
         }
+        return;
       }
 
       frames.push(makeFrame(seq++, "ws-server", "server_to_client", message));
@@ -296,6 +400,7 @@ export class WsServerDriver implements RunDriver {
             });
             break;
           case "cancel":
+            cancelRequested = true;
             send("cancel_job", {
               job_id: requireJobId(jobId, journey.manifest.name, "cancel")
             });
@@ -356,8 +461,13 @@ export class WsServerDriver implements RunDriver {
           `${journey.manifest.timeoutMs}ms waiting for a terminal job_update`;
       }
     } finally {
+      // Leak accounting is measured after the connection is gone, not at the
+      // terminal frame: tearing the socket down is what ends a run whose
+      // client stopped hearing from the server at all (the black-hole ws
+      // faults), and the server's own cleanup runs on disconnect.
       ws.close();
       await wsFrontEnd?.close();
+      counters = await settledSlotCounters(runners);
       await srv.close();
       bridge?.close();
     }
@@ -373,7 +483,8 @@ export class WsServerDriver implements RunDriver {
       status: terminalStatus ?? "unknown",
       error: terminalError,
       params: journey.manifest.params,
-      frames
+      frames,
+      resourceCounters: counters ? [counters] : []
     };
   }
 }

--- a/reliability/harness/src/index.ts
+++ b/reliability/harness/src/index.ts
@@ -2,6 +2,8 @@ export * from "./core/journey.js";
 export * from "./core/record.js";
 export * from "./core/normalize.js";
 export * from "./core/diff.js";
+export * from "./core/stable-json.js";
+export * from "./core/golden.js";
 export * from "./core/invariants/index.js";
 export * from "./drivers/index.js";
 export * from "./faults/index.js";

--- a/reliability/harness/tests/compare.test.ts
+++ b/reliability/harness/tests/compare.test.ts
@@ -44,8 +44,17 @@ function fakeDriver(name: string, record: RunRecord, opts: { supports?: boolean 
   };
 }
 
+/**
+ * These tests exercise `compareJourney`'s wiring against stub records that
+ * carry only job_update frames, so the journey's golden assertions are turned
+ * off here — a stub can't match a real run's fixtures, and the goldens have
+ * their own coverage in `golden.test.ts`.
+ */
 async function loadLinear(): Promise<Journey> {
-  return loadJourney(resolve(JOURNEYS_DIR, "linear-text-pipeline"));
+  const journey = await loadJourney(resolve(JOURNEYS_DIR, "linear-text-pipeline"));
+  journey.manifest.assertions.outputs = false;
+  journey.manifest.assertions.streamShape = false;
+  return journey;
 }
 
 describe("compareJourney", () => {

--- a/reliability/harness/tests/diff.test.ts
+++ b/reliability/harness/tests/diff.test.ts
@@ -58,6 +58,69 @@ describe("diffNormalizedRecords", () => {
     expect(formatStreamDiff(diff)).toContain("channel node:upper1");
   });
 
+  it("flags a divergence nested inside a message payload", async () => {
+    // Regression: the canonical key used to be
+    // `JSON.stringify(message, Object.keys(message).sort())`, whose array
+    // replacer is a key whitelist at EVERY depth — every nested object
+    // serialized as `{}`, so two different node results compared equal.
+    const baseline: NormalizedRunRecord = {
+      surface: "kernel",
+      status: "completed",
+      error: null,
+      jobId: "<job:0>",
+      workflowId: "<workflow:0>",
+      frames: [
+        {
+          seq: 0,
+          channel: "node:n1",
+          direction: "server_to_client",
+          surface: "kernel",
+          message: { type: "node_update", result: { output: "A" } }
+        }
+      ]
+    };
+    const candidate = cloneNormalized(baseline);
+    candidate.surface = "ws-server";
+    (candidate.frames[0].message["result"] as Record<string, unknown>)["output"] = "B";
+
+    const diff = diffNormalizedRecords(baseline, candidate);
+    expect(streamDiffIsEmpty(diff)).toBe(false);
+    expect(diff.channels.map((c) => c.channel)).toEqual(["node:n1"]);
+    expect(formatStreamDiff(diff)).toContain('"output":"B"');
+  });
+
+  it("treats key order as insignificant at every depth", () => {
+    const baseline: NormalizedRunRecord = {
+      surface: "kernel",
+      status: "completed",
+      error: null,
+      jobId: null,
+      workflowId: null,
+      frames: [
+        {
+          seq: 0,
+          channel: "node:n1",
+          direction: "server_to_client",
+          surface: "kernel",
+          message: { type: "node_update", result: { a: 1, b: [{ x: 1, y: 2 }] } }
+        }
+      ]
+    };
+    const candidate: NormalizedRunRecord = {
+      ...baseline,
+      surface: "ws-server",
+      frames: [
+        {
+          ...baseline.frames[0],
+          surface: "ws-server",
+          message: { result: { b: [{ y: 2, x: 1 }], a: 1 }, type: "node_update" }
+        }
+      ]
+    };
+
+    expect(streamDiffIsEmpty(diffNormalizedRecords(baseline, candidate))).toBe(true);
+  });
+
   it("flags a missing terminal frame as a divergence", async () => {
     const record = await loadRunRecordFromDebugBundle(BUNDLE_DIR);
     const baseline = normalizeRunRecord(record);

--- a/reliability/harness/tests/golden.test.ts
+++ b/reliability/harness/tests/golden.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Golden fixtures must decide the verdict (§4). Without these, a journey can
+ * declare `assertions.outputs`/`assertions.streamShape`, ship the fixtures,
+ * and have every surface return the same wrong answer while the report reads
+ * OK.
+ */
+import { describe, expect, it } from "vitest";
+import { resolve } from "node:path";
+import { loadJourney, type Journey } from "../src/core/journey.js";
+import { makeFrame, type RunRecord } from "../src/core/record.js";
+import {
+  checkGoldens,
+  streamShapeOf,
+  terminalOutputsOf
+} from "../src/core/golden.js";
+import { compareJourney, type CompareDriver } from "../src/compare.js";
+
+const JOURNEYS_DIR = resolve(__dirname, "../../journeys");
+
+async function loadLinear(): Promise<Journey> {
+  return loadJourney(resolve(JOURNEYS_DIR, "linear-text-pipeline"));
+}
+
+/** Turns a golden's normalized placeholders (`<node:0>`) back into concrete
+ * ids, so a synthesized record goes through the same normalization a driver's
+ * record does instead of arriving pre-normalized. */
+function deplaceholder(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value.replace(/^<([a-z-]+):(\d+)>$/, "$1-$2");
+  }
+  if (Array.isArray(value)) return value.map(deplaceholder);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+        k,
+        deplaceholder(v)
+      ])
+    );
+  }
+  return value;
+}
+
+/** A record whose outputs and stream match a journey's shipped goldens. */
+function goldenRecord(journey: Journey, surface: string): RunRecord {
+  const shape = journey.expected.streamShape as Array<{
+    channel: string;
+    message: Record<string, unknown>;
+  }>;
+  const frames = shape.map((entry, index) => {
+    const message = deplaceholder(entry.message) as Record<string, unknown>;
+    // The golden carries the placeholder id; the channel carries the real
+    // node id. Put the real one back so the record channels the same way a
+    // driver's would.
+    if (entry.channel.startsWith("node:")) {
+      message["node_id"] = entry.channel.slice("node:".length);
+    }
+    return makeFrame(index, surface, "server_to_client", message);
+  });
+  return {
+    journeyId: journey.manifest.name,
+    surface,
+    jobId: null,
+    workflowId: null,
+    startedAt: 0,
+    finishedAt: frames.length,
+    durationMs: null,
+    status: "completed",
+    error: null,
+    params: {},
+    frames,
+    resourceCounters: [
+      {
+        at: "after",
+        liveActors: 0,
+        pendingControlResponses: 0,
+        pendingTimers: 0,
+        pythonBridgePendingRequests: 0,
+        activeJobs: 0,
+        startingJobs: 0
+      }
+    ]
+  };
+}
+
+function fakeDriver(name: string, record: RunRecord): CompareDriver {
+  return { name, run: async () => record };
+}
+
+describe("terminalOutputsOf", () => {
+  it("keys output_update values by output_name, last value winning", () => {
+    const record = goldenRecord(
+      {
+        expected: {
+          streamShape: [
+            {
+              channel: "node:out1",
+              message: {
+                type: "output_update",
+                node_id: "n1",
+                output_name: "result",
+                value: "first"
+              }
+            },
+            {
+              channel: "node:out1",
+              message: {
+                type: "output_update",
+                node_id: "n1",
+                output_name: "result",
+                value: "last"
+              }
+            }
+          ],
+          outputs: null
+        },
+        manifest: { name: "x" }
+      } as unknown as Journey,
+      "kernel"
+    );
+    expect(terminalOutputsOf(record)).toEqual({ result: "last" });
+  });
+});
+
+describe("checkGoldens", () => {
+  it("passes when a record matches the journey's shipped fixtures", async () => {
+    const journey = await loadLinear();
+    const results = checkGoldens(journey, goldenRecord(journey, "kernel"));
+    expect(results.map((r) => r.kind).sort()).toEqual(["outputs", "streamShape"]);
+    expect(results.flatMap((r) => r.failures)).toEqual([]);
+  });
+
+  it("fails on a wrong output value", async () => {
+    const journey = await loadLinear();
+    const record = goldenRecord(journey, "kernel");
+    const output = record.frames.find(
+      (f) => (f.message as Record<string, unknown>)["type"] === "output_update"
+    )!;
+    (output.message as Record<string, unknown>)["value"] = "WRONG";
+
+    const outputs = checkGoldens(journey, record).find((r) => r.kind === "outputs")!;
+    expect(outputs.checked).toBe(true);
+    expect(outputs.failures.join(" ")).toMatch(/output "result"/);
+  });
+
+  it("fails on a missing frame in the stream shape", async () => {
+    const journey = await loadLinear();
+    const record = goldenRecord(journey, "kernel");
+    record.frames = record.frames.filter(
+      (f) => (f.message as Record<string, unknown>)["type"] !== "edge_update"
+    );
+
+    const shape = checkGoldens(journey, record).find((r) => r.kind === "streamShape")!;
+    expect(shape.failures.length).toBeGreaterThan(0);
+  });
+
+  it("tolerates cross-channel interleaving, comparing per channel", async () => {
+    const journey = await loadLinear();
+    const record = goldenRecord(journey, "kernel");
+    // Move one node's last frame to the end of the run: the global frame
+    // order changes, each channel's own order does not. (Which node id is
+    // seen first is unchanged, so the normalizer's placeholders still line
+    // up — see `golden.ts` on that limit.)
+    const moved = record.frames.filter((f) => f.channel === "node:upper1").pop()!;
+    record.frames = [...record.frames.filter((f) => f !== moved), moved];
+
+    const shape = checkGoldens(journey, record).find((r) => r.kind === "streamShape")!;
+    expect(shape.failures).toEqual([]);
+  });
+
+  it("skips (and says so) under an injected fault rather than comparing a broken run", async () => {
+    const journey = await loadLinear();
+    const record = goldenRecord(journey, "kernel");
+    record.frames = [];
+
+    const results = checkGoldens(journey, record, { faultsApplied: ["provider-429"] });
+    expect(results.every((r) => !r.checked)).toBe(true);
+    expect(results.every((r) => r.failures.length === 0)).toBe(true);
+    expect(results[0].skipReason).toMatch(/provider-429/);
+  });
+});
+
+describe("compareJourney golden integration", () => {
+  it("fails the verdict when both surfaces agree on the wrong output", async () => {
+    const journey = await loadLinear();
+    const makeWrong = (surface: string): RunRecord => {
+      const record = goldenRecord(journey, surface);
+      for (const frame of record.frames) {
+        const message = frame.message as Record<string, unknown>;
+        if (message["type"] === "output_update") message["value"] = "WRONG";
+      }
+      return record;
+    };
+
+    const report = await compareJourney(journey, [
+      fakeDriver("kernel", makeWrong("kernel")),
+      fakeDriver("ws-server", makeWrong("ws-server"))
+    ]);
+
+    // The surfaces agree — the cross-surface diff is clean, which is exactly
+    // why the golden has to be the thing that catches this.
+    expect(report.surfaces.every((s) => s.diffVsOracleEmpty)).toBe(true);
+    expect(report.verdict.ok).toBe(false);
+    expect(report.verdict.issues.some((i) => i.includes("outputs golden"))).toBe(true);
+  });
+
+  it("passes and reports the goldens as checked when both surfaces match", async () => {
+    const journey = await loadLinear();
+    const report = await compareJourney(journey, [
+      fakeDriver("kernel", goldenRecord(journey, "kernel")),
+      fakeDriver("ws-server", goldenRecord(journey, "ws-server"))
+    ]);
+
+    expect(report.verdict.ok).toBe(true);
+    for (const surface of report.surfaces) {
+      expect(surface.goldens.map((g) => g.checked)).toEqual([true, true]);
+    }
+  });
+});
+
+describe("streamShapeOf", () => {
+  it("drops client_to_server frames — goldens describe what a client receives", async () => {
+    const journey = await loadLinear();
+    const record = goldenRecord(journey, "kernel");
+    record.frames.push(
+      makeFrame(999, "kernel", "client_to_server", {
+        command: "cancel_job",
+        data: {}
+      })
+    );
+    expect(
+      streamShapeOf(record).some((e) => "command" in e.message)
+    ).toBe(false);
+  });
+});

--- a/reliability/harness/tests/invariants/leaks.test.ts
+++ b/reliability/harness/tests/invariants/leaks.test.ts
@@ -28,10 +28,6 @@ const ZERO: Omit<ResourceCounterSnapshot, "at"> = {
 };
 
 describe("checkLeaks: passing fixtures", () => {
-  it("reports nothing when no resource counters were captured (nothing to assess)", () => {
-    expect(checkLeaks(baseRecord())).toEqual([]);
-  });
-
   it("reports nothing when every post-run counter is zero", () => {
     const record = baseRecord([
       { at: "before", ...ZERO, liveActors: 3 },
@@ -51,6 +47,18 @@ describe("checkLeaks: passing fixtures", () => {
 });
 
 describe("checkLeaks: failing fixtures", () => {
+  it("flags a record with no post-run snapshot — an uninstrumented driver asserts nothing", () => {
+    expect(checkLeaks(baseRecord())).toEqual([
+      expect.objectContaining({ invariant: "leaks.not-instrumented" })
+    ]);
+  });
+
+  it("flags a record whose only snapshot is a pre-run baseline", () => {
+    expect(checkLeaks(baseRecord([{ at: "before", ...ZERO }]))).toEqual([
+      expect.objectContaining({ invariant: "leaks.not-instrumented" })
+    ]);
+  });
+
   it("flags a nonzero post-run counter", () => {
     const record = baseRecord([{ at: "after", ...ZERO, liveActors: 1, activeJobs: 2 }]);
 

--- a/reliability/harness/tests/invariants/terminal-uniqueness.test.ts
+++ b/reliability/harness/tests/invariants/terminal-uniqueness.test.ts
@@ -53,6 +53,52 @@ describe("checkTerminalUniqueness: failing fixtures", () => {
     expect(invariantIds).toContain("terminal-uniqueness.frames-after-terminal");
   });
 
+  it("discounts a duplicate terminal a driver tagged as documented surface redundancy", () => {
+    const snapshot = {
+      ...makeFrame(1, "ws-server", "server_to_client", {
+        type: "job_update",
+        status: "cancelled",
+        job_id: "job-1",
+        result: { outputs: {} }
+      }),
+      redundant: "ws-authoritative-terminal-snapshot"
+    };
+    const record = baseRecord([
+      makeFrame(0, "ws-server", "client_to_server", {
+        command: "cancel_job",
+        data: { job_id: "job-1" }
+      }),
+      makeFrame(1, "ws-server", "server_to_client", {
+        type: "job_update",
+        status: "cancelled",
+        job_id: "job-1"
+      }),
+      snapshot
+    ]);
+
+    expect(checkTerminalUniqueness(record)).toEqual([]);
+  });
+
+  it("flags an untagged duplicate terminal even on a surface that has documented repeats", () => {
+    // The driver only tags repeats it recognizes; this one it doesn't, so the
+    // invariant still sees two terminals.
+    const record = baseRecord([
+      makeFrame(0, "ws-server", "server_to_client", {
+        type: "job_update",
+        status: "completed",
+        job_id: "job-1"
+      }),
+      makeFrame(1, "ws-server", "server_to_client", {
+        type: "job_update",
+        status: "completed",
+        job_id: "job-1"
+      })
+    ]);
+
+    const invariantIds = checkTerminalUniqueness(record).map((v) => v.invariant);
+    expect(invariantIds).toContain("terminal-uniqueness.multiple");
+  });
+
   it("flags a completed terminal when a node errored and nothing was cancelled/suspended (precedence)", () => {
     const record = baseRecord([
       makeFrame(0, "kernel", "server_to_client", { type: "node_update", node_id: "n1", status: "error" }),

--- a/reliability/journeys/linear-text-pipeline/expected/stream.shape.json
+++ b/reliability/journeys/linear-text-pipeline/expected/stream.shape.json
@@ -9,27 +9,11 @@
     }
   },
   {
-    "channel": "node:const1",
-    "message": {
-      "type": "node_update",
-      "node_id": "<node:0>",
-      "node_name": "nodetool.constant.String",
-      "node_type": "nodetool.constant.String",
-      "status": "running",
-      "result": null,
-      "error": null,
-      "properties": {
-        "value": "hello reliability"
-      },
-      "provider_cost": null
-    }
-  },
-  {
     "channel": "node:upper1",
     "message": {
       "type": "node_update",
-      "node_id": "<node:1>",
-      "node_name": "nodetool.text.ToUppercase",
+      "node_id": "<node:0>",
+      "node_name": "upper1",
       "node_type": "nodetool.text.ToUppercase",
       "status": "running",
       "result": null,
@@ -42,8 +26,8 @@
     "channel": "node:out1",
     "message": {
       "type": "node_update",
-      "node_id": "<node:2>",
-      "node_name": "nodetool.output.Output",
+      "node_id": "<node:1>",
+      "node_name": "out1",
       "node_type": "nodetool.output.Output",
       "status": "running",
       "result": null,
@@ -62,22 +46,6 @@
       "edge_id": "<edge:0>",
       "status": "active",
       "counter": 1
-    }
-  },
-  {
-    "channel": "node:const1",
-    "message": {
-      "type": "node_update",
-      "node_id": "<node:0>",
-      "node_name": "nodetool.constant.String",
-      "node_type": "nodetool.constant.String",
-      "status": "completed",
-      "result": null,
-      "error": null,
-      "properties": {
-        "value": "hello reliability"
-      },
-      "provider_cost": null
     }
   },
   {
@@ -104,8 +72,8 @@
     "channel": "node:upper1",
     "message": {
       "type": "generation_complete",
-      "node_id": "<node:1>",
-      "node_name": "nodetool.text.ToUppercase",
+      "node_id": "<node:0>",
+      "node_name": "upper1",
       "node_type": "nodetool.text.ToUppercase",
       "outputs": {
         "output": "HELLO RELIABILITY"
@@ -119,8 +87,8 @@
     "channel": "node:upper1",
     "message": {
       "type": "node_update",
-      "node_id": "<node:1>",
-      "node_name": "nodetool.text.ToUppercase",
+      "node_id": "<node:0>",
+      "node_name": "upper1",
       "node_type": "nodetool.text.ToUppercase",
       "status": "completed",
       "result": {
@@ -145,7 +113,7 @@
     "channel": "node:out1",
     "message": {
       "type": "output_update",
-      "node_id": "<node:2>",
+      "node_id": "<node:1>",
       "node_name": "out1",
       "output_name": "result",
       "value": "HELLO RELIABILITY",
@@ -158,8 +126,8 @@
     "channel": "node:out1",
     "message": {
       "type": "generation_complete",
-      "node_id": "<node:2>",
-      "node_name": "nodetool.output.Output",
+      "node_id": "<node:1>",
+      "node_name": "out1",
       "node_type": "nodetool.output.Output",
       "outputs": {
         "output": "HELLO RELIABILITY"
@@ -174,8 +142,8 @@
     "channel": "node:out1",
     "message": {
       "type": "node_update",
-      "node_id": "<node:2>",
-      "node_name": "nodetool.output.Output",
+      "node_id": "<node:1>",
+      "node_name": "out1",
       "node_type": "nodetool.output.Output",
       "status": "completed",
       "result": {


### PR DESCRIPTION
Fixes six defects in the execution facade and the reliability comparison stack. Four were checks that could not fail, and one let a cancelled job run.

## 1. Cancelled queued jobs could still execute (P1)

`ExecutionSession.create()` starts the kernel. The WS runner read the persisted job status *after* creating the session, so a job cancelled while queued (via the DB-only tRPC `jobs.cancel` path, which leaves it in `jobQueue`) executed anyway — side effects included — and the cancelled branch never called `session.cancel()`.

The persistence block now runs before the session is created. The existing regression test only asserted the DB row still read `cancelled`, which the old code satisfied while running the workflow; it now asserts the executor was never invoked and that no `completed` frame was sent.

## 2. Golden fixtures never reached the verdict (P1)

`compareJourney` evaluated invariants and the cross-surface diff, and never touched `journey.expected.outputs` / `journey.expected.streamShape`. Kernel and ws-server could return the same wrong result and every journey passed.

New `core/golden.ts` compares terminal outputs and the normalized stream against `expected/`, per surface, and fails the surface on a mismatch. The stream comparison is per node-channel (the actor model legitimately interleaves across nodes, so a global index-wise compare would flag non-regressions). Faulted runs skip the comparison with a stated reason — a golden describes the unfaulted contract, and the fault journeys that declare `outputs` do so precisely because the run is supposed to fail under them.

`nodetool reliability update-goldens <journey>` recaptures fixtures from a fresh unfaulted kernel run (refusing a run that didn't complete). `linear-text-pipeline`'s `stream.shape.json` was stale and is refreshed: constant/input frames are now dropped by normalization, and `node_name` carries the node's name rather than its type. Values, statuses, edge updates and the terminal are unchanged.

## 3. Nested payload differences vanished from the diff (P1)

`canonicalKey` used `JSON.stringify(message, Object.keys(message).sort())`. The array replacer is a key *whitelist* applied at every nesting level, so every nested object serialized as `{}` — `{result:{output:"A"}}` and `{result:{output:"B"}}` compared equal, hiding output, metadata and nested error divergences. Replaced with a recursive stable serializer (`core/stable-json.ts`), shared with the golden comparison.

## 4. Every run built an unbounded, unread message queue (P1)

`ExecutionSession` always constructed a `MessageStream`, whose listener queued every message with no limit. No production caller iterates `session.messages` — they await `session.result` — so long-running runs retained the whole message history, including the real-time audio chunks the kernel deliberately avoids holding.

Capture is now opt-in (`captureMessages`) and bounded (`limits.messageBufferLimit`, default 10k); overflow stops queueing and makes the iterator throw rather than silently retaining. The reliability harness's kernel driver — the one consumer that drains the stream — opts in.

## 5. `cleanup-leaks` measured nothing (P2)

`checkLeaks` returned success when `resourceCounters` was absent, and no driver populated it, so every journey declaring `cleanup-leaks` asserted nothing.

- `WorkflowRunner` exposes `liveActorCount` / `pendingControlResponseCount`; `PythonBridgeBase` exposes `pendingRequestCount`; `ExecutionSession.resourceCounters()` reports them plus its own timer.
- `UnifiedWebSocketRunner` exposes `slotCounters`; `createTestUiServer` gains an `onRunnerCreated` hook so the harness can reach the per-connection runner, and the ws-server driver snapshots slots after the connection is torn down.
- A record with no post-run snapshot is now a violation: "nothing measured" must not read as "no leaks".

## 6. The ws-server driver hid duplicate terminal frames (P2)

The driver dropped every repeated `job_update` status, so "exactly one terminal update" could not fail on the only surface with a real wire. Repeats are now recorded, and tagged `redundant` only when they match this surface's documented shapes (the eager `running` ack, the eager `cancelled` ack for a cancel this driver requested, and the authoritative terminal snapshot carrying `result`). Tagged frames are dropped from cross-surface normalization and discounted by `terminal-uniqueness`; any other duplicate is untagged and fails both.

## Testing

- `reliability/harness`: 144 passed, 5 skipped (25 files) — includes new `golden.test.ts`, nested-payload and key-order diff cases, `terminal-uniqueness` tagged/untagged duplicate cases, and `leaks` not-instrumented cases.
- `packages/execution` 13, `packages/kernel` 934, `packages/websocket` 1992, `packages/runtime` 2634, `packages/cli` 444 — all passing.
- `npm run typecheck` clean for web/electron/packages (mobile fails only on uninstalled Expo deps in this environment); `tsc --noEmit` clean for every touched package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dx19BNKrnpQNVD2W8eoA5y

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dx19BNKrnpQNVD2W8eoA5y)_