### PR TITLE
fix(web): don't infer Local auth mode when /api/config is unreachable

### DIFF
--- a/web/src/lib/__tests__/runtimeConfig.test.ts
+++ b/web/src/lib/__tests__/runtimeConfig.test.ts
@@ -52,11 +52,51 @@ describe("runtimeConfig", () => {
   it("falls back to local defaults when the endpoint is unavailable", async () => {
     mockFetch.mockResolvedValue(jsonResponse(null, false));
 
-    const { loadRuntimeConfig, isAuthRequired } = await import("../runtimeConfig");
+    const { loadRuntimeConfig, isAuthRequired, isRuntimeConfigFromBackend } =
+      await import("../runtimeConfig");
     const config = await loadRuntimeConfig();
 
     expect(config.authMode).toBe("local");
     expect(isAuthRequired()).toBe(false);
+    expect(isRuntimeConfigFromBackend()).toBe(false);
+  });
+
+  it("retries before giving up on the endpoint", async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error("503"))
+      .mockRejectedValueOnce(new Error("503"))
+      .mockResolvedValue(jsonResponse({ authMode: "supabase" }));
+
+    const { loadRuntimeConfig, isAuthRequired, isRuntimeConfigFromBackend } =
+      await import("../runtimeConfig");
+    await loadRuntimeConfig();
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(isAuthRequired()).toBe(true);
+    expect(isRuntimeConfigFromBackend()).toBe(true);
+  });
+
+  // A bundle built with Supabase credentials targets a Supabase backend. An
+  // unreachable /api/config must not downgrade it to Local mode, which would
+  // log the user in as the single local user against a server enforcing auth.
+  it("falls back to supabase mode when the build carries Supabase credentials", async () => {
+    mockFetch.mockRejectedValue(new Error("backend down"));
+    process.env.VITE_SUPABASE_URL = "https://x.supabase.co";
+    process.env.VITE_SUPABASE_ANON_KEY = "anon";
+    try {
+      const { loadRuntimeConfig, isAuthRequired } = await import(
+        "../runtimeConfig"
+      );
+      const config = await loadRuntimeConfig();
+
+      expect(config.authMode).toBe("supabase");
+      expect(config.supabaseUrl).toBe("https://x.supabase.co");
+      expect(config.supabaseAnonKey).toBe("anon");
+      expect(isAuthRequired()).toBe(true);
+    } finally {
+      delete process.env.VITE_SUPABASE_URL;
+      delete process.env.VITE_SUPABASE_ANON_KEY;
+    }
   });
 
   it("caches after the first successful load", async () => {

--- a/web/src/lib/buildEnv.ts
+++ b/web/src/lib/buildEnv.ts
@@ -1,0 +1,26 @@
+/**
+ * Read a build-time `VITE_*` variable.
+ *
+ * `import.meta` is a syntax error under Jest's CommonJS transform, and the
+ * modules that reference it directly (`BASE_URL.ts`, `env.ts`,
+ * `supabaseClient.ts`) are all mocked away in tests for that reason. Modules
+ * that are exercised under Jest read their build-time values through here
+ * instead: `process.env` first, then `import.meta.env` behind a `Function`
+ * constructor so the transformer never sees the token.
+ */
+export const getBuildEnv = (name: string): string | undefined => {
+  if (typeof process !== "undefined" && process.env?.[name]) {
+    return process.env[name];
+  }
+  try {
+    const getEnv = new Function(
+      'return typeof import.meta !== "undefined" ? import.meta.env : undefined;'
+    );
+    const env = getEnv() as Record<string, string | undefined> | undefined;
+    const value = env?.[name];
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+  } catch {
+    // import.meta is unavailable in this environment (Jest CJS, SSR).
+    return undefined;
+  }
+};

--- a/web/src/lib/runtimeConfig.ts
+++ b/web/src/lib/runtimeConfig.ts
@@ -9,8 +9,13 @@
  *
  * Build-time `VITE_*` values remain a fallback in `supabaseClient.ts` for the
  * dev server and pure-static hosting where `/api/config` is not reachable.
+ * They are the fallback for the auth *mode* too: a bundle built with Supabase
+ * credentials is a Supabase deployment even when its backend is momentarily
+ * unreachable. Assuming Local mode there would silently log the user in as the
+ * single local user against a server that enforces auth.
  */
 import { BASE_URL } from "../stores/BASE_URL";
+import { getBuildEnv } from "./buildEnv";
 
 export type AuthMode = "local" | "supabase";
 
@@ -35,27 +40,50 @@ export interface RuntimeConfig {
   version: string | null;
 }
 
-const DEFAULT_CONFIG: RuntimeConfig = {
-  authMode: "local",
-  supabaseUrl: null,
-  supabaseAnonKey: null,
-  authRedirectUrl: null,
-  googleWorkspace: false,
-  googleScopes: [],
-  version: null
+/**
+ * Config to use when `/api/config` cannot be read: the build-time `VITE_*`
+ * values. A build carrying Supabase credentials targets a Supabase backend, so
+ * its auth mode falls back to `supabase`; a build without them (the dev server,
+ * the desktop app) falls back to `local`.
+ */
+const fallbackConfig = (): RuntimeConfig => {
+  const supabaseUrl = getBuildEnv("VITE_SUPABASE_URL") ?? null;
+  const supabaseAnonKey = getBuildEnv("VITE_SUPABASE_ANON_KEY") ?? null;
+  return {
+    authMode: supabaseUrl && supabaseAnonKey ? "supabase" : "local",
+    supabaseUrl,
+    supabaseAnonKey,
+    authRedirectUrl: getBuildEnv("VITE_AUTH_REDIRECT_URL") ?? null,
+    googleWorkspace: false,
+    googleScopes: [],
+    version: null
+  };
 };
 
-let current: RuntimeConfig = DEFAULT_CONFIG;
+/** Attempts against `/api/config`, and the per-attempt timeout. */
+const FETCH_ATTEMPTS = 3;
+const FETCH_TIMEOUT_MS = 4000;
+const RETRY_DELAY_MS = [300, 900];
+
+let current: RuntimeConfig = fallbackConfig();
 let loaded = false;
+let fromBackend = false;
 
 /** The last-loaded runtime config (defaults until `loadRuntimeConfig` resolves). */
 export const getRuntimeConfig = (): RuntimeConfig => current;
+
+/**
+ * True when the config in use came from the backend. False means
+ * `/api/config` was unreachable and the build-time fallback is in effect —
+ * the auth mode is inferred, not confirmed.
+ */
+export const isRuntimeConfigFromBackend = (): boolean => fromBackend;
 
 /** True when the backend enforces authentication (Supabase mode). */
 export const isAuthRequired = (): boolean => current.authMode === "supabase";
 
 const coerce = (data: unknown): RuntimeConfig => {
-  if (!data || typeof data !== "object") return DEFAULT_CONFIG;
+  if (!data || typeof data !== "object") return fallbackConfig();
   const d = data as Partial<RuntimeConfig>;
   return {
     authMode: d.authMode === "supabase" ? "supabase" : "local",
@@ -71,28 +99,51 @@ const coerce = (data: unknown): RuntimeConfig => {
 /** True when the backend offers the Google Workspace tools and nodes. */
 export const isGoogleWorkspaceEnabled = (): boolean => current.googleWorkspace;
 
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const fetchConfig = async (): Promise<RuntimeConfig> => {
+  const res = await fetch(`${BASE_URL}/api/config`, {
+    headers: { Accept: "application/json" },
+    // Don't let a slow/unreachable backend block app boot.
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+  });
+  if (!res.ok) throw new Error(`GET /api/config failed: ${res.status}`);
+  return coerce(await res.json());
+};
+
 /**
  * Fetch public runtime config from the backend (`GET /api/config`). Cached
- * after the first successful load. On failure (e.g. an older server without
- * the endpoint) it keeps the defaults so the app still boots.
+ * after the first load. Retried a few times, because a cold or restarting
+ * server answering one request with a 503 is not a reason to change the app's
+ * auth mode.
+ *
+ * When every attempt fails (an older server without the endpoint, a backend
+ * that is down) it falls back to the build-time config so the app still boots.
  */
 export const loadRuntimeConfig = async (): Promise<RuntimeConfig> => {
   if (loaded) return current;
-  try {
-    const res = await fetch(`${BASE_URL}/api/config`, {
-      headers: { Accept: "application/json" },
-      // Don't let a slow/unreachable backend block app boot.
-      signal: AbortSignal.timeout(5000)
-    });
-    if (!res.ok) throw new Error(`GET /api/config failed: ${res.status}`);
-    current = coerce(await res.json());
-  } catch (err) {
-    console.warn(
-      "Runtime config unavailable; falling back to local auth defaults.",
-      err
-    );
-    current = DEFAULT_CONFIG;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < FETCH_ATTEMPTS; attempt++) {
+    if (attempt > 0) {
+      await sleep(RETRY_DELAY_MS[attempt - 1] ?? 900);
+    }
+    try {
+      current = await fetchConfig();
+      fromBackend = true;
+      loaded = true;
+      return current;
+    } catch (err) {
+      lastError = err;
+    }
   }
+  current = fallbackConfig();
+  fromBackend = false;
   loaded = true;
+  console.warn(
+    `Runtime config unavailable after ${FETCH_ATTEMPTS} attempts; ` +
+      `falling back to build-time config (auth mode: ${current.authMode}).`,
+    lastError
+  );
   return current;
 };

--- a/web/src/stores/useAuth.ts
+++ b/web/src/stores/useAuth.ts
@@ -5,8 +5,10 @@ import type { Session, User, Provider } from "@supabase/supabase-js"; // Import 
 import {
   getRuntimeConfig,
   isAuthRequired,
-  isGoogleWorkspaceEnabled
+  isGoogleWorkspaceEnabled,
+  isRuntimeConfigFromBackend
 } from "../lib/runtimeConfig";
+import { getBuildEnv } from "../lib/buildEnv";
 import { syncGoogleProviderToken } from "../lib/googleSession";
 
 type OAuthProviderSupabase = Extract<Provider, "google" | "facebook">;
@@ -32,23 +34,7 @@ export const getAuthRedirectUrl = (): string => {
   if (fromRuntime) {
     return fromRuntime;
   }
-  // Try to use process.env first (for Jest tests) to avoid SyntaxError with import.meta outside a module
-  let configured;
-  if (typeof process !== "undefined" && process.env && process.env.VITE_AUTH_REDIRECT_URL) {
-      configured = process.env.VITE_AUTH_REDIRECT_URL;
-  } else {
-      // Use Function constructor to hide import.meta from Jest's Babel transformer
-      try {
-          const getEnv = new Function('return typeof import.meta !== "undefined" ? import.meta.env : undefined;');
-          const env = getEnv();
-          if (env) {
-              configured = env.VITE_AUTH_REDIRECT_URL;
-          }
-      } catch (_) {
-          // Ignore — import.meta may not be available in all environments
-      }
-  }
-
+  const configured = getBuildEnv("VITE_AUTH_REDIRECT_URL");
   if (typeof configured === "string" && configured.length > 0) {
     return configured;
   }
@@ -128,7 +114,12 @@ export const useAuth = create<LoginStore>((set, get) => ({
 
     if (!isAuthRequired()) {
       // Backend runs in Local mode — no login screen, single local user.
-      console.info("Auth: Local mode, setting state to logged_in.");
+      console.info(
+        isRuntimeConfigFromBackend()
+          ? "Auth: Local mode, setting state to logged_in."
+          : "Auth: Local mode inferred (backend config unreachable, no " +
+              "build-time Supabase credentials); setting state to logged_in."
+      );
       set({
         state: "logged_in", // Assume logged in for local dev
         session: null,


### PR DESCRIPTION
## What

`app.nodetool.ai` logs `Auth: Local mode, setting state to logged_in` in production, and signs the visitor in as the single local user.

## Why

`app.nodetool.ai` is a static Cloudflare Pages build (`web-deploy.yml`) that talks to `https://api.nodetool.ai`. It learns its auth mode from `GET /api/config` at boot. That call is a single attempt with a 5s timeout, and on failure `loadRuntimeConfig` fell back to a hardcoded `authMode: "local"`:

```ts
current = DEFAULT_CONFIG; // authMode: "local"
```

`useAuth.initialize()` reads that as "backend runs in Local mode", skips the login screen entirely, and sets `state: "logged_in"` with `user: { id: "1" }`.

The backend is currently answering that request with a Fly `503` (and otherwise hanging), so the fallback fires:

```
$ curl -m 45 https://api.nodetool.ai/api/config
HTTP/2 503
server: Fly/6e81cc776
```

The `503` is separate infrastructure trouble, but the frontend's response to it is wrong on its own: an unreachable backend is not evidence that auth is disabled, and Local mode is the least-safe thing to assume.

## Changes

- **Retry `/api/config`** — 3 attempts, 4s timeout each, 300/900ms backoff. One `503` from a cold or restarting server no longer flips the app's auth mode.
- **Fall back to the build-time config, not to a hardcoded local default.** A bundle built with `VITE_SUPABASE_URL` + `VITE_SUPABASE_ANON_KEY` targets a Supabase backend, so its fallback mode is `supabase`. `supabaseClient.ts` already treated those vars as the fallback for the *credentials* ("the dev server and pure-static hosting where `/api/config` is not reachable") while `runtimeConfig.ts` contradicted it on the *mode*. Builds without them — the dev server, the desktop app — still fall back to `local`.
- **`isRuntimeConfigFromBackend()`** reports whether the mode was confirmed by the backend or inferred from the build, and the Local-mode log line now says which.
- **`lib/buildEnv.ts`** holds the build-time env read. `import.meta` is a syntax error under Jest's CommonJS transform — which is why every module touching it directly is mocked away in `jest.config.ts` — so the `process.env`-first lookup `useAuth.getAuthRedirectUrl` already carried is now shared instead of duplicated.

With this, a down backend leaves `app.nodetool.ai` on the login screen instead of a fake logged-in session.

## Testing

- `npx jest src/lib/__tests__/runtimeConfig.test.ts src/stores/__tests__/useAuth.test.ts` — 9 passed. New cases cover the retry path and the Supabase-credentials fallback.
- `npx eslint` on the changed files — clean (one pre-existing `no-explicit-any` warning on the test's `fetch` stub).
- `npx tsc --noEmit` — the 20 errors reported are all pre-existing `TS2307`s for unbuilt `@nodetool-ai/*-nodes` dist in this sandbox; none are in the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgjECj2tXCSpZZLa52PkCu)_