### PR TITLE
Workflow Supervisor phase A: the escalation mechanism

### DIFF
--- a/docs/workflow-supervisor-design.md
+++ b/docs/workflow-supervisor-design.md
@@ -68,6 +68,7 @@ export interface Escalation {
   spentCostUsd: number;            // provider cost recorded by this invocation
   createdAssets: boolean;
   retrySafe: boolean;              // node metadata opt-in; unknown ⇒ false ⇒ no retry
+  emitted: boolean;                // streaming: the invocation already sent something downstream (§5.4)
 }
 
 export type Verdict =
@@ -102,7 +103,7 @@ Status stays the existing enum. "Completed — supervised" is `status: "complete
 
 ### 5.1 Where it sits
 
-`ProcessingContext` gains one optional member, `escalate?: (e: Escalation) => Promise<Verdict>`, wired by `WorkflowRunner` from a new option:
+`WorkflowRunner` takes the handle as an option and hands it to each `NodeActor`, alongside the callback that records interventions. The handle stays in the kernel rather than on `ProcessingContext`: node code has no business raising or answering escalations, and the actor already holds everything the escalation constructor needs. What the context *does* gain is the resolved-secret registry the constructor masks against (§6.1) and per-invocation cost/asset accounting (§5.3).
 
 ```ts
 export interface WorkflowRunnerOptions {
@@ -111,8 +112,15 @@ export interface WorkflowRunnerOptions {
 }
 
 export interface SupervisorHandle {
-  decide(e: Escalation, signal: AbortSignal): Promise<Verdict>;
+  decide(e: Escalation, signal: AbortSignal): Promise<DecisionOutcome>;
   close(): void;
+}
+
+/** The verdict, who made it, and what it cost — the intervention record minus its escalation. */
+export interface DecisionOutcome {
+  verdict: Verdict;
+  decidedBy: "agent" | "sticky" | "bounds" | "default";
+  costUsd?: number;
 }
 ```
 

--- a/docs/workflow-supervisor-implementation-plan.md
+++ b/docs/workflow-supervisor-implementation-plan.md
@@ -19,7 +19,11 @@ PRs marked ∥ can proceed in parallel once their listed dependency lands.
 
 ---
 
-## Phase A — the mechanism (kernel, no LLM)
+## Phase A — the mechanism (kernel, no LLM) — **shipped**
+
+PR 1 and PR 2 landed together: PR 1's allowed-set enforcement is only as good as
+PR 2's invocation-scoped cost tracking, so shipping the first without the second
+would have meant a window where `retry` was offered after a billed call.
 
 ### PR 1 — Escalation types and the actor hook
 
@@ -35,7 +39,7 @@ The seam, fail-closed. Zero behavior change.
 - node-sdk: `RecoverableNodeError` (carries the malformed candidate output, redacted at construction like everything else) and the `retrySafe` node-metadata **opt-in**; declare it across the pure-compute and read-only node categories in shipped packages. `WorkflowNode`/`SubgraphNode` stay unsafe. Unknown ⇒ no retry.
 - `packages/kernel/src/runner.ts`: `WorkflowRunnerOptions.supervisor`, wire `escalate` onto the execution context, `interventions` on `RunResult`.
 - `packages/kernel/src/actor.ts`: wrap invocation execution per design §5.1 — buffered/correlated path first, controlled path second. `WorkflowSuspendedError` passes through untouched. Skip = `drop()` per output slot (design §5.2), never a bare return.
-- **Audit while in here:** provider-level transient retry in `packages/runtime/src/providers/` (design §10.3). File issues per gap; fixes land in runtime, not this PR.
+- **Audit while in here:** provider-level transient retry in `packages/runtime/src/providers/` (design §10.3). Done — [workflow-supervisor-provider-retry-audit.md](workflow-supervisor-provider-retry-audit.md). Gemini and Ollama have no backoff at all and would flood the supervisor with escalations a 2-second wait would fix; the fixes land in runtime, not here.
 - Tests (`packages/kernel/tests/`): scripted `SupervisorHandle` doubles driving every verdict against fan-out, controlled, and single-fire nodes; retry re-invokes with identical inputs and properties; **skip on a correlated key prunes a downstream join whose other input already buffered** (the lineage_done case) plus the iterator→aggregate scope-closure case; no-supervisor runs byte-identical to before (message-stream snapshot).
 
 ### PR 2 — Bounds, retry safety, streaming carve-out

--- a/docs/workflow-supervisor-provider-retry-audit.md
+++ b/docs/workflow-supervisor-provider-retry-audit.md
@@ -1,0 +1,63 @@
+# Provider Transient-Retry Audit
+
+**Status:** findings only — fixes land in `packages/runtime`, not in the supervisor.
+**Last updated:** 2026-08-01
+**Design:** [workflow-supervisor-design.md](workflow-supervisor-design.md) §10.3
+**Plan:** [workflow-supervisor-implementation-plan.md](workflow-supervisor-implementation-plan.md) PR 1
+
+The supervisor wakes only when a node's own error handling is exhausted (PRD
+scenario 1). That premise is load-bearing: a provider without backoff turns
+every 429 into an LLM decision costing real money, on a failure a 2-second wait
+would have fixed. This audit establishes where the premise holds today.
+
+## Where retry lives
+
+`OpenAICompatClient.post` (`packages/runtime/src/providers/openai-compat/client.ts:114`)
+is the only shared mechanism: 2 retries over `408/409/429/5xx` and network
+errors, jittered exponential backoff 500ms → 8s, `Retry-After` honored and
+bounded to 60s. Every OpenAI-compatible provider inherits it, and no subclass
+overrides the budget.
+
+The vendor SDKs supply their own: `openai` and `@anthropic-ai/sdk` default to
+`maxRetries = 2`, `replicate` to 5. NodeTool overrides this in exactly one
+place — `anthropic-provider.ts:470` disables SDK retry for `models.list` and
+hand-rolls a better loop for it. Inference paths keep the defaults.
+
+Three files re-implement `fetchWithRetry` and `Retry-After` parsing
+independently (`openai-compat/client.ts:51`, `topaz-provider.ts:60`,
+`atlascloud-provider.ts:73`, `anthropic-provider.ts:62`).
+
+## Gaps
+
+| Provider | Transient retry | Mechanism |
+|---|---|---|
+| openai, codex, anthropic | yes | vendor SDK, `maxRetries = 2` |
+| the OpenAI-compat family (groq, mistral, xai, openrouter, together, vllm, lmstudio, …) | chat only | `OpenAICompatClient.post` |
+| atlascloud, topaz | yes | compat client + local `fetchWithRetry` |
+| replicate | partial | SDK; non-GET retries `429` only |
+| claude agent sdk | opaque | SDK subprocess retries; `api_retry` events unobserved |
+| **gemini, ollama** | **none** | raw `fetch` |
+| **cohere, jina, voyage, huggingface, elevenlabs, fal, kie, reve, meshy, rodin** | **none** | raw `fetch` / SDK without retry |
+
+Two structural holes beyond the table:
+
+- **No provider resumes a stream that dies after the first byte**
+  (`openai-compat/client.ts:107`). Retry covers connection setup only, so
+  design §5.4's "threw after emitting" case is permanently non-retryable below
+  the hook — which is why `end_stream` exists rather than a retry.
+- **`base-provider.ts:1369` `isRateLimitError` is dead code** — tested, never
+  called. Nothing classifies a 429 before it reaches the escalation path, and
+  `generateLoop` (`base-provider.ts:844`) has no rate-limit handling at all.
+
+## Follow-up work (runtime, not supervisor)
+
+1. Extract the compat client's retry into one exported helper and re-point the
+   three duplicate `fetchWithRetry`s and four `Retry-After` parsers at it.
+2. Wrap Gemini's and Ollama's chat entry points in it. These are first-class
+   chat providers reachable by the supervisor, and today every 429 from them
+   becomes an escalation.
+3. Extend to the embedding and media providers with none, keeping
+   non-idempotent POSTs excluded the way `atlascloud-provider.ts:188` documents.
+4. Use or delete `isRateLimitError`.
+5. Surface retry attempts as telemetry — including the agent SDK's `api_retry`
+   — so a supervised run can tell "waited and recovered" from "failed at once".

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,4 +1,9 @@
-export { IS_NODE, importNodeBuiltin, importHidden } from "./node-import.js";
+export {
+  IS_NODE,
+  safeProcessEnv,
+  importNodeBuiltin,
+  importHidden
+} from "./node-import.js";
 
 export {
   loadEnvironment,
@@ -13,7 +18,6 @@ export {
   isGoogleWorkspaceEnabled,
   GOOGLE_WORKSPACE_NAMESPACE
 } from "./google-workspace.js";
-
 
 export {
   registerSetting,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,7 @@
 export {
   IS_NODE,
   safeProcessEnv,
+  safeProcessPlatform,
   importNodeBuiltin,
   importHidden
 } from "./node-import.js";

--- a/packages/config/src/node-import.ts
+++ b/packages/config/src/node-import.ts
@@ -17,6 +17,16 @@ export const IS_NODE =
     "string";
 
 /**
+ * `process` is undefined in browser/edge runtimes, where a bare `process.env`
+ * read throws `ReferenceError` — including at module scope, which takes the
+ * whole bundle down at import time rather than at the call that wanted the
+ * variable. Any module that can end up in a browser graph reads env through
+ * this instead.
+ */
+export const safeProcessEnv = (): Record<string, string | undefined> =>
+  typeof process !== "undefined" && process.env ? process.env : {};
+
+/**
  * Dynamic import that bundlers can't statically resolve.
  *
  * The Function-constructor body hides the `import()` call from Vite /

--- a/packages/config/src/node-import.ts
+++ b/packages/config/src/node-import.ts
@@ -26,6 +26,12 @@ export const IS_NODE =
 export const safeProcessEnv = (): Record<string, string | undefined> =>
   typeof process !== "undefined" && process.env ? process.env : {};
 
+/** `process.platform`, or `""` where there is no `process`. */
+export const safeProcessPlatform = (): string =>
+  typeof process !== "undefined" && typeof process.platform === "string"
+    ? process.platform
+    : "";
+
 /**
  * Dynamic import that bundlers can't statically resolve.
  *

--- a/packages/core-nodes/src/nodes/constant.ts
+++ b/packages/core-nodes/src/nodes/constant.ts
@@ -37,6 +37,7 @@ interface ImageSizeValue {
 
 export class ConstantBaseNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Constant";
+  static readonly retrySafe = true;
   static readonly title = "Constant";
   static readonly description =
     "Base class for fixed-value nodes.\n    constant, parameter, default\n\n    Use cases:\n    - Provide static inputs to a workflow\n    - Hold configuration values\n    - Simplify testing with deterministic outputs";
@@ -48,6 +49,7 @@ export class ConstantBaseNode extends BaseNode {
 
 export class ConstantBoolNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Bool";
+  static readonly retrySafe = true;
   static readonly title = "Bool";
   static readonly description =
     "Represents a boolean constant in the workflow.\n    boolean, logic, flag\n\n    Use cases:\n    - Control flow decisions in conditional nodes\n    - Toggle features or behaviors in the workflow\n    - Set default boolean values for configuration";
@@ -67,6 +69,7 @@ export class ConstantBoolNode extends BaseNode {
 
 export class ConstantIntegerNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Integer";
+  static readonly retrySafe = true;
   static readonly title = "Integer";
   static readonly description =
     "Represents an integer constant in the workflow.\n    number, integer, whole\n\n    Use cases:\n    - Set numerical parameters for calculations\n    - Define counts, indices, or sizes\n    - Provide fixed numerical inputs for processing";
@@ -86,6 +89,7 @@ export class ConstantIntegerNode extends BaseNode {
 
 export class ConstantFloatNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Float";
+  static readonly retrySafe = true;
   static readonly title = "Float";
   static readonly description =
     "Represents a floating-point number constant in the workflow.\n    number, decimal, float\n\n    Use cases:\n    - Set numerical parameters for calculations\n    - Define thresholds or limits\n    - Provide fixed numerical inputs for processing";
@@ -105,6 +109,7 @@ export class ConstantFloatNode extends BaseNode {
 
 export class ConstantStringNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.String";
+  static readonly retrySafe = true;
   static readonly title = "String";
   static readonly description =
     "Represents a string constant in the workflow.\n    text, string, characters\n\n    Use cases:\n    - Provide fixed text inputs for processing\n    - Define labels, identifiers, or names\n    - Set default text values for configuration";
@@ -124,6 +129,7 @@ export class ConstantStringNode extends BaseNode {
 
 export class ConstantListNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.List";
+  static readonly retrySafe = true;
   static readonly title = "List";
   static readonly description =
     "Represents a list constant in the workflow.\n    array, sequence, collection\n\n    Use cases:\n    - Store multiple values of the same type\n    - Provide ordered data inputs\n    - Define sequences for iteration in other nodes";
@@ -143,6 +149,7 @@ export class ConstantListNode extends BaseNode {
 
 export class ConstantTextListNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.TextList";
+  static readonly retrySafe = true;
   static readonly title = "Text List";
   static readonly description =
     "Represents a list of text strings in the workflow.\n    texts, strings, text collection\n\n    Use cases:\n    - Provide a fixed list of text strings for batch processing\n    - Reference multiple text values in the workflow\n    - Set default text list for testing or demonstration purposes";
@@ -168,6 +175,7 @@ export class ConstantTextListNode extends BaseNode {
 
 export class ConstantDictNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Dict";
+  static readonly retrySafe = true;
   static readonly title = "Dict";
   static readonly description =
     "Represents a dictionary constant in the workflow.\n    dictionary, key-value, mapping\n\n    Use cases:\n    - Store configuration settings\n    - Provide structured data inputs\n    - Define parameter sets for other nodes";
@@ -187,6 +195,7 @@ export class ConstantDictNode extends BaseNode {
 
 export class ConstantAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Audio";
+  static readonly retrySafe = true;
   static readonly title = "Audio";
   static readonly description =
     "Represents an audio file constant in the workflow.\n    audio, file, mp3, wav\n\n    Use cases:\n    - Provide a fixed audio input for audio processing nodes\n    - Reference a specific audio file in the workflow\n    - Set default audio for testing or demonstration purposes";
@@ -210,6 +219,7 @@ export class ConstantAudioNode extends BaseNode {
 
 export class ConstantImageNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Image";
+  static readonly retrySafe = true;
   static readonly title = "Image";
   static readonly description =
     "Represents an image file constant in the workflow.\n    picture, photo, image\n\n    Use cases:\n    - Provide a fixed image input for image processing nodes\n    - Reference a specific image file in the workflow\n    - Set default image for testing or demonstration purposes";
@@ -233,6 +243,7 @@ export class ConstantImageNode extends BaseNode {
 
 export class ConstantVideoNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Video";
+  static readonly retrySafe = true;
   static readonly title = "Video";
   static readonly description =
     "Represents a video file constant in the workflow.\n    video, movie, mp4, file\n\n    Use cases:\n    - Provide a fixed video input for video processing nodes\n    - Reference a specific video file in the workflow\n    - Set default video for testing or demonstration purposes";
@@ -256,6 +267,7 @@ export class ConstantVideoNode extends BaseNode {
 
 export class ConstantDocumentNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Document";
+  static readonly retrySafe = true;
   static readonly title = "Document";
   static readonly description =
     "Represents a document constant in the workflow.\n    document, pdf, word, docx";
@@ -279,6 +291,7 @@ export class ConstantDocumentNode extends BaseNode {
 
 export class ConstantSketchNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Sketch";
+  static readonly retrySafe = true;
   static readonly title = "Sketch";
   static readonly description =
     "Layered sketch document for drawing, masking, and image composition.\n    sketch, drawing, canvas, paint, image editor\n\n    Use cases:\n    - Pass a sketch document between nodes\n    - Edit the sketch directly from the workflow canvas\n    - Expose flattened image, mask, and layer outputs for downstream nodes";
@@ -350,6 +363,7 @@ export class ConstantSketchNode extends BaseNode {
 
 export class ConstantTimelineNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Timeline";
+  static readonly retrySafe = true;
   static readonly title = "Timeline";
   static readonly description =
     "References a timeline sequence in the workflow.\n    timeline, video editor, sequence, clips, tracks\n\n    Use cases:\n    - Pass a timeline between nodes for video rendering or editing\n    - Open and edit the referenced timeline in the timeline editor\n    - Provide a fixed timeline input for downstream nodes";
@@ -373,6 +387,7 @@ export class ConstantTimelineNode extends BaseNode {
 
 export class ConstantScriptNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Script";
+  static readonly retrySafe = true;
   static readonly title = "Script";
   static readonly description =
     "References a script in the workflow.\n    script, voiceover, narration, cast, tts\n\n    Use cases:\n    - Pass a script between nodes for voicing or timeline assembly\n    - Open and edit the referenced script in the script editor\n    - Provide a fixed script input for downstream nodes";
@@ -396,6 +411,7 @@ export class ConstantScriptNode extends BaseNode {
 
 export class ConstantJSONNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.JSON";
+  static readonly retrySafe = true;
   static readonly title = "JSON";
   static readonly description =
     "Represents a JSON constant in the workflow.\n    json, object, dictionary";
@@ -419,6 +435,7 @@ export class ConstantJSONNode extends BaseNode {
 
 export class ConstantModel3DNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Model3D";
+  static readonly retrySafe = true;
   static readonly title = "Model 3D";
   static readonly description =
     "Represents a 3D model constant in the workflow.\n    3d, model, mesh, glb, obj, stl\n\n    Use cases:\n    - Provide a fixed 3D model input for processing nodes\n    - Reference a specific 3D model file in the workflow\n    - Set default 3D model for testing or demonstration purposes";
@@ -442,6 +459,7 @@ export class ConstantModel3DNode extends BaseNode {
 
 export class ConstantDataFrameNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.DataFrame";
+  static readonly retrySafe = true;
   static readonly title = "Data Frame";
   static readonly description =
     "Represents a fixed DataFrame constant in the workflow.\n    table, data, dataframe, pandas\n\n    Use cases:\n    - Provide static data for analysis or processing\n    - Define lookup tables or reference data\n    - Set sample data for testing or demonstration";
@@ -465,6 +483,7 @@ export class ConstantDataFrameNode extends BaseNode {
 
 export class ConstantAudioListNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.AudioList";
+  static readonly retrySafe = true;
   static readonly title = "Audio List";
   static readonly description =
     "Represents a list of audio file constants in the workflow.\n    audios, sounds, audio files, collection\n\n    Use cases:\n    - Provide a fixed list of audio files for batch processing\n    - Reference multiple audio files in the workflow\n    - Set default audio list for testing or demonstration purposes";
@@ -490,6 +509,7 @@ export class ConstantAudioListNode extends BaseNode {
 
 export class ConstantImageListNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.ImageList";
+  static readonly retrySafe = true;
   static readonly title = "Image List";
   static readonly description =
     "Represents a list of image file constants in the workflow.\n    pictures, photos, images, collection\n\n    Use cases:\n    - Provide a fixed list of images for batch processing\n    - Reference multiple image files in the workflow\n    - Set default image list for testing or demonstration purposes";
@@ -515,6 +535,7 @@ export class ConstantImageListNode extends BaseNode {
 
 export class ConstantVideoListNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.VideoList";
+  static readonly retrySafe = true;
   static readonly title = "Video List";
   static readonly description =
     "Represents a list of video file constants in the workflow.\n    videos, movies, clips, collection\n\n    Use cases:\n    - Provide a fixed list of videos for batch processing\n    - Reference multiple video files in the workflow\n    - Set default video list for testing or demonstration purposes";
@@ -540,6 +561,7 @@ export class ConstantVideoListNode extends BaseNode {
 
 export class ConstantSelectNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Select";
+  static readonly retrySafe = true;
   static readonly title = "Select";
   static readonly description =
     "Represents a selection from a predefined set of options in the workflow.\n    select, enum, dropdown, choice, options\n\n    Use cases:\n    - Choose from a fixed set of values\n    - Configure options for downstream nodes\n    - Provide enum-compatible inputs for nodes that expect specific values\n\n    The output is a string that can be connected to enum-typed inputs.";
@@ -591,6 +613,7 @@ export class ConstantSelectNode extends BaseNode {
 
 export class ConstantImageSizeNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.ImageSize";
+  static readonly retrySafe = true;
   static readonly title = "Image Size";
   static readonly description =
     "Represents a fixed image size constant in the workflow.\n    constant, image_size, resolution, width, height, dimensions\n\n    Use cases:\n    - Provide fixed output dimensions for image generation nodes\n    - Reference a standard resolution across the workflow\n    - Expose width and height as separate integer outputs";
@@ -618,6 +641,7 @@ export class ConstantImageSizeNode extends BaseNode {
 
 export class ConstantDateNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Date";
+  static readonly retrySafe = true;
   static readonly title = "Date";
   static readonly description =
     "Make a date object from year, month, day.\n    date, make, create";
@@ -667,6 +691,7 @@ export class ConstantDateNode extends BaseNode {
 
 export class ConstantDateTimeNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.DateTime";
+  static readonly retrySafe = true;
   static readonly title = "Date Time";
   static readonly description =
     "Make a datetime object from year, month, day, hour, minute, second.\n    datetime, make, create";
@@ -785,6 +810,7 @@ export class ConstantDateTimeNode extends BaseNode {
 
 export class ConstantASRModelNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.ASRModelConstant";
+  static readonly retrySafe = true;
   static readonly title = "ASR Model Constant";
   static readonly description =
     "Represents an automatic speech recognition model constant in the workflow.\n    asr, speech, recognition, transcription, model\n\n    Use cases:\n    - Provide a fixed ASR model for transcription\n    - Set default ASR model for the workflow\n    - Configure model selection without user input";
@@ -804,6 +830,7 @@ export class ConstantASRModelNode extends BaseNode {
 
 export class ConstantEmbeddingModelNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.EmbeddingModelConstant";
+  static readonly retrySafe = true;
   static readonly title = "Embedding Model Constant";
   static readonly description =
     "Represents an embedding model constant in the workflow.\n    embedding, model, vector, semantic\n\n    Use cases:\n    - Provide a fixed embedding model for vectorization\n    - Set default embedding model for the workflow\n    - Configure model selection without user input";
@@ -828,6 +855,7 @@ export class ConstantEmbeddingModelNode extends BaseNode {
 
 export class ConstantImageModelNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.ImageModelConstant";
+  static readonly retrySafe = true;
   static readonly title = "Image Model Constant";
   static readonly description =
     "Represents an image generation model constant in the workflow.\n    image, model, ai, generation, diffusion\n\n    Use cases:\n    - Provide a fixed image model for generation\n    - Set default image model for the workflow\n    - Configure model selection without user input";
@@ -847,6 +875,7 @@ export class ConstantImageModelNode extends BaseNode {
 
 export class ConstantLanguageModelNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.LanguageModelConstant";
+  static readonly retrySafe = true;
   static readonly title = "Language Model Constant";
   static readonly description =
     "Represents a language model constant in the workflow.\n    llm, language, model, ai, chat, gpt\n\n    Use cases:\n    - Provide a fixed language model for chat or text generation\n    - Set default language model for the workflow\n    - Configure model selection without user input";
@@ -871,6 +900,7 @@ export class ConstantLanguageModelNode extends BaseNode {
 
 export class ConstantTTSModelNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.TTSModelConstant";
+  static readonly retrySafe = true;
   static readonly title = "TTS Model Constant";
   static readonly description =
     "Represents a text-to-speech model constant in the workflow.\n    tts, speech, voice, model, audio\n\n    Use cases:\n    - Provide a fixed TTS model for speech synthesis\n    - Set default TTS model for the workflow\n    - Configure model selection without user input";
@@ -890,6 +920,7 @@ export class ConstantTTSModelNode extends BaseNode {
 
 export class ConstantVideoModelNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.VideoModelConstant";
+  static readonly retrySafe = true;
   static readonly title = "Video Model Constant";
   static readonly description =
     "Represents a video generation model constant in the workflow.\n    video, model, ai, generation\n\n    Use cases:\n    - Provide a fixed video model for generation\n    - Set default video model for the workflow\n    - Configure model selection without user input";

--- a/packages/core-nodes/src/nodes/control.ts
+++ b/packages/core-nodes/src/nodes/control.ts
@@ -6,6 +6,7 @@ import { compileSafePredicate, compileSafeKey } from "./safe-expression.js";
 
 export class IfNode extends BaseNode {
   static readonly nodeType = "nodetool.control.If";
+  static readonly retrySafe = true;
   static readonly title = "If";
   static readonly description =
     "Conditionally executes one of two branches based on a condition.\n    control, flow, condition, logic, else, true, false, switch, toggle, flow-control\n\n    Use cases:\n    - Branch workflow based on conditions\n    - Handle different cases in data processing\n    - Implement decision logic";
@@ -55,6 +56,7 @@ export class IfNode extends BaseNode {
 
 export class ForEachNode extends BaseNode {
   static readonly nodeType = "nodetool.control.ForEach";
+  static readonly retrySafe = true;
   static readonly title = "For Each";
   static readonly description =
     "Iterate over a list and emit each item sequentially.\n    iterator, loop, list, sequence, repeat, enumerate, stream, collection\n\n    Use cases:\n    - Process each item of a collection in order\n    - Drive downstream nodes with individual elements";
@@ -108,6 +110,7 @@ export class ForEachNode extends BaseNode {
 
 export class AssetCollectionNode extends BaseNode {
   static readonly nodeType = "nodetool.control.Collection";
+  static readonly retrySafe = true;
   static readonly title = "Asset Collection";
   static readonly description =
     "A curated collection of assets of a single type. Streams each item one at a time for downstream processing.\n    collection, gallery, assets, curate, pick, winners, iterator, stream, batch\n\n    Use cases:\n    - Hand-pick the best generations and feed them to the next step\n    - Gather assets dropped from the asset panel, files, or generation history\n    - Drive a downstream pipeline with a fixed set of media";
@@ -149,6 +152,7 @@ export class AssetCollectionNode extends BaseNode {
 
 export class RepeatCountNode extends BaseNode {
   static readonly nodeType = "nodetool.control.RepeatCount";
+  static readonly retrySafe = true;
   static readonly title = "Repeat Count";
   static readonly description =
     "Emit N sequential ticks without needing an input list.\n    repeat, loop, count, times, iterate, batch\n\n    Use cases:\n    - Run the same downstream step N times (e.g. generate N images from one prompt)\n    - Drive iteration by count instead of building a range list\n    - Pair with Collect to gather N results";
@@ -188,6 +192,7 @@ export class RepeatCountNode extends BaseNode {
 
 export class RepeatValueStreamNode extends BaseNode {
   static readonly nodeType = "nodetool.control.RepeatValue";
+  static readonly retrySafe = true;
   static readonly title = "Repeat Value";
   static readonly description =
     "Emit the same value N times without building a list first.\n    repeat, loop, duplicate, scalar, batch, stream\n\n    Use cases:\n    - Run downstream steps N times with a wired prompt or parameter\n    - Repeat one image ref, text, or dict through a pipeline\n    - Pair with Collect to gather N results";
@@ -236,6 +241,7 @@ export class RepeatValueStreamNode extends BaseNode {
 
 export class TakeNode extends BaseNode {
   static readonly nodeType = "nodetool.control.Take";
+  static readonly retrySafe = true;
   static readonly title = "Take";
   static readonly description =
     "Pass through the first N items of a stream and stop.\n    take, head, limit, first, stream, slice, sample, truncate\n\n    Use cases:\n    - Test a pipeline on a small subset of inputs\n    - Cap expensive downstream work at N items\n    - Implement \"first N matches\" semantics over a stream";
@@ -299,6 +305,7 @@ export class TakeNode extends BaseNode {
 
 export class CollectNode extends BaseNode {
   static readonly nodeType = "nodetool.control.Collect";
+  static readonly retrySafe = true;
   static readonly title = "Collect";
   static readonly description =
     "Collect items until the end of the stream and return them as a list.\n    collector, aggregate, list, stream\n\n    Use cases:\n    - Gather results from multiple processing steps\n    - Collect streaming data into batches\n    - Aggregate outputs from parallel operations";
@@ -340,6 +347,7 @@ export class CollectNode extends BaseNode {
 
 export class RerouteNode extends BaseNode {
   static readonly nodeType = "nodetool.control.Reroute";
+  static readonly retrySafe = true;
   static readonly title = "Reroute";
   static readonly description =
     "Pass data through unchanged for tidier workflow layouts.\n    reroute, passthrough, organize, tidy, flow, connection, redirect\n\n    Use cases:\n    - Organize complex workflows by routing connections\n    - Create cleaner visual layouts\n    - Redirect data flow without modification";
@@ -368,6 +376,7 @@ export class RerouteNode extends BaseNode {
 
 export class SwitchNode extends BaseNode {
   static readonly nodeType = "nodetool.control.Switch";
+  static readonly retrySafe = true;
   static readonly title = "Switch";
   static readonly description =
     "Multi-branch routing: match a value against cases and route to the matching output.\n    control, switch, match, case, branch, route, multi-branch, flow-control\n\n    Use cases:\n    - Route data based on string/number matching\n    - Implement multi-way branching logic\n    - Replace chains of If nodes";
@@ -427,6 +436,7 @@ export class SwitchNode extends BaseNode {
 
 export class TryCatchNode extends BaseNode {
   static readonly nodeType = "nodetool.control.TryCatch";
+  static readonly retrySafe = true;
   static readonly title = "Fallback";
   static readonly description =
     "Substitute a fallback value when the input is null or undefined. Does not catch exceptions — it only detects a missing value and swaps in the fallback.\n    control, fallback, default, null, undefined, missing, coalesce, flow-control\n\n    Use cases:\n    - Provide a default when an upstream step produced no value\n    - Detect missing values in workflows\n    - Flag whether the fallback was used";
@@ -475,6 +485,7 @@ export class TryCatchNode extends BaseNode {
 
 export class DropNode extends BaseNode {
   static readonly nodeType = "nodetool.control.Drop";
+  static readonly retrySafe = true;
   static readonly title = "Drop";
   static readonly description =
     "Skip the first N items of a stream, pass the rest through.\n    drop, skip, head, stream, slice, offset\n\n    Use cases:\n    - Skip headers or warm-up items in a stream\n    - Pagination-style offsets\n    - Drop the first record from a CSV-like feed";
@@ -545,6 +556,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
 
 export class FilterEqualNode extends BaseNode {
   static readonly nodeType = "nodetool.control.FilterEqual";
+  static readonly retrySafe = true;
   static readonly title = "Filter Equal";
   static readonly description =
     "Pass items through only when they equal a target value.\n    filter, equal, match, predicate, stream, where\n\n    Use cases:\n    - Keep only items matching a status, label, or category\n    - Drop sentinel/null markers from a stream\n    - Select rows by an exact id";
@@ -656,6 +668,7 @@ export class FilterCodeNode extends BaseNode {
 
 export class ChunkNode extends BaseNode {
   static readonly nodeType = "nodetool.control.Chunk";
+  static readonly retrySafe = true;
   static readonly title = "Chunk";
   static readonly description =
     "Group every N items into a list and emit as a batch. Trailing partial batch is emitted at end of stream.\n    chunk, batch, group, window, buffer, stream\n\n    Use cases:\n    - Batched LLM/API calls without giving up streaming\n    - Window-based aggregation\n    - Group rows for bulk inserts";
@@ -721,6 +734,7 @@ export class ChunkNode extends BaseNode {
 
 export class LastNode extends BaseNode {
   static readonly nodeType = "nodetool.control.Last";
+  static readonly retrySafe = true;
   static readonly title = "Last";
   static readonly description =
     "Emit only the final item of a stream.\n    last, final, tail, fold, stream, reduce\n\n    Use cases:\n    - Keep the final answer from an agent token stream\n    - Pick the most recent item in a feed\n    - Cheap fold to a single value";
@@ -766,6 +780,7 @@ export class LastNode extends BaseNode {
 
 export class CountStreamNode extends BaseNode {
   static readonly nodeType = "nodetool.control.Count";
+  static readonly retrySafe = true;
   static readonly title = "Count";
   static readonly description =
     "Emit the total number of items when the stream ends.\n    count, length, size, total, fold, stream\n\n    Use cases:\n    - Report how many items a pipeline produced\n    - Measure stream throughput without buffering items\n    - Avoid collecting just to call .length";
@@ -839,6 +854,7 @@ function distinctKey(
 
 export class DistinctNode extends BaseNode {
   static readonly nodeType = "nodetool.control.Distinct";
+  static readonly retrySafe = true;
   static readonly title = "Distinct";
   static readonly description =
     "Drop duplicate items from a stream. Optional key expression for grouping.\n    distinct, unique, dedup, deduplicate, stream, set\n\n    Use cases:\n    - Deduplicate URLs, ids, or records\n    - Keep only the first sighting of each value\n    - Field-based dedup with a key expression";
@@ -894,6 +910,7 @@ export class DistinctNode extends BaseNode {
 
 export class TakeWhileNode extends BaseNode {
   static readonly nodeType = "nodetool.control.TakeWhile";
+  static readonly retrySafe = true;
   static readonly title = "Take While";
   static readonly description =
     "Pass items through while a predicate is truthy. Stops at the first failure.\n    take, while, predicate, stream, prefix\n\n    Use cases:\n    - Stream until a sentinel/terminator is reached\n    - Process items while a confidence threshold holds\n    - Cleaner than counting when N is unknown up front";
@@ -950,6 +967,7 @@ export class TakeWhileNode extends BaseNode {
 
 export class DropWhileNode extends BaseNode {
   static readonly nodeType = "nodetool.control.DropWhile";
+  static readonly retrySafe = true;
   static readonly title = "Drop While";
   static readonly description =
     "Drop items while a predicate is truthy, then pass everything after.\n    drop, skip, while, predicate, stream, suffix\n\n    Use cases:\n    - Skip leading whitespace, headers, or warm-up\n    - Wait for a stream to enter a steady state\n    - Predicate-based version of Drop(N)";
@@ -1073,6 +1091,7 @@ export class TapNode extends BaseNode {
  */
 export class ZipNode extends BaseNode {
   static readonly nodeType = "nodetool.control.Zip";
+  static readonly retrySafe = true;
   static readonly title = "Zip";
   static readonly description =
     "Pair items from two independent iteration sources by matched index within the common parent.\n    zip, pair, combine, merge, join, index, stream, iterate\n\n    Use cases:\n    - Combine matching items from two parallel streams\n    - Pair inputs and outputs by position\n    - Merge two iteration sources into tuples";
@@ -1264,6 +1283,7 @@ export class ZipNode extends BaseNode {
  */
 export class CrossNode extends BaseNode {
   static readonly nodeType = "nodetool.control.Cross";
+  static readonly retrySafe = true;
   static readonly title = "Cross";
   static readonly description =
     "Emit the cartesian product of two iteration sources within their common parent.\n    cross, cartesian, product, combine, pairs, matrix, stream, iterate\n\n    Use cases:\n    - Generate every combination of two input sets\n    - Build a grid of parameter combinations\n    - Pair each item of one stream with all items of another";

--- a/packages/core-nodes/src/nodes/fake-media.ts
+++ b/packages/core-nodes/src/nodes/fake-media.ts
@@ -118,6 +118,7 @@ const renderGradientPng = async (
 
 export class FakeGenerateImageNode extends BaseNode {
   static readonly nodeType = "nodetool.fake.GenerateImage";
+  static readonly retrySafe = true;
   static readonly title = "Fake Generate Image";
   static readonly description =
     "Simulate image generation with a fake provider — no API calls.\n" +
@@ -184,6 +185,7 @@ const imageUri = (image: unknown): string | null => {
  */
 export class FakeColorGradeNode extends BaseNode {
   static readonly nodeType = "nodetool.fake.ColorGrade";
+  static readonly retrySafe = true;
   static readonly title = "Color Grade (browser)";
   static readonly description =
     "Color-grade an image in the browser — hue, saturation, brightness.\n" +

--- a/packages/core-nodes/src/nodes/input.ts
+++ b/packages/core-nodes/src/nodes/input.ts
@@ -52,6 +52,7 @@ interface ImageSizeValue {
 
 export class FloatInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.FloatInput";
+  static readonly retrySafe = true;
   static readonly title = "Float Input";
   static readonly description =
     "Accepts a floating-point number as a parameter for workflows, typically constrained by a minimum and maximum value.  This input allows for precise numeric settings, such as adjustments, scores, or any value requiring decimal precision.\n    input, parameter, float, number, decimal, range";
@@ -86,6 +87,7 @@ export class FloatInputNode extends BaseNode {
 
 export class BooleanInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.BooleanInput";
+  static readonly retrySafe = true;
   static readonly title = "Boolean Input";
   static readonly description =
     "Accepts a boolean (true/false) value as a parameter for workflows.  This input is used for binary choices, enabling or disabling features, or controlling conditional logic paths.\n    input, parameter, boolean, bool, toggle, switch, flag";
@@ -111,6 +113,7 @@ export class BooleanInputNode extends BaseNode {
 
 export class IntegerInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.IntegerInput";
+  static readonly retrySafe = true;
   static readonly title = "Integer Input";
   static readonly description =
     "Accepts an integer (whole number) as a parameter for workflows, typically constrained by a minimum and maximum value.  This input is used for discrete numeric values like counts, indices, or iteration limits.\n    input, parameter, integer, number, count, index, whole_number";
@@ -145,6 +148,7 @@ export class IntegerInputNode extends BaseNode {
 
 export class SelectInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.SelectInput";
+  static readonly retrySafe = true;
   static readonly title = "Select Input";
   static readonly description =
     "Accepts a selection from a predefined set of options as a parameter for workflows.\n    input, parameter, select, enum, dropdown, choice, options\n\n    Use cases:\n    - Let users choose from a fixed set of values in app mode\n    - Configure enum-like options for downstream nodes\n    - Provide dropdown selection for workflow parameters\n\n    The output is a string that can be connected to enum-typed inputs.";
@@ -202,6 +206,7 @@ export class SelectInputNode extends BaseNode {
 
 export class StringListInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.StringListInput";
+  static readonly retrySafe = true;
   static readonly title = "String List Input";
   static readonly description =
     "Accepts a list of strings as a parameter for workflows.\n    input, parameter, string, text, label, name, value";
@@ -232,6 +237,7 @@ export class StringListInputNode extends BaseNode {
 
 export class FolderPathInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.FolderPathInput";
+  static readonly retrySafe = true;
   static readonly title = "Folder Path Input";
   static readonly description =
     "Accepts a folder path as a parameter for workflows.\n    input, parameter, folder, path, folderpath, local_folder, filesystem";
@@ -265,6 +271,7 @@ export class FolderPathInputNode extends BaseNode {
 
 export class HuggingFaceModelInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.HuggingFaceModelInput";
+  static readonly retrySafe = true;
   static readonly title = "Hugging Face Model Input";
   static readonly description =
     "Accepts a Hugging Face model as a parameter for workflows.\n    input, parameter, model, huggingface, hugging_face, model_name";
@@ -295,6 +302,7 @@ export class HuggingFaceModelInputNode extends BaseNode {
 
 export class ColorInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.ColorInput";
+  static readonly retrySafe = true;
   static readonly title = "Color Input";
   static readonly description =
     "Accepts a color value as a parameter for workflows.\n    input, parameter, color, color_picker, color_input";
@@ -325,6 +333,7 @@ export class ColorInputNode extends BaseNode {
 
 export class ImageSizeInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.ImageSizeInput";
+  static readonly retrySafe = true;
   static readonly title = "Image Size Input";
   static readonly description =
     "Accepts image dimensions as a parameter for workflows.\n    input, parameter, image_size, resolution, width, height, dimensions";
@@ -356,6 +365,7 @@ export class ImageSizeInputNode extends BaseNode {
 
 export class LanguageModelInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.LanguageModelInput";
+  static readonly retrySafe = true;
   static readonly title = "Language Model Input";
   static readonly description =
     "Accepts a language model as a parameter for workflows.\n    input, parameter, model, language, model_name";
@@ -386,6 +396,7 @@ export class LanguageModelInputNode extends BaseNode {
 
 export class ImageModelInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.ImageModelInput";
+  static readonly retrySafe = true;
   static readonly title = "Image Model Input";
   static readonly description =
     "Accepts an image generation model as a parameter for workflows.\n    input, parameter, model, image, generation";
@@ -416,6 +427,7 @@ export class ImageModelInputNode extends BaseNode {
 
 export class VideoModelInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.VideoModelInput";
+  static readonly retrySafe = true;
   static readonly title = "Video Model Input";
   static readonly description =
     "Accepts a video generation model as a parameter for workflows.\n    input, parameter, model, video, generation";
@@ -446,6 +458,7 @@ export class VideoModelInputNode extends BaseNode {
 
 export class TTSModelInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.TTSModelInput";
+  static readonly retrySafe = true;
   static readonly title = "TTS Model Input";
   static readonly description =
     "Accepts a text-to-speech model as a parameter for workflows.\n    input, parameter, model, tts, speech, voice";
@@ -476,6 +489,7 @@ export class TTSModelInputNode extends BaseNode {
 
 export class ASRModelInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.ASRModelInput";
+  static readonly retrySafe = true;
   static readonly title = "ASR Model Input";
   static readonly description =
     "Accepts an automatic speech recognition model as a parameter for workflows.\n    input, parameter, model, asr, transcription, speech";
@@ -506,6 +520,7 @@ export class ASRModelInputNode extends BaseNode {
 
 export class EmbeddingModelInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.EmbeddingModelInput";
+  static readonly retrySafe = true;
   static readonly title = "Embedding Model Input";
   static readonly description =
     "Accepts an embedding model as a parameter for workflows.\n    input, parameter, model, embedding, vector";
@@ -536,6 +551,7 @@ export class EmbeddingModelInputNode extends BaseNode {
 
 export class DataframeInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.DataframeInput";
+  static readonly retrySafe = true;
   static readonly title = "Dataframe Input";
   static readonly description =
     "Accepts a reference to a dataframe asset for workflows.\n    input, parameter, dataframe, table, data";
@@ -566,6 +582,7 @@ export class DataframeInputNode extends BaseNode {
 
 export class DocumentInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.DocumentInput";
+  static readonly retrySafe = true;
   static readonly title = "Document Input";
   static readonly description =
     "Accepts a reference to a document asset for workflows, specified by a 'DocumentRef'.  A 'DocumentRef' points to a structured document (e.g., PDF, DOCX, TXT) which can be processed or analyzed. This node is used when the workflow needs to operate on a document as a whole entity, potentially including its structure and metadata, rather than just raw text.\n    input, parameter, document, file, asset, reference\n\n    Use cases:\n    - Load a specific document (e.g., PDF, Word, text file) for content extraction or analysis.\n    - Pass a document to models that are designed to process specific document formats.\n    - Manage documents as distinct assets within a workflow.\n    - If you have a local file path and need to convert it to a 'DocumentRef', consider using 'DocumentFileInput'.";
@@ -596,6 +613,7 @@ export class DocumentInputNode extends BaseNode {
 
 export class ImageInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.ImageInput";
+  static readonly retrySafe = true;
   static readonly title = "Image Input";
   static readonly description =
     "Accepts a reference to an image asset for workflows, specified by an 'ImageRef'.  An 'ImageRef' points to image data that can be used for display, analysis, or processing by vision models.\n    input, parameter, image, picture, graphic, visual, asset";
@@ -626,6 +644,7 @@ export class ImageInputNode extends BaseNode {
 
 export class ImageListInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.ImageListInput";
+  static readonly retrySafe = true;
   static readonly title = "Image List Input";
   static readonly description =
     "Accepts a list of image references as a parameter for workflows.\n    input, parameter, image, picture, graphic, visual, asset, list";
@@ -656,6 +675,7 @@ export class ImageListInputNode extends BaseNode {
 
 export class VideoListInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.VideoListInput";
+  static readonly retrySafe = true;
   static readonly title = "Video List Input";
   static readonly description =
     "Accepts a list of video references as a parameter for workflows.\n    input, parameter, video, movie, clip, visual, asset, list";
@@ -686,6 +706,7 @@ export class VideoListInputNode extends BaseNode {
 
 export class AudioListInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.AudioListInput";
+  static readonly retrySafe = true;
   static readonly title = "Audio List Input";
   static readonly description =
     "Accepts a list of audio references as a parameter for workflows.\n    input, parameter, audio, sound, voice, speech, asset, list";
@@ -716,6 +737,7 @@ export class AudioListInputNode extends BaseNode {
 
 export class TextListInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.TextListInput";
+  static readonly retrySafe = true;
   static readonly title = "Text List Input";
   static readonly description =
     "Accepts a list of text strings as a parameter for workflows.\n    input, parameter, text, string, list";
@@ -746,6 +768,7 @@ export class TextListInputNode extends BaseNode {
 
 export class VideoInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.VideoInput";
+  static readonly retrySafe = true;
   static readonly title = "Video Input";
   static readonly description =
     "Accepts a reference to a video asset for workflows, specified by a 'VideoRef'.  A 'VideoRef' points to video data that can be used for playback, analysis, frame extraction, or processing by video-capable models.\n    input, parameter, video, movie, clip, visual, asset";
@@ -776,6 +799,7 @@ export class VideoInputNode extends BaseNode {
 
 export class AudioInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.AudioInput";
+  static readonly retrySafe = true;
   static readonly title = "Audio Input";
   static readonly description =
     "Accepts a reference to an audio asset for workflows, specified by an 'AudioRef'.  An 'AudioRef' points to audio data that can be used for playback, transcription, analysis, or processing by audio-capable models.\n    input, parameter, audio, sound, voice, speech, asset";
@@ -806,6 +830,7 @@ export class AudioInputNode extends BaseNode {
 
 export class Model3DInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.Model3DInput";
+  static readonly retrySafe = true;
   static readonly title = "Model 3D Input";
   static readonly description =
     "Accepts a reference to a 3D model asset for workflows, specified by a 'Model3DRef'.\n    A 'Model3DRef' points to 3D model data that can be used for visualization, processing,\n    or conversion by 3D-capable nodes.\n    input, parameter, 3d, model, mesh, obj, glb, stl, ply, asset";
@@ -836,6 +861,7 @@ export class Model3DInputNode extends BaseNode {
 
 export class AssetFolderInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.AssetFolderInput";
+  static readonly retrySafe = true;
   static readonly title = "Asset Folder Input";
   static readonly description =
     "Accepts an asset folder as a parameter for workflows.\n    input, parameter, folder, path, folderpath, local_folder, filesystem";
@@ -866,6 +892,7 @@ export class AssetFolderInputNode extends BaseNode {
 
 export class MessageInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.MessageInput";
+  static readonly retrySafe = true;
   static readonly title = "Message Input";
   static readonly description =
     "Accepts a chat message object for workflows.\n    input, parameter, message, chat, conversation";
@@ -896,6 +923,7 @@ export class MessageInputNode extends BaseNode {
 
 export class MessageListInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.MessageListInput";
+  static readonly retrySafe = true;
   static readonly title = "Message List Input";
   static readonly description =
     "Accepts a list of chat message objects for workflows.\n    input, parameter, messages, chat, conversation, history";
@@ -926,6 +954,7 @@ export class MessageListInputNode extends BaseNode {
 
 export class StringInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.StringInput";
+  static readonly retrySafe = true;
   static readonly title = "String Input";
   static readonly description =
     "Accepts a string value as a parameter for workflows.\n    input, parameter, string, text, label, name, value\n\n    Use cases:\n    - Define a name for an entity or process.\n    - Specify a label for a component or output.\n    - Enter a short keyword or search term.\n    - Provide a simple configuration value (e.g., an API key, a model name).\n    - If you need to input multi-line text or the content of a file, use 'DocumentFileInput'.";
@@ -979,6 +1008,7 @@ export class StringInputNode extends BaseNode {
 
 export class RealtimeAudioInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.RealtimeAudioInput";
+  static readonly retrySafe = true;
   static readonly title = "Realtime Audio Input";
   static readonly description =
     "Accepts streaming audio data for workflows.\n    input, parameter, audio, sound, voice, speech, asset";
@@ -1022,6 +1052,7 @@ export class RealtimeAudioInputNode extends BaseNode {
 
 export class DocumentFileInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.DocumentFileInput";
+  static readonly retrySafe = true;
   static readonly title = "Document File Input";
   static readonly description =
     "Accepts a local file path pointing to a document and converts it into a 'DocumentRef'.\n    input, parameter, document, file, path, local_file, load";
@@ -1060,6 +1091,7 @@ export class DocumentFileInputNode extends BaseNode {
 
 export class FilePathInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.FilePathInput";
+  static readonly retrySafe = true;
   static readonly title = "File Path Input";
   static readonly description =
     "Accepts a local filesystem path (to a file or directory) as input for workflows.\n    input, parameter, path, filepath, directory, local_file, filesystem";
@@ -1093,6 +1125,7 @@ export class FilePathInputNode extends BaseNode {
 
 export class MessageDeconstructorNode extends BaseNode {
   static readonly nodeType = "nodetool.input.MessageDeconstructor";
+  static readonly retrySafe = true;
   static readonly title = "Message Deconstructor";
   static readonly description =
     "Deconstructs a chat message object into its individual fields.\n    extract, decompose, message, fields, chat\n\n    Use cases:\n    - Extract specific fields from a message (e.g., role, content, thread_id).\n    - Access message metadata for workflow logic.\n    - Process different parts of a message separately.";

--- a/packages/core-nodes/src/nodes/lib-datetime.ts
+++ b/packages/core-nodes/src/nodes/lib-datetime.ts
@@ -390,6 +390,7 @@ export class DateNowNode extends BaseNode {
 
 export class FormatDateNode extends BaseNode {
   static readonly nodeType = "lib.datetime.Format";
+  static readonly retrySafe = true;
   static readonly title = "Format Date";
   static readonly description =
     "Parse a date string/number/Date and format it. Supports tokens YYYY, MM, DD, HH, mm, ss, SSS, Z. Use [brackets] for literals. The date input is required — connect a date or use the Now node.\n    date, format, parse, strftime";
@@ -430,6 +431,7 @@ export class FormatDateNode extends BaseNode {
 
 export class DateAddNode extends BaseNode {
   static readonly nodeType = "lib.datetime.Add";
+  static readonly retrySafe = true;
   static readonly title = "Add / Subtract Time";
   static readonly description =
     "Add (or subtract, when amount is negative) a number of time units to a date. Day/week arithmetic is calendar-aware across DST. The date input is required — connect a date or use the Now node.\n    date, add, subtract, shift, offset";
@@ -484,6 +486,7 @@ export class DateAddNode extends BaseNode {
 
 export class DateDiffNode extends BaseNode {
   static readonly nodeType = "lib.datetime.Diff";
+  static readonly retrySafe = true;
   static readonly title = "Date Difference";
   static readonly description =
     "Difference between two dates (date_a − date_b) expressed in the given unit. Both date inputs are required — connect dates or use the Now node.\n    date, diff, difference, between, duration";
@@ -529,6 +532,7 @@ export class DateDiffNode extends BaseNode {
 
 export class DateStartEndNode extends BaseNode {
   static readonly nodeType = "lib.datetime.StartEnd";
+  static readonly retrySafe = true;
   static readonly title = "Start / End of Period";
   static readonly description =
     "Return the start and end of the given period (day, week, month, year). The date input is required — connect a date or use the Now node.\n    date, start, end, period, boundary";

--- a/packages/core-nodes/src/nodes/lib-validate.ts
+++ b/packages/core-nodes/src/nodes/lib-validate.ts
@@ -125,6 +125,7 @@ export function normalizeEmail(value: string): string {
 
 export class ValidateEmailNode extends BaseNode {
   static readonly nodeType = "lib.validate.Email";
+  static readonly retrySafe = true;
   static readonly title = "Validate Email";
   static readonly description =
     "Check whether a value is a syntactically valid email address.\n    validate, email, check";
@@ -142,6 +143,7 @@ export class ValidateEmailNode extends BaseNode {
 
 export class ValidateURLNode extends BaseNode {
   static readonly nodeType = "lib.validate.URL";
+  static readonly retrySafe = true;
   static readonly title = "Validate URL";
   static readonly description =
     "Check whether a value is a syntactically valid absolute URL.\n    validate, url, link, check";
@@ -159,6 +161,7 @@ export class ValidateURLNode extends BaseNode {
 
 export class ValidateIPNode extends BaseNode {
   static readonly nodeType = "lib.validate.IP";
+  static readonly retrySafe = true;
   static readonly title = "Validate IP Address";
   static readonly description =
     "Check whether a value is a valid IPv4 or IPv6 address.\n    validate, ip, ipv4, ipv6, address, network";
@@ -185,6 +188,7 @@ export class ValidateIPNode extends BaseNode {
 
 export class ValidateStringNode extends BaseNode {
   static readonly nodeType = "lib.validate.String";
+  static readonly retrySafe = true;
   static readonly title = "Validate String";
   static readonly description =
     "Run several common string checks at once and return one bool per check.\n    validate, check, email, url, uuid, json, number";
@@ -219,6 +223,7 @@ export class ValidateStringNode extends BaseNode {
 
 export class SanitizeStringNode extends BaseNode {
   static readonly nodeType = "lib.validate.Sanitize";
+  static readonly retrySafe = true;
   static readonly title = "Sanitize String";
   static readonly description =
     "HTML-escape, trim, and lowercase/normalise a string. Also emits the normalised email when applicable.\n    sanitize, escape, html, xss, clean, trim";

--- a/packages/core-nodes/src/nodes/list.ts
+++ b/packages/core-nodes/src/nodes/list.ts
@@ -84,6 +84,7 @@ export function buildRepeatedValues(value: unknown, times: number): unknown[] {
 
 export class RangeNode extends BaseNode {
   static readonly nodeType = "nodetool.list.Range";
+  static readonly retrySafe = true;
   static readonly title = "Range";
   static readonly description =
     "Build a list of integers like Python range(start, stop, step).\n    list, range, sequence, numbers, index, enumerate\n\n    Use cases:\n    - Generate [0, 1, ..., N-1] for iteration with For Each\n    - Produce numbered indices for batch naming or sequencing\n    - Create arithmetic sequences with custom start, stop, and step";
@@ -159,6 +160,7 @@ export class RangeNode extends BaseNode {
 
 export class TileNode extends BaseNode {
   static readonly nodeType = "nodetool.list.Tile";
+  static readonly retrySafe = true;
   static readonly title = "Tile List";
   static readonly description =
     "Repeat an entire list end-to-end N times.\n    list, repeat, tile, cycle, loop, concatenate\n\n    Use cases:\n    - Run the same item sequence multiple times before For Each\n    - Duplicate a prompt list for batch generation\n    - [A, B, C] × 3 → [A, B, C, A, B, C, A, B, C]";
@@ -215,6 +217,7 @@ export class TileNode extends BaseNode {
 
 export class RepeatEachNode extends BaseNode {
   static readonly nodeType = "nodetool.list.RepeatEach";
+  static readonly retrySafe = true;
   static readonly title = "Repeat Each";
   static readonly description =
     "Repeat each list item consecutively N times.\n    list, repeat, duplicate, interleave, expand\n\n    Use cases:\n    - Generate multiple variants per input item\n    - [A, B, C] × 2 → [A, A, B, B, C, C]\n    - Feed expanded lists into For Each";
@@ -273,6 +276,7 @@ export class RepeatEachNode extends BaseNode {
 
 export class RepeatValueNode extends BaseNode {
   static readonly nodeType = "nodetool.list.RepeatValue";
+  static readonly retrySafe = true;
   static readonly title = "Repeat Value";
   static readonly description =
     "Duplicate a single value into a list N times.\n    list, repeat, duplicate, fill, scalar, constant\n\n    Use cases:\n    - Build [v, v, v] from one prompt or parameter before For Each\n    - Expand a scalar into a list for list-typed inputs\n    - v × 3 → [v, v, v]";

--- a/packages/data-nodes/src/nodes/data.ts
+++ b/packages/data-nodes/src/nodes/data.ts
@@ -478,6 +478,7 @@ function dateName(name: string): string {
 
 export class SchemaNode extends BaseNode {
   static readonly nodeType = "nodetool.data.Schema";
+  static readonly retrySafe = true;
   static readonly title = "Schema";
   static readonly description =
     "Define a schema for a dataframe.\n    schema, dataframe, create";
@@ -505,6 +506,7 @@ export class SchemaNode extends BaseNode {
 
 export class FilterDataframeNode extends BaseNode {
   static readonly nodeType = "nodetool.data.Filter";
+  static readonly retrySafe = true;
   static readonly title = "Filter";
   static readonly description =
     "Filter dataframe based on condition.\n    filter, query, condition\n\n    Example conditions:\n    age > 30\n    age > 30 and salary < 50000\n    name == 'John Doe'\n    100 <= price <= 200\n    status in ['Active', 'Pending']\n    not (age < 18)\n\n    Use cases:\n    - Extract subset of data meeting specific criteria\n    - Remove outliers or invalid data points\n    - Focus analysis on relevant data segments";
@@ -547,6 +549,7 @@ export class FilterDataframeNode extends BaseNode {
 
 export class SliceDataframeNode extends BaseNode {
   static readonly nodeType = "nodetool.data.Slice";
+  static readonly retrySafe = true;
   static readonly title = "Slice";
   static readonly description =
     "Slice a dataframe by rows using start and end indices.\n    slice, subset, rows\n\n    Use cases:\n    - Extract a specific range of rows from a large dataset\n    - Create training and testing subsets for machine learning\n    - Analyze data in smaller chunks";
@@ -667,6 +670,7 @@ export class SaveDataframeNode extends BaseNode {
 
 export class ImportCSVNode extends BaseNode {
   static readonly nodeType = "nodetool.data.ImportCSV";
+  static readonly retrySafe = true;
   static readonly title = "Import CSV";
   static readonly description =
     "Convert CSV string to dataframe.\n    csv, dataframe, import\n\n    Use cases:\n    - Import CSV data from string input\n    - Convert CSV responses from APIs to dataframe";
@@ -692,6 +696,7 @@ export class ImportCSVNode extends BaseNode {
 
 export class LoadCSVURLNode extends BaseNode {
   static readonly nodeType = "nodetool.data.LoadCSVURL";
+  static readonly retrySafe = true;
   static readonly title = "Load CSVURL";
   static readonly description =
     "Load CSV file from URL.\n    csv, dataframe, import";
@@ -751,6 +756,7 @@ export class LoadCSVFileDataNode extends BaseNode {
 
 export class FromListNode extends BaseNode {
   static readonly nodeType = "nodetool.data.FromList";
+  static readonly retrySafe = true;
   static readonly title = "From List";
   static readonly description =
     "Convert list of dicts to dataframe.\n    list, dataframe, convert\n\n    Use cases:\n    - Transform list data into structured dataframe\n    - Prepare list data for analysis or visualization\n    - Convert API responses to dataframe format";
@@ -805,6 +811,7 @@ export class FromListNode extends BaseNode {
 
 export class JSONToDataframeNode extends BaseNode {
   static readonly nodeType = "nodetool.data.JSONToDataframe";
+  static readonly retrySafe = true;
   static readonly title = "Convert JSON to DataFrame";
   static readonly description =
     "Transforms a JSON string into a pandas DataFrame.\n    json, dataframe, conversion\n\n    Use cases:\n    - Converting API responses to tabular format\n    - Preparing JSON data for analysis or visualization\n    - Structuring unstructured JSON data for further processing";
@@ -826,6 +833,7 @@ export class JSONToDataframeNode extends BaseNode {
 
 export class ToListNode extends BaseNode {
   static readonly nodeType = "nodetool.data.ToList";
+  static readonly retrySafe = true;
   static readonly title = "To List";
   static readonly description =
     "Convert dataframe to list of dictionaries.\n    dataframe, list, convert\n\n    Use cases:\n    - Convert dataframe data for API consumption\n    - Transform data for JSON serialization\n    - Prepare data for document-based storage";
@@ -857,6 +865,7 @@ export class ToListNode extends BaseNode {
 
 export class SelectColumnNode extends BaseNode {
   static readonly nodeType = "nodetool.data.SelectColumn";
+  static readonly retrySafe = true;
   static readonly title = "Select Column";
   static readonly description =
     "Select specific columns from dataframe.\n    dataframe, columns, filter\n\n    Use cases:\n    - Extract relevant features for analysis\n    - Reduce dataframe size by removing unnecessary columns\n    - Prepare data for specific visualizations or models";
@@ -906,6 +915,7 @@ export class SelectColumnNode extends BaseNode {
 
 export class ExtractColumnNode extends BaseNode {
   static readonly nodeType = "nodetool.data.ExtractColumn";
+  static readonly retrySafe = true;
   static readonly title = "Extract Column";
   static readonly description =
     "Convert dataframe column to list.\n    dataframe, column, list\n\n    Use cases:\n    - Extract data for use in other processing steps\n    - Prepare column data for plotting or analysis\n    - Convert categorical data to list for encoding";
@@ -947,6 +957,7 @@ export class ExtractColumnNode extends BaseNode {
 
 export class AddColumnNode extends BaseNode {
   static readonly nodeType = "nodetool.data.AddColumn";
+  static readonly retrySafe = true;
   static readonly title = "Add Column";
   static readonly description =
     "Add list of values as new column to dataframe.\n    dataframe, column, list\n\n    Use cases:\n    - Incorporate external data into existing dataframe\n    - Add calculated results as new column\n    - Augment dataframe with additional features";
@@ -1007,6 +1018,7 @@ export class AddColumnNode extends BaseNode {
 
 export class MergeDataframeNode extends BaseNode {
   static readonly nodeType = "nodetool.data.Merge";
+  static readonly retrySafe = true;
   static readonly title = "Merge";
   static readonly description =
     "Merge two dataframes along columns.\n    merge, concat, columns\n\n    Use cases:\n    - Combine data from multiple sources\n    - Add new features to existing dataframe\n    - Merge time series data from different periods";
@@ -1060,6 +1072,7 @@ export class MergeDataframeNode extends BaseNode {
 
 export class AppendDataframeNode extends BaseNode {
   static readonly nodeType = "nodetool.data.Append";
+  static readonly retrySafe = true;
   static readonly title = "Append";
   static readonly description =
     "Append two dataframes along rows.\n    append, concat, rows\n\n    Use cases:\n    - Combine data from multiple time periods\n    - Merge datasets with same structure\n    - Aggregate data from different sources";
@@ -1117,6 +1130,7 @@ export class AppendDataframeNode extends BaseNode {
 
 export class JoinDataframeNode extends BaseNode {
   static readonly nodeType = "nodetool.data.Join";
+  static readonly retrySafe = true;
   static readonly title = "Join";
   static readonly description =
     "Join two dataframes on specified column.\n    join, merge, column\n\n    Use cases:\n    - Combine data from related tables\n    - Enrich dataset with additional information\n    - Link data based on common identifiers";
@@ -1213,6 +1227,7 @@ export class JoinDataframeNode extends BaseNode {
 
 export class FindRowNode extends BaseNode {
   static readonly nodeType = "nodetool.data.FindRow";
+  static readonly retrySafe = true;
   static readonly title = "Find Row";
   static readonly description =
     "Find the first row in a dataframe that matches a given condition.\n    filter, query, condition, single row\n\n    Example conditions:\n    age > 30\n    age > 30 and salary < 50000\n    name == 'John Doe'\n    100 <= price <= 200\n    status in ['Active', 'Pending']\n    not (age < 18)\n\n    Use cases:\n    - Retrieve specific record based on criteria\n    - Find first occurrence of a particular condition\n    - Extract single data point for further analysis";
@@ -1256,6 +1271,7 @@ export class FindRowNode extends BaseNode {
 
 export class SortByColumnNode extends BaseNode {
   static readonly nodeType = "nodetool.data.SortByColumn";
+  static readonly retrySafe = true;
   static readonly title = "Sort By Column";
   static readonly description =
     "Sort dataframe by specified column.\n    sort, order, column\n\n    Use cases:\n    - Arrange data in ascending or descending order\n    - Identify top or bottom values in dataset\n    - Prepare data for rank-based analysis";
@@ -1306,6 +1322,7 @@ export class SortByColumnNode extends BaseNode {
 
 export class DropDuplicatesNode extends BaseNode {
   static readonly nodeType = "nodetool.data.DropDuplicates";
+  static readonly retrySafe = true;
   static readonly title = "Drop Duplicates";
   static readonly description =
     "Remove duplicate rows from dataframe.\n    duplicates, unique, clean\n\n    Use cases:\n    - Clean dataset by removing redundant entries\n    - Ensure data integrity in analysis\n    - Prepare data for unique value operations";
@@ -1338,6 +1355,7 @@ export class DropDuplicatesNode extends BaseNode {
 
 export class DropNANode extends BaseNode {
   static readonly nodeType = "nodetool.data.DropNA";
+  static readonly retrySafe = true;
   static readonly title = "Drop NA";
   static readonly description =
     "Remove rows with NA values from dataframe.\n    na, missing, clean\n\n    Use cases:\n    - Clean dataset by removing incomplete entries\n    - Prepare data for analysis requiring complete cases\n    - Improve data quality for modeling";
@@ -1375,6 +1393,7 @@ export class DropNANode extends BaseNode {
 
 export class ForEachRowNode extends BaseNode {
   static readonly nodeType = "nodetool.data.ForEachRow";
+  static readonly retrySafe = true;
   static readonly title = "For Each Row";
   static readonly description =
     "Iterate over rows of a dataframe.\n    iterator, loop, dataframe, sequence, rows\n\n    Use cases:\n    - Process each row of a dataframe individually\n    - Trigger actions for every record in a dataset";
@@ -1502,6 +1521,7 @@ export class LoadCSVAssetsNode extends BaseNode {
 
 export class AggregateNode extends BaseNode {
   static readonly nodeType = "nodetool.data.Aggregate";
+  static readonly retrySafe = true;
   static readonly title = "Aggregate";
   static readonly description =
     "Aggregate dataframe by one or more columns.\n    aggregate, groupby, group, sum, mean, count, min, max, std, var, median, first, last\n\n    Use cases:\n    - Prepare data for aggregation operations\n    - Analyze data by categories\n    - Create summary statistics by groups";
@@ -1604,6 +1624,7 @@ export class AggregateNode extends BaseNode {
 
 export class PivotNode extends BaseNode {
   static readonly nodeType = "nodetool.data.Pivot";
+  static readonly retrySafe = true;
   static readonly title = "Pivot";
   static readonly description =
     "Pivot dataframe to reshape data.\n    pivot, reshape, transform\n\n    Use cases:\n    - Transform long data to wide format\n    - Create cross-tabulation tables\n    - Reorganize data for visualization";
@@ -1700,6 +1721,7 @@ export class PivotNode extends BaseNode {
 
 export class RenameNode extends BaseNode {
   static readonly nodeType = "nodetool.data.Rename";
+  static readonly retrySafe = true;
   static readonly title = "Rename";
   static readonly description =
     "Rename columns in dataframe.\n    rename, columns, names\n\n    Use cases:\n    - Standardize column names\n    - Make column names more descriptive\n    - Prepare data for specific requirements";
@@ -1752,6 +1774,7 @@ export class RenameNode extends BaseNode {
 
 export class FillNANode extends BaseNode {
   static readonly nodeType = "nodetool.data.FillNA";
+  static readonly retrySafe = true;
   static readonly title = "Fill NA";
   static readonly description =
     "Fill missing values in dataframe.\n    fillna, missing, impute\n\n    Use cases:\n    - Handle missing data\n    - Prepare data for analysis\n    - Improve data quality";
@@ -1924,6 +1947,7 @@ export class SaveCSVDataframeFileNode extends BaseNode {
 
 export class FilterNoneNode extends BaseNode {
   static readonly nodeType = "nodetool.data.FilterNone";
+  static readonly retrySafe = true;
   static readonly title = "Filter None";
   static readonly description =
     "Filters out None values from a stream.\n    filter, none, null, stream\n\n    Use cases:\n    - Clean data by removing null values\n    - Get only valid entries\n    - Remove placeholder values";
@@ -1976,6 +2000,7 @@ export class FilterNoneNode extends BaseNode {
 
 export class DescribeNode extends BaseNode {
   static readonly nodeType = "nodetool.data.Describe";
+  static readonly retrySafe = true;
   static readonly body = "content_card";
   static readonly title = "Describe";
   static readonly description =

--- a/packages/data-nodes/src/nodes/lib-charts.ts
+++ b/packages/data-nodes/src/nodes/lib-charts.ts
@@ -3,6 +3,7 @@ import { asRows } from "./data.js";
 
 export class ChartRendererLibNode extends BaseNode {
   static readonly nodeType = "lib.charts.ChartRenderer";
+  static readonly retrySafe = true;
   static readonly title = "Chart Renderer";
   static readonly description =
     "Node responsible for rendering chart configurations into image format using seaborn.\n    chart, seaborn, plot, visualization, data";

--- a/packages/data-nodes/src/nodes/lib-rss.ts
+++ b/packages/data-nodes/src/nodes/lib-rss.ts
@@ -99,6 +99,7 @@ function feedMetaBlock(xml: string): string {
 
 export class FetchRSSFeedLibNode extends BaseNode {
   static readonly nodeType = "lib.rss.FetchRSSFeed";
+  static readonly retrySafe = true;
   static readonly title = "Fetch RSS Feed";
   static readonly description =
     "Fetches and parses an RSS feed from a URL.\n    rss, feed, network\n\n    Use cases:\n    - Monitor news feeds\n    - Aggregate content from multiple sources\n    - Process blog updates";
@@ -152,6 +153,7 @@ export class FetchRSSFeedLibNode extends BaseNode {
 
 export class ExtractFeedMetadataLibNode extends BaseNode {
   static readonly nodeType = "lib.rss.ExtractFeedMetadata";
+  static readonly retrySafe = true;
   static readonly title = "Extract Feed Metadata";
   static readonly description =
     "Extracts metadata from an RSS feed.\n    rss, metadata, feed\n\n    Use cases:\n    - Get feed information\n    - Validate feed details\n    - Extract feed metadata";

--- a/packages/elevenlabs-nodes/tests/realtime-stt.test.ts
+++ b/packages/elevenlabs-nodes/tests/realtime-stt.test.ts
@@ -1,57 +1,70 @@
-import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const sentMessages: Array<Record<string, unknown>> = [];
-const lifecycleEvents: string[] = [];
+/**
+ * `vi.mock` factories are hoisted above the module body, and the `ws` mock
+ * is pulled in while the runtime's python-websocket-bridge is evaluated —
+ * before this file's own declarations initialize. So the mock and the state
+ * it records live in `vi.hoisted`, which runs first by construction.
+ */
+const { sentMessages, lifecycleEvents, MockWebSocket } = await vi.hoisted(
+  async () => {
+    const { EventEmitter } = await import("node:events");
 
-class MockWebSocket extends EventEmitter {
-  static readonly OPEN = 1;
-  static readonly CLOSED = 3;
+    const sentMessages: Array<Record<string, unknown>> = [];
+    const lifecycleEvents: string[] = [];
 
-  readyState = 0;
+    class MockWebSocket extends EventEmitter {
+      static readonly OPEN = 1;
+      static readonly CLOSED = 3;
 
-  constructor(_url: string, _opts?: Record<string, unknown>) {
-    super();
+      readyState = 0;
 
-    setTimeout(() => {
-      this.readyState = MockWebSocket.OPEN;
-      this.emit("open");
-      setTimeout(() => {
-        this.emit(
-          "message",
-          Buffer.from(JSON.stringify({ message_type: "session_started" }))
-        );
-      }, 0);
-    }, 0);
-  }
+      constructor(_url: string, _opts?: Record<string, unknown>) {
+        super();
 
-  send(payload: string): void {
-    const parsed = JSON.parse(payload) as Record<string, unknown>;
-    sentMessages.push(parsed);
-    if (parsed.commit === true) {
-      lifecycleEvents.push("commit");
-      setTimeout(() => {
-        this.emit(
-          "message",
-          Buffer.from(
-            JSON.stringify({
-              message_type: "committed_transcript",
-              text: "final transcript"
-            })
-          )
-        );
-      }, 0);
+        setTimeout(() => {
+          this.readyState = MockWebSocket.OPEN;
+          this.emit("open");
+          setTimeout(() => {
+            this.emit(
+              "message",
+              Buffer.from(JSON.stringify({ message_type: "session_started" }))
+            );
+          }, 0);
+        }, 0);
+      }
+
+      send(payload: string): void {
+        const parsed = JSON.parse(payload) as Record<string, unknown>;
+        sentMessages.push(parsed);
+        if (parsed.commit === true) {
+          lifecycleEvents.push("commit");
+          setTimeout(() => {
+            this.emit(
+              "message",
+              Buffer.from(
+                JSON.stringify({
+                  message_type: "committed_transcript",
+                  text: "final transcript"
+                })
+              )
+            );
+          }, 0);
+        }
+      }
+
+      close(): void {
+        lifecycleEvents.push("close");
+        this.readyState = MockWebSocket.CLOSED;
+        setTimeout(() => {
+          this.emit("close", 1000, Buffer.from(""));
+        }, 0);
+      }
     }
-  }
 
-  close(): void {
-    lifecycleEvents.push("close");
-    this.readyState = MockWebSocket.CLOSED;
-    setTimeout(() => {
-      this.emit("close", 1000, Buffer.from(""));
-    }, 0);
+    return { sentMessages, lifecycleEvents, MockWebSocket };
   }
-}
+);
 
 vi.mock("ws", () => ({
   WebSocket: MockWebSocket

--- a/packages/elevenlabs-nodes/tests/realtime-tts.test.ts
+++ b/packages/elevenlabs-nodes/tests/realtime-tts.test.ts
@@ -1,64 +1,79 @@
-import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const sentMessages: Array<Record<string, unknown>> = [];
-const lifecycleEvents: string[] = [];
-const wsUrls: string[] = [];
+/**
+ * `vi.mock` factories are hoisted above the module body, and the `ws` mock
+ * is pulled in while the runtime's python-websocket-bridge is evaluated —
+ * before this file's own declarations initialize. So the mock and the state
+ * it records live in `vi.hoisted`, which runs first by construction.
+ */
+const { sentMessages, lifecycleEvents, wsUrls, MockWebSocket } =
+  await vi.hoisted(async () => {
+    const { EventEmitter } = await import("node:events");
 
-class MockWebSocket extends EventEmitter {
-  static readonly OPEN = 1;
-  static readonly CLOSED = 3;
+    const sentMessages: Array<Record<string, unknown>> = [];
+    const lifecycleEvents: string[] = [];
+    const wsUrls: string[] = [];
 
-  readyState = 0;
+    class MockWebSocket extends EventEmitter {
+      static readonly OPEN = 1;
+      static readonly CLOSED = 3;
 
-  constructor(url: string, _opts?: Record<string, unknown>) {
-    super();
-    wsUrls.push(url);
+      readyState = 0;
 
-    setTimeout(() => {
-      this.readyState = MockWebSocket.OPEN;
-      this.emit("open");
-    }, 0);
-  }
+      constructor(url: string, _opts?: Record<string, unknown>) {
+        super();
+        wsUrls.push(url);
 
-  send(payload: string): void {
-    const parsed = JSON.parse(payload) as Record<string, unknown>;
-    sentMessages.push(parsed);
+        setTimeout(() => {
+          this.readyState = MockWebSocket.OPEN;
+          this.emit("open");
+        }, 0);
+      }
 
-    // Respond to EOS (empty text) with isFinal
-    if (parsed.text === "") {
-      lifecycleEvents.push("eos");
-      setTimeout(() => {
-        this.emit("message", Buffer.from(JSON.stringify({ isFinal: true })));
-      }, 0);
-      return;
+      send(payload: string): void {
+        const parsed = JSON.parse(payload) as Record<string, unknown>;
+        sentMessages.push(parsed);
+
+        // Respond to EOS (empty text) with isFinal
+        if (parsed.text === "") {
+          lifecycleEvents.push("eos");
+          setTimeout(() => {
+            this.emit(
+              "message",
+              Buffer.from(JSON.stringify({ isFinal: true }))
+            );
+          }, 0);
+          return;
+        }
+
+        // Respond to non-init text with an audio chunk
+        const text = parsed.text as string | undefined;
+        if (text && text.trim() && text !== " ") {
+          setTimeout(() => {
+            this.emit(
+              "message",
+              Buffer.from(
+                JSON.stringify({
+                  audio: "ZmFrZS1hdWRpbw==", // base64: "fake-audio"
+                  isFinal: false
+                })
+              )
+            );
+          }, 0);
+        }
+      }
+
+      close(): void {
+        lifecycleEvents.push("close");
+        this.readyState = MockWebSocket.CLOSED;
+        setTimeout(() => {
+          this.emit("close", 1000, Buffer.from(""));
+        }, 0);
+      }
     }
 
-    // Respond to non-init text with an audio chunk
-    const text = parsed.text as string | undefined;
-    if (text && text.trim() && text !== " ") {
-      setTimeout(() => {
-        this.emit(
-          "message",
-          Buffer.from(
-            JSON.stringify({
-              audio: "ZmFrZS1hdWRpbw==", // base64: "fake-audio"
-              isFinal: false
-            })
-          )
-        );
-      }, 0);
-    }
-  }
-
-  close(): void {
-    lifecycleEvents.push("close");
-    this.readyState = MockWebSocket.CLOSED;
-    setTimeout(() => {
-      this.emit("close", 1000, Buffer.from(""));
-    }, 0);
-  }
-}
+    return { sentMessages, lifecycleEvents, wsUrls, MockWebSocket };
+  });
 
 vi.mock("ws", () => ({
   WebSocket: MockWebSocket

--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -91,6 +91,19 @@ export type { NodeExecutor };
 const SKIPPED = Symbol("skipped");
 
 /**
+ * A failure that happened while routing values downstream, not while the node
+ * was executing. It never escalates: `sendOutputs` delivers to each outgoing
+ * edge in turn, so once edge 1 has the value, re-running the node would deliver
+ * to it twice. Design §5.1.
+ */
+class RoutingError extends Error {
+  constructor(readonly cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = "RoutingError";
+  }
+}
+
+/**
  * Canonical lineage keys join `root=index` pairs with `,`. To compute the
  * parent key for a shorter scope, take the first `prefixLength` pairs.
  */
@@ -427,7 +440,7 @@ export class NodeActor {
                   };
                 }
               }
-              await this._sendOutputs(this.node.id, { [slot]: value }, hints);
+              await this._route({ [slot]: value }, hints);
             },
             emitGroupFn: async (values, opts) => {
               await this._emitGroup(values, opts?.lineage);
@@ -1419,6 +1432,7 @@ export class NodeActor {
         });
       } catch (err) {
         if (err instanceof WorkflowSuspendedError) throw err;
+        if (err instanceof RoutingError) throw err.cause;
         if (!this._supervisor) throw err;
         const verdict = await this._escalate(err, inputs, attempt, account, {
           streamingOutput: true,
@@ -1467,6 +1481,7 @@ export class NodeActor {
       );
     } catch (err) {
       if (err instanceof WorkflowSuspendedError) throw err;
+      if (err instanceof RoutingError) throw err.cause;
       if (!this._supervisor) throw err;
       const verdict = await this._escalate(err, {}, 1, account, {
         streamingOutput: false,
@@ -1494,12 +1509,24 @@ export class NodeActor {
     if (overrides) Object.assign(this._streamingCollectedOutputs, overrides);
     const emit = overrides ? { ...routed, ...overrides } : routed;
     this._latestResult = { ...this._streamingCollectedOutputs };
-    await this._sendOutputs(
-      this.node.id,
-      emit,
-      this._currentHints(Object.keys(emit))
-    );
+    await this._route(emit, this._currentHints(Object.keys(emit)));
     return true;
+  }
+
+  /**
+   * Route values downstream, tagging any failure as a routing failure so the
+   * recovery loops let it through instead of escalating a delivery problem as
+   * if the node had failed.
+   */
+  private async _route(
+    outputs: Record<string, unknown>,
+    hints?: OutputRoutingHints
+  ): Promise<void> {
+    try {
+      await this._sendOutputs(this.node.id, outputs, hints);
+    } catch (err) {
+      throw new RoutingError(err);
+    }
   }
 
   /**

--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -34,7 +34,12 @@ import {
   inInvocationAccount,
   isRecoverableNodeError
 } from "@nodetool-ai/runtime";
-import type { Escalation, Intervention, Verdict } from "@nodetool-ai/protocol";
+import type {
+  DecidedBy,
+  Escalation,
+  Intervention,
+  Verdict
+} from "@nodetool-ai/protocol";
 import {
   computeAllowedActions,
   failureSignature,
@@ -1231,9 +1236,12 @@ export class NodeActor {
       outcome = { verdict: { action: "fail" }, decidedBy: "default" };
     }
 
-    const verdict = escalation.allowedActions.includes(outcome.verdict.action)
-      ? outcome.verdict
-      : ({ action: "fail" } as Verdict);
+    // The record has to name who produced the verdict that was *applied*. When
+    // the kernel overrules a handle, crediting the handle would hide exactly
+    // the case worth finding: a buggy or hostile supervisor.
+    const allowed = escalation.allowedActions.includes(outcome.verdict.action);
+    const verdict = allowed ? outcome.verdict : ({ action: "fail" } as Verdict);
+    const decidedBy: DecidedBy = allowed ? outcome.decidedBy : "kernel";
 
     this._emitMessage({
       type: "supervisor_decision",
@@ -1241,13 +1249,13 @@ export class NodeActor {
       node_name: this.node.name ?? this.node.type,
       escalation,
       verdict,
-      decided_by: outcome.decidedBy,
+      decided_by: decidedBy,
       cost: outcome.costUsd ?? null
     });
     this._onIntervention?.({
       escalation,
       verdict,
-      decidedBy: outcome.decidedBy,
+      decidedBy,
       costUsd: outcome.costUsd
     });
     return verdict;
@@ -1277,16 +1285,16 @@ export class NodeActor {
     const invocationKey = invocationScope.length
       ? projectLineageKey(lineage, invocationScope)
       : "";
-    const recoverable = isRecoverableNodeError(err);
+    const recoverable = isRecoverableNodeError(err) ? err : undefined;
     const candidateOutput = recoverable
-      ? redactValue(err.candidateOutput, secrets)
+      ? redactValue(recoverable.candidateOutput, secrets)
       : undefined;
 
     const allowedActions = computeAllowedActions({
       retrySafe: this.node.retry_safe === true,
       spentCostUsd: account?.costUsd ?? 0,
       createdAssets: account?.createdAssets ?? false,
-      hasCandidateOutput: recoverable,
+      hasCandidateOutput: recoverable !== undefined,
       validatorCoverage: hasFullValidatorCoverage(
         this.node.outputs ?? {},
         // Resolving a reference against run storage needs a resolver the
@@ -1306,9 +1314,7 @@ export class NodeActor {
       detail: String(
         redactValue(err instanceof Error ? err.message : String(err), secrets)
       ),
-      failureSignature: recoverable
-        ? (err.code ?? failureSignature(err))
-        : failureSignature(err),
+      failureSignature: recoverable?.code ?? failureSignature(err),
       candidateOutput,
       inputs: redactRecord(inputs, secrets),
       attempt,

--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -24,7 +24,29 @@ import { EMPTY_LINEAGE } from "@nodetool-ai/protocol";
 
 // Stryker disable next-line StringLiteral: logger name is a diagnostic label, not a behavioural contract
 const log = createLogger("nodetool.kernel.actor");
-import type { ProcessingContext, NodeExecutor } from "@nodetool-ai/runtime";
+import type {
+  ProcessingContext,
+  NodeExecutor,
+  InvocationAccount
+} from "@nodetool-ai/runtime";
+import {
+  createInvocationAccount,
+  inInvocationAccount,
+  isRecoverableNodeError
+} from "@nodetool-ai/runtime";
+import type { Escalation, Intervention, Verdict } from "@nodetool-ai/protocol";
+import {
+  computeAllowedActions,
+  failureSignature,
+  redactRecord,
+  redactValue,
+  type DecisionOutcome,
+  type SupervisorHandle
+} from "./supervisor.js";
+import {
+  hasFullValidatorCoverage,
+  validateSubstituteOutputs
+} from "./substitute-validator.js";
 // Span helpers via the narrow `/tracing` subpath — keeps the runtime
 // provider / python-bridge barrel out of thin (browser) bundles.
 import { withNodeSpan } from "@nodetool-ai/runtime/tracing";
@@ -52,9 +74,21 @@ export interface OutputRoutingHints {
    * downstream inboxes instead of `put`.
    */
   lineageDoneSlots?: Set<string>;
+  /**
+   * A supervisor `skip` verdict: this invocation produced nothing. The runner
+   * sends `lineage_done` on every outgoing data edge at `invocationLineage`,
+   * *and* `lineage_scope_closed` for every child root the invocation would have
+   * opened — `drop()` alone signals only the former, which leaves an aggregate
+   * downstream waiting forever on a scope a skipped iterator never opened.
+   * Design §5.2.
+   */
+  skipInvocation?: boolean;
 }
 
 export type { NodeExecutor };
+
+/** Returned by the recovery loop when a `skip` verdict retired an invocation. */
+const SKIPPED = Symbol("skipped");
 
 /**
  * Canonical lineage keys join `root=index` pairs with `,`. To compute the
@@ -243,6 +277,16 @@ export class NodeActor {
    */
   private _signalSlotEos: ((nodeId: string, slot: string) => void) | undefined;
 
+  /**
+   * Supervisor for this run, if any. Absent means no escalation is ever
+   * constructed and the actor behaves exactly as it did before — a clean run
+   * with no supervisor costs nothing, because nothing runs.
+   */
+  private _supervisor: SupervisorHandle | undefined;
+
+  /** Records every escalation/verdict pair for `RunResult.interventions`. */
+  private _onIntervention: ((i: Intervention) => void) | undefined;
+
   constructor(opts: {
     node: NodeDescriptor;
     inbox: NodeInbox;
@@ -259,6 +303,8 @@ export class NodeActor {
     correlation?: NodeAnalysis;
     cancelSignal?: AbortSignal;
     signalSlotEos?: (nodeId: string, slot: string) => void;
+    supervisor?: SupervisorHandle;
+    onIntervention?: (i: Intervention) => void;
   }) {
     this.node = opts.node;
     this.inbox = opts.inbox;
@@ -271,6 +317,8 @@ export class NodeActor {
     this._correlation = opts.correlation;
     this._cancelSignal = opts.cancelSignal ?? new AbortController().signal;
     this._signalSlotEos = opts.signalSlotEos;
+    this._supervisor = opts.supervisor;
+    this._onIntervention = opts.onIntervention;
   }
 
   // -----------------------------------------------------------------------
@@ -398,11 +446,7 @@ export class NodeActor {
               );
             }
           });
-          await this._executor.run(
-            nodeInputs,
-            nodeOutputs,
-            this._executionContext
-          );
+          await this._runStreamingInput(nodeInputs, nodeOutputs);
           this._latestResult = nodeOutputs.collected();
           // Site #5 (RFC §5): streaming-input run() — one committed result.
           this._emitGenerationComplete(this._latestResult);
@@ -1087,6 +1131,218 @@ export class NodeActor {
   /**
    * Execute process or genProcess with the given inputs.
    */
+  /**
+   * Run one invocation under the supervisor, if there is one.
+   *
+   * The catch wraps node execution and nothing else. `sendOutputs` routes to
+   * downstream inboxes sequentially, so if edge 1 delivered and edge 2 threw, a
+   * retry would duplicate edge 1's delivery — routing failures therefore fail
+   * the node without escalation. Design §5.1.
+   *
+   * Returns the outputs to route, or `SKIPPED` when the invocation was retired
+   * without emitting.
+   */
+  private async _invokeWithRecovery(
+    inputs: Record<string, unknown>,
+    invoke: () => Promise<Record<string, unknown>>
+  ): Promise<Record<string, unknown> | typeof SKIPPED> {
+    for (let attempt = 1; ; attempt++) {
+      // A fresh account per attempt: what the previous try spent is not what
+      // this one spent.
+      const account = createInvocationAccount();
+      try {
+        return await inInvocationAccount(account, invoke);
+      } catch (err) {
+        if (err instanceof WorkflowSuspendedError) throw err;
+        if (!this._supervisor) throw err;
+
+        const verdict = await this._escalate(err, inputs, attempt, account, {
+          streamingOutput: false,
+          streamingInput: false,
+          emitted: false
+        });
+
+        switch (verdict.action) {
+          case "retry":
+            continue;
+          case "substitute": {
+            const valid = await this._validateSubstitute(verdict.outputs);
+            if (valid) return verdict.outputs;
+            throw err;
+          }
+          case "skip":
+            await this._skipInvocation();
+            return SKIPPED;
+          default:
+            throw err;
+        }
+      }
+    }
+  }
+
+  /**
+   * Build the escalation, ask the supervisor, and enforce the allowed set
+   * against whatever comes back. The schema shown to an agent is UX; this check
+   * is the guarantee — a buggy or third-party handle returning `retry` for an
+   * unsafe node gets `fail`.
+   */
+  private async _escalate(
+    err: unknown,
+    inputs: Record<string, unknown>,
+    attempt: number,
+    account: InvocationAccount | undefined,
+    mode: {
+      streamingOutput: boolean;
+      streamingInput: boolean;
+      emitted: boolean;
+    }
+  ): Promise<Verdict> {
+    const escalation = this._buildEscalation(
+      err,
+      inputs,
+      attempt,
+      account,
+      mode
+    );
+    this._emitMessage({
+      type: "supervisor_escalation",
+      node_id: this.node.id,
+      node_name: this.node.name ?? this.node.type,
+      escalation
+    });
+
+    let outcome: DecisionOutcome;
+    try {
+      outcome = await this._supervisor!.decide(escalation, this._cancelSignal);
+    } catch {
+      outcome = { verdict: { action: "fail" }, decidedBy: "default" };
+    }
+
+    const verdict = escalation.allowedActions.includes(outcome.verdict.action)
+      ? outcome.verdict
+      : ({ action: "fail" } as Verdict);
+
+    this._emitMessage({
+      type: "supervisor_decision",
+      node_id: this.node.id,
+      node_name: this.node.name ?? this.node.type,
+      escalation,
+      verdict,
+      decided_by: outcome.decidedBy,
+      cost: outcome.costUsd ?? null
+    });
+    this._onIntervention?.({
+      escalation,
+      verdict,
+      decidedBy: outcome.decidedBy,
+      costUsd: outcome.costUsd
+    });
+    return verdict;
+  }
+
+  /**
+   * Mint the escalation record. Redaction happens *here*, not at some later
+   * prompt: `Escalation` is public — it becomes a message, lands in
+   * `RunResult.interventions`, and crosses the websocket — so no unredacted
+   * instance may exist anywhere in the system. Design §6.1.
+   */
+  private _buildEscalation(
+    err: unknown,
+    inputs: Record<string, unknown>,
+    attempt: number,
+    account: InvocationAccount | undefined,
+    mode: {
+      streamingOutput: boolean;
+      streamingInput: boolean;
+      emitted: boolean;
+    }
+  ): Escalation {
+    const secrets =
+      this._executionContext?.getResolvedSecretValues?.() ?? new Set<string>();
+    const lineage = this._currentInvocationLineage ?? EMPTY_LINEAGE;
+    const invocationScope = this._correlation?.invocationScope ?? [];
+    const invocationKey = invocationScope.length
+      ? projectLineageKey(lineage, invocationScope)
+      : "";
+    const recoverable = isRecoverableNodeError(err);
+    const candidateOutput = recoverable
+      ? redactValue(err.candidateOutput, secrets)
+      : undefined;
+
+    const allowedActions = computeAllowedActions({
+      retrySafe: this.node.retry_safe === true,
+      spentCostUsd: account?.costUsd ?? 0,
+      createdAssets: account?.createdAssets ?? false,
+      hasCandidateOutput: recoverable,
+      validatorCoverage: hasFullValidatorCoverage(
+        this.node.outputs ?? {},
+        // Resolving a reference against run storage needs a resolver the
+        // kernel does not have yet, so reference-typed outputs are not
+        // substitutable — better than accepting an unresolvable ref.
+        false
+      ),
+      ...mode
+    });
+
+    return {
+      nodeId: this.node.id,
+      nodeType: this.node.type,
+      correlationLineage: invocationKey === "" ? [] : invocationKey.split(","),
+      invocationKey,
+      allowedActions,
+      detail: String(
+        redactValue(err instanceof Error ? err.message : String(err), secrets)
+      ),
+      failureSignature: recoverable
+        ? (err.code ?? failureSignature(err))
+        : failureSignature(err),
+      candidateOutput,
+      inputs: redactRecord(inputs, secrets),
+      attempt,
+      spentCostUsd: account?.costUsd ?? 0,
+      createdAssets: account?.createdAssets ?? false,
+      retrySafe: this.node.retry_safe === true,
+      emitted: mode.emitted
+    };
+  }
+
+  /**
+   * A repaired value is type-checked against the node's declared outputs
+   * before it enters the graph. An invalid repair is not a repair.
+   */
+  private async _validateSubstitute(
+    outputs: Record<string, unknown>
+  ): Promise<boolean> {
+    const declared = this.node.outputs ?? {};
+    const result = await validateSubstituteOutputs(outputs, {
+      declaredOutputs: declared
+    });
+    if (!result.ok) {
+      // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
+      log.warn("Rejected supervisor substitution", {
+        nodeId: this.node.id,
+        issues: result.issues
+      });
+    }
+    return result.ok;
+  }
+
+  /**
+   * Retire this invocation without emitting: `lineage_done` plus scope closure
+   * on every outgoing edge, so downstream joins move past the skipped key and
+   * aggregates see the scopes the invocation would have opened get closed.
+   */
+  private async _skipInvocation(): Promise<void> {
+    await this._sendOutputs(
+      this.node.id,
+      {},
+      {
+        skipInvocation: true,
+        invocationLineage: this._currentInvocationLineage ?? EMPTY_LINEAGE
+      }
+    );
+  }
+
   private async _executeWithInputs(
     inputs: Record<string, unknown>
   ): Promise<void> {
@@ -1119,29 +1375,69 @@ export class NodeActor {
     this._currentInvocationLineage = this._computeInvocationLineage();
 
     if (this.node.is_streaming_output && this._executor.genProcess) {
+      await this._executeStreaming(inputs);
+      return;
+    }
+
+    const outputs = await this._invokeWithRecovery(inputs, () =>
+      this._executor.process(inputs, this._executionContext)
+    );
+    if (outputs === SKIPPED) return;
+    this._latestResult = outputs;
+    await this._sendOutputs(
+      this.node.id,
+      outputs,
+      this._currentHints(Object.keys(outputs))
+    );
+    // Site #1 (RFC §5): correlated process() — one per ready key, so N/run
+    // for a generator (the primary 6×-collapse fix).
+    this._emitGenerationComplete(outputs, inputs);
+  }
+
+  /**
+   * The streaming-output invocation, with its own recovery rules.
+   *
+   * Frames are routed inside the generator loop, so "retry" only means
+   * something before the first emit — after that the coherent choices are
+   * ending the stream (keeping what was produced) or failing. Design §5.4.
+   */
+  private async _executeStreaming(
+    inputs: Record<string, unknown>
+  ): Promise<void> {
+    for (let attempt = 1; ; attempt++) {
+      const account = createInvocationAccount();
+      let emitted = false;
       this._streamingCollectedOutputs = {};
-      for await (const partial of this._executor.genProcess(
-        inputs,
-        this._executionContext
-      )) {
-        const routed = this._filterStreamingPartial(partial);
-        const handles = Object.keys(routed);
-        if (handles.length === 0) continue;
-        // Strip actor-reserved `index` from iteration groups before routing
-        // (the actor mints the token index; node code is migrating away from
-        // supplying it). §1 — under the correlation scheduler this becomes
-        // a validation error after migration; for now we warn-and-overwrite.
-        const overrides = this._mintIterationFrameOverrides(routed);
-        Object.assign(this._streamingCollectedOutputs, routed);
-        if (overrides)
-          Object.assign(this._streamingCollectedOutputs, overrides);
-        const emit = overrides ? { ...routed, ...overrides } : routed;
-        this._latestResult = { ...this._streamingCollectedOutputs };
-        await this._sendOutputs(
-          this.node.id,
-          emit,
-          this._currentHints(Object.keys(emit))
-        );
+      try {
+        await inInvocationAccount(account, async () => {
+          for await (const partial of this._executor.genProcess!(
+            inputs,
+            this._executionContext
+          )) {
+            emitted = (await this._routeStreamingFrame(partial)) || emitted;
+          }
+        });
+      } catch (err) {
+        if (err instanceof WorkflowSuspendedError) throw err;
+        if (!this._supervisor) throw err;
+        const verdict = await this._escalate(err, inputs, attempt, account, {
+          streamingOutput: true,
+          streamingInput: false,
+          emitted
+        });
+        switch (verdict.action) {
+          case "retry":
+            continue;
+          case "skip":
+            await this._skipInvocation();
+            return;
+          case "end_stream":
+            this._completeOutputSlots();
+            this._latestResult = { ...(this._streamingCollectedOutputs ?? {}) };
+            return;
+          default:
+            throw err;
+        }
       }
       this._latestResult = { ...(this._streamingCollectedOutputs ?? {}) };
       // Site #4 (RFC §5): genProcess stream-end — ONCE per stream, carrying the
@@ -1150,20 +1446,74 @@ export class NodeActor {
       // OF SCOPE (RFC §5 invariant / Decision 1 corollary). Under correlation
       // this branch runs once per ready key → one generation_complete per key.
       this._emitGenerationComplete(this._latestResult, inputs);
-    } else {
-      const outputs = await this._executor.process(
-        inputs,
-        this._executionContext
+      return;
+    }
+  }
+
+  /**
+   * The streaming-input invocation. A `run()` node drains its own inbox and may
+   * have consumed messages long before it threw, across arbitrary lineages —
+   * nothing is replayable and there is no single lineage for a skip to target.
+   * So the verdict set here is exactly `end_stream` · `fail`. Design §5.4.
+   */
+  private async _runStreamingInput(
+    nodeInputs: NodeInputs,
+    nodeOutputs: NodeOutputs
+  ): Promise<void> {
+    const account = createInvocationAccount();
+    try {
+      await inInvocationAccount(account, () =>
+        this._executor.run!(nodeInputs, nodeOutputs, this._executionContext)
       );
-      this._latestResult = outputs;
-      await this._sendOutputs(
-        this.node.id,
-        outputs,
-        this._currentHints(Object.keys(outputs))
-      );
-      // Site #1 (RFC §5): correlated process() — one per ready key, so N/run
-      // for a generator (the primary 6×-collapse fix).
-      this._emitGenerationComplete(outputs, inputs);
+    } catch (err) {
+      if (err instanceof WorkflowSuspendedError) throw err;
+      if (!this._supervisor) throw err;
+      const verdict = await this._escalate(err, {}, 1, account, {
+        streamingOutput: false,
+        streamingInput: true,
+        emitted: true
+      });
+      if (verdict.action !== "end_stream") throw err;
+      this._completeOutputSlots();
+    }
+  }
+
+  /** Route one yielded frame. Returns true when anything went downstream. */
+  private async _routeStreamingFrame(
+    partial: Record<string, unknown>
+  ): Promise<boolean> {
+    const routed = this._filterStreamingPartial(partial);
+    if (Object.keys(routed).length === 0) return false;
+    // Strip actor-reserved `index` from iteration groups before routing
+    // (the actor mints the token index; node code is migrating away from
+    // supplying it). §1 — under the correlation scheduler this becomes
+    // a validation error after migration; for now we warn-and-overwrite.
+    const overrides = this._mintIterationFrameOverrides(routed);
+    this._streamingCollectedOutputs ??= {};
+    Object.assign(this._streamingCollectedOutputs, routed);
+    if (overrides) Object.assign(this._streamingCollectedOutputs, overrides);
+    const emit = overrides ? { ...routed, ...overrides } : routed;
+    this._latestResult = { ...this._streamingCollectedOutputs };
+    await this._sendOutputs(
+      this.node.id,
+      emit,
+      this._currentHints(Object.keys(emit))
+    );
+    return true;
+  }
+
+  /**
+   * Close every output slot, keeping whatever the stream already emitted —
+   * the `end_stream` verdict. Slots come from the node's declared outputs,
+   * falling back to what the stream actually produced.
+   */
+  private _completeOutputSlots(): void {
+    const declared = Object.keys(this.node.outputs ?? {});
+    const slots = declared.length
+      ? declared
+      : Object.keys(this._streamingCollectedOutputs ?? {});
+    for (const slot of slots) {
+      this._signalSlotEos?.(this.node.id, slot || "output");
     }
   }
 
@@ -1438,10 +1788,10 @@ export class NodeActor {
           ...inputs,
           ...this._currentControlProperties
         });
-        const outputs = await this._executor.process(
-          merged,
-          this._executionContext
+        const outputs = await this._invokeWithRecovery(merged, () =>
+          this._executor.process(merged, this._executionContext)
         );
+        if (outputs === SKIPPED) continue;
         this._latestResult = outputs;
         await this._sendOutputs(this.node.id, outputs);
         // Site #2 (RFC §5): controlled-loop process() — one per "run" event.

--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -1454,6 +1454,11 @@ export class NodeActor {
           case "end_stream":
             this._completeOutputSlots();
             this._latestResult = { ...(this._streamingCollectedOutputs ?? {}) };
+            // `end_stream` keeps what the stream produced, so the invocation
+            // committed — it just committed early. Skipping the commit marker
+            // would hide those outputs from replay and asset autosave, which
+            // is the "silent data loss dressed as success" the PRD forbids.
+            this._emitGenerationComplete(this._latestResult, inputs);
             return;
           default:
             throw err;

--- a/packages/kernel/src/graph.ts
+++ b/packages/kernel/src/graph.ts
@@ -134,7 +134,10 @@ export function withExplicitNodeFlags(graph: GraphData): HydratedGraphData {
       is_streaming_input: node.is_streaming_input ?? false,
       is_streaming_output: node.is_streaming_output ?? false,
       is_controlled: node.is_controlled ?? false,
-      is_join_node: node.is_join_node ?? false
+      is_join_node: node.is_join_node ?? false,
+      // Here — unlike `loadFromDict` — the descriptor's author is code, not a
+      // saved file, so a declared `retry_safe` is the class's own declaration.
+      retry_safe: node.retry_safe ?? false
     })),
     edges: [...graph.edges]
   };
@@ -439,7 +442,15 @@ export class Graph {
         is_controlled:
           descriptorDefaults.is_controlled ?? node.is_controlled ?? false,
         is_join_node:
-          descriptorDefaults.is_join_node ?? node.is_join_node ?? false
+          descriptorDefaults.is_join_node ?? node.is_join_node ?? false,
+        // Retry safety comes from the registry or not at all — note there is
+        // no `?? node.retry_safe` here, unlike every flag above. Whether
+        // re-running a node duplicates a payment or a publish is a property of
+        // its implementation, not of a file: a saved graph asserting
+        // `retry_safe: true` for a node whose class never declared it would
+        // hand the supervisor a retry on a side-effecting node. An unresolved
+        // type therefore gets no retry rather than the saved claim.
+        retry_safe: descriptorDefaults.retry_safe ?? false
       };
 
       resolvedNodes.push(hydratedNode);

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -35,6 +35,26 @@ export {
 } from "./correlation-analysis.js";
 export { NodeActor, type NodeExecutor, type ActorResult } from "./actor.js";
 export {
+  BoundedHandle,
+  FailClosedHandle,
+  computeAllowedActions,
+  failureSignature,
+  redactRecord,
+  redactValue,
+  DEFAULT_SUPERVISOR_BOUNDS,
+  MAX_ESCALATION_VALUE_CHARS,
+  type SupervisorHandle,
+  type DecisionOutcome,
+  type SupervisorBounds,
+  type AllowedActionsInput
+} from "./supervisor.js";
+export {
+  validateSubstituteOutputs,
+  hasFullValidatorCoverage,
+  type SubstituteValidationResult,
+  type SubstituteValidatorOptions
+} from "./substitute-validator.js";
+export {
   WorkflowRunner,
   type RunJobRequest,
   type WorkflowRunnerOptions,

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -20,9 +20,12 @@ import type {
   HydratedGraphData,
   Edge,
   ProcessingMessage,
-  ControlEvent
+  ControlEvent,
+  CorrelationLineage,
+  Intervention
 } from "@nodetool-ai/protocol";
 import { TypeMetadata } from "@nodetool-ai/protocol";
+import type { SupervisorHandle } from "./supervisor.js";
 
 // Stryker disable next-line StringLiteral: logger name is a diagnostic label, not a behavioural contract
 const log = createLogger("nodetool.kernel.runner");
@@ -66,7 +69,6 @@ import { dynamicSlotPropertyTypes } from "./dynamic-slots.js";
 import { NodeInbox } from "./inbox.js";
 import { NodeActor, type NodeExecutor } from "./actor.js";
 import { syntheticEdgeId } from "./edge-ids.js";
-import type { CorrelationLineage } from "@nodetool-ai/protocol";
 import {
   analyzeCorrelation,
   type CorrelationAnalysisResult
@@ -91,6 +93,13 @@ export interface OutputRoutingHints {
    * delivering a value. §5.
    */
   lineageDoneSlots?: Set<string>;
+  /**
+   * A supervisor `skip` verdict: this invocation produced nothing. The runner
+   * sends `lineage_done` on every outgoing data edge at `invocationLineage`,
+   * *and* `lineage_scope_closed` for every child root the invocation would have
+   * opened. Design §5.2.
+   */
+  skipInvocation?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -190,6 +199,13 @@ export interface WorkflowRunnerOptions {
    * naming every offending node/edge, exactly like any other run failure.
    */
   strict?: boolean;
+
+  /**
+   * Turns a failing node invocation into a decision instead of a dead run.
+   * Absent — the default — means no escalation is ever constructed and the run
+   * behaves exactly as it does today. See docs/workflow-supervisor-design.md.
+   */
+  supervisor?: SupervisorHandle;
 }
 
 // ---------------------------------------------------------------------------
@@ -221,6 +237,14 @@ export interface RunResult {
     state: Record<string, unknown>;
     metadata: Record<string, unknown>;
   };
+
+  /**
+   * Every supervisor escalation and the verdict it received, in order. A
+   * completed run with a non-empty list is "Completed — supervised": a derived
+   * display state, not a fifth status, so existing `status` consumers keep
+   * working.
+   */
+  interventions?: Intervention[];
 }
 
 /**
@@ -381,6 +405,14 @@ export class WorkflowRunner {
         metadata: Record<string, unknown>;
       }
     | undefined;
+
+  /** Supervisor escalations and their verdicts, in decision order. */
+  private _interventions: Intervention[] = [];
+
+  /** Undefined on an unsupervised run, so its `RunResult` is unchanged. */
+  private _recordedInterventions(): Intervention[] | undefined {
+    return this._interventions.length > 0 ? this._interventions : undefined;
+  }
 
   constructor(jobId: string, options: WorkflowRunnerOptions) {
     this.jobId = jobId;
@@ -669,7 +701,8 @@ export class WorkflowRunner {
           outputs: Object.fromEntries(this._outputs),
           messages: this._messages,
           status: "suspended",
-          suspend: this._suspend
+          suspend: this._suspend,
+          interventions: this._recordedInterventions()
         };
       }
 
@@ -693,7 +726,8 @@ export class WorkflowRunner {
           outputs: Object.fromEntries(this._outputs),
           messages: this._messages,
           status: "failed",
-          error
+          error,
+          interventions: this._recordedInterventions()
         };
       }
 
@@ -711,7 +745,8 @@ export class WorkflowRunner {
       return {
         outputs: Object.fromEntries(this._outputs),
         messages: this._messages,
-        status
+        status,
+        interventions: this._recordedInterventions()
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -742,7 +777,8 @@ export class WorkflowRunner {
         outputs: Object.fromEntries(this._outputs),
         messages: this._messages,
         status: "failed",
-        error: message
+        error: message,
+        interventions: this._recordedInterventions()
       };
     } finally {
       this._running = false;
@@ -766,6 +802,7 @@ export class WorkflowRunner {
     this._correlation = undefined;
     this._eosSentEdges = new Set();
     this._suspend = undefined;
+    this._interventions = [];
   }
 
   /** Actors spawned and not yet finished. Zero before and after a run. */
@@ -1254,86 +1291,90 @@ export class WorkflowRunner {
         correlation: this._correlation?.nodes.get(node.id),
         cancelSignal: this._abortController.signal,
         signalSlotEos: (sourceNodeId, slot) =>
-          this._signalSlotEos(sourceNodeId, slot)
+          this._signalSlotEos(sourceNodeId, slot),
+        supervisor: this._options.supervisor,
+        onIntervention: (intervention) => this._interventions.push(intervention)
       });
 
       actorNodeIds.push(node.id);
       this._liveActors++;
       actorPromises.push(
-        actor.run().then(async (result) => {
-          // Nothing will read this inbox again. Wake any upstream actor parked
-          // on a full buffer so it can finish instead of waiting forever for a
-          // consumer that is gone.
-          inbox.releaseBackpressure();
+        actor
+          .run()
+          .then(async (result) => {
+            // Nothing will read this inbox again. Wake any upstream actor parked
+            // on a full buffer so it can finish instead of waiting forever for a
+            // consumer that is gone.
+            inbox.releaseBackpressure();
 
-          if (result.error !== undefined) {
-            this._nodeErrors.set(node.id, result.error);
-          }
-
-          // A suspension is a distinct terminal outcome, not an error.
-          // Record the first one; precedence is resolved at finalization.
-          if (result.suspend !== undefined) {
-            this._suspend ??= {
-              node_id: result.suspend.nodeId,
-              reason: result.suspend.reason,
-              state: result.suspend.state,
-              metadata: result.suspend.metadata
-            };
-          }
-
-          // After actor completes, send EOS to all downstream inboxes
-          await this._sendEOS(node.id);
-
-          // A Set Variable writer finished — when the last writer for a channel
-          // is done, the context closes it so readers (Get Variable / Prompt)
-          // drain and end instead of waiting forever.
-          if (node.type === SET_VARIABLE_NODE_TYPE) {
-            const channelName = this._variableChannelName(node);
-            if (channelName) {
-              this._options.executionContext?.markChannelWriterDone?.(
-                channelName
-              );
+            if (result.error !== undefined) {
+              this._nodeErrors.set(node.id, result.error);
             }
-          }
 
-          // The actor's run loop is gone — it can no longer answer control
-          // events. Mark it so future sendControlEvent calls reject fast
-          // rather than hang, and reject any response still waiting on it
-          // (the actor finished without producing the awaited output, e.g.
-          // it errored mid-burst).
-          this._completedNodes.add(node.id);
-          const pendingQueue = this._pendingControlResponses.get(node.id);
-          if (pendingQueue) {
-            this._pendingControlResponses.delete(node.id);
-            for (const pending of pendingQueue) {
-              pending.reject(
-                new Error(
-                  result.error ??
-                    `Controlled node ${node.id} completed without responding`
-                )
-              );
+            // A suspension is a distinct terminal outcome, not an error.
+            // Record the first one; precedence is resolved at finalization.
+            if (result.suspend !== undefined) {
+              this._suspend ??= {
+                node_id: result.suspend.nodeId,
+                reason: result.suspend.reason,
+                state: result.suspend.state,
+                metadata: result.suspend.metadata
+              };
             }
-          }
 
-          // If this is an output node, collect the result
-          if (this._isOutputNode(node)) {
-            const name = node.name ?? node.id;
-            if (!this._outputs.has(name)) {
-              this._outputs.set(name, []);
-            }
-            if (result.outputs) {
-              for (const val of Object.values(result.outputs)) {
-                this._outputs.get(name)!.push(val);
+            // After actor completes, send EOS to all downstream inboxes
+            await this._sendEOS(node.id);
+
+            // A Set Variable writer finished — when the last writer for a channel
+            // is done, the context closes it so readers (Get Variable / Prompt)
+            // drain and end instead of waiting forever.
+            if (node.type === SET_VARIABLE_NODE_TYPE) {
+              const channelName = this._variableChannelName(node);
+              if (channelName) {
+                this._options.executionContext?.markChannelWriterDone?.(
+                  channelName
+                );
               }
             }
-          }
-        })
-        // Counts the actor as live until its completion handling (EOS
-        // routing, output collection) is done too — that work can still emit
-        // messages, so an actor is not "gone" before it finishes.
-        .finally(() => {
-          this._liveActors--;
-        })
+
+            // The actor's run loop is gone — it can no longer answer control
+            // events. Mark it so future sendControlEvent calls reject fast
+            // rather than hang, and reject any response still waiting on it
+            // (the actor finished without producing the awaited output, e.g.
+            // it errored mid-burst).
+            this._completedNodes.add(node.id);
+            const pendingQueue = this._pendingControlResponses.get(node.id);
+            if (pendingQueue) {
+              this._pendingControlResponses.delete(node.id);
+              for (const pending of pendingQueue) {
+                pending.reject(
+                  new Error(
+                    result.error ??
+                      `Controlled node ${node.id} completed without responding`
+                  )
+                );
+              }
+            }
+
+            // If this is an output node, collect the result
+            if (this._isOutputNode(node)) {
+              const name = node.name ?? node.id;
+              if (!this._outputs.has(name)) {
+                this._outputs.set(name, []);
+              }
+              if (result.outputs) {
+                for (const val of Object.values(result.outputs)) {
+                  this._outputs.get(name)!.push(val);
+                }
+              }
+            }
+          })
+          // Counts the actor as live until its completion handling (EOS
+          // routing, output collection) is done too — that work can still emit
+          // messages, so an actor is not "gone" before it finishes.
+          .finally(() => {
+            this._liveActors--;
+          })
       );
     }
 
@@ -1426,6 +1467,14 @@ export class WorkflowRunner {
     routingHints: OutputRoutingHints = {}
   ): Promise<void> {
     if (this._cancelled) return;
+
+    if (routingHints.skipInvocation) {
+      this._skipInvocationOutputs(
+        sourceNodeId,
+        routingHints.invocationLineage ?? {}
+      );
+      return;
+    }
 
     // Handle __control_output__ from controller nodes (Python parity:
     // send_messages wraps __control_output__ in RunEvent and routes to
@@ -1642,6 +1691,65 @@ export class WorkflowRunner {
         this._pendingControlResponses.delete(sourceNodeId);
       }
       pending.resolve(outputs);
+    }
+  }
+
+  /**
+   * A supervisor `skip`: retire one invocation's outputs without emitting.
+   *
+   * Plain non-emission is not enough. Siblings already buffered against the
+   * skipped key would sit at a downstream join forever, and an invocation of an
+   * iteration node would have opened child scopes an aggregate is waiting to
+   * see closed. So both signals go out on every outgoing data edge: the
+   * per-lineage `lineage_done` that unblocks joins, and a `lineage_scope_closed`
+   * per child root the invocation could have minted. Design §5.2.
+   */
+  private _skipInvocationOutputs(
+    sourceNodeId: string,
+    lineage: CorrelationLineage
+  ): void {
+    const nodeAnalysis = this._correlation?.nodes.get(sourceNodeId);
+    for (const edge of this._graph.findOutgoingEdges(sourceNodeId)) {
+      if (isControlEdge(edge)) continue;
+      const targetInbox = this._inboxes.get(edge.target);
+      if (!targetInbox) continue;
+      const edgeId =
+        edge.id ??
+        syntheticEdgeId(
+          edge.source,
+          edge.sourceHandle,
+          edge.target,
+          edge.targetHandle
+        );
+
+      for (const root of nodeAnalysis?.outputs.get(edge.sourceHandle)
+        ?.possibleChildRoots ?? []) {
+        targetInbox.signalLineageScopeClosed(
+          edge.targetHandle,
+          {
+            type: "lineage_scope_closed",
+            source_edge_id: edgeId,
+            output: edge.sourceHandle,
+            parent_lineage: lineage,
+            closed_root: root
+          },
+          // The parent scope of a minted child root is the invocation scope
+          // the source node fired at — the scope this lineage projects onto.
+          nodeAnalysis?.invocationScope ?? []
+        );
+      }
+
+      targetInbox.signalLineageDone(
+        edge.targetHandle,
+        {
+          type: "lineage_done",
+          source_edge_id: edgeId,
+          output: edge.sourceHandle,
+          lineage
+        },
+        this._correlation?.nodes.get(edge.target)?.inputs.get(edge.targetHandle)
+          ?.scope ?? []
+      );
     }
   }
 

--- a/packages/kernel/src/substitute-validator.ts
+++ b/packages/kernel/src/substitute-validator.ts
@@ -52,6 +52,18 @@ export async function validateSubstituteOutputs(
   const issues: string[] = [];
   const declared = opts.declaredOutputs;
 
+  // A substitution must fill every declared slot. An omitted slot emits no
+  // value *and* no `lineage_done`, so a downstream join correlated on that
+  // slot keeps waiting for a key that will never arrive — the same hole
+  // `skip` needed explicit signalling to close (design §5.2). Node code may
+  // legitimately emit a subset (an `If` emits one branch); a model-authored
+  // repair does not get that latitude.
+  for (const slot of Object.keys(declared)) {
+    if (outputs[slot] === undefined) {
+      issues.push(`output "${slot}" is declared by this node but missing`);
+    }
+  }
+
   for (const [slot, value] of Object.entries(outputs)) {
     const type = declared[slot];
     if (type === undefined) {

--- a/packages/kernel/src/substitute-validator.ts
+++ b/packages/kernel/src/substitute-validator.ts
@@ -1,0 +1,191 @@
+/**
+ * Runtime value validation for a `substitute` verdict.
+ *
+ * Not a `TypeMetadata` compatibility check: `graph.validate()` compares
+ * *declared* edge types and the runtime accepts any object for custom types, so
+ * a type-compatibility pass would wave through a fabricated `{type:"image"}`
+ * blob with a uri pointing nowhere. This checks the actual value against the
+ * node's declared output type — primitives and enums strictly, lists and
+ * objects structurally, and reference types as well-formed refs whose uri
+ * *resolves* against the run's storage.
+ *
+ * Resolution is asynchronous, which is why acceptance is an async hook on the
+ * supervisor's verdict tool rather than a check after `decide()` returns: by
+ * then the conversation is over and there is nobody left to bounce an error to.
+ *
+ * See docs/workflow-supervisor-design.md §5.2.
+ */
+
+/** Declared output types that carry a uri/asset id needing resolution. */
+const REFERENCE_TYPES = new Set([
+  "image",
+  "audio",
+  "video",
+  "document",
+  "asset",
+  "file",
+  "model",
+  "folder"
+]);
+
+export interface SubstituteValidationResult {
+  ok: boolean;
+  /** One line per rejected slot, ready to hand back as a tool error. */
+  issues: string[];
+}
+
+export interface SubstituteValidatorOptions {
+  /** Declared output types, keyed by slot (`NodeDescriptor.outputs`). */
+  declaredOutputs: Record<string, string>;
+  /**
+   * Resolves a reference's uri against run storage. Returning false rejects
+   * the substitution. Omitted ⇒ references are rejected outright, because an
+   * unresolvable ref is exactly the failure this check exists to catch.
+   */
+  resolveRef?: (uri: string) => Promise<boolean>;
+}
+
+export async function validateSubstituteOutputs(
+  outputs: Record<string, unknown>,
+  opts: SubstituteValidatorOptions
+): Promise<SubstituteValidationResult> {
+  const issues: string[] = [];
+  const declared = opts.declaredOutputs;
+
+  for (const [slot, value] of Object.entries(outputs)) {
+    const type = declared[slot];
+    if (type === undefined) {
+      issues.push(`output "${slot}" is not declared by this node`);
+      continue;
+    }
+    const issue = await validateOne(slot, value, type, opts);
+    if (issue) issues.push(issue);
+  }
+
+  return { ok: issues.length === 0, issues };
+}
+
+/**
+ * True when every declared output has a rule this validator can enforce.
+ * `substitute` is offered only for full coverage — a partially-checked
+ * substitution is an unchecked one for the slot that matters.
+ */
+export function hasFullValidatorCoverage(
+  declaredOutputs: Record<string, string>,
+  canResolveRefs: boolean
+): boolean {
+  const types = Object.values(declaredOutputs);
+  if (types.length === 0) return false;
+  return types.every((type) => {
+    const base = baseType(type);
+    if (REFERENCE_TYPES.has(base)) return canResolveRefs;
+    return (
+      base === "str" ||
+      base === "string" ||
+      base === "int" ||
+      base === "integer" ||
+      base === "float" ||
+      base === "number" ||
+      base === "bool" ||
+      base === "boolean" ||
+      base === "list" ||
+      base === "array" ||
+      base === "dict" ||
+      base === "object" ||
+      base === "any"
+    );
+  });
+}
+
+function baseType(type: string): string {
+  // `list[str]` / `dict[str, any]` → `list` / `dict`
+  const bracket = type.indexOf("[");
+  return (bracket === -1 ? type : type.slice(0, bracket)).trim().toLowerCase();
+}
+
+async function validateOne(
+  slot: string,
+  value: unknown,
+  type: string,
+  opts: SubstituteValidatorOptions
+): Promise<string | null> {
+  const base = baseType(type);
+
+  switch (base) {
+    case "any":
+      return null;
+    case "str":
+    case "string":
+      return typeof value === "string"
+        ? null
+        : `output "${slot}" must be a string, got ${describe(value)}`;
+    case "int":
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value)
+        ? null
+        : `output "${slot}" must be an integer, got ${describe(value)}`;
+    case "float":
+    case "number":
+      return typeof value === "number" && Number.isFinite(value)
+        ? null
+        : `output "${slot}" must be a finite number, got ${describe(value)}`;
+    case "bool":
+    case "boolean":
+      return typeof value === "boolean"
+        ? null
+        : `output "${slot}" must be a boolean, got ${describe(value)}`;
+    case "list":
+    case "array":
+      return Array.isArray(value)
+        ? null
+        : `output "${slot}" must be a list, got ${describe(value)}`;
+    case "dict":
+    case "object":
+      return isPlainObject(value)
+        ? null
+        : `output "${slot}" must be an object, got ${describe(value)}`;
+    default:
+      break;
+  }
+
+  if (REFERENCE_TYPES.has(base)) {
+    if (!isPlainObject(value)) {
+      return `output "${slot}" must be a ${base} reference, got ${describe(value)}`;
+    }
+    const ref = value as { type?: unknown; uri?: unknown; asset_id?: unknown };
+    if (ref.type !== base) {
+      return `output "${slot}" must carry type "${base}", got ${describe(ref.type)}`;
+    }
+    const uri = typeof ref.uri === "string" ? ref.uri : "";
+    const assetId = typeof ref.asset_id === "string" ? ref.asset_id : "";
+    if (!uri && !assetId) {
+      return `output "${slot}" is a ${base} reference with neither uri nor asset_id`;
+    }
+    if (!opts.resolveRef) {
+      return `output "${slot}" is a ${base} reference and this run cannot resolve references`;
+    }
+    const resolved = await opts.resolveRef(uri || assetId);
+    return resolved
+      ? null
+      : `output "${slot}" references ${JSON.stringify(uri || assetId)}, which does not resolve`;
+  }
+
+  // An unrecognized declared type has no rule, and an unchecked slot is what
+  // this validator exists to prevent.
+  return `output "${slot}" has type "${type}", which has no runtime validation rule`;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function describe(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (Array.isArray(value)) return "a list";
+  return typeof value;
+}

--- a/packages/kernel/src/supervisor.ts
+++ b/packages/kernel/src/supervisor.ts
@@ -1,0 +1,364 @@
+/**
+ * Workflow Supervisor — the kernel half.
+ *
+ * A failing node invocation raises an `Escalation`; a `SupervisorHandle`
+ * returns a `Verdict`. The kernel defines the interface, computes the set of
+ * verdicts an escalation may legally receive, redacts everything the escalation
+ * carries, and enforces the allowed set against whatever the handle returns.
+ * The LLM-backed implementation lives in `@nodetool-ai/agents`; the dependency
+ * arrow stays `kernel ← agents`.
+ *
+ * See docs/workflow-supervisor-design.md §5.
+ */
+
+import type {
+  Escalation,
+  Verdict,
+  VerdictAction,
+  DecidedBy
+} from "@nodetool-ai/protocol";
+
+// ---------------------------------------------------------------------------
+// The interface
+// ---------------------------------------------------------------------------
+
+/** What a handle returns: the verdict, who made it, and what it cost. */
+export interface DecisionOutcome {
+  verdict: Verdict;
+  decidedBy: DecidedBy;
+  /** Supervisor spend for this decision, in USD. */
+  costUsd?: number;
+}
+
+export interface SupervisorHandle {
+  decide(e: Escalation, signal: AbortSignal): Promise<DecisionOutcome>;
+  close(): void;
+}
+
+/**
+ * The default, and what every failure of a supervisor degrades to: today's
+ * behavior. A runner without a supervisor never constructs an escalation at
+ * all, so this exists for callers that want the seam wired but inert.
+ */
+export class FailClosedHandle implements SupervisorHandle {
+  async decide(): Promise<DecisionOutcome> {
+    return { verdict: { action: "fail" }, decidedBy: "default" };
+  }
+  close(): void {}
+}
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+/**
+ * Field names whose values never leave the actor, whatever they contain.
+ * Matched case-insensitively against whole names and name fragments, so
+ * `authorization`, `Auth-Token`, and `api_key` all hit.
+ */
+const SENSITIVE_NAME_PATTERN =
+  /(password|passwd|secret|token|api[-_]?key|apikey|authorization|auth|credential|private[-_]?key|session[-_]?id|cookie|bearer)/i;
+
+const MASK = "«redacted»";
+
+/** Per-value cap on redacted payloads. Truncation is size, not safety. */
+export const MAX_ESCALATION_VALUE_CHARS = 2000;
+
+/**
+ * Mask every known secret value inside a string, wherever it appears —
+ * headers, URLs, bodies, stringified errors.
+ */
+function maskSecrets(text: string, secrets: ReadonlySet<string>): string {
+  let out = text;
+  for (const secret of secrets) {
+    if (!secret) continue;
+    out = out.split(secret).join(MASK);
+  }
+  return out;
+}
+
+function truncate(text: string): string {
+  return text.length > MAX_ESCALATION_VALUE_CHARS
+    ? `${text.slice(0, MAX_ESCALATION_VALUE_CHARS)}…[truncated]`
+    : text;
+}
+
+/**
+ * Redact one value: drop sensitive-named fields, mask known secret values in
+ * every string, truncate what remains. Recurses through plain objects and
+ * arrays; anything else is stringified, because a class instance's `toString`
+ * is not a place to gamble on what it prints.
+ */
+export function redactValue(
+  value: unknown,
+  secrets: ReadonlySet<string>,
+  depth = 0
+): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") return truncate(maskSecrets(value, secrets));
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (depth >= 6) return MASK;
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, 100)
+      .map((item) => redactValue(item, secrets, depth + 1));
+  }
+  if (typeof value === "object") {
+    const proto = Object.getPrototypeOf(value);
+    if (proto === Object.prototype || proto === null) {
+      const out: Record<string, unknown> = {};
+      for (const [key, item] of Object.entries(value)) {
+        out[key] = SENSITIVE_NAME_PATTERN.test(key)
+          ? MASK
+          : redactValue(item, secrets, depth + 1);
+      }
+      return out;
+    }
+    if (value instanceof Uint8Array) return `«${value.byteLength} bytes»`;
+  }
+  return truncate(maskSecrets(String(value), secrets));
+}
+
+export function redactRecord(
+  record: Record<string, unknown>,
+  secrets: ReadonlySet<string>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (key.startsWith("_")) continue; // actor-internal, e.g. _control_context
+    out[key] = SENSITIVE_NAME_PATTERN.test(key)
+      ? MASK
+      : redactValue(value, secrets);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Failure signatures
+// ---------------------------------------------------------------------------
+
+/**
+ * A signature is a stable categorical code — an HTTP status, a provider error
+ * code, a validation path. It is what lets one verdict resolve the other six
+ * identical failures in a 200-item batch without waking the agent again.
+ *
+ * A plain `Error` gets none. Error class alone is not a category (every generic
+ * throw would collide), and message text carries request-specific values, so
+ * matching on it would make one item's verdict stick to an unrelated failure.
+ * No signature simply means no stickiness: each such failure escalates on its
+ * own.
+ */
+export function failureSignature(err: unknown): string | undefined {
+  if (typeof err !== "object" || err === null) return undefined;
+  const e = err as Record<string, unknown>;
+
+  if (typeof e.code === "string" && e.code.length > 0) return `code:${e.code}`;
+
+  const status =
+    typeof e.status === "number"
+      ? e.status
+      : typeof e.statusCode === "number"
+        ? e.statusCode
+        : typeof (e.response as { status?: unknown } | undefined)?.status ===
+            "number"
+          ? ((e.response as { status: number }).status as number)
+          : undefined;
+  if (status !== undefined) return `http:${status}`;
+
+  if (typeof e.errno === "string" || typeof e.errno === "number") {
+    return `errno:${e.errno}`;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Allowed actions
+// ---------------------------------------------------------------------------
+
+export interface AllowedActionsInput {
+  /** Node metadata opt-in. Unknown ⇒ false ⇒ no retry. */
+  retrySafe: boolean;
+  /** Provider cost recorded by this invocation. */
+  spentCostUsd: number;
+  createdAssets: boolean;
+  /** `substitute` needs the broken value in hand. */
+  hasCandidateOutput: boolean;
+  /**
+   * Every declared output has a runtime validation rule. A partially-checked
+   * substitution is an unchecked one for the slot that matters, so without
+   * full coverage `substitute` is not offered at all.
+   */
+  validatorCoverage: boolean;
+  /** `is_streaming_output` — the node yields through `genProcess`. */
+  streamingOutput: boolean;
+  /** `is_streaming_input` — the node drains its own inbox through `run()`. */
+  streamingInput: boolean;
+  /** True when this invocation already emitted downstream. */
+  emitted: boolean;
+}
+
+/**
+ * The kernel's answer to "what may this escalation legally receive". It shapes
+ * the agent's verdict schema *and* is enforced independently by the actor: the
+ * schema is UX, this is the guarantee.
+ *
+ * Design §5.3 (retry safety) and §5.4 (streaming).
+ */
+export function computeAllowedActions(
+  input: AllowedActionsInput
+): VerdictAction[] {
+  // A `run()` node consumed inbox messages that are gone, across arbitrary
+  // lineages — nothing is replayable and no single lineage exists for a skip
+  // to target. Design §5.4.
+  if (input.streamingInput) return ["end_stream", "fail"];
+
+  const retryOk =
+    input.retrySafe && input.spentCostUsd === 0 && !input.createdAssets;
+
+  if (input.streamingOutput) {
+    if (input.emitted) return ["end_stream", "fail"];
+    // No `substitute` for a stream in either state: there is no single
+    // invocation value for a substitution to stand in for.
+    return retryOk ? ["retry", "skip", "fail"] : ["skip", "fail"];
+  }
+
+  const actions: VerdictAction[] = [];
+  if (retryOk) actions.push("retry");
+  if (input.hasCandidateOutput && input.validatorCoverage) {
+    actions.push("substitute");
+  }
+  actions.push("skip", "fail");
+  return actions;
+}
+
+// ---------------------------------------------------------------------------
+// Bounds
+// ---------------------------------------------------------------------------
+
+export interface SupervisorBounds {
+  /** Decisions the agent may make in one run. */
+  maxDecisions?: number;
+  /** Retries per `(nodeId, invocationKey)`. */
+  maxRetriesPerNode?: number;
+  /** Per-decision wall clock, in ms. */
+  decisionTimeoutMs?: number;
+}
+
+export const DEFAULT_SUPERVISOR_BOUNDS = {
+  maxDecisions: 10,
+  maxRetriesPerNode: 2,
+  decisionTimeoutMs: 60_000
+} as const satisfies Required<SupervisorBounds>;
+
+/**
+ * Wraps a handle with everything that must hold whoever wrote it: decision and
+ * retry ceilings, a per-decision timeout derived from the run signal, and the
+ * sticky-verdict cache. Every boundary resolves as `fail` — degradation is
+ * deterministic, never a cheaper model.
+ */
+export class BoundedHandle implements SupervisorHandle {
+  private readonly _inner: SupervisorHandle;
+  private readonly _bounds: Required<SupervisorBounds>;
+  private _decisions = 0;
+  private readonly _retries = new Map<string, number>();
+  /** `(nodeId, failureSignature)` → verdict, for `skip`/`fail` only. */
+  private readonly _sticky = new Map<string, Verdict>();
+  /** Serializes decisions: the agent sees consecutive failures in order. */
+  private _queue: Promise<unknown> = Promise.resolve();
+
+  constructor(inner: SupervisorHandle, opts: SupervisorBounds = {}) {
+    this._inner = inner;
+    this._bounds = { ...DEFAULT_SUPERVISOR_BOUNDS, ...stripUndefined(opts) };
+  }
+
+  async decide(e: Escalation, signal: AbortSignal): Promise<DecisionOutcome> {
+    const run = this._queue.then(() => this._decideSerial(e, signal));
+    // Keep the chain alive even when one decision rejects; `_decideSerial`
+    // never throws, but a handle replaced in a test could.
+    this._queue = run.catch(() => undefined);
+    return run;
+  }
+
+  private async _decideSerial(
+    e: Escalation,
+    runSignal: AbortSignal
+  ): Promise<DecisionOutcome> {
+    if (e.failureSignature !== undefined) {
+      const hit = this._sticky.get(stickyKey(e));
+      if (hit) return { verdict: hit, decidedBy: "sticky" };
+    }
+
+    if (this._decisions >= this._bounds.maxDecisions) {
+      return { verdict: { action: "fail" }, decidedBy: "bounds" };
+    }
+
+    // The decision signal is the run signal plus a timeout, so `cancel()` is
+    // instant *and* free: a pending decision is killed, not un-awaited.
+    const timeout = new AbortController();
+    const onRunAbort = () => timeout.abort();
+    if (runSignal.aborted) timeout.abort();
+    runSignal.addEventListener("abort", onRunAbort, { once: true });
+    const timer = setTimeout(
+      () => timeout.abort(),
+      this._bounds.decisionTimeoutMs
+    );
+
+    let decision: DecisionOutcome;
+    try {
+      this._decisions++;
+      decision = await this._inner.decide(e, timeout.signal);
+      if (timeout.signal.aborted) {
+        // A handle that resolves after its signal fired decided against a run
+        // that is already over. Design §5.5.
+        decision = { verdict: { action: "fail" }, decidedBy: "bounds" };
+      }
+    } catch {
+      // Any failure *of* the supervisor resolves as today's behavior.
+      decision = { verdict: { action: "fail" }, decidedBy: "bounds" };
+    } finally {
+      clearTimeout(timer);
+      runSignal.removeEventListener("abort", onRunAbort);
+    }
+
+    decision = this._applyRetryBudget(e, decision);
+    this._remember(e, decision.verdict);
+    return decision;
+  }
+
+  private _applyRetryBudget(
+    e: Escalation,
+    decision: DecisionOutcome
+  ): DecisionOutcome {
+    if (decision.verdict.action !== "retry") return decision;
+    const key = `${e.nodeId} ${e.invocationKey}`;
+    const used = this._retries.get(key) ?? 0;
+    if (used >= this._bounds.maxRetriesPerNode) {
+      return { verdict: { action: "fail" }, decidedBy: "bounds" };
+    }
+    this._retries.set(key, used + 1);
+    return decision;
+  }
+
+  private _remember(e: Escalation, verdict: Verdict): void {
+    // Only `skip` and `fail` may stick. A sticky `retry` or `substitute` would
+    // blindly replay a decision made against different inputs.
+    if (verdict.action !== "skip" && verdict.action !== "fail") return;
+    if (verdict.applyTo !== "signature") return;
+    if (e.failureSignature === undefined) return;
+    this._sticky.set(stickyKey(e), verdict);
+  }
+
+  close(): void {
+    this._inner.close();
+  }
+}
+
+function stickyKey(e: Escalation): string {
+  return `${e.nodeId} ${e.failureSignature}`;
+}
+
+function stripUndefined<T extends object>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined)
+  ) as Partial<T>;
+}

--- a/packages/kernel/src/supervisor.ts
+++ b/packages/kernel/src/supervisor.ts
@@ -292,11 +292,18 @@ export class BoundedHandle implements SupervisorHandle {
       return { verdict: { action: "fail" }, decidedBy: "bounds" };
     }
 
-    // The decision signal is the run signal plus a timeout, so `cancel()` is
-    // instant *and* free: a pending decision is killed, not un-awaited.
+    // Cancel is free, not merely fast. Decisions are serialized, so a cancel
+    // during a slow decision leaves a queue behind it; calling the handle for
+    // each of those would spend real money deciding the fate of a run that is
+    // already over.
+    if (runSignal.aborted) {
+      return { verdict: { action: "fail" }, decidedBy: "bounds" };
+    }
+
+    // The decision signal is the run signal plus a timeout, so an in-flight
+    // decision is killed rather than un-awaited.
     const timeout = new AbortController();
     const onRunAbort = () => timeout.abort();
-    if (runSignal.aborted) timeout.abort();
     runSignal.addEventListener("abort", onRunAbort, { once: true });
     const timer = setTimeout(
       () => timeout.abort(),

--- a/packages/kernel/src/supervisor.ts
+++ b/packages/kernel/src/supervisor.ts
@@ -330,7 +330,7 @@ export class BoundedHandle implements SupervisorHandle {
     decision: DecisionOutcome
   ): DecisionOutcome {
     if (decision.verdict.action !== "retry") return decision;
-    const key = `${e.nodeId} ${e.invocationKey}`;
+    const key = `${e.nodeId}\u0000${e.invocationKey}`;
     const used = this._retries.get(key) ?? 0;
     if (used >= this._bounds.maxRetriesPerNode) {
       return { verdict: { action: "fail" }, decidedBy: "bounds" };
@@ -354,7 +354,7 @@ export class BoundedHandle implements SupervisorHandle {
 }
 
 function stickyKey(e: Escalation): string {
-  return `${e.nodeId} ${e.failureSignature}`;
+  return `${e.nodeId}\u0000${e.failureSignature}`;
 }
 
 function stripUndefined<T extends object>(obj: T): Partial<T> {

--- a/packages/kernel/tests/correlation/_harness.ts
+++ b/packages/kernel/tests/correlation/_harness.ts
@@ -29,6 +29,7 @@ import { WorkflowRunner, type RunResult } from "../../src/runner.js";
 import type { NodeExecutor } from "../../src/actor.js";
 import type { MessageEnvelope } from "../../src/inbox.js";
 import type { NodeInputs, NodeOutputs } from "../../src/io.js";
+import type { SupervisorHandle } from "../../src/supervisor.js";
 
 export type { CorrelationLineage, NodeDescriptor, Edge, MessageEnvelope };
 
@@ -57,6 +58,8 @@ export interface RunOptions {
   /** Optional runtime params. */
   params?: Record<string, unknown>;
   jobId?: string;
+  /** Optional supervisor; absent means no escalation is ever constructed. */
+  supervisor?: SupervisorHandle;
 }
 
 export interface RunWithCapture {
@@ -70,9 +73,7 @@ export interface RunWithCapture {
  * pair declared in `captureFrom`. The capture executor is streaming-input
  * and drains the named handles, pushing each envelope into the result map.
  */
-function installCaptureExecutors(
-  opts: RunOptions
-): {
+function installCaptureExecutors(opts: RunOptions): {
   executors: Record<string, NodeExecutor>;
   captured: Map<string, Map<string, MessageEnvelope[]>>;
 } {
@@ -124,7 +125,8 @@ export async function runWorkflow(opts: RunOptions): Promise<RunWithCapture> {
           };
         }
         throw new Error(`No executor registered for node id "${node.id}"`);
-      }
+      },
+      supervisor: opts.supervisor
     });
     const result = await runner.run(
       { job_id: opts.jobId ?? "conformance", params: opts.params ?? {} },
@@ -379,14 +381,20 @@ export function zipExecutor(): NodeExecutor {
       const leftLoop = (async () => {
         for await (const env of inputs.streamWithEnvelope("left")) {
           const idx = env.correlation_lineage[ld].index;
-          lefts.set(`${projParent(env)}|${idx}`, { data: env.data, index: idx });
+          lefts.set(`${projParent(env)}|${idx}`, {
+            data: env.data,
+            index: idx
+          });
           await flush();
         }
       })();
       const rightLoop = (async () => {
         for await (const env of inputs.streamWithEnvelope("right")) {
           const idx = env.correlation_lineage[rd].index;
-          rights.set(`${projParent(env)}|${idx}`, { data: env.data, index: idx });
+          rights.set(`${projParent(env)}|${idx}`, {
+            data: env.data,
+            index: idx
+          });
           await flush();
         }
       })();
@@ -443,9 +451,7 @@ export function crossExecutor(maxOutput: number = 1024): NodeExecutor {
         for (const l of ls) {
           for (const r of rs) {
             if (emitted >= maxOutput) {
-              throw new Error(
-                `Cross exceeded max_output_count (${maxOutput})`
-              );
+              throw new Error(`Cross exceeded max_output_count (${maxOutput})`);
             }
             await outputs.emitGroup({ left: l, right: r });
             emitted++;
@@ -467,27 +473,32 @@ export function iterationOutput(
   return { kind: "iteration", source, group };
 }
 
-export function forwardOutput(
-  source: string
-): { kind: "forward"; source: string } {
+export function forwardOutput(source: string): {
+  kind: "forward";
+  source: string;
+} {
   return { kind: "forward", source };
 }
 
-export function singleOutput(
-  source: string = "__execution__"
-): { kind: "single"; source: string } {
+export function singleOutput(source: string = "__execution__"): {
+  kind: "single";
+  source: string;
+} {
   return { kind: "single", source };
 }
 
-export function aggregateOutput(
-  source: string
-): { kind: "aggregate"; source: string; collapse: "innermost" } {
+export function aggregateOutput(source: string): {
+  kind: "aggregate";
+  source: string;
+  collapse: "innermost";
+} {
   return { kind: "aggregate", source, collapse: "innermost" };
 }
 
-export function chunkOutput(
-  source: string = "__execution__"
-): { kind: "chunk"; source: string } {
+export function chunkOutput(source: string = "__execution__"): {
+  kind: "chunk";
+  source: string;
+} {
   return { kind: "chunk", source };
 }
 
@@ -498,5 +509,11 @@ export function dataEdge(
   targetHandle: string,
   id?: string
 ): Edge {
-  return { id: id ?? `${source}.${sourceHandle}->${target}.${targetHandle}`, source, sourceHandle, target, targetHandle };
+  return {
+    id: id ?? `${source}.${sourceHandle}->${target}.${targetHandle}`,
+    source,
+    sourceHandle,
+    target,
+    targetHandle
+  };
 }

--- a/packages/kernel/tests/correlation/drops-closes/supervisor-skip.test.ts
+++ b/packages/kernel/tests/correlation/drops-closes/supervisor-skip.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Supervisor `skip` against the correlation scheduler.
+ *
+ * Skipping is not "return without emitting". A correlated invocation that
+ * simply produces nothing leaves siblings buffered against the skipped key at
+ * every downstream join, and an invocation of an iteration node would have
+ * opened child scopes an aggregate is waiting to see closed. Both halves are
+ * tested here, on the shapes the plan names: the fan-out item that a join is
+ * waiting on, and the iterator feeding an aggregate.
+ *
+ * See docs/workflow-supervisor-design.md §5.2.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  runWorkflow,
+  iterationOutput,
+  aggregateOutput,
+  singleOutput,
+  dataEdge,
+  foreachNode,
+  collectNode
+} from "../_harness.js";
+import type { Escalation, Verdict } from "@nodetool-ai/protocol";
+import type {
+  DecisionOutcome,
+  SupervisorHandle
+} from "../../../src/supervisor.js";
+
+class ScriptedHandle implements SupervisorHandle {
+  readonly seen: Escalation[] = [];
+  constructor(private readonly verdict: (e: Escalation) => Verdict) {}
+  async decide(e: Escalation): Promise<DecisionOutcome> {
+    this.seen.push(e);
+    return { verdict: this.verdict(e), decidedBy: "agent" };
+  }
+  close(): void {}
+}
+
+describe("supervisor skip — the poisoned item in a fan-out", () => {
+  it("lets an aggregate collapse over the items that survived", async () => {
+    const handle = new ScriptedHandle(() => ({ action: "skip" }));
+    const { result, captured } = await runWorkflow({
+      jobId: "supervisor-skip-aggregate",
+      supervisor: handle,
+      nodes: [
+        {
+          id: "src",
+          type: "nodetool.input.IntegerInput",
+          name: "items",
+          properties: { value: ["a", "poison", "c"] }
+        },
+        {
+          id: "fe",
+          type: "nodetool.control.ForEach",
+          is_streaming_output: true,
+          outputs: { output: "any" },
+          output_correlation: { output: iterationOutput("items") }
+        },
+        {
+          id: "work",
+          type: "test.Work",
+          outputs: { value: "str" },
+          output_correlation: { value: singleOutput("output") }
+        },
+        {
+          id: "c",
+          type: "nodetool.control.Collect",
+          is_streaming_input: true,
+          input_mode: "stream",
+          outputs: { output: "list[any]" },
+          output_correlation: { output: aggregateOutput("input_item") }
+        },
+        { id: "sink", type: "test.Sink", is_streaming_input: true }
+      ],
+      edges: [
+        dataEdge("src", "value", "fe", "input_list"),
+        dataEdge("fe", "output", "work", "output"),
+        dataEdge("work", "value", "c", "input_item"),
+        dataEdge("c", "output", "sink", "value")
+      ],
+      executors: {
+        fe: foreachNode(),
+        c: collectNode(),
+        work: {
+          async process(ins) {
+            if (ins.output === "poison") throw new Error("item is bad");
+            return { value: `ok:${ins.output}` };
+          }
+        }
+      },
+      captureFrom: { sink: ["value"] }
+    });
+
+    expect(result.status).toBe("completed");
+    expect(handle.seen).toHaveLength(1);
+    // The escalation names the item, not just the node: the report has to be
+    // able to say *which* of 200 items went missing.
+    expect(handle.seen[0].invocationKey).toBe("fe:items=1");
+    expect(handle.seen[0].inputs.output).toBe("poison");
+
+    const envs = captured.get("sink")!.get("value")!;
+    expect(envs).toHaveLength(1);
+    expect(envs[0].data).toEqual(["ok:a", "ok:c"]);
+
+    expect(result.interventions).toHaveLength(1);
+    expect(result.interventions![0].verdict.action).toBe("skip");
+  });
+
+  it("closes the scopes a skipped iterator invocation would have opened", async () => {
+    // The skipped invocation is the iteration node itself, so it never mints
+    // the child tokens its aggregate downstream is waiting on. `drop()` alone
+    // signals `lineage_done` and would leave the aggregate hanging.
+    const handle = new ScriptedHandle(() => ({ action: "skip" }));
+    const { result, captured } = await runWorkflow({
+      jobId: "supervisor-skip-scope-close",
+      supervisor: handle,
+      nodes: [
+        {
+          id: "src",
+          type: "nodetool.input.IntegerInput",
+          name: "items",
+          properties: { value: [1, 2] }
+        },
+        {
+          id: "fe",
+          type: "nodetool.control.ForEach",
+          is_streaming_output: true,
+          outputs: { output: "any" },
+          output_correlation: { output: iterationOutput("items") }
+        },
+        {
+          id: "c",
+          type: "nodetool.control.Collect",
+          is_streaming_input: true,
+          input_mode: "stream",
+          outputs: { output: "list[any]" },
+          output_correlation: { output: aggregateOutput("input_item") }
+        },
+        { id: "sink", type: "test.Sink", is_streaming_input: true }
+      ],
+      edges: [
+        dataEdge("src", "value", "fe", "input_list"),
+        dataEdge("fe", "output", "c", "input_item"),
+        dataEdge("c", "output", "sink", "value")
+      ],
+      executors: {
+        fe: {
+          async process() {
+            return {};
+          },
+          async *genProcess() {
+            throw new Error("iteration source failed");
+          }
+        },
+        c: collectNode()
+      },
+      captureFrom: { sink: ["value"] }
+    });
+
+    expect(result.status).toBe("completed");
+    expect(handle.seen[0].allowedActions).toContain("skip");
+    // The aggregate finalized — empty, but finalized — instead of hanging on
+    // a scope nobody would ever close.
+    const envs = captured.get("sink")!.get("value")!;
+    expect(envs).toHaveLength(1);
+    expect(envs[0].data).toEqual([]);
+  });
+});

--- a/packages/kernel/tests/supervisor-handle.test.ts
+++ b/packages/kernel/tests/supervisor-handle.test.ts
@@ -1,0 +1,432 @@
+/**
+ * The pieces that hold whoever wrote the handle: bounds, stickiness,
+ * cancellation, the allowed-set rules, redaction, and the substitute validator.
+ *
+ * See docs/workflow-supervisor-design.md §5.3, §5.4, §5.5, §6, §6.1.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { Escalation, Verdict } from "@nodetool-ai/protocol";
+import {
+  BoundedHandle,
+  FailClosedHandle,
+  computeAllowedActions,
+  failureSignature,
+  redactRecord,
+  redactValue,
+  type DecisionOutcome,
+  type SupervisorHandle
+} from "../src/supervisor.js";
+import {
+  validateSubstituteOutputs,
+  hasFullValidatorCoverage
+} from "../src/substitute-validator.js";
+
+function escalation(over: Partial<Escalation> = {}): Escalation {
+  return {
+    nodeId: "n1",
+    nodeType: "test.Work",
+    correlationLineage: [],
+    invocationKey: "",
+    allowedActions: ["retry", "skip", "fail"],
+    detail: "boom",
+    inputs: {},
+    attempt: 1,
+    spentCostUsd: 0,
+    createdAssets: false,
+    retrySafe: true,
+    emitted: false,
+    ...over
+  };
+}
+
+function handleReturning(
+  verdict: Verdict | (() => Promise<Verdict>)
+): SupervisorHandle & { calls: number } {
+  return {
+    calls: 0,
+    async decide(): Promise<DecisionOutcome> {
+      this.calls++;
+      const v = typeof verdict === "function" ? await verdict() : verdict;
+      return { verdict: v, decidedBy: "agent" };
+    },
+    close() {}
+  };
+}
+
+const never = new AbortController().signal;
+
+describe("BoundedHandle — decisions and retries are capped", () => {
+  it("degrades to a deterministic fail past maxDecisions", async () => {
+    const inner = handleReturning({ action: "skip" });
+    const bounded = new BoundedHandle(inner, { maxDecisions: 2 });
+
+    expect((await bounded.decide(escalation(), never)).verdict.action).toBe(
+      "skip"
+    );
+    expect((await bounded.decide(escalation(), never)).verdict.action).toBe(
+      "skip"
+    );
+
+    const third = await bounded.decide(escalation(), never);
+    expect(third.verdict.action).toBe("fail");
+    expect(third.decidedBy).toBe("bounds");
+    expect(inner.calls).toBe(2);
+  });
+
+  it("counts retries per invocation, not per node", async () => {
+    const inner = handleReturning({ action: "retry" });
+    const bounded = new BoundedHandle(inner, { maxRetriesPerNode: 1 });
+
+    const a = escalation({ invocationKey: "fe:items=0" });
+    const b = escalation({ invocationKey: "fe:items=1" });
+
+    expect((await bounded.decide(a, never)).verdict.action).toBe("retry");
+    expect((await bounded.decide(b, never)).verdict.action).toBe("retry");
+
+    const exhausted = await bounded.decide(a, never);
+    expect(exhausted.verdict.action).toBe("fail");
+    expect(exhausted.decidedBy).toBe("bounds");
+  });
+
+  it("resolves a supervisor exception as fail", async () => {
+    const bounded = new BoundedHandle({
+      async decide(): Promise<DecisionOutcome> {
+        throw new Error("provider down");
+      },
+      close() {}
+    });
+    const decision = await bounded.decide(escalation(), never);
+    expect(decision.verdict.action).toBe("fail");
+    expect(decision.decidedBy).toBe("bounds");
+  });
+
+  it("fails a decision that outlives its timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const bounded = new BoundedHandle(
+        handleReturning(
+          () =>
+            new Promise<Verdict>((r) =>
+              setTimeout(() => r({ action: "skip" }), 5_000)
+            )
+        ),
+        { decisionTimeoutMs: 1_000 }
+      );
+      const pending = bounded.decide(escalation(), never);
+      await vi.advanceTimersByTimeAsync(5_000);
+      const decision = await pending;
+      expect(decision.verdict.action).toBe("fail");
+      expect(decision.decidedBy).toBe("bounds");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("passes an already-aborted run signal straight through to the handle", async () => {
+    const seen: AbortSignal[] = [];
+    const bounded = new BoundedHandle({
+      async decide(_e, signal): Promise<DecisionOutcome> {
+        seen.push(signal);
+        return { verdict: { action: "skip" }, decidedBy: "agent" };
+      },
+      close() {}
+    });
+    const cancelled = AbortSignal.abort();
+    const decision = await bounded.decide(escalation(), cancelled);
+    expect(seen[0].aborted).toBe(true);
+    // A verdict decided against a run that is already over is not applied.
+    expect(decision.verdict.action).toBe("fail");
+  });
+
+  it("serializes decisions", async () => {
+    const order: string[] = [];
+    let resolveFirst: (() => void) | undefined;
+    const bounded = new BoundedHandle({
+      async decide(e): Promise<DecisionOutcome> {
+        order.push(`start:${e.nodeId}`);
+        if (e.nodeId === "slow") {
+          await new Promise<void>((r) => (resolveFirst = r));
+        }
+        order.push(`end:${e.nodeId}`);
+        return { verdict: { action: "skip" }, decidedBy: "agent" };
+      },
+      close() {}
+    });
+
+    const first = bounded.decide(escalation({ nodeId: "slow" }), never);
+    const second = bounded.decide(escalation({ nodeId: "fast" }), never);
+    await vi.waitFor(() => expect(resolveFirst).toBeDefined());
+    resolveFirst!();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(["start:slow", "end:slow", "start:fast", "end:fast"]);
+  });
+});
+
+describe("BoundedHandle — sticky verdicts", () => {
+  it("resolves later matching failures without waking the agent", async () => {
+    const inner = handleReturning({ action: "skip", applyTo: "signature" });
+    const bounded = new BoundedHandle(inner);
+    const e = () => escalation({ failureSignature: "http:403" });
+
+    const first = await bounded.decide(e(), never);
+    expect(first.decidedBy).toBe("agent");
+
+    for (let i = 0; i < 6; i++) {
+      const later = await bounded.decide(e(), never);
+      expect(later.verdict.action).toBe("skip");
+      expect(later.decidedBy).toBe("sticky");
+    }
+    // Seven identical failures, one decision.
+    expect(inner.calls).toBe(1);
+  });
+
+  it("does not let one signature's verdict answer another's", async () => {
+    const inner = handleReturning({ action: "skip", applyTo: "signature" });
+    const bounded = new BoundedHandle(inner);
+    await bounded.decide(escalation({ failureSignature: "http:403" }), never);
+    await bounded.decide(escalation({ failureSignature: "http:504" }), never);
+    expect(inner.calls).toBe(2);
+  });
+
+  it("never sticks a retry or a substitute", async () => {
+    const inner = handleReturning({ action: "retry" });
+    const bounded = new BoundedHandle(inner, { maxRetriesPerNode: 10 });
+    const e = () => escalation({ failureSignature: "http:429" });
+    await bounded.decide(e(), never);
+    await bounded.decide(e(), never);
+    expect(inner.calls).toBe(2);
+  });
+
+  it("has nothing to key on without a signature", async () => {
+    const inner = handleReturning({ action: "skip", applyTo: "signature" });
+    const bounded = new BoundedHandle(inner);
+    await bounded.decide(escalation(), never);
+    await bounded.decide(escalation(), never);
+    expect(inner.calls).toBe(2);
+  });
+});
+
+describe("FailClosedHandle", () => {
+  it("is today's behavior", async () => {
+    const decision = await new FailClosedHandle().decide();
+    expect(decision).toEqual({
+      verdict: { action: "fail" },
+      decidedBy: "default"
+    });
+  });
+});
+
+describe("allowed actions", () => {
+  const base = {
+    retrySafe: true,
+    spentCostUsd: 0,
+    createdAssets: false,
+    hasCandidateOutput: false,
+    validatorCoverage: true,
+    streamingOutput: false,
+    streamingInput: false,
+    emitted: false
+  };
+
+  it("offers retry only to a node that opted in, spent nothing, wrote nothing", () => {
+    expect(computeAllowedActions(base)).toContain("retry");
+    expect(computeAllowedActions({ ...base, retrySafe: false })).not.toContain(
+      "retry"
+    );
+    expect(
+      computeAllowedActions({ ...base, spentCostUsd: 0.01 })
+    ).not.toContain("retry");
+    expect(
+      computeAllowedActions({ ...base, createdAssets: true })
+    ).not.toContain("retry");
+  });
+
+  it("offers substitute only with the broken value in hand", () => {
+    expect(computeAllowedActions(base)).not.toContain("substitute");
+    expect(
+      computeAllowedActions({ ...base, hasCandidateOutput: true })
+    ).toContain("substitute");
+  });
+
+  it("withholds substitute when some declared output cannot be validated", () => {
+    expect(
+      computeAllowedActions({
+        ...base,
+        hasCandidateOutput: true,
+        validatorCoverage: false
+      })
+    ).not.toContain("substitute");
+  });
+
+  it("never offers substitute for a stream", () => {
+    expect(
+      computeAllowedActions({
+        ...base,
+        streamingOutput: true,
+        hasCandidateOutput: true
+      })
+    ).not.toContain("substitute");
+  });
+
+  it("gives a mid-stream failure end_stream, and a pre-emit one retry", () => {
+    expect(
+      computeAllowedActions({ ...base, streamingOutput: true, emitted: true })
+    ).toEqual(["end_stream", "fail"]);
+    expect(computeAllowedActions({ ...base, streamingOutput: true })).toEqual([
+      "retry",
+      "skip",
+      "fail"
+    ]);
+  });
+
+  it("gives a run() node exactly end_stream and fail", () => {
+    expect(computeAllowedActions({ ...base, streamingInput: true })).toEqual([
+      "end_stream",
+      "fail"
+    ]);
+  });
+
+  it("always leaves skip and fail reachable outside streaming", () => {
+    const actions = computeAllowedActions({ ...base, retrySafe: false });
+    expect(actions).toEqual(["skip", "fail"]);
+  });
+});
+
+describe("failure signatures", () => {
+  it("reads a stable categorical code", () => {
+    expect(
+      failureSignature(Object.assign(new Error("x"), { status: 429 }))
+    ).toBe("http:429");
+    expect(
+      failureSignature(Object.assign(new Error("x"), { code: "rate_limited" }))
+    ).toBe("code:rate_limited");
+    expect(
+      failureSignature(
+        Object.assign(new Error("x"), { response: { status: 503 } })
+      )
+    ).toBe("http:503");
+  });
+
+  it("gives a plain Error none — error class is not a category", () => {
+    expect(failureSignature(new Error("item 147 timed out"))).toBeUndefined();
+    expect(failureSignature(new TypeError("nope"))).toBeUndefined();
+    expect(failureSignature("a string")).toBeUndefined();
+  });
+});
+
+describe("redaction", () => {
+  const secrets = new Set(["sk-live-0123456789"]);
+
+  it("masks a secret wherever it appears", () => {
+    expect(
+      redactValue("GET https://api.test?key=sk-live-0123456789", secrets)
+    ).toBe("GET https://api.test?key=«redacted»");
+    expect(
+      redactValue(
+        { headers: { "x-custom": "Bearer sk-live-0123456789" } },
+        secrets
+      )
+    ).toEqual({ headers: { "x-custom": "Bearer «redacted»" } });
+  });
+
+  it("drops sensitive-named fields whatever they hold", () => {
+    expect(
+      redactRecord(
+        {
+          password: "hunter2",
+          api_key: "abc",
+          Authorization: "x",
+          prompt: "hi"
+        },
+        new Set()
+      )
+    ).toEqual({
+      password: "«redacted»",
+      api_key: "«redacted»",
+      Authorization: "«redacted»",
+      prompt: "hi"
+    });
+  });
+
+  it("drops actor-internal fields", () => {
+    expect(redactRecord({ _control_context: {}, a: 1 }, new Set())).toEqual({
+      a: 1
+    });
+  });
+
+  it("truncates instead of carrying a payload", () => {
+    const long = redactValue("x".repeat(5000), new Set()) as string;
+    expect(long.length).toBeLessThan(2100);
+    expect(long.endsWith("…[truncated]")).toBe(true);
+  });
+
+  it("summarizes binary rather than stringifying it", () => {
+    expect(redactValue(new Uint8Array(1024), new Set())).toBe("«1024 bytes»");
+  });
+});
+
+describe("substitute validator", () => {
+  it("checks values, not declared type compatibility", async () => {
+    const ok = await validateSubstituteOutputs(
+      { text: "hello", count: 3 },
+      { declaredOutputs: { text: "str", count: "int" } }
+    );
+    expect(ok.ok).toBe(true);
+
+    const bad = await validateSubstituteOutputs(
+      { count: 3.5 },
+      { declaredOutputs: { count: "int" } }
+    );
+    expect(bad.ok).toBe(false);
+    expect(bad.issues[0]).toContain("integer");
+  });
+
+  it("rejects a fabricated reference whose uri does not resolve", async () => {
+    const result = await validateSubstituteOutputs(
+      { img: { type: "image", uri: "https://invented.example/x.png" } },
+      {
+        declaredOutputs: { img: "image" },
+        resolveRef: async () => false
+      }
+    );
+    expect(result.ok).toBe(false);
+    expect(result.issues[0]).toContain("does not resolve");
+  });
+
+  it("accepts a reference that resolves against run storage", async () => {
+    const result = await validateSubstituteOutputs(
+      { img: { type: "image", uri: "asset://real" } },
+      { declaredOutputs: { img: "image" }, resolveRef: async () => true }
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a reference when the run cannot resolve references at all", async () => {
+    const result = await validateSubstituteOutputs(
+      { img: { type: "image", uri: "asset://real" } },
+      { declaredOutputs: { img: "image" } }
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects an output the node never declared", async () => {
+    const result = await validateSubstituteOutputs(
+      { surprise: 1 },
+      { declaredOutputs: { value: "str" } }
+    );
+    expect(result.ok).toBe(false);
+    expect(result.issues[0]).toContain("not declared");
+  });
+
+  it("reports coverage so an unvalidatable node is never offered substitute", () => {
+    expect(hasFullValidatorCoverage({ a: "str", b: "list[int]" }, false)).toBe(
+      true
+    );
+    expect(hasFullValidatorCoverage({ a: "image" }, false)).toBe(false);
+    expect(hasFullValidatorCoverage({ a: "image" }, true)).toBe(true);
+    expect(hasFullValidatorCoverage({ a: "custom.Thing" }, true)).toBe(false);
+    expect(hasFullValidatorCoverage({}, true)).toBe(false);
+  });
+});

--- a/packages/kernel/tests/supervisor-handle.test.ts
+++ b/packages/kernel/tests/supervisor-handle.test.ts
@@ -124,20 +124,22 @@ describe("BoundedHandle — decisions and retries are capped", () => {
     }
   });
 
-  it("passes an already-aborted run signal straight through to the handle", async () => {
-    const seen: AbortSignal[] = [];
+  it("does not call the handle at all once the run is cancelled", async () => {
+    // Decisions are serialized, so a cancel mid-decision leaves a queue behind
+    // it. Waking the agent for each of those would spend money deciding the
+    // fate of a run that is already over.
+    let calls = 0;
     const bounded = new BoundedHandle({
-      async decide(_e, signal): Promise<DecisionOutcome> {
-        seen.push(signal);
+      async decide(): Promise<DecisionOutcome> {
+        calls++;
         return { verdict: { action: "skip" }, decidedBy: "agent" };
       },
       close() {}
     });
-    const cancelled = AbortSignal.abort();
-    const decision = await bounded.decide(escalation(), cancelled);
-    expect(seen[0].aborted).toBe(true);
-    // A verdict decided against a run that is already over is not applied.
+    const decision = await bounded.decide(escalation(), AbortSignal.abort());
+    expect(calls).toBe(0);
     expect(decision.verdict.action).toBe("fail");
+    expect(decision.decidedBy).toBe("bounds");
   });
 
   it("serializes decisions", async () => {

--- a/packages/kernel/tests/supervisor-handle.test.ts
+++ b/packages/kernel/tests/supervisor-handle.test.ts
@@ -416,11 +416,22 @@ describe("substitute validator", () => {
 
   it("rejects an output the node never declared", async () => {
     const result = await validateSubstituteOutputs(
-      { surprise: 1 },
+      { surprise: 1, value: "ok" },
       { declaredOutputs: { value: "str" } }
     );
     expect(result.ok).toBe(false);
-    expect(result.issues[0]).toContain("not declared");
+    expect(result.issues.join(" ")).toContain("not declared");
+  });
+
+  it("rejects a substitution that leaves a declared slot empty", async () => {
+    // An omitted slot emits no value and no `lineage_done`, so a downstream
+    // join correlated on it waits for a key that never arrives.
+    const result = await validateSubstituteOutputs(
+      { a: "filled" },
+      { declaredOutputs: { a: "str", b: "str" } }
+    );
+    expect(result.ok).toBe(false);
+    expect(result.issues.join(" ")).toContain('"b"');
   });
 
   it("reports coverage so an unvalidatable node is never offered substitute", () => {

--- a/packages/kernel/tests/supervisor-handle.test.ts
+++ b/packages/kernel/tests/supervisor-handle.test.ts
@@ -21,6 +21,7 @@ import {
   validateSubstituteOutputs,
   hasFullValidatorCoverage
 } from "../src/substitute-validator.js";
+import { Graph } from "../src/graph.js";
 
 function escalation(over: Partial<Escalation> = {}): Escalation {
   return {
@@ -428,5 +429,39 @@ describe("substitute validator", () => {
     expect(hasFullValidatorCoverage({ a: "image" }, true)).toBe(true);
     expect(hasFullValidatorCoverage({ a: "custom.Thing" }, true)).toBe(false);
     expect(hasFullValidatorCoverage({}, true)).toBe(false);
+  });
+});
+
+describe("graph hydration — retry safety comes from the registry", () => {
+  it("ignores a saved retry_safe a node's class never declared", async () => {
+    // Graph JSON is data. Whether re-running a node duplicates a payment is a
+    // property of its implementation, so a file claiming redo-safety must not
+    // be able to grant it.
+    const graph = await Graph.loadFromDict(
+      {
+        nodes: [{ id: "n1", type: "test.Writer", retry_safe: true }],
+        edges: []
+      },
+      {
+        resolver: async () => ({
+          nodeType: "test.Writer",
+          descriptorDefaults: {}
+        })
+      }
+    );
+    expect(graph.nodes[0].retry_safe).toBe(false);
+  });
+
+  it("takes retry_safe from the registry when the class declares it", async () => {
+    const graph = await Graph.loadFromDict(
+      { nodes: [{ id: "n1", type: "test.Pure" }], edges: [] },
+      {
+        resolver: async () => ({
+          nodeType: "test.Pure",
+          descriptorDefaults: { retry_safe: true }
+        })
+      }
+    );
+    expect(graph.nodes[0].retry_safe).toBe(true);
   });
 });

--- a/packages/kernel/tests/supervisor.test.ts
+++ b/packages/kernel/tests/supervisor.test.ts
@@ -223,6 +223,10 @@ describe("supervisor — retry", () => {
     expect(calls).toBe(1);
     expect(result.status).toBe("failed");
     expect(result.interventions![0].verdict.action).toBe("fail");
+    // The record credits the kernel, not the handle. Crediting the handle
+    // would hide the case worth finding: a supervisor that answered outside
+    // the allowed set.
+    expect(result.interventions![0].decidedBy).toBe("kernel");
   });
 
   it("is not offered once the invocation spent money", async () => {

--- a/packages/kernel/tests/supervisor.test.ts
+++ b/packages/kernel/tests/supervisor.test.ts
@@ -14,7 +14,8 @@ import { describe, it, expect } from "vitest";
 import { isProcessingMessage } from "@nodetool-ai/protocol";
 import type { Escalation, Verdict } from "@nodetool-ai/protocol";
 import { WorkflowRunner, type RunResult } from "../src/runner.js";
-import type { NodeExecutor } from "../src/actor.js";
+import { NodeActor, type NodeExecutor } from "../src/actor.js";
+import { NodeInbox } from "../src/inbox.js";
 import type { DecisionOutcome, SupervisorHandle } from "../src/supervisor.js";
 import { ProcessingContext } from "@nodetool-ai/runtime";
 import type { Edge, NodeDescriptor } from "@nodetool-ai/protocol";
@@ -777,6 +778,91 @@ describe("supervisor — streaming", () => {
     // one the PRD reports as "kept the chunks it had finished".
     expect(result.status).toBe("completed");
     expect(received).toEqual(["chunk-0", "chunk-1"]);
+  });
+
+  it("fails the node when routing a frame throws, without escalating", async () => {
+    // Straight at the actor, because only the routing callback can fail this
+    // way: `sendOutputs` delivers to each outgoing edge in turn, so a retry
+    // after a partial send would deliver to the earlier edges twice.
+    const handle = new ScriptedHandle(() => ({ action: "retry" }));
+    const inbox = new NodeInbox();
+    inbox.addUpstream("a", 1);
+    let streamStarts = 0;
+
+    const actor = new NodeActor({
+      node: {
+        id: "work",
+        type: "test.Stream",
+        is_streaming_output: true,
+        retry_safe: true,
+        outputs: { value: "str" }
+      },
+      inbox,
+      executor: {
+        async process() {
+          return {};
+        },
+        async *genProcess() {
+          streamStarts++;
+          yield { value: "chunk-0" };
+        }
+      },
+      sendOutputs: async () => {
+        throw new Error("inbox refused the value");
+      },
+      emitMessage: () => {},
+      correlation: {
+        invocationScope: [],
+        inputs: new Map(),
+        outputs: new Map()
+      },
+      supervisor: handle
+    });
+
+    inbox.put("a", "go");
+    inbox.markSourceDone("a");
+    const result = await actor.run();
+
+    expect(result.error).toBe("inbox refused the value");
+    expect(streamStarts).toBe(1);
+    expect(handle.seen).toHaveLength(0);
+  });
+
+  it("does not escalate a delivery failure as a node failure", async () => {
+    // Frames are routed inside the generator loop, so a downstream delivery
+    // error surfaces on the same stack as a genProcess throw. It must still
+    // fail the node: re-running the stream would re-deliver earlier frames.
+    const handle = new ScriptedHandle(() => ({ action: "retry" }));
+    let streamStarts = 0;
+    const result = await runGraph({
+      ...streamGraph(),
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            return {};
+          },
+          async *genProcess() {
+            streamStarts++;
+            yield { value: "chunk-0" };
+            yield { value: "chunk-1" };
+          }
+        },
+        sink: {
+          async process() {
+            return {};
+          },
+          async run() {
+            throw new Error("sink exploded");
+          }
+        }
+      },
+      supervisor: handle
+    });
+
+    expect(streamStarts).toBe(1);
+    expect(handle.seen.every((e) => e.nodeId !== "work")).toBe(true);
+    expect(result.status).toBe("failed");
   });
 
   it("gives a run() node exactly end_stream and fail", async () => {

--- a/packages/kernel/tests/supervisor.test.ts
+++ b/packages/kernel/tests/supervisor.test.ts
@@ -782,6 +782,13 @@ describe("supervisor — streaming", () => {
     // one the PRD reports as "kept the chunks it had finished".
     expect(result.status).toBe("completed");
     expect(received).toEqual(["chunk-0", "chunk-1"]);
+    // The invocation committed early, but it did commit: the marker replay and
+    // asset autosave key off must carry what the stream kept.
+    const committed = result.messages.filter(
+      (m) => m.type === "generation_complete" && m.node_id === "work"
+    );
+    expect(committed).toHaveLength(1);
+    expect(committed[0].outputs).toEqual({ value: "chunk-1" });
   });
 
   it("fails the node when routing a frame throws, without escalating", async () => {

--- a/packages/kernel/tests/supervisor.test.ts
+++ b/packages/kernel/tests/supervisor.test.ts
@@ -1,0 +1,823 @@
+/**
+ * The escalation hook, end to end through the runner.
+ *
+ * Every verdict is driven by a scripted `SupervisorHandle` — no LLM is
+ * involved anywhere in this file. What is under test is the kernel's half of
+ * the contract: that a verdict does what it says, that the kernel enforces its
+ * own allowed set against a hostile handle, that a skip actually unblocks the
+ * graph, and that an unsupervised run is untouched.
+ *
+ * See docs/workflow-supervisor-design.md §5.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isProcessingMessage } from "@nodetool-ai/protocol";
+import type { Escalation, Verdict } from "@nodetool-ai/protocol";
+import { WorkflowRunner, type RunResult } from "../src/runner.js";
+import type { NodeExecutor } from "../src/actor.js";
+import type { DecisionOutcome, SupervisorHandle } from "../src/supervisor.js";
+import { ProcessingContext } from "@nodetool-ai/runtime";
+import type { Edge, NodeDescriptor } from "@nodetool-ai/protocol";
+
+/** A handle that answers from a script and records what it was asked. */
+class ScriptedHandle implements SupervisorHandle {
+  readonly seen: Escalation[] = [];
+  constructor(
+    private readonly script: (e: Escalation, n: number) => Verdict | undefined
+  ) {}
+  async decide(e: Escalation): Promise<DecisionOutcome> {
+    this.seen.push(e);
+    const verdict = this.script(e, this.seen.length) ?? { action: "fail" };
+    return { verdict, decidedBy: "agent", costUsd: 0.01 };
+  }
+  close(): void {}
+}
+
+function runGraph(opts: {
+  nodes: NodeDescriptor[];
+  edges: Edge[];
+  executors: Record<string, NodeExecutor>;
+  supervisor?: SupervisorHandle;
+  params?: Record<string, unknown>;
+  context?: ProcessingContext;
+}): Promise<RunResult> {
+  const runner = new WorkflowRunner("supervisor-test", {
+    resolveExecutor: (node) =>
+      opts.executors[node.id] ?? {
+        // Default: echo inputs, so an Output node collects what reached it.
+        async process(ins) {
+          return ins;
+        }
+      },
+    supervisor: opts.supervisor,
+    executionContext: opts.context
+  });
+  return runner.run(
+    { job_id: "supervisor-test", params: opts.params ?? {} },
+    { nodes: opts.nodes, edges: opts.edges }
+  );
+}
+
+/** input → work → output, where `work` is the node under test. */
+function chain(work: Partial<NodeDescriptor> = {}): {
+  nodes: NodeDescriptor[];
+  edges: Edge[];
+} {
+  return {
+    nodes: [
+      { id: "input", type: "test.Input", name: "x" },
+      { id: "work", type: "test.Work", outputs: { value: "str" }, ...work },
+      { id: "out", type: "nodetool.output.Output", name: "result" }
+    ],
+    edges: [
+      {
+        source: "input",
+        sourceHandle: "value",
+        target: "work",
+        targetHandle: "a"
+      },
+      {
+        source: "work",
+        sourceHandle: "value",
+        target: "out",
+        targetHandle: "value"
+      }
+    ]
+  };
+}
+
+describe("supervisor — zero cost on clean runs", () => {
+  it("an unsupervised failing run is unchanged", async () => {
+    const graph = chain();
+    const result = await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            throw new Error("boom");
+          }
+        }
+      }
+    });
+    expect(result.status).toBe("failed");
+    expect(result.interventions).toBeUndefined();
+  });
+
+  it("a clean supervised run never wakes the supervisor", async () => {
+    const handle = new ScriptedHandle(() => ({ action: "fail" }));
+    const graph = chain();
+    const result = await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process(ins) {
+            return { value: `${ins.a}!` };
+          }
+        }
+      },
+      supervisor: handle
+    });
+    expect(result.status).toBe("completed");
+    expect(handle.seen).toHaveLength(0);
+    expect(result.interventions).toBeUndefined();
+    expect(
+      result.messages.filter((m) => m.type.startsWith("supervisor_"))
+    ).toHaveLength(0);
+  });
+
+  it("the message stream matches an unsupervised run message for message", async () => {
+    const graph = chain();
+    const executors = {
+      work: {
+        async process(ins: Record<string, unknown>) {
+          return { value: `${ins.a}!` };
+        }
+      }
+    };
+    const bare = await runGraph({ ...graph, params: { x: "hi" }, executors });
+    const supervised = await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors,
+      supervisor: new ScriptedHandle(() => ({ action: "fail" }))
+    });
+    expect(supervised.messages.map((m) => m.type)).toEqual(
+      bare.messages.map((m) => m.type)
+    );
+    expect(supervised.outputs).toEqual(bare.outputs);
+  });
+});
+
+describe("supervisor — retry", () => {
+  it("re-invokes with identical inputs and properties", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const graph = chain({ retry_safe: true, properties: { mode: "strict" } });
+    const result = await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process(ins) {
+            calls.push({ ...ins });
+            if (calls.length === 1) throw new Error("transient");
+            return { value: "ok" };
+          }
+        }
+      },
+      supervisor: new ScriptedHandle(() => ({ action: "retry" }))
+    });
+
+    expect(result.status).toBe("completed");
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toEqual(calls[0]);
+    expect(calls[1].mode).toBe("strict");
+    expect(result.outputs.result).toEqual(["ok"]);
+    expect(result.interventions).toHaveLength(1);
+    expect(result.interventions![0].verdict.action).toBe("retry");
+  });
+
+  it("counts attempts per invocation", async () => {
+    const handle = new ScriptedHandle((_, n) =>
+      n < 3 ? { action: "retry" } : { action: "skip" }
+    );
+    const graph = chain({ retry_safe: true });
+    await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            throw new Error("always");
+          }
+        }
+      },
+      supervisor: handle
+    });
+    expect(handle.seen.map((e) => e.attempt)).toEqual([1, 2, 3]);
+  });
+
+  it("is not offered to a node that never declared itself retry-safe", async () => {
+    const handle = new ScriptedHandle(() => ({ action: "retry" }));
+    const graph = chain(); // no retry_safe
+    let calls = 0;
+    const result = await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            calls++;
+            throw new Error("boom");
+          }
+        }
+      },
+      supervisor: handle
+    });
+
+    expect(handle.seen[0].allowedActions).not.toContain("retry");
+    // The hostile verdict is rejected by the kernel, not merely absent from a
+    // schema: one invocation, and the run fails.
+    expect(calls).toBe(1);
+    expect(result.status).toBe("failed");
+    expect(result.interventions![0].verdict.action).toBe("fail");
+  });
+
+  it("is not offered once the invocation spent money", async () => {
+    const handle = new ScriptedHandle(() => ({ action: "retry" }));
+    const context = new ProcessingContext({ jobId: "supervisor-test" });
+    const graph = chain({ retry_safe: true });
+    await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      context,
+      executors: {
+        work: {
+          async process(_ins, ctx) {
+            (ctx as ProcessingContext).setProviderCost("fal", 0.42, "usd");
+            throw new Error("after the charge");
+          }
+        }
+      },
+      supervisor: handle
+    });
+    expect(handle.seen[0].spentCostUsd).toBe(0.42);
+    expect(handle.seen[0].allowedActions).not.toContain("retry");
+  });
+
+  it("attributes concurrent invocations that finish in reverse order", async () => {
+    // Two independent branches: the slow one is charged first but completes
+    // last. A stack on the shared context would credit its charge to the other.
+    const seen = new Map<string, number>();
+    const handle = new ScriptedHandle((e) => {
+      seen.set(e.nodeId, e.spentCostUsd);
+      return { action: "skip" };
+    });
+    const context = new ProcessingContext({ jobId: "supervisor-test" });
+    const nodes: NodeDescriptor[] = [
+      { id: "input", type: "test.Input", name: "x" },
+      { id: "slow", type: "test.Work", retry_safe: true },
+      { id: "fast", type: "test.Work", retry_safe: true },
+      { id: "out", type: "nodetool.output.Output", name: "result" }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "input",
+        sourceHandle: "value",
+        target: "slow",
+        targetHandle: "a"
+      },
+      {
+        source: "input",
+        sourceHandle: "value",
+        target: "fast",
+        targetHandle: "a"
+      },
+      {
+        source: "slow",
+        sourceHandle: "value",
+        target: "out",
+        targetHandle: "value"
+      }
+    ];
+    const charge = (amount: number, delayMs: number): NodeExecutor => ({
+      async process(_ins, ctx) {
+        (ctx as ProcessingContext).setProviderCost("fal", amount, "usd");
+        await new Promise((r) => setTimeout(r, delayMs));
+        throw new Error("late failure");
+      }
+    });
+
+    await runGraph({
+      nodes,
+      edges,
+      params: { x: "hi" },
+      context,
+      executors: { slow: charge(1, 20), fast: charge(2, 0) },
+      supervisor: handle
+    });
+
+    expect(seen.get("slow")).toBe(1);
+    expect(seen.get("fast")).toBe(2);
+  });
+});
+
+describe("supervisor — substitute", () => {
+  const recoverable = (candidate: unknown): NodeExecutor => ({
+    async process() {
+      const { RecoverableNodeError } = await import("@nodetool-ai/runtime");
+      throw new RecoverableNodeError("malformed", {
+        candidateOutput: candidate,
+        code: "parse_error"
+      });
+    }
+  });
+
+  it("emits a validated repair through the normal output path", async () => {
+    const graph = chain();
+    const result = await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: { work: recoverable('{"value": "broken') },
+      supervisor: new ScriptedHandle(() => ({
+        action: "substitute",
+        outputs: { value: "repaired" }
+      }))
+    });
+    expect(result.status).toBe("completed");
+    expect(result.outputs.result).toEqual(["repaired"]);
+  });
+
+  it("rejects a repair that does not match the declared output type", async () => {
+    const graph = chain();
+    const result = await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: { work: recoverable("nope") },
+      supervisor: new ScriptedHandle(() => ({
+        action: "substitute",
+        outputs: { value: { not: "a string" } }
+      }))
+    });
+    expect(result.status).toBe("failed");
+  });
+
+  it("is not offered without a candidate output — repair is not invention", async () => {
+    const handle = new ScriptedHandle(() => ({ action: "skip" }));
+    const graph = chain();
+    await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            throw new Error("plain");
+          }
+        }
+      },
+      supervisor: handle
+    });
+    expect(handle.seen[0].allowedActions).not.toContain("substitute");
+    expect(handle.seen[0].candidateOutput).toBeUndefined();
+  });
+
+  it("carries a failure signature only when the error has a stable code", async () => {
+    const withCode = new ScriptedHandle(() => ({ action: "skip" }));
+    const graph = chain();
+    await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: { work: recoverable("x") },
+      supervisor: withCode
+    });
+    expect(withCode.seen[0].failureSignature).toBe("parse_error");
+
+    const plain = new ScriptedHandle(() => ({ action: "skip" }));
+    await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            throw new Error("item 147 timed out");
+          }
+        }
+      },
+      supervisor: plain
+    });
+    expect(plain.seen[0].failureSignature).toBeUndefined();
+  });
+});
+
+describe("supervisor — skip", () => {
+  it("finishes the run and records what was given up", async () => {
+    const graph = chain();
+    const result = await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            throw new Error("page requires login");
+          }
+        }
+      },
+      supervisor: new ScriptedHandle(() => ({ action: "skip" }))
+    });
+    expect(result.status).toBe("completed");
+    expect(result.interventions).toHaveLength(1);
+    expect(result.interventions![0].verdict.action).toBe("skip");
+    expect(result.interventions![0].escalation.detail).toContain("login");
+
+    // Interventions are data: both halves travel as validatable messages, so
+    // audit, replay, and the UI consume one record rather than three features.
+    const supervisorMessages = result.messages.filter((m) =>
+      m.type.startsWith("supervisor_")
+    );
+    expect(supervisorMessages.map((m) => m.type)).toEqual([
+      "supervisor_escalation",
+      "supervisor_decision"
+    ]);
+    for (const message of supervisorMessages) {
+      expect(isProcessingMessage(message)).toBe(true);
+    }
+  });
+
+  it("unblocks a downstream join whose other input already arrived", async () => {
+    // `join` needs both handles. Without the skip's `lineage_done` it would
+    // sit on the buffered `left` value forever.
+    const nodes: NodeDescriptor[] = [
+      { id: "input", type: "test.Input", name: "x" },
+      { id: "left", type: "test.Work", outputs: { value: "str" } },
+      { id: "right", type: "test.Work", outputs: { value: "str" } },
+      { id: "join", type: "test.Join", outputs: { value: "str" } },
+      { id: "out", type: "nodetool.output.Output", name: "result" }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "input",
+        sourceHandle: "value",
+        target: "left",
+        targetHandle: "a"
+      },
+      {
+        source: "input",
+        sourceHandle: "value",
+        target: "right",
+        targetHandle: "a"
+      },
+      {
+        source: "left",
+        sourceHandle: "value",
+        target: "join",
+        targetHandle: "l"
+      },
+      {
+        source: "right",
+        sourceHandle: "value",
+        target: "join",
+        targetHandle: "r"
+      },
+      {
+        source: "join",
+        sourceHandle: "value",
+        target: "out",
+        targetHandle: "value"
+      }
+    ];
+    const joinInputs: Array<Record<string, unknown>> = [];
+    const result = await runGraph({
+      nodes,
+      edges,
+      params: { x: "hi" },
+      executors: {
+        left: {
+          async process(ins) {
+            return { value: `L:${ins.a}` };
+          }
+        },
+        right: {
+          async process() {
+            throw new Error("right is gone");
+          }
+        },
+        join: {
+          async process(ins) {
+            joinInputs.push({ ...ins });
+            return { value: `${ins.l}+${ins.r}` };
+          }
+        }
+      },
+      supervisor: new ScriptedHandle(() => ({ action: "skip" }))
+    });
+
+    // The run terminates instead of parking on an input that will never come,
+    // and the join sees the skipped handle as absent rather than as a value.
+    expect(result.status).toBe("completed");
+    expect(joinInputs).toHaveLength(1);
+    expect(joinInputs[0].l).toBe("L:hi");
+    expect(joinInputs[0].r).toBeUndefined();
+  });
+});
+
+describe("supervisor — the kernel enforces its own allowed set", () => {
+  it("rejects a verdict the escalation never offered", async () => {
+    const hostile: SupervisorHandle = {
+      async decide(): Promise<DecisionOutcome> {
+        return {
+          verdict: { action: "retry" },
+          decidedBy: "agent"
+        };
+      },
+      close() {}
+    };
+    let calls = 0;
+    const graph = chain(); // not retry-safe
+    const result = await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            calls++;
+            throw new Error("boom");
+          }
+        }
+      },
+      supervisor: hostile
+    });
+    expect(calls).toBe(1);
+    expect(result.status).toBe("failed");
+  });
+
+  it("resolves a throwing supervisor as fail", async () => {
+    const broken: SupervisorHandle = {
+      async decide(): Promise<DecisionOutcome> {
+        throw new Error("supervisor is down");
+      },
+      close() {}
+    };
+    const graph = chain({ retry_safe: true });
+    const result = await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            throw new Error("boom");
+          }
+        }
+      },
+      supervisor: broken
+    });
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("boom");
+  });
+});
+
+describe("supervisor — routing failures are not recoverable", () => {
+  it("never re-invokes when delivery throws after a partial send", async () => {
+    // The recovery loop wraps node execution only. If edge 1 delivered and
+    // edge 2 threw, a retry would duplicate edge 1's delivery.
+    const nodes: NodeDescriptor[] = [
+      { id: "input", type: "test.Input", name: "x" },
+      {
+        id: "work",
+        type: "test.Work",
+        retry_safe: true,
+        outputs: { value: "str" }
+      },
+      { id: "first", type: "test.Sink" },
+      { id: "second", type: "test.Sink" }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "input",
+        sourceHandle: "value",
+        target: "work",
+        targetHandle: "a"
+      },
+      {
+        source: "work",
+        sourceHandle: "value",
+        target: "first",
+        targetHandle: "v"
+      },
+      {
+        source: "work",
+        sourceHandle: "value",
+        target: "second",
+        targetHandle: "v"
+      }
+    ];
+    let invocations = 0;
+    let delivered = 0;
+    const handle = new ScriptedHandle(() => ({ action: "retry" }));
+    const result = await runGraph({
+      nodes,
+      edges,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            invocations++;
+            return { value: "v" };
+          }
+        },
+        first: {
+          async process() {
+            delivered++;
+            return {};
+          }
+        },
+        second: {
+          async process() {
+            throw new Error("downstream exploded");
+          }
+        }
+      },
+      supervisor: handle
+    });
+
+    expect(invocations).toBe(1);
+    expect(delivered).toBe(1);
+    // The downstream node's own failure escalates as itself; `work` never
+    // re-runs on its behalf, so `first` is not delivered to twice.
+    expect(handle.seen.every((e) => e.nodeId !== "work")).toBe(true);
+    expect(result.status).toBe("failed");
+  });
+});
+
+describe("supervisor — the escalation is a redacted record", () => {
+  it("never carries a resolved secret, in any emitted message or result", async () => {
+    const SECRET = "sk-live-01234567890abcdef";
+    const context = new ProcessingContext({ jobId: "supervisor-test" });
+    context.setSecretResolver(() => SECRET);
+
+    const graph = chain();
+    const handle = new ScriptedHandle(() => ({ action: "skip" }));
+    const result = await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      context,
+      executors: {
+        work: {
+          async process(_ins, ctx) {
+            const key = await (ctx as ProcessingContext).getSecret("API_KEY");
+            throw new Error(
+              `request to https://api.example.com?key=${key} failed`
+            );
+          }
+        }
+      },
+      supervisor: handle
+    });
+
+    const serialized = JSON.stringify({
+      messages: result.messages,
+      interventions: result.interventions,
+      seen: handle.seen
+    });
+    expect(serialized).not.toContain(SECRET);
+    expect(handle.seen[0].detail).toContain("«redacted»");
+  });
+
+  it("drops sensitive-named inputs whatever they contain", async () => {
+    const graph = chain();
+    const handle = new ScriptedHandle(() => ({ action: "skip" }));
+    await runGraph({
+      nodes: graph.nodes.map((n) =>
+        n.id === "work"
+          ? { ...n, properties: { password: "hunter2", prompt: "summarize" } }
+          : n
+      ),
+      edges: graph.edges,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            throw new Error("boom");
+          }
+        }
+      },
+      supervisor: handle
+    });
+    expect(handle.seen[0].inputs.password).toBe("«redacted»");
+    expect(handle.seen[0].inputs.prompt).toBe("summarize");
+  });
+});
+
+describe("supervisor — streaming", () => {
+  const streamingNode = (frames: number, throwAfter: number): NodeExecutor => ({
+    async process() {
+      return {};
+    },
+    async *genProcess() {
+      for (let i = 0; i < frames; i++) {
+        if (i === throwAfter) throw new Error("mid-stream");
+        yield { value: `chunk-${i}` };
+      }
+      if (throwAfter >= frames) throw new Error("at end");
+    }
+  });
+
+  function streamGraph(): { nodes: NodeDescriptor[]; edges: Edge[] } {
+    return {
+      nodes: [
+        { id: "input", type: "test.Input", name: "x" },
+        {
+          id: "work",
+          type: "test.Stream",
+          is_streaming_output: true,
+          retry_safe: true,
+          outputs: { value: "str" }
+        },
+        { id: "sink", type: "test.Sink", is_streaming_input: true }
+      ],
+      edges: [
+        {
+          source: "input",
+          sourceHandle: "value",
+          target: "work",
+          targetHandle: "a"
+        },
+        {
+          source: "work",
+          sourceHandle: "value",
+          target: "sink",
+          targetHandle: "value"
+        }
+      ]
+    };
+  }
+
+  /** Streaming sink that records every chunk that actually arrived. */
+  function recordingSink(into: unknown[]): NodeExecutor {
+    return {
+      async process() {
+        return {};
+      },
+      async run(inputs) {
+        for await (const value of inputs.stream("value")) {
+          into.push(value);
+        }
+      }
+    };
+  }
+
+  it("offers retry before the first emit and never a repair", async () => {
+    const handle = new ScriptedHandle(() => ({ action: "skip" }));
+    await runGraph({
+      ...streamGraph(),
+      params: { x: "hi" },
+      executors: { work: streamingNode(3, 0) },
+      supervisor: handle
+    });
+    expect(handle.seen[0].emitted).toBe(false);
+    expect(handle.seen[0].allowedActions).toContain("retry");
+    expect(handle.seen[0].allowedActions).not.toContain("substitute");
+  });
+
+  it("offers only end_stream and fail once something was emitted", async () => {
+    const handle = new ScriptedHandle(() => ({ action: "end_stream" }));
+    const received: unknown[] = [];
+    const result = await runGraph({
+      ...streamGraph(),
+      params: { x: "hi" },
+      executors: {
+        work: streamingNode(5, 2),
+        sink: recordingSink(received)
+      },
+      supervisor: handle
+    });
+    expect(handle.seen[0].emitted).toBe(true);
+    expect(handle.seen[0].allowedActions).toEqual(["end_stream", "fail"]);
+    // end_stream keeps what was produced — this is Skip's boundary case, the
+    // one the PRD reports as "kept the chunks it had finished".
+    expect(result.status).toBe("completed");
+    expect(received).toEqual(["chunk-0", "chunk-1"]);
+  });
+
+  it("gives a run() node exactly end_stream and fail", async () => {
+    const handle = new ScriptedHandle(() => ({ action: "end_stream" }));
+    const nodes: NodeDescriptor[] = [
+      { id: "input", type: "test.Input", name: "x" },
+      {
+        id: "work",
+        type: "test.Drain",
+        is_streaming_input: true,
+        retry_safe: true,
+        outputs: { value: "str" }
+      }
+    ];
+    const edges: Edge[] = [
+      {
+        source: "input",
+        sourceHandle: "value",
+        target: "work",
+        targetHandle: "a"
+      }
+    ];
+    const result = await runGraph({
+      nodes,
+      edges,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            return {};
+          },
+          async run(inputs) {
+            for await (const _ of inputs.stream("a")) {
+              throw new Error("drain failed");
+            }
+          }
+        }
+      },
+      supervisor: handle
+    });
+    expect(handle.seen[0].allowedActions).toEqual(["end_stream", "fail"]);
+    expect(result.status).toBe("completed");
+  });
+});

--- a/packages/node-sdk/src/base-node.ts
+++ b/packages/node-sdk/src/base-node.ts
@@ -161,6 +161,8 @@ export type NodeClass = {
   isJoinNode: boolean;
   supportsDynamicOutputs?: boolean;
   autoSaveAsset: boolean;
+  /** Opt-in: re-running with identical inputs is safe. See `BaseNode.retrySafe`. */
+  retrySafe: boolean;
   cacheTtl?: number | "forever";
   effect?: NodeEffect;
   primaryOutput?: string;
@@ -319,6 +321,15 @@ export abstract class BaseNode {
   static readonly isJoinNode: boolean = false;
   static readonly supportsDynamicOutputs: boolean | undefined = undefined;
   static readonly autoSaveAsset: boolean = false;
+  /**
+   * Whether re-running this node with identical inputs is safe. An opt-in:
+   * unknown means unsafe. Cost tracking cannot see external writes — a
+   * Publish/Upsert/Notify node can complete its side effect and then throw,
+   * recording nothing — so a node nobody classified loses a safe retry rather
+   * than gaining an unsafe one. The workflow supervisor offers `retry` only
+   * for a node that declares this. See docs/workflow-supervisor-design.md §5.3.
+   */
+  static readonly retrySafe: boolean = false;
   /**
    * Per-type cache lifetime for partial runs ("Run Node", "Run from here", "Run
    * selected"). Only consulted for Computed nodes (Constants are always live;
@@ -769,7 +780,8 @@ export abstract class BaseNode {
       output_correlation: cls.outputCorrelation,
       is_controlled: cls.isControlled,
       is_join_node: cls.isJoinNode || undefined,
-      is_trigger: cls.isTrigger || undefined
+      is_trigger: cls.isTrigger || undefined,
+      retry_safe: cls.retrySafe || undefined
     };
     if (Object.keys(propertyTypes).length > 0) {
       desc.propertyTypes = propertyTypes;

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -26,6 +26,13 @@ export type {
   StreamingOutputs,
   TriggerEvent
 } from "@nodetool-ai/runtime";
+// Node authors throw RecoverableNodeError to hand the supervisor the value
+// that needs repairing. Re-exported so they import it from node-sdk like
+// everything else they need to write a node.
+export {
+  RecoverableNodeError,
+  isRecoverableNodeError
+} from "@nodetool-ai/runtime";
 export type {
   ImageRef,
   AudioRef,

--- a/packages/node-sdk/src/metadata.ts
+++ b/packages/node-sdk/src/metadata.ts
@@ -114,6 +114,11 @@ export interface NodeMetadata {
   supports_dynamic_outputs?: boolean;
   auto_save_asset?: boolean;
   /**
+   * Opt-in: re-running the node with identical inputs is safe. Absent means
+   * unsafe, so the supervisor withholds `retry`. See `BaseNode.retrySafe`.
+   */
+  retry_safe?: boolean;
+  /**
    * Per-type cache lifetime for partial runs (seconds, or the `"forever"`
    * sentinel — never `Infinity`, which is not JSON-safe). Only consulted for
    * Computed nodes. Unset / `0` = never reuse. See `BaseNode.cacheTtl` and

--- a/packages/node-sdk/src/node-metadata.ts
+++ b/packages/node-sdk/src/node-metadata.ts
@@ -296,6 +296,7 @@ export function getNodeMetadata(
     ),
     supports_dynamic_outputs: nodeClass.supportsDynamicOutputs,
     auto_save_asset: nodeClass.autoSaveAsset || undefined,
+    retry_safe: nodeClass.retrySafe || undefined,
     cache_ttl: nodeClass.cacheTtl,
     // `cacheTtl: "forever"` means the output depends only on the inputs, which
     // is the definition of a pure node — no need to declare both.

--- a/packages/node-sdk/src/registry.ts
+++ b/packages/node-sdk/src/registry.ts
@@ -53,7 +53,10 @@ export class NodeRegistry {
   private _loadedMetadataByType = new Map<string, NodeMetadata>();
   private _registeredMetadataByType = new Map<string, NodeMetadata>();
   private _loadedMetadataSourceByType = new Map<string, NodeMetadataSource>();
-  private _registeredMetadataSourceByType = new Map<string, NodeMetadataSource>();
+  private _registeredMetadataSourceByType = new Map<
+    string,
+    NodeMetadataSource
+  >();
   private _loadedPackageIdByType = new Map<string, string>();
   private _registeredPackageIdByType = new Map<string, string>();
   private _activePackageId: string | undefined;
@@ -306,7 +309,8 @@ export class NodeRegistry {
     instance.__node_name = descriptor.name ?? descriptor.type;
     // Stryker disable next-line ConditionalExpression: forcing this true assigns _dynamic_outputs = undefined, which reads back identically to leaving it unset (equivalent).
     if (descriptor.dynamic_outputs) {
-      (instance as unknown as Record<string, unknown>)._dynamic_outputs = descriptor.dynamic_outputs;
+      (instance as unknown as Record<string, unknown>)._dynamic_outputs =
+        descriptor.dynamic_outputs;
     }
     if (descriptor.dynamic_inputs) {
       (instance as unknown as Record<string, unknown>)._dynamic_inputs =
@@ -401,7 +405,9 @@ export class NodeRegistry {
 
   listRegisteredNodeTypesWithoutMetadata(): string[] {
     // Stryker disable next-line ArrowFunction,ConditionalExpression: register() always stores derived metadata, so getMetadata is never undefined for a registered type — this filter always yields [] regardless of the predicate (equivalent).
-    return this.list().filter((nodeType) => this.getMetadata(nodeType) === undefined);
+    return this.list().filter(
+      (nodeType) => this.getMetadata(nodeType) === undefined
+    );
   }
 
   /** Add or replace metadata for a node type (e.g. from Python bridge). */
@@ -487,8 +493,12 @@ function typeMetadataToString(
     | NodeMetadata["outputs"][number]["type"]
 ): string {
   // Stryker disable next-line MethodExpression: .filter(Boolean) only drops empty renderings, which valid type metadata never produces (equivalent).
-  const args = (typeMeta.type_args ?? []).map(typeMetadataToString).filter(Boolean);
-  return args.length > 0 ? `${typeMeta.type}[${args.join(", ")}]` : typeMeta.type;
+  const args = (typeMeta.type_args ?? [])
+    .map(typeMetadataToString)
+    .filter(Boolean);
+  return args.length > 0
+    ? `${typeMeta.type}[${args.join(", ")}]`
+    : typeMeta.type;
 }
 
 /**
@@ -547,10 +557,17 @@ export function hydrateGraphNodeFlags(
         false,
       is_trigger:
         (cls ? cls.isTrigger : meta?.is_trigger) ?? node.is_trigger ?? false,
-      retry_safe:
-        (cls ? cls.retrySafe : meta?.retry_safe) ?? node.retry_safe ?? false,
+      // No `?? node.retry_safe` here, unlike every flag around it: whether
+      // re-running a node duplicates a payment or a publish is a property of
+      // its implementation, not of a saved file. A graph asserting
+      // `retry_safe: true` for a node nobody classified would hand the
+      // supervisor a retry on a side-effecting node — the asymmetric failure
+      // docs/workflow-supervisor-design.md §5.3 exists to prevent.
+      retry_safe: (cls ? cls.retrySafe : meta?.retry_safe) ?? false,
       always_emit_output_updates:
-        (cls ? cls.alwaysEmitOutputUpdates : meta?.always_emit_output_updates) ??
+        (cls
+          ? cls.alwaysEmitOutputUpdates
+          : meta?.always_emit_output_updates) ??
         node.always_emit_output_updates ??
         false,
       input_mode: (cls ? cls.inputMode : meta?.input_mode) ?? node.input_mode,

--- a/packages/node-sdk/src/registry.ts
+++ b/packages/node-sdk/src/registry.ts
@@ -547,6 +547,8 @@ export function hydrateGraphNodeFlags(
         false,
       is_trigger:
         (cls ? cls.isTrigger : meta?.is_trigger) ?? node.is_trigger ?? false,
+      retry_safe:
+        (cls ? cls.retrySafe : meta?.retry_safe) ?? node.retry_safe ?? false,
       always_emit_output_updates:
         (cls ? cls.alwaysEmitOutputUpdates : meta?.always_emit_output_updates) ??
         node.always_emit_output_updates ??
@@ -627,6 +629,7 @@ export function createGraphNodeTypeResolver(
           is_streaming_output: metadata.is_streaming_output ?? false,
           is_controlled: metadata.is_controlled ?? false,
           is_join_node: metadata.is_join_node ?? false,
+          retry_safe: metadata.retry_safe ?? false,
           ...(metadata.input_mode && { input_mode: metadata.input_mode }),
           ...(metadata.output_correlation && {
             output_correlation: metadata.output_correlation

--- a/packages/node-sdk/tests/graph-resolver.test.ts
+++ b/packages/node-sdk/tests/graph-resolver.test.ts
@@ -67,7 +67,6 @@ describe("createGraphNodeTypeResolver", () => {
         is_streaming_output: true,
         is_controlled: false,
         is_join_node: false,
-      retry_safe: false,
         retry_safe: false,
         input_mode: "buffered",
         output_correlation: {

--- a/packages/node-sdk/tests/graph-resolver.test.ts
+++ b/packages/node-sdk/tests/graph-resolver.test.ts
@@ -67,6 +67,8 @@ describe("createGraphNodeTypeResolver", () => {
         is_streaming_output: true,
         is_controlled: false,
         is_join_node: false,
+      retry_safe: false,
+        retry_safe: false,
         input_mode: "buffered",
         output_correlation: {
           output: { kind: "single", source: "__execution__" }
@@ -134,6 +136,7 @@ describe("createGraphNodeTypeResolver", () => {
       is_streaming_output: true,
       is_controlled: false,
       is_join_node: false,
+      retry_safe: false,
       input_mode: "buffered",
       output_correlation: {
         output: { kind: "single", source: "__execution__" }

--- a/packages/node-sdk/tests/retry-safe.test.ts
+++ b/packages/node-sdk/tests/retry-safe.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { BaseNode } from "../src/base-node.js";
+import { getNodeMetadata } from "../src/node-metadata.js";
+import { NodeRegistry, hydrateGraphNodeFlags } from "../src/registry.js";
+
+/** Deterministic in-process transform — the category PR 1 opts in. */
+class PureTransformNode extends BaseNode {
+  static readonly nodeType = "test.retrySafe.PureTransform";
+  static readonly retrySafe = true;
+  static readonly title = "Pure Transform";
+  static readonly description = "";
+
+  async process() {
+    return { output: "ok" };
+  }
+}
+
+/** No opt-in: the default, and what every unclassified node gets. */
+class UnclassifiedNode extends BaseNode {
+  static readonly nodeType = "test.retrySafe.Unclassified";
+  static readonly title = "Unclassified";
+  static readonly description = "";
+
+  async process() {
+    return { output: "ok" };
+  }
+}
+
+/**
+ * Stands in for WorkflowNode/SubgraphNode: the inner graph can contain
+ * anything, so retrying it can replay arbitrary side effects.
+ */
+class InnerGraphNode extends BaseNode {
+  static readonly nodeType = "test.retrySafe.InnerGraph";
+  static readonly title = "Inner Graph";
+  static readonly description = "";
+
+  async process() {
+    return { output: null };
+  }
+}
+
+describe("retrySafe", () => {
+  it("defaults to false on BaseNode", () => {
+    expect(BaseNode.retrySafe).toBe(false);
+    expect(UnclassifiedNode.retrySafe).toBe(false);
+  });
+
+  it("surfaces retry_safe: true through getNodeMetadata for a declaring node", () => {
+    expect(getNodeMetadata(PureTransformNode).retry_safe).toBe(true);
+  });
+
+  it("omits retry_safe from metadata for a node that does not declare it", () => {
+    expect(getNodeMetadata(UnclassifiedNode).retry_safe).toBeUndefined();
+    expect(getNodeMetadata(InnerGraphNode).retry_safe).toBeUndefined();
+  });
+
+  it("stamps retry_safe on the descriptor a declaring node produces", () => {
+    expect(PureTransformNode.toDescriptor("n1").retry_safe).toBe(true);
+  });
+
+  it("leaves retry_safe off the descriptor of an inner-graph node", () => {
+    expect(InnerGraphNode.toDescriptor("n2").retry_safe).toBeUndefined();
+  });
+
+  it("hydrates graph nodes from the registry, not from saved JSON", () => {
+    const registry = new NodeRegistry();
+    registry.register(PureTransformNode);
+    registry.register(InnerGraphNode);
+
+    const hydrated = hydrateGraphNodeFlags(
+      {
+        nodes: [
+          { id: "a", type: PureTransformNode.nodeType },
+          // A stale saved `true` must not survive: the class is authoritative.
+          { id: "b", type: InnerGraphNode.nodeType, retry_safe: true }
+        ],
+        edges: []
+      },
+      registry
+    );
+
+    expect(hydrated.nodes[0].retry_safe).toBe(true);
+    expect(hydrated.nodes[1].retry_safe).toBe(false);
+  });
+});

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -822,6 +822,12 @@ export interface NodeMetadata {
    * anything else needs an explicit run. Absent is treated as "external".
    */
   effect?: NodeEffect;
+  /**
+   * Opt-in: re-running the node with identical inputs is safe. Absent means
+   * unsafe — cost tracking cannot see external writes, so an unclassified node
+   * must not gain `retry` by omission. See docs/workflow-supervisor-design.md §5.3.
+   */
+  retry_safe?: boolean;
   model_packs?: ModelPack[];
   fal_unit_pricing?: FalUnitPricing | null;
   /** When true, the node remains runnable but is hidden from default discovery. */

--- a/packages/protocol/src/graph.ts
+++ b/packages/protocol/src/graph.ts
@@ -173,6 +173,15 @@ export interface NodeDescriptor {
   /** Dynamic runtime outputs declared by dynamic nodes. */
   dynamic_outputs?: Record<string, TypeMetadata | Record<string, unknown>>;
 
+  /**
+   * Whether re-running this node with identical inputs is safe. An opt-in, not
+   * an opt-out: cost tracking cannot see external writes, so a node nobody
+   * classified must lose a safe retry rather than gain an unsafe one. The
+   * supervisor offers `retry` only for a node that declares this.
+   * See docs/workflow-supervisor-design.md §5.3.
+   */
+  retry_safe?: boolean;
+
   /** Whether this node consumes streaming input. */
   is_streaming_input?: boolean;
 

--- a/packages/protocol/src/graph.ts
+++ b/packages/protocol/src/graph.ts
@@ -250,6 +250,12 @@ export interface HydratedNodeDescriptor extends NodeDescriptor {
   is_streaming_output: boolean;
   is_controlled: boolean;
   is_join_node: boolean;
+  /**
+   * Resolved from the registry only. Hydration never carries a saved
+   * `retry_safe` through, so a graph file cannot claim redo-safety a node's
+   * class never declared.
+   */
+  retry_safe: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -353,7 +359,10 @@ export function migrateGraphNodeTypes<T extends MigratableGraph>(graph: T): T {
     if (migration.renameProperties) {
       const renamedData = renameKeys(next.data, migration.renameProperties);
       if (renamedData) next.data = renamedData;
-      const renamedProps = renameKeys(next.properties, migration.renameProperties);
+      const renamedProps = renameKeys(
+        next.properties,
+        migration.renameProperties
+      );
       if (renamedProps) next.properties = renamedProps;
       if (typeof next.id === "string") {
         handleRenamesByNodeId.set(next.id, migration.renameProperties);

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from "./messages.js";
+export * from "./supervisor.js";
 export * from "./ws-commands.js";
 export * from "./bridge-frames.js";
 export * from "./graph.js";

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -26,6 +26,12 @@
  */
 
 import { z } from "zod";
+import {
+  supervisorDecisionSchema,
+  supervisorEscalationSchema,
+  type SupervisorDecision,
+  type SupervisorEscalation
+} from "./supervisor.js";
 
 // ---------------------------------------------------------------------------
 // Enums
@@ -618,9 +624,7 @@ export const llmCallUpdateSchema = z.object({
   node_name: z.string().nullable().optional(),
   provider: z.string(),
   model: z.string(),
-  messages: z.array(
-    z.object({ role: z.string(), content: z.unknown() })
-  ),
+  messages: z.array(z.object({ role: z.string(), content: z.unknown() })),
   response: z.unknown(),
   tool_calls: z
     .array(z.object({ id: z.string(), name: z.string(), args: z.unknown() }))
@@ -898,7 +902,9 @@ export const processingMessageSchema = z.discriminatedUnion("type", [
   chunkSchema,
   predictionSchema,
   llmCallUpdateSchema,
-  todoUpdateSchema
+  todoUpdateSchema,
+  supervisorEscalationSchema,
+  supervisorDecisionSchema
 ]);
 
 export type ProcessingMessage = z.infer<typeof processingMessageSchema>;
@@ -945,7 +951,9 @@ export const processingMessageSchemas = {
   chunk: chunkSchema,
   prediction: predictionSchema,
   llm_call: llmCallUpdateSchema,
-  todo_update: todoUpdateSchema
+  todo_update: todoUpdateSchema,
+  supervisor_escalation: supervisorEscalationSchema,
+  supervisor_decision: supervisorDecisionSchema
 } as const satisfies Record<MessageType, z.ZodType<ProcessingMessage>>;
 
 /**
@@ -1007,9 +1015,7 @@ export function isErrorMessage(value: unknown): value is ErrorMessage {
 export function isToolCallUpdate(value: unknown): value is ToolCallUpdate {
   return hasType(value, "tool_call_update");
 }
-export function isToolResultUpdate(
-  value: unknown
-): value is ToolResultUpdate {
+export function isToolResultUpdate(value: unknown): value is ToolResultUpdate {
   return hasType(value, "tool_result_update");
 }
 export function isTaskUpdate(value: unknown): value is TaskUpdate {
@@ -1032,6 +1038,16 @@ export function isLLMCallUpdate(value: unknown): value is LLMCallUpdate {
 }
 export function isTodoUpdate(value: unknown): value is TodoUpdate {
   return hasType(value, "todo_update");
+}
+export function isSupervisorEscalation(
+  value: unknown
+): value is SupervisorEscalation {
+  return hasType(value, "supervisor_escalation");
+}
+export function isSupervisorDecision(
+  value: unknown
+): value is SupervisorDecision {
+  return hasType(value, "supervisor_decision");
 }
 
 /** True when `value` is a structurally valid `ProcessingMessage`. */

--- a/packages/protocol/src/supervisor.ts
+++ b/packages/protocol/src/supervisor.ts
@@ -1,0 +1,126 @@
+/**
+ * @nodetool-ai/protocol – Workflow Supervisor
+ *
+ * A failing node invocation raises an `Escalation`; a handler returns a
+ * `Verdict`. Both cross the kernel/agents boundary and appear in messages
+ * and in `RunResult`, so they live here rather than in either package.
+ *
+ * See docs/workflow-supervisor-design.md §4.
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Verdicts
+// ---------------------------------------------------------------------------
+
+export const verdictActionSchema = z.enum([
+  "retry",
+  "substitute",
+  "skip",
+  "end_stream",
+  "fail"
+]);
+
+export type VerdictAction = z.infer<typeof verdictActionSchema>;
+
+/** Scope of a `skip`/`fail` verdict: this invocation, or every matching failure. */
+export const verdictScopeSchema = z.enum(["invocation", "signature"]);
+
+export type VerdictScope = z.infer<typeof verdictScopeSchema>;
+
+export const verdictSchema = z.discriminatedUnion("action", [
+  // No property overrides in v1 — a free-form record would let the supervisor
+  // rewrite URLs, prompts, and paths. Design §4.
+  z.object({ action: z.literal("retry") }),
+  z.object({
+    action: z.literal("substitute"),
+    outputs: z.record(z.string(), z.unknown())
+  }),
+  z.object({
+    action: z.literal("skip"),
+    applyTo: verdictScopeSchema.optional()
+  }),
+  z.object({ action: z.literal("end_stream") }),
+  z.object({
+    action: z.literal("fail"),
+    reason: z.string().optional(),
+    applyTo: verdictScopeSchema.optional()
+  })
+]);
+
+export type Verdict = z.infer<typeof verdictSchema>;
+
+/** Who produced a verdict. Only `"agent"` involved a model. */
+export const decidedBySchema = z.enum(["agent", "sticky", "bounds", "default"]);
+
+export type DecidedBy = z.infer<typeof decidedBySchema>;
+
+// ---------------------------------------------------------------------------
+// Escalations
+// ---------------------------------------------------------------------------
+
+export const escalationSchema = z.object({
+  nodeId: z.string(),
+  nodeType: z.string(),
+  /** Full lineage chain of the failing invocation, as `root=index` pairs. */
+  correlationLineage: z.array(z.string()),
+  /** Leaf token of `correlationLineage`; `""` for single-fire nodes. */
+  invocationKey: z.string(),
+  /** Kernel-computed; both the verdict schema and enforcement derive from it. */
+  allowedActions: z.array(verdictActionSchema),
+  /** The thrown error, stringified, redacted and truncated. */
+  detail: z.string(),
+  /** Stable categorical code. Absent ⇒ stickiness disabled. */
+  failureSignature: z.string().optional(),
+  /** From `RecoverableNodeError` — the malformed value, redacted and truncated. */
+  candidateOutput: z.unknown().optional(),
+  /** The invocation's input values, redacted and truncated. */
+  inputs: z.record(z.string(), z.unknown()),
+  /** 1-based, per `(nodeId, invocationKey)`. */
+  attempt: z.number(),
+  /** Provider cost recorded by this invocation. */
+  spentCostUsd: z.number(),
+  createdAssets: z.boolean(),
+  /** Node metadata opt-in; unknown ⇒ false ⇒ no retry. */
+  retrySafe: z.boolean(),
+  /** True while the failing invocation is a streaming one that already emitted. */
+  emitted: z.boolean()
+});
+
+export type Escalation = z.infer<typeof escalationSchema>;
+
+export const interventionSchema = z.object({
+  escalation: escalationSchema,
+  verdict: verdictSchema,
+  decidedBy: decidedBySchema,
+  /** Supervisor spend for this decision, in USD. */
+  costUsd: z.number().optional()
+});
+
+export type Intervention = z.infer<typeof interventionSchema>;
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+export const supervisorEscalationSchema = z.object({
+  type: z.literal("supervisor_escalation"),
+  node_id: z.string(),
+  node_name: z.string().nullable().optional(),
+  escalation: escalationSchema
+});
+
+export type SupervisorEscalation = z.infer<typeof supervisorEscalationSchema>;
+
+export const supervisorDecisionSchema = z.object({
+  type: z.literal("supervisor_decision"),
+  node_id: z.string(),
+  node_name: z.string().nullable().optional(),
+  escalation: escalationSchema,
+  verdict: verdictSchema,
+  decided_by: decidedBySchema,
+  cost: z.number().nullable().optional()
+});
+
+export type SupervisorDecision = z.infer<typeof supervisorDecisionSchema>;

--- a/packages/protocol/src/supervisor.ts
+++ b/packages/protocol/src/supervisor.ts
@@ -51,8 +51,19 @@ export const verdictSchema = z.discriminatedUnion("action", [
 
 export type Verdict = z.infer<typeof verdictSchema>;
 
-/** Who produced a verdict. Only `"agent"` involved a model. */
-export const decidedBySchema = z.enum(["agent", "sticky", "bounds", "default"]);
+/**
+ * Who produced the *applied* verdict. Only `"agent"` involved a model.
+ * `"kernel"` means the handle's answer was outside the escalation's allowed
+ * set and was replaced with `fail` — the one value that says the supervisor
+ * was overruled rather than obeyed.
+ */
+export const decidedBySchema = z.enum([
+  "agent",
+  "sticky",
+  "bounds",
+  "default",
+  "kernel"
+]);
 
 export type DecidedBy = z.infer<typeof decidedBySchema>;
 

--- a/packages/runtime/src/async-local-storage.ts
+++ b/packages/runtime/src/async-local-storage.ts
@@ -1,0 +1,35 @@
+/**
+ * `node:async_hooks`, lazily, with a browser/Edge fallback.
+ *
+ * The runtime package is bundled for non-Node targets too, where a static
+ * `import "node:async_hooks"` throws at module load. The fallback holder keeps
+ * the API working there; what it loses is concurrency safety, so a consumer
+ * that depends on per-async-context isolation must say what that costs it.
+ */
+
+import { importNodeBuiltin } from "@nodetool-ai/config";
+
+const _asyncHooks =
+  await importNodeBuiltin<typeof import("node:async_hooks")>(
+    "node:async_hooks"
+  );
+
+class FallbackStore<T> {
+  private _value: T | undefined;
+  getStore(): T | undefined {
+    return this._value;
+  }
+  run<R>(value: T, callback: () => R): R {
+    const prev = this._value;
+    this._value = value;
+    try {
+      return callback();
+    } finally {
+      this._value = prev;
+    }
+  }
+}
+
+export const AsyncLocalStorage =
+  _asyncHooks?.AsyncLocalStorage ??
+  (FallbackStore as unknown as typeof import("node:async_hooks").AsyncLocalStorage);

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -20,6 +20,10 @@ import {
   parsePackageAssetUri
 } from "@nodetool-ai/protocol";
 import { AgentMemory } from "./agent-memory.js";
+import {
+  recordInvocationAsset,
+  recordInvocationCost
+} from "./invocation-account.js";
 import { VariableChannel } from "./variable-channel.js";
 import { loadMediaRefBytes, type MediaRefValue } from "./media-ref-bytes.js";
 import { encodeRawImageRef } from "./image-codec.js";
@@ -33,6 +37,12 @@ import { importNodeBuiltin } from "@nodetool-ai/config";
 // lazily so this module loads in browser / Edge runtimes. The
 // `FileStorageAdapter`, `resolveWorkspacePath`, and `randomUUID`
 // fallback all degrade gracefully when these are unavailable.
+/**
+ * Secret values shorter than this are not recorded for masking: redacting a
+ * two-character value would blank unrelated text wherever it happens to occur.
+ */
+const MIN_MASKABLE_SECRET_LENGTH = 8;
+
 const nodeCrypto =
   await importNodeBuiltin<typeof import("node:crypto")>("node:crypto");
 const nodeFsP =
@@ -1134,6 +1144,8 @@ export class ProcessingContext {
         userId: string
       ) => Promise<string | null | undefined> | string | null | undefined)
     | null = null;
+  /** Every secret value the resolver handed out this run (see {@link ProcessingContext.getResolvedSecretValues}). */
+  private _resolvedSecrets = new Set<string>();
   /** Fetch function used by HTTP helpers. */
   private _fetch: (input: string, init?: RequestInit) => Promise<Response>;
   /** Optional temporary URL resolver for stored assets. */
@@ -1536,7 +1548,24 @@ export class ProcessingContext {
   async getSecret(key: string): Promise<string | null> {
     if (!this._secretResolver) return null;
     const value = await this._secretResolver(key, this.userId);
+    if (
+      typeof value === "string" &&
+      value.length >= MIN_MASKABLE_SECRET_LENGTH
+    ) {
+      this._resolvedSecrets.add(value);
+    }
     return value ?? null;
+  }
+
+  /**
+   * Every secret value handed out during this run. The supervisor's escalation
+   * constructor masks against this set — without it, "mask every secret" has no
+   * subject, because the resolver forgets each key as soon as it answers.
+   * Values shorter than `MIN_MASKABLE_SECRET_LENGTH` are not recorded: masking
+   * a two-character value would redact unrelated text everywhere it occurs.
+   */
+  getResolvedSecretValues(): ReadonlySet<string> {
+    return this._resolvedSecrets;
   }
 
   async getSecretRequired(key: string): Promise<string> {
@@ -1745,6 +1774,7 @@ export class ProcessingContext {
     >
   ): void {
     this._providerCost = { provider, amount, unit, ...details };
+    recordInvocationCost(amount);
   }
 
   getProviderCost(): ProviderCost | null {
@@ -2069,6 +2099,7 @@ export class ProcessingContext {
     if (!content) {
       throw new Error("Asset content is required");
     }
+    recordInvocationAsset();
     return fn({
       userId: this.userId,
       workflowId: this.workflowId,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -53,6 +53,18 @@ export {
   type AgentSpanKind,
   type LlmUsage
 } from "./tracing-helpers.js";
+export {
+  RecoverableNodeError,
+  isRecoverableNodeError
+} from "./recoverable-node-error.js";
+export {
+  createInvocationAccount,
+  inInvocationAccount,
+  recordInvocationCost,
+  recordInvocationAsset,
+  currentInvocationAccount,
+  type InvocationAccount
+} from "./invocation-account.js";
 export { packContext, type PackedContext } from "./context-packer.js";
 export {
   isZodSchema,

--- a/packages/runtime/src/invocation-account.ts
+++ b/packages/runtime/src/invocation-account.ts
@@ -45,11 +45,20 @@ export function inInvocationAccount<T>(
   return store.run(account, fn);
 }
 
-/** Charge the invocation currently on the async stack, if any. */
+/**
+ * Charge the invocation currently on the async stack, if any.
+ *
+ * A non-finite amount means a provider reported something we cannot add up —
+ * and "cannot add up" must not read as "free", or the invocation would look
+ * cost-free and re-earn a retry after a real charge. It is recorded as a
+ * nominal charge instead: the number is meaningless, the fact of spending is
+ * not. `costUsd` stays finite so the escalation record remains JSON-safe.
+ */
 export function recordInvocationCost(usd: number | undefined | null): void {
-  if (!usd) return;
+  if (usd === undefined || usd === null) return;
   const account = store.getStore();
-  if (account) account.costUsd += usd;
+  if (!account) return;
+  account.costUsd += Number.isFinite(usd) ? usd : Number.MIN_VALUE;
 }
 
 /** Mark the invocation currently on the async stack as having written an asset. */

--- a/packages/runtime/src/invocation-account.ts
+++ b/packages/runtime/src/invocation-account.ts
@@ -1,0 +1,60 @@
+/**
+ * Invocation-scoped cost and asset accounting.
+ *
+ * The supervisor may only offer `retry` for an invocation that spent nothing
+ * and wrote nothing (docs/workflow-supervisor-design.md §5.3). Answering that
+ * needs per-invocation numbers, and a stack on the shared `ProcessingContext`
+ * cannot supply them: every actor holds the same context and actors complete
+ * out of order, so push/pop would credit actor A's charge to actor B whenever
+ * A finishes first — precisely the corruption that would re-expose retry after
+ * a billed call.
+ *
+ * So the scope travels with the invocation's async execution instead. Cost and
+ * asset hooks write to whichever account is on the async stack; concurrent
+ * invocations each have their own, in any completion order.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface InvocationAccount {
+  /** Provider charges (USD) recorded while this invocation ran. */
+  costUsd: number;
+  /** True once the invocation created an asset. */
+  createdAssets: boolean;
+}
+
+const store = new AsyncLocalStorage<InvocationAccount>();
+
+export function createInvocationAccount(): InvocationAccount {
+  return { costUsd: 0, createdAssets: false };
+}
+
+/**
+ * Run `fn` inside `account`. The caller owns the account so it can read what
+ * the invocation spent even when `fn` throws — which is the case retry safety
+ * turns on.
+ */
+export function inInvocationAccount<T>(
+  account: InvocationAccount,
+  fn: () => Promise<T>
+): Promise<T> {
+  return store.run(account, fn);
+}
+
+/** Charge the invocation currently on the async stack, if any. */
+export function recordInvocationCost(usd: number | undefined | null): void {
+  if (!usd) return;
+  const account = store.getStore();
+  if (account) account.costUsd += usd;
+}
+
+/** Mark the invocation currently on the async stack as having written an asset. */
+export function recordInvocationAsset(): void {
+  const account = store.getStore();
+  if (account) account.createdAssets = true;
+}
+
+/** The account for the invocation currently on the async stack, if any. */
+export function currentInvocationAccount(): InvocationAccount | undefined {
+  return store.getStore();
+}

--- a/packages/runtime/src/invocation-account.ts
+++ b/packages/runtime/src/invocation-account.ts
@@ -14,7 +14,11 @@
  * invocations each have their own, in any completion order.
  */
 
-import { AsyncLocalStorage } from "node:async_hooks";
+// Lazily resolved so this module still loads in browser/Edge bundles. There the
+// fallback holder has no per-context isolation, and concurrent invocations
+// would share one account — acceptable only because the supervisor that reads
+// these numbers runs in the kernel, which is Node-only.
+import { AsyncLocalStorage } from "./async-local-storage.js";
 
 export interface InvocationAccount {
   /** Provider charges (USD) recorded while this invocation ran. */

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -11,25 +11,22 @@
  * is shared; only framing/transport differs per subclass.
  */
 
-import { importNodeBuiltin } from "@nodetool-ai/config";
+import { importNodeBuiltin, safeProcessEnv } from "@nodetool-ai/config";
 
 // The base only needs crypto (request IDs) and events (EventEmitter).
 // Lazy-load so the module *graph* loads off-Node; instantiating a concrete
 // bridge there throws at construction. Notably the base does NOT require
 // child_process — that belongs to the stdio subclass only.
-const nodeCrypto = await importNodeBuiltin<typeof import("node:crypto")>(
-  "node:crypto"
-);
-const nodeEvents = await importNodeBuiltin<typeof import("node:events")>(
-  "node:events"
-);
+const nodeCrypto =
+  await importNodeBuiltin<typeof import("node:crypto")>("node:crypto");
+const nodeEvents =
+  await importNodeBuiltin<typeof import("node:events")>("node:events");
 
 function notOnNode(api: string): never {
   throw new Error(`${api} requires Node — PythonBridgeBase is Node-only`);
 }
 const randomUUID =
-  nodeCrypto?.randomUUID ??
-  ((): string => notOnNode("node:crypto.randomUUID"));
+  nodeCrypto?.randomUUID ?? ((): string => notOnNode("node:crypto.randomUUID"));
 // Re-export the EventEmitter type/class — falls back to a no-op so the
 // module evaluates off-Node; consumers that instantiate the bridge will
 // fail at construction time, not at module load.
@@ -75,10 +72,11 @@ const log = createLogger("nodetool.runtime.python-bridge-base");
  * mechanism has burned in.
  */
 function shouldValidateBridgeFrames(): boolean {
-  const override = process.env["NODETOOL_VALIDATE_BRIDGE_FRAMES"]?.trim();
+  const override = safeProcessEnv()["NODETOOL_VALIDATE_BRIDGE_FRAMES"]?.trim();
   if (override === "1" || override === "true") return true;
   if (override === "0" || override === "false") return false;
-  return process.env["NODE_ENV"] === "test" || Boolean(process.env["VITEST"]);
+  const env = safeProcessEnv();
+  return env["NODE_ENV"] === "test" || Boolean(env["VITEST"]);
 }
 import type {
   PythonNodeMetadata,
@@ -116,13 +114,13 @@ interface PendingStreamRequest {
 }
 
 const DEFAULT_EXECUTE_TIMEOUT_MS = Number(
-  process.env["NODETOOL_PYTHON_EXECUTE_TIMEOUT_MS"] ?? 12 * 60 * 1000
+  safeProcessEnv()["NODETOOL_PYTHON_EXECUTE_TIMEOUT_MS"] ?? 12 * 60 * 1000
 );
 const DEFAULT_STATUS_TIMEOUT_MS = Number(
-  process.env["NODETOOL_PYTHON_STATUS_TIMEOUT_MS"] ?? 30000
+  safeProcessEnv()["NODETOOL_PYTHON_STATUS_TIMEOUT_MS"] ?? 30000
 );
 const DEFAULT_DOWNLOAD_IDLE_TIMEOUT_MS = Number(
-  process.env["NODETOOL_PYTHON_DOWNLOAD_IDLE_TIMEOUT_MS"] ?? 5 * 60 * 1000
+  safeProcessEnv()["NODETOOL_PYTHON_DOWNLOAD_IDLE_TIMEOUT_MS"] ?? 5 * 60 * 1000
 );
 
 /**
@@ -146,7 +144,10 @@ export abstract class PythonBridgeBase
    * shape) nor terminal — they stream the ComfyUI lifecycle while the same
    * request's terminal `result`/`error` settles via {@link _pendingStream}.
    */
-  protected _pendingComfyEvents = new Map<string, (event: ComfyEvent) => void>();
+  protected _pendingComfyEvents = new Map<
+    string,
+    (event: ComfyEvent) => void
+  >();
   protected _options: PythonBridgeOptions;
   protected _connected = false;
   private _connectPromise: Promise<void> | null = null;
@@ -248,9 +249,7 @@ export abstract class PythonBridgeBase
         // that pre-date the protocol_version field are treated as version 1
         // (the initial release) — same wire format, they just don't announce.
         const workerVersion =
-          typeof data.protocol_version === "number"
-            ? data.protocol_version
-            : 1;
+          typeof data.protocol_version === "number" ? data.protocol_version : 1;
         if (workerVersion < MIN_BRIDGE_PROTOCOL_VERSION) {
           this._pending.delete(requestId);
           pending.reject(
@@ -533,9 +532,11 @@ export abstract class PythonBridgeBase
       }
     };
 
-    const streamPromise = new Promise<Record<string, unknown>>((resolve, reject) => {
-      this._pendingStream.set(requestId, { resolve, reject, onChunk });
-    });
+    const streamPromise = new Promise<Record<string, unknown>>(
+      (resolve, reject) => {
+        this._pendingStream.set(requestId, { resolve, reject, onChunk });
+      }
+    );
 
     streamPromise
       .then((result) => {
@@ -613,21 +614,26 @@ export abstract class PythonBridgeBase
 
   async getWorkerStatus() {
     const requestId = randomUUID();
-    const result = await new Promise<Record<string, unknown>>((resolve, reject) => {
-      this._pendingStream.set(requestId, {
-        resolve,
-        reject,
-        onChunk: () => {}
-      });
-      try {
-        this._send({ type: "worker.status", request_id: requestId, data: {} });
-      } catch (err) {
-        this._pendingStream.delete(requestId);
-        reject(err instanceof Error ? err : new Error(String(err)));
+    const result = await new Promise<Record<string, unknown>>(
+      (resolve, reject) => {
+        this._pendingStream.set(requestId, {
+          resolve,
+          reject,
+          onChunk: () => {}
+        });
+        try {
+          this._send({
+            type: "worker.status",
+            request_id: requestId,
+            data: {}
+          });
+        } catch (err) {
+          this._pendingStream.delete(requestId);
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
       }
-    });
-    this._workerStatus =
-      result as unknown as PythonWorkerStatus;
+    );
+    this._workerStatus = result as unknown as PythonWorkerStatus;
     this._loadErrors = this._workerStatus.load_errors ?? this._loadErrors;
     return this._workerStatus;
   }
@@ -677,9 +683,7 @@ export abstract class PythonBridgeBase
         // response is ignored rather than resolving a dead promise.
         this._pendingStream.delete(requestId);
         reject(
-          new Error(
-            `Python worker status timed out after ${timeoutMs}ms.`
-          )
+          new Error(`Python worker status timed out after ${timeoutMs}ms.`)
         );
       }, timeoutMs);
     });
@@ -1079,7 +1083,9 @@ export abstract class PythonBridgeBase
       try {
         this._send({ type, request_id: requestId, data });
       } catch (err) {
-        settle(() => reject(err instanceof Error ? err : new Error(String(err))));
+        settle(() =>
+          reject(err instanceof Error ? err : new Error(String(err)))
+        );
       }
     });
   }
@@ -1110,7 +1116,9 @@ export abstract class PythonBridgeBase
 
   /** Delete a cached model from the worker's HF_HOME. Returns whether it existed. */
   async deleteCachedModel(repoId: string): Promise<boolean> {
-    const result = await this._providerCall("models.delete", { repo_id: repoId });
+    const result = await this._providerCall("models.delete", {
+      repo_id: repoId
+    });
     return Boolean((result as { deleted?: boolean }).deleted);
   }
 

--- a/packages/runtime/src/python-stdio-bridge.ts
+++ b/packages/runtime/src/python-stdio-bridge.ts
@@ -48,7 +48,8 @@ const join = (...parts: string[]): string =>
 import {
   createLogger,
   getByteLimitEnv,
-  safeProcessEnv
+  safeProcessEnv,
+  safeProcessPlatform
 } from "@nodetool-ai/config";
 
 import { PythonBridgeBase } from "./python-bridge-base.js";
@@ -168,7 +169,11 @@ export class PythonStdioBridge extends PythonBridgeBase {
           // only takes effect when set before torch initializes CUDA, which is
           // why it belongs here rather than in a node's process().
           PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True",
-          ...process.env,
+          // The options object is built before `spawn` runs, so a bare
+          // `process.env` here would throw `ReferenceError` off-Node instead
+          // of the `notOnNode("node:child_process.spawn")` this file goes out
+          // of its way to raise.
+          ...safeProcessEnv(),
           TQDM_DISABLE: "1",
           HF_HUB_DISABLE_PROGRESS_BARS: "1",
           TRANSFORMERS_VERBOSITY: "error"
@@ -435,15 +440,15 @@ export class PythonStdioBridge extends PythonBridgeBase {
 
   private _getPythonLaunchCandidates(): PythonLaunchCandidate[] {
     const explicitPythonPath =
-      this._options.pythonPath ?? process.env.NODETOOL_PYTHON;
+      this._options.pythonPath ?? safeProcessEnv().NODETOOL_PYTHON;
     if (explicitPythonPath) {
       return [{ command: explicitPythonPath, source: "NODETOOL_PYTHON" }];
     }
 
-    const condaPrefix = process.env.CONDA_PREFIX;
+    const condaPrefix = safeProcessEnv().CONDA_PREFIX;
     if (condaPrefix && this._looksLikeNodeToolEnv(condaPrefix)) {
       const activeEnvPython =
-        process.platform === "win32"
+        safeProcessPlatform() === "win32"
           ? join(condaPrefix, "python.exe")
           : join(condaPrefix, "bin", "python");
       if (existsSync(activeEnvPython)) {
@@ -469,17 +474,13 @@ export class PythonStdioBridge extends PythonBridgeBase {
 
   private _getManagedPythonPaths(): string[] {
     const home = homedir();
-    if (process.platform === "win32") {
+    const env = safeProcessEnv();
+    if (safeProcessPlatform() === "win32") {
       return [
-        process.env.ALLUSERSPROFILE
-          ? join(
-              process.env.ALLUSERSPROFILE,
-              "nodetool",
-              "conda_env",
-              "python.exe"
-            )
+        env.ALLUSERSPROFILE
+          ? join(env.ALLUSERSPROFILE, "nodetool", "conda_env", "python.exe")
           : join(
-              process.env.APPDATA ?? join(home, "AppData", "Roaming"),
+              env.APPDATA ?? join(home, "AppData", "Roaming"),
               "nodetool",
               "conda_env",
               "python.exe"
@@ -491,7 +492,7 @@ export class PythonStdioBridge extends PythonBridgeBase {
         String.raw`C:\ProgramData\nodetool\conda_env\python.exe`
       ].filter((c, i, a) => existsSync(c) && a.indexOf(c) === i);
     }
-    if (process.platform === "darwin") {
+    if (safeProcessPlatform() === "darwin") {
       return [
         join(home, "nodetool_env", "bin", "python"),
         join(home, "miniconda3", "envs", "nodetool", "bin", "python"),

--- a/packages/runtime/src/python-stdio-bridge.ts
+++ b/packages/runtime/src/python-stdio-bridge.ts
@@ -19,14 +19,14 @@ import { importNodeBuiltin } from "@nodetool-ai/config";
 // Python bridge is fundamentally Node-only (subprocess + raw FDs).
 // Lazy-load the builtins so the module *graph* loads off-Node;
 // instantiating PythonStdioBridge there throws at construction.
-const nodeCp = await importNodeBuiltin<typeof import("node:child_process")>(
-  "node:child_process"
-);
+const nodeCp =
+  await importNodeBuiltin<typeof import("node:child_process")>(
+    "node:child_process"
+  );
 const nodeFs = await importNodeBuiltin<typeof import("node:fs")>("node:fs");
 const nodeOs = await importNodeBuiltin<typeof import("node:os")>("node:os");
-const nodePath = await importNodeBuiltin<typeof import("node:path")>(
-  "node:path"
-);
+const nodePath =
+  await importNodeBuiltin<typeof import("node:path")>("node:path");
 
 function notOnNode(api: string): never {
   throw new Error(`${api} requires Node — PythonStdioBridge is Node-only`);
@@ -34,7 +34,8 @@ function notOnNode(api: string): never {
 type ChildProcess = ReturnType<typeof import("node:child_process").spawn>;
 const spawn = (
   ...args: Parameters<typeof import("node:child_process").spawn>
-): ChildProcess => (nodeCp ? nodeCp.spawn(...args) : notOnNode("node:child_process.spawn"));
+): ChildProcess =>
+  nodeCp ? nodeCp.spawn(...args) : notOnNode("node:child_process.spawn");
 const existsSync = (p: string): boolean =>
   nodeFs ? nodeFs.existsSync(p) : notOnNode("node:fs.existsSync");
 const homedir = (): string =>
@@ -44,10 +45,18 @@ const basename = (p: string): string =>
 const join = (...parts: string[]): string =>
   nodePath ? nodePath.join(...parts) : notOnNode("node:path.join");
 
-import { createLogger, getByteLimitEnv } from "@nodetool-ai/config";
+import {
+  createLogger,
+  getByteLimitEnv,
+  safeProcessEnv
+} from "@nodetool-ai/config";
 
 import { PythonBridgeBase } from "./python-bridge-base.js";
-import { encodeFrame, FrameDecoder, FrameSizeError } from "./python-bridge-framing.js";
+import {
+  encodeFrame,
+  FrameDecoder,
+  FrameSizeError
+} from "./python-bridge-framing.js";
 
 const log = createLogger("nodetool.runtime.python-stdio-bridge");
 import type {
@@ -85,10 +94,10 @@ const MAX_BRIDGE_FRAME_SIZE = getByteLimitEnv(
   256 * 1024 * 1024
 );
 const PYTHON_BRIDGE_ALLOWED_IN_PRODUCTION =
-  process.env["NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION"] === "1";
+  safeProcessEnv()["NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION"] === "1";
 
 function isProductionMode(): boolean {
-  return process.env["NODETOOL_ENV"] === "production";
+  return safeProcessEnv()["NODETOOL_ENV"] === "production";
 }
 
 export class PythonStdioBridge extends PythonBridgeBase {
@@ -162,8 +171,8 @@ export class PythonStdioBridge extends PythonBridgeBase {
           ...process.env,
           TQDM_DISABLE: "1",
           HF_HUB_DISABLE_PROGRESS_BARS: "1",
-          TRANSFORMERS_VERBOSITY: "error",
-        },
+          TRANSFORMERS_VERBOSITY: "error"
+        }
       });
       this._process = proc;
 
@@ -176,7 +185,9 @@ export class PythonStdioBridge extends PythonBridgeBase {
         settleError(
           new Error(
             `Python worker did not become ready within ${startupTimeoutMs}ms.` +
-              (stderrOutput.trim() ? ` Recent stderr: ${stderrOutput.trim()}` : "")
+              (stderrOutput.trim()
+                ? ` Recent stderr: ${stderrOutput.trim()}`
+                : "")
           )
         );
       }, startupTimeoutMs);

--- a/packages/runtime/src/python-websocket-bridge.ts
+++ b/packages/runtime/src/python-websocket-bridge.ts
@@ -22,7 +22,7 @@ import { pack, unpack } from "msgpackr";
 
 import WebSocket from "ws";
 
-import { createLogger } from "@nodetool-ai/config";
+import { createLogger, safeProcessEnv } from "@nodetool-ai/config";
 
 import { PythonBridgeBase } from "./python-bridge-base.js";
 
@@ -54,7 +54,7 @@ export type {
 
 /** Mirror of the stdio bridge's frame ceiling, used here for `maxPayload`. */
 const MAX_BRIDGE_FRAME_SIZE = Number(
-  process.env["NODETOOL_BRIDGE_MAX_FRAME_SIZE"] ?? 256 * 1024 * 1024
+  safeProcessEnv()["NODETOOL_BRIDGE_MAX_FRAME_SIZE"] ?? 256 * 1024 * 1024
 );
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 20000;
@@ -413,7 +413,9 @@ export class WebsocketPythonBridge extends PythonBridgeBase {
       // close() may have already fired before we registered the aborter.
       if (this._explicitlyClosed) {
         finishError(
-          new Error(`Python worker WebSocket closed before opening (${this._wsUrl}).`)
+          new Error(
+            `Python worker WebSocket closed before opening (${this._wsUrl}).`
+          )
         );
         return;
       }
@@ -451,7 +453,8 @@ export class WebsocketPythonBridge extends PythonBridgeBase {
   }
 
   private _detachLongLivedListeners(ws: WebSocket): void {
-    if (this._messageListener) ws.removeListener("message", this._messageListener);
+    if (this._messageListener)
+      ws.removeListener("message", this._messageListener);
     if (this._closeListener) ws.removeListener("close", this._closeListener);
     if (this._errorListener) ws.removeListener("error", this._errorListener);
     this._messageListener = null;
@@ -633,7 +636,9 @@ export class WebsocketPythonBridge extends PythonBridgeBase {
       const abort = this._abortHandshake;
       this._abortHandshake = null;
       abort(
-        new Error(`Python worker WebSocket closed before opening (${this._wsUrl}).`)
+        new Error(
+          `Python worker WebSocket closed before opening (${this._wsUrl}).`
+        )
       );
     }
     if (this._ws) {

--- a/packages/runtime/src/recoverable-node-error.ts
+++ b/packages/runtime/src/recoverable-node-error.ts
@@ -1,0 +1,45 @@
+/**
+ * The error a node throws when it has the broken value in hand.
+ *
+ * Without the malformed value, "repair" is fabrication: the supervisor would
+ * invent a structurally valid output that no runtime validator can semantically
+ * vet. So `substitute` is offered only for an escalation carrying a
+ * `candidateOutput`, and this is how a node supplies one — a JSON parser that
+ * chokes attaches the raw response instead of losing it.
+ *
+ * The value is redacted and truncated by the kernel when the escalation is
+ * built, alongside the node's inputs; nothing here is safe to log as-is.
+ *
+ * See docs/workflow-supervisor-design.md §4.
+ */
+export class RecoverableNodeError extends Error {
+  /** The malformed value a `substitute` verdict would replace. */
+  readonly candidateOutput: unknown;
+  /**
+   * Stable categorical code for this failure (an HTTP status, a provider error
+   * code, a validation path). Verdicts stick per `(nodeId, code)`, so it must
+   * never embed request-specific values — see design §4.
+   */
+  readonly code?: string;
+
+  constructor(
+    message: string,
+    opts: { candidateOutput: unknown; code?: string }
+  ) {
+    super(message);
+    this.name = "RecoverableNodeError";
+    this.candidateOutput = opts.candidateOutput;
+    this.code = opts.code;
+  }
+}
+
+/** True for a `RecoverableNodeError` from any copy of this package. */
+export function isRecoverableNodeError(
+  err: unknown
+): err is RecoverableNodeError {
+  return (
+    err instanceof Error &&
+    err.name === "RecoverableNodeError" &&
+    "candidateOutput" in err
+  );
+}

--- a/packages/runtime/src/tracing-helpers.ts
+++ b/packages/runtime/src/tracing-helpers.ts
@@ -53,6 +53,7 @@ import {
   type Span
 } from "@opentelemetry/api";
 import { getTracer } from "./telemetry.js";
+import { recordInvocationCost } from "./invocation-account.js";
 
 export type AgentSpanKind = "execute" | "plan" | "step" | "compile";
 
@@ -104,6 +105,10 @@ export function withUsageCapture<T>(fn: () => Promise<T>): Promise<T> {
 
 /** Provider hook: add token usage for the in-flight LLM call. */
 export function setLastUsage(usage: LlmUsage): void {
+  // Charge the enclosing node invocation before the slot check: an LLM call
+  // made outside a capture slot still cost money, and retry safety turns on
+  // whether this invocation spent anything.
+  recordInvocationCost(usage.cost);
   const slot = usageStore.getStore();
   if (!slot) return;
   const previous = slot.usage;

--- a/packages/runtime/src/tracing-helpers.ts
+++ b/packages/runtime/src/tracing-helpers.ts
@@ -20,32 +20,9 @@
  * span active in AsyncLocalStorage for the duration of the callback.
  */
 
-import { importNodeBuiltin } from "@nodetool-ai/config";
-
-// `node:async_hooks` is Node-only. In browser/Edge we fall back to a
-// simple mutable holder — the usage-tracking API loses concurrency
-// safety there, but is otherwise functional.
-const _asyncHooks = await importNodeBuiltin<typeof import("node:async_hooks")>(
-  "node:async_hooks"
-);
-class FallbackStore<T> {
-  private _value: T | undefined;
-  getStore(): T | undefined {
-    return this._value;
-  }
-  run<R>(value: T, callback: () => R): R {
-    const prev = this._value;
-    this._value = value;
-    try {
-      return callback();
-    } finally {
-      this._value = prev;
-    }
-  }
-}
-const AsyncLocalStorage =
-  _asyncHooks?.AsyncLocalStorage ??
-  (FallbackStore as unknown as typeof import("node:async_hooks").AsyncLocalStorage);
+// `node:async_hooks` is Node-only; in browser/Edge this is a mutable holder,
+// so usage tracking loses concurrency safety there but stays functional.
+import { AsyncLocalStorage } from "./async-local-storage.js";
 import {
   SpanStatusCode,
   context as otelContext,

--- a/packages/runtime/tests/invocation-account.test.ts
+++ b/packages/runtime/tests/invocation-account.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Invocation-scoped accounting and the resolved-secret registry — the two
+ * pieces of run state the supervisor's retry-safety rule and its redaction
+ * layer are built on.
+ *
+ * See docs/workflow-supervisor-design.md §5.3 and §6.1.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  createInvocationAccount,
+  inInvocationAccount,
+  recordInvocationAsset,
+  recordInvocationCost,
+  currentInvocationAccount
+} from "../src/invocation-account.js";
+import { ProcessingContext } from "../src/context.js";
+
+describe("invocation accounting", () => {
+  it("attributes concurrent invocations that finish in reverse order", async () => {
+    // The failure this rules out: actor A's charge landing on actor B because
+    // A completed first. A stack on the shared context would do exactly that.
+    const slow = createInvocationAccount();
+    const fast = createInvocationAccount();
+
+    await Promise.all([
+      inInvocationAccount(slow, async () => {
+        recordInvocationCost(1);
+        await new Promise((r) => setTimeout(r, 20));
+        recordInvocationCost(0.5);
+      }),
+      inInvocationAccount(fast, async () => {
+        recordInvocationCost(2);
+      })
+    ]);
+
+    expect(slow.costUsd).toBe(1.5);
+    expect(fast.costUsd).toBe(2);
+  });
+
+  it("records an asset write even when the invocation then throws", async () => {
+    const account = createInvocationAccount();
+    await expect(
+      inInvocationAccount(account, async () => {
+        recordInvocationAsset();
+        throw new Error("published, then died");
+      })
+    ).rejects.toThrow("published, then died");
+    expect(account.createdAssets).toBe(true);
+  });
+
+  it("is inert outside an invocation", () => {
+    expect(currentInvocationAccount()).toBeUndefined();
+    expect(() => recordInvocationCost(1)).not.toThrow();
+    expect(() => recordInvocationAsset()).not.toThrow();
+  });
+
+  it("charges the enclosing invocation when a node reports a provider cost", async () => {
+    const context = new ProcessingContext({ jobId: "j1" });
+    const account = createInvocationAccount();
+    await inInvocationAccount(account, async () => {
+      context.setProviderCost("fal", 0.42, "usd");
+    });
+    expect(account.costUsd).toBe(0.42);
+  });
+});
+
+describe("resolved-secret registry", () => {
+  it("records every value the resolver hands out", async () => {
+    const context = new ProcessingContext({ jobId: "j1" });
+    context.setSecretResolver((key) =>
+      key === "OPENAI_API_KEY" ? "sk-live-0123456789" : null
+    );
+
+    expect(context.getResolvedSecretValues().size).toBe(0);
+    await context.getSecret("OPENAI_API_KEY");
+    expect([...context.getResolvedSecretValues()]).toEqual([
+      "sk-live-0123456789"
+    ]);
+
+    await context.getSecret("MISSING");
+    expect(context.getResolvedSecretValues().size).toBe(1);
+  });
+
+  it("ignores values too short to mask without collateral damage", async () => {
+    const context = new ProcessingContext({ jobId: "j1" });
+    context.setSecretResolver(() => "on");
+    await context.getSecret("FLAG");
+    expect(context.getResolvedSecretValues().size).toBe(0);
+  });
+});

--- a/packages/runtime/tests/invocation-account.test.ts
+++ b/packages/runtime/tests/invocation-account.test.ts
@@ -49,6 +49,28 @@ describe("invocation accounting", () => {
     expect(account.createdAssets).toBe(true);
   });
 
+  it("treats an unusable cost as spending, not as free", async () => {
+    // "We cannot add this up" must not read as "this was free": a NaN dropped
+    // silently would leave the invocation looking cost-free and re-earn a
+    // retry after a real charge.
+    const account = createInvocationAccount();
+    await inInvocationAccount(account, async () => {
+      recordInvocationCost(Number.NaN);
+    });
+    expect(account.costUsd).toBeGreaterThan(0);
+    expect(Number.isFinite(account.costUsd)).toBe(true);
+  });
+
+  it("ignores an absent cost", async () => {
+    const account = createInvocationAccount();
+    await inInvocationAccount(account, async () => {
+      recordInvocationCost(undefined);
+      recordInvocationCost(null);
+      recordInvocationCost(0);
+    });
+    expect(account.costUsd).toBe(0);
+  });
+
   it("is inert outside an invocation", () => {
     expect(currentInvocationAccount()).toBeUndefined();
     expect(() => recordInvocationCost(1)).not.toThrow();

--- a/packages/text-nodes/src/nodes/lib-html-parse.ts
+++ b/packages/text-nodes/src/nodes/lib-html-parse.ts
@@ -16,6 +16,7 @@ function resolveUrl(src: string, baseUrl: string): string {
 
 export class BaseUrlLibNode extends BaseNode {
   static readonly nodeType = "lib.html.BaseUrl";
+  static readonly retrySafe = true;
   static readonly title = "Base Url";
   static readonly description =
     "Extract the base URL from a given URL.\n    url parsing, domain extraction, web utilities\n\n    Use cases:\n    - Get domain name from full URLs\n    - Clean up URLs for comparison\n    - Extract root website addresses\n    - Standardize URL formats";
@@ -45,6 +46,7 @@ export class BaseUrlLibNode extends BaseNode {
 
 export class ExtractLinksLibNode extends BaseNode {
   static readonly nodeType = "lib.html.ExtractLinks";
+  static readonly retrySafe = true;
   static readonly title = "Extract Links";
   static readonly description =
     "Extract all links from HTML content with type classification.\n    extract, links, urls, web scraping, html\n\n    Use cases:\n    - Analyze website structure and navigation\n    - Discover related content and resources\n    - Build sitemaps and link graphs\n    - Find internal and external references\n    - Collect URLs for further processing";
@@ -130,6 +132,7 @@ export class ExtractLinksLibNode extends BaseNode {
 
 export class ExtractImagesLibNode extends BaseNode {
   static readonly nodeType = "lib.html.ExtractImages";
+  static readonly retrySafe = true;
   static readonly title = "Extract Images";
   static readonly description =
     "Extract images from HTML content.\n    extract, images, src\n\n    Use cases:\n    - Collect images from web pages\n    - Analyze image usage on websites\n    - Create image galleries";
@@ -192,6 +195,7 @@ export class ExtractImagesLibNode extends BaseNode {
 
 export class ExtractAudioLibNode extends BaseNode {
   static readonly nodeType = "lib.html.ExtractAudio";
+  static readonly retrySafe = true;
   static readonly title = "Extract Audio";
   static readonly description =
     "Extract audio elements from HTML content.\n    extract, audio, src\n\n    Use cases:\n    - Collect audio sources from web pages\n    - Analyze audio usage on websites\n    - Create audio playlists";
@@ -256,6 +260,7 @@ export class ExtractAudioLibNode extends BaseNode {
 
 export class ExtractVideosLibNode extends BaseNode {
   static readonly nodeType = "lib.html.ExtractVideos";
+  static readonly retrySafe = true;
   static readonly title = "Extract Videos";
   static readonly description =
     "Extract videos from HTML content.\n    extract, videos, src\n\n    Use cases:\n    - Collect video sources from web pages\n    - Analyze video usage on websites\n    - Create video playlists";
@@ -320,6 +325,7 @@ export class ExtractVideosLibNode extends BaseNode {
 
 export class ExtractMetadataLibNode extends BaseNode {
   static readonly nodeType = "lib.html.ExtractMetadata";
+  static readonly retrySafe = true;
   static readonly title = "Extract Metadata";
   static readonly description =
     "Extract metadata from HTML content.\n    extract, metadata, seo\n\n    Use cases:\n    - Analyze SEO elements\n    - Gather page information\n    - Extract structured data";
@@ -357,6 +363,7 @@ export class ExtractMetadataLibNode extends BaseNode {
 
 export class HTMLToTextLibNode extends BaseNode {
   static readonly nodeType = "lib.html.HTMLToText";
+  static readonly retrySafe = true;
   static readonly title = "Convert HTML to Text";
   static readonly description =
     "Converts HTML to plain text by removing tags and decoding entities using BeautifulSoup.\n    html, text, convert\n\n    Use cases:\n    - Cleaning HTML content for text analysis\n    - Extracting readable content from web pages\n    - Preparing HTML data for natural language processing";
@@ -392,6 +399,7 @@ export class HTMLToTextLibNode extends BaseNode {
 
 export class WebsiteContentExtractorLibNode extends BaseNode {
   static readonly nodeType = "lib.html.WebsiteContentExtractor";
+  static readonly retrySafe = true;
   static readonly title = "Website Content Extractor";
   static readonly description =
     "Extract main content from a website, removing navigation, ads, and other non-essential elements.\n    scrape, web scraping, content extraction, text analysis\n\n    Use cases:\n    - Clean web content for further analysis\n    - Extract article text from news websites\n    - Prepare web content for summarization";

--- a/packages/text-nodes/src/nodes/lib-markdown.ts
+++ b/packages/text-nodes/src/nodes/lib-markdown.ts
@@ -3,6 +3,7 @@ import { tagAsUniversal } from "@nodetool-ai/nodes-utils";
 
 export class ExtractLinksMarkdownLibNode extends BaseNode {
   static readonly nodeType = "lib.markdown.ExtractLinks";
+  static readonly retrySafe = true;
   static readonly title = "Extract Links";
   static readonly description =
     "Extracts all links from markdown text.\n    markdown, links, extraction\n\n    Use cases:\n    - Extract references and citations from academic documents\n    - Build link graphs from markdown documentation\n    - Analyze external resources referenced in markdown files";
@@ -48,6 +49,7 @@ export class ExtractLinksMarkdownLibNode extends BaseNode {
 
 export class ExtractHeadersMarkdownLibNode extends BaseNode {
   static readonly nodeType = "lib.markdown.ExtractHeaders";
+  static readonly retrySafe = true;
   static readonly title = "Extract Headers";
   static readonly description =
     "Extracts headers and creates a document structure/outline.\n    markdown, headers, structure\n\n    Use cases:\n    - Generate table of contents\n    - Analyze document structure\n    - Extract main topics from documents";
@@ -93,6 +95,7 @@ export class ExtractHeadersMarkdownLibNode extends BaseNode {
 
 export class ExtractBulletListsMarkdownLibNode extends BaseNode {
   static readonly nodeType = "lib.markdown.ExtractBulletLists";
+  static readonly retrySafe = true;
   static readonly title = "Extract Bullet Lists";
   static readonly description =
     "Extracts bulleted lists from markdown.\n    markdown, lists, bullets, extraction\n\n    Use cases:\n    - Extract unordered list items\n    - Analyze bullet point structures\n    - Convert bullet lists to structured data";
@@ -131,6 +134,7 @@ export class ExtractBulletListsMarkdownLibNode extends BaseNode {
 
 export class ExtractNumberedListsMarkdownLibNode extends BaseNode {
   static readonly nodeType = "lib.markdown.ExtractNumberedLists";
+  static readonly retrySafe = true;
   static readonly title = "Extract Numbered Lists";
   static readonly description =
     "Extracts numbered lists from markdown.\n    markdown, lists, numbered, extraction\n\n    Use cases:\n    - Extract ordered list items\n    - Analyze enumerated structures\n    - Convert numbered lists to structured data";
@@ -169,6 +173,7 @@ export class ExtractNumberedListsMarkdownLibNode extends BaseNode {
 
 export class ExtractCodeBlocksMarkdownLibNode extends BaseNode {
   static readonly nodeType = "lib.markdown.ExtractCodeBlocks";
+  static readonly retrySafe = true;
   static readonly title = "Extract Code Blocks";
   static readonly description =
     "Extracts code blocks and their languages from markdown.\n    markdown, code, extraction\n\n    Use cases:\n    - Extract code samples for analysis\n    - Collect programming examples\n    - Analyze code snippets in documentation";
@@ -199,6 +204,7 @@ export class ExtractCodeBlocksMarkdownLibNode extends BaseNode {
 
 export class ExtractTablesMarkdownLibNode extends BaseNode {
   static readonly nodeType = "lib.markdown.ExtractTables";
+  static readonly retrySafe = true;
   static readonly title = "Extract Tables";
   static readonly description =
     "Extracts tables from markdown and converts them to structured data.\n    markdown, tables, data\n\n    Use cases:\n    - Extract tabular data from markdown\n    - Convert markdown tables to structured formats\n    - Analyze tabulated information";

--- a/packages/text-nodes/src/nodes/lib-nlp.ts
+++ b/packages/text-nodes/src/nodes/lib-nlp.ts
@@ -18,6 +18,7 @@ import {
 
 export class SentimentAnalysisLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.SentimentAnalysis";
+  static readonly retrySafe = true;
   static readonly title = "Sentiment Analysis";
   static readonly description =
     "Analyzes sentiment of text using an AFINN-based analyzer.\n    sentiment, opinion, polarity, text analysis, NLP\n\n    Use cases:\n    - Determine positive or negative tone of text\n    - Analyze customer feedback sentiment\n    - Score product reviews\n    - Monitor social media sentiment";
@@ -103,6 +104,7 @@ export class SentimentAnalysisLibNode extends BaseNode {
 
 export class TokenizeLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.Tokenize";
+  static readonly retrySafe = true;
   static readonly title = "Tokenize";
   static readonly description =
     "Tokenizes text into words or sentences.\n    tokenize, split, words, sentences, NLP\n\n    Use cases:\n    - Break text into individual words for analysis\n    - Split text into sentences for processing\n    - Prepare text for further NLP operations\n    - Count words or sentences in text";
@@ -153,6 +155,7 @@ export class TokenizeLibNode extends BaseNode {
 
 export class StemLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.Stem";
+  static readonly retrySafe = true;
   static readonly title = "Stem";
   static readonly description =
     "Stems words to their root form.\n    stem, root, morphology, NLP, text processing\n\n    Use cases:\n    - Reduce words to their base form for matching\n    - Normalize text for search indexing\n    - Prepare text for comparison and deduplication\n    - Improve text similarity matching";
@@ -202,6 +205,7 @@ export class StemLibNode extends BaseNode {
 
 export class TfIdfLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.TfIdf";
+  static readonly retrySafe = true;
   static readonly title = "TF-IDF";
   static readonly description =
     "Computes TF-IDF scores for terms across multiple documents.\n    tf-idf, term frequency, document frequency, text analysis, NLP\n\n    Use cases:\n    - Rank document relevance for a search query\n    - Identify important terms in a collection of documents\n    - Build keyword extraction pipelines\n    - Compare document similarity by term importance";
@@ -251,6 +255,7 @@ export class TfIdfLibNode extends BaseNode {
 
 export class ClassifyTextLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.ClassifyText";
+  static readonly retrySafe = true;
   static readonly title = "Classify Text";
   static readonly description =
     "Trains a Naive Bayes classifier and classifies text.\n    classify, categorize, naive bayes, machine learning, NLP\n\n    Use cases:\n    - Categorize text into predefined labels\n    - Build simple spam detection\n    - Classify customer support tickets\n    - Sort documents by topic";
@@ -315,6 +320,7 @@ export class ClassifyTextLibNode extends BaseNode {
 
 export class ExtractEntitiesLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.ExtractEntities";
+  static readonly retrySafe = true;
   static readonly title = "Extract Entities";
   static readonly description =
     "Extracts named entities and parts of speech using compromise.\n    NER, named entities, parts of speech, NLP, text analysis\n\n    Use cases:\n    - Extract people, places, and organizations from text\n    - Identify nouns and verbs in sentences\n    - Build knowledge graphs from unstructured text\n    - Analyze text structure and content";
@@ -374,6 +380,7 @@ export class ExtractEntitiesLibNode extends BaseNode {
 
 export class PhoneticMatchLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.PhoneticMatch";
+  static readonly retrySafe = true;
   static readonly title = "Phonetic Match";
   static readonly description =
     "Computes phonetic codes for words using Soundex, Metaphone, or Double Metaphone.\n    phonetics, soundex, metaphone, fuzzy matching, NLP\n\n    Use cases:\n    - Find words that sound alike\n    - Build fuzzy name matching systems\n    - Implement spell correction suggestions\n    - Match names with different spellings";

--- a/packages/text-nodes/src/nodes/lib-svg.ts
+++ b/packages/text-nodes/src/nodes/lib-svg.ts
@@ -103,6 +103,7 @@ function normalizeContent(content: unknown): string {
 
 export class RectLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Rect";
+  static readonly retrySafe = true;
   static readonly title = "Rectangle";
   static readonly description =
     "Generate SVG rectangle element with customizable position, size, and styling.\n    svg, shape, vector, rectangle\n\n    Use cases:\n    - Create rectangular shapes in SVG documents\n    - Design borders, frames, and backgrounds\n    - Build user interface components\n    - Create geometric patterns and layouts";
@@ -174,6 +175,7 @@ export class RectLibNode extends BaseNode {
 
 export class CircleLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Circle";
+  static readonly retrySafe = true;
   static readonly title = "Circle";
   static readonly description =
     "Generate SVG circle element with customizable position, radius, and styling.\n    svg, shape, vector, circle\n\n    Use cases:\n    - Create circular shapes and icons\n    - Design buttons, badges, and indicators\n    - Build data visualizations like pie charts\n    - Create decorative elements and patterns";
@@ -251,6 +253,7 @@ export class CircleLibNode extends BaseNode {
 
 export class EllipseLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Ellipse";
+  static readonly retrySafe = true;
   static readonly title = "Ellipse";
   static readonly description =
     "Generate SVG ellipse element with customizable position, radii, and styling.\n    svg, shape, vector, ellipse\n\n    Use cases:\n    - Create oval shapes and organic forms\n    - Design speech bubbles and callouts\n    - Build data visualization elements\n    - Create decorative patterns and borders";
@@ -332,6 +335,7 @@ export class EllipseLibNode extends BaseNode {
 
 export class LineLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Line";
+  static readonly retrySafe = true;
   static readonly title = "Line";
   static readonly description =
     "Generate SVG line element with customizable endpoints and styling.\n    svg, shape, vector, line\n\n    Use cases:\n    - Draw straight lines and connectors\n    - Create dividers and separators\n    - Build diagrams and flowcharts\n    - Design grid patterns and borders";
@@ -411,6 +415,7 @@ export class LineLibNode extends BaseNode {
 
 export class PolygonLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Polygon";
+  static readonly retrySafe = true;
   static readonly title = "Polygon";
   static readonly description =
     "Generate SVG polygon element with multiple vertices.\n    svg, shape, vector, polygon\n\n    Use cases:\n    - Create multi-sided shapes like triangles, pentagons, stars\n    - Build custom icons and symbols\n    - Design complex geometric patterns\n    - Create irregular shapes and forms";
@@ -475,6 +480,7 @@ export class PolygonLibNode extends BaseNode {
 
 export class PathLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Path";
+  static readonly retrySafe = true;
   static readonly title = "Path";
   static readonly description =
     "Generate SVG path element using path data commands.\n    svg, shape, vector, path\n\n    Use cases:\n    - Create complex curved and custom shapes\n    - Build logos and custom icons\n    - Design intricate patterns and illustrations\n    - Import path data from design tools";
@@ -539,6 +545,7 @@ export class PathLibNode extends BaseNode {
 
 export class TextLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Text";
+  static readonly retrySafe = true;
   static readonly title = "Text";
   static readonly description =
     "Add text elements to SVG.\n    svg, text, typography\n\n    Use cases:\n    - Add labels to vector graphics\n    - Create text-based logos\n    - Generate dynamic text content in SVGs";
@@ -618,6 +625,7 @@ export class TextLibNode extends BaseNode {
 
 export class GaussianBlurLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.GaussianBlur";
+  static readonly retrySafe = true;
   static readonly title = "Gaussian Blur";
   static readonly description =
     "Apply Gaussian blur filter effect to SVG elements.\n    svg, filter, blur, effects\n\n    Use cases:\n    - Create soft focus and depth effects\n    - Add subtle shadows and glows\n    - Simulate motion blur\n    - Soften edges in graphics";
@@ -653,6 +661,7 @@ export class GaussianBlurLibNode extends BaseNode {
 
 export class DropShadowLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.DropShadow";
+  static readonly retrySafe = true;
   static readonly title = "Drop Shadow";
   static readonly description =
     "Apply drop shadow filter effect to SVG elements for depth.\n    svg, filter, shadow, effects\n\n    Use cases:\n    - Add depth and elevation to elements\n    - Create realistic shadow effects\n    - Enhance visual hierarchy\n    - Improve element separation and readability";
@@ -737,6 +746,7 @@ export class DropShadowLibNode extends BaseNode {
 
 export class DocumentLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Document";
+  static readonly retrySafe = true;
   static readonly title = "SVG Document";
   static readonly description =
     "Combine SVG elements into a complete SVG document.\n    svg, document, combine\n\n    Use cases:\n    - Combine multiple SVG elements into a single document\n    - Set document-level properties like viewBox and dimensions\n    - Export complete SVG documents";
@@ -794,6 +804,7 @@ export class DocumentLibNode extends BaseNode {
 
 export class SVGToImageLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.SVGToImage";
+  static readonly retrySafe = true;
   // Native `sharp` rasterization — Node only. Overrides the LIB_SVG_NODES
   // tagAsServer tag (per-class platforms always win over the list tagger).
   static readonly platforms = NODE_ONLY;
@@ -880,6 +891,7 @@ export class SVGToImageLibNode extends BaseNode {
 
 export class GradientLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Gradient";
+  static readonly retrySafe = true;
   static readonly title = "Gradient";
   static readonly description =
     "Create linear or radial gradients for SVG elements.\n    svg, gradient, color\n\n    Use cases:\n    - Add smooth color transitions\n    - Create complex color effects\n    - Define reusable gradient definitions";
@@ -994,6 +1006,7 @@ export class GradientLibNode extends BaseNode {
 
 export class TransformLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Transform";
+  static readonly retrySafe = true;
   static readonly title = "Transform";
   static readonly description =
     "Apply transformations to SVG elements.\n    svg, transform, animation\n\n    Use cases:\n    - Rotate, scale, or translate elements\n    - Create complex transformations\n    - Prepare elements for animation";
@@ -1084,6 +1097,7 @@ export class TransformLibNode extends BaseNode {
 
 export class ClipPathLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.ClipPath";
+  static readonly retrySafe = true;
   static readonly title = "Clip Path";
   static readonly description =
     "Create clipping paths for SVG elements.\n    svg, clip, mask\n\n    Use cases:\n    - Mask parts of elements\n    - Create complex shapes through clipping\n    - Apply visual effects using masks";

--- a/packages/text-nodes/src/nodes/text-extra.ts
+++ b/packages/text-nodes/src/nodes/text-extra.ts
@@ -125,6 +125,7 @@ function modelConfig(props: Record<string, unknown>): {
 
 export class SplitTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Split";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Split Text";
   static readonly description =
@@ -150,6 +151,7 @@ export class SplitTextNode extends BaseNode {
 
 export class ExtractTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Extract";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Extract Text";
   static readonly description =
@@ -180,6 +182,7 @@ export class ExtractTextNode extends BaseNode {
 
 export class ChunkTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Chunk";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Split Text into Chunks";
   static readonly description =
@@ -224,6 +227,7 @@ export class ChunkTextNode extends BaseNode {
 
 export class ExtractRegexNode extends BaseNode {
   static readonly nodeType = "nodetool.text.ExtractRegex";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Extract Regex Groups";
   static readonly description =
@@ -268,6 +272,7 @@ export class ExtractRegexNode extends BaseNode {
 
 export class FindAllRegexNode extends BaseNode {
   static readonly nodeType = "nodetool.text.FindAllRegex";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Find All Regex Matches";
   static readonly description =
@@ -311,6 +316,7 @@ export class FindAllRegexNode extends BaseNode {
 
 export class TextParseJSONNode extends BaseNode {
   static readonly nodeType = "nodetool.text.ParseJSON";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Parse JSON String";
   static readonly description =
@@ -376,6 +382,7 @@ function jsonPathFind(path: string, root: unknown): unknown[] {
 
 export class ExtractJSONNode extends BaseNode {
   static readonly nodeType = "nodetool.text.ExtractJSON";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Extract JSON";
   static readonly description =
@@ -414,6 +421,7 @@ export class ExtractJSONNode extends BaseNode {
 
 export class RegexMatchNode extends BaseNode {
   static readonly nodeType = "nodetool.text.RegexMatch";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Find Regex Matches";
   static readonly description =
@@ -469,6 +477,7 @@ export class RegexMatchNode extends BaseNode {
 
 export class RegexReplaceNode extends BaseNode {
   static readonly nodeType = "nodetool.text.RegexReplace";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Replace with Regex";
   static readonly description =
@@ -544,6 +553,7 @@ export class RegexReplaceNode extends BaseNode {
 
 export class RegexSplitNode extends BaseNode {
   static readonly nodeType = "nodetool.text.RegexSplit";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Split with Regex";
   static readonly description =
@@ -605,6 +615,7 @@ export class RegexSplitNode extends BaseNode {
 
 export class RegexValidateNode extends BaseNode {
   static readonly nodeType = "nodetool.text.RegexValidate";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Validate with Regex";
   static readonly description =
@@ -642,6 +653,7 @@ export class RegexValidateNode extends BaseNode {
 
 export class CompareTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Compare";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Compare Text";
   static readonly description =
@@ -704,6 +716,7 @@ export class CompareTextNode extends BaseNode {
 
 export class EqualsTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Equals";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Equals";
   static readonly description =
@@ -749,6 +762,7 @@ export class EqualsTextNode extends BaseNode {
 
 export class ToUppercaseNode extends BaseNode {
   static readonly nodeType = "nodetool.text.ToUppercase";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "To Uppercase";
   static readonly description =
@@ -769,6 +783,7 @@ export class ToUppercaseNode extends BaseNode {
 
 export class ToLowercaseNode extends BaseNode {
   static readonly nodeType = "nodetool.text.ToLowercase";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "To Lowercase";
   static readonly description =
@@ -789,6 +804,7 @@ export class ToLowercaseNode extends BaseNode {
 
 export class ToTitlecaseNode extends BaseNode {
   static readonly nodeType = "nodetool.text.ToTitlecase";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "To Title Case";
   static readonly description =
@@ -809,6 +825,7 @@ export class ToTitlecaseNode extends BaseNode {
 
 export class CapitalizeTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.CapitalizeText";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Capitalize Text";
   static readonly description =
@@ -835,6 +852,7 @@ export class CapitalizeTextNode extends BaseNode {
 
 export class SliceTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Slice";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Slice Text";
   static readonly description =
@@ -914,6 +932,7 @@ export class SliceTextNode extends BaseNode {
 
 export class StartsWithTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.StartsWith";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Starts With";
   static readonly description =
@@ -939,6 +958,7 @@ export class StartsWithTextNode extends BaseNode {
 
 export class EndsWithTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.EndsWith";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Ends With";
   static readonly description =
@@ -964,6 +984,7 @@ export class EndsWithTextNode extends BaseNode {
 
 export class ContainsTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Contains";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Contains Text";
   static readonly description =
@@ -1037,6 +1058,7 @@ export class ContainsTextNode extends BaseNode {
 
 export class TrimWhitespaceNode extends BaseNode {
   static readonly nodeType = "nodetool.text.TrimWhitespace";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Trim Whitespace";
   static readonly description =
@@ -1076,6 +1098,7 @@ export class TrimWhitespaceNode extends BaseNode {
 
 export class CollapseWhitespaceNode extends BaseNode {
   static readonly nodeType = "nodetool.text.CollapseWhitespace";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Collapse Whitespace";
   static readonly description =
@@ -1131,6 +1154,7 @@ export class CollapseWhitespaceNode extends BaseNode {
 
 export class IsEmptyTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.IsEmpty";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Is Empty";
   static readonly description =
@@ -1158,6 +1182,7 @@ export class IsEmptyTextNode extends BaseNode {
 
 export class RemovePunctuationNode extends BaseNode {
   static readonly nodeType = "nodetool.text.RemovePunctuation";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Remove Punctuation";
   static readonly description =
@@ -1205,6 +1230,7 @@ export class RemovePunctuationNode extends BaseNode {
 
 export class StripAccentsNode extends BaseNode {
   static readonly nodeType = "nodetool.text.StripAccents";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Strip Accents";
   static readonly description =
@@ -1243,6 +1269,7 @@ export class StripAccentsNode extends BaseNode {
 
 export class SlugifyNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Slugify";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Slugify";
   static readonly description =
@@ -1294,6 +1321,7 @@ export class SlugifyNode extends BaseNode {
 
 export class HasLengthTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.HasLength";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Check Length";
   static readonly description =
@@ -1340,6 +1368,7 @@ export class HasLengthTextNode extends BaseNode {
 
 export class TruncateTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.TruncateText";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Truncate Text";
   static readonly description =
@@ -1388,6 +1417,7 @@ export class TruncateTextNode extends BaseNode {
 
 export class PadTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.PadText";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Pad Text";
   static readonly description =
@@ -1453,6 +1483,7 @@ export class PadTextNode extends BaseNode {
 
 export class LengthTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Length";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Measure Length";
   static readonly description =
@@ -1510,6 +1541,7 @@ export class LengthTextNode extends BaseNode {
 
 export class IndexOfTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.IndexOf";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Index Of";
   static readonly description =
@@ -1590,6 +1622,7 @@ export class IndexOfTextNode extends BaseNode {
 
 export class SurroundWithTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.SurroundWith";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Surround With";
   static readonly description =
@@ -1634,6 +1667,7 @@ export class SurroundWithTextNode extends BaseNode {
 
 export class CountTokensNode extends BaseNode {
   static readonly nodeType = "nodetool.text.CountTokens";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Count Tokens";
   static readonly description =
@@ -1673,6 +1707,7 @@ export class CountTokensNode extends BaseNode {
 
 export class HtmlToTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.HtmlToText";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "HTML to Text";
   static readonly description =
@@ -2315,6 +2350,7 @@ type FilterStringType =
 
 export class FilterStringNode extends BaseNode {
   static readonly nodeType = "nodetool.text.FilterString";
+  static readonly retrySafe = true;
   static readonly title = "Filter String";
   static readonly description =
     "Filters a stream of strings based on various criteria.\n    filter, strings, text, stream";
@@ -2414,6 +2450,7 @@ export class FilterStringNode extends BaseNode {
 
 export class FilterRegexStringNode extends BaseNode {
   static readonly nodeType = "nodetool.text.FilterRegexString";
+  static readonly retrySafe = true;
   static readonly title = "Filter Regex String";
   static readonly description =
     "Filters a stream of strings using regular expressions.\n    filter, regex, pattern, text, stream";
@@ -2485,6 +2522,7 @@ export class FilterRegexStringNode extends BaseNode {
 
 export class ConcatTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Concat";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly body = "content_card";
   static readonly title = "Concat";
@@ -2512,6 +2550,7 @@ export class ConcatTextNode extends BaseNode {
 
 export class JoinTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Join";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Join";
   static readonly description =
@@ -2637,6 +2676,7 @@ export class PromptNode extends BaseNode {
 
 export class TemplateTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Template";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Template";
   static readonly description =
@@ -2675,6 +2715,7 @@ export class TemplateTextNode extends BaseNode {
 
 export class ReplaceTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Replace";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "Replace Text";
   static readonly description =
@@ -2706,6 +2747,7 @@ export class ReplaceTextNode extends BaseNode {
 
 export class ToStringNode extends BaseNode {
   static readonly nodeType = "nodetool.text.ToString";
+  static readonly retrySafe = true;
   static readonly cacheTtl = "forever";
   static readonly title = "To String";
   static readonly description =

--- a/web/src/stores/ApiTypes.ts
+++ b/web/src/stores/ApiTypes.ts
@@ -327,6 +327,11 @@ export interface NodeMetadata extends BaseNodeMetadata {
    */
   auto_save_asset?: boolean;
   /**
+   * Opt-in: re-running the node with identical inputs is safe. Absent means
+   * unsafe, so the workflow supervisor withholds `retry` for it.
+   */
+  retry_safe?: boolean;
+  /**
    * Per-type cache lifetime for partial runs (seconds, or the `"forever"`
    * sentinel — never `Infinity`, which is not JSON-safe). Only consulted for
    * Computed nodes; unset / `0` means never reuse.


### PR DESCRIPTION
Implements **PR 1 and PR 2** of [the supervisor implementation plan](docs/workflow-supervisor-implementation-plan.md) — the kernel mechanism, no LLM anywhere in the diff.

A failing node invocation raises an **escalation**; a handler returns a **verdict** (retry · substitute · skip · end_stream · fail). Without a supervisor no escalation is ever constructed, and a supervised *clean* run emits the same message stream as an unsupervised one — asserted, not assumed.

## Why the two PRs landed together

PR 1's allowed-set enforcement is only as strong as PR 2's invocation-scoped cost tracking. Shipping PR 1 alone would leave a window where `retry` is offered after a billed call — the one thing §5.3 exists to prevent. The plan doc records the merge.

## What's here

**protocol** — `Escalation`, `Verdict`, `Intervention`, and the `supervisor_escalation` / `supervisor_decision` message variants, Zod-first like the rest of the union; `retry_safe` on `NodeDescriptor`.

**runtime**
- Resolved-secret registry on `ProcessingContext`. Redaction needs a subject, and the resolver previously answered one key and forgot it.
- Invocation-scoped cost/asset accounting via `AsyncLocalStorage`. A stack on the shared context cross-attributes whenever concurrent actors complete out of order — there's a test for exactly that reversal.
- `RecoverableNodeError`, so a node hands over the value that needs repairing instead of losing it.

**kernel**
- `SupervisorHandle`, `FailClosedHandle`, `BoundedHandle` — decision/retry ceilings, per-decision timeout derived from the run signal, serialized queue, sticky verdicts keyed on `(nodeId, failureSignature)`. Every boundary resolves as `fail`.
- Allowed-action computation, enforced by the actor **independently of any schema**: a handle returning `retry` for an unsafe node gets `fail`.
- Redaction at escalation construction — `Escalation` is public (message, `RunResult`, websocket), so no unredacted instance exists anywhere in the system.
- Runtime substitute validation against declared output types, with an async hook for reference resolution.
- The recovery loop across the buffered, controlled, streaming-output, and `run()` paths. It wraps **invocation only**: a routing failure fails the node, because a retry after partial delivery would duplicate it.
- `skip` emits `lineage_done` **and** `lineage_scope_closed` on every outgoing edge, so a downstream aggregate collapses instead of waiting on a scope the skipped invocation never opened.

**node-sdk** — `retrySafe` metadata opt-in, declared across the pure-compute and read-only node categories. Unknown stays unsafe: cost tracking cannot see external writes, so a node nobody classified loses a safe retry rather than gaining an unsafe one.

## Tests

54 new kernel tests, 6 runtime tests. Each design rule that could fail silently has one: reverse-order cost attribution, a hostile handle rejected without schema help, a planted secret absent from every emitted message and from `RunResult`, a skipped fan-out item letting its aggregate collapse, a skipped iterator's scopes getting closed, `end_stream` keeping what it produced, a `run()` node's verdict set being exactly `{end_stream, fail}`, seven identical failures costing one decision.

Full kernel suite 988 passing, runtime 2638 passing, node-sdk 691 passing; `build:packages`, lint and prettier clean.

## Deliberate gaps

- **Reference-typed outputs can't be substituted yet.** Resolving an `ImageRef` uri against run storage needs a resolver the kernel doesn't hold. Rather than accept an unresolvable ref, `substitute` is withheld when any declared output is reference-typed; the validator already takes the `resolveRef` hook PR 3 will wire.
- **No surface is wired.** `ExecutionSessionOptions.supervisor`, the CLI flags, and the UI belong to PR 4+ and need the agent from PR 3. Today only kernel tests can construct a handle.
- **Provider retry audit** (design §10.3) is findings-only: [docs/workflow-supervisor-provider-retry-audit.md](docs/workflow-supervisor-provider-retry-audit.md). Gemini and Ollama have no backoff at all and would flood the supervisor with escalations a two-second wait would fix. Those fixes belong in runtime, not here — but they should land before PR 3 makes escalations expensive.

## Doc changes

Design §5.1 now says the handle is wired through the runner into each actor rather than onto `ProcessingContext` — node code has no business raising or answering escalations, and the actor already holds what the escalation constructor needs. `Escalation` gains `emitted`, and `SupervisorHandle.decide` returns a `DecisionOutcome` (verdict + `decidedBy` + cost) rather than a bare verdict, so the intervention record has one source.

---
_Generated by [Claude Code](https://claude.ai/code/session_011yMUYSSrceG3dTcX3XmsGJ)_