### PR TITLE
Mini-app build harness: PRD, design doc, and implementation plan

### DIFF
--- a/docs/mini-app-build-harness-design.md
+++ b/docs/mini-app-build-harness-design.md
@@ -1,0 +1,357 @@
+# Design: Mini-App Build Harness
+
+**Author:** Matti Georgi
+**Status:** Draft — for review
+**Last updated:** 2026-08-02
+**PRD:** [mini-app-build-harness-prd.md](mini-app-build-harness-prd.md)
+**Implementation plan:** [mini-app-build-harness-implementation-plan.md](mini-app-build-harness-implementation-plan.md)
+
+How `nodetool app build` turns a prompt into a verified `ApplicationBundle`.
+The PRD says what and why; this says where the code goes, what each stage's
+contract is, and which existing modules do the work.
+
+---
+
+## 1. Placement
+
+The loop needs three things at once: GraphPlanner (`@nodetool-ai/agents`), the
+app document ops (`@nodetool-ai/app-runtime`), and the headless app simulator
+(today `packages/cli/src/app-debug/`). The dependency graph already almost
+allows it:
+
+```
+app-runtime ──┐
+execution ────┼──▶ agents ──▶ { cli, websocket }
+kernel ───────┘
+```
+
+- `agents` depends on `app-runtime` and `execution` today.
+- `cli` and `websocket` both depend on `agents` today.
+
+One move makes it work: **the app-debug simulation core relocates from
+`packages/cli/src/app-debug/` to `packages/execution/src/app-debug/`**. This is
+the same move `debug_workflow` already forced for the workflow harness — its
+summary reducer and triage live in `@nodetool-ai/execution/debug` precisely so
+CLI and server surfaces cannot drift. `execution` has every dependency the
+simulator needs (kernel, node-sdk, protocol, runtime), and the harness is
+already decoupled from CLI concerns: `AppDebugDeps` injects `loadFromDb`,
+`loadApplication`, and `runOnServer`, so the move carries no DB or filesystem
+code with it. The CLI keeps target resolution (files, DB ids), bundle writing,
+and the command itself, re-exporting the moved types.
+
+New code:
+
+```
+packages/agents/src/app-build/
+  types.ts        # BuildSpec, BuildReport, BuildComplaint, stage records
+  spec.ts         # Spec stage (StepExecutor + schema)
+  bridge.ts       # ui_app_* headless bridge, promoted from evals/surfaces/app.ts
+  author.ts       # Author stage (tool loop over the bridge)
+  interactions.ts # Interaction-script derivation from the spec
+  judge.ts        # Judge stage (goal-judge pattern)
+  build.ts        # Orchestrator: stages, repair loop, budgets
+packages/execution/src/app-debug/   # relocated simulator (app-spec, runtime, harness)
+packages/cli/src/commands/app.ts    # + `app build` subcommand
+packages/websocket/src/...          # `build_app` tool + HTTP surface
+```
+
+The evals keep working against the same surfaces: `evals/surfaces/app.ts`
+shrinks to a re-export of `app-build/bridge.ts` plus its cases, so the eval and
+the production author stage cannot diverge — the drift-prevention rule that
+file already documents, now enforced by sharing the implementation, not just
+the contract.
+
+## 2. Types
+
+All in `packages/agents/src/app-build/types.ts`; the report shape also lands in
+`@nodetool-ai/protocol` if the web surface consumes it (M4), mirroring how
+`Intervention` moved.
+
+```ts
+/** What the Spec stage produces and every later stage consumes. */
+interface BuildSpec {
+  title: string;
+  operations: Array<{
+    id: string;                       // stable slug, e.g. "draft"
+    objective: string;                // GraphPlanner objective, or —
+    workflowId?: string;              // — bind an existing workflow instead
+    inputs: Array<{ name: string; type: string; example: unknown }>;
+    outputs: Array<{ name: string; type: string }>;
+    streaming: boolean;
+  }>;
+  variables: Array<{ id: string; scope: "app" | "instance"; persist: boolean;
+                     writtenBy: string; readBy: string[] }>;
+  widgets: Array<{ role: string; type: string; binding: string;
+                   label: string; container?: string;
+                   visibleWhen?: string }>;   // condition source, verbatim
+  interactions: Array<{                        // the behavioral contract
+    name: string;                              // "draft-then-approve"
+    steps: InteractionStep[];                  // the app-debug script language
+    expect: Array<{ widget: string; check: "nonEmpty" | "equals" | "matches";
+                    value?: unknown }>;
+  }>;
+}
+
+/** One repair round's input: everything wrong, not a delta. */
+interface BuildComplaint {
+  round: number;
+  issues: BuildIssue[];              // stage, severity, message, widget/op ref
+  fingerprints: string[];            // stable ids for oscillation detection
+}
+
+interface BuildReport {
+  target: { prompt: string; specPath?: string };
+  spec: BuildSpec;
+  stages: StageRecord[];             // one per stage execution, repairs included
+  repairs: BuildComplaint[];
+  appDebug: AppDebugReport | null;   // the final Check+Run evidence, verbatim
+  judge: JudgeRecord | null;
+  verdict: { ok: boolean; reason: string; notSimulated: string[] };
+  cost: { usd: number; byStage: Record<string, number> };
+  bundle: ApplicationBundle | null;  // null only when verdict.ok is false
+}
+```
+
+`InteractionStep` is the existing app-debug script language (`set`, `click`,
+`change`, `run`, `cancel`) — the spec's behavioral contract is written in the
+oracle's own vocabulary, so Run needs no translation layer.
+
+## 3. Stages
+
+### 3.1 Spec
+
+One `StepExecutor` call with `BuildSpec` as the `outputSchema`. The prompt
+carries the widget catalog (`WIDGET_CATALOG` names, binding modes, fields), the
+operation policy vocabulary, and the medium-complexity shapes from the guide.
+Host-side validation beyond the schema, before any planning token is spent:
+
+- every widget `type` exists in `WIDGET_CATALOG`; its `binding` parses
+  (`parseBinding`) and names a declared operation input/output or variable;
+- every variable's `writtenBy`/`readBy` name declared operations or widgets;
+- every interaction's steps reference declared widgets/operations, and every
+  `expect` names a display widget;
+- at least one interaction per operation.
+
+Failures bounce back into the open `StepExecutor` conversation as tool errors
+(the supervisor's `finish_step` repair loop, reused as-is, `MAX_REPAIR_ROUNDS`
+= 3). A prompt that cannot be pinned — no operations derivable, or the model
+asks for widgets the catalog lacks — resolves as `failed` at this stage with
+the validation record as the reason. That is the PRD's "refuse rather than
+guess."
+
+`app build spec.json` enters here: parse, validate with the same code, skip
+the LLM.
+
+### 3.2 Plan
+
+Per spec operation, in declaration order:
+
+- `workflowId` set → load the workflow, `validateGraph`, extract IO
+  (`extractAppIO`), and check the spec's declared inputs/outputs against it.
+  A mismatch is a spec-stage complaint, not a planning job.
+- otherwise → `GraphPlanner.plan(objective, context)` with `inputs` seeded
+  from the spec's examples and `outputSchema` derived from the declared
+  outputs. The planner already gates on its own `submit_graph` validation;
+  the harness adds `validateGraph` + a check that the planned graph's
+  Input/Output node names cover the spec's declared surface — the app cannot
+  bind to an input the planner renamed. Missing names → one replan with the
+  delta named in the objective; still missing → `failed`.
+
+Planned graphs are held in memory as bundle entries — nothing writes to the
+database. That is what makes the loop runnable in CI and what makes the output
+an `ApplicationBundle` rather than a pile of rows.
+
+### 3.3 Author
+
+The tool loop from `tool-loop-eval` (provider `generateLoop` over
+`HeadlessTool[]`), promoted to production: the model drives the real `ui_app_*`
+contract against the bridge, starting from an empty document plus the bundle's
+workflows as `BindableWorkflow`s. The system prompt is the spec, rendered:
+operations to declare (with exact input/output mappings), variables, the widget
+list with bindings, the container structure.
+
+Termination: the model calls `ui_app_finish` (new bridge-only tool) or the
+turn cap (default 40 tool calls) trips. The bridge's `finalState()` yields the
+Puck document + `AppDocMeta`, assembled into the draft `ApplicationBundle`.
+
+On repair rounds the loop resumes with the *current* document loaded and the
+`BuildComplaint` rendered as the opening message — the model edits, it does
+not rebuild. Fingerprints that reappear after being absent end the loop (§5).
+
+### 3.4 Check
+
+`validateApp` from the relocated simulator, against the in-memory bundle
+(`app debug`'s existing `ApplicationBundle` target path, no DB). Errors →
+complaint; warnings ride along in the report but do not block. Then
+`validateGraph` per workflow again — authoring cannot change graphs today, but
+the gate is cheap and the invariant ("no LLM judge ever sees a statically
+invalid app") should not depend on that staying true.
+
+### 3.5 Run
+
+For each spec interaction, one simulator pass
+(`runAppDebug` equivalent on the in-memory bundle) with that interaction's
+steps, then the `expect` checks against the folded final state:
+
+- `nonEmpty` — the widget's state key received a value from a completed run;
+- `equals` / `matches` — value comparison after `formatTemplate` is applied,
+  so the check sees what the user would see.
+
+Failed expectations and simulator verdict issues both become complaints. The
+existing per-operation policy/timeout machinery applies unchanged; a spec
+interaction may exercise `cancel` and replacement policies like a hand-written
+script does today.
+
+### 3.6 Judge
+
+The `goal-judge` pattern from `graph-e2e`: one structured-output LLM call per
+interaction, given the spec's plain-language intent, the interaction's steps,
+and the final widget states (previewed with the same `previewValue` truncation
+the debug collector uses). Output: `{ achieved, confidence, reasons }`.
+`achieved: false` → complaint carrying the reasons.
+
+The judge runs only on a Check+Run-green app, is configured independently
+(`--judge-model`, default: a different model than the builder), and is skipped
+for deterministic eval cases. Judge failures (timeout, unparseable) count as
+not-achieved — fail closed, same rule as everywhere else.
+
+### 3.7 Repair
+
+The orchestrator (`build.ts`) is a plain loop, not an agent:
+
+```
+spec → plan → author ─▶ check ─▶ run ─▶ judge ─▶ ok? ─▶ bundle + report
+                ▲          │        │       │
+                └──────────┴────────┴───────┘   complaints, rounds ≤ maxRepairs
+```
+
+- Complaints route to **Author** by default. A complaint that names a missing
+  graph input/output (Plan's responsibility) routes to Plan for that one
+  operation, then falls through Author again. Spec is never revisited after it
+  validates — a bad spec fails, it doesn't mutate, so the target the judge
+  scores against is fixed for the whole build.
+- **Oscillation guard:** every issue gets a stable fingerprint
+  (stage + code + widget/op ref). A fingerprint absent in round N that
+  reappears in round N+1 ends the build as `failed` with both rounds cited.
+- **Budgets:** `maxRepairs` (default 3), wall clock (default 10 min), and USD.
+  Dollar enforcement reuses `TurnBudget` from the runtime provider layer
+  (built for the supervisor): every stage's provider call reserves
+  worst-case before the turn. Exhaustion mid-stage resolves that stage as
+  failed and the build as `failed` — reported, never silent.
+
+## 4. Oracle closures
+
+### 4.1 Conditions and format (R6)
+
+`@nodetool-ai/app-runtime/conditions.ts` already exports `parseCondition`,
+`evaluateCondition`, `readRef`, and `formatTemplate` — the web runtime's
+implementations. The gap is that the headless runtime never calls them. Fix,
+in the (relocated) simulator:
+
+- After every fold step, evaluate each widget's `visibleWhen`/`disabledWhen`
+  against current state and record it in the widget's simulated state.
+- A `click`/`change`/`set`-via-widget step on a currently hidden or disabled
+  widget is a **run failure** ("clicked Approve while hidden by
+  `draft == null`"), because no user could perform it.
+- Display expectations evaluate against the `format`-rendered value.
+- The report's `notSimulated` list drops these entries and keeps only what
+  remains genuinely browser-only (layout, focus, CSS).
+
+The verdict gains one check: a widget whose condition never becomes satisfiable
+across all executed interactions (always-hidden trigger) is an error — today's
+"app with no run trigger" check, generalized.
+
+### 4.2 Resources (R7)
+
+The headless runtime's `resourceCommand` branch currently no-ops ("headless
+runs have no resource providers attached"). Add:
+
+```ts
+interface HeadlessResourceProvider {
+  kind: ResourceKind;
+  list(): ResourceItem[];
+  get(id: string): ResourceItem | null;
+  apply(op: ResourceOperation): void;   // the doc-ops mutation verbs
+}
+```
+
+with one in-memory implementation, seedable from the interaction script
+(`{ seedResource: { id, items } }` step) or from `--params`. `from: "resource"`
+params resolve through it; resource widgets (picker, gallery, scene list)
+report their collection state like bound widgets report values. The web
+runtime is untouched — this provider exists only under the simulator.
+
+## 5. Surfaces
+
+### 5.1 CLI
+
+`packages/cli/src/commands/app.ts` gains `build`:
+
+```
+nodetool app build "<prompt>" | spec.json
+  -p/--provider, -m/--model          builder provider (registry ids, as everywhere)
+  --judge-model <provider/model>     default: NODETOOL_APP_JUDGE_MODEL or a
+                                     different model than the builder
+  --workflow <id> (repeatable)       pin existing workflows; Plan binds, never plans
+  --max-repairs <n>  --cost-cap <usd>  --timeout <ms>
+  --out <dir>  --json  --no-judge
+```
+
+Bundle layout extends the app-debug convention:
+`nodetool-debug/app-build-<slug>-<ts>/` with `report.json` (`BuildReport`),
+`report.md`, `app.bundle.json` (the deliverable), `spec.json`, and one
+`interactions/<name>/` per interaction holding that pass's
+`run-N.messages.jsonl`. Exit code 0 iff `verdict.ok`.
+
+### 5.2 Server tool and HTTP (M4)
+
+`build_app` registers next to `debug_workflow`:
+`POST /api/applications/build {prompt | spec, options}` running the same
+`buildApp()` from `@nodetool-ai/agents`. Long builds use the existing
+debug-session machinery (`packages/websocket/src/debug-sessions.ts`) for
+polling and cancel; the editor chat tool returns the `BuildReport` and offers
+the bundle for import through the normal bundle-import path.
+
+### 5.3 Eval suite
+
+One `EVAL_SUITES` entry (`eval.ts` — suites are data): id `app-build`. A case
+is a prompt (or spec, for the deterministic ones), a target-shape checklist
+(operations ≥ 2, a persisted variable, a working conditional, …), and for
+deterministic cases exact expected widget values with the judge skipped.
+Metrics: one-shot rate (green with zero repairs), green-within-budget rate,
+repair rounds, cost, duration; `--min-success` gates on green-within-budget.
+Two deterministic cases (template-only workflows, no model calls in the
+*product* under test) run in CI on every PR; the full suite runs nightly.
+
+## 6. Telemetry and cost attribution
+
+```
+app.build                       (orchestrator)
+  app.build.spec                (StepExecutor → llm.chat)
+  agent.plan                    (GraphPlanner, existing span, per operation)
+  app.build.author              (tool loop → llm.chat per turn)
+  app.build.check
+  app.build.run                 (→ workflow.run per interaction, existing)
+  app.build.judge               (→ llm.chat)
+```
+
+Every provider call carries the existing `gen_ai.usage.*` attributes; ledger
+rows are attributed to the build id and tagged `app-build` in `node_type`, so
+`nodetool costs` answers "what did generated apps cost this month" the same
+way it answers it for the supervisor.
+
+## 7. Failure modes
+
+Every row resolves as a reported `failed` build — no partial success, no
+silent bundle.
+
+| Failure | Resolution |
+| --- | --- |
+| Spec unpinnable / fails validation after 3 bounces | `failed`, validation record as reason |
+| Planner returns null / planned IO can't cover spec after 1 replan | `failed`, per-operation planning record |
+| Author turn cap trips without `ui_app_finish` | current document goes to Check anyway; its complaints count as the round's result |
+| Oscillation (fixed issue reappears) | `failed`, both rounds cited |
+| Any budget exhausted (rounds, wall clock, USD) | `failed`, best attempt's report attached, budget named |
+| Judge timeout / unparseable | interaction counts as not-achieved |
+| Kernel run crash during Run | the simulator's existing error surface → complaint; a second identical crash in the next round is oscillation |
+| Cancel (signal) | aborts the in-flight provider call and kernel run; `failed`, `reason: "cancelled"` |

--- a/docs/mini-app-build-harness-implementation-plan.md
+++ b/docs/mini-app-build-harness-implementation-plan.md
@@ -1,0 +1,237 @@
+# Implementation Plan: Mini-App Build Harness
+
+**Author:** Matti Georgi
+**Status:** Draft — for review
+**Last updated:** 2026-08-02
+**PRD:** [mini-app-build-harness-prd.md](mini-app-build-harness-prd.md)
+**Design:** [mini-app-build-harness-design.md](mini-app-build-harness-design.md)
+
+Written to be executed by an implementing agent (Opus) PR by PR. Each PR names
+its files, the invariants it must hold, and the tests that prove it. PRs
+marked ∥ can proceed in parallel once their listed dependency lands.
+
+---
+
+## 0. Ground rules
+
+- Every PR passes `npm run check` before commit. `packages/cli`,
+  `packages/execution`, `packages/agents`, and `packages/websocket` are plain
+  TS packages — no `build:packages` needed for their own tests, but run it
+  before any end-to-end `nodetool app debug` smoke since the CLI loads
+  decorator packages from `dist/`.
+- Read before writing. The modules this plan touches are documented in-file:
+  `packages/cli/src/app-debug/harness.ts` (orchestration),
+  `packages/agents/src/evals/surfaces/app.ts` (bridge + drift rules),
+  `packages/agents/src/evals/tool-loop-eval.ts` (loop driver),
+  `packages/cli/src/commands/eval.ts` ("suites are data"). Honor the
+  invariants their header comments state.
+- The relocation PR (PR 3) is behavior-preserving and must be provably so:
+  `nodetool app debug` output on the shipped example bundles is byte-identical
+  before and after (modulo timestamps/paths).
+- `BuildSpec`/`BuildReport` shapes change only via the design doc, in the same
+  PR.
+- No web UI work in this plan. The web surface (if any) consumes `BuildReport`
+  after M4; it does not define it.
+- Prose in reports and docs follows [WRITING_STYLE.md](WRITING_STYLE.md).
+
+## Phase M1 — close the oracle (independently shippable)
+
+### PR 1 — Simulate conditions and format (R6)
+
+All in `packages/cli/src/app-debug/` (pre-relocation — keep the diff where the
+code lives today; PR 3 moves it wholesale).
+
+- `runtime.ts`: after every fold into app state, evaluate each widget's
+  `visibleWhen`/`disabledWhen` via `parseCondition`/`evaluateCondition` from
+  `@nodetool-ai/app-runtime` (already exported — wire, don't reimplement).
+  Track per-widget `{ visible, disabled }` in the runtime's widget state.
+- `harness.ts`: an interaction step targeting a hidden or disabled widget
+  fails that step with a message naming the condition source
+  (`clicked "Approve" while hidden by \`draft == null\``). `set` steps that
+  address state keys directly (not widgets) are exempt — they model the
+  runtime, not a user.
+- Display checks and `report.md` previews render through `formatTemplate`
+  before comparison.
+- `types.ts`: widget final-state record gains `visible`/`disabled`; the
+  report's `notSimulated` (add the field if absent) no longer lists
+  conditions/format.
+- Verdict: new issue for a run-trigger widget whose `visibleWhen` never
+  evaluated true in any executed interaction.
+- Tests (`packages/cli/tests/` next to the existing app-debug tests): a
+  conditional Approve button — hidden click fails, satisfied click runs; a
+  `format` template changes an `equals` check's outcome; the never-visible
+  trigger verdict fires; an app with no conditions produces an unchanged
+  report.
+
+### PR 2 — Headless resource provider (R7) ∥ (with PR 1)
+
+- `runtime.ts`: `HeadlessResourceProvider` interface +
+  `InMemoryResourceProvider` (design §4.2); the `resourceCommand` branch
+  dispatches to it instead of no-opping.
+- `harness.ts` + `types.ts`: `seedResource` interaction step; `from:
+  "resource"` params resolve through the provider; resource widgets report
+  collection state in the final report.
+- Update the "Not simulated headlessly" paragraph in `CLAUDE.md` §
+  `nodetool app debug` and [mini-apps.md](mini-apps.md) "Checking an app" —
+  both currently list resources as unreachable.
+- Tests: a picker-fed param runs with seeded items and fails with an
+  actionable message when unseeded; a resource operation mutates the
+  collection and the report shows it.
+
+### PR 3 — Relocate the simulator to `@nodetool-ai/execution` (depends: PR 1, PR 2)
+
+- Move `app-spec.ts`, `runtime.ts`, `types.ts`, and the simulation half of
+  `harness.ts` to `packages/execution/src/app-debug/`; export from the package
+  index the way `execution/debug` already does. `markdown.ts` moves too (it
+  renders the report, needs nothing from cli).
+- Stays in `packages/cli/src/app-debug/`: `app-target.ts` (DB/file
+  resolution), bundle writing, the command wiring. It re-exports the moved
+  types so `@nodetool-ai/cli` importers don't break.
+- The harness's `runOnServer` / `loadFromDb` / `loadApplication` injections
+  already isolate it from cli's debug internals — the move must not grow new
+  parameters. Where `harness.ts` imports `../debug/collector.js`
+  (`previewValue`) and `../debug/types.js`, move those *types* and the small
+  preview helper into execution as well or inject them; do not drag the whole
+  cli debug module along.
+- Proof of behavior preservation: script a before/after `app debug --json` run
+  over every bundle in `packages/base-nodes/nodetool/examples/apps/` and diff
+  (normalize paths/timestamps). Keep the script in `scripts/` for PR review,
+  delete before merge or park under the eval fixtures.
+
+## Phase M2 — the loop
+
+### PR 4 — Promote the bridge, extract the tool-loop driver (depends: PR 3)
+
+- `packages/agents/src/app-build/bridge.ts`: move the bridge implementation
+  out of `evals/surfaces/app.ts` verbatim — tool contract, catalog use, and
+  the doc-meta passthrough to `@nodetool-ai/app-runtime` doc-ops are already
+  correct there. Add `ui_app_finish` (bridge-only termination tool) and a
+  `loadDocument` entry so repair rounds resume from the current document.
+- `evals/surfaces/app.ts` becomes: re-export of the bridge + the eval cases.
+  The file's header comment about drift updates to describe the new sharing.
+- `packages/agents/src/app-build/tool-loop.ts`: extract the generic
+  provider-driving loop from `tool-loop-eval.ts` (generateLoop over
+  `HeadlessTool[]`, turn cap, transcript capture) into a function both the
+  eval and the author stage call. The eval keeps its scoring; the loop moves.
+- Tests: existing `app-tools` eval passes unchanged (that suite *is* the
+  regression test for this PR); a unit test drives the bridge through
+  `loadDocument` → edit → `finalState` round-trip.
+
+### PR 5 — Types, spec stage, interaction derivation ∥ (with PR 4, depends: PR 3)
+
+- `packages/agents/src/app-build/types.ts`: `BuildSpec`, `BuildIssue`,
+  `BuildComplaint`, `StageRecord`, `BuildReport` per design §2.
+- `spec.ts`: one `StepExecutor` call with `BuildSpec` as `outputSchema`; the
+  host-side validation list from design §3.1, implemented against
+  `WIDGET_CATALOG` and `parseBinding` — reuse the supervisor's `finish_step`
+  bounce loop (it is a general `StepExecutor` feature since supervisor PR 3).
+  `specFromFile` parses + validates without the LLM.
+- `interactions.ts`: spec interactions are already `InteractionStep[]`; this
+  module only *completes* them — prepend `set` steps for declared inputs that
+  no step touches (using spec examples), and derive a minimal default
+  interaction (the existing `defaultInteractions` shape) for any operation the
+  spec forgot, flagging it as derived in the report.
+- Tests: schema-valid-but-catalog-invalid specs bounce with the right issue;
+  an unpinnable spec fails after 3 bounces; derivation covers a forgotten
+  operation and never overwrites an authored step.
+
+### PR 6 — Orchestrator, repair loop, `app build` CLI (depends: PR 4, PR 5)
+
+The core PR. `packages/agents/src/app-build/build.ts` + the CLI command.
+
+- `build.ts` — `buildApp(opts): Promise<BuildReport>`: the stage sequence from
+  design §3.7. Plan wraps `GraphPlanner` per operation (existing-workflow
+  binding first, IO-coverage check, one replan). Author runs the tool loop
+  from PR 4 with the spec rendered as system prompt. Check/Run call the
+  execution simulator on the in-memory `ApplicationBundle`. Judge is a stub
+  returning `achieved: true` this PR (lands in PR 7); the verdict says so in
+  `notSimulated`.
+- Repair: complaints as full issue sets, fingerprints, oscillation guard,
+  routing (Author default, Plan for graph-IO issues) — design §3.7 verbatim.
+- Budgets: `maxRepairs`, wall-clock, and USD via `TurnBudget` reservation on
+  every provider call (spec, plan, author turns). Exhaustion → `failed` with
+  the budget named. `AbortSignal` threads into every stage.
+- Ledger: stage provider calls attributed to the build id, `node_type:
+  "app-build"`.
+- Spans: `app.build` + per-stage children (design §6), via the existing agent
+  span helpers.
+- `packages/cli/src/commands/app.ts`: the `build` subcommand, flags and
+  bundle layout per design §5.1. Exit 0 iff `verdict.ok`.
+- Tests (`packages/agents/tests/`): a scripted provider (the eval harness's
+  mock pattern) drives a full green build over a template workflow with zero
+  real model calls; a complaint round edits rather than rebuilds (assert the
+  document diff is scoped); oscillation ends the build; each budget
+  exhaustion fails closed; cancel mid-author aborts cleanly. CLI test: `app
+  build spec.json --json` on a deterministic spec emits a parseable
+  `BuildReport` and writes the bundle layout.
+
+## Phase M3 — the score
+
+### PR 7 — Judge stage (R8) (depends: PR 6)
+
+- `packages/agents/src/app-build/judge.ts`: per-interaction structured-output
+  call following `evals/goal-judge.ts`; inputs and fail-closed rules per
+  design §3.6. `--judge-model` flag + `NODETOOL_APP_JUDGE_MODEL`; default
+  resolution picks a model ≠ builder when possible and records which ran.
+- Wire into `build.ts` behind `--no-judge`; judge complaints route to Author.
+- Tests: scripted judge verdicts flip the build outcome; judge timeout counts
+  as not-achieved; deterministic path never invokes it.
+
+### PR 8 — `app-build` eval suite (R5) (depends: PR 6; judge cases depend: PR 7)
+
+- Cases in `packages/agents/src/evals/app-build-cases.ts`: ≥ 8 prompts
+  meeting the PRD §4 bar (each case declares which medium-complexity traits it
+  exercises, and the set covers all of them), plus 2 deterministic spec-file
+  cases over template graphs with exact expected widget values, judge
+  skipped.
+- Runner in `evals/app-build-eval.ts`; one data entry in `EVAL_SUITES`
+  (`packages/cli/src/commands/eval.ts`) — follow the file's "suites are data"
+  rule, no new command block. Metrics and `--min-success` semantics per
+  design §5.3.
+- CI: deterministic cases join the Quality Gate; full suite gets a nightly
+  workflow following the GenSpend sync workflow's shape (report artifact, no
+  auto-merge decisions).
+- Tests: the suite runs end-to-end on the deterministic cases in CI with no
+  provider keys.
+
+## Phase M4 — surfaces
+
+### PR 9 — `build_app` server tool + HTTP (R9) (depends: PR 6; better after PR 7)
+
+- Register `build_app` next to `debug_workflow`;
+  `POST /api/applications/build` running `buildApp()`; long-build polling and
+  cancel through `packages/websocket/src/debug-sessions.ts`. Auth and
+  cost-cap defaults match `debug_workflow`'s posture.
+- The tool result is the `BuildReport`; the bundle imports through the
+  existing bundle-import endpoint, never auto-installs.
+- Tests: route test with a scripted provider; cancel over HTTP aborts the
+  build; the tool is listed for editor chat.
+
+### PR 10 — Supervisor composition (R10) ∥ (with PR 9, depends: PR 6)
+
+- `--supervise` + supervisor flags on `app build` configure
+  `ExecutionSessionOptions.supervisor` for the Run stage's kernel executions —
+  the same single integration point every surface uses. Interventions land in
+  the interaction's run report and roll up into `BuildReport`.
+- Test: a scripted supervisor skip during Run surfaces in the build report
+  and does not count as a build failure when expectations still pass.
+
+### PR 11 — P2 conveniences (R11, R12) (depends: PR 8)
+
+- `--watch` on spec-file targets: re-run on save, print a verdict diff —
+  reuse the `debug --watch` differ.
+- Example-apps regeneration: `scripts/build-example-apps.mjs` gains a mode
+  that runs `buildApp` from each curated spec and diffs against the shipped
+  bundle, reporting drift without overwriting — the curated bundles stay
+  hand-approved.
+
+## Sequencing summary
+
+```
+M1: PR1 ∥ PR2 → PR3
+M2: PR4 ∥ PR5 → PR6
+M3: PR7 → PR8 (deterministic cases of PR8 can start after PR6)
+M4: PR9 ∥ PR10 → PR11
+```
+
+The PRD's launch gate (§8) is measurable after PR 8; nothing in M4 blocks it.

--- a/docs/mini-app-build-harness-implementation-plan.md
+++ b/docs/mini-app-build-harness-implementation-plan.md
@@ -32,7 +32,8 @@ marked ∥ can proceed in parallel once their listed dependency lands.
   PR.
 - No web UI work in this plan. The web surface (if any) consumes `BuildReport`
   after M4; it does not define it.
-- Prose in reports and docs follows [WRITING_STYLE.md](WRITING_STYLE.md).
+- Prose in reports and docs follows the repo style rules in
+  `docs/WRITING_STYLE.md`.
 
 ## Phase M1 — close the oracle (independently shippable)
 

--- a/docs/mini-app-build-harness-prd.md
+++ b/docs/mini-app-build-harness-prd.md
@@ -3,6 +3,8 @@
 **Author:** Matti Georgi
 **Status:** Draft — for review
 **Last updated:** 2026-08-02
+**Design doc:** [mini-app-build-harness-design.md](mini-app-build-harness-design.md)
+**Implementation plan:** [mini-app-build-harness-implementation-plan.md](mini-app-build-harness-implementation-plan.md)
 **Related:** [mini-apps.md](mini-apps.md) · [app-builder.md](app-builder.md) · `nodetool app debug` (CLAUDE.md) · `packages/agents` app-tools eval
 
 ---

--- a/docs/mini-app-build-harness-prd.md
+++ b/docs/mini-app-build-harness-prd.md
@@ -1,0 +1,230 @@
+# PRD: Mini-App Build Harness
+
+**Author:** Matti Georgi
+**Status:** Draft — for review
+**Last updated:** 2026-08-02
+**Related:** [mini-apps.md](mini-apps.md) · [app-builder.md](app-builder.md) · `nodetool app debug` (CLAUDE.md) · `packages/agents` app-tools eval
+
+---
+
+## 1. Summary
+
+Today an agent can *check* a mini app (`nodetool app debug`) and can *edit* one
+(the `ui_app_*` tools), but nothing closes the loop. There is no command that
+takes "build me a product-photo captioner with an approve step" and returns a
+working, verified app — workflows included.
+
+The Build Harness is that command:
+
+```bash
+nodetool app build "Turn a product photo into three caption options; \
+  let me pick one and post-process it" -o captioner.app.json
+```
+
+Plan the workflows, author the app document, validate the wiring, run every
+operation headlessly, judge the result against the intent, repair what failed,
+repeat until green or out of budget. Output: an `ApplicationBundle` that
+imports and runs anywhere, plus the debug bundle proving it works.
+
+The bet is simple: **the model is good enough to one-shot a medium-complex app
+if the harness gives it the same feedback loop a human gets from the editor.**
+Every piece of that loop already exists in the repo. This PRD wires them into
+one machine and puts a number on it.
+
+**North-star metric: one-shot rate on the `app-build` eval suite** — the share
+of medium-complexity prompts that produce a green app with zero human edits.
+
+## 2. Problem
+
+### 2.1 The loop is open
+
+The build story for an agent today:
+
+1. Plan a workflow — GraphPlanner exists, evaled (`graph-planner`, `graph-e2e`).
+2. Author the app document — `ui_app_*` tools exist, evaled (`app-tools`),
+   and run headlessly against `@nodetool-ai/app-runtime` doc-ops.
+3. Verify — `nodetool app debug` validates bindings, simulates the runtime,
+   runs the kernel, and emits an `AppDebugReport` with a verdict.
+
+Each stage is solid in isolation. But nothing *drives* them in sequence, feeds
+the verdict back into the tools, or decides when to stop. An agent in editor
+chat improvises this loop turn by turn; an agent in CI or the CLI cannot run it
+at all. The result: app-building quality is whatever the conversation happens
+to produce, and we cannot measure or regress-test it.
+
+### 2.2 Verification has blind spots
+
+`app debug` cannot see everything the web runtime does, so a "green" app can
+still be broken on screen:
+
+- `visibleWhen` / `disabledWhen` / `format` are not simulated — a widget hidden
+  by a wrong condition reports as fine.
+- `from: "resource"` params have no headless provider — any app that reads a
+  picker cannot be exercised.
+- Interaction scripts are hand-written JSON. Nobody writes them, so the
+  approve-then-continue and slider-rerun shapes — the ones the
+  [guide](mini-apps-guide.md) teaches — go untested.
+
+A build loop is only as good as its oracle. These gaps are the oracle's bugs.
+
+### 2.3 There is no score
+
+`graph-planner` reports a one-shot rate for graphs. No suite reports one for
+apps. Without a number, model upgrades, prompt changes, and tool-contract edits
+ship blind — we find out an app shape regressed when a user hits it.
+
+### 2.4 Why now
+
+The example-apps pipeline (`scripts/build-example-apps.mjs`) hand-curates
+bundles because generation isn't trusted. Mobile ships app screens. The
+marketing site generates `/apps/*` landing pages. Every one of these consumes
+finished apps; none can produce them. App supply is the bottleneck, and the
+supply chain should be a prompt.
+
+## 3. Users
+
+**Agents first.** The harness is an agent-facing product; humans read its
+output, they don't operate it.
+
+| User | Surface | What they need |
+| --- | --- | --- |
+| Editor chat agent | `ui_app_*` + a `build_app` tool | One tool call that returns a working draft to refine with the user |
+| CLI / CI agent (Claude Code, cron) | `nodetool app build` | Prompt in, bundle + verdict out, exit code that means something |
+| Eval runner | `nodetool eval app-build` | The one-shot number, per case, gated with `--min-success` |
+| Human builder | App Builder | Imports the generated bundle and tweaks in Design view — never debugs wiring by hand |
+
+## 4. What "medium complex" means
+
+The target is pinned so "one-shot" can't be gamed by easy prompts. A
+medium-complex app has, per the eval suite's case definitions:
+
+- **2+ operations** over 2+ workflows (e.g. draft → approve → publish),
+- **8–15 widgets**, at least one layout container deep,
+- **variables**, including one `persist: true` app-scoped setting,
+- **one streaming output** folded into a display widget,
+- **one gated flow** — a second operation reading a variable the first wrote,
+- **one conditional** (`visibleWhen`/`disabledWhen`) that must actually gate.
+
+Roughly: the "review before publish" and "settings that stick" shapes from the
+guide, combined. Below this is a form; above it is a product.
+
+## 5. Product
+
+### 5.1 The loop
+
+```
+prompt ──▶ SPEC ──▶ PLAN ──▶ AUTHOR ──▶ CHECK ──▶ RUN ──▶ JUDGE ──▶ green? ──▶ bundle
+                     ▲                                        │
+                     └──────────── REPAIR (bounded) ◀─────────┘
+```
+
+| Stage | What runs | Exists today |
+| --- | --- | --- |
+| **Spec** | LLM turns the prompt into an app spec: operations, widget list, variables, interaction expectations | New |
+| **Plan** | GraphPlanner authors each workflow the spec names (or binds an existing one by id) | `packages/agents` GraphPlanner |
+| **Author** | LLM drives `ui_app_*` against the headless bridge to build the document | `evals/surfaces/app.ts` bridge, promoted out of evals |
+| **Check** | Static wiring pass — `app debug --no-run` + `validate` per workflow | `packages/cli/src/app-debug/` |
+| **Run** | Every operation, headlessly, with an interaction script **derived from the spec** (fill inputs, click run triggers, write the gate variable, click the second trigger) | `app debug` runtime + new script derivation |
+| **Judge** | LLM judge scores final widget states against the spec's expectations, same pattern as `graph-e2e`'s goal judge | `evals/goal-judge.ts` pattern |
+| **Repair** | Failures (validation issues, run errors, judge misses) go back to the author stage as a diff-shaped complaint; bounded rounds | New |
+
+Two hard rules, borrowed from the supervisor PRD's spine:
+
+- **Deterministic before generative.** Check runs before Run, Run before
+  Judge; an LLM judge never sees an app the static validator rejected. The
+  cheap oracle always fires first.
+- **Fail closed on budget.** Repair rounds (default 3), wall clock, and USD
+  cost are capped. Out of budget → the harness returns the best attempt marked
+  `failed`, with the full report of why. It never returns a silent
+  half-working bundle as success.
+
+### 5.2 Surfaces
+
+```bash
+nodetool app build "<prompt>"                    # bundle + report to nodetool-debug/
+nodetool app build "<prompt>" --workflow <id>    # bind existing workflow(s), plan none
+nodetool app build "<prompt>" --json             # full BuildReport for agents
+nodetool app build "<prompt>" --max-repairs 5 --cost-cap 1.00
+nodetool app build spec.json                     # skip the Spec stage, build from a spec file
+```
+
+- **`build_app` tool** on the server (like `debug_workflow`): editor chat and
+  MCP agents call the same loop, get the same `BuildReport`.
+- **`nodetool eval app-build`**: the suite from §4, standard eval flags,
+  `--min-success` as a CI gate. Two deterministic cases run without providers.
+
+### 5.3 The report
+
+`BuildReport` extends the existing `AppDebugReport`: per-stage outcome, every
+repair round with what was complained about and what changed, per-stage token
+and dollar cost, and the final verdict. `report.md` reads top-down as a story:
+what was built, what broke, what fixed it, what it cost. Spans follow the
+existing OTel hierarchy (`app.build` → `agent.plan` / `app.author` /
+`app.check` / `app.run` / `app.judge`).
+
+## 6. Requirements
+
+| # | Requirement | Priority |
+| --- | --- | --- |
+| R1 | `nodetool app build` runs the full loop from a prompt and emits an `ApplicationBundle` + `BuildReport` | P0 |
+| R2 | Author stage drives the real `ui_app_*` contract headlessly — no forked tool surface | P0 |
+| R3 | Interaction scripts derived from the spec; every operation and every declared event path exercised | P0 |
+| R4 | Repair loop consumes verdict issues as structured complaints; bounded by rounds, wall clock, and cost; fails closed | P0 |
+| R5 | `app-build` eval suite with ≥8 medium-complex cases and `--min-success` gating | P0 |
+| R6 | Headless runtime simulates `visibleWhen`/`disabledWhen`/`format`; a click on a hidden/disabled widget is a run failure | P0 |
+| R7 | Headless resource provider: seedable in-memory collections so `from: "resource"` params run | P1 |
+| R8 | LLM judge stage scoring widget end-states against spec expectations | P1 |
+| R9 | `build_app` server tool + HTTP surface | P1 |
+| R10 | `--supervise` composes: the run stage can put the supervisor on workflow failures | P1 |
+| R11 | Example-apps pipeline can regenerate a curated bundle via `app build spec.json` and diff against the shipped one | P2 |
+| R12 | `--watch` on a spec file: edit spec, re-run loop, print verdict diff (mirrors `debug --watch`) | P2 |
+
+## 7. Non-goals
+
+- **Pixel truth.** No browser, no screenshots, no layout aesthetics. The
+  browser surface stays where it is (`web` e2e); this harness judges wiring
+  and behavior. A beautiful-but-miswired app fails; an ugly-but-correct one
+  passes.
+- **Replacing the App Builder.** Humans still refine in Design view. The
+  harness produces the first 90%, not the last 10%.
+- **Open-ended agents.** An app with no fixed shape is Chat's job
+  ([mini-apps.md](mini-apps.md) says so); the harness refuses specs it cannot
+  pin to operations and widgets rather than guessing.
+- **Publishing.** The output is a bundle. Releases, spending limits, and
+  sharing stay in the app lifecycle, untouched.
+
+## 8. Success metrics
+
+| Metric | Target | Where it's read |
+| --- | --- | --- |
+| One-shot rate, `app-build` suite (zero repair rounds) | ≥ 60% at launch, ≥ 80% two model generations later | eval report, CI gate |
+| Green-within-budget rate (≤ 3 repairs) | ≥ 90% | eval report |
+| Repair convergence | median ≤ 1 round | `BuildReport` |
+| Cost per green app | ≤ $0.50 median on the suite | prediction ledger (`nodetool costs`, tagged `app-build`) |
+| Wall clock per app | ≤ 3 min median, providers warm | eval report |
+| Oracle honesty | 0 known false-greens: every R6/R7 gap closed or listed in the report's `notSimulated` field | `BuildReport` |
+
+The last row is the one that keeps the rest honest: a rising one-shot rate
+against a blind oracle is noise, not progress.
+
+## 9. Milestones
+
+1. **M1 — Close the oracle gaps.** R6 + R7 in `app debug`. Ship independently;
+   existing users of the debug harness benefit immediately.
+2. **M2 — The loop.** Spec → Plan → Author → Check → Run wired into
+   `nodetool app build` with repair (R1–R4). Judge stubbed to
+   verdict-only.
+3. **M3 — The score.** `app-build` suite + judge stage (R5, R8), CI gate on
+   deterministic cases, nightly full run.
+4. **M4 — Surfaces.** `build_app` tool (R9), supervisor composition (R10),
+   then the P2 conveniences.
+
+## 10. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Repair loops oscillate (fix A breaks B, fix B breaks A) | Complaints carry the full issue set, not the delta; a round that reintroduces a previously-fixed issue ends the loop early as `failed` |
+| Judge grades its own homework (same model plans and judges) | Judge model is independently configurable, defaults to a different model than the builder; deterministic cases skip the judge entirely |
+| Spec stage invents unbuildable apps | Spec is validated against the widget catalog and operation schema before Plan spends a token; unpinnable prompts are rejected at spec time (§7) |
+| Headless/browser drift makes green apps break in the web runtime | Author and Run stages consume `@nodetool-ai/app-runtime` doc-ops and fold — the same code the browser runs; anything the harness cannot share it must list in `notSimulated` |
+| Cost blowups on hard prompts | Same posture as the supervisor: caps are defaults, not options; exhausting one is a normal, reported outcome |


### PR DESCRIPTION
## What

The full doc set for a harness that one-shots medium-complex mini apps (workflows included) from a prompt:

- `docs/mini-app-build-harness-prd.md` — product spec
- `docs/mini-app-build-harness-design.md` — technical design
- `docs/mini-app-build-harness-implementation-plan.md` — PR-by-PR plan, written for an implementing agent

## Why

The build story is open-loop today: GraphPlanner plans graphs, the `ui_app_*` tools author documents, and `nodetool app debug` verifies apps — but nothing drives them in sequence, feeds verdicts back, or measures the result.

## The proposal, in one line

`nodetool app build "<prompt>"` → spec → plan → author → check → run → judge → bounded repair → `ApplicationBundle` + `BuildReport`, with **one-shot rate on a new `app-build` eval suite** as the north-star metric.

Key decisions pinned across the three docs:

- **Reuse over rebuild** — the loop is a driver over existing pieces: GraphPlanner, the headless `ui_app_*` bridge (promoted out of `evals/surfaces/app.ts` so eval and production share one implementation), and the `app debug` simulator.
- **Placement** — loop core in `packages/agents/src/app-build/`; the app-debug simulator relocates to `@nodetool-ai/execution` (the `execution/debug` precedent), so CLI, server tool, and evals consume one implementation.
- **Oracle first** — R6 is pure wiring (`app-runtime/conditions.ts` already exports `evaluateCondition`/`formatTemplate`; the headless runtime never calls them) plus an in-memory resource provider for R7; both ship independently as M1.
- **Fail closed** — repair rounds, wall clock, and USD (via the supervisor's `TurnBudget`) are capped; oscillating repairs end the build early; every failure mode resolves as a reported `failed`, never a silent half-working bundle.
- **A number, gated** — `nodetool eval app-build` with `--min-success` in CI; two deterministic cases run without provider keys.

Doc-only change; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4rLQBiGJKHZkatt9gx4ZY