### PR TITLE
Expose the full agent toolbelt over MCP

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -486,6 +486,28 @@ nodetool mcp uninstall
 
 The NodeTool server must be running (`nodetool serve`) for MCP to work.
 
+### What the MCP server exposes
+
+Two layers of tools land on `/mcp`:
+
+- **Native tools** — the read and render surface (`list_workflows`, `get_workflow`, `list_assets`,
+  `get_asset`, `list_jobs`, `get_job`, `list_nodes`, `search_nodes`, `get_node_info`,
+  `run_workflow`, `list_collections`, `query_collection`), which return thumbnails and MCP Apps
+  alongside their JSON.
+- **The agent toolbelt** — the same tools the in-app chat agent runs on, bridged from
+  `@nodetool-ai/agents`: workflow building and debugging (`create_workflow`, `validate_workflow`,
+  `debug_workflow`, `build_app`, `debug_app`, the `ui_*` graph editing tools), media generation
+  (`generate_image`, `generate_video`, `generate_speech`, `transcribe_audio`, …), files
+  (`read_file`, `write_file`, `edit_file`, `glob`, `grep`), web (`web_search`, `browser`,
+  `http_request`), documents, math, code execution, image critique, and thread memory. Google
+  Workspace tools appear only on deployments with a Google login.
+
+The bridged half needs a user to run as — its tools touch that user's secrets, assets, and files —
+so it is registered only on a session bound to one (`nodetool mcp serve`, the local `/mcp` mount, or
+an authenticated session). Where a name exists on both layers the native tool wins. File tools read
+and write under a per-user workspace at `<data-dir>/mcp-workspaces/<user-id>`, not the host
+filesystem.
+
 ## Agents
 
 ### `nodetool agent`

--- a/packages/websocket/src/mcp-agent-tools.ts
+++ b/packages/websocket/src/mcp-agent-tools.ts
@@ -1,14 +1,21 @@
 /**
  * Bridges the canonical agent tools (`@nodetool-ai/agents`) onto the MCP
- * server so external agents (Claude Code, ChatGPT, …) get the full
- * workflow-building and creative toolset — not just the read/render tools
- * defined natively in `mcp-server.ts`.
+ * server so external agents (Claude Code, ChatGPT, …) get the same toolbelt
+ * the in-app chat agent runs on — not just the read/render tools defined
+ * natively in `mcp-server.ts`.
+ *
+ * The bridged set is *derived*, not hand-listed: `getBuiltinTools()` plus
+ * `getAllMcpTools()` plus the Google Workspace tools are exactly what
+ * `unified-websocket-runner` assembles for a chat turn, so a tool added to
+ * either catalog reaches MCP with no edit here. Only tools whose constructor
+ * needs something the catalogs can't supply (a timeline loader, the lazily
+ * probed provider map) are named individually below.
  *
  * Each bridged tool reuses its agent `Tool.process()` handler verbatim; this
  * module only adapts the tool's JSON-Schema into the Zod shape the MCP SDK
- * expects and wraps the result in an MCP tool response. Names already owned by
- * the native registration (run_workflow, list_workflows, list_nodes, …) are
- * intentionally not bridged — the native versions render thumbnails and Apps.
+ * expects and wraps the result in an MCP tool response. Names the native
+ * registration already owns (run_workflow, list_workflows, list_nodes, …) are
+ * skipped — the native versions render thumbnails and Apps.
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -17,20 +24,7 @@ import type { JsonSchema, ProcessingContext } from "@nodetool-ai/runtime";
 import { ProcessingContext as ProcessingContextImpl } from "@nodetool-ai/runtime";
 import {
   Tool,
-  CreateWorkflowTool,
-  DebugWorkflowTool,
-  ResolveWorkflowEscalationTool,
-  BuildAppTool,
-  DebugAppTool,
-  ValidateWorkflowTool,
   ValidateTimelineTool,
-  GetExampleWorkflowTool,
-  ExportWorkflowDigraphTool,
-  GetJobLogsTool,
-  StartBackgroundJobTool,
-  ListModelsTool,
-  SaveAssetTool,
-  ReadAssetTool,
   FindModelTool,
   GenerateImageTool,
   EditImageTool,
@@ -39,13 +33,21 @@ import {
   GenerateSpeechTool,
   TranscribeAudioTool,
   EmbedTextTool,
-  createWorkflowDocumentTools
+  getBuiltinTools,
+  getAllMcpTools,
+  getGoogleWorkspaceTools
 } from "@nodetool-ai/agents";
+import { FileStorageAdapter } from "@nodetool-ai/runtime";
 import type { BaseProvider } from "@nodetool-ai/runtime";
 import type { TimelineLoader } from "@nodetool-ai/agents";
 import { getSecret, Asset, TimelineSequence } from "@nodetool-ai/models";
 import { WORKFLOW_DOCUMENT_TOOL_NAMES } from "@nodetool-ai/node-sdk";
-import { createLogger } from "@nodetool-ai/config";
+import {
+  createLogger,
+  getNodetoolDataDir,
+  isGoogleWorkspaceEnabled
+} from "@nodetool-ai/config";
+import { join } from "node:path";
 import { getAssetAdapter } from "./lib/storage.js";
 import { storeAssetWithThumbnail } from "./lib/thumbnail.js";
 import type { McpServerOptions } from "./mcp-server.js";
@@ -77,20 +79,40 @@ const MIME_TO_EXT: Record<string, string> = {
 };
 
 /**
+ * Per-user workspace directory the bridged file tools (read_file, write_file,
+ * glob, grep, …) are rooted at. Kept under the NodeTool data dir rather than a
+ * temp dir because an MCP session is long-lived and spans many calls — a file
+ * written on one call has to still be there on the next. One directory per
+ * user, so a multi-user mount cannot let one caller read another's files.
+ */
+function mcpWorkspaceDir(userId: string): string {
+  // A user id reaches the filesystem as a path segment here, so allow only
+  // characters that cannot traverse out of the parent directory.
+  const safeUserId = userId.replace(/[^A-Za-z0-9_-]/g, "_") || "default";
+  return join(getNodetoolDataDir(), "mcp-workspaces", safeUserId);
+}
+
+/** Test-only: expose the workspace path rule for isolation assertions. */
+export const __mcpWorkspaceDirForTests = mcpWorkspaceDir;
+
+/**
  * Build the shared ProcessingContext the bridged tools run against. REST-backed
  * tools (create_workflow, list_models, …) read `NODETOOL_API_URL` from the
  * inherited environment; media tools resolve providers via the secret resolver;
- * save/media tools persist artifacts through `createAsset`.
+ * save/media tools persist artifacts through `createAsset`; file tools read and
+ * write under the session's workspace directory.
  */
 function buildAgentToolContext(userId: string): ProcessingContext {
   const storage = getAssetAdapter();
+  const workspaceDir = mcpWorkspaceDir(userId);
   const context = new ProcessingContextImpl({
     jobId: "mcp-agent-tools",
     userId,
     // Bind secret lookups to the scoped user — never a global default.
     secretResolver: (key: string) => getSecret(key, userId),
     storage,
-    workspaceStorage: storage
+    workspaceDir,
+    workspaceStorage: new FileStorageAdapter(workspaceDir)
   });
   context.setModelInterfaces({
     createAsset: async (args) => {
@@ -279,14 +301,59 @@ function errorResponse(err: unknown) {
 }
 
 /**
- * Register the workflow-building and creative agent tools on `server`.
- * Called from `createMcpServer` after the native tools are registered, so a
- * name collision would surface as an SDK error rather than silently shadowing.
+ * Every agent tool the bridge offers, in registration order. Derived from the
+ * same catalogs `unified-websocket-runner` assembles a chat toolbelt from, so
+ * the two surfaces cannot drift.
+ *
+ * `providers` is the map `find_model` reads at call time — it is passed by
+ * reference and filled in lazily, so it is empty here.
+ */
+function collectBridgedTools(
+  options: McpServerOptions | undefined,
+  providers: Record<string, BaseProvider>
+): Tool[] {
+  return [
+    // The chat agent's built-ins: files, search, browser, code, PDF, math,
+    // vision, critique, thread memory, asset library, todo.
+    ...getBuiltinTools(),
+    // Workflow / node / job / asset / app tools, plus the ui_* workflow
+    // document tools. The read tools among them (list_workflows, get_asset, …)
+    // collide with the native registrations and are skipped by the caller.
+    ...getAllMcpTools({ registry: options?.registry }),
+    // Google Workspace runs on the token from the user's Google sign-in, so it
+    // only exists on deployments that have a login — same gate the runner uses.
+    ...(isGoogleWorkspaceEnabled() ? getGoogleWorkspaceTools() : []),
+    // Timelines have no REST route (the API is tRPC-only), so this tool takes a
+    // loader instead of fetching, and `getAllMcpTools` cannot construct it.
+    new ValidateTimelineTool(loadTimelineForUser),
+    // `getAllMcpTools` only offers the media tools when handed a populated
+    // provider map. Here they resolve providers from the scoped user's secrets
+    // at call time, so offer them unconditionally rather than probing every
+    // provider during server construction.
+    new GenerateImageTool(),
+    new EditImageTool(),
+    new GenerateVideoTool(),
+    new AnimateImageTool(),
+    new GenerateSpeechTool(),
+    new TranscribeAudioTool(),
+    new EmbedTextTool(),
+    new FindModelTool(providers)
+  ];
+}
+
+/**
+ * Register the agent toolbelt on `server`.
+ *
+ * Called from `createMcpServer` after the native tools are registered.
+ * `reservedNames` carries the names those registrations took; a bridged tool
+ * whose name is already spoken for is skipped rather than shadowing the native
+ * version (which renders thumbnails and Apps).
  */
 export function registerAgentMcpTools(
   server: McpServer,
   options?: McpServerOptions,
-  executeFrontendDocumentTool?: FrontendDocumentToolExecutor
+  executeFrontendDocumentTool?: FrontendDocumentToolExecutor,
+  reservedNames?: ReadonlySet<string>
 ): void {
   // Every bridged tool runs against one user's secrets and assets, so a
   // session without an explicit user binding gets no bridged tools at all —
@@ -344,33 +411,24 @@ export function registerAgentMcpTools(
     );
   };
 
-  const bridged: Tool[] = [
-    ...createWorkflowDocumentTools(options?.registry),
-    new CreateWorkflowTool(),
-    new DebugWorkflowTool(),
-    new ResolveWorkflowEscalationTool(),
-    new BuildAppTool(),
-    new DebugAppTool(),
-    new ValidateWorkflowTool(options?.registry),
-    new ValidateTimelineTool(loadTimelineForUser),
-    new GetExampleWorkflowTool(),
-    new ExportWorkflowDigraphTool(),
-    new GetJobLogsTool(),
-    new StartBackgroundJobTool(),
-    new ListModelsTool(),
-    new SaveAssetTool(),
-    new ReadAssetTool(),
-    new GenerateImageTool(),
-    new EditImageTool(),
-    new GenerateVideoTool(),
-    new AnimateImageTool(),
-    new GenerateSpeechTool(),
-    new TranscribeAudioTool(),
-    new EmbedTextTool()
-  ];
-  for (const tool of bridged) register(tool);
-
-  // find_model reads the configured-providers map at call time, so populate it
-  // before the handler runs.
-  register(new FindModelTool(sharedProviders), ensureProviders);
+  const taken = new Set<string>(reservedNames ?? []);
+  const skipped: string[] = [];
+  let registered = 0;
+  for (const tool of collectBridgedTools(options, sharedProviders)) {
+    if (taken.has(tool.name)) {
+      skipped.push(tool.name);
+      continue;
+    }
+    taken.add(tool.name);
+    // find_model reads the configured-providers map at call time, so populate
+    // it before the handler runs.
+    register(tool, tool instanceof FindModelTool ? ensureProviders : undefined);
+    registered += 1;
+  }
+  log.info("Registered agent MCP tools", {
+    userId: scope.userId,
+    source: scope.source,
+    registered,
+    skipped
+  });
 }

--- a/packages/websocket/src/mcp-server.ts
+++ b/packages/websocket/src/mcp-server.ts
@@ -334,6 +334,32 @@ function getRuntimeEnvironment(
 }
 
 /**
+ * Record the name of every tool registered on `server` into the returned set.
+ *
+ * The agent-tool bridge registers a toolbelt derived from the agent catalogs,
+ * which overlaps the native registrations by design (list_workflows, get_asset,
+ * …). It needs to know which names are already taken so it can skip them
+ * instead of throwing on the duplicate. Collecting them here — rather than
+ * keeping a second hand-written list of native names — means adding a native
+ * tool cannot silently break the bridge. Both entry points are wrapped:
+ * `tool()` for plain registrations, `registerTool()` for the MCP-App ones that
+ * `registerAppTool` goes through.
+ */
+function trackRegisteredToolNames(server: McpServer): Set<string> {
+  const names = new Set<string>();
+  const wrap = <T extends (name: string, ...rest: never[]) => unknown>(
+    original: T
+  ): T =>
+    ((name: string, ...rest: never[]) => {
+      names.add(name);
+      return original(name, ...rest);
+    }) as T;
+  server.tool = wrap(server.tool.bind(server));
+  server.registerTool = wrap(server.registerTool.bind(server));
+  return names;
+}
+
+/**
  * Create a configured MCP server with all NodeTool tools registered.
  */
 export function createMcpServer(options?: McpServerOptions): McpServer {
@@ -341,6 +367,7 @@ export function createMcpServer(options?: McpServerOptions): McpServer {
     name: "NodeTool API Server",
     version: "1.0.0"
   });
+  const registeredToolNames = trackRegisteredToolNames(server);
 
   const rendererIdParam = {
     renderer_id: z
@@ -863,19 +890,24 @@ export function createMcpServer(options?: McpServerOptions): McpServer {
     }
   );
 
-  // ── Workflow-building + creative tools (bridged from @nodetool-ai/agents) ──
-  // Registered last so any name collision with a native tool throws loudly.
-  registerAgentMcpTools(server, options, async (toolName, args) => {
-    const transport = resolveFrontendTransport();
-    if (!transport || !transport.isAlive) return { handled: false };
-    const result = await transport.executeTool(
-      transport.id,
-      `mcp-ui-${toolName}-${crypto.randomUUID()}`,
-      toolName,
-      args
-    );
-    return { handled: true, result };
-  });
+  // ── The agent toolbelt (bridged from @nodetool-ai/agents) ──
+  // Registered last, so the native tools above win every shared name.
+  registerAgentMcpTools(
+    server,
+    options,
+    async (toolName, args) => {
+      const transport = resolveFrontendTransport();
+      if (!transport || !transport.isAlive) return { handled: false };
+      const result = await transport.executeTool(
+        transport.id,
+        `mcp-ui-${toolName}-${crypto.randomUUID()}`,
+        toolName,
+        args
+      );
+      return { handled: true, result };
+    },
+    registeredToolNames
+  );
 
   return server;
 }

--- a/packages/websocket/tests/mcp-server-coverage.test.ts
+++ b/packages/websocket/tests/mcp-server-coverage.test.ts
@@ -1,5 +1,18 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  vi
+} from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { initTestDb, Workflow, Job, Asset } from "@nodetool-ai/models";
+import { getBuiltinTools, getAllMcpTools } from "@nodetool-ai/agents";
 import type { NodeMetadata, NodeRegistry } from "@nodetool-ai/node-sdk";
 import type { AgentTransport } from "../src/agent/transport.js";
 
@@ -495,7 +508,7 @@ describe("getLocalMcpServerUrl", () => {
   });
 });
 
-describe("bridged agent tools (workflow + creative)", () => {
+describe("bridged agent tools (the full agent toolbelt)", () => {
   function toolNames(server: ReturnType<typeof createMcpServer>): string[] {
     const tools = (
       server as unknown as {
@@ -506,6 +519,25 @@ describe("bridged agent tools (workflow + creative)", () => {
   }
 
   const scope = { userId: "1", source: "stdio-local" as const };
+
+  // The bridged file tools are rooted under the NodeTool data dir, and
+  // constructing the server creates that directory. Point it at a temp dir so
+  // the suite never touches the developer's real workspace.
+  let dataDir: string;
+  const dataDirEnv = process.platform === "win32" ? "APPDATA" : "XDG_DATA_HOME";
+  let previousDataDir: string | undefined;
+
+  beforeAll(() => {
+    previousDataDir = process.env[dataDirEnv];
+    dataDir = mkdtempSync(join(tmpdir(), "nodetool-mcp-test-"));
+    process.env[dataDirEnv] = dataDir;
+  });
+
+  afterAll(() => {
+    if (previousDataDir === undefined) delete process.env[dataDirEnv];
+    else process.env[dataDirEnv] = previousDataDir;
+    rmSync(dataDir, { recursive: true, force: true });
+  });
 
   it("registers the workflow-building and creative tools alongside native ones", () => {
     const server = createMcpServer({ agentToolsScope: scope });
@@ -546,6 +578,77 @@ describe("bridged agent tools (workflow + creative)", () => {
     for (const t of ["run_workflow", "list_workflows", "list_nodes", "get_job"]) {
       expect(names.has(t)).toBe(true);
     }
+  });
+
+  it("exposes every built-in agent tool, except names a native tool owns", () => {
+    const server = createMcpServer({ agentToolsScope: scope });
+    const names = new Set(toolNames(server));
+    const native = new Set(toolNames(createMcpServer()));
+    for (const tool of getBuiltinTools()) {
+      if (native.has(tool.name)) continue;
+      expect(names.has(tool.name)).toBe(true);
+    }
+  });
+
+  it("exposes the agent MCP catalog, except names a native tool owns", () => {
+    const server = createMcpServer({ agentToolsScope: scope });
+    const names = new Set(toolNames(server));
+    const native = new Set(toolNames(createMcpServer()));
+    for (const tool of getAllMcpTools({})) {
+      if (native.has(tool.name)) continue;
+      expect(names.has(tool.name)).toBe(true);
+    }
+  });
+
+  it("lets the native tool win every name the bridge also offers", () => {
+    // The native list_workflows / get_asset / list_nodes render thumbnails and
+    // MCP Apps; the agent catalog offers plain-JSON tools under the same names.
+    // The bridge must skip those rather than shadow them or throw.
+    const bridgedNames = new Set(
+      [...getBuiltinTools(), ...getAllMcpTools({})].map((t) => t.name)
+    );
+    const native = new Set(toolNames(createMcpServer()));
+    const overlap = [...bridgedNames].filter((n) => native.has(n));
+    expect(overlap.length).toBeGreaterThan(0);
+
+    const server = createMcpServer({ agentToolsScope: scope });
+    const tools = (
+      server as unknown as {
+        _registeredTools: Record<string, { description?: string }>;
+      }
+    )._registeredTools;
+    const nativeServer = (
+      createMcpServer() as unknown as {
+        _registeredTools: Record<string, { description?: string }>;
+      }
+    )._registeredTools;
+    for (const name of overlap) {
+      expect(tools[name].description).toBe(nativeServer[name].description);
+    }
+  });
+
+  it("roots file tools in a per-user workspace directory", async () => {
+    const { __mcpWorkspaceDirForTests } = await import(
+      "../src/mcp-agent-tools.js"
+    );
+    expect(__mcpWorkspaceDirForTests("user-a")).not.toBe(
+      __mcpWorkspaceDirForTests("user-b")
+    );
+    // A user id reaches the filesystem as a path segment — it must not escape.
+    expect(__mcpWorkspaceDirForTests("../../etc")).not.toContain("..");
+  });
+
+  it("write_file and read_file round-trip through the workspace", async () => {
+    const server = createMcpServer({ agentToolsScope: scope });
+    const written = await callTool(server, "write_file", {
+      file_path: "mcp-roundtrip.txt",
+      content: "hello"
+    });
+    expect(written.isError).toBeUndefined();
+    const read = await callTool(server, "read_file", {
+      file_path: "mcp-roundtrip.txt"
+    });
+    expect(read.content[0].text).toContain("hello");
   });
 
   it("does NOT register bridged tools on a session without a user scope", () => {


### PR DESCRIPTION
## What

The MCP bridge (`mcp-agent-tools.ts`) offered a hand-picked list of 21 tools out of the agent catalogs. External agents (Claude Code, ChatGPT, Claude Desktop) got workflow building and media generation, but none of the built-ins the in-app chat agent runs on — no files, web search, browser, code execution, PDF, math, image critique, or thread memory.

This derives the bridged set from the canonical catalogs instead of listing it. **22 bridged tools become 81** (102 total on `/mcp`, up from 51).

## How

`getBuiltinTools()` + `getAllMcpTools()` + the Google Workspace tools are exactly what `unified-websocket-runner` assembles for a chat turn, so the two surfaces can no longer drift — a tool added to either catalog reaches MCP with no edit in the bridge. Only tools whose constructor needs something the catalogs cannot supply stay named individually:

- `ValidateTimelineTool` — timelines have no REST route (tRPC-only), so it takes a loader
- `FindModelTool` — reads a provider map probed lazily on first call
- the media tools — `getAllMcpTools` gates them behind a populated provider map; here they resolve providers from the scoped user's secrets at call time

Google Workspace stays behind `isGoogleWorkspaceEnabled()`, the same gate the runner uses.

### Name collisions

The catalogs overlap the native registrations by design (`list_workflows`, `get_asset`, `list_nodes`, `run_workflow`, …). `createMcpServer` now records the names its own registrations take and hands them to the bridge, which skips them — the native versions keep winning, since they render thumbnails and MCP Apps. That set is collected by wrapping the two registration entry points (`tool()` and `registerTool()`) rather than kept as a second hand-written list, so adding a native tool cannot silently break the bridge.

Ten names are skipped: `list_workflows`, `get_workflow`, `run_workflow`, `list_jobs`, `get_job`, `list_assets`, `get_asset`, `list_nodes`, `search_nodes`, `get_node_info`.

### Workspace for the file tools

The bridge context pointed `workspaceStorage` at the asset store root, where a `write_file` would have collided with asset object keys. It now roots at `<data-dir>/mcp-workspaces/<user-id>` — one directory per user, so a multi-user mount cannot let one caller read another's files, with the id sanitized since it reaches the filesystem as a path segment. Durable rather than a temp dir because an MCP session is long-lived and spans many calls.

Unchanged: the bridge still registers nothing at all on a session without an `agentToolsScope`, since every bridged tool touches one user's secrets, assets, and now files.

## Test plan

- `packages/websocket/tests/mcp-server-coverage.test.ts` — five new cases: every built-in reaches MCP, the whole agent MCP catalog reaches MCP, the native tool wins each overlapping name (asserted by comparing descriptions), per-user workspace isolation and path-traversal sanitization, and a `write_file`/`read_file` round trip through the workspace. The suite now points the data dir at a temp dir so it never touches a developer's real workspace.
- `npm run test --workspace=packages/websocket` — 2034 passed (171 files).
- `npm run typecheck` — error count identical to the base commit (403, all pre-existing mobile/Expo dependency resolution in this sandbox).
- `npm run lint` — no errors; no new warnings in the changed files.
- Manually exercised bridged tools against a constructed server: `calculate` → 42, and `write_file` → `read_file` → `list_directory` round-tripping through `mcp-workspaces/<user>/`.

## Note for reviewers

This widens what an MCP client can do considerably — `run_code`, `write_file`, `browser`, `http_request`, and `download_file` are now reachable over `/mcp`. That matches the in-app chat agent, which already offers all of them, but the chat path puts them behind NodeTool's permission gate while MCP relies on the host client's own approval UI (Claude Code, Claude Desktop). Worth a deliberate yes rather than an assumed one.

Docs: `docs/cli.md` gains a "What the MCP server exposes" section describing both layers, the scoping requirement, and the workspace path.

---
_Generated by [Claude Code](https://claude.ai/code/session_016tcGtaVZtkxi1bSqmXNnmn)_