### PR TITLE
Seven gallery examples, and a test that runs them

### DIFF
--- a/packages/base-nodes/nodetool/examples/nodetool-base/Check a URL and an IP.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Check a URL and an IP.json
@@ -1,0 +1,191 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-08-02T10:00:00.000Z",
+  "updated_at": "2026-08-02T10:00:00.000Z",
+  "name": "Check a URL and an IP",
+  "tool_name": null,
+  "description": "Two shape tests that people routinely hand-roll with regex and get wrong. IP reports the family as well as validity, because 'is this an address' and 'is this v4' are different questions.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "u",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "https://nodetool.ai/docs?q=1"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  URL"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "a",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "2001:db8::8a2e:370:7334"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Address"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "vu",
+        "type": "lib.validate.URL",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Valid URL?"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "vi",
+        "type": "lib.validate.IP",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Address family"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "o1",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "url_ok"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "url_ok"
+      },
+      {
+        "id": "o2",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "is_ipv6"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "is_ipv6"
+      },
+      {
+        "id": "o3",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "is_ipv4"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "is_ipv4"
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "u",
+        "sourceHandle": "output",
+        "target": "vu",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e2",
+        "source": "a",
+        "sourceHandle": "output",
+        "target": "vi",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e3",
+        "source": "vu",
+        "sourceHandle": "output",
+        "target": "o1",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e4",
+        "source": "vi",
+        "sourceHandle": "is_ipv6",
+        "target": "o2",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e5",
+        "source": "vi",
+        "sourceHandle": "is_ipv4",
+        "target": "o3",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Chunk a Transcript for Indexing.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Chunk a Transcript for Indexing.json
@@ -1,0 +1,174 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-08-02T10:00:00.000Z",
+  "updated_at": "2026-08-02T10:00:00.000Z",
+  "name": "Chunk a Transcript for Indexing",
+  "tool_name": null,
+  "description": "Split a long passage into overlapping windows the way a RAG ingest does, then count them. `length` and `overlap` are counted in WORDS, not characters \u2014 a 90 here would swallow this whole passage into one chunk. Overlap is the point: a boundary landing mid-sentence loses the claim that straddles it, so neighbouring chunks share a tail. Counting needs Collection first, because Count consumes a stream and a list handed to it arrives as a single item.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "t",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "The keeper climbed the stair each evening. The lamp needed winding twice a night. By the third winter the mechanism had worn, and the light guttered where it had once held steady. Ships began to pass wider of the point."
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Transcript"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "ch",
+        "type": "nodetool.text.Chunk",
+        "data": {
+          "length": 12,
+          "overlap": 3,
+          "separator": " "
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  12 words, 3 overlap"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "fan",
+        "type": "nodetool.control.Collection",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Fan out"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "n",
+        "type": "nodetool.control.Count",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  How many"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "o1",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "chunks"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "chunks"
+      },
+      {
+        "id": "o2",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "chunk_count"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "chunk_count"
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "t",
+        "sourceHandle": "output",
+        "target": "ch",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "ch",
+        "sourceHandle": "output",
+        "target": "o1",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e3",
+        "source": "ch",
+        "sourceHandle": "output",
+        "target": "fan",
+        "targetHandle": "items"
+      },
+      {
+        "id": "e4",
+        "source": "fan",
+        "sourceHandle": "output",
+        "target": "n",
+        "targetHandle": "input_item"
+      },
+      {
+        "id": "e5",
+        "source": "n",
+        "sourceHandle": "output",
+        "target": "o2",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Keep Only the Long Lines.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Keep Only the Long Lines.json
@@ -1,0 +1,201 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-08-02T10:00:00.000Z",
+  "updated_at": "2026-08-02T10:00:00.000Z",
+  "name": "Keep Only the Long Lines",
+  "tool_name": null,
+  "description": "Fan a list into a stream, drop the items that fail a predicate, then gather what survived back into a list. Two nodes carry the lesson: Collection is the fan-out \u2014 a list fed straight into a stream operator arrives as one item \u2014 and Collect is the reverse, without which an output on a stream shows only the last value that passed.",
+  "tags": [
+    "data",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "src",
+        "type": "nodetool.constant.List",
+        "data": {
+          "value": [
+            "ok",
+            "a much longer line worth keeping",
+            "no",
+            "another long enough line"
+          ]
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Lines"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "fan",
+        "type": "nodetool.control.Collection",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Fan out"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "keep",
+        "type": "nodetool.control.FilterCode",
+        "data": {
+          "predicate": "item.length > 10"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Longer than 10"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "gather",
+        "type": "nodetool.control.Collect",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Gather"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "n",
+        "type": "nodetool.control.Count",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "5  How many"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "o1",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "kept"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "kept"
+      },
+      {
+        "id": "o2",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "count"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "count"
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "src",
+        "sourceHandle": "output",
+        "target": "fan",
+        "targetHandle": "items"
+      },
+      {
+        "id": "e2",
+        "source": "fan",
+        "sourceHandle": "output",
+        "target": "keep",
+        "targetHandle": "input_item"
+      },
+      {
+        "id": "e3",
+        "source": "keep",
+        "sourceHandle": "output",
+        "target": "gather",
+        "targetHandle": "input_item"
+      },
+      {
+        "id": "e4",
+        "source": "keep",
+        "sourceHandle": "output",
+        "target": "n",
+        "targetHandle": "input_item"
+      },
+      {
+        "id": "e5",
+        "source": "gather",
+        "sourceHandle": "output",
+        "target": "o1",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e6",
+        "source": "n",
+        "sourceHandle": "output",
+        "target": "o2",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Map a README's Structure.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Map a README's Structure.json
@@ -1,0 +1,250 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-08-02T10:00:00.000Z",
+  "updated_at": "2026-08-02T10:00:00.000Z",
+  "name": "Map a README's Structure",
+  "tool_name": null,
+  "description": "Read the shape of a Markdown document without parsing it by hand: headings for the outline, links for the reference graph, and fenced blocks for the code it teaches.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "md",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "# NodeTool\n\nVisual AI workflows.\n\n## Install\n\nSee the [docs](https://nodetool.ai/docs) and the [repo](https://github.com/nodetool-ai/nodetool).\n\n```bash\nnpm install\n```\n\n### Notes\n\n- runs locally\n- runs in the cloud\n"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  README"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "h",
+        "type": "lib.markdown.ExtractHeaders",
+        "data": {
+          "max_level": 3
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Outline"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "l",
+        "type": "lib.markdown.ExtractLinks",
+        "data": {
+          "include_titles": false
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Links"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "c",
+        "type": "lib.markdown.ExtractCodeBlocks",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Code blocks"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "b",
+        "type": "lib.markdown.ExtractBulletLists",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "5  Bullets"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "o1",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "headers"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "headers"
+      },
+      {
+        "id": "o2",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "links"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "links"
+      },
+      {
+        "id": "o3",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "code"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "code"
+      },
+      {
+        "id": "o4",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "bullets"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 560
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "bullets"
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "md",
+        "sourceHandle": "output",
+        "target": "h",
+        "targetHandle": "markdown"
+      },
+      {
+        "id": "e2",
+        "source": "md",
+        "sourceHandle": "output",
+        "target": "l",
+        "targetHandle": "markdown"
+      },
+      {
+        "id": "e3",
+        "source": "md",
+        "sourceHandle": "output",
+        "target": "c",
+        "targetHandle": "markdown"
+      },
+      {
+        "id": "e4",
+        "source": "md",
+        "sourceHandle": "output",
+        "target": "b",
+        "targetHandle": "markdown"
+      },
+      {
+        "id": "e5",
+        "source": "h",
+        "sourceHandle": "output",
+        "target": "o1",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e6",
+        "source": "l",
+        "sourceHandle": "output",
+        "target": "o2",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e7",
+        "source": "c",
+        "sourceHandle": "output",
+        "target": "o3",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e8",
+        "source": "b",
+        "sourceHandle": "output",
+        "target": "o4",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Read the Links Out of a Page.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Read the Links Out of a Page.json
@@ -1,0 +1,172 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-08-02T10:00:00.000Z",
+  "updated_at": "2026-08-02T10:00:00.000Z",
+  "name": "Read the Links Out of a Page",
+  "tool_name": null,
+  "description": "Resolve a page's base URL, then pull its anchors against it. `base_url` does not rewrite relative hrefs to absolute \u2014 it CLASSIFIES each link as internal or external, which is what you need to decide whether a crawler should follow it. The href comes back exactly as authored.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "url",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "https://nodetool.ai/guide/index.html"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Page URL"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "html",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "<html><head><title>Guide</title></head><body><a href=\"/docs\">Docs</a><a href=\"https://github.com/nodetool-ai/nodetool\">Source</a></body></html>"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  HTML"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "base",
+        "type": "lib.html.BaseUrl",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Base URL"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "links",
+        "type": "lib.html.ExtractLinks",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Anchors"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "o1",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "base"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "base"
+      },
+      {
+        "id": "o2",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "links"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "links"
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "url",
+        "sourceHandle": "output",
+        "target": "base",
+        "targetHandle": "url"
+      },
+      {
+        "id": "e2",
+        "source": "html",
+        "sourceHandle": "output",
+        "target": "links",
+        "targetHandle": "html"
+      },
+      {
+        "id": "e3",
+        "source": "base",
+        "sourceHandle": "output",
+        "target": "links",
+        "targetHandle": "base_url"
+      },
+      {
+        "id": "e4",
+        "source": "base",
+        "sourceHandle": "output",
+        "target": "o1",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e5",
+        "source": "links",
+        "sourceHandle": "links",
+        "target": "o2",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Redact and Tidy a Log Line.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Redact and Tidy a Log Line.json
@@ -1,0 +1,211 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-08-02T10:00:00.000Z",
+  "updated_at": "2026-08-02T10:00:00.000Z",
+  "name": "Redact and Tidy a Log Line",
+  "tool_name": null,
+  "description": "Two regex passes and a whitespace collapse, in the order that matters: redact before you normalise, or the pattern you are matching may already have been reshaped.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "raw",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "2026-08-02  WARN   user=ada.lovelace@example.com   ip=10.0.0.7    retry=3"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Log line"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "mail",
+        "type": "nodetool.text.RegexReplace",
+        "data": {
+          "pattern": "[\\w.+-]+@[\\w-]+\\.[\\w.]+",
+          "replacement": "<email>",
+          "count": 0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Redact email"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "ip",
+        "type": "nodetool.text.RegexReplace",
+        "data": {
+          "pattern": "\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b",
+          "replacement": "<ip>",
+          "count": 0
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Redact IP"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "tidy",
+        "type": "nodetool.text.CollapseWhitespace",
+        "data": {
+          "preserve_newlines": false,
+          "replacement": " ",
+          "trim_edges": true
+        },
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Collapse spaces"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "nums",
+        "type": "nodetool.text.FindAllRegex",
+        "data": {
+          "regex": "\\d+",
+          "dotall": false,
+          "ignorecase": false,
+          "multiline": false
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "5  Every number"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "o1",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "redacted"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "redacted"
+      },
+      {
+        "id": "o2",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "numbers"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "numbers"
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "raw",
+        "sourceHandle": "output",
+        "target": "mail",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e2",
+        "source": "mail",
+        "sourceHandle": "output",
+        "target": "ip",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e3",
+        "source": "ip",
+        "sourceHandle": "output",
+        "target": "tidy",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e4",
+        "source": "tidy",
+        "sourceHandle": "output",
+        "target": "nums",
+        "targetHandle": "text"
+      },
+      {
+        "id": "e5",
+        "source": "tidy",
+        "sourceHandle": "output",
+        "target": "o1",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e6",
+        "source": "nums",
+        "sourceHandle": "output",
+        "target": "o2",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Validate a Signup Payload.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Validate a Signup Payload.json
@@ -1,0 +1,196 @@
+{
+  "id": "",
+  "access": "private",
+  "created_at": "2026-08-02T10:00:00.000Z",
+  "updated_at": "2026-08-02T10:00:00.000Z",
+  "name": "Validate a Signup Payload",
+  "tool_name": null,
+  "description": "Run one submitted address through the checks a signup form needs: a strict email test, a bundle of shape checks in one pass, and the sanitised forms you would actually store. Sanitize returns three variants because escaping, trimming and email normalisation are different jobs.",
+  "tags": [
+    "text",
+    "example"
+  ],
+  "thumbnail": null,
+  "thumbnail_url": null,
+  "graph": {
+    "nodes": [
+      {
+        "id": "raw",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "  Ada.Lovelace+signup@Example.COM  "
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "1  Submitted"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "email",
+        "type": "lib.validate.Email",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "2  Valid email?"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "shape",
+        "type": "lib.validate.String",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "3  Shape checks"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "clean",
+        "type": "lib.validate.Sanitize",
+        "data": {},
+        "ui_properties": {
+          "position": {
+            "x": 960,
+            "y": 120
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true,
+          "title": "4  Sanitise"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "o1",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "is_email"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 0,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "is_email"
+      },
+      {
+        "id": "o2",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "is_alphanumeric"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 320,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "is_alphanumeric"
+      },
+      {
+        "id": "o3",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "normalized_email"
+        },
+        "ui_properties": {
+          "position": {
+            "x": 640,
+            "y": 340
+          },
+          "zIndex": 0,
+          "width": 280,
+          "selectable": true
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {},
+        "name": "normalized_email"
+      }
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "source": "raw",
+        "sourceHandle": "output",
+        "target": "email",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e2",
+        "source": "raw",
+        "sourceHandle": "output",
+        "target": "shape",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e3",
+        "source": "raw",
+        "sourceHandle": "output",
+        "target": "clean",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e4",
+        "source": "email",
+        "sourceHandle": "output",
+        "target": "o1",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e5",
+        "source": "shape",
+        "sourceHandle": "is_alphanumeric",
+        "target": "o2",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e6",
+        "source": "clean",
+        "sourceHandle": "normalized_email",
+        "target": "o3",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "input_schema": null,
+  "output_schema": null,
+  "settings": null,
+  "package_name": "nodetool-base",
+  "path": null,
+  "run_mode": null
+}

--- a/packages/base-nodes/tests/gallery-examples-run.test.ts
+++ b/packages/base-nodes/tests/gallery-examples-run.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Executes a set of shipped gallery examples and asserts what they emit.
+ *
+ * `example-workflows-validation.test.ts` hydrates all 200-odd gallery examples
+ * and checks their shape; it never runs one. A structurally valid example can
+ * still teach the opposite of its own description, and three of the seven
+ * added alongside this file did exactly that before being corrected:
+ *
+ *  - `nodetool.text.Chunk` counts `length`/`overlap` in WORDS. A value of 90
+ *    on a 38-word passage returned one chunk, so an example titled "chunk a
+ *    transcript" shipped a single unsplit chunk.
+ *  - `lib.html.ExtractLinks` does not rewrite relative hrefs against
+ *    `base_url`; it classifies each link internal or external. The example's
+ *    prose claimed resolution the node never performs.
+ *  - An output wired to a stream shows only the last value that passed, so
+ *    "keep only the long lines" displayed one line out of two until
+ *    `nodetool.control.Collect` gathered the stream back into a list.
+ *
+ * Validation caught none of those, which is the point of this file. Each
+ * assertion pins a concrete value — the chunk count, the classified link type,
+ * the gathered list — because "something was emitted" would have passed
+ * against all three.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { NodeRegistry, createGraphNodeTypeResolver } from "@nodetool-ai/node-sdk";
+import { ExecutionSession } from "@nodetool-ai/execution";
+import { registerBaseNodes } from "../src/index.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const GALLERY = path.resolve(__dirname, "../nodetool/examples/nodetool-base");
+
+function load(name: string): unknown {
+  const raw = JSON.parse(
+    fs.readFileSync(path.join(GALLERY, `${name}.json`), "utf8")
+  ) as { graph: unknown };
+  return raw.graph;
+}
+
+/** Mirrors the CLI and the websocket server: registry plus `resolveNodeType`. */
+async function run(name: string): Promise<Record<string, unknown[]>> {
+  const registry = new NodeRegistry();
+  registerBaseNodes(registry);
+  const session = await ExecutionSession.create({
+    graph: load(name),
+    registry,
+    resolveNodeType: createGraphNodeTypeResolver(registry).resolveNodeType,
+    jobId: `gallery-${name}`,
+    params: {}
+  } as never);
+  const result = await session.result;
+  expect(result.error ?? null).toBeNull();
+  expect(result.status).toBe("completed");
+  return (result.outputs ?? {}) as Record<string, unknown[]>;
+}
+
+describe("shipped gallery examples produce what they claim", () => {
+  it("Validate a Signup Payload normalises a messy address", async () => {
+    const out = await run("Validate a Signup Payload");
+    // Leading/trailing space and mixed case, still a valid address.
+    expect(out["is_email"]).toEqual([true]);
+    // '@' and '+' are not alphanumeric — the check that stops people using
+    // is_alphanumeric as a username test on an email field.
+    expect(out["is_alphanumeric"]).toEqual([false]);
+    expect(out["normalized_email"]).toEqual([
+      "ada.lovelace+signup@example.com"
+    ]);
+  });
+
+  it("Check a URL and an IP reports the address family, not just validity", async () => {
+    const out = await run("Check a URL and an IP");
+    expect(out["url_ok"]).toEqual([true]);
+    expect(out["is_ipv6"]).toEqual([true]);
+    expect(out["is_ipv4"]).toEqual([false]);
+  });
+
+  it("Map a README's Structure returns the outline with heading levels", async () => {
+    const out = await run("Map a README's Structure");
+    expect(out["headers"]?.[0]).toEqual([
+      { level: 1, text: "NodeTool", index: 0 },
+      { level: 2, text: "Install", index: 1 },
+      { level: 3, text: "Notes", index: 2 }
+    ]);
+    expect(out["code"]?.[0]).toEqual([
+      { language: "bash", code: "npm install" }
+    ]);
+  });
+
+  it("Keep Only the Long Lines gathers every survivor, not just the last", async () => {
+    const out = await run("Keep Only the Long Lines");
+    // Without Collect this was ["another long enough line"] — one of two.
+    expect(out["kept"]?.[0]).toEqual([
+      "a much longer line worth keeping",
+      "another long enough line"
+    ]);
+    expect(out["count"]).toEqual([2]);
+  });
+
+  it("Chunk a Transcript splits into overlapping windows", async () => {
+    const out = await run("Chunk a Transcript for Indexing");
+    const chunks = out["chunks"]?.[0] as string[];
+    // length/overlap are words. At 90 this was a single unsplit chunk.
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(out["chunk_count"]).toEqual([chunks.length]);
+    // The 3-word overlap is the feature: the tail of one chunk opens the next.
+    const tail = chunks[0].split(" ").slice(-3).join(" ");
+    expect(chunks[1].startsWith(tail)).toBe(true);
+  });
+
+  it("Redact and Tidy a Log Line redacts before it scans", async () => {
+    const out = await run("Redact and Tidy a Log Line");
+    expect(out["redacted"]).toEqual([
+      "2026-08-02 WARN user=<email> ip=<ip> retry=3"
+    ]);
+    // The IP's digits are gone because redaction ran first — the ordering the
+    // description calls out. 10, 0, 0 and 7 are absent by construction.
+    expect(out["numbers"]?.[0]).toEqual(["2026", "08", "02", "3"]);
+  });
+
+  it("Read the Links Out of a Page classifies rather than resolves", async () => {
+    const out = await run("Read the Links Out of a Page");
+    expect(out["base"]).toEqual(["https://nodetool.ai"]);
+    // href stays exactly as authored; base_url only decides internal/external.
+    expect(out["links"]?.[0]).toEqual([
+      { href: "/docs", text: "Docs", type: "internal" },
+      {
+        href: "https://github.com/nodetool-ai/nodetool",
+        text: "Source",
+        type: "external"
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
`example-workflows-validation.test.ts` hydrates all 200-odd gallery examples and
checks their shape. It never runs one. A structurally valid example can still
teach the opposite of its own description — and three of the seven added here
did exactly that before being corrected.

## What validation could not see

- **`nodetool.text.Chunk` counts `length`/`overlap` in words, not characters.**
  At 90 on a 38-word passage it returned a single chunk, so an example titled
  "chunk a transcript" shipped one unsplit chunk.
- **`lib.html.ExtractLinks` classifies, it does not resolve.** Relative hrefs are
  left exactly as authored; `base_url` only decides internal vs external. The
  example's prose claimed a resolution the node never performs.
- **An output wired to a stream shows only the last value that passed.** "Keep
  only the long lines" displayed one line out of two until
  `nodetool.control.Collect` gathered the stream back into a list.

Each assertion in the new test pins a concrete value — the chunk count, the
classified link type, the gathered list — because "something was emitted" would
have passed against all three.

## The examples

Offline and deterministic: every input is a constant in the graph, no model and
no network, so the assertions are exact.

| example | what it shows |
|---|---|
| Validate a Signup Payload | email checks over a messy address |
| Check a URL and an IP | URL validity, and the IP's address family |
| Map a README's Structure | headings and code blocks as an outline |
| Keep Only the Long Lines | a filtered stream gathered with `Collect` |
| Chunk a Transcript for Indexing | overlapping windows, sized in words |
| Redact and Tidy a Log Line | redaction ordered before scanning |
| Read the Links Out of a Page | links classified, hrefs left as authored |

`gallery-examples-run.test.ts` executes each through `ExecutionSession` with
`resolveNodeType` — the path `nodetool workflows run` and the websocket server
both take.

## Verification

On Node 22.22.1, against current main: the new test is **7/7**, the full example
suite (validation + execute + this) is **1675 passed**, typecheck clean.

## Overlap with #4649

These add 12 node types against main — `lib.validate.*`, `lib.markdown.*`,
`lib.html.BaseUrl`/`ExtractLinks`, `Chunk`, `FilterCode` — and **all 12 are
already covered by #4649**. The coverage delta on top of that PR is zero.

What is *not* redundant is the surface: these are gallery examples, discoverable
in the editor, where #4649 adds CLI examples under `examples/workflows/`. If you
would rather have one PR than two, this folds into #4649 cleanly — the two
branches touch no common file.

Worth noting that #4649 and this were written independently and both hit the
stream-into-`Output` collapse. That it was found twice suggests it is a trap in
the node model rather than one author's mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)