### PR TITLE
The rest of the image nodes — and four parameters that mean the opposite of what they read like

### DIFF
--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -162,6 +162,13 @@ this; locally, `apt-get install -y mesa-vulkan-drivers` or see
 [AGENTS.md § WebGPU on a headless machine](../../AGENTS.md#webgpu-on-a-headless-machine)
 for the no-root route.
 
+**`npm run workflow` does not exit after one of these.** The run itself finishes
+and prints its outputs, but the process then hangs: nothing destroys the Dawn
+`GPUDevice` acquired in `packages/gpu/src/context.ts`, so the event loop never
+drains. Interrupt it once you have the output, and don't put an image workflow
+in a script that waits on the exit code. Workflows with no image node exit
+normally, and the test harness is unaffected.
+
 ```bash
 # Background, radial/angular/diamond gradients, seeded noise
 npm run workflow -- ./examples/workflows/image_generators_cli.json
@@ -171,7 +178,32 @@ npm run workflow -- ./examples/workflows/image_geometry_cli.json
 
 # Invert, Posterize, compared pixel-wise with CompareImages
 npm run workflow -- ./examples/workflows/image_color_roundtrip_cli.json
+
+# CDL, curves, film look, HSL, lift/gamma/gain, split toning, vignette,
+# exposure, grade, levels, and the enhance filters
+npm run workflow -- ./examples/workflows/image_grading_cli.json
+
+# Affine, corner pin, displace, offset, pad, polar remap, spherize, paste
+npm run workflow -- ./examples/workflows/image_warp_cli.json
+
+# masks, channel shuffle/merge, chroma and luma keys, effects and filters
+npm run workflow -- ./examples/workflows/image_masks_effects_cli.json
 ```
+
+Three things about these nodes that the property names do not tell you:
+
+- **`lib.image.warp` distances are fractions of the image, not pixels.**
+  `Pad` with `left: 5` asks for five times the width, not a 5px border; use
+  `0.25`. `Offset` with `dx: 1` is a whole-width shift, so with wrap on it
+  returns the original image.
+- **Units are per-parameter elsewhere.** `filter.Expand.border`,
+  `effects.Outline.width` and `effects.DropShadow.radius` are pixels, while
+  `DropShadow.offset_x`/`offset_y` are fractions.
+- **`mask.Apply` reads coverage from the mask's alpha channel.**
+  `mask.FromImage` mode 0 reads alpha and mode 1 reads luminance, so deriving a
+  mask from an opaque image in mode 0 yields one that covers everything and
+  `Apply` silently does nothing. `DropShadow` and `Outline` likewise work on the
+  alpha silhouette and draw nothing against a fully opaque frame.
 
 `lib.image.warp.Tile` repeats the image *inside* the existing canvas rather
 than growing it: 3×2 tiles of a 64×64 image is still 64×64.

--- a/examples/workflows/image_grading_cli.json
+++ b/examples/workflows/image_grading_cli.json
@@ -1,0 +1,907 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "source",
+        "type": "lib.image.draw.LinearGradient",
+        "data": {
+          "width": 48,
+          "height": 32,
+          "color_a": { "type": "color", "value": "#102040" },
+          "color_b": { "type": "color", "value": "#e0c090" },
+          "angle": 30,
+          "midpoint": 0.5
+        }
+      },
+
+      {
+        "id": "exposure_neutral",
+        "type": "lib.image.color.Exposure",
+        "data": { "stops": 0 }
+      },
+      {
+        "id": "exposure_up",
+        "type": "lib.image.color.Exposure",
+        "data": { "stops": 1.5 }
+      },
+      {
+        "id": "grade",
+        "type": "lib.image.color.Grade",
+        "data": {
+          "brightness": 0.2,
+          "contrast": 1.3,
+          "saturation": 1.4,
+          "hue": 15,
+          "temperature": 0.2,
+          "tint": -0.1,
+          "shadows": 0.1,
+          "highlights": -0.1
+        }
+      },
+      {
+        "id": "channel_split",
+        "type": "lib.image.color.ChannelSplit",
+        "data": { "mode": 0 }
+      },
+
+      {
+        "id": "cdl",
+        "type": "lib.image.color_grading.CDL",
+        "data": {
+          "slope_r": 1.1,
+          "slope_g": 1,
+          "slope_b": 0.9,
+          "offset_r": 0.02,
+          "offset_g": 0,
+          "offset_b": -0.02,
+          "power_r": 1,
+          "power_g": 1,
+          "power_b": 1.1,
+          "saturation": 1.2
+        }
+      },
+      {
+        "id": "color_balance",
+        "type": "lib.image.color_grading.ColorBalance",
+        "data": { "temperature": 0.3, "tint": -0.2 }
+      },
+      {
+        "id": "curves",
+        "type": "lib.image.color_grading.Curves",
+        "data": {
+          "black_point": 0.05,
+          "white_point": 0.95,
+          "shadows": 0.1,
+          "midtones": 0.2,
+          "highlights": -0.1,
+          "red_midtones": 0.05,
+          "green_midtones": 0,
+          "blue_midtones": -0.05
+        }
+      },
+      {
+        "id": "film_look",
+        "type": "lib.image.color_grading.FilmLook",
+        "data": { "preset": "teal_orange", "intensity": 0.8 }
+      },
+      {
+        "id": "hsl",
+        "type": "lib.image.color_grading.HSLAdjust",
+        "data": {
+          "color_range": "blues",
+          "hue_shift": 20,
+          "saturation": 0.3,
+          "luminance": 0.1
+        }
+      },
+      {
+        "id": "lgg",
+        "type": "lib.image.color_grading.LiftGammaGain",
+        "data": {
+          "lift_r": 0.02,
+          "lift_g": 0,
+          "lift_b": -0.02,
+          "lift_master": 0.01,
+          "gamma_r": 1,
+          "gamma_g": 1.1,
+          "gamma_b": 1,
+          "gamma_master": 1,
+          "gain_r": 1.05,
+          "gain_g": 1,
+          "gain_b": 0.95,
+          "gain_master": 1
+        }
+      },
+      {
+        "id": "split_toning",
+        "type": "lib.image.color_grading.SplitToning",
+        "data": {
+          "shadow_hue": 210,
+          "shadow_saturation": 0.4,
+          "highlight_hue": 40,
+          "highlight_saturation": 0.3,
+          "balance": 0
+        }
+      },
+      {
+        "id": "vignette",
+        "type": "lib.image.color_grading.Vignette",
+        "data": { "amount": 0.6, "midpoint": 0.5, "feather": 0.5 }
+      },
+
+      {
+        "id": "adaptive_contrast",
+        "type": "lib.image.enhance.AdaptiveContrast",
+        "data": { "clip_limit": 2, "grid_size": 8 }
+      },
+      { "id": "detail", "type": "lib.image.enhance.Detail" },
+      { "id": "edge_enhance", "type": "lib.image.enhance.EdgeEnhance" },
+      { "id": "equalize", "type": "lib.image.enhance.Equalize" },
+      {
+        "id": "rank_filter",
+        "type": "lib.image.enhance.RankFilter",
+        "data": { "size": 3, "rank": 4 }
+      },
+      {
+        "id": "levels",
+        "type": "nodetool.image.Levels",
+        "data": {
+          "r_black": 10,
+          "r_gamma": 1.1,
+          "r_white": 245,
+          "g_black": 0,
+          "g_gamma": 1,
+          "g_white": 255,
+          "b_black": 5,
+          "b_gamma": 0.9,
+          "b_white": 250
+        }
+      },
+
+      {
+        "id": "cmp_exposure_neutral",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "exposure 0" }
+      },
+      {
+        "id": "cmp_exposure_up",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "exposure +1.5" }
+      },
+      {
+        "id": "cmp_grade",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "grade" }
+      },
+      {
+        "id": "cmp_channel_split",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "channel split" }
+      },
+      {
+        "id": "cmp_cdl",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "cdl" }
+      },
+      {
+        "id": "cmp_color_balance",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "colour balance" }
+      },
+      {
+        "id": "cmp_curves",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "curves" }
+      },
+      {
+        "id": "cmp_film_look",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "film look" }
+      },
+      {
+        "id": "cmp_hsl",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "hsl" }
+      },
+      {
+        "id": "cmp_lgg",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "lift/gamma/gain" }
+      },
+      {
+        "id": "cmp_split_toning",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "split toning" }
+      },
+      {
+        "id": "cmp_vignette",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "vignette" }
+      },
+      {
+        "id": "cmp_adaptive",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "adaptive contrast" }
+      },
+      {
+        "id": "cmp_detail",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "detail" }
+      },
+      {
+        "id": "cmp_edge",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "edge enhance" }
+      },
+      {
+        "id": "cmp_equalize",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "equalize" }
+      },
+      {
+        "id": "cmp_rank",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "rank filter" }
+      },
+      {
+        "id": "cmp_levels",
+        "type": "nodetool.compare.CompareImages",
+        "data": { "label_a": "source", "label_b": "levels" }
+      },
+
+      { "id": "meta_vignette", "type": "nodetool.image.GetMetadata" },
+
+      {
+        "id": "o_exposure_neutral",
+        "type": "nodetool.output.Output",
+        "name": "exposure_neutral_equal",
+        "data": { "name": "exposure_neutral_equal" }
+      },
+      {
+        "id": "o_exposure_up",
+        "type": "nodetool.output.Output",
+        "name": "exposure_up_equal",
+        "data": { "name": "exposure_up_equal" }
+      },
+      {
+        "id": "o_grade",
+        "type": "nodetool.output.Output",
+        "name": "grade_equal",
+        "data": { "name": "grade_equal" }
+      },
+      {
+        "id": "o_channel_split",
+        "type": "nodetool.output.Output",
+        "name": "channel_split_equal",
+        "data": { "name": "channel_split_equal" }
+      },
+      {
+        "id": "o_cdl",
+        "type": "nodetool.output.Output",
+        "name": "cdl_equal",
+        "data": { "name": "cdl_equal" }
+      },
+      {
+        "id": "o_color_balance",
+        "type": "nodetool.output.Output",
+        "name": "color_balance_equal",
+        "data": { "name": "color_balance_equal" }
+      },
+      {
+        "id": "o_curves",
+        "type": "nodetool.output.Output",
+        "name": "curves_equal",
+        "data": { "name": "curves_equal" }
+      },
+      {
+        "id": "o_film_look",
+        "type": "nodetool.output.Output",
+        "name": "film_look_equal",
+        "data": { "name": "film_look_equal" }
+      },
+      {
+        "id": "o_hsl",
+        "type": "nodetool.output.Output",
+        "name": "hsl_equal",
+        "data": { "name": "hsl_equal" }
+      },
+      {
+        "id": "o_lgg",
+        "type": "nodetool.output.Output",
+        "name": "lgg_equal",
+        "data": { "name": "lgg_equal" }
+      },
+      {
+        "id": "o_split_toning",
+        "type": "nodetool.output.Output",
+        "name": "split_toning_equal",
+        "data": { "name": "split_toning_equal" }
+      },
+      {
+        "id": "o_vignette",
+        "type": "nodetool.output.Output",
+        "name": "vignette_equal",
+        "data": { "name": "vignette_equal" }
+      },
+      {
+        "id": "o_adaptive",
+        "type": "nodetool.output.Output",
+        "name": "adaptive_equal",
+        "data": { "name": "adaptive_equal" }
+      },
+      {
+        "id": "o_detail",
+        "type": "nodetool.output.Output",
+        "name": "detail_equal",
+        "data": { "name": "detail_equal" }
+      },
+      {
+        "id": "o_edge",
+        "type": "nodetool.output.Output",
+        "name": "edge_equal",
+        "data": { "name": "edge_equal" }
+      },
+      {
+        "id": "o_equalize",
+        "type": "nodetool.output.Output",
+        "name": "equalize_equal",
+        "data": { "name": "equalize_equal" }
+      },
+      {
+        "id": "o_rank",
+        "type": "nodetool.output.Output",
+        "name": "rank_equal",
+        "data": { "name": "rank_equal" }
+      },
+      {
+        "id": "o_levels",
+        "type": "nodetool.output.Output",
+        "name": "levels_equal",
+        "data": { "name": "levels_equal" }
+      },
+      {
+        "id": "o_vig_w",
+        "type": "nodetool.output.Output",
+        "name": "vignette_width",
+        "data": { "name": "vignette_width" }
+      },
+      {
+        "id": "o_vig_h",
+        "type": "nodetool.output.Output",
+        "name": "vignette_height",
+        "data": { "name": "vignette_height" }
+      }
+    ],
+    "edges": [
+      {
+        "id": "s1",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "exposure_neutral",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s2",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "exposure_up",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s3",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "grade",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s4",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "channel_split",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s5",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cdl",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s6",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "color_balance",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s7",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "curves",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s8",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "film_look",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s9",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "hsl",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s10",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "lgg",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s11",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "split_toning",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s12",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "vignette",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s13",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "adaptive_contrast",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s14",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "detail",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s15",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "edge_enhance",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s16",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "equalize",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s17",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "rank_filter",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s18",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "levels",
+        "targetHandle": "image"
+      },
+
+      {
+        "id": "ca1",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_exposure_neutral",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb1",
+        "source": "exposure_neutral",
+        "sourceHandle": "output",
+        "target": "cmp_exposure_neutral",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca2",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_exposure_up",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb2",
+        "source": "exposure_up",
+        "sourceHandle": "output",
+        "target": "cmp_exposure_up",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca3",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_grade",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb3",
+        "source": "grade",
+        "sourceHandle": "output",
+        "target": "cmp_grade",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca4",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_channel_split",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb4",
+        "source": "channel_split",
+        "sourceHandle": "output",
+        "target": "cmp_channel_split",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca5",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_cdl",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb5",
+        "source": "cdl",
+        "sourceHandle": "output",
+        "target": "cmp_cdl",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca6",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_color_balance",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb6",
+        "source": "color_balance",
+        "sourceHandle": "output",
+        "target": "cmp_color_balance",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca7",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_curves",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb7",
+        "source": "curves",
+        "sourceHandle": "output",
+        "target": "cmp_curves",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca8",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_film_look",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb8",
+        "source": "film_look",
+        "sourceHandle": "output",
+        "target": "cmp_film_look",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca9",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_hsl",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb9",
+        "source": "hsl",
+        "sourceHandle": "output",
+        "target": "cmp_hsl",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca10",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_lgg",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb10",
+        "source": "lgg",
+        "sourceHandle": "output",
+        "target": "cmp_lgg",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca11",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_split_toning",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb11",
+        "source": "split_toning",
+        "sourceHandle": "output",
+        "target": "cmp_split_toning",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca12",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_vignette",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb12",
+        "source": "vignette",
+        "sourceHandle": "output",
+        "target": "cmp_vignette",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca13",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_adaptive",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb13",
+        "source": "adaptive_contrast",
+        "sourceHandle": "output",
+        "target": "cmp_adaptive",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca14",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_detail",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb14",
+        "source": "detail",
+        "sourceHandle": "output",
+        "target": "cmp_detail",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca15",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_edge",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb15",
+        "source": "edge_enhance",
+        "sourceHandle": "output",
+        "target": "cmp_edge",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca16",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_equalize",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb16",
+        "source": "equalize",
+        "sourceHandle": "output",
+        "target": "cmp_equalize",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca17",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_rank",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb17",
+        "source": "rank_filter",
+        "sourceHandle": "output",
+        "target": "cmp_rank",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca18",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_levels",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb18",
+        "source": "levels",
+        "sourceHandle": "output",
+        "target": "cmp_levels",
+        "targetHandle": "image_b"
+      },
+
+      {
+        "id": "mv",
+        "source": "vignette",
+        "sourceHandle": "output",
+        "target": "meta_vignette",
+        "targetHandle": "image"
+      },
+
+      {
+        "id": "z1",
+        "source": "cmp_exposure_neutral",
+        "sourceHandle": "equal",
+        "target": "o_exposure_neutral",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z2",
+        "source": "cmp_exposure_up",
+        "sourceHandle": "equal",
+        "target": "o_exposure_up",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z3",
+        "source": "cmp_grade",
+        "sourceHandle": "equal",
+        "target": "o_grade",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z4",
+        "source": "cmp_channel_split",
+        "sourceHandle": "equal",
+        "target": "o_channel_split",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z5",
+        "source": "cmp_cdl",
+        "sourceHandle": "equal",
+        "target": "o_cdl",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z6",
+        "source": "cmp_color_balance",
+        "sourceHandle": "equal",
+        "target": "o_color_balance",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z7",
+        "source": "cmp_curves",
+        "sourceHandle": "equal",
+        "target": "o_curves",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z8",
+        "source": "cmp_film_look",
+        "sourceHandle": "equal",
+        "target": "o_film_look",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z9",
+        "source": "cmp_hsl",
+        "sourceHandle": "equal",
+        "target": "o_hsl",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z10",
+        "source": "cmp_lgg",
+        "sourceHandle": "equal",
+        "target": "o_lgg",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z11",
+        "source": "cmp_split_toning",
+        "sourceHandle": "equal",
+        "target": "o_split_toning",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z12",
+        "source": "cmp_vignette",
+        "sourceHandle": "equal",
+        "target": "o_vignette",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z13",
+        "source": "cmp_adaptive",
+        "sourceHandle": "equal",
+        "target": "o_adaptive",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z14",
+        "source": "cmp_detail",
+        "sourceHandle": "equal",
+        "target": "o_detail",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z15",
+        "source": "cmp_edge",
+        "sourceHandle": "equal",
+        "target": "o_edge",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z16",
+        "source": "cmp_equalize",
+        "sourceHandle": "equal",
+        "target": "o_equalize",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z17",
+        "source": "cmp_rank",
+        "sourceHandle": "equal",
+        "target": "o_rank",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z18",
+        "source": "cmp_levels",
+        "sourceHandle": "equal",
+        "target": "o_levels",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z19",
+        "source": "meta_vignette",
+        "sourceHandle": "width",
+        "target": "o_vig_w",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z20",
+        "source": "meta_vignette",
+        "sourceHandle": "height",
+        "target": "o_vig_h",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/image_masks_effects_cli.json
+++ b/examples/workflows/image_masks_effects_cli.json
@@ -1,0 +1,1072 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "source",
+        "type": "lib.image.draw.LinearGradient",
+        "data": {
+          "width": 40,
+          "height": 24,
+          "color_a": {
+            "type": "color",
+            "value": "#ff0000"
+          },
+          "color_b": {
+            "type": "color",
+            "value": "#0000ff"
+          },
+          "angle": 0,
+          "midpoint": 0.5
+        }
+      },
+      {
+        "id": "alt",
+        "type": "lib.image.draw.Background",
+        "data": {
+          "width": 40,
+          "height": 24,
+          "color": {
+            "type": "color",
+            "value": "#00ff00"
+          }
+        }
+      },
+      {
+        "id": "grad",
+        "type": "lib.image.draw.RadialGradient",
+        "data": {
+          "width": 40,
+          "height": 24,
+          "color_inner": {
+            "type": "color",
+            "value": "#ffffff"
+          },
+          "color_outer": {
+            "type": "color",
+            "value": "#000000"
+          },
+          "radius": 0.5
+        }
+      },
+      {
+        "id": "silhouette",
+        "type": "lib.image.warp.Pad",
+        "data": {
+          "left": 0.25,
+          "top": 0.25,
+          "right": 0.25,
+          "bottom": 0.25,
+          "color": {
+            "type": "color",
+            "value": "#00000000"
+          }
+        }
+      },
+      {
+        "id": "mask_from",
+        "type": "lib.image.mask.FromImage",
+        "data": {
+          "mode": 1,
+          "invert": 0
+        }
+      },
+      {
+        "id": "mask_inv1",
+        "type": "lib.image.mask.Invert"
+      },
+      {
+        "id": "mask_inv2",
+        "type": "lib.image.mask.Invert"
+      },
+      {
+        "id": "mask_apply",
+        "type": "lib.image.mask.Apply",
+        "data": {
+          "invert": 0
+        }
+      },
+      {
+        "id": "tri_mask",
+        "type": "lib.image.Mask"
+      },
+      {
+        "id": "shuffle_id",
+        "type": "lib.image.channel.Shuffle",
+        "data": {
+          "r_from": 0,
+          "g_from": 1,
+          "b_from": 2,
+          "a_from": 3
+        }
+      },
+      {
+        "id": "shuffle_swap",
+        "type": "lib.image.channel.Shuffle",
+        "data": {
+          "r_from": 2,
+          "g_from": 1,
+          "b_from": 0,
+          "a_from": 3
+        }
+      },
+      {
+        "id": "merge",
+        "type": "lib.image.channel.Merge",
+        "data": {
+          "alpha_channel": 0
+        }
+      },
+      {
+        "id": "chroma",
+        "type": "lib.image.keyer.ChromaKey",
+        "data": {
+          "key_color": {
+            "type": "color",
+            "value": "#ff0000"
+          },
+          "tolerance": 0.4,
+          "softness": 0.1,
+          "spill": 0.2
+        }
+      },
+      {
+        "id": "luma",
+        "type": "lib.image.keyer.LumaKey",
+        "data": {
+          "low": 0.2,
+          "high": 0.8,
+          "softness": 0.1
+        }
+      },
+      {
+        "id": "fx_add",
+        "type": "lib.image.effects.Add",
+        "data": {
+          "gain": 0.5
+        }
+      },
+      {
+        "id": "fx_overlay_zero",
+        "type": "lib.image.effects.ColorOverlay",
+        "data": {
+          "color": {
+            "type": "color",
+            "value": "#00ff00"
+          },
+          "amount": 0
+        }
+      },
+      {
+        "id": "fx_overlay",
+        "type": "lib.image.effects.ColorOverlay",
+        "data": {
+          "color": {
+            "type": "color",
+            "value": "#00ff00"
+          },
+          "amount": 0.7
+        }
+      },
+      {
+        "id": "fx_shadow",
+        "type": "lib.image.effects.DropShadow",
+        "data": {
+          "color": {
+            "type": "color",
+            "value": "#000000"
+          },
+          "offset_x": 0.1,
+          "offset_y": 0.1,
+          "radius": 8,
+          "intensity": 1
+        }
+      },
+      {
+        "id": "fx_glow",
+        "type": "lib.image.effects.Glow",
+        "data": {
+          "threshold": 0.4,
+          "softness": 0.5,
+          "radius": 8,
+          "intensity": 1
+        }
+      },
+      {
+        "id": "fx_outline",
+        "type": "lib.image.effects.Outline",
+        "data": {
+          "color": {
+            "type": "color",
+            "value": "#ffff00"
+          },
+          "width": 3,
+          "threshold": 0.5
+        }
+      },
+      {
+        "id": "filt_contour",
+        "type": "lib.image.filter.Contour"
+      },
+      {
+        "id": "filt_smooth",
+        "type": "lib.image.filter.Smooth"
+      },
+      {
+        "id": "filt_expand",
+        "type": "lib.image.filter.Expand",
+        "data": {
+          "border": 4,
+          "fill": 0
+        }
+      },
+      {
+        "id": "cmp_mask_roundtrip",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "mask_from",
+          "label_b": "mask_inv2"
+        }
+      },
+      {
+        "id": "o_mask_roundtrip",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "mask_roundtrip_equal"
+        },
+        "name": "mask_roundtrip_equal"
+      },
+      {
+        "id": "cmp_mask_inverted",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "mask_from",
+          "label_b": "mask_inv1"
+        }
+      },
+      {
+        "id": "o_mask_inverted",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "mask_inverted_equal"
+        },
+        "name": "mask_inverted_equal"
+      },
+      {
+        "id": "cmp_mask_apply",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "mask_apply"
+        }
+      },
+      {
+        "id": "o_mask_apply",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "mask_apply_equal"
+        },
+        "name": "mask_apply_equal"
+      },
+      {
+        "id": "cmp_tri_mask",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "tri_mask"
+        }
+      },
+      {
+        "id": "o_tri_mask",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "tri_mask_equal"
+        },
+        "name": "tri_mask_equal"
+      },
+      {
+        "id": "cmp_shuffle_identity",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "shuffle_id"
+        }
+      },
+      {
+        "id": "o_shuffle_identity",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "shuffle_identity_equal"
+        },
+        "name": "shuffle_identity_equal"
+      },
+      {
+        "id": "cmp_shuffle_swapped",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "shuffle_swap"
+        }
+      },
+      {
+        "id": "o_shuffle_swapped",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "shuffle_swapped_equal"
+        },
+        "name": "shuffle_swapped_equal"
+      },
+      {
+        "id": "cmp_merge",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "merge"
+        }
+      },
+      {
+        "id": "o_merge",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "merge_equal"
+        },
+        "name": "merge_equal"
+      },
+      {
+        "id": "cmp_chroma",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "chroma"
+        }
+      },
+      {
+        "id": "o_chroma",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "chroma_equal"
+        },
+        "name": "chroma_equal"
+      },
+      {
+        "id": "cmp_luma",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "luma"
+        }
+      },
+      {
+        "id": "o_luma",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "luma_equal"
+        },
+        "name": "luma_equal"
+      },
+      {
+        "id": "cmp_fx_add",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "fx_add"
+        }
+      },
+      {
+        "id": "o_fx_add",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "fx_add_equal"
+        },
+        "name": "fx_add_equal"
+      },
+      {
+        "id": "cmp_overlay_zero",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "fx_overlay_zero"
+        }
+      },
+      {
+        "id": "o_overlay_zero",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "overlay_zero_equal"
+        },
+        "name": "overlay_zero_equal"
+      },
+      {
+        "id": "cmp_overlay",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "fx_overlay"
+        }
+      },
+      {
+        "id": "o_overlay",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "overlay_equal"
+        },
+        "name": "overlay_equal"
+      },
+      {
+        "id": "cmp_shadow",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "silhouette",
+          "label_b": "fx_shadow"
+        }
+      },
+      {
+        "id": "o_shadow",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "shadow_equal"
+        },
+        "name": "shadow_equal"
+      },
+      {
+        "id": "cmp_glow",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "fx_glow"
+        }
+      },
+      {
+        "id": "o_glow",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "glow_equal"
+        },
+        "name": "glow_equal"
+      },
+      {
+        "id": "cmp_outline",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "silhouette",
+          "label_b": "fx_outline"
+        }
+      },
+      {
+        "id": "o_outline",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "outline_equal"
+        },
+        "name": "outline_equal"
+      },
+      {
+        "id": "cmp_contour",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "filt_contour"
+        }
+      },
+      {
+        "id": "o_contour",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "contour_equal"
+        },
+        "name": "contour_equal"
+      },
+      {
+        "id": "cmp_smooth",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "filt_smooth"
+        }
+      },
+      {
+        "id": "o_smooth",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "smooth_equal"
+        },
+        "name": "smooth_equal"
+      },
+      {
+        "id": "meta_expand",
+        "type": "nodetool.image.GetMetadata"
+      },
+      {
+        "id": "o_expand_width",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "expand_width"
+        },
+        "name": "expand_width"
+      },
+      {
+        "id": "o_expand_height",
+        "type": "nodetool.output.Output",
+        "data": {
+          "name": "expand_height"
+        },
+        "name": "expand_height"
+      }
+    ],
+    "edges": [
+      {
+        "id": "e0",
+        "source": "alt",
+        "sourceHandle": "output",
+        "target": "silhouette",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e1",
+        "source": "grad",
+        "sourceHandle": "output",
+        "target": "mask_from",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e2",
+        "source": "mask_from",
+        "sourceHandle": "output",
+        "target": "mask_inv1",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e3",
+        "source": "mask_inv1",
+        "sourceHandle": "output",
+        "target": "mask_inv2",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e4",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "mask_apply",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e5",
+        "source": "mask_from",
+        "sourceHandle": "output",
+        "target": "mask_apply",
+        "targetHandle": "mask"
+      },
+      {
+        "id": "e6",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "tri_mask",
+        "targetHandle": "image1"
+      },
+      {
+        "id": "e7",
+        "source": "alt",
+        "sourceHandle": "output",
+        "target": "tri_mask",
+        "targetHandle": "image2"
+      },
+      {
+        "id": "e8",
+        "source": "mask_from",
+        "sourceHandle": "output",
+        "target": "tri_mask",
+        "targetHandle": "mask"
+      },
+      {
+        "id": "e9",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "shuffle_id",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e10",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "shuffle_swap",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e11",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "merge",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e12",
+        "source": "grad",
+        "sourceHandle": "output",
+        "target": "merge",
+        "targetHandle": "alpha"
+      },
+      {
+        "id": "e13",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "chroma",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e14",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "luma",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e15",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "fx_add",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e16",
+        "source": "alt",
+        "sourceHandle": "output",
+        "target": "fx_add",
+        "targetHandle": "over"
+      },
+      {
+        "id": "e17",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "fx_overlay_zero",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e18",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "fx_overlay",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e19",
+        "source": "silhouette",
+        "sourceHandle": "output",
+        "target": "fx_shadow",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e20",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "fx_glow",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e21",
+        "source": "silhouette",
+        "sourceHandle": "output",
+        "target": "fx_outline",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e22",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "filt_contour",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e23",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "filt_smooth",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e24",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "filt_expand",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e25",
+        "source": "mask_from",
+        "sourceHandle": "output",
+        "target": "cmp_mask_roundtrip",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e26",
+        "source": "mask_inv2",
+        "sourceHandle": "output",
+        "target": "cmp_mask_roundtrip",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e27",
+        "source": "cmp_mask_roundtrip",
+        "sourceHandle": "equal",
+        "target": "o_mask_roundtrip",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e28",
+        "source": "mask_from",
+        "sourceHandle": "output",
+        "target": "cmp_mask_inverted",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e29",
+        "source": "mask_inv1",
+        "sourceHandle": "output",
+        "target": "cmp_mask_inverted",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e30",
+        "source": "cmp_mask_inverted",
+        "sourceHandle": "equal",
+        "target": "o_mask_inverted",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e31",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_mask_apply",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e32",
+        "source": "mask_apply",
+        "sourceHandle": "output",
+        "target": "cmp_mask_apply",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e33",
+        "source": "cmp_mask_apply",
+        "sourceHandle": "equal",
+        "target": "o_mask_apply",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e34",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_tri_mask",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e35",
+        "source": "tri_mask",
+        "sourceHandle": "output",
+        "target": "cmp_tri_mask",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e36",
+        "source": "cmp_tri_mask",
+        "sourceHandle": "equal",
+        "target": "o_tri_mask",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e37",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_shuffle_identity",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e38",
+        "source": "shuffle_id",
+        "sourceHandle": "output",
+        "target": "cmp_shuffle_identity",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e39",
+        "source": "cmp_shuffle_identity",
+        "sourceHandle": "equal",
+        "target": "o_shuffle_identity",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e40",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_shuffle_swapped",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e41",
+        "source": "shuffle_swap",
+        "sourceHandle": "output",
+        "target": "cmp_shuffle_swapped",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e42",
+        "source": "cmp_shuffle_swapped",
+        "sourceHandle": "equal",
+        "target": "o_shuffle_swapped",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e43",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_merge",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e44",
+        "source": "merge",
+        "sourceHandle": "output",
+        "target": "cmp_merge",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e45",
+        "source": "cmp_merge",
+        "sourceHandle": "equal",
+        "target": "o_merge",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e46",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_chroma",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e47",
+        "source": "chroma",
+        "sourceHandle": "output",
+        "target": "cmp_chroma",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e48",
+        "source": "cmp_chroma",
+        "sourceHandle": "equal",
+        "target": "o_chroma",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e49",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_luma",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e50",
+        "source": "luma",
+        "sourceHandle": "output",
+        "target": "cmp_luma",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e51",
+        "source": "cmp_luma",
+        "sourceHandle": "equal",
+        "target": "o_luma",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e52",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_fx_add",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e53",
+        "source": "fx_add",
+        "sourceHandle": "output",
+        "target": "cmp_fx_add",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e54",
+        "source": "cmp_fx_add",
+        "sourceHandle": "equal",
+        "target": "o_fx_add",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e55",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_overlay_zero",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e56",
+        "source": "fx_overlay_zero",
+        "sourceHandle": "output",
+        "target": "cmp_overlay_zero",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e57",
+        "source": "cmp_overlay_zero",
+        "sourceHandle": "equal",
+        "target": "o_overlay_zero",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e58",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_overlay",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e59",
+        "source": "fx_overlay",
+        "sourceHandle": "output",
+        "target": "cmp_overlay",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e60",
+        "source": "cmp_overlay",
+        "sourceHandle": "equal",
+        "target": "o_overlay",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e61",
+        "source": "silhouette",
+        "sourceHandle": "output",
+        "target": "cmp_shadow",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e62",
+        "source": "fx_shadow",
+        "sourceHandle": "output",
+        "target": "cmp_shadow",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e63",
+        "source": "cmp_shadow",
+        "sourceHandle": "equal",
+        "target": "o_shadow",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e64",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_glow",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e65",
+        "source": "fx_glow",
+        "sourceHandle": "output",
+        "target": "cmp_glow",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e66",
+        "source": "cmp_glow",
+        "sourceHandle": "equal",
+        "target": "o_glow",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e67",
+        "source": "silhouette",
+        "sourceHandle": "output",
+        "target": "cmp_outline",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e68",
+        "source": "fx_outline",
+        "sourceHandle": "output",
+        "target": "cmp_outline",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e69",
+        "source": "cmp_outline",
+        "sourceHandle": "equal",
+        "target": "o_outline",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e70",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_contour",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e71",
+        "source": "filt_contour",
+        "sourceHandle": "output",
+        "target": "cmp_contour",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e72",
+        "source": "cmp_contour",
+        "sourceHandle": "equal",
+        "target": "o_contour",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e73",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_smooth",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "e74",
+        "source": "filt_smooth",
+        "sourceHandle": "output",
+        "target": "cmp_smooth",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "e75",
+        "source": "cmp_smooth",
+        "sourceHandle": "equal",
+        "target": "o_smooth",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e76",
+        "source": "filt_expand",
+        "sourceHandle": "output",
+        "target": "meta_expand",
+        "targetHandle": "image"
+      },
+      {
+        "id": "e77",
+        "source": "meta_expand",
+        "sourceHandle": "width",
+        "target": "o_expand_width",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e78",
+        "source": "meta_expand",
+        "sourceHandle": "height",
+        "target": "o_expand_height",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/image_warp_cli.json
+++ b/examples/workflows/image_warp_cli.json
@@ -1,0 +1,809 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "source",
+        "type": "lib.image.draw.Checkerboard",
+        "data": {
+          "width": 40,
+          "height": 24,
+          "cell_size": 8,
+          "color_a": {
+            "type": "color",
+            "value": "#ffffff"
+          },
+          "color_b": {
+            "type": "color",
+            "value": "#204080"
+          }
+        }
+      },
+      {
+        "id": "stamp",
+        "type": "lib.image.draw.Background",
+        "data": {
+          "width": 8,
+          "height": 8,
+          "color": {
+            "type": "color",
+            "value": "#ff0000"
+          }
+        }
+      },
+      {
+        "id": "displacement",
+        "type": "lib.image.draw.RadialGradient",
+        "data": {
+          "width": 40,
+          "height": 24,
+          "color_inner": {
+            "type": "color",
+            "value": "#ffffff"
+          },
+          "color_outer": {
+            "type": "color",
+            "value": "#000000"
+          },
+          "radius": 0.6
+        }
+      },
+      {
+        "id": "offset_zero",
+        "type": "lib.image.warp.Offset",
+        "data": {
+          "dx": 0,
+          "dy": 0,
+          "wrap": 1
+        }
+      },
+      {
+        "id": "offset_shift",
+        "type": "lib.image.warp.Offset",
+        "data": {
+          "dx": 0.25,
+          "dy": 0,
+          "wrap": 1
+        }
+      },
+      {
+        "id": "spherize_zero",
+        "type": "lib.image.warp.Spherize",
+        "data": {
+          "amount": 0
+        }
+      },
+      {
+        "id": "spherize_bulge",
+        "type": "lib.image.warp.Spherize",
+        "data": {
+          "amount": 0.6
+        }
+      },
+      {
+        "id": "affine_identity",
+        "type": "lib.image.warp.Affine",
+        "data": {
+          "target_width": 40,
+          "target_height": 24,
+          "m00": 1,
+          "m01": 0,
+          "tx": 0,
+          "m10": 0,
+          "m11": 1,
+          "ty": 0
+        }
+      },
+      {
+        "id": "affine_scaled",
+        "type": "lib.image.warp.Affine",
+        "data": {
+          "target_width": 60,
+          "target_height": 48,
+          "m00": 0.5,
+          "m01": 0,
+          "tx": 4,
+          "m10": 0,
+          "m11": 0.5,
+          "ty": 2
+        }
+      },
+      {
+        "id": "cornerpin_identity",
+        "type": "lib.image.warp.CornerPin",
+        "data": {
+          "h00": 1,
+          "h01": 0,
+          "h02": 0,
+          "h10": 0,
+          "h11": 1,
+          "h12": 0,
+          "h20": 0,
+          "h21": 0
+        }
+      },
+      {
+        "id": "cornerpin_skew",
+        "type": "lib.image.warp.CornerPin",
+        "data": {
+          "h00": 1,
+          "h01": 0.2,
+          "h02": 0,
+          "h10": 0.1,
+          "h11": 1,
+          "h12": 0,
+          "h20": 0,
+          "h21": 0
+        }
+      },
+      {
+        "id": "padded",
+        "type": "lib.image.warp.Pad",
+        "data": {
+          "left": 0.25,
+          "top": 0.5,
+          "right": 0.25,
+          "bottom": 0.5,
+          "color": {
+            "type": "color",
+            "value": "#000000"
+          }
+        }
+      },
+      {
+        "id": "polar",
+        "type": "lib.image.warp.PolarRemap",
+        "data": {
+          "mode": 0
+        }
+      },
+      {
+        "id": "displaced",
+        "type": "lib.image.warp.Displace",
+        "data": {
+          "amount_x": 4,
+          "amount_y": 4
+        }
+      },
+      {
+        "id": "pasted",
+        "type": "nodetool.image.Paste",
+        "data": {
+          "left": 4,
+          "top": 4
+        }
+      },
+      {
+        "id": "meta_pad",
+        "type": "nodetool.image.GetMetadata"
+      },
+      {
+        "id": "meta_affine",
+        "type": "nodetool.image.GetMetadata"
+      },
+      {
+        "id": "meta_paste",
+        "type": "nodetool.image.GetMetadata"
+      },
+      {
+        "id": "cmp_offset_zero",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "offset 0"
+        }
+      },
+      {
+        "id": "cmp_offset_shift",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "offset 8,4"
+        }
+      },
+      {
+        "id": "cmp_spherize_zero",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "spherize 0"
+        }
+      },
+      {
+        "id": "cmp_spherize_bulge",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "spherize 0.6"
+        }
+      },
+      {
+        "id": "cmp_affine_identity",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "affine identity"
+        }
+      },
+      {
+        "id": "cmp_cornerpin_identity",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "cornerpin identity"
+        }
+      },
+      {
+        "id": "cmp_cornerpin_skew",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "cornerpin skew"
+        }
+      },
+      {
+        "id": "cmp_polar",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "polar remap"
+        }
+      },
+      {
+        "id": "cmp_displaced",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "displaced"
+        }
+      },
+      {
+        "id": "cmp_pasted",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "pasted"
+        }
+      },
+      {
+        "id": "o_offset_zero",
+        "type": "nodetool.output.Output",
+        "name": "offset_zero_equal",
+        "data": {
+          "name": "offset_zero_equal"
+        }
+      },
+      {
+        "id": "o_offset_shift",
+        "type": "nodetool.output.Output",
+        "name": "offset_shift_equal",
+        "data": {
+          "name": "offset_shift_equal"
+        }
+      },
+      {
+        "id": "o_spherize_zero",
+        "type": "nodetool.output.Output",
+        "name": "spherize_zero_equal",
+        "data": {
+          "name": "spherize_zero_equal"
+        }
+      },
+      {
+        "id": "o_spherize_bulge",
+        "type": "nodetool.output.Output",
+        "name": "spherize_bulge_equal",
+        "data": {
+          "name": "spherize_bulge_equal"
+        }
+      },
+      {
+        "id": "o_affine_identity",
+        "type": "nodetool.output.Output",
+        "name": "affine_identity_equal",
+        "data": {
+          "name": "affine_identity_equal"
+        }
+      },
+      {
+        "id": "o_cornerpin_identity",
+        "type": "nodetool.output.Output",
+        "name": "cornerpin_identity_equal",
+        "data": {
+          "name": "cornerpin_identity_equal"
+        }
+      },
+      {
+        "id": "o_cornerpin_skew",
+        "type": "nodetool.output.Output",
+        "name": "cornerpin_skew_equal",
+        "data": {
+          "name": "cornerpin_skew_equal"
+        }
+      },
+      {
+        "id": "o_polar",
+        "type": "nodetool.output.Output",
+        "name": "polar_equal",
+        "data": {
+          "name": "polar_equal"
+        }
+      },
+      {
+        "id": "o_displaced",
+        "type": "nodetool.output.Output",
+        "name": "displaced_equal",
+        "data": {
+          "name": "displaced_equal"
+        }
+      },
+      {
+        "id": "o_pasted",
+        "type": "nodetool.output.Output",
+        "name": "pasted_equal",
+        "data": {
+          "name": "pasted_equal"
+        }
+      },
+      {
+        "id": "o_pad_w",
+        "type": "nodetool.output.Output",
+        "name": "pad_width",
+        "data": {
+          "name": "pad_width"
+        }
+      },
+      {
+        "id": "o_pad_h",
+        "type": "nodetool.output.Output",
+        "name": "pad_height",
+        "data": {
+          "name": "pad_height"
+        }
+      },
+      {
+        "id": "o_affine_w",
+        "type": "nodetool.output.Output",
+        "name": "affine_width",
+        "data": {
+          "name": "affine_width"
+        }
+      },
+      {
+        "id": "o_affine_h",
+        "type": "nodetool.output.Output",
+        "name": "affine_height",
+        "data": {
+          "name": "affine_height"
+        }
+      },
+      {
+        "id": "o_paste_w",
+        "type": "nodetool.output.Output",
+        "name": "paste_width",
+        "data": {
+          "name": "paste_width"
+        }
+      },
+      {
+        "id": "offset_full",
+        "type": "lib.image.warp.Offset",
+        "data": {
+          "dx": 1,
+          "dy": 0,
+          "wrap": 1
+        }
+      },
+      {
+        "id": "cmp_offset_full",
+        "type": "nodetool.compare.CompareImages",
+        "data": {
+          "label_a": "source",
+          "label_b": "offset dx=1 (full width)"
+        }
+      },
+      {
+        "id": "o_offset_full",
+        "type": "nodetool.output.Output",
+        "name": "offset_full_equal",
+        "data": {
+          "name": "offset_full_equal"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "id": "s1",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "offset_zero",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s2",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "offset_shift",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s3",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "spherize_zero",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s4",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "spherize_bulge",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s5",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "affine_identity",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s6",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "affine_scaled",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s7",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cornerpin_identity",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s8",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cornerpin_skew",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s9",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "padded",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s10",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "polar",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s11",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "displaced",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s12",
+        "source": "displacement",
+        "sourceHandle": "output",
+        "target": "displaced",
+        "targetHandle": "displacement"
+      },
+      {
+        "id": "s13",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "pasted",
+        "targetHandle": "image"
+      },
+      {
+        "id": "s14",
+        "source": "stamp",
+        "sourceHandle": "output",
+        "target": "pasted",
+        "targetHandle": "paste"
+      },
+      {
+        "id": "m1",
+        "source": "padded",
+        "sourceHandle": "output",
+        "target": "meta_pad",
+        "targetHandle": "image"
+      },
+      {
+        "id": "m2",
+        "source": "affine_scaled",
+        "sourceHandle": "output",
+        "target": "meta_affine",
+        "targetHandle": "image"
+      },
+      {
+        "id": "m3",
+        "source": "pasted",
+        "sourceHandle": "output",
+        "target": "meta_paste",
+        "targetHandle": "image"
+      },
+      {
+        "id": "ca1",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_offset_zero",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb1",
+        "source": "offset_zero",
+        "sourceHandle": "output",
+        "target": "cmp_offset_zero",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca2",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_offset_shift",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb2",
+        "source": "offset_shift",
+        "sourceHandle": "output",
+        "target": "cmp_offset_shift",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca3",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_spherize_zero",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb3",
+        "source": "spherize_zero",
+        "sourceHandle": "output",
+        "target": "cmp_spherize_zero",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca4",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_spherize_bulge",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb4",
+        "source": "spherize_bulge",
+        "sourceHandle": "output",
+        "target": "cmp_spherize_bulge",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca5",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_affine_identity",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb5",
+        "source": "affine_identity",
+        "sourceHandle": "output",
+        "target": "cmp_affine_identity",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca6",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_cornerpin_identity",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb6",
+        "source": "cornerpin_identity",
+        "sourceHandle": "output",
+        "target": "cmp_cornerpin_identity",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca7",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_cornerpin_skew",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb7",
+        "source": "cornerpin_skew",
+        "sourceHandle": "output",
+        "target": "cmp_cornerpin_skew",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca8",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_polar",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb8",
+        "source": "polar",
+        "sourceHandle": "output",
+        "target": "cmp_polar",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca9",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_displaced",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb9",
+        "source": "displaced",
+        "sourceHandle": "output",
+        "target": "cmp_displaced",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "ca10",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_pasted",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb10",
+        "source": "pasted",
+        "sourceHandle": "output",
+        "target": "cmp_pasted",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "z1",
+        "source": "cmp_offset_zero",
+        "sourceHandle": "equal",
+        "target": "o_offset_zero",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z2",
+        "source": "cmp_offset_shift",
+        "sourceHandle": "equal",
+        "target": "o_offset_shift",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z3",
+        "source": "cmp_spherize_zero",
+        "sourceHandle": "equal",
+        "target": "o_spherize_zero",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z4",
+        "source": "cmp_spherize_bulge",
+        "sourceHandle": "equal",
+        "target": "o_spherize_bulge",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z5",
+        "source": "cmp_affine_identity",
+        "sourceHandle": "equal",
+        "target": "o_affine_identity",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z6",
+        "source": "cmp_cornerpin_identity",
+        "sourceHandle": "equal",
+        "target": "o_cornerpin_identity",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z7",
+        "source": "cmp_cornerpin_skew",
+        "sourceHandle": "equal",
+        "target": "o_cornerpin_skew",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z8",
+        "source": "cmp_polar",
+        "sourceHandle": "equal",
+        "target": "o_polar",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z9",
+        "source": "cmp_displaced",
+        "sourceHandle": "equal",
+        "target": "o_displaced",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z10",
+        "source": "cmp_pasted",
+        "sourceHandle": "equal",
+        "target": "o_pasted",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z11",
+        "source": "meta_pad",
+        "sourceHandle": "width",
+        "target": "o_pad_w",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z12",
+        "source": "meta_pad",
+        "sourceHandle": "height",
+        "target": "o_pad_h",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z13",
+        "source": "meta_affine",
+        "sourceHandle": "width",
+        "target": "o_affine_w",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z14",
+        "source": "meta_affine",
+        "sourceHandle": "height",
+        "target": "o_affine_h",
+        "targetHandle": "value"
+      },
+      {
+        "id": "z15",
+        "source": "meta_paste",
+        "sourceHandle": "width",
+        "target": "o_paste_w",
+        "targetHandle": "value"
+      },
+      {
+        "id": "s15",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "offset_full",
+        "targetHandle": "image"
+      },
+      {
+        "id": "ca11",
+        "source": "source",
+        "sourceHandle": "output",
+        "target": "cmp_offset_full",
+        "targetHandle": "image_a"
+      },
+      {
+        "id": "cb11",
+        "source": "offset_full",
+        "sourceHandle": "output",
+        "target": "cmp_offset_full",
+        "targetHandle": "image_b"
+      },
+      {
+        "id": "z16",
+        "source": "cmp_offset_full",
+        "sourceHandle": "equal",
+        "target": "o_offset_full",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/packages/base-nodes/tests/image-processing-examples-run.test.ts
+++ b/packages/base-nodes/tests/image-processing-examples-run.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Executes the image-processing examples in `examples/workflows/` and asserts
+ * what each operation did to the pixels.
+ *
+ * Like `image-examples-run.test.ts`, these need a WebGPU adapter through Dawn.
+ * CI installs `mesa-vulkan-drivers` (lavapipe) for that; see
+ * [AGENTS.md § WebGPU on a headless machine]. Without a Vulkan ICD every case
+ * here fails with "No WebGPU adapter available (Node/Dawn)", which is a missing
+ * driver rather than a broken test.
+ *
+ * The assertions lean on one property throughout: **an operation set to its
+ * neutral value must return the original pixels exactly, and the same operation
+ * with a real setting must not.** `Exposure` at 0 stops, `Offset` at dx 0,
+ * an identity affine matrix, an identity channel shuffle, `ColorOverlay` at
+ * amount 0 — each is paired with an active counterpart. A node that ignored its
+ * input parameter would pass one half and fail the other, and a node that was
+ * silently a no-op fails the active half. "Something came back" proves neither.
+ *
+ * Comparisons run through `nodetool.compare.CompareImages`, which compares
+ * pixels including alpha — two images differing only in alpha compare unequal.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  NodeRegistry,
+  createGraphNodeTypeResolver
+} from "@nodetool-ai/node-sdk";
+import { ExecutionSession } from "@nodetool-ai/execution";
+import { registerBaseNodes } from "../src/index.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const EXAMPLES_DIR = path.resolve(__dirname, "../../../examples/workflows");
+
+async function run(file: string): Promise<Record<string, unknown[]>> {
+  const { graph } = JSON.parse(
+    fs.readFileSync(path.join(EXAMPLES_DIR, file), "utf8")
+  ) as { graph: unknown };
+  const registry = new NodeRegistry();
+  registerBaseNodes(registry);
+  const session = await ExecutionSession.create({
+    graph,
+    registry,
+    resolveNodeType: createGraphNodeTypeResolver(registry).resolveNodeType,
+    jobId: `image-proc-${file}`,
+    params: {}
+  } as never);
+  const result = await session.result;
+  expect(result.error ?? null, `${file} errored`).toBeNull();
+  expect(result.status, `${file} did not complete`).toBe("completed");
+  return (result.outputs ?? {}) as Record<string, unknown[]>;
+}
+
+/** Every listed output must report the image as changed from its reference. */
+function expectAllChanged(
+  out: Record<string, unknown[]>,
+  keys: string[]
+): void {
+  for (const k of keys) {
+    expect(out[k], `${k}: the operation left the image untouched`).toEqual([
+      false
+    ]);
+  }
+}
+
+describe("image_grading_cli", () => {
+  it("leaves the image alone at a neutral setting and changes it otherwise", async () => {
+    const out = await run("image_grading_cli.json");
+    // The pair that makes the rest meaningful: 0 stops is an exact identity,
+    // +1.5 stops is not. Without the first half, "changed" could just mean the
+    // op corrupts everything it touches.
+    expect(out["exposure_neutral_equal"]).toEqual([true]);
+    expect(out["exposure_up_equal"]).toEqual([false]);
+  });
+
+  it("applies every grading and enhancement operation", async () => {
+    const out = await run("image_grading_cli.json");
+    expectAllChanged(out, [
+      "grade_equal",
+      "channel_split_equal",
+      "cdl_equal",
+      "color_balance_equal",
+      "curves_equal",
+      "film_look_equal",
+      "hsl_equal",
+      "lgg_equal",
+      "split_toning_equal",
+      "vignette_equal",
+      "adaptive_equal",
+      "detail_equal",
+      "edge_equal",
+      "equalize_equal",
+      "rank_equal",
+      "levels_equal"
+    ]);
+    // Grading is per-pixel: the canvas is untouched.
+    expect(out["vignette_width"]).toEqual([48]);
+    expect(out["vignette_height"]).toEqual([32]);
+  });
+});
+
+describe("image_warp_cli", () => {
+  it("treats warp distances as fractions of the image, not pixels", async () => {
+    const out = await run("image_warp_cli.json");
+
+    // This is the trap. `Pad` takes each edge as a fraction of the
+    // corresponding dimension, so on a 40x24 image left/right 0.25 adds
+    // 0.25*40 per side and top/bottom 0.5 adds 0.5*24 per side. Read as pixels,
+    // `left: 5` would look like a 5px border; it actually asks for five times
+    // the width.
+    expect(out["pad_width"]).toEqual([60]);
+    expect(out["pad_height"]).toEqual([48]);
+
+    // Offset is the same: dx is a fraction of the width, so a whole-width
+    // shift with wrap on comes back byte-identical.
+    expect(out["offset_zero_equal"]).toEqual([true]);
+    expect(out["offset_shift_equal"]).toEqual([false]);
+    expect(out["offset_full_equal"]).toEqual([true]);
+  });
+
+  it("returns the original pixels for an identity transform", async () => {
+    const out = await run("image_warp_cli.json");
+    expect(out["affine_identity_equal"]).toEqual([true]);
+    expect(out["cornerpin_identity_equal"]).toEqual([true]);
+    expect(out["spherize_zero_equal"]).toEqual([true]);
+
+    expectAllChanged(out, [
+      "cornerpin_skew_equal",
+      "spherize_bulge_equal",
+      "polar_equal",
+      "displaced_equal",
+      "pasted_equal"
+    ]);
+  });
+
+  it("resamples to the affine target size and leaves Paste's canvas alone", async () => {
+    const out = await run("image_warp_cli.json");
+    // Affine sizes the output explicitly, unlike the other warps.
+    expect(out["affine_width"]).toEqual([60]);
+    expect(out["affine_height"]).toEqual([48]);
+    // Paste composites into the existing canvas rather than growing it.
+    expect(out["paste_width"]).toEqual([40]);
+  });
+});
+
+describe("image_masks_effects_cli", () => {
+  it("inverts a mask and inverts it back", async () => {
+    const out = await run("image_masks_effects_cli.json");
+    expect(out["mask_inverted_equal"]).toEqual([false]);
+    expect(out["mask_roundtrip_equal"]).toEqual([true]);
+  });
+
+  it("passes the image through an identity channel shuffle", async () => {
+    const out = await run("image_masks_effects_cli.json");
+    // r<-r, g<-g, b<-b, a<-a rebuilds the same image; swapping R and B does
+    // not. The source runs red to blue precisely so the swap is detectable —
+    // on a source where R and B happen to match, the swap is a real identity
+    // and proves nothing.
+    expect(out["shuffle_identity_equal"]).toEqual([true]);
+    expect(out["shuffle_swapped_equal"]).toEqual([false]);
+  });
+
+  it("treats ColorOverlay at amount 0 as a no-op", async () => {
+    const out = await run("image_masks_effects_cli.json");
+    expect(out["overlay_zero_equal"]).toEqual([true]);
+    expect(out["overlay_equal"]).toEqual([false]);
+  });
+
+  it("applies masks, keys, effects and filters", async () => {
+    const out = await run("image_masks_effects_cli.json");
+    expectAllChanged(out, [
+      // Apply reads coverage from the mask's *alpha*, so the mask comes from
+      // FromImage in luminance mode (1). Mode 0 reads alpha, and an opaque
+      // source yields a mask that covers everything — a silent no-op.
+      "mask_apply_equal",
+      "tri_mask_equal",
+      "merge_equal",
+      "chroma_equal",
+      "luma_equal",
+      "fx_add_equal",
+      // DropShadow and Outline work on the alpha silhouette, so they are fed a
+      // transparently-padded image; against a fully opaque frame there is no
+      // edge to draw and both are no-ops.
+      "shadow_equal",
+      "glow_equal",
+      "outline_equal",
+      "contour_equal",
+      "smooth_equal"
+    ]);
+  });
+
+  it("expands by a pixel border", async () => {
+    const out = await run("image_masks_effects_cli.json");
+    // Unlike the warp nodes, `Expand.border` is in pixels: 4 per side on a
+    // 40x24 image. Units are per-parameter here — `Outline.width` and
+    // `DropShadow.radius` are pixels too, while `DropShadow.offset_x` is a
+    // fraction.
+    expect(out["expand_width"]).toEqual([48]);
+    expect(out["expand_height"]).toEqual([32]);
+  });
+});


### PR DESCRIPTION
Round three, following #4649 and #4653. Covered node types go
**281 → 322 of 645 (43.6% → 49.9%)** — past halfway.

Three examples finish the image family that a WebGPU adapter made reachable:

- `image_grading_cli` — CDL, colour balance, curves, film look, HSL,
  lift/gamma/gain, split toning, vignette, exposure, grade, channel split,
  levels, and the enhance filters
- `image_warp_cli` — affine, corner pin, displace, offset, pad, polar remap,
  spherize, paste
- `image_masks_effects_cli` — masks, channel shuffle/merge, chroma and luma
  keys, add/overlay/shadow/glow/outline, contour/smooth/expand

## How these are asserted

Every operation gets a **pair**: set to its neutral value it must return the
original pixels *exactly*, and set to a real value it must not. Exposure at 0
stops, an identity affine matrix, an identity corner pin, Spherize at 0, an
identity channel shuffle, ColorOverlay at amount 0.

That pairing is what makes the result mean something. A node that ignored its
parameter passes one half and fails the other. A node that was silently a no-op
fails the active half. "An image came back" proves neither.

Comparisons run through `CompareImages`, which I checked compares **alpha** too —
two images differing only in alpha come back unequal — before relying on it for
the alpha-based operations.

## Four parameters that mean the opposite of what they read like

Each of these looked like a broken node first. I read the source before
concluding anything, and all four were the example holding it wrong:

- **`lib.image.warp` distances are fractions of the image, not pixels.**
  `Pad(left: 5)` on a 40×24 image asks for *five times the width* and returns
  440 wide. `0.25` is the 25% border it reads like. `Offset(dx: 1)` is a
  whole-width shift, so with wrap on it returns the original image.
- **Units are per-parameter elsewhere.** `filter.Expand.border`,
  `effects.Outline.width` and `effects.DropShadow.radius` are pixels, while
  `DropShadow.offset_x` is a fraction — mixed units inside a single node.
  `Outline` at `width: 0.1` rounds to zero and draws nothing.
- **`mask.Apply` reads coverage from the mask's alpha channel**, and
  `mask.FromImage` mode 0 reads alpha while mode 1 reads luminance. Derive a
  mask from an opaque image in mode 0 and you get one that covers everything —
  `Apply` is then a silent no-op.
- **`DropShadow` and `Outline` work on the alpha silhouette.** Against a fully
  opaque frame there is nothing to draw and both are no-ops.

One more was purely my test design: the first source ran green→white, which
makes R and B identical, so an R/B channel swap was a genuine identity and
proved nothing. The source now runs red→blue.

## A CLI bug this surfaced

**`npm run workflow` never exits after a workflow containing an image node.**
The run completes and prints correct outputs, then the process hangs. Nothing
destroys the Dawn `GPUDevice` acquired in `packages/gpu/src/context.ts`, so the
event loop never drains. Workflows with no image node exit 0; the test harness
is unaffected (all ten cases here run in 647 ms).

This is **not new to this PR** — `image_geometry_cli.json` from #4653 hangs the
same way. It also means my "runs clean through `npm run workflow`" claim on that
PR was wrong: I grepped the output of a `timeout`-killed process, which reports
success whether it exited or hung. The README now records the behaviour. I have
not fixed it here, because destroying the device is right for a one-shot CLI run
and wrong for a long-lived server, so it wants its own change.

## Verification

On Node 22.22.1 with a Vulkan ICD present:

- base-nodes: **2694 passed**, 31 files
- typecheck clean
- the three new examples produce correct outputs via the CLI (then hang, as above)

Assertions checked by mutation: making the neutral exposure non-neutral broke
the identity half; reverting `Pad` to pixel-looking values returned **440** where
the test demands 60; perturbing the identity channel shuffle broke that pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)