### PR TITLE
marketing: reposition the main landing pages as agent-first

### DIFF
--- a/marketing/public/cloud.md
+++ b/marketing/public/cloud.md
@@ -7,6 +7,6 @@ product: NodeTool
 ---
 # NodeTool Cloud
 
-NodeTool Cloud is the hosted browser edition of NodeTool. It provides the same workflow canvas without a desktop installation.
+NodeTool Cloud is the hosted browser edition of NodeTool. It provides the same agent-first workspace without a desktop installation: describe what you want and the agent builds and runs the workflow.
 
 Cloud uses bring-your-own provider keys. See [pricing](https://nodetool.ai/pricing.md) and [technical documentation](https://docs.nodetool.ai/llms.txt) for deployment and configuration details.

--- a/marketing/public/creatives.md
+++ b/marketing/public/creatives.md
@@ -1,10 +1,10 @@
 ---
 title: "NodeTool for Creatives"
-description: "A visual workspace for creative AI workflows."
+description: "An agent-first workspace for creative AI work."
 canonical: https://nodetool.ai/creatives
 markdown: https://nodetool.ai/creatives.md
 product: NodeTool
 ---
 # NodeTool for Creatives
 
-NodeTool lets creative teams combine image, video, audio, and language models in reusable visual workflows. It supports local and cloud models, editing tools, and provider keys that stay under the user's control.
+NodeTool lets creative teams combine image, video, audio, and language models in reusable visual workflows — and lets an agent do the building: describe the piece and the agent plans the shots, authors the workflow, and runs it. It supports local and cloud models, editing tools, and provider keys that stay under the user's control.

--- a/marketing/public/developers.md
+++ b/marketing/public/developers.md
@@ -1,12 +1,12 @@
 ---
 title: "NodeTool Developer Platform"
-description: "Build, run, extend, and deploy NodeTool workflows with code."
+description: "Build, run, extend, and deploy NodeTool workflows with code — or through an agent."
 canonical: https://nodetool.ai/developers
 markdown: https://nodetool.ai/developers.md
 product: NodeTool
 ---
 # NodeTool Developer Platform
 
-NodeTool provides a TypeScript SDK, CLI, HTTP and WebSocket APIs, custom-node APIs, and a deployable workflow runtime.
+NodeTool provides a TypeScript SDK, CLI, HTTP and WebSocket APIs, custom-node APIs, and a deployable workflow runtime. It is agent-first: every editor is exposed as tools, around 120 in all, and the full toolbelt speaks MCP, so Claude Code or any MCP-aware agent can build, validate, run, and debug workflows.
 
 Use the [CLI](https://docs.nodetool.ai/cli.md) for automation, the [node catalog](https://docs.nodetool.ai/nodes/catalog.json) to discover node schemas, and the [developer guide](https://docs.nodetool.ai/developer/index.md) to extend NodeTool.

--- a/marketing/public/index.md
+++ b/marketing/public/index.md
@@ -1,13 +1,13 @@
 ---
 title: "NodeTool"
-description: "The open-source creative AI workspace."
+description: "The open-source, agent-first creative workspace."
 canonical: https://nodetool.ai/
 markdown: https://nodetool.ai/index.md
 product: NodeTool
 ---
 # NodeTool
 
-NodeTool is an open-source visual workspace for building and running AI workflows. It connects image, video, audio, language, agent, and data models on a node-based canvas.
+NodeTool is an open-source, agent-first visual workspace for building and running AI workflows. Every editor is exposed to [agents](https://nodetool.ai/agents.md) as tools: an agent can build the workflow, run it, and repair what fails. The canvas connects image, video, audio, language, agent, and data models on a node-based graph.
 
 ## Editions
 

--- a/marketing/public/llms.txt
+++ b/marketing/public/llms.txt
@@ -1,9 +1,10 @@
 # NodeTool
 
-> NodeTool is the open-source creative AI workspace: a node-based canvas that wires image, video, audio, and text models from every major provider into one workflow, plus planning agents that run multi-step jobs on the same canvas. Bring your own API keys. Runs as a free desktop app (Studio) or in the browser (Cloud). Licensed AGPL-3.0.
+> NodeTool is the open-source, agent-first creative workspace: every editor — a node-based canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools. An agent builds workflows that wire image, video, audio, and text models from every major provider, runs them, and repairs what fails. Bring your own API keys. Runs as a free desktop app (Studio) or in the browser (Cloud). Licensed AGPL-3.0.
 
 ## What NodeTool is
 
+- An agent-first workspace: every editor is exposed to agents as tools, around 120 in all, and the full toolbelt speaks MCP for outside agents such as Claude Desktop and Claude Code.
 - A visual, node-based editor for building AI workflows: connect models and tools as nodes on a canvas instead of writing glue code.
 - Two editions of one open-source codebase: **Studio**, a free desktop app for macOS, Windows, and Linux, and **Cloud**, the same app hosted in a browser (currently in alpha).
 - Planning agents: give an agent a goal and it plans the steps, picks a model or tool, and executes multi-step tasks on the canvas.
@@ -18,14 +19,14 @@
 
 ## Key pages
 
-- [Home](https://nodetool.ai/index.md): what NodeTool is, Studio vs Cloud, what you can build.
-- [Studio](https://nodetool.ai/studio.md): the free, open-source desktop app; local models, offline use.
+- [Home](https://nodetool.ai/index.md): what NodeTool is, the agent-first model, Studio vs Cloud.
+- [Studio](https://nodetool.ai/studio.md): the free, open-source desktop app; the agent and models run locally.
 - [Cloud](https://nodetool.ai/cloud.md): the hosted, browser-based edition (alpha).
 - [Pricing](https://nodetool.ai/pricing.md): edition comparison and how BYOK pricing works.
-- [Agents](https://nodetool.ai/agents.md): building and running AI agents visually on the canvas.
+- [Agents](https://nodetool.ai/agents.md): the agent-first model: every editor exposed to agents as tools.
 - [For creatives](https://nodetool.ai/creatives.md): artists, motion designers, AI-native illustrators.
-- [For developers](https://nodetool.ai/developers.md): TypeScript SDK, REST API, custom nodes in TypeScript or Python.
-- [For marketing teams](https://nodetool.ai/marketing.md): product videos, ad creative, and brand assets at campaign scale.
+- [For developers](https://nodetool.ai/developers.md): TypeScript SDK, REST API, MCP server, custom nodes in TypeScript or Python.
+- [For marketing teams](https://nodetool.ai/marketing.md): hand a brief to an agent; campaign assets at volume.
 - [Documentation](https://docs.nodetool.ai/llms.txt): install guides, key concepts, node reference, API reference, CLI.
 
 ## Comparisons

--- a/marketing/public/marketing.md
+++ b/marketing/public/marketing.md
@@ -1,10 +1,10 @@
 ---
 title: "NodeTool for Marketing Teams"
-description: "Generate and adapt campaign assets with AI workflows."
+description: "Hand the brief to an agent; get campaign assets at volume."
 canonical: https://nodetool.ai/marketing
 markdown: https://nodetool.ai/marketing.md
 product: NodeTool
 ---
 # NodeTool for Marketing Teams
 
-NodeTool helps marketing teams build repeatable workflows for campaign visuals, product videos, social assets, and research. Workflows can be shared as focused mini-app interfaces while preserving the underlying graph.
+NodeTool helps marketing teams turn a brief into repeatable workflows for campaign visuals, product videos, social assets, and research — an agent builds the workflow from the brief and runs it at campaign volume. Workflows can be shared as focused mini-app interfaces while preserving the underlying graph.

--- a/marketing/public/studio.md
+++ b/marketing/public/studio.md
@@ -1,13 +1,13 @@
 ---
 title: "NodeTool Studio"
-description: "The local-first NodeTool desktop application."
+description: "The local-first, agent-first NodeTool desktop application."
 canonical: https://nodetool.ai/studio
 markdown: https://nodetool.ai/studio.md
 product: NodeTool
 ---
 # NodeTool Studio
 
-NodeTool Studio is the free desktop edition of NodeTool for macOS, Windows, and Linux. It runs workflows locally and can use local models or provider API keys.
+NodeTool Studio is the free desktop edition of NodeTool for macOS, Windows, and Linux. It runs workflows locally and can use local models or provider API keys. The agent runs locally too: it builds and runs workflows on your machine, and the full toolbelt is exposed over MCP for outside agents such as Claude Desktop and Claude Code.
 
 Use Studio when you need local execution, offline work, or control of workflow files and provider credentials.
 

--- a/marketing/scripts/generate-llms-txt.mjs
+++ b/marketing/scripts/generate-llms-txt.mjs
@@ -28,10 +28,11 @@ const BASE_URL = "https://nodetool.ai";
 // --- Preamble prose (hand-written; edit here) --------------------------------
 const PREAMBLE = `# NodeTool
 
-> NodeTool is the open-source creative AI workspace: a node-based canvas that wires image, video, audio, and text models from every major provider into one workflow, plus planning agents that run multi-step jobs on the same canvas. Bring your own API keys. Runs as a free desktop app (Studio) or in the browser (Cloud). Licensed AGPL-3.0.
+> NodeTool is the open-source, agent-first creative workspace: every editor — a node-based canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools. An agent builds workflows that wire image, video, audio, and text models from every major provider, runs them, and repairs what fails. Bring your own API keys. Runs as a free desktop app (Studio) or in the browser (Cloud). Licensed AGPL-3.0.
 
 ## What NodeTool is
 
+- An agent-first workspace: every editor is exposed to agents as tools, around 120 in all, and the full toolbelt speaks MCP for outside agents such as Claude Desktop and Claude Code.
 - A visual, node-based editor for building AI workflows: connect models and tools as nodes on a canvas instead of writing glue code.
 - Two editions of one open-source codebase: **Studio**, a free desktop app for macOS, Windows, and Linux, and **Cloud**, the same app hosted in a browser (currently in alpha).
 - Planning agents: give an agent a goal and it plans the steps, picks a model or tool, and executes multi-step tasks on the canvas.
@@ -48,14 +49,14 @@ const PREAMBLE = `# NodeTool
 
 /** A short blurb per key page, keyed by route (falls back to entry.description). */
 const KEY_PAGE_BLURBS = {
-  "/": "what NodeTool is, Studio vs Cloud, what you can build.",
-  "/studio": "the free, open-source desktop app; local models, offline use.",
+  "/": "what NodeTool is, the agent-first model, Studio vs Cloud.",
+  "/studio": "the free, open-source desktop app; the agent and models run locally.",
   "/cloud": "the hosted, browser-based edition (alpha).",
   "/pricing": "edition comparison and how BYOK pricing works.",
-  "/agents": "building and running AI agents visually on the canvas.",
+  "/agents": "the agent-first model: every editor exposed to agents as tools.",
   "/creatives": "artists, motion designers, AI-native illustrators.",
-  "/developers": "TypeScript SDK, REST API, custom nodes in TypeScript or Python.",
-  "/marketing": "product videos, ad creative, and brand assets at campaign scale.",
+  "/developers": "TypeScript SDK, REST API, MCP server, custom nodes in TypeScript or Python.",
+  "/marketing": "hand a brief to an agent; campaign assets at volume.",
 };
 
 const KEY_PAGE_LABELS = {
@@ -97,8 +98,8 @@ function markdownPath(route) {
 const MARKDOWN_PAGES = {
   "index.md": {
     title: "NodeTool",
-    description: "The open-source creative AI workspace.",
-    body: `NodeTool is an open-source visual workspace for building and running AI workflows. It connects image, video, audio, language, agent, and data models on a node-based canvas.
+    description: "The open-source, agent-first creative workspace.",
+    body: `NodeTool is an open-source, agent-first visual workspace for building and running AI workflows. Every editor is exposed to [agents](${BASE_URL}/agents.md) as tools: an agent can build the workflow, run it, and repair what fails. The canvas connects image, video, audio, language, agent, and data models on a node-based graph.
 
 ## Editions
 
@@ -114,8 +115,8 @@ const MARKDOWN_PAGES = {
   },
   "studio.md": {
     title: "NodeTool Studio",
-    description: "The local-first NodeTool desktop application.",
-    body: `NodeTool Studio is the free desktop edition of NodeTool for macOS, Windows, and Linux. It runs workflows locally and can use local models or provider API keys.
+    description: "The local-first, agent-first NodeTool desktop application.",
+    body: `NodeTool Studio is the free desktop edition of NodeTool for macOS, Windows, and Linux. It runs workflows locally and can use local models or provider API keys. The agent runs locally too: it builds and runs workflows on your machine, and the full toolbelt is exposed over MCP for outside agents such as Claude Desktop and Claude Code.
 
 Use Studio when you need local execution, offline work, or control of workflow files and provider credentials.
 
@@ -124,14 +125,15 @@ See the [installation guide](https://docs.nodetool.ai/installation.md) for suppo
   "cloud.md": {
     title: "NodeTool Cloud",
     description: "The hosted browser edition of NodeTool.",
-    body: `NodeTool Cloud is the hosted browser edition of NodeTool. It provides the same workflow canvas without a desktop installation.
+    body: `NodeTool Cloud is the hosted browser edition of NodeTool. It provides the same agent-first workspace without a desktop installation: describe what you want and the agent builds and runs the workflow.
 
 Cloud uses bring-your-own provider keys. See [pricing](${BASE_URL}/pricing.md) and [technical documentation](https://docs.nodetool.ai/llms.txt) for deployment and configuration details.`,
   },
   "developers.md": {
     title: "NodeTool Developer Platform",
-    description: "Build, run, extend, and deploy NodeTool workflows with code.",
-    body: `NodeTool provides a TypeScript SDK, CLI, HTTP and WebSocket APIs, custom-node APIs, and a deployable workflow runtime.
+    description:
+      "Build, run, extend, and deploy NodeTool workflows with code — or through an agent.",
+    body: `NodeTool provides a TypeScript SDK, CLI, HTTP and WebSocket APIs, custom-node APIs, and a deployable workflow runtime. It is agent-first: every editor is exposed as tools, around 120 in all, and the full toolbelt speaks MCP, so Claude Code or any MCP-aware agent can build, validate, run, and debug workflows.
 
 Use the [CLI](https://docs.nodetool.ai/cli.md) for automation, the [node catalog](https://docs.nodetool.ai/nodes/catalog.json) to discover node schemas, and the [developer guide](https://docs.nodetool.ai/developer/index.md) to extend NodeTool.`,
   },
@@ -150,13 +152,13 @@ Read the [agent documentation](https://docs.nodetool.ai/agents/index.md) for ins
   },
   "creatives.md": {
     title: "NodeTool for Creatives",
-    description: "A visual workspace for creative AI workflows.",
-    body: `NodeTool lets creative teams combine image, video, audio, and language models in reusable visual workflows. It supports local and cloud models, editing tools, and provider keys that stay under the user's control.`,
+    description: "An agent-first workspace for creative AI work.",
+    body: `NodeTool lets creative teams combine image, video, audio, and language models in reusable visual workflows — and lets an agent do the building: describe the piece and the agent plans the shots, authors the workflow, and runs it. It supports local and cloud models, editing tools, and provider keys that stay under the user's control.`,
   },
   "marketing.md": {
     title: "NodeTool for Marketing Teams",
-    description: "Generate and adapt campaign assets with AI workflows.",
-    body: `NodeTool helps marketing teams build repeatable workflows for campaign visuals, product videos, social assets, and research. Workflows can be shared as focused mini-app interfaces while preserving the underlying graph.`,
+    description: "Hand the brief to an agent; get campaign assets at volume.",
+    body: `NodeTool helps marketing teams turn a brief into repeatable workflows for campaign visuals, product videos, social assets, and research — an agent builds the workflow from the brief and runs it at campaign volume. Workflows can be shared as focused mini-app interfaces while preserving the underlying graph.`,
   },
 };
 

--- a/marketing/src/app/cloud/layout.tsx
+++ b/marketing/src/app/cloud/layout.tsx
@@ -1,9 +1,9 @@
 import JsonLd from "../../components/JsonLd";
 import type { Metadata } from "next";
 
-const TITLE = "Build AI Workflows in Your Browser — NodeTool Cloud (Alpha)";
+const TITLE = "The Agent-First Workspace in Your Browser — NodeTool Cloud (Alpha)";
 const DESCRIPTION =
-  "Build AI workflows in your browser — no install, no GPU required. NodeTool Cloud is the hosted, browser-based edition of the open-source NodeTool platform, currently in alpha (not yet generally available). Bring your own API keys for OpenAI, Anthropic, Gemini, Replicate, and more. AGPL-3.0.";
+  "The agent-first workspace in your browser — no install, no GPU required. Tell the agent what you want and it builds and runs the workflow. NodeTool Cloud is the hosted, browser-based edition of the open-source NodeTool platform, currently in alpha (not yet generally available). Bring your own API keys for OpenAI, Anthropic, Gemini, Replicate, and more. AGPL-3.0.";
 
 export const metadata: Metadata = {
   title: TITLE,
@@ -14,6 +14,8 @@ export const metadata: Metadata = {
   },
   keywords: [
     "NodeTool Cloud",
+    "agent-first workspace",
+    "browser AI agent",
     "hosted AI workflows",
     "browser AI workflow builder",
     "BYOK AI",
@@ -52,7 +54,7 @@ export default function CloudLayout({
           "@type": "SoftwareApplication",
           name: "NodeTool Cloud",
           description:
-            "Hosted, browser-based edition of the open-source NodeTool platform (alpha). Build AI workflows with no install and no GPU, bringing your own API keys for OpenAI, Anthropic, Gemini, Replicate, and more.",
+            "Hosted, browser-based edition of the open-source, agent-first NodeTool platform (alpha). Tell the agent what you want and it builds and runs the workflow — no install, no GPU, bringing your own API keys for OpenAI, Anthropic, Gemini, Replicate, and more.",
           applicationCategory: "MultimediaApplication",
           operatingSystem: "Web browser",
           url: "https://nodetool.ai/cloud",

--- a/marketing/src/app/cloud/page.tsx
+++ b/marketing/src/app/cloud/page.tsx
@@ -212,16 +212,17 @@ export default function CloudPage() {
                   id="cloud-hero-title"
                   className="mt-6 text-4xl md:text-6xl font-bold tracking-tight text-white leading-[1.05]"
                 >
-                  Visual AI workflows
+                  The agent-first workspace
                   <br />
                   <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-300 to-cyan-300">
                     in your browser.
                   </span>
                 </h1>
                 <p className="mt-6 text-lg text-slate-300 leading-relaxed max-w-xl">
-                  NodeTool Cloud is the hosted version of the same open-source
-                  app. There is nothing to install and no hardware to set up:
-                  sign in and start building. Bring your own API keys for
+                  NodeTool Cloud is the hosted version of the same open-source,
+                  agent-first app. There is nothing to install and no hardware
+                  to set up: sign in, say what you want, and the agent builds
+                  the workflow and runs it. Bring your own API keys for
                   whichever providers you want to use.
                 </p>
                 <div className="mt-6 rounded-lg border border-amber-500/30 bg-amber-500/[0.06] p-4 text-sm text-amber-100/90 max-w-xl">

--- a/marketing/src/app/creatives/layout.tsx
+++ b/marketing/src/app/creatives/layout.tsx
@@ -2,14 +2,16 @@ import JsonLd from "../../components/JsonLd";
 import type { Metadata, Viewport } from "next";
 
 export const metadata: Metadata = {
-  title: "NodeTool for working creatives | The open creative AI workspace",
+  title: "NodeTool for working creatives | The agent-first creative workspace",
   description:
-    "The open creative AI workspace, made for working artists, motion designers, and AI-native illustrators. Every major model from every major provider, called with your own keys, on one node-based canvas with masks, inpaint, outpaint, relight, upscale, and compositing built in.",
+    "The agent-first creative workspace, made for working artists, motion designers, and AI-native illustrators. Describe the piece and the agent plans the shots, builds the workflow, and runs every major model with your own keys — on one canvas with masks, inpaint, outpaint, relight, upscale, and compositing built in.",
   metadataBase: new URL("https://nodetool.ai"),
   alternates: {
     canonical: "/creatives",
   },
   keywords: [
+    "agent-first creative workspace",
+    "creative AI agent",
     "creative AI workspace",
     "BYOK creative AI",
     "ComfyUI alternative for creatives",
@@ -23,9 +25,9 @@ export const metadata: Metadata = {
     "AI tools for illustrators",
   ],
   openGraph: {
-    title: "NodeTool for working creatives | The open creative AI workspace",
+    title: "NodeTool for working creatives | The agent-first creative workspace",
     description:
-      "Every model. Your keys. Your canvas. The open-source creative AI workspace for working artists, motion designers, and illustrators.",
+      "Every model. Your keys. Your agent. The open-source, agent-first creative workspace for working artists, motion designers, and illustrators.",
     url: "https://nodetool.ai/creatives",
     siteName: "NodeTool",
     images: [
@@ -41,7 +43,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "NodeTool for working creatives",
     description:
-      "Every model. Your keys. Your canvas. The open creative AI workspace.",
+      "Every model. Your keys. Your agent. The open, agent-first creative workspace.",
     images: ["/preview.png"],
   },
 };
@@ -64,7 +66,7 @@ export default function CreativesLayout({
           "@type": "SoftwareApplication",
           name: "NodeTool for Creatives",
           description:
-            "The open creative AI workspace for working artists, motion designers, and AI-native illustrators. Every major model from every major provider, called with your own keys, on one node-based canvas with masks, inpaint, outpaint, relight, upscale, and compositing built in.",
+            "The agent-first creative workspace for working artists, motion designers, and AI-native illustrators. Describe the piece and the agent plans the shots, builds the workflow, and runs every major model with your own keys — on one canvas with masks, inpaint, outpaint, relight, upscale, and compositing built in.",
           applicationCategory: "MultimediaApplication",
           operatingSystem: "macOS, Windows, Linux, Web browser",
           url: "https://nodetool.ai/creatives",

--- a/marketing/src/app/creatives/page.tsx
+++ b/marketing/src/app/creatives/page.tsx
@@ -122,25 +122,26 @@ export default function CreativesPage() {
                 <div className="relative inline-flex items-center gap-2.5 px-6 py-2.5 rounded-full border border-rose-500/30 bg-gradient-to-r from-rose-500/[0.08] via-amber-500/[0.05] to-cyan-500/[0.08] mb-10 shadow-[0_0_40px_-10px_rgba(244,63,94,0.35)]">
                   <Sparkles className="w-4 h-4 text-rose-400" />
                   <span className="text-sm font-medium text-white tracking-wide">
-                    The open canvas for working creatives
+                    The agent-first canvas for working creatives
                   </span>
                 </div>
 
                 <h1 className="text-5xl md:text-7xl lg:text-[5.5rem] font-bold tracking-tight leading-[1.05] mb-10">
-                  <span className="text-white">Think it.</span>{" "}
+                  <span className="text-white">Say it.</span>{" "}
                   <span className="text-transparent bg-clip-text bg-gradient-to-r from-rose-400 via-amber-300 via-emerald-300 to-cyan-400">
-                    Generate it.
+                    Watch it made.
                   </span>
                   <br />
                   <span className="text-white/90 text-3xl md:text-5xl lg:text-6xl">
-                    Image, music &amp; video in one studio.
+                    Image, music &amp; video in one agent-first studio.
                   </span>
                 </h1>
 
                 <p className="text-lg md:text-xl text-slate-400 mb-12 max-w-3xl mx-auto leading-relaxed">
-                  Every model. Your keys. Your canvas. Bring Seedance, Kling, Veo,
-                  Runway, Luma, Suno, and Flux together in one open-source workspace,
-                  with no marked-up credits and nothing locking you in.
+                  Every model. Your keys. Your agent. Describe the piece and the
+                  agent plans the shots, builds the workflow, and runs Seedance,
+                  Kling, Veo, Runway, Luma, Suno, and Flux in one open-source
+                  workspace — no marked-up credits, nothing locking you in.
                 </p>
 
                 <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-14">

--- a/marketing/src/app/developers/layout.tsx
+++ b/marketing/src/app/developers/layout.tsx
@@ -2,15 +2,18 @@ import type { Metadata, Viewport } from "next";
 import JsonLd from "../../components/JsonLd";
 
 export const metadata: Metadata = {
-  title: "NodeTool for Developers | Open-Source AI Workflow SDK & API",
+  title: "NodeTool for Developers | Agent-First SDK, API & MCP Server",
   description:
-    "Build creative AI applications with NodeTool's TypeScript SDK and REST API. Workflows run in an async Node.js runner. Write custom nodes in TypeScript or Python, integrate with any model, and deploy to production. Open source under AGPL-3.0.",
+    "Build creative AI applications with NodeTool's TypeScript SDK and REST API — or let an agent do it: every editor is exposed as tools, around 120 in all, over MCP for Claude Code and any MCP-aware agent. Write custom nodes in TypeScript or Python, validate and debug workflows from the CLI, deploy to production. Open source under AGPL-3.0.",
   metadataBase: new URL("https://nodetool.ai"),
   alternates: {
     canonical: "/developers",
   },
   keywords: [
     "AI SDK",
+    "MCP server",
+    "agent tools API",
+    "agent-first platform",
     "TypeScript AI framework",
     "Python AI framework",
     "AI workflow API",
@@ -25,9 +28,9 @@ export const metadata: Metadata = {
     "model-agnostic SDK",
   ],
   openGraph: {
-    title: "NodeTool for Developers | Open-Source AI Workflow SDK & API",
+    title: "NodeTool for Developers | Agent-First SDK, API & MCP Server",
     description:
-      "Build creative AI applications with NodeTool's TypeScript SDK and REST API. Workflows run in an async Node.js runner. Write custom nodes in TypeScript or Python, integrate with any model, and deploy to production.",
+      "Build creative AI applications with NodeTool's TypeScript SDK and REST API — or point your agent at the MCP server and let it build them. Write custom nodes in TypeScript or Python, integrate with any model, and deploy to production.",
     url: "https://nodetool.ai/developers",
     siteName: "NodeTool",
     images: [
@@ -43,7 +46,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "NodeTool for Developers",
     description:
-      "Build creative AI applications with NodeTool's TypeScript SDK and REST API. Open source under AGPL-3.0.",
+      "Agent-first SDK, API, and MCP server for creative AI applications. Open source under AGPL-3.0.",
     images: ["/preview.png"],
   },
 };
@@ -66,7 +69,7 @@ export default function DevelopersLayout({
           "@type": "SoftwareSourceCode",
           name: "NodeTool",
           description:
-            "Open-source creative AI workspace. TypeScript SDK and REST API; write custom nodes in TypeScript or Python, drive the canvas from a CLI, and generate workflows in code.",
+            "Open-source, agent-first creative workspace. TypeScript SDK, REST API, and an MCP server exposing every editor as agent tools; write custom nodes in TypeScript or Python, drive the canvas from a CLI, and generate workflows in code.",
           codeRepository: "https://github.com/nodetool-ai/nodetool",
           programmingLanguage: ["TypeScript", "Python"],
           license: "https://github.com/nodetool-ai/nodetool/blob/main/LICENSE",

--- a/marketing/src/app/layout.tsx
+++ b/marketing/src/app/layout.tsx
@@ -17,16 +17,19 @@ const jetBrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "NodeTool — The open creative AI workspace",
+  title: "NodeTool — The agent-first creative workspace",
   description:
-    "NodeTool is the open-source creative AI workspace. Every major model from every major provider runs on one visual canvas, using your own keys, on your machine or in your browser. You pay providers directly: no credits, no markup, no lock-in.",
+    "NodeTool is the open-source, agent-first creative workspace. Every editor — canvas, sketch pad, storyboard, timeline, app builder — is exposed to agents as tools: say what you want and the agent builds the workflow and runs it across every major model, using your own keys. You pay providers directly: no credits, no markup, no lock-in.",
   metadataBase: new URL("https://nodetool.ai"),
   alternates: {
     canonical: "/",
   },
   keywords: [
+    "agent-first creative workspace",
     "creative AI workspace",
     "open source creative AI",
+    "agents that build workflows",
+    "MCP creative tools",
     "BYOK AI canvas",
     "AI workflow canvas",
     "ComfyUI alternative",
@@ -49,9 +52,9 @@ export const metadata: Metadata = {
     other: [{ rel: "manifest", url: "/site.webmanifest" }],
   },
   openGraph: {
-    title: "NodeTool — The open creative AI workspace",
+    title: "NodeTool — The agent-first creative workspace",
     description:
-      "Every major model from every major provider on one visual canvas, using your own keys. Image, video, audio, and text in one place. Open source, and you pay provider prices.",
+      "Every editor is exposed to agents as tools: say what you want and the agent builds the workflow and runs it across every major model, using your own keys. Open source, and you pay provider prices.",
     url: "https://nodetool.ai",
     siteName: "NodeTool",
     images: [
@@ -65,9 +68,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "NodeTool — The open creative AI workspace",
+    title: "NodeTool — The agent-first creative workspace",
     description:
-      "Every model. Your keys. Your canvas. The open-source creative AI workspace: bring your own keys to every major provider and pay their published prices.",
+      "Every model. Your keys. Your agent. The open-source, agent-first creative workspace: an agent builds and runs your workflows across every major provider, at their published prices.",
     images: ["/preview.png"],
   },
 };
@@ -94,7 +97,7 @@ export default function RootLayout({
               "@context": "https://schema.org",
               "@type": "SoftwareApplication",
               "name": "NodeTool",
-              "description": "NodeTool is the open-source creative AI workspace. Every major model from every major provider runs on one visual canvas, using your own keys. Image, video, audio, and text sit side by side, with masks, inpaint, outpaint, relight, upscale, and compositing built in. It runs as a desktop app on macOS, Windows, and Linux, or in the browser with NodeTool Cloud.",
+              "description": "NodeTool is the open-source, agent-first creative workspace. Every editor — the node canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools, around 120 in all: say what you want and the agent builds the workflow and runs it across every major model from every major provider, using your own keys. It runs as a desktop app on macOS, Windows, and Linux, or in the browser with NodeTool Cloud.",
               "applicationCategory": "MultimediaApplication",
               "applicationSubCategory": "Creative AI Workspace",
               "operatingSystem": "macOS, Windows, Linux",
@@ -113,6 +116,9 @@ export default function RootLayout({
               },
               "screenshot": "https://nodetool.ai/preview.png",
               "featureList": [
+                "Agent-first: every editor is exposed to agents as tools, around 120 in all",
+                "Agents plan, build, run, and repair workflows on the same surfaces you use",
+                "The full agent toolbelt speaks MCP, so Claude Desktop and Claude Code can drive NodeTool",
                 "One visual canvas for image, video, audio, and text",
                 "Bring your own keys to every major provider: FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, Together, Groq, Mistral, OpenRouter, HuggingFace",
                 "Pay providers directly at provider prices, no credits, no markup",
@@ -148,7 +154,7 @@ export default function RootLayout({
                 "https://github.com/nodetool-ai/nodetool",
                 "https://discord.gg/WmQTWZRcYE"
               ],
-              "description": "NodeTool builds the open creative AI workspace: a visual canvas that connects every major model from every major provider using the user's own keys, available as a desktop app and as a hosted browser edition."
+              "description": "NodeTool builds the open, agent-first creative workspace: every editor is exposed to agents as tools, connecting every major model from every major provider using the user's own keys, available as a desktop app and as a hosted browser edition."
             })
           }}
         />
@@ -166,7 +172,7 @@ export default function RootLayout({
                   "name": "What is NodeTool?",
                   "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "NodeTool is the open-source creative AI workspace. Every major model from every major provider (FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and more) runs on one visual canvas using your own keys. Image, video, audio, and text live side by side, with editing tools such as masks, inpaint, outpaint, relight, upscale, layers, and compositing built in. It runs as a desktop app on macOS, Windows, and Linux, or in the browser with NodeTool Cloud."
+                    "text": "NodeTool is the open-source, agent-first creative workspace. Every editor is exposed to agents as tools: say what you want and the agent builds the workflow and runs it across every major model from every major provider (FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and more) using your own keys. Image, video, audio, and text live side by side, with editing tools such as masks, inpaint, outpaint, relight, upscale, layers, and compositing built in. It runs as a desktop app on macOS, Windows, and Linux, or in the browser with NodeTool Cloud."
                   }
                 },
                 {

--- a/marketing/src/app/marketing/layout.tsx
+++ b/marketing/src/app/marketing/layout.tsx
@@ -2,14 +2,16 @@ import JsonLd from "../../components/JsonLd";
 import type { Metadata, Viewport } from "next";
 
 export const metadata: Metadata = {
-  title: "NodeTool for marketing teams | AI production at campaign scale",
+  title: "NodeTool for marketing teams | Agent-first production at campaign scale",
   description:
-    "The open AI workspace for marketing teams: product videos, ad creative, social calendars, and brand assets from every major model, called with your own keys, on one node-based canvas. No marked-up credits, no lock-in, output at campaign volume.",
+    "The agent-first workspace for marketing teams: hand the brief to an agent and it builds the workflow that turns out product videos, ad creative, social calendars, and brand assets from every major model, with your own keys. No marked-up credits, no lock-in, output at campaign volume.",
   metadataBase: new URL("https://nodetool.ai"),
   alternates: {
     canonical: "/marketing",
   },
   keywords: [
+    "AI marketing agent",
+    "agent-first marketing workspace",
     "AI product video generator",
     "AI content calendar tool",
     "brand asset generator AI",
@@ -18,9 +20,9 @@ export const metadata: Metadata = {
     "BYOK AI for marketing teams",
   ],
   openGraph: {
-    title: "NodeTool for marketing teams | AI production at campaign scale",
+    title: "NodeTool for marketing teams | Agent-first production at campaign scale",
     description:
-      "Product videos, ad creative, social calendars, and brand assets — every model, your keys, one canvas built for campaign volume.",
+      "Hand the brief to an agent: product videos, ad creative, social calendars, and brand assets — every model, your keys, built for campaign volume.",
     url: "https://nodetool.ai/marketing",
     siteName: "NodeTool",
     images: [
@@ -36,7 +38,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "NodeTool for marketing teams",
     description:
-      "Every model. Your keys. Your canvas. AI production at campaign scale.",
+      "Every model. Your keys. Your agent. AI production at campaign scale.",
     images: ["/preview.png"],
   },
 };
@@ -59,7 +61,7 @@ export default function MarketingLayout({
           "@type": "SoftwareApplication",
           name: "NodeTool for Marketing Teams",
           description:
-            "The open AI workspace for marketing teams: product videos, ad creative, social calendars, and brand assets from every major model, called with your own keys, on one node-based canvas. No marked-up credits, no lock-in, output at campaign volume.",
+            "The agent-first workspace for marketing teams: hand the brief to an agent and it builds the workflow that turns out product videos, ad creative, social calendars, and brand assets from every major model, with your own keys. No marked-up credits, no lock-in, output at campaign volume.",
           applicationCategory: "MultimediaApplication",
           operatingSystem: "macOS, Windows, Linux, Web browser",
           url: "https://nodetool.ai/marketing",

--- a/marketing/src/app/marketing/page.tsx
+++ b/marketing/src/app/marketing/page.tsx
@@ -125,7 +125,7 @@ export default function MarketingSegmentPage() {
                 <div className="relative inline-flex items-center gap-2.5 px-6 py-2.5 rounded-full border border-amber-500/30 bg-gradient-to-r from-amber-500/[0.08] via-emerald-500/[0.05] to-cyan-500/[0.08] mb-10 shadow-[0_0_40px_-10px_rgba(245,158,11,0.35)]">
                   <Sparkles className="w-4 h-4 text-amber-400" />
                   <span className="text-sm font-medium text-white tracking-wide">
-                    The open canvas for marketing production
+                    The agent-first canvas for marketing production
                   </span>
                 </div>
 
@@ -137,10 +137,11 @@ export default function MarketingSegmentPage() {
                 </h1>
 
                 <p className="text-lg md:text-xl text-slate-400 mb-12 max-w-3xl mx-auto leading-relaxed">
-                  Product videos, ad creative, social calendars, and brand
-                  assets from every major model, run with your own keys on one
-                  visual canvas. No marked-up credits, nothing locking you in,
-                  and built for steady output rather than one-off polish.
+                  Hand the brief to an agent: it builds the workflow that turns
+                  out product videos, ad creative, social calendars, and brand
+                  assets from every major model, run with your own keys. No
+                  marked-up credits, nothing locking you in, and built for
+                  steady output rather than one-off polish.
                 </p>
 
                 <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-14">

--- a/marketing/src/app/studio/layout.tsx
+++ b/marketing/src/app/studio/layout.tsx
@@ -1,9 +1,9 @@
 import JsonLd from "../../components/JsonLd";
 import type { Metadata } from "next";
 
-const TITLE = "NodeTool Studio — Local-First AI Workflow Desktop App";
+const TITLE = "NodeTool Studio — The Agent-First Desktop App";
 const DESCRIPTION =
-  "NodeTool Studio is the open-source desktop app for building AI workflows on your own hardware. Run Ollama, MLX, and GGUF models locally, work offline, keep your data on disk. macOS, Windows, Linux. AGPL-3.0.";
+  "NodeTool Studio is the open-source, agent-first desktop app: every editor is exposed to agents as tools, and the agent runs on your own hardware. Tell it what you want and it builds and runs workflows with Ollama, MLX, and GGUF models locally — offline, data on disk. macOS, Windows, Linux. AGPL-3.0.";
 
 export const metadata: Metadata = {
   title: TITLE,
@@ -14,6 +14,8 @@ export const metadata: Metadata = {
   },
   keywords: [
     "NodeTool Studio",
+    "agent-first desktop app",
+    "local AI agent",
     "local AI workflows",
     "offline AI",
     "Ollama desktop",
@@ -52,7 +54,7 @@ export default function StudioLayout({
           "@type": "SoftwareApplication",
           name: "NodeTool Studio",
           description:
-            "Open-source desktop app for building AI workflows on your own hardware. Run Ollama, MLX, and GGUF models locally, work offline, and keep your data on disk.",
+            "Open-source, agent-first desktop app: every editor is exposed to agents as tools, and the agent runs on your own hardware. Build and run AI workflows with Ollama, MLX, and GGUF models locally, work offline, and keep your data on disk.",
           applicationCategory: "MultimediaApplication",
           operatingSystem: "macOS, Windows, Linux",
           url: "https://nodetool.ai/studio",

--- a/marketing/src/app/studio/page.tsx
+++ b/marketing/src/app/studio/page.tsx
@@ -84,8 +84,8 @@ const proPoints = [
   },
   {
     icon: Code2,
-    title: "Custom Python and TypeScript nodes",
-    body: "Add your own code, install Python packages in the environment that ships with the app, or run code you do not trust inside Docker.",
+    title: "The agent lives here too",
+    body: "The chat agent drives every editor through the same tools you click, and the whole toolbelt speaks MCP — point Claude Desktop or Claude Code at Studio and they can build and run workflows on your machine.",
   },
 ];
 
@@ -206,17 +206,18 @@ export default function StudioPage() {
                   id="studio-hero-title"
                   className="mt-6 text-4xl md:text-6xl font-bold tracking-tight text-white leading-[1.05]"
                 >
-                  Build AI workflows that
+                  An agent-first studio that
                   <br />
                   <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-300 to-orange-300">
-                    run on your machine.
+                    runs on your machine.
                   </span>
                 </h1>
                 <p className="mt-6 text-lg text-slate-300 leading-relaxed max-w-xl">
                   NodeTool Studio is the desktop app for people who want their
-                  models, data, and results to stay on their own machine. Run
-                  free local models with Ollama and MLX, and bring your own keys
-                  for a cloud provider whenever you need one.
+                  models, data — and their agent — on their own machine. Tell
+                  the agent what you want and it builds and runs the workflow
+                  with free local models via Ollama and MLX, or with your own
+                  keys for a cloud provider whenever you need one.
                 </p>
                 <div className="mt-8 flex flex-col gap-3">
                   <SmartDownloadButton

--- a/marketing/src/components/ChatUISection.tsx
+++ b/marketing/src/components/ChatUISection.tsx
@@ -34,9 +34,9 @@ export default function ChatUISection() {
             transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Run your workflows <br />
+            An agent that <br />
             <span className="text-white">
-              by chatting
+              does the work
             </span>
           </motion.h2>
 
@@ -47,7 +47,10 @@ export default function ChatUISection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Skip the canvas when you don&apos;t need it. Ask in plain English, the right workflow runs, and the results come back in the conversation.
+            The chat isn&apos;t a help panel — it&apos;s an agent with the whole
+            app as its toolbelt, around 120 tools across every editor. Ask in
+            plain English and it builds the workflow, runs it, and leaves
+            behind something you can inspect, edit, and rerun.
           </motion.p>
         </div>
 

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -26,17 +26,18 @@ export default function NodeToolHero() {
             id="hero-title"
             className="mt-6 text-5xl font-bold leading-[1.05] tracking-tight text-white md:text-6xl"
           >
-            The open creative
+            The agent-first
             <br />
             <span className="bg-gradient-to-r from-rose-400 via-fuchsia-400 to-amber-300 bg-clip-text text-transparent">
-              AI workspace.
+              creative workspace.
             </span>
           </h1>
 
           <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-300 md:text-lg">
-            Films, posters, product videos, and music, made start to finish on
-            one canvas. Every major model, your own keys, and no credits or
-            markups in between.
+            Say what you want and the agent builds the workflow on your canvas
+            and runs it — films, posters, product videos, and music, start to
+            finish. Every major model, your own keys, and no credits or markups
+            in between.
           </p>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -57,7 +58,7 @@ export default function NodeToolHero() {
           <ul className="mt-8 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs font-medium text-slate-300">
             <li className="flex items-center gap-1.5">
               <Layers className="h-3.5 w-3.5 text-fuchsia-400" />
-              Image, video, audio, and text
+              Agents drive every editor
             </li>
             <li className="text-slate-700">•</li>
             <li className="flex items-center gap-1.5">

--- a/marketing/src/components/developers/DevelopersHero.tsx
+++ b/marketing/src/components/developers/DevelopersHero.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from "react";
 import { motion } from "framer-motion";
-import { Code2, Terminal, Boxes, Rocket } from "lucide-react";
+import { Code2, Terminal, Boxes, Rocket, Bot } from "lucide-react";
 
 export default function DevelopersHero() {
   return (
@@ -29,9 +29,9 @@ export default function DevelopersHero() {
           transition={{ duration: 0.25, delay: 0.05 }}
           className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight"
         >
-          <span className="text-white">Extend the </span>
+          <span className="text-white">Built for code. </span>
           <span className="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 via-purple-400 to-teal-400">
-            workspace.
+            Built for agents.
           </span>
         </motion.h1>
 
@@ -44,8 +44,10 @@ export default function DevelopersHero() {
         >
           TypeScript-first, async Node.js under the hood, the same open-source
           codebase that ships Studio and Cloud. Write a custom node, drive the
-          canvas from a CLI, generate workflows in code — and put the result in
-          front of your team without rewriting it for a different runtime.
+          canvas from a CLI, generate workflows in code — or point Claude Code
+          at the MCP server and let an agent do it: every editor is exposed as
+          tools, around 120 in all, with validators and debug harnesses built
+          for the agent loop.
         </motion.p>
 
         {/* Feature Pills */}
@@ -57,6 +59,7 @@ export default function DevelopersHero() {
         >
           {[
             { icon: Code2, text: "Developer SDK" },
+            { icon: Bot, text: "MCP Server" },
             { icon: Terminal, text: "Graph DSL" },
             { icon: Boxes, text: "Custom Nodes" },
             { icon: Rocket, text: "Cloud Deploy" },


### PR DESCRIPTION
#4665 repositioned the agents page as agent-first. This PR carries the same repositioning across the other main landing pages: home (`/`), `/studio`, `/cloud`, `/creatives`, `/developers`, and `/marketing`.

## What changed

Each page's hero, metadata (title/description/keywords/OpenGraph/Twitter), and JSON-LD now lead with the agent-first story in that page's own voice:

- **Home** — hero is now "The agent-first creative workspace"; the chat section is reframed from "run workflows by chatting" to an agent with the whole app as its toolbelt; root metadata, SoftwareApplication/Organization/FAQ JSON-LD updated.
- **Studio** — "An agent-first studio that runs on your machine": the agent and the models both run locally, and one of the "why local" cards now covers the local agent + MCP for Claude Desktop / Claude Code.
- **Cloud** — "The agent-first workspace in your browser": sign in, say what you want, the agent builds and runs the workflow.
- **Creatives** — "Say it. Watch it made." — the agent plans the shots, builds the workflow, and runs the models.
- **Developers** — "Built for code. Built for agents.": the MCP server and the ~120-tool `ui_*` contract join the SDK/CLI story, with a new MCP Server hero pill.
- **Marketing** — the "One brief" hero now hands the brief to an agent that builds the campaign workflow.

## Generated mirrors

The `public/*.md` page mirrors and `llms.txt` are generated by `scripts/generate-llms-txt.mjs`, so the agent-first copy for these pages (and the llms.txt preamble/key-page blurbs) moved into the generator's page table and the outputs were regenerated — `seo:check` passes. `gen:templates` / `gen:apps` produced no diffs.

## Checks

- `npx tsc --noEmit` (marketing tsconfig): clean
- `npm run lint` (marketing): pre-existing warnings only
- `npm run seo:check`: up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ghyide2AKMPUgr1yobzeK

---
_Generated by [Claude Code](https://claude.ai/code/session_016ghyide2AKMPUgr1yobzeK)_