### PR TITLE
Rebuild the Movie Trailer example on the storyboard nodes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ story. [See all use cases →]({{ '/use-cases' | relative_url }})
     <div class="usecase-body">
       <span class="usecase-tag">Film</span>
       <h3><a href="{{ '/use-cases/movie-trailer' | relative_url }}">Movie Trailer Generator</a></h3>
-      <p>One logline becomes a treatment, a shot list, key art, and a cut teaser.</p>
+      <p>One logline becomes a storyboard, key art, and a cut teaser.</p>
     </div>
   </article>
   <article class="usecase-card">

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -22,9 +22,9 @@ us, and you can switch any model for a better one the day it ships.
     <div class="usecase-body">
       <span class="usecase-tag">Film</span>
       <h3><a href="{{ '/use-cases/movie-trailer' | relative_url }}">Movie Trailer Generator</a></h3>
-      <p>Type one logline and the canvas builds a cinematic teaser: a showrunner agent writes the treatment, a list generator breaks it into shots, each shot is rendered as key art, animated, and cut into a finished trailer.</p>
+      <p>Type one logline and the canvas builds a cinematic teaser: a Director node storyboards it into shots, each shot is rendered as key art, animated, and cut into a finished trailer.</p>
       <div class="pipeline-chips">
-        <span>Logline</span><span>Treatment</span><span>Shots</span><span>Key art</span><span>Trailer</span>
+        <span>Logline</span><span>Storyboard</span><span>Shots</span><span>Key art</span><span>Trailer</span>
       </div>
     </div>
   </article>

--- a/docs/use-cases/movie-trailer.md
+++ b/docs/use-cases/movie-trailer.md
@@ -1,15 +1,15 @@
 ---
 layout: page
 title: "Movie Trailer Generator"
-description: "Type one logline and the canvas builds a cinematic teaser: a showrunner agent writes the treatment, a list generator breaks it into shots, a text-to-image model renders the key art, and a video model animates and cuts it into a finished trailer."
+description: "Type one logline and the canvas builds a cinematic teaser: a Director node storyboards it into shots, a text-to-image model renders the key art, and a video model animates and cuts it into a finished trailer."
 image: /assets/use-cases/trailer-shot-1.png
 ---
 
 <p class="usecase-eyebrow">Use case · Film</p>
 
-Type one logline and the canvas builds a cinematic teaser — a treatment, a shot
-list, key art for every beat, then animated and cut into a finished trailer. No
-editor, no studio, one canvas you can re-run for any story.
+Type one logline and the canvas builds a cinematic teaser — a storyboard, key
+art for every beat, then animated and cut into a finished trailer. No editor,
+no studio, one canvas you can re-run for any story.
 
 <div class="usecase-hero">
   <video src="{{ '/assets/use-cases/movie_trailer_example.mp4' | relative_url }}" poster="{{ '/assets/use-cases/trailer-shot-1.png' | relative_url }}" autoplay loop muted playsinline controls></video>
@@ -17,24 +17,24 @@ editor, no studio, one canvas you can re-run for any story.
 
 ## How it works
 
-A handful of nodes do the work. One line becomes a treatment, the treatment
+A handful of nodes do the work. One line becomes a storyboard, the storyboard
 becomes shots, the shots become a trailer.
 
 {% mermaid %}
 graph LR
   logline["Logline (String)"]
   vstyle["Visual style (String)"]
-  treatment["Treatment (Prompt)"]
-  showrunner["Showrunner (Agent)"]
-  shotlist["Shot list (ListGenerator)"]
+  count["Shot count (Integer)"]
+  director["Director → screenplay"]
+  shots["Screenplay Shots"]
   keyart["Key art (TextToImage)"]
   i2v["Animate (ImageToVideo)"]
   concat["Concat → Trailer"]
-  logline --> treatment
-  vstyle --> treatment
-  treatment --> showrunner
-  showrunner --> shotlist
-  shotlist --> keyart
+  logline --> director
+  vstyle --> director
+  count --> director
+  director --> shots
+  shots --> keyart
   keyart --> i2v
   i2v --> concat
 {% endmermaid %}
@@ -42,11 +42,13 @@ graph LR
 1. **Start with one line.** Type the logline. Two more inputs set the visual
    style and the shot count — that's the entire brief.
    *(e.g. "A getaway driver outruns a collapsing bridge · gritty daylight · 6 shots")*
-2. **Treatment, then shots.** A Prompt frames the brief, a showrunner agent
-   returns a teaser treatment, and a list generator breaks it into concrete,
-   one-line shots.
-3. **Render the key art.** Each shot is templated into a key-art prompt, then a
-   text-to-image model renders it as a cinematic 16:9 frame.
+2. **Direct the storyboard.** The Director node writes the screenplay: one shot
+   per beat, each with framing, lens, angle, and movement, under a single style
+   bible. It is the same node the Storyboard editor runs behind its Direct
+   button.
+3. **Render the key art.** Screenplay Shots turns each shot into an image prompt
+   — action, camera, style bible — and a text-to-image model renders it as a
+   cinematic 16:9 frame.
 4. **Animate and cut.** An image-to-video model animates every frame, then a
    Concat node stitches them into one finished trailer.
 
@@ -88,11 +90,12 @@ Nothing here is locked. Swap models, change the tone, or point it at a different
 story.
 
 - **Swap the video model.** Veo, Seedance, Kling, Runway. Change one node and
-  the treatment, shots, and key art stay exactly the same.
-- **Redirect the showrunner.** Rewrite the agent's system prompt for horror,
-  comedy, or arthouse without touching the pipeline.
-- **Restyle every shot.** The visual-style input flows into each key-art prompt.
-  Change one line and the whole trailer shifts mood.
+  the storyboard, shots, and key art stay exactly the same.
+- **Redirect the storyboard.** Raise the shot count, change the aspect ratio, or
+  point the Director at a different model. The rest of the graph is untouched.
+- **Restyle every shot.** The visual-style input becomes the screenplay's style
+  bible, and the style bible lands in every shot prompt. Change one line and the
+  whole trailer shifts mood.
 - **Re-run any story.** Drop in a new logline and run it again. The workflow is
   the reusable part, not this trailer.
 
@@ -103,8 +106,8 @@ any of them for a better model the day it ships.
 
 | Model | Role | Provider |
 | --- | --- | --- |
-| Gemini 3.1 Pro Preview | Writes the treatment and shot list | Gemini |
-| GPT Image-2 | Renders each shot's key art | kie |
+| GPT-5 mini | Directs the storyboard | OpenAI |
+| FLUX.1 Schnell | Renders each shot's key art | fal.ai |
 | Veo 3.1 Preview | Animates the frames into video | Gemini |
 
 See [Models &amp; Providers]({{ '/models-and-providers' | relative_url }}) to set up keys.

--- a/docs/use-cases/movie-trailer.md
+++ b/docs/use-cases/movie-trailer.md
@@ -106,8 +106,8 @@ any of them for a better model the day it ships.
 
 | Model | Role | Provider |
 | --- | --- | --- |
-| GPT-5 mini | Directs the storyboard | OpenAI |
-| FLUX.1 Schnell | Renders each shot's key art | fal.ai |
+| Gemini 3.1 Pro Preview | Directs the storyboard | Gemini |
+| GPT Image-2 | Renders each shot's key art | kie |
 | Veo 3.1 Preview | Animates the frames into video | Gemini |
 
 See [Models &amp; Providers]({{ '/models-and-providers' | relative_url }}) to set up keys.

--- a/marketing/src/app/use-cases/movie-trailer/layout.tsx
+++ b/marketing/src/app/use-cases/movie-trailer/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata, Viewport } from "next";
 
 const TITLE = "AI Movie Trailer Generator | NodeTool use case";
 const DESCRIPTION =
-  "Type one logline and the canvas builds a cinematic teaser. A showrunner agent writes the treatment, a list generator breaks it into shots, a text-to-image model renders the key art, and a video model animates and cuts it into a finished trailer, all on one open canvas with your own keys.";
+  "Type one logline and the canvas builds a cinematic teaser. A Director node storyboards it into shots, a text-to-image model renders the key art, and a video model animates and cuts it into a finished trailer, all on one open canvas with your own keys.";
 
 export const metadata: Metadata = {
   title: TITLE,
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "AI Movie Trailer Generator",
     description:
-      "From one logline to a cinematic teaser: treatment, shot list, key art, and a cut trailer, on one open canvas.",
+      "From one logline to a cinematic teaser: a storyboard, key art, and a cut trailer, on one open canvas.",
   },
 };
 

--- a/marketing/src/app/use-cases/movie-trailer/opengraph-image.tsx
+++ b/marketing/src/app/use-cases/movie-trailer/opengraph-image.tsx
@@ -7,7 +7,7 @@ export const contentType = ogContentType;
 export default function Image() {
   return ogImage(
     "AI Movie Trailer Generator",
-    "One logline becomes a treatment, a shot list, key art, and a cut trailer.",
+    "One logline becomes a storyboard, key art, and a cut trailer.",
     { image: "trailer-shot-1.png", accent: "amber", eyebrow: "Use case · Film" }
   );
 }

--- a/marketing/src/app/use-cases/movie-trailer/page.tsx
+++ b/marketing/src/app/use-cases/movie-trailer/page.tsx
@@ -8,9 +8,9 @@ import {
   Download,
   Play,
   FileText,
-  Sparkles,
   Image as ImageIcon,
   Film,
+  Clapperboard,
   RefreshCw,
   SlidersHorizontal,
   Wand2,
@@ -39,15 +39,15 @@ const steps = [
     detail: "A getaway driver outruns a collapsing bridge · gritty daylight · 6 shots",
   },
   {
-    icon: Sparkles,
-    title: "Treatment, then shots",
-    body: "A Prompt frames the brief, a showrunner agent returns a teaser treatment, and a list generator breaks it into concrete, one-line shots.",
-    detail: "Tone · beat arc · motifs · palette → 6 shots",
+    icon: Clapperboard,
+    title: "Direct the storyboard",
+    body: "One Director node writes the screenplay: a shot for every beat, each with its own camera direction, under one style bible.",
+    detail: "6 shots · framing, lens, angle, movement · one style bible",
   },
   {
     icon: ImageIcon,
     title: "Render the key art",
-    body: "Each shot is templated into a key-art prompt, then a text-to-image model renders it as a cinematic 16:9 frame.",
+    body: "Screenplay Shots turns each shot into an image prompt — action, camera, style — and a text-to-image model renders it as a cinematic 16:9 frame.",
     detail: "2K · anamorphic framing · film grain · no on-screen text",
   },
   {
@@ -62,17 +62,17 @@ const tweaks = [
   {
     icon: RefreshCw,
     title: "Swap the video model",
-    body: "Veo, Seedance, Kling, Runway. Change one node and the treatment, shots, and key art stay exactly the same.",
+    body: "Veo, Seedance, Kling, Runway. Change one node and the storyboard, shots, and key art stay exactly the same.",
   },
   {
     icon: SlidersHorizontal,
-    title: "Redirect the showrunner",
-    body: "Rewrite the agent's system prompt for horror, comedy, or arthouse without touching the pipeline.",
+    title: "Redirect the storyboard",
+    body: "Raise the shot count, change the aspect ratio, or point the Director at a different model. The rest of the graph is untouched.",
   },
   {
     icon: Wand2,
     title: "Restyle every shot",
-    body: "The visual-style input flows into each key-art prompt. Change one line and the whole trailer shifts mood.",
+    body: "The visual-style input becomes the screenplay's style bible, and the style bible lands in every shot prompt. Change one line and the whole trailer shifts mood.",
   },
   {
     icon: Repeat,
@@ -83,14 +83,14 @@ const tweaks = [
 
 const models = [
   {
-    name: "Gemini 3.1 Pro Preview",
-    role: "Writes the treatment and shot list",
-    provider: "Gemini",
+    name: "GPT-5 mini",
+    role: "Directs the storyboard",
+    provider: "OpenAI",
   },
   {
-    name: "GPT Image-2",
+    name: "FLUX.1 Schnell",
     role: "Renders each shot's key art",
-    provider: "kie",
+    provider: "fal.ai",
   },
   {
     name: "Veo 3.1 Preview",
@@ -154,10 +154,10 @@ export default function MovieTrailerUseCase() {
                 Movie Trailer Generator
               </h1>
               <p className="mt-6 text-lg md:text-xl text-slate-400 leading-relaxed">
-                Type one logline and the canvas builds the teaser: a treatment,
-                a shot list, key art for every beat — animated and cut into a
-                finished trailer. No editor, no studio, one canvas you can
-                re-run for any story.
+                Type one logline and the canvas builds the teaser: a Director
+                node storyboards it into shots, key art is rendered for every
+                beat, then animated and cut into a finished trailer. No editor,
+                no studio, one canvas you can re-run for any story.
               </p>
             </motion.div>
 
@@ -214,8 +214,8 @@ export default function MovieTrailerUseCase() {
                 How it works
               </h2>
               <p className="mt-4 text-lg text-slate-400 leading-relaxed">
-                A handful of nodes do the work. One line becomes a treatment, the
-                treatment becomes shots, the shots become a trailer.
+                A handful of nodes do the work. One line becomes a storyboard, the
+                storyboard becomes shots, the shots become a trailer.
               </p>
             </div>
 

--- a/marketing/src/app/use-cases/movie-trailer/page.tsx
+++ b/marketing/src/app/use-cases/movie-trailer/page.tsx
@@ -83,14 +83,14 @@ const tweaks = [
 
 const models = [
   {
-    name: "GPT-5 mini",
+    name: "Gemini 3.1 Pro Preview",
     role: "Directs the storyboard",
-    provider: "OpenAI",
+    provider: "Gemini",
   },
   {
-    name: "FLUX.1 Schnell",
+    name: "GPT Image-2",
     role: "Renders each shot's key art",
-    provider: "fal.ai",
+    provider: "kie",
   },
   {
     name: "Veo 3.1 Preview",

--- a/marketing/src/app/use-cases/useCaseEntries.ts
+++ b/marketing/src/app/use-cases/useCaseEntries.ts
@@ -24,8 +24,8 @@ export const useCaseEntries: UseCaseEntry[] = [
     title: "Movie Trailer Generator",
     category: "Film",
     teaser:
-      "Type one logline and the canvas builds a cinematic teaser. A showrunner agent writes the treatment, a list generator breaks it into shots, each shot is rendered as key art, animated, and cut into a finished trailer.",
-    pipeline: ["Logline", "Treatment", "Shots", "Key art", "Trailer"],
+      "Type one logline and the canvas builds a cinematic teaser. A Director node storyboards it into shots, each shot is rendered as key art, animated, and cut into a finished trailer.",
+    pipeline: ["Logline", "Storyboard", "Shots", "Key art", "Trailer"],
     video: "/movie_trailer_example.mp4",
     poster: "/trailer-shot-1-800.webp",
     accent: "amber",

--- a/marketing/src/components/MovieTrailerGraph.tsx
+++ b/marketing/src/components/MovieTrailerGraph.tsx
@@ -1,6 +1,13 @@
 "use client";
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { Type, Wand2, Sparkles, List, Image as ImageIcon, Film } from "lucide-react";
+import {
+  Type,
+  Hash,
+  Clapperboard,
+  List,
+  Image as ImageIcon,
+  Film,
+} from "lucide-react";
 import {
   NodeCanvas,
   FlowNode,
@@ -20,11 +27,11 @@ const H = 760;
 // the rendered DOM (offset chain — immune to the CSS scale), so the connectors
 // always land on the ports regardless of how the text reflows the node heights.
 const EDGES: Array<{ from: string; to: string; color: string }> = [
-  { from: "logline.out", to: "treatment.logline", color: "string" },
-  { from: "style.out", to: "treatment.style", color: "string" },
-  { from: "treatment.out", to: "showrunner.in", color: "string" },
-  { from: "showrunner.out", to: "shotlist.treatment", color: "string" },
-  { from: "shotlist.item", to: "keyframe.shot", color: "string" },
+  { from: "logline.out", to: "director.brief", color: "string" },
+  { from: "style.out", to: "director.style", color: "string" },
+  { from: "count.out", to: "director.count", color: "int" },
+  { from: "director.out", to: "shots.screenplay", color: "dict" },
+  { from: "shots.prompt", to: "keyframe.shot", color: "string" },
   { from: "keyframe.out", to: "i2v.image", color: "image" },
   { from: "i2v.out", to: "concat.video", color: "video" },
 ];
@@ -117,44 +124,45 @@ export default function MovieTrailerGraph() {
             <div data-node="style" style={{ position: "absolute", left: 40, top: 260 }}>
               <FlowNode title="Visual Style" icon={<Type size={16} />} style={{ position: "relative" }}>
                 <NodeProperty label="Value">
-                  Gritty, high-contrast daylight, dust and sparks, handheld telephoto.
+                  Cinematic film still, high-contrast daylight, dust and sparks, handheld telephoto.
                 </NodeProperty>
                 <HandleRow side="out" color="string" anchorId="style.out" />
               </FlowNode>
             </div>
 
-            <div data-node="treatment" style={{ position: "absolute", left: 470, top: 70 }}>
-              <FlowNode title="Prompt" icon={<Wand2 size={16} />} width={440} style={{ position: "relative" }}>
+            <div data-node="count" style={{ position: "absolute", left: 40, top: 490 }}>
+              <FlowNode title="Shot Count" icon={<Hash size={16} />} style={{ position: "relative" }}>
+                <NodeProperty label="Value" mono>
+                  6
+                </NodeProperty>
+                <HandleRow side="out" color="int" anchorId="count.out" />
+              </FlowNode>
+            </div>
+
+            <div data-node="director" style={{ position: "absolute", left: 470, top: 120 }}>
+              <FlowNode title="Director" icon={<Clapperboard size={16} />} width={440} style={{ position: "relative" }}>
                 <NodeText>
-                  {`You are a trailer director. Turn this logline into a teaser treatment: tone, an escalating beat arc, recurring motifs, and a color palette.`}
+                  {`Writes the storyboard: one shot per beat, each with its own camera direction, under a single style bible.`}
                 </NodeText>
                 <div style={{ padding: "0 8px", marginBottom: 8 }}>
-                  <NodeChip>{`{{ LOGLINE }}`}</NodeChip>
-                  <NodeChip>{`{{ STYLE }}`}</NodeChip>
+                  <NodeChip>screenplay</NodeChip>
+                  <NodeChip>style bible</NodeChip>
+                  <NodeChip>16:9</NodeChip>
                 </div>
-                <HandleRow side="in" color="string" label="Logline" anchorId="treatment.logline" />
-                <HandleRow side="in" color="string" label="Style" anchorId="treatment.style" />
-                <HandleRow side="out" color="string" anchorId="treatment.out" />
+                <HandleRow side="in" color="string" label="Brief" anchorId="director.brief" />
+                <HandleRow side="in" color="string" label="Style" anchorId="director.style" />
+                <HandleRow side="in" color="int" label="Shot Count" anchorId="director.count" />
+                <HandleRow side="out" color="dict" label="screenplay" anchorId="director.out" />
               </FlowNode>
             </div>
 
-            <div data-node="showrunner" style={{ position: "absolute", left: 980, top: 150 }}>
-              <FlowNode title="Showrunner Agent" icon={<Sparkles size={16} />} width={320} control style={{ position: "relative" }}>
-                <NodeProperty label="Returns" mono>
-                  {`Tone · beat arc · motifs · palette`}
+            <div data-node="shots" style={{ position: "absolute", left: 1360, top: 160 }}>
+              <FlowNode title="Screenplay Shots" icon={<List size={16} />} width={320} style={{ position: "relative" }}>
+                <NodeProperty label="Emits">
+                  One image prompt per shot: action, camera, style bible.
                 </NodeProperty>
-                <HandleRow side="in" color="string" label="Prompt" anchorId="showrunner.in" />
-                <HandleRow side="out" color="string" anchorId="showrunner.out" />
-              </FlowNode>
-            </div>
-
-            <div data-node="shotlist" style={{ position: "absolute", left: 1360, top: 160 }}>
-              <FlowNode title="List Generator" icon={<List size={16} />} width={320} style={{ position: "relative" }}>
-                <NodeProperty label="Generates">
-                  One concrete, cinematic shot description per line.
-                </NodeProperty>
-                <HandleRow side="in" color="string" label="Treatment" anchorId="shotlist.treatment" />
-                <HandleRow side="out" color="string" label="item" anchorId="shotlist.item" />
+                <HandleRow side="in" color="dict" label="Screenplay" anchorId="shots.screenplay" />
+                <HandleRow side="out" color="string" label="shot_prompt" anchorId="shots.prompt" />
               </FlowNode>
             </div>
 

--- a/marketing/src/data/templateCatalog.generated.ts
+++ b/marketing/src/data/templateCatalog.generated.ts
@@ -625,14 +625,15 @@ export const templateCatalog: CatalogCategory[] = [
       {
         "slug": "movie-trailer-generator",
         "name": "Movie Trailer Generator",
-        "description": "Type a single logline and get back a cinematic teaser. Prompt nodes template the inputs into a treatment and turn each shot into full cinematic key art; the shots are animated and cut together into the final trailer. Cost note: each shot runs through Veo 3.1 image-to-video, which is metered per second of generated video and is the most expensive step in the pipeline — a 6-shot trailer makes 6 Veo calls.",
+        "description": "Type a single logline and get back a cinematic teaser. The Director node writes the storyboard — a screenplay of shots with camera direction and one style bible — Screenplay Shots turns each shot into an image prompt, and the frames are rendered, animated, and cut together. Cost note: each shot runs through Veo 3.1 image-to-video, which is metered per second of generated video and is the most expensive step in the pipeline — a 6-shot trailer makes 6 Veo calls.",
         "tags": [
           "video",
           "generation",
           "ai",
           "storytelling",
           "creative",
-          "trailer"
+          "trailer",
+          "storyboard"
         ]
       },
       {

--- a/marketing/src/data/templateEntries.generated.ts
+++ b/marketing/src/data/templateEntries.generated.ts
@@ -12994,13 +12994,13 @@ export const templateEntries: TemplateEntry[] = [
   {
     "route": "/templates/movie-trailer-generator",
     "title": "Movie Trailer Generator — NodeTool AI Workflow Template",
-    "description": "Type a single logline and get back a cinematic teaser. Prompt nodes template the inputs into a treatment and turn each shot into full cinematic key art; the shots are animated and cut together into the final trailer. Cost note: each shot runs through Veo 3.1 image-to-video, which is metered per second of generated video and is the most expensive step in the pipeline — a 6-shot trailer makes 6 Veo calls.",
+    "description": "Type a single logline and get back a cinematic teaser. The Director node writes the storyboard — a screenplay of shots with camera direction and one style bible — Screenplay Shots turns each shot into an image prompt, and the frames are rendered, animated, and cut together. Cost note: each shot runs through Veo 3.1 image-to-video, which is metered per second of generated video and is the most expensive step in the pipeline — a 6-shot trailer makes 6 Veo calls.",
     "priority": 0.6,
     "changeFrequency": "monthly",
     "indexable": true,
     "slug": "movie-trailer-generator",
     "name": "Movie Trailer Generator",
-    "summary": "Type a single logline and get back a cinematic teaser. Prompt nodes template the inputs into a treatment and turn each shot into full cinematic key art; the shots are animated and cut together into the final trailer. Cost note: each shot runs through Veo 3.1 image-to-video, which is metered per second of generated video and is the most expensive step in the pipeline — a 6-shot trailer makes 6 Veo calls.",
+    "summary": "Type a single logline and get back a cinematic teaser. The Director node writes the storyboard — a screenplay of shots with camera direction and one style bible — Screenplay Shots turns each shot into an image prompt, and the frames are rendered, animated, and cut together. Cost note: each shot runs through Veo 3.1 image-to-video, which is metered per second of generated video and is the most expensive step in the pipeline — a 6-shot trailer makes 6 Veo calls.",
     "tags": [
       "video",
       "generation",
@@ -13008,24 +13008,15 @@ export const templateEntries: TemplateEntry[] = [
       "storytelling",
       "creative",
       "trailer",
+      "storyboard",
       "example"
     ],
     "category": "Video",
     "nodeTypes": [
       {
-        "type": "nodetool.text.Prompt",
-        "label": "Prompt",
-        "count": 3
-      },
-      {
         "type": "nodetool.input.StringInput",
         "label": "String Input",
-        "count": 3
-      },
-      {
-        "type": "nodetool.agents.Agent",
-        "label": "Agent",
-        "count": 1
+        "count": 2
       },
       {
         "type": "nodetool.control.Collect",
@@ -13038,13 +13029,18 @@ export const templateEntries: TemplateEntry[] = [
         "count": 1
       },
       {
+        "type": "nodetool.creative.Director",
+        "label": "Director",
+        "count": 1
+      },
+      {
         "type": "nodetool.video.ImageToVideo",
         "label": "Image To Video",
         "count": 1
       },
       {
-        "type": "nodetool.generators.ListGenerator",
-        "label": "List Generator",
+        "type": "nodetool.input.IntegerInput",
+        "label": "Integer Input",
         "count": 1
       },
       {
@@ -13053,12 +13049,17 @@ export const templateEntries: TemplateEntry[] = [
         "count": 1
       },
       {
+        "type": "nodetool.creative.ScreenplayShots",
+        "label": "Screenplay Shots",
+        "count": 1
+      },
+      {
         "type": "nodetool.image.TextToImage",
         "label": "Text To Image",
         "count": 1
       }
     ],
-    "nodeCount": 13,
+    "nodeCount": 10,
     "thumbnail": "/templates/movie-trailer-generator.jpg",
     "graph": {
       "nodes": [
@@ -13085,104 +13086,75 @@ export const templateEntries: TemplateEntry[] = [
           "type": "nodetool.input.StringInput",
           "title": "String Input",
           "x": 50,
-          "y": 373,
+          "y": 343,
           "width": 280,
-          "subtitle": "high-contrast daylight, dust and sparks, handheld telephoto, motion blur, hard sun, blown-out sky, gritty"
+          "subtitle": "cinematic film still, theatrical key art, anamorphic framing, high-contrast daylight, dust and sparks, handheld telephoto, motion blur, har…"
         },
         {
           "id": "shot_count",
-          "type": "nodetool.input.StringInput",
-          "title": "String Input",
+          "type": "nodetool.input.IntegerInput",
+          "title": "Integer Input",
           "x": 50,
           "y": 619,
-          "width": 280,
-          "subtitle": "6"
+          "width": 280
         },
         {
-          "id": "treatment_prompt",
-          "type": "nodetool.text.Prompt",
-          "title": "Prompt",
-          "x": 410,
-          "y": 50,
-          "width": 300,
-          "subtitle": "You are a trailer director. Turn this logline into a teaser treatment. Logline: {{ LOGLINE }} Visual style: {{ STYLE }} Shots: {{ COUNT }}…"
-        },
-        {
-          "id": "showrunner",
-          "type": "nodetool.agents.Agent",
-          "title": "Agent",
-          "x": 740,
-          "y": 83,
-          "width": 332,
-          "subtitle": "gpt-5-mini"
-        },
-        {
-          "id": "shotlist_prompt",
-          "type": "nodetool.text.Prompt",
-          "title": "Prompt",
-          "x": 1132,
-          "y": 323,
-          "width": 340,
-          "subtitle": "From this treatment, write exactly {{ COUNT }} cinematic shot descriptions for the teaser, one per line, no numbering or labels. Each line…"
-        },
-        {
-          "id": "shot_list",
-          "type": "nodetool.generators.ListGenerator",
-          "title": "List Generator",
-          "x": 1502,
-          "y": 380,
-          "width": 331,
-          "subtitle": "gpt-5-mini"
-        },
-        {
-          "id": "keyframe_prompt",
-          "type": "nodetool.text.Prompt",
-          "title": "Prompt",
-          "x": 1893,
-          "y": 428,
+          "id": "director",
+          "type": "nodetool.creative.Director",
+          "title": "Director",
+          "x": 430,
+          "y": 180,
           "width": 360,
-          "subtitle": "Cinematic film still, theatrical key art quality, 16:9. Shot: {{ SHOT }} Visual style: {{ STYLE }}. Anamorphic framing, dramatic volumetric…"
+          "subtitle": "gpt-5-mini"
+        },
+        {
+          "id": "shots",
+          "type": "nodetool.creative.ScreenplayShots",
+          "title": "Screenplay Shots",
+          "x": 860,
+          "y": 300,
+          "width": 320
         },
         {
           "id": "keyframe",
           "type": "nodetool.image.TextToImage",
           "title": "Text To Image",
-          "x": 2283,
-          "y": 467,
+          "x": 1250,
+          "y": 330,
           "width": 320,
           "subtitle": "fal-ai/flux/schnell"
         },
         {
-          "id": "e3c7d2b6-dc63-46a0-8e90-3998601e0faf",
+          "id": "animate",
           "type": "nodetool.video.ImageToVideo",
           "title": "Image To Video",
-          "x": 2633,
-          "y": 550,
+          "x": 1640,
+          "y": 400,
           "width": 331,
           "subtitle": "veo-3.1-generate-preview"
         },
         {
-          "id": "b8622937-e6d7-445f-bb19-e254b49a23ef",
-          "type": "nodetool.video.Concat",
-          "title": "Concat",
-          "x": 3185,
-          "y": 534,
-          "width": 320
-        },
-        {
-          "id": "403bb36a-0635-487b-ad4c-02b33ea1ff87",
+          "id": "collect",
           "type": "nodetool.control.Collect",
           "title": "Collect",
-          "x": 2994,
-          "y": 586,
+          "x": 2040,
+          "y": 436,
           "width": 161
+        },
+        {
+          "id": "concat",
+          "type": "nodetool.video.Concat",
+          "title": "Concat",
+          "x": 2260,
+          "y": 384,
+          "width": 320
         },
         {
           "id": "output-trailer",
           "type": "nodetool.output.Output",
           "title": "Output",
-          "x": 3505,
-          "y": 534,
+          "x": 2640,
+          "y": 384,
           "width": 280
         }
       ],
@@ -13190,103 +13162,61 @@ export const templateEntries: TemplateEntry[] = [
         {
           "source": "logline",
           "sourceHandle": "output",
-          "target": "treatment_prompt",
-          "targetHandle": "LOGLINE",
+          "target": "director",
+          "targetHandle": "brief",
           "color": "string"
         },
         {
           "source": "style",
           "sourceHandle": "output",
-          "target": "treatment_prompt",
-          "targetHandle": "STYLE",
+          "target": "director",
+          "targetHandle": "style",
           "color": "string"
         },
         {
           "source": "shot_count",
           "sourceHandle": "output",
-          "target": "treatment_prompt",
-          "targetHandle": "COUNT",
-          "color": "string"
+          "target": "director",
+          "targetHandle": "shot_count",
+          "color": "int"
         },
         {
-          "source": "treatment_prompt",
-          "sourceHandle": "output",
-          "target": "showrunner",
-          "targetHandle": "prompt",
-          "color": "string"
+          "source": "director",
+          "sourceHandle": "screenplay",
+          "target": "shots",
+          "targetHandle": "screenplay",
+          "color": "dict"
         },
         {
-          "source": "showrunner",
-          "sourceHandle": "text",
-          "target": "shotlist_prompt",
-          "targetHandle": "TREATMENT",
-          "color": "string"
-        },
-        {
-          "source": "style",
-          "sourceHandle": "output",
-          "target": "shotlist_prompt",
-          "targetHandle": "STYLE",
-          "color": "string"
-        },
-        {
-          "source": "shot_count",
-          "sourceHandle": "output",
-          "target": "shotlist_prompt",
-          "targetHandle": "COUNT",
-          "color": "string"
-        },
-        {
-          "source": "shotlist_prompt",
-          "sourceHandle": "output",
-          "target": "shot_list",
-          "targetHandle": "prompt",
-          "color": "string"
-        },
-        {
-          "source": "keyframe_prompt",
-          "sourceHandle": "output",
+          "source": "shots",
+          "sourceHandle": "shot_prompt",
           "target": "keyframe",
           "targetHandle": "prompt",
           "color": "string"
         },
         {
-          "source": "shot_list",
-          "sourceHandle": "item",
-          "target": "keyframe_prompt",
-          "targetHandle": "SHOT",
-          "color": "string"
-        },
-        {
           "source": "keyframe",
           "sourceHandle": "output",
-          "target": "e3c7d2b6-dc63-46a0-8e90-3998601e0faf",
+          "target": "animate",
           "targetHandle": "image",
           "color": "image"
         },
         {
-          "source": "e3c7d2b6-dc63-46a0-8e90-3998601e0faf",
+          "source": "animate",
           "sourceHandle": "output",
-          "target": "403bb36a-0635-487b-ad4c-02b33ea1ff87",
+          "target": "collect",
           "targetHandle": "input_item",
           "color": "video"
         },
         {
-          "source": "403bb36a-0635-487b-ad4c-02b33ea1ff87",
+          "source": "collect",
           "sourceHandle": "output",
-          "target": "b8622937-e6d7-445f-bb19-e254b49a23ef",
+          "target": "concat",
           "targetHandle": "ImageToVideo",
           "color": "list"
         },
         {
-          "source": "style",
-          "sourceHandle": "output",
-          "target": "keyframe_prompt",
-          "targetHandle": "STYLE",
-          "color": "string"
-        },
-        {
-          "source": "b8622937-e6d7-445f-bb19-e254b49a23ef",
+          "source": "concat",
           "sourceHandle": "output",
           "target": "output-trailer",
           "targetHandle": "value",

--- a/marketing/src/data/templateEntries.generated.ts
+++ b/marketing/src/data/templateEntries.generated.ts
@@ -13105,7 +13105,7 @@ export const templateEntries: TemplateEntry[] = [
           "x": 430,
           "y": 180,
           "width": 360,
-          "subtitle": "gpt-5-mini"
+          "subtitle": "gemini-3.1-pro-preview"
         },
         {
           "id": "shots",
@@ -13122,7 +13122,7 @@ export const templateEntries: TemplateEntry[] = [
           "x": 1250,
           "y": 330,
           "width": 320,
-          "subtitle": "fal-ai/flux/schnell"
+          "subtitle": "gpt-image-2-text-to-image"
         },
         {
           "id": "animate",

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Movie Trailer Generator.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Movie Trailer Generator.json
@@ -2,10 +2,10 @@
   "id": "movie_trailer_generator",
   "access": "public",
   "created_at": "2026-06-21T00:00:00.000000",
-  "updated_at": "2026-06-27T13:33:47.316Z",
+  "updated_at": "2026-08-03T00:00:00.000Z",
   "name": "Movie Trailer Generator",
   "tool_name": null,
-  "description": "Type a single logline and get back a cinematic teaser. Prompt nodes template the inputs into a treatment and turn each shot into full cinematic key art; the shots are animated and cut together into the final trailer. Cost note: each shot runs through Veo 3.1 image-to-video, which is metered per second of generated video and is the most expensive step in the pipeline \u2014 a 6-shot trailer makes 6 Veo calls.",
+  "description": "Type a single logline and get back a cinematic teaser. The Director node writes the storyboard — a screenplay of shots with camera direction and one style bible — Screenplay Shots turns each shot into an image prompt, and the frames are rendered, animated, and cut together. Cost note: each shot runs through Veo 3.1 image-to-video, which is metered per second of generated video and is the most expensive step in the pipeline — a 6-shot trailer makes 6 Veo calls.",
   "tags": [
     "video",
     "generation",
@@ -13,6 +13,7 @@
     "storytelling",
     "creative",
     "trailer",
+    "storyboard",
     "example"
   ],
   "thumbnail": "Movie Trailer Generator.jpg",
@@ -20,97 +21,53 @@
   "graph": {
     "edges": [
       {
-        "id": "e1",
+        "id": "e-logline-director",
         "source": "logline",
         "sourceHandle": "output",
-        "target": "treatment_prompt",
-        "targetHandle": "LOGLINE",
+        "target": "director",
+        "targetHandle": "brief",
         "ui_properties": {
           "className": "str"
         },
         "edge_type": "data"
       },
       {
-        "id": "e2",
+        "id": "e-style-director",
         "source": "style",
         "sourceHandle": "output",
-        "target": "treatment_prompt",
-        "targetHandle": "STYLE",
+        "target": "director",
+        "targetHandle": "style",
         "ui_properties": {
           "className": "str"
         },
         "edge_type": "data"
       },
       {
-        "id": "e3",
+        "id": "e-count-director",
         "source": "shot_count",
         "sourceHandle": "output",
-        "target": "treatment_prompt",
-        "targetHandle": "COUNT",
+        "target": "director",
+        "targetHandle": "shot_count",
         "ui_properties": {
-          "className": "str"
+          "className": "int"
         },
         "edge_type": "data"
       },
       {
-        "id": "e4",
-        "source": "treatment_prompt",
-        "sourceHandle": "output",
-        "target": "showrunner",
-        "targetHandle": "prompt",
+        "id": "e-director-shots",
+        "source": "director",
+        "sourceHandle": "screenplay",
+        "target": "shots",
+        "targetHandle": "screenplay",
         "ui_properties": {
-          "className": "str"
+          "className": "dict"
         },
         "edge_type": "data"
       },
       {
-        "id": "e5",
-        "source": "showrunner",
-        "sourceHandle": "text",
-        "target": "shotlist_prompt",
-        "targetHandle": "TREATMENT",
-        "ui_properties": {
-          "className": "str"
-        },
-        "edge_type": "data"
-      },
-      {
-        "id": "e6",
-        "source": "style",
-        "sourceHandle": "output",
-        "target": "shotlist_prompt",
-        "targetHandle": "STYLE",
-        "ui_properties": {
-          "className": "str"
-        },
-        "edge_type": "data"
-      },
-      {
-        "id": "e7",
-        "source": "shot_count",
-        "sourceHandle": "output",
-        "target": "shotlist_prompt",
-        "targetHandle": "COUNT",
-        "ui_properties": {
-          "className": "str"
-        },
-        "edge_type": "data"
-      },
-      {
-        "id": "e8",
-        "source": "shotlist_prompt",
-        "sourceHandle": "output",
-        "target": "shot_list",
-        "targetHandle": "prompt",
-        "ui_properties": {
-          "className": "str"
-        },
-        "edge_type": "data"
-      },
-      {
-        "id": "e12",
-        "source": "keyframe_prompt",
-        "sourceHandle": "output",
+        "id": "e-shots-keyframe",
+        "source": "shots",
+        "sourceHandle": "shot_prompt",
         "target": "keyframe",
         "targetHandle": "prompt",
         "ui_properties": {
@@ -119,21 +76,10 @@
         "edge_type": "data"
       },
       {
-        "id": "102da298-35fb-4e11-b9c1-09c61e246260",
-        "source": "shot_list",
-        "sourceHandle": "item",
-        "target": "keyframe_prompt",
-        "targetHandle": "SHOT",
-        "ui_properties": {
-          "className": "str"
-        },
-        "edge_type": "data"
-      },
-      {
-        "id": "1889e486-1dfe-467c-bafd-88fa3de7eb18",
+        "id": "e-keyframe-animate",
         "source": "keyframe",
         "sourceHandle": "output",
-        "target": "e3c7d2b6-dc63-46a0-8e90-3998601e0faf",
+        "target": "animate",
         "targetHandle": "image",
         "ui_properties": {
           "className": "image"
@@ -141,10 +87,10 @@
         "edge_type": "data"
       },
       {
-        "id": "c43efef4-548f-4176-8485-4bae2d5f7949",
-        "source": "e3c7d2b6-dc63-46a0-8e90-3998601e0faf",
+        "id": "e-animate-collect",
+        "source": "animate",
         "sourceHandle": "output",
-        "target": "403bb36a-0635-487b-ad4c-02b33ea1ff87",
+        "target": "collect",
         "targetHandle": "input_item",
         "ui_properties": {
           "className": "video"
@@ -152,10 +98,10 @@
         "edge_type": "data"
       },
       {
-        "id": "dec0ec9d-0ea3-4b4c-b8e2-1ec1f9927fee",
-        "source": "403bb36a-0635-487b-ad4c-02b33ea1ff87",
+        "id": "e-collect-concat",
+        "source": "collect",
         "sourceHandle": "output",
-        "target": "b8622937-e6d7-445f-bb19-e254b49a23ef",
+        "target": "concat",
         "targetHandle": "ImageToVideo",
         "ui_properties": {
           "className": "list"
@@ -163,19 +109,8 @@
         "edge_type": "data"
       },
       {
-        "id": "849b832f-8c49-488e-b21a-71c7367a2465",
-        "source": "style",
-        "sourceHandle": "output",
-        "target": "keyframe_prompt",
-        "targetHandle": "STYLE",
-        "ui_properties": {
-          "className": "str"
-        },
-        "edge_type": "data"
-      },
-      {
         "id": "edge-output-trailer",
-        "source": "b8622937-e6d7-445f-bb19-e254b49a23ef",
+        "source": "concat",
         "sourceHandle": "output",
         "target": "output-trailer",
         "targetHandle": "value",
@@ -187,7 +122,7 @@
         "id": "comment",
         "type": "nodetool.workflows.base_node.Comment",
         "data": {
-          "comment": "# \ud83c\udfac Movie Trailer Generator\n\nType one logline and the canvas builds a cinematic teaser. Prompt nodes do the work: one templates the inputs into a trailer treatment, one turns each shot into full cinematic key art.\n\n**Pipeline:** Logline \u2192 Treatment \u2192 Shot prompts \u2192 Keyframes \u2192 Image-to-Video \u2192 Concat\n\n**Cost note:** the Image-to-Video step runs on Veo 3.1, billed per second of generated video \u2014 the most expensive node here. A 6-shot trailer fires 6 Veo calls, so raising Shot Count raises cost linearly.\n\n**Try this:** change the visual style or shot count, or swap the image / video model."
+          "comment": "# 🎬 Movie Trailer Generator\n\nType one logline and the canvas builds a cinematic teaser. The Director node writes the storyboard in one step — the same node the Storyboard editor runs behind its Direct button — so the screenplay, the camera direction, and one style bible applied to every shot all come out of a single node.\n\n**Pipeline:** Logline → Director (storyboard) → Screenplay Shots → Keyframes → Image-to-Video → Concat\n\n**Cost note:** the Image-to-Video step runs on Veo 3.1, billed per second of generated video — the most expensive node here. A 6-shot trailer fires 6 Veo calls, so raising Shot Count raises cost linearly.\n\n**Try this:** change the visual style or shot count, or swap the image / video model."
         },
         "ui_properties": {
           "position": {
@@ -208,7 +143,7 @@
         "type": "nodetool.input.StringInput",
         "data": {
           "name": "Logline",
-          "value": "A getaway driver speeds onto a bridge as it starts to collapse \u2014 and the only way out is to outrun the gap."
+          "value": "A getaway driver speeds onto a bridge as it starts to collapse — and the only way out is to outrun the gap."
         },
         "ui_properties": {
           "position": {
@@ -217,7 +152,7 @@
           },
           "zIndex": 0,
           "width": 280,
-          "title": "1\ufe0f\u20e3 Logline",
+          "title": "1️⃣ Logline",
           "selectable": true,
           "bypassed": false
         },
@@ -229,16 +164,16 @@
         "type": "nodetool.input.StringInput",
         "data": {
           "name": "Visual Style",
-          "value": "high-contrast daylight, dust and sparks, handheld telephoto, motion blur, hard sun, blown-out sky, gritty"
+          "value": "cinematic film still, theatrical key art, anamorphic framing, high-contrast daylight, dust and sparks, handheld telephoto, motion blur, hard sun, blown-out sky, fine film grain, gritty"
         },
         "ui_properties": {
           "position": {
             "x": 50,
-            "y": 373
+            "y": 343
           },
           "zIndex": 0,
           "width": 280,
-          "title": "2\ufe0f\u20e3 Visual style",
+          "title": "2️⃣ Visual style",
           "selectable": true,
           "bypassed": false
         },
@@ -247,10 +182,12 @@
       },
       {
         "id": "shot_count",
-        "type": "nodetool.input.StringInput",
+        "type": "nodetool.input.IntegerInput",
         "data": {
           "name": "Shot Count",
-          "value": "6"
+          "value": 6,
+          "min": 1,
+          "max": 20
         },
         "ui_properties": {
           "position": {
@@ -258,42 +195,17 @@
             "y": 619
           },
           "zIndex": 0,
+          "selectable": true,
+          "bypassed": false,
           "width": 280,
-          "title": "3\ufe0f\u20e3 Shot count",
-          "selectable": true,
-          "bypassed": false
+          "title": "3️⃣ Shot count"
         },
         "dynamic_properties": {},
         "dynamic_outputs": {}
       },
       {
-        "id": "treatment_prompt",
-        "type": "nodetool.text.Prompt",
-        "data": {
-          "prompt": "You are a trailer director. Turn this logline into a teaser treatment.\n\nLogline: {{ LOGLINE }}\nVisual style: {{ STYLE }}\nShots: {{ COUNT }}\n\nReturn Markdown, no commentary:\n\nTone: 1-2 lines on the feeling the teaser must land.\nArc: {{ COUNT }} escalating beats, each one vivid sentence, building to a final reveal.\nMotifs: 2-3 recurring visual motifs to carry across every shot.\nPalette: 3-5 colors as Name + mood."
-        },
-        "ui_properties": {
-          "position": {
-            "x": 410,
-            "y": 50
-          },
-          "zIndex": 0,
-          "width": 300,
-          "height": 420,
-          "title": "Build treatment prompt",
-          "selectable": true,
-          "bypassed": false
-        },
-        "dynamic_properties": {
-          "LOGLINE": "A getaway driver speeds onto a bridge as it starts to collapse \u2014 and the only way out is to outrun the gap.",
-          "STYLE": "high-contrast daylight, dust and sparks, handheld telephoto, motion blur, hard sun, blown-out sky, gritty",
-          "COUNT": "6"
-        },
-        "dynamic_outputs": {}
-      },
-      {
-        "id": "showrunner",
-        "type": "nodetool.agents.Agent",
+        "id": "director",
+        "type": "nodetool.creative.Director",
         "data": {
           "model": {
             "type": "language_model",
@@ -303,100 +215,46 @@
             "path": null,
             "supported_tasks": []
           },
-          "system": "You are a film trailer director and editor. You write tight, cinematic teaser treatments. Every line is visual and concrete. No fluff, no meta commentary.",
-          "max_tokens": 100000
+          "brief": "",
+          "style": "",
+          "shot_count": 6,
+          "aspect_ratio": "16:9",
+          "max_tokens": 8192
         },
         "ui_properties": {
           "position": {
-            "x": 740,
-            "y": 83
+            "x": 430,
+            "y": 180
           },
           "zIndex": 0,
-          "width": 332,
-          "height": 353,
-          "title": "4\ufe0f\u20e3 Write the treatment",
           "selectable": true,
-          "bypassed": false
-        },
-        "dynamic_properties": {},
-        "dynamic_outputs": {}
-      },
-      {
-        "id": "shotlist_prompt",
-        "type": "nodetool.text.Prompt",
-        "data": {
-          "prompt": "From this treatment, write exactly {{ COUNT }} cinematic shot descriptions for the teaser, one per line, no numbering or labels. Each line is a single concrete image: subject, setting, camera and lens, lighting, motion. Carry the treatment's motifs and palette through every shot.\n\nVisual style: {{ STYLE }}\n\nTreatment:\n{{ TREATMENT }}"
-        },
-        "ui_properties": {
-          "position": {
-            "x": 1132,
-            "y": 323
-          },
-          "zIndex": 0,
-          "width": 340,
-          "height": 360,
-          "title": "Build shot-list prompt",
-          "selectable": true,
-          "bypassed": false
-        },
-        "dynamic_properties": {
-          "COUNT": "6",
-          "STYLE": "high-contrast daylight, dust and sparks, handheld telephoto, motion blur, hard sun, blown-out sky, gritty",
-          "TREATMENT": ""
-        },
-        "dynamic_outputs": {}
-      },
-      {
-        "id": "shot_list",
-        "type": "nodetool.generators.ListGenerator",
-        "data": {
-          "model": {
-            "type": "language_model",
-            "provider": "openai",
-            "id": "gpt-5-mini",
-            "name": "GPT-5 mini",
-            "path": null,
-            "supported_tasks": []
-          },
-          "max_tokens": 100000
-        },
-        "ui_properties": {
-          "position": {
-            "x": 1502,
-            "y": 380
-          },
-          "zIndex": 0,
-          "width": 331,
-          "height": 245,
-          "title": "5\ufe0f\u20e3 Generate shot prompts",
-          "selectable": true,
-          "bypassed": false
-        },
-        "dynamic_properties": {},
-        "dynamic_outputs": {}
-      },
-      {
-        "id": "keyframe_prompt",
-        "type": "nodetool.text.Prompt",
-        "data": {
-          "prompt": "Cinematic film still, theatrical key art quality, 16:9.\n\nShot: {{ SHOT }}\n\nVisual style: {{ STYLE }}. Anamorphic framing, dramatic volumetric lighting, rich cinematic color grading, fine film grain, atmospheric depth, photoreal detail. No on-screen text, no titles, no logos, no watermark, no distorted anatomy."
-        },
-        "ui_properties": {
-          "position": {
-            "x": 1893,
-            "y": 428
-          },
-          "zIndex": 0,
+          "bypassed": false,
           "width": 360,
-          "height": 420,
-          "title": "Build keyframe prompt",
+          "height": 400,
+          "title": "4️⃣ Direct the storyboard"
+        },
+        "dynamic_properties": {},
+        "dynamic_outputs": {}
+      },
+      {
+        "id": "shots",
+        "type": "nodetool.creative.ScreenplayShots",
+        "data": {
+          "screenplay": {}
+        },
+        "ui_properties": {
+          "position": {
+            "x": 860,
+            "y": 300
+          },
+          "zIndex": 0,
           "selectable": true,
-          "bypassed": false
+          "bypassed": false,
+          "width": 320,
+          "height": 260,
+          "title": "5️⃣ One prompt per shot"
         },
-        "dynamic_properties": {
-          "SHOT": "",
-          "STYLE": "high-contrast daylight, dust and sparks, handheld telephoto, motion blur, hard sun, blown-out sky, gritty"
-        },
+        "dynamic_properties": {},
         "dynamic_outputs": {}
       },
       {
@@ -411,7 +269,7 @@
             "path": null,
             "supported_tasks": []
           },
-          "negative_prompt": "",
+          "negative_prompt": "on-screen text, titles, logos, watermark, distorted anatomy",
           "aspect_ratio": "16:9",
           "resolution": "2K",
           "timeout_seconds": 0
@@ -419,13 +277,13 @@
         "ui_properties": {
           "selected": false,
           "position": {
-            "x": 2283,
-            "y": 467
+            "x": 1250,
+            "y": 330
           },
           "zIndex": 0,
           "width": 320,
           "height": 342,
-          "title": "6\ufe0f\u20e3 Render keyframes",
+          "title": "6️⃣ Render keyframes",
           "selectable": true,
           "bypassed": false,
           "selected_generation": "133f0bef77d34f2bbb3cbc49a97b592b",
@@ -435,7 +293,7 @@
         "dynamic_outputs": {}
       },
       {
-        "id": "e3c7d2b6-dc63-46a0-8e90-3998601e0faf",
+        "id": "animate",
         "type": "nodetool.video.ImageToVideo",
         "data": {
           "model": {
@@ -455,13 +313,13 @@
         "ui_properties": {
           "selected": false,
           "position": {
-            "x": 2633,
-            "y": 550
+            "x": 1640,
+            "y": 400
           },
           "zIndex": 0,
           "width": 331,
           "height": 222,
-          "title": "7\ufe0f\u20e3 Animate each keyframe (Veo, metered per second)",
+          "title": "7️⃣ Animate each keyframe (Veo, metered per second)",
           "selectable": true,
           "bypassed": false,
           "selected_generation": "8fb0f284a8e54876858f8155aff3dd5d",
@@ -478,36 +336,14 @@
         "dynamic_outputs": {}
       },
       {
-        "id": "b8622937-e6d7-445f-bb19-e254b49a23ef",
-        "type": "nodetool.video.Concat",
-        "data": {},
-        "ui_properties": {
-          "selected": false,
-          "position": {
-            "x": 3185,
-            "y": 534
-          },
-          "zIndex": 0,
-          "width": 320,
-          "height": 280,
-          "title": "\ud83c\udfac Final trailer",
-          "selectable": true,
-          "bypassed": false
-        },
-        "dynamic_properties": {
-          "ImageToVideo": ""
-        },
-        "dynamic_outputs": {}
-      },
-      {
-        "id": "403bb36a-0635-487b-ad4c-02b33ea1ff87",
+        "id": "collect",
         "type": "nodetool.control.Collect",
         "data": {},
         "ui_properties": {
           "selected": false,
           "position": {
-            "x": 2994,
-            "y": 586
+            "x": 2040,
+            "y": 436
           },
           "zIndex": 0,
           "width": 161,
@@ -520,6 +356,28 @@
         "dynamic_outputs": {}
       },
       {
+        "id": "concat",
+        "type": "nodetool.video.Concat",
+        "data": {},
+        "ui_properties": {
+          "selected": false,
+          "position": {
+            "x": 2260,
+            "y": 384
+          },
+          "zIndex": 0,
+          "width": 320,
+          "height": 280,
+          "title": "🎬 Final trailer",
+          "selectable": true,
+          "bypassed": false
+        },
+        "dynamic_properties": {
+          "ImageToVideo": ""
+        },
+        "dynamic_outputs": {}
+      },
+      {
         "id": "output-trailer",
         "type": "nodetool.output.Output",
         "data": {
@@ -527,10 +385,10 @@
         },
         "ui_properties": {
           "position": {
-            "x": 3505,
-            "y": 534
+            "x": 2640,
+            "y": 384
           },
-          "title": "8\ufe0f\u20e3 Trailer output",
+          "title": "8️⃣ Trailer output",
           "selectable": true
         }
       }
@@ -546,5 +404,5 @@
   "required_providers": null,
   "required_models": null,
   "html_app": null,
-  "etag": "3304e8bd39421697cc5bd574c6428dee"
+  "etag": null
 }

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Movie Trailer Generator.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Movie Trailer Generator.json
@@ -209,9 +209,9 @@
         "data": {
           "model": {
             "type": "language_model",
-            "provider": "openai",
-            "id": "gpt-5-mini",
-            "name": "GPT-5 mini",
+            "provider": "gemini",
+            "id": "gemini-3.1-pro-preview",
+            "name": "Gemini 3.1 Pro Preview",
             "path": null,
             "supported_tasks": []
           },
@@ -263,9 +263,9 @@
         "data": {
           "model": {
             "type": "image_model",
-            "provider": "fal_ai",
-            "id": "fal-ai/flux/schnell",
-            "name": "FLUX.1 Schnell",
+            "provider": "kie",
+            "id": "gpt-image-2-text-to-image",
+            "name": "GPT Image-2",
             "path": null,
             "supported_tasks": []
           },

--- a/packages/base-nodes/nodetool/package_metadata/nodetool-base.json
+++ b/packages/base-nodes/nodetool/package_metadata/nodetool-base.json
@@ -514,7 +514,7 @@
     {
       "id": "movie_trailer_generator",
       "name": "Movie Trailer Generator",
-      "description": "Type a single logline and get back a cinematic teaser. Prompt nodes template the inputs into a treatment and turn each shot into full cinematic key art; the shots are animated and cut together into the final trailer.",
+      "description": "Type a single logline and get back a cinematic teaser. The Director node writes the storyboard — a screenplay of shots with camera direction and one style bible — Screenplay Shots turns each shot into an image prompt, and the frames are rendered, animated, and cut together.",
       "tags": [
         "video",
         "generation",
@@ -522,6 +522,7 @@
         "storytelling",
         "creative",
         "trailer",
+        "storyboard",
         "example"
       ]
     },

--- a/packages/base-nodes/tests/exported-node-coverage.test.ts
+++ b/packages/base-nodes/tests/exported-node-coverage.test.ts
@@ -84,5 +84,8 @@ describe("exported base node coverage audit", () => {
     );
 
     expect(missing).toEqual([]);
-  });
+    // Reads every test file in every package: fast locally (~0.3 s), but on a
+    // cold CI filesystem with the rest of the suite running in parallel it has
+    // overrun the 5 s default.
+  }, 30000);
 });


### PR DESCRIPTION
## What

The Movie Trailer Generator example hand-rolled the direction layer: three `nodetool.text.Prompt` nodes and an `Agent` templated a treatment, a `ListGenerator` split it into shot lines, and another Prompt turned each line into key art.

`nodetool.creative.Director` already does all of that in one node — it is the node the Storyboard editor runs behind its **Direct** button (`web/src/hooks/storyboard/useDirectScreenplay.ts`) — and `nodetool.creative.ScreenplayShots` fans the screenplay out into one image prompt per shot, camera direction and style bible included.

**No new node was needed.** The wiring mirrors the already-shipped `Directed Film to Timeline` example.

### Before → after

```
Logline ┐
Style   ├→ Prompt → Agent → Prompt → ListGenerator → Prompt → TextToImage → ImageToVideo → Collect → Concat → Output
Count   ┘
```
```
Logline ┐
Style   ├→ Director → Screenplay Shots → TextToImage → ImageToVideo → Collect → Concat → Output
Count   ┘
```

14 nodes → 11, four prompt-templating nodes gone.

- Shot count becomes an `IntegerInput` (Director types `shot_count` as an int).
- The key-art wording that lived in a Prompt node moves into the style input — which becomes the screenplay's style bible, so `composeShotPrompt` puts it in every shot — and into the image node's negative prompt.
- Everything downstream of the keyframe render is unchanged.

## Models

The use-case page and the shipped graph had drifted apart: the page listed Gemini 3.1 Pro Preview and GPT Image-2 while the JSON pinned `openai/gpt-5-mini` and `fal-ai/flux/schnell`. The page keeps its names, and the graph now runs them — `gemini/gemini-3.1-pro-preview` on the Director, `kie/gpt-image-2-text-to-image` on the keyframe render. Veo 3.1 on the animate step is unchanged.

## Marketing / docs

The use-case page followed the old graph, so: steps, the rendered `MovieTrailerGraph`, the tweak cards, and the hero and meta copy all describe the Director/storyboard pipeline now, as does `docs/use-cases/movie-trailer.md`. Generated template catalog/entries regenerated.

## Verification

- `nodetool validate "…/Movie Trailer Generator.json"` → valid, 11 nodes, 9 edges (one informational untyped-dynamic-slot note on the pre-existing `Concat` input).
- `packages/base-nodes` `example-workflows-validation` + `example-workflows-execute` (1788 tests) pass. Under fake providers the trailer graph runs Director → Screenplay Shots → TextToImage → ImageToVideo → Collect and stops only at `Concat` on missing `ffprobe` in the sandbox — the same known outcome the suite already records for video examples.
- `marketing` `seo:check` clean; web and electron typecheck clean. (Mobile typecheck and the marketing tsc run report missing-dependency errors in this sandbox — those deps aren't installed — and no files in either were touched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qtw1kdD9fkZ1wXQiMNYFY1