### PR TITLE
Validate provider and model ids when a workflow is created and run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,11 +567,24 @@ code: `packages/websocket/src/lib/app-build-service.ts`.
 ### nodetool validate (Static Workflow Check)
 
 Checks a workflow against the node registry **without running it** — unknown
-node types, missing required properties, unselected models, dangling and
-mis-typed edges, dynamic slots typed with a JSON-Schema/TypeScript name instead
-of NodeTool's (`integer` → `int`), and Code node bodies. Returns in well under a
-second, so it's the cheap pre-flight before an expensive `debug` run. Accepts a
-workflow id, JSON file, or DSL `.ts` file. File/DSL targets need no database.
+node types, missing required properties, unselected models, model properties
+naming an unregistered provider or a model id that provider does not offer,
+dangling and mis-typed edges, dynamic slots typed with a
+JSON-Schema/TypeScript name instead of NodeTool's (`integer` → `int`), and Code
+node bodies. Returns in well under a second, so it's the cheap pre-flight
+before an expensive `debug` run. Accepts a workflow id, JSON file, or DSL `.ts`
+file. File/DSL targets need no database.
+
+Model references are found wherever they sit — a top-level property, an entry
+in a `list[…_model]`, one nested in a settings object, or a dynamic slot value.
+Both catalogs fail toward silence: an empty provider list means the registry
+could not be reached, and a catalog only enumerable over the network (Anthropic,
+Ollama, ASR ids anywhere) reports nothing rather than calling a real id a typo.
+The check runs at graph *creation* time too — `submit_graph`/`finish_graph`
+reject a provider or model the planner hallucinated, `create_workflow` refuses
+to save one — and `POST /api/workflows/:id/run|debug` refuses the run with a
+400 before the job row exists, instead of failing on the model node after the
+upstream half of the graph has been paid for.
 
 A `nodetool.code.Code` node's `code` is parsed, not just stored: a body that is
 not valid JavaScript, uses `import`/`export` (the sandbox has no module loader),

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -196,8 +196,11 @@ from inside an agent:
 
 - **`validate_workflow`** — static check of an inline `graph` ({nodes, edges})
   being built or a saved `workflow_id`: unknown node types, missing required
-  props, unselected models, dangling/mis-typed edges. Sub-second. Run it before
-  the expensive `debug`.
+  props, unselected models, unregistered providers, model ids the provider does
+  not offer, dangling/mis-typed edges. Sub-second. Run it before the expensive
+  `debug`. `create_workflow` and `POST /api/workflows/:id/run|debug` apply the
+  provider/model half of this check themselves, so a hallucinated model id is
+  refused at save and at run rather than surfacing mid-execution.
 - **`debug_workflow`** — run a workflow and return status, outputs, errors, job
   logs, and a graph overview in one call.
 - **`build_app`** — build a mini app from a prompt (or a pinned `BuildSpec`) and

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -153,7 +153,7 @@ close the build→verify loop. Run from source with `npm run dev:nodetool -- <cm
 
 | Command | Harness | When |
 |---|---|---|
-| `validate <id\|file>` (`validate.ts`) | Static graph check — unknown nodes, missing props, unselected models, dangling/mis-typed edges | **Cheap pre-flight before any run.** Sub-second; no DB for file/DSL targets. Core: `validateGraph` in `node-sdk` |
+| `validate <id\|file>` (`validate.ts`) | Static graph check — unknown nodes, missing props, unselected models, unregistered providers, model ids the provider does not offer, dangling/mis-typed edges | **Cheap pre-flight before any run.** Sub-second; no DB for file/DSL targets. Core: `validateGraph` in `node-sdk` |
 | `debug <id\|file>` (`debug.ts`) | Run a workflow end-to-end on the headless kernel and bundle every message/log/output/error/trace; `--browser` adds a real Playwright surface, `--stages` per-stage shots, `--watch` a per-save verdict diff | Run-and-inspect; iterative troubleshooting |
 | `node run <type> --props '{…}'` (`node.ts`) | Single-node harness — instantiate one node, feed a prop bag, print what it emits; `--no-secrets` skips the DB | Isolate one node without authoring a graph |
 | `run <file>` / `workflows run <id>` | Execute a workflow (id, JSON, or DSL `.ts`) | Quick run by id/file |

--- a/packages/agents/src/tools/finish-graph-tool.ts
+++ b/packages/agents/src/tools/finish-graph-tool.ts
@@ -8,7 +8,11 @@
  * surfaces while the model can still fix it instead of at runtime.
  */
 
-import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  listOfflineModelIds,
+  listRegisteredProviderIds,
+  type ProcessingContext
+} from "@nodetool-ai/runtime";
 import type { GraphData } from "@nodetool-ai/protocol";
 import {
   validateGraph,
@@ -37,6 +41,13 @@ const FINISH_GRAPH_INPUT_SCHEMA = {
  *   empty model is the intended output, not a defect. Left in, this check
  *   would reject the shape the planner is asked to produce and push it into
  *   pinning a model it has no basis to choose.
+ *
+ * A model the planner *does* pin is checked, though: `NodeRegistry` carries no
+ * provider catalog (it also runs in the browser), so without the two hooks
+ * below `validateGraph` skipped provider and model ids entirely and a
+ * hallucinated `fal-ai/flux/schnel` reached the graph the planner handed back.
+ * The planner runs server-side, so the runtime's own registry is the default;
+ * a caller with its own catalog overrides it.
  */
 export function metadataAwareRegistry(
   registry: GraphValidationRegistry
@@ -49,7 +60,13 @@ export function metadataAwareRegistry(
     validateNode: (descriptor, connectedHandles) =>
       registry
         .validateNode(descriptor, connectedHandles)
-        .filter((issue) => issue.code !== "unset_model")
+        .filter((issue) => issue.code !== "unset_model"),
+    listProviderIds: () =>
+      registry.listProviderIds?.() ?? listRegisteredProviderIds(),
+    listModelIds: (provider, modelType) =>
+      registry.listModelIds
+        ? registry.listModelIds(provider, modelType)
+        : listOfflineModelIds(provider, modelType)
   };
 }
 

--- a/packages/agents/src/tools/mcp-tools.ts
+++ b/packages/agents/src/tools/mcp-tools.ts
@@ -8,9 +8,19 @@
  */
 
 import type { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
-import { listRegisteredProviderIds } from "@nodetool-ai/runtime";
-import type { NodeMetadata, NodeRegistry } from "@nodetool-ai/node-sdk";
-import { validateGraph } from "@nodetool-ai/node-sdk";
+import {
+  listOfflineModelIds,
+  listRegisteredProviderIds
+} from "@nodetool-ai/runtime";
+import type {
+  GraphValidationIssue,
+  NodeMetadata,
+  NodeRegistry
+} from "@nodetool-ai/node-sdk";
+import {
+  collectModelSelectionIssues,
+  validateGraph
+} from "@nodetool-ai/node-sdk";
 import {
   validateTimelineSequence,
   type TimelineValidation
@@ -548,10 +558,68 @@ export function createWorkflowDocumentTools(
   );
 }
 
+/**
+ * The provider and model catalogs to check a graph's selections against.
+ * Defaults to the runtime's own — these tools run server-side — and is
+ * injectable so a caller with a different catalog, or a test, can supply one.
+ */
+export interface ModelCatalogs {
+  listProviderIds: () => readonly string[];
+  listModelIds: (
+    provider: string,
+    modelType: string
+  ) => readonly string[] | undefined;
+}
+
+const RUNTIME_MODEL_CATALOGS: ModelCatalogs = {
+  listProviderIds: () => listRegisteredProviderIds(),
+  listModelIds: (provider, modelType) =>
+    listOfflineModelIds(provider, modelType)
+};
+
+/**
+ * The provider/model half of graph validation, as tool-result data.
+ *
+ * Every model id in a graph an agent authored is a guess until something
+ * checks it, and the failure is expensive and late: the run starts, the
+ * upstream nodes execute, and the model node dies on a provider that was never
+ * registered. This is the cheap half of `validateGraph` — a property walk, no
+ * registry metadata — so a creation tool can afford it on every call.
+ *
+ * Returns null when every selection resolves.
+ */
+function modelSelectionError(
+  graph: unknown,
+  catalogs: ModelCatalogs
+): Record<string, unknown> | null {
+  if (!graph || typeof graph !== "object") return null;
+  const nodes = (graph as { nodes?: unknown }).nodes;
+  if (!Array.isArray(nodes)) return null;
+  const issues: GraphValidationIssue[] = collectModelSelectionIssues(
+    { nodes: nodes as never[] },
+    catalogs
+  );
+  if (issues.length === 0) return null;
+  return {
+    error:
+      "The graph selects providers or models the runtime cannot honour. Fix " +
+      "them (find_model returns a valid {provider, model_id} pair) and retry.",
+    issues: issues.map((issue) => ({
+      code: issue.code,
+      node_id: issue.nodeId,
+      node_type: issue.nodeType,
+      message: issue.message
+    }))
+  };
+}
+
 export class CreateWorkflowTool extends Tool {
   readonly name = "create_workflow";
   readonly description =
-    "Create a new workflow with a name, graph structure, and optional metadata.";
+    "Create a new workflow with a name, graph structure, and optional " +
+    "metadata. Model properties are checked before the workflow is created: " +
+    "an unregistered provider or a model id the provider does not offer is " +
+    "returned as an error instead of being saved.";
   readonly jsonSchema = {
     type: "object" as const,
     properties: {
@@ -579,13 +647,21 @@ export class CreateWorkflowTool extends Tool {
     required: ["name", "graph"]
   };
 
+  constructor(private readonly catalogs: ModelCatalogs = RUNTIME_MODEL_CATALOGS) {
+    super();
+  }
+
   async process(
     context: ProcessingContext,
     params: Record<string, unknown>
   ): Promise<unknown> {
+    const graph = normalizeWorkflowGraph(params["graph"]);
+    const badModels = modelSelectionError(graph, this.catalogs);
+    if (badModels) return badModels;
+
     return apiPost(context, "/api/workflows", {
       name: params["name"],
-      graph: normalizeWorkflowGraph(params["graph"]),
+      graph,
       description: params["description"],
       tags: params["tags"],
       access: params["access"] ?? "private"
@@ -1035,9 +1111,11 @@ export class ValidateWorkflowTool extends Tool {
   readonly description =
     "Statically validate a workflow against the node registry WITHOUT running " +
     "it: unknown node types, missing required properties, unselected models, " +
-    "and dangling or mis-typed edges. Pass an inline `graph` to check a graph " +
-    "you are building, or `workflow_id` to validate a saved one. Run this " +
-    "before saving or running to catch breakage in milliseconds.";
+    "model properties naming an unregistered provider or a model id that " +
+    "provider does not offer, and dangling or mis-typed edges. Pass an inline " +
+    "`graph` to check a graph you are building, or `workflow_id` to validate " +
+    "a saved one. Run this before saving or running to catch breakage in " +
+    "milliseconds.";
   readonly jsonSchema = {
     type: "object" as const,
     properties: {
@@ -1058,17 +1136,23 @@ export class ValidateWorkflowTool extends Tool {
   // falls back to fetching the workflow so the tool still returns something
   // useful in registry-free contexts (e.g. the multi-task planner).
   /**
-   * `listProviderIds` is supplied here rather than living on NodeRegistry: the
-   * registry also runs in the browser, which has no provider registry to reach.
-   * Without it `validateGraph` skips the `unknown_provider` check entirely, so
-   * a model naming a provider the runtime cannot construct passed silently on
-   * the agent surface. This tool always runs server-side, so the runtime's
-   * registry is the right default.
+   * The provider and model catalogs are supplied here rather than living on
+   * NodeRegistry: the registry also runs in the browser, which has neither to
+   * reach. Without them `validateGraph` skips the `unknown_provider` and
+   * `unknown_model` checks entirely, so a model naming a provider the runtime
+   * cannot construct — or an id that provider does not offer — passed silently
+   * on the agent surface, which is exactly where hallucinated ids come from.
+   * This tool always runs server-side, so the runtime's own catalogs are the
+   * right default.
    */
   constructor(
     private readonly registry?: NodeRegistry,
     private readonly listProviderIds: () => readonly string[] = () =>
-      listRegisteredProviderIds()
+      listRegisteredProviderIds(),
+    private readonly listModelIds: (
+      provider: string,
+      modelType: string
+    ) => readonly string[] | undefined = listOfflineModelIds
   ) {
     super();
   }
@@ -1125,7 +1209,9 @@ export class ValidateWorkflowTool extends Tool {
         getMetadata: (type) => registry.getMetadata(type),
         validateNode: (descriptor, connectedHandles) =>
           registry.validateNode(descriptor, connectedHandles),
-        listProviderIds: () => this.listProviderIds()
+        listProviderIds: () => this.listProviderIds(),
+        listModelIds: (provider, modelType) =>
+          this.listModelIds(provider, modelType)
       }
     );
   }

--- a/packages/agents/tests/mcp-tools.test.ts
+++ b/packages/agents/tests/mcp-tools.test.ts
@@ -108,6 +108,60 @@ describe("GetWorkflowTool", () => {
 describe("CreateWorkflowTool", () => {
   const tool = new CreateWorkflowTool();
 
+  // A workflow saved with a provider nothing can construct is a run that
+  // fails after the upstream nodes have already executed. The ids are in the
+  // graph the agent just wrote, so the mistake is cheap to catch here.
+  describe("model selection preflight", () => {
+    const catalogs = {
+      listProviderIds: () => ["kie"],
+      listModelIds: (provider: string, modelType: string) =>
+        provider === "kie" && modelType === "video_model"
+          ? ["wan/2-7-image-to-video"]
+          : undefined
+    };
+    const checked = new CreateWorkflowTool(catalogs);
+    const graphWith = (model: Record<string, unknown>) => ({
+      nodes: [
+        { id: "n1", type: "nodetool.video.ImageToVideo", properties: { model } }
+      ],
+      edges: []
+    });
+
+    it("refuses to create a workflow naming an unregistered provider", async () => {
+      const result = (await checked.process(ctx, {
+        name: "WF",
+        graph: graphWith({ type: "video_model", provider: "nope", id: "x" })
+      })) as { error: string; issues: Array<{ code: string }> };
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(result.error).toContain("providers or models");
+      expect(result.issues[0]?.code).toBe("unknown_provider");
+    });
+
+    it("refuses a model id the provider does not offer", async () => {
+      const result = (await checked.process(ctx, {
+        name: "WF",
+        graph: graphWith({ type: "video_model", provider: "kie", id: "wan/2" })
+      })) as { issues: Array<{ code: string; node_id: string }> };
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(result.issues[0]?.code).toBe("unknown_model");
+      expect(result.issues[0]?.node_id).toBe("n1");
+    });
+
+    it("creates the workflow when every selection resolves", async () => {
+      await checked.process(ctx, {
+        name: "WF",
+        graph: graphWith({
+          type: "video_model",
+          provider: "kie",
+          id: "wan/2-7-image-to-video"
+        })
+      });
+      expect(lastFetchUrl()).toBe(`${API_URL}/api/workflows`);
+    });
+  });
+
   it("calls POST /api/workflows with body", async () => {
     await tool.process(ctx, {
       name: "Test WF",
@@ -565,6 +619,44 @@ describe("ValidateWorkflowTool", () => {
     expect(result.error).toContain("no node registry");
     expect(result.validated).toBe(false);
     expect(result.graph).toBeUndefined();
+  });
+
+  // The model catalog is the half that was never wired: a graph naming a real
+  // provider and a model id it does not offer validated clean on this surface,
+  // which is exactly where hallucinated ids come from.
+  it("flags a model id the provider does not offer", async () => {
+    const registry = {
+      has: () => true,
+      getMetadata: () => ({ properties: [], outputs: [] }),
+      validateNode: () => []
+    };
+    const withCatalogs = new ValidateWorkflowTool(
+      registry as never,
+      () => ["kie"],
+      (provider, modelType) =>
+        provider === "kie" && modelType === "video_model"
+          ? ["wan/2-7-image-to-video"]
+          : undefined
+    );
+
+    const result = (await withCatalogs.process(ctx, {
+      graph: {
+        nodes: [
+          {
+            id: "n1",
+            type: "nodetool.video.ImageToVideo",
+            properties: {
+              model: { type: "video_model", provider: "kie", id: "wan/2-7" }
+            }
+          }
+        ],
+        edges: []
+      }
+    })) as { ok: boolean; issues: Array<{ code: string; message: string }> };
+
+    expect(result.ok).toBe(false);
+    const issue = result.issues.find((i) => i.code === "unknown_model");
+    expect(issue?.message).toContain("wan/2-7-image-to-video");
   });
 });
 

--- a/packages/agents/tests/planner-model-validation.test.ts
+++ b/packages/agents/tests/planner-model-validation.test.ts
@@ -71,4 +71,40 @@ return graph();`
     expect(result.status).toBe("graph_accepted");
     expect(tool.graph!.nodes[0].properties).not.toHaveProperty("model");
   });
+
+  // Omitting a model is the planner's intended output; pinning a wrong one is
+  // not. `NodeRegistry` carries no provider catalog, so before these two hooks
+  // were forwarded a hallucinated provider/model reached the finished graph.
+  describe("a model the planner does pin", () => {
+    const catalogRegistry = {
+      ...realRegistry,
+      listProviderIds: () => ["kie"],
+      listModelIds: (provider: string, modelType: string) =>
+        provider === "kie" && modelType === "language_model"
+          ? ["kimi/k2"]
+          : undefined
+    } as any;
+
+    const submit = (model: string, provider = "kie") =>
+      new SubmitGraphTool(catalogRegistry).process({} as any, {
+        code: `node("nodetool.agents.Agent", { prompt: "hi", model: { type: "language_model", provider: ${JSON.stringify(provider)}, id: ${JSON.stringify(model)} } }, "agent");
+return graph();`
+      }) as Promise<Record<string, unknown>>;
+
+    it("rejects a provider the runtime cannot construct", async () => {
+      const result = await submit("kimi/k2", "nonesuch");
+      expect(result.status).toBe("validation_failed");
+      expect((result.errors as string[]).join("\n")).toContain("nonesuch");
+    });
+
+    it("rejects a model id the provider does not offer", async () => {
+      const result = await submit("kimi/k3");
+      expect(result.status).toBe("validation_failed");
+      expect((result.errors as string[]).join("\n")).toContain("kimi/k2");
+    });
+
+    it("accepts a pair the catalogs know", async () => {
+      expect((await submit("kimi/k2")).status).toBe("graph_accepted");
+    });
+  });
 });

--- a/packages/node-sdk/src/graph-validation.ts
+++ b/packages/node-sdk/src/graph-validation.ts
@@ -266,7 +266,9 @@ function normalizeEdge(raw: GraphValidationEdge, index: number): NormEdge {
  * to carry a `provider` field.
  */
 function isModelRef(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+  // Null first, matching `asRecord` above: `typeof null === "object"`, so the
+  // check is load-bearing — without it `value.type` below throws on null.
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
     return false;
   }
   const kind = (value as Record<string, unknown>).type;
@@ -308,7 +310,7 @@ function collectModelRefs(
     );
     return;
   }
-  if (typeof value !== "object" || value === null) return;
+  if (value === null || typeof value !== "object") return;
   if (isModelRef(value)) {
     out.push({ path, ref: value as Record<string, unknown> });
     return;

--- a/packages/node-sdk/src/graph-validation.ts
+++ b/packages/node-sdk/src/graph-validation.ts
@@ -71,9 +71,9 @@ export interface GraphValidationIssue {
    * Stable category: "unknown_node" | "missing_id" | "duplicate_id" |
    * "property" | "dangling_edge" | "unknown_handle" | "missing_handle" |
    * "cycle" | "type_mismatch" | "fan_in" | "untyped_dynamic_slot" |
-   * "dynamic_type_mismatch" | "unknown_provider" | "slot_type_alias", plus the
-   * `code_*` categories a Code node body produces (see
-   * {@link validateCodeNodeBody}).
+   * "dynamic_type_mismatch" | "unknown_provider" | "missing_provider" |
+   * "unknown_model" | "slot_type_alias", plus the `code_*` categories a Code
+   * node body produces (see {@link validateCodeNodeBody}).
    *
    * - "missing_id" (error): a node with no id — unaddressable by any edge.
    * - "missing_handle" (error): an edge whose endpoints both exist but which
@@ -86,6 +86,9 @@ export interface GraphValidationIssue {
    *   the warnings-as-errors ratchet.
    * - "dynamic_type_mismatch" (warning): an inline `dynamic_properties` value
    *   does not match its slot's declared type.
+   * - "missing_provider" (error): a model reference carries an id but no
+   *   provider, so nothing can route it. See
+   *   {@link collectModelSelectionIssues} for this and its two siblings.
    * - "type_mismatch": a warning for declared properties (best-effort), an
    *   error when the target is a *declared* dynamic slot whose type the source
    *   output cannot satisfy.
@@ -257,19 +260,72 @@ function normalizeEdge(raw: GraphValidationEdge, index: number): NormEdge {
 }
 
 /**
- * Provider id of a model-reference property value, or undefined when the value
- * is not one. Model refs are tagged objects whose `type` ends in `_model`
- * (`image_model`, `asr_model`, `tts_model`, `language_model`, …), so keying on
- * that suffix avoids reacting to any unrelated object that happens to carry a
- * `provider` field. A blank provider is left to the existing unselected-model
- * check rather than reported as unknown.
+ * True for a model-reference value: a tagged object whose `type` ends in
+ * `_model` (`image_model`, `asr_model`, `tts_model`, `language_model`, …).
+ * Keying on that suffix avoids reacting to any unrelated object that happens
+ * to carry a `provider` field.
  */
-function modelProviderOf(value: unknown): string | undefined {
-  if (typeof value !== "object" || value === null) return undefined;
-  const rec = value as Record<string, unknown>;
-  const kind = rec.type;
-  if (typeof kind !== "string" || !kind.endsWith("_model")) return undefined;
-  const provider = rec.provider;
+function isModelRef(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const kind = (value as Record<string, unknown>).type;
+  return typeof kind === "string" && kind.endsWith("_model");
+}
+
+/** A model reference found in a node's property bag, with where it was found. */
+interface ModelRefSite {
+  /** Property path, e.g. `model`, `models[0]`, `config.model`. */
+  path: string;
+  ref: Record<string, unknown>;
+}
+
+/**
+ * How deep the property walk goes looking for model refs. A node's props are a
+ * shallow bag by convention; the depth exists for the shapes that nest one —
+ * a list of models, or a model inside a settings object — not to crawl payloads.
+ */
+const MODEL_REF_MAX_DEPTH = 4;
+
+/**
+ * Every model reference reachable from `value`.
+ *
+ * Checking only top-level property values missed the ones the type system
+ * allows anywhere: a `list[image_model]` property, or a model nested in a
+ * config object. Those fail exactly like a top-level one does — once the node
+ * runs — so they are worth the same check.
+ */
+function collectModelRefs(
+  value: unknown,
+  path: string,
+  out: ModelRefSite[],
+  depth = 0
+): void {
+  if (depth > MODEL_REF_MAX_DEPTH) return;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      collectModelRefs(item, `${path}[${index}]`, out, depth + 1)
+    );
+    return;
+  }
+  if (typeof value !== "object" || value === null) return;
+  if (isModelRef(value)) {
+    out.push({ path, ref: value as Record<string, unknown> });
+    return;
+  }
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    collectModelRefs(child, path ? `${path}.${key}` : key, out, depth + 1);
+  }
+}
+
+/**
+ * Provider id of a model reference, or undefined when it names none. A blank
+ * provider is left to {@link collectModelSelectionIssues}, which reports it
+ * only when an id is present — an entirely empty ref is an unselected model,
+ * which the registry's own property check already covers.
+ */
+function modelProviderOf(ref: Record<string, unknown>): string | undefined {
+  const provider = ref.provider;
   if (typeof provider !== "string" || provider === "") return undefined;
   return provider;
 }
@@ -350,15 +406,11 @@ function detectCycles(
 }
 
 /**
- * Model id of a model-reference property value. A blank id is an unselected
- * model, which the registry's own property check already reports.
+ * Model id of a model reference. A blank id is an unselected model, which the
+ * registry's own property check already reports.
  */
-function modelIdOf(value: unknown): string | undefined {
-  if (typeof value !== "object" || value === null) return undefined;
-  const rec = value as Record<string, unknown>;
-  const kind = rec.type;
-  if (typeof kind !== "string" || !kind.endsWith("_model")) return undefined;
-  const id = rec.id;
+function modelIdOf(ref: Record<string, unknown>): string | undefined {
+  const id = ref.id;
   if (typeof id !== "string" || id === "") return undefined;
   return id;
 }
@@ -368,11 +420,8 @@ function modelIdOf(value: unknown): string | undefined {
  * in depends on it: a provider's ASR ids and its image ids are separate lists,
  * and only some are knowable offline.
  */
-function modelKindOf(value: unknown): string | undefined {
-  if (typeof value !== "object" || value === null) return undefined;
-  const kind = (value as Record<string, unknown>).type;
-  if (typeof kind !== "string" || !kind.endsWith("_model")) return undefined;
-  return kind;
+function modelKindOf(ref: Record<string, unknown>): string {
+  return String(ref.type);
 }
 
 /**
@@ -408,6 +457,110 @@ function nearestModelIds(
     .map((entry) => entry.candidate);
 }
 
+
+/** The slice of the registry {@link collectModelSelectionIssues} needs. */
+export type ModelSelectionRegistry = Pick<
+  GraphValidationRegistry,
+  "listProviderIds" | "listModelIds"
+>;
+
+/**
+ * Every provider/model id in `graph` that the runtime cannot honour.
+ *
+ * Split out of {@link validateGraph} so a caller that wants only this — a run
+ * preflight, an agent about to save a graph — pays for a property walk instead
+ * of a full graph validation, and so all of them report the same thing. The
+ * checks stay in `validateGraph` too; this is the same code, not a second
+ * opinion.
+ *
+ * Both checks fail toward silence. An empty provider list means the registry
+ * could not be reached, not that zero providers exist; an undefined model list
+ * means the catalog is only knowable online. Neither is evidence of a bad id.
+ */
+export function collectModelSelectionIssues(
+  graph: GraphValidationInput,
+  registry: ModelSelectionRegistry
+): GraphValidationIssue[] {
+  const providerIds = registry.listProviderIds?.();
+  const knownProviders =
+    providerIds && providerIds.length > 0 ? new Set(providerIds) : null;
+  if (!knownProviders) return [];
+
+  const issues: GraphValidationIssue[] = [];
+  for (const node of graph.nodes ?? []) {
+    const nodeId = String(node.id ?? "");
+    const nodeType = String(node.type ?? "");
+    const sites: ModelRefSite[] = [];
+    for (const [propName, value] of Object.entries(readProperties(node))) {
+      collectModelRefs(value, propName, sites);
+    }
+    for (const [propName, value] of Object.entries(
+      readDynamicProperties(node)
+    )) {
+      collectModelRefs(value, propName, sites);
+    }
+
+    for (const { path, ref } of sites) {
+      const modelId = modelIdOf(ref);
+      const provider = modelProviderOf(ref);
+
+      if (provider === undefined) {
+        // No provider and no id is an unselected model — the registry's own
+        // property check reports that one. An id without a provider is
+        // different: it names a model nothing can route to.
+        if (modelId !== undefined) {
+          issues.push({
+            severity: "error",
+            code: "missing_provider",
+            nodeId,
+            nodeType,
+            message:
+              `Property "${path}" selects model "${modelId}" but names no ` +
+              "provider; the runtime cannot resolve a model id on its own"
+          });
+        }
+        continue;
+      }
+
+      if (!knownProviders.has(provider)) {
+        issues.push({
+          severity: "error",
+          code: "unknown_provider",
+          nodeId,
+          nodeType,
+          message:
+            `Property "${path}" selects provider "${provider}", which is ` +
+            `not registered. Known providers: ${[...knownProviders]
+              .sort()
+              .join(", ")}`
+        });
+        continue;
+      }
+
+      // The provider is real; the id it names may still not be. A model id is
+      // only checkable where the catalog is known offline — undefined from the
+      // registry means unknown, so nothing is reported.
+      if (modelId === undefined) continue;
+      const knownModels = registry.listModelIds?.(provider, modelKindOf(ref));
+      if (!knownModels || knownModels.length === 0) continue;
+      if (knownModels.includes(modelId)) continue;
+      const suggestions = nearestModelIds(modelId, knownModels);
+      issues.push({
+        severity: "error",
+        code: "unknown_model",
+        nodeId,
+        nodeType,
+        message:
+          `Property "${path}" selects model "${modelId}", which provider ` +
+          `"${provider}" does not offer.` +
+          (suggestions.length > 0
+            ? ` Did you mean: ${suggestions.join(", ")}?`
+            : "")
+      });
+    }
+  }
+  return issues;
+}
 
 export function validateGraph(
   graph: GraphValidationInput,
@@ -487,12 +640,6 @@ export function validateGraph(
       set.add(e.sourceHandle);
     }
   }
-
-  const providerIds = registry.listProviderIds?.();
-  // An empty list means the registry could not be reached, not that zero
-  // providers exist — checking against it would flag every model in the graph.
-  const knownProviders =
-    providerIds && providerIds.length > 0 ? new Set(providerIds) : null;
 
   // `byId` holds one node per id — a duplicate id is already an error, and
   // validating the shadowed copy's properties would report everything twice.
@@ -581,54 +728,13 @@ export function validateGraph(
       }
     }
 
-    // A model property naming a provider the runtime cannot construct fails
-    // only once the node runs — after the rest of the graph has already been
-    // paid for. The id is right there in the saved property, so check it here.
-    if (knownProviders) {
-      const props = readProperties(node);
-      for (const [propName, value] of Object.entries(props)) {
-        const provider = modelProviderOf(value);
-        if (provider === undefined) continue;
-        if (!knownProviders.has(provider)) {
-          issues.push({
-            severity: "error",
-            code: "unknown_provider",
-            nodeId: id,
-            nodeType: type,
-            message:
-              `Property "${propName}" selects provider "${provider}", which is ` +
-              `not registered. Known providers: ${[...knownProviders]
-                .sort()
-                .join(", ")}`
-          });
-          continue;
-        }
-
-        // The provider is real; the id it names may still not be. A model id
-        // is only checkable where the catalog is known offline — undefined
-        // from the registry means unknown, so nothing is reported.
-        const modelId = modelIdOf(value);
-        const modelKind = modelKindOf(value);
-        if (modelId === undefined || modelKind === undefined) continue;
-        const knownModels = registry.listModelIds?.(provider, modelKind);
-        if (!knownModels || knownModels.length === 0) continue;
-        if (knownModels.includes(modelId)) continue;
-        const suggestions = nearestModelIds(modelId, knownModels);
-        issues.push({
-          severity: "error",
-          code: "unknown_model",
-          nodeId: id,
-          nodeType: type,
-          message:
-            `Property "${propName}" selects model "${modelId}", which provider ` +
-            `"${provider}" does not offer.` +
-            (suggestions.length > 0
-              ? ` Did you mean: ${suggestions.join(", ")}?`
-              : "")
-        });
-      }
-    }
   }
+
+  // A model property naming a provider the runtime cannot construct, or an id
+  // that provider does not offer, fails only once the node runs — after the
+  // rest of the graph has already been paid for. Both are right there in the
+  // saved properties.
+  issues.push(...collectModelSelectionIssues({ nodes: [...byId.values()] }, registry));
 
   // ── Fan-in: >1 edge into a handle is only legal when the handle's declared
   // type is a list. Mirrors the kernel's correlation-analysis rule so an

--- a/packages/node-sdk/tests/graph-validation.test.ts
+++ b/packages/node-sdk/tests/graph-validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  collectModelSelectionIssues,
   validateGraph,
   validationHeadline,
   type GraphValidationRegistry
@@ -687,6 +688,158 @@ describe("unknown_model", () => {
       registry
     );
     expect(report.issues.some((i) => i.code === "unknown_model")).toBe(true);
+  });
+});
+
+describe("model selections in nested properties", () => {
+  const registry = {
+    has: () => true,
+    getMetadata: () => ({ properties: [], outputs: [] }) as never,
+    validateNode: () => [],
+    listProviderIds: () => ["kie", "openai"],
+    listModelIds: (provider: string, modelType: string) =>
+      provider === "kie" && modelType === "video_model"
+        ? ["wan/2-7-image-to-video"]
+        : undefined
+  };
+  const nodeWith = (properties: Record<string, unknown>) => ({
+    nodes: [{ id: "n", type: "nodetool.video.ImageToVideo", properties }],
+    edges: []
+  });
+
+  it("flags a model inside a list property", () => {
+    const report = validateGraph(
+      nodeWith({
+        models: [
+          { type: "video_model", provider: "kie", id: "wan/2-7-image-to-video" },
+          { type: "video_model", provider: "nonesuch", id: "x" }
+        ]
+      }),
+      registry
+    );
+    const issue = report.issues.find((i) => i.code === "unknown_provider");
+    expect(issue?.message).toContain("models[1]");
+  });
+
+  it("flags a model nested in a settings object", () => {
+    const report = validateGraph(
+      nodeWith({
+        config: {
+          model: { type: "video_model", provider: "kie", id: "not-a-model" }
+        }
+      }),
+      registry
+    );
+    const issue = report.issues.find((i) => i.code === "unknown_model");
+    expect(issue?.message).toContain("config.model");
+  });
+
+  it("checks dynamic property values too", () => {
+    const report = validateGraph(
+      {
+        nodes: [
+          {
+            id: "n",
+            type: "nodetool.video.ImageToVideo",
+            dynamic_properties: {
+              model: { type: "video_model", provider: "nonesuch", id: "x" }
+            }
+          }
+        ],
+        edges: []
+      },
+      registry
+    );
+    expect(report.issues.some((i) => i.code === "unknown_provider")).toBe(true);
+  });
+});
+
+describe("missing_provider", () => {
+  const registry = {
+    has: () => true,
+    getMetadata: () => ({ properties: [], outputs: [] }) as never,
+    validateNode: () => [],
+    listProviderIds: () => ["kie", "openai"]
+  };
+  const graphWith = (model: Record<string, unknown>) => ({
+    nodes: [{ id: "n", type: "nodetool.video.ImageToVideo", data: { model } }],
+    edges: []
+  });
+
+  it("flags a model id that names no provider", () => {
+    const report = validateGraph(
+      graphWith({ type: "video_model", id: "wan/2-7-image-to-video" }),
+      registry
+    );
+    const issue = report.issues.find((i) => i.code === "missing_provider");
+    expect(issue?.message).toContain("wan/2-7-image-to-video");
+    expect(report.ok).toBe(false);
+  });
+
+  // An entirely empty ref is an unselected model — the registry's own
+  // required-property check owns that complaint.
+  it("ignores a model reference with neither id nor provider", () => {
+    const report = validateGraph(graphWith({ type: "video_model" }), registry);
+    expect(report.issues.some((i) => i.code === "missing_provider")).toBe(false);
+  });
+
+  it("ignores a blank provider on an unselected model", () => {
+    const report = validateGraph(
+      graphWith({ type: "video_model", provider: "", id: "" }),
+      registry
+    );
+    expect(report.issues.some((i) => i.code === "missing_provider")).toBe(false);
+  });
+});
+
+describe("collectModelSelectionIssues", () => {
+  const registry = {
+    listProviderIds: () => ["kie"],
+    listModelIds: (provider: string, modelType: string) =>
+      provider === "kie" && modelType === "video_model"
+        ? ["wan/2-7-image-to-video"]
+        : undefined
+  };
+
+  it("reports the same issues without needing node metadata", () => {
+    const issues = collectModelSelectionIssues(
+      {
+        nodes: [
+          {
+            id: "n",
+            type: "nodetool.video.ImageToVideo",
+            properties: {
+              model: { type: "video_model", provider: "kie", id: "nope" }
+            }
+          }
+        ]
+      },
+      registry
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.code).toBe("unknown_model");
+    expect(issues[0]?.nodeId).toBe("n");
+  });
+
+  // Failing toward silence is the whole contract: an unreachable registry
+  // must not turn every model in the graph into an error.
+  it("reports nothing when no provider list is available", () => {
+    expect(
+      collectModelSelectionIssues(
+        {
+          nodes: [
+            {
+              id: "n",
+              type: "t",
+              properties: {
+                model: { type: "video_model", provider: "nonesuch", id: "x" }
+              }
+            }
+          ]
+        },
+        { listProviderIds: () => [] }
+      )
+    ).toEqual([]);
   });
 });
 

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -38,6 +38,7 @@ import {
   Asset
 } from "@nodetool-ai/models";
 import {
+  collectModelSelectionIssues,
   hydrateGraphNodeFlags,
   loadPythonPackageMetadata,
   type NodeMetadata,
@@ -56,6 +57,8 @@ import { bootstrapNodeRegistry } from "./node-registry-setup.js";
 import {
   PythonNodeExecutor,
   createPythonBridge,
+  listOfflineModelIds,
+  listRegisteredProviderIds,
   logPythonWorkerStderr,
   safeFetch,
   type NodeExecutor,
@@ -859,6 +862,29 @@ async function updateWorkflow(
   })) as Workflow;
 }
 
+/**
+ * Provider and model ids a run cannot honour, checked before the job exists.
+ *
+ * A model property naming an unregistered provider — or an id that provider
+ * does not offer — fails only when its node runs, by which time the upstream
+ * half of the graph has already executed and been paid for. The ids are in the
+ * saved properties, so the run can be refused in microseconds instead. Both
+ * checks fail toward silence: a catalog that cannot be enumerated offline
+ * reports nothing rather than guessing an id is wrong.
+ */
+function modelSelectionErrors(graph: { nodes?: unknown[] }): string[] {
+  return collectModelSelectionIssues(
+    { nodes: (graph.nodes ?? []) as never[] },
+    {
+      listProviderIds: () => listRegisteredProviderIds(),
+      listModelIds: (provider, modelType) =>
+        listOfflineModelIds(provider, modelType)
+    }
+  )
+    .filter((issue) => issue.severity === "error")
+    .map((issue) => `Node "${issue.nodeId}" (${issue.nodeType}): ${issue.message}`);
+}
+
 export async function handleWorkflowRun(
   request: Request,
   workflowId: string,
@@ -906,6 +932,14 @@ export async function handleWorkflowRun(
   // the legacy `type`. Hand-rolling it here drifted from the CLI — a graph
   // with a Comment node ran there and failed here with "Unknown node type".
   const runnableGraph = normalizeGraph(workflow.getGraph());
+
+  const badModels = modelSelectionErrors(runnableGraph);
+  if (badModels.length > 0) {
+    return errorResponse(
+      400,
+      `Workflow selects providers or models this runtime cannot honour:\n${badModels.join("\n")}`
+    );
+  }
 
   const runtime = await getWorkflowRuntimeEnvironment(options);
   const hasPythonNode = runnableGraph.nodes.some((node) => {

--- a/packages/websocket/tests/http-api-run-model-preflight.test.ts
+++ b/packages/websocket/tests/http-api-run-model-preflight.test.ts
@@ -1,0 +1,133 @@
+/**
+ * `POST /api/workflows/:id/run|debug` refuses a graph whose model properties
+ * name a provider the runtime cannot construct.
+ *
+ * Without the check the run started, executed everything upstream, and died on
+ * the model node — after the expensive half of the graph had already been paid
+ * for. The ids are in the saved properties, so the run is refused before the
+ * job row exists.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import os from "node:os";
+import { initTestDb, Workflow, Job } from "@nodetool-ai/models";
+import {
+  registerProvider,
+  unregisterProvider,
+  type BaseProvider
+} from "@nodetool-ai/runtime";
+import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+
+vi.mock("../src/lib/workflow-workspace.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../src/lib/workflow-workspace.js")
+  >("../src/lib/workflow-workspace.js");
+  return {
+    ...actual,
+    resolveWorkflowWorkspace: async () => os.tmpdir()
+  };
+});
+
+const { handleWorkflowRun } = await import("../src/http-api.js");
+
+const echoExecutor = {
+  async process(ins: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return ins;
+  }
+};
+
+const registry = {
+  has: (t: string) => t.startsWith("test."),
+  resolve: () => echoExecutor,
+  getClass: () => undefined,
+  resolveMetadata: () => undefined,
+  getMetadata: () => undefined,
+  listMetadata: () => []
+} as unknown as NodeRegistry;
+
+const PROVIDER_ID = "run_preflight_test_provider";
+
+const workflowWith = async (model: Record<string, unknown>): Promise<Workflow> =>
+  (await Workflow.create({
+    user_id: "user-1",
+    name: "Model WF",
+    access: "private",
+    graph: {
+      nodes: [{ id: "gen", type: "test.Echo", properties: { model } }],
+      edges: []
+    }
+  })) as Workflow;
+
+const run = (workflowId: string): Promise<Response> =>
+  handleWorkflowRun(
+    new Request("http://localhost/x", {
+      method: "POST",
+      headers: { "x-user-id": "user-1", "content-type": "application/json" },
+      body: JSON.stringify({})
+    }),
+    workflowId,
+    { registry }
+  );
+
+beforeEach(async () => {
+  await initTestDb();
+  // A real registration, so `listRegisteredProviderIds` is non-empty and the
+  // check runs at all — an empty list means "registry unreachable" and is
+  // deliberately skipped.
+  registerProvider(
+    PROVIDER_ID,
+    class {} as unknown as new (...args: never[]) => BaseProvider
+  );
+});
+
+afterEach(() => {
+  unregisterProvider(PROVIDER_ID);
+});
+
+describe("handleWorkflowRun model preflight", () => {
+  it("refuses a run naming an unregistered provider, before the job exists", async () => {
+    const workflow = await workflowWith({
+      type: "image_model",
+      provider: "definitely-not-registered",
+      id: "some/model"
+    });
+
+    const res = await run(workflow.id);
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("definitely-not-registered");
+
+    const [jobs] = await Job.paginate("user-1", {
+      workflowId: workflow.id,
+      limit: 10
+    });
+    expect(jobs).toHaveLength(0);
+  });
+
+  it("refuses a model id that names no provider", async () => {
+    const workflow = await workflowWith({
+      type: "image_model",
+      id: "some/model"
+    });
+
+    const res = await run(workflow.id);
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("names no provider");
+  });
+
+  it("runs a workflow whose provider is registered", async () => {
+    const workflow = await workflowWith({
+      type: "image_model",
+      provider: PROVIDER_ID,
+      id: "some/model"
+    });
+
+    const res = await run(workflow.id);
+    expect(res.status).toBe(200);
+  });
+
+  // An unselected model is the editor's own complaint, not a reason to refuse
+  // a run that may never reach the node.
+  it("lets an unselected model through", async () => {
+    const workflow = await workflowWith({ type: "image_model" });
+    expect((await run(workflow.id)).status).toBe(200);
+  });
+});


### PR DESCRIPTION
A model property naming a provider the runtime cannot construct — or a model id that provider does not offer — used to fail only once its node ran, after the upstream half of the graph had already executed and been paid for. The ids sit in the saved properties, so the mistake is cheap to catch. `validateGraph` already knew how; the surfaces that produce and consume graphs did not ask it.

## What changed

**`node-sdk` — one check, shared**

Split the provider/model checks out of `validateGraph` as `collectModelSelectionIssues`, so a caller that wants only them pays for a property walk instead of a full graph validation, and every surface reports the same thing. Two behavior changes come with it:

- Model refs are found wherever they sit — an entry in a `list[…_model]`, one nested in a settings object, a `dynamic_properties` value — not just top-level properties. The issue message names the path (`models[1]`, `config.model`).
- A ref carrying an `id` but no `provider` is reported as `missing_provider`. Nothing can route it. An entirely empty ref is still an unselected model, which the registry's own property check owns.

**Creation**

- `submit_graph` / `finish_graph`: `metadataAwareRegistry` built a fresh registry object and dropped `listProviderIds`/`listModelIds` on the floor, so the planner's own graphs were never checked and a hallucinated model id reached the finished graph. Forwarded, defaulting to the runtime's catalogs. An *omitted* model stays fine — that is the shape the planner is asked to produce; a pinned wrong one is not.
- `validate_workflow`: `listModelIds` was never passed, so the tool checked providers and skipped model ids entirely.
- `create_workflow`: refuses to save a graph whose selections do not resolve, returning each one with its node id rather than persisting it.

**Run**

`POST /api/workflows/:id/run|debug` refuses with a 400 before the job row exists — the path both `run_workflow` and `debug_workflow` take.

## Failing toward silence

Neither check guesses. An empty provider list means the registry could not be reached, not that zero providers exist; an undefined model list means the catalog is only knowable online (Anthropic, Ollama, ASR ids anywhere). Both report nothing rather than calling a real id a typo — the existing `listOfflineModelIds` contract, unchanged.

## Verification

- `packages/node-sdk` 755 tests, `packages/agents` 2014, `packages/websocket` 2073, `packages/cli` 481 — all pass.
- New coverage: nested/list/dynamic model refs, `missing_provider`, `collectModelSelectionIssues` in isolation, the planner rejecting a pinned bad provider and model, `create_workflow` refusing to POST, and the run endpoint's 400 (asserting no job row is created).
- `node scripts/validate-examples.mjs` — 248/248 shipped graphs validate cleanly under the widened check, so the walk produces no false positives on real content.
- `npm run lint` and `npm run typecheck` clean (mobile's typecheck failures are uninstalled Expo deps in this sandbox, pre-existing and unrelated).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1vtr87oUL8Cg8obMXdv9h)_