### PR TITLE
ci: add daily docs correctness and completeness workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -45,6 +45,7 @@ see below.
 | `user-journeys.yml` | `journeys`: nightly Playwright journey suite (build a graph and run it, chat, mini app, library). `reliability-ring1` (on push to `main`, schedule, dispatch): full `reliability/journeys/*` suite on kernel+ws-server with `--diff`, plus one packaged-backend journey — gates `fly-deploy.yml` | 1 | `journeys`: advisory until 2026-08-15, then required. `reliability-ring1`: required |
 | `release.yaml` | Cross-platform signed release artifacts, packed-tree smoke, a packed-backend reliability journey per OS, updater assets | 2 | Required |
 | `example-smoke-debug.yml` | Nightly + manual real-provider smoke via `nodetool debug` | 2 | Nightly (spend-capped), also dispatch-only |
+| `app-build-eval.yml` | Nightly `app-build` eval suite; reports the one-shot rate, gates nothing | none/maintenance | Advisory (report only) |
 | `aur-publish.yml` | Publish the AUR package on a GitHub release | none/maintenance | Required for its own job |
 | `claude-code-review.yml` | Claude reviews new/updated PRs | none/maintenance | Advisory |
 | `claude.yml` | Claude responds to `@claude` mentions and comments | none/maintenance | Advisory |
@@ -52,9 +53,12 @@ see below.
 | `dead-code-cleanup.yaml` | Scheduled agent removes unused exports/imports/code | none/maintenance | Advisory (`continue-on-error`) |
 | `dependency-cleanup.yaml` | Scheduled agent prunes unused deps, aligns/updates versions | none/maintenance | Advisory (`continue-on-error`) |
 | `docs-ci.yml` | Docs site build + internal link/image check on PR | none/maintenance | Required for `docs/**` |
+| `docs-completeness.yaml` | Daily agent documents undocumented CLI commands, routes, env vars, packages | none/maintenance | Advisory |
+| `docs-correctness.yaml` | Daily agent checks docs claims against the code and fixes stale ones | none/maintenance | Advisory |
 | `docs-lint.yml` | Markdown lint on push/PR | none/maintenance | Required for `**/*.md` |
 | `eas-build.yml` | Cloud-build the Expo app in `mobile/` on EAS | none/maintenance | Manual / tag-gated |
 | `flatpak-ci.yml` | Build the Flatpak desktop package | none/maintenance | Required for its own job |
+| `genspend-pricing.yml` | Nightly GenSpend price sync; opens a PR when a price moved | none/maintenance | Advisory |
 | `issue-triage.yml` | Labels new issues, flags duplicates, requests repro details | none/maintenance | n/a (read-only) |
 | `jekyll.yml` | Build and deploy the docs site to GitHub Pages | none/maintenance | Required for docs deploy |
 | `marketing-ci.yml` | Typecheck/lint/build/Playwright smoke for the marketing site; deploys to Cloudflare Workers on push to main | none/maintenance | Required for `marketing/**` |
@@ -73,7 +77,7 @@ see below.
 | `ui-primitives-compliance.yaml` | Scheduled agent migrates raw MUI imports to `ui_primitives/`, fixes hardcoded design tokens | none/maintenance | Advisory (`continue-on-error`) |
 | `workflow-example-validation.yaml` | Weekly `nodetool validate` + repair of shipped example workflows | none/maintenance | Advisory (`continue-on-error`) |
 
-38 workflow files, 12 in the three rings (5 Ring 0, 5 Ring 1, 2 Ring 2), 26 none/maintenance.
+43 workflow files, 12 in the three rings (5 Ring 0, 5 Ring 1, 2 Ring 2), 31 none/maintenance.
 
 F2 wires this table into the actual gates:
 
@@ -122,6 +126,8 @@ gh workflow run dependency-cleanup.yaml
 gh workflow run test-coverage.yaml
 gh workflow run ui-primitives-compliance.yaml
 gh workflow run workflow-example-validation.yaml
+gh workflow run docs-correctness.yaml
+gh workflow run docs-completeness.yaml
 gh workflow run example-smoke-debug.yml
 gh workflow run user-journeys.yml
 ```

--- a/.github/workflows/docs-completeness.yaml
+++ b/.github/workflows/docs-completeness.yaml
@@ -1,0 +1,206 @@
+name: Documentation Completeness
+
+# Features ship faster than their docs. A CLI command lands, an HTTP route is
+# added, a package appears, an env var starts gating behavior — and nothing in
+# CI notices that no page mentions any of it.
+#
+# This job inventories the surfaces users touch (CLI commands, HTTP routes,
+# NODETOOL_* env vars, workspace packages), diffs each inventory against what the
+# docs mention, and asks Claude to document the gaps it can verify from the code.
+# Markdown only. Opens a PR, never auto-merges.
+
+on:
+  schedule:
+    - cron: "40 5 * * *" # Daily at 05:40 UTC
+  workflow_dispatch:
+
+jobs:
+  docs-completeness:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      # The CLI enumerates its commands from the built node registry.
+      - name: Build packages
+        run: npm run build:packages
+
+      - name: Inventory documented vs. undocumented surfaces
+        id: coverage
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          mkdir -p docs-facts
+          DOCS="docs README.md AGENTS.md CLAUDE.md"
+
+          mentioned() {
+            grep -rqI -- "$1" $DOCS 2>/dev/null
+          }
+
+          # --- CLI commands -------------------------------------------------
+          npm run --silent dev:nodetool -- --help 2>/dev/null \
+            | awk '/^Commands:/{f=1;next} f && /^  [a-z]/{print $1}' \
+            | sort -u > docs-facts/cli-commands.txt || true
+          : > docs-facts/undocumented-cli.txt
+          while read -r cmd; do
+            [ -n "$cmd" ] || continue
+            mentioned "nodetool $cmd" || echo "$cmd" >> docs-facts/undocumented-cli.txt
+          done < docs-facts/cli-commands.txt
+
+          # --- HTTP routes --------------------------------------------------
+          grep -rhoE '\.(get|post|put|patch|delete)\(\s*[`"]/[^`"]*' \
+            packages/websocket/src --include="*.ts" 2>/dev/null \
+            | sed -E 's/^[^`"]*[`"]//' | sort -u > docs-facts/http-routes.txt || true
+          : > docs-facts/undocumented-routes.txt
+          while read -r route; do
+            [ -n "$route" ] || continue
+            mentioned "$route" || echo "$route" >> docs-facts/undocumented-routes.txt
+          done < docs-facts/http-routes.txt
+
+          # --- NODETOOL_* environment variables ------------------------------
+          grep -rhoE 'NODETOOL_[A-Z0-9_]+' packages web/src electron/src \
+            --include="*.ts" --include="*.tsx" --include="*.mjs" 2>/dev/null \
+            | sort -u > docs-facts/env-vars.txt || true
+          : > docs-facts/undocumented-env.txt
+          while read -r var; do
+            [ -n "$var" ] || continue
+            mentioned "$var" || echo "$var" >> docs-facts/undocumented-env.txt
+          done < docs-facts/env-vars.txt
+
+          # --- Packages without a README -------------------------------------
+          : > docs-facts/packages-without-readme.txt
+          for pkg in packages/*/; do
+            [ -f "$pkg/package.json" ] || continue
+            [ -f "$pkg/README.md" ] || echo "${pkg%/}" >> docs-facts/packages-without-readme.txt
+          done
+
+          CLI_GAPS=$(wc -l < docs-facts/undocumented-cli.txt)
+          ROUTE_GAPS=$(wc -l < docs-facts/undocumented-routes.txt)
+          ENV_GAPS=$(wc -l < docs-facts/undocumented-env.txt)
+          PKG_GAPS=$(wc -l < docs-facts/packages-without-readme.txt)
+          TOTAL=$((CLI_GAPS + ROUTE_GAPS + ENV_GAPS + PKG_GAPS))
+
+          {
+            echo "## Documentation Completeness"
+            echo ""
+            echo "| Surface | Undocumented |"
+            echo "|---|---|"
+            echo "| CLI commands | $CLI_GAPS |"
+            echo "| HTTP routes | $ROUTE_GAPS |"
+            echo "| NODETOOL_* env vars | $ENV_GAPS |"
+            echo "| Packages without README | $PKG_GAPS |"
+          } >> $GITHUB_STEP_SUMMARY
+
+          echo "DOC_GAPS=$TOTAL" >> $GITHUB_ENV
+
+      - name: Record base commit
+        run: echo "BASE_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Run Claude Code
+        if: env.DOC_GAPS != '0'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
+            --append-system-prompt "All prose you write follows docs/WRITING_STYLE.md: concise, concrete, no AI slop (leverage, seamless, robust, comprehensive, it's worth noting, rule-of-three padding). Document what the code does, in the voice the surrounding docs already use."
+          prompt: |
+            # Documentation Completeness
+
+            Document the NodeTool surfaces that no page currently mentions.
+
+            ## Gaps found for you
+            - `docs-facts/undocumented-cli.txt` — CLI commands no doc mentions
+            - `docs-facts/undocumented-routes.txt` — HTTP routes no doc mentions
+            - `docs-facts/undocumented-env.txt` — `NODETOOL_*` env vars no doc mentions
+            - `docs-facts/packages-without-readme.txt` — packages with no README
+
+            These lists are a plain-text grep, so they over-report: a route
+            documented as `/api/workflows/:id` will not match a grep for
+            `/api/workflows/:workflow_id`. Confirm each gap is real before writing
+            anything, and drop the ones that are already covered under another
+            spelling.
+
+            ## Where things belong
+            Read the existing page first and extend it in its own structure rather
+            than starting a new page:
+            - CLI commands → `docs/cli.md`, and the CLI section of `CLAUDE.md`
+            - HTTP routes → `docs/api-reference.md` / `docs/api.md`
+            - Env vars → `docs/configuration.md`
+            - A package's own behavior → that package's `README.md`
+
+            A new page is justified only when a subsystem has no home at all. If you
+            add one, link it from `docs/index.md` so it is reachable.
+
+            ## What to write
+            For each gap: what it is, when someone reaches for it, and a working
+            example — a real command with real flags, a real request/response shape,
+            a real env var value. Derive every detail from the code (`--help` output,
+            the route handler, the place the env var is read). Never invent a flag,
+            a default, or a response field.
+
+            Internal-only surfaces do not need user docs. If a route is internal
+            plumbing or an env var is a test hook, say so in the PR body and skip it
+            rather than writing a page nobody needs.
+
+            ## Rules
+            - **Markdown only.** Do not change code to match documentation.
+            - Match the surrounding page's heading depth, code-fence style, and voice.
+            - Do not rewrite documentation that already exists — this pass adds what
+              is missing.
+            - Do not touch CI workflow files.
+            - Keep changes focused — at most 8 gaps per PR, prioritizing CLI commands
+              and HTTP routes (what users hit first) over package READMEs.
+            - Do not commit the `docs-facts/` directory.
+
+            ## Before starting
+            - Run `gh pr list --state open --limit 20` — skip if a documentation
+              completeness PR is already open.
+
+            ## Verification
+            Every command you document must run as written. Check flags against
+            `nodetool <command> --help`, and check that any relative link you add
+            resolves on disk.
+
+            ## Submit
+            Create a PR titled "docs: document <surface>" whose body lists each gap
+            filled, where the documentation went, and where in the code you read the
+            behavior. List the gaps you deliberately skipped and why.
+
+      # A docs job that edits code has done something it was told not to. Catch it
+      # here rather than in review — the PR is already open by this point, so this
+      # step failing is the signal to close it.
+      - name: Guard — Markdown-only changes
+        if: always()
+        run: |
+          set -uo pipefail
+          rm -rf docs-facts
+          CHANGED=$( { git diff --name-only "${BASE_SHA:-HEAD}" HEAD; git status --porcelain | awk '{print $NF}'; } | sort -u )
+          CODE_CHANGES=$(echo "$CHANGED" | grep -v -E '\.(md|markdown)$' | grep -v '^$' || true)
+          if [ -n "$CODE_CHANGES" ]; then
+            echo "::error::Non-Markdown files were modified by a docs-only job:"
+            echo "$CODE_CHANGES"
+            exit 1
+          fi

--- a/.github/workflows/docs-correctness.yaml
+++ b/.github/workflows/docs-correctness.yaml
@@ -1,0 +1,183 @@
+name: Documentation Correctness
+
+# Docs drift silently: a flag gets renamed, a script disappears, a package moves,
+# and the page describing it keeps saying the old thing. Nothing in CI catches
+# that — `docs-ci.yml` proves the site builds and its links resolve, not that its
+# sentences are true.
+#
+# This job collects ground truth from the repo itself (CLI help, npm scripts,
+# workspace list, the week's code changes), hands it to Claude, and asks it to
+# check the docs that describe those surfaces against what the code actually
+# does. Markdown only — it never edits code to make a doc true. Opens a PR,
+# never auto-merges.
+
+on:
+  schedule:
+    - cron: "10 5 * * *" # Daily at 05:10 UTC
+  workflow_dispatch:
+
+jobs:
+  docs-correctness:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      # The CLI loads the node registry from dist/ (decorator packages), so its
+      # help output is only complete after a build.
+      - name: Build packages
+        run: npm run build:packages
+
+      - name: Collect ground truth
+        id: facts
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          mkdir -p docs-facts
+
+          # Every CLI command's help text — the reference the CLI docs and
+          # CLAUDE.md command blocks are supposed to match.
+          {
+            npm run --silent dev:nodetool -- --help
+            npm run --silent dev:nodetool -- --help 2>/dev/null \
+              | awk '/^Commands:/{f=1;next} f && /^  [a-z]/{print $1}' \
+              | sort -u \
+              | while read -r cmd; do
+                  echo ""
+                  echo "===== nodetool $cmd --help ====="
+                  npm run --silent dev:nodetool -- "$cmd" --help 2>&1 || true
+                done
+          } > docs-facts/cli-help.txt 2>&1 || true
+
+          node -e 'const s=require("./package.json").scripts||{};for(const k of Object.keys(s).sort())console.log(k+" = "+s[k])' \
+            > docs-facts/npm-scripts.txt 2>/dev/null || true
+
+          node -e 'const {workspaces=[]}=require("./package.json");console.log(workspaces.join("\n"))' \
+            > docs-facts/workspaces.txt 2>/dev/null || true
+          ls -1 packages >> docs-facts/workspaces.txt 2>/dev/null || true
+
+          # Docs describing code that moved this week are the likeliest to be stale.
+          git log --since="7 days ago" --name-only --pretty=format:"--- %h %s" \
+            > docs-facts/recent-changes.txt 2>/dev/null || true
+
+          {
+            echo "## Documentation Correctness — ground truth"
+            echo ""
+            echo "- CLI help: $(wc -l < docs-facts/cli-help.txt 2>/dev/null || echo 0) lines"
+            echo "- npm scripts: $(wc -l < docs-facts/npm-scripts.txt 2>/dev/null || echo 0)"
+            echo "- Commits in the last 7 days: $(git log --since='7 days ago' --oneline | wc -l)"
+          } >> $GITHUB_STEP_SUMMARY
+
+      - name: Record base commit
+        run: echo "BASE_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
+            --append-system-prompt "All prose you write follows docs/WRITING_STYLE.md: concise, concrete, no AI slop (leverage, seamless, robust, comprehensive, it's worth noting, rule-of-three padding). Fix slop you pass in paragraphs you are already editing."
+          prompt: |
+            # Documentation Correctness
+
+            Check NodeTool's documentation against what the code actually does, and
+            fix the statements that are wrong.
+
+            ## Ground truth collected for you
+            - `docs-facts/cli-help.txt` — every CLI command's real help output
+            - `docs-facts/npm-scripts.txt` — the npm scripts that actually exist
+            - `docs-facts/workspaces.txt` — the real workspace/package list
+            - `docs-facts/recent-changes.txt` — files changed in the last 7 days
+
+            Docs describing code that changed this week are the likeliest to be
+            stale. Start there, then widen.
+
+            ## Scope
+            - `docs/**/*.md`
+            - `README.md`, `AGENTS.md`, `CLAUDE.md`, and per-package `CLAUDE.md` / `AGENTS.md` / `README.md`
+
+            ## What counts as an error
+
+            **Commands that do not exist or take different flags.** Every `npm run …`
+            and `nodetool …` invocation in a doc must exist with the flags shown.
+            Check against `docs-facts/npm-scripts.txt` and `docs-facts/cli-help.txt`,
+            not memory.
+
+            **Paths and file names that no longer resolve.** Every path a doc names
+            (`packages/foo/src/bar.ts`, `web/src/components/…`, script names, config
+            files) must exist. Verify each with `ls`/`test -e`.
+
+            **Symbols that were renamed or removed.** Class, function, hook, store,
+            node type, and env var names quoted in prose must appear in the code.
+            Grep for each before trusting it.
+
+            **Descriptions contradicted by the code.** Defaults, ports, ordering,
+            required versions, return shapes, message formats. Read the code path
+            before rewriting the sentence.
+
+            **Internal links that point nowhere.** Relative Markdown links to files
+            or headings that no longer exist.
+
+            ## Rules
+            - **Markdown only.** Never edit code to make a doc true — if a doc
+              describes better behavior than the code has, leave the code alone and
+              note it in the PR body instead of rewriting the doc into fiction.
+            - Verify every claim you change. If you cannot confirm what the correct
+              statement is, delete the wrong sentence rather than guessing a new one.
+            - Do not restructure, reword, or "improve" prose that is already correct.
+              This PR is a correction pass, not an editing pass.
+            - Do not touch CI workflow files.
+            - Do not add new documentation pages — `docs-completeness.yaml` covers gaps.
+            - Keep changes focused — maximum 15 files per PR.
+            - Do not commit the `docs-facts/` directory.
+
+            ## Before starting
+            - Run `gh pr list --state open --limit 20` — skip if a documentation
+              correctness PR is already open.
+
+            ## Submit
+            If you found nothing wrong, say so and open no PR.
+
+            Otherwise create a PR titled "docs: fix stale documentation" whose body
+            lists each correction as: the file, what the doc claimed, what the code
+            actually does, and how you verified it. Add a separate "Code that
+            contradicts its own docs" section for anything you chose not to fix.
+
+      # A docs job that edits code has done something it was told not to. Catch it
+      # here rather than in review — the PR is already open by this point, so this
+      # step failing is the signal to close it.
+      - name: Guard — Markdown-only changes
+        if: always()
+        run: |
+          set -uo pipefail
+          rm -rf docs-facts
+          CHANGED=$( { git diff --name-only "${BASE_SHA:-HEAD}" HEAD; git status --porcelain | awk '{print $NF}'; } | sort -u )
+          CODE_CHANGES=$(echo "$CHANGED" | grep -v -E '\.(md|markdown)$' | grep -v '^$' || true)
+          if [ -n "$CODE_CHANGES" ]; then
+            echo "::error::Non-Markdown files were modified by a docs-only job:"
+            echo "$CODE_CHANGES"
+            exit 1
+          fi


### PR DESCRIPTION
Nothing in CI checks whether the docs say true things. `docs-ci.yml` proves the site builds and its internal links resolve; `docs-lint.yml` checks Markdown. Neither notices a renamed flag, a moved path, or a CLI command no page mentions.

Two scheduled agent workflows, in the shape the existing ones use (`dead-code-cleanup.yaml`, `type-safety.yaml`): a deterministic scan step gathers facts, Claude acts on them, a guard step checks the result.

## `docs-correctness.yaml` — daily, 05:10 UTC

Collects ground truth from the repo before the agent runs:

- `--help` output for every CLI command (after `build:packages`, since the CLI enumerates from `dist/`)
- the npm scripts that actually exist, from `package.json`
- the real workspace/package list
- files changed in the last 7 days — docs describing code that just moved are the likeliest to be stale

Claude checks the docs describing those surfaces against the code and corrects what is wrong: commands that don't exist or take different flags, paths that don't resolve, renamed symbols, defaults and ports contradicted by the code, dead relative links. It is told to verify every claim it changes and to delete a wrong sentence rather than guess a replacement, and not to reword prose that is already correct.

## `docs-completeness.yaml` — daily, 05:40 UTC

Inventories the surfaces users touch and diffs each against what the docs mention:

| Surface | Source |
|---|---|
| CLI commands | `nodetool --help` |
| HTTP routes | route registrations in `packages/websocket/src` |
| `NODETOOL_*` env vars | grep over `packages`, `web/src`, `electron/src` |
| Packages without a README | `packages/*/` |

The gap counts go to the step summary, and the agent step is skipped entirely when the total is zero. The prompt states that a plain-text grep over-reports (a route documented under a different parameter spelling won't match) and requires confirming each gap before writing. It routes new material into the page that already owns the subject rather than opening new pages, and allows skipping internal-only routes and test-hook env vars with a note in the PR body.

## Both

- **Markdown only.** A guard step diffs against the pre-agent commit and fails the run if any non-Markdown file was touched — a docs job that edits code to make a doc true has done the one thing it was told not to.
- Open a PR, never auto-merge. Both check for an already-open PR of their kind first.
- Cost is one agent pass per day each, on slots (05:10, 05:40 UTC) that no other scheduled workflow uses.

## Also in this diff

`.github/workflows/README.md`: added the two rows, plus the missing rows for `app-build-eval.yml` and `genspend-pricing.yml`, and corrected the file count — it read "38 workflow files … 26 none/maintenance" against an actual 41 before this change, 43 after.

## Verification

Both files parse as YAML and pass Prettier. The inventory greps were run against the current tree (51 route paths, 107 `NODETOOL_*` vars). The `--help`-driven steps need `build:packages` and so were not executed here; they are `continue-on-error` and each pipeline is `|| true`, so a scan miss degrades the agent's input rather than failing the run. The README's pre-existing Prettier warning is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqstcoPBCt4WmjsDBQmexr)_