### PR TITLE
fix: deliver trigger events on the resolveNodeType hydration path

### DIFF
--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -590,6 +590,13 @@ addSupervisorOptions(
       "--workspace <dir>",
       "Workspace directory for workspace-mode asset output (default: ./nodetool-output)"
     )
+    .option(
+      "--trigger-event <json>",
+      'Wake a trigger node as the scheduler/webhook adapter would: \'{"node_id":"watch","payload":{"path":"/tmp/a.csv","event":"created"}}\'. ' +
+        "Without it a webhook, file-watch or manual trigger has no event to " +
+        "emit and the run stalls until its timeout — so this is the only way " +
+        "to exercise a trigger-driven workflow from the CLI."
+    )
 )
   .action(
     async (
@@ -599,6 +606,7 @@ addSupervisorOptions(
         json?: boolean;
         assetOutputMode?: string;
         workspace?: string;
+        triggerEvent?: string;
       } & SupervisorCliOptions
     ) => {
       try {
@@ -609,6 +617,32 @@ addSupervisorOptions(
         const params = opts.params
           ? (JSON.parse(opts.params) as Record<string, unknown>)
           : {};
+
+        // A trigger node emits from `emitTriggerEvent`, not `genProcess`, and
+        // only when the run carries an event addressed to it. The kernel has
+        // always accepted one (`RunJobRequest.trigger_event`); nothing on the
+        // CLI could supply it, so a webhook or file-watch workflow could be
+        // validated but never executed. `input_id` defaults because every
+        // caller would otherwise invent the same throwaway id.
+        const triggerEvent = opts.triggerEvent
+          ? (() => {
+              const parsed = JSON.parse(opts.triggerEvent) as {
+                node_id?: string;
+                payload?: unknown;
+                input_id?: string;
+              };
+              if (!parsed.node_id) {
+                throw new Error(
+                  '--trigger-event needs a "node_id" naming the trigger node to wake.'
+                );
+              }
+              return {
+                node_id: parsed.node_id,
+                payload: parsed.payload ?? {},
+                input_id: parsed.input_id ?? `cli-${Date.now()}`
+              };
+            })()
+          : null;
 
         // Determine if argument is a file path or workflow ID
         if (
@@ -797,6 +831,7 @@ addSupervisorOptions(
           workflowId,
           params,
           context,
+          ...(triggerEvent ? { triggerEvent } : {}),
           // Message capture is retention, so it stays off unless a supervised
           // run needs the stream to print its `⛨` lines as they happen.
           ...(supervisor

--- a/packages/execution/tests/trigger-event-hydration.test.ts
+++ b/packages/execution/tests/trigger-event-hydration.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Trigger-event regression: a delivered event must reach the trigger node's
+ * outputs on the `resolveNodeType` hydration path, not just the
+ * `hydrateGraphNodeFlags` one.
+ *
+ * `actor.ts` gates the trigger entry point on `node.is_trigger`. Saved
+ * workflow JSON never carries that flag, so it has to come from the registry
+ * during hydration — and the two hydration paths are mutually exclusive
+ * (`session.ts`: `resolveNodeType` takes `Graph.loadFromDict`, otherwise
+ * `hydrateGraphNodeFlags`). `hydrateGraphNodeFlags` set the flag; the resolver
+ * path dropped it in two places at once — `createGraphNodeTypeResolver` never
+ * put `is_trigger` in its `descriptorDefaults`, and `loadFromDict` never read
+ * it — so it silently defaulted to false.
+ *
+ * The failure was quiet, which is why it survived: the run completed, the
+ * trigger node reported success, and the event was simply ignored. The node
+ * fell through to `genProcess()`, which waits on a live adapter a
+ * delivered-event run does not have, and emitted nothing. Every host passing
+ * `resolveNodeType` was affected — the CLI and the websocket server both do.
+ *
+ * The assertion is the payload value, not merely that something was emitted:
+ * the interval trigger's `genProcess()` path also emits a tick, so a test that
+ * only checked for output would have passed against the bug.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  BaseNode,
+  NodeRegistry,
+  createGraphNodeTypeResolver,
+  prop
+} from "@nodetool-ai/node-sdk";
+import type { StreamingOutputs, TriggerEvent } from "@nodetool-ai/node-sdk";
+import { ExecutionSession } from "../src/index.js";
+
+/**
+ * Minimal stand-in for the shipped trigger nodes: `genProcess` emits a value
+ * the delivered event never would, so the two paths are distinguishable.
+ */
+class ProbeTrigger extends BaseNode {
+  static readonly nodeType = "test.triggers.Probe";
+  static readonly isTrigger = true;
+  static readonly metadataOutputTypes = { body: "any" };
+
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async *genProcess(): AsyncGenerator<Record<string, unknown>> {
+    yield { body: "from-genProcess" };
+  }
+
+  override async emitTriggerEvent(
+    event: TriggerEvent,
+    outputs: StreamingOutputs
+  ): Promise<void> {
+    const payload = (event.payload ?? {}) as { body?: unknown };
+    await outputs.emit("body", payload.body);
+  }
+}
+
+class Sink extends BaseNode {
+  static readonly nodeType = "test.Sink";
+  static readonly title = "Sink";
+  static readonly metadataOutputTypes = { output: "any" };
+
+  @prop({ type: "any", default: null })
+  declare value: unknown;
+
+  async process(): Promise<Record<string, unknown>> {
+    return { output: this.value };
+  }
+}
+
+function registry(): NodeRegistry {
+  const r = new NodeRegistry();
+  r.register(ProbeTrigger as never);
+  r.register(Sink as never);
+  return r;
+}
+
+const graph = {
+  nodes: [
+    { id: "trig", type: "test.triggers.Probe", data: {} },
+    { id: "sink", type: "test.Sink", data: {} }
+  ],
+  edges: [
+    {
+      id: "e1",
+      source: "trig",
+      sourceHandle: "body",
+      target: "sink",
+      targetHandle: "value"
+    }
+  ]
+};
+
+async function runWith(useResolver: boolean) {
+  const reg = registry();
+  const session = await ExecutionSession.create({
+    graph: graph as never,
+    registry: reg,
+    jobId: `trig-${useResolver ? "resolver" : "flags"}`,
+    ...(useResolver
+      ? {
+          resolveNodeType:
+            createGraphNodeTypeResolver(reg).resolveNodeType
+        }
+      : {}),
+    triggerEvent: {
+      node_id: "trig",
+      payload: { body: "from-trigger-event" },
+      input_id: "i1"
+    }
+  } as never);
+  return session.result;
+}
+
+describe("trigger event delivery across both hydration paths", () => {
+  it("delivers the payload on the hydrateGraphNodeFlags path", async () => {
+    const result = await runWith(false);
+    expect(Object.values(result.outputs ?? {}).flat()).toEqual([
+      "from-trigger-event"
+    ]);
+  });
+
+  it("delivers the payload on the resolveNodeType path", async () => {
+    // The regression: this used to yield "from-genProcess", because
+    // is_trigger was false so the actor never took the trigger branch.
+    const result = await runWith(true);
+    expect(Object.values(result.outputs ?? {}).flat()).toEqual([
+      "from-trigger-event"
+    ]);
+  });
+});

--- a/packages/kernel/src/graph.ts
+++ b/packages/kernel/src/graph.ts
@@ -443,6 +443,15 @@ export class Graph {
           descriptorDefaults.is_controlled ?? node.is_controlled ?? false,
         is_join_node:
           descriptorDefaults.is_join_node ?? node.is_join_node ?? false,
+        // Without this the flag is dropped, because saved workflow JSON never
+        // carries it and only the registry knows. `actor.ts` gates the trigger
+        // entry point on `node.is_trigger`, so a webhook/manual/file-watch
+        // event delivered to a graph hydrated here was accepted and then
+        // silently ignored — the node fell through to `genProcess()`, waited
+        // for a live adapter that a delivered-event run does not have, and
+        // emitted nothing. Every host that passes `resolveNodeType` took this
+        // path, including the websocket server.
+        is_trigger: descriptorDefaults.is_trigger ?? node.is_trigger ?? false,
         // Retry safety comes from the registry or not at all — note there is
         // no `?? node.retry_safe` here, unlike every flag above. Whether
         // re-running a node duplicates a payment or a publish is a property of

--- a/packages/node-sdk/src/registry.ts
+++ b/packages/node-sdk/src/registry.ts
@@ -646,6 +646,14 @@ export function createGraphNodeTypeResolver(
           is_streaming_output: metadata.is_streaming_output ?? false,
           is_controlled: metadata.is_controlled ?? false,
           is_join_node: metadata.is_join_node ?? false,
+          // Same reason as the flags above, and the one that was missing:
+          // `actor.ts` gates the trigger entry point on this, and saved
+          // workflow JSON never carries it. Omitted here, every
+          // resolver-hydrated graph read `is_trigger: false`, so a delivered
+          // webhook/manual/file-watch event was accepted and silently
+          // dropped — the node fell through to `genProcess()` and emitted
+          // nothing.
+          is_trigger: metadata.is_trigger ?? false,
           retry_safe: metadata.retry_safe ?? false,
           ...(metadata.input_mode && { input_mode: metadata.input_mode }),
           ...(metadata.output_correlation && {

--- a/packages/node-sdk/tests/graph-resolver.test.ts
+++ b/packages/node-sdk/tests/graph-resolver.test.ts
@@ -67,6 +67,7 @@ describe("createGraphNodeTypeResolver", () => {
         is_streaming_output: true,
         is_controlled: false,
         is_join_node: false,
+        is_trigger: false,
         retry_safe: false,
         input_mode: "buffered",
         output_correlation: {
@@ -135,6 +136,7 @@ describe("createGraphNodeTypeResolver", () => {
       is_streaming_output: true,
       is_controlled: false,
       is_join_node: false,
+      is_trigger: false,
       retry_safe: false,
       input_mode: "buffered",
       output_correlation: {


### PR DESCRIPTION
A delivered webhook, manual or file-watch event was **accepted and then silently ignored**. The run completed, the trigger node reported success, and nothing came out of it.

## The bug

`actor.ts` gates the trigger entry point on `node.is_trigger`. Saved workflow JSON never carries that flag, so hydration has to supply it from the registry — and the two hydration paths are mutually exclusive:

```ts
// packages/execution/src/session.ts
if (options.resolveNodeType) {
  hydrated = await Graph.loadFromDict(normalized, { resolver: options.resolveNodeType });
} else if (registry) {
  hydrated = hydrateGraphNodeFlags(normalized, registry);   // <- set is_trigger
}
```

The resolver path dropped it **twice over**:

- `createGraphNodeTypeResolver` never put `is_trigger` in its `descriptorDefaults`
- `Graph.loadFromDict` never read it

Both enumerate the other flags explicitly — `is_streaming_input`, `is_streaming_output`, `is_controlled`, `is_join_node`, `retry_safe` — with comments explaining why each must be. So the omission reads as deliberate rather than missing, which is presumably how it survived.

With the flag false the actor skipped the trigger branch and fell through to `genProcess()`, which waits on a live adapter that a delivered-event run does not have.

**Every host that passes `resolveNodeType` was affected** — the CLI and the websocket server (`plugins/websocket.ts:229`).

## Why it stayed hidden

Interval triggers masked it. Their `genProcess()` emits a tick on start, so the run *did* produce output — just not the delivered one. A payload of `{"tick": 7}` came back as `1`. Webhook and file-watch emitted nothing at all.

## Also: `--trigger-event` on `workflows run`

The kernel has always accepted `RunJobRequest.trigger_event`; nothing on the CLI could supply one. A trigger-driven workflow could be validated but never executed — which is why zero of the 219 shipped examples use a trigger.

```bash
nodetool workflows run hook.json \
  --trigger-event '{"node_id":"hook","payload":{"body":{"repo":"nodetool","stars":1200}}}'
```

Adding it is what surfaced the bug: the flag looked inert until the flag it depends on turned out to be false.

## Verification

Before → after, same graphs:

| | before | after |
|---|---|---|
| webhook, `payload.body` | *(no output)* | `{"repo":"nodetool","stars":1200}` |
| interval, `payload.tick: 7` | `1` | `7` |

The regression test asserts the **payload value**, not that output exists — the interval's `genProcess` also emits, so a presence check would have passed against the bug. Confirmed by reverting both fixes: the resolver case fails with `from-genProcess`, the `hydrateGraphNodeFlags` case still passes. That asymmetry is the bug's exact shape.

`execution` 26 · `node-sdk` 691 · `kernel` 1001 · lint clean · cli typecheck clean.

The two `graph-resolver` expectations enumerate `descriptorDefaults` field by field and needed the new one.

## Follow-up

Trigger example workflows — there are none today, and now they can actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
