### PR TITLE
fix(websocket): close the socket of a rejected WebSocket upgrade

### DIFF
--- a/packages/websocket/src/lib/ws-upgrade.ts
+++ b/packages/websocket/src/lib/ws-upgrade.ts
@@ -1,0 +1,52 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+/** True when this request is a WebSocket handshake rather than a plain call. */
+export function isWebSocketUpgrade(req: FastifyRequest): boolean {
+  return req.headers["upgrade"]?.toLowerCase() === "websocket";
+}
+
+/**
+ * Refuse a request with 401, closing the connection when it is a WebSocket
+ * handshake.
+ *
+ * An upgrade cannot be refused through `reply.send()`. @fastify/websocket
+ * dispatches the handshake through the normal Fastify stack against a
+ * `ServerResponse` it assigned to the raw socket by hand, so that socket is
+ * outside the HTTP server's connection bookkeeping: writing a response to it
+ * closes nothing. The plugin does clean up after a refused upgrade, but from an
+ * `onResponse` hook gated on the `request.ws` flag its own `onRequest` hook
+ * sets — and hooks run in registration order, so an auth hook registered before
+ * the plugin short-circuits first and that cleanup never runs.
+ *
+ * The socket then outlives the request. The peer goes away, it parks in
+ * CLOSE_WAIT, and its descriptor is never released — one leaked fd per rejected
+ * connect. A client retrying a stale token exhausts the process's fd limit in
+ * hours, after which `accept()` fails and the server resets every incoming
+ * connection, health checks included.
+ *
+ * So answer the handshake on the socket and destroy it. `reply.hijack()` takes
+ * the request out of Fastify's lifecycle first, since we own the response from
+ * that point on.
+ */
+export function denyUnauthorized(
+  req: FastifyRequest,
+  reply: FastifyReply,
+  body: { error: string }
+): void {
+  if (!isWebSocketUpgrade(req)) {
+    reply.status(401).send(body);
+    return;
+  }
+
+  reply.hijack();
+
+  const socket = req.raw.socket;
+  if (!socket || socket.destroyed) return;
+  socket.write(
+    "HTTP/1.1 401 Unauthorized\r\n" +
+      "Connection: close\r\n" +
+      "Content-Length: 0\r\n" +
+      "\r\n"
+  );
+  socket.destroy();
+}

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -30,6 +30,7 @@ import { zipExtensionDist } from "./lib/extension-dist.js";
 import {
   isPublicAuthExemptRoute
 } from "./lib/public-routes.js";
+import { isWebSocketUpgrade, denyUnauthorized } from "./lib/ws-upgrade.js";
 import {
   resolveTrustLocalhost,
   isLoopbackAddress,
@@ -850,7 +851,7 @@ app.addHook("onRequest", async (req, reply) => {
   }
 
   // Extract token from the appropriate source
-  const isWs = req.headers["upgrade"]?.toLowerCase() === "websocket";
+  const isWs = isWebSocketUpgrade(req);
   const searchParams = new URLSearchParams(req.url.split("?")[1] ?? "");
   const provider = supabaseProvider ?? localProvider!;
   const token = isWs
@@ -862,12 +863,12 @@ app.addHook("onRequest", async (req, reply) => {
 
   if (supabaseMode) {
     if (!token) {
-      reply.status(401).send({ error: "Unauthorized" });
+      denyUnauthorized(req, reply, { error: "Unauthorized" });
       return;
     }
     const result = await supabaseProvider!.verifyToken(token);
     if (!result.ok) {
-      reply.status(401).send({ error: result.error ?? "Unauthorized" });
+      denyUnauthorized(req, reply, { error: result.error ?? "Unauthorized" });
       return;
     }
     req.userId = result.userId ?? null;
@@ -875,7 +876,9 @@ app.addHook("onRequest", async (req, reply) => {
     return;
   }
 
-  reply.status(401).send({ error: "Remote access requires authentication" });
+  denyUnauthorized(req, reply, {
+    error: "Remote access requires authentication"
+  });
 });
 
 // WebSocket support

--- a/packages/websocket/tests/ws-upgrade-auth-rejection.test.ts
+++ b/packages/websocket/tests/ws-upgrade-auth-rejection.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import fastifyWebSocket from "@fastify/websocket";
+import { connect, type AddressInfo, type Socket } from "node:net";
+
+import { denyUnauthorized } from "../src/lib/ws-upgrade.js";
+
+let app: FastifyInstance | null = null;
+
+afterEach(async () => {
+  await app?.close();
+  app = null;
+});
+
+/**
+ * A server shaped like the real one: a global `onRequest` hook that refuses
+ * everything, plus a WebSocket route the hook must keep unreachable.
+ */
+async function startServer(): Promise<{
+  port: number;
+  sockets: Set<Socket>;
+}> {
+  const instance = Fastify();
+
+  const sockets = new Set<Socket>();
+  instance.server.on("connection", (socket) => sockets.add(socket as Socket));
+
+  // Registration order matters, and this is the order server.ts uses: the auth
+  // hook goes on before @fastify/websocket. Fastify runs onRequest hooks in
+  // registration order, so a 401 here short-circuits before the plugin's own
+  // hook can mark the request as an upgrade — which is what its onResponse
+  // cleanup keys off to destroy the socket. Register the plugin first and the
+  // leak hides.
+  instance.addHook("onRequest", async (req, reply) => {
+    denyUnauthorized(req, reply, { error: "Unauthorized" });
+  });
+
+  await instance.register(fastifyWebSocket);
+
+  instance.get("/ws", { websocket: true }, () => {
+    throw new Error("a rejected upgrade must never reach the route handler");
+  });
+  instance.get("/api/thing", async () => ({ ok: true }));
+
+  await instance.listen({ port: 0, host: "127.0.0.1" });
+  app = instance;
+
+  return { port: (instance.server.address() as AddressInfo).port, sockets };
+}
+
+/**
+ * Open a WebSocket handshake, read whatever comes back, then walk away without
+ * a close handshake — what a browser tab or a proxy does when it gives up on a
+ * reconnect. The server, not the client, is responsible for the socket after
+ * this point.
+ */
+function rejectedUpgrade(port: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let received = "";
+    const client = connect(port, "127.0.0.1", () => {
+      client.write(
+        "GET /ws HTTP/1.1\r\n" +
+          `Host: 127.0.0.1:${port}\r\n` +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+          "Sec-WebSocket-Version: 13\r\n\r\n"
+      );
+    });
+    client.on("data", (chunk) => {
+      received += chunk.toString();
+    });
+    client.on("error", reject);
+    setTimeout(() => {
+      client.end();
+      setTimeout(() => resolve(received), 200);
+    }, 200);
+  });
+}
+
+describe("denyUnauthorized", () => {
+  it("destroys the socket of a rejected WebSocket upgrade", async () => {
+    const { port, sockets } = await startServer();
+
+    const response = await rejectedUpgrade(port);
+    expect(response).toContain("401");
+
+    // The leak this guards: answering an upgrade through `reply.send()` leaves
+    // the socket open. The peer is gone, so it parks in CLOSE_WAIT and its
+    // descriptor is never released — one per rejected connect, until the
+    // process hits its fd limit and stops accepting anything at all.
+    const leaked = [...sockets].filter((socket) => !socket.destroyed);
+    expect(leaked).toHaveLength(0);
+  });
+
+  it("still refuses a plain HTTP request through the normal reply path", async () => {
+    const { port } = await startServer();
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/thing`);
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+  });
+});


### PR DESCRIPTION
## The outage

The Fly app wedged on **Jul 31 03:16** and stayed down until restarted today — 3.5 days. Health check `servicecheck-00-http-7777` critical with output `EOF`; every request to nodetool.fly.dev timed out.

The process was alive the whole time: listening on 7777, 970 MB / 3916 used, load 0.00, timers still firing. It just could not accept a connection.

**File descriptors: 10240 / 10240.** Of 10219 socket fds, **7581 were in CLOSE_WAIT**, all on local port 7777, all from the Fly edge proxy. Once at the ceiling `accept()` fails, so the server resets every incoming connection instantly — I measured a 0.27 ms RST from *inside* the VM against 127.0.0.1. The `File-watch sweep failed` spam flooding the logs was a symptom: the sweep couldn't get a socket either.

Ruled out along the way: Supabase was `ACTIVE_HEALTHY` at 15/60 connections, `DATABASE_URL` and the pooler host were correct (connected with psql and ran the failing query fine), migrations applied, not memory, not OOM.

## Root cause

An upgrade refused by the auth hook leaks its file descriptor.

`@fastify/websocket` dispatches a handshake through the normal Fastify stack against a `ServerResponse` it assigns to the raw socket by hand, so the socket sits outside the HTTP server's connection bookkeeping — writing a response to it closes nothing.

The plugin *does* clean up after a refused upgrade, but from an `onResponse` hook gated on the `request.ws` flag its own `onRequest` hook sets. Fastify runs `onRequest` hooks in registration order, and `server.ts` registers the auth hook at line 796 and the plugin at line 885. So the 401 short-circuits first, the plugin never marks the request, and the cleanup never runs.

The socket outlives the request, parks in CLOSE_WAIT once the peer gives up, and is never released. One leaked descriptor per rejected connect. A client retrying a stale token exhausts 10240 in hours — the machine booted Jul 30 13:08 and wedged Jul 31 03:16, 14h08m later.

This only fires when `enforceAuth` is on (`AUTH_PROVIDER=supabase`), which is why it never reproduces locally, where loopback is trusted.

## The fix

The three 401s route through `denyUnauthorized`. Plain requests reply as before; an upgrade gets `reply.hijack()`, a raw 401, and `socket.destroy()`.

Explicit rather than reordering the plugin registration — the deny path should own the socket it refuses instead of depending on hook order.

## Verification

Reproduced 1:1 against the **deployed bundle**, running a second isolated copy on the machine (own port, throwaway SQLite, no prod DB):

| exercise | fds |
|---|---|
| 500 plain HTTP requests | flat at 26 |
| 100 WS connect/close, auth **off** | 26 → 76 → back to 26 |
| 100 WS connect/close, auth **on** | 26 → 76 → **stays 76** → 126 → **stays 126** |

100 of that server's 102 socket fds were in CLOSE_WAIT — the production signature exactly.

The regression test registers the hook before the plugin, the way `server.ts` does. **Register them the other way round and the leak hides** — my first version of this test did, and passed against the bug. With the correct ordering it fails twice over: the socket isn't destroyed, and `app.close()` hangs for 10s on the leaked socket. With the fix, green in 0.8s.

Full `packages/websocket` suite on Node 22.22.1: **1765 passed, 0 failed**. 29 files fail to load on a missing `@nodetool-ai/protocol` build artifact; stashing this change reproduces those failures identically on baseline. `tsc --noEmit`: 7 errors, all that same artifact, none in the changed files.

**Not verified:** the built bundle end to end — the worktree can't build. The mechanism is proven and the test is real, but the first true end-to-end proof is this deploy. Worth watching `fds` on the machine for a day after merge.

## Follow-up, not in this PR

`@fastify/rate-limit` is registered at line 724, also before the WS plugin, so a 429 on an upgrade leaks the same way. And `trustProxy` is false, so behind Fly every user shares one rate-limit key (the proxy IP) — the 1000/min limit is effectively site-wide. Same bug class, left out because I have not reproduced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)