### PR TITLE
RenderTimeline: composite through the editor's own compositor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55159,7 +55159,8 @@
         "@nodetool-ai/kernel": "*",
         "@nodetool-ai/node-sdk": "*",
         "@nodetool-ai/protocol": "*",
-        "@nodetool-ai/runtime": "*"
+        "@nodetool-ai/runtime": "*",
+        "@nodetool-ai/timeline": "*"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -55801,6 +55802,8 @@
         "@nodetool-ai/gpu": "*"
       },
       "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@webgpu/types": "^0.1.70",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"
       },
@@ -55911,8 +55914,10 @@
       "dependencies": {
         "@gltf-transform/core": "^4.3.0",
         "@gltf-transform/functions": "^4.3.0",
+        "@napi-rs/canvas": "^0.1.65",
         "@nodetool-ai/audio-nodes": "*",
         "@nodetool-ai/config": "*",
+        "@nodetool-ai/gpu": "*",
         "@nodetool-ai/node-sdk": "*",
         "@nodetool-ai/nodes-utils": "*",
         "@nodetool-ai/protocol": "*",
@@ -55928,6 +55933,7 @@
         "@types/chrome-remote-interface": "^0.33.0",
         "@types/node": "^22.0.0",
         "@types/three": "^0.185.0",
+        "@webgpu/types": "^0.1.70",
         "esbuild": "^0.28.1",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"

--- a/packages/timeline/AGENTS.md
+++ b/packages/timeline/AGENTS.md
@@ -38,3 +38,20 @@
   lands exactly on the input.
 - **Exclude the moving entity's own footprint from overlap/collision checks**
   (`excludeClipIds`) — otherwise a dragged clip reports overlapping itself.
+
+## Rendering (`src/render`, `@nodetool-ai/timeline/render`)
+
+- **One scene model, one compositor, three hosts.** The live preview, the
+  browser export and the server-side `RenderTimeline` node all resolve layers
+  with `computeActiveLayers` + `resolveAnimatedLayerProps` and place them with
+  `buildTransformMatrix`. A rule that lives in only one host is a rule the other
+  two will drift from — put it here.
+- **Nothing in `src/render` may be re-exported from the package root.** The root
+  export stays runtime-dependency-free (mobile compiles it from source); the
+  render module pulls in WebGPU through `@nodetool-ai/gpu`.
+- **Never read a WebGPU flag namespace (`GPUTextureUsage`, `GPUShaderStage`) at
+  module scope.** Under Node those globals only exist after the Dawn adapter
+  installs them with the device, so a module-scope read throws on import.
+- **Draw code takes a `RasterContext2D`, not a concrete canvas.** The browser
+  passes an `OffscreenCanvas` context and the server `@napi-rs/canvas`; a type
+  that only one of them satisfies breaks the other silently at build time.

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -18,6 +18,8 @@
     "@nodetool-ai/gpu": "*"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@webgpu/types": "^0.1.70",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2"
   },
@@ -27,6 +29,12 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./render": {
+      "nodetool-dev": "./src/render/index.ts",
+      "types": "./dist/render/index.d.ts",
+      "import": "./dist/render/index.js",
+      "default": "./dist/render/index.js"
     },
     "./dependencyHash.js": {
       "nodetool-dev": "./src/dependencyHash.ts",

--- a/packages/timeline/src/render/draw.ts
+++ b/packages/timeline/src/render/draw.ts
@@ -1,0 +1,424 @@
+/**
+ * draw — the 2D drawing rules for the layer kinds that are rasterized rather
+ * than decoded: captions, text clips and shapes.
+ *
+ * Written against {@link RasterContext2D}, the subset of the Canvas 2D API all
+ * three drawings need, so one implementation serves the browser
+ * (`OffscreenCanvas`) and the server (`@napi-rs/canvas`). Caching and the
+ * host's bitmap type stay with the caller — everything here just draws.
+ */
+
+import type { ClipShapeStyle, ClipTextStyle } from "../types.js";
+import type { AnimationSample, CompiledAnimation } from "../animation/index.js";
+import { sampleStaggeredAnimations } from "../animation/index.js";
+
+/**
+ * A fill or stroke paint. Canvas also accepts gradients and patterns, which
+ * these drawings never set — typed loosely so a real `CanvasRenderingContext2D`
+ * satisfies the interface.
+ */
+export type CanvasPaint = string | object;
+
+/** The Canvas 2D surface the rasterizers draw through. */
+export interface RasterContext2D {
+  font: string;
+  fillStyle: CanvasPaint;
+  strokeStyle: CanvasPaint;
+  lineWidth: number;
+  lineJoin: string;
+  textAlign: string;
+  textBaseline: string;
+  globalAlpha: number;
+  measureText(text: string): { width: number };
+  fillText(text: string, x: number, y: number): void;
+  strokeText(text: string, x: number, y: number): void;
+  beginPath(): void;
+  rect(x: number, y: number, w: number, h: number): void;
+  ellipse(
+    x: number,
+    y: number,
+    radiusX: number,
+    radiusY: number,
+    rotation: number,
+    startAngle: number,
+    endAngle: number
+  ): void;
+  moveTo(x: number, y: number): void;
+  lineTo(x: number, y: number): void;
+  fill(): void;
+  stroke(): void;
+  save(): void;
+  restore(): void;
+  translate(x: number, y: number): void;
+  rotate(angle: number): void;
+  scale(x: number, y: number): void;
+}
+
+// ── Captions ─────────────────────────────────────────────────────────────────
+
+const CAPTION_INACTIVE_COLOR = "#FFFFFF";
+const CAPTION_ACTIVE_COLOR = "#FFD60A";
+const CAPTION_OUTLINE_COLOR = "rgba(0, 0, 0, 0.85)";
+
+/** One word of a caption resolved at a point in time. */
+export interface ResolvedCaptionWord {
+  text: string;
+  /** True while the playhead is inside this word's spoken interval. */
+  active: boolean;
+}
+
+/**
+ * A caption's full per-frame state: every word of the line plus which one is
+ * currently spoken. Rasterized identically by every render surface.
+ */
+export interface ResolvedCaption {
+  words: ResolvedCaptionWord[];
+}
+
+/** Content signature of a caption raster, for host-side caching. */
+export function captionSignature(
+  caption: ResolvedCaption,
+  width: number,
+  height: number
+): string {
+  const words = caption.words
+    .map((w) => (w.active ? `*${w.text}` : w.text))
+    .join(" ");
+  return `${width}x${height}|${words}`;
+}
+
+interface MeasuredWord {
+  text: string;
+  active: boolean;
+  width: number;
+}
+
+/**
+ * Draw a caption as bold, outlined, lower-third text with the currently-spoken
+ * word highlighted, at full frame resolution — so it composites with an
+ * identity transform.
+ */
+export function drawCaption(
+  ctx: RasterContext2D,
+  caption: ResolvedCaption,
+  width: number,
+  height: number
+): void {
+  const fontSize = Math.max(24, Math.round(height * 0.05));
+  ctx.font = `700 ${fontSize}px Inter, Arial, sans-serif`;
+  ctx.textBaseline = "alphabetic";
+  ctx.lineJoin = "round";
+
+  const spaceWidth = ctx.measureText(" ").width;
+  const maxWidth = width * 0.9;
+
+  const measured: MeasuredWord[] = caption.words.map((w) => ({
+    text: w.text,
+    active: w.active,
+    width: ctx.measureText(w.text).width
+  }));
+
+  // Greedy word-wrap into lines that fit `maxWidth`.
+  const lines: MeasuredWord[][] = [];
+  let current: MeasuredWord[] = [];
+  let currentWidth = 0;
+  for (const word of measured) {
+    const advance = (current.length > 0 ? spaceWidth : 0) + word.width;
+    if (current.length > 0 && currentWidth + advance > maxWidth) {
+      lines.push(current);
+      current = [word];
+      currentWidth = word.width;
+    } else {
+      current.push(word);
+      currentWidth += advance;
+    }
+  }
+  if (current.length > 0) lines.push(current);
+
+  const lineHeight = fontSize * 1.25;
+  const totalHeight = lines.length * lineHeight;
+  const bottomMargin = height * 0.12;
+  // Baseline of the first line.
+  let y = height - bottomMargin - totalHeight + fontSize;
+
+  ctx.lineWidth = Math.max(2, fontSize * 0.12);
+  ctx.strokeStyle = CAPTION_OUTLINE_COLOR;
+
+  for (const line of lines) {
+    const lineWidth = line.reduce(
+      (sum, w, i) => sum + w.width + (i > 0 ? spaceWidth : 0),
+      0
+    );
+    let x = (width - lineWidth) / 2;
+    for (let i = 0; i < line.length; i++) {
+      const word = line[i];
+      if (i > 0) x += spaceWidth;
+      ctx.fillStyle = word.active
+        ? CAPTION_ACTIVE_COLOR
+        : CAPTION_INACTIVE_COLOR;
+      ctx.strokeText(word.text, x, y);
+      ctx.fillText(word.text, x, y);
+      x += word.width;
+    }
+    y += lineHeight;
+  }
+}
+
+// ── Text clips ───────────────────────────────────────────────────────────────
+
+/** Content signature of a text raster, for host-side caching. */
+export function textStyleSignature(
+  style: ClipTextStyle,
+  width: number,
+  height: number
+): string {
+  return `${width}x${height}|${style.text}|${style.fontFamily ?? "Inter"}|${style.fontSizePx}|${style.fontWeight ?? 400}|${style.color}|${style.align ?? "center"}|${style.maxWidthFrac ?? 0.8}`;
+}
+
+interface TextLayoutWord {
+  text: string;
+  /** Left edge in canvas px. */
+  x: number;
+  width: number;
+  /** Vertical center of the word's line (textBaseline "middle"). */
+  y: number;
+}
+
+interface WrappedLine {
+  text: string;
+  words: string[];
+}
+
+/**
+ * Greedy word-wrap by measured candidate width — the one wrap rule for both
+ * draw paths, so a staggered title breaks lines exactly like its
+ * un-staggered self.
+ */
+function wrapLines(
+  ctx: RasterContext2D,
+  text: string,
+  maxWidth: number
+): WrappedLine[] {
+  const lines: WrappedLine[] = [];
+  for (const paragraph of text.split(/\r?\n/)) {
+    const words = paragraph.split(/\s+/).filter(Boolean);
+    let line = "";
+    let lineWords: string[] = [];
+    for (const word of words) {
+      const candidate = line ? `${line} ${word}` : word;
+      if (line && ctx.measureText(candidate).width > maxWidth) {
+        lines.push({ text: line, words: lineWords });
+        line = word;
+        lineWords = [word];
+      } else {
+        line = candidate;
+        lineWords.push(word);
+      }
+    }
+    lines.push({ text: line, words: lineWords });
+  }
+  return lines;
+}
+
+/** Word-wrap `style.text` into positioned word boxes. */
+function layoutWords(
+  ctx: RasterContext2D,
+  style: ClipTextStyle,
+  width: number,
+  height: number
+): TextLayoutWord[] {
+  const fontSize = Math.max(1, style.fontSizePx);
+  const align = style.align ?? "center";
+  const maxWidth =
+    width * Math.min(1, Math.max(0.05, style.maxWidthFrac ?? 0.8));
+  const lines = wrapLines(ctx, style.text, maxWidth);
+  const spaceWidth = ctx.measureText(" ").width;
+  const lineHeight = fontSize * 1.2;
+  const firstY = height / 2 - ((lines.length - 1) * lineHeight) / 2;
+  const out: TextLayoutWord[] = [];
+
+  lines.forEach((line, lineIndex) => {
+    const widths = line.words.map((w) => ctx.measureText(w).width);
+    const lineWidth =
+      widths.reduce((sum, w) => sum + w, 0) +
+      spaceWidth * Math.max(0, line.words.length - 1);
+    let x =
+      align === "left"
+        ? (width - maxWidth) / 2
+        : align === "right"
+          ? (width + maxWidth) / 2 - lineWidth
+          : (width - lineWidth) / 2;
+    const y = firstY + lineIndex * lineHeight;
+    line.words.forEach((word, i) => {
+      out.push({ text: word, x, width: widths[i], y });
+      x += widths[i] + spaceWidth;
+    });
+  });
+  return out;
+}
+
+export function drawText(
+  ctx: RasterContext2D,
+  style: ClipTextStyle,
+  width: number,
+  height: number
+): void {
+  const fontSize = Math.max(1, style.fontSizePx);
+  const align = style.align ?? "center";
+  const maxWidth =
+    width * Math.min(1, Math.max(0.05, style.maxWidthFrac ?? 0.8));
+
+  ctx.font = `${style.fontWeight ?? 400} ${fontSize}px ${style.fontFamily ?? "Inter, Arial, sans-serif"}`;
+  const lines = wrapLines(ctx, style.text, maxWidth);
+
+  const lineHeight = fontSize * 1.2;
+  const firstBaseline = height / 2 - ((lines.length - 1) * lineHeight) / 2;
+  ctx.fillStyle = style.color;
+  ctx.textAlign = align;
+  ctx.textBaseline = "middle";
+  const x =
+    align === "left"
+      ? (width - maxWidth) / 2
+      : align === "right"
+        ? (width + maxWidth) / 2
+        : width / 2;
+  lines.forEach((entry, index) =>
+    ctx.fillText(entry.text, x, firstBaseline + index * lineHeight)
+  );
+}
+
+/**
+ * Per-frame input for a staggered text draw: the clip's compiled animations
+ * (at least one carrying a `stagger`) and the clip-local time.
+ */
+export interface TextRenderStagger {
+  compiled: CompiledAnimation[];
+  localMs: number;
+}
+
+/**
+ * Draw each word with its own animation sample: translate to the word's
+ * center (plus the sample's offset), rotate/scale about it, multiply alpha.
+ * Effect/mask properties are not applied per word (block-level, v1).
+ */
+export function drawStaggeredText(
+  ctx: RasterContext2D,
+  style: ClipTextStyle,
+  width: number,
+  height: number,
+  stagger: TextRenderStagger,
+  scratch: AnimationSample
+): void {
+  ctx.font = `${style.fontWeight ?? 400} ${Math.max(1, style.fontSizePx)}px ${style.fontFamily ?? "Inter, Arial, sans-serif"}`;
+  const words = layoutWords(ctx, style, width, height);
+  ctx.fillStyle = style.color;
+  ctx.textAlign = "left";
+  ctx.textBaseline = "middle";
+
+  words.forEach((word, index) => {
+    const s = sampleStaggeredAnimations(
+      stagger.compiled,
+      stagger.localMs,
+      index,
+      scratch
+    );
+    if (s.opacity <= 0 || s.scale <= 0) return;
+    ctx.save();
+    ctx.translate(word.x + word.width / 2 + s.offsetX, word.y + s.offsetY);
+    if (s.rotation !== 0) ctx.rotate(s.rotation);
+    if (s.scale !== 1) ctx.scale(s.scale, s.scale);
+    ctx.globalAlpha = s.opacity;
+    ctx.fillText(word.text, -word.width / 2, 0);
+    ctx.restore();
+  });
+}
+
+/**
+ * Where a stagger context sits relative to its animation windows, for cache
+ * policy: `"active"` while any staggered window covers `localMs` (the raster
+ * changes every frame — never cached), otherwise a static per-animation
+ * phase signature ("b"efore / "a"fter / "i"dle-loop) that keys the held frame.
+ */
+export function staggerPhase(stagger: TextRenderStagger): "active" | string {
+  let sig = "";
+  for (const anim of stagger.compiled) {
+    if (!anim.stagger) continue;
+    if (anim.loop) {
+      if (
+        stagger.localMs >= anim.windowStartMs &&
+        stagger.localMs < anim.windowEndMs
+      ) {
+        return "active";
+      }
+      sig += "i";
+      continue;
+    }
+    if (stagger.localMs < anim.windowStartMs) sig += "b";
+    else if (stagger.localMs > anim.windowEndMs) sig += "a";
+    else return "active";
+  }
+  return sig;
+}
+
+/** A fresh scratch sample for {@link drawStaggeredText}. */
+export function createStaggerScratch(): AnimationSample {
+  return {
+    offsetX: 0,
+    offsetY: 0,
+    scale: 1,
+    rotation: 0,
+    opacity: 1,
+    blur: 0,
+    brightness: 0,
+    saturation: 1
+  };
+}
+
+// ── Shapes ───────────────────────────────────────────────────────────────────
+
+/** Content signature of a shape raster, for host-side caching. */
+export function shapeStyleSignature(
+  style: ClipShapeStyle,
+  width: number,
+  height: number
+): string {
+  return `${width}x${height}|${JSON.stringify(style)}`;
+}
+
+function number(value: number | undefined, fallback: number): number {
+  return value ?? fallback;
+}
+
+export function drawShape(
+  ctx: RasterContext2D,
+  style: ClipShapeStyle,
+  width: number,
+  height: number
+): void {
+  const x = number(style.x, 0.25) * width;
+  const y = number(style.y, 0.25) * height;
+  const shapeWidth = number(style.width, 0.5) * width;
+  const shapeHeight = number(style.height, 0.5) * height;
+  ctx.fillStyle = style.fill ?? "transparent";
+  ctx.strokeStyle = style.stroke ?? "transparent";
+  ctx.lineWidth = number(style.strokeWidthPx, 0);
+  ctx.beginPath();
+  if (style.kind === "rect") ctx.rect(x, y, shapeWidth, shapeHeight);
+  if (style.kind === "ellipse") {
+    ctx.ellipse(
+      x + shapeWidth / 2,
+      y + shapeHeight / 2,
+      shapeWidth / 2,
+      shapeHeight / 2,
+      0,
+      0,
+      Math.PI * 2
+    );
+  }
+  if (style.kind === "line") {
+    ctx.moveTo(x, y);
+    ctx.lineTo(number(style.x2, 0.75) * width, number(style.y2, 0.75) * height);
+  }
+  if (style.fill) ctx.fill();
+  if (style.stroke && ctx.lineWidth > 0) ctx.stroke();
+}

--- a/packages/timeline/src/render/effects.ts
+++ b/packages/timeline/src/render/effects.ts
@@ -7,7 +7,7 @@ import type {
   TrackSharpenEffect,
   TrackVignetteEffect,
   TrackChromaKeyEffect
-} from "@nodetool-ai/timeline";
+} from "../types.js";
 import {
   createGPUContextFromDevice,
   createExecutor,
@@ -55,11 +55,20 @@ interface IntermediatePool {
   currentIndex: 0 | 1;
 }
 
-const INTERMEDIATE_USAGE =
-  GPUTextureUsage.TEXTURE_BINDING |
-  GPUTextureUsage.STORAGE_BINDING |
-  GPUTextureUsage.COPY_SRC |
-  GPUTextureUsage.COPY_DST;
+/**
+ * Read at pool-allocation time, not module load: under Node the WebGPU flag
+ * namespaces are installed on `globalThis` by the Dawn adapter when a device is
+ * acquired, so a module-scope read would throw on import in every server
+ * process — including the ones that only want the scene model.
+ */
+function intermediateUsage(): number {
+  return (
+    GPUTextureUsage.TEXTURE_BINDING |
+    GPUTextureUsage.STORAGE_BINDING |
+    GPUTextureUsage.COPY_SRC |
+    GPUTextureUsage.COPY_DST
+  );
+}
 
 /**
  * GPU pre-pass for per-clip color grading and Gaussian blur. Caller passes
@@ -237,7 +246,7 @@ export class WebGPUEffectsProcessor {
         width,
         height,
         format: "rgba8unorm",
-        usage: INTERMEDIATE_USAGE,
+        usage: intermediateUsage(),
         meta: { colorSpace: "srgb", alpha: "premultiplied" }
       });
     const pool: IntermediatePool = {

--- a/packages/timeline/src/render/frameCompositor.ts
+++ b/packages/timeline/src/render/frameCompositor.ts
@@ -1,0 +1,306 @@
+/**
+ * HeadlessFrameCompositor — composite one timeline frame without a canvas.
+ *
+ * Drives the same {@link WebGPULayerCompositor} and the same effects pre-pass
+ * the editor's preview uses, with the same placement math
+ * ({@link buildTransformMatrix} → inverse affine), so a frame rendered on a
+ * server is the frame the user previewed. The only difference from the browser
+ * compositor is the boundary: sources arrive as CPU RGBA buffers instead of
+ * `<video>`/`<img>` elements, and the result is read back to a CPU buffer
+ * instead of presented to a swap chain.
+ *
+ * The instance is reused across every frame of a render: source textures are
+ * kept per layer id (re-uploaded only when their pixels change), and the
+ * readback buffer is allocated once.
+ */
+
+import { blendModeGpuId } from "@nodetool-ai/gpu";
+import {
+  WebGPULayerCompositor,
+  forwardClipMatrixToInverseAffine
+} from "@nodetool-ai/gpu/webgpu";
+
+import type { AnimationSampleMask, WipeDirection } from "../animation/index.js";
+import type { ClipEffect, ClipTransform, TrackEffect } from "../types.js";
+import { WebGPUEffectsProcessor } from "./effects.js";
+import type { CompositorBlendMode } from "./sceneModel.js";
+import {
+  IDENTITY_TRANSFORM,
+  buildTransformMatrix,
+  containBaseScale
+} from "./transform.js";
+
+/** Shader edge codes (see `BLEND_COMPOSITE_FRAGMENT` params2). */
+const WIPE_EDGE: Record<WipeDirection, 1 | 2 | 3 | 4> = {
+  left: 1,
+  right: 2,
+  up: 3, // reveal from the layer's top edge
+  down: 4 // reveal from the layer's bottom edge
+};
+
+function wipeParams(
+  mask: AnimationSampleMask | undefined
+): { edge: 1 | 2 | 3 | 4; progress: number; softness: number } | undefined {
+  if (!mask) return undefined;
+  return {
+    edge: WIPE_EDGE[mask.direction],
+    progress: mask.progress,
+    softness: mask.softness
+  };
+}
+
+/** Decoded straight-alpha RGBA8 pixels for one layer. */
+export interface FrameLayerPixels {
+  /** Row-major RGBA8, length = width * height * 4. */
+  rgba: Uint8Array;
+  width: number;
+  height: number;
+  /**
+   * Changes whenever `rgba` holds different pixels. The compositor re-uploads
+   * only when it changes, so a still image or a held caption costs one upload
+   * for the whole render. Omit to upload every frame.
+   */
+  version?: string;
+}
+
+/** One layer of a frame, in the same shape the browser compositor consumes. */
+export interface FrameLayer {
+  /** Stable across frames for the same clip — keys the source texture. */
+  id: string;
+  source: FrameLayerPixels;
+  opacity: number;
+  blendMode: CompositorBlendMode;
+  zIndex: number;
+  transform?: ClipTransform;
+  /** Rounded-corner radius in source pixels. */
+  borderRadius?: number;
+  mask?: AnimationSampleMask;
+  effects?: ClipEffect[];
+  trackEffects?: TrackEffect[];
+}
+
+/** `copyTextureToBuffer` requires a 256-byte-aligned `bytesPerRow`. */
+const ROW_ALIGNMENT = 256;
+
+const TEXTURE_FORMAT: GPUTextureFormat = "rgba8unorm";
+
+interface SourceTexture {
+  texture: GPUTexture;
+  width: number;
+  height: number;
+  version: string;
+}
+
+export class HeadlessFrameCompositor {
+  private readonly device: GPUDevice;
+  private readonly core: WebGPULayerCompositor;
+  private readonly effects: WebGPUEffectsProcessor;
+  private readonly width: number;
+  private readonly height: number;
+  private readonly bytesPerRow: number;
+  private readonly readback: GPUBuffer;
+  private readonly sources = new Map<string, SourceTexture>();
+
+  constructor(device: GPUDevice, width: number, height: number) {
+    this.device = device;
+    this.width = Math.max(1, Math.floor(width));
+    this.height = Math.max(1, Math.floor(height));
+    this.core = new WebGPULayerCompositor(
+      device,
+      TEXTURE_FORMAT,
+      "linear",
+      "timeline-headless"
+    );
+    this.core.ensureSize(this.width, this.height);
+    this.effects = new WebGPUEffectsProcessor(device);
+    this.bytesPerRow =
+      Math.ceil((this.width * 4) / ROW_ALIGNMENT) * ROW_ALIGNMENT;
+    this.readback = device.createBuffer({
+      label: "timeline-headless-readback",
+      size: this.bytesPerRow * this.height,
+      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+    });
+  }
+
+  /**
+   * Composite `layers` over opaque black and return the frame as straight-alpha
+   * RGBA8 at the compositor's resolution.
+   */
+  async renderFrame(layers: FrameLayer[]): Promise<Uint8Array> {
+    const ordered = [...layers].sort((a, b) => a.zIndex - b.zIndex);
+    this.retainOnly(ordered);
+
+    const readStart = this.core.textureA;
+    const writeStart = this.core.textureB;
+    if (!readStart || !writeStart) {
+      throw new Error("Compositor failed to allocate accumulation textures");
+    }
+
+    const encoder = this.device.createCommandEncoder({
+      label: "timeline-headless-frame"
+    });
+
+    let readTex = readStart;
+    let writeTex = writeStart;
+    // Seed the accumulation with opaque black — the same background the
+    // preview composites over.
+    const seed = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: readTex.createView(),
+          clearValue: { r: 0, g: 0, b: 0, a: 1 },
+          loadOp: "clear",
+          storeOp: "store"
+        }
+      ]
+    });
+    seed.end();
+
+    this.core.beginFrame();
+    for (const layer of ordered) {
+      const src = this.uploadSource(layer);
+      if (!src) continue;
+
+      const clipEffects = layer.effects ?? [];
+      const trackEffects = layer.trackEffects ?? [];
+      const processed =
+        clipEffects.length > 0 || trackEffects.length > 0
+          ? this.effects.process(
+              layer.id,
+              src.texture,
+              src.width,
+              src.height,
+              clipEffects,
+              trackEffects
+            )
+          : src.texture;
+
+      const matrix = buildTransformMatrix(
+        layer.transform ?? IDENTITY_TRANSFORM,
+        containBaseScale(src.width, src.height, this.width, this.height),
+        this.width,
+        this.height
+      );
+      const invAffine = forwardClipMatrixToInverseAffine(
+        matrix,
+        src.width,
+        src.height,
+        this.width,
+        this.height
+      );
+
+      const radiusPx = layer.borderRadius ?? 0;
+      const radiusNormalized =
+        radiusPx > 0
+          ? Math.min(0.5, radiusPx / Math.min(src.width, src.height))
+          : 0;
+
+      this.core.renderBlendPass(encoder, readTex, writeTex, {
+        source: processed,
+        opacity: layer.opacity,
+        blendModeId: blendModeGpuId(layer.blendMode),
+        canvasW: this.width,
+        canvasH: this.height,
+        invAffine,
+        borderRadius: radiusNormalized,
+        wipe: wipeParams(layer.mask)
+      });
+
+      const tmp = readTex;
+      readTex = writeTex;
+      writeTex = tmp;
+    }
+
+    encoder.copyTextureToBuffer(
+      { texture: readTex },
+      {
+        buffer: this.readback,
+        bytesPerRow: this.bytesPerRow,
+        rowsPerImage: this.height
+      },
+      { width: this.width, height: this.height }
+    );
+    this.device.queue.submit([encoder.finish()]);
+
+    await this.readback.mapAsync(GPUMapMode.READ);
+    const mapped = new Uint8Array(this.readback.getMappedRange());
+    // The accumulation is premultiplied, but the opaque-black seed leaves every
+    // pixel at alpha 1, where premultiplied and straight alpha coincide — so
+    // dropping the 256-byte row padding is all that is left to do.
+    const rgba = new Uint8Array(this.width * this.height * 4);
+    const rowBytes = this.width * 4;
+    for (let row = 0; row < this.height; row++) {
+      rgba.set(
+        mapped.subarray(row * this.bytesPerRow, row * this.bytesPerRow + rowBytes),
+        row * rowBytes
+      );
+    }
+    this.readback.unmap();
+    return rgba;
+  }
+
+  private retainOnly(layers: FrameLayer[]): void {
+    const live = new Set(layers.map((l) => l.id));
+    for (const [id, entry] of this.sources) {
+      if (!live.has(id)) {
+        entry.texture.destroy();
+        this.sources.delete(id);
+      }
+    }
+    this.effects.retainOnly(live);
+  }
+
+  private uploadSource(layer: FrameLayer): SourceTexture | null {
+    const { rgba, width, height } = layer.source;
+    if (width <= 0 || height <= 0) return null;
+    if (rgba.length < width * height * 4) return null;
+
+    let entry = this.sources.get(layer.id);
+    if (!entry || entry.width !== width || entry.height !== height) {
+      entry?.texture.destroy();
+      entry = {
+        texture: this.device.createTexture({
+          label: `timeline-headless-source-${layer.id}`,
+          size: { width, height },
+          format: TEXTURE_FORMAT,
+          usage:
+            GPUTextureUsage.TEXTURE_BINDING |
+            GPUTextureUsage.COPY_DST |
+            GPUTextureUsage.COPY_SRC |
+            GPUTextureUsage.RENDER_ATTACHMENT
+        }),
+        width,
+        height,
+        version: ""
+      };
+      this.sources.set(layer.id, entry);
+    }
+
+    const version = layer.source.version;
+    if (version === undefined || entry.version !== version) {
+      // Re-wrap as an ArrayBuffer-backed view: `writeTexture` rejects
+      // SharedArrayBuffer-backed sources under the DOM WebGPU typings.
+      const data = new Uint8Array(
+        rgba.buffer as ArrayBuffer,
+        rgba.byteOffset,
+        rgba.byteLength
+      );
+      this.device.queue.writeTexture(
+        { texture: entry.texture },
+        data,
+        { bytesPerRow: width * 4, rowsPerImage: height },
+        { width, height }
+      );
+      entry.version = version ?? "";
+    }
+    return entry;
+  }
+
+  dispose(): void {
+    for (const entry of this.sources.values()) entry.texture.destroy();
+    this.sources.clear();
+    this.effects.dispose();
+    this.core.dispose();
+    this.readback.destroy();
+  }
+}

--- a/packages/timeline/src/render/index.ts
+++ b/packages/timeline/src/render/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @nodetool-ai/timeline/render — the shared render surface.
+ *
+ * The scene model, placement math, rasterization rules, effects pre-pass and
+ * headless frame compositor every timeline render path is built from: the
+ * editor's live preview, its in-browser exporter, and the server-side
+ * `RenderTimeline` node. Kept out of the package root because it pulls in
+ * WebGPU (`@nodetool-ai/gpu`) at runtime, which the root export deliberately
+ * does not.
+ */
+
+export * from "./sceneModel.js";
+export * from "./transform.js";
+export * from "./draw.js";
+export * from "./effects.js";
+export * from "./frameCompositor.js";

--- a/packages/timeline/src/render/sceneModel.ts
+++ b/packages/timeline/src/render/sceneModel.ts
@@ -1,33 +1,39 @@
 /**
  * sceneModel — the single source of truth for "what is on screen at time t".
  *
- * Both the live {@link PreviewCompositor} and the offline frame-by-frame
- * {@link renderTimeline} renderer drive their GPU layer lists from
+ * The live preview, the browser's offline exporter, and the server-side
+ * `RenderTimeline` node all drive their layer lists from
  * {@link computeActiveLayers}, so an exported video is composited from the
- * exact same scene description the user previewed — 1:1 with live.
+ * exact same scene description the user previewed — 1:1 with live, wherever
+ * the render runs.
  *
  * Everything here is pure (no DOM, no GPU, no store access) so it is trivially
- * testable and reusable across the live and render paths.
+ * testable and reusable across every render path.
  */
 
 import type {
-  AnimationSampleMask,
-  ClipAnimation,
   ClipEffect,
   ClipTransform,
-  CompiledAnimation,
   TimelineClip,
   TimelineTrack,
   TrackEffect
-} from "@nodetool-ai/timeline";
+} from "../types.js";
+import type {
+  AnimationSampleMask,
+  ClipAnimation,
+  CompiledAnimation
+} from "../animation/index.js";
 import {
   compileClipAnimations,
   countStaggerUnits,
   hasActiveAnimationWindow,
   hasStaggeredAnimation,
   sampleAnimations
-} from "@nodetool-ai/timeline";
-import type { CompositorBlendMode } from "./gpu/types";
+} from "../animation/index.js";
+import type { ResolvedCaption, TextRenderStagger } from "./draw.js";
+
+/** Blend mode a layer composites with. */
+export type CompositorBlendMode = NonNullable<TimelineClip["blendMode"]>;
 
 /**
  * Top-of-UI track (lowest `track.index`) renders on top in the composite —
@@ -168,20 +174,6 @@ export function clipSourceTimeSec(
     : Math.max(0.0001, clip.speedMultiplier ?? 1);
   const intoClipTimelineSec = (currentTimeMs - clip.startMs) / 1000;
   return Math.max(0, intoClipTimelineSec * rate + (clip.inPointMs ?? 0) / 1000);
-}
-
-/** One word of a caption resolved at a point in time. */
-export interface ResolvedCaptionWord {
-  text: string;
-  /** True while the playhead is inside this word's spoken interval. */
-  active: boolean;
-}
-
-/** A caption's full per-frame state: every word of the line plus which one is
- * currently spoken. Rasterised identically by the live preview and the export
- * (see `captionRender`). */
-export interface ResolvedCaption {
-  words: ResolvedCaptionWord[];
 }
 
 /**
@@ -626,16 +618,6 @@ function composeAnimatedEffects(
 }
 
 /**
- * Per-frame input the text rasterizer needs to draw a staggered text clip:
- * the clip's compiled animations (at least one staggered) and the clip-local
- * time. `null`/absent means the block raster path applies (cache by style).
- */
-export interface TextStaggerContext {
-  compiled: CompiledAnimation[];
-  localMs: number;
-}
-
-/**
  * Resolve the stagger context for a text layer at `currentTimeMs`, or `null`
  * when the clip has no staggered animation. Shared by the live preview, the
  * export renderer, and the agent frame harness so per-word motion is drawn
@@ -646,7 +628,7 @@ export function resolveTextStaggerContext(
   currentTimeMs: number,
   canvas: { width: number; height: number },
   cache?: AnimationCompileCache
-): TextStaggerContext | null {
+): TextRenderStagger | null {
   if (clip.mediaType !== "text") return null;
   const compiled = compiledFor(clip, canvas, cache);
   if (compiled.length === 0 || !hasStaggeredAnimation(compiled)) return null;

--- a/packages/timeline/src/render/transform.ts
+++ b/packages/timeline/src/render/transform.ts
@@ -1,4 +1,12 @@
-import type { ClipTransform } from "@nodetool-ai/timeline";
+/**
+ * transform — placement math shared by every timeline render surface.
+ *
+ * The live preview, the browser exporter and the server-side renderer all
+ * build a layer's placement matrix here, so a clip sits in the same spot in
+ * the preview, the gizmo, and the exported file.
+ */
+
+import type { ClipTransform } from "../types.js";
 
 export const IDENTITY_TRANSFORM: ClipTransform = {
   position: { x: 0, y: 0 },

--- a/packages/timeline/tests/render.sceneModel.test.ts
+++ b/packages/timeline/tests/render.sceneModel.test.ts
@@ -1,5 +1,6 @@
-import { makeClip, makeTrack } from "@nodetool-ai/timeline";
-import type { TimelineClip, TimelineTrack } from "@nodetool-ai/timeline";
+import { describe, expect, it } from "vitest";
+import { makeClip, makeTrack } from "../src/index.js";
+import type { TimelineClip, TimelineTrack } from "../src/index.js";
 
 import {
   clipSourceTimeSec,
@@ -10,7 +11,7 @@ import {
   resolveCaptionAtTime,
   trackZ,
   LAYER_Z_BASE
-} from "../sceneModel";
+} from "../src/render/sceneModel.js";
 
 const clip = (overrides: Partial<TimelineClip>): TimelineClip =>
   makeClip({

--- a/packages/timeline/tests/render.transform.test.ts
+++ b/packages/timeline/tests/render.transform.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it } from "vitest";
 import {
   containBaseScale,
   buildTransformMatrix,
   clipMatrixToCanvasAffine,
   IDENTITY_TRANSFORM
-} from "../transform";
+} from "../src/render/transform.js";
 
 interface ClipTransform {
   position: { x: number; y: number };

--- a/packages/timeline/tsconfig.json
+++ b/packages/timeline/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": [
+      "@webgpu/types",
+      "node"
+    ]
   },
   "include": [
     "src"

--- a/packages/video-nodes/package.json
+++ b/packages/video-nodes/package.json
@@ -17,8 +17,10 @@
   "dependencies": {
     "@gltf-transform/core": "^4.3.0",
     "@gltf-transform/functions": "^4.3.0",
+    "@napi-rs/canvas": "^0.1.65",
     "@nodetool-ai/audio-nodes": "*",
     "@nodetool-ai/config": "*",
+    "@nodetool-ai/gpu": "*",
     "@nodetool-ai/node-sdk": "*",
     "@nodetool-ai/nodes-utils": "*",
     "@nodetool-ai/protocol": "*",
@@ -34,6 +36,7 @@
     "@types/chrome-remote-interface": "^0.33.0",
     "@types/node": "^22.0.0",
     "@types/three": "^0.185.0",
+    "@webgpu/types": "^0.1.70",
     "esbuild": "^0.28.1",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2"

--- a/packages/video-nodes/src/nodes/timeline.ts
+++ b/packages/video-nodes/src/nodes/timeline.ts
@@ -2,11 +2,18 @@
  * Timeline nodes — operate on persisted timeline sequences (the video
  * editor's documents) referenced by the `timeline` type.
  *
- * RenderTimeline produces a rough cut with ffmpeg: video/image clips are
- * normalized to the sequence's resolution and concatenated in start order,
- * and audio-track clips are mixed in at their timeline offsets. Per-clip
- * effects, transitions, captions, overlay tracks, and speed changes are not
- * applied server-side — open the timeline editor for the full preview.
+ * RenderTimeline composites the sequence frame by frame through the same GPU
+ * compositor and scene model the editor's preview and its in-browser export
+ * use (`@nodetool-ai/timeline/render`), so a workflow render is the picture
+ * the user previewed: clip placement, transforms, opacity, blend modes,
+ * transitions, animations, effects, captions, text and shapes, across every
+ * visual track. ffmpeg decodes clip media into RGBA and encodes the result.
+ *
+ * Compositing needs a WebGPU device, which means the optional `webgpu` (Dawn)
+ * package and a working driver — the desktop app ships both; the headless
+ * server image today ships neither. Without one the node falls back to the
+ * older ffmpeg rough cut — video/image clips normalized and concatenated in
+ * start order — which ignores everything above and says so in the log.
  */
 
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
@@ -33,6 +40,10 @@ import {
   MissingBinaryError,
   videoRef
 } from "./ffmpeg-helpers.js";
+import {
+  CompositorUnavailableError,
+  renderTimelineComposited
+} from "./timeline/compositeRender.js";
 
 interface TimelineRefLike {
   type?: string;
@@ -80,15 +91,6 @@ async function ffprobeHasAudio(filePath: string): Promise<boolean> {
     if (error instanceof MissingBinaryError) throw error;
     return false;
   }
-}
-
-async function resolveClipBytes(
-  clip: TimelineClip,
-  context: ProcessingContext
-): Promise<Uint8Array | null> {
-  if (!clip.currentAssetId) return null;
-  const { bytes } = await context.resolveAssetBytes(clip.currentAssetId);
-  return bytes;
 }
 
 function trackById(
@@ -272,6 +274,32 @@ async function encodeSegment(opts: {
   );
 }
 
+/**
+ * Clips whose embedded audio the composited path must mix in itself: the
+ * rough cut carried a video clip's audio through its segment, but a
+ * frame-by-frame composite has no audio at all. Muted clips/tracks and clips
+ * whose audio was extracted onto an audio track (see
+ * {@link extractedAudioLinkIds}) are left out.
+ */
+function embeddedAudioClips(seq: TimelineSequence): TimelineClip[] {
+  const tracks = trackById(seq.tracks);
+  const suppressed = extractedAudioLinkIds(seq);
+  return seq.clips
+    .filter((clip) => {
+      const track = tracks.get(clip.trackId);
+      return (
+        (track?.type === "video" || track?.type === "overlay") &&
+        track.muted !== true &&
+        !clip.muted &&
+        clip.mediaType === "video" &&
+        !!clip.currentAssetId &&
+        clip.durationMs > 0 &&
+        !(typeof clip.linkId === "string" && suppressed.has(clip.linkId))
+      );
+    })
+    .sort((a, b) => a.startMs - b.startMs);
+}
+
 /** Per-clip audio chain: trim to in/out, apply gain, delay to timeline start. */
 function audioClipFilter(
   clip: TimelineClip,
@@ -293,11 +321,221 @@ function audioClipFilter(
   return `[${inputIndex}:a]${steps.join(",")}[${label}]`;
 }
 
+/** Anything that draws: media, titles, shapes, or a caption riding a clip. */
+function hasRenderableVisual(seq: TimelineSequence): boolean {
+  const tracks = trackById(seq.tracks);
+  return seq.clips.some((clip) => {
+    const track = tracks.get(clip.trackId);
+    if (!track || track.visible === false || clip.hidden) return false;
+    if (clip.caption) return true;
+    if (track.type !== "video" && track.type !== "overlay") return false;
+    if (clip.mediaType === "text") return !!clip.textStyle;
+    if (clip.mediaType === "shape") return !!clip.shapeStyle;
+    return (
+      (clip.mediaType === "video" || clip.mediaType === "image") &&
+      !!clip.currentAssetId
+    );
+  });
+}
+
+/** The sequence's own length, or the end of its last clip when it has none. */
+function totalDurationMs(seq: TimelineSequence): number {
+  if (seq.durationMs > 0) return seq.durationMs;
+  return seq.clips.reduce(
+    (end, clip) => Math.max(end, clip.startMs + clip.durationMs),
+    0
+  );
+}
+
+/** Materializes clip assets on disk once each, for ffmpeg to read. */
+class AssetFiles {
+  private readonly files = new Map<string, Promise<string | null>>();
+
+  constructor(
+    private readonly workDir: string,
+    private readonly context: ProcessingContext
+  ) {}
+
+  path(assetId: string): Promise<string | null> {
+    let pending = this.files.get(assetId);
+    if (!pending) {
+      pending = this.write(assetId);
+      this.files.set(assetId, pending);
+    }
+    return pending;
+  }
+
+  private async write(assetId: string): Promise<string | null> {
+    const { bytes } = await this.context.resolveAssetBytes(assetId);
+    if (!bytes) return null;
+    const file = path.join(this.workDir, `asset_${assetId}`);
+    await fs.writeFile(file, bytes);
+    return file;
+  }
+}
+
+/**
+ * The pre-compositor rough cut, kept as the fallback for hosts without a GPU:
+ * each video/image clip is normalized to the sequence frame and the segments
+ * are concatenated in start order. Gaps, overlaps, transforms and every other
+ * layer property are lost — it is a cut, not a render.
+ */
+async function renderRoughCut(opts: {
+  seq: TimelineSequence;
+  clips: TimelineClip[];
+  audioClips: TimelineClip[];
+  assets: AssetFiles;
+  workDir: string;
+  width: number;
+  height: number;
+  fps: number;
+}): Promise<string> {
+  const { seq, clips, audioClips, assets, workDir, width, height, fps } = opts;
+  const suppressedLinkIds = extractedAudioLinkIds(seq);
+
+  const segments: string[] = [];
+  for (const [i, clip] of clips.entries()) {
+    const srcPath = clip.currentAssetId
+      ? await assets.path(clip.currentAssetId)
+      : null;
+    if (!srcPath) {
+      console.warn(
+        `RenderTimeline: skipping clip "${clip.name}" — asset ${clip.currentAssetId} not found`
+      );
+      continue;
+    }
+    const segPath = path.join(workDir, `seg_${i}.mp4`);
+    await encodeSegment({
+      clip,
+      srcPath,
+      segPath,
+      width,
+      height,
+      fps,
+      suppressEmbeddedAudio:
+        typeof clip.linkId === "string" && suppressedLinkIds.has(clip.linkId)
+    });
+    segments.push(segPath);
+  }
+
+  const basePath = path.join(workDir, "base.mp4");
+  if (segments.length > 0) {
+    const listPath = path.join(workDir, "segments.txt");
+    await fs.writeFile(listPath, segments.map((p) => `file '${p}'`).join("\n"));
+    await execFfmpeg(
+      ["-y", "-f", "concat", "-safe", "0", "-i", listPath, "-c", "copy", basePath],
+      { maxBuffer: FFMPEG_MAX_BUFFER }
+    );
+    return basePath;
+  }
+
+  // Audio-only cut: synthesize a black picture to carry the mix.
+  const totalS =
+    Math.max(...audioClips.map((c) => c.startMs + c.durationMs)) / 1000;
+  await execFfmpeg(
+    [
+      "-y",
+      "-f",
+      "lavfi",
+      "-t",
+      String(totalS),
+      "-i",
+      `color=black:s=${width}x${height}:r=${fps}`,
+      "-f",
+      "lavfi",
+      "-t",
+      String(totalS),
+      "-i",
+      "anullsrc=channel_layout=stereo:sample_rate=48000",
+      "-c:v",
+      "libx264",
+      "-preset",
+      "veryfast",
+      "-c:a",
+      "aac",
+      basePath
+    ],
+    { maxBuffer: FFMPEG_MAX_BUFFER }
+  );
+  return basePath;
+}
+
+/**
+ * Mix `clips` into `basePath` at their timeline offsets. `baseHasAudio` says
+ * whether the base video carries a soundtrack of its own to keep (the rough
+ * cut does; a composited render does not).
+ */
+async function mixAudioInto(opts: {
+  basePath: string;
+  clips: TimelineClip[];
+  baseHasAudio: boolean;
+  assets: AssetFiles;
+  workDir: string;
+}): Promise<string> {
+  const { basePath, clips, baseHasAudio, assets, workDir } = opts;
+  const inputs: string[] = ["-i", basePath];
+  const filters: string[] = [];
+  const labels: string[] = [];
+  let inputIndex = 1;
+
+  for (const [i, clip] of clips.entries()) {
+    const audioPath = clip.currentAssetId
+      ? await assets.path(clip.currentAssetId)
+      : null;
+    if (!audioPath) {
+      console.warn(
+        `RenderTimeline: skipping audio of clip "${clip.name}" — asset ${clip.currentAssetId} not found`
+      );
+      continue;
+    }
+    if (!baseHasAudio && !(await ffprobeHasAudio(audioPath))) continue;
+    inputs.push("-i", audioPath);
+    const label = `a${i}`;
+    filters.push(audioClipFilter(clip, inputIndex, label));
+    labels.push(`[${label}]`);
+    inputIndex += 1;
+  }
+  if (labels.length === 0) return basePath;
+
+  const sources = baseHasAudio ? [`[0:a]`, ...labels] : labels;
+  const mix =
+    sources.length === 1
+      ? `${sources[0]}apad[aout]`
+      : `${sources.join("")}amix=inputs=${sources.length}:duration=longest:normalize=0,apad[aout]`;
+  const outPath = path.join(workDir, "mixed.mp4");
+  await execFfmpeg(
+    [
+      "-y",
+      ...inputs,
+      "-filter_complex",
+      [...filters, mix].join(";"),
+      "-map",
+      "0:v",
+      "-map",
+      "[aout]",
+      "-c:v",
+      "copy",
+      "-c:a",
+      "aac",
+      "-ar",
+      "48000",
+      "-ac",
+      "2",
+      // `apad` runs the mix past the picture; stop at the shorter stream so the
+      // render is exactly as long as the video.
+      "-shortest",
+      outPath
+    ],
+    { maxBuffer: FFMPEG_MAX_BUFFER }
+  );
+  return outPath;
+}
+
 export class RenderTimelineNode extends BaseNode {
   static readonly nodeType = "nodetool.timeline.RenderTimeline";
   static readonly title = "Render Timeline";
   static readonly description =
-    "Render a timeline sequence to a video (rough cut: clips are concatenated in start order, audio tracks are mixed in at their offsets).\n    timeline, render, video, export, cut\n\n    Use cases:\n    - Turn an edit assembled in the timeline editor into a shareable video\n    - Feed a rough cut into captioning, review, or upload nodes\n    - Automate exports of timelines built by other workflow nodes";
+    "Render a timeline sequence to a video, composited exactly as the timeline editor previews it (tracks, transforms, transitions, effects, captions and text), with audio mixed in at each clip's offset.\n    timeline, render, video, export, cut\n\n    Use cases:\n    - Turn an edit assembled in the timeline editor into a shareable video\n    - Feed a rough cut into captioning, review, or upload nodes\n    - Automate exports of timelines built by other workflow nodes";
   static readonly requiredRuntimes = ["ffmpeg"];
   static readonly metadataOutputTypes = {
     output: "video"
@@ -330,135 +568,80 @@ export class RenderTimelineNode extends BaseNode {
     const height = seq.height > 0 ? seq.height : 1080;
     const fps = seq.fps > 0 ? seq.fps : 30;
 
-    const videoClips = renderableVideoClips(seq);
-    const audioClips = this.include_audio === false ? [] : mixableAudioClips(seq);
-    const suppressedLinkIds = extractedAudioLinkIds(seq);
-    if (videoClips.length === 0 && audioClips.length === 0) {
+    const includeAudio = this.include_audio !== false;
+    const audioClips = includeAudio ? mixableAudioClips(seq) : [];
+    if (!hasRenderableVisual(seq) && audioClips.length === 0) {
       throw new Error(
         `Timeline "${seq.name}" has no renderable clips with media — generate or import clip media first`
       );
+    }
+    const durationMs = totalDurationMs(seq);
+    if (durationMs <= 0) {
+      throw new Error(`Timeline "${seq.name}" has zero duration`);
     }
 
     const workDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "nodetool-timeline-")
     );
     try {
-      // 1. Normalize each video/image clip into a uniform segment.
-      const segments: string[] = [];
-      for (const [i, clip] of videoClips.entries()) {
-        const bytes = await resolveClipBytes(clip, ctx);
-        if (!bytes) {
-          console.warn(
-            `RenderTimeline: skipping clip "${clip.name}" — asset ${clip.currentAssetId} not found`
-          );
-          continue;
-        }
-        const srcPath = path.join(workDir, `src_${i}`);
-        await fs.writeFile(srcPath, bytes);
-        const segPath = path.join(workDir, `seg_${i}.mp4`);
-        const suppressEmbeddedAudio =
-          typeof clip.linkId === "string" &&
-          suppressedLinkIds.has(clip.linkId);
-        await encodeSegment({
-          clip,
-          srcPath,
-          segPath,
+      const assets = new AssetFiles(workDir, ctx);
+      let basePath: string;
+      let baseHasAudio: boolean;
+      let audioToMix: TimelineClip[];
+
+      try {
+        basePath = path.join(workDir, "composited.mp4");
+        const { skippedClips } = await renderTimelineComposited({
+          sequence: seq,
           width,
           height,
           fps,
-          suppressEmbeddedAudio
+          durationMs,
+          resolveAssetPath: (assetId) => assets.path(assetId),
+          outPath: basePath
         });
-        segments.push(segPath);
-      }
-
-      // 2. Concatenate segments (or synthesize black video for audio-only cuts).
-      const basePath = path.join(workDir, "base.mp4");
-      if (segments.length > 0) {
-        const listPath = path.join(workDir, "segments.txt");
-        await fs.writeFile(
-          listPath,
-          segments.map((p) => `file '${p}'`).join("\n")
-        );
-        await execFfmpeg(
-          ["-y", "-f", "concat", "-safe", "0", "-i", listPath, "-c", "copy", basePath],
-          { maxBuffer: FFMPEG_MAX_BUFFER }
-        );
-      } else {
-        const totalS =
-          Math.max(...audioClips.map((c) => c.startMs + c.durationMs)) / 1000;
-        await execFfmpeg(
-          [
-            "-y",
-            "-f",
-            "lavfi",
-            "-t",
-            String(totalS),
-            "-i",
-            `color=black:s=${width}x${height}:r=${fps}`,
-            "-f",
-            "lavfi",
-            "-t",
-            String(totalS),
-            "-i",
-            "anullsrc=channel_layout=stereo:sample_rate=48000",
-            "-c:v",
-            "libx264",
-            "-preset",
-            "veryfast",
-            "-c:a",
-            "aac",
-            basePath
-          ],
-          { maxBuffer: FFMPEG_MAX_BUFFER }
-        );
-      }
-
-      // 3. Mix audio-track clips over the base at their timeline offsets.
-      let outPath = basePath;
-      if (audioClips.length > 0) {
-        const inputs: string[] = ["-i", basePath];
-        const filters: string[] = [];
-        const labels: string[] = [];
-        let inputIndex = 1;
-        for (const [i, clip] of audioClips.entries()) {
-          const bytes = await resolveClipBytes(clip, ctx);
-          if (!bytes) {
-            console.warn(
-              `RenderTimeline: skipping audio clip "${clip.name}" — asset ${clip.currentAssetId} not found`
-            );
-            continue;
-          }
-          const audioPath = path.join(workDir, `audio_${i}`);
-          await fs.writeFile(audioPath, bytes);
-          inputs.push("-i", audioPath);
-          const label = `a${i}`;
-          filters.push(audioClipFilter(clip, inputIndex, label));
-          labels.push(`[${label}]`);
-          inputIndex += 1;
-        }
-        if (labels.length > 0) {
-          outPath = path.join(workDir, "mixed.mp4");
-          const amix = `[0:a]${labels.join("")}amix=inputs=${labels.length + 1}:duration=first:normalize=0[aout]`;
-          await execFfmpeg(
-            [
-              "-y",
-              ...inputs,
-              "-filter_complex",
-              [...filters, amix].join(";"),
-              "-map",
-              "0:v",
-              "-map",
-              "[aout]",
-              "-c:v",
-              "copy",
-              "-c:a",
-              "aac",
-              outPath
-            ],
-            { maxBuffer: FFMPEG_MAX_BUFFER }
+        for (const name of skippedClips) {
+          console.warn(
+            `RenderTimeline: clip "${name}" was skipped — its media could not be decoded`
           );
         }
+        // A composite carries no sound: every audible clip is mixed in below,
+        // including the audio muxed into video clips.
+        baseHasAudio = false;
+        audioToMix = includeAudio
+          ? [...embeddedAudioClips(seq), ...audioClips]
+          : [];
+      } catch (error) {
+        if (!(error instanceof CompositorUnavailableError)) throw error;
+        console.warn(
+          `RenderTimeline: ${error.message} Falling back to a rough cut — ` +
+            "clip transforms, effects, transitions, captions and overlay " +
+            "tracks are not applied."
+        );
+        basePath = await renderRoughCut({
+          seq,
+          clips: renderableVideoClips(seq),
+          audioClips,
+          assets,
+          workDir,
+          width,
+          height,
+          fps
+        });
+        baseHasAudio = true;
+        audioToMix = audioClips;
       }
+
+      const outPath =
+        audioToMix.length > 0
+          ? await mixAudioInto({
+              basePath,
+              clips: audioToMix,
+              baseHasAudio,
+              assets,
+              workDir
+            })
+          : basePath;
 
       const rendered = new Uint8Array(await fs.readFile(outPath));
       const duration = await ffprobeDuration(outPath);

--- a/packages/video-nodes/src/nodes/timeline/compositeRender.ts
+++ b/packages/video-nodes/src/nodes/timeline/compositeRender.ts
@@ -1,0 +1,274 @@
+/**
+ * Frame-by-frame render of a timeline sequence, server-side.
+ *
+ * This is the editor's export path with the browser taken out: the same
+ * {@link computeActiveLayers} scene description, the same animation sampling,
+ * the same placement math, and the same GPU compositor
+ * ({@link HeadlessFrameCompositor}) — so a workflow render and the preview the
+ * user watched are the same picture. Only the boundaries differ: ffmpeg decodes
+ * clip media into RGBA and encodes the composited frames, in place of
+ * `<video>`/WebCodecs.
+ */
+
+import type { TimelineClip, TimelineSequence } from "@nodetool-ai/timeline";
+import type { FrameLayer } from "@nodetool-ai/timeline/render";
+import {
+  HeadlessFrameCompositor,
+  clipSourceTimeSec,
+  computeActiveLayers,
+  createAnimationCompileCache,
+  resolveAnimatedLayerProps,
+  resolveTextStaggerContext,
+  trackZ
+} from "@nodetool-ai/timeline/render";
+
+import {
+  decodeImageRgba,
+  fitWithin,
+  openFrameEncoder,
+  openVideoFrameStream,
+  probeVideoSize,
+  type RawImage,
+  type VideoFrameStream
+} from "./rawFrames.js";
+import { NodeRasterizer } from "./rasterizers.js";
+
+export interface CompositeRenderOptions {
+  sequence: TimelineSequence;
+  /** Sequence resolution and rate the frames are composited at. */
+  width: number;
+  height: number;
+  fps: number;
+  /** Total timeline length to render, in milliseconds. */
+  durationMs: number;
+  /** Resolve a clip's asset to a readable local file, or null if unavailable. */
+  resolveAssetPath: (assetId: string) => Promise<string | null>;
+  /** Destination video file. */
+  outPath: string;
+  onProgress?: (frame: number, totalFrames: number) => void;
+}
+
+export interface CompositeRenderResult {
+  totalFrames: number;
+  /** Clips whose media could not be decoded, by name — reported, not fatal. */
+  skippedClips: string[];
+}
+
+/** The GPU device is acquired lazily; this is what "no GPU here" looks like. */
+export class CompositorUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super(
+      "The timeline compositor needs a WebGPU device and none is available: " +
+        (cause instanceof Error ? cause.message : String(cause))
+    );
+    this.name = "CompositorUnavailableError";
+    this.cause = cause;
+  }
+}
+
+async function acquireDevice(): Promise<GPUDevice> {
+  try {
+    const { getNodeGPUDevice } = await import("@nodetool-ai/gpu/node");
+    return await getNodeGPUDevice();
+  } catch (error) {
+    throw new CompositorUnavailableError(error);
+  }
+}
+
+/** Per-clip decode state, opened on first use and closed when the clip ends. */
+interface ClipVideoSource {
+  stream: VideoFrameStream;
+  /** Frames already consumed — a stream only moves forward. */
+  endMs: number;
+}
+
+export async function renderTimelineComposited(
+  opts: CompositeRenderOptions
+): Promise<CompositeRenderResult> {
+  const { sequence, fps, durationMs, resolveAssetPath, outPath } = opts;
+  // H.264 requires even dimensions.
+  const width = Math.max(2, Math.floor(opts.width / 2) * 2);
+  const height = Math.max(2, Math.floor(opts.height / 2) * 2);
+  const totalFrames = Math.max(1, Math.round((durationMs / 1000) * fps));
+  const canvas = { width, height };
+
+  const device = await acquireDevice();
+  const compositor = new HeadlessFrameCompositor(device, width, height);
+  const rasterizer = new NodeRasterizer(width, height);
+  const encoder = openFrameEncoder({ outPath, width, height, fps });
+  const animCache = createAnimationCompileCache();
+
+  const videoSources = new Map<string, ClipVideoSource>();
+  const images = new Map<string, RawImage | null>();
+  const assetPaths = new Map<string, Promise<string | null>>();
+  const skippedClips = new Set<string>();
+
+  const pathFor = (assetId: string): Promise<string | null> => {
+    let pending = assetPaths.get(assetId);
+    if (!pending) {
+      pending = resolveAssetPath(assetId);
+      assetPaths.set(assetId, pending);
+    }
+    return pending;
+  };
+
+  const imageFor = async (assetId: string): Promise<RawImage | null> => {
+    if (images.has(assetId)) return images.get(assetId) ?? null;
+    const file = await pathFor(assetId);
+    let decoded: RawImage | null = null;
+    if (file) {
+      const size = await probeVideoSize(file);
+      if (size) decoded = await decodeImageRgba(file, fitWithin(size, canvas));
+    }
+    images.set(assetId, decoded);
+    return decoded;
+  };
+
+  const videoFor = async (
+    clip: TimelineClip,
+    assetId: string
+  ): Promise<VideoFrameStream | null> => {
+    const existing = videoSources.get(clip.id);
+    if (existing) return existing.stream;
+    const file = await pathFor(assetId);
+    if (!file) return null;
+    const size = await probeVideoSize(file);
+    if (!size) return null;
+    const stream = openVideoFrameStream({
+      filePath: file,
+      size: fitWithin(size, canvas),
+      fps,
+      // `clipSourceTimeSec` at the clip's own start is its in point, expressed
+      // the same way the preview seeks — so the first decoded frame is the
+      // frame the preview shows at the cut.
+      startSec: clipSourceTimeSec(clip, clip.startMs),
+      speed: clip.speedBaked ? 1 : Math.max(0.0001, clip.speedMultiplier ?? 1)
+    });
+    videoSources.set(clip.id, {
+      stream,
+      endMs: clip.startMs + clip.durationMs
+    });
+    return stream;
+  };
+
+  try {
+    for (let frame = 0; frame < totalFrames; frame++) {
+      const timeMs = (frame * 1000) / fps;
+
+      for (const [clipId, source] of videoSources) {
+        if (source.endMs < timeMs) {
+          source.stream.close();
+          videoSources.delete(clipId);
+        }
+      }
+
+      const layers: FrameLayer[] = [];
+      for (const layer of computeActiveLayers(
+        sequence.tracks,
+        sequence.clips,
+        timeMs
+      )) {
+        const anim = resolveAnimatedLayerProps(layer, timeMs, canvas, animCache);
+        const common = {
+          opacity: anim.opacity,
+          blendMode: layer.blendMode,
+          zIndex: trackZ(layer.trackIndex),
+          transform: anim.transform,
+          mask: anim.mask,
+          borderRadius: layer.borderRadius,
+          effects: anim.effects ?? layer.effects,
+          trackEffects: layer.trackEffects
+        };
+
+        if (layer.kind === "caption" && layer.caption) {
+          const raster = rasterizer.caption(layer.caption);
+          if (raster) {
+            layers.push({
+              ...common,
+              id: `c:${layer.clipId}`,
+              source: raster,
+              // Captions are drawn at frame resolution and composite untransformed.
+              transform: undefined,
+              borderRadius: undefined,
+              effects: undefined,
+              trackEffects: undefined
+            });
+          }
+          continue;
+        }
+
+        if (layer.kind === "text" && layer.textStyle) {
+          const stagger = resolveTextStaggerContext(
+            layer.clip,
+            timeMs,
+            canvas,
+            animCache
+          );
+          const raster = rasterizer.text(layer.textStyle, stagger);
+          if (raster) {
+            layers.push({ ...common, id: `t:${layer.clipId}`, source: raster });
+          }
+          continue;
+        }
+
+        if (layer.kind === "shape" && layer.shapeStyle) {
+          const raster = rasterizer.shape(layer.shapeStyle);
+          if (raster) {
+            layers.push({ ...common, id: `s:${layer.clipId}`, source: raster });
+          }
+          continue;
+        }
+
+        if (!layer.assetId) continue;
+
+        if (layer.kind === "video") {
+          const stream = await videoFor(layer.clip, layer.assetId);
+          if (!stream) {
+            skippedClips.add(layer.clip.name);
+            continue;
+          }
+          const index = Math.max(
+            0,
+            Math.round(((timeMs - layer.clip.startMs) * fps) / 1000)
+          );
+          const rgba = await stream.frameAt(index);
+          if (!rgba) continue;
+          layers.push({
+            ...common,
+            id: `v:${layer.clipId}`,
+            source: {
+              rgba,
+              width: stream.width,
+              height: stream.height,
+              version: `${layer.clipId}:${index}`
+            }
+          });
+          continue;
+        }
+
+        const image = await imageFor(layer.assetId);
+        if (!image) {
+          skippedClips.add(layer.clip.name);
+          continue;
+        }
+        layers.push({
+          ...common,
+          id: `i:${layer.clipId}`,
+          source: { ...image, version: layer.assetId }
+        });
+      }
+
+      await encoder.write(await compositor.renderFrame(layers));
+      opts.onProgress?.(frame + 1, totalFrames);
+    }
+
+    await encoder.finish();
+    return { totalFrames, skippedClips: [...skippedClips] };
+  } catch (error) {
+    encoder.abort();
+    throw error;
+  } finally {
+    for (const source of videoSources.values()) source.stream.close();
+    compositor.dispose();
+  }
+}

--- a/packages/video-nodes/src/nodes/timeline/rasterizers.ts
+++ b/packages/video-nodes/src/nodes/timeline/rasterizers.ts
@@ -1,0 +1,132 @@
+/**
+ * Server-side rasterization of the layer kinds that have no media behind them:
+ * captions, text clips and shapes.
+ *
+ * The drawing rules come from `@nodetool-ai/timeline/render` — the same ones
+ * the editor's preview and its in-browser export use — applied to a
+ * `@napi-rs/canvas` surface instead of an `OffscreenCanvas`. Output is
+ * straight-alpha RGBA at frame resolution, ready to hand to the compositor.
+ */
+
+import { createCanvas } from "@napi-rs/canvas";
+import type {
+  ClipShapeStyle,
+  ClipTextStyle
+} from "@nodetool-ai/timeline";
+import type {
+  RasterContext2D,
+  ResolvedCaption,
+  TextRenderStagger
+} from "@nodetool-ai/timeline/render";
+import {
+  captionSignature,
+  createStaggerScratch,
+  drawCaption,
+  drawShape,
+  drawStaggeredText,
+  drawText,
+  shapeStyleSignature,
+  staggerPhase,
+  textStyleSignature
+} from "@nodetool-ai/timeline/render";
+
+import type { RawImage } from "./rawFrames.js";
+
+/** A rasterized layer plus the signature that identifies its pixels. */
+export interface RasterResult extends RawImage {
+  /** Changes exactly when the pixels do — the compositor's upload key. */
+  version: string;
+}
+
+const MAX_CACHE_ENTRIES = 32;
+
+/**
+ * Draws through the shared rules and caches by content signature, so a title
+ * that holds still for 300 frames is rasterized once.
+ */
+export class NodeRasterizer {
+  private readonly cache = new Map<string, RasterResult>();
+
+  constructor(
+    private readonly width: number,
+    private readonly height: number
+  ) {}
+
+  caption(caption: ResolvedCaption): RasterResult | null {
+    if (caption.words.length === 0) return null;
+    return this.render(
+      `caption|${captionSignature(caption, this.width, this.height)}`,
+      (ctx) => drawCaption(ctx, caption, this.width, this.height)
+    );
+  }
+
+  shape(style: ClipShapeStyle): RasterResult | null {
+    return this.render(
+      `shape|${shapeStyleSignature(style, this.width, this.height)}`,
+      (ctx) => drawShape(ctx, style, this.width, this.height)
+    );
+  }
+
+  text(
+    style: ClipTextStyle,
+    stagger?: TextRenderStagger | null
+  ): RasterResult | null {
+    if (!style.text) return null;
+    const base = `text|${textStyleSignature(style, this.width, this.height)}`;
+    if (!stagger) {
+      return this.render(base, (ctx) =>
+        drawText(ctx, style, this.width, this.height)
+      );
+    }
+    const phase = staggerPhase(stagger);
+    // Mid-stagger the raster changes every frame, so it is keyed by time and
+    // never reused; a held frame outside the animation window caches by phase.
+    const key =
+      phase === "active"
+        ? `${base}|stg:${stagger.localMs}`
+        : `${base}|stg:${phase}`;
+    return this.render(
+      key,
+      (ctx) =>
+        drawStaggeredText(
+          ctx,
+          style,
+          this.width,
+          this.height,
+          stagger,
+          createStaggerScratch()
+        ),
+      phase !== "active"
+    );
+  }
+
+  private render(
+    key: string,
+    draw: (ctx: RasterContext2D) => void,
+    cacheable = true
+  ): RasterResult | null {
+    if (this.width <= 0 || this.height <= 0) return null;
+    if (cacheable) {
+      const hit = this.cache.get(key);
+      if (hit) return hit;
+    }
+    const canvas = createCanvas(this.width, this.height);
+    const ctx = canvas.getContext("2d");
+    draw(ctx as unknown as RasterContext2D);
+    const result: RasterResult = {
+      rgba: new Uint8Array(
+        ctx.getImageData(0, 0, this.width, this.height).data
+      ),
+      width: this.width,
+      height: this.height,
+      version: key
+    };
+    if (!cacheable) return result;
+    if (this.cache.size >= MAX_CACHE_ENTRIES) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest !== undefined) this.cache.delete(oldest);
+    }
+    this.cache.set(key, result);
+    return result;
+  }
+}

--- a/packages/video-nodes/src/nodes/timeline/rawFrames.ts
+++ b/packages/video-nodes/src/nodes/timeline/rawFrames.ts
@@ -1,0 +1,407 @@
+/**
+ * Raw RGBA plumbing between ffmpeg and the timeline compositor.
+ *
+ * The compositor wants CPU-side straight-alpha RGBA for every layer of every
+ * frame, and hands back the composited frame in the same form. ffmpeg does the
+ * decoding and encoding on both ends:
+ *
+ * - {@link decodeImageRgba} decodes a still once.
+ * - {@link openVideoFrameStream} decodes a clip lazily, one frame at a time.
+ *   Frames are consumed in timeline order, which for a clip is source order, so
+ *   a single streaming decode covers the whole render — no seeking, and no
+ *   multi-gigabyte scratch file.
+ * - {@link openFrameEncoder} pipes composited frames into one long-running
+ *   encoder.
+ */
+
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import type { Readable } from "node:stream";
+
+import { MissingBinaryError, execFfprobe } from "../ffmpeg-helpers.js";
+
+/** Pixel dimensions of a decoded source. */
+export interface RawSize {
+  width: number;
+  height: number;
+}
+
+/** Decoded straight-alpha RGBA8 pixels. */
+export interface RawImage extends RawSize {
+  rgba: Uint8Array;
+}
+
+/**
+ * Largest size that fits `source` inside `canvas` without upscaling and
+ * without changing its aspect ratio. Decoding beyond the frame the layer is
+ * composited into buys nothing; upscaling below it would change what a
+ * source-pixel unit (a blur radius, a corner radius) means.
+ */
+export function fitWithin(source: RawSize, canvas: RawSize): RawSize {
+  const scale = Math.min(
+    1,
+    canvas.width / Math.max(1, source.width),
+    canvas.height / Math.max(1, source.height)
+  );
+  return {
+    width: Math.max(1, Math.round(source.width * scale)),
+    height: Math.max(1, Math.round(source.height * scale))
+  };
+}
+
+/** Probe a media file's video dimensions, or `null` when it has no video. */
+export async function probeVideoSize(filePath: string): Promise<RawSize | null> {
+  const { stdout } = await execFfprobe([
+    "-v",
+    "error",
+    "-select_streams",
+    "v:0",
+    "-show_entries",
+    "stream=width,height",
+    "-of",
+    "csv=p=0:s=x",
+    filePath
+  ]);
+  const match = /^(\d+)x(\d+)/.exec(stdout.trim());
+  if (!match) return null;
+  return { width: Number(match[1]), height: Number(match[2]) };
+}
+
+function spawnFfmpeg(args: string[]): ChildProcessWithoutNullStreams {
+  return spawn("ffmpeg", args, { stdio: ["pipe", "pipe", "pipe"] });
+}
+
+/** Collect a process's stderr so a failure can say what ffmpeg complained about. */
+function captureStderr(stream: Readable): () => string {
+  const chunks: Buffer[] = [];
+  stream.on("data", (chunk: Buffer) => {
+    // Keep the tail only: a failing decode can be verbose, and the last lines
+    // are the ones that name the cause.
+    chunks.push(chunk);
+    if (chunks.length > 32) chunks.shift();
+  });
+  return () => Buffer.concat(chunks).toString("utf8").trim();
+}
+
+/** Decode a still image to straight-alpha RGBA at `size`. */
+export async function decodeImageRgba(
+  filePath: string,
+  size: RawSize
+): Promise<RawImage> {
+  const child = spawnFfmpeg([
+    "-v",
+    "error",
+    "-i",
+    filePath,
+    "-vf",
+    `scale=${size.width}:${size.height}`,
+    "-frames:v",
+    "1",
+    "-f",
+    "rawvideo",
+    "-pix_fmt",
+    "rgba",
+    "pipe:1"
+  ]);
+  const stderr = captureStderr(child.stderr);
+  const chunks: Buffer[] = [];
+  child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+
+  await new Promise<void>((resolve, reject) => {
+    child.on("error", (error: NodeJS.ErrnoException) =>
+      reject(
+        error.code === "ENOENT" ? new MissingBinaryError("ffmpeg") : error
+      )
+    );
+    child.on("close", (code) =>
+      code === 0
+        ? resolve()
+        : reject(new Error(`ffmpeg failed to decode image: ${stderr()}`))
+    );
+  });
+
+  const rgba = new Uint8Array(Buffer.concat(chunks));
+  const expected = size.width * size.height * 4;
+  if (rgba.length < expected) {
+    throw new Error(
+      `ffmpeg produced ${rgba.length} bytes for a ${size.width}x${size.height} frame (expected ${expected})`
+    );
+  }
+  return { rgba: rgba.subarray(0, expected), ...size };
+}
+
+/**
+ * A clip's frames, decoded on demand in timeline order.
+ *
+ * `frameAt` may only move forward: intermediate frames are decoded and dropped,
+ * which is what happens when a layer is skipped for a few frames (a video layer
+ * past the simultaneous-layer cap, say). Once the source runs out, the last
+ * frame is held — the same thing a `<video>` element shows in the preview when
+ * a clip outlives its media.
+ */
+export interface VideoFrameStream extends RawSize {
+  frameAt(index: number): Promise<Uint8Array | null>;
+  close(): void;
+}
+
+/** How many decoded frames ffmpeg may run ahead of the consumer. */
+const READAHEAD_FRAMES = 4;
+
+export interface VideoFrameStreamOptions {
+  filePath: string;
+  /** Decoded frame size (already fitted to the sequence frame). */
+  size: RawSize;
+  /** Timeline frame rate — one decoded frame per timeline frame. */
+  fps: number;
+  /** Source seconds to skip before the first frame (the clip's in point). */
+  startSec: number;
+  /** Playback rate: >1 consumes the source faster than the timeline. */
+  speed: number;
+}
+
+/**
+ * Start decoding `filePath` into RGBA frames at the timeline's frame rate.
+ * `setpts` applies the clip's speed so decoded frame *k* is exactly the source
+ * frame the preview shows at timeline frame *k* of the clip.
+ */
+export function openVideoFrameStream(
+  opts: VideoFrameStreamOptions
+): VideoFrameStream {
+  const { filePath, size, fps, startSec, speed } = opts;
+  const filters = [
+    speed !== 1 ? `setpts=PTS/${speed}` : null,
+    `fps=${fps}`,
+    `scale=${size.width}:${size.height}`,
+    "format=rgba"
+  ].filter((f): f is string => f !== null);
+
+  const child = spawnFfmpeg([
+    "-v",
+    "error",
+    ...(startSec > 0 ? ["-ss", String(startSec)] : []),
+    "-i",
+    filePath,
+    "-vf",
+    filters.join(","),
+    "-f",
+    "rawvideo",
+    "-pix_fmt",
+    "rgba",
+    "pipe:1"
+  ]);
+  const stderr = captureStderr(child.stderr);
+
+  const frameBytes = size.width * size.height * 4;
+  const reader = new FrameReader(child.stdout, frameBytes);
+  let spawnError: Error | null = null;
+  child.on("error", (error: NodeJS.ErrnoException) => {
+    spawnError =
+      error.code === "ENOENT" ? new MissingBinaryError("ffmpeg") : error;
+    reader.fail(spawnError);
+  });
+  child.on("close", (code) => {
+    if (code !== 0 && code !== null && !reader.done) {
+      reader.fail(new Error(`ffmpeg failed to decode clip: ${stderr()}`));
+    }
+  });
+
+  let nextIndex = 0;
+  let last: Uint8Array | null = null;
+
+  return {
+    width: size.width,
+    height: size.height,
+    async frameAt(index: number): Promise<Uint8Array | null> {
+      if (spawnError) throw spawnError;
+      while (nextIndex <= index) {
+        const frame = await reader.next();
+        nextIndex += 1;
+        if (!frame) return last;
+        last = frame;
+      }
+      return last;
+    },
+    close(): void {
+      reader.close();
+      child.kill("SIGKILL");
+    }
+  };
+}
+
+/**
+ * Pull exact-size frames out of a byte stream, with the read-ahead bounded by
+ * pausing the stream — a 1080p frame is 8 MB, so an unbounded buffer would let
+ * a fast decoder outrun the compositor into gigabytes of RAM.
+ */
+class FrameReader {
+  private chunks: Buffer[] = [];
+  private buffered = 0;
+  private waiting: ((frame: Uint8Array | null) => void) | null = null;
+  private failure: Error | null = null;
+  private rejectWaiting: ((error: Error) => void) | null = null;
+  private ended = false;
+  private closed = false;
+
+  constructor(
+    private readonly stream: Readable,
+    private readonly frameBytes: number
+  ) {
+    stream.on("data", (chunk: Buffer) => {
+      this.chunks.push(chunk);
+      this.buffered += chunk.length;
+      this.drain();
+      if (this.buffered > this.frameBytes * READAHEAD_FRAMES) {
+        stream.pause();
+      }
+    });
+    stream.on("end", () => {
+      this.ended = true;
+      this.drain();
+    });
+    stream.on("error", (error: Error) => this.fail(error));
+  }
+
+  get done(): boolean {
+    return this.ended || this.closed;
+  }
+
+  next(): Promise<Uint8Array | null> {
+    if (this.failure) return Promise.reject(this.failure);
+    const ready = this.take();
+    if (ready) return Promise.resolve(ready);
+    if (this.ended || this.closed) return Promise.resolve(null);
+    this.stream.resume();
+    return new Promise<Uint8Array | null>((resolve, reject) => {
+      this.waiting = resolve;
+      this.rejectWaiting = reject;
+    });
+  }
+
+  fail(error: Error): void {
+    this.failure = error;
+    const reject = this.rejectWaiting;
+    this.waiting = null;
+    this.rejectWaiting = null;
+    reject?.(error);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.chunks = [];
+    this.buffered = 0;
+    this.waiting?.(null);
+    this.waiting = null;
+    this.rejectWaiting = null;
+  }
+
+  private drain(): void {
+    if (!this.waiting) return;
+    const frame = this.take();
+    if (frame) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      this.rejectWaiting = null;
+      resolve(frame);
+      return;
+    }
+    if (this.ended) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      this.rejectWaiting = null;
+      resolve(null);
+    }
+  }
+
+  /** Splice one frame out of the buffered chunks, or `null` if short. */
+  private take(): Uint8Array | null {
+    if (this.buffered < this.frameBytes) return null;
+    const merged =
+      this.chunks.length === 1 ? this.chunks[0] : Buffer.concat(this.chunks);
+    const frame = merged.subarray(0, this.frameBytes);
+    const rest = merged.subarray(this.frameBytes);
+    this.chunks = rest.length > 0 ? [rest] : [];
+    this.buffered = rest.length;
+    if (this.buffered <= this.frameBytes * READAHEAD_FRAMES) {
+      this.stream.resume();
+    }
+    return new Uint8Array(frame);
+  }
+}
+
+/** A running encoder that turns written RGBA frames into a video file. */
+export interface FrameEncoder {
+  write(rgba: Uint8Array): Promise<void>;
+  /** Close the input and wait for the file to be finalized. */
+  finish(): Promise<void>;
+  abort(): void;
+}
+
+/**
+ * Start encoding RGBA frames written at `fps` into `outPath` (H.264/MP4). The
+ * alpha channel is dropped by the `yuv420p` conversion — every frame arrives
+ * composited over opaque black, so there is nothing to keep.
+ */
+export function openFrameEncoder(opts: {
+  outPath: string;
+  width: number;
+  height: number;
+  fps: number;
+}): FrameEncoder {
+  const { outPath, width, height, fps } = opts;
+  const child = spawnFfmpeg([
+    "-y",
+    "-v",
+    "error",
+    "-f",
+    "rawvideo",
+    "-pix_fmt",
+    "rgba",
+    "-s",
+    `${width}x${height}`,
+    "-r",
+    String(fps),
+    "-i",
+    "pipe:0",
+    "-c:v",
+    "libx264",
+    "-preset",
+    "veryfast",
+    "-pix_fmt",
+    "yuv420p",
+    outPath
+  ]);
+  const stderr = captureStderr(child.stderr);
+  // The encoder writes nothing to stdout, but an unread pipe would eventually
+  // block the process.
+  child.stdout.resume();
+
+  let failure: Error | null = null;
+  child.on("error", (error: NodeJS.ErrnoException) => {
+    failure = error.code === "ENOENT" ? new MissingBinaryError("ffmpeg") : error;
+  });
+  const closed = new Promise<number | null>((resolve) =>
+    child.on("close", (code) => resolve(code))
+  );
+
+  return {
+    async write(rgba: Uint8Array): Promise<void> {
+      if (failure) throw failure;
+      const ok = child.stdin.write(Buffer.from(rgba.buffer, rgba.byteOffset, rgba.byteLength));
+      if (!ok) {
+        await new Promise<void>((resolve) => child.stdin.once("drain", resolve));
+      }
+    },
+    async finish(): Promise<void> {
+      if (failure) throw failure;
+      child.stdin.end();
+      const code = await closed;
+      if (failure) throw failure;
+      if (code !== 0) {
+        throw new Error(`ffmpeg failed to encode the timeline: ${stderr()}`);
+      }
+    },
+    abort(): void {
+      child.stdin.destroy();
+      child.kill("SIGKILL");
+    }
+  };
+}

--- a/packages/video-nodes/tests/timeline-composite.test.ts
+++ b/packages/video-nodes/tests/timeline-composite.test.ts
@@ -1,0 +1,248 @@
+/**
+ * RenderTimeline's two render paths: the composited one (the GPU compositor
+ * the editor uses) and the rough-cut fallback taken when no GPU device can be
+ * acquired. `compositeRender` is mocked so the orchestration around it — what
+ * gets rendered, what audio is mixed, what the fallback does — is what's under
+ * test; child_process is mocked the same way as `timeline-nodes.test.ts`.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import fsSync from "node:fs";
+
+let execFileCalls: Array<{ cmd: string; args: string[] }> = [];
+
+function mockResponse(
+  cmd: string,
+  args: string[]
+): { stdout: string; stderr: string } {
+  if (cmd === "ffprobe") {
+    const argsStr = args.join(" ");
+    if (argsStr.includes("codec_type")) return { stdout: "audio\n", stderr: "" };
+    if (argsStr.includes("format=duration")) return { stdout: "4\n", stderr: "" };
+    return { stdout: "", stderr: "" };
+  }
+  const outputPath = args[args.length - 1];
+  fsSync.writeFileSync(outputPath, Buffer.from(`fake:${outputPath}`));
+  return { stdout: "", stderr: "" };
+}
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  const mockExecFile = (
+    cmd: string,
+    args: string[],
+    optionsOrCb: unknown,
+    maybeCb?: unknown
+  ) => {
+    execFileCalls.push({ cmd, args: [...args] });
+    const cb =
+      typeof optionsOrCb === "function"
+        ? (optionsOrCb as (e: Error | null, o: string, s: string) => void)
+        : typeof maybeCb === "function"
+          ? (maybeCb as (e: Error | null, o: string, s: string) => void)
+          : null;
+    if (!cb) return;
+    const resp = mockResponse(cmd, args);
+    cb(null, resp.stdout, resp.stderr);
+  };
+  (mockExecFile as unknown as Record<symbol, unknown>)[
+    Symbol.for("nodejs.util.promisify.custom")
+  ] = (cmd: string, args: string[]) => {
+    execFileCalls.push({ cmd, args: [...args] });
+    return Promise.resolve(mockResponse(cmd, args));
+  };
+  return { ...original, execFile: mockExecFile };
+});
+
+const renderComposited = vi.fn();
+
+vi.mock("../src/nodes/timeline/compositeRender.js", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    renderTimelineComposited: (opts: { outPath: string }) => {
+      fsSync.writeFileSync(opts.outPath, Buffer.from("fake:composited"));
+      return renderComposited(opts);
+    }
+  };
+});
+
+const { RenderTimelineNode } = await import("../src/nodes/timeline.js");
+const { CompositorUnavailableError } = await import(
+  "../src/nodes/timeline/compositeRender.js"
+);
+
+const VIDEO_TRACK = { id: "t-video", type: "video", index: 0, visible: true };
+const AUDIO_TRACK = { id: "t-audio", type: "audio", index: 1, visible: true };
+
+function sequence(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "seq-1",
+    name: "Test",
+    width: 1280,
+    height: 720,
+    fps: 30,
+    durationMs: 4000,
+    tracks: [VIDEO_TRACK, AUDIO_TRACK],
+    clips: [],
+    transcript: [],
+    ...overrides
+  };
+}
+
+function videoClip(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "clip-v",
+    trackId: "t-video",
+    name: "Shot",
+    startMs: 0,
+    durationMs: 4000,
+    mediaType: "video",
+    status: "generated",
+    currentAssetId: "asset-v",
+    ...overrides
+  };
+}
+
+function audioClip(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "clip-a",
+    trackId: "t-audio",
+    name: "Music",
+    startMs: 1000,
+    durationMs: 3000,
+    mediaType: "audio",
+    status: "generated",
+    currentAssetId: "asset-a",
+    ...overrides
+  };
+}
+
+function contextFor(seq: unknown) {
+  return {
+    getTimelineSequence: vi.fn().mockResolvedValue(seq),
+    resolveAssetBytes: vi
+      .fn()
+      .mockResolvedValue({ bytes: new Uint8Array([1, 2, 3]) })
+  };
+}
+
+async function render(seq: unknown, props: Record<string, unknown> = {}) {
+  const node = new RenderTimelineNode();
+  Object.assign(node, { timeline: { type: "timeline", id: "seq-1" }, ...props });
+  return node.process(contextFor(seq) as never);
+}
+
+function ffmpegArgs(): string[] {
+  return execFileCalls
+    .filter((c) => c.cmd === "ffmpeg")
+    .map((c) => c.args.join(" "));
+}
+
+beforeEach(() => {
+  execFileCalls = [];
+  renderComposited.mockReset();
+  renderComposited.mockResolvedValue({ totalFrames: 120, skippedClips: [] });
+});
+
+describe("RenderTimeline — composited path", () => {
+  it("composites the whole sequence at its resolution and rate", async () => {
+    await render(sequence({ clips: [videoClip()] }));
+
+    expect(renderComposited).toHaveBeenCalledTimes(1);
+    const opts = renderComposited.mock.calls[0][0];
+    expect(opts).toMatchObject({
+      width: 1280,
+      height: 720,
+      fps: 30,
+      durationMs: 4000
+    });
+    // No segment-per-clip encode: the rough cut is not involved.
+    expect(ffmpegArgs().some((a) => a.includes("-f concat"))).toBe(false);
+  });
+
+  it("renders a text-only timeline, which has no clip media at all", async () => {
+    const seq = sequence({
+      clips: [
+        videoClip({
+          id: "clip-t",
+          mediaType: "text",
+          currentAssetId: null,
+          textStyle: { text: "Hello", fontSizePx: 64, color: "#fff" }
+        })
+      ]
+    });
+    await expect(render(seq)).resolves.toBeDefined();
+    expect(renderComposited).toHaveBeenCalledTimes(1);
+  });
+
+  it("mixes a video clip's own audio in, since a composite carries none", async () => {
+    await render(sequence({ clips: [videoClip(), audioClip()] }));
+
+    const mix = ffmpegArgs().find((a) => a.includes("amix"));
+    expect(mix).toBeDefined();
+    // Both the audio-track clip and the video clip's embedded audio, and no
+    // `[0:a]` — the composited base video is silent.
+    expect(mix).toContain("amix=inputs=2");
+    expect(mix).not.toContain("[0:a]");
+    expect(mix).toContain("-shortest");
+  });
+
+  it("leaves a video clip's audio out when it was extracted onto an audio track", async () => {
+    const seq = sequence({
+      clips: [
+        videoClip({ linkId: "link-1" }),
+        audioClip({ linkId: "link-1", trackId: "t-audio" })
+      ]
+    });
+    await render(seq);
+
+    const mix = ffmpegArgs().find((a) => a.includes("apad"));
+    expect(mix).toBeDefined();
+    // One source only: the extracted audio clip.
+    expect(mix).not.toContain("amix");
+  });
+
+  it("skips audio entirely when include_audio is off", async () => {
+    await render(sequence({ clips: [videoClip(), audioClip()] }), {
+      include_audio: false
+    });
+    expect(ffmpegArgs().some((a) => a.includes("amix"))).toBe(false);
+  });
+
+  it("rejects a timeline with nothing to render", async () => {
+    await expect(render(sequence())).rejects.toThrow(/no renderable clips/);
+  });
+});
+
+describe("RenderTimeline — fallback when no GPU is available", () => {
+  beforeEach(() => {
+    renderComposited.mockRejectedValue(
+      new CompositorUnavailableError(new Error("no adapter"))
+    );
+  });
+
+  it("falls back to the rough cut", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await render(sequence({ clips: [videoClip()] }));
+
+    expect(ffmpegArgs().some((a) => a.includes("-f concat"))).toBe(true);
+    expect(warn.mock.calls.flat().join(" ")).toMatch(/rough cut/);
+    warn.mockRestore();
+  });
+
+  it("keeps the rough cut's own soundtrack in the mix", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    await render(sequence({ clips: [videoClip(), audioClip()] }));
+
+    const mix = ffmpegArgs().find((a) => a.includes("amix"));
+    expect(mix).toContain("[0:a]");
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces a non-GPU failure instead of silently degrading", async () => {
+    renderComposited.mockRejectedValue(new Error("encoder exploded"));
+    await expect(render(sequence({ clips: [videoClip()] }))).rejects.toThrow(
+      /encoder exploded/
+    );
+  });
+});

--- a/packages/video-nodes/tests/timeline-nodes.test.ts
+++ b/packages/video-nodes/tests/timeline-nodes.test.ts
@@ -3,6 +3,11 @@
  * TimelineTranscriptNode, AddClipsToTimelineNode). child_process is mocked:
  * ffprobe answers duration/stream queries and the ffmpeg mock writes its
  * output file, so the full render pipeline runs without ffmpeg installed.
+ *
+ * RenderTimeline's compositor is forced unavailable here, pinning these cases
+ * to the rough-cut fallback they assert on — otherwise what they exercise
+ * would depend on whether the host happens to have a GPU. The composited path
+ * is covered by `timeline-composite.test.ts`.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import fsSync from "node:fs";
@@ -65,6 +70,19 @@ vi.mock("node:child_process", async (importOriginal) => {
     }
   };
   return { ...original, execFile: mockExecFile };
+});
+
+vi.mock("../src/nodes/timeline/compositeRender.js", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  const { CompositorUnavailableError } = original as {
+    CompositorUnavailableError: new (cause: unknown) => Error;
+  };
+  return {
+    ...original,
+    renderTimelineComposited: () => {
+      throw new CompositorUnavailableError(new Error("no adapter in tests"));
+    }
+  };
 });
 
 const {
@@ -161,6 +179,8 @@ function stubContext(seq: ReturnType<typeof baseSequence> | null) {
 
 beforeEach(() => {
   execFileCalls = [];
+  // The fallback logs what the rough cut drops; not the subject of these tests.
+  vi.spyOn(console, "warn").mockImplementation(() => {});
 });
 
 describe("RenderTimelineNode", () => {

--- a/packages/video-nodes/tests/timeline-raw-frames.test.ts
+++ b/packages/video-nodes/tests/timeline-raw-frames.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The RGBA plumbing between ffmpeg and the timeline compositor: frames are
+ * sliced out of a byte stream that arrives in arbitrary chunks, a skipped
+ * layer must not desync the stream, and a clip that outlives its media holds
+ * its last frame. `spawn` is faked so no ffmpeg is involved.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { PassThrough, Writable } from "node:stream";
+
+interface FakeChild extends EventEmitter {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  stdin: Writable & { written: Buffer[] };
+  kill: (signal?: string) => boolean;
+}
+
+let spawned: FakeChild[] = [];
+
+function makeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  const written: Buffer[] = [];
+  const stdin = new Writable({
+    write(chunk, _enc, cb) {
+      written.push(Buffer.from(chunk));
+      cb();
+    }
+  }) as Writable & { written: Buffer[] };
+  stdin.written = written;
+  child.stdin = stdin;
+  child.kill = () => true;
+  return child;
+}
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    spawn: () => {
+      const child = makeChild();
+      spawned.push(child);
+      return child;
+    }
+  };
+});
+
+const { fitWithin, openFrameEncoder, openVideoFrameStream } = await import(
+  "../src/nodes/timeline/rawFrames.js"
+);
+
+/** A 1×1 RGBA frame filled with `value`. */
+function frame(value: number): Buffer {
+  return Buffer.from([value, value, value, 255]);
+}
+
+beforeEach(() => {
+  spawned = [];
+});
+
+describe("fitWithin", () => {
+  it("shrinks a source to fit the frame, keeping its aspect", () => {
+    expect(fitWithin({ width: 3840, height: 2160 }, { width: 1920, height: 1080 }))
+      .toEqual({ width: 1920, height: 1080 });
+    expect(fitWithin({ width: 1000, height: 4000 }, { width: 1920, height: 1080 }))
+      .toEqual({ width: 270, height: 1080 });
+  });
+
+  it("never upscales — a small source stays its own size", () => {
+    expect(fitWithin({ width: 64, height: 64 }, { width: 1920, height: 1080 }))
+      .toEqual({ width: 64, height: 64 });
+  });
+});
+
+describe("openVideoFrameStream", () => {
+  const open = () =>
+    openVideoFrameStream({
+      filePath: "/tmp/clip.mp4",
+      size: { width: 1, height: 1 },
+      fps: 30,
+      startSec: 0,
+      speed: 1
+    });
+
+  it("slices frames out of chunks that don't align with frame boundaries", async () => {
+    const stream = open();
+    const child = spawned[0];
+    // Three frames delivered as two ragged chunks.
+    const all = Buffer.concat([frame(1), frame(2), frame(3)]);
+    child.stdout.write(all.subarray(0, 6));
+    child.stdout.write(all.subarray(6));
+
+    expect(await stream.frameAt(0)).toEqual(new Uint8Array(frame(1)));
+    expect(await stream.frameAt(1)).toEqual(new Uint8Array(frame(2)));
+    expect(await stream.frameAt(2)).toEqual(new Uint8Array(frame(3)));
+  });
+
+  it("waits for frames that have not been decoded yet", async () => {
+    const stream = open();
+    const child = spawned[0];
+    const pending = stream.frameAt(0);
+    child.stdout.write(frame(7));
+    expect(await pending).toEqual(new Uint8Array(frame(7)));
+  });
+
+  it("drops the frames of a skipped index instead of desyncing", async () => {
+    const stream = open();
+    const child = spawned[0];
+    child.stdout.write(Buffer.concat([frame(1), frame(2), frame(3)]));
+
+    // Frames 0 and 1 are never asked for (the layer was skipped).
+    expect(await stream.frameAt(2)).toEqual(new Uint8Array(frame(3)));
+  });
+
+  it("holds the last frame once the source runs out", async () => {
+    const stream = open();
+    const child = spawned[0];
+    child.stdout.write(frame(9));
+    child.stdout.end();
+
+    expect(await stream.frameAt(0)).toEqual(new Uint8Array(frame(9)));
+    expect(await stream.frameAt(5)).toEqual(new Uint8Array(frame(9)));
+  });
+
+  it("reports a decode failure with ffmpeg's own message", async () => {
+    const stream = open();
+    const child = spawned[0];
+    child.stderr.write("moov atom not found");
+    child.stdout.end();
+    child.emit("close", 1);
+
+    await expect(stream.frameAt(0)).rejects.toThrow(/moov atom not found/);
+  });
+});
+
+describe("openFrameEncoder", () => {
+  it("writes each composited frame to the encoder and finalizes on exit 0", async () => {
+    const encoder = openFrameEncoder({
+      outPath: "/tmp/out.mp4",
+      width: 1,
+      height: 1,
+      fps: 30
+    });
+    const child = spawned[0];
+
+    await encoder.write(new Uint8Array(frame(1)));
+    await encoder.write(new Uint8Array(frame(2)));
+    const done = encoder.finish();
+    child.emit("close", 0);
+    await done;
+
+    expect(Buffer.concat(child.stdin.written)).toEqual(
+      Buffer.concat([frame(1), frame(2)])
+    );
+  });
+
+  it("fails with ffmpeg's message when the encode exits non-zero", async () => {
+    const encoder = openFrameEncoder({
+      outPath: "/tmp/out.mp4",
+      width: 1,
+      height: 1,
+      fps: 30
+    });
+    const child = spawned[0];
+    child.stderr.write("height not divisible by 2");
+    const done = encoder.finish();
+    child.emit("close", 1);
+
+    await expect(done).rejects.toThrow(/height not divisible by 2/);
+  });
+});

--- a/packages/video-nodes/tsconfig.json
+++ b/packages/video-nodes/tsconfig.json
@@ -4,16 +4,39 @@
     "outDir": "dist",
     "rootDir": "src",
     "noUnusedLocals": false,
-    "noUnusedParameters": false
+    "noUnusedParameters": false,
+    "types": [
+      "node",
+      "@webgpu/types"
+    ]
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "references": [
-    { "path": "../config" },
-    { "path": "../protocol" },
-    { "path": "../runtime" },
-    { "path": "../node-sdk" },
-    { "path": "../nodes-utils" },
-    { "path": "../audio-nodes" },
-    { "path": "../timeline" }
+    {
+      "path": "../config"
+    },
+    {
+      "path": "../protocol"
+    },
+    {
+      "path": "../runtime"
+    },
+    {
+      "path": "../node-sdk"
+    },
+    {
+      "path": "../nodes-utils"
+    },
+    {
+      "path": "../audio-nodes"
+    },
+    {
+      "path": "../timeline"
+    },
+    {
+      "path": "../gpu"
+    }
   ]
 }

--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -27,6 +27,8 @@ export default {
     "^@nodetool-ai/runtime/zod-schema$":
       "<rootDir>/../packages/runtime/src/zod-schema.ts",
     "^@nodetool-ai/timeline$": "<rootDir>/../packages/timeline/src/index.ts",
+    "^@nodetool-ai/timeline/render$":
+      "<rootDir>/../packages/timeline/src/render/index.ts",
     // node-sdk ships ESM-only dist; the cost-estimate subpath is a pure module
     // (protocol + pricing-bundle types only), so map it to src rather than
     // pull the heavy barrel (pack-loader, registry) into jsdom.

--- a/web/src/components/timeline/README.md
+++ b/web/src/components/timeline/README.md
@@ -53,9 +53,12 @@ The **Export** action in the `TopBar` renders the sequence to an MP4 entirely
 in the browser. It reuses the *same* compositor and scene description as the
 live preview, so an exported frame is identical to what playback showed:
 
-- `preview/sceneModel.ts` — the single source of truth for "what is on screen
-  at time *t*" (`computeActiveLayers`). Both `PreviewCompositor` (live) and the
-  renderer drive their GPU layer lists from it.
+- `@nodetool-ai/timeline/render` — the shared render module: the scene model
+  ("what is on screen at time *t*", `computeActiveLayers`), the placement math,
+  the caption/text/shape drawing rules, and the effects pre-pass. The live
+  `PreviewCompositor`, this renderer, and the server-side
+  `nodetool.timeline.RenderTimeline` node all drive their layer lists from it,
+  so a render is the same picture wherever it runs.
 - `render/TimelineRenderer.ts` — steps the playhead in exact `1 / fps`
   increments, seeks each video element to the precise source frame (waiting for
   `seeked` so decoding is deterministic, not best-effort), composites at full
@@ -66,6 +69,12 @@ live preview, so an exported frame is identical to what playback showed:
   `OfflineAudioContext`.
 - `useTimelineExport` (`hooks/timeline/`) — wires the store + asset URLs to the
   renderer, reports progress, and downloads the resulting file.
+
+The same sequence renders server-side through `RenderTimeline`
+(`packages/video-nodes`), which drives the shared scene model and the headless
+`HeadlessFrameCompositor` with ffmpeg on both ends (decode to RGBA, encode the
+composited frames) — see that node for what it needs (a WebGPU device) and what
+it falls back to without one.
 
 The renderer composites at the sequence's true `width × height` (clamped to even
 dimensions for H.264). mediabunny and the WebGPU compositor are dynamically

--- a/web/src/components/timeline/preview/PreviewCompositor.tsx
+++ b/web/src/components/timeline/preview/PreviewCompositor.tsx
@@ -54,8 +54,8 @@ import {
   trackZ,
   PREVIEW_OVERLAY_Z,
   MAX_VIDEO_LAYERS
-} from "./sceneModel";
-import type { ActiveLayer, ResolvedCaption } from "./sceneModel";
+} from "@nodetool-ai/timeline/render";
+import type { ActiveLayer, ResolvedCaption } from "@nodetool-ai/timeline/render";
 import { CaptionRasterizer } from "./captionRender";
 import { TextRasterizer } from "./textRender";
 import { ShapeRasterizer } from "./shapeRender";

--- a/web/src/components/timeline/preview/TransformGizmoOverlay.tsx
+++ b/web/src/components/timeline/preview/TransformGizmoOverlay.tsx
@@ -21,8 +21,11 @@
 import React, { useRef, useState } from "react";
 import type { ClipTransform } from "@nodetool-ai/timeline";
 
-import { buildTransformMatrix, containBaseScale } from "./gpu/transform";
-import { PREVIEW_OVERLAY_Z } from "./sceneModel";
+import {
+  buildTransformMatrix,
+  containBaseScale
+} from "@nodetool-ai/timeline/render";
+import { PREVIEW_OVERLAY_Z } from "@nodetool-ai/timeline/render";
 import {
   HANDLE_SIZE,
   ROTATION_HANDLE_OFFSET,

--- a/web/src/components/timeline/preview/__tests__/animationResolve.test.ts
+++ b/web/src/components/timeline/preview/__tests__/animationResolve.test.ts
@@ -11,8 +11,8 @@ import {
   createAnimationCompileCache,
   hasActiveAnimation,
   resolveAnimatedLayerProps
-} from "../sceneModel";
-import type { ActiveLayer } from "../sceneModel";
+} from "@nodetool-ai/timeline/render";
+import type { ActiveLayer } from "@nodetool-ai/timeline/render";
 
 const CANVAS = { width: 1000, height: 1000 };
 

--- a/web/src/components/timeline/preview/__tests__/captionRender.test.ts
+++ b/web/src/components/timeline/preview/__tests__/captionRender.test.ts
@@ -1,5 +1,5 @@
 import { captionSignature } from "../captionRender";
-import type { ResolvedCaption } from "../sceneModel";
+import type { ResolvedCaption } from "@nodetool-ai/timeline/render";
 
 describe("captionRender", () => {
   describe("captionSignature", () => {

--- a/web/src/components/timeline/preview/__tests__/rasterClipFrames.test.ts
+++ b/web/src/components/timeline/preview/__tests__/rasterClipFrames.test.ts
@@ -31,7 +31,7 @@ jest.mock("../gpu/canvas2dCompositor", () => ({
   }))
 }));
 
-jest.mock("../sceneModel", () => ({
+jest.mock("@nodetool-ai/timeline/render", () => ({
   createAnimationCompileCache: jest.fn(() => new Map()),
   resolveAnimatedLayerProps,
   resolveTextStaggerContext: jest.fn(() => null)

--- a/web/src/components/timeline/preview/__tests__/textStagger.test.ts
+++ b/web/src/components/timeline/preview/__tests__/textStagger.test.ts
@@ -12,7 +12,7 @@ import {
   resolveAnimatedLayerProps,
   resolveTextStaggerContext,
   type ActiveLayer
-} from "../sceneModel";
+} from "@nodetool-ai/timeline/render";
 
 const CANVAS = { width: 1920, height: 1080 };
 

--- a/web/src/components/timeline/preview/captionRender.ts
+++ b/web/src/components/timeline/preview/captionRender.ts
@@ -11,94 +11,12 @@
  * with the currently-spoken word highlighted.
  */
 
-import type { ResolvedCaption } from "./sceneModel";
+import type { ResolvedCaption } from "@nodetool-ai/timeline/render";
+import { captionSignature, drawCaption } from "@nodetool-ai/timeline/render";
 
-const INACTIVE_COLOR = "#FFFFFF";
-const ACTIVE_COLOR = "#FFD60A";
-const OUTLINE_COLOR = "rgba(0, 0, 0, 0.85)";
 const MAX_CACHE_ENTRIES = 64;
 
-/** @visibleForTesting */
-export function captionSignature(
-  caption: ResolvedCaption,
-  width: number,
-  height: number
-): string {
-  const words = caption.words
-    .map((w) => (w.active ? `*${w.text}` : w.text))
-    .join(" ");
-  return `${width}x${height}|${words}`;
-}
-
-interface MeasuredWord {
-  text: string;
-  active: boolean;
-  width: number;
-}
-
-function drawCaption(
-  ctx: OffscreenCanvasRenderingContext2D,
-  caption: ResolvedCaption,
-  width: number,
-  height: number
-): void {
-  const fontSize = Math.max(24, Math.round(height * 0.05));
-  ctx.font = `700 ${fontSize}px Inter, Arial, sans-serif`;
-  ctx.textBaseline = "alphabetic";
-  ctx.lineJoin = "round";
-
-  const spaceWidth = ctx.measureText(" ").width;
-  const maxWidth = width * 0.9;
-
-  const measured: MeasuredWord[] = caption.words.map((w) => ({
-    text: w.text,
-    active: w.active,
-    width: ctx.measureText(w.text).width
-  }));
-
-  // Greedy word-wrap into lines that fit `maxWidth`.
-  const lines: MeasuredWord[][] = [];
-  let current: MeasuredWord[] = [];
-  let currentWidth = 0;
-  for (const word of measured) {
-    const advance = (current.length > 0 ? spaceWidth : 0) + word.width;
-    if (current.length > 0 && currentWidth + advance > maxWidth) {
-      lines.push(current);
-      current = [word];
-      currentWidth = word.width;
-    } else {
-      current.push(word);
-      currentWidth += advance;
-    }
-  }
-  if (current.length > 0) lines.push(current);
-
-  const lineHeight = fontSize * 1.25;
-  const totalHeight = lines.length * lineHeight;
-  const bottomMargin = height * 0.12;
-  // Baseline of the first line.
-  let y = height - bottomMargin - totalHeight + fontSize;
-
-  ctx.lineWidth = Math.max(2, fontSize * 0.12);
-  ctx.strokeStyle = OUTLINE_COLOR;
-
-  for (const line of lines) {
-    const lineWidth = line.reduce(
-      (sum, w, i) => sum + w.width + (i > 0 ? spaceWidth : 0),
-      0
-    );
-    let x = (width - lineWidth) / 2;
-    for (let i = 0; i < line.length; i++) {
-      const word = line[i];
-      if (i > 0) x += spaceWidth;
-      ctx.fillStyle = word.active ? ACTIVE_COLOR : INACTIVE_COLOR;
-      ctx.strokeText(word.text, x, y);
-      ctx.fillText(word.text, x, y);
-      x += word.width;
-    }
-    y += lineHeight;
-  }
-}
+export { captionSignature };
 
 /**
  * Caches caption bitmaps by content signature so scrubbing or replaying the

--- a/web/src/components/timeline/preview/gpu/canvas2dCompositor.ts
+++ b/web/src/components/timeline/preview/gpu/canvas2dCompositor.ts
@@ -4,7 +4,7 @@ import {
   buildTransformMatrix,
   clipMatrixToCanvasAffine,
   containBaseScale
-} from "./transform";
+} from "@nodetool-ai/timeline/render";
 import { isSourceReady, shouldPresentFrame, sourceDimensions } from "./source";
 import type {
   CompositeLayer,

--- a/web/src/components/timeline/preview/gpu/compositor.ts
+++ b/web/src/components/timeline/preview/gpu/compositor.ts
@@ -3,12 +3,12 @@ import {
   WebGPULayerCompositor,
   forwardClipMatrixToInverseAffine
 } from "@nodetool-ai/gpu/webgpu";
-import { WebGPUEffectsProcessor } from "./effectsProcessor";
 import {
   IDENTITY_TRANSFORM,
+  WebGPUEffectsProcessor,
   buildTransformMatrix,
   containBaseScale
-} from "./transform";
+} from "@nodetool-ai/timeline/render";
 import type {
   CompositeLayer,
   CompositeSource,

--- a/web/src/components/timeline/preview/gpu/types.ts
+++ b/web/src/components/timeline/preview/gpu/types.ts
@@ -2,11 +2,11 @@ import type {
   AnimationSampleMask,
   ClipEffect,
   ClipTransform,
-  TimelineClip,
   TrackEffect
 } from "@nodetool-ai/timeline";
+import type { CompositorBlendMode } from "@nodetool-ai/timeline/render";
 
-export type CompositorBlendMode = NonNullable<TimelineClip["blendMode"]>;
+export type { CompositorBlendMode };
 
 export type CompositeSource =
   | HTMLVideoElement

--- a/web/src/components/timeline/preview/rasterClipFrames.ts
+++ b/web/src/components/timeline/preview/rasterClipFrames.ts
@@ -5,7 +5,7 @@ import {
   createAnimationCompileCache,
   resolveAnimatedLayerProps,
   resolveTextStaggerContext
-} from "./sceneModel";
+} from "@nodetool-ai/timeline/render";
 import { ShapeRasterizer } from "./shapeRender";
 import { TextRasterizer } from "./textRender";
 

--- a/web/src/components/timeline/preview/shapeRender.ts
+++ b/web/src/components/timeline/preview/shapeRender.ts
@@ -1,52 +1,13 @@
+/**
+ * shapeRender — rasterise a shape clip to an `ImageBitmap`. The geometry is
+ * drawn by `@nodetool-ai/timeline/render`, shared with the server-side
+ * renderer; the bitmap cache stays here.
+ */
+
 import type { ClipShapeStyle } from "@nodetool-ai/timeline";
+import { drawShape, shapeStyleSignature } from "@nodetool-ai/timeline/render";
 
 const MAX_CACHE_ENTRIES = 64;
-
-function number(value: number | undefined, fallback: number): number {
-  return value ?? fallback;
-}
-
-function shapeStyleSignature(
-  style: ClipShapeStyle,
-  width: number,
-  height: number
-): string {
-  return `${width}x${height}|${JSON.stringify(style)}`;
-}
-
-function drawShape(
-  ctx: OffscreenCanvasRenderingContext2D,
-  style: ClipShapeStyle,
-  width: number,
-  height: number
-): void {
-  const x = number(style.x, 0.25) * width;
-  const y = number(style.y, 0.25) * height;
-  const shapeWidth = number(style.width, 0.5) * width;
-  const shapeHeight = number(style.height, 0.5) * height;
-  ctx.fillStyle = style.fill ?? "transparent";
-  ctx.strokeStyle = style.stroke ?? "transparent";
-  ctx.lineWidth = number(style.strokeWidthPx, 0);
-  ctx.beginPath();
-  if (style.kind === "rect") ctx.rect(x, y, shapeWidth, shapeHeight);
-  if (style.kind === "ellipse") {
-    ctx.ellipse(
-      x + shapeWidth / 2,
-      y + shapeHeight / 2,
-      shapeWidth / 2,
-      shapeHeight / 2,
-      0,
-      0,
-      Math.PI * 2
-    );
-  }
-  if (style.kind === "line") {
-    ctx.moveTo(x, y);
-    ctx.lineTo(number(style.x2, 0.75) * width, number(style.y2, 0.75) * height);
-  }
-  if (style.fill) ctx.fill();
-  if (style.stroke && ctx.lineWidth > 0) ctx.stroke();
-}
 
 export class ShapeRasterizer {
   private cache = new Map<string, ImageBitmap>();

--- a/web/src/components/timeline/preview/textRender.ts
+++ b/web/src/components/timeline/preview/textRender.ts
@@ -1,203 +1,29 @@
-import type { ClipTextStyle, CompiledAnimation } from "@nodetool-ai/timeline";
-import { sampleStaggeredAnimations } from "@nodetool-ai/timeline";
-import type { AnimationSample } from "@nodetool-ai/timeline";
+/**
+ * textRender — rasterise a text clip to an `ImageBitmap`.
+ *
+ * Layout, wrapping and the staggered per-word draw live in
+ * `@nodetool-ai/timeline/render`, shared with the server-side renderer, so a
+ * title reads the same in the preview, the browser export and a workflow
+ * render. What stays here is the browser's bitmap cache.
+ */
+
+import type {
+  AnimationSample,
+  ClipTextStyle,
+  CompiledAnimation
+} from "@nodetool-ai/timeline";
+import type { TextRenderStagger } from "@nodetool-ai/timeline/render";
+import {
+  createStaggerScratch,
+  drawStaggeredText,
+  drawText,
+  staggerPhase,
+  textStyleSignature
+} from "@nodetool-ai/timeline/render";
 
 const MAX_CACHE_ENTRIES = 64;
 
-/**
- * Per-frame input for a staggered text draw: the clip's compiled animations
- * (at least one carrying a `stagger`) and the clip-local time. Structurally
- * identical to `TextStaggerContext` from `sceneModel` — declared here too so
- * the rasterizer has no dependency on the scene model.
- */
-export interface TextRenderStagger {
-  compiled: CompiledAnimation[];
-  localMs: number;
-}
-
-function textStyleSignature(
-  style: ClipTextStyle,
-  width: number,
-  height: number
-): string {
-  return `${width}x${height}|${style.text}|${style.fontFamily ?? "Inter"}|${style.fontSizePx}|${style.fontWeight ?? 400}|${style.color}|${style.align ?? "center"}|${style.maxWidthFrac ?? 0.8}`;
-}
-
-interface TextLayoutWord {
-  text: string;
-  /** Left edge in canvas px. */
-  x: number;
-  width: number;
-  /** Vertical center of the word's line (textBaseline "middle"). */
-  y: number;
-}
-
-interface WrappedLine {
-  text: string;
-  words: string[];
-}
-
-/**
- * Greedy word-wrap by measured candidate width — the one wrap rule for both
- * draw paths, so a staggered title breaks lines exactly like its
- * un-staggered self.
- */
-function wrapLines(
-  ctx: OffscreenCanvasRenderingContext2D,
-  text: string,
-  maxWidth: number
-): WrappedLine[] {
-  const lines: WrappedLine[] = [];
-  for (const paragraph of text.split(/\r?\n/)) {
-    const words = paragraph.split(/\s+/).filter(Boolean);
-    let line = "";
-    let lineWords: string[] = [];
-    for (const word of words) {
-      const candidate = line ? `${line} ${word}` : word;
-      if (line && ctx.measureText(candidate).width > maxWidth) {
-        lines.push({ text: line, words: lineWords });
-        line = word;
-        lineWords = [word];
-      } else {
-        line = candidate;
-        lineWords.push(word);
-      }
-    }
-    lines.push({ text: line, words: lineWords });
-  }
-  return lines;
-}
-
-/** Word-wrap `style.text` into positioned word boxes. */
-function layoutWords(
-  ctx: OffscreenCanvasRenderingContext2D,
-  style: ClipTextStyle,
-  width: number,
-  height: number
-): TextLayoutWord[] {
-  const fontSize = Math.max(1, style.fontSizePx);
-  const align = style.align ?? "center";
-  const maxWidth =
-    width * Math.min(1, Math.max(0.05, style.maxWidthFrac ?? 0.8));
-  const lines = wrapLines(ctx, style.text, maxWidth);
-  const spaceWidth = ctx.measureText(" ").width;
-  const lineHeight = fontSize * 1.2;
-  const firstY = height / 2 - ((lines.length - 1) * lineHeight) / 2;
-  const out: TextLayoutWord[] = [];
-
-  lines.forEach((line, lineIndex) => {
-    const widths = line.words.map((w) => ctx.measureText(w).width);
-    const lineWidth =
-      widths.reduce((sum, w) => sum + w, 0) +
-      spaceWidth * Math.max(0, line.words.length - 1);
-    let x =
-      align === "left"
-        ? (width - maxWidth) / 2
-        : align === "right"
-          ? (width + maxWidth) / 2 - lineWidth
-          : (width - lineWidth) / 2;
-    const y = firstY + lineIndex * lineHeight;
-    line.words.forEach((word, i) => {
-      out.push({ text: word, x, width: widths[i], y });
-      x += widths[i] + spaceWidth;
-    });
-  });
-  return out;
-}
-
-function drawText(
-  ctx: OffscreenCanvasRenderingContext2D,
-  style: ClipTextStyle,
-  width: number,
-  height: number
-): void {
-  const fontSize = Math.max(1, style.fontSizePx);
-  const align = style.align ?? "center";
-  const maxWidth =
-    width * Math.min(1, Math.max(0.05, style.maxWidthFrac ?? 0.8));
-
-  ctx.font = `${style.fontWeight ?? 400} ${fontSize}px ${style.fontFamily ?? "Inter, Arial, sans-serif"}`;
-  const lines = wrapLines(ctx, style.text, maxWidth);
-
-  const lineHeight = fontSize * 1.2;
-  const firstBaseline = height / 2 - ((lines.length - 1) * lineHeight) / 2;
-  ctx.fillStyle = style.color;
-  ctx.textAlign = align;
-  ctx.textBaseline = "middle";
-  const x =
-    align === "left"
-      ? (width - maxWidth) / 2
-      : align === "right"
-        ? (width + maxWidth) / 2
-        : width / 2;
-  lines.forEach((entry, index) =>
-    ctx.fillText(entry.text, x, firstBaseline + index * lineHeight)
-  );
-}
-
-/**
- * Draw each word with its own animation sample: translate to the word's
- * center (plus the sample's offset), rotate/scale about it, multiply alpha.
- * Effect/mask properties are not applied per word (block-level, v1).
- */
-function drawStaggeredText(
-  ctx: OffscreenCanvasRenderingContext2D,
-  style: ClipTextStyle,
-  width: number,
-  height: number,
-  stagger: TextRenderStagger,
-  scratch: AnimationSample
-): void {
-  ctx.font = `${style.fontWeight ?? 400} ${Math.max(1, style.fontSizePx)}px ${style.fontFamily ?? "Inter, Arial, sans-serif"}`;
-  const words = layoutWords(ctx, style, width, height);
-  ctx.fillStyle = style.color;
-  ctx.textAlign = "left";
-  ctx.textBaseline = "middle";
-
-  words.forEach((word, index) => {
-    const s = sampleStaggeredAnimations(
-      stagger.compiled,
-      stagger.localMs,
-      index,
-      scratch
-    );
-    if (s.opacity <= 0 || s.scale <= 0) return;
-    ctx.save();
-    ctx.translate(word.x + word.width / 2 + s.offsetX, word.y + s.offsetY);
-    if (s.rotation !== 0) ctx.rotate(s.rotation);
-    if (s.scale !== 1) ctx.scale(s.scale, s.scale);
-    ctx.globalAlpha = s.opacity;
-    ctx.fillText(word.text, -word.width / 2, 0);
-    ctx.restore();
-  });
-}
-
-/**
- * Where a stagger context sits relative to its animation windows, for cache
- * policy: `"active"` while any staggered window covers `localMs` (the raster
- * changes every frame — never cached), otherwise a static per-animation
- * phase signature ("b"efore / "a"fter / "i"dle-loop) that keys the held frame.
- */
-function staggerPhase(stagger: TextRenderStagger): "active" | string {
-  let sig = "";
-  for (const anim of stagger.compiled) {
-    if (!anim.stagger) continue;
-    if (anim.loop) {
-      if (
-        stagger.localMs >= anim.windowStartMs &&
-        stagger.localMs < anim.windowEndMs
-      ) {
-        return "active";
-      }
-      sig += "i";
-      continue;
-    }
-    if (stagger.localMs < anim.windowStartMs) sig += "b";
-    else if (stagger.localMs > anim.windowEndMs) sig += "a";
-    else return "active";
-  }
-  return sig;
-}
+export type { TextRenderStagger };
 
 let nextCompiledRefId = 1;
 /** Stable id per compiled-animations array reference, for cache keys. */
@@ -226,16 +52,7 @@ export class TextRasterizer {
     string,
     { timeKey: string; bitmap: ImageBitmap }
   >();
-  private scratchSample: AnimationSample = {
-    offsetX: 0,
-    offsetY: 0,
-    scale: 1,
-    rotation: 0,
-    opacity: 1,
-    blur: 0,
-    brightness: 0,
-    saturation: 1
-  };
+  private scratchSample: AnimationSample = createStaggerScratch();
 
   /**
    * Rasterize `style` at sequence resolution. Pass `stagger` for a text clip

--- a/web/src/components/timeline/render/TimelineRenderer.ts
+++ b/web/src/components/timeline/render/TimelineRenderer.ts
@@ -30,7 +30,7 @@ import {
   resolveAnimatedLayerProps,
   resolveTextStaggerContext,
   trackZ
-} from "../preview/sceneModel";
+} from "@nodetool-ai/timeline/render";
 import { CaptionRasterizer } from "../preview/captionRender";
 import { TextRasterizer } from "../preview/textRender";
 import { ShapeRasterizer } from "../preview/shapeRender";

--- a/web/src/components/timeline/render/__tests__/TimelineRenderer.motion.test.ts
+++ b/web/src/components/timeline/render/__tests__/TimelineRenderer.motion.test.ts
@@ -90,7 +90,7 @@ jest.mock("../../preview/shapeRender", () => ({
 import {
   createAnimationCompileCache,
   resolveAnimatedLayerProps
-} from "../../preview/sceneModel";
+} from "@nodetool-ai/timeline/render";
 import { renderTimeline } from "../TimelineRenderer";
 
 describe("renderTimeline motion", () => {


### PR DESCRIPTION
`nodetool.timeline.RenderTimeline` produced a rough cut: video/image clips normalized and concatenated by ffmpeg in start order. Gaps, overlaps, transforms, opacity, blend modes, transitions, animations, effects, captions, text, shapes and overlay tracks were all dropped — the node's own docstring said "open the timeline editor for the full preview".

It now renders the sequence frame by frame through the **same scene model and GPU compositor** the live preview and the in-browser export use, so a workflow render is the picture the user previewed.

## What moved into `@nodetool-ai/timeline/render`

A new subpath export (kept out of the package root, which stays runtime-dependency-free for mobile):

- `sceneModel.ts` — `computeActiveLayers`, crossfades, animation resolution (moved from `web/src/components/timeline/preview/`)
- `transform.ts` — `buildTransformMatrix` / `containBaseScale` (moved from `preview/gpu/`)
- `effects.ts` — `WebGPUEffectsProcessor` (moved from `preview/gpu/`); its texture-usage flags are now read at allocation time, not module scope, so importing the module under Node doesn't throw before a device exists
- `draw.ts` — the caption/text/shape drawing rules lifted out of the web rasterizers, written against a `RasterContext2D` that both `OffscreenCanvas` and `@napi-rs/canvas` satisfy
- `frameCompositor.ts` — new `HeadlessFrameCompositor`: `WebGPULayerCompositor` + the effects pre-pass with CPU RGBA in and out, reusing source textures and one readback buffer across frames

Web keeps its bitmap caches and canvas-presenting compositor and imports the rest. The two moved test files became vitest tests in `packages/timeline/tests`.

## Server-side render (`packages/video-nodes/src/nodes/timeline/`)

- `rawFrames.ts` — one streaming raw-RGBA ffmpeg decode per clip (frames are consumed in source order, so no seeking and no multi-GB scratch file), read-ahead bounded by pausing the stream; stills decoded once; a single long-running encoder fed the composited frames. A clip that outlives its media holds its last frame, matching the preview.
- `rasterizers.ts` — captions/text/shapes drawn through the shared rules onto `@napi-rs/canvas`.
- `compositeRender.ts` — the frame loop: scene model → animation sampling → rasterize/decode → composite → encode.
- Audio: a composite carries no sound, so every audible clip is mixed in afterwards — including the audio muxed into video clips, unless it was extracted onto an audio track (the existing `linkId` rule). Output is normalized to 48 kHz stereo.

## Fallback

Compositing needs a WebGPU device: the optional `webgpu` (Dawn) package plus a driver. The desktop bundle ships it; the headless server image deliberately does not (`scripts/bundle-backend.mjs` stages `webgpu` on the desktop profile only). Without one the node logs what is lost and falls back to the old rough cut. Any other failure propagates instead of silently degrading.

## Verification

Installed `mesa-vulkan-drivers` + `ffmpeg` in the dev container and ran the real path end to end:

- A sequence with a video clip, a transformed/rotated image clip with a blur effect and `screen` blend, a text clip, a shape clip and a caption rendered to a valid 640×360 MP4; extracted frames show correct placement, track ordering, opacity, the active caption word, and the rasterized title.
- `RenderTimelineNode.process` end to end produced h264 + aac, 2.000 s, with the video's own audio and an offset audio clip mixed in.
- A direct blur check confirms the effects pre-pass runs headlessly (edge pixel 0 → 13, 255 → 206).

New tests: `timeline-composite.test.ts` (both render paths, audio-mix composition, the extracted-audio rule, the fallback and its limits) and `timeline-raw-frames.test.ts` (ragged-chunk frame slicing, skipped indices, EOF hold, encoder plumbing).

`npm run typecheck`, `npm run lint` and `npm run test` pass; the mobile legs fail only because this sandbox has no mobile dependencies installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzkcSEoR5ufD28B1NF5X2Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzkcSEoR5ufD28B1NF5X2Y)_