### PR TITLE
Fix the CLI hang after a GPU workflow, and 13 examples that could never run

### DIFF
--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -21,63 +21,70 @@ Input merge order:
 3. `--inputs-json`
 4. `--input`
 
-## Legacy examples
+## Routing examples
 
 ```bash
 npm run workflow -- ./examples/workflows/hello_reroute.json --json
-npm run workflow -- ./examples/workflows/concat_text.json --json
 npm run workflow -- ./examples/workflows/if_true_route.json --json
-npm run workflow -- ./examples/workflows/list_range_foreach.json --json
-npm run workflow -- ./examples/workflows/combine_dictionary.json --json
 ```
 
 ## CLI input/output examples
 
 ```bash
-# 1) hello_input_output_cli.json
+# hello_input_output_cli.json
 npm run workflow -- ./examples/workflows/hello_input_output_cli.json --input text='hello from cli'
 
-# 2) concat_text_cli.json
-npm run workflow -- ./examples/workflows/concat_text_cli.json --inputs-json '{"a":"Node","b":"Tool"}'
-
-# 3) format_text_cli.json
-npm run workflow -- ./examples/workflows/format_text_cli.json --inputs-json '{"template":"Hi {{ name }} from {{ city }}","name":"Ada","city":"Paris"}'
-
-# 4) replace_text_cli.json
-npm run workflow -- ./examples/workflows/replace_text_cli.json --input text='a-b-a-b' --input old='a' --input new='x'
-
-# 5) compare_numbers_cli.json
-npm run workflow -- ./examples/workflows/compare_numbers_cli.json --input a=9 --input b=4 --input comparison='>'
-
-# 6) if_branch_cli.json
+# if_branch_cli.json
 npm run workflow -- ./examples/workflows/if_branch_cli.json --input condition=true --input payload='{"kind":"demo","value":42}'
 
-# 7) list_range_cli.json
-npm run workflow -- ./examples/workflows/list_range_cli.json --input start=1 --input stop=10 --input step=2
-
-# 8) list_slice_cli.json
-npm run workflow -- ./examples/workflows/list_slice_cli.json --input values='[0,1,2,3,4,5]' --input start=2 --input stop=5
-
-# 9) list_aggregates_cli.json
-npm run workflow -- ./examples/workflows/list_aggregates_cli.json --input values='[3,6,9,12]'
-
-# 10) combine_dictionary_cli.json
-npm run workflow -- ./examples/workflows/combine_dictionary_cli.json --input dict_a='{"left":1,"shared":"L"}' --input dict_b='{"right":2,"shared":"R"}'
-
-# 11) get_dictionary_value_cli.json
-npm run workflow -- ./examples/workflows/get_dictionary_value_cli.json --input dictionary='{"name":"nodetool","lang":"ts"}' --input key='lang' --input default='missing'
-
-# 12) parse_json_dictionary_cli.json
-npm run workflow -- ./examples/workflows/parse_json_dictionary_cli.json --input json_string='"{\"project\":\"nodetool\",\"version\":1}"'
-
-# 13) import_csv_select_cli.json
+# import_csv_select_cli.json
 npm run workflow -- ./examples/workflows/import_csv_select_cli.json --input csv_data=$'team,score,city\nA,10,NY\nB,5,SF' --input columns='team,score'
 
-# 14) import_csv_aggregate_cli.json
+# import_csv_aggregate_cli.json
 npm run workflow -- ./examples/workflows/import_csv_aggregate_cli.json --input csv_data=$'team,score\nA,10\nA,20\nB,5' --input columns='team' --input aggregation='sum'
 
-# 15) wait_node_cli.json
+# wait_node_cli.json
 npm run workflow -- ./examples/workflows/wait_node_cli.json --input input='{"message":"hello"}' --input timeout_seconds=0.02
+```
+
+## Trigger examples
+
+One per trigger type, offline and deterministic. These carry no model node, so an
+assertion never depends on an LLM.
+`packages/base-nodes/tests/trigger-examples-run.test.ts` delivers an event to
+each and asserts the payload that comes out.
+
+```bash
+npm run workflow -- ./examples/workflows/trigger_webhook_cli.json
+npm run workflow -- ./examples/workflows/trigger_manual_cli.json
+npm run workflow -- ./examples/workflows/trigger_interval_cli.json
+npm run workflow -- ./examples/workflows/trigger_filewatch_cli.json
+```
+
+The interval and file-watch triggers wait on a live scheduler or filesystem
+watcher, so run bare they never finish — that is the node behaving correctly.
+The test wakes them with a delivered event instead.
+
+## Python-node examples
+
+These need the Python bridge (`nodetool.worker`); without it they fail to
+resolve the node type.
+
+```bash
+npm run workflow -- ./examples/workflows/lib_librosa_mfcc_cli.json
+npm run workflow -- ./examples/workflows/lib_pedalboard_reverb_cli.json
+```
+
+## DSL examples
+
+TypeScript rather than JSON — run with `nodetool run`, which accepts a `.ts`
+file directly.
+
+```bash
+npm run dev:nodetool -- run ./examples/workflows/add_numbers.ts
+npm run dev:nodetool -- run ./examples/workflows/concat_text.ts
+npm run dev:nodetool -- run ./examples/workflows/list_operations.ts
+npm run dev:nodetool -- run ./examples/workflows/flux_3_dogs.ts   # needs FAL_API_KEY
 ```
 
 ## Offline node examples
@@ -178,17 +185,21 @@ than growing it: 3×2 tiles of a 64×64 image is still 64×64.
 
 ## Agent + OpenAI provider examples
 
+These call a real provider, so they need `OPENAI_API_KEY`. Each carries its
+model on the `LanguageModelInput` node, so `nodetool validate` passes without
+running them.
+
 ```bash
-# 16) agent_openai_basic_cli.json
+# agent_openai_basic_cli.json
 npm run workflow -- ./examples/workflows/agent_openai_basic_cli.json --input prompt='Write one sentence about workflow testing.'
 
-# 17) agent_openai_with_thread_cli.json
+# agent_openai_with_thread_cli.json
 npm run workflow -- ./examples/workflows/agent_openai_with_thread_cli.json --input title='OpenAI Thread Demo' --input prompt='List two automation benefits.'
 
-# 18) agent_openai_with_history_cli.json
+# agent_openai_with_history_cli.json
 npm run workflow -- ./examples/workflows/agent_openai_with_history_cli.json --input history='[{"role":"user","content":"I created provider abstractions."},{"role":"assistant","content":"Great, now add integration tests."}]' --input prompt='Suggest one next step.'
 
-# 19) agent_openai_with_messages_cli.json
+# agent_openai_with_messages_cli.json
 npm run workflow -- ./examples/workflows/agent_openai_with_messages_cli.json --input message='{"id":"m1","thread_id":"t1","role":"user","provider":"openai","model":"gpt-4o","content":[{"type":"text","text":"Summarize this plan in one line."}]}'
 ```
 
@@ -205,7 +216,6 @@ npm run workflow -- ./examples/workflows/if_branch_cli.json --params-file /tmp/w
 
 - By default, CLI output includes resolved `params` and final `outputs`.
 - Use `--json` to print the full raw run result.
-- `parse_json_dictionary_cli.json` expects `json_string` to be a string containing JSON, so the value itself must be quoted as shown above.
 - Workflow shape:
   - `graph.nodes` + `graph.edges`
   - optional `params` keyed by input-node `name`

--- a/examples/workflows/agent_openai_basic_cli.json
+++ b/examples/workflows/agent_openai_basic_cli.json
@@ -1,28 +1,62 @@
 {
   "graph": {
     "nodes": [
-      { "id": "system", "type": "test.Input", "name": "system" },
-      { "id": "prompt", "type": "test.Input", "name": "prompt" },
-      { "id": "model", "type": "nodetool.input.LanguageModelInput", "name": "model" },
-      { "id": "agent", "type": "nodetool.agents.Agent" },
-      { "id": "sink", "type": "nodetool.control.Reroute", "name": "agent_text" }
+      {
+        "id": "system",
+        "type": "nodetool.input.StringInput",
+        "name": "system",
+        "data": {
+          "name": "system"
+        }
+      },
+      {
+        "id": "prompt",
+        "type": "nodetool.input.StringInput",
+        "name": "prompt",
+        "data": {
+          "name": "prompt"
+        }
+      },
+      {
+        "id": "model",
+        "type": "nodetool.input.LanguageModelInput",
+        "name": "model",
+        "data": {
+          "value": {
+            "type": "language_model",
+            "provider": "openai",
+            "id": "gpt-4o",
+            "name": "GPT-4o"
+          },
+          "name": "model"
+        }
+      },
+      {
+        "id": "agent",
+        "type": "nodetool.agents.Agent"
+      },
+      {
+        "id": "sink",
+        "type": "nodetool.control.Reroute",
+        "name": "agent_text"
+      }
     ],
     "edges": [
       {
         "source": "system",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "agent",
         "targetHandle": "system"
       },
       {
         "source": "prompt",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "agent",
         "targetHandle": "prompt"
       },
       {
         "source": "model",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "agent",
         "targetHandle": "model"
       },
@@ -44,4 +78,3 @@
     }
   }
 }
-

--- a/examples/workflows/agent_openai_with_history_cli.json
+++ b/examples/workflows/agent_openai_with_history_cli.json
@@ -1,35 +1,76 @@
 {
   "graph": {
     "nodes": [
-      { "id": "system", "type": "test.Input", "name": "system" },
-      { "id": "prompt", "type": "test.Input", "name": "prompt" },
-      { "id": "history", "type": "test.Input", "name": "history" },
-      { "id": "model", "type": "nodetool.input.LanguageModelInput", "name": "model" },
-      { "id": "agent", "type": "nodetool.agents.Agent" },
-      { "id": "sink", "type": "nodetool.control.Reroute", "name": "agent_text" }
+      {
+        "id": "system",
+        "type": "nodetool.input.StringInput",
+        "name": "system",
+        "data": {
+          "name": "system"
+        }
+      },
+      {
+        "id": "prompt",
+        "type": "nodetool.input.StringInput",
+        "name": "prompt",
+        "data": {
+          "name": "prompt"
+        }
+      },
+      {
+        "id": "history",
+        "type": "nodetool.input.MessageListInput",
+        "name": "history",
+        "data": {
+          "name": "history"
+        }
+      },
+      {
+        "id": "model",
+        "type": "nodetool.input.LanguageModelInput",
+        "name": "model",
+        "data": {
+          "value": {
+            "type": "language_model",
+            "provider": "openai",
+            "id": "gpt-4o",
+            "name": "GPT-4o"
+          },
+          "name": "model"
+        }
+      },
+      {
+        "id": "agent",
+        "type": "nodetool.agents.Agent"
+      },
+      {
+        "id": "sink",
+        "type": "nodetool.control.Reroute",
+        "name": "agent_text"
+      }
     ],
     "edges": [
       {
         "source": "system",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "agent",
         "targetHandle": "system"
       },
       {
         "source": "prompt",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "agent",
         "targetHandle": "prompt"
       },
       {
         "source": "history",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "agent",
         "targetHandle": "history"
       },
       {
         "source": "model",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "agent",
         "targetHandle": "model"
       },
@@ -45,8 +86,14 @@
     "system": "You are a coding assistant.",
     "prompt": "Continue from history and suggest one next action.",
     "history": [
-      { "role": "user", "content": "I built a workflow runner in TS." },
-      { "role": "assistant", "content": "Great. Add provider support next." }
+      {
+        "role": "user",
+        "content": "I built a workflow runner in TS."
+      },
+      {
+        "role": "assistant",
+        "content": "Great. Add provider support next."
+      }
     ],
     "model": {
       "provider": "openai",
@@ -55,4 +102,3 @@
     }
   }
 }
-

--- a/examples/workflows/agent_openai_with_messages_cli.json
+++ b/examples/workflows/agent_openai_with_messages_cli.json
@@ -1,17 +1,51 @@
 {
   "graph": {
     "nodes": [
-      { "id": "message", "type": "nodetool.input.MessageInput", "name": "message" },
-      { "id": "extract", "type": "nodetool.input.MessageDeconstructor" },
-      { "id": "system", "type": "test.Input", "name": "system" },
-      { "id": "model", "type": "nodetool.input.LanguageModelInput", "name": "model" },
-      { "id": "agent", "type": "nodetool.agents.Agent" },
-      { "id": "sink", "type": "nodetool.control.Reroute", "name": "agent_text" }
+      {
+        "id": "message",
+        "type": "nodetool.input.MessageInput",
+        "name": "message"
+      },
+      {
+        "id": "extract",
+        "type": "nodetool.input.MessageDeconstructor"
+      },
+      {
+        "id": "system",
+        "type": "nodetool.input.StringInput",
+        "name": "system",
+        "data": {
+          "name": "system"
+        }
+      },
+      {
+        "id": "model",
+        "type": "nodetool.input.LanguageModelInput",
+        "name": "model",
+        "data": {
+          "value": {
+            "type": "language_model",
+            "provider": "openai",
+            "id": "gpt-4o",
+            "name": "GPT-4o"
+          },
+          "name": "model"
+        }
+      },
+      {
+        "id": "agent",
+        "type": "nodetool.agents.Agent"
+      },
+      {
+        "id": "sink",
+        "type": "nodetool.control.Reroute",
+        "name": "agent_text"
+      }
     ],
     "edges": [
       {
         "source": "message",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "extract",
         "targetHandle": "value"
       },
@@ -23,13 +57,13 @@
       },
       {
         "source": "system",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "agent",
         "targetHandle": "system"
       },
       {
         "source": "model",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "agent",
         "targetHandle": "model"
       },
@@ -49,7 +83,12 @@
       "role": "user",
       "provider": "openai",
       "model": "gpt-4o",
-      "content": [{ "type": "text", "text": "Summarize why provider abstractions matter." }]
+      "content": [
+        {
+          "type": "text",
+          "text": "Summarize why provider abstractions matter."
+        }
+      ]
     },
     "model": {
       "provider": "openai",
@@ -58,4 +97,3 @@
     }
   }
 }
-

--- a/examples/workflows/agent_openai_with_thread_cli.json
+++ b/examples/workflows/agent_openai_with_thread_cli.json
@@ -1,19 +1,67 @@
 {
   "graph": {
     "nodes": [
-      { "id": "title", "type": "test.Input", "name": "title" },
-      { "id": "system", "type": "test.Input", "name": "system" },
-      { "id": "prompt", "type": "test.Input", "name": "prompt" },
-      { "id": "model", "type": "nodetool.input.LanguageModelInput", "name": "model" },
-      { "id": "thread", "type": "nodetool.agents.CreateThread" },
-      { "id": "thread_sink", "type": "nodetool.control.Reroute", "name": "thread_id" },
-      { "id": "agent", "type": "nodetool.agents.Agent" },
-      { "id": "text_sink", "type": "nodetool.control.Reroute", "name": "agent_text" }
+      {
+        "id": "title",
+        "type": "nodetool.input.StringInput",
+        "name": "title",
+        "data": {
+          "name": "title"
+        }
+      },
+      {
+        "id": "system",
+        "type": "nodetool.input.StringInput",
+        "name": "system",
+        "data": {
+          "name": "system"
+        }
+      },
+      {
+        "id": "prompt",
+        "type": "nodetool.input.StringInput",
+        "name": "prompt",
+        "data": {
+          "name": "prompt"
+        }
+      },
+      {
+        "id": "model",
+        "type": "nodetool.input.LanguageModelInput",
+        "name": "model",
+        "data": {
+          "value": {
+            "type": "language_model",
+            "provider": "openai",
+            "id": "gpt-4o-mini",
+            "name": "GPT-4o Mini"
+          },
+          "name": "model"
+        }
+      },
+      {
+        "id": "thread",
+        "type": "nodetool.agents.CreateThread"
+      },
+      {
+        "id": "thread_sink",
+        "type": "nodetool.control.Reroute",
+        "name": "thread_id"
+      },
+      {
+        "id": "agent",
+        "type": "nodetool.agents.Agent"
+      },
+      {
+        "id": "text_sink",
+        "type": "nodetool.control.Reroute",
+        "name": "agent_text"
+      }
     ],
     "edges": [
       {
         "source": "title",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "thread",
         "targetHandle": "title"
       },
@@ -31,19 +79,19 @@
       },
       {
         "source": "system",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "agent",
         "targetHandle": "system"
       },
       {
         "source": "prompt",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "agent",
         "targetHandle": "prompt"
       },
       {
         "source": "model",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "agent",
         "targetHandle": "model"
       },
@@ -66,4 +114,3 @@
     }
   }
 }
-

--- a/examples/workflows/hello_input_output_cli.json
+++ b/examples/workflows/hello_input_output_cli.json
@@ -1,13 +1,24 @@
 {
   "graph": {
     "nodes": [
-      { "id": "src", "type": "test.Input", "name": "text" },
-      { "id": "sink", "type": "nodetool.control.Reroute", "name": "output" }
+      {
+        "id": "src",
+        "type": "nodetool.input.StringInput",
+        "name": "text",
+        "data": {
+          "name": "text"
+        }
+      },
+      {
+        "id": "sink",
+        "type": "nodetool.control.Reroute",
+        "name": "output"
+      }
     ],
     "edges": [
       {
         "source": "src",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "sink",
         "targetHandle": "input_value"
       }
@@ -15,4 +26,3 @@
   },
   "params": {}
 }
-

--- a/examples/workflows/hello_reroute.json
+++ b/examples/workflows/hello_reroute.json
@@ -1,13 +1,24 @@
 {
   "graph": {
     "nodes": [
-      { "id": "src", "type": "test.Input", "name": "text" },
-      { "id": "sink", "type": "nodetool.control.Reroute", "name": "output" }
+      {
+        "id": "src",
+        "type": "nodetool.input.StringInput",
+        "name": "text",
+        "data": {
+          "name": "text"
+        }
+      },
+      {
+        "id": "sink",
+        "type": "nodetool.control.Reroute",
+        "name": "output"
+      }
     ],
     "edges": [
       {
         "source": "src",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "sink",
         "targetHandle": "input_value"
       }

--- a/examples/workflows/if_branch_cli.json
+++ b/examples/workflows/if_branch_cli.json
@@ -1,22 +1,47 @@
 {
   "graph": {
     "nodes": [
-      { "id": "condition", "type": "test.Input", "name": "condition" },
-      { "id": "payload", "type": "test.Input", "name": "payload" },
-      { "id": "if", "type": "nodetool.control.If" },
-      { "id": "when_true", "type": "nodetool.control.Reroute", "name": "when_true" },
-      { "id": "when_false", "type": "nodetool.control.Reroute", "name": "when_false" }
+      {
+        "id": "condition",
+        "type": "nodetool.input.BooleanInput",
+        "name": "condition",
+        "data": {
+          "name": "condition"
+        }
+      },
+      {
+        "id": "payload",
+        "type": "nodetool.input.StringInput",
+        "name": "payload",
+        "data": {
+          "name": "payload"
+        }
+      },
+      {
+        "id": "if",
+        "type": "nodetool.control.If"
+      },
+      {
+        "id": "when_true",
+        "type": "nodetool.control.Reroute",
+        "name": "when_true"
+      },
+      {
+        "id": "when_false",
+        "type": "nodetool.control.Reroute",
+        "name": "when_false"
+      }
     ],
     "edges": [
       {
         "source": "condition",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "if",
         "targetHandle": "condition"
       },
       {
         "source": "payload",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "if",
         "targetHandle": "value"
       },
@@ -36,4 +61,3 @@
   },
   "params": {}
 }
-

--- a/examples/workflows/if_true_route.json
+++ b/examples/workflows/if_true_route.json
@@ -1,22 +1,47 @@
 {
   "graph": {
     "nodes": [
-      { "id": "payload", "type": "test.Input", "name": "payload" },
-      { "id": "condition", "type": "test.Input", "name": "condition" },
-      { "id": "if", "type": "nodetool.control.If" },
-      { "id": "true_sink", "type": "nodetool.control.Reroute", "name": "when_true" },
-      { "id": "false_sink", "type": "nodetool.control.Reroute", "name": "when_false" }
+      {
+        "id": "payload",
+        "type": "nodetool.input.StringInput",
+        "name": "payload",
+        "data": {
+          "name": "payload"
+        }
+      },
+      {
+        "id": "condition",
+        "type": "nodetool.input.BooleanInput",
+        "name": "condition",
+        "data": {
+          "name": "condition"
+        }
+      },
+      {
+        "id": "if",
+        "type": "nodetool.control.If"
+      },
+      {
+        "id": "true_sink",
+        "type": "nodetool.control.Reroute",
+        "name": "when_true"
+      },
+      {
+        "id": "false_sink",
+        "type": "nodetool.control.Reroute",
+        "name": "when_false"
+      }
     ],
     "edges": [
       {
         "source": "payload",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "if",
         "targetHandle": "value"
       },
       {
         "source": "condition",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "if",
         "targetHandle": "condition"
       },
@@ -35,10 +60,7 @@
     ]
   },
   "params": {
-    "payload": {
-      "kind": "example",
-      "value": 42
-    },
+    "payload": "{\"kind\": \"example\", \"value\": 42}",
     "condition": true
   }
 }

--- a/examples/workflows/import_csv_aggregate_cli.json
+++ b/examples/workflows/import_csv_aggregate_cli.json
@@ -1,17 +1,48 @@
 {
   "graph": {
     "nodes": [
-      { "id": "csv", "type": "test.Input", "name": "csv_data" },
-      { "id": "groups", "type": "test.Input", "name": "columns" },
-      { "id": "agg_name", "type": "test.Input", "name": "aggregation" },
-      { "id": "import", "type": "nodetool.data.ImportCSV" },
-      { "id": "aggregate", "type": "nodetool.data.Aggregate" },
-      { "id": "sink", "type": "nodetool.control.Reroute", "name": "grouped" }
+      {
+        "id": "csv",
+        "type": "nodetool.input.StringInput",
+        "name": "csv_data",
+        "data": {
+          "name": "csv_data"
+        }
+      },
+      {
+        "id": "groups",
+        "type": "nodetool.input.StringInput",
+        "name": "columns",
+        "data": {
+          "name": "columns"
+        }
+      },
+      {
+        "id": "agg_name",
+        "type": "nodetool.input.StringInput",
+        "name": "aggregation",
+        "data": {
+          "name": "aggregation"
+        }
+      },
+      {
+        "id": "import",
+        "type": "nodetool.data.ImportCSV"
+      },
+      {
+        "id": "aggregate",
+        "type": "nodetool.data.Aggregate"
+      },
+      {
+        "id": "sink",
+        "type": "nodetool.control.Reroute",
+        "name": "grouped"
+      }
     ],
     "edges": [
       {
         "source": "csv",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "import",
         "targetHandle": "csv_data"
       },
@@ -23,13 +54,13 @@
       },
       {
         "source": "groups",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "aggregate",
         "targetHandle": "columns"
       },
       {
         "source": "agg_name",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "aggregate",
         "targetHandle": "aggregation"
       },
@@ -47,4 +78,3 @@
     "aggregation": "sum"
   }
 }
-

--- a/examples/workflows/import_csv_select_cli.json
+++ b/examples/workflows/import_csv_select_cli.json
@@ -1,16 +1,40 @@
 {
   "graph": {
     "nodes": [
-      { "id": "csv", "type": "test.Input", "name": "csv_data" },
-      { "id": "columns", "type": "test.Input", "name": "columns" },
-      { "id": "import", "type": "nodetool.data.ImportCSV" },
-      { "id": "select", "type": "nodetool.data.SelectColumn" },
-      { "id": "sink", "type": "nodetool.control.Reroute", "name": "dataframe" }
+      {
+        "id": "csv",
+        "type": "nodetool.input.StringInput",
+        "name": "csv_data",
+        "data": {
+          "name": "csv_data"
+        }
+      },
+      {
+        "id": "columns",
+        "type": "nodetool.input.StringInput",
+        "name": "columns",
+        "data": {
+          "name": "columns"
+        }
+      },
+      {
+        "id": "import",
+        "type": "nodetool.data.ImportCSV"
+      },
+      {
+        "id": "select",
+        "type": "nodetool.data.SelectColumn"
+      },
+      {
+        "id": "sink",
+        "type": "nodetool.control.Reroute",
+        "name": "dataframe"
+      }
     ],
     "edges": [
       {
         "source": "csv",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "import",
         "targetHandle": "csv_data"
       },
@@ -22,7 +46,7 @@
       },
       {
         "source": "columns",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "select",
         "targetHandle": "columns"
       },
@@ -39,4 +63,3 @@
     "columns": "team,score"
   }
 }
-

--- a/examples/workflows/lib_librosa_mfcc_cli.json
+++ b/examples/workflows/lib_librosa_mfcc_cli.json
@@ -1,13 +1,44 @@
 {
   "graph": {
     "nodes": [
-      { "id": "audio_in", "type": "test.Input", "name": "audio_path" },
-      { "id": "mfcc", "type": "lib.librosa.analysis.MFCC", "data": { "n_mfcc": 13, "n_fft": 2048, "hop_length": 512, "fmin": 0, "fmax": 8000 } },
-      { "id": "out", "type": "nodetool.control.Reroute", "name": "output" }
+      {
+        "id": "audio_in",
+        "type": "nodetool.input.StringInput",
+        "name": "audio_path",
+        "data": {
+          "name": "audio_path"
+        }
+      },
+      {
+        "id": "mfcc",
+        "type": "lib.librosa.analysis.MFCC",
+        "data": {
+          "n_mfcc": 13,
+          "n_fft": 2048,
+          "hop_length": 512,
+          "fmin": 0,
+          "fmax": 8000
+        }
+      },
+      {
+        "id": "out",
+        "type": "nodetool.control.Reroute",
+        "name": "output"
+      }
     ],
     "edges": [
-      { "source": "audio_in", "sourceHandle": "value", "target": "mfcc", "targetHandle": "audio" },
-      { "source": "mfcc", "sourceHandle": "output", "target": "out", "targetHandle": "input_value" }
+      {
+        "source": "audio_in",
+        "sourceHandle": "output",
+        "target": "mfcc",
+        "targetHandle": "audio"
+      },
+      {
+        "source": "mfcc",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "input_value"
+      }
     ]
   },
   "params": {}

--- a/examples/workflows/lib_pedalboard_reverb_cli.json
+++ b/examples/workflows/lib_pedalboard_reverb_cli.json
@@ -1,13 +1,43 @@
 {
   "graph": {
     "nodes": [
-      { "id": "audio_in", "type": "test.Input", "name": "audio_path" },
-      { "id": "reverb", "type": "lib.pedalboard.Reverb", "data": { "room_scale": 0.5, "damping": 0.5, "wet_level": 0.15, "dry_level": 0.5 } },
-      { "id": "out", "type": "nodetool.control.Reroute", "name": "output" }
+      {
+        "id": "audio_in",
+        "type": "nodetool.input.StringInput",
+        "name": "audio_path",
+        "data": {
+          "name": "audio_path"
+        }
+      },
+      {
+        "id": "reverb",
+        "type": "lib.pedalboard.Reverb",
+        "data": {
+          "room_scale": 0.5,
+          "damping": 0.5,
+          "wet_level": 0.15,
+          "dry_level": 0.5
+        }
+      },
+      {
+        "id": "out",
+        "type": "nodetool.control.Reroute",
+        "name": "output"
+      }
     ],
     "edges": [
-      { "source": "audio_in", "sourceHandle": "value", "target": "reverb", "targetHandle": "audio" },
-      { "source": "reverb", "sourceHandle": "output", "target": "out", "targetHandle": "input_value" }
+      {
+        "source": "audio_in",
+        "sourceHandle": "output",
+        "target": "reverb",
+        "targetHandle": "audio"
+      },
+      {
+        "source": "reverb",
+        "sourceHandle": "output",
+        "target": "out",
+        "targetHandle": "input_value"
+      }
     ]
   },
   "params": {}

--- a/examples/workflows/wait_node_cli.json
+++ b/examples/workflows/wait_node_cli.json
@@ -1,16 +1,42 @@
 {
   "graph": {
     "nodes": [
-      { "id": "value", "type": "test.Input", "name": "input" },
-      { "id": "timeout", "type": "test.Input", "name": "timeout_seconds" },
-      { "id": "wait", "type": "nodetool.triggers.Wait" },
-      { "id": "sink", "type": "nodetool.control.Reroute", "name": "wait_result" }
+      {
+        "id": "value",
+        "type": "nodetool.input.StringInput",
+        "name": "input",
+        "data": {
+          "name": "input"
+        }
+      },
+      {
+        "id": "timeout",
+        "type": "nodetool.input.FloatInput",
+        "name": "timeout_seconds",
+        "data": {
+          "name": "timeout_seconds"
+        }
+      },
+      {
+        "id": "wait",
+        "type": "nodetool.triggers.Wait"
+      },
+      {
+        "id": "sink",
+        "type": "nodetool.control.Reroute",
+        "name": "wait_result"
+      }
     ],
     "edges": [
-      { "source": "value", "sourceHandle": "value", "target": "wait", "targetHandle": "input" },
+      {
+        "source": "value",
+        "sourceHandle": "output",
+        "target": "wait",
+        "targetHandle": "input"
+      },
       {
         "source": "timeout",
-        "sourceHandle": "value",
+        "sourceHandle": "output",
         "target": "wait",
         "targetHandle": "timeout_seconds"
       },
@@ -23,7 +49,7 @@
     ]
   },
   "params": {
-    "input": { "message": "hello" },
+    "input": "{\"message\": \"hello\"}",
     "timeout_seconds": 0.05
   }
 }

--- a/packages/gpu/src/node.ts
+++ b/packages/gpu/src/node.ts
@@ -43,6 +43,17 @@ let devicePromise: Promise<GPUDevice> | null = null;
  * then fires after the instance is finalized, it locks a freed mutex and the
  * process dies with `SIGSEGV` in `dawn::native::InstanceBase::ProcessEvents`
  * (no JS error, just a hard crash). Retaining every instance prevents that.
+ *
+ * The cost of retaining is that **the Node event loop never drains again**: the
+ * re-scheduled `ProcessEvents()` stays an active handle for the process
+ * lifetime. A long-lived host (the server, the Electron backend) does not care.
+ * A one-shot host must call `process.exit()` once its work is done rather than
+ * setting `process.exitCode` and returning, or it hangs after printing its
+ * results — with the workflow having completed perfectly. `nodetool workflows
+ * run` and `scripts/run-workflow.mjs` both exit explicitly for this reason.
+ *
+ * There is deliberately no teardown export here: destroying the device does not
+ * stop the runner, and releasing the instance is the SIGSEGV above.
  */
 const retainedDawnInstances: GPU[] = [];
 

--- a/scripts/run-workflow.mjs
+++ b/scripts/run-workflow.mjs
@@ -485,7 +485,16 @@ async function main() {
   }
 
   if (pythonBridge) pythonBridge.close();
-  process.exitCode = result.status === "completed" ? 0 : 1;
+  // Exit explicitly rather than setting `exitCode` and letting the loop drain.
+  // A workflow containing an image node acquires a Dawn GPU instance, and
+  // dawn.node's AsyncRunner re-schedules `ProcessEvents()` on the event loop
+  // for as long as that instance lives — which is the process lifetime, because
+  // releasing it segfaults (see `retainedDawnInstances` in
+  // packages/gpu/src/node.ts). The loop therefore never drains and the run
+  // hangs after printing its results. Every write above is awaited, so there is
+  // nothing buffered left to lose. `nodetool workflows run` already exits this
+  // way for the same reason.
+  process.exit(result.status === "completed" ? 0 : 1);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
Three defects, all found by trying to actually use the shipped examples while
building #4649 / #4653 / #4655.

## 1. `npm run workflow` never exited after an image workflow

The run completed and printed correct results, then the process hung forever.

`dawn.node`'s AsyncRunner re-schedules `ProcessEvents()` on the Node event loop
for as long as the Dawn instance lives, and the instance is retained for the
process lifetime because releasing it segfaults (`retainedDawnInstances` in
`packages/gpu/src/node.ts`). So the loop never drains.
`scripts/run-workflow.mjs` set `process.exitCode` and returned — it now calls
`process.exit()`, which is what `nodetool workflows run` already did. **That
surface never hung**, which is why this went unnoticed.

Every write before the exit is awaited, so nothing buffered is lost, and a
failing workflow still exits 1 (verified).

The retention comment explained why the instance is kept but not what keeping it
costs. It now says a one-shot host must exit explicitly, and that there is
deliberately no teardown export: destroying the device does not stop the runner,
and releasing the instance is the segfault.

## 2. Thirteen examples used a node type that only exists in tests

`test.Input` is registered ad hoc inside unit tests and is **not in the node
registry**. Every example using it failed immediately for anyone who ran it —
including five the README advertised with copy-pasteable commands. They were
structurally plausible and never executed, which is the exact failure mode the
example-coverage work exists to close.

Each is now a real `nodetool.input.*` node, chosen from the type its own `params`
value supplies, with edges corrected from the `value` handle `test.Input` emitted
on to the `output` handle the real inputs use. Several also wired an existing
`LanguageModelInput` from `value`, so they were broken twice over.

Two params were dicts and no input node accepts a dict; both fed `any`-typed
ports (`If.value`, `Wait.input`), so they are now the JSON text of the same
value. The four agent examples carry their model on the `LanguageModelInput`
node rather than only in `params`, so they validate without being run.

| | before | after |
|---|---|---|
| pass `nodetool validate` | 0 of 13 | 11 of 13 |
| run offline end to end | 0 | 7 |

The two exceptions are the Python-node examples, whose types live outside the TS
registry — expected, and unchanged by this PR.

## 3. The README described a directory that had drifted away from it

**Thirteen entries pointed at files that do not exist**, and **ten example files
went unmentioned** — including the four trigger examples from #4642. It now
lists what is actually there (routing, CLI I/O, triggers, Python nodes, DSL
`.ts`) and says what each needs to run.

## Verification

Node 22.22.1, Vulkan ICD present:

- image workflows through `npm run workflow`: **exit 0** (were hanging at 124)
- non-image workflows: still exit 0; a failing workflow: still exit 1
- 11 of 13 repaired examples pass `nodetool validate`; 7 execute offline, checked by exit code
- base-nodes **2666 passed** / 30 files, execution **128 passed** / 15 files
- `packages/gpu` lint and typecheck clean

## One thing I could not fix

`npm run build:packages` failed twice during this work, on a different package
each time, each passing standalone immediately after — the reason I have been
building with `--concurrency=2`. I could not reproduce it: three consecutive
full-concurrency `--force` builds all passed 59/59. Both original failures
happened under heavy concurrent load on a 4-CPU box, so resource exhaustion is
the likely cause, but I have no evidence and did not want to change the build
system on a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)