### PR TITLE
Make the example suites actually gate the examples they assert on

### DIFF
--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -169,12 +169,10 @@ this; locally, `apt-get install -y mesa-vulkan-drivers` or see
 [AGENTS.md § WebGPU on a headless machine](../../AGENTS.md#webgpu-on-a-headless-machine)
 for the no-root route.
 
-**`npm run workflow` does not exit after one of these.** The run itself finishes
-and prints its outputs, but the process then hangs: nothing destroys the Dawn
-`GPUDevice` acquired in `packages/gpu/src/context.ts`, so the event loop never
-drains. Interrupt it once you have the output, and don't put an image workflow
-in a script that waits on the exit code. Workflows with no image node exit
-normally, and the test harness is unaffected.
+These used to hang the CLI after printing their results: Dawn keeps a handle on
+the event loop for the process lifetime, so a host that waits for the loop to
+drain never exits. `scripts/run-workflow.mjs` now exits explicitly once the run
+is done, so they finish normally and the exit code is usable in a script.
 
 ```bash
 # Background, radial/angular/diamond gradients, seeded noise

--- a/turbo.json
+++ b/turbo.json
@@ -37,7 +37,15 @@
         "vitest.config.*",
         "jest.config.*",
         "tsconfig*.json",
-        "package.json"
+        "package.json",
+        // Fixtures the base-nodes suites read from outside their own package:
+        // the shipped example graphs. Without these, editing an example does
+        // not change the test task's hash, so turbo replays a cached pass and
+        // the suites that assert on those very files never run. CI restores
+        // `.turbo/cache` with a prefix `restore-keys`, so the stale hit
+        // survives across runs and a broken example reports green.
+        "$TURBO_ROOT$/examples/workflows/**",
+        "$TURBO_ROOT$/packages/base-nodes/nodetool/examples/**"
       ],
       "outputs": [],
       "env": ["NODETOOL_LOG_LEVEL"]


### PR DESCRIPTION
Follow-up to #4659, which merged before this was ready.

## The example tests were not gating the examples

The `test` task's `inputs` in `turbo.json` listed only files inside each
package. The base-nodes suites read their fixtures from **outside** their
package — `examples/workflows/` and the shipped gallery under
`packages/base-nodes/nodetool/examples/`. Neither path was an input, so editing
an example did not change the task's hash and turbo replayed a cached pass. The
suites that assert on those very files never ran.

That is not just a local convenience. `.github/actions/setup-build` restores
`.turbo/cache` with a prefix `restore-keys`, so every CI run inherits an earlier
run's cache and the stale hit survives across runs. **A pull request that broke
an example reported success.**

`--affected` *does* select base-nodes for a root-level change, which is what
makes this easy to miss: the task is scheduled, the log looks green, and nothing
executes.

## Demonstrated, both directions, for both paths

Corrupting the string `text_transforms_cli` asserts on:

| | turbo | result |
|---|---|---|
| before | `cache hit, replaying logs` | "2666 passed", exit 0 — **green** |
| after | `cache miss, executing` | `expected [ 'CORRUPTED VALUE' ] to deeply equal [ 'hello nodetool' ]`, exit 1 |

Corrupting a gallery example (`Check a URL and an IP.json`) went the same way —
replayed pass before, `cache miss, executing` and a failing assertion after.

The cost is that any example edit now re-runs that package's tests rather than
replaying them. That is the point.

## Also: a doc that went stale between two PRs

#4655 added a warning that `npm run workflow` hangs after an image workflow.
#4659 fixed the hang. They merged in that order, so the README kept telling
people to interrupt a run that now ends by itself, and to keep image workflows
out of any script that reads an exit code. Both false. Verified against current
main — `npm run workflow` on `image_geometry_cli` exits 0 — and the text now
says what happened instead.

## Note on how this was found

This work started from a trigger bug where a test reported success while the
thing it checked was broken, and every round since has insisted assertions must
demonstrably fail when the behaviour is wrong. Mine did — on a developer
machine. I never checked whether CI was running them at all. Verifying the
alarm and not the wiring is the same mistake in a different place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)