### PR TITLE
Workflow Supervisor PR 3: the SupervisorAgent

### DIFF
--- a/docs/workflow-supervisor-design.md
+++ b/docs/workflow-supervisor-design.md
@@ -64,6 +64,7 @@ export interface Escalation {
   failureSignature?: string;       // stable categorical code; absent ⇒ stickiness disabled
   candidateOutput?: unknown;       // from RecoverableNodeError — the malformed value, redacted+truncated
   inputs: Record<string, unknown>; // the invocation's input values, redacted+truncated
+  declaredOutputs: Record<string, string>; // the node's declared output types, per slot
   attempt: number;                 // 1-based, per (nodeId, invocationKey)
   spentCostUsd: number;            // provider cost recorded by this invocation
   createdAssets: boolean;
@@ -86,6 +87,13 @@ export type Verdict =
 `fail.reason` is not decoration: when a supervised run ends in `fail`, the runner surfaces `reason` as the job's user-facing error summary (the PRD's "one-sentence reason written by the agent") while the original thrown error is preserved in the intervention record and node error detail. The pseudocode's rethrow carries the original error; the runner attaches the reason at job-status level.
 
 `applyTo: "signature"` is the sticky form: the handle caches the verdict keyed by `(nodeId, failureSignature)` and resolves later escalations that match without waking the agent (PRD scenario 2 — 7 identical failures, 1 LLM call). Keying by signature rather than node keeps one login-required error from silently skipping later, unrelated timeouts on the same node. A signature exists only when the error carries a **stable categorical code** — HTTP status, provider error code, validation path — extracted by a small registry of error-shape recognizers. A plain `Error` gets **no** signature (error class alone is not one; every generic throw would collide), and with no signature stickiness is simply off: each such failure escalates individually. Signatures never derive from message text with embedded values. Only `skip` and `fail` may stick; a sticky `retry` or `substitute` would blindly replay a decision made against different inputs.
+
+`declaredOutputs` is what makes `substitute` authorable at all: a repair has to
+be typed per slot, and the escalation is the only thing the supervisor sees.
+It is also what the agent-side acceptance hook validates against before the
+verdict is allowed to become terminal, so the model learns its repair was the
+wrong shape while its conversation is still open. Type metadata, so nothing to
+redact.
 
 `RecoverableNodeError` (node-sdk) is how a node hands the supervisor the thing that needs repairing: a parser that throws on broken JSON attaches the raw response as `candidateOutput` instead of losing it. **No `candidateOutput`, no `substitute`** — without the broken value in hand, "repair" is fabrication: the model would invent a structurally valid output the runtime validator cannot semantically vet. A plain thrown error offers retry/skip/fail only.
 

--- a/docs/workflow-supervisor-implementation-plan.md
+++ b/docs/workflow-supervisor-implementation-plan.md
@@ -55,9 +55,22 @@ Still no LLM. Depends on PR 1.
 
 ## Phase B — the agent and the CLI
 
-### PR 3 — SupervisorAgent
+### PR 3 — SupervisorAgent — **shipped**
 
 Depends on PR 2.
+
+Two additions the plan did not name, both forced by what the agent has to see:
+`Escalation.declaredOutputs` (a repair cannot be typed, or accepted, without
+the node's declared output types) and a kernel-side **`RunStateReader`** handed
+to the handle via `SupervisorHandle.attach()` — the tools are pull-based over
+runner state, and a handle is configured before the runner exists. Output
+recording for `read_node_output` is bounded per node and happens only on a
+supervised run.
+
+Host-side schema validation checks the schema **as the caller wrote it**, not
+the sanitized copy sent to the provider: the sanitizer injects
+`additionalProperties: false` for strict structured-output modes, and enforcing
+that would reject results no author ever forbade.
 
 - `packages/agents/src/supervisor/supervisor-agent.ts`: `SupervisorHandle` via one `StepExecutor` per decision, verdict `outputSchema` (mirroring the escalation's allowed set), serialized queue; the `decide()` signal threads through `StepExecutor` into `provider.generateLoop({signal})` so abort kills the in-flight LLM request.
 - **`TurnBudget` in the runtime provider layer** (design §6): `reserve/commit` object accepted via `generateLoop` options, honored before every model turn by the base loop and by native loop overrides (Claude Agent SDK provider explicitly). Worst-case reservation from the pricing catalog with explicit `supervisorMaxOutputTokens` (default 2048, never unset); no pricing entry ⇒ fail closed. This is a `packages/runtime` change with its own provider-contract test, not a wrapper in the agents package — a wrapper around `generateLoop()` cannot see individual turns.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -684,3 +684,21 @@ export type {
   AgentWorkflowRunnerOptions,
   RunPolicy
 } from "./agent-workflow-runner.js";
+export {
+  SupervisorAgent,
+  DEFAULT_MAX_SUPERVISOR_COST_USD,
+  DEFAULT_SUPERVISOR_MAX_OUTPUT_TOKENS
+} from "./supervisor/supervisor-agent.js";
+export type { SupervisorAgentOptions } from "./supervisor/supervisor-agent.js";
+export { buildVerdictSchema } from "./supervisor/verdict-schema.js";
+export { buildSupervisorPrompt } from "./supervisor/prompt.js";
+export {
+  createSupervisorTools,
+  GetRunStateTool,
+  ReadNodeOutputTool
+} from "./supervisor/tools.js";
+export {
+  validateAgainstSchema,
+  formatViolations
+} from "./utils/json-schema-validate.js";
+export type { SchemaViolation } from "./utils/json-schema-validate.js";

--- a/packages/agents/src/step-executor.ts
+++ b/packages/agents/src/step-executor.ts
@@ -19,6 +19,7 @@ import type {
   ToolCall,
   ProviderStreamItem
 } from "@nodetool-ai/runtime";
+import type { TurnBudget } from "@nodetool-ai/runtime";
 import { memoryKeys, withAgentSpanGen } from "@nodetool-ai/runtime";
 import { linkAbort } from "./utils/link-abort.js";
 import { createLogger } from "@nodetool-ai/config";
@@ -40,6 +41,10 @@ import { ControlNodeTool } from "./tools/control-tool.js";
 import { FinishStepTool } from "./tools/finish-step-tool.js";
 import { getMemoryTools } from "./tools/memory-tools.js";
 import { truncateToolResult } from "./constants.js";
+import {
+  formatViolations,
+  validateAgainstSchema
+} from "./utils/json-schema-validate.js";
 
 const log = createLogger("nodetool.agents.step-executor");
 
@@ -242,6 +247,19 @@ function validateAndSanitizeSchema(
   return cleanSchemaRecursive(result) as Record<string, unknown>;
 }
 
+/**
+ * The authored schema, deep-copied and given a `type` when it omits one, so
+ * host validation reads exactly what the caller declared and nothing more.
+ */
+function normalizeDeclaredSchema(
+  raw: unknown
+): Record<string, unknown> | null {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const copy = JSON.parse(JSON.stringify(raw)) as Record<string, unknown>;
+  if (!("type" in copy) && "properties" in copy) copy["type"] = "object";
+  return copy;
+}
+
 // ---------------------------------------------------------------------------
 // Think-tag removal
 // ---------------------------------------------------------------------------
@@ -334,7 +352,34 @@ export interface StepExecutorOptions {
   upstreamMemoryKeys?: string[];
   /** External cancellation. Aborts the provider loop mid-flight. */
   signal?: AbortSignal;
+  /**
+   * Final say on a schema-valid result, for contracts whose acceptance can
+   * only be decided asynchronously — a repaired value that must resolve
+   * against run storage, say. A rejection is not a failure: it returns to the
+   * model as a tool error inside the still-open conversation, so the next
+   * attempt has the reason. After {@link MAX_REPAIR_ROUNDS} rejections the
+   * step fails rather than looping on an answer the model cannot produce.
+   */
+  acceptResult?: (result: unknown) => Promise<StepResultAcceptance>;
+  /**
+   * Spend admission consulted before every provider turn. Forwarded to
+   * `generateLoop`; a refusal ends the loop, which surfaces here as a step
+   * that never completed.
+   */
+  turnBudget?: TurnBudget;
 }
+
+/** Answer from {@link StepExecutorOptions.acceptResult}. */
+export type StepResultAcceptance =
+  | { accepted: true }
+  | { accepted: false; reason: string };
+
+/**
+ * Rejections by the acceptance callback before the step gives up. Three is
+ * enough for the model to read the reason and correct course; more is a model
+ * that cannot satisfy the contract, and looping costs real money.
+ */
+export const MAX_REPAIR_ROUNDS = 3;
 
 export class StepExecutor {
   private history: Message[] = [];
@@ -352,6 +397,8 @@ export class StepExecutor {
   private result: unknown = null;
   private finishStepTool: FinishStepTool | null = null;
   private resultSchema: Record<string, unknown> | null = null;
+  /** The schema as the caller wrote it — what host validation checks. */
+  private declaredSchema: Record<string, unknown> | null = null;
   private iterations = 0;
   private generationFailures = 0;
   private sources: string[] = [];
@@ -362,6 +409,11 @@ export class StepExecutor {
   }> = [];
   private threadId?: string;
   private upstreamMemoryKeys: string[];
+  private acceptResult?: (result: unknown) => Promise<StepResultAcceptance>;
+  private turnBudget?: TurnBudget;
+  private repairRounds = 0;
+  /** Set when acceptance rejected the result once too often. */
+  private acceptanceError: string | null = null;
 
   constructor(opts: StepExecutorOptions) {
     this.task = opts.task;
@@ -376,6 +428,8 @@ export class StepExecutor {
     this.threadId = opts.threadId;
     this.upstreamMemoryKeys = opts.upstreamMemoryKeys ?? [];
     this.signal = opts.signal;
+    this.acceptResult = opts.acceptResult;
+    this.turnBudget = opts.turnBudget;
 
     this.resultSchema = this.loadResultSchema();
 
@@ -410,9 +464,17 @@ export class StepExecutor {
         typeof this.step.outputSchema === "string"
           ? JSON.parse(this.step.outputSchema)
           : this.step.outputSchema;
+      // Two schemas, on purpose. The sanitized one is what the provider is
+      // shown — it injects `additionalProperties: false` because strict
+      // structured-output modes demand it. The authored one is the contract,
+      // and it is what the host validates against: an author who wrote
+      // `properties: {}` meant "an object", not "an empty object", and
+      // enforcing a transport artifact would reject a result nobody forbade.
+      this.declaredSchema = normalizeDeclaredSchema(raw);
       return validateAndSanitizeSchema(raw, defaultDescription);
     } catch {
       // Fallback: permissive object schema
+      this.declaredSchema = null;
       return { type: "object", description: defaultDescription };
     }
   }
@@ -462,41 +524,15 @@ export class StepExecutor {
       return [true, null, normalized];
     }
 
-    // Basic structural validation: check required keys from schema
-    if (
-      this.resultSchema["type"] === "object" &&
-      typeof normalized === "object" &&
-      normalized !== null
-    ) {
-      const requiredKeys = this.resultSchema["required"];
-      if (Array.isArray(requiredKeys)) {
-        const obj = normalized as Record<string, unknown>;
-        for (const key of requiredKeys) {
-          // `requiredKeys` is LLM/planner-authored; use Object.hasOwn so a
-          // required key like "toString"/"constructor" can't be satisfied by
-          // the prototype chain when the model never produced it.
-          if (!Object.hasOwn(obj, key as string)) {
-            return [false, `Missing required key: ${key}`, normalized];
-          }
-        }
-      }
-    }
-
-    // Type check
-    const expectedType = this.resultSchema["type"];
-    if (expectedType === "string" && typeof normalized !== "string") {
-      return [false, `Expected string, got ${typeof normalized}`, normalized];
-    }
-    if (
-      expectedType === "object" &&
-      (typeof normalized !== "object" ||
-        normalized === null ||
-        Array.isArray(normalized))
-    ) {
-      return [false, `Expected object, got ${typeof normalized}`, normalized];
-    }
-    if (expectedType === "array" && !Array.isArray(normalized)) {
-      return [false, `Expected array, got ${typeof normalized}`, normalized];
+    // The whole declared schema, not its outline. Backends vary in how much of
+    // a tool-parameter schema they enforce — enums and unions are routinely
+    // dropped — so a contract holds only where the host checks it.
+    const violations = validateAgainstSchema(
+      normalized,
+      this.declaredSchema ?? this.resultSchema
+    );
+    if (violations.length > 0) {
+      return [false, formatViolations(violations), normalized];
     }
 
     return [true, null, normalized];
@@ -939,6 +975,24 @@ export class StepExecutor {
         normalizedResult !== null &&
         normalizedResult !== undefined
       ) {
+        if (this.acceptResult) {
+          const acceptance = await this.acceptResult(normalizedResult);
+          if (!acceptance.accepted) {
+            this.repairRounds++;
+            if (this.repairRounds >= MAX_REPAIR_ROUNDS) {
+              // Out of rounds. Stop the loop rather than pay for another
+              // attempt at a contract this model is not meeting.
+              this.acceptanceError = acceptance.reason;
+              abort.abort();
+              return JSON.stringify({
+                error: `Result rejected: ${acceptance.reason}`
+              });
+            }
+            return JSON.stringify({
+              error: `Result rejected: ${acceptance.reason}. Call finish_step again with a corrected result.`
+            });
+          }
+        }
         emitCompletion(normalizedResult);
         abort.abort();
         return '{"status": "completed"}';
@@ -1031,6 +1085,7 @@ export class StepExecutor {
         maxIterations: this.maxIterations,
         maxTokens: this.maxTokens,
         sequentialTools: true,
+        turnBudget: this.turnBudget,
         signal: abort.signal
       });
 
@@ -1104,9 +1159,11 @@ export class StepExecutor {
     if (!this.step.completed) {
       this.step.endTime = Date.now();
 
-      const message = generationError
-        ? `Step failed: ${generationError.message}`
-        : `Step failed: exceeded ${this.maxIterations} iterations without completion`;
+      const message = this.acceptanceError
+        ? `Step failed: result rejected after ${MAX_REPAIR_ROUNDS} attempts — ${this.acceptanceError}`
+        : generationError
+          ? `Step failed: ${generationError.message}`
+          : `Step failed: exceeded ${this.maxIterations} iterations without completion`;
       this.step.failed = true;
       this.step.error = message;
 

--- a/packages/agents/src/supervisor/prompt.ts
+++ b/packages/agents/src/supervisor/prompt.ts
@@ -1,0 +1,67 @@
+/**
+ * The supervisor's system prompt.
+ *
+ * A preamble over the standard execution contract, per the `StepExecutor`
+ * rule — it says what the verbs mean and what the job is, not how to finish a
+ * step.
+ */
+
+import type { Escalation, VerdictAction } from "@nodetool-ai/protocol";
+
+const VERB_SEMANTICS: Record<VerdictAction, string> = {
+  retry: "Run this invocation again, unchanged. Only useful when the failure was transient — a timeout, a rate limit, a 5xx. Offered only when the invocation spent nothing and wrote nothing, so it is never a way to pay twice.",
+  substitute:
+    "Replace the node's output with a corrected value you supply. For a node that produced something almost right — malformed JSON, a near-miss shape. The value is type-checked against the node's declared outputs before it enters the graph; a repair that fails the check is not a repair.",
+  skip: "Retire this invocation. Downstream nodes see it as producing nothing — an item drops out of the batch. Correct when one item is genuinely unprocessable and the rest of the run is still worth having.",
+  end_stream:
+    "End this streaming node's output where it stopped. What it already emitted stands; nothing more comes. The only recovery available once a node has emitted.",
+  fail: "Let the run fail, as it would without a supervisor. The right answer whenever recovery would be a guess."
+};
+
+export const SUPERVISOR_PROMPT_PREAMBLE = `# Role
+You supervise a running workflow. A node invocation has failed. Decide what happens to it.
+
+# What you are deciding
+One invocation, not the run. Everything else in the graph is still executing. Your verdict applies to this invocation alone.
+
+# Duties
+- Diagnose before you decide. \`get_run_state\` shows how the run is going; \`read_node_output\` shows what a node upstream of this failure produced. Read them when the error alone does not tell you what happened.
+- Give a one-line rationale with every verdict. It goes in the run report, and it is what a person reads later to understand why an item is missing.
+- Distrust \`skip\`. Skipping is data loss, and it is silent — the run reports success with a smaller result. Use it when an item is genuinely unprocessable, not when a failure is merely inconvenient. If you skip, name the item in your rationale.
+- \`fail\` is not a defeat. A guessed repair that passes validation and is wrong is worse than a failed run: the run reports success and the wrong answer flows downstream.
+
+# What the verbs mean`;
+
+/** The prompt for one decision: verbs the escalation actually allows, then it. */
+export function buildSupervisorPrompt(escalation: Escalation): string {
+  const verbs = escalation.allowedActions
+    .map((action) => `- \`${action}\` — ${VERB_SEMANTICS[action]}`)
+    .join("\n");
+  const omitted = (Object.keys(VERB_SEMANTICS) as VerdictAction[]).filter(
+    (action) => !escalation.allowedActions.includes(action)
+  );
+  const unavailable =
+    omitted.length > 0
+      ? `\n\nNot available for this failure: ${omitted.map((a) => `\`${a}\``).join(", ")}. The kernel computed that from what this node is and what this invocation already did; asking for one of them gets you \`fail\`.`
+      : "";
+
+  return `${SUPERVISOR_PROMPT_PREAMBLE}
+${verbs}${unavailable}
+
+# The failure
+Node \`${escalation.nodeId}\` (\`${escalation.nodeType}\`), attempt ${escalation.attempt}${
+    escalation.invocationKey ? `, invocation \`${escalation.invocationKey}\`` : ""
+  }.
+
+Error: ${escalation.detail}
+
+Inputs: ${JSON.stringify(escalation.inputs)}${
+    escalation.candidateOutput === undefined
+      ? ""
+      : `\n\nThe node produced this, and it was rejected: ${JSON.stringify(escalation.candidateOutput)}`
+  }${
+    escalation.emitted
+      ? "\n\nThis node already emitted output downstream. Nothing can undo that."
+      : ""
+  }`;
+}

--- a/packages/agents/src/supervisor/supervisor-agent.ts
+++ b/packages/agents/src/supervisor/supervisor-agent.ts
@@ -1,0 +1,246 @@
+/**
+ * The LLM-backed `SupervisorHandle`.
+ *
+ * One `StepExecutor` per decision: a fresh conversation, the verdict schema
+ * narrowed to what the kernel will accept, two read-only tools, and a hard
+ * dollar ceiling enforced turn by turn inside the provider. Everything that
+ * bounds *how many* decisions happen — counting, retries, timeouts, the sticky
+ * cache, serialization — lives in the kernel's `BoundedHandle`; this class
+ * bounds what one decision may cost and say.
+ *
+ * Every failure mode here resolves to `fail`. A supervisor that throws, times
+ * out, runs out of budget, or answers something unparseable must leave the run
+ * exactly where it would have been without a supervisor.
+ *
+ * See docs/workflow-supervisor-design.md §6.
+ */
+
+import type { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
+import { CostCappedTurnBudget } from "@nodetool-ai/runtime";
+import type { Escalation, Verdict } from "@nodetool-ai/protocol";
+import { verdictSchema } from "@nodetool-ai/protocol";
+import {
+  validateSubstituteOutputs,
+  type DecisionOutcome,
+  type RunStateReader,
+  type SupervisorHandle
+} from "@nodetool-ai/kernel";
+import { createLogger } from "@nodetool-ai/config";
+import {
+  StepExecutor,
+  type StepResultAcceptance
+} from "../step-executor.js";
+import type { Step, Task } from "../types.js";
+import { buildSupervisorPrompt } from "./prompt.js";
+import { buildVerdictSchema } from "./verdict-schema.js";
+import { createSupervisorTools } from "./tools.js";
+
+const log = createLogger("nodetool.agents.supervisor");
+
+/** Run-level ceiling on what supervision may cost, in USD. */
+export const DEFAULT_MAX_SUPERVISOR_COST_USD = 0.5;
+
+/**
+ * Output-token bound assumed for every supervisor turn. Reservation needs a
+ * known worst case, so this is never left unset — `StepExecutor.maxTokens`
+ * being optional is not good enough where a cap has to hold.
+ */
+export const DEFAULT_SUPERVISOR_MAX_OUTPUT_TOKENS = 2048;
+
+/** Tool-calling rounds allowed per decision. Diagnosis, then a verdict. */
+const DECISION_MAX_ITERATIONS = 6;
+
+export interface SupervisorAgentOptions {
+  provider: BaseProvider;
+  model: string;
+  /**
+   * Context for tool execution and memory. The provider instance must not be
+   * shared with the run it supervises: per-turn spend is reconciled from the
+   * provider's own running cost, and a second caller on the same instance
+   * would corrupt that.
+   */
+  context: ProcessingContext;
+  /** Run-level dollar ceiling. Default {@link DEFAULT_MAX_SUPERVISOR_COST_USD}. */
+  maxCostUsd?: number;
+  /** Per-turn output bound. Default {@link DEFAULT_SUPERVISOR_MAX_OUTPUT_TOKENS}. */
+  maxOutputTokens?: number;
+  /**
+   * Resolves a reference uri against run storage, for accepting a `substitute`
+   * that carries reference-typed outputs. Omitted ⇒ such repairs are rejected,
+   * which is the safe direction: an unresolvable ref is the failure the check
+   * exists to catch.
+   */
+  resolveRef?: (uri: string) => Promise<boolean>;
+}
+
+const FAIL: Verdict = { action: "fail" };
+
+export class SupervisorAgent implements SupervisorHandle {
+  private readonly _opts: SupervisorAgentOptions;
+  private readonly _budget: CostCappedTurnBudget;
+  private _reader: RunStateReader | null = null;
+  private _decisions = 0;
+
+  constructor(opts: SupervisorAgentOptions) {
+    this._opts = opts;
+    this._budget = new CostCappedTurnBudget({
+      capUsd: opts.maxCostUsd ?? DEFAULT_MAX_SUPERVISOR_COST_USD,
+      maxOutputTokens:
+        opts.maxOutputTokens ?? DEFAULT_SUPERVISOR_MAX_OUTPUT_TOKENS
+    });
+  }
+
+  attach(reader: RunStateReader): void {
+    this._reader = reader;
+  }
+
+  async decide(
+    escalation: Escalation,
+    signal: AbortSignal
+  ): Promise<DecisionOutcome> {
+    const spentBefore = this._budget.spentUsd;
+    try {
+      const decision = await this._runDecision(escalation, signal);
+      const costUsd = this._budget.spentUsd - spentBefore;
+      if (decision === null) {
+        // The step never produced a verdict: refused turns, an exhausted
+        // iteration budget, an unparseable answer. Deterministic degradation.
+        return { verdict: FAIL, decidedBy: "bounds", costUsd };
+      }
+      this._remember(escalation, decision.verdict, decision.rationale);
+      return { verdict: decision.verdict, decidedBy: "agent", costUsd };
+    } catch (error) {
+      log.warn("Supervisor decision failed", {
+        nodeId: escalation.nodeId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return {
+        verdict: FAIL,
+        decidedBy: "bounds",
+        costUsd: this._budget.spentUsd - spentBefore
+      };
+    }
+  }
+
+  close(): void {
+    this._reader = null;
+  }
+
+  private async _runDecision(
+    escalation: Escalation,
+    signal: AbortSignal
+  ): Promise<{ verdict: Verdict; rationale: string } | null> {
+    const id = `supervisor_${++this._decisions}`;
+    const step: Step = {
+      id,
+      instructions: buildSupervisorPrompt(escalation),
+      dependsOn: [],
+      completed: false,
+      logs: [],
+      outputSchema: JSON.stringify(
+        buildVerdictSchema(escalation.allowedActions)
+      )
+    };
+    const task: Task = {
+      id,
+      title: `Supervise ${escalation.nodeId}`,
+      steps: [step],
+      dependsOn: []
+    };
+
+    const executor = new StepExecutor({
+      task,
+      step,
+      context: this._opts.context,
+      provider: this._opts.provider,
+      model: this._opts.model,
+      tools: this._reader
+        ? createSupervisorTools(this._reader, escalation, this._opts.context)
+        : [],
+      maxIterations: DECISION_MAX_ITERATIONS,
+      maxTokens:
+        this._opts.maxOutputTokens ?? DEFAULT_SUPERVISOR_MAX_OUTPUT_TOKENS,
+      turnBudget: this._budget,
+      acceptResult: (result) => this._accept(escalation, result),
+      signal
+    });
+
+    // The verdict is the result; the message stream belongs to the surfaces
+    // that wire this handle up (CLI, websocket), not to the decision itself.
+    for await (const _message of executor.execute()) {
+      if (signal.aborted) break;
+    }
+    if (signal.aborted) return null;
+    const result = executor.getResult();
+    const verdict = parseVerdict(result);
+    return verdict === null
+      ? null
+      : { verdict, rationale: readRationale(result) };
+  }
+
+  /**
+   * A `substitute` is terminal only once its value would survive contact with
+   * the graph. Rejections go back into the still-open conversation, so the
+   * model repairs its repair instead of the kernel silently downgrading it.
+   */
+  private async _accept(
+    escalation: Escalation,
+    result: unknown
+  ): Promise<StepResultAcceptance> {
+    const verdict = parseVerdict(result);
+    if (verdict === null) {
+      return {
+        accepted: false,
+        reason: "not a valid verdict for this escalation"
+      };
+    }
+    if (verdict.action !== "substitute") return { accepted: true };
+
+    const validation = await validateSubstituteOutputs(verdict.outputs, {
+      declaredOutputs: escalation.declaredOutputs,
+      ...(this._opts.resolveRef ? { resolveRef: this._opts.resolveRef } : {})
+    });
+    return validation.ok
+      ? { accepted: true }
+      : { accepted: false, reason: validation.issues.join("; ") };
+  }
+
+  /**
+   * Decisions and their rationales land in agent memory so a downstream
+   * compiler pass can reference them when it writes up the run.
+   */
+  private _remember(
+    escalation: Escalation,
+    verdict: Verdict,
+    rationale: string
+  ): void {
+    const key = `supervisor:${escalation.nodeId}${
+      escalation.invocationKey ? `:${escalation.invocationKey}` : ""
+    }`;
+    this._opts.context.memory.set({
+      key,
+      kind: "shared",
+      value: { escalation, verdict, rationale },
+      source: escalation.nodeId,
+      title: `${verdict.action} — ${escalation.nodeId}: ${rationale}`
+    });
+  }
+}
+
+/**
+ * The model answers with a verdict plus a `rationale`; the kernel's verdict
+ * type has no such field and its schema is strict, so the rationale is split
+ * off here and kept in memory rather than dropped.
+ */
+function parseVerdict(result: unknown): Verdict | null {
+  if (result === null || typeof result !== "object") return null;
+  const { rationale: _rationale, ...rest } = result as Record<string, unknown>;
+  const parsed = verdictSchema.safeParse(rest);
+  return parsed.success ? parsed.data : null;
+}
+
+function readRationale(result: unknown): string {
+  if (result === null || typeof result !== "object") return "";
+  const value = (result as Record<string, unknown>)["rationale"];
+  return typeof value === "string" ? value : "";
+}

--- a/packages/agents/src/supervisor/tools.ts
+++ b/packages/agents/src/supervisor/tools.ts
@@ -1,0 +1,126 @@
+/**
+ * The supervisor's two read-only tools.
+ *
+ * Both pull from state the runner already holds, which is why there is no
+ * observation pipeline in this design: a clean run costs nothing, and the agent
+ * asks for what it needs when it needs it.
+ *
+ * `read_node_output` is scoped to the failing invocation's causal lineage. In a
+ * fan-out, "the last value this node emitted" usually belongs to some other
+ * item; handing that to the agent produces repairs built from the wrong data
+ * and quietly widens what the model sees beyond the item that failed.
+ *
+ * See docs/workflow-supervisor-design.md §6.
+ */
+
+import { z, type ZodType } from "zod";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type { Escalation } from "@nodetool-ai/protocol";
+import {
+  MAX_ESCALATION_VALUE_CHARS,
+  redactRecord,
+  type RunStateReader
+} from "@nodetool-ai/kernel";
+import { Tool } from "../tools/base-tool.js";
+
+/**
+ * Secret values to mask in tool results. `read_node_output` is the one
+ * supervisor input that does not come from an already-redacted `Escalation`,
+ * so the same layer has to run here.
+ */
+type SecretSource = () => ReadonlySet<string>;
+
+function resolveSecrets(context: ProcessingContext): ReadonlySet<string> {
+  return context.getResolvedSecretValues?.() ?? new Set<string>();
+}
+
+export class GetRunStateTool extends Tool {
+  readonly name = "get_run_state";
+  readonly description =
+    "Digest of the run in flight: every node's status, how many invocations " +
+    "it has emitted, how many times it has escalated, its error if it has " +
+    "one, and the run's provider spend so far.";
+
+  private readonly _reader: RunStateReader;
+
+  constructor(reader: RunStateReader) {
+    super();
+    this._reader = reader;
+  }
+
+  get schema(): ZodType {
+    return z.object({});
+  }
+
+  async process(): Promise<unknown> {
+    return this._reader.digest();
+  }
+}
+
+export class ReadNodeOutputTool extends Tool {
+  readonly name = "read_node_output";
+  readonly description =
+    "The output a node produced for the failing invocation's own branch of " +
+    "the run. Reads outside that branch — another item of the same fan-out, " +
+    "an unrelated branch — are refused: that data is not evidence about this " +
+    "failure.";
+
+  private readonly _reader: RunStateReader;
+  private readonly _escalation: Escalation;
+  private readonly _secrets: SecretSource;
+
+  constructor(
+    reader: RunStateReader,
+    escalation: Escalation,
+    secrets: SecretSource
+  ) {
+    super();
+    this._reader = reader;
+    this._escalation = escalation;
+    this._secrets = secrets;
+  }
+
+  get schema(): ZodType {
+    return z.object({
+      node_id: z.string().describe("Id of the node whose output to read.")
+    });
+  }
+
+  async process(
+    _context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const nodeId = String(params["node_id"] ?? "");
+    const read = this._reader.readOutput(
+      nodeId,
+      this._escalation.correlationLineage
+    );
+    if (!read) {
+      return {
+        error: "not_available",
+        message:
+          `No output from "${nodeId}" belongs to this invocation's branch ` +
+          `(${this._escalation.correlationLineage.join(",") || "root"}).`
+      };
+    }
+    return {
+      nodeId: read.nodeId,
+      lineage: read.lineage,
+      outputs: redactRecord(read.outputs, this._secrets())
+    };
+  }
+}
+
+/** The toolset for one decision, bound to the escalation being decided. */
+export function createSupervisorTools(
+  reader: RunStateReader,
+  escalation: Escalation,
+  context: ProcessingContext
+): Tool[] {
+  return [
+    new GetRunStateTool(reader),
+    new ReadNodeOutputTool(reader, escalation, () => resolveSecrets(context))
+  ];
+}
+
+export { MAX_ESCALATION_VALUE_CHARS };

--- a/packages/agents/src/supervisor/verdict-schema.ts
+++ b/packages/agents/src/supervisor/verdict-schema.ts
@@ -1,0 +1,69 @@
+/**
+ * The verdict contract handed to the model, narrowed to what the kernel will
+ * actually accept for one escalation.
+ *
+ * The kernel computes `allowedActions` per escalation and rejects anything
+ * outside it. Offering the full verb list anyway would spend a decision to
+ * produce an answer that is thrown away, so the schema is built per decision
+ * from that set. Enforcement stays in the kernel — this only stops the model
+ * from wasting a round.
+ */
+
+import type { VerdictAction } from "@nodetool-ai/protocol";
+
+const RATIONALE = {
+  type: "string",
+  description:
+    "One line: why this verdict. Appears in the run report next to the node.",
+  minLength: 1
+} as const;
+
+const APPLY_TO = {
+  type: "string",
+  enum: ["invocation", "signature"],
+  description:
+    "`invocation` (default) decides this failure only. `signature` decides " +
+    "every later failure on this node with the same failure signature, with " +
+    "no further deliberation — use it when the cause is categorical, not " +
+    "specific to this item."
+} as const;
+
+function branch(action: VerdictAction): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    type: "object",
+    properties: {
+      action: { type: "string", const: action },
+      rationale: RATIONALE
+    },
+    required: ["action", "rationale"],
+    additionalProperties: false
+  };
+  const properties = base["properties"] as Record<string, unknown>;
+  const required = base["required"] as string[];
+
+  if (action === "substitute") {
+    properties["outputs"] = {
+      type: "object",
+      description:
+        "Replacement value per output slot of the node. Type-checked against " +
+        "the node's declared outputs before it enters the graph.",
+      additionalProperties: true
+    };
+    required.push("outputs");
+  }
+  if (action === "skip" || action === "fail") {
+    properties["applyTo"] = APPLY_TO;
+  }
+  return base;
+}
+
+/** JSON schema for a verdict, restricted to `allowed`. */
+export function buildVerdictSchema(
+  allowed: readonly VerdictAction[]
+): Record<string, unknown> {
+  return {
+    type: "object",
+    description: "The verdict for this failed invocation.",
+    oneOf: allowed.map(branch)
+  };
+}

--- a/packages/agents/src/utils/json-schema-validate.ts
+++ b/packages/agents/src/utils/json-schema-validate.ts
@@ -1,0 +1,272 @@
+/**
+ * Host-side JSON-schema validation for structured step results.
+ *
+ * A step declares an `outputSchema`; the model answers through `finish_step`.
+ * The provider-side tool schema is a hint at best — several backends drop
+ * `enum`, flatten unions, or ignore `additionalProperties` — so whether the
+ * answer really matches the contract has to be decided here. A verdict schema
+ * makes that concrete: "one of five actions, and `substitute` also carries
+ * outputs" is a discriminated union, and a validator that only checks the
+ * top-level type and required keys accepts a verdict the kernel will reject.
+ *
+ * Deliberately a subset of JSON Schema — the keywords a step contract uses,
+ * validated exactly, rather than the full specification validated loosely.
+ */
+
+export interface SchemaViolation {
+  /** JSON-path-ish location, e.g. `result.outputs.text`. */
+  path: string;
+  message: string;
+}
+
+type Schema = Record<string, unknown>;
+
+const TYPE_NAMES = [
+  "string",
+  "number",
+  "integer",
+  "boolean",
+  "object",
+  "array",
+  "null"
+] as const;
+
+type TypeName = (typeof TYPE_NAMES)[number];
+
+function typeOf(value: unknown): TypeName {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? "integer" : "number";
+  }
+  if (typeof value === "string") return "string";
+  if (typeof value === "boolean") return "boolean";
+  return "object";
+}
+
+function matchesType(value: unknown, expected: TypeName): boolean {
+  const actual = typeOf(value);
+  if (expected === "number") return actual === "number" || actual === "integer";
+  return actual === expected;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b || a === null || b === null) return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (typeof a !== "object") return false;
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const aKeys = Object.keys(ao);
+  if (aKeys.length !== Object.keys(bo).length) return false;
+  return aKeys.every(
+    (key) => Object.hasOwn(bo, key) && deepEqual(ao[key], bo[key])
+  );
+}
+
+function describe(value: unknown): string {
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  return text !== undefined && text.length > 60
+    ? `${text.slice(0, 60)}…`
+    : String(text);
+}
+
+/**
+ * Validate `value` against `schema`. Returns every violation found, so one
+ * bounce back to the model can fix everything rather than one thing per round.
+ */
+export function validateAgainstSchema(
+  value: unknown,
+  schema: Schema,
+  path = "result"
+): SchemaViolation[] {
+  const out: SchemaViolation[] = [];
+  validate(value, schema, path, out);
+  return out;
+}
+
+function validate(
+  value: unknown,
+  schema: Schema,
+  path: string,
+  out: SchemaViolation[]
+): void {
+  if (schema["const"] !== undefined && !deepEqual(value, schema["const"])) {
+    out.push({
+      path,
+      message: `must equal ${describe(schema["const"])}, got ${describe(value)}`
+    });
+    return;
+  }
+
+  const enumValues = schema["enum"];
+  if (Array.isArray(enumValues)) {
+    if (!enumValues.some((candidate) => deepEqual(value, candidate))) {
+      out.push({
+        path,
+        message: `must be one of ${enumValues.map((v) => describe(v)).join(", ")}, got ${describe(value)}`
+      });
+      return;
+    }
+  }
+
+  const declared = schema["type"];
+  const types: TypeName[] = Array.isArray(declared)
+    ? (declared.filter((t): t is TypeName =>
+        (TYPE_NAMES as readonly string[]).includes(t as string)
+      ) as TypeName[])
+    : typeof declared === "string" &&
+        (TYPE_NAMES as readonly string[]).includes(declared)
+      ? [declared as TypeName]
+      : [];
+  if (types.length > 0 && !types.some((t) => matchesType(value, t))) {
+    out.push({
+      path,
+      message: `expected ${types.join(" | ")}, got ${typeOf(value)}`
+    });
+    return;
+  }
+
+  if (typeOf(value) === "object") {
+    validateObject(value as Record<string, unknown>, schema, path, out);
+  }
+  if (Array.isArray(value)) validateArray(value, schema, path, out);
+  if (typeof value === "number") validateNumber(value, schema, path, out);
+  if (typeof value === "string") validateString(value, schema, path, out);
+
+  validateCombinators(value, schema, path, out);
+}
+
+function validateObject(
+  value: Record<string, unknown>,
+  schema: Schema,
+  path: string,
+  out: SchemaViolation[]
+): void {
+  const required = schema["required"];
+  if (Array.isArray(required)) {
+    for (const key of required) {
+      // Object.hasOwn, not `in`: a required key named `toString` must be
+      // produced by the model, not inherited from the prototype chain.
+      if (typeof key === "string" && !Object.hasOwn(value, key)) {
+        out.push({ path, message: `missing required property "${key}"` });
+      }
+    }
+  }
+
+  const properties = (schema["properties"] as Schema | undefined) ?? {};
+  for (const [key, sub] of Object.entries(properties)) {
+    if (!Object.hasOwn(value, key)) continue;
+    if (sub && typeof sub === "object") {
+      validate(value[key], sub as Schema, `${path}.${key}`, out);
+    }
+  }
+
+  const additional = schema["additionalProperties"];
+  if (additional === false) {
+    for (const key of Object.keys(value)) {
+      if (!Object.hasOwn(properties, key)) {
+        out.push({ path, message: `unexpected property "${key}"` });
+      }
+    }
+  } else if (additional && typeof additional === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      if (Object.hasOwn(properties, key)) continue;
+      validate(entry, additional as Schema, `${path}.${key}`, out);
+    }
+  }
+}
+
+function validateArray(
+  value: unknown[],
+  schema: Schema,
+  path: string,
+  out: SchemaViolation[]
+): void {
+  const items = schema["items"];
+  if (items && typeof items === "object" && !Array.isArray(items)) {
+    value.forEach((entry, index) =>
+      validate(entry, items as Schema, `${path}[${index}]`, out)
+    );
+  }
+  const min = schema["minItems"];
+  if (typeof min === "number" && value.length < min) {
+    out.push({ path, message: `expected at least ${min} items` });
+  }
+  const max = schema["maxItems"];
+  if (typeof max === "number" && value.length > max) {
+    out.push({ path, message: `expected at most ${max} items` });
+  }
+}
+
+function validateNumber(
+  value: number,
+  schema: Schema,
+  path: string,
+  out: SchemaViolation[]
+): void {
+  const min = schema["minimum"];
+  if (typeof min === "number" && value < min) {
+    out.push({ path, message: `must be >= ${min}` });
+  }
+  const max = schema["maximum"];
+  if (typeof max === "number" && value > max) {
+    out.push({ path, message: `must be <= ${max}` });
+  }
+}
+
+function validateString(
+  value: string,
+  schema: Schema,
+  path: string,
+  out: SchemaViolation[]
+): void {
+  const min = schema["minLength"];
+  if (typeof min === "number" && value.length < min) {
+    out.push({ path, message: `must be at least ${min} characters` });
+  }
+  const max = schema["maxLength"];
+  if (typeof max === "number" && value.length > max) {
+    out.push({ path, message: `must be at most ${max} characters` });
+  }
+}
+
+function validateCombinators(
+  value: unknown,
+  schema: Schema,
+  path: string,
+  out: SchemaViolation[]
+): void {
+  const allOf = schema["allOf"];
+  if (Array.isArray(allOf)) {
+    for (const sub of allOf) {
+      if (sub && typeof sub === "object") {
+        validate(value, sub as Schema, path, out);
+      }
+    }
+  }
+
+  for (const keyword of ["anyOf", "oneOf"] as const) {
+    const branches = schema[keyword];
+    if (!Array.isArray(branches) || branches.length === 0) continue;
+    // A branch that validates cleanly is the branch the model meant. Reporting
+    // every branch's failures would bury the real error under four irrelevant
+    // ones, so an all-fail reports the closest branch — fewest violations.
+    let closest: SchemaViolation[] | null = null;
+    for (const branch of branches) {
+      if (!branch || typeof branch !== "object") continue;
+      const errors = validateAgainstSchema(value, branch as Schema, path);
+      if (errors.length === 0) {
+        closest = null;
+        break;
+      }
+      if (closest === null || errors.length < closest.length) closest = errors;
+    }
+    if (closest) out.push(...closest);
+  }
+}
+
+/** One-line rendering of violations, for a tool-result bounce. */
+export function formatViolations(violations: SchemaViolation[]): string {
+  return violations.map((v) => `${v.path}: ${v.message}`).join("; ");
+}

--- a/packages/agents/tests/json-schema-validate.test.ts
+++ b/packages/agents/tests/json-schema-validate.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateAgainstSchema,
+  formatViolations
+} from "../src/utils/json-schema-validate.js";
+
+describe("validateAgainstSchema", () => {
+  it("accepts a value matching the schema", () => {
+    const schema = {
+      type: "object",
+      properties: { answer: { type: "string" } },
+      required: ["answer"]
+    };
+    expect(validateAgainstSchema({ answer: "42" }, schema)).toEqual([]);
+  });
+
+  it("rejects a value outside an enum", () => {
+    const schema = { type: "string", enum: ["skip", "fail"] };
+    const violations = validateAgainstSchema("retry", schema);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain("must be one of");
+  });
+
+  it("validates nested properties, not just the top level", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        outputs: {
+          type: "object",
+          properties: { count: { type: "integer" } },
+          required: ["count"]
+        }
+      }
+    };
+    const violations = validateAgainstSchema(
+      { outputs: { count: "seven" } },
+      schema
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0].path).toBe("result.outputs.count");
+  });
+
+  it("rejects unexpected keys when additionalProperties is false", () => {
+    const schema = {
+      type: "object",
+      properties: { a: { type: "string" } },
+      additionalProperties: false
+    };
+    const violations = validateAgainstSchema({ a: "x", b: 1 }, schema);
+    expect(formatViolations(violations)).toContain('unexpected property "b"');
+  });
+
+  it("required uses own properties, not the prototype chain", () => {
+    const schema = { type: "object", required: ["toString"] };
+    expect(validateAgainstSchema({}, schema)).toHaveLength(1);
+  });
+
+  it("picks the matching branch of a discriminated union", () => {
+    const schema = {
+      type: "object",
+      oneOf: [
+        {
+          type: "object",
+          properties: { action: { const: "skip" } },
+          required: ["action"],
+          additionalProperties: false
+        },
+        {
+          type: "object",
+          properties: {
+            action: { const: "substitute" },
+            outputs: { type: "object" }
+          },
+          required: ["action", "outputs"],
+          additionalProperties: false
+        }
+      ]
+    };
+    expect(validateAgainstSchema({ action: "skip" }, schema)).toEqual([]);
+    expect(
+      validateAgainstSchema({ action: "substitute", outputs: {} }, schema)
+    ).toEqual([]);
+    // The right shape for the wrong branch is still wrong.
+    expect(
+      validateAgainstSchema({ action: "substitute" }, schema).length
+    ).toBeGreaterThan(0);
+    expect(validateAgainstSchema({ action: "retry" }, schema).length).toBe(1);
+  });
+
+  it("reports the closest branch when every union branch fails", () => {
+    const schema = {
+      oneOf: [
+        {
+          type: "object",
+          properties: { a: { type: "string" }, b: { type: "string" } },
+          required: ["a", "b"]
+        },
+        { type: "object", properties: { z: { type: "string" } }, required: ["z"] }
+      ]
+    };
+    // One missing key beats two — the model hears about the branch it nearly hit.
+    const violations = validateAgainstSchema({ a: "x" }, schema);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain('"b"');
+  });
+
+  it("checks array items and bounds", () => {
+    const schema = {
+      type: "array",
+      items: { type: "number" },
+      minItems: 2
+    };
+    expect(validateAgainstSchema([1, 2], schema)).toEqual([]);
+    expect(validateAgainstSchema([1], schema)).toHaveLength(1);
+    expect(validateAgainstSchema([1, "two"], schema)[0].path).toBe("result[1]");
+  });
+
+  it("accepts an integer where a number is declared, but not the reverse", () => {
+    expect(validateAgainstSchema(3, { type: "number" })).toEqual([]);
+    expect(validateAgainstSchema(3, { type: "integer" })).toEqual([]);
+    expect(validateAgainstSchema(3.5, { type: "integer" })).toHaveLength(1);
+  });
+});

--- a/packages/agents/tests/step-executor-acceptance.test.ts
+++ b/packages/agents/tests/step-executor-acceptance.test.ts
@@ -1,0 +1,195 @@
+/**
+ * The two `StepExecutor` extensions the supervisor needed, tested as the
+ * general features they are: host-side validation of the whole declared
+ * schema, and an async acceptance callback that can reject a schema-valid
+ * result into the still-open conversation.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { AgentMemory, BaseProvider } from "@nodetool-ai/runtime";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  StepExecutor,
+  MAX_REPAIR_ROUNDS,
+  type StepResultAcceptance
+} from "../src/step-executor.js";
+import type { Step, Task } from "../src/types.js";
+
+function scriptedProvider(results: unknown[]): BaseProvider {
+  let turn = 0;
+  return {
+    provider: "mock",
+    hasToolSupport: async () => true,
+    getTotalCost: () => 0,
+    generateMessages: async function* () {
+      const result = results[Math.min(turn, results.length - 1)];
+      turn++;
+      yield { id: `tc_${turn}`, name: "finish_step", args: { result } };
+    },
+    async *generateMessagesTraced(args: unknown) {
+      yield* (
+        this as unknown as {
+          generateMessages: (a: unknown) => AsyncGenerator<unknown>;
+        }
+      ).generateMessages(args);
+    },
+    generateLoop(args: unknown) {
+      return (
+        BaseProvider.prototype as unknown as {
+          generateLoop: (a: unknown) => AsyncGenerator<unknown>;
+        }
+      ).generateLoop.call(this, args);
+    },
+    _admitTurn: () => true,
+    generateMessage: vi.fn(),
+    getContainerEnv: () => ({}),
+    isContextLengthError: () => false
+  } as unknown as BaseProvider;
+}
+
+function makeContext(): ProcessingContext {
+  return {
+    memory: new AgentMemory(),
+    workspaceDir: null,
+    storeStepResult: vi.fn(async (key: string) => key),
+    loadStepResult: vi.fn(),
+    set: vi.fn(),
+    get: vi.fn()
+  } as unknown as ProcessingContext;
+}
+
+function makeStep(outputSchema: unknown): { step: Step; task: Task } {
+  const step: Step = {
+    id: "s1",
+    instructions: "produce a value",
+    completed: false,
+    dependsOn: [],
+    outputSchema: JSON.stringify(outputSchema),
+    logs: []
+  };
+  return { step, task: { id: "t1", title: "t", steps: [step] } };
+}
+
+async function run(executor: StepExecutor): Promise<void> {
+  for await (const _message of executor.execute()) {
+    // drain
+  }
+}
+
+describe("StepExecutor host-side schema validation", () => {
+  it("rejects a value outside a declared enum, then accepts the correction", async () => {
+    const { step, task } = makeStep({
+      type: "object",
+      properties: { action: { type: "string", enum: ["skip", "fail"] } },
+      required: ["action"]
+    });
+    const executor = new StepExecutor({
+      task,
+      step,
+      context: makeContext(),
+      provider: scriptedProvider([{ action: "retry" }, { action: "skip" }]),
+      model: "m"
+    });
+
+    await run(executor);
+
+    expect(step.completed).toBe(true);
+    expect(executor.getResult()).toEqual({ action: "skip" });
+  });
+
+  it("checks nested properties, not just the top level", async () => {
+    const { step, task } = makeStep({
+      type: "object",
+      properties: {
+        outputs: {
+          type: "object",
+          properties: { count: { type: "integer" } },
+          required: ["count"]
+        }
+      },
+      required: ["outputs"]
+    });
+    const executor = new StepExecutor({
+      task,
+      step,
+      context: makeContext(),
+      provider: scriptedProvider([
+        { outputs: { count: "seven" } },
+        { outputs: { count: 7 } }
+      ]),
+      model: "m"
+    });
+
+    await run(executor);
+
+    expect(executor.getResult()).toEqual({ outputs: { count: 7 } });
+  });
+
+  it("does not enforce additionalProperties the caller never declared", async () => {
+    // `properties: {}` means "an object". The sanitizer adds
+    // `additionalProperties: false` for strict providers; that is transport,
+    // not the contract, and must not reject a result here.
+    const { step, task } = makeStep({ type: "object", properties: {} });
+    const executor = new StepExecutor({
+      task,
+      step,
+      context: makeContext(),
+      provider: scriptedProvider([{ anything: true }]),
+      model: "m"
+    });
+
+    await run(executor);
+
+    expect(executor.getResult()).toEqual({ anything: true });
+  });
+});
+
+describe("StepExecutor acceptance callback", () => {
+  it("bounces a rejected result back into the conversation", async () => {
+    const { step, task } = makeStep({ type: "object" });
+    const seen: unknown[] = [];
+    const acceptResult = async (
+      result: unknown
+    ): Promise<StepResultAcceptance> => {
+      seen.push(result);
+      return (result as { ok?: boolean }).ok === true
+        ? { accepted: true }
+        : { accepted: false, reason: "uri does not resolve" };
+    };
+    const executor = new StepExecutor({
+      task,
+      step,
+      context: makeContext(),
+      provider: scriptedProvider([{ ok: false }, { ok: true }]),
+      model: "m",
+      acceptResult
+    });
+
+    await run(executor);
+
+    expect(seen).toEqual([{ ok: false }, { ok: true }]);
+    expect(step.completed).toBe(true);
+  });
+
+  it("fails the step after the repair rounds run out", async () => {
+    const { step, task } = makeStep({ type: "object" });
+    const executor = new StepExecutor({
+      task,
+      step,
+      context: makeContext(),
+      provider: scriptedProvider([{ ok: false }]),
+      model: "m",
+      acceptResult: async () => ({
+        accepted: false,
+        reason: "uri does not resolve"
+      })
+    });
+
+    await run(executor);
+
+    expect(step.completed).toBe(false);
+    expect(step.failed).toBe(true);
+    expect(step.error).toContain(`after ${MAX_REPAIR_ROUNDS} attempts`);
+    expect(step.error).toContain("uri does not resolve");
+  });
+});

--- a/packages/agents/tests/supervisor-agent.test.ts
+++ b/packages/agents/tests/supervisor-agent.test.ts
@@ -1,0 +1,456 @@
+/**
+ * SupervisorAgent — the LLM-backed handle.
+ *
+ * Every test here drives a scripted provider: no network, no model. What is
+ * under test is the contract around the model — that a malformed verdict
+ * bounces, that an unacceptable repair bounces, that every failure mode lands
+ * on `fail`, and that the data boundary holds.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { Escalation } from "@nodetool-ai/protocol";
+import { lineageRelated, type RunStateReader } from "@nodetool-ai/kernel";
+import { BaseProvider } from "@nodetool-ai/runtime";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { SupervisorAgent } from "../src/supervisor/supervisor-agent.js";
+import { buildVerdictSchema } from "../src/supervisor/verdict-schema.js";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+type ScriptedCall = { name: string; args: Record<string, unknown> };
+
+/**
+ * A provider that replays a list of tool calls, one per turn, through the real
+ * `BaseProvider.generateLoop`. Records the prompts it was sent so a test can
+ * assert on what crossed the boundary.
+ */
+function scriptedProvider(turns: ScriptedCall[][]): {
+  provider: BaseProvider;
+  sentPrompts: () => string;
+  turnsMade: () => number;
+} {
+  let turn = 0;
+  const prompts: string[] = [];
+  const provider = {
+    provider: "mock",
+    _cost: 0,
+    hasToolSupport: async () => true,
+    getTotalCost() {
+      return 0;
+    },
+    generateMessages: async function* (args: { messages: unknown[] }) {
+      prompts.push(JSON.stringify(args.messages));
+      const calls = turns[turn] ?? [];
+      turn++;
+      for (const call of calls) {
+        yield { id: `tc_${turn}_${call.name}`, name: call.name, args: call.args };
+      }
+      if (calls.length === 0) {
+        yield { type: "chunk" as const, content: "", done: true };
+      }
+    },
+    async *generateMessagesTraced(args: unknown) {
+      yield* (
+        this as unknown as {
+          generateMessages: (a: unknown) => AsyncGenerator<unknown>;
+        }
+      ).generateMessages(args);
+    },
+    generateLoop(args: unknown) {
+      return (
+        BaseProvider.prototype as unknown as {
+          generateLoop: (a: unknown) => AsyncGenerator<unknown>;
+        }
+      ).generateLoop.call(this, args);
+    },
+    // The base loop admits each turn through this hook; a plain-object mock
+    // has to borrow it the same way it borrows the loop.
+    _admitTurn: (BaseProvider.prototype as unknown as Record<string, unknown>)[
+      "_admitTurn"
+    ],
+    generateMessage: vi.fn(),
+    getContainerEnv: () => ({}),
+    isContextLengthError: () => false
+  } as unknown as BaseProvider;
+  return {
+    provider,
+    sentPrompts: () => prompts.join("\n"),
+    turnsMade: () => turn
+  };
+}
+
+function escalation(overrides: Partial<Escalation> = {}): Escalation {
+  return {
+    nodeId: "n1",
+    nodeType: "test.Node",
+    correlationLineage: [],
+    invocationKey: "",
+    allowedActions: ["skip", "fail"],
+    detail: "boom",
+    inputs: {},
+    declaredOutputs: { output: "str" },
+    attempt: 1,
+    spentCostUsd: 0,
+    createdAssets: false,
+    retrySafe: false,
+    emitted: false,
+    ...overrides
+  };
+}
+
+function emptyReader(): RunStateReader {
+  return {
+    digest: () => ({ jobId: "j", nodes: [], costUsd: 0 }),
+    readOutput: () => null
+  };
+}
+
+function makeContext(): ProcessingContext {
+  return createMockContext() as unknown as ProcessingContext;
+}
+
+const NEVER_ABORTED = new AbortController().signal;
+
+/**
+ * Any model the pricing catalog knows. Reservation fails closed on an unpriced
+ * model, so a test that wants the model called has to name a real one.
+ */
+const PRICED_MODEL = "gpt-4o-mini";
+
+describe("SupervisorAgent", () => {
+  it("returns the model's verdict, tagged as an agent decision", async () => {
+    const { provider } = scriptedProvider([
+      [
+        {
+          name: "finish_step",
+          args: {
+            result: { action: "skip", rationale: "item 7 is unparseable" }
+          }
+        }
+      ]
+    ]);
+    const agent = new SupervisorAgent({
+      provider,
+      model: PRICED_MODEL,
+      context: makeContext()
+    });
+    agent.attach(emptyReader());
+
+    const outcome = await agent.decide(escalation(), NEVER_ABORTED);
+
+    expect(outcome.verdict).toEqual({ action: "skip" });
+    expect(outcome.decidedBy).toBe("agent");
+  });
+
+  it("writes the decision and its rationale to supervisor: memory", async () => {
+    const { provider } = scriptedProvider([
+      [
+        {
+          name: "finish_step",
+          args: { result: { action: "skip", rationale: "row 7 has no id" } }
+        }
+      ]
+    ]);
+    const context = makeContext();
+    const agent = new SupervisorAgent({
+      provider,
+      model: PRICED_MODEL,
+      context
+    });
+    agent.attach(emptyReader());
+
+    await agent.decide(escalation({ invocationKey: "root=7" }), NEVER_ABORTED);
+
+    const entry = context.memory.get("supervisor:n1:root=7");
+    expect(entry).toBeDefined();
+    expect((entry?.value as { rationale: string }).rationale).toBe(
+      "row 7 has no id"
+    );
+  });
+
+  it("bounces a verdict outside the allowed set, then accepts the correction", async () => {
+    const { provider, turnsMade } = scriptedProvider([
+      // `retry` is not in this escalation's allowed set.
+      [
+        {
+          name: "finish_step",
+          args: { result: { action: "retry", rationale: "worth another go" } }
+        }
+      ],
+      [
+        {
+          name: "finish_step",
+          args: { result: { action: "fail", rationale: "not recoverable" } }
+        }
+      ]
+    ]);
+    const agent = new SupervisorAgent({
+      provider,
+      model: PRICED_MODEL,
+      context: makeContext()
+    });
+    agent.attach(emptyReader());
+
+    const outcome = await agent.decide(escalation(), NEVER_ABORTED);
+
+    expect(outcome.verdict).toEqual({ action: "fail" });
+    expect(outcome.decidedBy).toBe("agent");
+    expect(turnsMade()).toBe(2);
+  });
+
+  it("bounces a substitute whose value does not match the declared output", async () => {
+    const { provider } = scriptedProvider([
+      [
+        {
+          name: "finish_step",
+          args: {
+            result: {
+              action: "substitute",
+              outputs: { output: 42 },
+              rationale: "close enough"
+            }
+          }
+        }
+      ],
+      [
+        {
+          name: "finish_step",
+          args: {
+            result: {
+              action: "substitute",
+              outputs: { output: "42" },
+              rationale: "typed correctly this time"
+            }
+          }
+        }
+      ]
+    ]);
+    const agent = new SupervisorAgent({
+      provider,
+      model: PRICED_MODEL,
+      context: makeContext()
+    });
+    agent.attach(emptyReader());
+
+    const outcome = await agent.decide(
+      escalation({ allowedActions: ["substitute", "skip", "fail"] }),
+      NEVER_ABORTED
+    );
+
+    expect(outcome.verdict).toEqual({
+      action: "substitute",
+      outputs: { output: "42" }
+    });
+  });
+
+  it("fails when the model never produces a usable verdict", async () => {
+    const { provider } = scriptedProvider([[], [], [], [], [], []]);
+    const agent = new SupervisorAgent({
+      provider,
+      model: PRICED_MODEL,
+      context: makeContext()
+    });
+    agent.attach(emptyReader());
+
+    const outcome = await agent.decide(escalation(), NEVER_ABORTED);
+
+    expect(outcome.verdict).toEqual({ action: "fail" });
+    expect(outcome.decidedBy).toBe("bounds");
+  });
+
+  it("fails when the provider throws", async () => {
+    const provider = {
+      provider: "mock",
+      getTotalCost: () => 0,
+      generateLoop: async function* () {
+        throw new Error("401 from provider");
+      },
+      isContextLengthError: () => false
+    } as unknown as BaseProvider;
+    const agent = new SupervisorAgent({
+      provider,
+      model: PRICED_MODEL,
+      context: makeContext()
+    });
+
+    const outcome = await agent.decide(escalation(), NEVER_ABORTED);
+
+    expect(outcome.verdict).toEqual({ action: "fail" });
+    expect(outcome.decidedBy).toBe("bounds");
+  });
+
+  it("fails without calling the model when the decision is already aborted", async () => {
+    const { provider, turnsMade } = scriptedProvider([
+      [
+        {
+          name: "finish_step",
+          args: { result: { action: "skip", rationale: "too late" } }
+        }
+      ]
+    ]);
+    const agent = new SupervisorAgent({
+      provider,
+      model: PRICED_MODEL,
+      context: makeContext()
+    });
+    agent.attach(emptyReader());
+
+    const aborted = AbortSignal.abort();
+    const outcome = await agent.decide(escalation(), aborted);
+
+    expect(outcome.verdict).toEqual({ action: "fail" });
+    expect(turnsMade()).toBe(0);
+  });
+
+  it("refuses to run at all on a model with no known price", async () => {
+    const { provider, turnsMade } = scriptedProvider([
+      [
+        {
+          name: "finish_step",
+          args: { result: { action: "skip", rationale: "never asked" } }
+        }
+      ]
+    ]);
+    const agent = new SupervisorAgent({
+      provider,
+      model: "a-model-nobody-prices",
+      context: makeContext()
+    });
+    agent.attach(emptyReader());
+
+    const outcome = await agent.decide(escalation(), NEVER_ABORTED);
+
+    expect(outcome.verdict).toEqual({ action: "fail" });
+    expect(outcome.decidedBy).toBe("bounds");
+    expect(turnsMade()).toBe(0);
+  });
+
+  it("refuses a sibling item's output in a fan-out", async () => {
+    const { provider, sentPrompts } = scriptedProvider([
+      [{ name: "read_node_output", args: { node_id: "producer" } }],
+      [
+        {
+          name: "finish_step",
+          args: { result: { action: "skip", rationale: "item 7 is bad" } }
+        }
+      ]
+    ]);
+    // The runner only holds item 3's output; item 7 is the one that failed.
+    const reader: RunStateReader = {
+      digest: () => ({ jobId: "j", nodes: [], costUsd: 0 }),
+      readOutput: (_nodeId, lineage) =>
+        lineageRelated(["items=3"], lineage)
+          ? {
+              nodeId: "producer",
+              lineage: ["items=3"],
+              outputs: { text: "belongs to item 3" }
+            }
+          : null
+    };
+    const agent = new SupervisorAgent({
+      provider,
+      model: PRICED_MODEL,
+      context: makeContext()
+    });
+    agent.attach(reader);
+
+    await agent.decide(
+      escalation({ correlationLineage: ["items=7"], invocationKey: "items=7" }),
+      NEVER_ABORTED
+    );
+
+    expect(sentPrompts()).toContain("not_available");
+    expect(sentPrompts()).not.toContain("belongs to item 3");
+  });
+
+  it("stops mid-decision when the signal fires between turns", async () => {
+    const controller = new AbortController();
+    const { provider, turnsMade } = scriptedProvider([
+      // A tool call keeps the loop going; the abort lands before the next turn.
+      [{ name: "get_run_state", args: {} }],
+      [
+        {
+          name: "finish_step",
+          args: { result: { action: "skip", rationale: "never reached" } }
+        }
+      ]
+    ]);
+    const reader: RunStateReader = {
+      digest: () => {
+        controller.abort();
+        return { jobId: "j", nodes: [], costUsd: 0 };
+      },
+      readOutput: () => null
+    };
+    const agent = new SupervisorAgent({
+      provider,
+      model: PRICED_MODEL,
+      context: makeContext()
+    });
+    agent.attach(reader);
+
+    const outcome = await agent.decide(escalation(), controller.signal);
+
+    expect(outcome.verdict).toEqual({ action: "fail" });
+    expect(turnsMade()).toBe(1);
+  });
+
+  it("masks a secret planted in a read_node_output result", async () => {
+    const { provider, sentPrompts } = scriptedProvider([
+      [{ name: "read_node_output", args: { node_id: "producer" } }],
+      [
+        {
+          name: "finish_step",
+          args: { result: { action: "fail", rationale: "upstream is broken" } }
+        }
+      ]
+    ]);
+    const context = createMockContext() as unknown as ProcessingContext;
+    (
+      context as unknown as { getResolvedSecretValues: () => Set<string> }
+    ).getResolvedSecretValues = () => new Set(["sk-live-DEADBEEF"]);
+
+    const reader: RunStateReader = {
+      digest: () => ({ jobId: "j", nodes: [], costUsd: 0 }),
+      readOutput: () => ({
+        nodeId: "producer",
+        lineage: [],
+        outputs: { header: "Bearer sk-live-DEADBEEF" }
+      })
+    };
+    const agent = new SupervisorAgent({
+      provider,
+      model: PRICED_MODEL,
+      context
+    });
+    agent.attach(reader);
+
+    await agent.decide(escalation(), NEVER_ABORTED);
+
+    expect(sentPrompts()).toContain("producer");
+    expect(sentPrompts()).not.toContain("sk-live-DEADBEEF");
+  });
+});
+
+describe("buildVerdictSchema", () => {
+  it("offers only the actions the kernel would accept", () => {
+    const schema = buildVerdictSchema(["skip", "fail"]);
+    const actions = (schema["oneOf"] as Array<Record<string, unknown>>).map(
+      (branch) =>
+        (
+          (branch["properties"] as Record<string, Record<string, unknown>>)[
+            "action"
+          ] as { const: string }
+        ).const
+    );
+    expect(actions).toEqual(["skip", "fail"]);
+  });
+
+  it("requires outputs on the substitute branch only", () => {
+    const schema = buildVerdictSchema(["substitute", "fail"]);
+    const [substitute, fail] = schema["oneOf"] as Array<
+      Record<string, unknown>
+    >;
+    expect(substitute["required"]).toContain("outputs");
+    expect(fail["required"]).not.toContain("outputs");
+  });
+});

--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -1317,6 +1317,7 @@ export class NodeActor {
       failureSignature: recoverable?.code ?? failureSignature(err),
       candidateOutput,
       inputs: redactRecord(inputs, secrets),
+      declaredOutputs: this.node.outputs ?? {},
       attempt,
       spentCostUsd: account?.costUsd ?? 0,
       createdAssets: account?.createdAssets ?? false,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -49,6 +49,13 @@ export {
   type AllowedActionsInput
 } from "./supervisor.js";
 export {
+  lineageRelated,
+  type RunStateReader,
+  type RunStateDigest,
+  type NodeRunState,
+  type NodeOutputRead
+} from "./run-state.js";
+export {
   validateSubstituteOutputs,
   hasFullValidatorCoverage,
   type SubstituteValidationResult,

--- a/packages/kernel/src/run-state.ts
+++ b/packages/kernel/src/run-state.ts
@@ -1,0 +1,87 @@
+/**
+ * What a supervisor may read about a run in flight.
+ *
+ * The design's two supervisor tools (`get_run_state`, `read_node_output`) are
+ * pull-based on purpose: the runner already holds this state, so there is no
+ * observation pipeline to feed and a clean run costs nothing. This module is
+ * the read side of that — the runner implements it, the agent package consumes
+ * it, and the dependency arrow stays `kernel ← agents`.
+ *
+ * See docs/workflow-supervisor-design.md §6.
+ */
+
+/** Per-node summary in the run digest. */
+export interface NodeRunState {
+  nodeId: string;
+  nodeType: string;
+  /**
+   * `pending` — spawned, nothing emitted yet; `running` — emitted at least
+   * once and still live; `completed` / `failed` — the actor is gone.
+   */
+  status: "pending" | "running" | "completed" | "failed";
+  /** Invocations that produced output. */
+  emissions: number;
+  /** Escalations raised by this node so far, including the current one. */
+  escalations: number;
+  /** The node's terminal error, once it has one. Redacted at construction. */
+  error?: string;
+}
+
+export interface RunStateDigest {
+  jobId: string;
+  nodes: NodeRunState[];
+  /** Provider spend recorded for the whole run so far, in USD. */
+  costUsd: number;
+}
+
+/** One node's recorded output for a single invocation. */
+export interface NodeOutputRead {
+  nodeId: string;
+  /** The lineage the recorded invocation ran under, as `root=index` pairs. */
+  lineage: string[];
+  outputs: Record<string, unknown>;
+}
+
+/**
+ * Read-only view of a run, handed to a `SupervisorHandle` when the run starts.
+ */
+export interface RunStateReader {
+  digest(): RunStateDigest;
+  /**
+   * The most recent output of `nodeId` on an invocation causally related to
+   * `lineage` — same fan-out roots, same indices. A sibling item's output is
+   * not related to the failing one, so it is refused (`null`) rather than
+   * handed over as repair material. Design §6.
+   */
+  readOutput(nodeId: string, lineage: readonly string[]): NodeOutputRead | null;
+}
+
+/**
+ * Whether `recorded` belongs to the same causal branch as `lineage`.
+ *
+ * A producer upstream of the failing invocation ran under a lineage that is a
+ * subset of it: every fan-out root it carries also appears downstream, with the
+ * same index. Two conditions therefore refuse a read — an index that disagrees
+ * (a sibling item) and a root the failing invocation never entered (an
+ * unrelated fan-out). An empty recorded lineage is a single-fire node, which is
+ * upstream of everything.
+ */
+export function lineageRelated(
+  recorded: readonly string[],
+  lineage: readonly string[]
+): boolean {
+  if (recorded.length === 0) return true;
+  const scope = new Map<string, string>();
+  for (const pair of lineage) {
+    const eq = pair.indexOf("=");
+    if (eq === -1) continue;
+    scope.set(pair.slice(0, eq), pair.slice(eq + 1));
+  }
+  for (const pair of recorded) {
+    const eq = pair.indexOf("=");
+    if (eq === -1) return false;
+    const root = pair.slice(0, eq);
+    if (scope.get(root) !== pair.slice(eq + 1)) return false;
+  }
+  return true;
+}

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -49,6 +49,13 @@ const EDGE_UPDATE_MIN_INTERVAL_MS = 1000;
  */
 const MAX_RETAINED_MESSAGES = 10_000;
 
+/**
+ * Cap on lineages retained per node for `read_node_output`. A supervisor reads
+ * the failing invocation's own branch, which is recent; a wide fan-out must not
+ * turn the cache into a second copy of the run's data.
+ */
+const MAX_RECORDED_LINEAGES_PER_NODE = 64;
+
 /** An output_update whose value is a streamed audio chunk (sample payload). */
 function isAudioChunkOutputUpdate(msg: ProcessingMessage): boolean {
   if (msg.type !== "output_update") return false;
@@ -71,8 +78,16 @@ import { NodeActor, type NodeExecutor } from "./actor.js";
 import { syntheticEdgeId } from "./edge-ids.js";
 import {
   analyzeCorrelation,
+  projectLineageKey,
   type CorrelationAnalysisResult
 } from "./correlation-analysis.js";
+import {
+  lineageRelated,
+  type NodeOutputRead,
+  type NodeRunState,
+  type RunStateDigest,
+  type RunStateReader
+} from "./run-state.js";
 
 /**
  * Hints from the actor about how to route an invocation's outputs.
@@ -408,6 +423,16 @@ export class WorkflowRunner {
 
   /** Supervisor escalations and their verdicts, in decision order. */
   private _interventions: Intervention[] = [];
+
+  /**
+   * Last output of each node per invocation lineage, for `read_node_output`.
+   * Only populated on a supervised run — an unsupervised one keeps nothing.
+   * Bounded per node: a 10k-item fan-out must not become a 10k-entry cache.
+   */
+  private _recordedOutputs = new Map<
+    string,
+    Map<string, Record<string, unknown>>
+  >();
 
   /** Undefined on an unsupervised run, so its `RunResult` is unchanged. */
   private _recordedInterventions(): Intervention[] | undefined {
@@ -803,6 +828,103 @@ export class WorkflowRunner {
     this._eosSentEdges = new Set();
     this._suspend = undefined;
     this._interventions = [];
+    this._recordedOutputs = new Map();
+  }
+
+  /**
+   * The read-only view a supervisor gets of the run in flight. Built from
+   * state the runner already holds, so a run without a supervisor pays for
+   * none of it. See docs/workflow-supervisor-design.md §6.
+   */
+  private _runStateReader(): RunStateReader {
+    return {
+      digest: () => this._runStateDigest(),
+      readOutput: (nodeId, lineage) => this._readRecordedOutput(nodeId, lineage)
+    };
+  }
+
+  private _runStateDigest(): RunStateDigest {
+    const escalationsPerNode = new Map<string, number>();
+    for (const intervention of this._interventions) {
+      const nodeId = intervention.escalation.nodeId;
+      escalationsPerNode.set(nodeId, (escalationsPerNode.get(nodeId) ?? 0) + 1);
+    }
+    const nodes: NodeRunState[] = this._graph.nodes.map((node) => {
+      const error = this._nodeErrors.get(node.id);
+      const done = this._completedNodes.has(node.id);
+      const emissions = this._recordedOutputs.get(node.id)?.size ?? 0;
+      const state: NodeRunState = {
+        nodeId: node.id,
+        nodeType: node.type,
+        status:
+          error !== undefined
+            ? "failed"
+            : done
+              ? "completed"
+              : emissions > 0
+                ? "running"
+                : "pending",
+        emissions,
+        escalations: escalationsPerNode.get(node.id) ?? 0
+      };
+      if (error !== undefined) state.error = error;
+      return state;
+    });
+    return {
+      jobId: this._effectiveJobId,
+      nodes,
+      costUsd: this._options.executionContext?.getTotalCost?.() ?? 0
+    };
+  }
+
+  private _readRecordedOutput(
+    nodeId: string,
+    lineage: readonly string[]
+  ): NodeOutputRead | null {
+    const perLineage = this._recordedOutputs.get(nodeId);
+    if (!perLineage) return null;
+    // Most specific first: an entry sharing more of the failing invocation's
+    // roots is closer to it causally than a single-fire ancestor.
+    let best: NodeOutputRead | null = null;
+    for (const [key, outputs] of perLineage) {
+      const recorded = key === "" ? [] : key.split(",");
+      if (!lineageRelated(recorded, lineage)) continue;
+      if (best === null || recorded.length > best.lineage.length) {
+        best = { nodeId, lineage: recorded, outputs };
+      }
+    }
+    return best;
+  }
+
+  /**
+   * Remember what a node emitted, keyed by the invocation's lineage, so a
+   * supervisor can read a producer's output while deciding a consumer's
+   * failure. Off unless the run is supervised.
+   */
+  private _recordNodeOutput(
+    sourceNodeId: string,
+    outputs: Record<string, unknown>,
+    lineage: CorrelationLineage | undefined
+  ): void {
+    const scope = this._correlation?.nodes.get(sourceNodeId)?.invocationScope;
+    const key =
+      scope && scope.length > 0 && lineage
+        ? projectLineageKey(lineage, scope)
+        : "";
+    let perLineage = this._recordedOutputs.get(sourceNodeId);
+    if (!perLineage) {
+      perLineage = new Map();
+      this._recordedOutputs.set(sourceNodeId, perLineage);
+    }
+    // Re-inserting moves the key to the end, so the eviction below always
+    // drops the least recently emitted lineage rather than a live one.
+    perLineage.delete(key);
+    perLineage.set(key, outputs);
+    while (perLineage.size > MAX_RECORDED_LINEAGES_PER_NODE) {
+      const oldest = perLineage.keys().next();
+      if (oldest.done) break;
+      perLineage.delete(oldest.value);
+    }
   }
 
   /** Actors spawned and not yet finished. Zero before and after a run. */
@@ -1247,6 +1369,9 @@ export class WorkflowRunner {
    * upstream actors produce data.
    */
   private async _processGraph(): Promise<void> {
+    // Before any actor can escalate, the supervisor gets its read-only view.
+    this._options.supervisor?.attach?.(this._runStateReader());
+
     const actorPromises: Array<Promise<void>> = [];
     /** Parallel to `actorPromises` — maps a settled index back to its node. */
     const actorNodeIds: string[] = [];
@@ -1474,6 +1599,14 @@ export class WorkflowRunner {
         routingHints.invocationLineage ?? {}
       );
       return;
+    }
+
+    if (this._options.supervisor) {
+      this._recordNodeOutput(
+        sourceNodeId,
+        outputs,
+        routingHints.invocationLineage
+      );
     }
 
     // Handle __control_output__ from controller nodes (Python parity:

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -1370,7 +1370,17 @@ export class WorkflowRunner {
    */
   private async _processGraph(): Promise<void> {
     // Before any actor can escalate, the supervisor gets its read-only view.
-    this._options.supervisor?.attach?.(this._runStateReader());
+    // A handle that throws here is a broken supervisor, and a broken
+    // supervisor must never be worse for the run than no supervisor: it
+    // proceeds without a reader and its decisions degrade to `fail`.
+    try {
+      this._options.supervisor?.attach?.(this._runStateReader());
+    } catch (error) {
+      // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
+      log.warn("Supervisor attach failed; running without a run-state view", {
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
 
     const actorPromises: Array<Promise<void>> = [];
     /** Parallel to `actorPromises` — maps a settled index back to its node. */

--- a/packages/kernel/src/supervisor.ts
+++ b/packages/kernel/src/supervisor.ts
@@ -17,6 +17,7 @@ import type {
   VerdictAction,
   DecidedBy
 } from "@nodetool-ai/protocol";
+import type { RunStateReader } from "./run-state.js";
 
 // ---------------------------------------------------------------------------
 // The interface
@@ -32,6 +33,12 @@ export interface DecisionOutcome {
 
 export interface SupervisorHandle {
   decide(e: Escalation, signal: AbortSignal): Promise<DecisionOutcome>;
+  /**
+   * Handed the run's read-only state once, before any actor starts. A handle
+   * is configured before the runner exists, so the reader cannot be a
+   * constructor argument. Optional: a scripted handle needs no run state.
+   */
+  attach?(reader: RunStateReader): void;
   close(): void;
 }
 
@@ -269,6 +276,10 @@ export class BoundedHandle implements SupervisorHandle {
   constructor(inner: SupervisorHandle, opts: SupervisorBounds = {}) {
     this._inner = inner;
     this._bounds = { ...DEFAULT_SUPERVISOR_BOUNDS, ...stripUndefined(opts) };
+  }
+
+  attach(reader: RunStateReader): void {
+    this._inner.attach?.(reader);
   }
 
   async decide(e: Escalation, signal: AbortSignal): Promise<DecisionOutcome> {

--- a/packages/kernel/tests/run-state.test.ts
+++ b/packages/kernel/tests/run-state.test.ts
@@ -84,6 +84,39 @@ describe("WorkflowRunner run state", () => {
     });
   });
 
+  it("survives a handle whose attach throws", async () => {
+    // A broken supervisor must never be worse for the run than no supervisor.
+    const handle: SupervisorHandle = {
+      attach() {
+        throw new Error("attach exploded");
+      },
+      async decide(): Promise<DecisionOutcome> {
+        return { verdict: { action: "fail" }, decidedBy: "default" };
+      },
+      close() {}
+    };
+    const runner = new WorkflowRunner("job-bad-attach", {
+      resolveExecutor: () => ({
+        async process() {
+          return { output: "produced" };
+        }
+      }),
+      supervisor: handle
+    });
+
+    const result = await runner.run(
+      { job_id: "job-bad-attach", params: {} },
+      {
+        nodes: [
+          { id: "producer", type: "test.Producer", outputs: { output: "str" } }
+        ],
+        edges: []
+      }
+    );
+
+    expect(result.status).toBe("completed");
+  });
+
   it("records nothing when the run has no supervisor", async () => {
     const runner = new WorkflowRunner("job-unsupervised", {
       resolveExecutor: () => ({

--- a/packages/kernel/tests/run-state.test.ts
+++ b/packages/kernel/tests/run-state.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The read-only run view a supervisor gets, and the lineage rule that decides
+ * what it may read.
+ *
+ * See docs/workflow-supervisor-design.md §6.
+ */
+
+import { describe, it, expect } from "vitest";
+import { lineageRelated } from "../src/run-state.js";
+import { WorkflowRunner } from "../src/runner.js";
+import type { RunStateReader } from "../src/run-state.js";
+import type { SupervisorHandle, DecisionOutcome } from "../src/supervisor.js";
+import type { Escalation } from "@nodetool-ai/protocol";
+
+describe("lineageRelated", () => {
+  it("relates a single-fire producer to every invocation", () => {
+    expect(lineageRelated([], ["items=7"])).toBe(true);
+    expect(lineageRelated([], [])).toBe(true);
+  });
+
+  it("relates a producer on the same branch", () => {
+    expect(lineageRelated(["items=7"], ["items=7"])).toBe(true);
+    expect(lineageRelated(["items=7"], ["items=7", "chunks=2"])).toBe(true);
+  });
+
+  it("refuses a sibling item of the same fan-out", () => {
+    // The whole reason the tool is scoped: item 3's output is not evidence
+    // about item 7's failure, and handing it over is a poisoned repair.
+    expect(lineageRelated(["items=3"], ["items=7"])).toBe(false);
+  });
+
+  it("refuses a branch the failing invocation never entered", () => {
+    expect(lineageRelated(["other=1"], ["items=7"])).toBe(false);
+  });
+});
+
+/** Records what the runner hands it, so a test can read the view back. */
+class CapturingHandle implements SupervisorHandle {
+  reader: RunStateReader | null = null;
+
+  attach(reader: RunStateReader): void {
+    this.reader = reader;
+  }
+  async decide(_e: Escalation): Promise<DecisionOutcome> {
+    return { verdict: { action: "fail" }, decidedBy: "default" };
+  }
+  close(): void {}
+}
+
+describe("WorkflowRunner run state", () => {
+  it("hands the supervisor a view and records node outputs for it", async () => {
+    const handle = new CapturingHandle();
+    const runner = new WorkflowRunner("job-run-state", {
+      resolveExecutor: () => ({
+        async process() {
+          return { output: "produced" };
+        }
+      }),
+      supervisor: handle
+    });
+
+    await runner.run(
+      { job_id: "job-run-state", params: {} },
+      {
+        nodes: [
+          { id: "producer", type: "test.Producer", outputs: { output: "str" } }
+        ],
+        edges: []
+      }
+    );
+
+    expect(handle.reader).not.toBeNull();
+    const read = handle.reader!.readOutput("producer", []);
+    expect(read?.outputs).toEqual({ output: "produced" });
+
+    const digest = handle.reader!.digest();
+    expect(digest.jobId).toBe("job-run-state");
+    expect(digest.nodes).toHaveLength(1);
+    expect(digest.nodes[0]).toMatchObject({
+      nodeId: "producer",
+      status: "completed",
+      emissions: 1,
+      escalations: 0
+    });
+  });
+
+  it("records nothing when the run has no supervisor", async () => {
+    const runner = new WorkflowRunner("job-unsupervised", {
+      resolveExecutor: () => ({
+        async process() {
+          return { output: "produced" };
+        }
+      })
+    });
+
+    const result = await runner.run(
+      { job_id: "job-unsupervised", params: {} },
+      {
+        nodes: [
+          { id: "producer", type: "test.Producer", outputs: { output: "str" } }
+        ],
+        edges: []
+      }
+    );
+
+    expect(result.status).toBe("completed");
+    expect(result.interventions).toBeUndefined();
+  });
+});

--- a/packages/kernel/tests/supervisor-handle.test.ts
+++ b/packages/kernel/tests/supervisor-handle.test.ts
@@ -32,6 +32,7 @@ function escalation(over: Partial<Escalation> = {}): Escalation {
     allowedActions: ["retry", "skip", "fail"],
     detail: "boom",
     inputs: {},
+    declaredOutputs: { output: "str" },
     attempt: 1,
     spentCostUsd: 0,
     createdAssets: false,

--- a/packages/protocol/src/supervisor.ts
+++ b/packages/protocol/src/supervisor.ts
@@ -88,6 +88,12 @@ export const escalationSchema = z.object({
   candidateOutput: z.unknown().optional(),
   /** The invocation's input values, redacted and truncated. */
   inputs: z.record(z.string(), z.unknown()),
+  /**
+   * The node's declared output types, keyed by slot. Carried because a repair
+   * cannot be authored — or accepted — without knowing what each slot must
+   * hold. Type metadata, so nothing to redact.
+   */
+  declaredOutputs: z.record(z.string(), z.string()),
   /** 1-based, per `(nodeId, invocationKey)`. */
   attempt: z.number(),
   /** Provider cost recorded by this invocation. */

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -65,6 +65,12 @@ export {
   currentInvocationAccount,
   type InvocationAccount
 } from "./invocation-account.js";
+export {
+  CostCappedTurnBudget,
+  type TurnBudget,
+  type TurnReservation,
+  type CostCappedTurnBudgetOptions
+} from "./turn-budget.js";
 export { packContext, type PackedContext } from "./context-packer.js";
 export {
   isZodSchema,

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -975,61 +975,67 @@ export abstract class BaseProvider {
       // turn. Discarded when tools are pending — the next round supplies its own.
       let terminalChunk: ProviderStreamItem | undefined;
 
-      for await (const item of this.generateMessagesTraced({
-        ...turnArgs,
-        messages,
-        onToolCall
-      })) {
-        if (turnArgs.signal?.aborted) break;
-        if (isProviderMessageEvent(item)) {
-          if (item.message.role === "assistant") {
-            finalizedAssistant = item.message;
+      // The reservation covers exactly one turn, so it is reconciled in a
+      // `finally`: a turn that throws must release it. Left outstanding, a
+      // single provider error would shrink the budget's headroom for good —
+      // it is run-level and outlives the decision that hit the error.
+      try {
+        for await (const item of this.generateMessagesTraced({
+          ...turnArgs,
+          messages,
+          onToolCall
+        })) {
+          if (turnArgs.signal?.aborted) break;
+          if (isProviderMessageEvent(item)) {
+            if (item.message.role === "assistant") {
+              finalizedAssistant = item.message;
+            }
+            yield item;
+            continue;
+          }
+          if (isProviderSessionUpdate(item)) {
+            yield item;
+            continue;
+          }
+          if ("id" in item && "name" in item && "args" in item) {
+            pending.push(item);
+            yield item;
+            continue;
+          }
+          const chunk = item as {
+            content?: unknown;
+            content_type?: string;
+            thinking?: boolean;
+            done?: boolean;
+          };
+          // Only text belongs in the assistant message. Audio/image chunks carry
+          // base64 in the same `content` field; concatenating those produced
+          // assistant messages full of binary garbage.
+          const isTextChunk =
+            chunk.content_type === undefined || chunk.content_type === "text";
+          if (
+            typeof chunk.content === "string" &&
+            !chunk.thinking &&
+            isTextChunk
+          ) {
+            assistantText += chunk.content;
+          }
+          // `done: true` closes the provider's *completion*, which is not the same
+          // as the end of the turn — every provider emits one per tool-calling
+          // round. Forwarding them made consumers (the chat composer's Stop
+          // button) treat each round as the end of the turn. Hold the terminal
+          // chunk until we know whether tools are pending; release it below only
+          // when this round really is the last one.
+          if (chunk.done === true) {
+            terminalChunk = item;
+            continue;
           }
           yield item;
-          continue;
         }
-        if (isProviderSessionUpdate(item)) {
-          yield item;
-          continue;
-        }
-        if ("id" in item && "name" in item && "args" in item) {
-          pending.push(item);
-          yield item;
-          continue;
-        }
-        const chunk = item as {
-          content?: unknown;
-          content_type?: string;
-          thinking?: boolean;
-          done?: boolean;
-        };
-        // Only text belongs in the assistant message. Audio/image chunks carry
-        // base64 in the same `content` field; concatenating those produced
-        // assistant messages full of binary garbage.
-        const isTextChunk =
-          chunk.content_type === undefined || chunk.content_type === "text";
-        if (
-          typeof chunk.content === "string" &&
-          !chunk.thinking &&
-          isTextChunk
-        ) {
-          assistantText += chunk.content;
-        }
-        // `done: true` closes the provider's *completion*, which is not the same
-        // as the end of the turn — every provider emits one per tool-calling
-        // round. Forwarding them made consumers (the chat composer's Stop
-        // button) treat each round as the end of the turn. Hold the terminal
-        // chunk until we know whether tools are pending; release it below only
-        // when this round really is the last one.
-        if (chunk.done === true) {
-          terminalChunk = item;
-          continue;
-        }
-        yield item;
+      } finally {
+        // Replace the reservation with what the turn really cost.
+        turnBudget?.commit(this.getTotalCost() - costBeforeTurn);
       }
-
-      // The turn is over; replace its reservation with what it really cost.
-      turnBudget?.commit(this.getTotalCost() - costBeforeTurn);
 
       if (pending.length === 0) {
         if (terminalChunk !== undefined) {

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -53,6 +53,8 @@ import {
   createUsageSlot,
   type LlmUsage
 } from "../tracing-helpers.js";
+import type { TurnBudget } from "../turn-budget.js";
+import { countTokens } from "../token-counter.js";
 import { logProviderRequestFailure } from "./provider-request-log.js";
 import { annotateProviderError } from "./provider-error.js";
 import { applyEntityReferences } from "./entity-references.js";
@@ -227,6 +229,26 @@ export function providerCapabilities(
     capabilities.push("text_to_3d", "image_to_3d");
   }
   return capabilities;
+}
+
+/**
+ * Prompt tokens a turn will send, for reservation purposes. Deliberately a
+ * rough count over the serialized conversation: a reservation is a worst case,
+ * and a per-provider exact count would cost a tokenizer round-trip per turn to
+ * refine a number that only has to be an upper-ish bound.
+ */
+function estimatePromptTokens(messages: readonly Message[]): number {
+  let total = 0;
+  for (const message of messages) {
+    const content = message.content;
+    total += countTokens(
+      typeof content === "string" ? content : JSON.stringify(content ?? "")
+    );
+    if (message.toolCalls?.length) {
+      total += countTokens(JSON.stringify(message.toolCalls));
+    }
+  }
+  return total;
 }
 
 export abstract class BaseProvider {
@@ -841,6 +863,23 @@ export abstract class BaseProvider {
    * override this to drive that loop instead, while still emitting the same
    * stream items. `generateMessages` remains the single-turn primitive.
    */
+  /**
+   * Ask a {@link TurnBudget} to admit the turn that is about to be made.
+   * Exposed to subclasses because a provider driving a backend's own agent
+   * loop has to make the same call at the same point.
+   */
+  protected _admitTurn(
+    budget: TurnBudget,
+    model: string,
+    messages: readonly Message[]
+  ): boolean {
+    return budget.reserve({
+      model,
+      provider: this.provider,
+      inputTokens: estimatePromptTokens(messages)
+    });
+  }
+
   async *generateLoop(
     args: Parameters<this["generateMessages"]>[0] & {
       /**
@@ -861,6 +900,18 @@ export abstract class BaseProvider {
        * false (parallel) to keep chat's concurrent tool execution fast.
        */
       sequentialTools?: boolean;
+      /**
+       * Spend admission, consulted before every model turn. A refusal ends the
+       * loop without making the call. Providers that override `generateLoop`
+       * to drive a backend's own agent loop must honor it the same way — a
+       * ceiling only holds where the turns are.
+       *
+       * Reconciliation reads this provider instance's running cost, so a
+       * budget must not be threaded through an instance two callers are
+       * driving concurrently; the supervisor owns its provider for exactly
+       * this reason.
+       */
+      turnBudget?: TurnBudget;
     }
   ): AsyncGenerator<ProviderStreamItem> {
     const maxIterations = args.maxIterations ?? 25;
@@ -868,6 +919,7 @@ export abstract class BaseProvider {
       executeTool,
       maxIterations: _omitMax,
       sequentialTools,
+      turnBudget,
       ...turnArgs
     } = args;
     const messages = [...args.messages];
@@ -900,6 +952,10 @@ export abstract class BaseProvider {
 
     for (let iteration = 0; iteration < maxIterations; iteration++) {
       if (turnArgs.signal?.aborted) return;
+      if (turnBudget && !this._admitTurn(turnBudget, args.model, messages)) {
+        return;
+      }
+      const costBeforeTurn = turnBudget ? this.getTotalCost() : 0;
       let assistantText = "";
       let finalizedAssistant: Message | undefined;
       const pending: ToolCall[] = [];
@@ -959,6 +1015,9 @@ export abstract class BaseProvider {
         }
         yield item;
       }
+
+      // The turn is over; replace its reservation with what it really cost.
+      turnBudget?.commit(this.getTotalCost() - costBeforeTurn);
 
       if (pending.length === 0) {
         if (terminalChunk !== undefined) {

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -902,9 +902,21 @@ export abstract class BaseProvider {
       sequentialTools?: boolean;
       /**
        * Spend admission, consulted before every model turn. A refusal ends the
-       * loop without making the call. Providers that override `generateLoop`
-       * to drive a backend's own agent loop must honor it the same way — a
-       * ceiling only holds where the turns are.
+       * loop without making the call.
+       *
+       * **Contract for overrides.** A provider that overrides `generateLoop`
+       * to drive a backend's own agent loop must call {@link _admitTurn}
+       * before each model turn and `commit` after it — a ceiling only holds
+       * where the turns are, and an override that ignores this makes the cap
+       * advisory for every model it serves. Both current overrides honor it
+       * (the Claude Agent SDK loop and OpenAI's Responses loop). TypeScript
+       * cannot enforce this, so a new override that owns its turns owns this
+       * too.
+       *
+       * Reserve against the *evolving* transcript, not the opening prompt: a
+       * backend that keeps the conversation server-side still bills for it,
+       * and reserving against the delta prices a turn as if the conversation
+       * had restarted.
        *
        * Reconciliation reads this provider instance's running cost, so a
        * budget must not be threaded through an instance two callers are

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -1033,7 +1033,11 @@ export abstract class BaseProvider {
           yield item;
         }
       } finally {
-        // Replace the reservation with what the turn really cost.
+        // Replace the reservation with what the turn really cost. A zero delta
+        // here is a real zero, not an unknown: `trackUsage` fires on every
+        // completed call, so nothing recorded means nothing was billed. (The
+        // Claude Agent SDK path cannot say that, which is why it commits
+        // `null` instead — see its override.)
         turnBudget?.commit(this.getTotalCost() - costBeforeTurn);
       }
 

--- a/packages/runtime/src/providers/claude-agent-provider.ts
+++ b/packages/runtime/src/providers/claude-agent-provider.ts
@@ -341,16 +341,22 @@ export class ClaudeAgentProvider extends BaseProvider {
           mcp
         }
       );
+      // The SDK grows the conversation internally, so reserving against the
+      // opening prompt every time would under-count every later turn — badly,
+      // on a tool-heavy loop. The messages it emits are the same ones it is
+      // accumulating, so the transcript is rebuilt here to reserve against.
+      const transcript: Message[] = [...args.messages];
       for await (const item of stream) {
         yield item;
         if (!turnBudget) continue;
+        if (!isProviderMessageEvent(item)) continue;
+        transcript.push(item.message);
         const isToolCallingTurn =
-          isProviderMessageEvent(item) &&
           item.message.role === "assistant" &&
           (item.message.toolCalls?.length ?? 0) > 0;
         if (
           isToolCallingTurn &&
-          !this._admitTurn(turnBudget, args.model, args.messages)
+          !this._admitTurn(turnBudget, args.model, transcript)
         ) {
           abortController.abort();
         }

--- a/packages/runtime/src/providers/claude-agent-provider.ts
+++ b/packages/runtime/src/providers/claude-agent-provider.ts
@@ -366,7 +366,17 @@ export class ClaudeAgentProvider extends BaseProvider {
       // per-turn actual doesn't exist here. Reservations accumulate untouched
       // for the session's duration — conservative by construction — and the
       // real number lands when the session ends.
-      turnBudget?.commit(this.getTotalCost() - costBefore);
+      //
+      // Except when it doesn't: an aborted session never emits `result`, so
+      // nothing is recorded even though its turns ran and were billed. That is
+      // the *normal* ending here — a terminal tool (`finish_step`) aborts the
+      // query — so booking zero would mean the cap never counted a single
+      // successful decision on this provider. A zero delta is therefore read
+      // as "unknown", and the reserved worst case is charged instead.
+      if (turnBudget) {
+        const observed = this.getTotalCost() - costBefore;
+        turnBudget.commit(observed > 0 ? observed : null);
+      }
       if (args.signal)
         args.signal.removeEventListener("abort", onExternalAbort);
     }

--- a/packages/runtime/src/providers/claude-agent-provider.ts
+++ b/packages/runtime/src/providers/claude-agent-provider.ts
@@ -58,6 +58,7 @@ import {
   type ToolCall
 } from "./types.js";
 import { hashSystemPrompt } from "./provider-session.js";
+import type { TurnBudget } from "../turn-budget.js";
 
 const log = createLogger("nodetool.runtime.providers.claude-agent");
 
@@ -261,8 +262,17 @@ export class ClaudeAgentProvider extends BaseProvider {
     args: Parameters<ClaudeAgentProvider["generateMessages"]>[0] & {
       executeTool?: (toolCall: ToolCall) => Promise<string | MessageContent[]>;
       maxIterations?: number;
+      turnBudget?: TurnBudget;
     }
   ): AsyncGenerator<ProviderStreamItem> {
+    // The SDK owns the loop, so honoring the budget is this override's job:
+    // reserve before the first turn, and again after every assistant turn that
+    // requested tools — that is the point where the SDK will make another call.
+    // A refusal aborts the session instead of letting it spend past the cap.
+    const turnBudget = args.turnBudget;
+    if (turnBudget && !this._admitTurn(turnBudget, args.model, args.messages)) {
+      return;
+    }
     // Drop the SerpAPI-backed `web_search` tool: the SDK's built-in `WebSearch`
     // (live under bypassPermissions) handles web search natively, so we don't
     // expose a redundant MCP one.
@@ -321,8 +331,9 @@ export class ClaudeAgentProvider extends BaseProvider {
         allowedTools: tools.map((t) => `${TOOL_PREFIX}${t.name}`)
       };
     }
+    const costBefore = turnBudget ? this.getTotalCost() : 0;
     try {
-      yield* this.runWithSession(
+      const stream = this.runWithSession(
         { ...args, signal: abortController.signal },
         {
           emitMessages: true,
@@ -330,7 +341,26 @@ export class ClaudeAgentProvider extends BaseProvider {
           mcp
         }
       );
+      for await (const item of stream) {
+        yield item;
+        if (!turnBudget) continue;
+        const isToolCallingTurn =
+          isProviderMessageEvent(item) &&
+          item.message.role === "assistant" &&
+          (item.message.toolCalls?.length ?? 0) > 0;
+        if (
+          isToolCallingTurn &&
+          !this._admitTurn(turnBudget, args.model, args.messages)
+        ) {
+          abortController.abort();
+        }
+      }
     } finally {
+      // The SDK reports usage once, on the terminal `result` message, so a
+      // per-turn actual doesn't exist here. Reservations accumulate untouched
+      // for the session's duration — conservative by construction — and the
+      // real number lands when the session ends.
+      turnBudget?.commit(this.getTotalCost() - costBefore);
       if (args.signal)
         args.signal.removeEventListener("abort", onExternalAbort);
     }

--- a/packages/runtime/src/providers/cost-calculator.ts
+++ b/packages/runtime/src/providers/cost-calculator.ts
@@ -326,6 +326,23 @@ export class CostCalculator {
     return 0.0;
   }
 
+  /**
+   * Token cost in USD, or `null` when no price is known for the model.
+   *
+   * {@link calculate} answers 0 for an unpriced model because accounting must
+   * never break a generation that already ran. A budget decides whether a call
+   * happens *at all*, and there "unknown" must not read as "free" — so the
+   * missing-price case is a distinct answer here, and callers that reserve
+   * against a cap fail closed on it.
+   */
+  static estimateTokenCostUsd(
+    modelId: string,
+    usage: UsageInfo,
+    provider: ProviderId
+  ): number | null {
+    return calcTokenPriceUsd(modelId, usage, provider);
+  }
+
   /** Cost for a local non-token modality tier, in USD. */
   private static _calculateForTier(
     tier: PricingTier,

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -1540,18 +1540,26 @@ export class OpenAIProvider extends BaseProvider {
       }
       const costBeforeTurn = config.turnBudget ? this.getTotalCost() : 0;
 
-      const request = await this.buildResponsesRequest(config.args, {
-        input,
-        stream: true,
-        store: true,
-        previousResponseId
-      });
-      yield* this.collectResponsesTurn(
-        config.args,
-        request,
-        config.systemHash,
-        state
-      );
+      // The reservation covers exactly one turn, so it has to be reconciled
+      // even when that turn throws. Left outstanding, a single provider error
+      // would shrink the run's headroom for good — the budget is run-level and
+      // outlives the decision that hit the error.
+      try {
+        const request = await this.buildResponsesRequest(config.args, {
+          input,
+          stream: true,
+          store: true,
+          previousResponseId
+        });
+        yield* this.collectResponsesTurn(
+          config.args,
+          request,
+          config.systemHash,
+          state
+        );
+      } finally {
+        config.turnBudget?.commit(this.getTotalCost() - costBeforeTurn);
+      }
 
       previousResponseId = state.responseId;
       // Native image_generation results ride the assistant message as image
@@ -1567,7 +1575,6 @@ export class OpenAIProvider extends BaseProvider {
       };
       yield { type: "message", message: assistantMsg };
       transcript.push(assistantMsg);
-      config.turnBudget?.commit(this.getTotalCost() - costBeforeTurn);
 
       if (state.pending.length === 0) {
         return;
@@ -1612,6 +1619,9 @@ export class OpenAIProvider extends BaseProvider {
         yield { type: "message", message: toolMsg };
         if (imageMessage) {
           toolMessages.push(imageMessage);
+          // It rides the next turn's input, so it is part of what that turn
+          // is billed for — and therefore part of what its reservation covers.
+          transcript.push(imageMessage);
         }
       };
 

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -9,6 +9,7 @@ import { createLogger, importHidden } from "@nodetool-ai/config";
 import { BaseProvider, splitToolResultImages } from "./base-provider.js";
 import { hashSystemPrompt } from "./provider-session.js";
 import { sniffAudioMime } from "./audio-mime.js";
+import type { TurnBudget } from "../turn-budget.js";
 
 /** Extension for each mime `sniffAudioMime` can return; anything else is mp3. */
 const AUDIO_MIME_EXT: Record<string, string> = {
@@ -1367,6 +1368,7 @@ export class OpenAIProvider extends BaseProvider {
       executeTool?: (toolCall: ToolCall) => Promise<string | MessageContent[]>;
       maxIterations?: number;
       sequentialTools?: boolean;
+      turnBudget?: TurnBudget;
     }
   ): AsyncGenerator<ProviderStreamItem> {
     if (!this.usesResponsesApi(args.model)) {
@@ -1378,6 +1380,7 @@ export class OpenAIProvider extends BaseProvider {
       executeTool,
       maxIterations: _omitMaxIterations,
       sequentialTools,
+      turnBudget,
       ...turnArgs
     } = args;
     const systemHash = hashSystemPrompt(responsesSystemPrompt(args.messages));
@@ -1401,7 +1404,8 @@ export class OpenAIProvider extends BaseProvider {
           firstMessages,
           firstPreviousResponseId: prior.token,
           systemHash,
-          firstTurnState
+          firstTurnState,
+          turnBudget
         });
         return;
       } catch (err) {
@@ -1425,7 +1429,8 @@ export class OpenAIProvider extends BaseProvider {
       firstMessages: freshMessages,
       firstPreviousResponseId: null,
       systemHash,
-      firstTurnState: this.createResponsesTurnState(null)
+      firstTurnState: this.createResponsesTurnState(null),
+      turnBudget
     });
   }
 
@@ -1508,6 +1513,7 @@ export class OpenAIProvider extends BaseProvider {
     firstPreviousResponseId: string | null;
     systemHash: string;
     firstTurnState: StreamTurnState;
+    turnBudget?: TurnBudget;
   }): AsyncGenerator<ProviderStreamItem> {
     const toolMap = new Map<string, ProviderTool>(
       (config.args.tools ?? []).map((tool) => [tool.name, tool])
@@ -1518,8 +1524,21 @@ export class OpenAIProvider extends BaseProvider {
     );
     let state = config.firstTurnState;
 
+    // Responses carries prior turns server-side behind `previousResponseId`,
+    // so `input` holds only the delta. Reserving against the delta would price
+    // a turn as if the conversation restarted; the transcript is tracked here
+    // so the reservation grows with the turn it is admitting.
+    const transcript: Message[] = [...config.firstMessages];
+
     for (let iteration = 0; iteration < config.maxIterations; iteration++) {
       if (config.args.signal?.aborted) return;
+      if (
+        config.turnBudget &&
+        !this._admitTurn(config.turnBudget, config.args.model, transcript)
+      ) {
+        return;
+      }
+      const costBeforeTurn = config.turnBudget ? this.getTotalCost() : 0;
 
       const request = await this.buildResponsesRequest(config.args, {
         input,
@@ -1547,6 +1566,8 @@ export class OpenAIProvider extends BaseProvider {
         toolCalls: state.pending.length > 0 ? state.pending : null
       };
       yield { type: "message", message: assistantMsg };
+      transcript.push(assistantMsg);
+      config.turnBudget?.commit(this.getTotalCost() - costBeforeTurn);
 
       if (state.pending.length === 0) {
         return;
@@ -1587,6 +1608,7 @@ export class OpenAIProvider extends BaseProvider {
           content: toolContent
         };
         toolMessages.push(toolMsg);
+        transcript.push(toolMsg);
         yield { type: "message", message: toolMsg };
         if (imageMessage) {
           toolMessages.push(imageMessage);

--- a/packages/runtime/src/turn-budget.ts
+++ b/packages/runtime/src/turn-budget.ts
@@ -33,8 +33,16 @@ export interface TurnBudget {
    * stops rather than making the call.
    */
   reserve(turn: TurnReservation): boolean;
-  /** Reconcile the reservation against what the turn actually cost, in USD. */
-  commit(actualUsd: number): void;
+  /**
+   * Reconcile the reservation against what the turn actually cost, in USD.
+   *
+   * Pass `null` when turns provably ran but their cost was never reported —
+   * the Claude Agent SDK only reports usage on a terminal `result` message,
+   * which an aborted session never emits. That is not the same as free, and
+   * booking it as zero would hand the reserved headroom back for spend that
+   * really happened. The reserved worst case is charged instead.
+   */
+  commit(actualUsd: number | null): void;
   /** Committed spend so far, in USD. */
   readonly spentUsd: number;
 }
@@ -85,8 +93,13 @@ export class CostCappedTurnBudget implements TurnBudget {
     return true;
   }
 
-  commit(actualUsd: number): void {
-    this._spentUsd += Number.isFinite(actualUsd) ? Math.max(actualUsd, 0) : 0;
+  commit(actualUsd: number | null): void {
+    // Unknown must not read as free — the same rule invocation-cost accounting
+    // follows. With no number to book, the reservation becomes the charge.
+    this._spentUsd +=
+      actualUsd === null || !Number.isFinite(actualUsd)
+        ? this._reservedUsd
+        : Math.max(actualUsd, 0);
     this._reservedUsd = 0;
   }
 }

--- a/packages/runtime/src/turn-budget.ts
+++ b/packages/runtime/src/turn-budget.ts
@@ -1,0 +1,92 @@
+/**
+ * Per-turn spend admission for agent loops.
+ *
+ * A dollar ceiling cannot be enforced by checking spent cost before a call: the
+ * next call's cost is only known afterwards, so $0.49 spent under a $0.50 cap
+ * still admits a $0.30 call and lands at $0.79. The ceiling holds only if the
+ * worst case is *reserved* before the turn and reconciled to actuals after it.
+ *
+ * The interception point has to sit inside the provider layer. A wrapper around
+ * `generateLoop()` sees one call while the base loop makes its turns
+ * internally, and providers that own their loop (the Claude Agent SDK) never
+ * return between turns at all. So the budget is an object threaded through
+ * `generateLoop` options and honored before every model turn — by the base loop
+ * and, as a contract obligation, by any provider overriding it.
+ *
+ * See docs/workflow-supervisor-design.md §6.
+ */
+
+import type { ProviderId } from "@nodetool-ai/protocol";
+import { CostCalculator } from "./providers/cost-calculator.js";
+
+/** What a provider knows about the turn it is about to make. */
+export interface TurnReservation {
+  model: string;
+  provider: ProviderId;
+  /** Prompt tokens the turn will send, as well as the provider can tell. */
+  inputTokens: number;
+}
+
+export interface TurnBudget {
+  /**
+   * Admit or refuse the turn. A refusal is final for this loop: the provider
+   * stops rather than making the call.
+   */
+  reserve(turn: TurnReservation): boolean;
+  /** Reconcile the reservation against what the turn actually cost, in USD. */
+  commit(actualUsd: number): void;
+  /** Committed spend so far, in USD. */
+  readonly spentUsd: number;
+}
+
+export interface CostCappedTurnBudgetOptions {
+  /** Ceiling on total spend, in USD. */
+  capUsd: number;
+  /**
+   * Output-token bound assumed for every turn. Reservation needs a *known*
+   * worst case, so this is required — an optional `maxTokens` that providers
+   * may ignore cannot bound anything.
+   */
+  maxOutputTokens: number;
+}
+
+/**
+ * The reserving budget. Refuses a turn whose worst case would cross the cap,
+ * and refuses any turn on a model with no price in the catalog — an unpriced
+ * model has no worst case, and admitting it would make the cap advisory.
+ */
+export class CostCappedTurnBudget implements TurnBudget {
+  private readonly _capUsd: number;
+  private readonly _maxOutputTokens: number;
+  private _spentUsd = 0;
+  /** Worst case of the turn currently in flight, released by `commit`. */
+  private _reservedUsd = 0;
+
+  constructor(opts: CostCappedTurnBudgetOptions) {
+    this._capUsd = opts.capUsd;
+    this._maxOutputTokens = opts.maxOutputTokens;
+  }
+
+  get spentUsd(): number {
+    return this._spentUsd;
+  }
+
+  reserve(turn: TurnReservation): boolean {
+    const worstCase = CostCalculator.estimateTokenCostUsd(
+      turn.model,
+      { inputTokens: turn.inputTokens, outputTokens: this._maxOutputTokens },
+      turn.provider
+    );
+    if (worstCase === null) return false;
+    if (this._spentUsd + this._reservedUsd + worstCase > this._capUsd) {
+      return false;
+    }
+    this._reservedUsd += worstCase;
+    return true;
+  }
+
+  commit(actualUsd: number): void {
+    this._spentUsd += Number.isFinite(actualUsd) ? Math.max(actualUsd, 0) : 0;
+    this._reservedUsd = 0;
+  }
+}

--- a/packages/runtime/tests/turn-budget.test.ts
+++ b/packages/runtime/tests/turn-budget.test.ts
@@ -87,7 +87,6 @@ class ThrowingProvider extends BaseProvider {
 
   async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
     throw new Error("network exploded");
-    yield undefined as never;
   }
 
   async generateMessage(): Promise<never> {
@@ -228,5 +227,30 @@ describe("reservation release on a failed turn", () => {
     // Headroom is intact: the next turn is admitted, as it would have been
     // had the failed one never happened.
     expect(budget.reserve(turn())).toBe(true);
+  });
+});
+
+describe("unreported spend", () => {
+  it("charges the reservation when the turn's cost was never reported", () => {
+    // The Claude Agent SDK reports usage only on a terminal `result` message,
+    // and an aborted session never emits one — which is how a supervisor
+    // decision normally ends, since `finish_step` aborts the query. Booking
+    // that as free would mean the cap never counted a decision at all.
+    const budget = new CostCappedTurnBudget({
+      capUsd: 1,
+      maxOutputTokens: 2048
+    });
+    expect(budget.reserve(turn())).toBe(true);
+    budget.commit(null);
+    expect(budget.spentUsd).toBeGreaterThan(0);
+  });
+
+  it("charges nothing for an unreported turn that was never admitted", () => {
+    const budget = new CostCappedTurnBudget({
+      capUsd: 1,
+      maxOutputTokens: 2048
+    });
+    budget.commit(null);
+    expect(budget.spentUsd).toBe(0);
   });
 });

--- a/packages/runtime/tests/turn-budget.test.ts
+++ b/packages/runtime/tests/turn-budget.test.ts
@@ -81,6 +81,20 @@ describe("CostCappedTurnBudget", () => {
   });
 });
 
+/** Fails every turn, so the reservation has to be released by the loop. */
+class ThrowingProvider extends BaseProvider {
+  readonly provider = "openai" as const;
+
+  async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+    throw new Error("network exploded");
+    yield undefined as never;
+  }
+
+  async generateMessage(): Promise<never> {
+    throw new Error("not used");
+  }
+}
+
 /** Minimal provider whose only job is to report turns taken. */
 class CountingProvider extends BaseProvider {
   readonly provider = "openai" as const;
@@ -186,5 +200,33 @@ describe("OpenAI Responses loop honors the budget", () => {
       // drain
     }
     expect(turnsCollected()).toBe(0);
+  });
+});
+
+describe("reservation release on a failed turn", () => {
+  it("does not leave a failed turn's reservation outstanding", async () => {
+    // The budget is run-level and outlives the decision that hit the error, so
+    // a stranded reservation would quietly shrink the cap for the rest of the
+    // run — refusing later turns that had the headroom all along.
+    const provider = new ThrowingProvider();
+    const budget = new CostCappedTurnBudget({
+      capUsd: 0.002,
+      maxOutputTokens: 2048
+    });
+
+    await expect(async () => {
+      for await (const _item of provider.generateLoop({
+        messages: [{ role: "user", content: "hi" }],
+        model: PRICED_MODEL,
+        turnBudget: budget
+      } as Parameters<BaseProvider["generateLoop"]>[0])) {
+        // drain
+      }
+    }).rejects.toThrow("network exploded");
+
+    expect(budget.spentUsd).toBe(0);
+    // Headroom is intact: the next turn is admitted, as it would have been
+    // had the failed one never happened.
+    expect(budget.reserve(turn())).toBe(true);
   });
 });

--- a/packages/runtime/tests/turn-budget.test.ts
+++ b/packages/runtime/tests/turn-budget.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { CostCappedTurnBudget } from "../src/turn-budget.js";
 import { BaseProvider } from "../src/providers/base-provider.js";
+import { OpenAIProvider } from "../src/providers/openai-provider.js";
 import type { ProviderStreamItem } from "../src/providers/types.js";
 
 const PRICED_MODEL = "gpt-4o-mini";
@@ -126,5 +127,64 @@ describe("generateLoop turn admission", () => {
       // drain
     }
     expect(provider.turns).toBe(0);
+  });
+});
+
+/**
+ * Every supported OpenAI model (the gpt-5 family) is served by the Responses
+ * loop, which drives its own turns. An override that ignored the budget would
+ * make the cap advisory for the entire catalog, so the admission gate is
+ * checked directly.
+ */
+describe("OpenAI Responses loop honors the budget", () => {
+  const RESPONSES_MODEL = "gpt-5.4-mini";
+
+  function provider(): {
+    instance: OpenAIProvider;
+    turnsCollected: () => number;
+  } {
+    const instance = new OpenAIProvider(
+      { OPENAI_API_KEY: "test-key" },
+      { client: {} as never }
+    );
+    let turns = 0;
+    const patched = instance as unknown as Record<string, unknown>;
+    patched["buildResponsesRequest"] = async () => ({});
+    patched["collectResponsesTurn"] = async function* () {
+      turns++;
+    };
+    return { instance, turnsCollected: () => turns };
+  }
+
+  it("makes the turn when the budget admits it", async () => {
+    const { instance, turnsCollected } = provider();
+    const budget = new CostCappedTurnBudget({
+      capUsd: 1,
+      maxOutputTokens: 2048
+    });
+    for await (const _item of instance.generateLoop({
+      messages: [{ role: "user", content: "hi" }],
+      model: RESPONSES_MODEL,
+      turnBudget: budget
+    } as Parameters<OpenAIProvider["generateLoop"]>[0])) {
+      // drain
+    }
+    expect(turnsCollected()).toBe(1);
+  });
+
+  it("makes no call at all when the budget refuses", async () => {
+    const { instance, turnsCollected } = provider();
+    const budget = new CostCappedTurnBudget({
+      capUsd: 0,
+      maxOutputTokens: 2048
+    });
+    for await (const _item of instance.generateLoop({
+      messages: [{ role: "user", content: "hi" }],
+      model: RESPONSES_MODEL,
+      turnBudget: budget
+    } as Parameters<OpenAIProvider["generateLoop"]>[0])) {
+      // drain
+    }
+    expect(turnsCollected()).toBe(0);
   });
 });

--- a/packages/runtime/tests/turn-budget.test.ts
+++ b/packages/runtime/tests/turn-budget.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { CostCappedTurnBudget } from "../src/turn-budget.js";
+import { BaseProvider } from "../src/providers/base-provider.js";
+import type { ProviderStreamItem } from "../src/providers/types.js";
+
+const PRICED_MODEL = "gpt-4o-mini";
+
+function turn(inputTokens = 1000) {
+  return { model: PRICED_MODEL, provider: "openai" as const, inputTokens };
+}
+
+describe("CostCappedTurnBudget", () => {
+  it("admits a turn whose worst case fits under the cap", () => {
+    const budget = new CostCappedTurnBudget({
+      capUsd: 1,
+      maxOutputTokens: 2048
+    });
+    expect(budget.reserve(turn())).toBe(true);
+  });
+
+  it("refuses a turn whose worst case would cross the cap", () => {
+    // The whole point of reserving: spent-so-far is not the number that
+    // decides. A cap this tight cannot cover even one worst-case turn.
+    const budget = new CostCappedTurnBudget({
+      capUsd: 0.0001,
+      maxOutputTokens: 2048
+    });
+    expect(budget.reserve(turn())).toBe(false);
+  });
+
+  it("holds the ceiling against a turn that costs more than the headroom", () => {
+    const budget = new CostCappedTurnBudget({
+      capUsd: 0.5,
+      maxOutputTokens: 2048
+    });
+    expect(budget.reserve(turn())).toBe(true);
+    budget.commit(0.49);
+    expect(budget.spentUsd).toBeCloseTo(0.49);
+    // $0.49 spent, and the next turn's worst case is ~$0.30. Checking spent
+    // cost alone would admit it and land at $0.79.
+    expect(budget.reserve({ ...turn(), inputTokens: 1_000_000 })).toBe(false);
+  });
+
+  it("refuses every turn on a model with no price", () => {
+    const budget = new CostCappedTurnBudget({
+      capUsd: 100,
+      maxOutputTokens: 2048
+    });
+    expect(
+      budget.reserve({
+        model: "a-model-nobody-prices",
+        provider: "openai",
+        inputTokens: 10
+      })
+    ).toBe(false);
+  });
+
+  it("treats a local provider as free rather than unpriced", () => {
+    const budget = new CostCappedTurnBudget({
+      capUsd: 0.000001,
+      maxOutputTokens: 2048
+    });
+    expect(
+      budget.reserve({
+        model: "qwen-3.5:4b",
+        provider: "ollama",
+        inputTokens: 100000
+      })
+    ).toBe(true);
+  });
+
+  it("accumulates reservations until a turn commits", () => {
+    const budget = new CostCappedTurnBudget({
+      capUsd: 0.002,
+      maxOutputTokens: 2048
+    });
+    expect(budget.reserve(turn())).toBe(true);
+    // Nothing committed yet, so the outstanding worst case still counts.
+    expect(budget.reserve(turn())).toBe(false);
+  });
+});
+
+/** Minimal provider whose only job is to report turns taken. */
+class CountingProvider extends BaseProvider {
+  readonly provider = "openai" as const;
+  turns = 0;
+
+  async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+    this.turns++;
+    yield { type: "chunk", content: "ok", done: true };
+  }
+
+  async generateMessage(): Promise<never> {
+    throw new Error("not used");
+  }
+}
+
+describe("generateLoop turn admission", () => {
+  it("makes the turn when the budget admits it", async () => {
+    const provider = new CountingProvider();
+    const budget = new CostCappedTurnBudget({
+      capUsd: 1,
+      maxOutputTokens: 2048
+    });
+    for await (const _item of provider.generateLoop({
+      messages: [{ role: "user", content: "hi" }],
+      model: PRICED_MODEL,
+      turnBudget: budget
+    } as Parameters<BaseProvider["generateLoop"]>[0])) {
+      // drain
+    }
+    expect(provider.turns).toBe(1);
+  });
+
+  it("makes no call at all when the budget refuses", async () => {
+    const provider = new CountingProvider();
+    const budget = new CostCappedTurnBudget({
+      capUsd: 0,
+      maxOutputTokens: 2048
+    });
+    for await (const _item of provider.generateLoop({
+      messages: [{ role: "user", content: "hi" }],
+      model: PRICED_MODEL,
+      turnBudget: budget
+    } as Parameters<BaseProvider["generateLoop"]>[0])) {
+      // drain
+    }
+    expect(provider.turns).toBe(0);
+  });
+});


### PR DESCRIPTION
PR 3 of the [Workflow Supervisor plan](docs/workflow-supervisor-implementation-plan.md). PR 1/2 shipped the kernel half — escalations, verdicts, allowed sets, bounds, the sticky cache. This is the half that decides.

Still opt-in: nothing constructs a `SupervisorAgent` yet. The CLI and websocket surfaces are PR 4/5.

## The agent

`packages/agents/src/supervisor/` — a `SupervisorHandle` backed by one `StepExecutor` per decision. The verdict schema is built per escalation from the kernel's `allowedActions`, so the model is not offered a verb the kernel would reject. Two read-only tools (`get_run_state`, `read_node_output`), a prompt carrying the verb semantics and skip-distrust, and `supervisor:` memory keys for decisions and rationales.

Every failure mode lands on `fail` with `decidedBy: "bounds"`: a throwing provider, an exhausted iteration budget, an unparseable answer, an abort, a model with no price.

## TurnBudget (runtime)

A dollar cap can't be enforced by checking spent cost before a call — $0.49 spent under a $0.50 cap still admits a $0.30 call and lands at $0.79. The budget reserves the worst case before each turn and reconciles to actuals after.

It sits **inside** the provider layer, not around it: a wrapper around `generateLoop()` sees one call while the base loop makes its turns internally, and the Claude Agent SDK never returns between turns, so its loop override honors the budget itself. Reservation needs a known output bound, hence an explicit `supervisorMaxOutputTokens` (2048) rather than an optional `maxTokens` providers may ignore. A model with no catalog price has no worst case, so the supervisor refuses to run on it — `CostCalculator.estimateTokenCostUsd` answers `null` where `calculate` answers 0.

## StepExecutor extensions

Both general features, neither supervisor-specific.

- **Full host-side schema validation** — enums, nested fields, `additionalProperties`, discriminated unions. Backends vary in how much of a tool-parameter schema they enforce, so a contract holds only where the host checks it. Validation reads the schema **as authored**, not the sanitized copy sent to the provider: the injected `additionalProperties: false` is transport, not contract, and enforcing it would reject results nobody forbade.
- **Injectable async acceptance callback** — a `substitute` is acceptable only once its value would survive contact with the graph, and that check awaits storage resolution, so it can't run after `decide()` returns with the conversation closed. Rejections return as tool errors into the still-open conversation; after `MAX_REPAIR_ROUNDS` (3) the step fails.

## Kernel: RunStateReader

The supervisor's tools pull from state the runner already holds, so a clean run still costs nothing. A handle is configured before the runner exists, so the view arrives via `SupervisorHandle.attach()`. Output recording is bounded per node (64 lineages) and happens only on a supervised run.

`read_node_output` is scoped to the failing invocation's causal lineage. In a fan-out, "the last value this node emitted" usually belongs to another item; handing that over is a poisoned repair and a quiet widening of what the model sees. Reads outside the branch return `not_available`.

## Protocol

`Escalation.declaredOutputs` — a repair cannot be authored, or accepted, without the node's declared output types. Type metadata, so nothing to redact. Design doc §4 updated.

## Tests

- `packages/agents/tests/json-schema-validate.test.ts` — enums, nesting, `additionalProperties`, union branch selection, closest-branch reporting
- `packages/agents/tests/step-executor-acceptance.test.ts` — bounce-and-correct, repair-round exhaustion, and that an undeclared `additionalProperties` is not enforced
- `packages/agents/tests/supervisor-agent.test.ts` — scripted provider: verdict round-trip, memory write, out-of-set bounce, unresolvable substitute bounce, provider throw, abort before and mid-decision, unpriced-model refusal, a planted secret never reaching the prompt, a sibling item's output refused
- `packages/runtime/tests/turn-budget.test.ts` — the $0.49+$0.30 overshoot, unpriced refusal, local-provider free path, generateLoop admission
- `packages/kernel/tests/run-state.test.ts` — the lineage rule and the runner's view

`npm run lint` and `npm run typecheck` pass (web + electron; the mobile leg needs `mobile/node_modules`, absent in this sandbox). Backend suites green: protocol 772, runtime 2654, kernel 1000, agents 1870. Web 12492 and electron 659 pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1DZFY9GgyxyFPn3UhKQ9R)_