### PR TITLE
Move the chat composer off the dashboard into the empty tab view

### DIFF
--- a/web/src/components/chat/containers/ChatComposerLayout.tsx
+++ b/web/src/components/chat/containers/ChatComposerLayout.tsx
@@ -5,11 +5,9 @@ import { ComposerSlotProvider } from "../composer/composerSlotContext";
 import PersistentComposer from "../composer/PersistentComposer";
 
 /**
- * Layout route wrapping the start page (/dashboard) and the chat view
- * (/chat/:thread_id). Keeps a single composer instance mounted across
- * navigation between the two so the composer's draft text and focus survive and
- * its position can be animated (FLIP) from the centered start-page slot to the
- * pinned-bottom chat slot.
+ * Layout route wrapping the chat view (/chat/:thread_id). Keeps a single
+ * composer instance mounted across navigation between threads so its draft text
+ * and focus survive and its position can be FLIP-animated between slots.
  */
 const ChatComposerLayout: React.FC = () => {
   return (

--- a/web/src/components/portal/DashboardHero.tsx
+++ b/web/src/components/portal/DashboardHero.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
 import { useTheme } from "@mui/material/styles";
-import { memo, type ReactNode } from "react";
+import { memo } from "react";
 import { MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 import WelcomeFlow from "./WelcomeFlow";
 import { wrapStyles } from "./dashboardChrome";
@@ -35,10 +35,6 @@ const heroStyles = (theme: Theme) =>
         paddingTop: getSpacingPx(SPACING.md),
         paddingBottom: getSpacingPx(SPACING.md)
       }
-    },
-    ".hero-composer": {
-      margin: `${getSpacingPx(7)} auto 0`, // was 26px auto 0
-      maxWidth: 720
     },
     ".hero-foot": {
       marginTop: getSpacingPx(SPACING.md),
@@ -89,15 +85,12 @@ interface DashboardHeroProps {
   onPickTrack: (trackId: WelcomeTrackId) => void;
   onOpenEmptyCanvas: () => void;
   onOpenSettings: () => void;
-  /** The persistent-composer slot, anchored below the modality cards. */
-  composer: ReactNode;
 }
 
 const DashboardHero: React.FC<DashboardHeroProps> = ({
   onPickTrack,
   onOpenEmptyCanvas,
-  onOpenSettings,
-  composer
+  onOpenSettings
 }) => {
   const theme = useTheme();
 
@@ -111,8 +104,6 @@ const DashboardHero: React.FC<DashboardHeroProps> = ({
           fullWidth
           hideFooter
         />
-
-        <div className="hero-composer">{composer}</div>
 
         <div className="hero-foot">
           <button

--- a/web/src/components/portal/Portal.tsx
+++ b/web/src/components/portal/Portal.tsx
@@ -9,10 +9,8 @@ import { usePortalChat } from "./usePortalChat";
 import { useDashboardData } from "../../hooks/useDashboardData";
 import { useWorkflowActions } from "../../hooks/useWorkflowActions";
 import useSecretsStore from "../../stores/SecretsStore";
-import { useEnsureChatConnected } from "../../hooks/useEnsureChatConnected";
 import { usePanelStore } from "../../stores/PanelStore";
-import { Message, MessageContent, LanguageModel } from "../../stores/ApiTypes";
-import ComposerSlot from "../chat/composer/ComposerSlot";
+import { LanguageModel } from "../../stores/ApiTypes";
 import PortalSetupFlow from "./PortalSetupFlow";
 import DashboardHero from "./DashboardHero";
 import DashboardDownloads from "./DashboardDownloads";
@@ -77,18 +75,14 @@ const Portal: React.FC = () => {
   const theme = useTheme();
   const navigate = useNavigate();
   const [portalState, setPortalState] = useState<PortalState>("idle");
-  const [pendingMessage, setPendingMessage] = useState<string | null>(null);
   const [pendingTrack, setPendingTrack] = useState<WelcomeTrackId | null>(null);
-
-  useEnsureChatConnected({ disconnectOnUnmount: false });
 
   // The dashboard wants the full width; collapse the left panel on entry.
   useEffect(() => {
     usePanelStore.getState().setVisibility(false);
   }, []);
 
-  const { selectedModel, sendMessage, newThread, setSelectedModel } =
-    usePortalChat();
+  const { setSelectedModel } = usePortalChat();
   const { sortedWorkflows, isLoadingWorkflows } = useDashboardData();
   const { handleCreateNewWorkflow } = useWorkflowActions();
 
@@ -137,38 +131,8 @@ const Portal: React.FC = () => {
     navigate("/dashboard");
   }, [navigate]);
 
-  const sendAndNavigate = useCallback(
-    async (content: MessageContent[], _prompt: string) => {
-      const threadId = await newThread();
-      if (!threadId) return;
-      const message: Message = {
-        type: "message",
-        role: "user",
-        content,
-        thread_id: threadId,
-        created_at: new Date().toISOString(),
-        model: selectedModel?.id
-      };
-      await sendMessage(message);
-      navigate(`/chat/${threadId}`);
-    },
-    [newThread, sendMessage, navigate, selectedModel]
-  );
-
-  const handleSendMessage = useCallback(
-    async (content: MessageContent[], prompt: string) => {
-      if (!hasConfiguredProvider) {
-        setPendingMessage(prompt);
-        setPortalState("setup");
-        return;
-      }
-      await sendAndNavigate(content, prompt);
-    },
-    [hasConfiguredProvider, sendAndNavigate]
-  );
-
   const handleSetupComplete = useCallback(
-    async (defaultModel: string | null) => {
+    (defaultModel: string | null) => {
       if (defaultModel) {
         const [provider, ...idParts] = defaultModel.split(":");
         const id = idParts.join(":");
@@ -186,26 +150,13 @@ const Portal: React.FC = () => {
         const trackId = pendingTrack;
         setPendingTrack(null);
         createStarterWorkflow(trackId);
-        return;
-      }
-      if (pendingMessage) {
-        const text = pendingMessage;
-        setPendingMessage(null);
-        await sendAndNavigate([{ type: "text", text }], text);
       }
     },
-    [
-      pendingTrack,
-      pendingMessage,
-      setSelectedModel,
-      createStarterWorkflow,
-      sendAndNavigate
-    ]
+    [pendingTrack, setSelectedModel, createStarterWorkflow]
   );
 
   const handleSetupBack = useCallback(() => {
     setPendingTrack(null);
-    setPendingMessage(null);
     setPortalState("idle");
   }, []);
 
@@ -246,12 +197,6 @@ const Portal: React.FC = () => {
             onPickTrack={handlePickTrack}
             onOpenEmptyCanvas={handleCreateNewWorkflow}
             onOpenSettings={handleOpenSettings}
-            composer={
-              <ComposerSlot
-                className="chat-input-section"
-                onSend={handleSendMessage}
-              />
-            }
           />
           <GettingStartedChecklist
             hasConfiguredProvider={hasConfiguredProvider}

--- a/web/src/components/workspace/WorkspaceEmptyView.tsx
+++ b/web/src/components/workspace/WorkspaceEmptyView.tsx
@@ -1,0 +1,111 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import type { Theme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
+import { memo, useCallback, useEffect, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import useGlobalChatStore from "../../stores/GlobalChatStore";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import type { Message, MessageContent } from "../../stores/ApiTypes";
+import ChatInputSection from "../chat/containers/ChatInputSection";
+import { Caption, SPACING, getSpacingPx } from "../ui_primitives";
+
+const styles = (theme: Theme) =>
+  css({
+    position: "absolute",
+    inset: 0,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: getSpacingPx(SPACING.lg),
+    padding: theme.spacing(0, 3),
+    textAlign: "center",
+    color: theme.vars.palette.text.secondary,
+
+    ".empty-composer": {
+      width: "100%",
+      maxWidth: 720,
+      display: "flex",
+      justifyContent: "center"
+    }
+  });
+
+/**
+ * Shown in the workspace when no tabs are open. Carries the chat composer that
+ * used to live on the dashboard hero: a message sent here creates a thread,
+ * opens it as a chat tab, and delivers the message to that tab.
+ */
+const WorkspaceEmptyView = () => {
+  const theme = useTheme();
+  const emptyStyles = useMemo(() => styles(theme), [theme]);
+
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+
+  const { status, selectedModel, setSelectedModel, stopGeneration } =
+    useGlobalChatStore(
+      useShallow((state) => ({
+        status: state.status,
+        selectedModel: state.selectedModel,
+        setSelectedModel: state.setSelectedModel,
+        stopGeneration: state.stopGeneration
+      }))
+    );
+  const connect = useGlobalChatStore((state) => state.connect);
+
+  useEffect(() => {
+    connect().catch((error) => {
+      console.error("Failed to connect chat:", error);
+    });
+  }, [connect]);
+
+  const handleSend = useCallback(
+    async (content: MessageContent[]) => {
+      const store = useGlobalChatStore.getState();
+      try {
+        const threadId = await store.createNewThread();
+        openTab({
+          type: "chat",
+          ref: threadId,
+          mode: "view",
+          title: "New chat"
+        });
+        const message: Message = {
+          type: "message",
+          role: "user",
+          content,
+          thread_id: threadId,
+          created_at: new Date().toISOString(),
+          model: store.selectedModel?.id
+        };
+        await store.sendMessage(message, threadId);
+      } catch (error) {
+        console.error("Failed to start chat:", error);
+      }
+    },
+    [openTab]
+  );
+
+  // ChatInputSection has no "stopping" state; the composer treats it as idle.
+  const inputStatus = status === "stopping" ? "connected" : status;
+
+  return (
+    <div css={emptyStyles} className="workspace-empty">
+      <Caption color="secondary">
+        No tabs open — ask below to start a chat, or use + to open a document.
+      </Caption>
+      <div className="empty-composer">
+        <ChatInputSection
+          status={inputStatus}
+          onSendMessage={handleSend}
+          onStop={stopGeneration}
+          selectedModel={selectedModel}
+          onModelChange={setSelectedModel}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default memo(WorkspaceEmptyView);

--- a/web/src/components/workspace/WorkspaceShell.tsx
+++ b/web/src/components/workspace/WorkspaceShell.tsx
@@ -16,7 +16,8 @@ import {
 } from "../../config/constants";
 import WorkspaceTabBar from "./WorkspaceTabBar";
 import TabContent from "./TabContent";
-import { Caption, Z_INDEX } from "../ui_primitives";
+import WorkspaceEmptyView from "./WorkspaceEmptyView";
+import { Z_INDEX } from "../ui_primitives";
 
 const ACTIVE_TAB_STYLE: React.CSSProperties = {
   opacity: 1,
@@ -88,16 +89,6 @@ const styles = (theme: Theme) =>
       flexDirection: "column",
       minHeight: 0,
       minWidth: 0
-    },
-    "& .workspace-empty": {
-      position: "absolute",
-      inset: 0,
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      textAlign: "center",
-      padding: theme.spacing(0, 3),
-      color: theme.vars.palette.text.secondary
     }
   });
 
@@ -174,13 +165,7 @@ const WorkspaceShell = () => {
             className="workspace-content"
             style={{ marginLeft: contentMarginLeft }}
           >
-            {tabs.length === 0 && (
-              <div className="workspace-empty">
-                <Caption color="secondary">
-                  No tabs open — use + to open or create a document.
-                </Caption>
-              </div>
-            )}
+            {tabs.length === 0 && <WorkspaceEmptyView />}
             {tabs.map((tab) => {
               const isActive = tab.id === activeTabId;
               return (

--- a/web/src/components/workspace/__tests__/WorkspaceEmptyView.test.tsx
+++ b/web/src/components/workspace/__tests__/WorkspaceEmptyView.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+
+import WorkspaceEmptyView from "../WorkspaceEmptyView";
+import mockTheme from "../../../__mocks__/themeMock";
+import type { MessageContent } from "../../../stores/ApiTypes";
+
+const openTab = jest.fn();
+const createNewThread = jest.fn().mockResolvedValue("thread-1");
+const sendMessage = jest.fn().mockResolvedValue(undefined);
+const connect = jest.fn().mockResolvedValue(undefined);
+const stopGeneration = jest.fn();
+const setSelectedModel = jest.fn();
+
+const chatState = {
+  status: "connected",
+  selectedModel: { type: "language_model", provider: "openai", id: "gpt-5" },
+  setSelectedModel,
+  stopGeneration,
+  createNewThread,
+  sendMessage,
+  connect
+};
+
+jest.mock("../../../stores/GlobalChatStore", () => {
+  const useStore = (selector: (state: unknown) => unknown) =>
+    selector(chatState);
+  useStore.getState = () => chatState;
+  return { __esModule: true, default: useStore };
+});
+
+jest.mock("../../../stores/WorkspaceTabsStore", () => ({
+  __esModule: true,
+  useWorkspaceTabsStore: (selector: (state: unknown) => unknown) =>
+    selector({ openTab })
+}));
+
+jest.mock("../../chat/containers/ChatInputSection", () => ({
+  __esModule: true,
+  default: ({
+    onSendMessage
+  }: {
+    onSendMessage: (content: MessageContent[], prompt: string) => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() => onSendMessage([{ type: "text", text: "hello" }], "hello")}
+    >
+      send
+    </button>
+  )
+}));
+
+const renderEmptyView = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <WorkspaceEmptyView />
+    </ThemeProvider>
+  );
+
+describe("WorkspaceEmptyView", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the composer with the empty-workspace hint", () => {
+    renderEmptyView();
+    expect(screen.getByText(/No tabs open/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "send" })).toBeInTheDocument();
+  });
+
+  it("opens a chat tab for the new thread and sends the message to it", async () => {
+    const user = userEvent.setup();
+    renderEmptyView();
+
+    await user.click(screen.getByRole("button", { name: "send" }));
+
+    await waitFor(() => expect(createNewThread).toHaveBeenCalled());
+    expect(openTab).toHaveBeenCalledWith({
+      type: "chat",
+      ref: "thread-1",
+      mode: "view",
+      title: "New chat"
+    });
+    await waitFor(() =>
+      expect(sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          role: "user",
+          thread_id: "thread-1",
+          content: [{ type: "text", text: "hello" }]
+        }),
+        "thread-1"
+      )
+    );
+  });
+});

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -193,16 +193,16 @@ function getRoutes() {
       element: <NavigateToStart />
     },
     {
+      path: "/dashboard",
+      element: (
+        <ProtectedRoute>
+          <Portal />
+        </ProtectedRoute>
+      )
+    },
+    {
       element: <ChatComposerLayout />,
       children: [
-        {
-          path: "/dashboard",
-          element: (
-            <ProtectedRoute>
-              <Portal />
-            </ProtectedRoute>
-          )
-        },
         {
           path: "/chat/:thread_id?",
           element: (


### PR DESCRIPTION
The chat composer no longer sits in the dashboard hero. It now lives in the workspace's empty state: with no tabs open, the center renders the composer instead of the one-line "No tabs open" hint.

## Changes

- **`web/src/components/workspace/WorkspaceEmptyView.tsx`** (new) — the empty-workspace view: the hint plus a `ChatInputSection`. Sending creates a thread, opens it as a `chat` tab, and delivers the message to that thread (`sendMessage(message, threadId)`), so the user stays in the workspace instead of navigating to `/chat/:id`.
- **`WorkspaceShell.tsx`** — renders `WorkspaceEmptyView` when `tabs.length === 0`; its inline `.workspace-empty` styles moved into the new component.
- **`portal/DashboardHero.tsx`** — drops the `composer` prop and the `.hero-composer` slot styles.
- **`portal/Portal.tsx`** — removes the `ComposerSlot`, the send/navigate handlers, and the `pendingMessage` setup detour. The provider-setup flow still gates starter tracks (`pendingTrack`).
- **`index.tsx` / `ChatComposerLayout.tsx`** — `/dashboard` routes on its own now; the layout exists to hand one composer instance between slots, and the dashboard no longer has one. It still wraps `/chat/:thread_id`.
- **`__tests__/WorkspaceEmptyView.test.tsx`** (new) — asserts the composer renders and that a send opens the chat tab for the new thread and targets it.

## Notes

- The dashboard's "no provider key yet → run setup first" detour applied only to the composer path; a send from the empty view goes straight through, and a key-less user gets the normal chat error. The setup flow still fires for the starter-track path on the dashboard.
- `npx jest` on the new test passes; `tsc --noEmit` reports nothing on the touched files (the remaining repo-wide errors are pre-existing, from unbuilt package `dist/`s in this sandbox). ESLint clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkovhhJBwsabu4oAAQsrE8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkovhhJBwsabu4oAAQsrE8)_