### PR TITLE
Harness review fixes: validators, debug surfaces, supervisor, app build/debug, evals

### DIFF
--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -621,9 +621,15 @@ graph it produced satisfied every state predicate. The same run of
 `escalate-missing-capability` escalated correctly, built the fallback the user
 described, and scored **0.92**, docked only for exceeding a call budget. Under
 weighting the first is capped at 0.5 and the second lands near 0.97, which is
-the ordering the numbers should have had. `criticalFailures` per case and
-`criticalCleanRate` in the summary make it visible without reading the check
-list, and the text report prefixes those failures with `[critical]`.
+the ordering the numbers should have had. `criticalFailures` per case makes it
+visible without reading the check list, and the text report prefixes those
+failures with `[critical]`.
+
+Severity also decides the gated metric. A case is a **success** only when the
+loop completed *and* no critical check failed, and `successRate` — what
+`--min-success` reads — counts those. "The loop ran to a stop without a
+provider error" is reported alongside as `completionRate`: it is a liveness
+signal, not a result, and a model that called zero tools scores 100% on it.
 
 Ten suites are registered:
 

--- a/packages/agents/src/app-build/author.ts
+++ b/packages/agents/src/app-build/author.ts
@@ -100,10 +100,16 @@ export async function runAuthorStage(
   const costBefore = opts.provider.getTotalCost();
   const host = opts.workflows[0];
 
+  // Every operation's workflow is loaded, not just the first: an app with two
+  // operations binds against both, and a workflow the bridge does not hold
+  // reports no bindable surface at all.
   const bridge = createAppToolBridge({
     title: opts.spec.title,
     finishTool: true,
-    ...(host ? { workflowId: host.key, workflow: bindable(host.io) } : {})
+    ...(host ? { workflowId: host.key, workflow: bindable(host.io) } : {}),
+    workflows: Object.fromEntries(
+      opts.workflows.map((workflow) => [workflow.key, bindable(workflow.io)])
+    )
   });
   if (opts.resumeFrom) bridge.loadDocument(opts.resumeFrom);
 

--- a/packages/agents/src/app-build/bridge.ts
+++ b/packages/agents/src/app-build/bridge.ts
@@ -50,6 +50,8 @@ import {
   WIDGET_CATALOG,
   type AppDocMeta,
   type BindableWorkflow,
+  type BindingTargets,
+  type OperationTargets,
   type InputMapping,
   type OperationBinding,
   type OperationPatch,
@@ -133,6 +135,13 @@ export interface AppBridgeInitialState {
   workflowId?: string;
   /** Bindable surface of that host workflow: its input/output nodes and channels. */
   workflow?: BindableWorkflow;
+  /**
+   * Every other workflow this editor has loaded, keyed by workflow id. An app
+   * with one operation per workflow binds against all of them, so reporting
+   * node targets for the host alone would leave every further operation with
+   * no bindable surface.
+   */
+  workflows?: Readonly<Record<string, BindableWorkflow>>;
   /**
    * Offer `ui_app_finish` so the model can end the loop deliberately. Off by
    * default: the eval surface exposes the frontend contract and nothing else.
@@ -302,6 +311,33 @@ export function createAppToolBridge(
   let finishSummary: string | null = null;
   const hostWorkflowId = initial.workflowId ?? "wf-app";
   const hostWorkflow = initial.workflow ?? EMPTY_WORKFLOW;
+  const loadedWorkflows = new Map<string, BindableWorkflow>([
+    [hostWorkflowId, hostWorkflow],
+    ...Object.entries(initial.workflows ?? {})
+  ]);
+
+  /**
+   * Binding targets across every loaded workflow. `bindingTargets` resolves one
+   * host workflow per call, so each further one is resolved in its own call and
+   * its operations replace the empty entries the host pass produced.
+   */
+  const allBindingTargets = (): BindingTargets => {
+    const base = bindingTargets(meta, hostWorkflowId, hostWorkflow);
+    const resolved = new Map<string, OperationTargets>();
+    for (const [workflowId, workflow] of loadedWorkflows) {
+      if (workflowId === hostWorkflowId) continue;
+      for (const operation of bindingTargets(meta, workflowId, workflow)
+        .operations) {
+        if (operation.ioAvailable) resolved.set(operation.operationId, operation);
+      }
+    }
+    return {
+      ...base,
+      operations: base.operations.map(
+        (operation) => resolved.get(operation.operationId) ?? operation
+      )
+    };
+  };
   let idSeq = 0;
   // Track every id in use so generated ids never collide with an explicitly
   // seeded one (e.g. seeding "Heading-1" then adding a Heading).
@@ -884,10 +920,7 @@ export function createAppToolBridge(
         "operation over a workflow this editor has not loaded reports " +
         "ioAvailable: false and no node lists.",
       z.object({ application_id: applicationIdParam }),
-      async () => ({
-        ok: true,
-        ...bindingTargets(meta, hostWorkflowId, hostWorkflow)
-      })
+      async () => ({ ok: true, ...allBindingTargets() })
     )
   ];
 

--- a/packages/agents/src/app-build/build.ts
+++ b/packages/agents/src/app-build/build.ts
@@ -65,7 +65,7 @@ import {
   type JudgeInteractionInput,
   type JudgeWidgetState
 } from "./judge.js";
-import { runSpecStage, specFromFile } from "./spec.js";
+import { resolveSpecWidget, runSpecStage, specFromFile } from "./spec.js";
 import {
   issueFingerprint,
   type BuildComplaint,
@@ -181,7 +181,12 @@ const issue = (
   stage: BuildIssue["stage"],
   code: string,
   message: string,
-  ref: { widget?: string; operation?: string } = {},
+  ref: {
+    widget?: string;
+    operation?: string;
+    interaction?: string;
+    step?: number;
+  } = {},
   severity: BuildIssue["severity"] = "error"
 ): BuildIssue => ({
   stage,
@@ -189,11 +194,17 @@ const issue = (
   severity,
   message,
   ...(ref.widget !== undefined ? { widget: ref.widget } : {}),
-  ...(ref.operation !== undefined ? { operation: ref.operation } : {})
+  ...(ref.operation !== undefined ? { operation: ref.operation } : {}),
+  ...(ref.interaction !== undefined ? { interaction: ref.interaction } : {}),
+  ...(ref.step !== undefined ? { step: ref.step } : {})
 });
 
 const errorsOf = (issues: readonly BuildIssue[]): BuildIssue[] =>
   issues.filter((i) => i.severity === "error");
+
+/** The provider failure an authoring round reported, when it reported one. */
+const providerErrorOf = (issues: readonly BuildIssue[]): string | null =>
+  issues.find((i) => i.code === "author_provider_error")?.message ?? null;
 
 /** What the build spent, in total and per stage. */
 const costOf = (stages: readonly StageRecord[]): BuildReport["cost"] => {
@@ -307,19 +318,22 @@ function bindSteps(
   appSpec: AppSpec | null
 ): { steps: InteractionStep[]; issues: BuildIssue[] } {
   const issues: BuildIssue[] = [];
-  const resolve = (role: string): string => {
-    const declared = spec.widgets.find((w) => w.role === role);
+  // A script may name a widget by role, label, or unique type — the same three
+  // ways the Spec stage resolved it. Resolving by role alone here would turn a
+  // spec the Spec gate accepted into a complaint the Author cannot satisfy.
+  const resolve = (ref: string): string => {
+    const declared = resolveSpecWidget(spec, ref);
     const placed = declared ? placedWidget(appSpec, declared) : null;
     if (placed) return placed.id;
     issues.push(
       issue(
         "check",
         "widget_missing",
-        `the script addresses widget "${role}", which is not in the app — place a ${declared?.type ?? "widget"} labelled "${declared?.label ?? role}"`,
-        { widget: role }
+        `the script addresses widget "${ref}", which is not in the app — place a ${declared?.type ?? "widget"} labelled "${declared?.label ?? ref}"`,
+        { widget: declared?.role ?? ref }
       )
     );
-    return role;
+    return ref;
   };
   const bound = steps.map((step) => {
     if ("click" in step) return { click: resolve(step.click) };
@@ -667,7 +681,7 @@ function checkExpectation(
       "run",
       "expect_widget_missing",
       `interaction "${interaction}" expects widget "${expectation.widget}", which the app does not have`,
-      { widget: expectation.widget }
+      { widget: expectation.widget, interaction }
     );
   }
   // The check sees what the user would see: the rendered `format` template
@@ -675,7 +689,8 @@ function checkExpectation(
   const shown = state.display ?? state.value;
   const fail = (why: string): BuildIssue =>
     issue("run", "expect_failed", `interaction "${interaction}": ${why}`, {
-      widget: expectation.widget
+      widget: expectation.widget,
+      interaction
     });
 
   if (expectation.check === "nonEmpty") {
@@ -807,17 +822,26 @@ async function runRunStage(
         `interaction "${interaction.name}"`,
         run.summary
       )) {
-        issues.push(issue("run", "supervised", line, {}, "warning"));
+        issues.push(
+          issue(
+            "run",
+            "supervised",
+            line,
+            { interaction: interaction.name },
+            "warning"
+          )
+        );
       }
     }
 
-    for (const step of report.interactions) {
+    for (const [index, step] of report.interactions.entries()) {
       if (!step.error) continue;
       issues.push(
         issue(
           "run",
           "step_failed",
-          `interaction "${interaction.name}" step ${step.step}: ${step.error}`
+          `interaction "${interaction.name}" step ${step.step}: ${step.error}`,
+          { interaction: interaction.name, step: index }
         )
       );
     }
@@ -834,13 +858,13 @@ async function runRunStage(
           "run",
           "run_issue",
           `interaction "${interaction.name}": ${problem}`,
-          { widget: widgetOf(problem) },
+          { widget: widgetOf(problem), interaction: interaction.name },
           runIssueSeverity
         )
       );
     }
     for (const expectation of interaction.expect) {
-      const declared = spec.widgets.find((w) => w.role === expectation.widget);
+      const declared = resolveSpecWidget(spec, expectation.widget);
       const placed = declared ? placedWidget(report.spec, declared) : null;
       const state = report.widgets.find((w) => w.id === placed?.id);
       const failure = checkExpectation(expectation, state, interaction.name);
@@ -1087,22 +1111,48 @@ async function buildAppImpl(opts: BuildAppOptions): Promise<BuildReport> {
       key: workflow.key,
       io: workflow.io
     }));
-    const authored = await withSpan("app.build.author", { "app.build.round": round }, () =>
-      runAuthorStage({
-        spec,
-        workflows: authorWorkflows,
-        provider: options.provider,
-        model: options.model,
-        round,
-        maxTurns: opts.maxAuthorTurns ?? DEFAULT_AUTHOR_TURNS,
-        turnBudget: budget,
-        ...(document ? { resumeFrom: document } : {}),
-        ...(complaint ? { complaint } : {}),
-        ...(opts.signal ? { signal: opts.signal } : {}),
-        ...(opts.onLog ? { onLog: opts.onLog } : {})
-      })
-    );
+    const author = () =>
+      withSpan("app.build.author", { "app.build.round": round }, () =>
+        runAuthorStage({
+          spec,
+          workflows: authorWorkflows,
+          provider: options.provider,
+          model: options.model,
+          round,
+          maxTurns: opts.maxAuthorTurns ?? DEFAULT_AUTHOR_TURNS,
+          turnBudget: budget,
+          ...(document ? { resumeFrom: document } : {}),
+          ...(complaint ? { complaint } : {}),
+          ...(opts.signal ? { signal: opts.signal } : {}),
+          ...(opts.onLog ? { onLog: opts.onLog } : {})
+        })
+      );
+    let authored = await author();
     stages.push(authored.record);
+    // A provider that errored is infrastructure, not a defect the Author can
+    // repair: it gets one retry, and a second failure ends the build. Routing
+    // it through the complaint loop would ask the model to "fix: connection
+    // reset" and, since its fingerprint never varies, read as oscillation.
+    let providerError = providerErrorOf(authored.record.issues);
+    if (providerError && !budgetStop()) {
+      log_(`author: provider error (${providerError}) — retrying once`);
+      authored = await author();
+      stages.push(authored.record);
+      providerError = providerErrorOf(authored.record.issues);
+    }
+    if (providerError) {
+      return failedReport(
+        target,
+        spec,
+        interactions,
+        stages,
+        repairs,
+        appDebug,
+        `authoring failed: ${providerError}`,
+        judge,
+        supervision
+      );
+    }
     document = authored.document;
     if (opts.signal?.aborted) {
       return failedReport(
@@ -1316,6 +1366,24 @@ async function buildAppImpl(opts: BuildAppOptions): Promise<BuildReport> {
         })
       );
       stages.push(replanned.record);
+      // A replan that failed leaves the stale graph in place, so the next round
+      // would author against the same missing node and burn every remaining
+      // round on a complaint nothing can satisfy. Plan errors are terminal on
+      // the first pass; they are terminal here too.
+      const replanErrors = errorsOf(replanned.record.issues);
+      if (replanErrors.length > 0) {
+        return failedReport(
+          target,
+          spec,
+          interactions,
+          stages,
+          repairs,
+          appDebug,
+          `replanning failed: ${replanErrors[0]?.message ?? ""}`,
+          judge,
+          supervision
+        );
+      }
       for (const workflow of replanned.workflows) {
         const index = workflows.findIndex(
           (w) => w.operationId === workflow.operationId
@@ -1394,8 +1462,10 @@ async function recordBuildCost(
     try {
       await Prediction.create({
         user_id: opts.ledger.userId,
-        provider: opts.provider.provider,
-        model: opts.model,
+        // A stage that ran somewhere else — the Judge, on its own model — bills
+        // where it ran, not where the builder did.
+        provider: stage.provider ?? opts.provider.provider,
+        model: stage.model ?? opts.model,
         node_id: buildId,
         node_type: "app-build",
         workflow_id: opts.ledger.workflowId ?? null,

--- a/packages/agents/src/app-build/judge.ts
+++ b/packages/agents/src/app-build/judge.ts
@@ -284,26 +284,46 @@ export async function judgeInteraction(
   const abort = () => controller.abort();
   opts.signal?.addEventListener("abort", abort);
   let timedOut = false;
+  /**
+   * The deadline is a race, not just an abort: a provider that ignores the
+   * signal would otherwise never resolve, and the fail-closed verdict this
+   * function promises would never be produced.
+   */
+  const expired: unique symbol = Symbol("judge-timeout");
+  let expire: (value: typeof expired) => void = () => {};
+  const deadline = new Promise<typeof expired>((resolve) => {
+    expire = resolve;
+  });
   const timer = setTimeout(() => {
     timedOut = true;
     controller.abort();
+    expire(expired);
   }, timeoutMs);
 
   try {
-    const reply = await opts.provider.generateMessageTraced({
-      messages: [
-        { role: "system", content: SYSTEM_PROMPT },
-        {
-          role: "user",
-          content: renderJudgePrompt(opts.spec, opts.input, opts.prompt)
-        }
-      ] as Message[],
-      model: opts.model,
-      tools: [],
-      maxTokens: JUDGE_MAX_TOKENS,
-      temperature: 0,
-      signal: controller.signal
-    });
+    const reply = await Promise.race([
+      opts.provider.generateMessageTraced({
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          {
+            role: "user",
+            content: renderJudgePrompt(opts.spec, opts.input, opts.prompt)
+          }
+        ] as Message[],
+        model: opts.model,
+        tools: [],
+        maxTokens: JUDGE_MAX_TOKENS,
+        temperature: 0,
+        signal: controller.signal
+      }),
+      deadline
+    ]);
+    if (reply === expired) {
+      return notAchieved(
+        name,
+        `the judge did not answer within ${timeoutMs}ms, so the interaction counts as not achieved`
+      );
+    }
     const answer = parseJudgeAnswer(extractText(reply.content));
     if (!answer) {
       return notAchieved(
@@ -382,6 +402,10 @@ export async function runJudgeStage(
     record: {
       stage: "judge",
       round: opts.round,
+      // The judge defaults away from the builder, so its spend bills to the
+      // model that actually ran.
+      provider: opts.provider.provider,
+      model: opts.model,
       startedAt: new Date(startedAt).toISOString(),
       durationMs: Date.now() - startedAt,
       issues,

--- a/packages/agents/src/app-build/spec.ts
+++ b/packages/agents/src/app-build/spec.ts
@@ -274,9 +274,23 @@ function checkWidgets(spec: BuildSpec): BuildIssue[] {
   const issues: BuildIssue[] = [];
   const seen = new Set<string>();
   const variableIds = new Set(spec.variables.map((v) => v.id));
+  // The link from a spec role to the widget the author placed is the label it
+  // was told to use verbatim, so two widgets sharing one label resolve to
+  // neither and both are reported missing from an app that has them both.
+  const seenLabels = new Set<string>();
 
   for (const widget of spec.widgets) {
     const ref = { widget: widget.role };
+    if (widget.label !== "" && seenLabels.has(widget.label)) {
+      issues.push(
+        issue(
+          "duplicate_widget_label",
+          `two widgets share the label "${widget.label}" — labels are how a placed widget is matched back to its role, so each must be unique`,
+          ref
+        )
+      );
+    }
+    seenLabels.add(widget.label);
     if (seen.has(widget.role)) {
       issues.push(
         issue(

--- a/packages/agents/src/app-build/types.ts
+++ b/packages/agents/src/app-build/types.ts
@@ -115,14 +115,28 @@ export interface BuildIssue {
   widget?: string;
   /** Operation id the issue is about, when it is about one. */
   operation?: string;
+  /** Interaction the issue arose in — Run-stage issues carry one. */
+  interaction?: string;
+  /** Index of the interaction step the issue is about, when it is about one. */
+  step?: number;
 }
 
 /**
  * The stable identity of an issue across rounds. The oscillation guard compares
  * these, so it must not carry anything that varies with wording or ordering.
+ *
+ * Run-stage issues add the interaction (and the step inside it) they arose in:
+ * without it every failed step of every interaction shares one fingerprint, and
+ * a build making real progress reads as oscillating.
  */
-export const issueFingerprint = (issue: BuildIssue): string =>
-  `${issue.stage}:${issue.code}:${issue.widget ?? issue.operation ?? "-"}`;
+export const issueFingerprint = (issue: BuildIssue): string => {
+  const ref = issue.widget ?? issue.operation ?? "-";
+  const where =
+    issue.interaction === undefined
+      ? ""
+      : `:${issue.interaction}${issue.step === undefined ? "" : `#${issue.step}`}`;
+  return `${issue.stage}:${issue.code}:${ref}${where}`;
+};
 
 /** One repair round's input: everything wrong, not a delta. */
 export interface BuildComplaint {
@@ -137,6 +151,10 @@ export interface StageRecord {
   stage: BuildStage;
   /** Repair round this execution belongs to; 0 is the first pass. */
   round: number;
+  /** Provider this execution billed to, when it is not the builder's. */
+  provider?: string;
+  /** Model this execution billed to, when it is not the builder's. */
+  model?: string;
   status: "ok" | "failed" | "skipped";
   startedAt: string;
   durationMs: number;

--- a/packages/agents/src/evals/graph-e2e-eval.ts
+++ b/packages/agents/src/evals/graph-e2e-eval.ts
@@ -105,6 +105,8 @@ export interface GraphE2eEvalCase {
   /**
    * Skip the LLM judge — for cases whose outputs are fully pinned down by
    * `requiredOutputPatterns` (pure string mechanics, exact arithmetic).
+   * `goalAchieved` then follows the output checks, and no separate
+   * `goal-achieved` check is scored: it would count those same checks twice.
    */
   skipJudge?: boolean;
 }
@@ -428,9 +430,16 @@ async function runCase(
   if (!run?.ok) {
     goalDetail = graph ? "run did not complete" : "no graph to run";
   } else if (evalCase.skipJudge) {
-    // Judge-free case: the output checks pin the result down exactly.
-    goalAchieved = outputChecks.every((c) => c.pass);
-    goalDetail = goalAchieved ? undefined : "output checks failed";
+    // Judge-free case: the output checks pin the result down exactly. They are
+    // already in `checks` and scored there, so no `goal-achieved` check is
+    // pushed below — it would weigh the same failures a second time. A case
+    // with no output checks pins nothing, so it cannot claim the goal.
+    goalAchieved = outputChecks.length > 0 && outputChecks.every((c) => c.pass);
+    goalDetail = goalAchieved
+      ? undefined
+      : outputChecks.length === 0
+        ? "skipJudge case declares no output checks"
+        : "output checks failed";
   } else {
     judge = await judgeGoalAchievement({
       provider: opts.judgeProvider ?? opts.provider,
@@ -444,11 +453,13 @@ async function runCase(
     goalAchieved = judge.achieved;
     goalDetail = judge.error ?? judge.reasoning;
   }
-  checks.push({
-    name: "goal-achieved",
-    pass: goalAchieved,
-    detail: goalDetail
-  });
+  if (!evalCase.skipJudge) {
+    checks.push({
+      name: "goal-achieved",
+      pass: goalAchieved,
+      detail: goalDetail
+    });
+  }
 
   const score = checks.filter((c) => c.pass).length / checks.length;
 

--- a/packages/agents/src/evals/tool-loop-eval.ts
+++ b/packages/agents/src/evals/tool-loop-eval.ts
@@ -23,6 +23,11 @@
  * {@link scoreToolLoopChecks} weighs them accordingly and caps a run that
  * missed a critical check, so "built the wrong thing" can never outscore "built
  * the right thing a bit wastefully".
+ *
+ * Severity also decides the suite's headline number: `successRate` counts the
+ * cases that completed *and* passed every critical check, so a model that
+ * called no tool at all cannot pass. How often the loop merely ran to a stop is
+ * reported separately as `completionRate`.
  */
 
 import type { BaseProvider } from "@nodetool-ai/runtime";
@@ -137,6 +142,13 @@ export interface ToolLoopCaseResult {
   /** The loop ran to a natural stop / cap without a fatal provider error. */
   accepted: boolean;
   /**
+   * The case did what it exists to test: the loop completed AND no `critical`
+   * check failed. This — not {@link accepted} — is what the suite's success
+   * rate and the `--min-success` gate read, because a model that made zero
+   * tool calls still "completes".
+   */
+  success: boolean;
+  /**
    * Severity-weighted fraction of checks passed, capped at
    * {@link CRITICAL_FAILURE_SCORE_CAP} when a critical check failed (0 when the
    * loop did not run).
@@ -163,12 +175,17 @@ export interface ToolLoopEvalReport {
     total: number;
     skipped: number;
     accepted: number;
-    /** accepted / (total - skipped) */
+    /** Cases that completed with every critical check passing. */
+    successful: number;
+    /**
+     * successful / (total - skipped) — the gated metric. A run that merely
+     * finished without a provider error is not a success.
+     */
     successRate: number;
+    /** accepted / (total - skipped): the loop ran, whatever it built. */
+    completionRate: number;
     /** Mean expectation score over non-skipped cases. */
     meanScore: number;
-    /** Fraction of non-skipped cases with no failing critical check. */
-    criticalCleanRate: number;
     avgToolCalls: number;
     totalCostUsd: number;
   };
@@ -411,14 +428,16 @@ async function runCase<TFinal>(
     checks.push(...checkToolLoopExpectations(observation, evalCase.expect));
   }
   const score = accepted ? scoreToolLoopChecks(checks) : 0;
+  const criticalFailures = countCriticalFailures(checks);
 
   return {
     caseId: evalCase.id,
     description: evalCase.description,
     skipped: false,
     accepted,
+    success: accepted && criticalFailures === 0,
     score,
-    criticalFailures: countCriticalFailures(checks),
+    criticalFailures,
     checks,
     toolCalls: run.countsByName,
     totalToolCalls: run.totalCalls,
@@ -446,6 +465,7 @@ export async function runToolLoopEval<TFinal = ToolLoopFinalState>(
         description: evalCase.description,
         skipped: true,
         accepted: false,
+        success: false,
         score: 0,
         criticalFailures: 0,
         checks: [],
@@ -461,7 +481,7 @@ export async function runToolLoopEval<TFinal = ToolLoopFinalState>(
     const result = await runCase(evalCase, opts);
     const failed = result.checks.filter((c) => !c.pass);
     opts.onEvent?.(
-      `  ${result.accepted ? "PASS" : "FAIL"} score=${result.score.toFixed(2)} ` +
+      `  ${result.success ? "PASS" : "FAIL"} score=${result.score.toFixed(2)} ` +
         `tools=${result.totalToolCalls} ${Math.round(result.durationMs / 1000)}s` +
         (failed.length > 0
           ? ` | failed: ${failed.map((c) => c.name).join(", ")}`
@@ -472,17 +492,16 @@ export async function runToolLoopEval<TFinal = ToolLoopFinalState>(
 
   const ran = results.filter((r) => !r.skipped);
   const acceptedResults = ran.filter((r) => r.accepted);
+  const successful = ran.filter((r) => r.success).length;
   const summary = {
     total: results.length,
     skipped: results.length - ran.length,
     accepted: acceptedResults.length,
-    successRate: ran.length > 0 ? acceptedResults.length / ran.length : 0,
+    successful,
+    successRate: ran.length > 0 ? successful / ran.length : 0,
+    completionRate: ran.length > 0 ? acceptedResults.length / ran.length : 0,
     meanScore:
       ran.length > 0 ? ran.reduce((a, r) => a + r.score, 0) / ran.length : 0,
-    criticalCleanRate:
-      ran.length > 0
-        ? ran.filter((r) => r.criticalFailures === 0).length / ran.length
-        : 0,
     avgToolCalls:
       ran.length > 0
         ? ran.reduce((a, r) => a + r.totalToolCalls, 0) / ran.length
@@ -521,7 +540,14 @@ export function formatToolLoopReport(report: ToolLoopEvalReport): string {
     lines.push(
       [
         r.caseId.padEnd(24),
-        (r.skipped ? "skip" : r.accepted ? "pass" : "FAIL").padEnd(7),
+        (r.skipped
+          ? "skip"
+          : r.success
+            ? "pass"
+            : r.accepted
+              ? "FAIL"
+              : "ERROR"
+        ).padEnd(7),
         (r.skipped ? "-" : r.score.toFixed(2)).padEnd(6),
         (r.skipped ? "-" : String(r.criticalFailures)).padEnd(5),
         String(r.totalToolCalls).padEnd(6),
@@ -539,9 +565,9 @@ export function formatToolLoopReport(report: ToolLoopEvalReport): string {
   const s = report.summary;
   lines.push("");
   lines.push(
-    `success ${s.accepted}/${s.total - s.skipped} (${(s.successRate * 100).toFixed(0)}%)` +
+    `success ${s.successful}/${s.total - s.skipped} (${(s.successRate * 100).toFixed(0)}%)` +
+      `  completed ${(s.completionRate * 100).toFixed(0)}%` +
       `  mean score ${s.meanScore.toFixed(2)}` +
-      `  critical-clean ${(s.criticalCleanRate * 100).toFixed(0)}%` +
       `  avg tools ${s.avgToolCalls.toFixed(1)}` +
       (s.totalCostUsd > 0 ? `  cost $${s.totalCostUsd.toFixed(4)}` : "") +
       (s.skipped > 0 ? `  (${s.skipped} skipped)` : "")

--- a/packages/agents/src/tools/mcp-tools.ts
+++ b/packages/agents/src/tools/mcp-tools.ts
@@ -8,6 +8,7 @@
  */
 
 import type { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
+import { listRegisteredProviderIds } from "@nodetool-ai/runtime";
 import type { NodeMetadata, NodeRegistry } from "@nodetool-ai/node-sdk";
 import { validateGraph } from "@nodetool-ai/node-sdk";
 import {
@@ -1056,7 +1057,19 @@ export class ValidateWorkflowTool extends Tool {
   // When a registry is available the tool validates locally; without one it
   // falls back to fetching the workflow so the tool still returns something
   // useful in registry-free contexts (e.g. the multi-task planner).
-  constructor(private readonly registry?: NodeRegistry) {
+  /**
+   * `listProviderIds` is supplied here rather than living on NodeRegistry: the
+   * registry also runs in the browser, which has no provider registry to reach.
+   * Without it `validateGraph` skips the `unknown_provider` check entirely, so
+   * a model naming a provider the runtime cannot construct passed silently on
+   * the agent surface. This tool always runs server-side, so the runtime's
+   * registry is the right default.
+   */
+  constructor(
+    private readonly registry?: NodeRegistry,
+    private readonly listProviderIds: () => readonly string[] = () =>
+      listRegisteredProviderIds()
+  ) {
     super();
   }
 
@@ -1084,6 +1097,15 @@ export class ValidateWorkflowTool extends Tool {
       };
     }
 
+    // `edges` reaches `.map()` inside validateGraph — a non-array would throw a
+    // raw TypeError past the tool's structured error shape.
+    if (graph.edges !== undefined && !Array.isArray(graph.edges)) {
+      return {
+        error:
+          "`graph.edges` must be an array of edges ({source, sourceHandle, target, targetHandle})."
+      };
+    }
+
     if (!this.registry) {
       // Returning the graph with a note read as a pass to every caller that
       // checks for issues rather than for prose. A validator with no registry
@@ -1095,9 +1117,16 @@ export class ValidateWorkflowTool extends Tool {
       };
     }
 
+    const registry = this.registry;
     return validateGraph(
       { nodes: graph.nodes as never[], edges: (graph.edges ?? []) as never[] },
-      this.registry
+      {
+        has: (type) => registry.has(type),
+        getMetadata: (type) => registry.getMetadata(type),
+        validateNode: (descriptor, connectedHandles) =>
+          registry.validateNode(descriptor, connectedHandles),
+        listProviderIds: () => this.listProviderIds()
+      }
     );
   }
 
@@ -1123,6 +1152,13 @@ export type TimelineLoader = (
   context: ProcessingContext,
   id: string
 ) => Promise<TimelineToolRecord | null>;
+
+/** A positive finite number from a tool param, or undefined. */
+function numberParam(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
 
 /** Unwrap a stored document that may still be JSON text. */
 function parseTimelineDocument(document: unknown): unknown {
@@ -1167,6 +1203,21 @@ export class ValidateTimelineTool extends Tool {
         description:
           "Inline TimelineDocument to validate ({ tracks, clips, markers }). " +
           "Takes precedence over timeline_id."
+      },
+      fps: {
+        type: "number" as const,
+        description:
+          "Frame rate the inline document renders at (default 30). Timing " +
+          "checks are frame-based, so a document authored at another fps " +
+          "validates against the wrong grid without this. Ignored for timeline_id."
+      },
+      width: {
+        type: "number" as const,
+        description: "Render width of the inline document. Ignored for timeline_id."
+      },
+      height: {
+        type: "number" as const,
+        description: "Render height of the inline document. Ignored for timeline_id."
       }
     }
   };
@@ -1186,7 +1237,13 @@ export class ValidateTimelineTool extends Tool {
     const timelineId = params["timeline_id"] as string | undefined;
 
     let document = inline;
-    let meta: { fps?: number; width?: number; height?: number } = {};
+    // An inline document carries no stored render settings, so the caller
+    // supplies them; the timeline_id path overwrites these from the row.
+    let meta: { fps?: number; width?: number; height?: number } = {
+      fps: numberParam(params["fps"]),
+      width: numberParam(params["width"]),
+      height: numberParam(params["height"])
+    };
     let name: string | undefined;
 
     if (document === undefined && timelineId) {

--- a/packages/agents/tests/app-build-bridge.test.ts
+++ b/packages/agents/tests/app-build-bridge.test.ts
@@ -107,3 +107,74 @@ describe("document round-trip", () => {
     expect(first.finalState().components).toHaveLength(2);
   });
 });
+
+describe("ui_app_get_binding_targets", () => {
+  const workflow = (prefix: string) => ({
+    inputs: [{ nodeId: `${prefix}-in`, name: "prompt", label: "prompt" }],
+    outputs: [{ nodeId: `${prefix}-out`, name: "text", label: "text" }],
+    variables: []
+  });
+
+  it("reports node targets for every loaded workflow, not just the host", async () => {
+    const bridge = createAppToolBridge({
+      workflowId: "wf-draft",
+      workflow: workflow("draft"),
+      workflows: {
+        "wf-draft": workflow("draft"),
+        "wf-publish": workflow("publish")
+      }
+    });
+    const tools = toolsOf(bridge);
+    for (const [id, workflowId] of [
+      ["draft", "wf-draft"],
+      ["publish", "wf-publish"]
+    ]) {
+      await tools["ui_app_add_operation"].execute({
+        application_id: APP,
+        id,
+        target_workflow_id: workflowId
+      });
+    }
+
+    const targets = (await tools["ui_app_get_binding_targets"].execute({
+      application_id: APP
+    })) as {
+      operations: Array<{
+        operationId: string;
+        ioAvailable: boolean;
+        inputs: Array<{ binding: string }>;
+        outputs: Array<{ binding: string }>;
+      }>;
+    };
+
+    expect(targets.operations.map((o) => o.operationId)).toEqual([
+      "draft",
+      "publish"
+    ]);
+    expect(targets.operations.every((o) => o.ioAvailable)).toBe(true);
+    expect(targets.operations[1]?.inputs.map((i) => i.binding)).toEqual([
+      "op:publish/in:publish-in"
+    ]);
+    expect(targets.operations[1]?.outputs.map((o) => o.binding)).toEqual([
+      "op:publish/out:publish-out"
+    ]);
+  });
+
+  it("still reports no surface for a workflow it has not loaded", async () => {
+    const bridge = createAppToolBridge({
+      workflowId: "wf-draft",
+      workflow: workflow("draft")
+    });
+    const tools = toolsOf(bridge);
+    await tools["ui_app_add_operation"].execute({
+      application_id: APP,
+      id: "publish",
+      target_workflow_id: "wf-publish"
+    });
+
+    const targets = (await tools["ui_app_get_binding_targets"].execute({
+      application_id: APP
+    })) as { operations: Array<{ ioAvailable: boolean }> };
+    expect(targets.operations[0]?.ioAvailable).toBe(false);
+  });
+});

--- a/packages/agents/tests/app-build-build.test.ts
+++ b/packages/agents/tests/app-build-build.test.ts
@@ -21,7 +21,7 @@ import type {
 } from "@nodetool-ai/execution/app-debug";
 import { collectExecutionSummary } from "@nodetool-ai/execution/debug";
 import { buildApp, type BuildAppOptions } from "../src/app-build/build.js";
-import type { BuildSpec } from "../src/app-build/types.js";
+import { issueFingerprint, type BuildSpec } from "../src/app-build/types.js";
 import { createMockContext } from "./_helpers/mock-context.js";
 
 // --- fixtures ---------------------------------------------------------------
@@ -575,6 +575,95 @@ describe("buildApp", () => {
     expect(report.repairs[0]?.issues.map((i) => i.code)).toContain("run_issue");
   });
 
+  it("resolves a script's widget references by label, not only by role", async () => {
+    // The Spec gate accepts a reference by label; the loop must resolve it the
+    // same way, or the app it green-lit fails on a widget it does have.
+    const byLabel = spec();
+    byLabel.interactions[0]!.steps[1] = { click: "Draft it" };
+    byLabel.interactions[0]!.expect = [{ widget: "Draft", check: "nonEmpty" }];
+
+    const provider = scriptedProvider([goodAuthorScript()]);
+    const report = await buildApp(options(provider, { spec: byLabel }));
+
+    expect(report.verdict.ok).toBe(true);
+    const run = report.stages.find((s) => s.stage === "run");
+    expect(run?.issues).toEqual([]);
+  });
+
+  it("ends the build on a provider error instead of asking for a repair", async () => {
+    const provider = scriptedProvider([goodAuthorScript()]);
+    const failing = {
+      ...provider,
+      // eslint-disable-next-line require-yield
+      async *generateLoop(): AsyncGenerator<ProviderStreamItem> {
+        throw new Error("connection reset");
+      }
+    } as unknown as BaseProvider;
+    const report = await buildApp(options(failing, { maxRepairs: 3 }));
+
+    expect(report.verdict.ok).toBe(false);
+    expect(report.verdict.reason).toBe("authoring failed: connection reset");
+    // One retry, then the build stops — the complaint loop never sees it.
+    expect(report.stages.filter((s) => s.stage === "author")).toHaveLength(2);
+    expect(report.repairs).toEqual([]);
+  });
+
+  it("ends the build when a routed replan fails", async () => {
+    const provider = scriptedProvider([badBindingScript()]);
+    let loads = 0;
+    const report = await buildApp(
+      options(provider, {
+        maxRepairs: 3,
+        // The replan the binding complaint routes cannot load the workflow, so
+        // the stale graph would otherwise survive into every remaining round.
+        loadWorkflow: async (id: string) =>
+          id === "wf1" && loads++ === 0
+            ? { graph: GRAPH, name: "Drafter workflow" }
+            : null
+      })
+    );
+
+    expect(report.verdict.ok).toBe(false);
+    expect(report.verdict.reason).toMatch(/^replanning failed:/);
+    expect(report.stages.filter((s) => s.stage === "author")).toHaveLength(1);
+  });
+
+  it("writes the judge's ledger row against the judge's own model", async () => {
+    const builder = scriptedProvider([goodAuthorScript()], {
+      costPerCall: 0.01
+    });
+    const judgeProvider = {
+      provider: "judge-provider",
+      getTotalCost: (() => {
+        let calls = 0;
+        return () => (calls++ === 0 ? 0 : 0.5);
+      })(),
+      generateMessageTraced: async () => ({
+        role: "assistant",
+        content: '{"achieved": true, "confidence": 1, "reasons": ["ok"]}'
+      })
+    } as unknown as BaseProvider;
+    const create = vi.fn(async () => ({}));
+    vi.doMock("@nodetool-ai/models", () => ({ Prediction: { create } }));
+
+    await buildApp(
+      options(builder, {
+        ledger: { userId: "1" },
+        buildId: "build-judge",
+        judge: { provider: judgeProvider, model: "judge-model" }
+      })
+    );
+
+    const rows = create.mock.calls.map(
+      (call) => call[0] as unknown as { provider: string; model: string }
+    );
+    expect(rows).toContainEqual(
+      expect.objectContaining({ provider: "judge-provider", model: "judge-model" })
+    );
+    expect(rows.filter((r) => r.provider === "scripted")).not.toHaveLength(0);
+    vi.doUnmock("@nodetool-ai/models");
+  });
+
   it("writes one ledger row per billable stage when attributed", async () => {
     const provider = scriptedProvider([goodAuthorScript()], {
       costPerCall: 0.01
@@ -595,5 +684,34 @@ describe("buildApp", () => {
     expect(row.node_type).toBe("app-build");
     expect(row.node_id).toBe("build-1");
     vi.doUnmock("@nodetool-ai/models");
+  });
+});
+
+describe("issueFingerprint", () => {
+  it("separates the same run failure in two interactions", () => {
+    const failure = (interaction: string, step: number) =>
+      issueFingerprint({
+        stage: "run",
+        code: "step_failed",
+        severity: "error",
+        message: "…",
+        interaction,
+        step
+      });
+    expect(failure("draft", 0)).not.toBe(failure("publish", 0));
+    expect(failure("draft", 0)).not.toBe(failure("draft", 1));
+    expect(failure("draft", 0)).toBe(failure("draft", 0));
+  });
+
+  it("leaves an issue with no interaction unchanged", () => {
+    expect(
+      issueFingerprint({
+        stage: "check",
+        code: "widget_missing",
+        severity: "error",
+        message: "…",
+        widget: "draft-output"
+      })
+    ).toBe("check:widget_missing:draft-output");
   });
 });

--- a/packages/agents/tests/app-build-judge.test.ts
+++ b/packages/agents/tests/app-build-judge.test.ts
@@ -22,6 +22,7 @@ import type {
 import { collectExecutionSummary } from "@nodetool-ai/execution/debug";
 import { buildApp, type BuildAppOptions } from "../src/app-build/build.js";
 import {
+  judgeInteraction,
   parseJudgeAnswer,
   renderJudgePrompt,
   resolveJudgeModelSpec,
@@ -420,6 +421,38 @@ describe("parseJudgeAnswer", () => {
       confidence: 0,
       reasons: ["(no reason given)"]
     });
+  });
+});
+
+describe("judgeInteraction", () => {
+  it("times out on a provider that ignores the abort signal", async () => {
+    const deaf = {
+      provider: "deaf",
+      getTotalCost: () => 0,
+      // No abort listener: without a race the await would never resolve and the
+      // fail-closed verdict would never be produced.
+      generateMessageTraced: () => new Promise(() => {})
+    } as unknown as BaseProvider;
+
+    const verdict = await judgeInteraction({
+      spec: spec(),
+      provider: deaf,
+      model: "m",
+      timeoutMs: 20,
+      input: {
+        interaction: {
+          name: "draft-once",
+          steps: [{ click: "run-button" }],
+          expect: [],
+          derived: false,
+          addedSteps: []
+        },
+        widgets: []
+      }
+    });
+
+    expect(verdict.achieved).toBe(false);
+    expect(verdict.reasons.join(" ")).toMatch(/did not answer within 20ms/);
   });
 });
 

--- a/packages/agents/tests/app-build-spec.test.ts
+++ b/packages/agents/tests/app-build-spec.test.ts
@@ -110,6 +110,15 @@ describe("validateBuildSpec", () => {
     expect(codes).toContain("unknown_widget_type");
   });
 
+  it("rejects two widgets sharing one label", () => {
+    const spec = validSpec();
+    spec.widgets[2]!.label = "Prompt";
+    const issue = validateBuildSpec(spec).find(
+      (i) => i.code === "duplicate_widget_label"
+    );
+    expect(issue?.widget).toBe("draft-output");
+  });
+
   it("rejects a binding that names an input no operation declares", () => {
     const spec = validSpec();
     spec.widgets[0]!.binding = "op:draft/in:topic";

--- a/packages/agents/tests/escalation-tool-loop.test.ts
+++ b/packages/agents/tests/escalation-tool-loop.test.ts
@@ -356,8 +356,10 @@ describe("runToolLoopEval with an escalation channel", () => {
     const text = formatToolLoopReport(report);
 
     expect(text).toContain("[critical] tool:ask_user");
-    expect(text).toContain("critical-clean 0%");
-    expect(report.summary.criticalCleanRate).toBe(0);
+    expect(text).toContain("success 0/1 (0%)");
+    expect(report.summary.successRate).toBe(0);
+    // The loop itself ran fine; the case still fails, which is the point.
+    expect(report.summary.completionRate).toBe(1);
   });
 
   it("flags an off-script question and hands back the fallback answer", async () => {

--- a/packages/agents/tests/graph-e2e-eval.test.ts
+++ b/packages/agents/tests/graph-e2e-eval.test.ts
@@ -271,6 +271,12 @@ describe("runGraphE2eEval", () => {
     expect(judged).toBe(0);
     expect(report.cases[0].goalAchieved).toBe(true);
     expect(report.cases[0].success).toBe(true);
+    // The output checks decide the goal; scoring them again under a
+    // `goal-achieved` check would weigh the same failures twice.
+    expect(report.cases[0].checks.some((c) => c.name === "goal-achieved")).toBe(
+      false
+    );
+    expect(report.cases[0].score).toBe(1);
   });
 
   it("skips model-dependent cases without configured providers", async () => {

--- a/packages/agents/tests/tool-loop-eval.test.ts
+++ b/packages/agents/tests/tool-loop-eval.test.ts
@@ -216,9 +216,27 @@ describe("runToolLoopEval", () => {
     expect(report.summary.total).toBe(2);
     expect(report.summary.skipped).toBe(1);
     expect(report.summary.accepted).toBe(1);
+    expect(report.summary.successful).toBe(1);
     expect(report.summary.successRate).toBe(1);
+    expect(report.summary.completionRate).toBe(1);
     expect(report.summary.avgToolCalls).toBe(6);
     expect(report.summary.totalCostUsd).toBe(0);
+  });
+
+  it("does not count a loop that called no tool as a success", async () => {
+    // The failure this guards: `accepted` only means "no provider error", so a
+    // model that said nothing scored 100% on the gated metric.
+    const report = await runToolLoopEval({
+      provider: createScriptedProvider([]),
+      model: "test-model",
+      cases: [GOOD_CASE]
+    });
+    const r = report.cases[0];
+    expect(r.accepted).toBe(true);
+    expect(r.success).toBe(false);
+    expect(r.criticalFailures).toBeGreaterThan(0);
+    expect(report.summary.successRate).toBe(0);
+    expect(report.summary.completionRate).toBe(1);
   });
 
   it("penalizes error results and violated expectations", async () => {

--- a/packages/cli/src/command-errors.ts
+++ b/packages/cli/src/command-errors.ts
@@ -1,0 +1,13 @@
+/**
+ * One failure shape for the harness commands.
+ *
+ * An agent that invoked a command with `--json` parses stdout. When the command
+ * crashes it used to get a stderr string and nothing to parse, so the failure
+ * was indistinguishable from a broken pipe. The human message still goes to
+ * stderr; `--json` additionally puts `{"error": …}` on stdout.
+ */
+export function printCommandError(err: unknown, json?: boolean): void {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(message);
+  if (json) console.log(JSON.stringify({ error: message }, null, 2));
+}

--- a/packages/cli/src/commands/app.ts
+++ b/packages/cli/src/commands/app.ts
@@ -32,6 +32,8 @@ import {
   parseSupervisorFlags,
   type SupervisorCliOptions
 } from "../supervisor.js";
+import { numericOptionParser, parseNumericOption } from "../numeric-options.js";
+import { printCommandError } from "../command-errors.js";
 
 interface AppDebugCliOptions {
   params?: string;
@@ -80,8 +82,10 @@ export function registerAppCommands(program: Command): void {
       "--out <dir>",
       "Bundle output directory (default: nodetool-debug/app-<id>-<timestamp>)"
     )
-    .option("--timeout <ms>", "Per-run timeout in milliseconds", (v: string) =>
-      parseInt(v, 10)
+    .option(
+      "--timeout <ms>",
+      "Per-run timeout in milliseconds",
+      numericOptionParser("--timeout", { integer: true, min: 0 })
     )
     .option("--json", "Print the full AppDebugReport as JSON to stdout")
     .action(async (ref: string, opts: AppDebugCliOptions) => {
@@ -145,7 +149,7 @@ export function registerAppCommands(program: Command): void {
         }
         process.exit(report.verdict.ok ? 0 : 1);
       } catch (e) {
-        console.error(String(e));
+        printCommandError(e, opts.json);
         process.exit(1);
       }
     });
@@ -187,7 +191,7 @@ export function registerAppCommands(program: Command): void {
       try {
         process.exit(await runAppBuild(ref, opts));
       } catch (e) {
-        console.error(String(e));
+        printCommandError(e, opts.json);
         process.exit(1);
       }
     }
@@ -217,6 +221,31 @@ async function runAppBuild(
     return 1;
   }
   const supervisorConfig = parseSupervisorFlags(opts);
+  // Parsed before anything expensive is built: a mistyped bound must fail the
+  // command, not silently become `NaN` and disable the cap it configures.
+  const bounds = {
+    ...(opts.maxRepairs !== undefined
+      ? {
+          maxRepairs: parseNumericOption(opts.maxRepairs, "--max-repairs", {
+            integer: true,
+            min: 0
+          })
+        }
+      : {}),
+    ...(opts.costCap !== undefined
+      ? {
+          costCapUsd: parseNumericOption(opts.costCap, "--cost-cap", { min: 0 })
+        }
+      : {}),
+    ...(opts.timeout !== undefined
+      ? {
+          timeoutMs: parseNumericOption(opts.timeout, "--timeout", {
+            integer: true,
+            min: 0
+          })
+        }
+      : {})
+  };
 
   const [
     { buildApp, renderBuildReportMarkdown, resolveJudgeModelSpec },
@@ -310,9 +339,7 @@ async function runAppBuild(
           : null;
       },
       ...(opts.workflow ? { pinnedWorkflowIds: opts.workflow } : {}),
-      ...(opts.maxRepairs ? { maxRepairs: Number(opts.maxRepairs) } : {}),
-      ...(opts.costCap ? { costCapUsd: Number(opts.costCap) } : {}),
-      ...(opts.timeout ? { timeoutMs: Number(opts.timeout) } : {}),
+      ...bounds,
       buildId,
       ledger: { userId: "1" },
       onLog: (line) => {

--- a/packages/cli/src/commands/debug.ts
+++ b/packages/cli/src/commands/debug.ts
@@ -20,6 +20,8 @@ import {
   parseSupervisorFlags,
   type SupervisorCliOptions
 } from "../supervisor.js";
+import { numericOptionParser } from "../numeric-options.js";
+import { printCommandError } from "../command-errors.js";
 
 interface DebugCliOptions extends SupervisorCliOptions {
   server?: boolean;
@@ -61,7 +63,7 @@ export function registerDebugCommands(program: Command): void {
     .option(
       "--timeout <ms>",
       "Per-surface run timeout in milliseconds",
-      (v: string) => parseInt(v, 10)
+      numericOptionParser("--timeout", { integer: true, min: 0 })
     )
       .option("--json", "Print the full DebugReport as JSON to stdout")
       .option(
@@ -149,7 +151,7 @@ export function registerDebugCommands(program: Command): void {
         });
         process.exit(0);
       } catch (e) {
-        console.error(String(e));
+        printCommandError(e, opts.json);
         process.exit(1);
       }
     });

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -17,6 +17,7 @@
 import type { Command } from "commander";
 import type { BaseProvider } from "@nodetool-ai/runtime";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+import { parseNumericOption } from "../numeric-options.js";
 
 interface EvalCliOptions {
   provider?: string;
@@ -29,6 +30,8 @@ interface EvalCliOptions {
   maxIterations?: string;
   timeout?: string;
   minSuccess?: string;
+  /** `provider/model` for the suites that judge their own output. */
+  judgeModel?: string;
   /** commander negated flag: `--no-find-model` sets this to false. */
   findModel?: boolean;
 }
@@ -58,6 +61,17 @@ interface EvalRunDeps {
   maxIterations?: number;
   /** Per-case execution timeout (ms), for suites that run what they plan. */
   timeoutMs?: number;
+  /**
+   * Judge provider/model for the suites that grade their own output
+   * (`graph-e2e`, `app-build`), from `--judge-model`. Undefined leaves each
+   * suite's own default in place.
+   */
+  judge?: { provider: BaseProvider; model: string };
+  /**
+   * Human-facing line (suite preamble). A no-op under `--json`, so stdout
+   * carries exactly one JSON document.
+   */
+  log: (line: string) => void;
   /** Progress callback (one line per event, for CLI display). */
   onEvent: (line: string) => void;
 }
@@ -123,7 +137,7 @@ const graphPlannerSuite: EvalSuite = {
 
     const cases = selectCases(GRAPH_PLANNER_EVAL_CASES, deps.caseIds);
 
-    console.log(
+    deps.log(
       `Running ${cases.length} case(s) with ${deps.providerId}/${deps.model}` +
         (deps.providers && Object.keys(deps.providers).length > 0
           ? ` (find_model: ${Object.keys(deps.providers).join(", ")})`
@@ -176,7 +190,7 @@ const graphE2eSuite: EvalSuite = {
 
     const cases = selectCases(GRAPH_E2E_EVAL_CASES, deps.caseIds);
 
-    console.log(
+    deps.log(
       `Running ${cases.length} graph-e2e case(s) with ${deps.providerId}/${deps.model}` +
         (deps.providers && Object.keys(deps.providers).length > 0
           ? ` (find_model: ${Object.keys(deps.providers).join(", ")})`
@@ -190,6 +204,10 @@ const graphE2eSuite: EvalSuite = {
       providers: deps.providers,
       runGraph: createEvalGraphRunner(),
       cases,
+      // Without this the judge is the run's own provider/model grading itself.
+      ...(deps.judge
+        ? { judgeProvider: deps.judge.provider, judgeModel: deps.judge.model }
+        : {}),
       maxRetries: deps.maxRetries,
       timeoutMs: deps.timeoutMs,
       onEvent: deps.onEvent
@@ -226,7 +244,7 @@ const codeGenSuite: EvalSuite = {
       await import("@nodetool-ai/agents");
 
     const cases = selectCases(CODE_GEN_EVAL_CASES, deps.caseIds);
-    console.log(
+    deps.log(
       `Running ${cases.length} code-gen case(s) with ${deps.providerId}/${deps.model}`
     );
 
@@ -264,7 +282,7 @@ const subtaskSuite: EvalSuite = {
 
     const cases = selectCases(SUBTASK_EVAL_CASES, deps.caseIds);
 
-    console.log(
+    deps.log(
       `Running ${cases.length} subtask case(s) with ${deps.providerId}/${deps.model}` +
         (deps.providers && Object.keys(deps.providers).length > 0
           ? ""
@@ -309,7 +327,7 @@ const taskPlannerSuite: EvalSuite = {
     } = await import("@nodetool-ai/agents");
 
     const cases = selectCases(TASK_PLANNER_EVAL_CASES, deps.caseIds);
-    console.log(
+    deps.log(
       `Running ${cases.length} task-planner case(s) with ${deps.providerId}/${deps.model}`
     );
 
@@ -351,7 +369,7 @@ const scriptPlannerSuite: EvalSuite = {
     } = await import("@nodetool-ai/agents");
 
     const cases = selectCases(SCRIPT_PLANNER_EVAL_CASES, deps.caseIds);
-    console.log(
+    deps.log(
       `Running ${cases.length} script-planner case(s) with ${deps.providerId}/${deps.model}`
     );
 
@@ -410,7 +428,7 @@ const appBuildSuite: EvalSuite = {
     ]);
 
     const cases = selectCases(APP_BUILD_EVAL_CASES, deps.caseIds);
-    console.log(
+    deps.log(
       `Running ${cases.length} app-build case(s) with ${deps.providerId}/${deps.model}` +
         (deps.providers && Object.keys(deps.providers).length > 0
           ? ` (find_model: ${Object.keys(deps.providers).join(", ")})`
@@ -429,6 +447,16 @@ const appBuildSuite: EvalSuite = {
         storage: new FileStorageAdapter(getDefaultAssetsPath())
       }),
       ...(deps.providers ? { providers: deps.providers } : {}),
+      // `--judge-model` overrides `buildApp`'s own judge default.
+      ...(deps.judge
+        ? {
+            judge: {
+              enabled: true,
+              provider: deps.judge.provider,
+              model: deps.judge.model
+            }
+          }
+        : {}),
       runOnServer,
       cases,
       ...(deps.timeoutMs !== undefined ? { timeoutMs: deps.timeoutMs } : {}),
@@ -496,7 +524,7 @@ function makeToolLoopSuite(
         deps.caseIds
       );
 
-      console.log(
+      deps.log(
         `Running ${cases.length} ${id} case(s) with ${deps.providerId}/${deps.model}`
       );
 
@@ -589,7 +617,12 @@ export const EVAL_SUITES: readonly EvalSuite[] = [
  */
 async function runSuite(suite: EvalSuite, opts: EvalCliOptions): Promise<void> {
   if (opts.list) {
-    for (const c of await suite.listCases()) {
+    const cases = await suite.listCases();
+    if (opts.json) {
+      console.log(JSON.stringify(cases, null, 2));
+      return;
+    }
+    for (const c of cases) {
       console.log(
         `${c.id.padEnd(24)} ${c.description}` +
           (c.needsModelProviders ? " (needs model providers)" : "")
@@ -599,7 +632,9 @@ async function runSuite(suite: EvalSuite, opts: EvalCliOptions): Promise<void> {
   }
 
   if (!opts.provider || !opts.model) {
-    console.error("--provider and --model are required (or use --list)");
+    const message = "--provider and --model are required (or use --list)";
+    console.error(message);
+    if (opts.json) console.log(JSON.stringify({ error: message }, null, 2));
     process.exitCode = 1;
     return;
   }
@@ -623,6 +658,10 @@ async function runSuite(suite: EvalSuite, opts: EvalCliOptions): Promise<void> {
           .filter(Boolean)
       : undefined;
 
+    const judge = opts.judgeModel
+      ? await resolveJudge(opts.judgeModel, createProviderStrict)
+      : undefined;
+
     const result = await suite.run({
       provider,
       providerId: opts.provider,
@@ -630,11 +669,31 @@ async function runSuite(suite: EvalSuite, opts: EvalCliOptions): Promise<void> {
       registry,
       providers,
       caseIds,
-      maxRetries: opts.maxRetries ? Number(opts.maxRetries) : undefined,
-      maxIterations: opts.maxIterations
-        ? Number(opts.maxIterations)
-        : undefined,
-      timeoutMs: opts.timeout ? Number(opts.timeout) : undefined,
+      ...(judge ? { judge } : {}),
+      maxRetries:
+        opts.maxRetries !== undefined
+          ? parseNumericOption(opts.maxRetries, "--max-retries", {
+              integer: true,
+              min: 0
+            })
+          : undefined,
+      maxIterations:
+        opts.maxIterations !== undefined
+          ? parseNumericOption(opts.maxIterations, "--max-iterations", {
+              integer: true,
+              min: 1
+            })
+          : undefined,
+      timeoutMs:
+        opts.timeout !== undefined
+          ? parseNumericOption(opts.timeout, "--timeout", {
+              integer: true,
+              min: 0
+            })
+          : undefined,
+      log: (line) => {
+        if (!opts.json) console.log(line);
+      },
       onEvent: (line) => {
         if (!opts.json) console.log(line);
       }
@@ -647,7 +706,7 @@ async function runSuite(suite: EvalSuite, opts: EvalCliOptions): Promise<void> {
         JSON.stringify(result.report, null, 2),
         "utf-8"
       );
-      console.log(`Report written to ${opts.out}`);
+      if (!opts.json) console.log(`Report written to ${opts.out}`);
     }
 
     if (opts.json) {
@@ -657,7 +716,10 @@ async function runSuite(suite: EvalSuite, opts: EvalCliOptions): Promise<void> {
     }
 
     if (opts.minSuccess !== undefined) {
-      const threshold = Number(opts.minSuccess);
+      const threshold = parseNumericOption(opts.minSuccess, "--min-success", {
+        min: 0,
+        max: 1
+      });
       if (result.successRate < threshold) {
         console.error(
           `Success rate ${result.successRate.toFixed(2)} below threshold ${threshold}`
@@ -666,9 +728,34 @@ async function runSuite(suite: EvalSuite, opts: EvalCliOptions): Promise<void> {
       }
     }
   } catch (err) {
-    console.error(err instanceof Error ? err.message : String(err));
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(message);
+    // An agent reading `--json` gets parseable output on the failure path too.
+    if (opts.json) console.log(JSON.stringify({ error: message }, null, 2));
     process.exitCode = 1;
   }
+}
+
+/**
+ * Resolve `--judge-model` (`provider/model`) into a live provider. Model ids
+ * carry slashes themselves, so the split is decided by the provider registry,
+ * exactly as `--supervisor-model` does.
+ */
+async function resolveJudge(
+  spec: string,
+  createProvider: (id: string) => Promise<BaseProvider>
+): Promise<{ provider: BaseProvider; model: string }> {
+  const { listRegisteredProviderIds } = await import("@nodetool-ai/runtime");
+  const registered = listRegisteredProviderIds();
+  const cut = spec.indexOf("/");
+  const head = cut === -1 ? spec : spec.slice(0, cut).toLowerCase();
+  if (cut === -1 || !registered.includes(head)) {
+    throw new Error(
+      `--judge-model must be "<provider>/<model>" with a registered provider ` +
+        `(got "${spec}"). Example: openai/gpt-5.4-mini.`
+    );
+  }
+  return { provider: await createProvider(head), model: spec.slice(cut + 1) };
 }
 
 export function registerEvalCommand(program: Command): void {
@@ -700,6 +787,10 @@ export function registerEvalCommand(program: Command): void {
       .option(
         "--timeout <ms>",
         "Per-case execution timeout for suites that run what they plan (graph-e2e; default 300000)"
+      )
+      .option(
+        "--judge-model <provider/model>",
+        "Model that judges outputs for the self-judging suites (graph-e2e, app-build). Default: the run's own provider/model, which grades its own work"
       )
       .option(
         "--min-success <rate>",

--- a/packages/cli/src/commands/node.ts
+++ b/packages/cli/src/commands/node.ts
@@ -6,6 +6,7 @@
  * Heavy deps (registry + runtime) load lazily inside the action.
  */
 import type { Command } from "commander";
+import { printCommandError } from "../command-errors.js";
 
 interface NodeRunCliOptions {
   props?: string;
@@ -87,7 +88,7 @@ export function registerNodeCommands(program: Command): void {
         }
         process.exit(result.ok ? 0 : 1);
       } catch (e) {
-        console.error(String(e));
+        printCommandError(e, opts.json);
         process.exit(1);
       }
     });

--- a/packages/cli/src/commands/timeline.ts
+++ b/packages/cli/src/commands/timeline.ts
@@ -19,6 +19,7 @@ import type {
   TimelineValidation
 } from "@nodetool-ai/execution/timeline-debug";
 import type { TimelineSequenceRecord } from "../timeline-debug/target.js";
+import { printCommandError } from "../command-errors.js";
 
 interface TimelineValidateCliOptions {
   json?: boolean;
@@ -90,7 +91,7 @@ export function registerTimelineCommands(program: Command): void {
           (opts.warningsAsErrors === true && validation.warnings.length > 0);
         process.exit(failed ? 1 : 0);
       } catch (e) {
-        console.error(String(e));
+        printCommandError(e, opts.json);
         process.exit(1);
       }
     });
@@ -137,7 +138,7 @@ export function registerTimelineCommands(program: Command): void {
         }
         process.exit(report.verdict.ok ? 0 : 1);
       } catch (e) {
-        console.error(String(e));
+        printCommandError(e, opts.json);
         process.exit(1);
       }
     });

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -13,6 +13,7 @@ import {
   type GraphValidationIssue,
   type GraphValidationReport
 } from "@nodetool-ai/node-sdk";
+import { printCommandError } from "../command-errors.js";
 
 interface ValidateCliOptions {
   json?: boolean;
@@ -63,7 +64,7 @@ export function registerValidateCommand(program: Command): void {
           (opts.warningsAsErrors === true && report.counts.warnings > 0);
         process.exit(failed ? 1 : 0);
       } catch (e) {
-        console.error(String(e));
+        printCommandError(e, opts.json);
         process.exit(1);
       }
     });

--- a/packages/cli/src/numeric-options.ts
+++ b/packages/cli/src/numeric-options.ts
@@ -1,0 +1,68 @@
+/**
+ * One numeric-flag parser for every CLI command.
+ *
+ * `Number(opts.x)` fails open: `--min-success 0,8` becomes `NaN`, and every
+ * comparison against `NaN` is false — so a CI gate silently stops gating and a
+ * cost cap silently stops capping. A flag that cannot be read is an error, not
+ * a default, so this throws with the flag named.
+ *
+ * The error is Commander's `InvalidArgumentError`, so a parser used as an
+ * `argParser` prints one clean line instead of a stack trace; everywhere else
+ * it is an ordinary `Error` the command's own catch reports.
+ */
+import { InvalidArgumentError } from "commander";
+
+export interface NumericOptionConstraints {
+  /** Reject values below this bound (inclusive). */
+  min?: number;
+  /** Reject values above this bound (inclusive). */
+  max?: number;
+  /** Reject non-integers. */
+  integer?: boolean;
+}
+
+/**
+ * Parse a numeric CLI option, throwing a message that names the flag.
+ *
+ * @param value Raw option text as Commander handed it over.
+ * @param flag Flag name for the error message, e.g. `--min-success`.
+ */
+export function parseNumericOption(
+  value: string,
+  flag: string,
+  constraints: NumericOptionConstraints = {}
+): number {
+  const trimmed = value.trim();
+  const n = trimmed === "" ? Number.NaN : Number(trimmed);
+  const kind = constraints.integer ? "an integer" : "a number";
+  if (!Number.isFinite(n)) {
+    throw new InvalidArgumentError(`${flag} must be ${kind} (got "${value}")`);
+  }
+  if (constraints.integer && !Number.isInteger(n)) {
+    throw new InvalidArgumentError(
+      `${flag} must be an integer (got "${value}")`
+    );
+  }
+  if (constraints.min !== undefined && n < constraints.min) {
+    throw new InvalidArgumentError(
+      `${flag} must be ${kind} >= ${constraints.min} (got "${value}")`
+    );
+  }
+  if (constraints.max !== undefined && n > constraints.max) {
+    throw new InvalidArgumentError(
+      `${flag} must be ${kind} <= ${constraints.max} (got "${value}")`
+    );
+  }
+  return n;
+}
+
+/**
+ * Commander `argParser` form: `.option("--timeout <ms>", "…",
+ * numericOptionParser("--timeout", { integer: true, min: 0 }))`.
+ */
+export function numericOptionParser(
+  flag: string,
+  constraints: NumericOptionConstraints = {}
+): (value: string) => number {
+  return (value: string) => parseNumericOption(value, flag, constraints);
+}

--- a/packages/cli/src/supervisor.ts
+++ b/packages/cli/src/supervisor.ts
@@ -20,6 +20,7 @@ import type { SupervisorHandle } from "@nodetool-ai/execution";
 import type { Intervention, ProcessingMessage } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import type { Command } from "commander";
+import { parseNumericOption } from "./numeric-options.js";
 
 /**
  * Model used when `--supervise` is given without `--supervisor-model`.
@@ -75,19 +76,11 @@ export function addSupervisorOptions(command: Command): Command {
 }
 
 function positiveInt(value: string, flag: string): number {
-  const n = Number(value);
-  if (!Number.isInteger(n) || n < 0) {
-    throw new Error(`${flag} must be a non-negative integer (got "${value}")`);
-  }
-  return n;
+  return parseNumericOption(value, flag, { integer: true, min: 0 });
 }
 
 function positiveNumber(value: string, flag: string): number {
-  const n = Number(value);
-  if (!Number.isFinite(n) || n < 0) {
-    throw new Error(`${flag} must be a non-negative number (got "${value}")`);
-  }
-  return n;
+  return parseNumericOption(value, flag, { min: 0 });
 }
 
 /**

--- a/packages/cli/tests/eval-command.test.ts
+++ b/packages/cli/tests/eval-command.test.ts
@@ -47,6 +47,7 @@ describe("registerEvalCommand", () => {
           "--json",
           "--out",
           "--max-retries",
+          "--judge-model",
           "--min-success",
           "--no-find-model"
         ])

--- a/packages/cli/tests/numeric-options.test.ts
+++ b/packages/cli/tests/numeric-options.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for the shared numeric-flag parser (src/numeric-options.ts).
+ *
+ * The bug it exists to prevent: `Number("0,8")` is `NaN`, and `rate < NaN` is
+ * false — a CI gate that silently stops gating. Every case here is a value a
+ * user actually types.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  numericOptionParser,
+  parseNumericOption
+} from "../src/numeric-options.js";
+import { printCommandError } from "../src/command-errors.js";
+
+describe("parseNumericOption", () => {
+  it("parses plain numbers", () => {
+    expect(parseNumericOption("0.8", "--min-success")).toBe(0.8);
+    expect(parseNumericOption(" 12 ", "--timeout")).toBe(12);
+  });
+
+  it("rejects values that would become NaN", () => {
+    for (const bad of ["0,8", "abc", "", "  ", "1.2.3"]) {
+      expect(() => parseNumericOption(bad, "--min-success")).toThrow(
+        /--min-success must be a number/
+      );
+    }
+  });
+
+  it("rejects infinities", () => {
+    expect(() => parseNumericOption("Infinity", "--cost-cap")).toThrow(
+      /--cost-cap/
+    );
+  });
+
+  it("enforces integer, min and max", () => {
+    expect(() =>
+      parseNumericOption("1.5", "--max-retries", { integer: true })
+    ).toThrow(/--max-retries must be an integer/);
+    expect(() => parseNumericOption("-1", "--timeout", { min: 0 })).toThrow(
+      /--timeout must be a number >= 0/
+    );
+    expect(() =>
+      parseNumericOption("1.5", "--min-success", { min: 0, max: 1 })
+    ).toThrow(/--min-success must be a number <= 1/);
+  });
+
+  it("names the flag in the message", () => {
+    expect(() => parseNumericOption("x", "--cost-cap")).toThrow(
+      '--cost-cap must be a number (got "x")'
+    );
+  });
+
+  it("exposes a Commander argParser form", () => {
+    const parse = numericOptionParser("--timeout", { integer: true, min: 0 });
+    expect(parse("500")).toBe(500);
+    expect(() => parse("soon")).toThrow(/--timeout/);
+  });
+});
+
+describe("printCommandError", () => {
+  it("writes the message to stderr and nothing to stdout by default", () => {
+    const out: string[] = [];
+    const err: string[] = [];
+    const log = console.log;
+    const error = console.error;
+    console.log = (line: string) => out.push(line);
+    console.error = (line: string) => err.push(line);
+    try {
+      printCommandError(new Error("boom"));
+      printCommandError(new Error("boom"), true);
+    } finally {
+      console.log = log;
+      console.error = error;
+    }
+    expect(err).toEqual(["boom", "boom"]);
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0])).toEqual({ error: "boom" });
+  });
+});

--- a/packages/execution/src/app-debug/app-spec.ts
+++ b/packages/execution/src/app-debug/app-spec.ts
@@ -12,6 +12,7 @@ import {
   encodeBinding,
   parseApplicationDocument,
   parseBinding,
+  parseCondition,
   resolveBinding,
   stateKey,
   widgetBindingProps,
@@ -418,6 +419,29 @@ export function validateApp(
     op.io || op.id !== defaultOperationId ? op : { ...op, io }
   );
   const operationIds = new Set(operations.map((op) => op.id));
+  // Node ids per operation, for the operations whose workflow resolved. An
+  // operation with no `io` has no graph to check against, so its bindings are
+  // left alone rather than reported as missing nodes.
+  const nodeIdsByOperation = new Map<string, ReadonlySet<string>>(
+    operations
+      .filter((op) => op.io !== null)
+      .map((op) => [op.id, new Set(op.io?.nodeIds ?? [])])
+  );
+  /**
+   * The node an ID-form binding names, when the operation's graph does not have
+   * it. `parseBinding` accepts any well-formed token, so a widget bound to a
+   * node that was deleted (or never existed) resolves to a ref addressing a
+   * state slot no run ever fills — a silent blank widget without this check.
+   */
+  const missingNode = (
+    binding: string | null,
+    ref: BindingRef | null
+  ): { operationId: string; nodeId: string } | null => {
+    if (!parseBinding(binding) || !ref || !("nodeId" in ref)) return null;
+    const known = nodeIdsByOperation.get(ref.operationId);
+    if (!known || known.has(ref.nodeId)) return null;
+    return { operationId: ref.operationId, nodeId: ref.nodeId };
+  };
   const variableIds = knownVariableIds(io, context);
   const resourceIds = new Set(spec.resources.map((r) => r.id));
 
@@ -467,10 +491,33 @@ export function validateApp(
         );
       }
     }
+    const missing = missingNode(w.binding, w.ref);
+    if (missing) {
+      errors.push(
+        `${where}: bound to "${w.binding}" but operation "${missing.operationId}" runs a workflow with no node "${missing.nodeId}".`
+      );
+    }
+    // An unresolvable condition binding is not enforced at runtime — the widget
+    // shows and stays enabled — so the author sees a condition that quietly
+    // does nothing.
+    for (const [prop, props] of [
+      ["visibleWhen", w.visibleWhen],
+      ["disabledWhen", w.disabledWhen]
+    ] as const) {
+      if (!props?.binding || parseCondition(props, scope)) continue;
+      warnings.push(
+        `${where}: ${prop} reads "${props.binding}", which resolves to nothing — the condition never applies, so the widget stays visible and enabled.`
+      );
+    }
     for (const extra of w.extraBindings) {
+      const extraMissing = missingNode(extra.binding, extra.ref);
       if (!extra.ref) {
         errors.push(
           `${where}: ${extra.prop} is bound to "${extra.binding}" but the workflow has no output or variable with that name.`
+        );
+      } else if (extraMissing) {
+        errors.push(
+          `${where}: ${extra.prop} is bound to "${extra.binding}" but operation "${extraMissing.operationId}" runs a workflow with no node "${extraMissing.nodeId}".`
         );
       } else if (extra.ref.kind === "output") {
         displayedOutputs.add(`${extra.ref.operationId}:${extra.ref.nodeId}`);

--- a/packages/execution/src/app-debug/runtime.ts
+++ b/packages/execution/src/app-debug/runtime.ts
@@ -20,6 +20,7 @@ import {
   evaluateCondition,
   formatTemplate,
   initialVariableValues,
+  isLiveInvocation,
   liveInvocations,
   messagesToEvents,
   operationError,
@@ -119,6 +120,24 @@ export const describeCondition = (
   const op = props.op ?? "notEmpty";
   const value = props.value === undefined || props.value === "" ? "" : ` ${props.value}`;
   return `${props.binding} ${op}${value}`;
+};
+
+/**
+ * Why a ref cannot be written, or null when it can.
+ *
+ * Only a run fills an output slot or an operation's execution state, so a
+ * script that writes one has named the wrong thing — the value would land in
+ * the inputs namespace, where nothing reads it.
+ */
+export const writeRefusal = (ref: BindingRef): string | null => {
+  switch (ref.kind) {
+    case "output":
+      return "resolves to an output, which only a run can fill, and cannot be set";
+    case "execution":
+      return "resolves to execution state, which only a run can fill, and cannot be set";
+    default:
+      return null;
+  }
 };
 
 /**
@@ -513,8 +532,16 @@ export class HeadlessAppRuntime {
     return this.errorFor(this.init.defaultOperationId);
   }
 
-  /** Write a value through its resolved binding. */
+  /**
+   * Write a value through its resolved binding.
+   *
+   * A ref {@link writeRefusal} rejects throws instead of landing in the inputs
+   * namespace: an output slot only a run fills, written as an input, is a value
+   * no reader ever sees, and the step that wrote it must not report success.
+   */
   write(ref: BindingRef, value: unknown): void {
+    const refusal = writeRefusal(ref);
+    if (refusal) throw new Error(refusal);
     const key = stateKey(ref);
     switch (ref.kind) {
       case "variable":
@@ -646,8 +673,13 @@ export class HeadlessAppRuntime {
 
   /** Cancel an operation's live invocations (or one named invocation). */
   cancel(operationId: string, invocationId?: string): string[] {
+    // A named invocation is filtered on liveness like the bare path: cancelling
+    // one that already completed or failed would overwrite what it reported.
     const targets = invocationId
-      ? [invocationId].filter((id) => this.state.invocations[id])
+      ? [invocationId].filter((id) => {
+          const invocation = this.state.invocations[id];
+          return invocation ? isLiveInvocation(invocation) : false;
+        })
       : liveInvocations(this.state, operationId).map((i) => i.id);
     for (const id of targets) {
       this.state = applyEvent(this.state, {
@@ -753,10 +785,12 @@ export class HeadlessAppRuntime {
     record.runIndex = outcome.runIndex;
 
     // The headless runner awaits the whole stream, so every message belongs to
-    // the invocation just started; stamp it where the server did not.
+    // the invocation just started — including the `job_update` and `edge_update`
+    // the kernel stamps with the *server's* job id, which the fold would
+    // otherwise fail to resolve and drop, losing a job-level failure.
     const stamped = outcome.messages.map((message) => ({
       ...message,
-      job_id: message.job_id ?? invocation.id
+      job_id: invocation.id
     }));
     const outputVariables = new Map(
       outputVariableTargets(operation.binding).map((t) => [t.nodeId, t.variableId])

--- a/packages/execution/src/app-debug/simulate.ts
+++ b/packages/execution/src/app-debug/simulate.ts
@@ -25,8 +25,10 @@ import {
   DEFAULT_OPERATION_ID,
   eventToAction,
   parseBinding,
+  parseInputStateKey,
   resolveBinding,
   stateKey,
+  type InputSlot,
   type OperationBinding
 } from "@nodetool-ai/app-runtime";
 import {
@@ -41,6 +43,7 @@ import {
 import {
   effectiveTimeoutMs,
   HeadlessAppRuntime,
+  writeRefusal,
   type HeadlessOperationInit
 } from "./runtime.js";
 import type {
@@ -172,6 +175,46 @@ function conditionalNodeIds(graph: DebugGraph): Set<string> {
     }
   }
   return conditional;
+}
+
+/**
+ * Overlay the live values of node-property bindings onto the graph, the way the
+ * web runtime does before every run (`collectNodePropertyOverlays` →
+ * `withNodeProperties` in `web/src/components/appbuilder/nodeBinding.ts`).
+ *
+ * A widget bound `op:main/prop:node7#strength` writes an input slot keyed by
+ * node and property, which no input node reads — the value only reaches the run
+ * as a property of the node it names. The web helpers take ReactFlow nodes, so
+ * the mapping is repeated here against the kernel shape (`node.properties`);
+ * `parseInputStateKey` — the shared inverse of the state key — is what both
+ * sides actually agree on.
+ */
+export function withNodePropertyOverlays(
+  graph: DebugGraph,
+  inputs: Record<string, InputSlot>
+): DebugGraph {
+  const byNode = new Map<string, Record<string, unknown>>();
+  for (const [key, slot] of Object.entries(inputs)) {
+    if (slot.value === undefined) continue;
+    const parsed = parseInputStateKey(key);
+    if (!parsed?.property) continue;
+    const existing = byNode.get(parsed.nodeId);
+    if (existing) existing[parsed.property] = slot.value;
+    else byNode.set(parsed.nodeId, { [parsed.property]: slot.value });
+  }
+  if (byNode.size === 0) return graph;
+  return {
+    nodes: graph.nodes.map((node) => {
+      const overlay = typeof node.id === "string" ? byNode.get(node.id) : undefined;
+      if (!overlay) return node;
+      const properties =
+        typeof node.properties === "object" && node.properties !== null
+          ? (node.properties as Record<string, unknown>)
+          : {};
+      return { ...node, properties: { ...properties, ...overlay } };
+    }),
+    edges: graph.edges
+  };
 }
 
 /** Node ids keyed by the `name` their data carries, for name-form bindings. */
@@ -401,10 +444,11 @@ export async function simulateApp(
       bindingByOperation.set(binding.id, binding);
       context.operations.push(operationSpec(binding, operationIO, unavailable));
     }
+    // The first declared operation, exactly as the web runtime picks it
+    // (`operations[0]` in `useAppRuntime`) — so a bare-name binding resolves to
+    // the same operation headlessly and in the browser.
     context.defaultOperationId =
-      context.operations.find((op) => op.id === DEFAULT_OPERATION_ID)?.id ??
-      context.operations[0]?.id ??
-      DEFAULT_OPERATION_ID;
+      context.operations[0]?.id ?? DEFAULT_OPERATION_ID;
   }
 
   const { spec, issues: parseIssues, warnings: parseWarnings } = parseAppSpec(
@@ -465,7 +509,7 @@ export async function simulateApp(
     ) => {
       log(`Running operation "${operationId}"…`);
       const outcome = await deps.runOnServer({
-        graph,
+        graph: withNodePropertyOverlays(graph, runtime.state.inputs),
         workflowId,
         params,
         ...(timeoutMs != null ? { timeoutMs } : {})
@@ -546,18 +590,25 @@ export async function simulateApp(
       ...(options.timeoutMs != null ? { timeoutMs: options.timeoutMs } : {})
     });
 
-    /** Write a value addressed by name (a param, or an `--interact` set step). */
+    /**
+     * Write a value addressed by name (a param, or an `--interact` set step),
+     * returning why it did not land, or null once it did. Reading a name in
+     * write mode first and read mode second means an output name resolves — to
+     * a slot nothing can write, which is a failed step, not a silent no-op.
+     */
     const writeByName = (
       name: string,
       value: unknown,
       operationId = context.defaultOperationId
-    ): boolean => {
+    ): string | null => {
       const ref =
         resolveBinding(name, scope, "write", operationId) ??
         resolveBinding(name, scope, "read", operationId);
-      if (!ref) return false;
+      if (!ref) return `"${name}" matches no input, output, or variable.`;
+      const refusal = writeRefusal(ref);
+      if (refusal) return `"${name}" ${refusal}.`;
       runtime.write(ref, value);
-      return true;
+      return null;
     };
 
     /** Seed one collection, reporting why a bad seed did nothing. */
@@ -595,11 +646,8 @@ export async function simulateApp(
         if (failure) report.validation.warnings.push(failure);
         continue;
       }
-      if (!writeByName(key, value)) {
-        report.validation.warnings.push(
-          `Param "${key}" matches no input, output, or variable in the workflow.`
-        );
-      }
+      const failure = writeByName(key, value);
+      if (failure) report.validation.warnings.push(`Param ${failure}`);
     }
 
     /** Dispatch one action, tracking which run it produced. */
@@ -633,11 +681,9 @@ export async function simulateApp(
       report.interactions.push(record);
 
       if ("set" in step) {
-        if (writeByName(step.set.key, step.set.value, step.set.operationId)) {
-          record.actions.push(`set ${step.set.key}`);
-        } else {
-          record.error = `"${step.set.key}" matches no input, output, or variable.`;
-        }
+        const failure = writeByName(step.set.key, step.set.value, step.set.operationId);
+        if (failure) record.error = failure;
+        else record.actions.push(`set ${step.set.key}`);
         continue;
       }
 
@@ -690,7 +736,20 @@ export async function simulateApp(
         continue;
       }
       if ("change" in step && step.value !== undefined) {
-        if (found.ref) runtime.write(found.ref, step.value);
+        // A change whose value never landed must not go on to fire the widget's
+        // events: the run behind them would read the old value.
+        if (!found.ref) {
+          record.error = found.binding
+            ? `changed "${named}" but its binding "${found.binding}" resolves to nothing — nothing was set.`
+            : `changed "${named}", which has no binding to write to.`;
+          continue;
+        }
+        const refusal = writeRefusal(found.ref);
+        if (refusal) {
+          record.error = `changed "${named}", whose binding "${found.binding ?? ""}" ${refusal}.`;
+          continue;
+        }
+        runtime.write(found.ref, step.value);
         record.actions.push(`set ${found.stateKey ?? found.id}`);
       }
       // A run from a bound write widget carries its binding; the web engine

--- a/packages/execution/tests/app-debug-runtime.test.ts
+++ b/packages/execution/tests/app-debug-runtime.test.ts
@@ -126,6 +126,36 @@ describe("HeadlessAppRuntime", () => {
     expect(rt.error).toBe("job died");
   });
 
+  it("folds messages the kernel stamped with the server's own job id", async () => {
+    // The kernel stamps `job_update` (and `edge_update`) with the job id the
+    // server minted, which never matches the harness's invocation id. Dropping
+    // those loses every job-level failure, so they are re-stamped before the
+    // fold.
+    const rt = runtime(async () => [
+      { type: "output_update", node_id: "out1", value: "partial" },
+      { type: "job_update", job_id: "debug-1730000000", status: "failed", error: "bad params" }
+    ]);
+    await rt.dispatch({ kind: "run", operationId: "main" });
+    expect(rt.state.invocations["headless-1"].status).toBe("failed");
+    expect(rt.error).toBe("bad params");
+  });
+
+  it("refuses to write a value into an output slot", () => {
+    const rt = runtime();
+    expect(() => rt.write(OUT_RESULT, "typed by hand")).toThrow(
+      /resolves to an output/
+    );
+    expect(rt.read(OUT_RESULT)).toBeUndefined();
+    expect(rt.state.inputs["main:out1"]).toBeUndefined();
+  });
+
+  it("leaves a settled invocation alone when a cancel names it", async () => {
+    const rt = runtime(async () => [{ type: "job_update", status: "completed" }]);
+    await rt.dispatch({ kind: "run", operationId: "main" });
+    expect(rt.cancel("main", "headless-1")).toEqual([]);
+    expect(rt.state.invocations["headless-1"].status).toBe("completed");
+  });
+
   it("mutates variables without running", async () => {
     const run = vi.fn(async () => []);
     const rt = runtime(run);

--- a/packages/execution/tests/app-debug-simulate.test.ts
+++ b/packages/execution/tests/app-debug-simulate.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for the parts of the simulator that decide what a run actually sees and
+ * what a scripted step is allowed to do: node-property overlays, writes that
+ * address something no widget can fill, and which operation a bare-name binding
+ * resolves against. The workflow runner is stubbed, so what these assert is the
+ * simulator's own behaviour.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { simulateApp } from "../src/app-debug/simulate.js";
+import { collectExecutionSummary } from "../src/debug/collector.js";
+import type {
+  AppServerRunInput,
+  AppServerRunOutcome
+} from "../src/app-debug/simulate.js";
+import type {
+  InteractionStep,
+  ResolvedAppTarget
+} from "../src/app-debug/types.js";
+import { resolvedBundle, resolvedWorkflow } from "./app-debug-fixtures.js";
+
+const graph = {
+  nodes: [
+    {
+      id: "in1",
+      type: "nodetool.input.StringInput",
+      data: { name: "prompt", value: "hello" }
+    },
+    {
+      id: "llm1",
+      type: "nodetool.text.Generate",
+      data: { name: "generate", strength: 0.2 }
+    },
+    { id: "out1", type: "nodetool.output.StringOutput", data: { name: "result" } }
+  ],
+  edges: []
+};
+
+const runButton = {
+  type: "Button",
+  props: {
+    id: "Button-1",
+    label: "Run",
+    events: [{ trigger: "click", kind: "run", key: "", value: "" }]
+  }
+};
+
+const appTarget = (content: Array<Record<string, unknown>>): ResolvedAppTarget =>
+  resolvedWorkflow(graph, {
+    version: 2,
+    variables: [],
+    data: { root: { props: { title: "Sim App" } }, content, zones: {} }
+  });
+
+const stubRunner = () =>
+  vi.fn<(input: AppServerRunInput) => Promise<AppServerRunOutcome>>(async () => {
+    const messages = [
+      { type: "output_update", node_id: "out1", output_name: "output", value: "done" },
+      { type: "job_update", status: "completed" }
+    ];
+    const summary = collectExecutionSummary(messages);
+    summary.status = "completed";
+    return {
+      report: {
+        surface: "server",
+        ok: true,
+        status: "completed",
+        error: null,
+        durationMs: 5,
+        summary,
+        trace: null
+      },
+      rawMessages: messages as never[]
+    };
+  });
+
+const run = async (target: ResolvedAppTarget, interact?: InteractionStep[]) => {
+  const runOnServer = stubRunner();
+  const report = await simulateApp(
+    target,
+    { ...(interact ? { interact } : {}) },
+    { loadFromDb: async () => null, runOnServer }
+  );
+  return { report, runOnServer };
+};
+
+/** The `properties` a run's graph carried for one node. */
+const propsOf = (input: AppServerRunInput, nodeId: string) =>
+  input.graph.nodes.find((n) => n.id === nodeId)?.properties as
+    | Record<string, unknown>
+    | undefined;
+
+describe("app debug — node-property bindings", () => {
+  it("overlays a widget-driven node property onto the graph the run receives", async () => {
+    const target = appTarget([
+      {
+        type: "Slider",
+        props: { id: "Slider-1", binding: "op:main/prop:llm1#strength" }
+      },
+      { type: "Markdown", props: { id: "Markdown-1", binding: "result" } },
+      runButton
+    ]);
+    const { report, runOnServer } = await run(target, [
+      { set: { key: "op:main/prop:llm1#strength", value: 0.9 } },
+      { click: "Button-1" }
+    ]);
+
+    expect(report.interactions.map((i) => i.error)).toEqual([null, null]);
+    expect(propsOf(runOnServer.mock.calls[0][0], "llm1")).toMatchObject({
+      strength: 0.9
+    });
+    // The resolved target keeps the stored value — the overlay is per run.
+    expect(target.graph.nodes.find((n) => n.id === "llm1")?.properties).toMatchObject(
+      { strength: 0.2 }
+    );
+  });
+
+  it("leaves the graph alone when no node property is bound", async () => {
+    const { runOnServer } = await run(
+      appTarget([
+        { type: "TextInput", props: { id: "TextInput-1", binding: "prompt" } },
+        { type: "Markdown", props: { id: "Markdown-1", binding: "result" } },
+        runButton
+      ])
+    );
+
+    expect(propsOf(runOnServer.mock.calls[0][0], "llm1")).toMatchObject({
+      strength: 0.2
+    });
+  });
+});
+
+describe("app debug — writes that cannot land", () => {
+  it("fails a set step that names an output", async () => {
+    const { report } = await run(
+      appTarget([
+        { type: "TextInput", props: { id: "TextInput-1", binding: "prompt" } },
+        { type: "Markdown", props: { id: "Markdown-1", binding: "result" } },
+        runButton
+      ]),
+      [{ set: { key: "result", value: "typed by hand" } }]
+    );
+
+    expect(report.interactions[0]).toMatchObject({ actions: [] });
+    expect(report.interactions[0].error).toMatch(/resolves to an output/);
+    expect(report.verdict.ok).toBe(false);
+  });
+
+  it("fails a change step on a widget whose binding resolves to nothing", async () => {
+    const { report } = await run(
+      appTarget([
+        { type: "TextInput", props: { id: "TextInput-1", binding: "ghost" } },
+        { type: "Markdown", props: { id: "Markdown-1", binding: "result" } },
+        runButton
+      ]),
+      [{ change: "TextInput-1", value: "typed" }]
+    );
+
+    expect(report.interactions[0]).toMatchObject({ actions: [] });
+    expect(report.interactions[0].error).toMatch(/resolves to nothing/);
+  });
+
+  it("warns instead of failing when a param names an output", async () => {
+    const runOnServer = stubRunner();
+    const report = await simulateApp(
+      appTarget([
+        { type: "TextInput", props: { id: "TextInput-1", binding: "prompt" } },
+        { type: "Markdown", props: { id: "Markdown-1", binding: "result" } },
+        runButton
+      ]),
+      { params: { result: "typed by hand" } },
+      { loadFromDb: async () => null, runOnServer }
+    );
+
+    expect(report.validation.warnings.join("\n")).toMatch(
+      /Param "result" resolves to an output/
+    );
+  });
+
+  it("clears a value when a change step sets null", async () => {
+    // The input's default is non-empty, so a `disabledWhen … empty` button is
+    // enabled until the step clears the field.
+    const { report } = await run(
+      appTarget([
+        { type: "TextInput", props: { id: "TextInput-1", binding: "prompt" } },
+        { type: "Markdown", props: { id: "Markdown-1", binding: "result" } },
+        {
+          ...runButton,
+          props: {
+            ...runButton.props,
+            disabledWhen: { binding: "prompt", op: "empty" }
+          }
+        }
+      ]),
+      [{ change: "TextInput-1", value: null }, { click: "Button-1" }]
+    );
+
+    expect(report.interactions[0].actions).toEqual(["set main:in1"]);
+    expect(report.interactions[1].error).toMatch(/disabled by `prompt empty`/);
+  });
+});
+
+describe("app debug — default operation", () => {
+  it("resolves a bare name against the first declared operation", async () => {
+    const target = resolvedBundle({
+      schemaVersion: 1,
+      name: "Two-step App",
+      description: "",
+      app: {
+        schemaVersion: 3,
+        ui: {
+          root: { props: { title: "Two-step App" } },
+          content: [
+            { type: "Markdown", props: { id: "Markdown-1", binding: "result" } },
+            runButton
+          ],
+          zones: {}
+        },
+        operations: [
+          {
+            id: "draft",
+            name: "Draft",
+            workflowId: "wf-draft",
+            inputs: {},
+            outputs: {},
+            policy: "replace"
+          },
+          {
+            id: "main",
+            name: "Publish",
+            workflowId: "wf-main",
+            inputs: {},
+            outputs: {},
+            policy: "replace"
+          }
+        ],
+        resources: [],
+        variables: []
+      },
+      workflows: [
+        {
+          key: "wf-draft",
+          name: "Draft",
+          graph: {
+            nodes: [
+              {
+                id: "outA",
+                type: "nodetool.output.StringOutput",
+                data: { name: "result" }
+              }
+            ],
+            edges: []
+          }
+        },
+        {
+          key: "wf-main",
+          name: "Publish",
+          graph: {
+            nodes: [
+              {
+                id: "outB",
+                type: "nodetool.output.StringOutput",
+                data: { name: "result" }
+              }
+            ],
+            edges: []
+          }
+        }
+      ]
+    });
+
+    const { report } = await run(target, []);
+
+    // The web runtime takes `operations[0]`, whatever it is called, so the same
+    // document must not resolve "result" to the operation named "main" here.
+    expect(report.widgets.find((w) => w.id === "Markdown-1")?.stateKey).toBe(
+      "draft:outA"
+    );
+  });
+});
+
+describe("app debug — static binding checks", () => {
+  it("errors on an ID-form binding to a node the workflow does not have", async () => {
+    const { report } = await run(
+      appTarget([
+        { type: "TextInput", props: { id: "TextInput-1", binding: "prompt" } },
+        {
+          type: "Markdown",
+          props: { id: "Markdown-1", binding: "op:main/out:ghost" }
+        },
+        runButton
+      ]),
+      []
+    );
+
+    expect(report.validation.errors.join("\n")).toMatch(
+      /Markdown "Markdown-1": bound to "op:main\/out:ghost" but operation "main" runs a workflow with no node "ghost"/
+    );
+    expect(report.verdict.ok).toBe(false);
+  });
+
+  it("warns when a condition binding resolves to nothing", async () => {
+    const { report } = await run(
+      appTarget([
+        { type: "TextInput", props: { id: "TextInput-1", binding: "prompt" } },
+        {
+          type: "Markdown",
+          props: {
+            id: "Markdown-1",
+            binding: "result",
+            visibleWhen: { binding: "ghostName", op: "notEmpty" }
+          }
+        },
+        runButton
+      ]),
+      []
+    );
+
+    expect(report.validation.warnings.join("\n")).toMatch(
+      /visibleWhen reads "ghostName", which resolves to nothing/
+    );
+    // The runtime behaviour is unchanged: an unresolvable condition is ignored.
+    expect(report.widgets.find((w) => w.id === "Markdown-1")?.visible).toBe(true);
+  });
+});

--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -1183,11 +1183,10 @@ export class NodeActor {
         switch (verdict.action) {
           case "retry":
             continue;
-          case "substitute": {
-            const valid = await this._validateSubstitute(verdict.outputs);
-            if (valid) return verdict.outputs;
-            throw err;
-          }
+          // `_escalate` only returns `substitute` for outputs that passed
+          // validation, so what comes back here is ready to route.
+          case "substitute":
+            return verdict.outputs;
           case "skip":
             await this._skipInvocation();
             return SKIPPED;
@@ -1233,13 +1232,21 @@ export class NodeActor {
     try {
       outcome = await this._supervisor!.decide(escalation, this._cancelSignal);
     } catch {
-      outcome = { verdict: { action: "fail" }, decidedBy: "default" };
+      // A failure *of* the supervisor, which is what the bounds exist to
+      // absorb — same class, and so the same label, as a timed-out decision.
+      outcome = { verdict: { action: "fail" }, decidedBy: "bounds" };
     }
 
     // The record has to name who produced the verdict that was *applied*. When
     // the kernel overrules a handle, crediting the handle would hide exactly
-    // the case worth finding: a buggy or hostile supervisor.
-    const allowed = escalation.allowedActions.includes(outcome.verdict.action);
+    // the case worth finding: a buggy or hostile supervisor. A repair whose
+    // values do not match the node's declared outputs is overruled here, not
+    // after the fact: the intervention must record what happened, and a
+    // rejected repair is a `fail`, not a repair.
+    const allowed =
+      escalation.allowedActions.includes(outcome.verdict.action) &&
+      (outcome.verdict.action !== "substitute" ||
+        (await this._validateSubstitute(outcome.verdict.outputs)));
     const verdict = allowed ? outcome.verdict : ({ action: "fail" } as Verdict);
     const decidedBy: DecidedBy = allowed ? outcome.decidedBy : "kernel";
 

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -36,6 +36,7 @@ export {
 export { NodeActor, type NodeExecutor, type ActorResult } from "./actor.js";
 export {
   BoundedHandle,
+  ensureBounded,
   FailClosedHandle,
   computeAllowedActions,
   failureSignature,

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -25,6 +25,7 @@ import type {
   Intervention
 } from "@nodetool-ai/protocol";
 import { TypeMetadata } from "@nodetool-ai/protocol";
+import { ensureBounded, redactValue } from "./supervisor.js";
 import type { SupervisorHandle } from "./supervisor.js";
 
 // Stryker disable next-line StringLiteral: logger name is a diagnostic label, not a behavioural contract
@@ -439,10 +440,20 @@ export class WorkflowRunner {
     return this._interventions.length > 0 ? this._interventions : undefined;
   }
 
+  /**
+   * The handle every escalation actually goes through: whatever the caller
+   * configured, under the kernel's bounds. Nothing else in the runner reads
+   * `_options.supervisor`.
+   */
+  private readonly _supervisor: SupervisorHandle | undefined;
+
   constructor(jobId: string, options: WorkflowRunnerOptions) {
     this.jobId = jobId;
     this._effectiveJobId = jobId;
     this._options = options;
+    this._supervisor = options.supervisor
+      ? ensureBounded(options.supervisor)
+      : undefined;
   }
 
   // -----------------------------------------------------------------------
@@ -844,6 +855,13 @@ export class WorkflowRunner {
   }
 
   private _runStateDigest(): RunStateDigest {
+    // A node error is raw `err.message` — an HTTP failure echoing its URL
+    // carries the key it was called with. The digest goes to the supervisor
+    // model, so it is redacted here, where the digest is built, exactly as the
+    // actor redacts an escalation's `detail`.
+    const secrets =
+      this._options.executionContext?.getResolvedSecretValues?.() ??
+      new Set<string>();
     const escalationsPerNode = new Map<string, number>();
     for (const intervention of this._interventions) {
       const nodeId = intervention.escalation.nodeId;
@@ -867,7 +885,9 @@ export class WorkflowRunner {
         emissions,
         escalations: escalationsPerNode.get(node.id) ?? 0
       };
-      if (error !== undefined) state.error = error;
+      if (error !== undefined) {
+        state.error = String(redactValue(error, secrets));
+      }
       return state;
     });
     return {
@@ -1374,7 +1394,7 @@ export class WorkflowRunner {
     // supervisor must never be worse for the run than no supervisor: it
     // proceeds without a reader and its decisions degrade to `fail`.
     try {
-      this._options.supervisor?.attach?.(this._runStateReader());
+      this._supervisor?.attach?.(this._runStateReader());
     } catch (error) {
       // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
       log.warn("Supervisor attach failed; running without a run-state view", {
@@ -1427,7 +1447,7 @@ export class WorkflowRunner {
         cancelSignal: this._abortController.signal,
         signalSlotEos: (sourceNodeId, slot) =>
           this._signalSlotEos(sourceNodeId, slot),
-        supervisor: this._options.supervisor,
+        supervisor: this._supervisor,
         onIntervention: (intervention) => this._interventions.push(intervention)
       });
 
@@ -1611,7 +1631,7 @@ export class WorkflowRunner {
       return;
     }
 
-    if (this._options.supervisor) {
+    if (this._supervisor) {
       this._recordNodeOutput(
         sourceNodeId,
         outputs,

--- a/packages/kernel/src/substitute-validator.ts
+++ b/packages/kernel/src/substitute-validator.ts
@@ -81,6 +81,10 @@ export async function validateSubstituteOutputs(
  * True when every declared output has a rule this validator can enforce.
  * `substitute` is offered only for full coverage — a partially-checked
  * substitution is an unchecked one for the slot that matters.
+ *
+ * `any` is not coverage: a rule that accepts everything checks nothing, so an
+ * all-`any` node would offer a repair no validator could reject. It is treated
+ * like a reference type the run cannot resolve — no substitute.
  */
 export function hasFullValidatorCoverage(
   declaredOutputs: Record<string, string>,
@@ -103,8 +107,7 @@ export function hasFullValidatorCoverage(
       base === "list" ||
       base === "array" ||
       base === "dict" ||
-      base === "object" ||
-      base === "any"
+      base === "object"
     );
   });
 }
@@ -124,8 +127,6 @@ async function validateOne(
   const base = baseType(type);
 
   switch (base) {
-    case "any":
-      return null;
     case "str":
     case "string":
       return typeof value === "string"

--- a/packages/kernel/src/supervisor.ts
+++ b/packages/kernel/src/supervisor.ts
@@ -34,6 +34,12 @@ export interface DecisionOutcome {
 export interface SupervisorHandle {
   decide(e: Escalation, signal: AbortSignal): Promise<DecisionOutcome>;
   /**
+   * True when the handle already enforces the run's bounds. Set by
+   * `BoundedHandle`; `ensureBounded` reads it so a handle bounded by its
+   * caller is not wrapped a second time.
+   */
+  readonly bounded?: boolean;
+  /**
    * Handed the run's read-only state once, before any actor starts. A handle
    * is configured before the runner exists, so the reader cannot be a
    * constructor argument. Optional: a scripted handle needs no run state.
@@ -264,6 +270,7 @@ export const DEFAULT_SUPERVISOR_BOUNDS = {
  * deterministic, never a cheaper model.
  */
 export class BoundedHandle implements SupervisorHandle {
+  readonly bounded = true;
   private readonly _inner: SupervisorHandle;
   private readonly _bounds: Required<SupervisorBounds>;
   private _decisions = 0;
@@ -296,7 +303,12 @@ export class BoundedHandle implements SupervisorHandle {
   ): Promise<DecisionOutcome> {
     if (e.failureSignature !== undefined) {
       const hit = this._sticky.get(stickyKey(e));
-      if (hit) return { verdict: hit, decidedBy: "sticky" };
+      // A cached verdict is only a shortcut for a decision this escalation
+      // could have received anyway. Replaying one the escalation does not
+      // allow buys nothing: the actor overrules it to `fail`. Decide afresh.
+      if (hit && e.allowedActions.includes(hit.action)) {
+        return { verdict: hit, decidedBy: "sticky" };
+      }
     }
 
     if (this._decisions >= this._bounds.maxDecisions) {
@@ -369,6 +381,21 @@ export class BoundedHandle implements SupervisorHandle {
   close(): void {
     this._inner.close();
   }
+}
+
+/**
+ * Bound a handle, once. `WorkflowRunnerOptions.supervisor` takes any
+ * `SupervisorHandle`, and an unbounded one — a handle that answers `retry`
+ * forever, or whose `decide()` never resolves — spins or parks an actor for
+ * the life of the process. The ceilings are the kernel's, not the caller's,
+ * so the runner applies them itself; a handle its caller already bounded is
+ * returned untouched.
+ */
+export function ensureBounded(
+  handle: SupervisorHandle,
+  opts: SupervisorBounds = {}
+): SupervisorHandle {
+  return handle.bounded === true ? handle : new BoundedHandle(handle, opts);
 }
 
 function stickyKey(e: Escalation): string {

--- a/packages/kernel/tests/supervisor-handle.test.ts
+++ b/packages/kernel/tests/supervisor-handle.test.ts
@@ -203,6 +203,30 @@ describe("BoundedHandle — sticky verdicts", () => {
     expect(inner.calls).toBe(2);
   });
 
+  it("decides afresh when the cached verdict is not allowed here", async () => {
+    // The same signature can reach an escalation with a different allowed set
+    // — a streaming invocation that already emitted cannot be skipped. Serving
+    // the cached `skip` there only earns a kernel override to `fail`.
+    const inner = handleReturning({ action: "skip", applyTo: "signature" });
+    const bounded = new BoundedHandle(inner);
+    const first = await bounded.decide(
+      escalation({ failureSignature: "http:403" }),
+      never
+    );
+    expect(first.verdict.action).toBe("skip");
+
+    const narrowed = await bounded.decide(
+      escalation({
+        failureSignature: "http:403",
+        allowedActions: ["end_stream", "fail"],
+        emitted: true
+      }),
+      never
+    );
+    expect(narrowed.decidedBy).not.toBe("sticky");
+    expect(inner.calls).toBe(2);
+  });
+
   it("has nothing to key on without a signature", async () => {
     const inner = handleReturning({ action: "skip", applyTo: "signature" });
     const bounded = new BoundedHandle(inner);
@@ -443,6 +467,20 @@ describe("substitute validator", () => {
     expect(hasFullValidatorCoverage({ a: "image" }, true)).toBe(true);
     expect(hasFullValidatorCoverage({ a: "custom.Thing" }, true)).toBe(false);
     expect(hasFullValidatorCoverage({}, true)).toBe(false);
+  });
+
+  it("does not count `any` as coverage", async () => {
+    // A rule that accepts everything checks nothing: an all-`any` node would
+    // offer a repair no validator could ever reject.
+    expect(hasFullValidatorCoverage({ a: "any" }, true)).toBe(false);
+    expect(hasFullValidatorCoverage({ a: "str", b: "any" }, true)).toBe(false);
+
+    const result = await validateSubstituteOutputs(
+      { a: { anything: true } },
+      { declaredOutputs: { a: "any" } }
+    );
+    expect(result.ok).toBe(false);
+    expect(result.issues[0]).toContain("no runtime validation rule");
   });
 });
 

--- a/packages/kernel/tests/supervisor.test.ts
+++ b/packages/kernel/tests/supervisor.test.ts
@@ -16,7 +16,13 @@ import type { Escalation, Verdict } from "@nodetool-ai/protocol";
 import { WorkflowRunner, type RunResult } from "../src/runner.js";
 import { NodeActor, type NodeExecutor } from "../src/actor.js";
 import { NodeInbox } from "../src/inbox.js";
-import type { DecisionOutcome, SupervisorHandle } from "../src/supervisor.js";
+import {
+  BoundedHandle,
+  DEFAULT_SUPERVISOR_BOUNDS,
+  type DecisionOutcome,
+  type SupervisorHandle
+} from "../src/supervisor.js";
+import type { RunStateReader } from "../src/run-state.js";
 import { ProcessingContext } from "@nodetool-ai/runtime";
 import type { Edge, NodeDescriptor } from "@nodetool-ai/protocol";
 
@@ -346,6 +352,18 @@ describe("supervisor — substitute", () => {
       }))
     });
     expect(result.status).toBe("failed");
+    // The audit trail must say what happened. A repair the kernel refused is
+    // a fail, and crediting the handle with a substitution it did not get to
+    // make would make the intervention record a lie.
+    expect(result.interventions).toHaveLength(1);
+    expect(result.interventions![0].verdict.action).toBe("fail");
+    expect(result.interventions![0].decidedBy).toBe("kernel");
+    const decisions = result.messages.filter(
+      (m) => (m as { type?: string }).type === "supervisor_decision"
+    ) as Array<{ verdict: { action: string }; decided_by: string }>;
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].verdict.action).toBe("fail");
+    expect(decisions[0].decided_by).toBe("kernel");
   });
 
   it("is not offered without a candidate output — repair is not invention", async () => {
@@ -558,6 +576,111 @@ describe("supervisor — the kernel enforces its own allowed set", () => {
     });
     expect(result.status).toBe("failed");
     expect(result.error).toContain("boom");
+    // A failure *of* the supervisor is what the bounds absorb, so it is
+    // labelled like every other one — not "default", which means nobody was
+    // configured to decide.
+    expect(result.interventions![0].decidedBy).toBe("bounds");
+  });
+
+  it("caps a handle that answers retry forever", async () => {
+    // `WorkflowRunnerOptions.supervisor` takes any handle. An unbounded one
+    // that always says retry would spin the actor for the life of the process,
+    // so the runner applies the kernel's bounds itself.
+    const runaway: SupervisorHandle = {
+      async decide(): Promise<DecisionOutcome> {
+        return { verdict: { action: "retry" }, decidedBy: "agent" };
+      },
+      close() {}
+    };
+    let calls = 0;
+    const graph = chain({ retry_safe: true });
+    const result = await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            calls++;
+            throw new Error("always");
+          }
+        }
+      },
+      supervisor: runaway
+    });
+
+    // First invocation plus DEFAULT_SUPERVISOR_BOUNDS.maxRetriesPerNode.
+    expect(calls).toBe(1 + DEFAULT_SUPERVISOR_BOUNDS.maxRetriesPerNode);
+    expect(result.status).toBe("failed");
+    expect(result.interventions!.at(-1)!.decidedBy).toBe("bounds");
+  });
+
+  it("does not bound a handle its caller already bounded", async () => {
+    const inner: SupervisorHandle = {
+      async decide(): Promise<DecisionOutcome> {
+        return { verdict: { action: "retry" }, decidedBy: "agent" };
+      },
+      close() {}
+    };
+    let calls = 0;
+    const graph = chain({ retry_safe: true });
+    await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      executors: {
+        work: {
+          async process() {
+            calls++;
+            throw new Error("always");
+          }
+        }
+      },
+      supervisor: new BoundedHandle(inner, { maxRetriesPerNode: 1 })
+    });
+    // Double-wrapping would spend the outer budget on top of this one.
+    expect(calls).toBe(2);
+  });
+});
+
+describe("supervisor — the run digest is redacted", () => {
+  it("never hands a node's raw error text to the supervisor", async () => {
+    const SECRET = "sk-live-01234567890abcdef";
+    const context = new ProcessingContext({ jobId: "supervisor-test" });
+    context.setSecretResolver(() => SECRET);
+
+    let reader: RunStateReader | null = null;
+    const handle: SupervisorHandle = {
+      attach(r) {
+        reader = r;
+      },
+      async decide(): Promise<DecisionOutcome> {
+        return { verdict: { action: "fail" }, decidedBy: "agent" };
+      },
+      close() {}
+    };
+
+    const graph = chain();
+    await runGraph({
+      ...graph,
+      params: { x: "hi" },
+      context,
+      executors: {
+        work: {
+          async process(_ins, ctx) {
+            const key = await (ctx as ProcessingContext).getSecret("API_KEY");
+            throw new Error(
+              `request to https://api.example.com?key=${key} failed`
+            );
+          }
+        }
+      },
+      supervisor: handle
+    });
+
+    const digest = reader!.digest();
+    const failed = digest.nodes.find((n) => n.nodeId === "work");
+    expect(failed?.status).toBe("failed");
+    expect(failed?.error).toContain("«redacted»");
+    expect(JSON.stringify(digest)).not.toContain(SECRET);
   });
 });
 

--- a/packages/node-sdk/src/graph-validation.ts
+++ b/packages/node-sdk/src/graph-validation.ts
@@ -68,12 +68,18 @@ export type GraphValidationSeverity = "error" | "warning" | "info";
 export interface GraphValidationIssue {
   severity: GraphValidationSeverity;
   /**
-   * Stable category: "unknown_node" | "duplicate_id" | "property" |
-   * "dangling_edge" | "unknown_handle" | "type_mismatch" | "fan_in" |
-   * "untyped_dynamic_slot" | "dynamic_type_mismatch" | "unknown_provider" |
-   * "slot_type_alias", plus the `code_*` categories a Code node body produces
-   * (see {@link validateCodeNodeBody}).
+   * Stable category: "unknown_node" | "missing_id" | "duplicate_id" |
+   * "property" | "dangling_edge" | "unknown_handle" | "missing_handle" |
+   * "cycle" | "type_mismatch" | "fan_in" | "untyped_dynamic_slot" |
+   * "dynamic_type_mismatch" | "unknown_provider" | "slot_type_alias", plus the
+   * `code_*` categories a Code node body produces (see
+   * {@link validateCodeNodeBody}).
    *
+   * - "missing_id" (error): a node with no id — unaddressable by any edge.
+   * - "missing_handle" (error): an edge whose endpoints both exist but which
+   *   names no source/target handle, so the kernel cannot route it.
+   * - "cycle" (error): a self-loop, or a cycle in the data subgraph the
+   *   kernel's correlation analysis requires to be a DAG.
    * - "untyped_dynamic_slot" (info): an edge targets a dynamic input that
    *   carries no `dynamic_inputs` declaration, so its type cannot be checked.
    *   Legacy graphs produce one per dynamic edge; never an error, and below
@@ -187,9 +193,22 @@ function readDynamicOutputs(
   );
 }
 
-/** The declared properties of a node, from either graph shape. */
+/**
+ * The declared properties of a node, from either graph shape.
+ *
+ * The editor's `NodeData` nests the props bag under `data.properties` (the same
+ * wrapper `readDynamicInputs` and friends unwrap). Reading `data` itself as the
+ * bag made every editor-exported node look like it was missing every required
+ * property. `data` is still the fallback for older/hand-written shapes that
+ * flattened the props onto it.
+ */
 function readProperties(node: GraphValidationNode): Record<string, unknown> {
-  return (node.properties ?? node.data ?? {}) as Record<string, unknown>;
+  return (
+    asRecord(node.properties) ??
+    asRecord(node.data?.properties) ??
+    asRecord(node.data) ??
+    {}
+  );
 }
 
 interface NormEdge {
@@ -243,6 +262,81 @@ function modelProviderOf(value: unknown): string | undefined {
   return provider;
 }
 
+/**
+ * Self-loops and cycles — both fatal at run time, neither visible before it.
+ *
+ * `Graph.validateEdgeEndpoints` (kernel) rejects a self-loop on *any* edge:
+ * the node waits on an input only its own completion can close, so the run
+ * hangs. `analyzeCorrelation` requires the **data** subgraph to be a DAG, and
+ * its topological sort skips control edges — so cycles are looked for over
+ * data edges only, matching the kernel exactly.
+ *
+ * Kahn's algorithm, iterative: a deep graph must not blow the stack.
+ */
+function detectCycles(
+  byId: ReadonlyMap<string, GraphValidationNode>,
+  normEdges: readonly NormEdge[]
+): GraphValidationIssue[] {
+  const issues: GraphValidationIssue[] = [];
+  const selfLooped = new Set<string>();
+  for (const e of normEdges) {
+    if (e.source !== e.target || !byId.has(e.source)) continue;
+    if (selfLooped.has(e.source)) continue;
+    selfLooped.add(e.source);
+    issues.push({
+      severity: "error",
+      code: "cycle",
+      nodeId: e.source,
+      nodeType: String(byId.get(e.source)?.type ?? ""),
+      edgeId: e.id,
+      message: `Node "${e.source}" is connected to itself by edge "${e.id}"; self-loop edges are not supported and deadlock the run`
+    });
+  }
+
+  const incoming = new Map<string, number>();
+  const outgoing = new Map<string, string[]>();
+  for (const id of byId.keys()) {
+    incoming.set(id, 0);
+    outgoing.set(id, []);
+  }
+  for (const e of normEdges) {
+    if (e.isControl) continue;
+    if (e.source === e.target) continue;
+    if (!byId.has(e.source) || !byId.has(e.target)) continue;
+    outgoing.get(e.source)!.push(e.target);
+    incoming.set(e.target, (incoming.get(e.target) ?? 0) + 1);
+  }
+
+  const queue: string[] = [];
+  for (const [id, count] of incoming) {
+    if (count === 0) queue.push(id);
+  }
+  let ordered = 0;
+  // Index instead of shift(): shift() on a large array is O(n) per call.
+  for (let head = 0; head < queue.length; head++) {
+    ordered++;
+    for (const target of outgoing.get(queue[head]) ?? []) {
+      const next = (incoming.get(target) ?? 0) - 1;
+      incoming.set(target, next);
+      if (next === 0) queue.push(target);
+    }
+  }
+
+  if (ordered < byId.size) {
+    const seen = new Set(queue);
+    const remaining = [...byId.keys()].filter((id) => !seen.has(id));
+    issues.push({
+      severity: "error",
+      code: "cycle",
+      nodeId: remaining[0],
+      nodeType: String(byId.get(remaining[0])?.type ?? ""),
+      message: `Cycle detected in graph; the kernel's correlation analysis requires a DAG. Involved nodes: ${remaining.join(", ")}`
+    });
+  }
+
+  return issues;
+}
+
 export function validateGraph(
   graph: GraphValidationInput,
   registry: GraphValidationRegistry
@@ -257,6 +351,16 @@ export function validateGraph(
   for (const node of nodes) {
     const id = String(node.id ?? "");
     const type = String(node.type ?? "");
+    if (!id) {
+      // Nothing can address this node: no edge can name it, and the runner
+      // keys every message by node id.
+      issues.push({
+        severity: "error",
+        code: "missing_id",
+        nodeType: type,
+        message: `Node of type "${type || "(no type)"}" has no id`
+      });
+    }
     if (id && seenIds.has(id)) {
       issues.push({
         severity: "error",
@@ -318,15 +422,16 @@ export function validateGraph(
   const knownProviders =
     providerIds && providerIds.length > 0 ? new Set(providerIds) : null;
 
-  for (const node of nodes) {
-    const id = String(node.id ?? "");
+  // `byId` holds one node per id — a duplicate id is already an error, and
+  // validating the shadowed copy's properties would report everything twice.
+  for (const [id, node] of byId) {
     const type = String(node.type ?? "");
     if (!type || !registry.has(type)) continue;
     const propIssues = registry.validateNode(
       {
         id,
         type,
-        properties: node.properties ?? node.data ?? {},
+        properties: readProperties(node),
         // Without these the registry cannot reach validateDynamicSlots, so a
         // slot declared `required` is never checked.
         dynamic_inputs: readDynamicInputs(node),
@@ -468,6 +573,9 @@ export function validateGraph(
     }
   }
 
+  // ── Cycles: the kernel requires a DAG ────────────────────────────────────
+  issues.push(...detectCycles(byId, normEdges));
+
   // ── Edges: endpoints, handles, type compatibility ────────────────────────
   for (const e of normEdges) {
     const sourceNode = byId.get(e.source);
@@ -489,6 +597,32 @@ export function validateGraph(
       });
     }
     if (!sourceNode || !targetNode) continue;
+
+    // Both endpoints exist but the edge names no handle: the kernel routes
+    // messages by `${source}:${sourceHandle}`, so an empty handle matches
+    // nothing and the edge silently carries no data. The handle checks below
+    // are all gated on a non-empty handle, so without this the edge would
+    // validate clean.
+    if (!e.sourceHandle) {
+      issues.push({
+        severity: "error",
+        code: "missing_handle",
+        edgeId: e.id,
+        nodeId: e.source,
+        nodeType: String(sourceNode.type ?? ""),
+        message: `Edge "${e.id}" names no source handle on node "${e.source}" — it cannot be routed`
+      });
+    }
+    if (!e.targetHandle) {
+      issues.push({
+        severity: "error",
+        code: "missing_handle",
+        edgeId: e.id,
+        nodeId: e.target,
+        nodeType: String(targetNode.type ?? ""),
+        message: `Edge "${e.id}" names no target handle on node "${e.target}" — it cannot be routed`
+      });
+    }
 
     const sourceMeta = registry.getMetadata(String(sourceNode.type ?? ""));
     const targetMeta = registry.getMetadata(String(targetNode.type ?? ""));

--- a/packages/node-sdk/src/type-compat.ts
+++ b/packages/node-sdk/src/type-compat.ts
@@ -110,9 +110,13 @@ export function valueIncompatibleWithType(
   switch (base) {
     case "str":
       return typeof value !== "string";
+    // NaN and ±Infinity are numbers to `typeof` but nothing downstream can use
+    // them: they do not survive JSON, and an `int` slot holding 3.5 is the same
+    // defect as one holding "3.5".
     case "int":
+      return !Number.isInteger(value);
     case "float":
-      return typeof value !== "number";
+      return typeof value !== "number" || !Number.isFinite(value);
     case "bool":
       return typeof value !== "boolean";
     default:

--- a/packages/node-sdk/tests/graph-validation.test.ts
+++ b/packages/node-sdk/tests/graph-validation.test.ts
@@ -805,3 +805,177 @@ describe("slot_type_alias", () => {
     expect(report.issues.some((i) => i.code === "slot_type_alias")).toBe(false);
   });
 });
+
+describe("validateGraph — cycles", () => {
+  const registry = fakeRegistry({
+    "a.N": meta("a.N", { in: "str" }, { out: "str" })
+  });
+  const node = (id: string) => ({ id, type: "a.N" });
+  const edge = (id: string, source: string, target: string) => ({
+    id,
+    source,
+    sourceHandle: "out",
+    target,
+    targetHandle: "in"
+  });
+
+  it("flags a self-loop", () => {
+    const report = validateGraph(
+      { nodes: [node("1")], edges: [edge("e1", "1", "1")] },
+      registry
+    );
+    expect(report.ok).toBe(false);
+    const issue = report.issues.find((i) => i.code === "cycle");
+    expect(issue?.nodeId).toBe("1");
+    expect(issue?.message).toContain("connected to itself");
+  });
+
+  it("flags a self-loop on a control edge too", () => {
+    const report = validateGraph(
+      {
+        nodes: [node("1")],
+        edges: [{ ...edge("e1", "1", "1"), edge_type: "control" }]
+      },
+      registry
+    );
+    expect(report.issues.some((i) => i.code === "cycle")).toBe(true);
+  });
+
+  it("flags a multi-node cycle and names every node in it", () => {
+    const report = validateGraph(
+      {
+        nodes: [node("1"), node("2"), node("3")],
+        edges: [
+          edge("e1", "1", "2"),
+          edge("e2", "2", "3"),
+          edge("e3", "3", "1")
+        ]
+      },
+      registry
+    );
+    expect(report.ok).toBe(false);
+    const issue = report.issues.find((i) => i.message.includes("Cycle detected"));
+    expect(issue?.code).toBe("cycle");
+    expect(issue?.message).toContain("1, 2, 3");
+  });
+
+  it("ignores control edges when looking for cycles (the kernel does)", () => {
+    const report = validateGraph(
+      {
+        nodes: [node("1"), node("2")],
+        edges: [
+          edge("e1", "1", "2"),
+          { ...edge("e2", "2", "1"), edge_type: "control" }
+        ]
+      },
+      registry
+    );
+    expect(report.issues.some((i) => i.code === "cycle")).toBe(false);
+  });
+
+  it("does not flag a diamond", () => {
+    const registryList = fakeRegistry({
+      "a.N": meta("a.N", { in: "str" }, { out: "str" }),
+      "a.Join": meta("a.Join", { in: "list[str]" }, { out: "str" })
+    });
+    const report = validateGraph(
+      {
+        nodes: [node("1"), node("2"), node("3"), { id: "4", type: "a.Join" }],
+        edges: [
+          edge("e1", "1", "2"),
+          edge("e2", "1", "3"),
+          edge("e3", "2", "4"),
+          edge("e4", "3", "4")
+        ]
+      },
+      registryList
+    );
+    expect(report.issues.some((i) => i.code === "cycle")).toBe(false);
+  });
+
+  it("handles a long chain without recursing", () => {
+    const nodes = Array.from({ length: 20000 }, (_, i) => node(`n${i}`));
+    const edges = Array.from({ length: 19999 }, (_, i) =>
+      edge(`e${i}`, `n${i}`, `n${i + 1}`)
+    );
+    const report = validateGraph({ nodes, edges }, registry);
+    expect(report.issues.some((i) => i.code === "cycle")).toBe(false);
+  });
+});
+
+describe("validateGraph — node/edge shape", () => {
+  const registry = fakeRegistry(
+    {
+      "a.Source": meta("a.Source", {}, { out: "str" }),
+      "a.LLM": meta("a.LLM", { prompt: "str" }, { out: "str" })
+    },
+    { "a.LLM": ["prompt"] }
+  );
+
+  it("reads properties from the editor's nested data.properties", () => {
+    const report = validateGraph(
+      {
+        nodes: [
+          {
+            id: "1",
+            type: "a.LLM",
+            data: { properties: { prompt: "hello" }, dynamic_properties: {} }
+          }
+        ],
+        edges: []
+      },
+      registry
+    );
+    expect(report.issues.filter((i) => i.code === "property")).toEqual([]);
+    expect(report.ok).toBe(true);
+  });
+
+  it("still reads a flattened data bag", () => {
+    const report = validateGraph(
+      { nodes: [{ id: "1", type: "a.LLM", data: { prompt: "hello" } }], edges: [] },
+      registry
+    );
+    expect(report.issues.filter((i) => i.code === "property")).toEqual([]);
+  });
+
+  it("flags an edge that names no handles", () => {
+    const report = validateGraph(
+      {
+        nodes: [
+          { id: "1", type: "a.Source" },
+          { id: "2", type: "a.LLM", properties: { prompt: "x" } }
+        ],
+        edges: [{ id: "e1", source: "1", target: "2" }]
+      },
+      registry
+    );
+    expect(report.ok).toBe(false);
+    const missing = report.issues.filter((i) => i.code === "missing_handle");
+    expect(missing).toHaveLength(2);
+    expect(missing.map((i) => i.nodeId).sort()).toEqual(["1", "2"]);
+  });
+
+  it("flags a node with no id", () => {
+    const report = validateGraph(
+      { nodes: [{ type: "a.Source" }], edges: [] },
+      registry
+    );
+    expect(report.ok).toBe(false);
+    expect(report.issues.some((i) => i.code === "missing_id")).toBe(true);
+  });
+
+  it("reports a duplicate id's properties only once", () => {
+    const report = validateGraph(
+      {
+        nodes: [
+          { id: "dup", type: "a.LLM", properties: {} },
+          { id: "dup", type: "a.LLM", properties: {} }
+        ],
+        edges: []
+      },
+      registry
+    );
+    expect(report.issues.filter((i) => i.code === "property")).toHaveLength(1);
+    expect(report.issues.filter((i) => i.code === "duplicate_id")).toHaveLength(1);
+  });
+});

--- a/packages/node-sdk/tests/type-compat.test.ts
+++ b/packages/node-sdk/tests/type-compat.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { typesIncompatible } from "../src/type-compat.js";
+import {
+  typesIncompatible,
+  valueIncompatibleWithType
+} from "../src/type-compat.js";
 
 describe("typesIncompatible", () => {
   it("flags clearly different scalars", () => {
@@ -31,5 +34,33 @@ describe("typesIncompatible", () => {
     expect(typesIncompatible("enum", "int")).toBe(true);
     expect(typesIncompatible("cv", "str")).toBe(true);
     expect(typesIncompatible("chunk", "image")).toBe(true);
+  });
+});
+
+describe("valueIncompatibleWithType — numbers", () => {
+  it("rejects a non-integer in an int slot", () => {
+    expect(valueIncompatibleWithType(3.5, "int")).toBe(true);
+    expect(valueIncompatibleWithType(3, "int")).toBe(false);
+    expect(valueIncompatibleWithType("3", "int")).toBe(true);
+  });
+
+  it("rejects non-finite numbers on both numeric types", () => {
+    for (const type of ["int", "float"]) {
+      expect(valueIncompatibleWithType(Number.NaN, type)).toBe(true);
+      expect(valueIncompatibleWithType(Number.POSITIVE_INFINITY, type)).toBe(true);
+      expect(valueIncompatibleWithType(Number.NEGATIVE_INFINITY, type)).toBe(true);
+    }
+  });
+
+  it("accepts whole and fractional values in a float slot", () => {
+    expect(valueIncompatibleWithType(3, "float")).toBe(false);
+    expect(valueIncompatibleWithType(3.5, "float")).toBe(false);
+    expect(valueIncompatibleWithType("3.5", "float")).toBe(true);
+  });
+
+  it("leaves null/undefined and containers alone", () => {
+    expect(valueIncompatibleWithType(null, "int")).toBe(false);
+    expect(valueIncompatibleWithType(undefined, "int")).toBe(false);
+    expect(valueIncompatibleWithType(3.5, "list[int]")).toBe(false);
   });
 });

--- a/packages/websocket/src/debug-sessions.ts
+++ b/packages/websocket/src/debug-sessions.ts
@@ -21,6 +21,7 @@
 
 import { randomUUID } from "node:crypto";
 import { createLogger } from "@nodetool-ai/config";
+import { validateSubstituteOutputs } from "@nodetool-ai/kernel";
 import type { DecisionOutcome, SupervisorHandle } from "@nodetool-ai/kernel";
 import type { Escalation, Verdict } from "@nodetool-ai/protocol";
 
@@ -31,6 +32,19 @@ export const INTERACTIVE_DECISION_TIMEOUT_MS = 10 * 60_000;
 
 /** How long a settled session's report stays fetchable. */
 const SESSION_DONE_TTL_MS = 10 * 60_000;
+
+/**
+ * Hard ceiling on a session's life. The TTL sweep only arms once a run
+ * settles, so a run whose `done` never resolves — a wedged bridge, a promise
+ * nobody rejects — used to hold its session (and the run behind it) forever.
+ */
+export const SESSION_MAX_LIFETIME_MS = 60 * 60_000;
+
+/** How long `cancel()` waits for the run to settle before answering anyway. */
+export const CANCEL_SETTLE_TIMEOUT_MS = 30_000;
+
+/** Live (unsettled) sessions one user may hold at once. */
+export const MAX_LIVE_SESSIONS_PER_USER = 8;
 
 const FAIL_CLOSED: DecisionOutcome = {
   verdict: { action: "fail" },
@@ -110,8 +124,17 @@ export class InteractiveEscalationHandle implements SupervisorHandle {
    * string instead of throwing so the HTTP layer can 400 with it; the verdict
    * is checked against the escalation's `allowedActions` here so the agent can
    * correct itself, and enforced again by the kernel regardless.
+   *
+   * A `substitute` payload is validated here too, against the same rules the
+   * actor applies. Accepting it and letting the kernel reject it fails the
+   * node with its *original* error and burns the decision — the agent never
+   * learns its repair was malformed. Rejecting here keeps the escalation
+   * parked, so it can answer again.
    */
-  submit(escalationId: string, verdict: Verdict): { error: string } | null {
+  async submit(
+    escalationId: string,
+    verdict: Verdict
+  ): Promise<{ error: string } | null> {
     const pending = this._pending;
     if (!pending) {
       return {
@@ -131,6 +154,26 @@ export class InteractiveEscalationHandle implements SupervisorHandle {
           `Verdict "${verdict.action}" is not allowed for this escalation. ` +
           `Allowed: ${pending.escalation.allowedActions.join(", ")}.`
       };
+    }
+    if (verdict.action === "substitute") {
+      const result = await validateSubstituteOutputs(verdict.outputs, {
+        declaredOutputs: pending.escalation.declaredOutputs
+      });
+      if (!result.ok) {
+        return {
+          error:
+            "Substituted outputs are invalid, so the escalation is still " +
+            `awaiting a verdict: ${result.issues.join("; ")}`
+        };
+      }
+      // Validation is async; the escalation may have failed closed meanwhile.
+      if (this._pending !== pending) {
+        return {
+          error:
+            "The escalation stopped awaiting a verdict while the substituted " +
+            "outputs were being validated."
+        };
+      }
     }
     pending.settle({ verdict, decidedBy: "agent" });
     return null;
@@ -156,6 +199,9 @@ export interface CreateDebugSessionOptions {
   /** Resolves with the final report once the run settles. Must never reject. */
   done: Promise<Record<string, unknown>>;
   cancel: () => void;
+  /** Overrides for tests; production uses the module constants. */
+  maxLifetimeMs?: number;
+  cancelWaitMs?: number;
 }
 
 export class DebugSession {
@@ -164,8 +210,11 @@ export class DebugSession {
   readonly workflowId: string | null;
   readonly jobId: string;
   private readonly _handle: InteractiveEscalationHandle;
+  /** The run's own completion, raced with a forced settle. Never rejects. */
   private readonly _done: Promise<Record<string, unknown>>;
   private readonly _cancel: () => void;
+  private readonly _cancelWaitMs: number;
+  private _force: (report: Record<string, unknown>) => void = () => {};
   private _report: Record<string, unknown> | null = null;
 
   constructor(options: CreateDebugSessionOptions, onSettled: () => void) {
@@ -174,18 +223,55 @@ export class DebugSession {
     this.workflowId = options.workflowId;
     this.jobId = options.jobId;
     this._handle = options.handle;
-    this._done = options.done;
     this._cancel = options.cancel;
+    this._cancelWaitMs = options.cancelWaitMs ?? CANCEL_SETTLE_TIMEOUT_MS;
+    // A run that never settles must not hold the session — or its waiters —
+    // open forever, so every wait goes through this race rather than through
+    // the run's own promise.
+    const forced = new Promise<Record<string, unknown>>((resolve) => {
+      this._force = resolve;
+    });
+    this._done = Promise.race([options.done, forced]);
     void this._done.then((report) => {
       this._report = report;
       onSettled();
     });
   }
 
+  /** True until the run (or a forced settle) has produced a final report. */
+  isLive(): boolean {
+    return this._report === null;
+  }
+
+  /**
+   * Settle the session without the run: cancel what can be cancelled, fail the
+   * parked escalation closed, and hand every waiter a failed report. Used by
+   * the lifetime ceiling and by a cancel the run does not answer.
+   */
+  forceSettle(reason: string): void {
+    try {
+      this._cancel();
+    } catch (error) {
+      log.warn("cancel threw while force-settling a debug session", {
+        sessionId: this.id,
+        error: String(error)
+      });
+    }
+    this._handle.close();
+    this._force({
+      status: "failed",
+      error: reason,
+      job_id: this.jobId,
+      workflow_id: this.workflowId,
+      outputs: {}
+    });
+  }
+
   /**
    * Wait until the run either parks an escalation or settles. There is no
-   * wait cap: the non-interactive endpoint awaits the whole run too, and a
-   * parked decision fails closed on its own timeout, so this always resolves.
+   * wait cap of its own: the non-interactive endpoint awaits the whole run
+   * too, a parked decision fails closed on its own timeout, and the session's
+   * lifetime ceiling settles anything that outlives both.
    */
   async waitForEvent(): Promise<DebugSessionEvent> {
     const pending = this._handle.current();
@@ -231,30 +317,93 @@ export class DebugSession {
     return { kind: "running" };
   }
 
-  submitVerdict(escalationId: string, verdict: Verdict): { error: string } | null {
+  async submitVerdict(
+    escalationId: string,
+    verdict: Verdict
+  ): Promise<{ error: string } | null> {
     if (this._report) {
       return { error: "The run has already finished." };
     }
     return this._handle.submit(escalationId, verdict);
   }
 
-  /** Cancel the run; resolves once the run settles with its final report. */
+  /**
+   * Cancel the run and return its final report. The wait is bounded: a run
+   * that ignores cancellation used to hang the cancel request itself, so past
+   * the deadline the session settles on its own and answers with that.
+   */
   async cancel(): Promise<Record<string, unknown>> {
-    this._cancel();
+    try {
+      this._cancel();
+    } catch (error) {
+      log.warn("cancel threw for a debug session", {
+        sessionId: this.id,
+        error: String(error)
+      });
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<"timeout">((resolve) => {
+      timer = setTimeout(() => resolve("timeout"), this._cancelWaitMs);
+      timer.unref?.();
+    });
+    try {
+      const outcome = await Promise.race([this._done, deadline]);
+      if (outcome !== "timeout") return outcome;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+    this.forceSettle(
+      `Cancel requested, but the run did not settle within ${this._cancelWaitMs}ms.`
+    );
     return this._done;
+  }
+}
+
+/** Thrown by `create()` when a user already holds the maximum live sessions. */
+export class TooManyDebugSessionsError extends Error {
+  constructor(limit: number) {
+    super(
+      `Too many active debug sessions (limit ${limit}). Cancel or finish one ` +
+        "with POST /api/debug/sessions/:id/cancel before starting another."
+    );
+    this.name = "TooManyDebugSessionsError";
   }
 }
 
 class DebugSessionRegistry {
   private readonly _sessions = new Map<string, DebugSession>();
 
+  /** Live sessions this user holds. */
+  liveCount(userId: string): number {
+    let count = 0;
+    for (const session of this._sessions.values()) {
+      if (session.userId === userId && session.isLive()) count += 1;
+    }
+    return count;
+  }
+
   create(options: CreateDebugSessionOptions): DebugSession {
+    if (this.liveCount(options.userId) >= MAX_LIVE_SESSIONS_PER_USER) {
+      throw new TooManyDebugSessionsError(MAX_LIVE_SESSIONS_PER_USER);
+    }
+    let lifetime: ReturnType<typeof setTimeout> | undefined;
     const session = new DebugSession(options, () => {
+      if (lifetime) clearTimeout(lifetime);
       const timer = setTimeout(() => {
         this._sessions.delete(session.id);
       }, SESSION_DONE_TTL_MS);
       timer.unref?.();
     });
+    lifetime = setTimeout(() => {
+      log.warn("debug session hit its lifetime ceiling", {
+        sessionId: session.id,
+        jobId: options.jobId
+      });
+      session.forceSettle(
+        "The run exceeded the maximum session lifetime and was force-settled."
+      );
+    }, options.maxLifetimeMs ?? SESSION_MAX_LIFETIME_MS);
+    lifetime.unref?.();
     this._sessions.set(session.id, session);
     log.info("interactive debug session opened", {
       sessionId: session.id,

--- a/packages/websocket/src/debug-sessions.ts
+++ b/packages/websocket/src/debug-sessions.ts
@@ -386,15 +386,14 @@ class DebugSessionRegistry {
     if (this.liveCount(options.userId) >= MAX_LIVE_SESSIONS_PER_USER) {
       throw new TooManyDebugSessionsError(MAX_LIVE_SESSIONS_PER_USER);
     }
-    let lifetime: ReturnType<typeof setTimeout> | undefined;
     const session = new DebugSession(options, () => {
-      if (lifetime) clearTimeout(lifetime);
+      clearTimeout(lifetime);
       const timer = setTimeout(() => {
         this._sessions.delete(session.id);
       }, SESSION_DONE_TTL_MS);
       timer.unref?.();
     });
-    lifetime = setTimeout(() => {
+    const lifetime = setTimeout(() => {
       log.warn("debug session hit its lifetime ceiling", {
         sessionId: session.id,
         jobId: options.jobId

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -65,13 +65,16 @@ import { BoundedHandle, WorkflowRunner } from "@nodetool-ai/kernel";
 import { verdictSchema } from "@nodetool-ai/protocol";
 import {
   buildRunVerdict,
-  collectExecutionSummary
+  collectExecutionSummary,
+  collectInterventionWarnings,
+  normalizeGraph
 } from "@nodetool-ai/execution";
 import {
   debugSessions,
   DebugSession,
   InteractiveEscalationHandle,
   INTERACTIVE_DECISION_TIMEOUT_MS,
+  TooManyDebugSessionsError,
   type DebugSessionEvent
 } from "./debug-sessions.js";
 import {
@@ -802,51 +805,11 @@ export async function handleWorkflowRun(
   const params = body?.params ?? {};
   const interactive = body?.interactive === true;
 
-  const graph = workflow.getGraph();
-  const runnableGraph: {
-    nodes: Array<{
-      id: string;
-      type: string;
-      [key: string]: unknown;
-    }>;
-    edges: Array<{
-      id?: string | null;
-      source: string;
-      target: string;
-      sourceHandle: string;
-      targetHandle: string;
-      edge_type?: "data" | "control";
-      [key: string]: unknown;
-    }>;
-  } = {
-    nodes: graph.nodes.map((node) => {
-      const record = node as Record<string, unknown>;
-      return {
-        ...record,
-        id: String(record.id ?? ""),
-        type: String(record.type ?? ""),
-        properties: (record.properties ?? record.data ?? {}) as Record<
-          string,
-          unknown
-        >
-      };
-    }),
-    edges: graph.edges.map((edge) => {
-      const record = edge as Record<string, unknown>;
-      return {
-        ...record,
-        id:
-          typeof record.id === "string" || record.id == null
-            ? (record.id as string | null | undefined)
-            : String(record.id),
-        source: String(record.source ?? ""),
-        target: String(record.target ?? ""),
-        sourceHandle: String(record.sourceHandle ?? ""),
-        targetHandle: String(record.targetHandle ?? ""),
-        edge_type: record.edge_type === "control" ? "control" : "data"
-      };
-    })
-  };
+  // One normalization for every host: `data` → `properties`, editor-only
+  // nodes (Comment/Group/Reroute) pruned, and edges typed from `edge_type` or
+  // the legacy `type`. Hand-rolling it here drifted from the CLI — a graph
+  // with a Comment node ran there and failed here with "Unknown node type".
+  const runnableGraph = normalizeGraph(workflow.getGraph());
 
   const runtime = await getWorkflowRuntimeEnvironment(options);
   const hasPythonNode = runnableGraph.nodes.some((node) => {
@@ -887,15 +850,26 @@ export async function handleWorkflowRun(
       // These are API inputs: anything but a sane integer (NaN, Infinity,
       // negatives, fractions) falls back to the default rather than reaching
       // `BoundedHandle` — a NaN timeout would fail every decision instantly.
-      const maxDecisions = boundedRunOption(body?.max_decisions, 1);
-      const maxRetriesPerNode = boundedRunOption(body?.max_retries_per_node, 0);
+      const maxDecisions = boundedRunOption(
+        body?.max_decisions,
+        1,
+        MAX_INTERACTIVE_DECISIONS
+      );
+      const maxRetriesPerNode = boundedRunOption(
+        body?.max_retries_per_node,
+        0,
+        MAX_INTERACTIVE_RETRIES_PER_NODE
+      );
       interactiveHandle = new InteractiveEscalationHandle();
       supervisorHandle = new BoundedHandle(interactiveHandle, {
         ...(maxDecisions !== undefined ? { maxDecisions } : {}),
         ...(maxRetriesPerNode !== undefined ? { maxRetriesPerNode } : {}),
         decisionTimeoutMs:
-          boundedRunOption(body?.decision_timeout_ms, 1) ??
-          INTERACTIVE_DECISION_TIMEOUT_MS
+          boundedRunOption(
+            body?.decision_timeout_ms,
+            1,
+            MAX_INTERACTIVE_DECISION_TIMEOUT_MS
+          ) ?? INTERACTIVE_DECISION_TIMEOUT_MS
       });
     }
     runner = new WorkflowRunner(job.id, {
@@ -917,15 +891,7 @@ export async function handleWorkflowRun(
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    try {
-      job.markFailed(message);
-      await job.save();
-    } catch (saveError) {
-      log.warn("failed to persist failed job status", {
-        jobId: job.id,
-        error: String(saveError)
-      });
-    }
+    await markJobFailed(job, message);
     throw error instanceof Error ? error : new Error(message);
   }
 
@@ -938,15 +904,7 @@ export async function handleWorkflowRun(
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      try {
-        job.markFailed(message);
-        await job.save();
-      } catch (saveError) {
-        log.warn("failed to persist failed job status", {
-          jobId: job.id,
-          error: String(saveError)
-        });
-      }
+      await markJobFailed(job, message);
       throw error instanceof Error ? error : new Error(message);
     }
 
@@ -974,15 +932,7 @@ export async function handleWorkflowRun(
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      try {
-        job.markFailed(message);
-        await job.save();
-      } catch (saveError) {
-        log.warn("failed to persist failed job status", {
-          jobId: job.id,
-          error: String(saveError)
-        });
-      }
+      await markJobFailed(job, message);
       // Keep the payload shape of a failed run — the debug surface still gets
       // a summary and verdict — instead of a bare {status, error} object.
       const failed: WorkflowRunResult = {
@@ -999,25 +949,74 @@ export async function handleWorkflowRun(
     }
   })();
 
-  const session = debugSessions.create({
-    userId,
-    workflowId,
-    jobId: job.id,
-    handle: interactiveHandle!,
-    done: runPromise,
-    cancel: () => runner.cancel()
-  });
+  let session: DebugSession;
+  try {
+    session = debugSessions.create({
+      userId,
+      workflowId,
+      jobId: job.id,
+      handle: interactiveHandle!,
+      done: runPromise,
+      cancel: () => runner.cancel()
+    });
+  } catch (error) {
+    // The run is already going; without a session nobody can answer it, so
+    // cancel it rather than leave an unreachable run behind.
+    runner.cancel();
+    if (error instanceof TooManyDebugSessionsError) {
+      return errorResponse(429, error.message);
+    }
+    throw error instanceof Error ? error : new Error(String(error));
+  }
   const event = await session.waitForEvent();
   return jsonResponse(debugSessionEventPayload(session, event));
 }
 
 type WorkflowRunResult = Awaited<ReturnType<WorkflowRunner["run"]>>;
 
-/** An interactive-run bound from the request body: an integer ≥ min, or undefined. */
-function boundedRunOption(value: unknown, min: number): number | undefined {
-  return typeof value === "number" && Number.isInteger(value) && value >= min
-    ? value
-    : undefined;
+/**
+ * Server-side ceilings for the interactive bounds a caller may ask for. The
+ * request body is an API input, so a number nobody would type by hand — a
+ * decision timeout of a day, ten thousand decisions — is clamped rather than
+ * honored. `DEFAULT_SUPERVISOR_BOUNDS` sets the shape of what is reasonable;
+ * these are the generous end of it.
+ */
+const MAX_INTERACTIVE_DECISIONS = 100;
+const MAX_INTERACTIVE_RETRIES_PER_NODE = 20;
+const MAX_INTERACTIVE_DECISION_TIMEOUT_MS = 30 * 60_000;
+
+/**
+ * An interactive-run bound from the request body: an integer in `[min, max]`,
+ * or undefined. Out-of-range highs clamp to `max`; anything that is not a sane
+ * integer (NaN, Infinity, negatives, fractions) is undefined so the caller
+ * gets the default instead of a bound that fails every decision instantly.
+ */
+function boundedRunOption(
+  value: unknown,
+  min: number,
+  max: number
+): number | undefined {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < min) {
+    return undefined;
+  }
+  return Math.min(value, max);
+}
+
+/**
+ * Mark a job failed and persist it. Persistence is best effort: the run has
+ * already failed, and a save error must not replace the caller's error with a
+ * database one.
+ */
+async function markJobFailed(job: Job, message: string): Promise<void> {
+  try {
+    job.markFailed(message);
+    await job.save();
+  } catch (saveError) {
+    log.warn("failed to persist failed job status", {
+      jobId: job.id,
+      error: String(saveError)
+    });
+  }
 }
 
 async function finalizeWorkflowRunJob(
@@ -1047,6 +1046,15 @@ function buildWorkflowRunPayload(
     // harness computes, instead of leaving a caller to infer a run's health
     // from a status string.
     const summary = collectExecutionSummary(result.messages);
+    const verdict = buildRunVerdict(summary, {
+      ok: result.status === "completed",
+      status: result.status,
+      error: result.error ?? null
+    });
+    // Supervisor decisions are warnings, never issues — a rescued run still
+    // completed — but without them a supervised run reads as "ran clean".
+    // Same composition the CLI harness's cross-surface verdict does.
+    const warnings = collectInterventionWarnings("Server", summary);
     return {
       job_id: jobId,
       workflow_id: workflowId,
@@ -1054,11 +1062,16 @@ function buildWorkflowRunPayload(
       outputs: result.outputs,
       error: result.error ?? null,
       summary,
-      verdict: buildRunVerdict(summary, {
-        ok: result.status === "completed",
-        status: result.status,
-        error: result.error ?? null
-      })
+      verdict:
+        warnings.length > 0
+          ? {
+              ...verdict,
+              headline: verdict.ok
+                ? `${verdict.headline} (supervised)`
+                : verdict.headline,
+              warnings
+            }
+          : verdict
     };
   }
 
@@ -1149,7 +1162,10 @@ export async function handleDebugSessionRequest(
           .join("; ")}`
       );
     }
-    const rejected = session.submitVerdict(body.escalation_id, parsed.data);
+    const rejected = await session.submitVerdict(
+      body.escalation_id,
+      parsed.data
+    );
     if (rejected) return errorResponse(400, rejected.error);
     const event = await session.waitForEvent();
     return jsonResponse(debugSessionEventPayload(session, event));

--- a/packages/websocket/src/lib/app-build-service.ts
+++ b/packages/websocket/src/lib/app-build-service.ts
@@ -24,6 +24,7 @@ import { createLogger, getDefaultAssetsPath } from "@nodetool-ai/config";
 import {
   buildApp,
   parseBuildSpec,
+  resolveJudgeModelSpec,
   DEFAULT_BUILD_COST_CAP_USD,
   type BuildReport,
   type BuildSpec
@@ -58,6 +59,12 @@ export interface AppBuildRequest {
   spec?: unknown;
   provider?: string;
   model?: string;
+  /**
+   * `provider/model` (or a bare model id on the builder's provider) for the
+   * Judge stage. Omitted ⇒ an independent default from the configured
+   * providers, so a build is not graded by the model that authored it.
+   */
+  judge_model?: string;
   /** Workflow ids to pin, in operation declaration order. */
   workflow_ids?: string[];
   max_repairs?: number;
@@ -115,18 +122,32 @@ async function loadConfiguredProviders(
   return providers;
 }
 
-/** A body number that is a finite positive value, or undefined. */
-function positive(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? value
-    : undefined;
+/**
+ * A body number that is a finite positive value. Absent stays absent — a
+ * present-but-invalid one is rejected rather than replaced by a default, since
+ * `cost_cap_usd: 0` silently becoming $2 spends money the caller said not to.
+ */
+function positive(field: string, value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throwApiError(
+      ApiErrorCode.INVALID_INPUT,
+      `${field} must be a positive number.`
+    );
+  }
+  return value;
 }
 
-/** A body number that is a non-negative integer, or undefined. */
-function count(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isInteger(value) && value >= 0
-    ? value
-    : undefined;
+/** A body number that is a non-negative integer. Present-but-invalid is an error. */
+function count(field: string, value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throwApiError(
+      ApiErrorCode.INVALID_INPUT,
+      `${field} must be a non-negative integer.`
+    );
+  }
+  return value;
 }
 
 function resolveModel(body: AppBuildRequest): {
@@ -143,6 +164,42 @@ function resolveModel(body: AppBuildRequest): {
     );
   }
   return { provider, model };
+}
+
+/**
+ * Which model judges the build. The same resolution the CLI runs: an explicit
+ * `judge_model` wins, then `NODETOOL_APP_JUDGE_MODEL`, then the best candidate
+ * among the configured providers that is not what the builder used. A model
+ * grading its own work is the weakest reviewer available, so the server does
+ * not default to it either.
+ */
+function resolveJudge(init: {
+  builder: BaseProvider;
+  builderModel: string;
+  explicit?: string;
+  providers: Record<string, BaseProvider>;
+}): { provider: BaseProvider; model: string } {
+  const resolution = resolveJudgeModelSpec({
+    ...(init.explicit !== undefined ? { explicit: init.explicit } : {}),
+    builderProviderId: init.builder.provider,
+    builderModel: init.builderModel,
+    isAvailable: (id: string) =>
+      id === init.builder.provider || id in init.providers
+  });
+  const provider =
+    resolution.providerId === init.builder.provider
+      ? init.builder
+      : init.providers[resolution.providerId];
+  if (!provider) {
+    if (init.explicit) {
+      throwApiError(
+        ApiErrorCode.INVALID_INPUT,
+        `judge_model names provider "${resolution.providerId}", which is not configured.`
+      );
+    }
+    return { provider: init.builder, model: init.builderModel };
+  }
+  return { provider, model: resolution.model };
 }
 
 function resolveSpec(body: AppBuildRequest): BuildSpec | null {
@@ -214,8 +271,15 @@ export async function runApplicationBuild(
 
   const controller = new AbortController();
   const logLines: string[] = [];
-  const maxRepairs = count(body.max_repairs);
-  const timeoutMs = positive(body.timeout_ms);
+  const maxRepairs = count("max_repairs", body.max_repairs);
+  const timeoutMs = positive("timeout_ms", body.timeout_ms);
+  const costCapUsd = positive("cost_cap_usd", body.cost_cap_usd);
+  const judge = resolveJudge({
+    builder: provider,
+    builderModel: selection.model,
+    providers,
+    ...(body.judge_model ? { explicit: body.judge_model } : {})
+  });
 
   // The promise a session fronts must never reject: a rejected build would
   // leave the session parked forever with no report to hand back.
@@ -247,7 +311,8 @@ export async function runApplicationBuild(
           ? { pinnedWorkflowIds: body.workflow_ids }
           : {}),
         ...(maxRepairs !== undefined ? { maxRepairs } : {}),
-        costCapUsd: positive(body.cost_cap_usd) ?? DEFAULT_BUILD_COST_CAP_USD,
+        judge: { provider: judge.provider, model: judge.model },
+        costCapUsd: costCapUsd ?? DEFAULT_BUILD_COST_CAP_USD,
         ...(timeoutMs !== undefined ? { timeoutMs } : {}),
         signal: controller.signal,
         buildId,

--- a/packages/websocket/tests/debug-sessions.test.ts
+++ b/packages/websocket/tests/debug-sessions.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The session registry behind the interactive run/debug endpoints: verdict
+ * validation at submit time, and the lifetime guarantees that keep a run
+ * nobody finishes from holding a session (and its cancel request) forever.
+ */
+import { describe, it, expect } from "vitest";
+import type { Escalation, Verdict } from "@nodetool-ai/protocol";
+import {
+  debugSessions,
+  InteractiveEscalationHandle,
+  MAX_LIVE_SESSIONS_PER_USER,
+  TooManyDebugSessionsError,
+  type ParkedEscalation
+} from "../src/debug-sessions.js";
+
+function escalation(overrides: Partial<Escalation> = {}): Escalation {
+  return {
+    nodeId: "work",
+    nodeType: "test.Fail",
+    correlationLineage: [],
+    invocationKey: "",
+    allowedActions: ["substitute", "skip", "fail"],
+    detail: "boom 42",
+    inputs: {},
+    declaredOutputs: { value: "str" },
+    attempt: 1,
+    spentCostUsd: 0,
+    createdAssets: false,
+    retrySafe: false,
+    emitted: false,
+    ...overrides
+  };
+}
+
+/** Park an escalation on a fresh handle and return everything to assert on. */
+function park(e: Escalation = escalation()): {
+  handle: InteractiveEscalationHandle;
+  controller: AbortController;
+  parked: Promise<ParkedEscalation>;
+  decided: Promise<{ verdict: Verdict }>;
+} {
+  const handle = new InteractiveEscalationHandle();
+  const controller = new AbortController();
+  const parked = new Promise<ParkedEscalation>((resolve) => {
+    handle.subscribe(resolve);
+  });
+  const decided = handle.decide(e, controller.signal);
+  return { handle, controller, parked, decided };
+}
+
+describe("InteractiveEscalationHandle.submit", () => {
+  it("rejects a substitute payload that does not match the declared outputs", async () => {
+    const { handle, parked, decided } = park();
+    const { id } = await parked;
+
+    const rejected = await handle.submit(id, {
+      action: "substitute",
+      outputs: { value: 42 }
+    });
+    expect(rejected?.error).toContain('output "value" must be a string');
+
+    // The escalation is still parked, so the caller can answer again.
+    expect(handle.current()?.id).toBe(id);
+
+    const accepted = await handle.submit(id, {
+      action: "substitute",
+      outputs: { value: "repaired" }
+    });
+    expect(accepted).toBeNull();
+    expect((await decided).verdict).toEqual({
+      action: "substitute",
+      outputs: { value: "repaired" }
+    });
+  });
+
+  it("rejects a substitute that leaves a declared slot unfilled", async () => {
+    const { handle, parked } = park(
+      escalation({ declaredOutputs: { a: "str", b: "int" } })
+    );
+    const { id } = await parked;
+
+    const rejected = await handle.submit(id, {
+      action: "substitute",
+      outputs: { a: "ok" }
+    });
+    expect(rejected?.error).toContain('output "b"');
+    expect(handle.current()?.id).toBe(id);
+
+    handle.close();
+  });
+
+  it("still rejects verdicts outside the allowed actions", async () => {
+    const { handle, parked } = park(
+      escalation({ allowedActions: ["skip", "fail"] })
+    );
+    const { id } = await parked;
+
+    const rejected = await handle.submit(id, {
+      action: "substitute",
+      outputs: { value: "anything" }
+    });
+    expect(rejected?.error).toContain("not allowed");
+    handle.close();
+  });
+});
+
+describe("debug session lifetime", () => {
+  it("force-settles a run that never finishes, and reports why", async () => {
+    const session = debugSessions.create({
+      userId: "lifetime-user",
+      workflowId: "wf-1",
+      jobId: "job-1",
+      handle: new InteractiveEscalationHandle(),
+      // A run whose promise never resolves — the leak this ceiling exists for.
+      done: new Promise<Record<string, unknown>>(() => {}),
+      cancel: () => {},
+      maxLifetimeMs: 20
+    });
+
+    const event = await session.waitForEvent();
+    expect(event.kind).toBe("done");
+    if (event.kind !== "done") throw new Error("expected a done event");
+    expect(event.report.status).toBe("failed");
+    expect(String(event.report.error)).toContain("maximum session lifetime");
+    expect(session.isLive()).toBe(false);
+  });
+
+  it("answers a cancel the run never acknowledges", async () => {
+    let cancelled = false;
+    const session = debugSessions.create({
+      userId: "cancel-user",
+      workflowId: "wf-2",
+      jobId: "job-2",
+      handle: new InteractiveEscalationHandle(),
+      done: new Promise<Record<string, unknown>>(() => {}),
+      cancel: () => {
+        cancelled = true;
+      },
+      cancelWaitMs: 20
+    });
+
+    const report = await session.cancel();
+    expect(cancelled).toBe(true);
+    expect(report.status).toBe("failed");
+    expect(String(report.error)).toContain("did not settle");
+  });
+
+  it("caps live sessions per user and frees the slot once one settles", async () => {
+    const open = (
+      done: Promise<Record<string, unknown>>
+    ): ReturnType<typeof debugSessions.create> =>
+      debugSessions.create({
+        userId: "cap-user",
+        workflowId: "wf-3",
+        jobId: "job-3",
+        handle: new InteractiveEscalationHandle(),
+        done,
+        cancel: () => {},
+        cancelWaitMs: 10
+      });
+
+    const sessions = [];
+    for (let i = 0; i < MAX_LIVE_SESSIONS_PER_USER; i++) {
+      sessions.push(open(new Promise<Record<string, unknown>>(() => {})));
+    }
+    expect(debugSessions.liveCount("cap-user")).toBe(
+      MAX_LIVE_SESSIONS_PER_USER
+    );
+    expect(() => open(Promise.resolve({ status: "completed" }))).toThrow(
+      TooManyDebugSessionsError
+    );
+
+    // A settled session is not a live one: freeing a slot admits the next run.
+    const first = sessions[0];
+    if (!first) throw new Error("expected a session");
+    await first.cancel();
+    expect(debugSessions.liveCount("cap-user")).toBe(
+      MAX_LIVE_SESSIONS_PER_USER - 1
+    );
+    const admitted = open(new Promise<Record<string, unknown>>(() => {}));
+    expect(admitted.isLive()).toBe(true);
+
+    for (const session of sessions.slice(1)) await session.cancel();
+    await admitted.cancel();
+  });
+});

--- a/packages/websocket/tests/http-api-run-normalization.test.ts
+++ b/packages/websocket/tests/http-api-run-normalization.test.ts
@@ -1,0 +1,172 @@
+/**
+ * `POST /api/workflows/:id/run|debug` normalizes the saved graph with the
+ * shared `normalizeGraph` every other host uses. It used to hand-roll it:
+ * editor-only nodes survived (a workflow with a Comment ran on the CLI and
+ * failed here with "Unknown node type") and a control edge stored under the
+ * editor's `type` key executed as a data edge.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import os from "node:os";
+import { initTestDb, Workflow, Job } from "@nodetool-ai/models";
+import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+
+vi.mock("../src/lib/workflow-workspace.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../src/lib/workflow-workspace.js")
+  >("../src/lib/workflow-workspace.js");
+  return {
+    ...actual,
+    resolveWorkflowWorkspace: async () => os.tmpdir()
+  };
+});
+
+const { handleWorkflowRun } = await import("../src/http-api.js");
+
+const echoExecutor = {
+  async process(
+    ins: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    return ins;
+  }
+};
+
+// An editor-only node has no executor anywhere: resolving one is the failure
+// this normalization prevents.
+const registry = {
+  has: (t: string) => t === "test.Echo" || t === "nodetool.output.Output",
+  resolve: (node: { type: string }) => {
+    if (!node.type.startsWith("test.") && node.type !== "nodetool.output.Output") {
+      throw new Error(`Unknown node type "${node.type}"`);
+    }
+    return echoExecutor;
+  },
+  getClass: () => undefined,
+  resolveMetadata: () => undefined,
+  getMetadata: () => undefined,
+  listMetadata: () => []
+} as unknown as NodeRegistry;
+
+beforeEach(async () => {
+  await initTestDb();
+});
+
+describe("handleWorkflowRun graph normalization", () => {
+  it("prunes editor-only nodes and their edges, and lifts data to properties", async () => {
+    const workflow = (await Workflow.create({
+      user_id: "user-1",
+      name: "Commented WF",
+      access: "private",
+      graph: {
+        nodes: [
+          {
+            id: "note",
+            type: "nodetool.workflows.base_node.Comment",
+            data: { comment: ["a note"] }
+          },
+          { id: "work", type: "test.Echo", data: { value: "hi" } },
+          {
+            id: "out",
+            type: "nodetool.output.Output",
+            name: "result",
+            properties: {}
+          }
+        ],
+        edges: [
+          {
+            source: "work",
+            sourceHandle: "value",
+            target: "out",
+            targetHandle: "value"
+          },
+          // An edge onto the comment: it must go with the node it touches.
+          {
+            source: "note",
+            sourceHandle: "value",
+            target: "out",
+            targetHandle: "value"
+          }
+        ]
+      }
+    })) as Workflow;
+
+    const res = await handleWorkflowRun(
+      new Request("http://localhost/x", {
+        method: "POST",
+        headers: { "x-user-id": "user-1", "content-type": "application/json" },
+        body: JSON.stringify({})
+      }),
+      workflow.id,
+      { registry }
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe("completed");
+
+    const [jobs] = await Job.paginate("user-1", {
+      workflowId: workflow.id,
+      limit: 10
+    });
+    expect(jobs).toHaveLength(1);
+    const graph = jobs[0].graph as {
+      nodes: Array<Record<string, unknown>>;
+      edges: Array<Record<string, unknown>>;
+    };
+    expect(graph.nodes.map((n) => n.id)).toEqual(["work", "out"]);
+    expect(graph.nodes[0].properties).toEqual({ value: "hi" });
+    expect(graph.edges).toHaveLength(1);
+    expect(graph.edges[0].edge_type).toBe("data");
+  });
+
+  it("reads a control edge stored under the editor's `type` key", async () => {
+    const workflow = (await Workflow.create({
+      user_id: "user-1",
+      name: "Control WF",
+      access: "private",
+      graph: {
+        nodes: [
+          { id: "work", type: "test.Echo", properties: { value: "hi" } },
+          {
+            id: "out",
+            type: "nodetool.output.Output",
+            name: "result",
+            properties: {}
+          }
+        ],
+        edges: [
+          {
+            source: "work",
+            sourceHandle: "value",
+            target: "out",
+            targetHandle: "value"
+          },
+          {
+            source: "work",
+            sourceHandle: "value",
+            target: "out",
+            targetHandle: "__control__",
+            type: "control"
+          }
+        ]
+      }
+    })) as Workflow;
+
+    await handleWorkflowRun(
+      new Request("http://localhost/x", {
+        method: "POST",
+        headers: { "x-user-id": "user-1", "content-type": "application/json" },
+        body: JSON.stringify({})
+      }),
+      workflow.id,
+      { registry }
+    );
+
+    const [jobs] = await Job.paginate("user-1", {
+      workflowId: workflow.id,
+      limit: 10
+    });
+    const graph = jobs[0].graph as { edges: Array<Record<string, unknown>> };
+    const control = graph.edges.find((e) => e.targetHandle === "__control__");
+    expect(control?.edge_type).toBe("control");
+    expect(control?.type).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes the highest-leverage findings from a full review of the CLI/agent harnesses (`debug`, `app debug`, `app build`, `validate`, `timeline`, `node run`, the eval suites, and the supervisor/escalation machinery).

## Static validator (`nodetool validate` / `validate_workflow` / `validate_timeline`)
- Cycle and self-loop detection in `validateGraph` (new `cycle` issue code), matching the kernel's DAG semantics: self-loops on any edge, multi-node cycles over data edges
- `readProperties` now understands the editor's nested `data.properties` shape, fixing mass false "missing required property" errors on editor-exported graphs
- New `missing_handle` error for edges with empty handles between known nodes; new `missing_id` for id-less nodes; duplicate-id nodes no longer double-report property issues
- `int` slots require integers; `int`/`float` reject non-finite values
- `validate_workflow` runs the `unknown_provider` check (registry facade with `listProviderIds`) and returns structured errors for non-array `nodes`/`edges`; `validate_timeline` accepts `fps`/`width`/`height` for inline documents

## Supervisor / kernel
- `WorkflowRunner` idempotently wraps any supplied supervisor handle in `BoundedHandle`, making retry/decision/timeout caps kernel-owned
- Run-state digest errors are redacted against resolved secrets before reaching `get_run_state`
- Sticky verdicts no longer bypass a new escalation's allowed set; substitute payloads are validated before the intervention is recorded (a rejected repair records as `fail`, not "repaired"); `any`-typed outputs no longer count as validator coverage; a throwing `decide()` resolves as `decidedBy: "bounds"`

## Server debug surface
- `POST /api/workflows/:id/run|debug` uses the shared `normalizeGraph` (editor-only node pruning, legacy control-edge typing)
- Interactive `substitute` verdicts are validated at `submit()`; invalid payloads return the issue list with the escalation still parked
- Debug sessions get a hard lifetime ceiling, bounded cancel, and a per-user live-session cap (429); interactive bounds from the body are clamped
- Server debug verdicts carry intervention warnings and a "(supervised)" marker, matching the CLI

## App debug simulator
- `job_id` is stamped unconditionally in the headless fold, so job-level failures set the invocation's failed state instead of defaulting to completed
- Widget-driven node-property overlays are applied before headless runs, matching the web runtime; default operation is `operations[0]`, also matching the web
- `set`/`change` steps naming an output or unresolvable ref fail with a clear message instead of silently misfiling; explicit-id `cancel` checks liveness
- Static validation errors on ID-form bindings to unknown nodes and warns on unresolvable condition bindings

## App build harness
- Run-stage widget references resolve via `resolveSpecWidget` (role, label, or unique type), matching the Spec gate — no more unfixable `widget_missing` complaints; new `duplicate_widget_label` spec error
- Author-stage provider errors retry once then end the build instead of entering the complaint/oscillation machinery; run-stage issue fingerprints carry the interaction and step, so unrelated failures no longer read as oscillation; a failed routed replan ends the build
- The author bridge receives every operation's workflow, so `ui_app_get_binding_targets` works past the first operation
- The server build surface resolves an independent judge (`judge_model` in the body, else `resolveJudgeModelSpec`), rejects invalid budget values, and bills the judge's ledger row to the judge's own model; the judge timeout races a deadline so a provider ignoring abort still fails closed

## CLI / evals
- Shared `parseNumericOption` throws on non-finite/out-of-range flag values — a `--cost-cap` or `--min-success` typo previously disabled the cap/gate silently
- Tool-loop suites gate `--min-success` on accepted + zero critical failures (old accepted/ran number kept as `completionRate`)
- `--json` emits exactly one JSON document (preambles silenced; crash paths emit `{error}` JSON); new `--judge-model` threads an independent judge into `graph-e2e` and `app-build` evals; `skipJudge` cases no longer double-count output checks

Local verification: `npm run build:packages`, lint clean, web/electron typecheck clean, and full test suites for the six changed packages — kernel 1006, node-sdk 738, execution 140, agents 2007, cli 468, websocket 2042, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Schq8Fpuqj3hy1HwkuN1d3