### PR TITLE
Workflow Supervisor PRs 4 and 5: the CLI surface and workflows as agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,49 @@ npm run dev:nodetool -- run workflow.ts            # Run a TypeScript DSL file
 npm run dev:nodetool -- run workflow.ts --json     # Output results as JSON
 ```
 
+### Supervised runs (`--supervise`)
+
+`--supervise` puts an agent on the failure path: a node invocation that throws
+after its own error handling raises an escalation, and the agent answers with
+one verdict — retry, repair the output, skip the item, or fail. Without the
+flag no escalation is ever constructed and the run is unchanged.
+
+Available on `nodetool run`, `nodetool workflows run`, and `nodetool debug`
+(server surface). The flags configure `ExecutionSessionOptions.supervisor` —
+the one integration point every surface shares; no CLI code touches
+`WorkflowRunner`.
+
+```bash
+npm run dev:nodetool -- workflows run <id> --supervise
+npm run dev:nodetool -- run workflow.ts --supervise --max-decisions 5
+npm run dev:nodetool -- debug <id> --supervise --supervisor-cost-cap 0.25
+npm run dev:nodetool -- workflows run <id> --supervise \
+  --supervisor-model openrouter/openai/gpt-5.4-mini --max-retries 1
+```
+
+```
+--supervise                       Supervise this run (off unless passed)
+--max-decisions <n>               Decisions allowed in the run (default 10)
+--max-retries <n>                 Retries per node invocation (default 2)
+--supervisor-cost-cap <usd>       Ceiling on supervisor spend (default 0.50)
+--supervisor-model <provider/model>  Default anthropic/claude-sonnet-4-6,
+                                  or NODETOOL_SUPERVISOR_MODEL
+```
+
+Each decision prints a `⛨` line as it happens and the run ends with a
+supervised summary (`⛨ supervised: 2 skipped, 1 retried, 3 decisions,
++$0.0200`). With `--json` the decisions appear as `interventions` (run
+commands; `nodetool run` wraps them as `{results, interventions}`) or
+`server.summary.interventions` plus a `server.supervised` rollup (`debug`).
+It is the `Intervention` record from `@nodetool-ai/protocol`, which the editor
+surface consumes unchanged. Supervisor spend goes into the prediction
+ledger `nodetool costs` reads, one row per billable decision, attributed to the
+run and tagged `supervisor` in `node_type`.
+
+Every supervisor failure (timeout, unparseable verdict, exhausted budget,
+cancelled run) resolves as `fail`. Details:
+[docs/workflow-supervisor-design.md](docs/workflow-supervisor-design.md).
+
 ### nodetool debug (Workflow Debug Harness)
 
 Runs a workflow end-to-end on the **server** (headless kernel `WorkflowRunner`)
@@ -282,6 +325,7 @@ npm run dev:nodetool -- debug <id> --no-server --browser   # browser only
 npm run dev:nodetool -- debug <id> --out ./mydebug         # custom bundle dir
 npm run dev:nodetool -- debug <id> --timeout 60000         # per-surface timeout (ms)
 npm run dev:nodetool -- debug workflow.json --watch        # re-run on file change, print a verdict diff
+npm run dev:nodetool -- debug <id> --supervise             # supervise the server surface (see above)
 ```
 
 The `--watch` flag (file targets only) re-runs after every save and prints just

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -98,6 +98,7 @@ Executes a workflow by ID (from the local database), JSON file, or TypeScript DS
 
 - `--params <json>` — JSON string of workflow parameters.
 - `--json` — output result as JSON.
+- `--supervise` and its bounds — see [Supervised runs](#supervised-runs).
 
 **Examples:**
 
@@ -150,6 +151,7 @@ Shorthand for running a TypeScript DSL workflow file directly.
 **Options:**
 
 - `--json` — output results as JSON.
+- `--supervise` and its bounds — see [Supervised runs](#supervised-runs).
 
 **Examples:**
 
@@ -157,6 +159,62 @@ Shorthand for running a TypeScript DSL workflow file directly.
 nodetool run workflow.ts
 nodetool run workflow.ts --json
 ```
+
+## Supervised runs
+
+`--supervise` puts an agent on the failure path: when a node invocation throws
+after its own error handling is exhausted, the agent sees the failure and
+answers with one verdict — retry, repair the output, skip the item, or fail.
+Without the flag nothing changes: no escalation is constructed and the run is
+the run it was before.
+
+Available on `nodetool run`, `nodetool workflows run`, and `nodetool debug`
+(server surface).
+
+**Options:**
+
+- `--supervise` — supervise this run. Off unless passed.
+- `--max-decisions <n>` — decisions allowed in the run (default 10).
+- `--max-retries <n>` — retries per node invocation (default 2).
+- `--supervisor-cost-cap <usd>` — ceiling on supervisor spend (default 0.50),
+  enforced by reservation before each model turn, not after.
+- `--supervisor-model <provider/model>` — who supervises (default
+  `anthropic/claude-sonnet-4-6`, or `NODETOOL_SUPERVISOR_MODEL`). The leading
+  segment must be a registered provider; the rest is the model id, slashes and
+  all (`openrouter/openai/gpt-5.4-mini`).
+
+Passing a bound without `--supervise` is an error rather than a silent
+unsupervised run.
+
+**Output.** Each decision prints a `⛨` line as it happens, and the run ends
+with a supervised summary:
+
+```
+⛨ fetch-item [3] skipped — HTTP 404 (agent, $0.0041)
+⛨ supervised: 2 skipped, 1 retried, 3 decisions, +$0.0200
+```
+
+With `--json`, the decisions are in `interventions` — alongside the outputs in
+`workflows run`, and under `{results, interventions}` in `nodetool run`, whose
+bare results shape is left alone for unsupervised runs. `nodetool debug` puts
+them in `server.summary.interventions` with a `server.supervised` rollup. Each
+record carries the
+escalation the agent saw (node, item lineage, redacted inputs, allowed
+actions), the verdict, who decided it (`agent`, `sticky`, `bounds`, `default`,
+`kernel`), and its cost.
+
+**Cost.** Supervisor spend lands in the same ledger `nodetool costs` reads, one
+row per billable decision, attributed to the run and tagged `supervisor` in
+`node_type` — so supervision is separable from the workflow's own spend:
+
+```bash
+nodetool costs list --limit 20        # supervisor rows show node_type=supervisor
+```
+
+**Bounds are the guarantee.** Every supervisor failure (timeout, an unparseable
+verdict, an exhausted budget, a cancelled run) resolves as `fail`, which is
+what would have happened without it. What each verdict means and why
+retry is opt-in per node: [workflow-supervisor-design.md](workflow-supervisor-design.md).
 
 ## Database Migrations
 

--- a/docs/workflow-supervisor-implementation-plan.md
+++ b/docs/workflow-supervisor-implementation-plan.md
@@ -91,13 +91,40 @@ Depends on PR 3.
 - Supervisor cost attributed through the existing cost tracking so `nodetool costs` sees it (PRD open question 3 resolved: attributed to the run, tagged `supervisor`).
 - Docs: CLI section in root `CLAUDE.md` + `docs/cli.md`.
 
-### PR 5 — Workflows as agents ∥ (with PR 4)
+### PR 5 — Workflows as agents ∥ (with PR 4) — **shipped**
 
 Depends on PR 3.
 
+Three things the plan did not anticipate, all forced by the websocket half.
+
+A `supervise` flag alone cannot start a supervisor: something has to name the
+model. The run request therefore carries an optional `supervisor`
+(`SupervisorRunOptions`: provider, model, the three bounds, cost cap) next to
+the flag, falling back to the connection's configured default model and then to
+`NODETOOL_SUPERVISOR_PROVIDER` / `NODETOOL_SUPERVISOR_MODEL` — the last exists
+because trigger-driven headless runs have no connection defaults at all. A
+request that asks for supervision it cannot get runs **unsupervised** rather
+than failing, which is the same fail-closed rule every other supervisor failure
+follows.
+
+The trigger flag is a real column (`trigger_registrations.supervise`, default
+`0`, migration `20260801_000001`), read by the dispatcher into the headless run.
+Registration sync mutates existing rows in place, so re-syncing a workflow never
+resets it.
+
+The supervisor gets a **dedicated provider instance** (`getProvider`, not the
+context's cached one) and a listener-free context copy: per-turn spend is
+reconciled from the provider's own running cost, so a second caller on the same
+instance would corrupt the dollar cap, and the decision's own provider traffic
+is not the run's message stream. The escalation and the verdict still cross the
+websocket — they are emitted by the kernel on the run's context.
+
+`ExecutionSessionOptions.supervisor` is PR 4's deliverable and landed here
+because PR 5 needs it; the two branches carry the same three-line change.
+
 - `AgentOptions.graph?: GraphData | { workflowId: string }`; fourth branch in `Agent._executeImpl`: hydrate, run through `ExecutionSession` with self as supervisor, forward messages, `getResults()` returns run outputs. The branch adopts the common `AgentPolicy` object (`packages/agents/src/agent-policy.ts`); it does not add a fifth ad-hoc policy.
 - Websocket: `supervise` flag on run requests; forward `supervisor_*` messages to clients. Trigger rows carry the flag but it **defaults to off** — the flip to default-on belongs to PR 8's gate, nowhere earlier.
-- Tests: `Agent({graph})` returns identical outputs to a bare runner on a clean graph; interventions surface in the message stream.
+- Tests: `Agent({graph})` returns identical outputs to a bare runner on a clean graph; interventions surface in the message stream. Plus what makes the branch trustworthy: a scripted `skip` completes a run that otherwise fails and a scripted `fail` does not, a clean supervised run emits no `supervisor_*` message at all, an aborted signal cancels the run, and `createRunSupervisor` returns no handle without an explicit flag and a resolvable model.
 
 ## Phase C — the product surface
 

--- a/docs/workflow-supervisor-implementation-plan.md
+++ b/docs/workflow-supervisor-implementation-plan.md
@@ -81,9 +81,34 @@ that would reject results no author ever forbade.
 - `supervisor:` memory keys for decisions + rationales.
 - Tests: mock provider returning scripted tool-calls/verdicts; malformed verdict exercises the `finish_step` bounce loop; an unresolvable substitute ref bounces back into the open conversation; supervisor exceptions and timeouts resolve as `fail`; abort mid-decision cancels the provider call; a secret value planted in a `read_node_output` result never appears in the outbound prompt; in a fan-out, `read_node_output` refuses a sibling item's output; reservation blocks the $0.49+$0.30 overshoot mid-decision.
 
-### PR 4 — CLI surface ∥ (with PR 5)
+### PR 4 — CLI surface ∥ (with PR 5) — **shipped**
 
 Depends on PR 3.
+
+Two deviations the plan did not anticipate.
+
+**`nodetool run` is a DSL command, not a session command.** `nodetool run
+<dsl-file>` executes through `@nodetool-ai/dsl`'s own `run()`, which constructs
+a `WorkflowRunner` directly — one of the grandfathered sites this PR is
+forbidden to grow supervision on. So `--supervise` switches that command onto
+`ExecutionSession` (`packages/cli/src/run-dsl-supervised.ts`) and the
+unsupervised path stays byte-identical on the old one. One user-visible
+consequence: the supervised path does not rethrow the first node error the way
+the DSL path does. A node error the supervisor resolved is not a run failure;
+only the run's terminal status decides.
+
+**The summary line's item counts do not exist at run level.** "198/200 items"
+presumes a batch the kernel never names: it counts invocations, not the items a
+user thinks in. `formatSupervisedSummary` takes an optional item total for a
+caller that knows one and otherwise reports decisions — `⛨ supervised: 2
+skipped, 1 retried, 3 decisions, +$0.0200`.
+
+The intervention record shipped as `Intervention` from `@nodetool-ai/protocol`
+(minted in PR 1), unchanged — `RunResult.interventions`, the
+`supervisor_decision` message, and the `--json` block are the same record, so
+PR 6 has one shape to consume. The rollup and the two printed lines live in
+`@nodetool-ai/execution` beside the debug reducer, so the CLI, the debug
+bundle, and the HTTP debug endpoint cannot drift.
 
 - **`ExecutionSessionOptions.supervisor`** in `packages/execution` — the single integration point; CLI and websocket surfaces configure the facade, never `WorkflowRunner` directly (design §7). Grandfathered direct-construction sites are out of scope but must not gain supervision ad hoc.
 - `--supervise`, `--max-decisions`, `--max-retries`, `--supervisor-cost-cap`, `--supervisor-model` on `nodetool run` and `nodetool debug` (the latter through the shared debug service in `@nodetool-ai/execution`, not around it).

--- a/package-lock.json
+++ b/package-lock.json
@@ -54676,6 +54676,7 @@
         "@llamaindex/liteparse": "^1.5.2",
         "@nodetool-ai/app-runtime": "*",
         "@nodetool-ai/config": "*",
+        "@nodetool-ai/execution": "*",
         "@nodetool-ai/kernel": "*",
         "@nodetool-ai/models": "*",
         "@nodetool-ai/node-sdk": "*",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -20,6 +20,7 @@
     "@llamaindex/liteparse": "^1.5.2",
     "@nodetool-ai/app-runtime": "*",
     "@nodetool-ai/config": "*",
+    "@nodetool-ai/execution": "*",
     "@nodetool-ai/kernel": "*",
     "@nodetool-ai/models": "*",
     "@nodetool-ai/node-sdk": "*",

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -26,12 +26,19 @@ import type {
   Chunk
 } from "@nodetool-ai/protocol";
 import { TaskUpdateEvent } from "@nodetool-ai/protocol";
+import { BoundedHandle, type SupervisorBounds } from "@nodetool-ai/kernel";
 import { TaskPlanner } from "./task-planner.js";
+import {
+  resolveAgentGraph,
+  runWorkflowAsAgent,
+  type AgentGraphSource
+} from "./workflow-agent.js";
+import { SupervisorAgent } from "./supervisor/supervisor-agent.js";
 import { TaskExecutor } from "./task-executor.js";
 import { ParallelTaskExecutor } from "./parallel-task-executor.js";
 import { CompilerAgent } from "./compiler-agent.js";
 import { GraphPlanner } from "./graph-planner.js";
-import { AgentWorkflowRunner } from "./agent-workflow-runner.js";
+import { AgentWorkflowRunner, applyRunPolicy } from "./agent-workflow-runner.js";
 import { ScriptPlanner } from "./script-planner.js";
 import { ScriptRunner } from "./script-runner.js";
 import type { Tool } from "./tools/base-tool.js";
@@ -285,6 +292,28 @@ export interface AgentOptions {
    * script API.
    */
   script?: string;
+  /**
+   * Run an existing workflow as this agent: an inline graph, or
+   * `{ workflowId }` to hydrate one from the workflow table. There is no
+   * planning phase — the graph is the plan — and the agent supervises the run
+   * instead of authoring it, so `getResults()` returns the run's outputs.
+   * Requires {@link registry}. Takes precedence over every planning mode.
+   *
+   * Supervision is opt-in: without {@link supervise} the run is an ordinary
+   * kernel run that never constructs an escalation.
+   */
+  graph?: AgentGraphSource;
+  /**
+   * Supervise the {@link graph} run: a failing node invocation escalates to
+   * this agent, which answers with a verdict (retry / substitute / skip /
+   * end_stream / fail). Default `false` — the flip to default-on is gated on
+   * the eval suite, not on this option.
+   */
+  supervise?: boolean;
+  /** Decision, retry, and timeout ceilings for {@link supervise}. */
+  supervisorBounds?: SupervisorBounds;
+  /** Dollar ceiling on supervision for the whole run. */
+  maxSupervisorCostUsd?: number;
   /** Script mode: concurrent `agent()` calls beyond this queue. Default 8. */
   maxConcurrentAgents?: number;
   /** Script mode: lifetime `agent()` call cap per run. Default 100. */
@@ -374,6 +403,10 @@ export class Agent {
   private readonly useGraphPlanner: boolean;
   private readonly useScriptPlanner: boolean;
   private readonly script?: string;
+  private readonly graphSource?: AgentGraphSource;
+  private readonly supervise: boolean;
+  private readonly supervisorBounds?: SupervisorBounds;
+  private readonly maxSupervisorCostUsd?: number;
   private readonly registry?: NodeRegistry;
   private readonly providers?: Record<string, BaseProvider>;
   private readonly securityMonitorEnabled: boolean;
@@ -416,6 +449,10 @@ export class Agent {
     this.useGraphPlanner = opts.useGraphPlanner === true;
     this.useScriptPlanner = opts.useScriptPlanner === true;
     this.script = opts.script;
+    this.graphSource = opts.graph;
+    this.supervise = opts.supervise === true;
+    this.supervisorBounds = opts.supervisorBounds;
+    this.maxSupervisorCostUsd = opts.maxSupervisorCostUsd;
     this.registry = opts.registry;
     this.providers = opts.providers;
     this.securityMonitorEnabled = opts.securityMonitor?.enabled === true;
@@ -686,6 +723,13 @@ export class Agent {
       this.workspace ??
       path.join(os.homedir(), "nodetool_workspace", Date.now().toString());
     await fs.mkdir(workspacePath, { recursive: true });
+
+    // A supplied graph is already the plan: no planner runs, and the agent's
+    // job is to supervise the run rather than author it.
+    if (this.graphSource) {
+      yield* this.executeSuppliedGraph(context, mergedSystemPrompt);
+      return;
+    }
 
     if (this.initialTask) {
       yield* this.executeSingleTask(
@@ -1261,6 +1305,100 @@ export class Agent {
       }
       yield item;
     }
+  }
+
+  /**
+   * Workflows as agents: run a supplied graph on the kernel with this agent as
+   * the run's supervisor. No planning phase — the graph is the plan — so the
+   * only judgment the model supplies is a verdict on a broken invocation.
+   *
+   * The run obeys the same {@link AgentPolicy} as every other mode: the policy's
+   * turn and token bounds are stamped onto model-less Agent nodes exactly as
+   * the graph-planner branch stamps them, and nothing here invents a second set
+   * of numbers. Supervision's own ceilings (decisions, retries, dollars) are the
+   * supervisor's, shared with every other surface that configures one.
+   */
+  private async *executeSuppliedGraph(
+    context: ProcessingContext,
+    systemPrompt: string | undefined
+  ): AsyncGenerator<ProcessingMessage> {
+    if (!this.registry) {
+      throw new Error(
+        "Agent({ graph }) requires a NodeRegistry to resolve node executors."
+      );
+    }
+
+    const graph = applyRunPolicy(
+      await resolveAgentGraph(this.graphSource!, context),
+      {
+        providerId: this.provider.provider,
+        modelId: this.model,
+        ...(systemPrompt ? { systemPrompt } : {}),
+        maxStepIterations: this.policy.maxStepIterations,
+        ...(this.policy.maxTokens !== undefined
+          ? { maxTokens: this.policy.maxTokens }
+          : {})
+      }
+    );
+
+    yield {
+      type: "log_update",
+      node_id: "workflow_executor",
+      node_name: this.name,
+      content: `Running workflow: ${graph.nodes.length} nodes, ${graph.edges.length} edges${
+        this.supervise ? " (supervised)" : ""
+      }...`,
+      severity: "info"
+    } satisfies LogUpdate;
+
+    const supervisor = this.supervise
+      ? new BoundedHandle(
+          new SupervisorAgent({
+            provider: this.provider,
+            model: this.reasoningModel,
+            // The supervisor reads and writes the run's memory (`supervisor:`
+            // keys) but must not push its own provider chatter into the run's
+            // message stream, so it gets a listener-free copy.
+            context: context.copy({
+              shareMemory: true,
+              inheritMessageListeners: false
+            }),
+            ...(this.maxSupervisorCostUsd !== undefined
+              ? { maxCostUsd: this.maxSupervisorCostUsd }
+              : {})
+          }),
+          this.supervisorBounds ?? {}
+        )
+      : undefined;
+
+    const run = runWorkflowAsAgent({
+      graph,
+      registry: this.registry,
+      context,
+      params: this.inputs,
+      ...(supervisor ? { supervisor } : {}),
+      ...(this.signal ? { signal: this.signal } : {})
+    });
+
+    let next = await run.next();
+    while (!next.done) {
+      yield next.value;
+      next = await run.next();
+    }
+    const result = next.value;
+
+    if (result.status === "failed") {
+      throw new Error(result.error ?? "Workflow run failed");
+    }
+
+    this.results = result.outputs ?? {};
+
+    log.info("Agent completed", {
+      name: this.name,
+      status: result.status,
+      interventions: result.interventions?.length ?? 0
+    });
+    this.persistAgentRunMemory();
   }
 
   /**

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -684,6 +684,11 @@ export type {
   AgentWorkflowRunnerOptions,
   RunPolicy
 } from "./agent-workflow-runner.js";
+export { resolveAgentGraph, runWorkflowAsAgent } from "./workflow-agent.js";
+export type {
+  AgentGraphSource,
+  WorkflowAgentRunOptions
+} from "./workflow-agent.js";
 export {
   SupervisorAgent,
   DEFAULT_MAX_SUPERVISOR_COST_USD,

--- a/packages/agents/src/workflow-agent.ts
+++ b/packages/agents/src/workflow-agent.ts
@@ -1,0 +1,131 @@
+/**
+ * Workflows as agents — the run half of `Agent`'s graph branch.
+ *
+ * A saved workflow is already a plan, so this path has no planning phase: the
+ * graph runs on the kernel through `ExecutionSession`, and the agent supplies
+ * judgment only where a node breaks, as the run's `SupervisorHandle`. That is
+ * the whole difference from `AgentWorkflowRunner`, which executes a graph the
+ * planner just wrote and cannot supervise it.
+ *
+ * See docs/workflow-supervisor-design.md §7 entry point 3.
+ */
+
+import { randomUUID } from "node:crypto";
+import { createLogger } from "@nodetool-ai/config";
+import { ExecutionSession, type RawGraphInput } from "@nodetool-ai/execution";
+import type { RunResult, SupervisorHandle } from "@nodetool-ai/kernel";
+import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type { GraphData, ProcessingMessage } from "@nodetool-ai/protocol";
+
+const log = createLogger("nodetool.agents.workflow-agent");
+
+/** Either an inline graph or a saved workflow to hydrate one from. */
+export type AgentGraphSource = GraphData | { workflowId: string };
+
+export interface WorkflowAgentRunOptions {
+  graph: GraphData;
+  /** Resolves every node's executor. Hydration reads flags off it too. */
+  registry: NodeRegistry;
+  /** The run's context. A child copy is made so listeners stay separated. */
+  context: ProcessingContext;
+  /** Start params, keyed by input-node name. */
+  params?: Record<string, unknown>;
+  /**
+   * The run's supervisor, already wrapped in the kernel's `BoundedHandle`.
+   * Omitted, the run behaves exactly as an unsupervised one.
+   */
+  supervisor?: SupervisorHandle;
+  /** External cancellation; aborting it cancels the run. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Hydrate a graph source into a graph. A `{ workflowId }` source is read from
+ * the workflow table under the context's user, so a workflow the caller may
+ * not read stays unreadable here too.
+ */
+export async function resolveAgentGraph(
+  source: AgentGraphSource,
+  context: ProcessingContext
+): Promise<GraphData> {
+  if (!("workflowId" in source)) return source;
+  const { Workflow } = await import("@nodetool-ai/models");
+  const workflow = await Workflow.find(context.userId, source.workflowId);
+  if (!workflow) {
+    throw new Error(`Workflow not found: ${source.workflowId}`);
+  }
+  return workflow.getGraph() as unknown as GraphData;
+}
+
+/**
+ * Run a graph and yield the kernel's messages live; the terminal `RunResult`
+ * is the generator's return value.
+ *
+ * Messages are forwarded to the caller's context as well as yielded, matching
+ * `AgentWorkflowRunner`: a host that only reads the shared context's queue (the
+ * websocket runner, when an Agent node runs inside a workflow) must still see
+ * the inner run.
+ */
+export async function* runWorkflowAsAgent(
+  options: WorkflowAgentRunOptions
+): AsyncGenerator<ProcessingMessage, RunResult> {
+  const { graph, registry, context, supervisor, signal } = options;
+  const jobId = randomUUID();
+
+  // A child context keeps the inner run's listeners off the caller's, the same
+  // separation `AgentWorkflowRunner` makes; memory is shared so sub-agents
+  // inside the graph — and the supervisor's `supervisor:` keys — land in the
+  // run's one memory.
+  const runContext = context.copy({
+    shareMemory: true,
+    inheritMessageListeners: false
+  });
+  const removeListener = runContext.addMessageListener((message) => {
+    context.emit(message);
+  });
+
+  const session = await ExecutionSession.create({
+    graph: graph as unknown as RawGraphInput,
+    registry,
+    jobId,
+    context: runContext,
+    params: options.params ?? {},
+    captureMessages: true,
+    ...(supervisor ? { supervisor } : {})
+  });
+
+  const onAbort = (): void => session.cancel("cancelled");
+  if (signal?.aborted) session.cancel("cancelled");
+  else signal?.addEventListener("abort", onAbort, { once: true });
+
+  log.info("Running workflow as agent", {
+    jobId,
+    nodes: graph.nodes.length,
+    edges: graph.edges.length,
+    supervised: Boolean(supervisor)
+  });
+
+  let drained = false;
+  try {
+    for await (const message of session.messages) {
+      yield message;
+    }
+    drained = true;
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+    removeListener();
+    // A consumer that stops early (a `break`, or a throw upstream) leaves the
+    // run executing and billing. The stream only closes when the run settles,
+    // so anything short of a full drain means the caller walked away.
+    if (!drained) session.cancel("cancelled");
+  }
+
+  const result = await session.result;
+  log.info("Workflow-as-agent run finished", {
+    jobId,
+    status: result.status,
+    interventions: result.interventions?.length ?? 0
+  });
+  return result;
+}

--- a/packages/agents/tests/agent-graph-mode.test.ts
+++ b/packages/agents/tests/agent-graph-mode.test.ts
@@ -1,0 +1,353 @@
+/**
+ * `Agent({ graph })` — workflows as agents.
+ *
+ * The branch has two jobs and both are tested against real execution: on a
+ * clean graph it must be indistinguishable from a bare `WorkflowRunner`, and
+ * on a broken one the supervisor's verdict must actually reach the run and
+ * show up in the message stream. The supervising model is a scripted
+ * provider — no network.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  BaseNode,
+  NodeRegistry,
+  hydrateGraphNodeFlags,
+  prop
+} from "@nodetool-ai/node-sdk";
+import { WorkflowRunner } from "@nodetool-ai/kernel";
+import { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
+import type { GraphData, ProcessingMessage } from "@nodetool-ai/protocol";
+import { Agent } from "../src/agent.js";
+
+/** Any model the pricing catalog knows — reservation fails closed otherwise. */
+const PRICED_MODEL = "gpt-4o-mini";
+
+class Value extends BaseNode {
+  static readonly nodeType = "test.graph.Value";
+  static readonly title = "Value";
+  static readonly description = "Constant value";
+
+  @prop({ type: "int", default: 0 })
+  declare value: unknown;
+
+  async process(): Promise<Record<string, unknown>> {
+    return { output: this.value };
+  }
+}
+
+class Double extends BaseNode {
+  static readonly nodeType = "test.graph.Double";
+  static readonly title = "Double";
+  static readonly description = "Doubles a number";
+
+  @prop({ type: "int", default: 0 })
+  declare value: unknown;
+
+  async process(): Promise<Record<string, unknown>> {
+    return { output: Number(this.value ?? 0) * 2 };
+  }
+}
+
+class Boom extends BaseNode {
+  static readonly nodeType = "test.graph.Boom";
+  static readonly title = "Boom";
+  static readonly description = "Always throws";
+
+  @prop({ type: "int", default: 0 })
+  declare value: unknown;
+
+  async process(): Promise<Record<string, unknown>> {
+    throw new Error("node exploded");
+  }
+}
+
+function buildRegistry(): NodeRegistry {
+  const registry = new NodeRegistry();
+  registry.register(Value);
+  registry.register(Double);
+  registry.register(Boom);
+  return registry;
+}
+
+function cleanGraph(): GraphData {
+  return {
+    nodes: [
+      { id: "v", type: "test.graph.Value", properties: { value: 21 } },
+      { id: "d", type: "test.graph.Double", properties: {} }
+    ],
+    edges: [
+      {
+        id: "e1",
+        source: "v",
+        sourceHandle: "output",
+        target: "d",
+        targetHandle: "value"
+      }
+    ]
+  } as unknown as GraphData;
+}
+
+function brokenGraph(): GraphData {
+  return {
+    nodes: [
+      { id: "v", type: "test.graph.Value", properties: { value: 1 } },
+      { id: "b", type: "test.graph.Boom", properties: {} }
+    ],
+    edges: [
+      {
+        id: "e1",
+        source: "v",
+        sourceHandle: "output",
+        target: "b",
+        targetHandle: "value"
+      }
+    ]
+  } as unknown as GraphData;
+}
+
+function makeContext(): ProcessingContext {
+  return new ProcessingContext({
+    jobId: `job_${Math.random().toString(36).slice(2)}`,
+    workflowId: null,
+    userId: "1"
+  });
+}
+
+type ScriptedCall = { name: string; args: Record<string, unknown> };
+
+/**
+ * Replays scripted tool calls through the real `BaseProvider.generateLoop`,
+ * the same double `supervisor-agent.test.ts` uses.
+ */
+function scriptedProvider(turns: ScriptedCall[][]): BaseProvider {
+  let turn = 0;
+  return {
+    provider: "mock",
+    hasToolSupport: async () => true,
+    getTotalCost: () => 0,
+    generateMessages: async function* () {
+      const calls = turns[turn] ?? [];
+      turn++;
+      for (const call of calls) {
+        yield { id: `tc_${turn}_${call.name}`, name: call.name, args: call.args };
+      }
+      if (calls.length === 0) {
+        yield { type: "chunk" as const, content: "", done: true };
+      }
+    },
+    async *generateMessagesTraced(args: unknown) {
+      yield* (
+        this as unknown as {
+          generateMessages: (a: unknown) => AsyncGenerator<unknown>;
+        }
+      ).generateMessages(args);
+    },
+    generateLoop(args: unknown) {
+      return (
+        BaseProvider.prototype as unknown as {
+          generateLoop: (a: unknown) => AsyncGenerator<unknown>;
+        }
+      ).generateLoop.call(this, args);
+    },
+    _admitTurn: (BaseProvider.prototype as unknown as Record<string, unknown>)[
+      "_admitTurn"
+    ],
+    generateMessage: vi.fn(),
+    getContainerEnv: () => ({}),
+    isContextLengthError: () => false,
+    setMessageEmitter: () => {}
+  } as unknown as BaseProvider;
+}
+
+/** A provider that must never be called. */
+function unusedProvider(): BaseProvider {
+  return scriptedProvider([]);
+}
+
+async function collect(
+  agent: Agent,
+  context: ProcessingContext,
+  signal?: AbortSignal
+): Promise<ProcessingMessage[]> {
+  const messages: ProcessingMessage[] = [];
+  for await (const message of agent.execute(
+    context,
+    signal ? { signal } : undefined
+  )) {
+    messages.push(message);
+  }
+  return messages;
+}
+
+describe("Agent({ graph }) — clean run", () => {
+  it("returns the outputs a bare WorkflowRunner produces", async () => {
+    const registry = buildRegistry();
+
+    const baselineContext = makeContext();
+    const runner = new WorkflowRunner("baseline", {
+      resolveExecutor: (node) => registry.resolve(node),
+      executionContext: baselineContext
+    });
+    const baseline = await runner.run(
+      { job_id: "baseline" },
+      hydrateGraphNodeFlags(cleanGraph(), registry)
+    );
+
+    const agent = new Agent({
+      name: "graph-agent",
+      objective: "run the workflow",
+      provider: unusedProvider(),
+      model: PRICED_MODEL,
+      registry,
+      graph: cleanGraph()
+    });
+    await collect(agent, makeContext());
+
+    expect(baseline.status).toBe("completed");
+    expect(agent.getResults()).toEqual(baseline.outputs);
+    expect(agent.getResults()).toEqual({ d: [42] });
+  });
+
+  it("forwards the run's messages to the caller's context", async () => {
+    const registry = buildRegistry();
+    const context = makeContext();
+    const seen: ProcessingMessage[] = [];
+    context.addMessageListener((message) => seen.push(message));
+
+    const agent = new Agent({
+      name: "graph-agent",
+      objective: "run the workflow",
+      provider: unusedProvider(),
+      model: PRICED_MODEL,
+      registry,
+      graph: cleanGraph()
+    });
+    const yielded = await collect(agent, context);
+
+    expect(yielded.some((m) => m.type === "node_update")).toBe(true);
+    expect(seen.some((m) => m.type === "node_update")).toBe(true);
+  });
+
+  it("throws when the run fails and no supervisor can recover it", async () => {
+    const registry = buildRegistry();
+    const agent = new Agent({
+      name: "graph-agent",
+      objective: "run the workflow",
+      provider: unusedProvider(),
+      model: PRICED_MODEL,
+      registry,
+      graph: brokenGraph()
+    });
+
+    await expect(collect(agent, makeContext())).rejects.toThrow(
+      /node exploded/
+    );
+  });
+});
+
+describe("Agent({ graph, supervise: true })", () => {
+  it("applies the supervisor's verdict and surfaces the intervention", async () => {
+    const registry = buildRegistry();
+    const provider = scriptedProvider([
+      [
+        {
+          name: "finish_step",
+          args: {
+            result: { action: "skip", rationale: "one item, not the run" }
+          }
+        }
+      ]
+    ]);
+
+    const agent = new Agent({
+      name: "graph-agent",
+      objective: "run the workflow",
+      provider,
+      model: PRICED_MODEL,
+      registry,
+      graph: brokenGraph(),
+      supervise: true
+    });
+
+    const messages = await collect(agent, makeContext());
+
+    const escalation = messages.find(
+      (m) => m.type === "supervisor_escalation"
+    ) as { escalation: { nodeId: string } } | undefined;
+    expect(escalation?.escalation.nodeId).toBe("b");
+
+    const decision = messages.find((m) => m.type === "supervisor_decision") as
+      | { verdict: { action: string }; decided_by: string }
+      | undefined;
+    expect(decision?.verdict.action).toBe("skip");
+    expect(decision?.decided_by).toBe("agent");
+
+    // The verdict reached the run: the invocation was retired without emitting
+    // (an empty output list for the node), and the run completed instead of
+    // failing on "node exploded".
+    expect(agent.getResults()).toEqual({ b: [] });
+  });
+
+  it("fails the run when the supervisor answers with fail", async () => {
+    const registry = buildRegistry();
+    const provider = scriptedProvider([
+      [
+        {
+          name: "finish_step",
+          args: { result: { action: "fail", rationale: "unrecoverable" } }
+        }
+      ]
+    ]);
+
+    const agent = new Agent({
+      name: "graph-agent",
+      objective: "run the workflow",
+      provider,
+      model: PRICED_MODEL,
+      registry,
+      graph: brokenGraph(),
+      supervise: true
+    });
+
+    await expect(collect(agent, makeContext())).rejects.toThrow();
+  });
+
+  it("never escalates on a clean run", async () => {
+    const registry = buildRegistry();
+    const provider = scriptedProvider([]);
+    const agent = new Agent({
+      name: "graph-agent",
+      objective: "run the workflow",
+      provider,
+      model: PRICED_MODEL,
+      registry,
+      graph: cleanGraph(),
+      supervise: true
+    });
+
+    const messages = await collect(agent, makeContext());
+    expect(messages.some((m) => m.type.startsWith("supervisor_"))).toBe(false);
+    expect(agent.getResults()).toEqual({ d: [42] });
+  });
+});
+
+describe("Agent({ graph }) — cancellation", () => {
+  it("cancels the run when the caller's signal is already aborted", async () => {
+    const registry = buildRegistry();
+    const controller = new AbortController();
+    controller.abort();
+
+    const agent = new Agent({
+      name: "graph-agent",
+      objective: "run the workflow",
+      provider: unusedProvider(),
+      model: PRICED_MODEL,
+      registry,
+      graph: cleanGraph()
+    });
+
+    await collect(agent, makeContext(), controller.signal);
+    expect(agent.getResults()).not.toEqual({ d: [42] });
+  });
+});

--- a/packages/cli/src/commands/debug.ts
+++ b/packages/cli/src/commands/debug.ts
@@ -9,8 +9,19 @@
  * unit-testable.
  */
 import type { Command } from "commander";
+import {
+  formatInterventionLine,
+  formatSupervisedSummary,
+  summarizeInterventions
+} from "@nodetool-ai/execution/debug";
+import type { Intervention } from "@nodetool-ai/protocol";
+import {
+  addSupervisorOptions,
+  parseSupervisorFlags,
+  type SupervisorCliOptions
+} from "../supervisor.js";
 
-interface DebugCliOptions {
+interface DebugCliOptions extends SupervisorCliOptions {
   server?: boolean;
   browser?: boolean;
   trace?: boolean;
@@ -23,8 +34,9 @@ interface DebugCliOptions {
 }
 
 export function registerDebugCommands(program: Command): void {
-  program
-    .command("debug <workflow_id_or_file>")
+  addSupervisorOptions(
+    program
+      .command("debug <workflow_id_or_file>")
     .description(
       "Run a workflow end-to-end (server and/or browser) and collect a full debug bundle"
     )
@@ -51,12 +63,12 @@ export function registerDebugCommands(program: Command): void {
       "Per-surface run timeout in milliseconds",
       (v: string) => parseInt(v, 10)
     )
-    .option("--json", "Print the full DebugReport as JSON to stdout")
-    .option(
-      "--watch",
-      "Re-run on file change and print a diff of the verdict (file targets only)"
-    )
-    .action(async (ref: string, opts: DebugCliOptions) => {
+      .option("--json", "Print the full DebugReport as JSON to stdout")
+      .option(
+        "--watch",
+        "Re-run on file change and print a diff of the verdict (file targets only)"
+      )
+  ).action(async (ref: string, opts: DebugCliOptions) => {
       try {
         const { initDb, Workflow } = await import("@nodetool-ai/models");
         const { initMasterKey } = await import("@nodetool-ai/security");
@@ -84,8 +96,11 @@ export function registerDebugCommands(program: Command): void {
 
         // In watch mode keep a stable bundle dir so each re-run overwrites
         // rather than littering timestamped directories.
+        const supervisor = parseSupervisorFlags(opts);
+
         const runOptions = {
           server: opts.server,
+          ...(supervisor ? { supervisor } : {}),
           browser: opts.browser ?? false,
           trace: opts.trace ?? false,
           stages: opts.stages ?? false,
@@ -183,9 +198,13 @@ function watchSlug(ref: string): string {
 }
 
 function printSummary(report: {
-  verdict: { ok: boolean; headline: string; issues: string[] };
+  verdict: { ok: boolean; headline: string; issues: string[]; warnings?: string[] };
   bundleDir: string | null;
-  server: { status: string; summary: { counts: { errored: number } } } | null;
+  server: {
+    status: string;
+    summary: { counts: { errored: number }; interventions: Intervention[] };
+    supervised?: { provider: string; model: string };
+  } | null;
   browser: { status: string; unavailableReason?: string; consoleErrors: string[] } | null;
 }): void {
   const mark = report.verdict.ok ? "✅" : "❌";
@@ -194,6 +213,15 @@ function printSummary(report: {
     console.log(
       `  server:  ${report.server.status} (${report.server.summary.counts.errored} node error(s))`
     );
+    const interventions = report.server.summary.interventions;
+    if (report.server.supervised && interventions.length > 0) {
+      for (const intervention of interventions) {
+        console.log(`  ${formatInterventionLine(intervention)}`);
+      }
+      console.log(
+        `  ${formatSupervisedSummary(summarizeInterventions(interventions))}`
+      );
+    }
   }
   if (report.browser) {
     console.log(
@@ -205,6 +233,10 @@ function printSummary(report: {
   if (report.verdict.issues.length > 0) {
     console.log("\nIssues:");
     for (const issue of report.verdict.issues) console.log(`  - ${issue}`);
+  }
+  if (report.verdict.warnings && report.verdict.warnings.length > 0) {
+    console.log("\nWarnings:");
+    for (const warning of report.verdict.warnings) console.log(`  - ${warning}`);
   }
   if (report.bundleDir) {
     const parts = ["report.md / report.json", "workflow.json"];

--- a/packages/cli/src/debug/harness.ts
+++ b/packages/cli/src/debug/harness.ts
@@ -89,7 +89,9 @@ export async function runDebug(
       workflowId: resolved.info.workflowId,
       params,
       tracePath,
-      timeoutMs: options.timeoutMs
+      timeoutMs: options.timeoutMs,
+      ...(options.supervisor ? { supervisor: options.supervisor } : {}),
+      onInterventionLine: log
     });
 
     const messagesPath = join(serverDir, "messages.jsonl");

--- a/packages/cli/src/debug/markdown.ts
+++ b/packages/cli/src/debug/markdown.ts
@@ -2,6 +2,11 @@
  * Renders a `DebugReport` as a human-readable Markdown document (report.md in
  * the bundle). Pure — no IO — so it's trivially testable.
  */
+import {
+  formatInterventionLine,
+  formatSupervisedSummary,
+  summarizeInterventions
+} from "@nodetool-ai/execution/debug";
 import type {
   BrowserRunReport,
   DebugReport,
@@ -59,6 +64,16 @@ function summarySection(summary: ExecutionSummary): string[] {
           (call.error ? ` · ERROR ${call.error}` : "")
       );
     }
+  }
+
+  if (summary.interventions.length > 0) {
+    lines.push("", "**Interventions**");
+    for (const intervention of summary.interventions) {
+      lines.push(`- ${formatInterventionLine(intervention)}`);
+    }
+    lines.push(
+      `- ${formatSupervisedSummary(summarizeInterventions(summary.interventions))}`
+    );
   }
 
   if (summary.logs.length > 0) {

--- a/packages/cli/src/debug/server-runner.ts
+++ b/packages/cli/src/debug/server-runner.ts
@@ -12,7 +12,14 @@ import { getSecret } from "@nodetool-ai/models";
 import { ExecutionSession } from "@nodetool-ai/execution";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
 import { ProcessingContext, FileStorageAdapter } from "@nodetool-ai/runtime";
+import { summarizeInterventions } from "@nodetool-ai/execution/debug";
 import { buildFullRegistry } from "../node-registry.js";
+import {
+  createSupervisorHandle,
+  recordSupervisorCost,
+  streamInterventionLines,
+  type SupervisorRunConfig
+} from "../supervisor.js";
 import { collectExecutionSummary } from "./collector.js";
 import { readTraceSummary } from "./trace.js";
 import type { DebugGraph, ServerRunReport } from "./types.js";
@@ -24,6 +31,10 @@ export interface ServerRunInput {
   /** Absolute path telemetry was told to write spans to; read back for trace summary. */
   tracePath?: string | null;
   timeoutMs?: number;
+  /** Supervise this run (`--supervise` and its bounds). */
+  supervisor?: SupervisorRunConfig;
+  /** Sink for the inline `⛨` lines. Defaults to stderr. */
+  onInterventionLine?: (line: string) => void;
 }
 
 export interface ServerRunOutcome {
@@ -65,6 +76,12 @@ export async function runOnServer(input: ServerRunInput): Promise<ServerRunOutco
   // resolving a synthetic result while abandoning a still-running kernel, the
   // facade calls `session.cancel("timeout")`, which actually tears the run
   // down, and `session.result` only settles once that teardown completes.
+  // Supervision plumbs through the facade — the one integration point every
+  // surface shares (docs/workflow-supervisor-design.md §7).
+  const supervisor = input.supervisor
+    ? await createSupervisorHandle({ config: input.supervisor, context })
+    : null;
+
   const session = await ExecutionSession.create({
     graph,
     registry,
@@ -72,13 +89,27 @@ export async function runOnServer(input: ServerRunInput): Promise<ServerRunOutco
     workflowId,
     params,
     context,
-    limits: { runTimeoutMs: input.timeoutMs }
+    limits: { runTimeoutMs: input.timeoutMs },
+    // Capture is retention, so it stays off unless a supervised run needs the
+    // stream to print its `⛨` lines as they happen.
+    ...(supervisor
+      ? { supervisor: supervisor.handle, captureMessages: true }
+      : {})
   });
+
+  const interventionLines = supervisor
+    ? streamInterventionLines(
+        session.messages,
+        input.onInterventionLine ?? ((line) => console.error(line))
+      )
+    : Promise.resolve();
 
   // `session.result` never rejects — kernel failures (including an unknown
   // node type surfaced during executor resolution) resolve as `status:
   // "failed"` instead of throwing, so no try/catch is needed here.
   const result = await session.result;
+  await interventionLines;
+  supervisor?.handle.close();
   const timedOut = session.cancelReason === "timeout";
 
   const messages = (result.messages ?? []) as ProcessingMessage[];
@@ -101,6 +132,18 @@ export async function runOnServer(input: ServerRunInput): Promise<ServerRunOutco
     trace = await readTraceSummary(input.tracePath);
   }
 
+  const interventions = result.interventions ?? [];
+  if (supervisor && interventions.length > 0) {
+    await recordSupervisorCost({
+      interventions,
+      jobId,
+      workflowId,
+      userId: "1",
+      providerId: supervisor.providerId,
+      model: supervisor.model
+    });
+  }
+
   const report: ServerRunReport = {
     surface: "server",
     ok: result.status === "completed",
@@ -108,7 +151,16 @@ export async function runOnServer(input: ServerRunInput): Promise<ServerRunOutco
     error: error ?? summary.error,
     durationMs: Date.now() - startedAt,
     summary,
-    trace
+    trace,
+    ...(supervisor
+      ? {
+          supervised: {
+            provider: supervisor.providerId,
+            model: supervisor.model,
+            summary: summarizeInterventions(interventions)
+          }
+        }
+      : {})
   };
 
   return { report, rawMessages: messages };

--- a/packages/cli/src/debug/types.ts
+++ b/packages/cli/src/debug/types.ts
@@ -34,7 +34,11 @@ export interface DebugTargetInfo {
 
 // The execution-summary vocabulary is shared with every other host that
 // reports on a run — see `@nodetool-ai/execution`.
-import type { ExecutionSummary } from "@nodetool-ai/execution/debug";
+import type {
+  ExecutionSummary,
+  SupervisedRunSummary
+} from "@nodetool-ai/execution/debug";
+import type { SupervisorRunConfig } from "../supervisor.js";
 
 export type {
   DebugError,
@@ -73,6 +77,15 @@ export interface ServerRunReport {
   messagesFile?: string;
   /** Bundle-relative path to the raw trace JSONL. */
   traceFile?: string;
+  /**
+   * Present only on a supervised run: who supervised it and the rollup of what
+   * they decided. The decisions themselves are `summary.interventions`.
+   */
+  supervised?: {
+    provider: string;
+    model: string;
+    summary: SupervisedRunSummary;
+  };
 }
 
 /** A canvas screenshot captured at one stage of the browser run. */
@@ -150,4 +163,10 @@ export interface DebugOptions {
   outDir?: string;
   /** Per-surface run timeout, ms. */
   timeoutMs?: number;
+  /**
+   * Supervise the server surface (`--supervise` and its bounds). The browser
+   * surface runs the workflow through the web runtime, which has no supervisor
+   * of its own until the editor toggle ships, so it is unaffected.
+   */
+  supervisor?: SupervisorRunConfig;
 }

--- a/packages/cli/src/debug/verdict.ts
+++ b/packages/cli/src/debug/verdict.ts
@@ -6,7 +6,11 @@
  * debug endpoint and the agent-facing `debug_workflow` tool reach the same
  * verdict for the same run; this module only composes the two surfaces.
  */
-import { collectRunIssues, describeErrors } from "@nodetool-ai/execution/debug";
+import {
+  collectInterventionWarnings,
+  collectRunIssues,
+  describeErrors
+} from "@nodetool-ai/execution/debug";
 import type {
   BrowserRunReport,
   DebugVerdict,
@@ -75,5 +79,17 @@ export function buildVerdict(
     headline = `Workflow has issues — ${first}`;
   }
 
-  return { ok, headline, issues };
+  // Supervisor decisions are warnings, never issues: a run the supervisor
+  // rescued is still a run that completed, but a reader has to be told what
+  // was skipped or repaired to get there.
+  const warnings = server
+    ? collectInterventionWarnings("Server", server.summary)
+    : [];
+
+  return {
+    ok,
+    headline: ok && warnings.length > 0 ? `${headline} (supervised)` : headline,
+    issues,
+    ...(warnings.length > 0 ? { warnings } : {})
+  };
 }

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -21,6 +21,7 @@ import { spawnSync } from "node:child_process";
 import { createInterface } from "node:readline";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import type { AppRouter } from "@nodetool-ai/websocket/trpc";
+import type { Intervention } from "@nodetool-ai/protocol";
 import { workflowToDsl } from "@nodetool-ai/dsl";
 import {
   initDb,
@@ -53,6 +54,15 @@ import {
 } from "@nodetool-ai/runtime";
 import type { AssetOutputMode } from "@nodetool-ai/runtime";
 import { mkdirSync } from "node:fs";
+import {
+  addSupervisorOptions,
+  createSupervisorHandle,
+  parseSupervisorFlags,
+  printSupervisedSummary,
+  recordSupervisorCost,
+  streamInterventionLines,
+  type SupervisorCliOptions
+} from "./supervisor.js";
 import { registerPackageCommands } from "./commands/package.js";
 import { registerDeployCommands } from "./commands/deploy.js";
 import { registerHfCommands } from "./commands/models-hf.js";
@@ -312,11 +322,13 @@ function parseTraceStdout(v: string | boolean): "pretty" | "json" | false {
 // run — execute a TypeScript/JavaScript DSL workflow file
 // ---------------------------------------------------------------------------
 
-program
-  .command("run <dsl-file>")
-  .description("Run a TypeScript/JavaScript DSL workflow file")
-  .option("--json", "Output results as JSON (default: pretty-print)")
-  .action(async (dslFile: string, opts: { json?: boolean }) => {
+addSupervisorOptions(
+  program
+    .command("run <dsl-file>")
+    .description("Run a TypeScript/JavaScript DSL workflow file")
+    .option("--json", "Output results as JSON (default: pretty-print)")
+)
+  .action(async (dslFile: string, opts: { json?: boolean } & SupervisorCliOptions) => {
     try {
       const { resolve } = await import("node:path");
       const { runDslFile } = await import("./run-dsl.js");
@@ -325,11 +337,38 @@ program
 
       registerBaseNodes(NodeRegistry.global);
 
+      const supervisorConfig = parseSupervisorFlags(opts);
       const absolutePath = resolve(dslFile);
-      const results = await runDslFile(absolutePath);
+      let results: Record<string, Record<string, unknown>>;
+      let interventions: Intervention[] = [];
+      if (supervisorConfig) {
+        // The supervisor's provider key comes from the secret store, and its
+        // spend is written to the local ledger — both need the DB.
+        await setupDb();
+        const { runDslFileSupervised } = await import(
+          "./run-dsl-supervised.js"
+        );
+        const run = await runDslFileSupervised(
+          absolutePath,
+          supervisorConfig,
+          opts.json === true
+        );
+        results = run.results;
+        interventions = run.interventions;
+      } else {
+        results = await runDslFile(absolutePath);
+      }
 
       if (opts.json) {
-        console.log(JSON.stringify(results, null, 2));
+        // A supervised run reports what the supervisor did alongside the
+        // outputs; an unsupervised one keeps the bare results shape.
+        console.log(
+          JSON.stringify(
+            supervisorConfig ? { results, interventions } : results,
+            null,
+            2
+          )
+        );
       } else {
         for (const [workflowName, outputs] of Object.entries(results)) {
           console.log(`\n${workflowName}:`);
@@ -536,20 +575,22 @@ workflows
     }
   });
 
-workflows
-  .command("run <workflow_id_or_file>")
-  .description("Run a workflow by ID, JSON file, or TypeScript DSL file")
-  .option("--params <json>", "JSON params string")
-  .option("--json", "Output as JSON")
-  .option(
-    "--asset-output-mode <mode>",
-    "How media outputs are materialized: native | raw | data_uri | workspace | storage_url | temp_url",
-    "native"
-  )
-  .option(
-    "--workspace <dir>",
-    "Workspace directory for workspace-mode asset output (default: ./nodetool-output)"
-  )
+addSupervisorOptions(
+  workflows
+    .command("run <workflow_id_or_file>")
+    .description("Run a workflow by ID, JSON file, or TypeScript DSL file")
+    .option("--params <json>", "JSON params string")
+    .option("--json", "Output as JSON")
+    .option(
+      "--asset-output-mode <mode>",
+      "How media outputs are materialized: native | raw | data_uri | workspace | storage_url | temp_url",
+      "native"
+    )
+    .option(
+      "--workspace <dir>",
+      "Workspace directory for workspace-mode asset output (default: ./nodetool-output)"
+    )
+)
   .action(
     async (
       idOrFile: string,
@@ -558,9 +599,10 @@ workflows
         json?: boolean;
         assetOutputMode?: string;
         workspace?: string;
-      }
+      } & SupervisorCliOptions
     ) => {
       try {
+        const supervisorConfig = parseSupervisorFlags(opts);
         await setupDb();
         let graph: { nodes: any[]; edges: any[] };
         let workflowId: string | null = null;
@@ -723,8 +765,19 @@ workflows
           }
         });
 
+        const supervisor = supervisorConfig
+          ? await createSupervisorHandle({
+              config: supervisorConfig,
+              context
+            })
+          : null;
+
         console.error(
-          `Running workflow${workflowId ? ` ${workflowId}` : ""}...`
+          `Running workflow${workflowId ? ` ${workflowId}` : ""}` +
+            (supervisor
+              ? ` supervised by ${supervisor.providerId}/${supervisor.model}`
+              : "") +
+            "..."
         );
 
         // ExecutionSession owns graph hydration, Python-bridge connection
@@ -743,10 +796,33 @@ workflows
           jobId,
           workflowId,
           params,
-          context
+          context,
+          // Message capture is retention, so it stays off unless a supervised
+          // run needs the stream to print its `⛨` lines as they happen.
+          ...(supervisor
+            ? { supervisor: supervisor.handle, captureMessages: true }
+            : {})
         });
 
+        const interventionLines = supervisor
+          ? streamInterventionLines(session.messages)
+          : Promise.resolve();
+
         const result = await session.result;
+        await interventionLines;
+        supervisor?.handle.close();
+
+        const interventions = result.interventions ?? [];
+        if (supervisor && interventions.length > 0) {
+          await recordSupervisorCost({
+            interventions,
+            jobId,
+            workflowId,
+            userId: "1",
+            providerId: supervisor.providerId,
+            model: supervisor.model
+          });
+        }
 
         if (opts.json) {
           console.log(JSON.stringify(result, null, 2));
@@ -763,6 +839,7 @@ workflows
               }
             }
           }
+          printSupervisedSummary(interventions);
         }
 
         process.exit(result.status === "completed" ? 0 : 1);

--- a/packages/cli/src/run-dsl-supervised.ts
+++ b/packages/cli/src/run-dsl-supervised.ts
@@ -1,0 +1,107 @@
+/**
+ * `nodetool run --supervise` — the DSL file path, executed under supervision.
+ *
+ * `@nodetool-ai/dsl`'s own `run()` constructs a `WorkflowRunner` directly: one
+ * of the grandfathered direct-construction sites that must not gain
+ * supervision ad hoc (docs/workflow-supervisor-implementation-plan.md, PR 4).
+ * So a supervised DSL run goes through `ExecutionSession` instead, and an
+ * unsupervised one keeps taking the untouched `runDslFile` path.
+ *
+ * Lives in its own module because it pulls the session facade, the node
+ * registries, and a provider — none of which an unsupervised `nodetool run`
+ * should load.
+ */
+import { getDefaultAssetsPath } from "@nodetool-ai/config";
+import { ExecutionSession } from "@nodetool-ai/execution";
+import { getSecret } from "@nodetool-ai/models";
+import type { Intervention } from "@nodetool-ai/protocol";
+import { createGraphNodeTypeResolver } from "@nodetool-ai/node-sdk";
+import { ProcessingContext, FileStorageAdapter } from "@nodetool-ai/runtime";
+import { buildFullRegistry } from "./node-registry.js";
+import { dslWorkflowToGraph, loadDslWorkflows } from "./run-dsl.js";
+import {
+  createSupervisorHandle,
+  printSupervisedSummary,
+  recordSupervisorCost,
+  streamInterventionLines,
+  type SupervisorRunConfig
+} from "./supervisor.js";
+
+export interface SupervisedDslRun {
+  /** Workflow outputs, keyed by export name — the unsupervised path's shape. */
+  results: Record<string, Record<string, unknown>>;
+  /** Every decision the supervisor made, across the file's workflows. */
+  interventions: Intervention[];
+}
+
+export async function runDslFileSupervised(
+  filePath: string,
+  config: SupervisorRunConfig,
+  jsonMode: boolean
+): Promise<SupervisedDslRun> {
+  const workflows = await loadDslWorkflows(filePath);
+  const registry = buildFullRegistry();
+  const results: Record<string, Record<string, unknown>> = {};
+  const allInterventions: Intervention[] = [];
+
+  for (const [name, workflow] of Object.entries(workflows)) {
+    const jobId = `dsl-${Date.now()}-${name}`;
+    const context = new ProcessingContext({
+      jobId,
+      workflowId: null,
+      userId: "1",
+      secretResolver: getSecret,
+      storage: new FileStorageAdapter(getDefaultAssetsPath())
+    });
+
+    const supervisor = await createSupervisorHandle({ config, context });
+    console.error(
+      `Running ${name} supervised by ${supervisor.providerId}/${supervisor.model}...`
+    );
+
+    const session = await ExecutionSession.create({
+      graph: dslWorkflowToGraph(workflow),
+      registry,
+      resolveNodeType: createGraphNodeTypeResolver(registry).resolveNodeType,
+      jobId,
+      params: {},
+      context,
+      supervisor: supervisor.handle,
+      captureMessages: true
+    });
+
+    const lines = streamInterventionLines(session.messages);
+    const result = await session.result;
+    await lines;
+    supervisor.handle.close();
+
+    const interventions = result.interventions ?? [];
+    allInterventions.push(...interventions);
+    if (interventions.length > 0) {
+      await recordSupervisorCost({
+        interventions,
+        jobId,
+        workflowId: null,
+        userId: "1",
+        providerId: supervisor.providerId,
+        model: supervisor.model
+      });
+      if (!jsonMode) printSupervisedSummary(interventions, console.error);
+    }
+
+    // A node error the supervisor resolved is not a run failure — unlike the
+    // unsupervised DSL path, which rethrows the first node error it finds.
+    // Only the run's own terminal status decides.
+    if (result.status === "failed") {
+      throw new Error(result.error ?? `Workflow ${name} failed`);
+    }
+
+    const outputs: Record<string, unknown> = {};
+    for (const [outputName, values] of Object.entries(result.outputs)) {
+      if (values.length > 0) outputs[outputName] = values[values.length - 1];
+    }
+    results[name] = outputs;
+  }
+
+  return { results, interventions: allInterventions };
+}

--- a/packages/cli/src/run-dsl.ts
+++ b/packages/cli/src/run-dsl.ts
@@ -20,28 +20,61 @@ export function isWorkflow(value: unknown): value is Workflow {
   );
 }
 
-export async function runDslFile(
+/** Every exported `Workflow` in the file, keyed by export name. */
+export async function loadDslWorkflows(
   filePath: string
-): Promise<Record<string, Record<string, unknown>>> {
+): Promise<Record<string, Workflow>> {
   const moduleUrl = pathToFileURL(filePath).href;
   const mod = (await tsImport(moduleUrl, import.meta.url)) as Record<
     string,
     unknown
   >;
 
-  const results: Record<string, Record<string, unknown>> = {};
-  let found = false;
-
+  const workflows: Record<string, Workflow> = {};
   for (const [name, value] of Object.entries(mod)) {
-    if (isWorkflow(value)) {
-      found = true;
-      results[name] = await runWorkflow(value);
-    }
+    if (isWorkflow(value)) workflows[name] = value;
   }
 
-  if (!found) {
+  if (Object.keys(workflows).length === 0) {
     throw new Error(`No Workflow exports found in ${filePath}`);
   }
+  return workflows;
+}
 
+export async function runDslFile(
+  filePath: string
+): Promise<Record<string, Record<string, unknown>>> {
+  const workflows = await loadDslWorkflows(filePath);
+  const results: Record<string, Record<string, unknown>> = {};
+  for (const [name, wf] of Object.entries(workflows)) {
+    results[name] = await runWorkflow(wf);
+  }
   return results;
+}
+
+/**
+ * The graph shape `ExecutionSession` takes, from a DSL workflow. `run()` in
+ * `@nodetool-ai/dsl` builds the same descriptors against its own
+ * `WorkflowRunner`; supervision goes through the session facade instead
+ * (docs/workflow-supervisor-design.md §7), so the mapping is needed here too.
+ */
+export function dslWorkflowToGraph(wf: Workflow): {
+  nodes: Array<Record<string, unknown>>;
+  edges: Array<Record<string, unknown>>;
+} {
+  return {
+    nodes: wf.nodes.map((n) => ({
+      id: n.id,
+      type: n.type,
+      properties: n.data,
+      is_streaming_output: n.streaming,
+      is_streaming_input: n.streamingInput
+    })),
+    edges: wf.edges.map((e) => ({
+      source: e.source,
+      sourceHandle: e.sourceHandle,
+      target: e.target,
+      targetHandle: e.targetHandle
+    }))
+  };
 }

--- a/packages/cli/src/supervisor.ts
+++ b/packages/cli/src/supervisor.ts
@@ -1,0 +1,305 @@
+/**
+ * The CLI's supervisor surface: five flags, one handle, and the lines a
+ * supervised run prints.
+ *
+ * Flag parsing and model-spec resolution are pure so they can be unit-tested
+ * without a provider, a database, or a kernel. Everything that needs a
+ * provider or the agents package is behind a dynamic import, so an
+ * unsupervised run loads none of it.
+ *
+ * The handle goes to `ExecutionSessionOptions.supervisor` — the one
+ * integration point every surface shares (docs/workflow-supervisor-design.md
+ * §7). No CLI code touches `WorkflowRunner`.
+ */
+import {
+  formatInterventionLine,
+  formatSupervisedSummary,
+  summarizeInterventions
+} from "@nodetool-ai/execution/debug";
+import type { SupervisorHandle } from "@nodetool-ai/execution";
+import type { Intervention, ProcessingMessage } from "@nodetool-ai/protocol";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type { Command } from "commander";
+
+/**
+ * Model used when `--supervise` is given without `--supervisor-model`.
+ * `NODETOOL_SUPERVISOR_MODEL` overrides it.
+ */
+export const DEFAULT_SUPERVISOR_MODEL = "anthropic/claude-sonnet-4-6";
+
+/** The five flags, as Commander parses them. */
+export interface SupervisorCliOptions {
+  supervise?: boolean;
+  maxDecisions?: string;
+  maxRetries?: string;
+  supervisorCostCap?: string;
+  supervisorModel?: string;
+}
+
+/**
+ * A validated supervisor configuration. Every bound is optional: an omitted
+ * flag means "whatever the kernel's `BoundedHandle` and the `SupervisorAgent`
+ * default to", so the defaults live in one place instead of being copied here.
+ */
+export interface SupervisorRunConfig {
+  /** `provider/model`, as written or defaulted. Resolved when the handle is built. */
+  modelSpec: string;
+  maxDecisions?: number;
+  maxRetriesPerNode?: number;
+  maxCostUsd?: number;
+}
+
+/** Register the supervisor flags on a run-shaped command. */
+export function addSupervisorOptions(command: Command): Command {
+  return command
+    .option(
+      "--supervise",
+      "Let a supervisor agent decide what to do when a node fails (retry / repair / skip / fail)"
+    )
+    .option(
+      "--max-decisions <n>",
+      "Supervisor decisions allowed in this run (default: 10)"
+    )
+    .option(
+      "--max-retries <n>",
+      "Supervisor retries allowed per node invocation (default: 2)"
+    )
+    .option(
+      "--supervisor-cost-cap <usd>",
+      "Ceiling on supervisor spend for this run, in USD (default: 0.50)"
+    )
+    .option(
+      "--supervisor-model <provider/model>",
+      `Model that supervises the run (default: ${DEFAULT_SUPERVISOR_MODEL})`
+    );
+}
+
+function positiveInt(value: string, flag: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new Error(`${flag} must be a non-negative integer (got "${value}")`);
+  }
+  return n;
+}
+
+function positiveNumber(value: string, flag: string): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(`${flag} must be a non-negative number (got "${value}")`);
+  }
+  return n;
+}
+
+/**
+ * Turn the flags into a config, or `null` when the run is unsupervised.
+ *
+ * A bound passed without `--supervise` is a mistake worth reporting: it reads
+ * as "supervision, bounded", and silently running unsupervised would hide a
+ * failure the user asked to be handled.
+ */
+export function parseSupervisorFlags(
+  opts: SupervisorCliOptions
+): SupervisorRunConfig | null {
+  const bounded =
+    opts.maxDecisions !== undefined ||
+    opts.maxRetries !== undefined ||
+    opts.supervisorCostCap !== undefined ||
+    opts.supervisorModel !== undefined;
+
+  if (!opts.supervise) {
+    if (bounded) {
+      throw new Error(
+        "Supervisor options were given without --supervise; add --supervise or drop them."
+      );
+    }
+    return null;
+  }
+
+  return {
+    modelSpec:
+      opts.supervisorModel ??
+      process.env.NODETOOL_SUPERVISOR_MODEL ??
+      DEFAULT_SUPERVISOR_MODEL,
+    ...(opts.maxDecisions !== undefined
+      ? { maxDecisions: positiveInt(opts.maxDecisions, "--max-decisions") }
+      : {}),
+    ...(opts.maxRetries !== undefined
+      ? { maxRetriesPerNode: positiveInt(opts.maxRetries, "--max-retries") }
+      : {}),
+    ...(opts.supervisorCostCap !== undefined
+      ? {
+          maxCostUsd: positiveNumber(
+            opts.supervisorCostCap,
+            "--supervisor-cost-cap"
+          )
+        }
+      : {})
+  };
+}
+
+/**
+ * Split `provider/model` into its parts.
+ *
+ * Model ids themselves contain slashes (`openrouter/openai/gpt-5.4-mini`), so
+ * the split is decided by the registry rather than by counting separators:
+ * the leading segment is the provider only if a provider by that name is
+ * registered.
+ */
+export function parseModelSpec(
+  spec: string,
+  isRegisteredProvider: (id: string) => boolean
+): { providerId: string; model: string } {
+  const cut = spec.indexOf("/");
+  const head = cut === -1 ? spec : spec.slice(0, cut);
+  if (cut === -1 || !isRegisteredProvider(head.toLowerCase())) {
+    throw new Error(
+      `--supervisor-model must be "<provider>/<model>" with a registered provider ` +
+        `(got "${spec}"). Example: anthropic/claude-sonnet-4-6.`
+    );
+  }
+  return { providerId: head.toLowerCase(), model: spec.slice(cut + 1) };
+}
+
+export interface SupervisorHandleInit {
+  config: SupervisorRunConfig;
+  /**
+   * The run's context — the supervisor's tools and its `supervisor:` memory
+   * keys share it, so a downstream agent can read the decisions back. The
+   * *provider* is a fresh instance and is never the run's.
+   */
+  context: ProcessingContext;
+}
+
+export interface BuiltSupervisor {
+  handle: SupervisorHandle;
+  providerId: string;
+  model: string;
+}
+
+/**
+ * Build the bounded, LLM-backed handle. Imports are dynamic so the agents
+ * package and a provider are loaded only for a run that asked for them.
+ */
+export async function createSupervisorHandle(
+  init: SupervisorHandleInit
+): Promise<BuiltSupervisor> {
+  const [{ BoundedHandle }, { SupervisorAgent }, { listRegisteredProviderIds }] =
+    await Promise.all([
+      import("@nodetool-ai/kernel"),
+      import("@nodetool-ai/agents"),
+      import("@nodetool-ai/runtime")
+    ]);
+  const { createProviderStrict } = await import("./providers.js");
+
+  const { providerId, model } = parseModelSpec(init.config.modelSpec, (id) =>
+    listRegisteredProviderIds().includes(id)
+  );
+  const provider = await createProviderStrict(providerId);
+
+  const agent = new SupervisorAgent({
+    provider,
+    model,
+    context: init.context,
+    ...(init.config.maxCostUsd !== undefined
+      ? { maxCostUsd: init.config.maxCostUsd }
+      : {})
+  });
+
+  const handle = new BoundedHandle(agent, {
+    ...(init.config.maxDecisions !== undefined
+      ? { maxDecisions: init.config.maxDecisions }
+      : {}),
+    ...(init.config.maxRetriesPerNode !== undefined
+      ? { maxRetriesPerNode: init.config.maxRetriesPerNode }
+      : {})
+  });
+
+  return { handle, providerId, model };
+}
+
+/**
+ * Print one `⛨` line per decision as it happens, by draining the session's
+ * message stream. Lines go to stderr so `--json` stdout stays parseable.
+ */
+export async function streamInterventionLines(
+  messages: AsyncIterable<ProcessingMessage>,
+  write: (line: string) => void = (line) => console.error(line)
+): Promise<void> {
+  for await (const message of messages) {
+    if (message.type !== "supervisor_decision") continue;
+    write(
+      formatInterventionLine({
+        escalation: message.escalation,
+        verdict: message.verdict,
+        decidedBy: message.decided_by,
+        ...(typeof message.cost === "number" ? { costUsd: message.cost } : {})
+      })
+    );
+  }
+}
+
+/** The run's closing supervised line. Nothing is printed for a clean run. */
+export function printSupervisedSummary(
+  interventions: readonly Intervention[],
+  write: (line: string) => void = (line) => console.log(line)
+): void {
+  if (interventions.length === 0) return;
+  write(formatSupervisedSummary(summarizeInterventions(interventions)));
+}
+
+export interface SupervisorCostAttribution {
+  interventions: readonly Intervention[];
+  jobId: string;
+  workflowId: string | null;
+  userId: string;
+  providerId: string;
+  model: string;
+}
+
+/**
+ * Write supervisor spend into the prediction ledger `nodetool costs` reads.
+ *
+ * One row per decision that cost money, attributed to the run (workflow id,
+ * plus the job id in metadata — the ledger has no job column) and tagged
+ * `supervisor` in `node_type`, so supervision is separable from the spend of
+ * the workflow it supervised. Best-effort: a ledger failure never fails a run
+ * that already finished. Returns the number of rows written.
+ */
+export async function recordSupervisorCost(
+  attribution: SupervisorCostAttribution
+): Promise<number> {
+  const billable = attribution.interventions.filter(
+    (i) => typeof i.costUsd === "number" && i.costUsd > 0
+  );
+  if (billable.length === 0) return 0;
+
+  const { Prediction } = await import("@nodetool-ai/models");
+  let written = 0;
+  for (const intervention of billable) {
+    try {
+      await Prediction.create({
+        user_id: attribution.userId,
+        provider: attribution.providerId,
+        model: attribution.model,
+        node_id: intervention.escalation.nodeId,
+        node_type: "supervisor",
+        workflow_id: attribution.workflowId,
+        cost: intervention.costUsd,
+        status: "completed",
+        metadata: {
+          kind: "supervisor",
+          job_id: attribution.jobId,
+          decided_by: intervention.decidedBy,
+          verdict: intervention.verdict.action,
+          escalated_node_type: intervention.escalation.nodeType
+        }
+      });
+      written += 1;
+    } catch (err) {
+      console.error(
+        `Failed to record supervisor cost: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+  return written;
+}

--- a/packages/cli/src/supervisor.ts
+++ b/packages/cli/src/supervisor.ts
@@ -199,7 +199,14 @@ export async function createSupervisorHandle(
   const agent = new SupervisorAgent({
     provider,
     model,
-    context: init.context,
+    // The supervisor reads and writes the run's memory (`supervisor:` keys)
+    // but must not push its own provider chatter into the run's message
+    // stream — the CLI drains that stream for `⛨` lines — so it gets a
+    // listener-free copy, matching the agent surface.
+    context: init.context.copy({
+      shareMemory: true,
+      inheritMessageListeners: false
+    }),
     ...(init.config.maxCostUsd !== undefined
       ? { maxCostUsd: init.config.maxCostUsd }
       : {})

--- a/packages/cli/tests/supervisor.test.ts
+++ b/packages/cli/tests/supervisor.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const created: Array<Record<string, unknown>> = [];
+
+vi.mock("@nodetool-ai/models", () => ({
+  Prediction: {
+    create: async (row: Record<string, unknown>) => {
+      created.push(row);
+      return row;
+    }
+  }
+}));
+
+import {
+  DEFAULT_SUPERVISOR_MODEL,
+  parseModelSpec,
+  parseSupervisorFlags,
+  printSupervisedSummary,
+  recordSupervisorCost
+} from "../src/supervisor.js";
+import type { Intervention } from "@nodetool-ai/protocol";
+
+describe("parseSupervisorFlags", () => {
+  beforeEach(() => {
+    delete process.env.NODETOOL_SUPERVISOR_MODEL;
+  });
+
+  it("returns null when the run is unsupervised", () => {
+    expect(parseSupervisorFlags({})).toBeNull();
+  });
+
+  it("maps every flag onto the bounds the handle is built with", () => {
+    expect(
+      parseSupervisorFlags({
+        supervise: true,
+        maxDecisions: "4",
+        maxRetries: "1",
+        supervisorCostCap: "0.25",
+        supervisorModel: "openai/gpt-5.4-mini"
+      })
+    ).toEqual({
+      modelSpec: "openai/gpt-5.4-mini",
+      maxDecisions: 4,
+      maxRetriesPerNode: 1,
+      maxCostUsd: 0.25
+    });
+  });
+
+  it("leaves omitted bounds unset so the kernel and agent defaults apply", () => {
+    expect(parseSupervisorFlags({ supervise: true })).toEqual({
+      modelSpec: DEFAULT_SUPERVISOR_MODEL
+    });
+  });
+
+  it("honors NODETOOL_SUPERVISOR_MODEL when no model flag is given", () => {
+    process.env.NODETOOL_SUPERVISOR_MODEL = "ollama/qwen-3.5:4b";
+    expect(parseSupervisorFlags({ supervise: true })?.modelSpec).toBe(
+      "ollama/qwen-3.5:4b"
+    );
+  });
+
+  it("rejects bounds passed without --supervise", () => {
+    expect(() => parseSupervisorFlags({ maxDecisions: "3" })).toThrow(
+      /without --supervise/
+    );
+  });
+
+  it("rejects non-numeric bounds", () => {
+    expect(() =>
+      parseSupervisorFlags({ supervise: true, maxDecisions: "lots" })
+    ).toThrow(/--max-decisions/);
+    expect(() =>
+      parseSupervisorFlags({ supervise: true, supervisorCostCap: "-1" })
+    ).toThrow(/--supervisor-cost-cap/);
+  });
+});
+
+describe("parseModelSpec", () => {
+  const known = (id: string) => ["anthropic", "openrouter"].includes(id);
+
+  it("splits provider from model", () => {
+    expect(parseModelSpec("anthropic/claude-sonnet-4-6", known)).toEqual({
+      providerId: "anthropic",
+      model: "claude-sonnet-4-6"
+    });
+  });
+
+  it("keeps slashes that belong to the model id", () => {
+    expect(parseModelSpec("openrouter/openai/gpt-5.4-mini", known)).toEqual({
+      providerId: "openrouter",
+      model: "openai/gpt-5.4-mini"
+    });
+  });
+
+  it("rejects a bare model id and an unregistered provider", () => {
+    expect(() => parseModelSpec("claude-sonnet-4-6", known)).toThrow(
+      /<provider>\/<model>/
+    );
+    expect(() => parseModelSpec("nope/some-model", known)).toThrow(
+      /<provider>\/<model>/
+    );
+  });
+});
+
+function intervention(costUsd: number | undefined): Intervention {
+  return {
+    escalation: {
+      nodeId: "fetch",
+      nodeType: "test.Fetch",
+      correlationLineage: [],
+      invocationKey: "",
+      allowedActions: ["skip", "fail"],
+      detail: "HTTP 404",
+      inputs: {},
+      declaredOutputs: {},
+      attempt: 1,
+      spentCostUsd: 0,
+      createdAssets: false,
+      retrySafe: false,
+      emitted: false
+    },
+    verdict: { action: "skip" },
+    decidedBy: "agent",
+    ...(costUsd === undefined ? {} : { costUsd })
+  };
+}
+
+describe("recordSupervisorCost", () => {
+  beforeEach(() => {
+    created.length = 0;
+  });
+
+  it("writes one ledger row per billable decision, tagged supervisor", async () => {
+    const written = await recordSupervisorCost({
+      interventions: [intervention(0.012), intervention(undefined)],
+      jobId: "job-1",
+      workflowId: "wf-1",
+      userId: "1",
+      providerId: "anthropic",
+      model: "claude-sonnet-4-6"
+    });
+
+    expect(written).toBe(1);
+    expect(created).toHaveLength(1);
+    expect(created[0]).toMatchObject({
+      user_id: "1",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      node_id: "fetch",
+      node_type: "supervisor",
+      workflow_id: "wf-1",
+      cost: 0.012,
+      status: "completed"
+    });
+    expect(created[0].metadata).toMatchObject({
+      kind: "supervisor",
+      job_id: "job-1",
+      decided_by: "agent",
+      verdict: "skip"
+    });
+  });
+
+  it("writes nothing when no decision cost money", async () => {
+    const written = await recordSupervisorCost({
+      interventions: [intervention(0)],
+      jobId: "job-1",
+      workflowId: null,
+      userId: "1",
+      providerId: "anthropic",
+      model: "claude-sonnet-4-6"
+    });
+    expect(written).toBe(0);
+    expect(created).toHaveLength(0);
+  });
+});
+
+describe("printSupervisedSummary", () => {
+  it("prints nothing for a run with no interventions", () => {
+    const lines: string[] = [];
+    printSupervisedSummary([], (line) => lines.push(line));
+    expect(lines).toEqual([]);
+  });
+
+  it("prints the supervised line for a run with interventions", () => {
+    const lines: string[] = [];
+    printSupervisedSummary([intervention(0.01)], (line) => lines.push(line));
+    expect(lines).toEqual(["⛨ supervised: 1 skipped, 1 decision, +$0.0100"]);
+  });
+});

--- a/packages/cli/tests/supervisor.test.ts
+++ b/packages/cli/tests/supervisor.test.ts
@@ -11,8 +11,36 @@ vi.mock("@nodetool-ai/models", () => ({
   }
 }));
 
+const supervisorAgents: Array<Record<string, unknown>> = [];
+
+vi.mock("@nodetool-ai/agents", () => ({
+  SupervisorAgent: class {
+    constructor(opts: Record<string, unknown>) {
+      supervisorAgents.push(opts);
+    }
+  }
+}));
+
+vi.mock("@nodetool-ai/kernel", () => ({
+  BoundedHandle: class {
+    constructor(
+      readonly inner: unknown,
+      readonly bounds: unknown
+    ) {}
+  }
+}));
+
+vi.mock("@nodetool-ai/runtime", () => ({
+  listRegisteredProviderIds: () => ["anthropic"]
+}));
+
+vi.mock("../src/providers.js", () => ({
+  createProviderStrict: async (id: string) => ({ id })
+}));
+
 import {
   DEFAULT_SUPERVISOR_MODEL,
+  createSupervisorHandle,
   parseModelSpec,
   parseSupervisorFlags,
   printSupervisedSummary,
@@ -185,5 +213,33 @@ describe("printSupervisedSummary", () => {
     const lines: string[] = [];
     printSupervisedSummary([intervention(0.01)], (line) => lines.push(line));
     expect(lines).toEqual(["⛨ supervised: 1 skipped, 1 decision, +$0.0100"]);
+  });
+});
+
+describe("createSupervisorHandle", () => {
+  it("gives the supervisor a listener-free copy of the run context", async () => {
+    supervisorAgents.length = 0;
+    const copies: Array<Record<string, unknown>> = [];
+    const runContext = {
+      copy: (opts: Record<string, unknown>) => {
+        copies.push(opts);
+        return { marker: "copy" };
+      }
+    };
+
+    await createSupervisorHandle({
+      config: { modelSpec: "anthropic/claude-sonnet-4-6" },
+      context: runContext as never
+    });
+
+    // The CLI drains the run's message stream for `⛨` lines; the supervisor's
+    // own provider chatter must not land in it, and its `supervisor:` memory
+    // keys must still reach the run's one memory.
+    expect(copies).toEqual([
+      { shareMemory: true, inheritMessageListeners: false }
+    ]);
+    expect(supervisorAgents).toHaveLength(1);
+    expect(supervisorAgents[0]?.context).not.toBe(runContext);
+    expect(supervisorAgents[0]?.context).toEqual({ marker: "copy" });
   });
 });

--- a/packages/execution/src/debug/collector.ts
+++ b/packages/execution/src/debug/collector.ts
@@ -6,7 +6,7 @@
  * report identically. Only `import type` is used here so the module stays free of
  * runtime workspace dependencies (testable under the CLI vitest stub setup).
  */
-import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import type { Intervention, ProcessingMessage } from "@nodetool-ai/protocol";
 import type {
   EdgeDebug,
   ExecutionSummary,
@@ -82,6 +82,7 @@ export function collectExecutionSummary(
   const edges = new Map<string, EdgeDebug>();
   const llmCalls: LlmCallDebug[] = [];
   const outputs: NodeOutput[] = [];
+  const interventions: Intervention[] = [];
   let status = "unknown";
   let error: string | null = null;
 
@@ -191,6 +192,11 @@ export function collectExecutionSummary(
         logs.push({ nodeId: null, severity: "error", content: message });
         break;
       }
+      case "supervisor_decision": {
+        const intervention = readIntervention(msg);
+        if (intervention) interventions.push(intervention);
+        break;
+      }
       case "llm_call": {
         llmCalls.push({
           nodeId: str(msg.node_id) ?? "",
@@ -228,14 +234,42 @@ export function collectExecutionSummary(
     edges: [...edges.values()],
     llmCalls,
     outputs,
+    interventions,
     counts: {
       nodes: nodeList.length,
       completed: nodeList.filter((n) => n.status === "completed").length,
       errored: errored.length,
       logs: logs.length,
       outputs: outputs.length,
-      llmCalls: llmCalls.length
+      llmCalls: llmCalls.length,
+      interventions: interventions.length
     },
     errors
+  };
+}
+
+/**
+ * Read a `supervisor_decision` message as an `Intervention`.
+ *
+ * Structural rather than schema-validated: this module stays free of runtime
+ * imports (the browser harness feeds it decoded JSON bags), so it checks the
+ * fields the record is keyed on and drops anything else. A message the kernel
+ * emitted always passes.
+ */
+function readIntervention(msg: Record<string, unknown>): Intervention | null {
+  const escalation = msg.escalation;
+  const verdict = msg.verdict;
+  if (!escalation || typeof escalation !== "object") return null;
+  if (!verdict || typeof verdict !== "object") return null;
+  if (typeof (verdict as { action?: unknown }).action !== "string") return null;
+  const decidedBy = msg.decided_by;
+  const cost = msg.cost;
+  return {
+    escalation: escalation as Intervention["escalation"],
+    verdict: verdict as Intervention["verdict"],
+    decidedBy: (typeof decidedBy === "string"
+      ? decidedBy
+      : "agent") as Intervention["decidedBy"],
+    ...(typeof cost === "number" ? { costUsd: cost } : {})
   };
 }

--- a/packages/execution/src/debug/collector.ts
+++ b/packages/execution/src/debug/collector.ts
@@ -16,6 +16,19 @@ import type {
   NodeOutput
 } from "./types.js";
 
+/**
+ * The deciders a `supervisor_decision` may name. Written as a total record so
+ * a new value in the protocol enum fails this file rather than slipping
+ * through as an unrecognized string.
+ */
+const DECIDED_BY: Record<Intervention["decidedBy"], true> = {
+  agent: true,
+  sticky: true,
+  bounds: true,
+  default: true,
+  kernel: true
+};
+
 const MAX_STRING_PREVIEW = 2000;
 const MAX_ARRAY_PREVIEW = 50;
 /** Fields that commonly carry base64 / data-URI payloads worth collapsing. */
@@ -263,13 +276,17 @@ function readIntervention(msg: Record<string, unknown>): Intervention | null {
   if (!verdict || typeof verdict !== "object") return null;
   if (typeof (verdict as { action?: unknown }).action !== "string") return null;
   const decidedBy = msg.decided_by;
+  // `decided_by` is required by the message schema, and only `"agent"` means a
+  // model was involved. Guessing it would misreport who decided — and inflate
+  // the agent-decision count the cost rollup reads — so an unrecognized value
+  // drops the record rather than defaulting.
+  if (typeof decidedBy !== "string") return null;
+  if (!Object.prototype.hasOwnProperty.call(DECIDED_BY, decidedBy)) return null;
   const cost = msg.cost;
   return {
     escalation: escalation as Intervention["escalation"],
     verdict: verdict as Intervention["verdict"],
-    decidedBy: (typeof decidedBy === "string"
-      ? decidedBy
-      : "agent") as Intervention["decidedBy"],
+    decidedBy: decidedBy as Intervention["decidedBy"],
     ...(typeof cost === "number" ? { costUsd: cost } : {})
   };
 }

--- a/packages/execution/src/debug/index.ts
+++ b/packages/execution/src/debug/index.ts
@@ -8,8 +8,19 @@
  * session.
  */
 export { collectExecutionSummary, previewValue } from "./collector.js";
+// Intervention reporting lives one level up (it is not debug-only) but is
+// re-exported here so a host on this dependency-free subpath can print a
+// supervised run without pulling the session facade's runtime deps.
+export {
+  INTERVENTION_MARK,
+  formatInterventionLine,
+  formatSupervisedSummary,
+  summarizeInterventions
+} from "../supervisor.js";
+export type { SupervisedRunSummary } from "../supervisor.js";
 export {
   buildRunVerdict,
+  collectInterventionWarnings,
   collectRunIssues,
   describeErrors
 } from "./verdict.js";

--- a/packages/execution/src/debug/types.ts
+++ b/packages/execution/src/debug/types.ts
@@ -8,6 +8,8 @@
  * different, thinner shape than the CLI did for the same run.
  */
 
+import type { Intervention } from "@nodetool-ai/protocol";
+
 /** A single value emitted by a node (output_update / generation_complete). */
 export interface NodeOutput {
   nodeId?: string;
@@ -72,6 +74,12 @@ export interface ExecutionSummary {
   llmCalls: LlmCallDebug[];
   /** Workflow-level outputs (Output / Preview nodes). */
   outputs: NodeOutput[];
+  /**
+   * Supervisor decisions, in decision order — empty on an unsupervised run.
+   * Folded from `supervisor_decision` messages, so it is the same record the
+   * kernel puts on `RunResult.interventions`.
+   */
+  interventions: Intervention[];
   counts: {
     nodes: number;
     completed: number;
@@ -79,6 +87,7 @@ export interface ExecutionSummary {
     logs: number;
     outputs: number;
     llmCalls: number;
+    interventions: number;
   };
   errors: DebugError[];
 }

--- a/packages/execution/src/debug/verdict.ts
+++ b/packages/execution/src/debug/verdict.ts
@@ -38,6 +38,30 @@ export function collectRunIssues(
   return issues;
 }
 
+/**
+ * What supervision decided, as things worth reading but not failures — a
+ * skipped invocation leaves the run `completed` with less output than the
+ * graph promised, which no status field says out loud.
+ */
+export function collectInterventionWarnings(
+  prefix: string,
+  summary: ExecutionSummary,
+  limit = 5
+): string[] {
+  if (summary.interventions.length === 0) return [];
+  const warnings = summary.interventions
+    .slice(0, limit)
+    .map(
+      (i) =>
+        `${prefix} supervisor ${i.verdict.action} on ${i.escalation.nodeId}` +
+        `${i.escalation.invocationKey ? ` [${i.escalation.invocationKey}]` : ""}` +
+        `: ${i.escalation.detail.replace(/\s+/g, " ").slice(0, 200)}`
+    );
+  const rest = summary.interventions.length - warnings.length;
+  if (rest > 0) warnings.push(`${prefix} …${rest} more supervisor decision(s)`);
+  return warnings;
+}
+
 /** Verdict for a single-surface run. */
 export function buildRunVerdict(
   summary: ExecutionSummary,

--- a/packages/execution/src/index.ts
+++ b/packages/execution/src/index.ts
@@ -4,6 +4,13 @@
 export { ExecutionSession } from "./session.js";
 export { normalizeGraph } from "./normalize-graph.js";
 export { DEFAULT_MESSAGE_BUFFER_LIMIT } from "./message-stream.js";
+export {
+  INTERVENTION_MARK,
+  formatInterventionLine,
+  formatSupervisedSummary,
+  summarizeInterventions
+} from "./supervisor.js";
+export type { SupervisedRunSummary } from "./supervisor.js";
 export type {
   BridgeFactory,
   Edge,
@@ -13,7 +20,8 @@ export type {
   NodeDescriptor,
   ProcessingMessage,
   RawGraphInput,
-  RunResult
+  RunResult,
+  SupervisorHandle
 } from "./types.js";
 export type { NodeTypeResolver, ResolvedNodeType } from "@nodetool-ai/kernel";
 
@@ -25,6 +33,7 @@ export {
 } from "./debug/collector.js";
 export {
   buildRunVerdict,
+  collectInterventionWarnings,
   collectRunIssues,
   describeErrors
 } from "./debug/verdict.js";

--- a/packages/execution/src/session.ts
+++ b/packages/execution/src/session.ts
@@ -193,7 +193,8 @@ export class ExecutionSession {
       executionContext: context,
       validateNode: options.validateNode,
       bufferLimit: options.limits?.bufferLimit ?? null,
-      strict: options.strict
+      strict: options.strict,
+      supervisor: options.supervisor
     });
 
     try {

--- a/packages/execution/src/session.ts
+++ b/packages/execution/src/session.ts
@@ -193,7 +193,8 @@ export class ExecutionSession {
       executionContext: context,
       validateNode: options.validateNode,
       bufferLimit: options.limits?.bufferLimit ?? null,
-      strict: options.strict
+      strict: options.strict,
+      ...(options.supervisor ? { supervisor: options.supervisor } : {})
     });
 
     try {

--- a/packages/execution/src/supervisor.ts
+++ b/packages/execution/src/supervisor.ts
@@ -1,0 +1,135 @@
+/**
+ * Reporting for supervised runs: one vocabulary for "what did the supervisor
+ * do", shared by every surface that prints or serializes it.
+ *
+ * The record itself is `Intervention` from `@nodetool-ai/protocol` — minted by
+ * the kernel, carried on `RunResult.interventions` and on every
+ * `supervisor_decision` message. Nothing here reshapes it; these are the
+ * rollup and the two lines a surface prints.
+ *
+ * See docs/workflow-supervisor-design.md §4 and §7.
+ */
+import type { DecidedBy, Intervention, VerdictAction } from "@nodetool-ai/protocol";
+
+/** The shield that marks a supervised line. */
+export const INTERVENTION_MARK = "⛨";
+
+/** Per-run rollup of what supervision decided and what it cost. */
+export interface SupervisedRunSummary {
+  /** Interventions recorded, whoever decided them. */
+  decisions: number;
+  /** Decisions that actually reached the model — the ones that cost money. */
+  agentDecisions: number;
+  byAction: Record<VerdictAction, number>;
+  byDecider: Record<DecidedBy, number>;
+  /** Supervisor spend for the run, in USD. */
+  costUsd: number;
+}
+
+const ZERO_ACTIONS: Record<VerdictAction, number> = {
+  retry: 0,
+  substitute: 0,
+  skip: 0,
+  end_stream: 0,
+  fail: 0
+};
+
+const ZERO_DECIDERS: Record<DecidedBy, number> = {
+  agent: 0,
+  sticky: 0,
+  bounds: 0,
+  default: 0,
+  kernel: 0
+};
+
+export function summarizeInterventions(
+  interventions: readonly Intervention[]
+): SupervisedRunSummary {
+  const byAction = { ...ZERO_ACTIONS };
+  const byDecider = { ...ZERO_DECIDERS };
+  let costUsd = 0;
+  for (const item of interventions) {
+    byAction[item.verdict.action] += 1;
+    byDecider[item.decidedBy] += 1;
+    costUsd += item.costUsd ?? 0;
+  }
+  return {
+    decisions: interventions.length,
+    agentDecisions: byDecider.agent,
+    byAction,
+    byDecider,
+    costUsd
+  };
+}
+
+/** Human-readable phrase for a verdict, in the product's four verbs. */
+function describeVerdict(intervention: Intervention): string {
+  const { verdict } = intervention;
+  switch (verdict.action) {
+    case "retry":
+      return "retried";
+    case "substitute":
+      return "repaired output";
+    case "skip":
+      return verdict.applyTo === "signature"
+        ? "skipped (and every matching failure)"
+        : "skipped";
+    case "end_stream":
+      // Presented under skip per design §4: the kernel action stays distinct,
+      // the record keeps it, the reader sees one verb family.
+      return "skipped the rest, kept what was produced";
+    case "fail":
+      return verdict.reason ? `failed — ${verdict.reason}` : "failed";
+  }
+}
+
+/**
+ * One inline line per intervention, e.g.
+ * `⛨ fetch-item [3] skipped — HTTP 404 (agent, $0.0041)`.
+ */
+export function formatInterventionLine(intervention: Intervention): string {
+  const { escalation } = intervention;
+  const item = escalation.invocationKey ? ` [${escalation.invocationKey}]` : "";
+  const cost =
+    intervention.costUsd && intervention.costUsd > 0
+      ? `, $${intervention.costUsd.toFixed(4)}`
+      : "";
+  return (
+    `${INTERVENTION_MARK} ${escalation.nodeId}${item} ` +
+    `${describeVerdict(intervention)} — ${escalation.detail} ` +
+    `(${intervention.decidedBy}${cost})`
+  );
+}
+
+/**
+ * The run's closing supervised line, e.g.
+ * `⛨ supervised: 3 decisions, 2 skipped, 1 retried, +$0.0200`.
+ *
+ * Item counts (`198/200 items`) are a fan-out property no run-level record
+ * carries — the kernel counts invocations, not the batch a user thinks in —
+ * so a caller that knows its item total passes it in; otherwise the line
+ * reports decisions.
+ */
+export function formatSupervisedSummary(
+  summary: SupervisedRunSummary,
+  items?: { total: number; produced: number }
+): string {
+  const parts: string[] = [];
+  if (items) parts.push(`${items.produced}/${items.total} items`);
+  const verbs: Array<[VerdictAction, string]> = [
+    ["skip", "skipped"],
+    ["end_stream", "stream(s) ended early"],
+    ["retry", "retried"],
+    ["substitute", "repaired"],
+    ["fail", "failed"]
+  ];
+  for (const [action, label] of verbs) {
+    const n = summary.byAction[action];
+    if (n > 0) parts.push(`${n} ${label}`);
+  }
+  parts.push(
+    `${summary.decisions} decision${summary.decisions === 1 ? "" : "s"}`
+  );
+  parts.push(`+$${summary.costUsd.toFixed(4)}`);
+  return `${INTERVENTION_MARK} supervised: ${parts.join(", ")}`;
+}

--- a/packages/execution/src/types.ts
+++ b/packages/execution/src/types.ts
@@ -11,7 +11,8 @@ import type {
   NodeExecutor,
   NodeTypeResolver,
   NodeValidator,
-  RunResult
+  RunResult,
+  SupervisorHandle
 } from "@nodetool-ai/kernel";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
 import type { PythonBridgeBase, ProcessingContext } from "@nodetool-ai/runtime";
@@ -144,6 +145,15 @@ export interface ExecutionSessionOptions {
   requireTerminalResult?: boolean;
   /** Forwarded to `WorkflowRunnerOptions.validateNode`. */
   validateNode?: NodeValidator;
+  /**
+   * Forwarded to `WorkflowRunnerOptions.supervisor` — the one integration
+   * point every surface shares for workflow supervision
+   * (docs/workflow-supervisor-design.md §7). Omitted, the run behaves exactly
+   * as it does today: no escalation is ever constructed. Wrap the handle in
+   * the kernel's `BoundedHandle` before passing it; this facade adds no bounds
+   * of its own.
+   */
+  supervisor?: SupervisorHandle;
   /**
    * Forwarded to `WorkflowRunnerOptions.strict` (docs/RELIABILITY_ARCHITECTURE.md
    * §12): turns advisory lifecycle checks (`_checkPendingInboxWork`, pending

--- a/packages/execution/src/types.ts
+++ b/packages/execution/src/types.ts
@@ -11,7 +11,8 @@ import type {
   NodeExecutor,
   NodeTypeResolver,
   NodeValidator,
-  RunResult
+  RunResult,
+  SupervisorHandle
 } from "@nodetool-ai/kernel";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
 import type { PythonBridgeBase, ProcessingContext } from "@nodetool-ai/runtime";
@@ -163,6 +164,23 @@ export interface ExecutionSessionOptions {
    * for the cap that catches a consumer falling behind.
    */
   captureMessages?: boolean;
+  /**
+   * Workflow supervisor for this run — the single integration point every
+   * surface shares (docs/workflow-supervisor-design.md §7). Forwarded to
+   * `WorkflowRunnerOptions.supervisor`; omitted, no escalation is ever
+   * constructed and the run behaves exactly as it does today.
+   *
+   * Wrap the handle in the kernel's `BoundedHandle` before passing it: the
+   * facade adds no bounds of its own, so an unwrapped handle runs with no
+   * decision ceiling, no retry ceiling, and no per-decision timeout.
+   */
+  supervisor?: SupervisorHandle;
 }
 
-export type { NodeDescriptor, Edge, ProcessingMessage, RunResult };
+export type {
+  NodeDescriptor,
+  Edge,
+  ProcessingMessage,
+  RunResult,
+  SupervisorHandle
+};

--- a/packages/execution/tests/session-supervisor.test.ts
+++ b/packages/execution/tests/session-supervisor.test.ts
@@ -1,0 +1,97 @@
+/**
+ * `ExecutionSessionOptions.supervisor` — the one integration point every
+ * surface configures supervision through (docs/workflow-supervisor-design.md
+ * §7). What matters here is that the facade forwards the handle to the runner
+ * and adds nothing: a scripted handle's verdict must change the run's outcome,
+ * and a session without one must never escalate.
+ */
+import { describe, it, expect } from "vitest";
+import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import type { DecisionOutcome, SupervisorHandle } from "@nodetool-ai/kernel";
+import { ExecutionSession } from "../src/index.js";
+import { buildTestRegistry } from "./fixtures.js";
+
+const NO_BRIDGE = async () => null;
+
+class Boom extends BaseNode {
+  static readonly nodeType = "test.execution.Boom";
+  static readonly title = "Boom";
+  static readonly description = "Always throws";
+
+  @prop({ type: "int", default: 0 })
+  declare value: unknown;
+
+  async process(): Promise<Record<string, unknown>> {
+    throw new Error("node exploded");
+  }
+}
+
+function graph() {
+  return {
+    nodes: [
+      { id: "v", type: "nodetool.input.Value", properties: {} },
+      { id: "b", type: "test.execution.Boom", properties: {} }
+    ],
+    edges: [
+      {
+        source: "v",
+        sourceHandle: "output",
+        target: "b",
+        targetHandle: "value"
+      }
+    ]
+  };
+}
+
+/** Answers every escalation the same way, and counts the calls. */
+class ScriptedHandle implements SupervisorHandle {
+  calls = 0;
+  constructor(private readonly outcome: DecisionOutcome) {}
+  async decide(): Promise<DecisionOutcome> {
+    this.calls++;
+    return this.outcome;
+  }
+  close(): void {}
+}
+
+describe("ExecutionSession — supervisor", () => {
+  it("forwards the handle: a skip verdict completes a run that would fail", async () => {
+    const registry = buildTestRegistry();
+    registry.register(Boom);
+    const supervisor = new ScriptedHandle({
+      verdict: { action: "skip" },
+      decidedBy: "agent"
+    });
+
+    const session = await ExecutionSession.create({
+      graph: graph(),
+      registry,
+      bridgeFactory: NO_BRIDGE,
+      params: { v: 1 },
+      supervisor
+    });
+
+    const result = await session.result;
+
+    expect(supervisor.calls).toBe(1);
+    expect(result.status).toBe("completed");
+    expect(result.interventions?.[0]?.verdict.action).toBe("skip");
+  });
+
+  it("escalates nothing without a handle", async () => {
+    const registry = buildTestRegistry();
+    registry.register(Boom);
+
+    const session = await ExecutionSession.create({
+      graph: graph(),
+      registry,
+      bridgeFactory: NO_BRIDGE,
+      params: { v: 1 }
+    });
+
+    const result = await session.result;
+
+    expect(result.status).toBe("failed");
+    expect(result.interventions).toBeUndefined();
+  });
+});

--- a/packages/execution/tests/supervisor.test.ts
+++ b/packages/execution/tests/supervisor.test.ts
@@ -6,7 +6,12 @@
  * Every verdict here comes from a scripted handle; no LLM is involved.
  */
 import { describe, it, expect } from "vitest";
-import type { Escalation, Intervention, Verdict } from "@nodetool-ai/protocol";
+import type {
+  Escalation,
+  Intervention,
+  ProcessingMessage,
+  Verdict
+} from "@nodetool-ai/protocol";
 import type { DecisionOutcome, SupervisorHandle } from "@nodetool-ai/kernel";
 import { ExecutionSession } from "../src/index.js";
 import {
@@ -130,6 +135,24 @@ describe("interventions in the debug summary", () => {
     const summary = collectExecutionSummary(result.messages ?? []);
     expect(summary.interventions).toEqual([]);
     expect(summary.counts.interventions).toBe(0);
+  });
+
+  it("drops a decision whose decider is missing or unrecognized", async () => {
+    const result = await run(new ScriptedHandle({ action: "skip" }));
+    const real = (result.messages ?? []).find(
+      (m) => m.type === "supervisor_decision"
+    ) as Record<string, unknown> | undefined;
+    expect(real).toBeDefined();
+
+    // Guessing a decider would report a model decided when none did, and
+    // inflate the agent-decision count the cost rollup reads.
+    for (const decidedBy of [undefined, "someone_else"]) {
+      const summary = collectExecutionSummary([
+        { ...real, decided_by: decidedBy }
+      ] as unknown as ProcessingMessage[]);
+      expect(summary.interventions).toEqual([]);
+      expect(summary.counts.interventions).toBe(0);
+    }
   });
 });
 

--- a/packages/execution/tests/supervisor.test.ts
+++ b/packages/execution/tests/supervisor.test.ts
@@ -1,0 +1,197 @@
+/**
+ * `ExecutionSessionOptions.supervisor` — the single integration point every
+ * surface configures (docs/workflow-supervisor-design.md §7), plus the
+ * reporting the CLI and the debug bundle print from it.
+ *
+ * Every verdict here comes from a scripted handle; no LLM is involved.
+ */
+import { describe, it, expect } from "vitest";
+import type { Escalation, Intervention, Verdict } from "@nodetool-ai/protocol";
+import type { DecisionOutcome, SupervisorHandle } from "@nodetool-ai/kernel";
+import { ExecutionSession } from "../src/index.js";
+import {
+  collectExecutionSummary,
+  formatInterventionLine,
+  formatSupervisedSummary,
+  summarizeInterventions
+} from "../src/debug/index.js";
+
+class ScriptedHandle implements SupervisorHandle {
+  readonly seen: Escalation[] = [];
+  closed = false;
+  constructor(
+    private readonly verdict: Verdict,
+    private readonly costUsd = 0.01
+  ) {}
+  async decide(e: Escalation): Promise<DecisionOutcome> {
+    this.seen.push(e);
+    return { verdict: this.verdict, decidedBy: "agent", costUsd: this.costUsd };
+  }
+  close(): void {
+    this.closed = true;
+  }
+}
+
+const GRAPH = {
+  nodes: [
+    { id: "input", type: "test.Input", name: "x" },
+    { id: "work", type: "test.Work", outputs: { value: "str" } },
+    { id: "out", type: "nodetool.output.Output", name: "result" }
+  ],
+  edges: [
+    {
+      source: "input",
+      sourceHandle: "value",
+      target: "work",
+      targetHandle: "a"
+    },
+    {
+      source: "work",
+      sourceHandle: "value",
+      target: "out",
+      targetHandle: "value"
+    }
+  ]
+};
+
+/** `work` throws; everything else echoes its inputs. */
+const resolveExecutor = (node: { id: string }) =>
+  node.id === "work"
+    ? {
+        async process(): Promise<Record<string, unknown>> {
+          throw new Error("boom");
+        }
+      }
+    : {
+        async process(inputs: Record<string, unknown>) {
+          return inputs;
+        }
+      };
+
+async function run(supervisor?: SupervisorHandle) {
+  const session = await ExecutionSession.create({
+    graph: GRAPH,
+    resolveExecutor,
+    jobId: "supervisor-session-test",
+    params: { x: "hi" },
+    ...(supervisor ? { supervisor } : {})
+  });
+  return session.result;
+}
+
+describe("ExecutionSession — supervisor option", () => {
+  it("forwards the handle so a skip verdict rescues a failing run", async () => {
+    const handle = new ScriptedHandle({ action: "skip" });
+    const result = await run(handle);
+
+    expect(handle.seen).toHaveLength(1);
+    expect(handle.seen[0]?.nodeId).toBe("work");
+    expect(result.status).toBe("completed");
+    expect(result.interventions).toHaveLength(1);
+    expect(result.interventions?.[0]?.verdict.action).toBe("skip");
+    expect(result.interventions?.[0]?.decidedBy).toBe("agent");
+    expect(result.interventions?.[0]?.costUsd).toBeCloseTo(0.01);
+  });
+
+  it("a run without a supervisor is unchanged", async () => {
+    const bare = await run();
+    // No handle configured: nothing escalates, no interventions are recorded,
+    // and the failure is the same failure as before supervision existed.
+    expect(bare.status).toBe("failed");
+    expect(bare.interventions).toBeUndefined();
+    expect(
+      (bare.messages ?? []).some((m) => m.type.startsWith("supervisor_"))
+    ).toBe(false);
+  });
+
+  it("leaves the message stream of an unsupervised run byte-identical", async () => {
+    const strip = (result: Awaited<ReturnType<typeof run>>) =>
+      (result.messages ?? []).map((m) => m.type);
+
+    const first = await run();
+    const second = await run();
+    expect(strip(first)).toEqual(strip(second));
+  });
+});
+
+describe("interventions in the debug summary", () => {
+  it("folds supervisor_decision messages into the shared summary", async () => {
+    const result = await run(new ScriptedHandle({ action: "skip" }));
+    const summary = collectExecutionSummary(result.messages ?? []);
+
+    expect(summary.counts.interventions).toBe(1);
+    expect(summary.interventions[0]?.escalation.nodeId).toBe("work");
+    expect(summary.interventions[0]?.verdict.action).toBe("skip");
+    expect(summary.interventions[0]?.decidedBy).toBe("agent");
+  });
+
+  it("reports no interventions for an unsupervised run", async () => {
+    const result = await run();
+    const summary = collectExecutionSummary(result.messages ?? []);
+    expect(summary.interventions).toEqual([]);
+    expect(summary.counts.interventions).toBe(0);
+  });
+});
+
+describe("intervention reporting", () => {
+  const intervention = (
+    over: Partial<Intervention> = {},
+    escalation: Partial<Escalation> = {}
+  ): Intervention => ({
+    escalation: {
+      nodeId: "fetch",
+      nodeType: "test.Fetch",
+      correlationLineage: [],
+      invocationKey: "",
+      allowedActions: ["skip", "fail"],
+      detail: "HTTP 404",
+      inputs: {},
+      declaredOutputs: {},
+      attempt: 1,
+      spentCostUsd: 0,
+      createdAssets: false,
+      retrySafe: false,
+      emitted: false,
+      ...escalation
+    },
+    verdict: { action: "skip" },
+    decidedBy: "agent",
+    costUsd: 0.01,
+    ...over
+  });
+
+  it("rolls up actions, deciders and cost", () => {
+    const summary = summarizeInterventions([
+      intervention(),
+      intervention({ verdict: { action: "retry" }, decidedBy: "sticky" }),
+      intervention({ verdict: { action: "fail" }, costUsd: undefined })
+    ]);
+    expect(summary.decisions).toBe(3);
+    expect(summary.agentDecisions).toBe(2);
+    expect(summary.byAction.skip).toBe(1);
+    expect(summary.byAction.retry).toBe(1);
+    expect(summary.byDecider.sticky).toBe(1);
+    expect(summary.costUsd).toBeCloseTo(0.02);
+  });
+
+  it("prints one shield line per decision, with the item key when there is one", () => {
+    const line = formatInterventionLine(
+      intervention({}, { invocationKey: "3" })
+    );
+    expect(line).toContain("⛨");
+    expect(line).toContain("fetch [3]");
+    expect(line).toContain("skipped");
+    expect(line).toContain("HTTP 404");
+    expect(line).toContain("agent");
+  });
+
+  it("prints a supervised summary line, with item counts when known", () => {
+    const summary = summarizeInterventions([intervention(), intervention()]);
+    expect(formatSupervisedSummary(summary)).toBe(
+      "⛨ supervised: 2 skipped, 2 decisions, +$0.0200"
+    );
+    expect(
+      formatSupervisedSummary(summary, { total: 200, produced: 198 })
+    ).toContain("198/200 items");
+  });
+});

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -992,6 +992,7 @@ function getCreateSchemaSql(): string {
       "run_count" integer NOT NULL DEFAULT 0,
       "expires_at" text,
       "max_runs" integer,
+      "supervise" integer NOT NULL DEFAULT 0,
       "created_at" text NOT NULL,
       "updated_at" text NOT NULL
     );

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -2422,6 +2422,29 @@ export const migrations: MigrationDef[] = [
       // The `user_id` columns stay: SQLite cannot drop a column portably and
       // the column is inert to code that does not read it.
     }
+  },
+
+  // ── Workflow supervision opt-in on trigger_registrations ───────────
+  // A trigger run can be supervised: a failing node escalates to a model
+  // instead of failing the run outright. The column defaults to 0 and no
+  // existing registration is touched — enabling supervision shares failure
+  // context with a model, so consent is per-registration and forward-looking
+  // (docs/workflow-supervisor-design.md §6.1).
+  {
+    version: "20260801_000001",
+    name: "add_trigger_registration_supervise",
+    createsTables: [],
+    modifiesTables: ["trigger_registrations"],
+    async up(db) {
+      if (!(await db.tableExists("trigger_registrations"))) return;
+      if (await db.columnExists("trigger_registrations", "supervise")) return;
+      await db.execute(
+        "ALTER TABLE trigger_registrations ADD COLUMN supervise INTEGER NOT NULL DEFAULT 0"
+      );
+    },
+    async down() {
+      // no-op: SQLite cannot drop columns portably, and leaving it is inert.
+    }
   }
 ];
 

--- a/packages/models/src/schema-pg/trigger-registrations.ts
+++ b/packages/models/src/schema-pg/trigger-registrations.ts
@@ -26,6 +26,7 @@ export const triggerRegistrations = pgTable(
     run_count: integer("run_count").notNull().default(0),
     expires_at: text("expires_at"),
     max_runs: integer("max_runs"),
+    supervise: integer("supervise").notNull().default(0),
     created_at: text("created_at").notNull(),
     updated_at: text("updated_at").notNull()
   },

--- a/packages/models/src/schema/trigger-registrations.ts
+++ b/packages/models/src/schema/trigger-registrations.ts
@@ -29,6 +29,11 @@ export const triggerRegistrations = sqliteTable(
     run_count: integer("run_count").notNull().default(0),
     expires_at: text("expires_at"),
     max_runs: integer("max_runs"),
+    // Workflow supervision for runs this trigger starts. Off by default and
+    // never migrated on: enabling supervision shares failure context with a
+    // model, so consent is per-registration and forward-looking
+    // (docs/workflow-supervisor-design.md §6.1).
+    supervise: integer("supervise").notNull().default(0),
     created_at: text("created_at").notNull(),
     updated_at: text("updated_at").notNull()
   },

--- a/packages/models/src/trigger-registration.ts
+++ b/packages/models/src/trigger-registration.ts
@@ -25,6 +25,8 @@ export class TriggerRegistration extends DBModel {
   declare run_count: number;
   declare expires_at: string | null;
   declare max_runs: number | null;
+  /** 1 when runs from this trigger are supervised. Off (0) by default. */
+  declare supervise: number;
   declare created_at: string;
   declare updated_at: string;
 
@@ -42,6 +44,7 @@ export class TriggerRegistration extends DBModel {
     this.run_count ??= 0;
     this.expires_at ??= null;
     this.max_runs ??= null;
+    this.supervise ??= 0;
     this.created_at ??= now;
     this.updated_at ??= now;
   }

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 55;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 56;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -931,6 +931,16 @@ export interface RunJobRequest {
   require_terminal_result?: boolean;
   /** Additive execution relaxations. Omitted values preserve current behavior. */
   execution_options?: RunJobExecutionOptions;
+  /**
+   * Supervise this run: a node invocation that fails after its own error
+   * handling escalates to a supervisor agent, which answers with a verdict.
+   * **Off unless the client asks for it** — supervision sends failure context
+   * (node inputs, error text) to a model, so it is never implied by anything
+   * else on the request. See docs/workflow-supervisor-design.md.
+   */
+  supervise?: boolean;
+  /** Supervisor configuration. Ignored unless `supervise` is true. */
+  supervisor?: SupervisorRunOptions;
   resource_limits?: ResourceLimits | null;
   /**
    * The mini app this run belongs to, when it was started by one. Present only
@@ -959,6 +969,26 @@ export interface RunJobRequest {
     payload: unknown;
     input_id: string;
   } | null;
+}
+
+/**
+ * What a run's supervisor is allowed to be and to spend. Every field is
+ * optional: a host that only sets `supervise: true` gets its configured
+ * defaults (provider/model) and the kernel's default bounds.
+ */
+export interface SupervisorRunOptions {
+  /** Provider id for the supervising model; defaults to the server's. */
+  provider?: string;
+  /** Model id for the supervising model; defaults to the server's. */
+  model?: string;
+  /** Decisions the supervisor may make in this run. */
+  max_decisions?: number;
+  /** Retries per `(node, invocation)`. */
+  max_retries_per_node?: number;
+  /** Per-decision wall clock, in ms. */
+  decision_timeout_ms?: number;
+  /** Dollar ceiling on supervision for the whole run. */
+  cost_cap_usd?: number;
 }
 
 export interface RunJobExecutionOptions {

--- a/packages/websocket/src/headless-job-runner.ts
+++ b/packages/websocket/src/headless-job-runner.ts
@@ -25,7 +25,9 @@ import {
 } from "@nodetool-ai/execution";
 import { Job, Workflow, getSecret } from "@nodetool-ai/models";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+import type { SupervisorRunOptions } from "@nodetool-ai/protocol";
 import { FileStorageAdapter, ProcessingContext } from "@nodetool-ai/runtime";
+import { createRunSupervisor } from "./run-supervisor.js";
 import { resolveWorkflowWorkspace } from "./lib/workflow-workspace.js";
 
 const log = createLogger("nodetool.websocket.headless-job");
@@ -48,6 +50,16 @@ export interface StartHeadlessJobOptions {
   jobName?: string;
   /** Node registry to resolve executors from. Defaults to the bootstrapped server registry. */
   registry?: NodeRegistry;
+  /**
+   * Supervise this run (docs/workflow-supervisor-design.md). Off unless the
+   * caller asks — the trigger dispatcher passes the registration's own flag,
+   * which defaults to off. Without a configured supervisor model
+   * (`NODETOOL_SUPERVISOR_PROVIDER` / `NODETOOL_SUPERVISOR_MODEL`) the run
+   * proceeds unsupervised rather than failing.
+   */
+  supervise?: boolean;
+  /** Supervisor configuration. Ignored unless `supervise` is true. */
+  supervisor?: SupervisorRunOptions | null;
   /**
    * Called once the run is *accepted* — the workflow resolved and the `Job` row
    * exists — which is long before this function's promise settles on terminal
@@ -185,6 +197,12 @@ export async function startHeadlessJob(
   // → throw). `session.result` never rejects — kernel failures (including an
   // unknown node type) resolve as `status: "failed"` instead of throwing, so
   // the job still settles instead of leaving a phantom "running" row behind.
+  const supervisor = await createRunSupervisor({
+    supervise: options.supervise,
+    supervisor: options.supervisor,
+    context
+  });
+
   const session = await ExecutionSession.create({
     graph: graph as unknown as RawGraphInput,
     registry,
@@ -192,7 +210,8 @@ export async function startHeadlessJob(
     workflowId,
     params,
     triggerEvent: options.triggerEvent ?? null,
-    context
+    context,
+    ...(supervisor ? { supervisor } : {})
   });
 
   const result = await session.result;

--- a/packages/websocket/src/run-supervisor.ts
+++ b/packages/websocket/src/run-supervisor.ts
@@ -1,0 +1,113 @@
+/**
+ * Builds the `SupervisorHandle` a supervised run gets, for every server-side
+ * entry point that starts one (the websocket runner, the headless/trigger
+ * runner).
+ *
+ * Supervision is opt-in and stays opt-in: this returns `null` for anything
+ * short of an explicit `supervise: true` plus a resolvable model, and a run
+ * without a handle constructs no escalation at all. A misconfiguration
+ * therefore degrades to today's behavior rather than failing the run — the
+ * fail-closed rule the whole design follows.
+ *
+ * See docs/workflow-supervisor-design.md §7 entry point 4.
+ */
+
+import { createLogger } from "@nodetool-ai/config";
+import { SupervisorAgent } from "@nodetool-ai/agents";
+import { BoundedHandle, type SupervisorHandle } from "@nodetool-ai/kernel";
+import type { SupervisorRunOptions } from "@nodetool-ai/protocol";
+import { getProvider, type ProcessingContext } from "@nodetool-ai/runtime";
+
+const log = createLogger("nodetool.websocket.run-supervisor");
+
+export interface CreateRunSupervisorOptions {
+  /** The request's flag. Anything but `true` yields `null`. */
+  supervise?: boolean | undefined;
+  /** Per-request supervisor configuration. */
+  supervisor?: SupervisorRunOptions | null | undefined;
+  /** The run's context — used for secrets, memory, and tool execution. */
+  context: ProcessingContext;
+  /** Server-configured fallbacks when the request names neither. */
+  defaultProvider?: string | undefined;
+  defaultModel?: string | undefined;
+}
+
+/**
+ * Resolve the supervising model. Request first, then the caller's configured
+ * defaults, then the environment — the last exists for hosts that have no
+ * per-connection defaults at all (the trigger dispatcher's headless runs).
+ */
+function resolveModel(options: CreateRunSupervisorOptions): {
+  provider: string;
+  model: string;
+} | null {
+  const provider =
+    options.supervisor?.provider ??
+    options.defaultProvider ??
+    process.env["NODETOOL_SUPERVISOR_PROVIDER"];
+  const model =
+    options.supervisor?.model ??
+    options.defaultModel ??
+    process.env["NODETOOL_SUPERVISOR_MODEL"];
+  if (!provider || !model) return null;
+  return { provider, model };
+}
+
+export async function createRunSupervisor(
+  options: CreateRunSupervisorOptions
+): Promise<SupervisorHandle | null> {
+  if (options.supervise !== true) return null;
+
+  const selection = resolveModel(options);
+  if (!selection) {
+    log.warn(
+      "Supervision requested but no supervisor model is configured — running unsupervised"
+    );
+    return null;
+  }
+
+  // A dedicated provider instance, not the one the run's nodes resolve
+  // through the context: per-turn spend is reconciled from the provider's own
+  // running cost, so a second caller on the same instance would corrupt the
+  // supervisor's dollar cap.
+  let provider;
+  try {
+    provider = await getProvider(selection.provider, (key) =>
+      options.context.getSecret(key)
+    );
+  } catch (error) {
+    log.warn("Supervisor provider unavailable — running unsupervised", {
+      provider: selection.provider,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return null;
+  }
+
+  const agent = new SupervisorAgent({
+    provider,
+    model: selection.model,
+    // The supervisor shares the run's memory (its `supervisor:` keys belong to
+    // the run) but not its listeners: the decision's own provider traffic is
+    // not the run's message stream. The kernel emits the escalation and the
+    // verdict on the run's context regardless.
+    context: options.context.copy({
+      shareMemory: true,
+      inheritMessageListeners: false
+    }),
+    ...(options.supervisor?.cost_cap_usd !== undefined
+      ? { maxCostUsd: options.supervisor.cost_cap_usd }
+      : {})
+  });
+
+  return new BoundedHandle(agent, {
+    ...(options.supervisor?.max_decisions !== undefined
+      ? { maxDecisions: options.supervisor.max_decisions }
+      : {}),
+    ...(options.supervisor?.max_retries_per_node !== undefined
+      ? { maxRetriesPerNode: options.supervisor.max_retries_per_node }
+      : {}),
+    ...(options.supervisor?.decision_timeout_ms !== undefined
+      ? { decisionTimeoutMs: options.supervisor.decision_timeout_ms }
+      : {})
+  });
+}

--- a/packages/websocket/src/triggers/dispatcher.ts
+++ b/packages/websocket/src/triggers/dispatcher.ts
@@ -509,6 +509,8 @@ export class TriggerDispatcher {
         workflowId: registration.workflow_id,
         userId: registration.user_id,
         params: triggerRunParams(registration, nowMs),
+        // Per-registration opt-in, off unless the row says otherwise.
+        supervise: registration.supervise === 1,
         triggerEvent: {
           node_id: input.nodeId,
           payload: input.payload,

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -36,6 +36,7 @@ import {
   ExecutionSession,
   type RawGraphInput as ExecutionSessionRawGraph
 } from "@nodetool-ai/execution";
+import { createRunSupervisor } from "./run-supervisor.js";
 import {
   Application,
   Asset,
@@ -90,7 +91,8 @@ import type {
   HydratedGraphData,
   NodeDescriptor,
   ProcessingMessage,
-  ProviderCost
+  ProviderCost,
+  SupervisorRunOptions
 } from "@nodetool-ai/protocol";
 import {
   getSdkV1SafeErrorMessage,
@@ -1491,6 +1493,14 @@ export interface RunJobRequest {
     event_detail?: "full" | "outputs" | "terminal";
     asset_persistence?: "auto" | "temporary";
   };
+  /**
+   * Supervise this run (docs/workflow-supervisor-design.md). Off unless the
+   * client asks: supervision sends failure context to a model, so nothing else
+   * on the request implies it.
+   */
+  supervise?: boolean;
+  /** Supervisor configuration. Ignored unless `supervise` is true. */
+  supervisor?: SupervisorRunOptions | null;
   /** Internal monotonic timestamp captured when runJob accepts the request. */
   _accepted_at_ms?: number;
   settings?: Record<string, unknown>;
@@ -3003,6 +3013,17 @@ export class UnifiedWebSocketRunner {
     // is passed through as-is (not rebuilt from a registry+bridge) because
     // this class only ever holds the bootstrap-injected closure, never a
     // `NodeRegistry` instance.
+    // Opt-in per request; a run that asked for no supervisor gets none, and a
+    // supervisor that cannot be built leaves the run unsupervised rather than
+    // failing it.
+    const supervisor = await createRunSupervisor({
+      supervise: req.supervise,
+      supervisor: req.supervisor,
+      context,
+      defaultProvider: this.defaultProvider,
+      defaultModel: this.defaultModel
+    });
+
     const session = await ExecutionSession.create({
       graph: graph as unknown as ExecutionSessionRawGraph,
       resolveExecutor: (node) =>
@@ -3014,7 +3035,8 @@ export class UnifiedWebSocketRunner {
       workflowId,
       context,
       params: req.params ?? {},
-      validateNode: this.validateNode
+      validateNode: this.validateNode,
+      ...(supervisor ? { supervisor } : {})
     });
 
     const active: ActiveJob = {

--- a/packages/websocket/tests/run-supervisor.test.ts
+++ b/packages/websocket/tests/run-supervisor.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `createRunSupervisor` — the server-side supervisor factory.
+ *
+ * Supervision is opt-in and fails closed: no flag, no unresolvable model, and
+ * no unavailable provider may produce a handle, because a run without one
+ * behaves exactly as it does today.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { ProcessingContext } from "@nodetool-ai/runtime";
+import { createRunSupervisor } from "../src/run-supervisor.js";
+
+function context(): ProcessingContext {
+  return new ProcessingContext({ jobId: "j1", workflowId: null, userId: "1" });
+}
+
+const ENV_KEYS = [
+  "NODETOOL_SUPERVISOR_PROVIDER",
+  "NODETOOL_SUPERVISOR_MODEL"
+] as const;
+
+afterEach(() => {
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+describe("createRunSupervisor", () => {
+  it("returns null without an explicit supervise flag", async () => {
+    expect(
+      await createRunSupervisor({
+        context: context(),
+        defaultProvider: "openai",
+        defaultModel: "gpt-4o-mini"
+      })
+    ).toBeNull();
+    expect(
+      await createRunSupervisor({
+        supervise: false,
+        context: context(),
+        defaultProvider: "openai",
+        defaultModel: "gpt-4o-mini"
+      })
+    ).toBeNull();
+  });
+
+  it("returns null when no supervisor model is configured", async () => {
+    expect(
+      await createRunSupervisor({ supervise: true, context: context() })
+    ).toBeNull();
+  });
+
+  it("returns null when the provider cannot be built (unknown id, missing key)", async () => {
+    expect(
+      await createRunSupervisor({
+        supervise: true,
+        supervisor: { provider: "not_a_registered_provider", model: "x" },
+        context: context()
+      })
+    ).toBeNull();
+  });
+
+  it("builds a handle from the request's provider and model", async () => {
+    // A provider that needs no API key, so the test asserts on the wiring
+    // rather than on a configured secret store.
+    const handle = await createRunSupervisor({
+      supervise: true,
+      supervisor: { provider: "claude_agent_sdk", model: "sonnet" },
+      context: context()
+    });
+    expect(handle).not.toBeNull();
+    handle?.close();
+  });
+
+  it("falls back to the environment when nothing else names a model", async () => {
+    process.env["NODETOOL_SUPERVISOR_PROVIDER"] = "claude_agent_sdk";
+    process.env["NODETOOL_SUPERVISOR_MODEL"] = "sonnet";
+    const handle = await createRunSupervisor({
+      supervise: true,
+      context: context()
+    });
+    expect(handle).not.toBeNull();
+    handle?.close();
+  });
+});

--- a/packages/websocket/tests/supervisor-relay.test.ts
+++ b/packages/websocket/tests/supervisor-relay.test.ts
@@ -1,0 +1,116 @@
+/**
+ * `supervisor_*` relay.
+ *
+ * The kernel emits `supervisor_escalation` / `supervisor_decision` on the run's
+ * context; the client's intervention feed only exists if the websocket runner
+ * relays them. A node posts both messages here — no model, no escalation — so
+ * what is under test is the relay itself: neither type may be dropped, and both
+ * carry the run's `job_id` / `workflow_id`.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { unpack } from "msgpackr";
+import { initTestDb } from "@nodetool-ai/models";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type { Escalation } from "@nodetool-ai/protocol";
+import {
+  UnifiedWebSocketRunner,
+  type WebSocketConnection,
+  type WebSocketReceiveFrame
+} from "../src/unified-websocket-runner.js";
+
+class MockWS implements WebSocketConnection {
+  clientState: "connected" | "disconnected" = "connected";
+  applicationState: "connected" | "disconnected" = "connected";
+  sentBytes: Uint8Array[] = [];
+  queue: Array<WebSocketReceiveFrame> = [];
+  async accept() {}
+  async receive(): Promise<WebSocketReceiveFrame> {
+    return this.queue.shift() ?? { type: "websocket.disconnect" };
+  }
+  async sendBytes(data: Uint8Array) {
+    this.sentBytes.push(data);
+  }
+  async sendText() {}
+  async close() {
+    this.clientState = "disconnected";
+    this.applicationState = "disconnected";
+  }
+}
+
+const escalation: Escalation = {
+  nodeId: "n1",
+  nodeType: "test.Node",
+  correlationLineage: [],
+  invocationKey: "",
+  allowedActions: ["skip", "fail"],
+  detail: "boom",
+  inputs: {},
+  declaredOutputs: { output: "str" },
+  attempt: 1,
+  spentCostUsd: 0,
+  createdAssets: false,
+  retrySafe: false,
+  emitted: false
+};
+
+let ws: MockWS;
+
+beforeEach(async () => {
+  await initTestDb();
+  ws = new MockWS();
+});
+
+describe("supervisor message relay", () => {
+  it("relays escalation and decision messages to the client", async () => {
+    const runner = new UnifiedWebSocketRunner({
+      resolveExecutor: () => ({
+        async process(
+          _inputs: Record<string, unknown>,
+          context?: ProcessingContext
+        ) {
+          context?.postMessage({
+            type: "supervisor_escalation",
+            node_id: "n1",
+            node_name: "Node",
+            escalation
+          });
+          context?.postMessage({
+            type: "supervisor_decision",
+            node_id: "n1",
+            node_name: "Node",
+            escalation,
+            verdict: { action: "skip" },
+            decided_by: "agent",
+            cost: 0.0002
+          });
+          return { output: "ok" };
+        }
+      })
+    });
+
+    await runner.connect(ws);
+    await runner.runJob({
+      job_id: "JOB1",
+      workflow_id: "WF1",
+      graph: { nodes: [{ id: "n1", type: "test.Node" }], edges: [] }
+    });
+    await new Promise((r) => setTimeout(r, 200));
+
+    const sent = ws.sentBytes.map((b) => unpack(b) as Record<string, unknown>);
+    const relayedEscalation = sent.find(
+      (m) => m.type === "supervisor_escalation"
+    );
+    const relayedDecision = sent.find((m) => m.type === "supervisor_decision");
+
+    expect(relayedEscalation).toBeDefined();
+    expect(relayedEscalation?.job_id).toBe("JOB1");
+    expect(relayedEscalation?.workflow_id).toBe("WF1");
+    expect(relayedDecision).toBeDefined();
+    expect(
+      (relayedDecision?.verdict as { action: string } | undefined)?.action
+    ).toBe("skip");
+    expect(relayedDecision?.decided_by).toBe("agent");
+
+    await runner.disconnect();
+  });
+});


### PR DESCRIPTION
Ships the two parallel PRs of Phase B from [docs/workflow-supervisor-implementation-plan.md](docs/workflow-supervisor-implementation-plan.md). Both depend on PR 3 (#4634) and on nothing else, so they land together.

## PR 4 — the CLI surface

- **`ExecutionSessionOptions.supervisor`** in `packages/execution` is the single integration point (design §7). It forwards to `WorkflowRunnerOptions.supervisor`; no CLI code touches `WorkflowRunner`, and no grandfathered direct-construction site gained supervision.
- **Flags** `--supervise`, `--max-decisions`, `--max-retries`, `--supervisor-cost-cap`, `--supervisor-model` on `nodetool run`, `nodetool workflows run`, and `nodetool debug`. Parsing and model-spec resolution are pure (`packages/cli/src/supervisor.ts`); the agents package and the provider load behind dynamic imports, so an unsupervised run pays nothing. `debug` goes through the shared debug service — the collector folds `supervisor_decision` into `ExecutionSummary.interventions`, and intervention warnings feed the verdict's `warnings`, never its `issues`.
- **Output**: inline `⛨` lines streamed from the session messages (on stderr, so `--json` stdout stays parseable), a supervised summary line (`⛨ supervised: 2 skipped, 1 retried, 3 decisions, +$0.0200`), and an `interventions` block in `--json`. The record is protocol's `Intervention` unchanged, so PR 6's UI consumes one shape.
- **Cost**: `recordSupervisorCost` writes one `Prediction` row per billable decision — `node_type: "supervisor"`, `workflow_id` = the run, `metadata.job_id`/`decided_by`/`verdict`. Every `nodetool costs` subcommand sees it.

Two deviations, both recorded in the plan: `nodetool run` is a DSL command executing through `@nodetool-ai/dsl`'s own runner, so `--supervise` switches it onto `ExecutionSession` while the unsupervised path stays untouched; and the plan's "198/200 items" is a batch the kernel never names, so the summary takes an optional item total and otherwise reports decisions.

## PR 5 — workflows as agents

- **The fourth branch.** `AgentOptions.graph?: GraphData | { workflowId: string }` plus `supervise`, `supervisorBounds`, `maxSupervisorCostUsd`. `Agent._executeImpl` dispatches to `executeSuppliedGraph` before every planning mode; the mechanics live in `packages/agents/src/workflow-agent.ts` — child context with shared memory, messages forwarded to the parent, signal wired to `session.cancel`, `getResults()` returning the run outputs. Supervision builds `BoundedHandle(SupervisorAgent)` from the agent's own provider and reasoning model. The branch adopts the existing `AgentPolicy`: `maxStepIterations`/`maxTokens` reach the graph's Agent nodes through the same `applyRunPolicy` the graph-planner branch uses, so there is no fifth ad-hoc policy.
- **Websocket.** `RunJobRequest.supervise` and `supervisor?: SupervisorRunOptions`. `createRunSupervisor` is the single factory shared by the main run path and the headless/trigger runner; it returns `null` unless `supervise === true` and a provider and model resolve (request → connection defaults → env). `supervisor_*` messages pass through the relay untouched, now under test.
- **Triggers** carry a `supervise` column (sqlite + pg, migration `20260801_000001`), defaulting to `0` and forwarded by the dispatcher; registration sync mutates rows in place so a re-sync never resets it. Nothing is flipped on anywhere — the default flip belongs to PR 8's gate.

## Merge reconciliation

Both branches independently added `ExecutionSessionOptions.supervisor` (PR 5 cannot run without it). Resolved to a single field with the stricter doc comment, and to the conditional-spread forwarding form in `session.ts`.

## Tests

New: `packages/execution/tests/supervisor.test.ts`, `packages/cli/tests/supervisor.test.ts`, `packages/agents/tests/agent-graph-mode.test.ts`, `packages/execution/tests/session-supervisor.test.ts`, `packages/websocket/tests/run-supervisor.test.ts`, `packages/websocket/tests/supervisor-relay.test.ts`.

The graph-mode suite covers the load-bearing claims: outputs identical to a bare `WorkflowRunner` on a clean graph, a scripted `skip` completing a run that would otherwise fail while surfacing `supervisor_escalation`/`supervisor_decision`, a scripted `fail` still failing, a clean supervised run emitting no `supervisor_*` at all, and an aborted signal cancelling the run.

## Verification

Run on the merged tree, not on the individual branches:

- `npm run build:packages` — 60/60
- `npx vitest run --root packages/{execution,agents,cli,websocket,kernel,models}` — 23, 1877, 458, 2008, 1001, 783 passed
- `npm run lint` — exit 0 (pre-existing react-hooks warnings only, none in touched files); `check:deps`, `check:circular`, `check:execution-boundary`, `check:coupled-deps`, `check:lockfile` all pass
- `npm run typecheck` — web and electron clean. **Mobile fails for an environmental reason**: `mobile/` is not a root workspace and its `node_modules` was never installed in this container, so every error is `TS2307: Cannot find module 'react-native' / 'expo-*'` plus `TS6053: File 'expo/tsconfig.base' not found`. No error names a file in this diff, and no mobile file was touched.

## Out of scope

No UI (PR 6), no `Assert` node (PR 7), no `ReplayHandle` or eval suite (PR 8), no default flipped on. There is no editor or API surface for *setting* a trigger's `supervise` bit yet — the column, model field, and dispatcher read exist; the write path is a PR 6/8 toggle. The browser debug surface stays unsupervised until PR 6.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K83nCW1jVkfQCTKV96iBgP)_