### PR TITLE
Offline node examples, and a test that asserts what they compute

### DIFF
--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -80,6 +80,51 @@ npm run workflow -- ./examples/workflows/import_csv_aggregate_cli.json --input c
 npm run workflow -- ./examples/workflows/wait_node_cli.json --input input='{"message":"hello"}' --input timeout_seconds=0.02
 ```
 
+## Offline node examples
+
+Self-contained: every input is a constant in the graph, so these take no
+`--input` and reach no model, network or disk. Each one covers a cluster of
+nodes that had no example before, and
+`packages/base-nodes/tests/pure-node-examples-run.test.ts` executes all ten and
+asserts the value every node produced.
+
+```bash
+# string transforms — trim, case, prefix/suffix, index, slice
+npm run workflow -- ./examples/workflows/text_transforms_cli.json
+
+# regex match/extract/filter, JSON parsing, chunking with overlap
+npm run workflow -- ./examples/workflows/text_regex_parse_cli.json
+
+# markdown → headers, bullet and numbered lists, code blocks, tables
+npm run workflow -- ./examples/workflows/markdown_extract_cli.json
+
+# HTML → title/description/keywords, links, images, video, audio, plain text
+npm run workflow -- ./examples/workflows/html_extract_cli.json
+
+# email / URL / IP validation and sanitizing untrusted text
+npm run workflow -- ./examples/workflows/validate_strings_cli.json
+
+# building lists by range, repetition and tiling
+npm run workflow -- ./examples/workflows/list_build_cli.json
+
+# streams: filter, drop-while, tap, collect; plus Switch and fallback routing
+npm run workflow -- ./examples/workflows/control_flow_stream_cli.json
+
+# formatting, shifting and comparing dates
+npm run workflow -- ./examples/workflows/datetime_cli.json
+
+# querying a dataframe parsed out of a markdown table
+npm run workflow -- ./examples/workflows/dataframe_query_cli.json
+
+# writing a workflow variable and reading it back
+npm run workflow -- ./examples/workflows/variables_cli.json
+```
+
+A stream wired straight into an `Output` records only its **last** item —
+`Output` captures the value its actor holds when it completes. Put a
+`nodetool.control.Collect` in between to materialize the whole stream;
+`control_flow_stream_cli.json` shows the wiring.
+
 ## Agent + OpenAI provider examples
 
 ```bash

--- a/examples/workflows/control_flow_stream_cli.json
+++ b/examples/workflows/control_flow_stream_cli.json
@@ -1,0 +1,349 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "ticks",
+        "type": "nodetool.control.RepeatCount",
+        "data": {
+          "count": 6
+        }
+      },
+      {
+        "id": "evens",
+        "type": "nodetool.control.FilterCode",
+        "data": {
+          "predicate": "item % 2 === 0"
+        }
+      },
+      {
+        "id": "after_warmup",
+        "type": "nodetool.control.DropWhile",
+        "data": {
+          "predicate": "item < 3"
+        }
+      },
+      {
+        "id": "tap",
+        "type": "nodetool.control.Tap",
+        "data": {
+          "label": "tick"
+        }
+      },
+      {
+        "id": "route_hit",
+        "type": "nodetool.control.Switch",
+        "data": {
+          "value": "beta",
+          "cases": [
+            "alpha",
+            "beta",
+            "gamma"
+          ],
+          "input": "payload"
+        }
+      },
+      {
+        "id": "route_miss",
+        "type": "nodetool.control.Switch",
+        "data": {
+          "value": "delta",
+          "cases": [
+            "alpha",
+            "beta",
+            "gamma"
+          ],
+          "input": "payload"
+        }
+      },
+      {
+        "id": "fallback_used",
+        "type": "nodetool.control.TryCatch",
+        "data": {
+          "value": null,
+          "fallback": "default-value"
+        }
+      },
+      {
+        "id": "fallback_unused",
+        "type": "nodetool.control.TryCatch",
+        "data": {
+          "value": "present",
+          "fallback": "default-value"
+        }
+      },
+      {
+        "id": "out_evens",
+        "type": "nodetool.output.Output",
+        "name": "evens",
+        "data": {
+          "name": "evens"
+        }
+      },
+      {
+        "id": "out_after_warmup",
+        "type": "nodetool.output.Output",
+        "name": "after_warmup",
+        "data": {
+          "name": "after_warmup"
+        }
+      },
+      {
+        "id": "out_tapped",
+        "type": "nodetool.output.Output",
+        "name": "tapped",
+        "data": {
+          "name": "tapped"
+        }
+      },
+      {
+        "id": "out_matched",
+        "type": "nodetool.output.Output",
+        "name": "matched",
+        "data": {
+          "name": "matched"
+        }
+      },
+      {
+        "id": "out_matched_index",
+        "type": "nodetool.output.Output",
+        "name": "matched_index",
+        "data": {
+          "name": "matched_index"
+        }
+      },
+      {
+        "id": "out_default",
+        "type": "nodetool.output.Output",
+        "name": "routed_to_default",
+        "data": {
+          "name": "routed_to_default"
+        }
+      },
+      {
+        "id": "out_default_index",
+        "type": "nodetool.output.Output",
+        "name": "default_index",
+        "data": {
+          "name": "default_index"
+        }
+      },
+      {
+        "id": "out_fallback",
+        "type": "nodetool.output.Output",
+        "name": "fallback",
+        "data": {
+          "name": "fallback"
+        }
+      },
+      {
+        "id": "out_fallback_flag",
+        "type": "nodetool.output.Output",
+        "name": "fallback_flag",
+        "data": {
+          "name": "fallback_flag"
+        }
+      },
+      {
+        "id": "out_passthrough",
+        "type": "nodetool.output.Output",
+        "name": "passthrough",
+        "data": {
+          "name": "passthrough"
+        }
+      },
+      {
+        "id": "out_passthrough_flag",
+        "type": "nodetool.output.Output",
+        "name": "passthrough_flag",
+        "data": {
+          "name": "passthrough_flag"
+        }
+      },
+      {
+        "id": "collect_evens",
+        "type": "nodetool.control.Collect"
+      },
+      {
+        "id": "collect_after_warmup",
+        "type": "nodetool.control.Collect"
+      },
+      {
+        "id": "collect_tapped",
+        "type": "nodetool.control.Collect"
+      },
+      {
+        "id": "sparse_items",
+        "type": "nodetool.control.ForEach",
+        "data": {
+          "input_list": [
+            "alpha",
+            null,
+            "beta",
+            null,
+            "gamma"
+          ],
+          "limit": -1
+        }
+      },
+      {
+        "id": "drop_nulls",
+        "type": "nodetool.data.FilterNone"
+      },
+      {
+        "id": "collect_present",
+        "type": "nodetool.control.Collect"
+      },
+      {
+        "id": "out_present",
+        "type": "nodetool.output.Output",
+        "name": "present",
+        "data": {
+          "name": "present"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "ticks",
+        "sourceHandle": "output",
+        "target": "evens",
+        "targetHandle": "input_item"
+      },
+      {
+        "id": "e2",
+        "source": "ticks",
+        "sourceHandle": "output",
+        "target": "after_warmup",
+        "targetHandle": "input_item"
+      },
+      {
+        "id": "e3",
+        "source": "ticks",
+        "sourceHandle": "output",
+        "target": "tap",
+        "targetHandle": "input_item"
+      },
+      {
+        "id": "e4a",
+        "source": "evens",
+        "sourceHandle": "output",
+        "target": "collect_evens",
+        "targetHandle": "input_item"
+      },
+      {
+        "id": "e4b",
+        "source": "collect_evens",
+        "sourceHandle": "output",
+        "target": "out_evens",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e5a",
+        "source": "after_warmup",
+        "sourceHandle": "output",
+        "target": "collect_after_warmup",
+        "targetHandle": "input_item"
+      },
+      {
+        "id": "e5b",
+        "source": "collect_after_warmup",
+        "sourceHandle": "output",
+        "target": "out_after_warmup",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e6a",
+        "source": "tap",
+        "sourceHandle": "output",
+        "target": "collect_tapped",
+        "targetHandle": "input_item"
+      },
+      {
+        "id": "e6b",
+        "source": "collect_tapped",
+        "sourceHandle": "output",
+        "target": "out_tapped",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e7",
+        "source": "route_hit",
+        "sourceHandle": "matched",
+        "target": "out_matched",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e8",
+        "source": "route_hit",
+        "sourceHandle": "index",
+        "target": "out_matched_index",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e9",
+        "source": "route_miss",
+        "sourceHandle": "default",
+        "target": "out_default",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e10",
+        "source": "route_miss",
+        "sourceHandle": "index",
+        "target": "out_default_index",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e11",
+        "source": "fallback_used",
+        "sourceHandle": "output",
+        "target": "out_fallback",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e12",
+        "source": "fallback_used",
+        "sourceHandle": "has_error",
+        "target": "out_fallback_flag",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e13",
+        "source": "fallback_unused",
+        "sourceHandle": "output",
+        "target": "out_passthrough",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e14",
+        "source": "fallback_unused",
+        "sourceHandle": "has_error",
+        "target": "out_passthrough_flag",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e15",
+        "source": "sparse_items",
+        "sourceHandle": "output",
+        "target": "drop_nulls",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e16",
+        "source": "drop_nulls",
+        "sourceHandle": "output",
+        "target": "collect_present",
+        "targetHandle": "input_item"
+      },
+      {
+        "id": "e17",
+        "source": "collect_present",
+        "sourceHandle": "output",
+        "target": "out_present",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/dataframe_query_cli.json
+++ b/examples/workflows/dataframe_query_cli.json
@@ -1,0 +1,100 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "report",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "| node | runs | status |\n| --- | --- | --- |\n| Concat | 12 | ok |\n| Chunk | 48 | ok |\n| Pivot | 3 | failed |\n"
+        }
+      },
+      {
+        "id": "table",
+        "type": "lib.markdown.ExtractTables"
+      },
+      {
+        "id": "first_failed",
+        "type": "nodetool.data.FindRow",
+        "data": {
+          "condition": "status == 'failed'"
+        }
+      },
+      {
+        "id": "first_busy",
+        "type": "nodetool.data.FindRow",
+        "data": {
+          "condition": "runs > 20"
+        }
+      },
+      {
+        "id": "out_table",
+        "type": "nodetool.output.Output",
+        "name": "table",
+        "data": {
+          "name": "table"
+        }
+      },
+      {
+        "id": "out_failed",
+        "type": "nodetool.output.Output",
+        "name": "first_failed",
+        "data": {
+          "name": "first_failed"
+        }
+      },
+      {
+        "id": "out_busy",
+        "type": "nodetool.output.Output",
+        "name": "first_busy",
+        "data": {
+          "name": "first_busy"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "report",
+        "sourceHandle": "output",
+        "target": "table",
+        "targetHandle": "markdown"
+      },
+      {
+        "id": "e2",
+        "source": "table",
+        "sourceHandle": "output",
+        "target": "first_failed",
+        "targetHandle": "df"
+      },
+      {
+        "id": "e3",
+        "source": "table",
+        "sourceHandle": "output",
+        "target": "first_busy",
+        "targetHandle": "df"
+      },
+      {
+        "id": "e4",
+        "source": "table",
+        "sourceHandle": "output",
+        "target": "out_table",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e5",
+        "source": "first_failed",
+        "sourceHandle": "output",
+        "target": "out_failed",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e6",
+        "source": "first_busy",
+        "sourceHandle": "output",
+        "target": "out_busy",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/datetime_cli.json
+++ b/examples/workflows/datetime_cli.json
@@ -1,0 +1,129 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "format",
+        "type": "lib.datetime.Format",
+        "data": {
+          "date": "2026-08-02T10:30:00Z",
+          "pattern": "YYYY-MM-DD"
+        }
+      },
+      {
+        "id": "add_days",
+        "type": "lib.datetime.Add",
+        "data": { "date": "2026-08-02T00:00:00Z", "amount": 30, "unit": "day" }
+      },
+      {
+        "id": "diff",
+        "type": "lib.datetime.Diff",
+        "data": {
+          "date_a": "2026-08-02T00:00:00Z",
+          "date_b": "2026-09-01T00:00:00Z",
+          "unit": "day"
+        }
+      },
+      {
+        "id": "month",
+        "type": "lib.datetime.StartEnd",
+        "data": { "date": "2026-08-02T10:30:00Z", "unit": "month" }
+      },
+      { "id": "now", "type": "lib.datetime.Now" },
+
+      {
+        "id": "out_formatted",
+        "type": "nodetool.output.Output",
+        "name": "formatted",
+        "data": { "name": "formatted" }
+      },
+      {
+        "id": "out_added",
+        "type": "nodetool.output.Output",
+        "name": "added_iso",
+        "data": { "name": "added_iso" }
+      },
+      {
+        "id": "out_diff",
+        "type": "nodetool.output.Output",
+        "name": "diff_days",
+        "data": { "name": "diff_days" }
+      },
+      {
+        "id": "out_is_before",
+        "type": "nodetool.output.Output",
+        "name": "a_is_before_b",
+        "data": { "name": "a_is_before_b" }
+      },
+      {
+        "id": "out_month_start",
+        "type": "nodetool.output.Output",
+        "name": "month_start",
+        "data": { "name": "month_start" }
+      },
+      {
+        "id": "out_month_end",
+        "type": "nodetool.output.Output",
+        "name": "month_end",
+        "data": { "name": "month_end" }
+      },
+      {
+        "id": "out_now_epoch",
+        "type": "nodetool.output.Output",
+        "name": "now_epoch_ms",
+        "data": { "name": "now_epoch_ms" }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "format",
+        "sourceHandle": "formatted",
+        "target": "out_formatted",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e2",
+        "source": "add_days",
+        "sourceHandle": "iso",
+        "target": "out_added",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e3",
+        "source": "diff",
+        "sourceHandle": "diff",
+        "target": "out_diff",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e4",
+        "source": "diff",
+        "sourceHandle": "is_before",
+        "target": "out_is_before",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e5",
+        "source": "month",
+        "sourceHandle": "start_iso",
+        "target": "out_month_start",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e6",
+        "source": "month",
+        "sourceHandle": "end_iso",
+        "target": "out_month_end",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e7",
+        "source": "now",
+        "sourceHandle": "epoch_ms",
+        "target": "out_now_epoch",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/html_extract_cli.json
+++ b/examples/workflows/html_extract_cli.json
@@ -1,0 +1,216 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "page",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "<html><head><title>NodeTool Docs</title><meta name=\"description\" content=\"Visual AI workflows\"><meta name=\"keywords\" content=\"workflow, nodes, ai\"></head><body><h1>Docs</h1><p>Start with the <a href=\"/workflows\">workflow guide</a> or the <a href=\"https://github.com/nodetool-ai/nodetool\">source</a>.</p><img src=\"/img/editor.png\" alt=\"editor\"><video src=\"/media/tour.mp4\"></video><audio src=\"/media/intro.mp3\"></audio></body></html>"
+        }
+      },
+      {
+        "id": "url",
+        "type": "nodetool.constant.String",
+        "data": { "value": "https://docs.nodetool.ai/guide/triggers?page=2#events" }
+      },
+
+      {
+        "id": "meta",
+        "type": "lib.html.ExtractMetadata"
+      },
+      {
+        "id": "links",
+        "type": "lib.html.ExtractLinks",
+        "data": { "base_url": "https://docs.nodetool.ai" }
+      },
+      {
+        "id": "images",
+        "type": "lib.html.ExtractImages",
+        "data": { "base_url": "https://docs.nodetool.ai" }
+      },
+      {
+        "id": "videos",
+        "type": "lib.html.ExtractVideos",
+        "data": { "base_url": "https://docs.nodetool.ai" }
+      },
+      {
+        "id": "audios",
+        "type": "lib.html.ExtractAudio",
+        "data": { "base_url": "https://docs.nodetool.ai" }
+      },
+      { "id": "to_text", "type": "lib.html.HTMLToText" },
+      { "id": "base", "type": "lib.html.BaseUrl" },
+
+      {
+        "id": "out_title",
+        "type": "nodetool.output.Output",
+        "name": "title",
+        "data": { "name": "title" }
+      },
+      {
+        "id": "out_description",
+        "type": "nodetool.output.Output",
+        "name": "description",
+        "data": { "name": "description" }
+      },
+      {
+        "id": "out_keywords",
+        "type": "nodetool.output.Output",
+        "name": "keywords",
+        "data": { "name": "keywords" }
+      },
+      {
+        "id": "out_links",
+        "type": "nodetool.output.Output",
+        "name": "links",
+        "data": { "name": "links" }
+      },
+      {
+        "id": "out_images",
+        "type": "nodetool.output.Output",
+        "name": "images",
+        "data": { "name": "images" }
+      },
+      {
+        "id": "out_videos",
+        "type": "nodetool.output.Output",
+        "name": "videos",
+        "data": { "name": "videos" }
+      },
+      {
+        "id": "out_audios",
+        "type": "nodetool.output.Output",
+        "name": "audios",
+        "data": { "name": "audios" }
+      },
+      {
+        "id": "out_text",
+        "type": "nodetool.output.Output",
+        "name": "text",
+        "data": { "name": "text" }
+      },
+      {
+        "id": "out_base",
+        "type": "nodetool.output.Output",
+        "name": "base_url",
+        "data": { "name": "base_url" }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "page",
+        "sourceHandle": "output",
+        "target": "meta",
+        "targetHandle": "html"
+      },
+      {
+        "id": "e2",
+        "source": "page",
+        "sourceHandle": "output",
+        "target": "links",
+        "targetHandle": "html"
+      },
+      {
+        "id": "e3",
+        "source": "page",
+        "sourceHandle": "output",
+        "target": "images",
+        "targetHandle": "html"
+      },
+      {
+        "id": "e4",
+        "source": "page",
+        "sourceHandle": "output",
+        "target": "videos",
+        "targetHandle": "html"
+      },
+      {
+        "id": "e5",
+        "source": "page",
+        "sourceHandle": "output",
+        "target": "audios",
+        "targetHandle": "html"
+      },
+      {
+        "id": "e6",
+        "source": "page",
+        "sourceHandle": "output",
+        "target": "to_text",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e7",
+        "source": "url",
+        "sourceHandle": "output",
+        "target": "base",
+        "targetHandle": "url"
+      },
+
+      {
+        "id": "e8",
+        "source": "meta",
+        "sourceHandle": "title",
+        "target": "out_title",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e9",
+        "source": "meta",
+        "sourceHandle": "description",
+        "target": "out_description",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e10",
+        "source": "meta",
+        "sourceHandle": "keywords",
+        "target": "out_keywords",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e11",
+        "source": "links",
+        "sourceHandle": "links",
+        "target": "out_links",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e12",
+        "source": "images",
+        "sourceHandle": "images",
+        "target": "out_images",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e13",
+        "source": "videos",
+        "sourceHandle": "videos",
+        "target": "out_videos",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e14",
+        "source": "audios",
+        "sourceHandle": "audios",
+        "target": "out_audios",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e15",
+        "source": "to_text",
+        "sourceHandle": "output",
+        "target": "out_text",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e16",
+        "source": "base",
+        "sourceHandle": "output",
+        "target": "out_base",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/list_build_cli.json
+++ b/examples/workflows/list_build_cli.json
@@ -1,0 +1,82 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "range",
+        "type": "nodetool.list.Range",
+        "data": { "start": 0, "stop": 10, "step": 2, "count": 10 }
+      },
+      {
+        "id": "repeat_value",
+        "type": "nodetool.list.RepeatValue",
+        "data": { "value": "ok", "times": 3 }
+      },
+      {
+        "id": "tile",
+        "type": "nodetool.list.Tile",
+        "data": { "input_list": ["a", "b"], "times": 3 }
+      },
+      {
+        "id": "repeat_each",
+        "type": "nodetool.list.RepeatEach",
+        "data": { "input_list": ["a", "b"], "times": 3 }
+      },
+
+      {
+        "id": "out_range",
+        "type": "nodetool.output.Output",
+        "name": "range",
+        "data": { "name": "range" }
+      },
+      {
+        "id": "out_repeat_value",
+        "type": "nodetool.output.Output",
+        "name": "repeat_value",
+        "data": { "name": "repeat_value" }
+      },
+      {
+        "id": "out_tile",
+        "type": "nodetool.output.Output",
+        "name": "tile",
+        "data": { "name": "tile" }
+      },
+      {
+        "id": "out_repeat_each",
+        "type": "nodetool.output.Output",
+        "name": "repeat_each",
+        "data": { "name": "repeat_each" }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "range",
+        "sourceHandle": "output",
+        "target": "out_range",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e2",
+        "source": "repeat_value",
+        "sourceHandle": "output",
+        "target": "out_repeat_value",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e3",
+        "source": "tile",
+        "sourceHandle": "output",
+        "target": "out_tile",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e4",
+        "source": "repeat_each",
+        "sourceHandle": "output",
+        "target": "out_repeat_each",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/markdown_extract_cli.json
+++ b/examples/workflows/markdown_extract_cli.json
@@ -1,0 +1,153 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "doc",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "# Release Notes\n\n## Added\n\n- trigger examples\n- an executing test\n\n## Steps\n\n1. build the packages\n2. run the suite\n\n```bash\nnpm run test\n```\n\n| node | covered |\n| --- | --- |\n| Concat | yes |\n| Chunk | no |\n"
+        }
+      },
+
+      {
+        "id": "headers",
+        "type": "lib.markdown.ExtractHeaders",
+        "data": { "max_level": 6 }
+      },
+      {
+        "id": "headers_h1",
+        "type": "lib.markdown.ExtractHeaders",
+        "data": { "max_level": 1 }
+      },
+      { "id": "bullets", "type": "lib.markdown.ExtractBulletLists" },
+      { "id": "numbered", "type": "lib.markdown.ExtractNumberedLists" },
+      { "id": "code", "type": "lib.markdown.ExtractCodeBlocks" },
+      { "id": "tables", "type": "lib.markdown.ExtractTables" },
+
+      {
+        "id": "out_headers",
+        "type": "nodetool.output.Output",
+        "name": "headers",
+        "data": { "name": "headers" }
+      },
+      {
+        "id": "out_headers_h1",
+        "type": "nodetool.output.Output",
+        "name": "headers_h1",
+        "data": { "name": "headers_h1" }
+      },
+      {
+        "id": "out_bullets",
+        "type": "nodetool.output.Output",
+        "name": "bullets",
+        "data": { "name": "bullets" }
+      },
+      {
+        "id": "out_numbered",
+        "type": "nodetool.output.Output",
+        "name": "numbered",
+        "data": { "name": "numbered" }
+      },
+      {
+        "id": "out_code",
+        "type": "nodetool.output.Output",
+        "name": "code_blocks",
+        "data": { "name": "code_blocks" }
+      },
+      {
+        "id": "out_tables",
+        "type": "nodetool.output.Output",
+        "name": "tables",
+        "data": { "name": "tables" }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "doc",
+        "sourceHandle": "output",
+        "target": "headers",
+        "targetHandle": "markdown"
+      },
+      {
+        "id": "e2",
+        "source": "doc",
+        "sourceHandle": "output",
+        "target": "headers_h1",
+        "targetHandle": "markdown"
+      },
+      {
+        "id": "e3",
+        "source": "doc",
+        "sourceHandle": "output",
+        "target": "bullets",
+        "targetHandle": "markdown"
+      },
+      {
+        "id": "e4",
+        "source": "doc",
+        "sourceHandle": "output",
+        "target": "numbered",
+        "targetHandle": "markdown"
+      },
+      {
+        "id": "e5",
+        "source": "doc",
+        "sourceHandle": "output",
+        "target": "code",
+        "targetHandle": "markdown"
+      },
+      {
+        "id": "e6",
+        "source": "doc",
+        "sourceHandle": "output",
+        "target": "tables",
+        "targetHandle": "markdown"
+      },
+
+      {
+        "id": "e7",
+        "source": "headers",
+        "sourceHandle": "output",
+        "target": "out_headers",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e8",
+        "source": "headers_h1",
+        "sourceHandle": "output",
+        "target": "out_headers_h1",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e9",
+        "source": "bullets",
+        "sourceHandle": "output",
+        "target": "out_bullets",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e10",
+        "source": "numbered",
+        "sourceHandle": "output",
+        "target": "out_numbered",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e11",
+        "source": "code",
+        "sourceHandle": "output",
+        "target": "out_code",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e12",
+        "source": "tables",
+        "sourceHandle": "output",
+        "target": "out_tables",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/text_regex_parse_cli.json
+++ b/examples/workflows/text_regex_parse_cli.json
@@ -1,0 +1,223 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "line",
+        "type": "nodetool.constant.String",
+        "data": { "value": "order-1042 shipped 2026-08-02 to matti@nodetool.ai" }
+      },
+      {
+        "id": "json_text",
+        "type": "nodetool.constant.String",
+        "data": { "value": "{\"repo\": \"nodetool\", \"stars\": 1200}" }
+      },
+      {
+        "id": "words",
+        "type": "nodetool.constant.String",
+        "data": { "value": "alpha beta gamma delta" }
+      },
+
+      {
+        "id": "match_date",
+        "type": "nodetool.text.RegexMatch",
+        "data": { "pattern": "(\\d{4})-(\\d{2})-(\\d{2})", "group": 0 }
+      },
+      {
+        "id": "match_year",
+        "type": "nodetool.text.RegexMatch",
+        "data": { "pattern": "(\\d{4})-(\\d{2})-(\\d{2})", "group": 1 }
+      },
+      {
+        "id": "extract_parts",
+        "type": "nodetool.text.ExtractRegex",
+        "data": { "regex": "order-(\\d+) shipped (\\S+)" }
+      },
+      {
+        "id": "keep_order",
+        "type": "nodetool.text.FilterRegexString",
+        "data": { "pattern": "order-\\d+", "full_match": false }
+      },
+      {
+        "id": "drop_nomatch",
+        "type": "nodetool.text.FilterRegexString",
+        "data": { "pattern": "invoice-\\d+", "full_match": false }
+      },
+      { "id": "parse", "type": "nodetool.text.ParseJSON" },
+      {
+        "id": "chunk",
+        "type": "nodetool.text.Chunk",
+        "data": { "length": 2, "overlap": 0, "separator": " " }
+      },
+      {
+        "id": "chunk_overlap",
+        "type": "nodetool.text.Chunk",
+        "data": { "length": 2, "overlap": 1, "separator": " " }
+      },
+
+      {
+        "id": "out_date",
+        "type": "nodetool.output.Output",
+        "name": "date",
+        "data": { "name": "date" }
+      },
+      {
+        "id": "out_year",
+        "type": "nodetool.output.Output",
+        "name": "year",
+        "data": { "name": "year" }
+      },
+      {
+        "id": "out_parts",
+        "type": "nodetool.output.Output",
+        "name": "parts",
+        "data": { "name": "parts" }
+      },
+      {
+        "id": "out_kept",
+        "type": "nodetool.output.Output",
+        "name": "kept",
+        "data": { "name": "kept" }
+      },
+      {
+        "id": "out_dropped",
+        "type": "nodetool.output.Output",
+        "name": "dropped",
+        "data": { "name": "dropped" }
+      },
+      {
+        "id": "out_parsed",
+        "type": "nodetool.output.Output",
+        "name": "parsed",
+        "data": { "name": "parsed" }
+      },
+      {
+        "id": "out_chunks",
+        "type": "nodetool.output.Output",
+        "name": "chunks",
+        "data": { "name": "chunks" }
+      },
+      {
+        "id": "out_chunks_overlap",
+        "type": "nodetool.output.Output",
+        "name": "chunks_overlap",
+        "data": { "name": "chunks_overlap" }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "line",
+        "sourceHandle": "output",
+        "target": "match_date",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "line",
+        "sourceHandle": "output",
+        "target": "match_year",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e3",
+        "source": "line",
+        "sourceHandle": "output",
+        "target": "extract_parts",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e4",
+        "source": "line",
+        "sourceHandle": "output",
+        "target": "keep_order",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e5",
+        "source": "line",
+        "sourceHandle": "output",
+        "target": "drop_nomatch",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e6",
+        "source": "json_text",
+        "sourceHandle": "output",
+        "target": "parse",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e7",
+        "source": "words",
+        "sourceHandle": "output",
+        "target": "chunk",
+        "targetHandle": "text"
+      },
+
+      {
+        "id": "e8",
+        "source": "match_date",
+        "sourceHandle": "output",
+        "target": "out_date",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e9",
+        "source": "match_year",
+        "sourceHandle": "output",
+        "target": "out_year",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e10",
+        "source": "extract_parts",
+        "sourceHandle": "output",
+        "target": "out_parts",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e11",
+        "source": "keep_order",
+        "sourceHandle": "output",
+        "target": "out_kept",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e12",
+        "source": "drop_nomatch",
+        "sourceHandle": "output",
+        "target": "out_dropped",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e13",
+        "source": "parse",
+        "sourceHandle": "output",
+        "target": "out_parsed",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e14",
+        "source": "chunk",
+        "sourceHandle": "output",
+        "target": "out_chunks",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e15",
+        "source": "words",
+        "sourceHandle": "output",
+        "target": "chunk_overlap",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e16",
+        "source": "chunk_overlap",
+        "sourceHandle": "output",
+        "target": "out_chunks_overlap",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/text_transforms_cli.json
+++ b/examples/workflows/text_transforms_cli.json
@@ -1,0 +1,208 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "raw",
+        "type": "nodetool.constant.String",
+        "data": { "value": "  hello nodetool  " }
+      },
+      {
+        "id": "trim",
+        "type": "nodetool.text.TrimWhitespace",
+        "data": { "trim_start": true, "trim_end": true }
+      },
+      { "id": "upper", "type": "nodetool.text.ToUppercase" },
+      { "id": "capitalize", "type": "nodetool.text.CapitalizeText" },
+      {
+        "id": "starts",
+        "type": "nodetool.text.StartsWith",
+        "data": { "prefix": "hello" }
+      },
+      {
+        "id": "ends",
+        "type": "nodetool.text.EndsWith",
+        "data": { "suffix": "tool" }
+      },
+      {
+        "id": "index",
+        "type": "nodetool.text.IndexOf",
+        "data": { "substring": "node", "case_sensitive": true }
+      },
+      {
+        "id": "length",
+        "type": "nodetool.text.HasLength",
+        "data": { "exact_length": 14 }
+      },
+      {
+        "id": "slice",
+        "type": "nodetool.text.Extract",
+        "data": { "start": 6, "end": 14 }
+      },
+
+      {
+        "id": "out_trimmed",
+        "type": "nodetool.output.Output",
+        "name": "trimmed",
+        "data": { "name": "trimmed" }
+      },
+      {
+        "id": "out_upper",
+        "type": "nodetool.output.Output",
+        "name": "upper",
+        "data": { "name": "upper" }
+      },
+      {
+        "id": "out_capitalized",
+        "type": "nodetool.output.Output",
+        "name": "capitalized",
+        "data": { "name": "capitalized" }
+      },
+      {
+        "id": "out_starts",
+        "type": "nodetool.output.Output",
+        "name": "starts_with_hello",
+        "data": { "name": "starts_with_hello" }
+      },
+      {
+        "id": "out_ends",
+        "type": "nodetool.output.Output",
+        "name": "ends_with_tool",
+        "data": { "name": "ends_with_tool" }
+      },
+      {
+        "id": "out_index",
+        "type": "nodetool.output.Output",
+        "name": "index_of_node",
+        "data": { "name": "index_of_node" }
+      },
+      {
+        "id": "out_length",
+        "type": "nodetool.output.Output",
+        "name": "has_length_14",
+        "data": { "name": "has_length_14" }
+      },
+      {
+        "id": "out_slice",
+        "type": "nodetool.output.Output",
+        "name": "slice_6_14",
+        "data": { "name": "slice_6_14" }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e_raw_trim",
+        "source": "raw",
+        "sourceHandle": "output",
+        "target": "trim",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e_trim_upper",
+        "source": "trim",
+        "sourceHandle": "output",
+        "target": "upper",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e_trim_capitalize",
+        "source": "trim",
+        "sourceHandle": "output",
+        "target": "capitalize",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e_trim_starts",
+        "source": "trim",
+        "sourceHandle": "output",
+        "target": "starts",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e_trim_ends",
+        "source": "trim",
+        "sourceHandle": "output",
+        "target": "ends",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e_trim_index",
+        "source": "trim",
+        "sourceHandle": "output",
+        "target": "index",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e_trim_length",
+        "source": "trim",
+        "sourceHandle": "output",
+        "target": "length",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e_trim_slice",
+        "source": "trim",
+        "sourceHandle": "output",
+        "target": "slice",
+        "targetHandle": "text"
+      },
+
+      {
+        "id": "e_out_trimmed",
+        "source": "trim",
+        "sourceHandle": "output",
+        "target": "out_trimmed",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_out_upper",
+        "source": "upper",
+        "sourceHandle": "output",
+        "target": "out_upper",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_out_capitalized",
+        "source": "capitalize",
+        "sourceHandle": "output",
+        "target": "out_capitalized",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_out_starts",
+        "source": "starts",
+        "sourceHandle": "output",
+        "target": "out_starts",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_out_ends",
+        "source": "ends",
+        "sourceHandle": "output",
+        "target": "out_ends",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_out_index",
+        "source": "index",
+        "sourceHandle": "output",
+        "target": "out_index",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_out_length",
+        "source": "length",
+        "sourceHandle": "output",
+        "target": "out_length",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_out_slice",
+        "source": "slice",
+        "sourceHandle": "output",
+        "target": "out_slice",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/validate_strings_cli.json
+++ b/examples/workflows/validate_strings_cli.json
@@ -1,0 +1,249 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "email",
+        "type": "nodetool.constant.String",
+        "data": { "value": "Matti@Nodetool.AI " }
+      },
+      {
+        "id": "url",
+        "type": "nodetool.constant.String",
+        "data": { "value": "https://nodetool.ai/docs" }
+      },
+      {
+        "id": "not_a_url",
+        "type": "nodetool.constant.String",
+        "data": { "value": "nodetool" }
+      },
+      {
+        "id": "ipv4",
+        "type": "nodetool.constant.String",
+        "data": { "value": "192.168.1.24" }
+      },
+      {
+        "id": "ipv6",
+        "type": "nodetool.constant.String",
+        "data": { "value": "2001:db8::1" }
+      },
+      {
+        "id": "unsafe",
+        "type": "nodetool.constant.String",
+        "data": { "value": "  <script>alert(1)</script>  " }
+      },
+
+      { "id": "is_email", "type": "lib.validate.Email" },
+      { "id": "is_url", "type": "lib.validate.URL" },
+      { "id": "is_url_no", "type": "lib.validate.URL" },
+      { "id": "ip4", "type": "lib.validate.IP" },
+      { "id": "ip6", "type": "lib.validate.IP" },
+      { "id": "classify", "type": "lib.validate.String" },
+      { "id": "sanitize", "type": "lib.validate.Sanitize" },
+
+      {
+        "id": "out_is_email",
+        "type": "nodetool.output.Output",
+        "name": "is_email",
+        "data": { "name": "is_email" }
+      },
+      {
+        "id": "out_is_url",
+        "type": "nodetool.output.Output",
+        "name": "is_url",
+        "data": { "name": "is_url" }
+      },
+      {
+        "id": "out_is_url_no",
+        "type": "nodetool.output.Output",
+        "name": "is_url_negative",
+        "data": { "name": "is_url_negative" }
+      },
+      {
+        "id": "out_ipv4",
+        "type": "nodetool.output.Output",
+        "name": "ipv4_flag",
+        "data": { "name": "ipv4_flag" }
+      },
+      {
+        "id": "out_ipv6",
+        "type": "nodetool.output.Output",
+        "name": "ipv6_flag",
+        "data": { "name": "ipv6_flag" }
+      },
+      {
+        "id": "out_ipv4_is_v6",
+        "type": "nodetool.output.Output",
+        "name": "ipv4_is_v6",
+        "data": { "name": "ipv4_is_v6" }
+      },
+      {
+        "id": "out_class_uuid",
+        "type": "nodetool.output.Output",
+        "name": "url_is_uuid",
+        "data": { "name": "url_is_uuid" }
+      },
+      {
+        "id": "out_class_url",
+        "type": "nodetool.output.Output",
+        "name": "url_is_url",
+        "data": { "name": "url_is_url" }
+      },
+      {
+        "id": "out_escaped",
+        "type": "nodetool.output.Output",
+        "name": "escaped",
+        "data": { "name": "escaped" }
+      },
+      {
+        "id": "out_trimmed",
+        "type": "nodetool.output.Output",
+        "name": "trimmed",
+        "data": { "name": "trimmed" }
+      },
+      {
+        "id": "out_normalized_email",
+        "type": "nodetool.output.Output",
+        "name": "normalized_email",
+        "data": { "name": "normalized_email" }
+      },
+      { "id": "sanitize_email", "type": "lib.validate.Sanitize" }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "email",
+        "sourceHandle": "output",
+        "target": "is_email",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e2",
+        "source": "url",
+        "sourceHandle": "output",
+        "target": "is_url",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e3",
+        "source": "not_a_url",
+        "sourceHandle": "output",
+        "target": "is_url_no",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e4",
+        "source": "ipv4",
+        "sourceHandle": "output",
+        "target": "ip4",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e5",
+        "source": "ipv6",
+        "sourceHandle": "output",
+        "target": "ip6",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e6",
+        "source": "url",
+        "sourceHandle": "output",
+        "target": "classify",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e7",
+        "source": "unsafe",
+        "sourceHandle": "output",
+        "target": "sanitize",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e8",
+        "source": "email",
+        "sourceHandle": "output",
+        "target": "sanitize_email",
+        "targetHandle": "value"
+      },
+
+      {
+        "id": "e9",
+        "source": "is_email",
+        "sourceHandle": "output",
+        "target": "out_is_email",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e10",
+        "source": "is_url",
+        "sourceHandle": "output",
+        "target": "out_is_url",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e11",
+        "source": "is_url_no",
+        "sourceHandle": "output",
+        "target": "out_is_url_no",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e12",
+        "source": "ip4",
+        "sourceHandle": "is_ipv4",
+        "target": "out_ipv4",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e13",
+        "source": "ip6",
+        "sourceHandle": "is_ipv6",
+        "target": "out_ipv6",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e14",
+        "source": "ip4",
+        "sourceHandle": "is_ipv6",
+        "target": "out_ipv4_is_v6",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e15",
+        "source": "classify",
+        "sourceHandle": "is_uuid",
+        "target": "out_class_uuid",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e16",
+        "source": "classify",
+        "sourceHandle": "is_url",
+        "target": "out_class_url",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e17",
+        "source": "sanitize",
+        "sourceHandle": "escaped",
+        "target": "out_escaped",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e18",
+        "source": "sanitize",
+        "sourceHandle": "trimmed",
+        "target": "out_trimmed",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e19",
+        "source": "sanitize_email",
+        "sourceHandle": "normalized_email",
+        "target": "out_normalized_email",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/variables_cli.json
+++ b/examples/workflows/variables_cli.json
@@ -1,0 +1,53 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "set_run",
+        "type": "nodetool.variable.SetVariable",
+        "data": { "name": "run_label", "value": "nightly-42" }
+      },
+      {
+        "id": "get_run",
+        "type": "nodetool.variable.GetVariable",
+        "data": { "name": "run_label" }
+      },
+
+      {
+        "id": "out_set",
+        "type": "nodetool.output.Output",
+        "name": "set_returns",
+        "data": { "name": "set_returns" }
+      },
+      {
+        "id": "out_get",
+        "type": "nodetool.output.Output",
+        "name": "read_back",
+        "data": { "name": "read_back" }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "set_run",
+        "sourceHandle": "output",
+        "target": "get_run",
+        "targetHandle": "trigger"
+      },
+      {
+        "id": "e2",
+        "source": "set_run",
+        "sourceHandle": "output",
+        "target": "out_set",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e3",
+        "source": "get_run",
+        "sourceHandle": "output",
+        "target": "out_get",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/packages/base-nodes/tests/pure-node-examples-run.test.ts
+++ b/packages/base-nodes/tests/pure-node-examples-run.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Executes the offline example workflows in `examples/workflows/` and asserts
+ * the value every node produced.
+ *
+ * The companion to `trigger-examples-run.test.ts`, for the same reason. The
+ * gallery harness (`example-workflows-execute.test.ts`) runs 216 examples
+ * against a fake context and asserts only that each one *completes or fails
+ * with a recognised error class*. A node that returns the wrong answer passes
+ * that check, and 491 of the 689 registered node types had no example at all.
+ * These cases pin behaviour: every assertion is on a value, computed by hand
+ * from the input, so a node that silently changes its output fails here.
+ *
+ * Nothing here touches a model, the network, or the filesystem — the graphs are
+ * string constants and pure transforms, so the assertions are exact and the
+ * suite is deterministic. `lib.datetime.Now` is the one exception, and it is
+ * asserted on shape.
+ *
+ * Runs through `ExecutionSession` with `resolveNodeType`: the path
+ * `nodetool workflows run` and the websocket server both take.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  NodeRegistry,
+  createGraphNodeTypeResolver
+} from "@nodetool-ai/node-sdk";
+import { ExecutionSession } from "@nodetool-ai/execution";
+import { registerBaseNodes } from "../src/index.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const EXAMPLES_DIR = path.resolve(__dirname, "../../../examples/workflows");
+
+async function run(file: string): Promise<Record<string, unknown[]>> {
+  const { graph } = JSON.parse(
+    fs.readFileSync(path.join(EXAMPLES_DIR, file), "utf8")
+  ) as { graph: unknown };
+  const registry = new NodeRegistry();
+  registerBaseNodes(registry);
+  const session = await ExecutionSession.create({
+    graph,
+    registry,
+    resolveNodeType: createGraphNodeTypeResolver(registry).resolveNodeType,
+    jobId: `pure-example-${file}`,
+    params: {}
+  } as never);
+  const result = await session.result;
+  expect(result.error ?? null, `${file} errored`).toBeNull();
+  expect(result.status, `${file} did not complete`).toBe("completed");
+  return (result.outputs ?? {}) as Record<string, unknown[]>;
+}
+
+describe("text_transforms_cli", () => {
+  it("applies each string transform to the same trimmed source", async () => {
+    const out = await run("text_transforms_cli.json");
+    // The constant is "  hello nodetool  "; every other node reads the trimmed
+    // form, so the offsets below are into "hello nodetool" (14 chars).
+    expect(out["trimmed"]).toEqual(["hello nodetool"]);
+    expect(out["upper"]).toEqual(["HELLO NODETOOL"]);
+    // Capitalize raises the first letter only — it is not title case.
+    expect(out["capitalized"]).toEqual(["Hello nodetool"]);
+    expect(out["starts_with_hello"]).toEqual([true]);
+    expect(out["ends_with_tool"]).toEqual([true]);
+    expect(out["index_of_node"]).toEqual([6]);
+    expect(out["has_length_14"]).toEqual([true]);
+    expect(out["slice_6_14"]).toEqual(["nodetool"]);
+  });
+});
+
+describe("text_regex_parse_cli", () => {
+  it("matches, extracts, filters, parses and chunks", async () => {
+    const out = await run("text_regex_parse_cli.json");
+
+    // RegexMatch returns a list; `group` selects which capture to return,
+    // 0 being the whole match.
+    expect(out["date"]).toEqual([["2026-08-02"]]);
+    expect(out["year"]).toEqual([["2026"]]);
+
+    // ExtractRegex returns the capture groups, not the whole match.
+    expect(out["parts"]).toEqual([["1042", "2026-08-02"]]);
+
+    // FilterRegexString is a filter, not an extractor: on a match it forwards
+    // the *whole* value through, and on a miss it emits nothing at all. The
+    // empty array for the miss is the assertion that matters — it is what
+    // distinguishes a filter from a node that returns "".
+    expect(out["kept"]).toEqual([
+      "order-1042 shipped 2026-08-02 to matti@nodetool.ai"
+    ]);
+    expect(out["dropped"]).toEqual([]);
+
+    expect(out["parsed"]).toEqual([{ repo: "nodetool", stars: 1200 }]);
+
+    // Chunk's `length` counts separator-delimited tokens, not characters:
+    // "alpha beta gamma delta" at length 2 splits into two 2-word chunks.
+    expect(out["chunks"]).toEqual([["alpha beta", "gamma delta"]]);
+    // overlap 1 slides the window one token at a time, so the final chunk is
+    // the one-token tail.
+    expect(out["chunks_overlap"]).toEqual([
+      ["alpha beta", "beta gamma", "gamma delta", "delta"]
+    ]);
+  });
+});
+
+describe("markdown_extract_cli", () => {
+  it("pulls headers, lists, code blocks and tables out of one document", async () => {
+    const out = await run("markdown_extract_cli.json");
+
+    expect(out["headers"]).toEqual([
+      [
+        { level: 1, text: "Release Notes", index: 0 },
+        { level: 2, text: "Added", index: 1 },
+        { level: 2, text: "Steps", index: 2 }
+      ]
+    ]);
+    // max_level is a ceiling, so the same document yields only the h1.
+    expect(out["headers_h1"]).toEqual([
+      [{ level: 1, text: "Release Notes", index: 0 }]
+    ]);
+
+    // Lists nest one level: a list *per list block* in the document.
+    expect(out["bullets"]).toEqual([
+      [[{ text: "trigger examples" }, { text: "an executing test" }]]
+    ]);
+    expect(out["numbered"]).toEqual([
+      [["build the packages", "run the suite"]]
+    ]);
+
+    expect(out["code_blocks"]).toEqual([
+      [{ language: "bash", code: "npm run test" }]
+    ]);
+
+    expect(out["tables"]).toEqual([
+      {
+        rows: [
+          { node: "Concat", covered: "yes" },
+          { node: "Chunk", covered: "no" }
+        ]
+      }
+    ]);
+  });
+});
+
+describe("validate_strings_cli", () => {
+  it("classifies emails, URLs and IPs, and sanitizes untrusted text", async () => {
+    const out = await run("validate_strings_cli.json");
+
+    expect(out["is_email"]).toEqual([true]);
+    expect(out["is_url"]).toEqual([true]);
+    expect(out["is_url_negative"]).toEqual([false]);
+
+    expect(out["ipv4_flag"]).toEqual([true]);
+    expect(out["ipv6_flag"]).toEqual([true]);
+    // The v4/v6 flags are independent, not a single "is an IP" bit.
+    expect(out["ipv4_is_v6"]).toEqual([false]);
+
+    expect(out["url_is_url"]).toEqual([true]);
+    expect(out["url_is_uuid"]).toEqual([false]);
+
+    // Sanitize does not trim before escaping, and escapes the forward slash
+    // too — both are load-bearing if you compare the output to a fixture.
+    expect(out["escaped"]).toEqual([
+      "  &lt;script&gt;alert(1)&lt;&#x2F;script&gt;  "
+    ]);
+    expect(out["trimmed"]).toEqual(["<script>alert(1)</script>"]);
+    // Normalizing lowercases the address and drops surrounding whitespace.
+    expect(out["normalized_email"]).toEqual(["matti@nodetool.ai"]);
+  });
+});
+
+describe("list_build_cli", () => {
+  it("builds lists by range, repetition and tiling", async () => {
+    const out = await run("list_build_cli.json");
+    // stop is exclusive: 0..10 step 2 stops at 8.
+    expect(out["range"]).toEqual([[0, 2, 4, 6, 8]]);
+    expect(out["repeat_value"]).toEqual([["ok", "ok", "ok"]]);
+    // Tile repeats the whole list; RepeatEach repeats each element in place.
+    // Same inputs, different order — that is the only thing separating them.
+    expect(out["tile"]).toEqual([["a", "b", "a", "b", "a", "b"]]);
+    expect(out["repeat_each"]).toEqual([["a", "a", "a", "b", "b", "b"]]);
+  });
+});
+
+describe("control_flow_stream_cli", () => {
+  it("filters, drops, taps and collects a stream, and routes a switch", async () => {
+    const out = await run("control_flow_stream_cli.json");
+
+    // Each of these is a Collect away from its Output on purpose. A terminal
+    // Output records the value its actor holds at completion, so wiring a
+    // stream straight into one keeps the *last* item and silently loses the
+    // rest — [4] instead of [0, 2, 4]. Collect is what materializes a stream.
+    expect(out["evens"]).toEqual([[0, 2, 4]]);
+    expect(out["after_warmup"]).toEqual([[3, 4, 5]]);
+    expect(out["tapped"]).toEqual([[0, 1, 2, 3, 4, 5]]);
+    expect(out["present"]).toEqual([["alpha", "beta", "gamma"]]);
+
+    // Switch emits on exactly one of matched/default, never both.
+    expect(out["matched"]).toEqual(["payload"]);
+    expect(out["matched_index"]).toEqual([1]);
+    expect(out["routed_to_default"]).toEqual(["payload"]);
+    expect(out["default_index"]).toEqual([-1]);
+
+    // TryCatch swaps in the fallback for a null value; it does not catch
+    // thrown errors, despite the name.
+    expect(out["fallback"]).toEqual(["default-value"]);
+    expect(out["fallback_flag"]).toEqual([true]);
+    expect(out["passthrough"]).toEqual(["present"]);
+    expect(out["passthrough_flag"]).toEqual([false]);
+  });
+});
+
+describe("datetime_cli", () => {
+  it("formats, shifts and compares fixed dates", async () => {
+    const out = await run("datetime_cli.json");
+
+    expect(out["formatted"]).toEqual(["2026-08-02"]);
+    // 2026-08-02 + 30 days. August has 31 days, so this lands on Sep 1.
+    expect(out["added_iso"]).toEqual(["2026-09-01T00:00:00.000Z"]);
+
+    // Diff is date_a - date_b, so an earlier `a` gives a negative number.
+    // The sign is the thing worth pinning; is_before says the same in a
+    // form that does not depend on argument order.
+    expect(out["diff_days"]).toEqual([-30]);
+    expect(out["a_is_before_b"]).toEqual([true]);
+
+    // The period end is inclusive, to the last millisecond.
+    expect(out["month_start"]).toEqual(["2026-08-01T00:00:00.000Z"]);
+    expect(out["month_end"]).toEqual(["2026-08-31T23:59:59.999Z"]);
+
+    // Now is the one non-deterministic node here, so it is asserted on shape.
+    const [epoch] = out["now_epoch_ms"] as number[];
+    expect(typeof epoch).toBe("number");
+    expect(epoch).toBeGreaterThan(1_700_000_000_000);
+  });
+});
+
+describe("html_extract_cli", () => {
+  it("extracts metadata, links and media from one HTML document", async () => {
+    const out = await run("html_extract_cli.json");
+
+    expect(out["title"]).toEqual(["NodeTool Docs"]);
+    expect(out["description"]).toEqual(["Visual AI workflows"]);
+    expect(out["keywords"]).toEqual(["workflow, nodes, ai"]);
+
+    // href stays relative; base_url is used to classify internal vs external,
+    // not to rewrite the link.
+    expect(out["links"]).toEqual([
+      [
+        { href: "/workflows", text: "workflow guide", type: "internal" },
+        {
+          href: "https://github.com/nodetool-ai/nodetool",
+          text: "source",
+          type: "external"
+        }
+      ]
+    ]);
+
+    // Media refs are the opposite: base_url *is* applied, and each comes back
+    // as a typed asset ref rather than a bare string.
+    expect(out["images"]).toEqual([
+      [{ uri: "https://docs.nodetool.ai/img/editor.png", type: "image" }]
+    ]);
+    expect(out["videos"]).toEqual([
+      [{ uri: "https://docs.nodetool.ai/media/tour.mp4", type: "video" }]
+    ]);
+    expect(out["audios"]).toEqual([
+      [{ uri: "https://docs.nodetool.ai/media/intro.mp3", type: "audio" }]
+    ]);
+
+    expect(out["text"]).toEqual([
+      "DOCS\n\nStart with the workflow guide [/workflows] or the source " +
+        "[https://github.com/nodetool-ai/nodetool].\n\neditor [/img/editor.png]"
+    ]);
+
+    // BaseUrl drops the path, query and fragment.
+    expect(out["base_url"]).toEqual(["https://docs.nodetool.ai"]);
+  });
+});
+
+describe("dataframe_query_cli", () => {
+  it("queries a dataframe parsed out of a markdown table", async () => {
+    const out = await run("dataframe_query_cli.json");
+
+    // Markdown cells arrive as strings — including the numeric column.
+    expect(out["table"]).toEqual([
+      {
+        rows: [
+          { node: "Concat", runs: "12", status: "ok" },
+          { node: "Chunk", runs: "48", status: "ok" },
+          { node: "Pivot", runs: "3", status: "failed" }
+        ]
+      }
+    ]);
+
+    expect(out["first_failed"]).toEqual([
+      { rows: [{ node: "Pivot", runs: "3", status: "failed" }] }
+    ]);
+
+    // `runs > 20` still compares numerically against those strings, so it
+    // picks 48 and not the lexicographically larger "3".
+    expect(out["first_busy"]).toEqual([
+      { rows: [{ node: "Chunk", runs: "48", status: "ok" }] }
+    ]);
+  });
+});
+
+describe("variables_cli", () => {
+  it("writes a workflow variable and reads it back", async () => {
+    const out = await run("variables_cli.json");
+    // SetVariable forwards the value it stored, which is what sequences
+    // GetVariable behind it through the `trigger` input. Without that edge
+    // the read can run first and return nothing.
+    expect(out["set_returns"]).toEqual(["nightly-42"]);
+    expect(out["read_back"]).toEqual(["nightly-42"]);
+  });
+});


### PR DESCRIPTION
Rebased onto main now that #4644 has landed. Was stacked on it; it squash-merged,
so the stack is gone and this is a single commit against main.

## The gap

198 of 645 registered node types had an example; the other 447 had none.

The existing gallery harness (`example-workflows-execute.test.ts`) runs all 233
shipped examples, but asserts only that each **completes or fails with a
recognised error class**. A node that returns the *wrong answer* passes it. This
adds coverage where the assertion can be exact.

## What's here

Ten examples in `examples/workflows/`. Every input is a constant in the graph —
no model, no network, no disk — so the assertions are values and the suite is
deterministic.

- `text_transforms` — trim, case, prefix/suffix, index, slice
- `text_regex_parse` — regex match/extract/filter, JSON parse, chunking
- `markdown_extract` — headers, bullet and numbered lists, code, tables
- `html_extract` — metadata, links, images, video, audio, plain text
- `validate_strings` — email/URL/IP shape checks, sanitizing
- `list_build` — range, repeat, tile
- `control_flow_stream` — filter, drop-while, tap, collect; Switch; fallback
- `datetime` — format, shift, compare
- `dataframe_query` — querying a dataframe parsed from a markdown table
- `variables` — write a workflow variable and read it back

Covered types: **198 → 247 of 645 (30.7% → 38.3%)**.

`pure-node-examples-run.test.ts` executes all ten through `ExecutionSession`
with `resolveNodeType` — the path `nodetool workflows run` and the websocket
server both take — and asserts every value. Each expectation was computed by
hand from the input *before* the run, so the test pins behaviour rather than
recording it.

## Three nodes that don't do what their property names suggest

Found by predicting the output first and finding the run disagreed. All three
are now pinned, with the reasoning in comments:

- **`Chunk`'s `length` counts separator-delimited tokens, not characters.**
- **`FilterRegexString` is a filter, not an extractor** — it forwards the whole
  value on a match and emits *nothing* on a miss. The empty-array assertion for
  the miss is what distinguishes those two behaviours.
- **`FilterNone` is a streaming node.** Fed a static list through its property
  it silently emits nothing; it needs a real stream, so it is driven by
  `ForEach`.

## One general result

**A stream wired straight into an `Output` keeps only the last item.** The
runner collects a terminal output once, from the actor's final result, so
`evens` came back `[4]` instead of `[0, 2, 4]`. `Collect` is what materializes a
stream. The example is wired through one, and both the test and the README say
why.

## Verification

The assertions were checked by mutating two examples — changing a source string,
and deleting a `Collect`. Both fail, the second reproducing exactly the
`[4]`-instead-of-`[0,2,4]` collapse.

On Node 22.22.1, rebuilt against current main:

- base-nodes: 2612 passed, 28 files
- node-sdk: 723 passed, 51 files
- typecheck clean
- all ten also run clean through `npm run workflow`, not just the test harness

#4644 removed 44 node types (`lib.os`, `lib.http`, `lib.graphql`), taking the
registry from 689 to 645. All 53 types these examples use survive, and an audit
of every node type in all 243 tracked examples against the rebuilt registry
found no new dangling references.