### PR TITLE
feat(agents): script → voiced takes → timeline without a workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -634,6 +634,25 @@ the verdict is ok. Validation and report rules live in
 `@nodetool-ai/execution/timeline-debug`; the CLI keeps target resolution, the
 interaction script, and the bundle.
 
+### Script voicing tools (no workflow, no browser)
+
+An agent voices a script and cuts it without authoring a workflow:
+**`voice_script_lines`** synthesizes each line with its cast voice and saves the
+take onto the line, and **`assemble_script_timeline`** lays the voiced takes end
+to end into a saved timeline sequence — which `validate_timeline` then checks.
+**`list_scripts`** and **`get_script`** find the script and report each line's
+status (`draft`, `stale`, `voiced`, `no_voice`).
+
+Voicing defaults to every line that is draft or stale, so one call covers a
+script; a line uses its own voice unless the call overrides provider+model+voice
+for all of them. Word timings come from a best-effort transcription pass and
+ride into the assembled clips as captions. The voice, staleness, and script →
+timeline rules live in `@nodetool-ai/timeline`
+(`effectiveVoice`/`needsVoicing`/`buildScriptTimeline`), shared with the editor
+and the `nodetool.script.*` nodes. Code:
+`packages/agents/src/tools/script-voice-tools.ts`. The `ui_script_*` tools
+remain the path when the script is open in a browser.
+
 ### nodetool node run (Single-Node Harness)
 
 Runs one node in isolation — instantiate it, feed it a property bag, print what

--- a/package-lock.json
+++ b/package-lock.json
@@ -55328,7 +55328,8 @@
       "version": "0.7.0-rc.32",
       "license": "MIT",
       "dependencies": {
-        "@nodetool-ai/gpu": "*"
+        "@nodetool-ai/gpu": "*",
+        "@nodetool-ai/protocol": "*"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -227,6 +227,48 @@ for await (const msg of agent.execute(ctx)) {
 const result = agent.getResults();
 ```
 
+## Script Voicing Tools (`src/tools/script-voice-tools.ts`)
+
+The headless path from a written script to voiced takes and an assembled
+voiceover sequence. The editor voices a line over the chat WebSocket's
+`generate_media` / `transcribe_audio` RPCs, and the `nodetool.script.*` nodes do
+it inside a workflow; an agent outside the browser had neither. These call the
+provider directly, save each take as an asset, and write it back onto the
+persisted script.
+
+| Tool | Does |
+|---|---|
+| `list_scripts` | Scripts newest first, with line and voiced counts |
+| `get_script` | Cast, lines, and each line's voicing status |
+| `voice_script_lines` | TTS per line → a take, current on its line |
+| `assemble_script_timeline` | Voiced takes → a saved `timeline_sequences` row |
+
+`get_script` reports the status the editor's gutter shows — `draft` (never
+voiced), `stale` (text or voice changed since the take), `voiced`, `no_voice` —
+and `voice_script_lines` defaults to every line that is draft or stale, so a
+whole script is one call. Each line uses its own voice (its override, else its
+speaker's) unless the call passes provider+model+voice to override them all; a
+half-specified override is an error, not a guess. Lines are voiced concurrently
+(default 3, max 8, 60 per call) and each take lands through a CAS on the row's
+`updated_at`.
+
+Synthesis delegates to `GenerateSpeechTool`, so the encoded/streaming-PCM
+provider split is handled in one place. Word timings come from a best-effort ASR
+pass (`whisper-1` by default, `transcribe: false` to skip it) and ride into the
+assembled clips as captions. Take duration is ffprobe's answer, falling back to
+the last word timing and then to the 3s placeholder — a take stays assemblable
+without an exact length.
+
+The voice rule (`effectiveVoice`), the staleness rule (`needsVoicing`) and the
+script → timeline mapping (`buildScriptTimeline`) live in
+`@nodetool-ai/timeline`; the editor's "Send to timeline" and
+`nodetool.script.ScriptToTimeline` call the same functions, so the three
+surfaces cannot drift. Re-assembly rewrites this script's voiceover track in
+place and keeps clips other surfaces added.
+
+Tests: `tests/script-voice-tools.test.ts` (in-memory DB, fake provider — no
+network).
+
 ## Google Workspace Tools (`src/tools/google-workspace-tools.ts`)
 
 Drive, Gmail, Docs, Sheets and Calendar tools that authenticate with the access

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -399,6 +399,13 @@ export {
   getAssetLibraryTools,
   ASSET_LIBRARY_TOOL_NAMES
 } from "./tools/asset-library-tools.js";
+export {
+  ListScriptsTool,
+  GetScriptTool,
+  VoiceScriptLinesTool,
+  AssembleScriptTimelineTool,
+  SCRIPT_VOICE_TOOL_NAMES
+} from "./tools/script-voice-tools.js";
 
 // Plan cache + checkpoint store (opt-in planning/execution persistence)
 export {

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -91,6 +91,12 @@ import {
   ThreadMemoryDeleteTool
 } from "./thread-memory-tools.js";
 import { AssetSearchTool, AssetListTool } from "./asset-library-tools.js";
+import {
+  ListScriptsTool,
+  GetScriptTool,
+  VoiceScriptLinesTool,
+  AssembleScriptTimelineTool
+} from "./script-voice-tools.js";
 
 export const BUILTIN_TOOL_CLASSES: ReadonlyArray<new () => Tool> = [
   // Filesystem (workspace-relative)
@@ -113,6 +119,12 @@ export const BUILTIN_TOOL_CLASSES: ReadonlyArray<new () => Tool> = [
   // Asset library (discover + reuse generated/uploaded media)
   AssetSearchTool,
   AssetListTool,
+
+  // Script → voiced takes → timeline, without authoring a workflow
+  ListScriptsTool,
+  GetScriptTool,
+  VoiceScriptLinesTool,
+  AssembleScriptTimelineTool,
 
   // Vision (lazy image loading: handles → pixels on demand)
   ListImagesTool,

--- a/packages/agents/src/tools/script-voice-tools.ts
+++ b/packages/agents/src/tools/script-voice-tools.ts
@@ -1,0 +1,759 @@
+/**
+ * Script voicing tools — the fast path from a written script to voiced takes
+ * and an assembled voiceover sequence, with no workflow in between.
+ *
+ * The script editor voices a line over the chat WebSocket's `generate_media` /
+ * `transcribe_audio` RPCs, and `nodetool.script.*` nodes do it inside a
+ * workflow. An agent working headlessly (chat, CLI, MCP) had neither: it had to
+ * author and run a workflow, or drive the `ui_script_*` tools, which only work
+ * while that script is open in a browser. These tools call the provider
+ * directly, save each take as an asset, and write it back onto the persisted
+ * script.
+ *
+ *   list_scripts             — find a script to work on
+ *   get_script               — cast, lines, and each line's voicing status
+ *   voice_script_lines       — synthesize the lines that need it, many per call
+ *   assemble_script_timeline — voiced takes → a saved timeline sequence
+ *
+ * The voice rule (`effectiveVoice`), the staleness rule (`needsVoicing`) and
+ * the script → timeline mapping (`buildScriptTimeline`) come from
+ * `@nodetool-ai/timeline`, the same module the editor and the nodes use, so a
+ * headlessly voiced script matches one voiced in the UI.
+ *
+ * Every write is a compare-and-swap against the row's `updated_at` with a
+ * bounded retry, because lines are voiced concurrently and each take lands on
+ * the same script document.
+ */
+
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { Script, TimelineSequence } from "@nodetool-ai/models";
+import type {
+  ScriptDocument,
+  ScriptLine,
+  ScriptTake,
+  ScriptVoiceBinding
+} from "@nodetool-ai/models";
+import {
+  buildScriptTimeline,
+  currentTake,
+  effectiveVoice,
+  needsVoicing,
+  scriptLines,
+  PLACEHOLDER_LINE_MS
+} from "@nodetool-ai/timeline";
+import type { CaptionWord } from "@nodetool-ai/timeline";
+import { Tool } from "./base-tool.js";
+import { GenerateSpeechTool } from "./media-tools.js";
+
+const execFile = promisify(execFileCb);
+
+/** Lines voiced at once. Bounded so one call cannot fan out unboundedly. */
+const DEFAULT_CONCURRENCY = 3;
+const MAX_CONCURRENCY = 8;
+/** Lines one call may voice, so a whole-script call cannot run away. */
+const MAX_LINES_PER_CALL = 60;
+/** Attempts to land a document write before reporting a conflict. */
+const CAS_ATTEMPTS = 5;
+
+/** Word-timing default, matching the editor's take transcription. */
+const DEFAULT_ASR_PROVIDER = "openai";
+const DEFAULT_ASR_MODEL = "whisper-1";
+
+type ToolError = { error: string };
+
+const isError = (value: unknown): value is ToolError =>
+  !!value &&
+  typeof value === "object" &&
+  typeof (value as ToolError).error === "string";
+
+const errorMessage = (e: unknown): string =>
+  e instanceof Error ? e.message : String(e);
+
+interface ScriptHandle {
+  row: Script;
+  doc: ScriptDocument;
+}
+
+async function loadScript(
+  context: ProcessingContext,
+  scriptId: unknown
+): Promise<ScriptHandle | ToolError> {
+  if (typeof scriptId !== "string" || !scriptId) {
+    return { error: "script_id is required (use list_scripts to find one)." };
+  }
+  const row = await Script.findById(scriptId);
+  // A script owned by someone else reads as missing — the same rule the tRPC
+  // router's ownership check applies.
+  if (!row || row.user_id !== context.userId) {
+    return { error: `Script ${scriptId} was not found.` };
+  }
+  return { row, doc: row.toDocument() };
+}
+
+/** Resolve a line reference: line id, 0-based reading-order index, or its text. */
+function findLine(lines: ScriptLine[], target: string): ScriptLine | undefined {
+  const byId = lines.find((l) => l.id === target);
+  if (byId) return byId;
+  const index = Number(target);
+  if (Number.isInteger(index) && index >= 0 && index < lines.length) {
+    return lines[index];
+  }
+  const text = target.trim().toLowerCase();
+  return lines.find((l) => l.text.trim().toLowerCase() === text);
+}
+
+function clampConcurrency(value: unknown): number {
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n) || n < 1) return DEFAULT_CONCURRENCY;
+  return Math.min(n, MAX_CONCURRENCY);
+}
+
+/** Run `task` over `items`, at most `limit` in flight. */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  task: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      for (;;) {
+        const index = next++;
+        if (index >= items.length) return;
+        results[index] = await task(items[index]);
+      }
+    }
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+/**
+ * Append a take to one line and persist the script.
+ *
+ * Lines are voiced concurrently against a single row, so the write is a CAS on
+ * `updated_at`: on conflict the row is re-read and the take appended to the
+ * fresher document, never to the stale copy the synthesis started from.
+ */
+async function appendTake(
+  scriptId: string,
+  lineId: string,
+  take: ScriptTake
+): Promise<ScriptLine | ToolError> {
+  for (let attempt = 0; attempt < CAS_ATTEMPTS; attempt++) {
+    const row = await Script.findById(scriptId);
+    if (!row) return { error: `Script ${scriptId} was not found.` };
+    const doc = row.toDocument();
+    let updated: ScriptLine | undefined;
+    const sections = doc.sections.map((section) => ({
+      ...section,
+      lines: section.lines.map((line) => {
+        if (line.id !== lineId) return line;
+        updated = {
+          ...line,
+          takes: [...line.takes, take],
+          currentTakeId: take.id
+        };
+        return updated;
+      })
+    }));
+    if (!updated) return { error: `Line ${lineId} is no longer in the script.` };
+    const saved = await Script.updateFieldsIfUnchanged(
+      scriptId,
+      row.updated_at,
+      { document: JSON.stringify({ ...doc, sections }) }
+    );
+    if (saved) return updated;
+  }
+  return {
+    error: `Script ${scriptId} is being modified concurrently; the take was synthesized but could not be saved. Retry the call.`
+  };
+}
+
+/**
+ * Duration of the synthesized audio.
+ *
+ * ffprobe is the accurate answer and is what the editor's browser probe and the
+ * VoiceScript node both effectively measure. When it is unavailable (no ffmpeg
+ * on PATH), the last word timing is a close second, and the placeholder is the
+ * floor — a take is still playable and still assemblable without an exact
+ * length.
+ */
+async function measureDurationMs(
+  bytes: Uint8Array,
+  words: CaptionWord[]
+): Promise<number> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "nodetool-voice-"));
+  const file = path.join(dir, "take");
+  try {
+    await fs.writeFile(file, bytes);
+    const { stdout } = await execFile("ffprobe", [
+      "-v",
+      "error",
+      "-show_entries",
+      "format=duration",
+      "-of",
+      "default=noprint_wrappers=1:nokey=1",
+      file
+    ]);
+    const seconds = parseFloat(stdout.trim());
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return Math.round(seconds * 1000);
+    }
+  } catch {
+    // ffprobe missing or unreadable output — fall through to the estimates.
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+  const lastWordEnd = words.length > 0 ? words[words.length - 1].endMs : 0;
+  return lastWordEnd > 0 ? lastWordEnd : PLACEHOLDER_LINE_MS;
+}
+
+/** Word timings for a take. Best-effort: a failed pass leaves the take playable. */
+async function transcribeWords(
+  context: ProcessingContext,
+  audio: Uint8Array,
+  provider: string,
+  model: string
+): Promise<CaptionWord[]> {
+  try {
+    const asr = await context.getProvider(provider);
+    const result = await asr.automaticSpeechRecognition({
+      audio,
+      model,
+      word_timestamps: true
+    });
+    return (result.chunks ?? [])
+      .map((chunk) => ({
+        word: chunk.text.trim(),
+        startMs: Math.round(chunk.timestamp[0] * 1000),
+        endMs: Math.round(chunk.timestamp[1] * 1000)
+      }))
+      .filter((w) => w.word.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+/** Per-line outcome, one row per selected line. */
+interface LineOutcome {
+  line_id: string;
+  index: number;
+  text: string;
+  ok: boolean;
+  take_id?: string;
+  asset_id?: string;
+  duration_ms?: number;
+  word_count?: number;
+  error?: string;
+}
+
+/** The voicing state of a line, as the editor's gutter shows it. */
+function lineStatus(
+  line: ScriptLine,
+  voice: ScriptVoiceBinding | null
+): "draft" | "stale" | "voiced" | "no_voice" {
+  if (!voice) return "no_voice";
+  if (!currentTake(line)) return "draft";
+  return needsVoicing(line, voice) ? "stale" : "voiced";
+}
+
+const LINE_TARGETS_SCHEMA = {
+  type: "array" as const,
+  items: { type: "string" as const },
+  description:
+    "Lines to voice, each a line id, 0-based reading-order index, or the " +
+    "line's exact text. Omit to voice every line that is unvoiced or stale."
+};
+
+export class ListScriptsTool extends Tool {
+  readonly name = "list_scripts";
+  readonly description =
+    "List the caller's scripts, newest first: id, name, cast size, line count, " +
+    "how many lines are voiced, and the timeline it was assembled into. Start " +
+    "here when the user names a script but not its id.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      limit: {
+        type: "number" as const,
+        description: "Max scripts to return (default 20)."
+      }
+    }
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    if (!context.userId) return { error: "No user is bound to this session." };
+    const limit = Math.max(1, Math.min(Number(params["limit"]) || 20, 100));
+    const rows = await Script.listByUser(context.userId, limit);
+    return {
+      scripts: rows.map((row) => {
+        const doc = row.toDocument();
+        const lines = scriptLines(doc.sections);
+        return {
+          id: row.id,
+          name: row.name,
+          cast: doc.cast.length,
+          lines: lines.length,
+          voiced: lines.filter(
+            (line) => lineStatus(line, effectiveVoice(line, doc.cast)) === "voiced"
+          ).length,
+          timeline_id: row.timeline_id ?? undefined,
+          updated_at: row.updated_at
+        };
+      })
+    };
+  }
+
+  userMessage(): string {
+    return "Listing scripts";
+  }
+}
+
+export class GetScriptTool extends Tool {
+  readonly name = "get_script";
+  readonly description =
+    "Read one script: its cast with each speaker's voice, and every line in " +
+    "reading order with its id, index, speaker, text, direction, pause, " +
+    "effective voice, and voicing status ('draft' = never voiced, 'stale' = " +
+    "text or voice changed since the take, 'voiced' = up to date, 'no_voice' = " +
+    "no speaker voice assigned). Call this before voicing — the other tools " +
+    "address lines by these ids.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      script_id: { type: "string" as const, description: "Script id." }
+    },
+    required: ["script_id"]
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const handle = await loadScript(context, params["script_id"]);
+    if (isError(handle)) return handle;
+    const { row, doc } = handle;
+    return {
+      id: row.id,
+      name: row.name,
+      timeline_id: row.timeline_id ?? undefined,
+      cast: doc.cast.map((speaker) => ({
+        id: speaker.id,
+        name: speaker.name,
+        voice: speaker.voice ?? null
+      })),
+      lines: scriptLines(doc.sections).map((line, index) => {
+        const voice = effectiveVoice(line, doc.cast);
+        return {
+          id: line.id,
+          index,
+          speaker_id: line.speakerId ?? null,
+          text: line.text,
+          direction: line.direction,
+          pause_after_ms: line.pauseAfterMs,
+          voice,
+          status: lineStatus(line, voice),
+          take_count: line.takes.length
+        };
+      })
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Reading script ${String(params["script_id"])}`;
+  }
+}
+
+export class VoiceScriptLinesTool extends Tool {
+  readonly name = "voice_script_lines";
+  readonly description =
+    "Synthesize speech for a script's lines by calling the TTS provider " +
+    "directly — no workflow is created or run. Each take is saved as an audio " +
+    "asset, appended to its line, and made the line's current take (earlier " +
+    "takes are kept). Omit `targets` to voice every line that is unvoiced or " +
+    "stale, so a whole script is one call. Each line uses its own voice (its " +
+    "override, else its speaker's) unless you pass provider/model/voice to " +
+    "override them all. Word timings are transcribed best-effort so the " +
+    "assembled timeline carries captions.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      script_id: { type: "string" as const, description: "Script id." },
+      targets: LINE_TARGETS_SCHEMA,
+      provider: {
+        type: "string" as const,
+        description:
+          "TTS provider id (from find_model, capability=text_to_speech). Overrides every line's own voice."
+      },
+      model: {
+        type: "string" as const,
+        description: "TTS model id (from find_model). Overrides every line's own voice."
+      },
+      voice: {
+        type: "string" as const,
+        description: "Voice id for the override. Required when provider/model are passed."
+      },
+      speed: {
+        type: "number" as const,
+        description: "Speech speed multiplier passed to the provider (e.g. 0.25–4.0)."
+      },
+      transcribe: {
+        type: "boolean" as const,
+        description:
+          "Transcribe each take for word timings (default true). Set false to skip the extra ASR call."
+      },
+      asr_provider: {
+        type: "string" as const,
+        description: `Provider for word timings (default ${DEFAULT_ASR_PROVIDER}).`
+      },
+      asr_model: {
+        type: "string" as const,
+        description: `Model for word timings (default ${DEFAULT_ASR_MODEL}).`
+      },
+      concurrency: {
+        type: "number" as const,
+        description: `Lines voiced in parallel (default ${DEFAULT_CONCURRENCY}, max ${MAX_CONCURRENCY}).`
+      }
+    },
+    required: ["script_id"]
+  };
+
+  private readonly speech = new GenerateSpeechTool();
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const handle = await loadScript(context, params["script_id"]);
+    if (isError(handle)) return handle;
+    const { row, doc } = handle;
+
+    const override = voiceOverrideFrom(params);
+    if (isError(override)) return override;
+
+    const lines = scriptLines(doc.sections);
+    const selected = selectLines(lines, params["targets"], override, doc);
+    if (isError(selected)) return selected;
+    if (selected.length === 0) {
+      return {
+        voiced: 0,
+        results: [],
+        note: "No line needs voicing. Every line with a voice is already up to date; name lines explicitly with `targets` to re-voice them."
+      };
+    }
+    if (selected.length > MAX_LINES_PER_CALL) {
+      return {
+        error: `${selected.length} lines selected, over the ${MAX_LINES_PER_CALL}-line per-call limit. Pass targets in batches.`
+      };
+    }
+
+    const speed = typeof params["speed"] === "number" ? params["speed"] : undefined;
+    const transcribe = params["transcribe"] !== false;
+    const asrProvider =
+      typeof params["asr_provider"] === "string"
+        ? (params["asr_provider"] as string)
+        : DEFAULT_ASR_PROVIDER;
+    const asrModel =
+      typeof params["asr_model"] === "string"
+        ? (params["asr_model"] as string)
+        : DEFAULT_ASR_MODEL;
+
+    const results = await mapWithConcurrency(
+      selected,
+      clampConcurrency(params["concurrency"]),
+      async ({ line, index }): Promise<LineOutcome> => {
+        const base: LineOutcome = {
+          line_id: line.id,
+          index,
+          text: line.text,
+          ok: false
+        };
+        const text = line.text.trim();
+        if (!text) return { ...base, error: "Line has no text to voice." };
+        const voice = override ?? effectiveVoice(line, doc.cast);
+        if (!voice) {
+          return {
+            ...base,
+            error:
+              "Line has no voice — give its speaker a voice, set a per-line override, or pass provider/model/voice to this call."
+          };
+        }
+
+        try {
+          const synthesized = (await this.speech.process(context, {
+            provider: voice.provider,
+            model: voice.model,
+            text,
+            voice: voice.voice,
+            speed
+          })) as {
+            asset_id?: string;
+            asset_uri?: string;
+            error?: string;
+          };
+          if (synthesized.error) return { ...base, error: synthesized.error };
+          if (!synthesized.asset_id) {
+            return {
+              ...base,
+              error:
+                "The take was synthesized but could not be saved as an asset, so it cannot be attached to the line. This host has no asset storage wired."
+            };
+          }
+
+          const { bytes } = await context.resolveAssetBytes(
+            synthesized.asset_uri ?? synthesized.asset_id
+          );
+          const audio = bytes ?? new Uint8Array();
+          const words = transcribe
+            ? await transcribeWords(context, audio, asrProvider, asrModel)
+            : [];
+          const durationMs = await measureDurationMs(audio, words);
+
+          const take: ScriptTake = {
+            id: `take_${randomUUID()}`,
+            assetId: synthesized.asset_id,
+            durationMs,
+            words,
+            textSnapshot: line.text,
+            voiceSnapshot: voice,
+            createdAt: new Date().toISOString()
+          };
+          const saved = await appendTake(row.id, line.id, take);
+          if (isError(saved)) return { ...base, error: saved.error };
+
+          return {
+            ...base,
+            ok: true,
+            take_id: take.id,
+            asset_id: take.assetId,
+            duration_ms: durationMs,
+            word_count: words.length
+          };
+        } catch (e) {
+          return { ...base, error: `text_to_speech failed: ${errorMessage(e)}` };
+        }
+      }
+    );
+
+    return {
+      script_id: row.id,
+      voiced: results.filter((r) => r.ok).length,
+      failed: results.filter((r) => !r.ok).length,
+      results
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    const targets = params["targets"];
+    const count = Array.isArray(targets) ? `${targets.length} ` : "";
+    return `Voicing ${count}script lines`;
+  }
+}
+
+/** The call-level voice override, or null when the lines' own voices apply. */
+function voiceOverrideFrom(
+  params: Record<string, unknown>
+): ScriptVoiceBinding | null | ToolError {
+  const provider = params["provider"];
+  const model = params["model"];
+  const voice = params["voice"];
+  const any = [provider, model, voice].some((v) => typeof v === "string" && v);
+  if (!any) return null;
+  if (
+    typeof provider !== "string" ||
+    !provider ||
+    typeof model !== "string" ||
+    !model ||
+    typeof voice !== "string" ||
+    !voice
+  ) {
+    return {
+      error:
+        "A voice override needs all three of provider, model, and voice (use find_model with capability=text_to_speech). Omit all three to use each line's own voice."
+    };
+  }
+  return { provider, model, voice };
+}
+
+interface SelectedLine {
+  line: ScriptLine;
+  index: number;
+}
+
+/**
+ * The lines a voicing call acts on: the explicit `targets` when given, else
+ * every line that needs voicing — the default that makes a whole script one
+ * call. An override applies to every named line, since the caller chose the
+ * voice; without one, staleness is measured against the line's own voice.
+ */
+function selectLines(
+  lines: ScriptLine[],
+  targets: unknown,
+  override: ScriptVoiceBinding | null,
+  doc: ScriptDocument
+): SelectedLine[] | ToolError {
+  if (targets === undefined || targets === null) {
+    return lines
+      .map((line, index) => ({ line, index }))
+      .filter(({ line }) => {
+        const voice = override ?? effectiveVoice(line, doc.cast);
+        return (
+          line.text.trim().length > 0 && !!voice && needsVoicing(line, voice)
+        );
+      });
+  }
+  const list = Array.isArray(targets) ? targets : [targets];
+  const selected: SelectedLine[] = [];
+  for (const raw of list) {
+    const target = String(raw);
+    const line = findLine(lines, target);
+    if (!line) {
+      return {
+        error: `No line matches "${target}". Call get_script to list line ids and indexes.`
+      };
+    }
+    if (selected.some((s) => s.line.id === line.id)) continue;
+    selected.push({ line, index: lines.indexOf(line) });
+  }
+  return selected;
+}
+
+export class AssembleScriptTimelineTool extends Tool {
+  readonly name = "assemble_script_timeline";
+  readonly description =
+    "Lay a script's voiced takes end to end into a voiceover timeline sequence " +
+    "and save it, without building a workflow. Each clip carries its take's " +
+    "word timings, the speaker label, and a link back to its script line, so a " +
+    "later re-voice can round-trip into the cut. Lines with no voiced take are " +
+    "skipped and listed. Re-running rebuilds the same sequence in place, " +
+    "keeping clips other surfaces added. Validate the result with " +
+    "validate_timeline before rendering.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      script_id: { type: "string" as const, description: "Script id." },
+      name: {
+        type: "string" as const,
+        description: "Name for the sequence. Defaults to the script's name."
+      },
+      fps: { type: "number" as const, description: "Frame rate (default 30)." }
+    },
+    required: ["script_id"]
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const handle = await loadScript(context, params["script_id"]);
+    if (isError(handle)) return handle;
+    const { row, doc } = handle;
+
+    const assembled = buildScriptTimeline({
+      scriptId: row.id,
+      cast: doc.cast,
+      sections: doc.sections
+    });
+    if (assembled.clips.length === 0) {
+      return {
+        error:
+          "No line has a voiced take, so there is nothing to assemble. Run voice_script_lines first.",
+        skipped_line_ids: assembled.skippedLineIds
+      };
+    }
+
+    const fps = Math.max(1, Math.min(Number(params["fps"]) || 30, 120));
+    const name =
+      typeof params["name"] === "string" && params["name"]
+        ? (params["name"] as string)
+        : row.name;
+
+    const existing = row.timeline_id
+      ? await TimelineSequence.findById(row.timeline_id)
+      : null;
+    const reuse = existing && existing.user_id === context.userId ? existing : null;
+
+    let tracks = assembled.tracks;
+    let clips = assembled.clips;
+    let durationMs = assembled.durationMs;
+
+    if (reuse) {
+      // Re-assembling replaces this script's voiceover track and clips, and
+      // leaves everything another surface put in the sequence alone.
+      const previous = reuse.toDocument();
+      const foreignClips = previous.clips.filter((c) => c.scriptId !== row.id);
+      const scriptTrackIds = new Set(
+        previous.clips.filter((c) => c.scriptId === row.id).map((c) => c.trackId)
+      );
+      const foreignTrackIds = new Set(foreignClips.map((c) => c.trackId));
+      const foreignTracks = previous.tracks.filter(
+        (t) => foreignTrackIds.has(t.id) || !scriptTrackIds.has(t.id)
+      );
+      tracks = [...assembled.tracks, ...foreignTracks];
+      clips = [...assembled.clips, ...foreignClips];
+      durationMs = clips.reduce(
+        (end, c) => Math.max(end, c.startMs + c.durationMs),
+        0
+      );
+    }
+
+    const sequence =
+      reuse ??
+      new TimelineSequence({
+        user_id: context.userId,
+        project_id: row.project_id,
+        name
+      });
+    sequence.name = name;
+    sequence.fps = fps;
+    sequence.duration_ms = durationMs;
+    sequence.fromDocument({
+      ...(reuse ? reuse.toDocument() : {}),
+      tracks,
+      clips,
+      markers: reuse ? reuse.toDocument().markers : []
+    });
+    await sequence.save();
+
+    if (row.timeline_id !== sequence.id) {
+      await Script.updateFieldsIfUnchanged(row.id, row.updated_at, {
+        timeline_id: sequence.id
+      });
+    }
+
+    return {
+      ok: true,
+      timeline_id: sequence.id,
+      name: sequence.name,
+      fps,
+      duration_ms: durationMs,
+      clip_count: clips.length,
+      track_count: tracks.length,
+      skipped_line_ids: assembled.skippedLineIds
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Assembling script ${String(params["script_id"])} into a timeline`;
+  }
+}
+
+/** Every tool in this module, for toolbelt assembly and docs. */
+export const SCRIPT_VOICE_TOOL_NAMES = [
+  "list_scripts",
+  "get_script",
+  "voice_script_lines",
+  "assemble_script_timeline"
+] as const;

--- a/packages/agents/src/tools/tool-permissions.ts
+++ b/packages/agents/src/tools/tool-permissions.ts
@@ -73,6 +73,8 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   list_workflows: "read",
   get_workflow: "read",
   validate_workflow: "read",
+  list_scripts: "read",
+  get_script: "read",
   validate_timeline: "read",
   get_example_workflow: "read",
   export_workflow_digraph: "read",
@@ -159,6 +161,10 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   generate_video: "write",
   animate_image: "write",
   generate_speech: "write",
+  // Voicing calls a TTS model per line and writes takes onto a local script;
+  // assembly writes a timeline row.
+  voice_script_lines: "write",
+  assemble_script_timeline: "write",
   transcribe_audio: "write",
   embed_text: "write",
   openai_image_generation: "write",

--- a/packages/agents/tests/script-voice-tools.test.ts
+++ b/packages/agents/tests/script-voice-tools.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  Asset,
+  ModelObserver,
+  Script,
+  TimelineSequence,
+  initTestDb
+} from "@nodetool-ai/models";
+import type { ScriptLine, ScriptTake } from "@nodetool-ai/models";
+import {
+  ListScriptsTool,
+  GetScriptTool,
+  VoiceScriptLinesTool,
+  AssembleScriptTimelineTool
+} from "../src/tools/script-voice-tools.js";
+import { permissionCategoryFor } from "../src/tools/tool-permissions.js";
+import { BUILTIN_TOOL_CLASSES } from "../src/tools/builtin-tools.js";
+
+/**
+ * A real 500ms mono 16-bit WAV at 8kHz. Real bytes so the duration probe has
+ * something to measure: with ffprobe on PATH it reads 500ms, and without it
+ * the word timings below say 500ms too — the assertion holds either way.
+ */
+const TAKE_MS = 500;
+function wav(durationMs = TAKE_MS): Uint8Array {
+  const sampleRate = 8000;
+  const samples = Math.round((sampleRate * durationMs) / 1000);
+  const dataBytes = samples * 2;
+  const buffer = new ArrayBuffer(44 + dataBytes);
+  const view = new DataView(buffer);
+  const ascii = (offset: number, text: string) => {
+    for (let i = 0; i < text.length; i++) view.setUint8(offset + i, text.charCodeAt(i));
+  };
+  ascii(0, "RIFF");
+  view.setUint32(4, 36 + dataBytes, true);
+  ascii(8, "WAVE");
+  ascii(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  ascii(36, "data");
+  view.setUint32(40, dataBytes, true);
+  return new Uint8Array(buffer);
+}
+
+const VOICE = { provider: "openai", model: "tts-1", voice: "alloy" };
+
+interface CtxOptions {
+  userId?: string;
+  tts?: () => Promise<{ data: Uint8Array; mimeType: string }>;
+  asrWords?: Array<{ text: string; timestamp: [number, number] }>;
+  /** Error the streaming TTS fallback raises. */
+  streamError?: string;
+}
+
+function ctx(options: CtxOptions = {}) {
+  const stored = new Map<string, Uint8Array>();
+  const textToSpeechEncoded = vi.fn(
+    options.tts ?? (async () => ({ data: wav(), mimeType: "audio/wav" }))
+  );
+  const automaticSpeechRecognition = vi.fn(async () => ({
+    text: "hello",
+    chunks:
+      options.asrWords ??
+      ([{ text: "hello", timestamp: [0, TAKE_MS / 1000] }] as Array<{
+        text: string;
+        timestamp: [number, number];
+      }>)
+  }));
+  const context = {
+    userId: options.userId ?? "u1",
+    getProvider: vi.fn(async () => ({
+      textToSpeechEncoded,
+      automaticSpeechRecognition
+    })),
+    createAsset: vi.fn(
+      async (args: { name: string; contentType: string; content: Uint8Array }) => {
+        const asset = await Asset.create<Asset>({
+          user_id: "u1",
+          name: args.name,
+          content_type: args.contentType
+        });
+        stored.set(asset.id, args.content);
+        return asset;
+      }
+    ),
+    // GenerateSpeechTool falls back to the streaming path when the encoded one
+    // fails, so the fake has to answer both.
+    streamProviderPrediction: async function* () {
+      throw new Error(options.streamError ?? "no streaming TTS in this fake");
+    },
+    resolveAssetBytes: vi.fn(async (uri: string) => ({
+      bytes: stored.get(uri.replace("asset://", "").split(".")[0]) ?? null
+    }))
+  };
+  return {
+    context: context as unknown as ProcessingContext,
+    textToSpeechEncoded,
+    automaticSpeechRecognition
+  };
+}
+
+const line = (overrides: Partial<ScriptLine> & { id: string }): ScriptLine => ({
+  text: "A line",
+  takes: [],
+  ...overrides
+});
+
+const take = (overrides: Partial<ScriptTake> & { id: string }): ScriptTake => ({
+  assetId: "a-old",
+  durationMs: 1000,
+  words: [],
+  textSnapshot: "A line",
+  voiceSnapshot: VOICE,
+  createdAt: new Date().toISOString(),
+  ...overrides
+});
+
+async function makeScript(
+  lines: ScriptLine[],
+  cast = [{ id: "sp1", name: "Narrator", voice: VOICE }]
+): Promise<Script> {
+  return Script.create<Script>({
+    user_id: "u1",
+    project_id: "default",
+    name: "Script",
+    document: JSON.stringify({
+      cast,
+      sections: [{ id: "sec1", title: "Main", lines }]
+    })
+  });
+}
+
+describe("script voice tools", () => {
+  beforeEach(() => initTestDb());
+  afterEach(() => ModelObserver.clear());
+
+  it("registers as built-ins with sane permissions", () => {
+    const names = BUILTIN_TOOL_CLASSES.map((Cls) => new Cls().name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "list_scripts",
+        "get_script",
+        "voice_script_lines",
+        "assemble_script_timeline"
+      ])
+    );
+    expect(permissionCategoryFor("get_script")).toBe("read");
+    expect(permissionCategoryFor("voice_script_lines")).toBe("write");
+  });
+
+  it("lists scripts and reports each line's voicing status", async () => {
+    const row = await makeScript([
+      line({ id: "l1", speakerId: "sp1", text: "Voiced", currentTakeId: "t1", takes: [take({ id: "t1", textSnapshot: "Voiced" })] }),
+      line({ id: "l2", speakerId: "sp1", text: "Edited", currentTakeId: "t2", takes: [take({ id: "t2", textSnapshot: "Before the edit" })] }),
+      line({ id: "l3", speakerId: "sp1", text: "Never voiced" }),
+      line({ id: "l4", text: "No speaker" })
+    ]);
+
+    const listed = (await new ListScriptsTool().process(ctx().context, {})) as {
+      scripts: Array<{ id: string; lines: number; voiced: number }>;
+    };
+    expect(listed.scripts[0]).toMatchObject({ id: row.id, lines: 4, voiced: 1 });
+
+    const read = (await new GetScriptTool().process(ctx().context, {
+      script_id: row.id
+    })) as { lines: Array<{ id: string; index: number; status: string }> };
+    expect(read.lines.map((l) => [l.id, l.index, l.status])).toEqual([
+      ["l1", 0, "voiced"],
+      ["l2", 1, "stale"],
+      ["l3", 2, "draft"],
+      ["l4", 3, "no_voice"]
+    ]);
+  });
+
+  it("hides a script owned by another user", async () => {
+    const row = await makeScript([line({ id: "l1" })]);
+    const result = (await new GetScriptTool().process(
+      ctx({ userId: "other" }).context,
+      { script_id: row.id }
+    )) as { error: string };
+    expect(result.error).toContain("not found");
+  });
+
+  it("voices every line that needs it, with each line's own voice", async () => {
+    const row = await makeScript([
+      line({ id: "l1", speakerId: "sp1", text: "First" }),
+      line({
+        id: "l2",
+        speakerId: "sp1",
+        text: "Already done",
+        currentTakeId: "t2",
+        takes: [take({ id: "t2", textSnapshot: "Already done" })]
+      }),
+      line({ id: "l3", speakerId: "sp1", text: "Third" })
+    ]);
+    const { context, textToSpeechEncoded } = ctx();
+
+    const result = (await new VoiceScriptLinesTool().process(context, {
+      script_id: row.id
+    })) as {
+      voiced: number;
+      failed: number;
+      results: Array<{ line_id: string; duration_ms?: number; word_count?: number }>;
+    };
+
+    expect(result.voiced).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(result.results.map((r) => r.line_id)).toEqual(["l1", "l3"]);
+    expect(result.results[0].duration_ms).toBe(TAKE_MS);
+    expect(result.results[0].word_count).toBe(1);
+    expect(textToSpeechEncoded.mock.calls[0][0]).toMatchObject({
+      model: "tts-1",
+      voice: "alloy"
+    });
+
+    const saved = (await Script.findById(row.id))!.toDocument();
+    const lines = saved.sections[0].lines;
+    expect(lines[0].takes).toHaveLength(1);
+    expect(lines[0].currentTakeId).toBe(lines[0].takes[0].id);
+    expect(lines[0].takes[0].textSnapshot).toBe("First");
+    // The up-to-date line is untouched.
+    expect(lines[1].currentTakeId).toBe("t2");
+  });
+
+  it("skips a line with no voice and says how to fix it", async () => {
+    const row = await makeScript([line({ id: "l1", text: "Orphan" })], []);
+    const result = (await new VoiceScriptLinesTool().process(ctx().context, {
+      script_id: row.id,
+      targets: ["l1"]
+    })) as { voiced: number; results: Array<{ error?: string }> };
+    expect(result.voiced).toBe(0);
+    expect(result.results[0].error).toContain("no voice");
+  });
+
+  it("applies a call-level voice override to the named lines", async () => {
+    const row = await makeScript([line({ id: "l1", speakerId: "sp1", text: "Line" })]);
+    const { context, textToSpeechEncoded } = ctx();
+
+    await new VoiceScriptLinesTool().process(context, {
+      script_id: row.id,
+      targets: ["0"],
+      provider: "elevenlabs",
+      model: "eleven_v3",
+      voice: "rachel"
+    });
+
+    expect(textToSpeechEncoded.mock.calls[0][0]).toMatchObject({
+      model: "eleven_v3",
+      voice: "rachel"
+    });
+  });
+
+  it("rejects a half-specified voice override", async () => {
+    const row = await makeScript([line({ id: "l1", speakerId: "sp1" })]);
+    const result = (await new VoiceScriptLinesTool().process(ctx().context, {
+      script_id: row.id,
+      provider: "elevenlabs"
+    })) as { error: string };
+    expect(result.error).toContain("provider, model, and voice");
+  });
+
+  it("reports a failed synthesis per line without failing the batch", async () => {
+    const row = await makeScript([
+      line({ id: "l1", speakerId: "sp1", text: "One" }),
+      line({ id: "l2", speakerId: "sp1", text: "Two" })
+    ]);
+    let call = 0;
+    const { context } = ctx({
+      // Both TTS paths fail for the first line — the encoded one the tool
+      // prefers, and the streaming one it falls back to.
+      streamError: "provider exploded",
+      tts: async () => {
+        call += 1;
+        if (call === 1) throw new Error("provider exploded");
+        return { data: wav(), mimeType: "audio/wav" };
+      }
+    });
+
+    const result = (await new VoiceScriptLinesTool().process(context, {
+      script_id: row.id,
+      concurrency: 1
+    })) as { voiced: number; failed: number; results: Array<{ error?: string }> };
+
+    expect(result.failed).toBe(1);
+    expect(result.voiced).toBe(1);
+    expect(result.results[0].error).toContain("provider exploded");
+  });
+
+  it("skips transcription when asked, falling back to the placeholder length", async () => {
+    const row = await makeScript([line({ id: "l1", speakerId: "sp1", text: "Line" })]);
+    const { context, automaticSpeechRecognition } = ctx();
+
+    const result = (await new VoiceScriptLinesTool().process(context, {
+      script_id: row.id,
+      transcribe: false
+    })) as { results: Array<{ duration_ms?: number; word_count?: number }> };
+
+    expect(automaticSpeechRecognition).not.toHaveBeenCalled();
+    expect(result.results[0].word_count).toBe(0);
+    // ffprobe reads the real WAV; without it on PATH the placeholder applies.
+    expect([TAKE_MS, 3000]).toContain(result.results[0].duration_ms);
+  });
+
+  it("assembles voiced takes into a timeline and links it to the script", async () => {
+    const row = await makeScript([
+      line({
+        id: "l1",
+        speakerId: "sp1",
+        text: "First line",
+        pauseAfterMs: 250,
+        currentTakeId: "t1",
+        takes: [
+          take({
+            id: "t1",
+            assetId: "a1",
+            durationMs: 1000,
+            textSnapshot: "First line",
+            words: [{ word: "First", startMs: 0, endMs: 400 }]
+          })
+        ]
+      }),
+      line({ id: "l2", speakerId: "sp1", text: "Not voiced" }),
+      line({
+        id: "l3",
+        speakerId: "sp1",
+        text: "Third line",
+        currentTakeId: "t3",
+        takes: [take({ id: "t3", assetId: "a3", durationMs: 800, textSnapshot: "Third line" })]
+      })
+    ]);
+
+    const result = (await new AssembleScriptTimelineTool().process(ctx().context, {
+      script_id: row.id
+    })) as {
+      timeline_id: string;
+      duration_ms: number;
+      clip_count: number;
+      skipped_line_ids: string[];
+    };
+
+    expect(result.clip_count).toBe(2);
+    // 1000 + 250 pause + 800
+    expect(result.duration_ms).toBe(2050);
+    expect(result.skipped_line_ids).toEqual(["l2"]);
+
+    const sequence = (await TimelineSequence.findById(result.timeline_id))!;
+    const document = sequence.toDocument();
+    expect(document.clips[0]).toMatchObject({
+      startMs: 0,
+      durationMs: 1000,
+      currentAssetId: "a1",
+      scriptId: row.id,
+      scriptLineId: "l1",
+      speaker: "Narrator",
+      voice: "alloy"
+    });
+    expect(document.clips[0].caption?.words).toHaveLength(1);
+    expect(document.clips[1].startMs).toBe(1250);
+    expect((await Script.findById(row.id))!.timeline_id).toBe(result.timeline_id);
+
+    // Re-assembling updates the same sequence and keeps foreign clips.
+    const again = (await new AssembleScriptTimelineTool().process(ctx().context, {
+      script_id: row.id
+    })) as { timeline_id: string; clip_count: number };
+    expect(again.timeline_id).toBe(result.timeline_id);
+    expect(again.clip_count).toBe(2);
+  });
+
+  it("refuses to assemble a script with nothing voiced", async () => {
+    const row = await makeScript([line({ id: "l1", speakerId: "sp1" })]);
+    const result = (await new AssembleScriptTimelineTool().process(ctx().context, {
+      script_id: row.id
+    })) as { error: string };
+    expect(result.error).toContain("voice_script_lines");
+  });
+});

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -15,7 +15,8 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@nodetool-ai/gpu": "*"
+    "@nodetool-ai/gpu": "*",
+    "@nodetool-ai/protocol": "*"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -7,6 +7,7 @@ export * from "./defaults.js";
 // `dependencyHash` is intentionally NOT re-exported: it depends on
 // `node:crypto`, which breaks browser bundles. Server consumers should
 // import it directly from "@nodetool-ai/timeline/dependencyHash".
+export * from "./script.js";
 export * from "./splitClip.js";
 export * from "./trimClip.js";
 export * from "./sourceRate.js";

--- a/packages/timeline/src/script.ts
+++ b/packages/timeline/src/script.ts
@@ -1,0 +1,137 @@
+/**
+ * Script → timeline assembly, and the voicing rules around it.
+ *
+ * A script owns its text; audio is derived. Assembly projects each line's
+ * current take into a voiceover track: one asset-backed audio clip per voiced
+ * line, laid end to end in reading order with the line's authored
+ * `pauseAfterMs` gap. Every clip carries its take's word timings, the speaker
+ * label, and two linkage keys (`scriptId` + `scriptLineId`) so a later re-voice
+ * can round-trip its new take into the assembled sequence — the script mirror
+ * of the storyboard's board/shot bridge.
+ *
+ * One module because three surfaces need the same answer: the editor's "Send
+ * to timeline", the `nodetool.script.*` nodes, and the headless
+ * `assemble_script_timeline` agent tool. Types come from
+ * `@nodetool-ai/protocol` as types only, so this stays free of runtime deps.
+ */
+
+import type {
+  ScriptLine,
+  ScriptSection,
+  Speaker,
+  Take,
+  VoiceBinding
+} from "@nodetool-ai/protocol/api-schemas/scripts.js";
+import { makeClip, makeTrack } from "./defaults.js";
+import type { CaptionWord, TimelineClip, TimelineTrack } from "./types.js";
+
+/** Clip length for a take whose duration could not be determined. */
+export const PLACEHOLDER_LINE_MS = 3000;
+
+export interface ScriptAssemblyInput {
+  /** Script id stamped onto each clip, linking the cut back to the script. */
+  scriptId: string;
+  cast: Speaker[];
+  sections: ScriptSection[];
+}
+
+export interface AssembledScriptTimeline {
+  tracks: TimelineTrack[];
+  clips: TimelineClip[];
+  /** Total length of the voiceover track in ms (last clip end). */
+  durationMs: number;
+  /** Lines skipped because they have no voiced current take. */
+  skippedLineIds: string[];
+}
+
+/** Every line of the script in reading order. */
+export const scriptLines = (sections: ScriptSection[]): ScriptLine[] =>
+  sections.flatMap((section) => section.lines);
+
+/** The current take of a line, if one is selected and present. */
+export const currentTake = (line: ScriptLine): Take | undefined =>
+  line.takes.find((take) => take.id === line.currentTakeId);
+
+/** The voice a line is voiced with: its own override, else its speaker's. */
+export const effectiveVoice = (
+  line: ScriptLine,
+  cast: Speaker[]
+): VoiceBinding | null => {
+  if (line.voiceOverride) return line.voiceOverride;
+  const speaker = cast.find((s) => s.id === line.speakerId);
+  return speaker?.voice ?? null;
+};
+
+/**
+ * Whether a line needs (re-)voicing: it has no current take, or the text or
+ * voice drifted from what that take was voiced from. Staleness is derived,
+ * never stored.
+ */
+export const needsVoicing = (
+  line: ScriptLine,
+  voice: VoiceBinding | null
+): boolean => {
+  const take = currentTake(line);
+  if (!take) return true;
+  return (
+    take.textSnapshot !== line.text ||
+    JSON.stringify(take.voiceSnapshot ?? null) !== JSON.stringify(voice)
+  );
+};
+
+/** A line is assemblable when its current take landed as an audio asset. */
+export const isAssemblableLine = (line: ScriptLine): boolean => {
+  const take = currentTake(line);
+  return !!take && typeof take.assetId === "string" && take.assetId.length > 0;
+};
+
+/** Copy a take's word timings into the timeline's `CaptionWord` shape. */
+export const takeCaptionWords = (take: Take): CaptionWord[] =>
+  take.words.map((w) => ({ word: w.word, startMs: w.startMs, endMs: w.endMs }));
+
+export function buildScriptTimeline(
+  input: ScriptAssemblyInput
+): AssembledScriptTimeline {
+  const track = makeTrack({ type: "audio", name: "Voiceover", index: 0 });
+  const tracks: TimelineTrack[] = [track];
+  const clips: TimelineClip[] = [];
+  const skippedLineIds: string[] = [];
+
+  const speakerName = (speakerId?: string | null): string | undefined =>
+    speakerId ? input.cast.find((s) => s.id === speakerId)?.name : undefined;
+
+  let cursorMs = 0;
+  for (const line of scriptLines(input.sections)) {
+    const take = currentTake(line);
+    if (!take || !take.assetId) {
+      skippedLineIds.push(line.id);
+      continue;
+    }
+    const durationMs =
+      take.durationMs > 0 ? take.durationMs : PLACEHOLDER_LINE_MS;
+    const words = takeCaptionWords(take);
+    clips.push(
+      makeClip({
+        trackId: track.id,
+        name: line.text.slice(0, 40) || "Line",
+        startMs: cursorMs,
+        durationMs,
+        mediaType: "audio",
+        sourceType: "imported",
+        bindingKind: "text-to-audio",
+        status: "generated",
+        currentAssetId: take.assetId,
+        prompt: line.text,
+        voice: effectiveVoice(line, input.cast)?.voice,
+        speaker: speakerName(line.speakerId),
+        caption: words.length ? { words } : undefined,
+        scriptId: input.scriptId,
+        scriptLineId: line.id,
+        versions: []
+      })
+    );
+    cursorMs += durationMs + Math.max(0, line.pauseAfterMs ?? 0);
+  }
+
+  return { tracks, clips, durationMs: cursorMs, skippedLineIds };
+}

--- a/packages/video-nodes/src/nodes/script.ts
+++ b/packages/video-nodes/src/nodes/script.ts
@@ -15,18 +15,26 @@ import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { concatBytes, encodePcm16Wav } from "@nodetool-ai/audio-nodes";
 import {
   assembleSubtitleCues,
+  buildScriptTimeline,
+  currentTake,
+  effectiveVoice,
   formatSubtitles,
-  makeClip,
   makeSequence,
-  makeTrack,
-  type CaptionWord,
+  needsVoicing,
+  scriptLines,
+  PLACEHOLDER_LINE_MS,
   type SubtitleEntry,
   type SubtitleFormat,
   type SubtitleGranularity,
-  type TimelineClip,
-  type TimelineSequence,
-  type TimelineTrack
+  type TimelineSequence
 } from "@nodetool-ai/timeline";
+import type {
+  ScriptLine,
+  ScriptSection,
+  Speaker,
+  Take,
+  VoiceBinding
+} from "@nodetool-ai/protocol/api-schemas/scripts.js";
 import { tagAsNode } from "@nodetool-ai/nodes-utils";
 import { promises as fs } from "node:fs";
 import os from "node:os";
@@ -36,52 +44,13 @@ import { ffprobeDuration } from "./ffmpeg-helpers.js";
 
 const scriptRefDefault = { type: "script", id: null, data: null } as const;
 
-/** Fallback clip length for a take whose duration could not be determined. */
-const PLACEHOLDER_LINE_MS = 3000;
-
 // ── Script document shapes (structurally match @nodetool-ai/models Script) ──
 
-interface VoiceBindingLike {
-  provider: string;
-  model: string;
-  voice: string;
-  settings?: Record<string, unknown>;
-}
-
-interface ScriptTakeLike {
-  id: string;
-  assetId: string;
-  durationMs: number;
-  words: CaptionWord[];
-  textSnapshot: string;
-  voiceSnapshot: VoiceBindingLike | null;
-  createdAt: string;
-  favorite?: boolean;
-  costCredits?: number;
-}
-
-interface ScriptLineLike {
-  id: string;
-  speakerId?: string | null;
-  text: string;
-  direction?: string;
-  pauseAfterMs?: number;
-  voiceOverride?: VoiceBindingLike | null;
-  takes: ScriptTakeLike[];
-  currentTakeId?: string | null;
-}
-
-interface ScriptSpeakerLike {
-  id: string;
-  name: string;
-  color?: string;
-  voice?: VoiceBindingLike | null;
-}
-
-interface ScriptDocumentLike {
-  cast: ScriptSpeakerLike[];
-  sections: { id: string; title?: string; lines: ScriptLineLike[] }[];
-}
+type VoiceBindingLike = VoiceBinding;
+type ScriptTakeLike = Take;
+type ScriptLineLike = ScriptLine;
+type ScriptSpeakerLike = Speaker;
+type ScriptDocumentLike = { cast: Speaker[]; sections: ScriptSection[] };
 
 interface ScriptResponseLike {
   id: string;
@@ -121,33 +90,7 @@ async function loadScript(
 }
 
 const allLines = (doc: ScriptDocumentLike): ScriptLineLike[] =>
-  doc.sections.flatMap((s) => s.lines);
-
-const currentTake = (line: ScriptLineLike): ScriptTakeLike | undefined =>
-  line.takes.find((t) => t.id === line.currentTakeId);
-
-/** The voice a line will be voiced with: its override, else its speaker's. */
-const effectiveVoice = (
-  line: ScriptLineLike,
-  cast: ScriptSpeakerLike[]
-): VoiceBindingLike | null => {
-  if (line.voiceOverride) return line.voiceOverride;
-  const speaker = cast.find((s) => s.id === line.speakerId);
-  return speaker?.voice ?? null;
-};
-
-/** Whether a line needs (re-)voicing: no current take, or text/voice drifted. */
-const needsVoicing = (
-  line: ScriptLineLike,
-  voice: VoiceBindingLike | null
-): boolean => {
-  const take = currentTake(line);
-  if (!take) return true;
-  return (
-    take.textSnapshot !== line.text ||
-    JSON.stringify(take.voiceSnapshot) !== JSON.stringify(voice)
-  );
-};
+  scriptLines(doc.sections);
 
 // ── Nodes ────────────────────────────────────────────────────────────────────
 
@@ -317,44 +260,15 @@ export class ScriptToTimelineNode extends BaseNode {
     }
     const script = await loadScript(this.script, context);
     const doc = script.document;
-    const cast = doc.cast ?? [];
     const name = script.name?.trim() || "Script voiceover";
 
-    const track = makeTrack({ type: "audio", name: "Voiceover", index: 0 });
-    const tracks: TimelineTrack[] = [track];
-    const clips: TimelineClip[] = [];
-
-    const speakerName = (speakerId?: string | null): string | undefined =>
-      speakerId ? cast.find((s) => s.id === speakerId)?.name : undefined;
-
-    let cursorMs = 0;
-    for (const line of allLines(doc)) {
-      const take = currentTake(line);
-      if (!take || !take.assetId) continue;
-      const durationMs =
-        take.durationMs > 0 ? take.durationMs : PLACEHOLDER_LINE_MS;
-      clips.push(
-        makeClip({
-          trackId: track.id,
-          name: line.text.slice(0, 40) || "Line",
-          startMs: cursorMs,
-          durationMs,
-          mediaType: "audio",
-          sourceType: "imported",
-          bindingKind: "text-to-audio",
-          status: "generated",
-          currentAssetId: take.assetId,
-          prompt: line.text,
-          voice: effectiveVoice(line, cast)?.voice,
-          speaker: speakerName(line.speakerId),
-          caption: take.words.length ? { words: take.words } : undefined,
-          scriptId: script.id,
-          scriptLineId: line.id,
-          versions: []
-        })
-      );
-      cursorMs += durationMs + Math.max(0, line.pauseAfterMs ?? 0);
-    }
+    // Same mapping the editor's "Send to timeline" and the headless
+    // assemble_script_timeline tool use.
+    const { tracks, clips, durationMs: cursorMs } = buildScriptTimeline({
+      scriptId: script.id,
+      cast: doc.cast ?? [],
+      sections: doc.sections
+    });
 
     if (clips.length === 0) {
       throw new Error(

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1475,6 +1475,14 @@ function formatUiContext(uiContext?: UiContext | null): string {
       "After editing a timeline sequence, call `validate_timeline` with its id. It statically catches clips on missing tracks, overlaps, fades longer than their clip, and timings that cannot render — before the user renders."
     );
   }
+
+  const hasScript =
+    focused?.type === "script" || open.some((ref) => ref.type === "script");
+  if (hasScript) {
+    lines.push(
+      "To voice a script, do not author a workflow: `voice_script_lines` synthesizes each line with its cast voice and saves the takes onto the script, and `assemble_script_timeline` lays the voiced takes into a timeline sequence. Both default to the whole script, so one call covers it."
+    );
+  }
   return lines.join("\n");
 }
 

--- a/web/src/components/script/assembleScriptTimeline.ts
+++ b/web/src/components/script/assembleScriptTimeline.ts
@@ -1,102 +1,32 @@
 /**
  * assembleScriptTimeline — pure mapping from a script to a timeline document.
  *
- * The script owns its text; audio is derived. "Send to timeline" projects the
- * current takes into a voiceover track: one asset-backed audio clip per voiced
- * line, laid end to end in reading order with each line's `pauseAfterMs` gap.
- * Every clip carries its take's word timings (`caption`), the speaker label,
- * and two linkage keys (`scriptId` + `scriptLineId`) so a later re-voice can
- * round-trip its new take into the assembled sequence — the script mirror of
- * the storyboard's `storyboardBoardId`/`storyboardShotId` bridge.
- *
- * Lines without a voiced current take are skipped (reported as
- * `skippedLineIds`) rather than laid as placeholders.
+ * The mapping lives in `@nodetool-ai/timeline` so the editor's "Send to
+ * timeline", the `nodetool.script.*` nodes, and the headless
+ * `assemble_script_timeline` agent tool all lay the same voiceover track; this
+ * module only adapts the editor's draft shape to it.
  */
 
-import { makeClip, makeTrack } from "@nodetool-ai/timeline";
-import type {
-  CaptionWord,
-  TimelineClip,
-  TimelineTrack
-} from "@nodetool-ai/timeline";
 import {
-  effectiveVoice,
-  type ScriptDraft,
-  type ScriptLine,
-  type ScriptTake
-} from "../../stores/script/ScriptStore";
+  buildScriptTimeline,
+  type AssembledScriptTimeline
+} from "@nodetool-ai/timeline";
+import type { ScriptDraft } from "../../stores/script/ScriptStore";
 
-/** Fallback clip length for a take whose duration was never probed. */
-const PLACEHOLDER_LINE_MS = 3000;
+export {
+  currentTake,
+  isAssemblableLine,
+  takeCaptionWords
+} from "@nodetool-ai/timeline";
 
-export interface AssembledScriptDocument {
-  tracks: TimelineTrack[];
-  clips: TimelineClip[];
-  /** Total length of the voiceover track in ms (last clip end). */
-  durationMs: number;
-  /** Lines skipped because they have no voiced current take. */
-  skippedLineIds: string[];
-}
-
-/** The current take of a line, if one is selected and present. */
-export const currentTake = (line: ScriptLine): ScriptTake | undefined =>
-  line.takes.find((t) => t.id === line.currentTakeId);
-
-/** A line is assemblable when its current take landed as an audio asset. */
-export const isAssemblableLine = (line: ScriptLine): boolean => {
-  const take = currentTake(line);
-  return !!take && typeof take.assetId === "string" && take.assetId.length > 0;
-};
-
-/** Copy a take's word timings into the timeline's `CaptionWord` shape. */
-export const takeCaptionWords = (take: ScriptTake): CaptionWord[] =>
-  take.words.map((w) => ({ word: w.word, startMs: w.startMs, endMs: w.endMs }));
+export type AssembledScriptDocument = AssembledScriptTimeline;
 
 export function buildScriptTimelineDocument(
   script: ScriptDraft
 ): AssembledScriptDocument {
-  const track = makeTrack({ type: "audio", name: "Voiceover", index: 0 });
-  const tracks: TimelineTrack[] = [track];
-  const clips: TimelineClip[] = [];
-  const skippedLineIds: string[] = [];
-
-  const speakerName = (speakerId?: string | null): string | undefined =>
-    speakerId
-      ? script.cast.find((s) => s.id === speakerId)?.name
-      : undefined;
-
-  let cursorMs = 0;
-  for (const line of script.sections.flatMap((s) => s.lines)) {
-    const take = currentTake(line);
-    if (!take || !take.assetId) {
-      skippedLineIds.push(line.id);
-      continue;
-    }
-    const durationMs =
-      take.durationMs > 0 ? take.durationMs : PLACEHOLDER_LINE_MS;
-    const words = takeCaptionWords(take);
-    clips.push(
-      makeClip({
-        trackId: track.id,
-        name: line.text.slice(0, 40) || "Line",
-        startMs: cursorMs,
-        durationMs,
-        mediaType: "audio",
-        sourceType: "imported",
-        bindingKind: "text-to-audio",
-        status: "generated",
-        currentAssetId: take.assetId,
-        prompt: line.text,
-        voice: effectiveVoice(line, script.cast)?.voice,
-        speaker: speakerName(line.speakerId),
-        caption: words.length ? { words } : undefined,
-        scriptId: script.id,
-        scriptLineId: line.id,
-        versions: []
-      })
-    );
-    cursorMs += durationMs + Math.max(0, line.pauseAfterMs ?? 0);
-  }
-
-  return { tracks, clips, durationMs: cursorMs, skippedLineIds };
+  return buildScriptTimeline({
+    scriptId: script.id,
+    cast: script.cast,
+    sections: script.sections
+  });
 }


### PR DESCRIPTION
## What

The script surface's sibling to #4692. The editor voices a line over the chat WebSocket's `generate_media` / `transcribe_audio` RPCs, and the `nodetool.script.*` nodes do it inside a workflow — an agent outside the browser had neither path.

Four backend tools close the gap. They call the provider directly, save each take as an audio asset, and write it back onto the persisted script:

| Tool | Does |
|---|---|
| `list_scripts` | Scripts newest first, with line and voiced counts |
| `get_script` | Cast, lines, and each line's voicing status |
| `voice_script_lines` | TTS per line → a take, made current on its line |
| `assemble_script_timeline` | Voiced takes → a saved `timeline_sequences` row |

`get_script` reports the status the editor's gutter shows — `draft`, `stale`, `voiced`, `no_voice` — and `assemble_script_timeline` produces a sequence `validate_timeline` can check.

## How

- **One call per script.** `voice_script_lines` defaults to every line that is draft or stale; `targets` takes line ids, reading-order indexes, or the line text. Lines voice concurrently (3 by default, 8 max, 60 per call) and each take lands through a CAS on the row's `updated_at`.
- **Each line keeps its own voice** (its override, else its speaker's). A call-level `provider`+`model`+`voice` overrides them all; a half-specified override is an error naming `find_model`, not a guess.
- **Synthesis delegates to `GenerateSpeechTool`**, so the encoded-vs-streaming-PCM provider split stays in one place. Word timings come from a best-effort ASR pass (`whisper-1` default, `transcribe: false` to skip) and ride into the assembled clips as captions.
- **Duration** is ffprobe's answer, falling back to the last word timing and then the 3s placeholder — a take stays assemblable without an exact length.
- **Failures are per line.** A provider error is reported in that line's result row; the rest of the batch still lands.
- **One mapping, three surfaces.** `effectiveVoice`, `needsVoicing` and `buildScriptTimeline` moved into `@nodetool-ai/timeline`; `web/`'s "Send to timeline" and `nodetool.script.ScriptToTimeline` now call them instead of carrying their own copies. Re-assembly rewrites this script's voiceover track in place and keeps clips other surfaces added.
- The chat prompt points at these tools when a script is open.

## Testing

- `packages/agents/tests/script-voice-tools.test.ts` — 11 cases against an in-memory DB with a fake provider (no network): status reporting, ownership isolation, the draft/stale default, per-line voice vs call-level override, the half-override rejection, per-line failure, `transcribe: false`, and assembly (pause-aware timings, captions, speaker/voice labels, script linkage, re-assembly in place).
- `npm run lint`, web + electron typecheck, and the `agents` (2018), `websocket` (2069), `video-nodes` (190), `timeline` (219) and `web` script suites all pass.

Independent of #4692 — both add a file to `packages/timeline` and a section to `CLAUDE.md`, so whichever lands second may need a trivial merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvGiAhUe4sgTBZspja2ni5)_