### PR TITLE
fix(web): detect server-side runtimes so ffmpeg isn't reported missing in Docker

### DIFF
--- a/packages/websocket/src/lib/runtime-detection.ts
+++ b/packages/websocket/src/lib/runtime-detection.ts
@@ -1,0 +1,108 @@
+/**
+ * Detects which external runtimes (ffmpeg, pandoc, yt-dlp, …) are present on
+ * the machine running the server.
+ *
+ * The desktop app answers this over Electron IPC, because it also installs the
+ * runtimes. A browser client — the web build, and every Docker/Fly deployment —
+ * has no such channel, so without this it assumed nothing was installed and
+ * showed "Requires FFmpeg" on nodes that run fine, since the container ships
+ * ffmpeg.
+ *
+ * Detection is a PATH scan for an executable file, not a spawn: it costs a few
+ * `access()` calls, cannot hang, and cannot run client-supplied strings.
+ * Results are cached briefly so a canvas full of video nodes probes once.
+ */
+import { constants as fsConstants, promises as fs } from "node:fs";
+import path from "node:path";
+
+/**
+ * Runtime ids whose executable is named differently from the id. Ids not
+ * listed here are probed under their own name (`ffmpeg`, `pandoc`, `tmux`, …).
+ */
+const RUNTIME_COMMANDS: Record<string, string> = {
+  nodejs: "node",
+  pdftotext: "pdftotext",
+  pdftoppm: "pdftoppm"
+};
+
+/** The runtimes a client gets when it asks for no particular ones. */
+export const KNOWN_RUNTIMES = [
+  "python",
+  "nodejs",
+  "bash",
+  "ruby",
+  "lua",
+  "ffmpeg",
+  "ffprobe",
+  "pandoc",
+  "pdftotext",
+  "pdftoppm",
+  "yt-dlp",
+  "tmux",
+  "claude"
+] as const;
+
+/** Ids that are safe to probe: a bare command name, nothing path-like. */
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/;
+
+const CACHE_TTL_MS = 30_000;
+const cache = new Map<string, { installed: boolean; at: number }>();
+
+function candidateNames(command: string): string[] {
+  if (process.platform !== "win32") return [command];
+  const exts = (process.env["PATHEXT"] ?? ".EXE;.CMD;.BAT;.COM").split(";");
+  return [command, ...exts.filter(Boolean).map((ext) => command + ext)];
+}
+
+async function isExecutable(file: string): Promise<boolean> {
+  try {
+    await fs.access(file, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Whether `command` resolves to an executable on PATH. */
+export async function hasExecutable(command: string): Promise<boolean> {
+  const dirs = (process.env["PATH"] ?? "").split(path.delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    for (const name of candidateNames(command)) {
+      if (await isExecutable(path.join(dir, name))) return true;
+    }
+  }
+  return false;
+}
+
+export interface RuntimeStatus {
+  id: string;
+  installed: boolean;
+}
+
+/**
+ * Report install status for each runtime id. Unknown-but-safe ids are probed
+ * under their own name; an id that isn't a bare command name reports
+ * `installed: false` rather than touching the filesystem with it.
+ */
+export async function detectRuntimes(
+  ids: readonly string[] = KNOWN_RUNTIMES
+): Promise<RuntimeStatus[]> {
+  const now = Date.now();
+  return Promise.all(
+    ids.map(async (id) => {
+      if (!SAFE_ID.test(id)) return { id, installed: false };
+      const cached = cache.get(id);
+      if (cached && now - cached.at < CACHE_TTL_MS) {
+        return { id, installed: cached.installed };
+      }
+      const installed = await hasExecutable(RUNTIME_COMMANDS[id] ?? id);
+      cache.set(id, { installed, at: now });
+      return { id, installed };
+    })
+  );
+}
+
+/** Drop cached probe results (tests, and after an install changes PATH). */
+export function clearRuntimeDetectionCache(): void {
+  cache.clear();
+}

--- a/packages/websocket/src/trpc/routers/packs.ts
+++ b/packages/websocket/src/trpc/routers/packs.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
 import { getPackSnapshot, reloadPacks } from "../../pack-snapshot.js";
+import { detectRuntimes, KNOWN_RUNTIMES } from "../../lib/runtime-detection.js";
 import {
   readBuiltinPackOverrides,
   readPackTrustFromFile,
@@ -104,6 +105,25 @@ export const packsRouter = router({
   list: protectedProcedure.output(packsListOutput).query(() => ({
     packs: getPackSnapshot().map(toDto)
   })),
+
+  /**
+   * Which external runtimes (ffmpeg, pandoc, yt-dlp, …) are on the *server's*
+   * PATH. The desktop app answers this over Electron IPC; browser clients —
+   * including every Docker deployment — have no IPC and ask the server that
+   * would actually spawn the binary.
+   */
+  runtimeStatuses: protectedProcedure
+    .input(
+      z.object({ ids: z.array(z.string()).max(64).optional() }).optional()
+    )
+    .output(
+      z.object({
+        statuses: z.array(z.object({ id: z.string(), installed: z.boolean() }))
+      })
+    )
+    .query(async ({ input }) => ({
+      statuses: await detectRuntimes(input?.ids ?? KNOWN_RUNTIMES)
+    })),
 
   /** Effective trust config (env + config file + defaults merged). */
   getTrust: protectedProcedure.output(trustSchema).query(() =>

--- a/packages/websocket/tests/runtime-detection.test.ts
+++ b/packages/websocket/tests/runtime-detection.test.ts
@@ -1,0 +1,74 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearRuntimeDetectionCache,
+  detectRuntimes,
+  hasExecutable,
+  KNOWN_RUNTIMES
+} from "../src/lib/runtime-detection.js";
+
+const origPath = process.env["PATH"];
+let dir: string;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), "nodetool-runtime-detect-"));
+  await fs.writeFile(path.join(dir, "ffmpeg"), "#!/bin/sh\n", { mode: 0o755 });
+  await fs.writeFile(path.join(dir, "notexec"), "#!/bin/sh\n", { mode: 0o644 });
+  process.env["PATH"] = dir;
+  clearRuntimeDetectionCache();
+});
+
+afterEach(async () => {
+  process.env["PATH"] = origPath;
+  clearRuntimeDetectionCache();
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe("hasExecutable", () => {
+  it("finds an executable on PATH", async () => {
+    await expect(hasExecutable("ffmpeg")).resolves.toBe(true);
+  });
+
+  it("ignores a file that is not executable", async () => {
+    await expect(hasExecutable("notexec")).resolves.toBe(false);
+  });
+
+  it("reports a missing command as absent", async () => {
+    await expect(hasExecutable("definitely-not-here")).resolves.toBe(false);
+  });
+});
+
+describe("detectRuntimes", () => {
+  it("reports ffmpeg installed when it is on PATH", async () => {
+    const statuses = await detectRuntimes(["ffmpeg", "pandoc"]);
+    expect(statuses).toEqual([
+      { id: "ffmpeg", installed: true },
+      { id: "pandoc", installed: false }
+    ]);
+  });
+
+  it("covers every known runtime by default", async () => {
+    const statuses = await detectRuntimes();
+    expect(statuses.map((s) => s.id)).toEqual([...KNOWN_RUNTIMES]);
+  });
+
+  it("refuses path-like ids instead of probing them", async () => {
+    const statuses = await detectRuntimes(["../../bin/sh", "ff mpeg", ""]);
+    expect(statuses.every((s) => !s.installed)).toBe(true);
+  });
+
+  it("caches a probe result", async () => {
+    await detectRuntimes(["ffmpeg"]);
+    await fs.rm(path.join(dir, "ffmpeg"));
+    await expect(detectRuntimes(["ffmpeg"])).resolves.toEqual([
+      { id: "ffmpeg", installed: true }
+    ]);
+    clearRuntimeDetectionCache();
+    await expect(detectRuntimes(["ffmpeg"])).resolves.toEqual([
+      { id: "ffmpeg", installed: false }
+    ]);
+  });
+});

--- a/web/src/__mocks__/trpcClientMock.ts
+++ b/web/src/__mocks__/trpcClientMock.ts
@@ -138,6 +138,12 @@ export const trpcClient = {
   skills: {
     list: { query: emptyQuery() }
   },
+  packs: {
+    list: { query: emptyQuery() },
+    listBuiltins: { query: emptyQuery() },
+    getTrust: { query: emptyQuery() },
+    runtimeStatuses: { query: jest.fn(async () => ({ statuses: [] })) }
+  },
   users: {
     list: { query: emptyQuery() },
     get: { query: emptyQuery() },

--- a/web/src/components/node/NodeDependencyWarning.helpers.ts
+++ b/web/src/components/node/NodeDependencyWarning.helpers.ts
@@ -1,3 +1,5 @@
+import { trpcClient } from "../../trpc/client";
+
 export const RUNTIME_LABELS: Record<string, string> = {
   ffmpeg: "FFmpeg & Codecs",
   python: "Python",
@@ -34,19 +36,41 @@ export const RUNTIME_TO_PACKAGE_ID: Record<string, string> = {
 let cachedStatuses: Record<string, boolean> | null = null;
 let fetchPromise: Promise<void> | null = null;
 
+function toStatusMap(
+  statuses: Array<{ id: string; installed: boolean }>
+): Record<string, boolean> {
+  const map: Record<string, boolean> = {};
+  for (const s of statuses) {
+    map[s.id] = s.installed;
+    // The Electron API keys by package id, the server by runtime id; index
+    // both so lookups don't have to know which source answered.
+    const pkgId = RUNTIME_TO_PACKAGE_ID[s.id];
+    if (pkgId) {map[pkgId] = s.installed;}
+  }
+  return map;
+}
+
+/**
+ * Load runtime statuses from the desktop app when it's there, otherwise from
+ * the server — which is the machine that would spawn ffmpeg anyway, so its
+ * PATH is the one that decides whether a node can run.
+ */
 export async function refreshRuntimeStatuses(): Promise<void> {
   const api = window.api;
-  if (!api?.packages?.getRuntimeStatuses) {return;}
-  try {
-    const statuses: Array<{ id: string; installed: boolean }> =
-      await api.packages.getRuntimeStatuses();
-    const map: Record<string, boolean> = {};
-    for (const s of statuses) {
-      map[s.id] = s.installed;
+  if (api?.packages?.getRuntimeStatuses) {
+    try {
+      cachedStatuses = toStatusMap(await api.packages.getRuntimeStatuses());
+    } catch {
+      // If IPC fails, assume nothing is installed so warnings stay visible.
     }
-    cachedStatuses = map;
+    return;
+  }
+  try {
+    const res = await trpcClient.packs.runtimeStatuses.query();
+    cachedStatuses = toStatusMap(res.statuses);
   } catch {
-    // If IPC fails, assume nothing is installed so warnings stay visible.
+    // Server unreachable or too old for the endpoint: leave the cache empty,
+    // which keeps the warnings visible.
   }
 }
 

--- a/web/src/components/node/NodeDependencyWarning.tsx
+++ b/web/src/components/node/NodeDependencyWarning.tsx
@@ -93,12 +93,6 @@ const NodeDependencyWarning: FC<NodeDependencyWarningProps> = ({
   const openPackageManager = useOpenPackageManager();
 
   const checkRuntimes = useCallback(async (forceRefresh = false) => {
-    if (!isElectron) {
-      setMissingRuntimes(requiredRuntimes);
-      setLoading(false);
-      return;
-    }
-
     // Only refresh statuses when cache is empty or explicitly forced.
     await ensureRuntimeStatuses(forceRefresh);
 
@@ -109,7 +103,7 @@ const NodeDependencyWarning: FC<NodeDependencyWarningProps> = ({
     });
     setMissingRuntimes(missing);
     setLoading(false);
-  }, [requiredRuntimes, isElectron]);
+  }, [requiredRuntimes]);
 
   useEffect(() => {
     let cancelled = false;
@@ -177,7 +171,8 @@ const NodeDependencyWarning: FC<NodeDependencyWarningProps> = ({
         </button>
       ) : (
         <div className="warning-text">
-          This runtime must be installed on your system to use this node.
+          Install it on the machine running the NodeTool server to use this
+          node.
         </div>
       )}
     </div>

--- a/web/src/components/node/__tests__/NodeDependencyWarning.helpers.test.ts
+++ b/web/src/components/node/__tests__/NodeDependencyWarning.helpers.test.ts
@@ -5,6 +5,10 @@ import {
   refreshRuntimeStatuses,
   ensureRuntimeStatuses
 } from "../NodeDependencyWarning.helpers";
+import { trpcClient } from "../../../trpc/client";
+
+const runtimeStatusesQuery = trpcClient.packs.runtimeStatuses
+  .query as unknown as jest.Mock;
 
 describe("RUNTIME_LABELS", () => {
   it("maps every runtime to a human-readable label", () => {
@@ -30,19 +34,48 @@ describe("getCachedRuntimeStatuses", () => {
 });
 
 describe("refreshRuntimeStatuses", () => {
-  it("returns early when window.api is unavailable", async () => {
+  afterEach(() => {
+    runtimeStatusesQuery.mockReset();
+    runtimeStatusesQuery.mockResolvedValue({ statuses: [] });
+  });
+
+  it("asks the server when window.api is unavailable", async () => {
     const w = window as unknown as Record<string, unknown>;
     const origApi = w.api;
     w.api = undefined;
-    await expect(refreshRuntimeStatuses()).resolves.toBeUndefined();
+    runtimeStatusesQuery.mockResolvedValue({
+      statuses: [{ id: "ffmpeg", installed: true }]
+    });
+    await refreshRuntimeStatuses();
+    expect(runtimeStatusesQuery).toHaveBeenCalled();
+    expect(getCachedRuntimeStatuses()?.["ffmpeg"]).toBe(true);
     w.api = origApi;
   });
 
-  it("returns early when packages.getRuntimeStatuses is missing", async () => {
+  it("asks the server when packages.getRuntimeStatuses is missing", async () => {
     const w = window as unknown as Record<string, unknown>;
     const origApi = w.api;
     w.api = { packages: {} };
-    await expect(refreshRuntimeStatuses()).resolves.toBeUndefined();
+    runtimeStatusesQuery.mockResolvedValue({
+      statuses: [{ id: "ffmpeg", installed: false }]
+    });
+    await refreshRuntimeStatuses();
+    expect(runtimeStatusesQuery).toHaveBeenCalled();
+    expect(getCachedRuntimeStatuses()?.["ffmpeg"]).toBe(false);
+    w.api = origApi;
+  });
+
+  it("prefers the desktop IPC when it is there", async () => {
+    const w = window as unknown as Record<string, unknown>;
+    const origApi = w.api;
+    const getRuntimeStatuses = jest
+      .fn()
+      .mockResolvedValue([{ id: "ffmpeg", installed: true }]);
+    w.api = { packages: { getRuntimeStatuses } };
+    await refreshRuntimeStatuses();
+    expect(getRuntimeStatuses).toHaveBeenCalled();
+    expect(runtimeStatusesQuery).not.toHaveBeenCalled();
+    expect(getCachedRuntimeStatuses()?.["ffmpeg"]).toBe(true);
     w.api = origApi;
   });
 });

--- a/web/src/components/packages/usePackageManager.ts
+++ b/web/src/components/packages/usePackageManager.ts
@@ -250,8 +250,10 @@ export function usePackageManager(params: {
     void fetchThirdParty();
   }, [fetchThirdParty]);
   useEffect(() => {
-    if (!rtAvailable) return;
+    // Refresh in the browser too: the server reports what is on its PATH, so
+    // the list shows real status even where installing needs the desktop app.
     void rtRefresh();
+    if (!rtAvailable) return;
     rtSubscribe();
     return () => rtUnsubscribe();
   }, [rtAvailable, rtRefresh, rtSubscribe, rtUnsubscribe]);
@@ -408,15 +410,21 @@ export function usePackageManager(params: {
           name: rt.name,
           desc: rt.description,
           badge: rt.installed ? "installed" : "notInstalled",
-          buttons: {
-            install: !rt.installed,
-            update: false,
-            uninstall: rt.installed,
-            busy,
-            onInstall: () => void rtInstall(rt.id),
-            onUpdate: () => {},
-            onUninstall: () => void rtUninstall(rt.id)
-          }
+          // Installing runs through the desktop app; in the browser the row is
+          // status-only.
+          ...(rtAvailable
+            ? {
+                buttons: {
+                  install: !rt.installed,
+                  update: false,
+                  uninstall: rt.installed,
+                  busy,
+                  onInstall: () => void rtInstall(rt.id),
+                  onUpdate: () => {},
+                  onUninstall: () => void rtUninstall(rt.id)
+                }
+              }
+            : {})
         };
       });
     } else if (cat === "included") {

--- a/web/src/stores/RuntimePackagesStore.ts
+++ b/web/src/stores/RuntimePackagesStore.ts
@@ -14,6 +14,24 @@ import { create } from "zustand";
 import type { StoreApi } from "zustand";
 
 import { createErrorMessage } from "../utils/errorHandling";
+import { trpcClient } from "../trpc/client";
+
+/** Display names for the runtimes the server reports (it sends bare ids). */
+const SERVER_RUNTIME_LABELS: Record<string, string> = {
+  python: "Python",
+  nodejs: "Node.js",
+  bash: "Bash",
+  ruby: "Ruby",
+  lua: "Lua",
+  ffmpeg: "FFmpeg",
+  ffprobe: "ffprobe",
+  pandoc: "Pandoc",
+  pdftotext: "PDF Tools (pdftotext)",
+  pdftoppm: "PDF Tools (pdftoppm)",
+  "yt-dlp": "yt-dlp",
+  tmux: "tmux",
+  claude: "Claude Code CLI"
+};
 
 interface RuntimePackageStatus {
   id: string;
@@ -98,7 +116,31 @@ const useRuntimePackagesStore = create<RuntimePackagesStore>((set, get) => ({
   refresh: async () => {
     const api = runtimeApi();
     if (!api) {
-      set({ available: false });
+      // No desktop IPC (browser / Docker deployment): the server can still say
+      // what is on its PATH, so the list reports real status even though
+      // installing from here isn't possible.
+      set({ available: false, isLoading: true, error: null });
+      try {
+        const res = await trpcClient.packs.runtimeStatuses.query();
+        set({
+          statuses: res.statuses.map(({ id, installed }) => ({
+            id,
+            name: SERVER_RUNTIME_LABELS[id] ?? id,
+            description: installed
+              ? "Installed on the server."
+              : "Not installed on the server.",
+            installed,
+            installing: false
+          })),
+          isLoading: false
+        });
+      } catch (err: unknown) {
+        set({
+          isLoading: false,
+          error: createErrorMessage(err, "Failed to load runtime packages")
+            .message
+        });
+      }
       return;
     }
     set({ isLoading: true, error: null });


### PR DESCRIPTION
## The bug

In the production Docker image ffmpeg is installed (`Dockerfile` line 125), but the UI reports it as missing: video and document nodes show a "Requires FFmpeg & Codecs" warning, and the Package Manager's **Software** tab lists nothing.

Runtime detection went only through Electron IPC:

- `NodeDependencyWarning.tsx` returned `setMissingRuntimes(requiredRuntimes)` — everything missing — whenever `window.api` was absent, which is every browser client.
- `RuntimePackagesStore.refresh()` bailed out with `available: false` and an empty status list for the same reason.

So any non-desktop deployment reported "not installed" regardless of what was actually on the machine that runs the binary.

## The fix

- **New `packs.runtimeStatuses` tRPC query** (`packages/websocket/src/lib/runtime-detection.ts`) reporting which runtimes are on the *server's* PATH. Detection is a PATH scan for an executable file rather than a spawn: it can't hang, and it can't run client-supplied strings — ids must be bare command names (`^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$`), anything path-like reports `installed: false` without touching the filesystem. Results cache for 30s so a canvas full of video nodes probes once.
- **`NodeDependencyWarning`** uses the desktop IPC when present and the server otherwise. The server is the machine that would spawn ffmpeg anyway, so its PATH is what decides whether a node can run. The non-desktop copy now points at the right machine ("Install it on the machine running the NodeTool server").
- **Package Manager Software tab** shows real status in the browser, with install buttons hidden — installing runtimes still needs the desktop app, and the existing desktop-only notice stays.

A failed probe leaves the cache empty, which keeps the warnings visible — a server too old for the endpoint behaves as it does today.

## Tests

- `packages/websocket/tests/runtime-detection.test.ts` — PATH hit/miss, non-executable file, path-like ids refused, default runtime list, cache behavior.
- `NodeDependencyWarning.helpers.test.ts` — server fallback in both no-IPC shapes, and that the desktop IPC still wins when it's there.

`npm run typecheck` (web + electron), `npm run lint`, `packages/websocket` (2076 tests), and the touched web suites (787 tests) all pass. Mobile typecheck fails in this sandbox because its Expo dependencies aren't installed — unrelated to this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKdZPmFkNMvfj65cYDcgyY)_