### PR TITLE
Close six gates that reported success without checking anything

### DIFF
--- a/.claude/skills/nodetool-agent-config/SKILL.md
+++ b/.claude/skills/nodetool-agent-config/SKILL.md
@@ -11,10 +11,10 @@ You help users create and configure NodeTool agents — autonomous AI systems th
 Objective → Agent → (Skill resolution → Planning → Execution) → Result
 ```
 
-Three agent classes (from `@nodetool-ai/agents`):
+Agent classes (from `@nodetool-ai/agents`):
 - **Agent**: Multi-step with planning, tool use, iterative execution
-- **SimpleAgent**: Single-step with structured output schema
-- **AgentExecutor**: Lightweight value extraction
+- **TaskPlanner**: Decompose an objective into a task DAG
+- **ParallelTaskExecutor**: Execute independent tasks of a plan concurrently
 
 # YAML Config Template
 

--- a/.github/workflows/quality-guard.yml
+++ b/.github/workflows/quality-guard.yml
@@ -56,6 +56,11 @@ jobs:
       - name: Run quality checks
         id: check
         continue-on-error: true
+        # `shell: bash` runs with `-eo pipefail`. Without it GitHub's default is
+        # `bash -e`, where `if npm run typecheck | tee log; then` tests *tee's*
+        # status — always 0 — so every check below reported Passed and
+        # `has-errors` was always false, whatever the commands did.
+        shell: bash
         run: |
           echo "## Pre-Flight Quality Check" >> $GITHUB_STEP_SUMMARY
           FAIL=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ protocol → config → security → auth → storage
 - **Styling**: MUI v7 + `sx` prop for one-off, `styled()` for reusable. Theme values only, no hardcoded colors/spacing. Prefer `FlexRow`/`FlexColumn` over `Box sx={{ display: "flex" }}` when the shorthand props (`gap`, `align`, `justify`) reduce verbosity; use `Box` directly when you have significant additional `sx` overrides anyway.
 - **Node graph**: ReactFlow 12. Nodes extend `BaseNode` from `@nodetool-ai/node-sdk`.
 - **LLM providers**: All in `packages/runtime/src/providers/` — Anthropic, OpenAI, Gemini, Ollama, Mistral, Groq, Claude Agent SDK
-- **Agent system**: `packages/agents/` — full planning agent (TaskPlanner → DAG of Steps), SimpleAgent (single-step), AgentExecutor (value extraction)
+- **Agent system**: `packages/agents/` — full planning agent (TaskPlanner → DAG of Steps), TaskExecutor/ParallelTaskExecutor (walk the DAG), StepExecutor (tool-calling loop for one step)
 - **Workflow execution**: Actor-model in `packages/kernel/` — DAG-based, message-passing between node actors
 - **Python bridge**: `PythonStdioBridge` in `packages/runtime/` — spawns `python -m nodetool.worker --stdio`, communicates via length-prefixed msgpack over stdin/stdout. Lazy-connected on first workflow with Python nodes.
 - **Serialization**: MsgPack for WebSocket messages, JSON for REST API
@@ -177,36 +177,40 @@ npm run nodetool -- <command>
 npm run chat -- [flags]
 ```
 
-### nodetool chat (Agent Mode)
+### nodetool chat
+
+Every chat session runs the unified agent loop. There is no mode to select:
+`-a, --agent` and `--no-agent` are accepted for backwards compatibility and do
+nothing (`packages/cli/src/index.ts` marks both `[deprecated] No-op`).
 
 ```bash
-# Interactive agent chat
-npm run dev:chat -- --agent --provider openai --model gpt-5.4-mini
-npm run dev:chat -- --agent --provider anthropic --model claude-sonnet-5
+# Interactive chat
+npm run dev:chat -- --provider openai --model gpt-5.4-mini
+npm run dev:chat -- --provider anthropic --model claude-sonnet-5
 
 # Piped input (non-interactive)
-echo "research 5 AI topics" | npm run dev:chat -- --agent --provider openai --model gpt-5.4-mini
+echo "research 5 AI topics" | npm run dev:chat -- --provider openai --model gpt-5.4-mini
 
 # Connect to running WebSocket server
-npm run dev:chat -- --agent --url ws://localhost:7777/ws
+npm run dev:chat -- --url ws://localhost:7777/ws
 ```
 
 Chat flags:
 ```
--a, --agent [mode]       Agent mode: off | loop | plan | graph | multi-agent
-                         (default: plan when --agent is given without a value)
---no-agent               Force agent mode off
 -p, --provider <name>    anthropic, openai, gemini, xai, groq, mistral, deepseek,
                          moonshot, minimax, cerebras, together, openrouter,
-                         huggingface, replicate, kie, aki, ollama, lmstudio
+                         huggingface, replicate, kie, aki, ollama, lmstudio,
+                         claude_agent_sdk, codex, gmi, mlx, node_llama_cpp
                          (any registry provider id also works, e.g. vllm, llama_cpp)
 -m, --model <id>         Model ID (e.g. claude-sonnet-5, gpt-5.4-mini)
 -w, --workspace <path>   Workspace directory for file tools
 --tools <list>           Comma-separated tool names
 -u, --url <ws-url>       Connect to WebSocket server instead of local provider
+-a, --agent [mode]       [deprecated] No-op
+--no-agent               [deprecated] No-op
 ```
 
-Interactive commands: `/agent <off|loop|plan|graph|multi-agent>`, `/model <id>`, `/provider <name>`, `/tools`, `/clear`, `/exit`
+Interactive commands: `/help`, `/new`, `/clear`, `/compact [instructions]`, `/model <id>`, `/provider <name>`, `/tools`, `/exit`, `/quit`
 
 ### nodetool serve
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -36,7 +36,7 @@ Structured result (validated against output JSON schema)
 | Class | When to Use | Source |
 |---|---|---|
 | **Agent** | Multi-step objectives needing decomposition (full DAG planning + execution) | `packages/agents/src/agent.ts` |
-| **AgentExecutor** | Lightweight value extraction | `packages/agents/src/agent-executor.ts` |
+| **ParallelTaskExecutor** | Execute independent tasks of a plan concurrently | `packages/agents/src/parallel-task-executor.ts` |
 | **TaskPlanner** | Decompose an objective into a task DAG | `packages/agents/src/task-planner.ts` |
 | **TaskExecutor** | Walk the step DAG, respecting dependency order | `packages/agents/src/task-executor.ts` |
 | **StepExecutor** | Run the tool-calling loop for a single step | `packages/agents/src/step-executor.ts` |

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "build:web": "turbo run build --filter=web",
     "build:mcpb": "node scripts/build-mcpb.mjs --smoke",
     "build": "turbo run build",
-    "test:packages": "turbo run test --filter=\"./packages/*\"",
+    "test:packages": "turbo run test --filter=\"./packages/*\" --filter=\"./reliability/*\"",
     "turbo": "turbo",
     "turbo:build": "turbo run build",
     "turbo:build:packages": "turbo run build --filter=\"./packages/*\"",

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -1,7 +1,7 @@
 # @nodetool-ai/agents
 
 The planning agent system: `TaskPlanner` → `TaskExecutor` → `StepExecutor`,
-plus `SimpleAgent`, the parallel task executor, skills, and agent tools.
+plus `ParallelTaskExecutor`, skills, and agent tools.
 
 ## Responsibilities
 

--- a/packages/base-nodes/nodetool/examples/apps/brand-and-social.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/brand-and-social.app.json
@@ -815,7 +815,7 @@
             "data": {
               "model": {
                 "type": "image_model",
-                "provider": "huggingface_fal_ai",
+                "provider": "fal_ai",
                 "id": "fal-ai/flux/schnell",
                 "name": "FLUX.1 Schnell",
                 "path": null,
@@ -1355,7 +1355,7 @@
             "data": {
               "model": {
                 "type": "image_model",
-                "provider": "huggingface_fal_ai",
+                "provider": "fal_ai",
                 "id": "fal-ai/flux/schnell",
                 "name": "FLUX.1 Schnell",
                 "path": null,
@@ -1914,7 +1914,7 @@
             "data": {
               "model": {
                 "type": "image_model",
-                "provider": "huggingface_fal_ai",
+                "provider": "fal_ai",
                 "id": "fal-ai/flux/schnell",
                 "name": "FLUX.1 Schnell",
                 "path": null,

--- a/packages/base-nodes/nodetool/examples/apps/concept-studio.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/concept-studio.app.json
@@ -651,7 +651,7 @@
             "data": {
               "model": {
                 "type": "image_model",
-                "provider": "huggingface_fal_ai",
+                "provider": "fal_ai",
                 "id": "fal-ai/flux/schnell",
                 "name": "FLUX.1 Schnell",
                 "path": null,
@@ -1125,7 +1125,7 @@
             "data": {
               "model": {
                 "type": "image_model",
-                "provider": "huggingface_fal_ai",
+                "provider": "fal_ai",
                 "id": "fal-ai/flux/schnell",
                 "name": "FLUX.1 Schnell",
                 "path": null,

--- a/packages/base-nodes/nodetool/examples/apps/film-studio.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/film-studio.app.json
@@ -942,7 +942,7 @@
             "data": {
               "model": {
                 "type": "image_model",
-                "provider": "huggingface_fal_ai",
+                "provider": "fal_ai",
                 "id": "fal-ai/flux/schnell",
                 "name": "FLUX.1 Schnell",
                 "path": null,
@@ -1051,7 +1051,7 @@
             "data": {
               "model": {
                 "type": "image_model",
-                "provider": "huggingface_fal_ai",
+                "provider": "fal_ai",
                 "id": "fal-ai/flux/schnell",
                 "name": "FLUX.1 Schnell",
                 "path": null,
@@ -1536,7 +1536,7 @@
             "data": {
               "model": {
                 "type": "image_model",
-                "provider": "huggingface_fal_ai",
+                "provider": "fal_ai",
                 "id": "fal-ai/flux/schnell",
                 "name": "FLUX.1 Schnell",
                 "path": null,
@@ -2140,7 +2140,7 @@
             "data": {
               "model": {
                 "type": "image_model",
-                "provider": "huggingface_fal_ai",
+                "provider": "fal_ai",
                 "id": "fal-ai/flux/schnell",
                 "name": "FLUX.1 Schnell",
                 "path": null,

--- a/packages/base-nodes/nodetool/examples/apps/photo-studio.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/photo-studio.app.json
@@ -631,7 +631,7 @@
             "data": {
               "model": {
                 "type": "image_model",
-                "provider": "huggingface_fal_ai",
+                "provider": "fal_ai",
                 "id": "fal-ai/flux/schnell",
                 "name": "FLUX.1 Schnell",
                 "path": null,

--- a/packages/base-nodes/nodetool/examples/apps/product-launch-kit.app.json
+++ b/packages/base-nodes/nodetool/examples/apps/product-launch-kit.app.json
@@ -529,7 +529,7 @@
             "data": {
               "model": {
                 "type": "image_model",
-                "provider": "huggingface_fal_ai",
+                "provider": "fal_ai",
                 "id": "fal-ai/flux/schnell",
                 "name": "FLUX.1 Schnell",
                 "path": null,
@@ -807,7 +807,7 @@
             "data": {
               "model": {
                 "type": "image_model",
-                "provider": "huggingface_fal_ai",
+                "provider": "fal_ai",
                 "id": "fal-ai/flux/schnell",
                 "name": "FLUX.1 Schnell",
                 "path": null,

--- a/packages/base-nodes/vitest.config.ts
+++ b/packages/base-nodes/vitest.config.ts
@@ -51,7 +51,12 @@ export default defineConfig({
   },
   test: {
     include: ["tests/**/*.test.ts"],
-    exclude: ["tests/e2e/**/*.test.ts"],
-    passWithNoTests: true
+    exclude: ["tests/e2e/**/*.test.ts"]
+    // No `passWithNoTests`: this package has 31 suites, and two blocking CI
+    // commands select from them by filename substring — the `parity` leg
+    // (`npm test -w @nodetool-ai/base-nodes -- parity example-workflows`) and
+    // `test:integration` (`-- example-workflows-execute`). With
+    // passWithNoTests, renaming a targeted file made those filters match
+    // nothing and exit 0, so the gate reported green while running no tests.
   }
 });

--- a/reliability/harness/tests/journeys/host-sigkill-restart.test.ts
+++ b/reliability/harness/tests/journeys/host-sigkill-restart.test.ts
@@ -47,7 +47,14 @@ import { packWebSocketMessage, unpackWebSocketMessage } from "@nodetool-ai/webso
 import { initDb, closeDb, Job } from "@nodetool-ai/models";
 import { findRepoRoot, resolveTsxBin } from "../../src/drivers/repo-root.js";
 
-const BOOT_TIMEOUT_MS = 20_000;
+// This journey boots the server twice (once fresh, once after the SIGKILL),
+// and each boot pays `tsx`'s runtime TypeScript compile. On an idle machine the
+// whole test runs in ~29s; on a loaded CI runner doing a cold, fully-parallel
+// package run, a single boot alone overran the old 20s cap and the suite failed
+// with "never became healthy within 20000ms". Budget for the slow case rather
+// than the fast one — this is still a hard cap, just one wide enough that
+// tripping it means the server genuinely did not come up.
+const BOOT_TIMEOUT_MS = 60_000;
 
 function freePort(): Promise<number> {
   return new Promise((resolvePromise, reject) => {
@@ -199,7 +206,9 @@ describe("host-sigkill-restart (task D3)", () => {
 
   it(
     "SIGKILL mid-run + relaunch: the new process is healthy, a fresh run succeeds, and the killed run's Job row is never silently rewritten by the restart",
-    { timeout: 60_000 },
+    // Two boots at up to BOOT_TIMEOUT_MS each, plus the run itself — the old
+    // 60s budget could not fit even two worst-case boots.
+    { timeout: 180_000 },
     async () => {
       dbDir = await mkdtemp(join(tmpdir(), "reliability-sigkill-"));
       const dbPath = join(dbDir, "nodetool.sqlite3");

--- a/scripts/validate-examples.mjs
+++ b/scripts/validate-examples.mjs
@@ -18,7 +18,15 @@
 // drift before it merges at all.
 
 import { execFileSync } from "node:child_process";
-import { readdirSync, statSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -36,59 +44,142 @@ function findExamples(dir) {
     const stat = statSync(full);
     if (stat.isDirectory()) {
       results.push(...findExamples(full));
-    } else if (
-      entry.endsWith(".json") &&
-      // `*.app.json` files are ApplicationBundles, not workflow graphs. They
-      // are validated by scripts/build-example-apps.mjs, which runs
-      // `nodetool app debug --no-run` over each one.
-      !entry.endsWith(".app.json") &&
-      full.includes("/examples/")
-    ) {
+    } else if (entry.endsWith(".json") && full.includes("/examples/")) {
       results.push(full);
     }
   }
   return results;
 }
 
-const examples = findExamples(join(repoRoot, "packages")).sort();
+// `*.app.json` files are ApplicationBundles: an app document plus the full
+// graphs of the workflows it binds. They used to be skipped here, on the
+// grounds that `scripts/build-example-apps.mjs` validated them by running
+// `nodetool app debug --no-run`. It does not: `app debug` checks widget
+// bindings and never consults the node registry, and no CI workflow runs
+// build-example-apps at all. The result was that the bundles users actually
+// install had no gate on node types, properties, edges, or providers — and
+// five of them shipped `provider: "huggingface_fal_ai"`, which the runtime
+// cannot construct. Validate each embedded graph with the same validator the
+// plain examples get.
+function expandBundle(file) {
+  let bundle;
+  try {
+    bundle = JSON.parse(readFileSync(file, "utf8"));
+  } catch (err) {
+    return { parseError: err.message, workflows: [] };
+  }
+  const workflows = Array.isArray(bundle?.workflows) ? bundle.workflows : [];
+  return {
+    parseError: workflows.length === 0 ? "bundle declares no workflows" : null,
+    workflows: workflows.map((wf, i) => ({
+      label: wf?.name || wf?.key || `workflow[${i}]`,
+      graph: wf?.graph
+    }))
+  };
+}
 
-if (examples.length === 0) {
+const examples = findExamples(join(repoRoot, "packages")).sort();
+const bundles = examples.filter((f) => f.endsWith(".app.json"));
+const workflowExamples = examples.filter((f) => !f.endsWith(".app.json"));
+
+if (workflowExamples.length === 0) {
   console.error("No example JSON files found under packages/**/examples/ — check the search path.");
   process.exit(1);
 }
 
-console.log(`Validating ${examples.length} example workflow(s)...\n`);
+if (bundles.length === 0) {
+  console.error("No *.app.json bundles found under packages/**/examples/ — check the search path.");
+  process.exit(1);
+}
 
-let failures = 0;
-for (const file of examples) {
-  const rel = file.slice(repoRoot.length + 1);
+function indent(text) {
+  return text
+    .split("\n")
+    .map((line) => `        ${line}`)
+    .join("\n");
+}
+
+// Validate one graph file with the built CLI. Returns null on success, or the
+// validator's output on failure.
+function validateFile(path) {
   try {
-    execFileSync(
-      "node",
-      [cliEntry, "validate", file, "--warnings-as-errors"],
-      { stdio: "pipe", encoding: "utf8" }
-    );
-    console.log(`  ok    ${rel}`);
+    execFileSync("node", [cliEntry, "validate", path, "--warnings-as-errors"], {
+      stdio: "pipe",
+      encoding: "utf8"
+    });
+    return null;
   } catch (err) {
-    failures += 1;
-    console.log(`  FAIL  ${rel}`);
-    const output = [err.stdout, err.stderr].filter(Boolean).join("\n");
-    console.log(
-      output
-        .split("\n")
-        .map((line) => `        ${line}`)
-        .join("\n")
-    );
+    return [err.stdout, err.stderr].filter(Boolean).join("\n");
   }
 }
 
-console.log(`\n${examples.length - failures}/${examples.length} examples validate cleanly.`);
+console.log(
+  `Validating ${workflowExamples.length} example workflow(s) and ` +
+    `${bundles.length} app bundle(s)...\n`
+);
+
+let failures = 0;
+let checked = 0;
+
+for (const file of workflowExamples) {
+  const rel = file.slice(repoRoot.length + 1);
+  checked += 1;
+  const output = validateFile(file);
+  if (output === null) {
+    console.log(`  ok    ${rel}`);
+  } else {
+    failures += 1;
+    console.log(`  FAIL  ${rel}`);
+    console.log(indent(output));
+  }
+}
+
+// Each bundle's embedded workflows are written to a scratch file and run
+// through the same validator, so a bundle graph is held to exactly the standard
+// a standalone example graph is.
+const scratch = mkdtempSync(join(tmpdir(), "validate-app-bundles-"));
+for (const file of bundles) {
+  const rel = file.slice(repoRoot.length + 1);
+  const { parseError, workflows } = expandBundle(file);
+  if (parseError) {
+    checked += 1;
+    failures += 1;
+    console.log(`  FAIL  ${rel}`);
+    console.log(indent(parseError));
+    continue;
+  }
+  for (const [i, wf] of workflows.entries()) {
+    checked += 1;
+    const label = `${rel} › ${wf.label}`;
+    if (!wf.graph) {
+      failures += 1;
+      console.log(`  FAIL  ${label}`);
+      console.log(indent("bundled workflow has no graph"));
+      continue;
+    }
+    const scratchFile = join(scratch, `${i}.json`);
+    writeFileSync(scratchFile, JSON.stringify({ name: wf.label, graph: wf.graph }));
+    const output = validateFile(scratchFile);
+    if (output === null) {
+      console.log(`  ok    ${label}`);
+    } else {
+      failures += 1;
+      console.log(`  FAIL  ${label}`);
+      console.log(indent(output.replaceAll(scratchFile, label)));
+    }
+  }
+}
+rmSync(scratch, { recursive: true, force: true });
+
+console.log(`\n${checked - failures}/${checked} graphs validate cleanly.`);
 
 if (failures > 0) {
   console.error(
-    `\n${failures} example(s) failed validation. Fix the graph to match the current node registry, or run:\n` +
+    `\n${failures} graph(s) failed validation. Fix the graph to match the current node registry, or run:\n` +
       `  npm run dev:nodetool -- validate "<path>" --json\n` +
-      `to see the full report for a single file.`
+      `to see the full report for a single file.\n` +
+      `For a bundled app graph, the path is the *.app.json file; the failing\n` +
+      `workflow is named after the › in the line above.`
   );
   process.exit(1);
 }

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,20 @@
     ".nvmrc",
     "package-lock.json",
     "scripts/build-typescript-workspace.mjs",
-    "scripts/copy-manifests.mjs"
+    "scripts/copy-manifests.mjs",
+    // Files that package tests read from outside any package. These must live
+    // here, not in a task's `inputs`: the PR gate runs `turbo run test
+    // --filter="./packages/*" --affected`, and `--affected` scopes the graph by
+    // package ownership *before* input hashes are consulted. Turbo attributes a
+    // root-level file to the root workspace, which no package depends on, so a
+    // PR touching only these paths pruned the graph to zero test tasks and the
+    // leg reported green. Only `globalDependencies` short-circuits that.
+    "Dockerfile",
+    "scripts/genspend/**",
+    "scripts/sync-genspend-pricing.mjs",
+    "scripts/example-apps/**",
+    "web/src/hooks/editor/useChatIntegration.ts",
+    "web/src/utils/codeOutputInference.ts"
   ],
   "globalEnv": ["NODE_ENV", "CI"],
   "tasks": {


### PR DESCRIPTION
Hunt for signals that look like evidence and aren't: something a reader would reasonably take as "this works", with nothing behind it that establishes that.

Method was mutation, not reading: break the thing on purpose, confirm something goes red, revert. Every finding below has a red/green pair. Candidates that survived reading but died under mutation are listed at the bottom — one of them was mine.

---

## 1. Shipped app bundles had no registry gate

The only finding with user-visible breakage already in the tree.

`scripts/validate-examples.mjs` skipped `*.app.json`, with a comment deferring to `scripts/build-example-apps.mjs`, "which runs `nodetool app debug --no-run` over each one". Two things were wrong with that: `app debug` validates widget bindings and never consults the node registry (zero references to `validateGraph` in `packages/execution/src/app-debug/`), and no CI workflow runs `build-example-apps` at all.

**RED — the named delegate, on a bundle seeded with a node type that cannot exist:**
```
$ python3 -c "...replace nodetool.text.Prompt -> nodetool.totally.BogusDoesNotExist..."
$ nodetool app debug bogus.app.json --no-run
GATE_EXIT=0
✅ App wiring is valid (static check only — no run executed).
  app: Concept Studio · 36 widget(s)
```

The consequence had already shipped. 12 nodes across 5 installable bundles set `provider: "huggingface_fal_ai"`, which no package registers — the same string `packages/node-sdk/tests/graph-validation.test.ts:544` uses as its canonical *unregistered-provider* fixture. The source workflows these bundles were built from use `fal_ai`; the bundles were stale snapshots of graphs already fixed upstream. At runtime `getProvider` is an exact `Map.get` that throws — no alias layer, no fallback, and none of the five apps expose the `model` property for a user to override.

**Fix:** bundles now expand to their embedded graphs and run through the same validator the plain examples get; the 12 provider ids are corrected to `fal_ai`.

```
RED   (gate fixed, data still broken): 238/248 graphs clean, 10 failures, exit 1
GREEN (both fixed):                    248/248 graphs clean,             exit 0
```
Coverage went from 236 graphs to 248 — the 12 bundle graphs were previously ungated. The 10 failures landed on exactly the 5 suspected bundles.

## 2. `turbo --affected` pruned root-file-only PRs to zero test tasks

`--affected` scopes the graph by package ownership *before* input hashes are consulted, so turbo attributes a root-level file to the root workspace, which no package depends on. A PR touching only `Dockerfile`, `scripts/**`, or `web/src/**` ran no backend test and the leg reported green. This defeated the `$TURBO_ROOT$` entries in the `test` task's `inputs` added for exactly this purpose — only `globalDependencies` short-circuits the pruning.

Suites this silenced, each reading a fixture outside its own package: `websocket/dockerfile-examples` (root `Dockerfile`), `model-pricing/genspend-sync` (`scripts/genspend/*`), `agents/sandbox-manifest-drift` (`web/src/**` — i.e. exactly the drift it exists to detect).

```
RED   (original turbo.json, Dockerfile-only commit): test tasks = 0
GREEN (fix applied, same commit):                    test tasks = 58
```
Verified for all four paths (`Dockerfile`, `web/src/utils/codeOutputInference.ts`, `scripts/genspend/aliases.json`, `scripts/example-apps/apps.mjs`) — all now 58. Positive control: `tsconfig.base.json`, already in `globalDependencies`, yields the full graph both before and after.

## 3. `quality-guard.yml` reported every check as Passed

`if npm run typecheck 2>&1 | tee typecheck.log; then` tests **tee's** exit status, which is 0 whenever the log write succeeds. GitHub's default shell is `bash -e`, which does not set `pipefail`. `FAIL` never became 1 and `has-errors` was always `false`.

```
BEFORE (bash -e):              AFTER (shell: bash -> bash -eo pipefail):
  TypeScript: Passed             TypeScript: Failed
  has-errors=false               has-errors=true
  exit=0                         exit=1
```
The workflow has zero callers today, so this gates nothing — but the post-check block in the same file does it correctly, which marks this as an unnoticed copy-paste divergence rather than a deliberate choice.

## 4. `passWithNoTests` hid a vanished filter in base-nodes

Two blocking CI commands select tests by filename substring (the `parity` leg, and `test:integration`). With `passWithNoTests: true`, renaming a targeted file makes the filter match nothing and exit 0. base-nodes has 31 suites and does not need the flag; the genuinely-empty node packages keep it.

```
RED   nonexistent filter -> exit 0
GREEN nonexistent filter -> exit 1;  real `parity` filter still passes (exit 0)
```

## 5. `reliability/harness` ran in no workflow

25 suites, 144 tests, wired into nothing: `test:packages` filters to `./packages/*`, and root `test` covers only web/electron/mobile. Its own `scripts/reliability-ring1.mjs` justifies excluding two journeys from the Ring 1 loop because their happy paths are "covered by the harness's own tests (part of `npm run test`)" — `npm run test` never reached them, so those happy paths were covered by nothing.

```
RED   reliability harness test task present: False (58 tasks)
GREEN reliability harness test task present: True  (59 tasks)
Suite passes clean: 25 files, 144 passed | 5 skipped, exit 0
```

## 6. Docs asserting APIs that do not exist

`SimpleAgent` and `AgentExecutor` have **zero** occurrences in any `.ts`/`.tsx` under `packages/`, `web/`, `electron/`, and `packages/agents/src/agent-executor.ts` is not a file — yet four docs named them, including `.claude/skills/nodetool-agent-config/SKILL.md`, which instructs agents to pick between them. Corrected to the classes that exist (`TaskPlanner`, `TaskExecutor`, `ParallelTaskExecutor`, `StepExecutor`).

Chat's `--agent`/`--no-agent` flags and the `/agent` command were documented as functional with a mode list. The source marks both flags `[deprecated] No-op`, and `/agent` is not in `COMMANDS`. Every chat example in CLAUDE.md passed the dead flag, so a reader thinks they are selecting a planning mode when nothing happens. Also filled in five real providers the list omitted and the four real slash commands it lacked.

---

## Checked and found sound (negative results)

- **`packages/integration-nodes/tests/regression-api-data.test.ts:109`** — an un-awaited `expect(node.process()).rejects.toThrow(...)`. Reads as a dead assertion in a named regression test. It is not: removing the credential check from the source and rebuilding turns it **red** (exit 1). Vitest attributes floating rejections to the test. My first run appeared to confirm the bug — that was a stale-`dist` artifact, since the test imports the package, not `src/`. Rebuilding reversed the result.
- **`examples/workflows/**` under `--affected`** — genuinely covered. The always-on `parity` leg runs plain vitest with no turbo, so the suites reading those files are not silenced. Only the three cross-boundary suites in §2 were.
- **Snapshot tests** — none exist repo-wide; zero `toMatchSnapshot` calls, zero `.snap` files.
- **`.only`** — none in test code; `forbidOnly` is set for CI in the Playwright config.
- **`continue-on-error` / `|| true` in workflows** — every instance is on a diagnostic, cleanup, or explicitly-advisory step. No gate silently disarmed.
- **Smoke scripts** (`docker-smoke.mjs`, `smoke-backend-bundle.mjs`, `verify-backend-bundle.mjs`) — these assert properly and exit non-zero. `verify-backend-bundle.mjs` even treats an empty reference set as an error, which is the standard the rest of this PR applies elsewhere.

Two of my own verification commands were themselves false signals, which is the point of the method: `echo "EXIT=$?"` after a pipe (captures the pipe, not the command — used `${PIPESTATUS[0]}` after), and a `pgrep -f validate-examples.mjs` liveness check that matched **its own waiter shell's command line**, reporting "still running" for a job that had finished. Both are the exact shape being hunted.

## Not fixed, deliberately

Two larger candidates surfaced and are left alone rather than patched speculatively: `nodetool validate` checks a model's *provider* but never its *id*, so a retired model id in a shipped example passes the gate and fails at runtime; and a family of image nodes with unit-ambiguous parameters that silently no-op (pixel-vs-fraction offsets, enum values falling through to a default branch). Both are real, neither is a one-line fix, and both deserve their own change.

## Verification

`npm run lint` exit 0. `typecheck:web` and `typecheck:electron` exit 0. `npm run typecheck` fails only on `mobile/`, whose deps are not installed in this sandbox (it is deliberately not a root workspace); no change here touches mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYhGMYc5daRdA9mbVR8Ue3

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYhGMYc5daRdA9mbVR8Ue3)_