### PR TITLE
marketing: reposition the agents page as agent-first

### DIFF
--- a/marketing/public/agents.md
+++ b/marketing/public/agents.md
@@ -1,12 +1,12 @@
 ---
 title: "NodeTool Agents"
-description: "Build planning agents that use models, tools, and workflows."
+description: "NodeTool is agent-first: every editor is exposed to agents as tools."
 canonical: https://nodetool.ai/agents
 markdown: https://nodetool.ai/agents.md
 product: NodeTool
 ---
 # NodeTool Agents
 
-NodeTool agents plan multi-step tasks, call tools, and run workflows on the same visual canvas as media and data pipelines.
+NodeTool is agent-first. Every editor — the node canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools, around 120 in all. An agent plans multi-step tasks, builds and runs workflows, and repairs what fails, on the same surfaces you use. The full toolbelt is also exposed over MCP for outside agents such as Claude Desktop and Claude Code.
 
 Read the [agent documentation](https://docs.nodetool.ai/agents/index.md) for installation, schema discovery, validation, execution, and job monitoring.

--- a/marketing/public/llms.txt
+++ b/marketing/public/llms.txt
@@ -43,6 +43,7 @@
 - [FAQ hub](https://nodetool.ai/faq): all questions, grouped by category.
 - [What is NodeTool?](https://nodetool.ai/faq/what-is-nodetool)
 - [Is NodeTool open source?](https://nodetool.ai/faq/is-nodetool-open-source)
+- [What does it mean that NodeTool is agent-first?](https://nodetool.ai/faq/what-does-agent-first-mean)
 - [What does "bring your own keys" mean for me?](https://nodetool.ai/faq/what-is-byok)
 - [Does NodeTool mark up model pricing?](https://nodetool.ai/faq/does-nodetool-mark-up-model-pricing)
 - [Studio or Cloud — which should I use?](https://nodetool.ai/faq/studio-or-cloud)

--- a/marketing/scripts/generate-llms-txt.mjs
+++ b/marketing/scripts/generate-llms-txt.mjs
@@ -137,8 +137,9 @@ Use the [CLI](https://docs.nodetool.ai/cli.md) for automation, the [node catalog
   },
   "agents.md": {
     title: "NodeTool Agents",
-    description: "Build planning agents that use models, tools, and workflows.",
-    body: `NodeTool agents plan multi-step tasks, call tools, and run workflows on the same visual canvas as media and data pipelines.
+    description:
+      "NodeTool is agent-first: every editor is exposed to agents as tools.",
+    body: `NodeTool is agent-first. Every editor — the node canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools, around 120 in all. An agent plans multi-step tasks, builds and runs workflows, and repairs what fails, on the same surfaces you use. The full toolbelt is also exposed over MCP for outside agents such as Claude Desktop and Claude Code.
 
 Read the [agent documentation](https://docs.nodetool.ai/agents/index.md) for installation, schema discovery, validation, execution, and job monitoring.`,
   },

--- a/marketing/src/app/agents/layout.tsx
+++ b/marketing/src/app/agents/layout.tsx
@@ -1,9 +1,9 @@
 import JsonLd from "../../components/JsonLd";
 import type { Metadata } from "next";
 
-const TITLE = "AI Agent Workflow Builder — Visual Canvas | NodeTool";
+const TITLE = "Agent-First Creative Workspace | NodeTool";
 const DESCRIPTION =
-  "Build and run AI agents visually — agents on a node canvas that plan the steps, pick the model, and do the work, no code required. Wire image, video, music, and voice models — Flux, Seedance, Veo, Kling, Suno, ElevenLabs — into agents that ship the work. Open source, your own keys, runs on your machine.";
+  "NodeTool is agent-first: every editor — node canvas, sketch pad, storyboard, video timeline, script, 3D scene, app builder — is exposed to agents as tools, around 120 in all. Say what you want and the agent plans the steps, builds the workflow, runs it across Flux, Seedance, Veo, Kling, Suno, and ElevenLabs, and fixes what fails. Open source, your own keys, runs on your machine.";
 
 export const metadata: Metadata = {
   title: TITLE,
@@ -13,15 +13,18 @@ export const metadata: Metadata = {
     canonical: "/agents",
   },
   keywords: [
+    "agent-first app",
     "AI agent workflow builder",
     "visual AI agent builder",
     "no-code AI agents",
     "plan-act agents",
+    "agents that build workflows",
+    "agents that build apps",
+    "supervised agent runs",
+    "MCP creative tools",
     "creative AI agents",
     "art director agent",
     "brief to asset",
-    "automated brand pack",
-    "AI motion design agent",
     "creative workflow automation",
     "image generation agent",
     "video generation agent",
@@ -58,7 +61,7 @@ export default function AgentsLayout({
           "@type": "SoftwareApplication",
           name: "NodeTool Agents",
           description:
-            "AI agents built visually on NodeTool's node canvas: give an agent a goal and it plans the steps, picks the model, and does the work across image, video, music, and voice models — Flux, Seedance, Veo, Kling, Suno, ElevenLabs. Open source, your own keys, runs on your machine.",
+            "NodeTool is agent-first: every editor in the app is exposed to agents as tools. Give an agent a goal and it plans the steps, builds the workflow on the canvas, runs it across image, video, music, and voice models — Flux, Seedance, Veo, Kling, Suno, ElevenLabs — and repairs what fails. The same tools are exposed over MCP for outside agents. Open source, your own keys, runs on your machine.",
           applicationCategory: "MultimediaApplication",
           operatingSystem: "macOS, Windows, Linux, Web browser",
           url: "https://nodetool.ai/agents",

--- a/marketing/src/components/agents/AgentBuildRunDeploy.tsx
+++ b/marketing/src/components/agents/AgentBuildRunDeploy.tsx
@@ -23,12 +23,12 @@ export default function AgentBuildRunDeploy() {
             <div className="relative mx-auto max-w-6xl w-full z-10">
                 <div className="mb-12 text-center max-w-2xl mx-auto">
                     <h2 className="text-4xl md:text-5xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-white via-slate-200 to-slate-400 mb-4 tracking-tight">
-                        Brief it. Direct it. Iterate.
+                        Say it. Watch it build. Keep it.
                     </h2>
                     <p className="text-slate-400 text-lg">
-                        Hand your agent a creative brief, watch it pick models and generate
-                        variants, then save the winning run as a node you can rerun for the
-                        next campaign.
+                        The agent works with the same tools you click. It builds the actual
+                        workflow on your canvas, runs it in front of you, and leaves behind
+                        something you can rerun — not a chat transcript.
                     </p>
                 </div>
 
@@ -44,8 +44,8 @@ export default function AgentBuildRunDeploy() {
 
                 <div className="grid grid-cols-1 gap-8 md:grid-cols-3 relative z-10">
                     <Card
-                        title="Write the brief"
-                        subtitle="Set the look, the mood, and what you need delivered. Choose the image, video, and audio models the agent should direct: Flux, Seedance, Veo, Suno, ElevenLabs."
+                        title="Say what you want"
+                        subtitle="Describe the spot, the app, or the pipeline in chat. The agent plans the steps and authors the graph itself — picks the nodes, wires the edges, selects the models: Flux, Seedance, Veo, Suno, ElevenLabs."
                         step={1}
                         accentColor="blue"
                     >
@@ -53,8 +53,8 @@ export default function AgentBuildRunDeploy() {
                     </Card>
 
                     <Card
-                        title="Watch it direct"
-                        subtitle="See the agent think through the shot, choose a model, produce variations, and try again when a render misses the brief. Every decision is on screen."
+                        title="Watch it work"
+                        subtitle="Every tool call lands on your screen: nodes appear, renders come back, the timeline fills. When a render misses the brief the agent retries, and when a call is yours to make it stops and asks."
                         step={2}
                         accentColor="purple"
                     >
@@ -62,8 +62,8 @@ export default function AgentBuildRunDeploy() {
                     </Card>
 
                     <Card
-                        title="Iterate the cut"
-                        subtitle="Adjust the prompt, swap a model, or re-run one part. You can also save the whole agent and use it again on the next campaign."
+                        title="Keep what it built"
+                        subtitle="The result is a workflow or mini app you can inspect, edit, and rerun for the next campaign — with an agent supervising the failure path on a decision and cost budget you set."
                         step={3}
                         accentColor="emerald"
                     >
@@ -312,16 +312,16 @@ function RunGraphic() {
                     <span>Brief: &quot;Sneaker launch, 9:16, neon noir&quot;</span>
                 </div>
                 <div className="flex items-start gap-2 text-blue-400 animate-[fadeIn_0.5s_ease-out_1.5s_both]">
-                    <span className="shrink-0">[DIRECTOR]</span>
-                    <span>Plan: 4 stills, then animate the hero shot.</span>
+                    <span className="shrink-0">[PLAN]</span>
+                    <span>4 stills, animate the hero shot, score it.</span>
                 </div>
                 <div className="flex items-start gap-2 text-yellow-400 animate-[fadeIn_0.5s_ease-out_2.5s_both]">
-                    <span className="shrink-0">[MODEL]</span>
-                    <span>flux_pro(prompt=&quot;rain-soaked alley, chrome accents&quot;)</span>
+                    <span className="shrink-0">[TOOL]</span>
+                    <span>ui_add_node(&quot;flux_pro&quot;) · ui_connect_nodes · ui_run_workflow</span>
                 </div>
                 <div className="flex items-start gap-2 text-purple-400 animate-[fadeIn_0.5s_ease-out_3.5s_both]">
-                    <span className="shrink-0">[RENDER]</span>
-                    <span>4 variants ready · routing best to Seedance…</span>
+                    <span className="shrink-0">[RETRY]</span>
+                    <span>Variant 2 missed the brief · new prompt, rerunning…</span>
                 </div>
             </div>
         </div>

--- a/marketing/src/components/agents/AgentFeaturesSection.tsx
+++ b/marketing/src/components/agents/AgentFeaturesSection.tsx
@@ -23,44 +23,44 @@ export default function AgentFeaturesSection({
   const features = [
     {
       icon: Brain,
-      title: "Briefs become storyboards",
+      title: "The whole app is the toolbelt",
       description:
-        "Give it a one-line prompt or a full mood board. The agent plans the shots, picks a model for each one, and lays out a board you can rearrange before anything is rendered.",
+        "Around 120 tools cover every editor: the node canvas, the layered sketch pad, the storyboard, the video timeline, the script editor, the 3D scene, and the app builder. If you can click it, an agent can drive it.",
       color: "teal",
     },
     {
       icon: GitFork,
-      title: "Batch variants in parallel",
+      title: "Agents build workflows",
       description:
-        "Need ten versions of the hero frame in five aspect ratios? The agent spreads the work across providers, runs them at the same time, and brings the results back ranked for review.",
+        "Describe the pipeline and the agent authors the graph itself — picks the nodes, wires the edges, selects the models — and validates it before anything runs. What it leaves behind is a workflow you can inspect, edit, and rerun.",
       color: "blue",
     },
     {
-      icon: Users,
-      title: "A crew, not a single model",
+      icon: Wand2,
+      title: "Agents build apps — and test them",
       description:
-        "Run a director, a stylist, and a colorist as separate agents that hand work to each other on a shared board. Each gets the model and prompt that suits its job.",
+        "Ask for a mini app and the agent plans the workflows, places the widgets, wires them together, then runs every interaction and has a second model judge whether the result does what you asked. No passing verdict, no app.",
       color: "cyan",
     },
     {
-      icon: Wand2,
-      title: "Image, video, music — one room",
+      icon: Users,
+      title: "An agent on the failure path",
       description:
-        "Agents can call Flux, Nano Banana, and Ideogram for stills, Seedance, Veo, Kling, and Runway for motion, Suno for score, and ElevenLabs for voice. All on one canvas.",
+        "Supervised runs put an agent on call: when a step fails mid-run, it decides — retry, repair the output, skip the item, or stop — inside a decision and cost budget you set, with every intervention logged.",
       color: "emerald",
     },
     {
       icon: Eye,
-      title: "See every decision",
+      title: "It asks instead of guessing",
       description:
-        "Watch the agent think through the composition, switch models when a render misses the mark, and record every prompt it tried. Nothing is hidden when the deadline is close.",
+        "When a job is missing something only you can decide — a name, a look, permission to delete — the agent stops and asks. Every plan, tool call, prompt, and dollar of model spend is on the record.",
       color: "pink",
     },
     {
       icon: Sparkles,
-      title: "Bottle your art direction",
+      title: "Bring your own agent",
       description:
-        "Save a style guide once (palette, lens, mood, and the prompts behind them) and every agent on your canvas follows it automatically.",
+        "The full toolbelt is exposed over MCP. Point Claude Desktop, Claude Code, or any MCP-aware agent at NodeTool and it gets the same tools the built-in chat uses: build workflows, run them, read the results.",
       color: "amber",
     },
   ];
@@ -93,9 +93,9 @@ export default function AgentFeaturesSection({
             transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Built to{" "}
+            Agent-first,{" "}
             <span className="text-white">
-              direct, not babysit.
+              not agent-flavored.
             </span>
           </motion.h2>
 
@@ -106,9 +106,10 @@ export default function AgentFeaturesSection({
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            An agent sits on the same canvas as your image, video, and audio
-            work. The difference is that it arrives with a plan, an eye for the
-            brief, and the ability to try again when a render misses.
+            Most tools bolted a chat panel onto an editor. NodeTool went the
+            other way: the entire app is built as tools an agent can operate.
+            Agents don&apos;t just answer questions about your work — they do
+            the work, on the same surfaces you use.
           </motion.p>
         </div>
 

--- a/marketing/src/components/agents/AgentIntegrationsSection.tsx
+++ b/marketing/src/components/agents/AgentIntegrationsSection.tsx
@@ -196,7 +196,8 @@ export default function AgentIntegrationsSection({
           <p className="text-slate-400 mb-6 max-w-2xl mx-auto">
             NodeTool is open source. Wrap any provider as a node, plug in a private
             checkpoint, or drive the canvas from the TypeScript SDK — agents pick it up
-            like a first-class tool the moment it lands on the canvas.
+            like a first-class tool the moment it lands on the canvas. And because the
+            whole toolbelt speaks MCP, outside agents get it too.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a

--- a/marketing/src/components/agents/AgentsGraphHero.tsx
+++ b/marketing/src/components/agents/AgentsGraphHero.tsx
@@ -100,21 +100,24 @@ export default function AgentsGraphHero() {
                         <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-rose-500/10 border border-rose-500/20 mb-6">
                             <Sparkles className="w-4 h-4 text-rose-300" />
                             <span className="text-sm font-medium text-rose-200">
-                                Agents for creative work
+                                An agent-first creative workspace
                             </span>
                         </div>
 
                         <h1 className="text-5xl md:text-7xl font-bold tracking-tight text-white mb-8">
-                            An art director <br />
+                            The whole studio is <br />
                             <span className="text-transparent bg-clip-text bg-gradient-to-r from-rose-400 via-amber-300 to-cyan-400">
-                                that never sleeps.
+                                the agent&apos;s toolbelt.
                             </span>
                         </h1>
 
                         <p className="text-lg md:text-xl text-slate-400 mb-10 leading-relaxed max-w-2xl mx-auto">
-                            Drop an agent on the canvas, hand it a brief, and watch it plan the shot,
-                            pick the right model, generate variants, and stitch the cut — across Flux,
-                            Seedance, Veo, Kling, Suno, and ElevenLabs. You direct, it executes.
+                            NodeTool isn&apos;t a chat box bolted onto an editor. Every surface —
+                            the node canvas, the sketch pad, the storyboard, the video timeline,
+                            the app builder — is exposed to agents as tools, around 120 in all.
+                            Hand over a brief and the agent plans the shots, builds the workflow,
+                            runs it across Flux, Seedance, Veo, Kling, Suno, and ElevenLabs, and
+                            retries what misses. You direct, it executes.
                         </p>
 
                         <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -132,7 +135,7 @@ export default function AgentsGraphHero() {
                             <span className="w-1 h-1 rounded-full bg-slate-700" />
                             <span>Your own keys, paid straight to the provider</span>
                             <span className="w-1 h-1 rounded-full bg-slate-700" />
-                            <span>Watch every step</span>
+                            <span>Every decision on screen</span>
                         </div>
                     </motion.div>
                 </div>

--- a/marketing/src/data/faqEntries.ts
+++ b/marketing/src/data/faqEntries.ts
@@ -193,6 +193,15 @@ const seeds: FaqSeed[] = [
     surfaces: [],
   },
   {
+    slug: "what-does-agent-first-mean",
+    question: "What does it mean that NodeTool is agent-first?",
+    answerMd:
+      "Every editor in NodeTool — the node canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools, around 120 in all. An agent doesn't describe what you could do; it builds the workflow, runs it, and repairs what fails, on the same surfaces you use. The same tools are exposed over **MCP**, so outside agents such as Claude Desktop and Claude Code can drive NodeTool too.",
+    category: "general",
+    relatedRoute: "/agents",
+    surfaces: ["agents"],
+  },
+  {
     slug: "what-is-a-planning-agent",
     question: "What is a planning agent?",
     answerMd:

--- a/marketing/src/data/templateCatalog.generated.ts
+++ b/marketing/src/data/templateCatalog.generated.ts
@@ -1316,6 +1316,22 @@ export const templateCatalog: CatalogCategory[] = [
         ]
       },
       {
+        "slug": "check-a-url-and-an-ip",
+        "name": "Check a URL and an IP",
+        "description": "Two shape tests that people routinely hand-roll with regex and get wrong. IP reports the family as well as validity, because 'is this an address' and 'is this v4' are different questions.",
+        "tags": [
+          "text"
+        ]
+      },
+      {
+        "slug": "chunk-a-transcript-for-indexing",
+        "name": "Chunk a Transcript for Indexing",
+        "description": "Split a long passage into overlapping windows the way a RAG ingest does, then count them. `length` and `overlap` are counted in WORDS, not characters — a 90 here would swallow this whole passage into one chunk. Overlap is the point: a boundary landing mid-sentence loses the claim that straddles it, so neighbouring chunks share a tail. Counting needs Collection first, because Count consumes a stream and a list handed to it arrives as a single item.",
+        "tags": [
+          "text"
+        ]
+      },
+      {
         "slug": "conditional-logic-engine",
         "name": "Conditional Logic Engine",
         "description": "Teaching example for control flow: one number drives two independent decision structures built entirely from If nodes — there is no dedicated numeric-compare or boolean-logic node in NodeTool, so this shows the actual pattern: PadText + Compare + Equals turn the number into a boolean, then pairs of If nodes sharing one condition (each holding its own value, taking the opposite branch) act as the ternary select and OR you'd otherwise reach for. No LLM calls.",
@@ -1426,6 +1442,14 @@ export const templateCatalog: CatalogCategory[] = [
         ]
       },
       {
+        "slug": "map-a-readmes-structure",
+        "name": "Map a README's Structure",
+        "description": "Read the shape of a Markdown document without parsing it by hand: headings for the outline, links for the reference graph, and fenced blocks for the code it teaches.",
+        "tags": [
+          "text"
+        ]
+      },
+      {
         "slug": "one-tagline-six-markets",
         "name": "One Tagline, Six Markets",
         "description": "A tagline in six languages with a back-translation for each, so someone who reads none of them can still see what was actually said.",
@@ -1462,9 +1486,25 @@ export const templateCatalog: CatalogCategory[] = [
         ]
       },
       {
+        "slug": "read-the-links-out-of-a-page",
+        "name": "Read the Links Out of a Page",
+        "description": "Resolve a page's base URL, then pull its anchors against it. `base_url` does not rewrite relative hrefs to absolute — it CLASSIFIES each link as internal or external, which is what you need to decide whether a crawler should follow it. The href comes back exactly as authored.",
+        "tags": [
+          "text"
+        ]
+      },
+      {
         "slug": "redact-email-addresses",
         "name": "Redact Email Addresses",
         "description": "A regex replace standing in for the everyday cleanup step — strip personal data out of text before it reaches a model or a log.",
+        "tags": [
+          "text"
+        ]
+      },
+      {
+        "slug": "redact-and-tidy-a-log-line",
+        "name": "Redact and Tidy a Log Line",
+        "description": "Two regex passes and a whitespace collapse, in the order that matters: redact before you normalise, or the pattern you are matching may already have been reshaped.",
         "tags": [
           "text"
         ]
@@ -1600,6 +1640,14 @@ export const templateCatalog: CatalogCategory[] = [
         "slug": "validate-a-postcode-shape",
         "name": "Validate a Postcode Shape",
         "description": "RegexValidate answers whether text matches a pattern — a guard to run before you trust user input or model output as structured data.",
+        "tags": [
+          "text"
+        ]
+      },
+      {
+        "slug": "validate-a-signup-payload",
+        "name": "Validate a Signup Payload",
+        "description": "Run one submitted address through the checks a signup form needs: a strict email test, a bundle of shape checks in one pass, and the sanitised forms you would actually store. Sanitize returns three variants because escaping, trimming and email normalisation are different jobs.",
         "tags": [
           "text"
         ]
@@ -1788,6 +1836,14 @@ export const templateCatalog: CatalogCategory[] = [
         "slug": "join-two-tables-on-a-key",
         "name": "Join Two Tables on a Key",
         "description": "A key join: names in one table, roles in another, matched on id. The everyday shape of pulling a model's structured output together with the records it refers to.",
+        "tags": [
+          "data"
+        ]
+      },
+      {
+        "slug": "keep-only-the-long-lines",
+        "name": "Keep Only the Long Lines",
+        "description": "Fan a list into a stream, drop the items that fail a predicate, then gather what survived back into a list. Two nodes carry the lesson: Collection is the fan-out — a list fed straight into a stream operator arrives as one item — and Collect is the reverse, without which an output on a stream shows only the last value that passed.",
         "tags": [
           "data"
         ]

--- a/marketing/src/data/templateEntries.generated.ts
+++ b/marketing/src/data/templateEntries.generated.ts
@@ -3816,6 +3816,280 @@ export const templateEntries: TemplateEntry[] = [
     }
   },
   {
+    "route": "/templates/check-a-url-and-an-ip",
+    "title": "Check a URL and an IP — NodeTool AI Workflow Template",
+    "description": "Two shape tests that people routinely hand-roll with regex and get wrong. IP reports the family as well as validity, because 'is this an address' and 'is this v4' are different questions.",
+    "priority": 0.3,
+    "changeFrequency": "monthly",
+    "indexable": false,
+    "slug": "check-a-url-and-an-ip",
+    "name": "Check a URL and an IP",
+    "summary": "Two shape tests that people routinely hand-roll with regex and get wrong. IP reports the family as well as validity, because 'is this an address' and 'is this v4' are different questions.",
+    "tags": [
+      "text",
+      "example"
+    ],
+    "category": "Text & Data",
+    "nodeTypes": [
+      {
+        "type": "nodetool.output.Output",
+        "label": "Output",
+        "count": 3
+      },
+      {
+        "type": "nodetool.constant.String",
+        "label": "String",
+        "count": 2
+      },
+      {
+        "type": "lib.validate.IP",
+        "label": "IP",
+        "count": 1
+      },
+      {
+        "type": "lib.validate.URL",
+        "label": "URL",
+        "count": 1
+      }
+    ],
+    "nodeCount": 7,
+    "thumbnail": null,
+    "graph": {
+      "nodes": [
+        {
+          "id": "u",
+          "type": "nodetool.constant.String",
+          "title": "String",
+          "x": 0,
+          "y": 120,
+          "width": 280,
+          "subtitle": "https://nodetool.ai/docs?q=1"
+        },
+        {
+          "id": "a",
+          "type": "nodetool.constant.String",
+          "title": "String",
+          "x": 320,
+          "y": 120,
+          "width": 280,
+          "subtitle": "2001:db8::8a2e:370:7334"
+        },
+        {
+          "id": "vu",
+          "type": "lib.validate.URL",
+          "title": "URL",
+          "x": 640,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "vi",
+          "type": "lib.validate.IP",
+          "title": "IP",
+          "x": 960,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "o1",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 0,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o2",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 320,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o3",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 640,
+          "y": 340,
+          "width": 280
+        }
+      ],
+      "edges": [
+        {
+          "source": "u",
+          "sourceHandle": "output",
+          "target": "vu",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "a",
+          "sourceHandle": "output",
+          "target": "vi",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "vu",
+          "sourceHandle": "output",
+          "target": "o1",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "vi",
+          "sourceHandle": "is_ipv6",
+          "target": "o2",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "vi",
+          "sourceHandle": "is_ipv4",
+          "target": "o3",
+          "targetHandle": "value",
+          "color": "any"
+        }
+      ]
+    }
+  },
+  {
+    "route": "/templates/chunk-a-transcript-for-indexing",
+    "title": "Chunk a Transcript for Indexing — NodeTool AI Workflow Template",
+    "description": "Split a long passage into overlapping windows the way a RAG ingest does, then count them. `length` and `overlap` are counted in WORDS, not characters — a 90 here would swallow this whole passage into one chunk. Overlap is the point: a boundary landing mid-sentence loses the claim that straddles it, so neighbouring chunks share a tail. Counting needs Collection first, because Count consumes a stream and a list handed to it arrives as a single item.",
+    "priority": 0.3,
+    "changeFrequency": "monthly",
+    "indexable": false,
+    "slug": "chunk-a-transcript-for-indexing",
+    "name": "Chunk a Transcript for Indexing",
+    "summary": "Split a long passage into overlapping windows the way a RAG ingest does, then count them. `length` and `overlap` are counted in WORDS, not characters — a 90 here would swallow this whole passage into one chunk. Overlap is the point: a boundary landing mid-sentence loses the claim that straddles it, so neighbouring chunks share a tail. Counting needs Collection first, because Count consumes a stream and a list handed to it arrives as a single item.",
+    "tags": [
+      "text",
+      "example"
+    ],
+    "category": "Text & Data",
+    "nodeTypes": [
+      {
+        "type": "nodetool.output.Output",
+        "label": "Output",
+        "count": 2
+      },
+      {
+        "type": "nodetool.text.Chunk",
+        "label": "Chunk",
+        "count": 1
+      },
+      {
+        "type": "nodetool.control.Collection",
+        "label": "Collection",
+        "count": 1
+      },
+      {
+        "type": "nodetool.control.Count",
+        "label": "Count",
+        "count": 1
+      },
+      {
+        "type": "nodetool.constant.String",
+        "label": "String",
+        "count": 1
+      }
+    ],
+    "nodeCount": 6,
+    "thumbnail": null,
+    "graph": {
+      "nodes": [
+        {
+          "id": "t",
+          "type": "nodetool.constant.String",
+          "title": "String",
+          "x": 0,
+          "y": 120,
+          "width": 280,
+          "subtitle": "The keeper climbed the stair each evening. The lamp needed winding twice a night. By the third winter the mechanism had worn, and the light…"
+        },
+        {
+          "id": "ch",
+          "type": "nodetool.text.Chunk",
+          "title": "Chunk",
+          "x": 320,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "fan",
+          "type": "nodetool.control.Collection",
+          "title": "Collection",
+          "x": 640,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "n",
+          "type": "nodetool.control.Count",
+          "title": "Count",
+          "x": 960,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "o1",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 0,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o2",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 320,
+          "y": 340,
+          "width": 280
+        }
+      ],
+      "edges": [
+        {
+          "source": "t",
+          "sourceHandle": "output",
+          "target": "ch",
+          "targetHandle": "text",
+          "color": "any"
+        },
+        {
+          "source": "ch",
+          "sourceHandle": "output",
+          "target": "o1",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "ch",
+          "sourceHandle": "output",
+          "target": "fan",
+          "targetHandle": "items",
+          "color": "any"
+        },
+        {
+          "source": "fan",
+          "sourceHandle": "output",
+          "target": "n",
+          "targetHandle": "input_item",
+          "color": "any"
+        },
+        {
+          "source": "n",
+          "sourceHandle": "output",
+          "target": "o2",
+          "targetHandle": "value",
+          "color": "any"
+        }
+      ]
+    }
+  },
+  {
     "route": "/templates/circles-and-lines",
     "title": "Circles and Lines — NodeTool AI Workflow Template",
     "description": "The remaining SVG primitives in one document — circle, ellipse and line — so the shape vocabulary is visible in one place.",
@@ -10780,6 +11054,160 @@ export const templateEntries: TemplateEntry[] = [
     }
   },
   {
+    "route": "/templates/keep-only-the-long-lines",
+    "title": "Keep Only the Long Lines — NodeTool AI Workflow Template",
+    "description": "Fan a list into a stream, drop the items that fail a predicate, then gather what survived back into a list. Two nodes carry the lesson: Collection is the fan-out — a list fed straight into a stream operator arrives as one item — and Collect is the reverse, without which an output on a stream shows only the last value that passed.",
+    "priority": 0.3,
+    "changeFrequency": "monthly",
+    "indexable": false,
+    "slug": "keep-only-the-long-lines",
+    "name": "Keep Only the Long Lines",
+    "summary": "Fan a list into a stream, drop the items that fail a predicate, then gather what survived back into a list. Two nodes carry the lesson: Collection is the fan-out — a list fed straight into a stream operator arrives as one item — and Collect is the reverse, without which an output on a stream shows only the last value that passed.",
+    "tags": [
+      "data",
+      "example"
+    ],
+    "category": "Text & Data",
+    "nodeTypes": [
+      {
+        "type": "nodetool.output.Output",
+        "label": "Output",
+        "count": 2
+      },
+      {
+        "type": "nodetool.control.Collect",
+        "label": "Collect",
+        "count": 1
+      },
+      {
+        "type": "nodetool.control.Collection",
+        "label": "Collection",
+        "count": 1
+      },
+      {
+        "type": "nodetool.control.Count",
+        "label": "Count",
+        "count": 1
+      },
+      {
+        "type": "nodetool.control.FilterCode",
+        "label": "Filter Code",
+        "count": 1
+      },
+      {
+        "type": "nodetool.constant.List",
+        "label": "List",
+        "count": 1
+      }
+    ],
+    "nodeCount": 7,
+    "thumbnail": null,
+    "graph": {
+      "nodes": [
+        {
+          "id": "src",
+          "type": "nodetool.constant.List",
+          "title": "List",
+          "x": 0,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "fan",
+          "type": "nodetool.control.Collection",
+          "title": "Collection",
+          "x": 320,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "keep",
+          "type": "nodetool.control.FilterCode",
+          "title": "Filter Code",
+          "x": 640,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "gather",
+          "type": "nodetool.control.Collect",
+          "title": "Collect",
+          "x": 960,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "n",
+          "type": "nodetool.control.Count",
+          "title": "Count",
+          "x": 0,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o1",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 320,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o2",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 640,
+          "y": 340,
+          "width": 280
+        }
+      ],
+      "edges": [
+        {
+          "source": "src",
+          "sourceHandle": "output",
+          "target": "fan",
+          "targetHandle": "items",
+          "color": "any"
+        },
+        {
+          "source": "fan",
+          "sourceHandle": "output",
+          "target": "keep",
+          "targetHandle": "input_item",
+          "color": "any"
+        },
+        {
+          "source": "keep",
+          "sourceHandle": "output",
+          "target": "gather",
+          "targetHandle": "input_item",
+          "color": "any"
+        },
+        {
+          "source": "keep",
+          "sourceHandle": "output",
+          "target": "n",
+          "targetHandle": "input_item",
+          "color": "any"
+        },
+        {
+          "source": "gather",
+          "sourceHandle": "output",
+          "target": "o1",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "n",
+          "sourceHandle": "output",
+          "target": "o2",
+          "targetHandle": "value",
+          "color": "any"
+        }
+      ]
+    }
+  },
+  {
     "route": "/templates/keep-only-the-matches",
     "title": "Keep Only the Matches — NodeTool AI Workflow Template",
     "description": "Equality filter over a stream. `invert` turns it into a reject list without a second node.",
@@ -11291,6 +11719,191 @@ export const templateEntries: TemplateEntry[] = [
           "source": "tts",
           "sourceHandle": "audio",
           "target": "out",
+          "targetHandle": "value",
+          "color": "any"
+        }
+      ]
+    }
+  },
+  {
+    "route": "/templates/map-a-readme-s-structure",
+    "title": "Map a README's Structure — NodeTool AI Workflow Template",
+    "description": "Read the shape of a Markdown document without parsing it by hand: headings for the outline, links for the reference graph, and fenced blocks for the code it teaches.",
+    "priority": 0.3,
+    "changeFrequency": "monthly",
+    "indexable": false,
+    "slug": "map-a-readme-s-structure",
+    "name": "Map a README's Structure",
+    "summary": "Read the shape of a Markdown document without parsing it by hand: headings for the outline, links for the reference graph, and fenced blocks for the code it teaches.",
+    "tags": [
+      "text",
+      "example"
+    ],
+    "category": "Text & Data",
+    "nodeTypes": [
+      {
+        "type": "nodetool.output.Output",
+        "label": "Output",
+        "count": 4
+      },
+      {
+        "type": "lib.markdown.ExtractBulletLists",
+        "label": "Extract Bullet Lists",
+        "count": 1
+      },
+      {
+        "type": "lib.markdown.ExtractCodeBlocks",
+        "label": "Extract Code Blocks",
+        "count": 1
+      },
+      {
+        "type": "lib.markdown.ExtractHeaders",
+        "label": "Extract Headers",
+        "count": 1
+      },
+      {
+        "type": "lib.markdown.ExtractLinks",
+        "label": "Extract Links",
+        "count": 1
+      },
+      {
+        "type": "nodetool.constant.String",
+        "label": "String",
+        "count": 1
+      }
+    ],
+    "nodeCount": 9,
+    "thumbnail": null,
+    "graph": {
+      "nodes": [
+        {
+          "id": "md",
+          "type": "nodetool.constant.String",
+          "title": "String",
+          "x": 0,
+          "y": 120,
+          "width": 280,
+          "subtitle": "# NodeTool Visual AI workflows. ## Install See the [docs](https://nodetool.ai/docs) and the [repo](https://github.com/nodetool-ai/nodetool)…"
+        },
+        {
+          "id": "h",
+          "type": "lib.markdown.ExtractHeaders",
+          "title": "Extract Headers",
+          "x": 320,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "l",
+          "type": "lib.markdown.ExtractLinks",
+          "title": "Extract Links",
+          "x": 640,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "c",
+          "type": "lib.markdown.ExtractCodeBlocks",
+          "title": "Extract Code Blocks",
+          "x": 960,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "b",
+          "type": "lib.markdown.ExtractBulletLists",
+          "title": "Extract Bullet Lists",
+          "x": 0,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o1",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 320,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o2",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 640,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o3",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 960,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o4",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 0,
+          "y": 560,
+          "width": 280
+        }
+      ],
+      "edges": [
+        {
+          "source": "md",
+          "sourceHandle": "output",
+          "target": "h",
+          "targetHandle": "markdown",
+          "color": "any"
+        },
+        {
+          "source": "md",
+          "sourceHandle": "output",
+          "target": "l",
+          "targetHandle": "markdown",
+          "color": "any"
+        },
+        {
+          "source": "md",
+          "sourceHandle": "output",
+          "target": "c",
+          "targetHandle": "markdown",
+          "color": "any"
+        },
+        {
+          "source": "md",
+          "sourceHandle": "output",
+          "target": "b",
+          "targetHandle": "markdown",
+          "color": "any"
+        },
+        {
+          "source": "h",
+          "sourceHandle": "output",
+          "target": "o1",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "l",
+          "sourceHandle": "output",
+          "target": "o2",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "c",
+          "sourceHandle": "output",
+          "target": "o3",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "b",
+          "sourceHandle": "output",
+          "target": "o4",
           "targetHandle": "value",
           "color": "any"
         }
@@ -16805,6 +17418,137 @@ export const templateEntries: TemplateEntry[] = [
     }
   },
   {
+    "route": "/templates/read-the-links-out-of-a-page",
+    "title": "Read the Links Out of a Page — NodeTool AI Workflow Template",
+    "description": "Resolve a page's base URL, then pull its anchors against it. `base_url` does not rewrite relative hrefs to absolute — it CLASSIFIES each link as internal or external, which is what you need to decide whether a crawler should follow it. The href comes back exactly as authored.",
+    "priority": 0.3,
+    "changeFrequency": "monthly",
+    "indexable": false,
+    "slug": "read-the-links-out-of-a-page",
+    "name": "Read the Links Out of a Page",
+    "summary": "Resolve a page's base URL, then pull its anchors against it. `base_url` does not rewrite relative hrefs to absolute — it CLASSIFIES each link as internal or external, which is what you need to decide whether a crawler should follow it. The href comes back exactly as authored.",
+    "tags": [
+      "text",
+      "example"
+    ],
+    "category": "Text & Data",
+    "nodeTypes": [
+      {
+        "type": "nodetool.output.Output",
+        "label": "Output",
+        "count": 2
+      },
+      {
+        "type": "nodetool.constant.String",
+        "label": "String",
+        "count": 2
+      },
+      {
+        "type": "lib.html.BaseUrl",
+        "label": "Base Url",
+        "count": 1
+      },
+      {
+        "type": "lib.html.ExtractLinks",
+        "label": "Extract Links",
+        "count": 1
+      }
+    ],
+    "nodeCount": 6,
+    "thumbnail": null,
+    "graph": {
+      "nodes": [
+        {
+          "id": "url",
+          "type": "nodetool.constant.String",
+          "title": "String",
+          "x": 0,
+          "y": 120,
+          "width": 280,
+          "subtitle": "https://nodetool.ai/guide/index.html"
+        },
+        {
+          "id": "html",
+          "type": "nodetool.constant.String",
+          "title": "String",
+          "x": 320,
+          "y": 120,
+          "width": 280,
+          "subtitle": "<html><head><title>Guide</title></head><body><a href=\"/docs\">Docs</a><a href=\"https://github.com/nodetool-ai/nodetool\">Source</a></body></h…"
+        },
+        {
+          "id": "base",
+          "type": "lib.html.BaseUrl",
+          "title": "Base Url",
+          "x": 640,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "links",
+          "type": "lib.html.ExtractLinks",
+          "title": "Extract Links",
+          "x": 960,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "o1",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 0,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o2",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 320,
+          "y": 340,
+          "width": 280
+        }
+      ],
+      "edges": [
+        {
+          "source": "url",
+          "sourceHandle": "output",
+          "target": "base",
+          "targetHandle": "url",
+          "color": "any"
+        },
+        {
+          "source": "html",
+          "sourceHandle": "output",
+          "target": "links",
+          "targetHandle": "html",
+          "color": "any"
+        },
+        {
+          "source": "base",
+          "sourceHandle": "output",
+          "target": "links",
+          "targetHandle": "base_url",
+          "color": "any"
+        },
+        {
+          "source": "base",
+          "sourceHandle": "output",
+          "target": "o1",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "links",
+          "sourceHandle": "links",
+          "target": "o2",
+          "targetHandle": "value",
+          "color": "any"
+        }
+      ]
+    }
+  },
+  {
     "route": "/templates/redact-email-addresses",
     "title": "Redact Email Addresses — NodeTool AI Workflow Template",
     "description": "A regex replace standing in for the everyday cleanup step — strip personal data out of text before it reaches a model or a log.",
@@ -16878,6 +17622,156 @@ export const templateEntries: TemplateEntry[] = [
           "source": "rr",
           "sourceHandle": "output",
           "target": "out",
+          "targetHandle": "value",
+          "color": "any"
+        }
+      ]
+    }
+  },
+  {
+    "route": "/templates/redact-and-tidy-a-log-line",
+    "title": "Redact and Tidy a Log Line — NodeTool AI Workflow Template",
+    "description": "Two regex passes and a whitespace collapse, in the order that matters: redact before you normalise, or the pattern you are matching may already have been reshaped.",
+    "priority": 0.3,
+    "changeFrequency": "monthly",
+    "indexable": false,
+    "slug": "redact-and-tidy-a-log-line",
+    "name": "Redact and Tidy a Log Line",
+    "summary": "Two regex passes and a whitespace collapse, in the order that matters: redact before you normalise, or the pattern you are matching may already have been reshaped.",
+    "tags": [
+      "text",
+      "example"
+    ],
+    "category": "Text & Data",
+    "nodeTypes": [
+      {
+        "type": "nodetool.output.Output",
+        "label": "Output",
+        "count": 2
+      },
+      {
+        "type": "nodetool.text.RegexReplace",
+        "label": "Regex Replace",
+        "count": 2
+      },
+      {
+        "type": "nodetool.text.CollapseWhitespace",
+        "label": "Collapse Whitespace",
+        "count": 1
+      },
+      {
+        "type": "nodetool.text.FindAllRegex",
+        "label": "Find All Regex",
+        "count": 1
+      },
+      {
+        "type": "nodetool.constant.String",
+        "label": "String",
+        "count": 1
+      }
+    ],
+    "nodeCount": 7,
+    "thumbnail": null,
+    "graph": {
+      "nodes": [
+        {
+          "id": "raw",
+          "type": "nodetool.constant.String",
+          "title": "String",
+          "x": 0,
+          "y": 120,
+          "width": 280,
+          "subtitle": "2026-08-02 WARN user=ada.lovelace@example.com ip=10.0.0.7 retry=3"
+        },
+        {
+          "id": "mail",
+          "type": "nodetool.text.RegexReplace",
+          "title": "Regex Replace",
+          "x": 320,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "ip",
+          "type": "nodetool.text.RegexReplace",
+          "title": "Regex Replace",
+          "x": 640,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "tidy",
+          "type": "nodetool.text.CollapseWhitespace",
+          "title": "Collapse Whitespace",
+          "x": 960,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "nums",
+          "type": "nodetool.text.FindAllRegex",
+          "title": "Find All Regex",
+          "x": 0,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o1",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 320,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o2",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 640,
+          "y": 340,
+          "width": 280
+        }
+      ],
+      "edges": [
+        {
+          "source": "raw",
+          "sourceHandle": "output",
+          "target": "mail",
+          "targetHandle": "text",
+          "color": "any"
+        },
+        {
+          "source": "mail",
+          "sourceHandle": "output",
+          "target": "ip",
+          "targetHandle": "text",
+          "color": "any"
+        },
+        {
+          "source": "ip",
+          "sourceHandle": "output",
+          "target": "tidy",
+          "targetHandle": "text",
+          "color": "any"
+        },
+        {
+          "source": "tidy",
+          "sourceHandle": "output",
+          "target": "nums",
+          "targetHandle": "text",
+          "color": "any"
+        },
+        {
+          "source": "tidy",
+          "sourceHandle": "output",
+          "target": "o1",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "nums",
+          "sourceHandle": "output",
+          "target": "o2",
           "targetHandle": "value",
           "color": "any"
         }
@@ -24206,6 +25100,156 @@ export const templateEntries: TemplateEntry[] = [
           "source": "rv",
           "sourceHandle": "output",
           "target": "out",
+          "targetHandle": "value",
+          "color": "any"
+        }
+      ]
+    }
+  },
+  {
+    "route": "/templates/validate-a-signup-payload",
+    "title": "Validate a Signup Payload — NodeTool AI Workflow Template",
+    "description": "Run one submitted address through the checks a signup form needs: a strict email test, a bundle of shape checks in one pass, and the sanitised forms you would actually store. Sanitize returns three variants because escaping, trimming and email normalisation are different jobs.",
+    "priority": 0.3,
+    "changeFrequency": "monthly",
+    "indexable": false,
+    "slug": "validate-a-signup-payload",
+    "name": "Validate a Signup Payload",
+    "summary": "Run one submitted address through the checks a signup form needs: a strict email test, a bundle of shape checks in one pass, and the sanitised forms you would actually store. Sanitize returns three variants because escaping, trimming and email normalisation are different jobs.",
+    "tags": [
+      "text",
+      "example"
+    ],
+    "category": "Text & Data",
+    "nodeTypes": [
+      {
+        "type": "nodetool.output.Output",
+        "label": "Output",
+        "count": 3
+      },
+      {
+        "type": "lib.validate.Email",
+        "label": "Email",
+        "count": 1
+      },
+      {
+        "type": "lib.validate.Sanitize",
+        "label": "Sanitize",
+        "count": 1
+      },
+      {
+        "type": "nodetool.constant.String",
+        "label": "String",
+        "count": 1
+      },
+      {
+        "type": "lib.validate.String",
+        "label": "String",
+        "count": 1
+      }
+    ],
+    "nodeCount": 7,
+    "thumbnail": null,
+    "graph": {
+      "nodes": [
+        {
+          "id": "raw",
+          "type": "nodetool.constant.String",
+          "title": "String",
+          "x": 0,
+          "y": 120,
+          "width": 280,
+          "subtitle": "Ada.Lovelace+signup@Example.COM"
+        },
+        {
+          "id": "email",
+          "type": "lib.validate.Email",
+          "title": "Email",
+          "x": 320,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "shape",
+          "type": "lib.validate.String",
+          "title": "String",
+          "x": 640,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "clean",
+          "type": "lib.validate.Sanitize",
+          "title": "Sanitize",
+          "x": 960,
+          "y": 120,
+          "width": 280
+        },
+        {
+          "id": "o1",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 0,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o2",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 320,
+          "y": 340,
+          "width": 280
+        },
+        {
+          "id": "o3",
+          "type": "nodetool.output.Output",
+          "title": "Output",
+          "x": 640,
+          "y": 340,
+          "width": 280
+        }
+      ],
+      "edges": [
+        {
+          "source": "raw",
+          "sourceHandle": "output",
+          "target": "email",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "raw",
+          "sourceHandle": "output",
+          "target": "shape",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "raw",
+          "sourceHandle": "output",
+          "target": "clean",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "email",
+          "sourceHandle": "output",
+          "target": "o1",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "shape",
+          "sourceHandle": "is_alphanumeric",
+          "target": "o2",
+          "targetHandle": "value",
+          "color": "any"
+        },
+        {
+          "source": "clean",
+          "sourceHandle": "normalized_email",
+          "target": "o3",
           "targetHandle": "value",
           "color": "any"
         }


### PR DESCRIPTION
## What

Rewrites the `/agents` marketing page to lead with the agent-first story instead of the creative-director framing. Copy only — no layout or component-structure changes.

## Why

The page sold "an art director that never sleeps" while the product shipped something bigger. Evidence from the codebase the new copy is grounded in:

- **~120 `ui_*` tools** cover every editor — node canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, app builder (`grep '"ui_*"' web/src` → 118 unique tools).
- **Agents author graphs** — GraphPlanner + `validate_workflow` (#4614, #4619).
- **Agents build and test mini apps** — `nodetool app build`: spec → plan → author → check → run → judge, with an independent judge model (#4647, #4648).
- **Supervised runs** — an agent on the failure path with retry/repair/skip/fail verdicts, decision and cost budgets, logged interventions (#4633–#4635).
- **Interactive escalations** — agents (or the user) answer instead of the run guessing (#4639, #4640).
- **Full agent toolbelt over MCP** — outside agents like Claude Desktop/Claude Code drive the same tools (#4652, plus the `.mcpb` bundle).

## Changes

- `AgentsGraphHero`: new badge, headline ("The whole studio is the agent's toolbelt."), sub-copy, and trust line.
- `AgentBuildRunDeploy`: reframed as Say it → Watch it work → Keep it; the animated trace now shows real `ui_*` tool calls and a retry.
- `AgentFeaturesSection`: six features rewritten around the toolbelt, graph authoring, app build + judge, supervised runs, ask-instead-of-guess, and bring-your-own-agent via MCP.
- `AgentIntegrationsSection`: banner mentions the toolbelt speaking MCP.
- `layout.tsx`: title, description, keywords, and JSON-LD updated to the agent-first positioning.
- `public/agents.md`: markdown mirror updated to match.
- `faqEntries.ts`: new "What does it mean that NodeTool is agent-first?" row pinned to the agents surface.

## Verification

- `npx tsc --noEmit` in `marketing/` — clean.
- `next lint` on all edited files — no warnings or errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015exYZTXpS5cuMF3CYTvGS6

---
_Generated by [Claude Code](https://claude.ai/code/session_015exYZTXpS5cuMF3CYTvGS6)_