### PR TITLE
fix(apps): close Mini Apps data-inheritance hole and fix release/run attribution

### DIFF
--- a/mobile/ARCHITECTURE.md
+++ b/mobile/ARCHITECTURE.md
@@ -147,9 +147,15 @@ ApplicationAppView   # renders the document's widget tree
 - **Bindings key on node IDs** (`op:main/in:<nodeId>`), so renaming a node in
   the editor never breaks an app. Bare names still resolve — that's the legacy
   document form.
-- **Run identity**: the runtime claims the job id of the run it dispatched and
-  drops messages from any other job, so a run started in the chain editor never
-  folds into what the app shows.
+- **Run identity**: the runtime mints the job id before it sends the run and
+  passes it as the request's `job_id`, which the server honours. Messages are
+  matched on that id alone, so neither a run started in the chain editor nor a
+  second parallel invocation folds into the wrong slot.
+- **Release identity**: every run of an app sends `application_id` and, for a
+  run of the released snapshot, `application_version`. The server gates the run
+  on the app's spend budget and files it in the release ledger; a run that omits
+  them is unmetered, so `useApplicationApp` hands the identity down to
+  `useAppRuntime` and on into the run request.
 - **Run policy and timeout** are enforced, not just parsed: `decideRun` decides
   what a run colliding with a live one does (`replace` cancels first, `queue`
   waits, `parallel` starts), and an operation's `timeoutMs` cancels the run and

--- a/mobile/src/components/app_runtime/ApplicationAppView.tsx
+++ b/mobile/src/components/app_runtime/ApplicationAppView.tsx
@@ -11,6 +11,7 @@ import { ScrollView, StyleSheet, Text, View } from "react-native";
 import type { ApplicationDocument } from "@nodetool-ai/app-runtime";
 
 import { useTheme } from "../../hooks/useTheme";
+import type { ApplicationRunIdentity } from "../../hooks/useApplications";
 import type { Workflow } from "../../types/workflow";
 import { AppRuntimeContext } from "./AppRuntimeContext";
 import { useAppRuntime } from "./useAppRuntime";
@@ -55,6 +56,11 @@ interface ApplicationAppViewProps {
   applicationId?: string;
   /** The workflow the document's operations run. */
   workflow: Workflow;
+  /**
+   * Release identity sent with every run, so the server can meter it against
+   * the app's budget. Absent only where no application backs the document.
+   */
+  application?: ApplicationRunIdentity;
   /** Falls back to the app's name when the document's root has no title. */
   title?: string;
 }
@@ -63,12 +69,14 @@ const ApplicationAppView: React.FC<ApplicationAppViewProps> = ({
   document,
   applicationId,
   workflow,
+  application,
   title,
 }) => {
   const { colors } = useTheme();
   const runtime = useAppRuntime(workflow, {
     document,
     ...(applicationId ? { instanceKey: applicationId } : {}),
+    ...(application ? { application } : {}),
   });
 
   const heading = String(document.ui.root.props?.title ?? title ?? "");

--- a/mobile/src/components/app_runtime/__tests__/ApplicationAppView.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/ApplicationAppView.test.tsx
@@ -5,6 +5,7 @@
  */
 import React from "react";
 import { fireEvent, render, screen, act } from "@testing-library/react-native";
+import { v4 as uuidv4 } from "uuid";
 import {
   parseApplicationDocument,
   type ApplicationDocument,
@@ -147,6 +148,9 @@ describe("ApplicationAppView", () => {
     mockRun.mockClear();
     mockCancel.mockClear();
     mockRunnerState.job_id = null;
+    // The runtime mints the job id before it sends the run; the tests below
+    // emit messages for the id it will hand out.
+    (uuidv4 as jest.Mock).mockReturnValue("job-1");
   });
 
   it("renders the application document", () => {

--- a/mobile/src/components/app_runtime/__tests__/useAppRuntime.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/useAppRuntime.test.tsx
@@ -5,6 +5,7 @@
  */
 import { act, renderHook, waitFor } from "@testing-library/react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { v4 as uuidv4 } from "uuid";
 import type { ApplicationDocument } from "@nodetool-ai/app-runtime";
 
 import type { Workflow } from "../../../types/workflow";
@@ -101,14 +102,22 @@ const doc = (
   ...overrides,
 });
 
-const renderRuntime = (workflowId: string, document: ApplicationDocument) => {
+const renderRuntime = (
+  workflowId: string,
+  document: ApplicationDocument,
+  options: { application?: { id: string; version?: number | null } } = {}
+) => {
   disposeAppRuntimeStore(appInstanceId(workflowId));
   return renderHook(() =>
-    useAppRuntime(makeWorkflow(workflowId), { document })
+    useAppRuntime(makeWorkflow(workflowId), { document, ...options })
   );
 };
 
-/** Start a run and let the server answer with a job id. */
+/**
+ * Start a run. The job id is minted by the runtime before the request goes
+ * out, so the ids here are the ones the (mocked) uuid factory hands out in
+ * dispatch order.
+ */
 const startRun = async (
   runtime: { dispatch: (action: { kind: "run"; operationId: string }) => void },
   operationId: string,
@@ -120,11 +129,21 @@ const startRun = async (
   emit({ type: "job_update", job_id: jobId, status: "running" });
 };
 
+/** The run options the runtime handed the workflow runner for call `index`. */
+const runOptions = (index = 0) =>
+  mockRun.mock.calls[index][2] as {
+    jobId?: string;
+    application?: { id: string; version?: number | null };
+  };
+
 beforeEach(async () => {
   mockHandlers.clear();
   mockRun.mockClear();
   mockCancel.mockClear();
   mockRunnerState.job_id = null;
+  // jest.setup mocks uuid with one constant value; runs need distinct ids.
+  let minted = 0;
+  (uuidv4 as jest.Mock).mockImplementation(() => `job-${++minted}`);
   await AsyncStorage.clear();
 });
 
@@ -371,12 +390,12 @@ describe("multiple operations", () => {
   it("runs the operation the action names, not the first one", async () => {
     const { result } = renderRuntime("wf-multi", multiDoc);
 
-    await startRun(result.current, "second", "job-2");
-    emit({ type: "output_update", job_id: "job-2", node_id: "o1", value: "ok" });
+    await startRun(result.current, "second", "job-1");
+    emit({ type: "output_update", job_id: "job-1", node_id: "o1", value: "ok" });
 
     expect(mockRun.mock.calls[0][0]).toEqual({ prompt: "fixed" });
     const state = result.current.store.getState();
-    expect(state.invocations["job-2"].operationId).toBe("second");
+    expect(state.invocations["job-1"].operationId).toBe("second");
     expect(state.variables.second_out).toBe("ok");
   });
 
@@ -394,6 +413,128 @@ describe("multiple operations", () => {
     );
     expect(failed?.status).toBe("failed");
     expect(failed?.error).toContain("wf-elsewhere");
+  });
+});
+
+describe("run identity", () => {
+  it("sends the application id and released version with the run", async () => {
+    const { result } = renderRuntime("wf-release", doc(), {
+      application: { id: "app-1", version: 7 },
+    });
+
+    await startRun(result.current, "main", "job-1");
+
+    expect(runOptions().application).toEqual({ id: "app-1", version: 7 });
+  });
+
+  it("sends a null version for a draft run", async () => {
+    const { result } = renderRuntime("wf-draft", doc(), {
+      application: { id: "app-1", version: null },
+    });
+
+    await startRun(result.current, "main", "job-1");
+
+    expect(runOptions().application).toEqual({ id: "app-1", version: null });
+  });
+
+  it("sends the job id it minted, and owns the invocation under it", async () => {
+    const { result } = renderRuntime("wf-jobid", doc());
+
+    await startRun(result.current, "main", "job-1");
+
+    expect(runOptions().jobId).toBe("job-1");
+    expect(result.current.store.getState().invocations["job-1"]).toBeDefined();
+  });
+});
+
+describe("message routing", () => {
+  const parallelDoc = doc({
+    operations: [
+      {
+        id: "main",
+        name: "Run",
+        workflowId: "wf",
+        inputs: {},
+        outputs: {},
+        policy: "parallel",
+      },
+      {
+        id: "other",
+        name: "Other",
+        workflowId: "wf",
+        inputs: {},
+        outputs: {},
+        policy: "parallel",
+      },
+    ],
+  });
+
+  it("routes each concurrent run's messages to its own invocation", async () => {
+    const { result } = renderRuntime("wf-concurrent", parallelDoc);
+
+    await startRun(result.current, "main", "job-1");
+    await startRun(result.current, "other", "job-2");
+
+    // The second run answers first — arrival order says nothing about which
+    // invocation a message belongs to.
+    emit({
+      type: "output_update",
+      job_id: "job-2",
+      node_id: "o1",
+      value: "second",
+    });
+    emit({
+      type: "output_update",
+      job_id: "job-1",
+      node_id: "o1",
+      value: "first",
+    });
+    emit({ type: "job_update", job_id: "job-2", status: "completed" });
+
+    const state = result.current.store.getState();
+    expect(state.outputs["main:o1"]).toMatchObject({
+      invocationId: "job-1",
+      value: "first",
+    });
+    expect(state.outputs["other:o1"]).toMatchObject({
+      invocationId: "job-2",
+      value: "second",
+    });
+    expect(state.invocations["job-1"].operationId).toBe("main");
+    expect(state.invocations["job-1"].status).toBe("running");
+    expect(state.invocations["job-2"].operationId).toBe("other");
+    expect(state.invocations["job-2"].status).toBe("completed");
+    expect(runOptions(0).jobId).toBe("job-1");
+    expect(runOptions(1).jobId).toBe("job-2");
+  });
+
+  it("ignores a message for a job this app never started", async () => {
+    const { result } = renderRuntime("wf-foreign-job", parallelDoc);
+
+    await startRun(result.current, "main", "job-1");
+    emit({
+      type: "output_update",
+      job_id: "someone-elses-job",
+      node_id: "o1",
+      value: "not mine",
+    });
+    emit({
+      type: "job_update",
+      job_id: "someone-elses-job",
+      status: "failed",
+      error: "boom",
+    });
+
+    const state = result.current.store.getState();
+    // The slot still holds only what this app's own run seeded: pending, no
+    // value, owned by the invocation this app started.
+    expect(state.outputs["main:o1"]).toMatchObject({
+      invocationId: "job-1",
+      status: "pending",
+      value: undefined,
+    });
+    expect(state.invocations["someone-elses-job"]).toBeUndefined();
+    expect(state.invocations["job-1"].status).toBe("running");
   });
 });
 

--- a/mobile/src/components/app_runtime/useAppRuntime.ts
+++ b/mobile/src/components/app_runtime/useAppRuntime.ts
@@ -8,10 +8,11 @@
  * with a live one — live in `@nodetool-ai/app-runtime`; this hook is the React
  * Native adapter around them.
  *
- * Run identity is the load-bearing part: every invocation this app starts is
- * registered by its `job_id`, and a streaming message for any other job is
- * dropped, so a run started in the chain editor never folds into what the app
- * shows.
+ * Run identity is the load-bearing part: the job id is minted here, before the
+ * run request is sent, and the server honours it. Every invocation this app
+ * starts is registered under that id and a streaming message for any other job
+ * is dropped, so neither a run started in the chain editor nor a second
+ * parallel invocation of this app can fold into the wrong slot.
  *
  * Unlike web there is no reactive subgraph path — mobile has no browser worker
  * — so every `run` action runs the whole workflow on the server. A document may
@@ -20,6 +21,7 @@
  * holds only this one, and says so instead of running the wrong graph.
  */
 import { useCallback, useEffect, useMemo, useRef } from "react";
+import { v4 as uuidv4 } from "uuid";
 import {
   decideRun,
   implicitOperation,
@@ -66,16 +68,11 @@ type RawMessage = Record<string, unknown>;
 /** Trailing window before a variable change is written to storage. */
 const PERSIST_DEBOUNCE_MS = 300;
 
-/**
- * A run that has been dispatched but whose `job_id` has not come back yet.
- * Starts are claimed in dispatch order, which is what lets two parallel
- * invocations of one operation each find their own job.
- */
-interface PendingStart {
+/** A run this app dispatched, holding the timer that enforces its timeout. */
+interface StartedRun {
   operationId: string;
+  invocationId: string;
   timeoutMs?: number;
-  /** Set once the run's job id arrives. */
-  invocationId?: string;
   timer?: ReturnType<typeof setTimeout>;
 }
 
@@ -90,13 +87,20 @@ export interface AppRuntimeOptions {
    * the application id. Defaults to the workflow id.
    */
   instanceKey?: string;
+  /**
+   * The application these runs belong to. Sent with every run request so the
+   * server can check the app's spend budget and file the run in its release
+   * ledger; a run without it is unmetered. `version` is the released version,
+   * null for a run of the draft.
+   */
+  application?: { id: string; version?: number | null };
 }
 
 export const useAppRuntime = (
   workflow: Workflow | undefined,
   options: AppRuntimeOptions = {}
 ): AppRuntimeContextValue => {
-  const { document, instanceKey } = options;
+  const { document, instanceKey, application } = options;
   const workflowId = workflow?.id;
   const io = useMemo(() => extractWorkflowIO(workflow), [workflow]);
 
@@ -277,12 +281,10 @@ export const useAppRuntime = (
   // Invocations this app started, by job id. A streaming message for anything
   // else is not ours — that is the cross-run contamination fix.
   const ownedRef = useRef(new Map<string, InvocationState>());
-  // Runs dispatched but not yet matched to a job id, oldest first.
-  const pendingStartsRef = useRef<PendingStart[]>([]);
-  // Claimed runs that still hold a timeout timer, by invocation id.
-  const startsByInvocationRef = useRef(new Map<string, PendingStart>());
+  // Dispatched runs that still hold a timeout timer, by invocation id.
+  const startsByInvocationRef = useRef(new Map<string, StartedRun>());
 
-  const clearTimer = useCallback((start: PendingStart | undefined) => {
+  const clearTimer = useCallback((start: StartedRun | undefined) => {
     if (start?.timer) {
       clearTimeout(start.timer);
       start.timer = undefined;
@@ -341,23 +343,18 @@ export const useAppRuntime = (
     },
     [store]
   );
-  const failRunRef = useRef(failRun);
-  failRunRef.current = failRun;
 
-  /** Register a run this app started against the start that is waiting for it. */
-  const claimInvocation = useCallback(
-    (jobId: string) => {
-      const start = pendingStartsRef.current.shift();
-      if (!start) {return;}
-      start.invocationId = jobId;
-      startsByInvocationRef.current.set(jobId, start);
+  /** Register a run under the job id it was dispatched with. */
+  const registerInvocation = useCallback(
+    (start: StartedRun) => {
+      startsByInvocationRef.current.set(start.invocationId, start);
       const invocation: InvocationState = {
-        id: jobId,
+        id: start.invocationId,
         operationId: start.operationId,
         status: "running",
         startedAt: Date.now(),
       };
-      ownedRef.current.set(jobId, invocation);
+      ownedRef.current.set(start.invocationId, invocation);
       store.getState().dispatchEvent({
         type: "runStarted",
         invocation,
@@ -368,22 +365,17 @@ export const useAppRuntime = (
     },
     [outputKey, store]
   );
-  const claimRef = useRef(claimInvocation);
-  claimRef.current = claimInvocation;
 
   useEffect(() => {
     if (!workflowId) {return undefined;}
 
     const handler = (message: RawMessage) => {
       const jobId = message.job_id;
-      // A message with no job id cannot be attributed to one of this app's
-      // invocations, so it is not folded.
+      // Only jobs this app minted an id for are folded. A message with no job
+      // id, or one naming a run started elsewhere (the chain editor, another
+      // app instance), belongs to nobody here.
       if (typeof jobId !== "string") {return;}
-      if (!ownedRef.current.has(jobId)) {
-        // The first job id to arrive after we dispatched a run is that run.
-        if (pendingStartsRef.current.length === 0) {return;}
-        claimRef.current(jobId);
-      }
+      if (!ownedRef.current.has(jobId)) {return;}
       foldRef.current(message);
     };
 
@@ -458,22 +450,15 @@ export const useAppRuntime = (
   );
 
   const startTimeout = useCallback(
-    (start: PendingStart) => {
+    (start: StartedRun) => {
       if (!start.timeoutMs || start.timeoutMs <= 0) {return;}
       const limit = start.timeoutMs;
       start.timer = setTimeout(() => {
         start.timer = undefined;
-        const message = `Run timed out after ${limit}ms`;
-        if (start.invocationId) {
-          void cancelInvocations([start.invocationId], message);
-          return;
-        }
-        // The run never reported a job id, so there is nothing to cancel — the
-        // failure is all the app can show.
-        pendingStartsRef.current = pendingStartsRef.current.filter(
-          (pending) => pending !== start
+        void cancelInvocations(
+          [start.invocationId],
+          `Run timed out after ${limit}ms`
         );
-        failRunRef.current(start.operationId, message);
       }, limit);
     },
     [cancelInvocations]
@@ -517,26 +502,39 @@ export const useAppRuntime = (
           resourceRefsRef.current.get(resourceBindingId),
       });
 
-      const start: PendingStart = {
+      // The job id is minted before the request goes out and sent as the
+      // request's `job_id`, which the server honours. That is what makes the
+      // invocation identifiable: two runs in flight at once each own their id
+      // rather than racing for whichever job id arrives first.
+      const start: StartedRun = {
         operationId: target.id,
+        invocationId: uuidv4(),
         timeoutMs: target.timeoutMs,
       };
-      pendingStartsRef.current.push(start);
+      registerInvocation(start);
       startTimeout(start);
       try {
-        await runnerStore.getState().run(params, workflow);
+        await runnerStore.getState().run(params, workflow, {
+          jobId: start.invocationId,
+          ...(application ? { application } : {}),
+        });
       } catch (error) {
-        pendingStartsRef.current = pendingStartsRef.current.filter(
-          (pending) => pending !== start
-        );
         clearTimer(start);
-        failRun(
-          target.id,
-          error instanceof Error ? error.message : "Run failed"
-        );
+        startsByInvocationRef.current.delete(start.invocationId);
+        const message =
+          error instanceof Error ? error.message : "Run failed";
+        const invocation = ownedRef.current.get(start.invocationId);
+        if (invocation) {invocation.status = "failed";}
+        store.getState().dispatchEvent({
+          type: "invocationStatus",
+          invocationId: start.invocationId,
+          status: "failed",
+          error: message,
+        });
       }
     },
     [
+      application,
       cancelInvocations,
       clearTimer,
       failRun,
@@ -544,6 +542,7 @@ export const useAppRuntime = (
       isRunnable,
       operation.id,
       operations,
+      registerInvocation,
       runnerStore,
       startTimeout,
       store,
@@ -561,24 +560,14 @@ export const useAppRuntime = (
       const live = Object.values(store.getState().invocations)
         .filter((i) => i.operationId === operationId && isLiveInvocation(i))
         .map((i) => i.id);
-      // A run dispatched but not yet claimed has no job to cancel; dropping its
-      // start keeps a late job id from being adopted as a live run.
-      pendingStartsRef.current = pendingStartsRef.current.filter((start) => {
-        if (start.operationId !== operationId) {return true;}
-        clearTimer(start);
-        return false;
-      });
       await cancelInvocations(live);
     },
-    [cancelInvocations, clearTimer, store]
+    [cancelInvocations, store]
   );
 
   // A screen that goes away leaves no timer behind to fail a run nobody sees.
   useEffect(
     () => () => {
-      for (const start of pendingStartsRef.current) {
-        if (start.timer) {clearTimeout(start.timer);}
-      }
       for (const start of startsByInvocationRef.current.values()) {
         if (start.timer) {clearTimeout(start.timer);}
       }

--- a/mobile/src/components/app_runtime/useAppRuntime.ts
+++ b/mobile/src/components/app_runtime/useAppRuntime.ts
@@ -516,6 +516,7 @@ export const useAppRuntime = (
       try {
         await runnerStore.getState().run(params, workflow, {
           jobId: start.invocationId,
+          operationId: target.id,
           ...(application ? { application } : {}),
         });
       } catch (error) {

--- a/mobile/src/hooks/useApplications.test.tsx
+++ b/mobile/src/hooks/useApplications.test.tsx
@@ -140,6 +140,8 @@ describe('useApplications', () => {
     expect(result.current.workflow?.graph).toEqual(pinnedGraph);
     // A pinned graph makes the workflow request unnecessary.
     expect(mockWorkflowQuery.enabled).toBe(false);
+    // The identity every run of this app must send, so the server can meter it.
+    expect(result.current.application).toEqual({ id: 'a1', version: 1 });
   });
 
   it('falls back to the draft document and the live workflow', async () => {
@@ -157,6 +159,8 @@ describe('useApplications', () => {
     await waitFor(() => expect(result.current.source).toBe('draft'));
     expect(mockWorkflowQuery.enabled).toBe(true);
     expect(result.current.workflow?.id).toBe('wf-1');
+    // Still an app run — budgeted — but not a run of any released version.
+    expect(result.current.application).toEqual({ id: 'a1', version: null });
   });
 
   it('fetches nothing until an application id is known', () => {

--- a/mobile/src/hooks/useApplications.ts
+++ b/mobile/src/hooks/useApplications.ts
@@ -79,6 +79,16 @@ export function useApplicationRelease(
   });
 }
 
+/**
+ * What a run request has to carry so the server can meter it: the app it
+ * belongs to, and the released version it executes when the released snapshot
+ * is what is being rendered. A draft run carries a null version.
+ */
+export interface ApplicationRunIdentity {
+  id: string;
+  version: number | null;
+}
+
 export interface ApplicationApp {
   name: string;
   /** The document to render, once both requests have resolved. */
@@ -87,6 +97,8 @@ export interface ApplicationApp {
   workflow: Workflow | null;
   /** Which document won: the published release or the draft. */
   source: 'release' | 'draft' | null;
+  /** Release identity every run of this app must send; null until it loads. */
+  application: ApplicationRunIdentity | null;
   isLoading: boolean;
   error: Error | null;
 }
@@ -152,11 +164,25 @@ export function useApplicationApp(id: string | undefined): ApplicationApp {
     return liveWorkflow.data ? normalizeWorkflow(liveWorkflow.data) : null;
   }, [application.data, liveWorkflow.data, pinned, workflowId]);
 
+  // The version claim follows the document that won: a run of the released
+  // snapshot is a release run, a run of the draft is not.
+  const runIdentity = useMemo((): ApplicationRunIdentity | null => {
+    if (!id || !document.document) {
+      return null;
+    }
+    return {
+      id,
+      version:
+        document.source === 'release' ? release.data?.version ?? null : null,
+    };
+  }, [document.document, document.source, id, release.data]);
+
   return {
     name: application.data?.name ?? '',
     document: document.document,
     workflow,
     source: document.source,
+    application: runIdentity,
     isLoading:
       application.isLoading ||
       release.isLoading ||

--- a/mobile/src/screens/AppScreen.tsx
+++ b/mobile/src/screens/AppScreen.tsx
@@ -21,7 +21,7 @@ type Props = NativeStackScreenProps<RootStackParamList, 'App'>;
 export default function AppScreen({ route, navigation }: Props) {
   const { colors } = useTheme();
   const { applicationId } = route.params;
-  const { name, document, workflow, isLoading, error } =
+  const { name, document, workflow, application, isLoading, error } =
     useApplicationApp(applicationId);
 
   useEffect(() => {
@@ -58,6 +58,7 @@ export default function AppScreen({ route, navigation }: Props) {
       document={document}
       applicationId={applicationId}
       workflow={workflow}
+      {...(application ? { application } : {})}
       title={name}
     />
   );

--- a/mobile/src/stores/WorkflowRunner.test.ts
+++ b/mobile/src/stores/WorkflowRunner.test.ts
@@ -149,6 +149,33 @@ describe('WorkflowRunner', () => {
       expect(nodeIds).toEqual(['a', 'c']);
       expect(sent.data.graph.edges).toHaveLength(1);
     });
+
+    it('carries no application identity for a plain workflow run', async () => {
+      await bootStore();
+      const sent = mockWs.send.mock.calls[0][0] as {
+        data: Record<string, unknown>;
+      };
+      expect(sent.data.application_id).toBeNull();
+      expect(sent.data.application_version).toBeNull();
+      expect(sent.data.job_id).toBeUndefined();
+    });
+
+    it('sends the client job id and the release identity of an app run', async () => {
+      const store = createWorkflowRunnerStore('app-run-test');
+      mockWs.subscribe.mockImplementation(() => () => {});
+      await store.getState().run({}, makeWorkflow(), {
+        jobId: 'job-abc',
+        application: { id: 'app-1', version: 3 },
+      });
+      const sent = mockWs.send.mock.calls[0][0] as {
+        data: Record<string, unknown>;
+      };
+      expect(sent.data.job_id).toBe('job-abc');
+      expect(sent.data.application_id).toBe('app-1');
+      expect(sent.data.application_version).toBe(3);
+      // The store tracks the run under the id it sent, not the first one back.
+      expect(store.getState().job_id).toBe('job-abc');
+    });
   });
 
   describe('job_update', () => {

--- a/mobile/src/stores/WorkflowRunner.ts
+++ b/mobile/src/stores/WorkflowRunner.ts
@@ -37,6 +37,22 @@ export type RunnerState =
   | "cancelled"
   | "completed";
 
+/** Extra, rarely-set run options. An object so the arity stops growing. */
+export type RunOptions = {
+  /**
+   * Client-minted job id. The server honours it (`req.job_id ?? randomUUID()`),
+   * which is what lets a caller match a run's messages to the run it started
+   * instead of guessing from arrival order.
+   */
+  jobId?: string;
+  /**
+   * The mini app this run belongs to. Drives the server-side budget check, the
+   * spend cap, and the release ledger; a run that omits it is not metered.
+   * `version` is the released version, absent for a draft run.
+   */
+  application?: { id: string; version?: number | null };
+};
+
 export type WorkflowRunner = {
   workflow: Workflow | null;
   job_id: string | null;
@@ -57,6 +73,7 @@ export type WorkflowRunner = {
   run: (
     params: Record<string, unknown>,
     workflow: Workflow,
+    options?: RunOptions,
   ) => Promise<void>;
 
   ensureConnection: () => Promise<void>;
@@ -152,13 +169,20 @@ export const createWorkflowRunnerStore = (
       runnerStores.delete(workflowId);
     },
 
-    run: async (params: Record<string, unknown>, workflow: Workflow) => {
+    run: async (
+      params: Record<string, unknown>,
+      workflow: Workflow,
+      options?: RunOptions
+    ) => {
       console.log(`WorkflowRunner[${workflowId}]: Starting workflow run`);
 
       await get().ensureConnection();
 
       set({
         workflow,
+        // A caller that minted the job id owns the run identity; without one
+        // the store adopts the id of the first message that arrives.
+        job_id: options?.jobId ?? null,
         state: "running",
         logs: [],
         results: null,
@@ -205,6 +229,11 @@ export const createWorkflowRunnerStore = (
           edges: activeEdges,
         },
         resource_limits: {},
+        ...(options?.jobId ? { job_id: options.jobId } : {}),
+        // Present only for app runs: the server gates them on the app's budget
+        // and files them in the release ledger.
+        application_id: options?.application?.id ?? null,
+        application_version: options?.application?.version ?? null,
       };
 
       await webSocketService.send(

--- a/mobile/src/stores/WorkflowRunner.ts
+++ b/mobile/src/stores/WorkflowRunner.ts
@@ -51,6 +51,11 @@ export type RunOptions = {
    * `version` is the released version, absent for a draft run.
    */
   application?: { id: string; version?: number | null };
+  /**
+   * The app operation this run executes. Recorded on the ledger row so
+   * per-operation spend reports reflect which operation actually ran.
+   */
+  operationId?: string;
 };
 
 export type WorkflowRunner = {
@@ -234,6 +239,7 @@ export const createWorkflowRunnerStore = (
         // and files them in the release ledger.
         application_id: options?.application?.id ?? null,
         application_version: options?.application?.version ?? null,
+        operation_id: options?.operationId ?? null,
       };
 
       await webSocketService.send(

--- a/packages/app-runtime/src/bindings.ts
+++ b/packages/app-runtime/src/bindings.ts
@@ -16,6 +16,7 @@
  *   node:<nodeId>#<prop>               legacy node property (default operation)
  *   <name>                             legacy input / output / variable name
  */
+import { DEFAULT_OPERATION_ID } from "./document.js";
 import type { VariableDeclaration } from "./document.js";
 
 export type ExecutionField = "running" | "progress" | "error" | "activity";
@@ -227,11 +228,33 @@ export const parseBinding = (binding?: string | null): BindingRef | null => {
 export type BindingMode = "read" | "write" | "none";
 
 /**
+ * Documents written by an earlier builder hard-coded `main` as the operation of
+ * every binding, whatever the document's own operation was called. When the app
+ * binds exactly one operation and it is not `main`, such a token can only have
+ * meant that operation, so it resolves there instead of addressing a state slot
+ * no run ever fills. Resolution only — the stored document keeps the token it
+ * has until the author edits that binding.
+ *
+ * Narrow on purpose: any other operation id is left alone, so a document that
+ * genuinely names an operation the caller's scope has not loaded still resolves
+ * to what it says.
+ */
+const onKnownOperation = (ref: BindingRef, scope: BindingScope): BindingRef => {
+  if (!("operationId" in ref) || ref.operationId !== DEFAULT_OPERATION_ID) {
+    return ref;
+  }
+  const only = scope.operations.length === 1 ? scope.operations[0] : undefined;
+  if (!only || only.operationId === DEFAULT_OPERATION_ID) return ref;
+  return { ...ref, operationId: only.operationId };
+};
+
+/**
  * Resolve a stored binding string to a {@link BindingRef} against the live
  * graph. Explicit tokens resolve directly (their `operationId` is filled in
- * from the default when the legacy `node:` form omitted it); a bare name is
- * looked up by mode — a write widget means an input node, a read widget means
- * an output node or a variable.
+ * from the default when the legacy `node:` form omitted it, and remapped by
+ * {@link onKnownOperation} when they name an operation the app does not have);
+ * a bare name is looked up by mode — a write widget means an input node, a read
+ * widget means an output node or a variable.
  *
  * Returns null when the binding cannot be resolved: a renamed node in a legacy
  * document, a deleted variable. Callers surface that as a validation error
@@ -246,9 +269,9 @@ export const resolveBinding = (
   const explicit = parseBinding(binding);
   if (explicit) {
     if (explicit.kind === "nodeProperty" && explicit.operationId === "") {
-      return { ...explicit, operationId };
+      return onKnownOperation({ ...explicit, operationId }, scope);
     }
-    return explicit;
+    return onKnownOperation(explicit, scope);
   }
   if (typeof binding !== "string" || binding.length === 0) return null;
 

--- a/packages/app-runtime/tests/bindings.test.ts
+++ b/packages/app-runtime/tests/bindings.test.ts
@@ -96,6 +96,45 @@ describe("resolveBinding", () => {
   it("returns null for a name the graph no longer has", () => {
     expect(resolveBinding("renamed_away", scope, "write")).toBeNull();
   });
+
+  it("resolves a legacy `main` token onto the app's sole operation", () => {
+    const soleOperation: BindingScope = {
+      ...scope,
+      defaultOperationId: "operation_1",
+      operations: [{ ...scope.operations[0], operationId: "operation_1" }]
+    };
+    expect(resolveBinding("op:main/in:n1", soleOperation, "write")).toEqual({
+      kind: "input",
+      operationId: "operation_1",
+      nodeId: "n1"
+    });
+    expect(resolveBinding("op:main/exec#running", soleOperation)).toEqual({
+      kind: "execution",
+      operationId: "operation_1",
+      field: "running"
+    });
+  });
+
+  it("leaves an operation the app declares alone", () => {
+    const twoOperations: BindingScope = {
+      ...scope,
+      operations: [
+        scope.operations[0],
+        { ...scope.operations[0], operationId: "draft" }
+      ]
+    };
+    expect(resolveBinding("op:draft/in:n1", twoOperations, "write")).toEqual({
+      kind: "input",
+      operationId: "draft",
+      nodeId: "n1"
+    });
+    // Two operations: nothing to disambiguate an unknown one onto.
+    expect(resolveBinding("op:gone/in:n1", twoOperations, "write")).toEqual({
+      kind: "input",
+      operationId: "gone",
+      nodeId: "n1"
+    });
+  });
 });
 
 describe("migrateBindings", () => {

--- a/packages/models/src/application-budget.ts
+++ b/packages/models/src/application-budget.ts
@@ -19,6 +19,7 @@ import {
   applicationBudgets,
   applicationInvocations
 } from "./schema/application-budgets.js";
+import { applications } from "./schema/applications.js";
 
 export type BudgetPeriod = "day" | "month" | "total";
 
@@ -53,6 +54,8 @@ export type BudgetDecision =
 export interface InvocationRecord {
   id: string;
   applicationId: string;
+  /** Owner of the app when the run was recorded; null on pre-existing rows. */
+  userId: string | null;
   version: number | null;
   invocationId: string;
   operationId: string;
@@ -75,6 +78,7 @@ const toBudget = (row: Record<string, unknown>): ApplicationBudget => ({
 const toRecord = (row: Record<string, unknown>): InvocationRecord => ({
   id: String(row.id),
   applicationId: String(row.application_id),
+  userId: row.user_id == null ? null : String(row.user_id),
   version: row.version == null ? null : Number(row.version),
   invocationId: String(row.invocation_id),
   operationId: String(row.operation_id ?? ""),
@@ -84,6 +88,24 @@ const toRecord = (row: Record<string, unknown>): InvocationRecord => ({
   createdAt: String(row.created_at),
   settledAt: row.settled_at == null ? null : String(row.settled_at)
 });
+
+/**
+ * Who a ledger row belongs to. The ledger is read by application id, and ids
+ * are client-supplied, so each row records the owner of the app that produced
+ * it instead of leaving that to whatever row holds the id later. Callers that
+ * already know the user pass it; the rest read it off the parent.
+ */
+async function ownerOfApplication(
+  applicationId: string
+): Promise<string | null> {
+  const db = getDb();
+  const rows = await db
+    .select({ user_id: applications.user_id })
+    .from(applications)
+    .where(eq(applications.id, applicationId))
+    .limit(1);
+  return (rows[0]?.user_id as string | undefined) ?? null;
+}
 
 /** Start of the window a period covers, or null for "total". */
 export const periodStart = (period: BudgetPeriod, now: Date): string | null => {
@@ -220,26 +242,15 @@ export async function checkApplicationBudget(
 }
 
 /** Record a run against the app. Also the release telemetry row. */
-export async function recordInvocation(input: {
-  applicationId: string;
-  version?: number | null;
-  invocationId: string;
-  operationId?: string;
-  estimatedUsd?: number;
-}): Promise<InvocationRecord> {
+export async function recordInvocation(
+  input: ReserveInput
+): Promise<InvocationRecord> {
   const db = getDb();
+  const userId =
+    input.userId ?? (await ownerOfApplication(input.applicationId));
   const rows = await db
     .insert(applicationInvocations)
-    .values({
-      id: createTimeOrderedUuid(),
-      application_id: input.applicationId,
-      version: input.version ?? null,
-      invocation_id: input.invocationId,
-      operation_id: input.operationId ?? "",
-      estimated_usd: input.estimatedUsd ?? 0,
-      status: "running",
-      created_at: new Date().toISOString()
-    })
+    .values(invocationRow(input, userId))
     .returning();
   return toRecord(rows[0] as Record<string, unknown>);
 }
@@ -296,9 +307,10 @@ export type Reservation =
     };
 
 /** Values every reserved row carries, independent of which driver writes it. */
-const invocationRow = (input: ReserveInput) => ({
+const invocationRow = (input: ReserveInput, userId: string | null) => ({
   id: createTimeOrderedUuid(),
   application_id: input.applicationId,
+  user_id: userId,
   version: input.version ?? null,
   invocation_id: input.invocationId,
   operation_id: input.operationId ?? "",
@@ -326,6 +338,8 @@ const overBudget = (
 
 export interface ReserveInput {
   applicationId: string;
+  /** Owner the run is booked against. Read off the app when omitted. */
+  userId?: string | null;
   version?: number | null;
   invocationId: string;
   operationId?: string;
@@ -349,11 +363,15 @@ export async function reserveInvocation(
 ): Promise<Reservation> {
   const estimatedUsd = input.estimatedUsd ?? 0;
   const db = getDb();
+  // Resolved before the transaction: the SQLite branch runs synchronously and
+  // cannot await a lookup of its own.
+  const userId =
+    input.userId ?? (await ownerOfApplication(input.applicationId));
 
   // No budget row means unmetered, so there is nothing to serialize on.
   const configured = await getApplicationBudget(input.applicationId);
   if (!configured) {
-    const record = await recordInvocation(input);
+    const record = await recordInvocation({ ...input, userId });
     return {
       allowed: true,
       record,
@@ -389,7 +407,7 @@ export async function reserveInvocation(
       if (!budgetRow) {
         const orphan = tx
           .insert(applicationInvocations)
-          .values(invocationRow(input))
+          .values(invocationRow(input, userId))
           .returning()
           .get();
         return unmetered(toRecord(orphan as Record<string, unknown>));
@@ -418,7 +436,7 @@ export async function reserveInvocation(
       if (refused) return { allowed: false, ...refused, usage, budget };
       const row = tx
         .insert(applicationInvocations)
-        .values(invocationRow(input))
+        .values(invocationRow(input, userId))
         .returning()
         .get();
       return {
@@ -442,7 +460,7 @@ export async function reserveInvocation(
     if (!budgetRow) {
       const [orphan] = await tx
         .insert(applicationInvocations)
-        .values(invocationRow(input))
+        .values(invocationRow(input, userId))
         .returning();
       return unmetered(toRecord(orphan as Record<string, unknown>));
     }
@@ -469,7 +487,7 @@ export async function reserveInvocation(
     if (refused) return { allowed: false, ...refused, usage, budget };
     const [row] = await tx
       .insert(applicationInvocations)
-      .values(invocationRow(input))
+      .values(invocationRow(input, userId))
       .returning();
     return {
       allowed: true,
@@ -479,16 +497,27 @@ export async function reserveInvocation(
   });
 }
 
-/** Recent runs of an application, newest first. */
+/**
+ * Recent runs of an application, newest first. `userId` scopes the read to the
+ * owner the rows were written for; rows predating the column stay visible.
+ */
 export async function listInvocations(
   applicationId: string,
-  limit = 50
+  limit = 50,
+  userId?: string
 ): Promise<InvocationRecord[]> {
   const db = getDb();
+  const scope =
+    userId === undefined
+      ? eq(applicationInvocations.application_id, applicationId)
+      : and(
+          eq(applicationInvocations.application_id, applicationId),
+          sql`(${applicationInvocations.user_id} IS NULL OR ${applicationInvocations.user_id} = ${userId})`
+        );
   const rows = await db
     .select()
     .from(applicationInvocations)
-    .where(eq(applicationInvocations.application_id, applicationId))
+    .where(scope)
     .orderBy(sql`${applicationInvocations.created_at} desc`)
     .limit(limit);
   return rows.map((r: Record<string, unknown>) => toRecord(r));

--- a/packages/models/src/application.ts
+++ b/packages/models/src/application.ts
@@ -8,7 +8,7 @@
  * owns a UI document plus typed bindings, and each binding names a workflow.
  */
 import { createHash } from "node:crypto";
-import { eq, desc, and, max } from "drizzle-orm";
+import { eq, desc, and, max, sql } from "drizzle-orm";
 import {
   APP_SCHEMA_VERSION,
   createEmptyDocument,
@@ -24,8 +24,12 @@ import {
   ModelObserver,
   createTimeOrderedUuid
 } from "./base-model.js";
-import { getDb } from "./db.js";
+import { getDb, getDbType } from "./db.js";
 import { applications, applicationVersions } from "./schema/applications.js";
+import {
+  applicationBudgets,
+  applicationInvocations
+} from "./schema/application-budgets.js";
 import { Workflow, type WorkflowGraph } from "./workflow.js";
 import { WorkflowVersion } from "./workflow-version.js";
 
@@ -102,6 +106,36 @@ export class ApplicationConflictError extends Error {
     super(`Application ${id} was modified concurrently`);
     this.name = "ApplicationConflictError";
   }
+}
+
+/** An id a client asked for that is already taken, by anyone. */
+export class ApplicationIdInUseError extends Error {
+  constructor(id: string) {
+    super(`Application id ${id} is already in use`);
+    this.name = "ApplicationIdInUseError";
+  }
+}
+
+export class InvalidApplicationIdError extends Error {
+  constructor(id: string) {
+    super(`Application id ${id} is not a valid identifier`);
+    this.name = "InvalidApplicationIdError";
+  }
+}
+
+/**
+ * Ids may be supplied by the client — bundle import and the example apps both
+ * need a stable one — so the shape is pinned here: printable, path-safe, and
+ * short enough to log. Anything else is rejected rather than normalized into
+ * something the caller did not ask for.
+ */
+const APPLICATION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+/** Trim and validate a client-supplied id, or throw. */
+export function normalizeApplicationId(raw: string): string {
+  const id = raw.trim();
+  if (!APPLICATION_ID_RE.test(id)) throw new InvalidApplicationIdError(raw);
+  return id;
 }
 
 /** Derive a release's capability summary from the document's bindings. */
@@ -203,6 +237,83 @@ export class Application extends DBModel {
 
   static async findById(id: string): Promise<Application | null> {
     return Application.get<Application>(id);
+  }
+
+  /**
+   * Create a row whose id is not already taken by anyone.
+   *
+   * `save()` upserts, so creating over an existing id would silently adopt —
+   * or clobber — another account's app. Ids are global (a client may supply
+   * one), so the insert is a plain insert and a collision is an error even
+   * when the row belongs to the caller.
+   */
+  static async createUnique(
+    data: Record<string, unknown>
+  ): Promise<Application> {
+    const app = new Application(data);
+    app.id = normalizeApplicationId(app.id);
+    app.beforeSave();
+    const db = getDb();
+    try {
+      await db
+        .insert(applications)
+        .values(app.toRow() as typeof applications.$inferInsert);
+    } catch (error) {
+      if (await Application.findById(app.id)) {
+        throw new ApplicationIdInUseError(app.id);
+      }
+      throw error;
+    }
+    ModelObserver.notify(app, ModelChangeEvent.CREATED);
+    return app;
+  }
+
+  /**
+   * Delete the app and everything hanging off it, in one transaction.
+   *
+   * The declared foreign keys cascade on PostgreSQL and on better-sqlite3,
+   * which turns `PRAGMA foreign_keys` on — but that pragma is per-connection,
+   * and a SQLite connection opened without it silently keeps the children.
+   * They carry no owner of their own, so one left behind is readable by
+   * whoever next claims this id. The children are therefore deleted
+   * explicitly, and the parent last, so a failure anywhere leaves the app
+   * intact rather than half-erased.
+   */
+  override async delete(): Promise<void> {
+    const db = getDb();
+    const id = this.id;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const statements = (tx: any): unknown[] => [
+      tx
+        .delete(applicationVersions)
+        .where(eq(applicationVersions.application_id, id)),
+      tx
+        .delete(applicationInvocations)
+        .where(eq(applicationInvocations.application_id, id)),
+      tx
+        .delete(applicationBudgets)
+        .where(eq(applicationBudgets.application_id, id)),
+      tx.delete(applications).where(eq(applications.id, id))
+    ];
+
+    if (getDbType() === "sqlite") {
+      // better-sqlite3 transactions must be fully synchronous; an async
+      // callback returns a Promise the driver rejects.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      db.transaction((tx: any): void => {
+        for (const statement of statements(tx)) {
+          (statement as { run: () => void }).run();
+        }
+      });
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await db.transaction(async (tx: any): Promise<void> => {
+        for (const statement of statements(tx)) await statement;
+      });
+    }
+
+    ModelObserver.notify(this, ModelChangeEvent.DELETED);
   }
 
   static async listByUser(userId: string, limit = 50): Promise<Application[]> {
@@ -408,6 +519,8 @@ export async function publishApplication(
     .select({ value: max(applicationVersions.version) })
     .from(applicationVersions)
     .where(eq(applicationVersions.application_id, application.id));
+  // Only names the pinned workflow versions. The number the release actually
+  // gets is read again inside the transaction below, where it is authoritative.
   const nextVersion = Number(highest[0]?.value ?? 0) + 1;
 
   const pinned = await pinWorkflows(draft, application.user_id, nextVersion);
@@ -422,58 +535,137 @@ export async function publishApplication(
     [...pinned].map(([workflowId, entry]) => [workflowId, entry.graphHash])
   );
 
-  await db
-    .update(applicationVersions)
-    .set({ released: 0 })
-    .where(eq(applicationVersions.application_id, application.id));
+  const snapshot = {
+    id: createTimeOrderedUuid(),
+    application_id: application.id,
+    user_id: application.user_id,
+    document: JSON.stringify(document),
+    capabilities: JSON.stringify(deriveCapabilities(document, graphHashes)),
+    workflow_graphs: JSON.stringify(Object.fromEntries(pinned)),
+    released: 1,
+    created_at: new Date().toISOString()
+  };
 
-  const rows = await db
-    .insert(applicationVersions)
-    .values({
-      id: createTimeOrderedUuid(),
-      application_id: application.id,
-      version: nextVersion,
-      document: JSON.stringify(document),
-      capabilities: JSON.stringify(deriveCapabilities(document, graphHashes)),
-      workflow_graphs: JSON.stringify(Object.fromEntries(pinned)),
-      released: 1,
-      created_at: new Date().toISOString()
-    })
-    .returning();
+  // Reading the highest version, clearing the old release flag and inserting
+  // the new snapshot are one step. Two publishers that interleaved here used to
+  // mint the same version number and leave two rows flagged released, which
+  // made "the released version" whichever row the engine happened to return
+  // first. The unique index on (application_id, version) is the backstop: a
+  // publisher that still races through fails instead of duplicating.
+  if (getDbType() === "sqlite") {
+    // better-sqlite3 transactions must be fully synchronous; an async callback
+    // returns a Promise the driver rejects.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const row = db.transaction((tx: any): Record<string, unknown> => {
+      const highestInTx = tx
+        .select({ value: max(applicationVersions.version) })
+        .from(applicationVersions)
+        .where(eq(applicationVersions.application_id, application.id))
+        .get();
+      tx.update(applicationVersions)
+        .set({ released: 0 })
+        .where(eq(applicationVersions.application_id, application.id))
+        .run();
+      return tx
+        .insert(applicationVersions)
+        .values({ ...snapshot, version: Number(highestInTx?.value ?? 0) + 1 })
+        .returning()
+        .get() as Record<string, unknown>;
+    }) as Record<string, unknown>;
+    return toReleaseResponse(row);
+  }
 
-  return toReleaseResponse(rows[0] as Record<string, unknown>);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const row = await db.transaction(async (tx: any) => {
+    // Locking the app row serializes publishes of the same app: a second
+    // publisher waits here instead of reading a version number this one is
+    // about to take.
+    await tx
+      .select()
+      .from(applications)
+      .where(eq(applications.id, application.id))
+      .limit(1)
+      .for("update");
+    const [highestInTx] = await tx
+      .select({ value: max(applicationVersions.version) })
+      .from(applicationVersions)
+      .where(eq(applicationVersions.application_id, application.id));
+    await tx
+      .update(applicationVersions)
+      .set({ released: 0 })
+      .where(eq(applicationVersions.application_id, application.id));
+    const [inserted] = await tx
+      .insert(applicationVersions)
+      .values({ ...snapshot, version: Number(highestInTx?.value ?? 0) + 1 })
+      .returning();
+    return inserted as Record<string, unknown>;
+  });
+  return toReleaseResponse(row);
 }
 
+/**
+ * The application's rows, optionally narrowed to one owner. Snapshots written
+ * before the column existed carry a null `user_id` and stay visible — the app
+ * row's ownership check is what covered them.
+ */
+const ownedBy = (applicationId: string, userId?: string) =>
+  userId === undefined
+    ? eq(applicationVersions.application_id, applicationId)
+    : and(
+        eq(applicationVersions.application_id, applicationId),
+        sql`(${applicationVersions.user_id} IS NULL OR ${applicationVersions.user_id} = ${userId})`
+      );
+
+/**
+ * Snapshots of an application, newest first.
+ *
+ * `userId` scopes the read to the owner the snapshots were written for. A
+ * version row is looked up by application id alone, and ids are
+ * client-supplied, so a caller acting for a user passes theirs rather than
+ * trusting that the app row holding this id is still the one that published.
+ */
 export async function listApplicationVersions(
   applicationId: string,
-  limit = 50
+  limit = 50,
+  userId?: string
 ): Promise<ApplicationVersionResponse[]> {
   const db = getDb();
   const rows = await db
     .select()
     .from(applicationVersions)
-    .where(eq(applicationVersions.application_id, applicationId))
+    .where(ownedBy(applicationId, userId))
     .orderBy(desc(applicationVersions.version))
     .limit(limit);
   return rows.map((r: Record<string, unknown>) => toVersionResponse(r));
 }
 
-/** The snapshot a published app currently serves, if any. */
-export async function releasedApplicationVersion(
-  applicationId: string
-): Promise<ApplicationVersionResponse | null> {
+/**
+ * The released row, or null. Ordered by version so an inconsistent table —
+ * two rows flagged released by some earlier write — resolves to the newest
+ * one rather than to whichever row the engine returns first.
+ */
+async function releasedRow(
+  applicationId: string,
+  userId?: string
+): Promise<Record<string, unknown> | null> {
   const db = getDb();
   const rows = await db
     .select()
     .from(applicationVersions)
     .where(
-      and(
-        eq(applicationVersions.application_id, applicationId),
-        eq(applicationVersions.released, 1)
-      )
+      and(ownedBy(applicationId, userId), eq(applicationVersions.released, 1))
     )
+    .orderBy(desc(applicationVersions.version))
     .limit(1);
-  const row = rows[0] as Record<string, unknown> | undefined;
+  return (rows[0] as Record<string, unknown> | undefined) ?? null;
+}
+
+/** The snapshot a published app currently serves, if any. */
+export async function releasedApplicationVersion(
+  applicationId: string,
+  userId?: string
+): Promise<ApplicationVersionResponse | null> {
+  const row = await releasedRow(applicationId, userId);
   return row ? toVersionResponse(row) : null;
 }
 
@@ -482,43 +674,75 @@ export async function releasedApplicationVersion(
  * needs to run the release rather than the draft.
  */
 export async function releasedApplicationRelease(
-  applicationId: string
+  applicationId: string,
+  userId?: string
 ): Promise<ApplicationReleaseResponse | null> {
-  const db = getDb();
-  const rows = await db
-    .select()
-    .from(applicationVersions)
-    .where(
-      and(
-        eq(applicationVersions.application_id, applicationId),
-        eq(applicationVersions.released, 1)
-      )
-    )
-    .limit(1);
-  const row = rows[0] as Record<string, unknown> | undefined;
+  const row = await releasedRow(applicationId, userId);
   return row ? toReleaseResponse(row) : null;
 }
 
-/** Move the release pointer to an existing version (publish or rollback). */
+/**
+ * Move the release pointer to an existing version (publish or rollback).
+ *
+ * The target is checked first and the flag is moved in one transaction:
+ * rolling back to a version that does not exist used to clear the current
+ * release before discovering there was nothing to promote, leaving a published
+ * app serving nothing.
+ */
 export async function releaseApplicationVersion(
   applicationId: string,
-  version: number
+  version: number,
+  userId?: string
 ): Promise<ApplicationVersionResponse | null> {
   const db = getDb();
-  await db
-    .update(applicationVersions)
-    .set({ released: 0 })
-    .where(eq(applicationVersions.application_id, applicationId));
-  const rows = await db
-    .update(applicationVersions)
-    .set({ released: 1 })
-    .where(
-      and(
-        eq(applicationVersions.application_id, applicationId),
-        eq(applicationVersions.version, version)
-      )
-    )
-    .returning();
-  const row = rows[0] as Record<string, unknown> | undefined;
+  const target = and(
+    ownedBy(applicationId, userId),
+    eq(applicationVersions.version, version)
+  );
+
+  if (getDbType() === "sqlite") {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const row = db.transaction((tx: any): Record<string, unknown> | null => {
+      const existing = tx
+        .select()
+        .from(applicationVersions)
+        .where(target)
+        .limit(1)
+        .get();
+      if (!existing) return null;
+      tx.update(applicationVersions)
+        .set({ released: 0 })
+        .where(eq(applicationVersions.application_id, applicationId))
+        .run();
+      return tx
+        .update(applicationVersions)
+        .set({ released: 1 })
+        .where(target)
+        .returning()
+        .get() as Record<string, unknown>;
+    }) as Record<string, unknown> | null;
+    return row ? toVersionResponse(row) : null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const row = await db.transaction(async (tx: any) => {
+    const [existing] = await tx
+      .select()
+      .from(applicationVersions)
+      .where(target)
+      .limit(1)
+      .for("update");
+    if (!existing) return null;
+    await tx
+      .update(applicationVersions)
+      .set({ released: 0 })
+      .where(eq(applicationVersions.application_id, applicationId));
+    const [promoted] = await tx
+      .update(applicationVersions)
+      .set({ released: 1 })
+      .where(target)
+      .returning();
+    return (promoted as Record<string, unknown>) ?? null;
+  });
   return row ? toVersionResponse(row) : null;
 }

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -534,6 +534,30 @@ const TABLE_COLUMNS: Record<string, Record<string, string>> = {
     created_by: "text",
     created_at: "text",
     revoked_at: "text"
+  },
+  application_versions: {
+    id: "text",
+    application_id: "text",
+    user_id: "text",
+    version: "integer",
+    document: "text",
+    capabilities: "text",
+    workflow_graphs: "text",
+    released: "integer",
+    created_at: "text"
+  },
+  application_invocations: {
+    id: "text",
+    application_id: "text",
+    user_id: "text",
+    version: "integer",
+    invocation_id: "text",
+    operation_id: "text",
+    estimated_usd: "real",
+    actual_usd: "real",
+    status: "text",
+    created_at: "text",
+    settled_at: "text"
   }
 };
 
@@ -1029,7 +1053,8 @@ function getCreateSchemaSql(): string {
 
     CREATE TABLE IF NOT EXISTS "application_versions" (
       "id" text PRIMARY KEY NOT NULL,
-      "application_id" text NOT NULL,
+      "application_id" text NOT NULL REFERENCES "applications" ("id") ON DELETE CASCADE,
+      "user_id" text,
       "version" integer NOT NULL,
       "document" text NOT NULL,
       "capabilities" text NOT NULL,
@@ -1039,9 +1064,10 @@ function getCreateSchemaSql(): string {
     );
     CREATE INDEX IF NOT EXISTS "idx_application_version_app" ON "application_versions" ("application_id");
     CREATE INDEX IF NOT EXISTS "idx_application_version_released" ON "application_versions" ("released");
+    CREATE UNIQUE INDEX IF NOT EXISTS "idx_application_version_app_version" ON "application_versions" ("application_id", "version");
 
     CREATE TABLE IF NOT EXISTS "application_budgets" (
-      "application_id" text PRIMARY KEY NOT NULL,
+      "application_id" text PRIMARY KEY NOT NULL REFERENCES "applications" ("id") ON DELETE CASCADE,
       "period" text NOT NULL DEFAULT 'month',
       "max_usd" real,
       "max_invocations" integer,
@@ -1051,7 +1077,8 @@ function getCreateSchemaSql(): string {
 
     CREATE TABLE IF NOT EXISTS "application_invocations" (
       "id" text PRIMARY KEY NOT NULL,
-      "application_id" text NOT NULL,
+      "application_id" text NOT NULL REFERENCES "applications" ("id") ON DELETE CASCADE,
+      "user_id" text,
       "version" integer,
       "invocation_id" text NOT NULL,
       "operation_id" text NOT NULL DEFAULT '',

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -153,6 +153,9 @@ export type { StoryboardDocument, StoryboardResponse } from "./storyboard.js";
 export {
   Application,
   ApplicationConflictError,
+  ApplicationIdInUseError,
+  InvalidApplicationIdError,
+  normalizeApplicationId,
   deriveCapabilities,
   publishApplication,
   listApplicationVersions,

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -2332,5 +2332,278 @@ export const migrations: MigrationDef[] = [
       // no-op: the lifted documents are the canonical copy now, and pushing
       // them back onto workflows would resurrect the storage this removes.
     }
+  },
+
+  // ── Tie an application's children to the application ────────────────
+  // `application_versions`, `application_invocations` and
+  // `application_budgets` referenced `applications.id` by convention only:
+  // no foreign key, no owner of their own. Deleting an app removed the parent
+  // row and left the children behind, and an application id is
+  // client-supplied — so recreating a deleted id handed the previous owner's
+  // snapshots, ledger and budget to whoever claimed it next.
+  //
+  // Orphans are removed, the children gain the owner they were written for,
+  // duplicate versions are collapsed so `(application_id, version)` can be
+  // unique, and the tables get real ON DELETE CASCADE foreign keys.
+  {
+    version: "20260801_000000",
+    name: "cascade_and_own_application_children",
+    createsTables: [],
+    modifiesTables: [
+      "application_versions",
+      "application_invocations",
+      "application_budgets"
+    ],
+    async up(db) {
+      if (!(await db.tableExists("applications"))) return;
+
+      const children = [
+        "application_versions",
+        "application_invocations",
+        "application_budgets"
+      ];
+      const present: string[] = [];
+      for (const table of children) {
+        if (await db.tableExists(table)) present.push(table);
+      }
+
+      // Children whose parent is already gone. These are exactly the rows a
+      // recreated id would inherit.
+      for (const table of present) {
+        await db.execute(
+          `DELETE FROM ${table}
+            WHERE application_id NOT IN (SELECT id FROM applications)`
+        );
+      }
+
+      // Ownership, backfilled from the parent.
+      for (const table of ["application_versions", "application_invocations"]) {
+        if (!present.includes(table)) continue;
+        if (!(await db.columnExists(table, "user_id"))) {
+          await db.execute(`ALTER TABLE ${table} ADD COLUMN user_id TEXT`);
+        }
+        await db.execute(
+          `UPDATE ${table}
+              SET user_id = (
+                SELECT user_id FROM applications
+                 WHERE applications.id = ${table}.application_id
+              )
+            WHERE user_id IS NULL`
+        );
+      }
+
+      if (present.includes("application_versions")) {
+        await dedupeApplicationVersions(db);
+        await db.execute(
+          `CREATE UNIQUE INDEX IF NOT EXISTS idx_application_version_app_version
+             ON application_versions (application_id, version)`
+        );
+      }
+
+      for (const table of present) {
+        await addApplicationForeignKey(db, table);
+      }
+    },
+    async down(db) {
+      await db.execute(
+        "DROP INDEX IF EXISTS idx_application_version_app_version"
+      );
+      if (db.dbType !== "postgres") return;
+      for (const table of [
+        "application_versions",
+        "application_invocations",
+        "application_budgets"
+      ]) {
+        await db.execute(
+          `ALTER TABLE IF EXISTS ${table}
+             DROP CONSTRAINT IF EXISTS ${table}_application_id_fkey`
+        );
+      }
+      // The `user_id` columns stay: SQLite cannot drop a column portably and
+      // the column is inert to code that does not read it.
+    }
   }
 ];
+
+/**
+ * Collapse what the missing constraints allowed: two snapshots sharing a
+ * version number, and two snapshots flagged released. The newest row wins in
+ * both cases, which is the one a client last saw.
+ */
+async function dedupeApplicationVersions(
+  db: MigrationDBAdapter
+): Promise<void> {
+  const duplicates = await db.fetchall(
+    `SELECT application_id, version
+       FROM application_versions
+      GROUP BY application_id, version
+     HAVING COUNT(*) > 1`
+  );
+  for (const duplicate of duplicates) {
+    const rows = await db.fetchall(
+      `SELECT id FROM application_versions
+        WHERE application_id = ? AND version = ?
+        ORDER BY created_at DESC, id DESC`,
+      [duplicate.application_id, duplicate.version]
+    );
+    for (const row of rows.slice(1)) {
+      await db.execute("DELETE FROM application_versions WHERE id = ?", [
+        row.id
+      ]);
+    }
+  }
+
+  const multiReleased = await db.fetchall(
+    `SELECT application_id
+       FROM application_versions
+      WHERE released = 1
+      GROUP BY application_id
+     HAVING COUNT(*) > 1`
+  );
+  for (const app of multiReleased) {
+    const rows = await db.fetchall(
+      `SELECT id FROM application_versions
+        WHERE application_id = ? AND released = 1
+        ORDER BY version DESC`,
+      [app.application_id]
+    );
+    for (const row of rows.slice(1)) {
+      await db.execute(
+        "UPDATE application_versions SET released = 0 WHERE id = ?",
+        [row.id]
+      );
+    }
+  }
+}
+
+/** The columns and indexes each child table is rebuilt with under SQLite. */
+const SQLITE_CHILD_TABLES: Record<
+  string,
+  { definition: string; columns: string[]; indexes: string[] }
+> = {
+  application_versions: {
+    definition: `
+      id TEXT PRIMARY KEY NOT NULL,
+      application_id TEXT NOT NULL REFERENCES applications (id) ON DELETE CASCADE,
+      user_id TEXT,
+      version INTEGER NOT NULL,
+      document TEXT NOT NULL,
+      capabilities TEXT NOT NULL,
+      workflow_graphs TEXT,
+      released INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL
+    `,
+    columns: [
+      "id",
+      "application_id",
+      "user_id",
+      "version",
+      "document",
+      "capabilities",
+      "workflow_graphs",
+      "released",
+      "created_at"
+    ],
+    indexes: [
+      "CREATE INDEX IF NOT EXISTS idx_application_version_app ON application_versions (application_id)",
+      "CREATE INDEX IF NOT EXISTS idx_application_version_released ON application_versions (released)",
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_application_version_app_version ON application_versions (application_id, version)"
+    ]
+  },
+  application_invocations: {
+    definition: `
+      id TEXT PRIMARY KEY NOT NULL,
+      application_id TEXT NOT NULL REFERENCES applications (id) ON DELETE CASCADE,
+      user_id TEXT,
+      version INTEGER,
+      invocation_id TEXT NOT NULL,
+      operation_id TEXT NOT NULL DEFAULT '',
+      estimated_usd REAL NOT NULL DEFAULT 0,
+      actual_usd REAL,
+      status TEXT NOT NULL DEFAULT 'running',
+      created_at TEXT NOT NULL,
+      settled_at TEXT
+    `,
+    columns: [
+      "id",
+      "application_id",
+      "user_id",
+      "version",
+      "invocation_id",
+      "operation_id",
+      "estimated_usd",
+      "actual_usd",
+      "status",
+      "created_at",
+      "settled_at"
+    ],
+    indexes: [
+      "CREATE INDEX IF NOT EXISTS idx_application_invocation_app ON application_invocations (application_id)",
+      "CREATE INDEX IF NOT EXISTS idx_application_invocation_created ON application_invocations (created_at)",
+      "CREATE INDEX IF NOT EXISTS idx_application_invocation_invocation ON application_invocations (invocation_id)"
+    ]
+  },
+  application_budgets: {
+    definition: `
+      application_id TEXT PRIMARY KEY NOT NULL REFERENCES applications (id) ON DELETE CASCADE,
+      period TEXT NOT NULL DEFAULT 'month',
+      max_usd REAL,
+      max_invocations INTEGER,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    `,
+    columns: [
+      "application_id",
+      "period",
+      "max_usd",
+      "max_invocations",
+      "created_at",
+      "updated_at"
+    ],
+    indexes: []
+  }
+};
+
+/**
+ * Point a child table at `applications.id` with ON DELETE CASCADE.
+ *
+ * PostgreSQL takes the constraint directly. SQLite cannot add one to an
+ * existing table, so the table is rebuilt — the standard copy/drop/rename —
+ * and skipped entirely once the declaration is there.
+ */
+async function addApplicationForeignKey(
+  db: MigrationDBAdapter,
+  table: string
+): Promise<void> {
+  if (db.dbType === "postgres") {
+    const existing = await db.fetchone(
+      "SELECT 1 AS found FROM pg_constraint WHERE conname = ?",
+      [`${table}_application_id_fkey`]
+    );
+    if (existing) return;
+    await db.execute(
+      `ALTER TABLE ${table}
+         ADD CONSTRAINT ${table}_application_id_fkey
+         FOREIGN KEY (application_id) REFERENCES applications (id)
+         ON DELETE CASCADE`
+    );
+    return;
+  }
+
+  const spec = SQLITE_CHILD_TABLES[table];
+  if (!spec) return;
+  const current = await db.fetchone(
+    "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+    [table]
+  );
+  if (String(current?.sql ?? "").includes("REFERENCES")) return;
+
+  const columns = spec.columns.join(", ");
+  await db.execute(`CREATE TABLE ${table}__new (${spec.definition})`);
+  await db.execute(
+    `INSERT INTO ${table}__new (${columns}) SELECT ${columns} FROM ${table}`
+  );
+  await db.execute(`DROP TABLE ${table}`);
+  await db.execute(`ALTER TABLE ${table}__new RENAME TO ${table}`);
+  for (const index of spec.indexes) await db.execute(index);
+}

--- a/packages/models/src/schema-pg/application-budgets.ts
+++ b/packages/models/src/schema-pg/application-budgets.ts
@@ -1,8 +1,12 @@
 import { pgTable, text, integer, real, index } from "drizzle-orm/pg-core";
 
+import { applications } from "./applications.js";
+
 /** See the SQLite schema for the column semantics. */
 export const applicationBudgets = pgTable("application_budgets", {
-  application_id: text("application_id").primaryKey(),
+  application_id: text("application_id")
+    .primaryKey()
+    .references(() => applications.id, { onDelete: "cascade" }),
   period: text("period").notNull().default("month"),
   max_usd: real("max_usd"),
   max_invocations: integer("max_invocations"),
@@ -14,7 +18,10 @@ export const applicationInvocations = pgTable(
   "application_invocations",
   {
     id: text("id").primaryKey(),
-    application_id: text("application_id").notNull(),
+    application_id: text("application_id")
+      .notNull()
+      .references(() => applications.id, { onDelete: "cascade" }),
+    user_id: text("user_id"),
     version: integer("version"),
     invocation_id: text("invocation_id").notNull(),
     operation_id: text("operation_id").notNull().default(""),

--- a/packages/models/src/schema-pg/applications.ts
+++ b/packages/models/src/schema-pg/applications.ts
@@ -1,4 +1,10 @@
-import { pgTable, text, integer, index } from "drizzle-orm/pg-core";
+import {
+  pgTable,
+  text,
+  integer,
+  index,
+  uniqueIndex
+} from "drizzle-orm/pg-core";
 import { jsonText } from "./helpers.js";
 import type { ApplicationDocument } from "@nodetool-ai/app-runtime";
 import type { ApplicationCapabilities } from "../application.js";
@@ -27,7 +33,10 @@ export const applicationVersions = pgTable(
   "application_versions",
   {
     id: text("id").primaryKey(),
-    application_id: text("application_id").notNull(),
+    application_id: text("application_id")
+      .notNull()
+      .references(() => applications.id, { onDelete: "cascade" }),
+    user_id: text("user_id"),
     version: integer("version").notNull(),
     document: jsonText<ApplicationDocument>()("document").notNull(),
     capabilities: jsonText<ApplicationCapabilities>()("capabilities").notNull(),
@@ -37,6 +46,10 @@ export const applicationVersions = pgTable(
   },
   (table) => [
     index("idx_application_version_app").on(table.application_id),
-    index("idx_application_version_released").on(table.released)
+    index("idx_application_version_released").on(table.released),
+    uniqueIndex("idx_application_version_app_version").on(
+      table.application_id,
+      table.version
+    )
   ]
 );

--- a/packages/models/src/schema/application-budgets.ts
+++ b/packages/models/src/schema/application-budgets.ts
@@ -1,5 +1,7 @@
 import { sqliteTable, text, integer, real, index } from "drizzle-orm/sqlite-core";
 
+import { applications } from "./applications.js";
+
 /**
  * The spend ceiling a published app runs under.
  *
@@ -8,7 +10,9 @@ import { sqliteTable, text, integer, real, index } from "drizzle-orm/sqlite-core
  * the ledger is summed over.
  */
 export const applicationBudgets = sqliteTable("application_budgets", {
-  application_id: text("application_id").primaryKey(),
+  application_id: text("application_id")
+    .primaryKey()
+    .references(() => applications.id, { onDelete: "cascade" }),
   /** "day" | "month" | "total" — the window `max_usd` applies to. */
   period: text("period").notNull().default("month"),
   max_usd: real("max_usd"),
@@ -30,7 +34,11 @@ export const applicationInvocations = sqliteTable(
   "application_invocations",
   {
     id: text("id").primaryKey(),
-    application_id: text("application_id").notNull(),
+    application_id: text("application_id")
+      .notNull()
+      .references(() => applications.id, { onDelete: "cascade" }),
+    /** Owner of the app at run time, copied from the parent. */
+    user_id: text("user_id"),
     /** Released version this ran against; null for a draft run. */
     version: integer("version"),
     /** Equals the run's `job_id`. */

--- a/packages/models/src/schema/applications.ts
+++ b/packages/models/src/schema/applications.ts
@@ -1,4 +1,10 @@
-import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+  uniqueIndex
+} from "drizzle-orm/sqlite-core";
 
 /**
  * A mini app: a UI document plus typed bindings to workflow operations,
@@ -34,7 +40,20 @@ export const applicationVersions = sqliteTable(
   "application_versions",
   {
     id: text("id").primaryKey(),
-    application_id: text("application_id").notNull(),
+    /**
+     * The app this snapshot belongs to. The cascade is what keeps a deleted
+     * app's history from outliving it: an id is client-supplied, so an orphan
+     * left behind here would be readable by whoever recreates that id.
+     */
+    application_id: text("application_id")
+      .notNull()
+      .references(() => applications.id, { onDelete: "cascade" }),
+    /**
+     * Owner at publish time, copied from the parent. Version reads happen
+     * against an application id alone, so the snapshot carries the owner it
+     * was written for rather than trusting whatever row holds that id now.
+     */
+    user_id: text("user_id"),
     /** Monotonic per application. */
     version: integer("version").notNull(),
     document: text("document").notNull(),
@@ -52,6 +71,12 @@ export const applicationVersions = sqliteTable(
   },
   (table) => [
     index("idx_application_version_app").on(table.application_id),
-    index("idx_application_version_released").on(table.released)
+    index("idx_application_version_released").on(table.released),
+    // Two publishers that read the same MAX(version) must not both land: the
+    // second insert fails instead of minting a duplicate version number.
+    uniqueIndex("idx_application_version_app_version").on(
+      table.application_id,
+      table.version
+    )
   ]
 );

--- a/packages/models/tests/application-budget.test.ts
+++ b/packages/models/tests/application-budget.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 
 import { initTestDb } from "../src/db.js";
+import { Application } from "../src/application.js";
 import {
   applicationUsage,
   checkApplicationBudget,
@@ -13,13 +14,26 @@ import {
 } from "../src/application-budget.js";
 
 const APP = "app-1";
+const OTHER_APP = "app-2";
+
+/**
+ * Budgets and ledger rows are children of an application row — the foreign key
+ * is what keeps a deleted app's spend from being inherited — so the parents
+ * exist before anything is booked against them.
+ */
+const seedApps = async () => {
+  for (const id of [APP, OTHER_APP]) {
+    await Application.create<Application>({ id, user_id: "u1" });
+  }
+};
 
 const run = (invocationId: string, estimatedUsd: number) =>
   recordInvocation({ applicationId: APP, invocationId, estimatedUsd });
 
 describe("application budgets", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     initTestDb();
+    await seedApps();
   });
 
   it("allows any run when no budget is configured", async () => {
@@ -76,7 +90,7 @@ describe("application budgets", () => {
   it("leaves an invocation belonging to another application untouched", async () => {
     await run("job-1", 2);
 
-    expect(await settleInvocation("app-2", "job-1", 0)).toBeNull();
+    expect(await settleInvocation(OTHER_APP, "job-1", 0)).toBeNull();
 
     const [row] = await listInvocations(APP);
     expect(row).toMatchObject({ actualUsd: null, status: "running" });
@@ -95,7 +109,7 @@ describe("application budgets", () => {
   it("scopes usage to another application's ledger", async () => {
     await run("job-1", 3);
     await recordInvocation({
-      applicationId: "app-2",
+      applicationId: OTHER_APP,
       invocationId: "job-2",
       estimatedUsd: 9
     });

--- a/packages/models/tests/application.test.ts
+++ b/packages/models/tests/application.test.ts
@@ -6,14 +6,26 @@ import { eq } from "drizzle-orm";
 import { getDb, initTestDb } from "../src/db.js";
 import { applicationVersions } from "../src/schema/applications.js";
 import {
+  applicationBudgets,
+  applicationInvocations
+} from "../src/schema/application-budgets.js";
+import {
   Application,
+  ApplicationIdInUseError,
+  InvalidApplicationIdError,
   deriveCapabilities,
+  normalizeApplicationId,
   listApplicationVersions,
   publishApplication,
   releaseApplicationVersion,
   releasedApplicationRelease,
   releasedApplicationVersion
 } from "../src/application.js";
+import {
+  listInvocations,
+  recordInvocation,
+  setApplicationBudget
+} from "../src/application-budget.js";
 import { Workflow } from "../src/workflow.js";
 import { WorkflowVersion } from "../src/workflow-version.js";
 
@@ -288,5 +300,191 @@ describe("deriveCapabilities", () => {
       workflows: [],
       resources: []
     });
+  });
+});
+
+describe("application ids", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("accepts a client-supplied id and refuses a second claim on it", async () => {
+    await Application.createUnique({
+      id: "my-app",
+      user_id: "u1",
+      document: JSON.stringify(documentWith())
+    });
+
+    // Even for the same user: `save()` upserts, `createUnique` does not.
+    await expect(
+      Application.createUnique({ id: "my-app", user_id: "u1" })
+    ).rejects.toThrow(ApplicationIdInUseError);
+    // And most of all not for anyone else.
+    await expect(
+      Application.createUnique({ id: "my-app", user_id: "u2" })
+    ).rejects.toThrow(ApplicationIdInUseError);
+  });
+
+  it("rejects an id that is not a plain identifier", () => {
+    expect(() => normalizeApplicationId("../etc/passwd")).toThrow(
+      InvalidApplicationIdError
+    );
+    expect(() => normalizeApplicationId("")).toThrow(InvalidApplicationIdError);
+    expect(normalizeApplicationId("  app_1.b-2  ")).toBe("app_1.b-2");
+  });
+});
+
+describe("deleting an application", () => {
+  beforeEach(async () => {
+    initTestDb();
+    await createWorkflow();
+  });
+
+  const countIn = async (
+    table:
+      | typeof applicationVersions
+      | typeof applicationInvocations
+      | typeof applicationBudgets,
+    applicationId: string
+  ): Promise<number> => {
+    const rows = await getDb().select().from(table);
+    return rows.filter(
+      (r: Record<string, unknown>) => r.application_id === applicationId
+    ).length;
+  };
+
+  const childCounts = async (applicationId: string) => ({
+    versions: await countIn(applicationVersions, applicationId),
+    invocations: await countIn(applicationInvocations, applicationId),
+    budgets: await countIn(applicationBudgets, applicationId)
+  });
+
+  it("takes its versions, ledger and budget with it", async () => {
+    const app = await createApp();
+    await publishApplication(app);
+    await setApplicationBudget(app.id, { period: "total", maxUsd: 5 });
+    await recordInvocation({ applicationId: app.id, invocationId: "job-1" });
+    expect(await childCounts(app.id)).toEqual({
+      versions: 1,
+      invocations: 1,
+      budgets: 1
+    });
+
+    await app.delete();
+
+    expect(await childCounts(app.id)).toEqual({
+      versions: 0,
+      invocations: 0,
+      budgets: 0
+    });
+  });
+
+  it("leaves a recreated id with none of the deleted app's data", async () => {
+    const app = await Application.createUnique({
+      id: "shared-id",
+      user_id: "u1",
+      document: JSON.stringify(documentWith())
+    });
+    await publishApplication(app);
+    await recordInvocation({ applicationId: app.id, invocationId: "job-1" });
+    await app.delete();
+
+    // The attack the cascade closes: claim the id someone else gave up.
+    const impostor = await Application.createUnique({
+      id: "shared-id",
+      user_id: "u2",
+      document: JSON.stringify(documentWith())
+    });
+
+    expect(await listApplicationVersions(impostor.id)).toEqual([]);
+    expect(await releasedApplicationVersion(impostor.id)).toBeNull();
+    expect(await listInvocations(impostor.id)).toEqual([]);
+  });
+
+  it("does not touch another application's rows", async () => {
+    const app = await createApp();
+    const other = await createApp();
+    await publishApplication(other);
+
+    await app.delete();
+
+    expect(await listApplicationVersions(other.id)).toHaveLength(1);
+  });
+});
+
+describe("release transitions", () => {
+  beforeEach(async () => {
+    initTestDb();
+    await createWorkflow();
+  });
+
+  it("keeps at most one released row and one row per version", async () => {
+    const app = await createApp();
+    await publishApplication(app);
+    await publishApplication(app);
+    await publishApplication(app);
+
+    const rows = await getDb()
+      .select()
+      .from(applicationVersions)
+      .where(eq(applicationVersions.application_id, app.id));
+    expect(rows.map((r: Record<string, unknown>) => r.version).sort()).toEqual([
+      1, 2, 3
+    ]);
+    expect(
+      rows.filter((r: Record<string, unknown>) => Number(r.released) === 1)
+    ).toHaveLength(1);
+  });
+
+  it("refuses a second snapshot with the same version number", async () => {
+    const app = await createApp();
+    const published = await publishApplication(app);
+
+    await expect(
+      getDb()
+        .insert(applicationVersions)
+        .values({
+          id: "dupe",
+          application_id: app.id,
+          user_id: "u1",
+          version: published.version,
+          document: JSON.stringify(documentWith()),
+          capabilities: "{}",
+          released: 0,
+          created_at: new Date().toISOString()
+        })
+    ).rejects.toThrow();
+  });
+
+  it("stamps each snapshot with the owner that published it", async () => {
+    const app = await createApp();
+    await publishApplication(app);
+
+    expect(await listApplicationVersions(app.id, 50, "u1")).toHaveLength(1);
+    expect(await listApplicationVersions(app.id, 50, "u2")).toEqual([]);
+    expect(await releasedApplicationVersion(app.id, "u2")).toBeNull();
+  });
+
+  it("leaves the current release standing when the rollback target is missing", async () => {
+    const app = await createApp();
+    await publishApplication(app);
+    const current = await publishApplication(app);
+
+    expect(await releaseApplicationVersion(app.id, 99)).toBeNull();
+
+    // The old code cleared the flag before finding out there was nothing to
+    // promote, leaving the published app serving no version at all.
+    expect((await releasedApplicationVersion(app.id))?.version).toBe(
+      current.version
+    );
+  });
+
+  it("does not roll back to another owner's snapshot", async () => {
+    const app = await createApp();
+    await publishApplication(app);
+    await publishApplication(app);
+
+    expect(await releaseApplicationVersion(app.id, 1, "u2")).toBeNull();
+    expect((await releasedApplicationVersion(app.id))?.version).toBe(2);
   });
 });

--- a/packages/models/tests/migration-application-cascade.test.ts
+++ b/packages/models/tests/migration-application-cascade.test.ts
@@ -1,0 +1,195 @@
+/**
+ * The migration that ties an application's children to the application.
+ *
+ * The rows seeded here are what a database written before the foreign keys
+ * looks like: children of an app that was deleted, children with no owner of
+ * their own, and two snapshots sharing a version number.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+
+import {
+  MigrationRunner,
+  SQLiteMigrationAdapter
+} from "../src/migrations/index.js";
+
+/** The last migration before the cascade. */
+const BEFORE_CASCADE = "20260726_000002";
+const CASCADE = "20260801_000000";
+
+const createAdapter = (): SQLiteMigrationAdapter => {
+  const db = new Database(":memory:");
+  db.pragma("journal_mode = WAL");
+  return new SQLiteMigrationAdapter(db);
+};
+
+const seedApplication = (
+  adapter: SQLiteMigrationAdapter,
+  id: string,
+  userId: string
+): Promise<void> =>
+  adapter.execute(
+    `INSERT INTO applications
+       (id, user_id, project_id, name, description, document, created_at, updated_at)
+     VALUES (?, ?, 'default', ?, '', '{}', ?, ?)`,
+    [
+      id,
+      userId,
+      `App ${id}`,
+      "2026-01-01T00:00:00.000Z",
+      "2026-01-01T00:00:00.000Z"
+    ]
+  );
+
+const seedVersion = (
+  adapter: SQLiteMigrationAdapter,
+  fields: {
+    id: string;
+    applicationId: string;
+    version: number;
+    released?: number;
+    createdAt?: string;
+  }
+): Promise<void> =>
+  adapter.execute(
+    `INSERT INTO application_versions
+       (id, application_id, version, document, capabilities, released, created_at)
+     VALUES (?, ?, ?, '{}', '{}', ?, ?)`,
+    [
+      fields.id,
+      fields.applicationId,
+      fields.version,
+      fields.released ?? 0,
+      fields.createdAt ?? "2026-01-01T00:00:00.000Z"
+    ]
+  );
+
+const seedInvocation = (
+  adapter: SQLiteMigrationAdapter,
+  id: string,
+  applicationId: string
+): Promise<void> =>
+  adapter.execute(
+    `INSERT INTO application_invocations
+       (id, application_id, invocation_id, operation_id, estimated_usd, status, created_at)
+     VALUES (?, ?, ?, 'main', 0, 'running', '2026-01-01T00:00:00.000Z')`,
+    [id, applicationId, `job-${id}`]
+  );
+
+describe("cascade_and_own_application_children", () => {
+  let adapter: SQLiteMigrationAdapter;
+  let runner: MigrationRunner;
+
+  beforeEach(async () => {
+    adapter = createAdapter();
+    runner = new MigrationRunner(adapter);
+    await runner.migrate({ target: BEFORE_CASCADE });
+    await seedApplication(adapter, "kept", "owner");
+  });
+
+  it("deletes children whose application is gone and backfills the rest", async () => {
+    await seedVersion(adapter, {
+      id: "v-kept",
+      applicationId: "kept",
+      version: 1,
+      released: 1
+    });
+    await seedVersion(adapter, {
+      id: "v-orphan",
+      applicationId: "deleted",
+      version: 1
+    });
+    await seedInvocation(adapter, "i-kept", "kept");
+    await seedInvocation(adapter, "i-orphan", "deleted");
+    await adapter.execute(
+      `INSERT INTO application_budgets
+         (application_id, period, max_usd, created_at, updated_at)
+       VALUES ('deleted', 'total', 5, '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`
+    );
+
+    expect(await runner.migrate()).toContain(CASCADE);
+
+    expect(
+      await adapter.fetchall("SELECT id, user_id FROM application_versions")
+    ).toEqual([{ id: "v-kept", user_id: "owner" }]);
+    expect(
+      await adapter.fetchall("SELECT id, user_id FROM application_invocations")
+    ).toEqual([{ id: "i-kept", user_id: "owner" }]);
+    expect(await adapter.fetchall("SELECT * FROM application_budgets")).toEqual(
+      []
+    );
+  });
+
+  it("collapses duplicate versions and extra released rows", async () => {
+    await seedVersion(adapter, {
+      id: "v-old",
+      applicationId: "kept",
+      version: 1,
+      released: 1,
+      createdAt: "2026-01-01T00:00:00.000Z"
+    });
+    await seedVersion(adapter, {
+      id: "v-new",
+      applicationId: "kept",
+      version: 1,
+      released: 1,
+      createdAt: "2026-01-02T00:00:00.000Z"
+    });
+    await seedVersion(adapter, {
+      id: "v-two",
+      applicationId: "kept",
+      version: 2,
+      released: 1
+    });
+
+    await runner.migrate();
+
+    // The newest of the two v1 rows survives, and only one row stays released.
+    const rows = await adapter.fetchall(
+      "SELECT id, version, released FROM application_versions ORDER BY version"
+    );
+    expect(rows).toEqual([
+      { id: "v-new", version: 1, released: 0 },
+      { id: "v-two", version: 2, released: 1 }
+    ]);
+  });
+
+  it("leaves the children unreachable once the parent is deleted", async () => {
+    await seedVersion(adapter, {
+      id: "v-kept",
+      applicationId: "kept",
+      version: 1
+    });
+    await seedInvocation(adapter, "i-kept", "kept");
+
+    await runner.migrate();
+
+    // better-sqlite3 enforces foreign keys, so the declared cascade fires.
+    await adapter.execute("DELETE FROM applications WHERE id = 'kept'");
+
+    expect(
+      await adapter.fetchall("SELECT * FROM application_versions")
+    ).toEqual([]);
+    expect(
+      await adapter.fetchall("SELECT * FROM application_invocations")
+    ).toEqual([]);
+  });
+
+  it("refuses a duplicate version number afterwards", async () => {
+    await seedVersion(adapter, {
+      id: "v1",
+      applicationId: "kept",
+      version: 1
+    });
+    await runner.migrate();
+
+    await expect(
+      seedVersion(adapter, {
+        id: "v1-again",
+        applicationId: "kept",
+        version: 1
+      })
+    ).rejects.toThrow(/UNIQUE/i);
+  });
+});

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 54;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 55;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -935,6 +935,14 @@ export interface RunJobRequest {
   /** Released version the run executes against; absent for a draft run. */
   application_version?: number | null;
   /**
+   * The app operation this run implements, when the app declares more than the
+   * one. The ledger stores it alongside the invocation, so per-operation
+   * governance reports ("which button costs the money") can be built from real
+   * runs. Optional: a client that omits it still runs, its rows just carry no
+   * operation.
+   */
+  operation_id?: string | null;
+  /**
    * Wake-up payload for a trigger-driven run: the trigger node whose event
    * started this job, the durable input's id (for idempotent ack), and the
    * event payload itself. Present only for runs started by the trigger

--- a/packages/protocol/src/ws-commands.ts
+++ b/packages/protocol/src/ws-commands.ts
@@ -115,7 +115,8 @@ export const runJobDataSchema = z
       .optional(),
     settings: z.record(z.string(), z.unknown()).optional(),
     application_id: z.string().nullable().optional(),
-    application_version: z.number().nullable().optional()
+    application_version: z.number().nullable().optional(),
+    operation_id: z.string().nullable().optional()
   })
   .passthrough();
 

--- a/packages/websocket/src/lib/applications-service.ts
+++ b/packages/websocket/src/lib/applications-service.ts
@@ -140,6 +140,7 @@ export async function getApplication(
  * is — the caller learns their id was refused, not who holds it.
  */
 async function insertApplication(
+  userId: string,
   data: Record<string, unknown>
 ): Promise<Application> {
   try {
@@ -149,10 +150,15 @@ async function insertApplication(
       throwApiError(ApiErrorCode.INVALID_INPUT, "Invalid application id");
     }
     if (error instanceof ApplicationIdInUseError) {
-      throwApiError(
-        ApiErrorCode.ALREADY_EXISTS,
-        "An application with that id already exists"
-      );
+      // The id was taken between the caller's existence check and this insert.
+      // Answer exactly as that check would have: the owner gets their app back
+      // so a retried create stays idempotent, and everyone else gets the same
+      // answer a missing id gets. Reporting "already exists" here would make
+      // the losing side of the race the one place that reveals an id is held.
+      const existing =
+        typeof data.id === "string" ? await Application.findById(data.id) : null;
+      if (existing && existing.user_id === userId) return existing;
+      throwApiError(ApiErrorCode.NOT_FOUND, "Application not found");
     }
     throw error;
   }
@@ -186,7 +192,7 @@ export async function createApplication(
     (input.fromWorkflowId
       ? await documentFromWorkflow(input.fromWorkflowId, userId)
       : createEmptyDocument());
-  const app = await insertApplication({
+  const app = await insertApplication(userId, {
     id,
     user_id: userId,
     project_id: input.projectId,
@@ -349,7 +355,7 @@ export async function importApplicationBundle(
     });
   }
 
-  const app = await insertApplication({
+  const app = await insertApplication(userId, {
     user_id: userId,
     project_id: input.projectId,
     name: result.app.name,

--- a/packages/websocket/src/lib/applications-service.ts
+++ b/packages/websocket/src/lib/applications-service.ts
@@ -19,9 +19,12 @@ import {
 } from "@nodetool-ai/app-runtime";
 import {
   Application,
+  ApplicationIdInUseError,
+  InvalidApplicationIdError,
   Workflow,
   createStableUuid,
   createTimeOrderedUuid,
+  normalizeApplicationId,
   releasedApplicationRelease
 } from "@nodetool-ai/models";
 import {
@@ -129,12 +132,48 @@ export async function getApplication(
   return applicationResponse.parse(app.toResponse());
 }
 
+/**
+ * Create the row, mapping the model's id errors onto API errors.
+ *
+ * Ids are global: an app the caller does not own occupies its id just as much
+ * as one they do, and the row it names is reported the same way a missing one
+ * is — the caller learns their id was refused, not who holds it.
+ */
+async function insertApplication(
+  data: Record<string, unknown>
+): Promise<Application> {
+  try {
+    return await Application.createUnique(data);
+  } catch (error) {
+    if (error instanceof InvalidApplicationIdError) {
+      throwApiError(ApiErrorCode.INVALID_INPUT, "Invalid application id");
+    }
+    if (error instanceof ApplicationIdInUseError) {
+      throwApiError(
+        ApiErrorCode.ALREADY_EXISTS,
+        "An application with that id already exists"
+      );
+    }
+    throw error;
+  }
+}
+
 export async function createApplication(
   userId: string,
   input: CreateApplicationInput
 ): Promise<ApplicationResponse> {
+  let id: string | undefined;
   if (input.id) {
-    const existing = await Application.findById(input.id);
+    try {
+      id = normalizeApplicationId(input.id);
+    } catch {
+      throwApiError(ApiErrorCode.INVALID_INPUT, "Invalid application id");
+    }
+    // Creating over an existing id is idempotent for its owner — a retried
+    // create returns the same app — and refused for everyone else. The id must
+    // never be reused, because the app's versions, ledger and budget are keyed
+    // on it and a deleted app's children could otherwise be inherited.
+    const existing = await Application.findById(id);
     if (existing) {
       if (existing.user_id !== userId) {
         throwApiError(ApiErrorCode.NOT_FOUND, "Application not found");
@@ -147,15 +186,14 @@ export async function createApplication(
     (input.fromWorkflowId
       ? await documentFromWorkflow(input.fromWorkflowId, userId)
       : createEmptyDocument());
-  const app = new Application({
-    id: input.id,
+  const app = await insertApplication({
+    id,
     user_id: userId,
     project_id: input.projectId,
     name: input.name,
     description: input.description,
     document: JSON.stringify(document)
   });
-  await app.save();
   return applicationResponse.parse(app.toResponse());
 }
 
@@ -195,6 +233,13 @@ export async function updateApplication(
   return applicationResponse.parse(updated.toResponse());
 }
 
+/**
+ * Delete the app together with its versions, ledger and budget.
+ *
+ * `Application.delete` is the cascade: the child tables carry no owner check
+ * of their own, so leaving a row behind hands it to whoever next claims this
+ * id — an id a client is free to name.
+ */
 export async function deleteApplication(
   userId: string,
   id: string
@@ -222,7 +267,7 @@ export async function exportApplicationBundle(
 ): Promise<ApplicationBundleSchema> {
   const app = await loadOwnedApplication(userId, id);
   const release = options.released
-    ? await releasedApplicationRelease(id)
+    ? await releasedApplicationRelease(id, userId)
     : null;
   if (options.released && !release) {
     throwApiError(ApiErrorCode.NOT_FOUND, "Application has no released version");
@@ -304,14 +349,13 @@ export async function importApplicationBundle(
     });
   }
 
-  const app = new Application({
+  const app = await insertApplication({
     user_id: userId,
     project_id: input.projectId,
     name: result.app.name,
     description: result.app.description,
     document: JSON.stringify(result.app.document)
   });
-  await app.save();
   return applicationResponse.parse(app.toResponse());
 }
 
@@ -324,6 +368,6 @@ export async function releasedApplicationDocument(
   id: string
 ): Promise<ApplicationReleaseResponse | null> {
   await loadOwnedApplication(userId, id);
-  const release = await releasedApplicationRelease(id);
+  const release = await releasedApplicationRelease(id, userId);
   return release ? applicationReleaseResponse.parse(release) : null;
 }

--- a/packages/websocket/src/trpc/routers/applications.ts
+++ b/packages/websocket/src/trpc/routers/applications.ts
@@ -111,7 +111,11 @@ export const applicationsRouter = router({
     .output(z.array(applicationVersionResponse))
     .query(async ({ ctx, input }) => {
       await loadOwned(ctx.userId, input.id);
-      const versions = await listApplicationVersions(input.id);
+      const versions = await listApplicationVersions(
+        input.id,
+        undefined,
+        ctx.userId
+      );
       return versions.map((v) => applicationVersionResponse.parse(v));
     }),
 
@@ -120,7 +124,7 @@ export const applicationsRouter = router({
     .output(applicationVersionResponse.nullable())
     .query(async ({ ctx, input }) => {
       await loadOwned(ctx.userId, input.id);
-      const version = await releasedApplicationVersion(input.id);
+      const version = await releasedApplicationVersion(input.id, ctx.userId);
       return version ? applicationVersionResponse.parse(version) : null;
     }),
 
@@ -173,7 +177,7 @@ export const applicationsRouter = router({
     .output(z.array(invocationRecord))
     .query(async ({ ctx, input }) => {
       await loadOwned(ctx.userId, input.id);
-      const records = await listInvocations(input.id);
+      const records = await listInvocations(input.id, undefined, ctx.userId);
       return records.map((r) => invocationRecord.parse(r));
     }),
 
@@ -186,7 +190,7 @@ export const applicationsRouter = router({
     .output(invocationRecord)
     .mutation(async ({ ctx, input }) => {
       await loadOwned(ctx.userId, input.id);
-      const release = await releasedApplicationVersion(input.id);
+      const release = await releasedApplicationVersion(input.id, ctx.userId);
       // One transaction checks the budget and claims the run against it;
       // checking and then recording lets concurrent callers all read a total
       // that excludes each other and all be admitted.
@@ -227,7 +231,11 @@ export const applicationsRouter = router({
     .output(applicationVersionResponse)
     .mutation(async ({ ctx, input }) => {
       await loadOwned(ctx.userId, input.id);
-      const released = await releaseApplicationVersion(input.id, input.version);
+      const released = await releaseApplicationVersion(
+        input.id,
+        input.version,
+        ctx.userId
+      );
       if (!released) {
         throwApiError(ApiErrorCode.NOT_FOUND, "Application version not found");
       }

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -2529,10 +2529,15 @@ export class UnifiedWebSocketRunner {
    */
   private async claimedApplicationVersion(
     applicationId: string,
-    claimed: number | null | undefined
+    claimed: number | null | undefined,
+    userId: string
   ): Promise<number | null> {
     if (claimed == null) return null;
-    const versions = await listApplicationVersions(applicationId, 10_000);
+    const versions = await listApplicationVersions(
+      applicationId,
+      10_000,
+      userId
+    );
     return versions.some((v) => v.version === claimed) ? claimed : null;
   }
 
@@ -2594,7 +2599,7 @@ export class UnifiedWebSocketRunner {
       const released =
         req.application_version == null
           ? null
-          : await releasedApplicationVersion(applicationId);
+          : await releasedApplicationVersion(applicationId, userId);
       if (req.application_version != null && !released) {
         // A release run of an app that has released nothing. The claim is
         // unsupportable rather than merely stale, and letting it through would
@@ -2625,7 +2630,8 @@ export class UnifiedWebSocketRunner {
         // attribution: it can name a version it once had, not one it invents.
         const claimed = await this.claimedApplicationVersion(
           applicationId,
-          req.application_version
+          req.application_version,
+          userId
         );
         if (!claimed) {
           return this.refuseRun(

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -41,6 +41,7 @@ import {
   Asset,
   ImageDocument,
   Job,
+  listApplicationVersions,
   releasedApplicationVersion,
   reserveInvocation,
   settleInvocation,
@@ -1501,6 +1502,13 @@ export interface RunJobRequest {
   application_id?: string | null;
   /** Released version the run executes against; absent for a draft run. */
   application_version?: number | null;
+  /**
+   * The app operation this run implements. Recorded on the ledger row so
+   * per-operation governance reports come from real runs rather than being
+   * inferred from workflow ids. Optional — a client that omits it still runs,
+   * its rows just carry no operation.
+   */
+  operation_id?: string | null;
 }
 
 export interface RunJobExecutionOptions {
@@ -2511,6 +2519,24 @@ export class UnifiedWebSocketRunner {
   }
 
   /**
+   * The version number a stale client claimed, if the app really has it —
+   * otherwise null, and the claim is unsupportable.
+   *
+   * Version history is per app and short (one row per publish), so listing it
+   * is cheap; the ceiling exists only because the model helper takes a limit,
+   * and it has to be high enough that an old claim is never truncated away by
+   * the newest releases.
+   */
+  private async claimedApplicationVersion(
+    applicationId: string,
+    claimed: number | null | undefined
+  ): Promise<number | null> {
+    if (claimed == null) return null;
+    const versions = await listApplicationVersions(applicationId, 10_000);
+    return versions.some((v) => v.version === claimed) ? claimed : null;
+  }
+
+  /**
    * Gate an app's run on its spend budget. Runs of a published app execute with
    * the creator's secrets, so this refuses before the job exists rather than
    * reporting an overspend afterwards. Returns false when the run was refused
@@ -2561,9 +2587,10 @@ export class UnifiedWebSocketRunner {
     try {
       const estimatedUsd = this.estimateRunCost(req);
       // The client says whether this is a release run or a draft run; the
-      // server says which release. Taking the number from the client would let
-      // a run bill itself to a version it never executed, and the ledger is
-      // also the release telemetry.
+      // server decides which release the ledger records. A number taken on
+      // faith would let a run bill itself to a version it never executed, and
+      // the ledger is also the release telemetry — so a claim is only honoured
+      // below once the server has found that version in the app's history.
       const released =
         req.application_version == null
           ? null
@@ -2579,6 +2606,9 @@ export class UnifiedWebSocketRunner {
           "This app has no released version to run"
         );
       }
+      // Which version the ledger row belongs to. The release is the default,
+      // because that is what a current client runs.
+      let version = released?.version ?? null;
       if (released && released.version !== req.application_version) {
         log.warn("Run claimed a version other than the released one", {
           applicationId,
@@ -2586,14 +2616,44 @@ export class UnifiedWebSocketRunner {
           claimed: req.application_version,
           released: released.version
         });
+        // A client that loaded the app before the newest release still holds
+        // that older snapshot and is about to execute it. Filing the run under
+        // the current release would credit v2's metrics and budget with a run
+        // of v1, so the row follows what actually ran — but only once the
+        // server has confirmed the claimed version is a real version of this
+        // app. That check is what keeps the client from picking its own
+        // attribution: it can name a version it once had, not one it invents.
+        const claimed = await this.claimedApplicationVersion(
+          applicationId,
+          req.application_version
+        );
+        if (!claimed) {
+          return this.refuseRun(
+            req,
+            jobId,
+            ApiErrorCode.INVALID_INPUT,
+            `This app has no version ${req.application_version} to run`
+          );
+        }
+        version = claimed;
+        // The run proceeds, but the client is stale and has no other way to
+        // learn it: nothing in a job's updates mentions releases.
+        this.sendDetached({
+          type: "notification",
+          node_id: "",
+          severity: "warning",
+          workflow_id: req.workflow_id ?? null,
+          content: `Running version ${claimed} of this app; version ${released.version} has since been released. Reload to get the latest.`
+        });
       }
       // Reserving claims the run against the budget in the same transaction
       // that checks it, so concurrent runs of one app cannot each read a total
       // that excludes the others and all be admitted.
       const decision = await reserveInvocation({
         applicationId,
-        version: released?.version ?? null,
+        version,
         invocationId: jobId,
+        operationId: req.operation_id ?? undefined,
         estimatedUsd
       });
       if (!decision.allowed) {

--- a/packages/websocket/tests/application-budget-gate.test.ts
+++ b/packages/websocket/tests/application-budget-gate.test.ts
@@ -190,13 +190,66 @@ describe("application budget gate", () => {
     expect(await listInvocations("no-such-app")).toEqual([]);
   });
 
-  it("bills a release run to the released version, not the claimed one", async () => {
+  it("bills a release run to the released version", async () => {
+    await publishApplication(await seedApp());
+
+    await run({ application_id: APP, application_version: 1 });
+
+    const [record] = await listInvocations(APP);
+    expect(record).toMatchObject({ invocationId: "job-1", version: 1 });
+  });
+
+  it("bills a stale client's run to the version it actually ran", async () => {
+    // v1 is published, then v2 supersedes it. A client that loaded the app in
+    // between still holds v1's snapshot and executes it, so v1 is what the
+    // ledger has to say — crediting v2 would corrupt the new release's metrics.
+    const app = await seedApp();
+    await publishApplication(app);
+    await publishApplication(app);
+
+    await run({ application_id: APP, application_version: 1 });
+
+    const [record] = await listInvocations(APP);
+    expect(record).toMatchObject({ invocationId: "job-1", version: 1 });
+    expect(startJob).toHaveBeenCalledOnce();
+    // The client is told it is behind; nothing else in a job's updates would
+    // reveal that a newer release exists.
+    const notice = messages(ws).find((m) => m.type === "notification");
+    expect(notice).toMatchObject({ severity: "warning" });
+    expect(String(notice?.content)).toMatch(/version 2 has since been released/);
+  });
+
+  it("refuses a run claiming a version the application never had", async () => {
     await publishApplication(await seedApp());
 
     await run({ application_id: APP, application_version: 99 });
 
+    expect(startJob).not.toHaveBeenCalled();
+    const failure = messages(ws).find(
+      (m) => m.type === "job_update" && m.status === "failed"
+    );
+    expect(failure).toMatchObject({ error_code: "INVALID_INPUT" });
+    // An unsupportable claim bills nothing — not the release it named, and not
+    // the release that happens to be current.
+    expect(await listInvocations(APP)).toEqual([]);
+  });
+
+  it("records the operation a run belongs to", async () => {
+    await seedApp();
+
+    await run({ application_id: APP, operation_id: "main" });
+
     const [record] = await listInvocations(APP);
-    expect(record).toMatchObject({ invocationId: "job-1", version: 1 });
+    expect(record).toMatchObject({ invocationId: "job-1", operationId: "main" });
+  });
+
+  it("records an empty operation for a client that sends none", async () => {
+    await seedApp();
+
+    await run({ application_id: APP });
+
+    const [record] = await listInvocations(APP);
+    expect(record).toMatchObject({ operationId: "" });
   });
 
   it("refuses a release run of an app that has released nothing", async () => {
@@ -275,6 +328,10 @@ describe("application invocation settlement", () => {
 
   beforeEach(async () => {
     await initTestDb();
+    // Ledger rows hang off an application row — the foreign key cascades a
+    // deleted app's spend away — so both apps these tests book against exist.
+    await seedApp();
+    await seedApp({ id: "other-app" });
     vi.clearAllMocks();
     ws = new MockWebSocket();
     runner = new UnifiedWebSocketRunner({

--- a/packages/websocket/tests/applications-service.test.ts
+++ b/packages/websocket/tests/applications-service.test.ts
@@ -4,7 +4,7 @@
  * two halves that keep one user's data out of another's app: deleting an app
  * takes its children with it, and an id that is taken cannot be claimed again.
  */
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createEmptyDocument } from "@nodetool-ai/app-runtime";
 import {
   Application,
@@ -90,6 +90,44 @@ describe("applications service", () => {
     const app = await Application.findById("taken");
     expect(app?.user_id).toBe(OTHER);
     expect(app?.name).toBe("Theirs");
+  });
+
+  /**
+   * The existence check and the insert are two statements, so an id can be
+   * claimed in between. The loser of that race has to answer exactly as the
+   * check would have, or it becomes the one place that reveals an id is held.
+   */
+  it("answers a lost id race the way the existence check would", async () => {
+    await createApplication(OTHER, input({ id: "raced", name: "Theirs" }));
+    // Hide the row from the pre-check so the insert is what finds the clash.
+    const findById = vi
+      .spyOn(Application, "findById")
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      createApplication(USER, input({ id: "raced", name: "Mine" }))
+    ).rejects.toThrow(/not found/i);
+
+    findById.mockRestore();
+  });
+
+  it("returns the owner's app when they lose a race with themselves", async () => {
+    const first = await createApplication(
+      USER,
+      input({ id: "mine-raced", name: "Mine" })
+    );
+    const findById = vi
+      .spyOn(Application, "findById")
+      .mockResolvedValueOnce(null);
+
+    const again = await createApplication(
+      USER,
+      input({ id: "mine-raced", name: "Renamed" })
+    );
+
+    expect(again.id).toBe(first.id);
+    expect(again.name).toBe("Mine");
+    findById.mockRestore();
   });
 
   it("refuses an id that is not a plain identifier", async () => {

--- a/packages/websocket/tests/applications-service.test.ts
+++ b/packages/websocket/tests/applications-service.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Application ids are supplied by the client, and everything an app owns —
+ * snapshots, ledger, budget — is keyed on that id alone. These tests cover the
+ * two halves that keep one user's data out of another's app: deleting an app
+ * takes its children with it, and an id that is taken cannot be claimed again.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { createEmptyDocument } from "@nodetool-ai/app-runtime";
+import {
+  Application,
+  Workflow,
+  initTestDb,
+  listApplicationVersions,
+  listInvocations,
+  publishApplication,
+  recordInvocation,
+  setApplicationBudget
+} from "@nodetool-ai/models";
+import type { CreateApplicationInput } from "@nodetool-ai/protocol/api-schemas/applications.js";
+
+import {
+  createApplication,
+  deleteApplication
+} from "../src/lib/applications-service.js";
+
+const USER = "user-1";
+const OTHER = "user-2";
+
+const appDocument = () => {
+  const doc = createEmptyDocument("Demo");
+  doc.operations = [
+    {
+      id: "main",
+      name: "Run",
+      workflowId: "wf1",
+      inputs: {},
+      outputs: {},
+      policy: "replace"
+    }
+  ];
+  return doc;
+};
+
+/** The parsed input the transports hand the service. */
+const input = (fields: {
+  id?: string;
+  name: string;
+}): CreateApplicationInput => ({
+  ...fields,
+  description: "",
+  projectId: "default",
+  document: appDocument()
+});
+
+const seedWorkflow = () =>
+  Workflow.create<Workflow>({
+    id: "wf1",
+    user_id: USER,
+    name: "Demo workflow",
+    graph: { nodes: [{ id: "n1", type: "nodetool.text.Concat" }], edges: [] }
+  });
+
+describe("applications service", () => {
+  beforeEach(async () => {
+    await initTestDb();
+    await seedWorkflow();
+  });
+
+  it("returns the caller's own app when a create repeats its id", async () => {
+    const first = await createApplication(
+      USER,
+      input({ id: "my-app", name: "Mine" })
+    );
+    const again = await createApplication(
+      USER,
+      input({ id: "my-app", name: "Renamed" })
+    );
+
+    expect(again.id).toBe(first.id);
+    expect(again.name).toBe("Mine");
+  });
+
+  it("refuses an id another user already holds", async () => {
+    await createApplication(OTHER, input({ id: "taken", name: "Theirs" }));
+
+    await expect(
+      createApplication(USER, input({ id: "taken", name: "Mine" }))
+    ).rejects.toThrow(/not found/i);
+
+    const app = await Application.findById("taken");
+    expect(app?.user_id).toBe(OTHER);
+    expect(app?.name).toBe("Theirs");
+  });
+
+  it("refuses an id that is not a plain identifier", async () => {
+    await expect(
+      createApplication(USER, input({ id: "../../etc/passwd", name: "Sneaky" }))
+    ).rejects.toThrow(/invalid application id/i);
+  });
+
+  it("deletes the app's versions, ledger and budget with it", async () => {
+    const created = await createApplication(
+      USER,
+      input({ id: "doomed", name: "Doomed" })
+    );
+    const app = (await Application.findById(created.id))!;
+    await publishApplication(app);
+    await setApplicationBudget(app.id, { period: "total", maxUsd: 5 });
+    await recordInvocation({ applicationId: app.id, invocationId: "job-1" });
+
+    await deleteApplication(USER, app.id);
+
+    expect(await listApplicationVersions(app.id)).toEqual([]);
+    expect(await listInvocations(app.id)).toEqual([]);
+
+    // The id is free again, but it comes with none of the old app's data.
+    const reclaimed = await createApplication(
+      OTHER,
+      input({ id: "doomed", name: "Theirs now" })
+    );
+    expect(await listApplicationVersions(reclaimed.id)).toEqual([]);
+    expect(await listInvocations(reclaimed.id)).toEqual([]);
+  });
+
+  it("does not delete another user's app", async () => {
+    await createApplication(OTHER, input({ id: "theirs", name: "Theirs" }));
+
+    await expect(deleteApplication(USER, "theirs")).rejects.toThrow(
+      /not found/i
+    );
+    expect(await Application.findById("theirs")).not.toBeNull();
+  });
+});

--- a/web/src/components/appbuilder/AppBuilderShell.tsx
+++ b/web/src/components/appbuilder/AppBuilderShell.tsx
@@ -33,6 +33,11 @@ export interface AppBuilderShellProps {
   /** The workflow whose inputs, outputs, and nodes bindings may reference. */
   workflow: Workflow;
   /**
+   * The graph of every workflow the document's operations run, by workflow id,
+   * so a binding on the second operation is offered that operation's surface.
+   */
+  operationWorkflows?: Record<string, Workflow>;
+  /**
    * Workflow the agent panel edits. Omitted when the app has no workflow bound
    * yet, which also hides the panel.
    */
@@ -90,6 +95,7 @@ const AppBuilderShell: React.FC<AppBuilderShellProps> = ({
   applicationId,
   document,
   workflow,
+  operationWorkflows,
   agentWorkflowId,
   header,
   banner,
@@ -176,6 +182,7 @@ const AppBuilderShell: React.FC<AppBuilderShellProps> = ({
             onMetaChange={setMeta}
             dataOpen={dataOpen}
             onToggleData={toggleData}
+            operationWorkflows={operationWorkflows}
           />
         </Box>
       </FlexColumn>

--- a/web/src/components/appbuilder/ApplicationAppBuilder.tsx
+++ b/web/src/components/appbuilder/ApplicationAppBuilder.tsx
@@ -103,9 +103,14 @@ const ApplicationAppBuilder: React.FC<ApplicationAppBuilderProps> = ({
   });
   const fetchedRef = useRef(fetched);
   fetchedRef.current = fetched;
-  // Which graphs have arrived. The graphs themselves are read from the ref, so
-  // the map keeps its identity across renders that changed nothing.
-  const fetchedKey = Object.keys(fetched).join("|");
+  // Which graphs have arrived, and when each last changed. The graphs are read
+  // from the ref, so the map keeps its identity across renders that changed
+  // nothing -- but keying on ids alone would pin the first copy of a graph
+  // forever, and a refetched workflow would go on serving the binding pickers
+  // a surface it no longer has.
+  const fetchedKey = workflowIds
+    .map((id, index) => `${id}:${workflowQueries[index]?.dataUpdatedAt ?? 0}`)
+    .join("|");
   const operationWorkflows = useMemo(
     () => fetchedRef.current,
     [fetchedKey]

--- a/web/src/components/appbuilder/ApplicationAppBuilder.tsx
+++ b/web/src/components/appbuilder/ApplicationAppBuilder.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { useQueries } from "@tanstack/react-query";
 
 import {
   AlertBanner,
@@ -75,14 +75,43 @@ const ApplicationAppBuilder: React.FC<ApplicationAppBuilderProps> = ({
   }, [application]);
 
   const operationWorkflowId = document?.operations[0]?.workflowId ?? "";
-  const { data: workflow } = useQuery({
-    queryKey: ["app-builder-workflow", operationWorkflowId],
-    queryFn: async () => await fetchWorkflow(operationWorkflowId),
-    enabled: !!operationWorkflowId,
-    staleTime: 0,
-    refetchOnWindowFocus: false,
-    retry: false
+
+  // Every workflow the app's operations run, not just the first: a binding
+  // authored on the second operation is offered that workflow's own surface.
+  const workflowIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const operation of document?.operations ?? []) {
+      if (operation.workflowId) ids.add(operation.workflowId);
+    }
+    return [...ids].sort();
+  }, [document]);
+
+  const workflowQueries = useQueries({
+    queries: workflowIds.map((id) => ({
+      queryKey: ["app-builder-workflow", id],
+      queryFn: async () => await fetchWorkflow(id),
+      staleTime: 0,
+      refetchOnWindowFocus: false,
+      retry: false
+    }))
   });
+
+  const fetched: Record<string, Workflow> = {};
+  workflowIds.forEach((id, index) => {
+    const data = workflowQueries[index]?.data;
+    if (data) fetched[id] = data;
+  });
+  const fetchedRef = useRef(fetched);
+  fetchedRef.current = fetched;
+  // Which graphs have arrived. The graphs themselves are read from the ref, so
+  // the map keeps its identity across renders that changed nothing.
+  const fetchedKey = Object.keys(fetched).join("|");
+  const operationWorkflows = useMemo(
+    () => fetchedRef.current,
+    [fetchedKey]
+  );
+
+  const workflow = operationWorkflows[operationWorkflowId];
 
   const editorWorkflow = useMemo(
     () =>
@@ -150,6 +179,7 @@ const ApplicationAppBuilder: React.FC<ApplicationAppBuilderProps> = ({
       applicationId={applicationId}
       document={document}
       workflow={editorWorkflow}
+      operationWorkflows={operationWorkflows}
       agentWorkflowId={workflow?.id}
       onSave={(next) => void handleSave(next)}
       banner={

--- a/web/src/components/appbuilder/__tests__/fields.test.tsx
+++ b/web/src/components/appbuilder/__tests__/fields.test.tsx
@@ -1,11 +1,13 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 
 import mockTheme from "../../../__mocks__/themeMock";
 import { bindingField, conditionField, variableField } from "../puck/fields";
 import { BuilderWorkflowProvider } from "../puck/BuilderWorkflowContext";
+import type { OperationBinding } from "@nodetool-ai/app-runtime";
+
 import { WorkflowState } from "../workflowState";
 
 jest.mock("@puckeditor/core", () => ({
@@ -133,5 +135,147 @@ describe("execution + logic vocabulary", () => {
     }
     // `contains` compares against a literal, so the value box is offered.
     expect(screen.getByLabelText("Value")).toBeInTheDocument();
+  });
+});
+
+describe("bindings target the app's declared operations", () => {
+  const operation = (id: string, name: string): OperationBinding => ({
+    id,
+    name,
+    workflowId: `wf-${id}`,
+    inputs: {},
+    outputs: {},
+    policy: "replace"
+  });
+
+  const stateWith = (
+    inputs: WorkflowState["inputs"],
+    outputs: WorkflowState["outputs"] = []
+  ): WorkflowState => ({
+    inputs,
+    outputs,
+    variables: [],
+    nodes: [],
+    resources: []
+  });
+
+  const promptInput = stateWith([
+    {
+      nodeId: "i1",
+      nodeType: "nodetool.input.StringInput",
+      name: "prompt",
+      label: "Prompt",
+      kind: "string"
+    }
+  ]);
+
+  const renderWithOperations = (
+    element: React.ReactElement,
+    operations: OperationBinding[],
+    states: Map<string, WorkflowState>
+  ) =>
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <BuilderWorkflowProvider
+          value={states.get(operations[0].id) ?? emptyState}
+          operations={operations}
+          states={states}
+        >
+          {element}
+        </BuilderWorkflowProvider>
+      </ThemeProvider>
+    );
+
+  it("writes the generated operation id of a blank app, not `main`", async () => {
+    const onChange = jest.fn();
+    const ops = [operation("operation_1", "Operation 1")];
+    renderWithOperations(
+      bindingField("write").render({ ...fieldProps, onChange }),
+      ops,
+      new Map([["operation_1", promptInput]])
+    );
+
+    await userEvent.click(
+      screen.getByPlaceholderText(/Search inputs and node properties/i)
+    );
+    await userEvent.click(await screen.findByRole("option", { name: "Prompt" }));
+
+    expect(onChange).toHaveBeenCalledWith("op:operation_1/in:i1");
+  });
+
+  it("binds a widget to the operation the author picks", async () => {
+    const onChange = jest.fn();
+    const ops = [operation("draft", "Draft"), operation("publish", "Publish")];
+    const states = new Map([
+      ["draft", promptInput],
+      [
+        "publish",
+        stateWith([
+          {
+            nodeId: "i2",
+            nodeType: "nodetool.input.StringInput",
+            name: "slug",
+            label: "Slug",
+            kind: "string"
+          }
+        ])
+      ]
+    ]);
+    renderWithOperations(
+      bindingField("write").render({ ...fieldProps, onChange }),
+      ops,
+      states
+    );
+
+    await userEvent.click(screen.getByRole("combobox", { name: /Operation/i }));
+    await userEvent.click(await screen.findByRole("option", { name: "Publish" }));
+
+    await userEvent.click(
+      screen.getByPlaceholderText(/Search inputs and node properties/i)
+    );
+    await userEvent.click(await screen.findByRole("option", { name: "Slug" }));
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith("op:publish/in:i2")
+    );
+  });
+
+  it("resolves a legacy `main` binding onto the app's sole operation", () => {
+    const ops = [operation("operation_1", "Operation 1")];
+    const states = new Map([
+      [
+        "operation_1",
+        stateWith([], [
+          {
+            nodeId: "o1",
+            nodeType: "nodetool.output.StringOutput",
+            name: "result",
+            label: "Result"
+          }
+        ])
+      ]
+    ]);
+    renderWithOperations(
+      bindingField("read").render({ ...fieldProps, value: "op:main/out:o1" }),
+      ops,
+      states
+    );
+
+    // The stored token names an operation the app does not have; it resolves to
+    // the only one, so the picker shows the bound output instead of nothing.
+    expect(screen.getByRole("combobox", { name: /Bind to/i })).toHaveTextContent(
+      "output · Result"
+    );
+  });
+
+  it("offers no operation chooser to a single-operation app", () => {
+    renderWithOperations(
+      bindingField("write").render(fieldProps),
+      [operation("operation_1", "Operation 1")],
+      new Map([["operation_1", promptInput]])
+    );
+    expect(
+      screen.queryByRole("combobox", { name: /Operation/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/appbuilder/puck/BuilderWorkflowContext.tsx
+++ b/web/src/components/appbuilder/puck/BuilderWorkflowContext.tsx
@@ -2,56 +2,142 @@
  * Provides the bindable workflow surface (inputs / outputs / variables) to
  * Puck's custom binding fields, which can't otherwise reach component-external
  * data.
+ *
+ * An app binds one operation per workflow it runs, and a binding names the
+ * operation it belongs to. So the editor carries the document's operations and
+ * the operation the author is currently binding against — the pickers persist
+ * that id instead of assuming an operation called `main` exists.
  */
-import React, { createContext, useContext, useMemo } from "react";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState
+} from "react";
 import {
   DEFAULT_OPERATION_ID,
-  type BindingScope
+  type BindingScope,
+  type OperationBinding
 } from "@nodetool-ai/app-runtime";
 
 import { WorkflowState } from "../workflowState";
 
-const BuilderWorkflowContext = createContext<WorkflowState>({
+const EMPTY_STATE: WorkflowState = {
   inputs: [],
   outputs: [],
   variables: [],
   nodes: [],
   resources: []
+};
+
+interface BuilderWorkflowContextValue {
+  /** Every operation the document declares, in document order. */
+  operations: ReadonlyArray<OperationBinding>;
+  /** The operation a new binding is written against. */
+  selectedOperationId: string;
+  selectOperation: (operationId: string) => void;
+  /** The bindable surface of one operation; the host workflow's when unknown. */
+  workflowFor: (operationId?: string) => WorkflowState;
+}
+
+const BuilderWorkflowContext = createContext<BuilderWorkflowContextValue>({
+  operations: [],
+  selectedOperationId: DEFAULT_OPERATION_ID,
+  selectOperation: () => {},
+  workflowFor: () => EMPTY_STATE
 });
 
-export const BuilderWorkflowProvider: React.FC<{
+export interface BuilderWorkflowProviderProps {
+  /** The host workflow's bindable surface. */
   value: WorkflowState;
+  /** The document's operations. Empty for an app with none bound yet. */
+  operations?: ReadonlyArray<OperationBinding>;
+  /**
+   * The bindable surface per operation id, for apps whose operations run
+   * different workflows. An operation absent here falls back to the host.
+   */
+  states?: ReadonlyMap<string, WorkflowState>;
   children: React.ReactNode;
-}> = ({ value, children }) => (
-  <BuilderWorkflowContext.Provider value={value}>
-    {children}
-  </BuilderWorkflowContext.Provider>
-);
+}
 
-export const useBuilderWorkflow = (): WorkflowState =>
+export const BuilderWorkflowProvider: React.FC<BuilderWorkflowProviderProps> = ({
+  value,
+  operations = [],
+  states,
+  children
+}) => {
+  const [selected, setSelected] = useState<string | null>(null);
+  const selectedOperationId =
+    selected && operations.some((op) => op.id === selected)
+      ? selected
+      : operations[0]?.id ?? DEFAULT_OPERATION_ID;
+
+  const workflowFor = useCallback(
+    (operationId?: string): WorkflowState => {
+      if (!operationId) return value;
+      return states?.get(operationId) ?? value;
+    },
+    [states, value]
+  );
+
+  const context = useMemo<BuilderWorkflowContextValue>(
+    () => ({
+      operations,
+      selectedOperationId,
+      selectOperation: setSelected,
+      workflowFor
+    }),
+    [operations, selectedOperationId, value, workflowFor]
+  );
+
+  return (
+    <BuilderWorkflowContext.Provider value={context}>
+      {children}
+    </BuilderWorkflowContext.Provider>
+  );
+};
+
+/** The bindable surface of the operation currently being bound against. */
+export const useBuilderWorkflow = (): WorkflowState => {
+  const { selectedOperationId, workflowFor } = useContext(
+    BuilderWorkflowContext
+  );
+  return workflowFor(selectedOperationId);
+};
+
+/** The document's operations plus the one the pickers write bindings against. */
+export const useBuilderOperations = (): BuilderWorkflowContextValue =>
   useContext(BuilderWorkflowContext);
 
 /**
  * The same scope the runtime resolves bindings against, so the editor's
- * pickers can normalize a stored binding (a legacy name or an ID token) to one
- * canonical form before matching it against their options.
+ * pickers can normalize a stored binding (a legacy name, a legacy `main` token,
+ * or an ID token) to one canonical form before matching it against their
+ * options.
  */
 export const useBuilderBindingScope = (): BindingScope => {
-  const { inputs, outputs, variables, nodes } = useBuilderWorkflow();
-  return useMemo(
-    () => ({
-      defaultOperationId: DEFAULT_OPERATION_ID,
-      operations: [
-        {
-          operationId: DEFAULT_OPERATION_ID,
-          inputs: inputs.map(({ nodeId, name }) => ({ nodeId, name })),
-          outputs: outputs.map(({ nodeId, name }) => ({ nodeId, name })),
-          nodeIds: nodes.map((n) => n.id),
-          variableNames: variables
-        }
-      ],
+  const { operations, workflowFor } = useContext(BuilderWorkflowContext);
+  // `workflowFor` is rebuilt whenever the host graph or an operation's graph
+  // changes, so it alone keeps the scope current.
+  return useMemo(() => {
+    const ids =
+      operations.length > 0
+        ? operations.map((op) => op.id)
+        : [DEFAULT_OPERATION_ID];
+    return {
+      defaultOperationId: ids[0],
+      operations: ids.map((operationId) => {
+        const state = workflowFor(operationId);
+        return {
+          operationId,
+          inputs: state.inputs.map(({ nodeId, name }) => ({ nodeId, name })),
+          outputs: state.outputs.map(({ nodeId, name }) => ({ nodeId, name })),
+          nodeIds: state.nodes.map((n) => n.id),
+          variableNames: state.variables
+        };
+      }),
       variables: []
-    }),
-    [inputs, outputs, variables, nodes]
-  );
+    };
+  }, [operations, workflowFor]);
 };

--- a/web/src/components/appbuilder/puck/PuckAppEditor.tsx
+++ b/web/src/components/appbuilder/puck/PuckAppEditor.tsx
@@ -15,7 +15,7 @@ import TuneIcon from "@mui/icons-material/Tune";
 import { Workflow } from "../../../stores/ApiTypes";
 import { NodeContext } from "../../../contexts/NodeContext";
 import { useWorkflowManager } from "../../../contexts/WorkflowManagerContext";
-import { extractWorkflowState } from "../workflowState";
+import { extractWorkflowState, type WorkflowState } from "../workflowState";
 import { useAppRuntime } from "../runtime/useAppRuntime";
 import { AppRuntimeContext } from "../runtime/AppRuntimeContext";
 import { BuilderWorkflowProvider } from "./BuilderWorkflowContext";
@@ -23,7 +23,12 @@ import { appConfig } from "./config";
 import PuckAgentBinder from "./PuckAgentBinder";
 import { generateAppData } from "../generateAppDoc";
 import { isRenderableData } from "../appData";
-import { EMPTY_DOC_META, type AppDocMeta } from "@nodetool-ai/app-runtime";
+import {
+  APP_SCHEMA_VERSION,
+  EMPTY_DOC_META,
+  type AppDocMeta,
+  type ApplicationDocument
+} from "@nodetool-ai/app-runtime";
 import {
   Box,
   Dialog,
@@ -52,6 +57,12 @@ interface PuckAppEditorProps {
   onMetaChange?: (next: AppDocMeta) => void;
   dataOpen?: boolean;
   onToggleData?: () => void;
+  /**
+   * The graph of every workflow the document's operations run, by workflow id.
+   * An operation whose workflow is missing binds against nothing — the host
+   * workflow's surface is not another operation's.
+   */
+  operationWorkflows?: Record<string, Workflow>;
 }
 
 /**
@@ -168,17 +179,49 @@ const PuckAppEditor: React.FC<PuckAppEditorProps> = ({
   meta = EMPTY_DOC_META,
   onMetaChange,
   dataOpen = false,
-  onToggleData
+  onToggleData,
+  operationWorkflows
 }) => {
   const workflowState = useMemo(
     () => extractWorkflowState(workflow, meta.resources),
     [workflow, meta.resources]
   );
+
+  // One bindable surface per declared operation, so a widget bound to the
+  // second operation is offered that workflow's inputs and outputs.
+  const operationStates = useMemo(() => {
+    const states = new Map<string, WorkflowState>();
+    for (const operation of meta.operations) {
+      const target =
+        operation.workflowId === workflow.id
+          ? workflow
+          : operationWorkflows?.[operation.workflowId];
+      states.set(operation.id, extractWorkflowState(target, meta.resources));
+    }
+    return states;
+  }, [meta.operations, meta.resources, operationWorkflows, workflow]);
+
+  // The design canvas resolves bindings against the document's real operations,
+  // not an implicit one — otherwise a widget bound to `operation_1` renders as
+  // unbound in the builder.
+  const designDocument = useMemo<ApplicationDocument>(
+    () => ({
+      schemaVersion: APP_SCHEMA_VERSION,
+      ui: data as ApplicationDocument["ui"],
+      operations: meta.operations,
+      resources: meta.resources,
+      variables: meta.variables
+    }),
+    [data, meta]
+  );
   const handleMetaChange = useCallback(
     (next: AppDocMeta) => onMetaChange?.(next),
     [onMetaChange]
   );
-  const designRuntime = useAppRuntime(workflow, true);
+  const designRuntime = useAppRuntime(workflow, true, {
+    document: designDocument,
+    workflowOverrides: operationWorkflows
+  });
   // Property components resolved by WorkflowInputWidget (AudioProperty) read
   // the workflow's node store via NodeContext — same wrap as the runtime view.
   const nodeStore = useWorkflowManager((s) => s.nodeStores[workflow.id]);
@@ -254,7 +297,11 @@ const PuckAppEditor: React.FC<PuckAppEditorProps> = ({
 
   return (
     <NodeContext.Provider value={nodeStore ?? null}>
-      <BuilderWorkflowProvider value={workflowState}>
+      <BuilderWorkflowProvider
+        value={workflowState}
+        operations={meta.operations}
+        states={operationStates}
+      >
         <AppRuntimeContext.Provider value={designRuntime}>
           <Box
             className={`appbuilder-editor${

--- a/web/src/components/appbuilder/puck/config.tsx
+++ b/web/src/components/appbuilder/puck/config.tsx
@@ -8,6 +8,7 @@ import { useAppRuntimeContext } from "../runtime/AppRuntimeContext";
 import {
   bindingField,
   conditionField,
+  operationField,
   resourceBindingField,
   variableField
 } from "./fields";
@@ -119,7 +120,10 @@ const eventsField = (
         }
       : {}),
     key: variableField("State variable"),
-    value: { type: "text", label: "Value" }
+    value: { type: "text", label: "Value" },
+    // Which workflow a run/cancel drives. Only rendered by a multi-operation
+    // app; otherwise the event runs the app's sole operation.
+    operationId: operationField("Operation")
   },
   defaultItemProps: {
     trigger,

--- a/web/src/components/appbuilder/puck/fields.tsx
+++ b/web/src/components/appbuilder/puck/fields.tsx
@@ -14,7 +14,6 @@ import type { AutocompleteOption } from "../../ui_primitives";
 import useMetadataStore from "../../../stores/MetadataStore";
 import type { Property } from "../../../stores/ApiTypes";
 import {
-  DEFAULT_OPERATION_ID,
   encodeBinding,
   parseBinding,
   resolveBinding,
@@ -31,12 +30,74 @@ import {
 import { getSlotFields, updateComponentProps } from "./puckDataOps";
 import {
   useBuilderBindingScope,
+  useBuilderOperations,
   useBuilderWorkflow
 } from "./BuilderWorkflowContext";
+import type { WorkflowState } from "../workflowState";
 import type { WorkflowInputIO } from "../workflowIO";
 
 type Option = { label: string; value: string };
 const NONE: Option = { label: "— none —", value: "" };
+
+/**
+ * The operation a picker binds against, and that operation's graph surface.
+ *
+ * A stored binding carries its own operation, so editing an existing binding
+ * stays on the operation it was authored for; a fresh one goes to the operation
+ * the author selected. An operation the document no longer declares (a legacy
+ * `main` token among them) falls back to the selection, which resolves such a
+ * binding onto the app's sole operation.
+ */
+const useBindingOperation = (
+  binding: string
+): {
+  operationId: string;
+  operations: ReadonlyArray<{ id: string; name: string }>;
+  workflow: WorkflowState;
+  select: (operationId: string) => void;
+} => {
+  const { operations, selectedOperationId, selectOperation, workflowFor } =
+    useBuilderOperations();
+  const stored = parseBinding(binding);
+  const named =
+    stored && "operationId" in stored ? stored.operationId : undefined;
+  const operationId =
+    named && operations.some((op) => op.id === named)
+      ? named
+      : selectedOperationId;
+  return {
+    operationId,
+    operations: operations.map(({ id, name }) => ({ id, name })),
+    workflow: workflowFor(operationId),
+    select: selectOperation
+  };
+};
+
+/**
+ * Operation chooser, shown only when the app binds more than one — a
+ * single-operation app has nothing to choose. Switching clears the binding:
+ * another operation runs another graph, so the picked node does not carry over.
+ */
+const OperationSelect: React.FC<{
+  operations: ReadonlyArray<{ id: string; name: string }>;
+  value: string;
+  readOnly?: boolean;
+  onChange: (operationId: string) => void;
+}> = ({ operations, value, readOnly, onChange }) => {
+  if (operations.length < 2) return null;
+  return (
+    <SelectField
+      label="Operation"
+      value={value}
+      options={operations.map((op) => ({
+        label: op.name || op.id,
+        value: op.id
+      }))}
+      disabled={readOnly}
+      onChange={onChange}
+    />
+  );
+};
 
 /**
  * Normalize a stored binding to its ID form. Documents written before ID-based
@@ -114,14 +175,16 @@ const ReadBindingPicker: React.FC<{
   readOnly?: boolean;
   onChange: (value: string) => void;
 }> = ({ label, value, readOnly, onChange }) => {
-  const { outputs, variables } = useBuilderWorkflow();
+  const { operationId, operations, workflow, select } =
+    useBindingOperation(value);
+  const { outputs, variables } = workflow;
   const scope = useBuilderBindingScope();
   const options: Option[] = [
     ...outputs.map((o) => ({
       label: `output · ${o.label}`,
       value: encodeBinding({
         kind: "output",
-        operationId: DEFAULT_OPERATION_ID,
+        operationId,
         nodeId: o.nodeId
       })
     })),
@@ -129,20 +192,31 @@ const ReadBindingPicker: React.FC<{
       label: `variable · ${v}`,
       value: encodeBinding({ kind: "variable", variableId: v })
     })),
-    ...EXECUTION_OPTIONS
+    ...executionOptions(operationId)
   ];
   return (
-    <Picker
-      label={label}
-      value={canonicalBinding(value, scope, "read")}
-      options={options}
-      // Execution fields are always bindable, so "nothing to bind" is about
-      // the workflow's own outputs and variables.
-      hintVisible={outputs.length === 0 && variables.length === 0}
-      emptyHint="Add an Output node or Set Variable node to the workflow."
-      readOnly={readOnly}
-      onChange={onChange}
-    />
+    <FlexColumn gap={0.5}>
+      <OperationSelect
+        operations={operations}
+        value={operationId}
+        readOnly={readOnly}
+        onChange={(next) => {
+          select(next);
+          onChange("");
+        }}
+      />
+      <Picker
+        label={label}
+        value={canonicalBinding(value, scope, "read")}
+        options={options}
+        // Execution fields are always bindable, so "nothing to bind" is about
+        // the workflow's own outputs and variables.
+        hintVisible={outputs.length === 0 && variables.length === 0}
+        emptyHint="Add an Output node or Set Variable node to the workflow."
+        readOnly={readOnly}
+        onChange={onChange}
+      />
+    </FlexColumn>
   );
 };
 
@@ -199,7 +273,9 @@ const WriteBindingPicker: React.FC<{
   readOnly?: boolean;
   onChange: (value: string) => void;
 }> = ({ label, value, readOnly, onChange }) => {
-  const { inputs, nodes } = useBuilderWorkflow();
+  const { operationId, operations, workflow, select } =
+    useBindingOperation(value);
+  const { inputs, nodes } = workflow;
   const scope = useBuilderBindingScope();
   const getMetadata = useMetadataStore((s) => s.getMetadata);
   const getPuck = useGetPuck();
@@ -209,7 +285,7 @@ const WriteBindingPicker: React.FC<{
       label: `input · ${input.label}`,
       value: encodeBinding({
         kind: "input",
-        operationId: DEFAULT_OPERATION_ID,
+        operationId,
         nodeId: input.nodeId
       }),
       group: INPUTS_GROUP,
@@ -249,7 +325,7 @@ const WriteBindingPicker: React.FC<{
           label: `${group} · ${rowLabel}`,
           value: encodeBinding({
             kind: "nodeProperty",
-            operationId: DEFAULT_OPERATION_ID,
+            operationId,
             nodeId: node.id,
             property: prop.name
           }),
@@ -261,7 +337,7 @@ const WriteBindingPicker: React.FC<{
     }
 
     return [...inputOptions, ...nodeOptions];
-  }, [inputs, nodes, getMetadata]);
+  }, [inputs, nodes, getMetadata, operationId]);
 
   const { selectedOption, resolvedOptions } = useMemo(() => {
     const canonical = canonicalBinding(value, scope, "write");
@@ -322,6 +398,15 @@ const WriteBindingPicker: React.FC<{
 
   return (
     <FlexColumn gap={0.5}>
+      <OperationSelect
+        operations={operations}
+        value={operationId}
+        readOnly={readOnly}
+        onChange={(next) => {
+          select(next);
+          onChange("");
+        }}
+      />
       <Autocomplete<BindingOption>
         label={label}
         placeholder="Search inputs and node properties…"
@@ -347,6 +432,47 @@ const WriteBindingPicker: React.FC<{
         </Caption>
       )}
     </FlexColumn>
+  );
+};
+
+/**
+ * Which operation a run/cancel event drives. The document's own operations are
+ * the options — an app is not assumed to have one called `main`. Renders
+ * nothing while the app binds a single operation: there is nothing to choose,
+ * and an event that names none runs that one.
+ */
+export const operationField = (label = "Operation"): CustomField<string> => ({
+  type: "custom",
+  label,
+  render: ({ value, onChange, readOnly }) => (
+    <EventOperationPicker
+      label={label}
+      value={value ?? ""}
+      readOnly={readOnly}
+      onChange={onChange}
+    />
+  )
+});
+
+const EventOperationPicker: React.FC<{
+  label: string;
+  value: string;
+  readOnly?: boolean;
+  onChange: (value: string) => void;
+}> = ({ label, value, readOnly, onChange }) => {
+  const { operations } = useBuilderOperations();
+  if (operations.length < 2) return null;
+  return (
+    <SelectField
+      label={label}
+      value={operations.some((op) => op.id === value) ? value : ""}
+      options={[
+        { label: "— default —", value: "" },
+        ...operations.map((op) => ({ label: op.name || op.id, value: op.id }))
+      ]}
+      disabled={readOnly}
+      onChange={onChange}
+    />
   );
 };
 
@@ -414,21 +540,18 @@ const OPS_WITH_VALUE = new Set([
  * What a run reports about itself. Bindable from any read widget (a Text
  * showing the agent's current step) and from a condition.
  */
-const EXECUTION_OPTIONS: Option[] = (
-  [
-    ["running", "is running"],
-    ["progress", "progress"],
-    ["error", "error"],
-    ["activity", "activity"]
-  ] as const
-).map(([field, label]) => ({
-  label: `run · ${label}`,
-  value: encodeBinding({
-    kind: "execution",
-    operationId: DEFAULT_OPERATION_ID,
-    field
-  })
-}));
+const EXECUTION_FIELDS = [
+  ["running", "is running"],
+  ["progress", "progress"],
+  ["error", "error"],
+  ["activity", "activity"]
+] as const;
+
+const executionOptions = (operationId: string): Option[] =>
+  EXECUTION_FIELDS.map(([field, label]) => ({
+    label: `run · ${label}`,
+    value: encodeBinding({ kind: "execution", operationId, field })
+  }));
 
 /**
  * Condition field: a state reference, an operator, and (for comparisons) a
@@ -456,14 +579,17 @@ const ConditionEditor: React.FC<{
   readOnly?: boolean;
   onChange: (value: ConditionProps) => void;
 }> = ({ label, value, readOnly, onChange }) => {
-  const { inputs, outputs, variables } = useBuilderWorkflow();
+  const { operationId, operations, workflow, select } = useBindingOperation(
+    value.binding ?? ""
+  );
+  const { inputs, outputs, variables } = workflow;
   const scope = useBuilderBindingScope();
   const options: Option[] = [
     ...outputs.map((o) => ({
       label: `output · ${o.label}`,
       value: encodeBinding({
         kind: "output",
-        operationId: DEFAULT_OPERATION_ID,
+        operationId,
         nodeId: o.nodeId
       })
     })),
@@ -471,7 +597,7 @@ const ConditionEditor: React.FC<{
       label: `input · ${i.label}`,
       value: encodeBinding({
         kind: "input",
-        operationId: DEFAULT_OPERATION_ID,
+        operationId,
         nodeId: i.nodeId
       })
     })),
@@ -479,11 +605,20 @@ const ConditionEditor: React.FC<{
       label: `variable · ${v}`,
       value: encodeBinding({ kind: "variable", variableId: v })
     })),
-    ...EXECUTION_OPTIONS
+    ...executionOptions(operationId)
   ];
   const op = value.op ?? "notEmpty";
   return (
     <FlexColumn gap={0.5}>
+      <OperationSelect
+        operations={operations}
+        value={operationId}
+        readOnly={readOnly}
+        onChange={(next) => {
+          select(next);
+          onChange({ ...value, binding: "" });
+        }}
+      />
       <Picker
         label={label}
         value={canonicalBinding(value.binding ?? "", scope, "none")}

--- a/web/src/components/appbuilder/runtime/useAppRuntime.ts
+++ b/web/src/components/appbuilder/runtime/useAppRuntime.ts
@@ -667,7 +667,7 @@ export const useAppRuntime = (
             // workflow limit rather than queue behind the run in flight.
             entry.operation.policy === "parallel",
             undefined,
-            { application }
+            { application, operationId }
           );
         claimInvocation(operationId, jobId, true);
       } catch (error) {

--- a/web/src/stores/WorkflowRunner.ts
+++ b/web/src/stores/WorkflowRunner.ts
@@ -97,6 +97,8 @@ const buildRunJobData = (opts: {
   concurrent?: boolean;
   /** Set when a mini app started this run, so the server meters it. */
   application?: { id: string; version?: number };
+  /** The app operation this run implements, so the ledger row carries it. */
+  operationId?: string;
 }): RunJobRequest & { settings?: Record<string, unknown>; job_id: string; concurrent?: boolean; graph: WorkflowGraph } => {
   const activeNodes: Node<NodeData>[] = [];
   const bypassedNodeIds = new Set<string>();
@@ -131,7 +133,8 @@ const buildRunJobData = (opts: {
     job_id: opts.jobId,
     concurrent: opts.concurrent,
     application_id: opts.application?.id ?? null,
-    application_version: opts.application?.version ?? null
+    application_version: opts.application?.version ?? null,
+    operation_id: opts.operationId ?? null
   };
 };
 
@@ -139,6 +142,12 @@ const buildRunJobData = (opts: {
 export interface RunOptions {
   /** The mini app this run belongs to; drives the server-side budget check. */
   application?: { id: string; version?: number };
+  /**
+   * The app operation this run implements. Recorded on the app's ledger row so
+   * spend can be reported per operation instead of per app. Only meaningful
+   * alongside `application`.
+   */
+  operationId?: string;
 }
 
 export type WorkflowRunner = {
@@ -522,7 +531,8 @@ export const createWorkflowRunnerStore = (
         authToken: auth_token,
         userId: user,
         concurrent,
-        application: options?.application
+        application: options?.application,
+        operationId: options?.operationId
       });
 
       if (queueRun) {

--- a/web/src/stores/__tests__/WorkflowRunner.test.ts
+++ b/web/src/stores/__tests__/WorkflowRunner.test.ts
@@ -461,5 +461,36 @@ describe("WorkflowRunner", () => {
         })
       );
     });
+
+    it("sends the app operation so the ledger row records which one ran", async () => {
+      randomUUIDMock.mockReturnValueOnce("job-op");
+      await store
+        .getState()
+        .run({}, testWorkflow, [], [], undefined, undefined, undefined, undefined, {
+          application: { id: "app-1", version: 2 },
+          operationId: "draft"
+        });
+      expect(globalWebSocketManager.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "run_job",
+          data: expect.objectContaining({
+            application_id: "app-1",
+            application_version: 2,
+            operation_id: "draft"
+          })
+        })
+      );
+    });
+
+    it("sends a null operation for a run no app started", async () => {
+      randomUUIDMock.mockReturnValueOnce("job-no-op");
+      await store.getState().run({}, testWorkflow, [], []);
+      expect(globalWebSocketManager.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "run_job",
+          data: expect.objectContaining({ operation_id: null })
+        })
+      );
+    });
   });
 });


### PR DESCRIPTION
Fixes seven issues in the Mini Apps platform: four release-blocking, three correctness gaps. Each is a separate commit.

## P1 — Deleted application data can be inherited by another user

Application ids are client-supplied, and deleting an app removed only the parent `applications` row. Versions, budgets, invocations and pinned workflow graphs had no ownership column and no cascading foreign key. A user who knew a deleted app's id could recreate it under their own account: the ownership check passed against the new parent row while child reads returned the previous owner's orphaned releases and usage data.

- Real FKs with `ON DELETE CASCADE` from every child table, in both the SQLite and Postgres schemas.
- `Application.delete()` erases children in one transaction. FK enforcement is per connection, so the cascade is declared *and* performed rather than assumed — better-sqlite3 does enable the pragma by default, which a test now pins.
- `application_versions` and `application_invocations` carry a `user_id` stamped from the parent; the reads that take only an application id filter on it, and the tRPC router and websocket runner pass the caller's id. Rows predating the migration have a null `user_id` and stay visible.
- Ids are validated and claimed through an insert that fails on reuse (`ApplicationIdInUseError`) instead of an upsert. An id held by another user returns `NOT_FOUND`, so the error doesn't leak its existence.
- Migration `20260801_000000` deletes orphans, backfills `user_id`, dedupes, and rebuilds with the constraints. Idempotent on re-run.

## P1 — Publishing and rollback are non-atomic

Publishing read `MAX(version)`, cleared the released flag and inserted the new row as separate statements, with nothing in the schema forbidding a duplicate version or a second released row. Concurrent publishes could produce either, leaving the released lookup to pick arbitrarily. Rollback to a nonexistent version cleared the current release first and could leave the app with nothing released.

- Each transition is one transaction; Postgres locks the parent row `FOR UPDATE` to serialize publishers.
- `UNIQUE (application_id, version)`, with the migration deduping first.
- Rollback verifies the target exists and belongs to the app *before* clearing anything.
- The released lookup orders by version rather than trusting a single flag.

## P1 — Blank and custom-operation apps produce broken bindings

The builder wrote every binding against the operation `main`, but a blank app's first operation is created as "Operation 1" and slugified to `operation_1`. The runtime keys inputs and outputs `opId:nodeId`, so controls bound to `main:*` never reached the run and outputs never updated. The same literal made a second workflow-backed operation impossible to author.

- The builder context carries the document's operations and a selected one; each binding persists the id it actually targets.
- Multi-operation apps get an operation picker on read/write/condition fields and on run/cancel events; single-operation apps render unchanged.
- Documents already saved with `main` still resolve: `resolveBinding` maps that token onto the sole declared operation when the scope has exactly one and it isn't named `main`. Resolution happens on read — no saved document is rewritten — and any other operation id passes through untouched.

## P1 — Mobile Mini Apps bypass application budgets and telemetry

Mobile loaded the released snapshot but sent neither `application_id` nor `application_version`, and the server's budget gate permits requests without an application id. Every mobile run of a released app escaped its reservation, spending cap, ledger row and settlement. The identity now threads from the loaded snapshot through to the run request; a draft run sends a null version, which the server reads as "app run, not a release run".

## P2 — Mobile could attach a job to the wrong invocation

Mobile minted no job id: the first message with an unrecognized job id claimed the oldest pending invocation, so parallel runs — or any other workflow on the same connection — could deliver status and outputs to the wrong operation. The runtime now mints the id before dispatch, sends it as `job_id` (which the server honours), and folds a message only when it already owns that job id.

## P2 — Stale released clients recorded as running the current release

A client running a cached release claimed its own version, the server logged the mismatch, then reserved and ledgered the run against whatever is released now — while executing the client's graph. Release metrics and budget attribution described a version the run never touched.

The server now checks the claim against the app's version history. A real past version is honoured and recorded; a version the app never had is refused with `INVALID_INPUT`, matching the existing "no released version" refusal. The client still cannot invent its own attribution — a number is only trusted once found in the history — and a stale client gets a warning notification telling it to reload.

## P2 — Production runs omit operation-level telemetry

Runs carried no operation id, so every reservation landed under the ledger's empty-string default and per-operation reports were flat. `operation_id` is now optional on `RunJobRequest` and threaded from both the web and mobile app runtimes through to `reserveInvocation`, defaulting to the old value for clients that omit it.

## Not addressed here

Two points from the review are scope decisions rather than defects, and are left alone deliberately:

- Publishing still behaves as owner-only version management rather than distribution — released document access is ownership-gated and no route serves another user's application.
- Mobile supports only the first workflow-backed operation.

Both should be documented or built out before Mini Apps are described as shareable applications. Happy to do either in a follow-up.

## Verification

`npm run typecheck`, `npm run lint` and `npm run test` all pass on a freshly built tree — 1063 + 63 + 73 suites, ~14,145 tests, exit 0.

New tests cover: cascade deletion removes children and a reclaimed id sees nothing; id reuse and malformed ids are rejected; publish is atomic with one released row and no duplicate versions; rollback to a missing version leaves the current release standing; migration orphan-cleanup, backfill and dedupe; blank-app bindings target the generated operation id; a two-operation app binds each widget to its own operation; legacy `main` bindings still resolve; the mobile run request carries release identity; concurrent mobile runs route to the correct invocation and an unknown job id is ignored; a run claiming a real older version is ledgered against it while a nonexistent version is refused; `operation_id` reaches the reservation.

Note for reviewers: `packages/models`'s migration count assertion moved 54 → 55, and `application-budget-gate.test.ts` gained `seedApp()` calls in one `beforeEach` — its "invocation settlement" block seeded no parent rows, which the new foreign key made fail.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Su7dXD6fnXtKKbdCcM2vS)_