### PR TITLE
docs: the parity rule and the verification discipline the last two PRs paid for

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,51 @@ npm run test       # Run all tests
 
 All three must pass before the task is complete.
 
+Running suites per package instead is fine when the full run is too slow — but
+run every package `nodetool affected` names, not the ones you remember touching.
+`lint` passing is not `test` passing: a change to `packages/websocket` that was
+linted and never tested broke two route suites, and CI found it rather than the
+author.
+
+### Claims, Checks, and Measurements
+
+Verification failures in this repo are rarely "forgot to run the tests". They
+are green signals that were never earned. Four rules, each paid for:
+
+**Prove a new check can fail.** Invert the condition once and watch it go red,
+then restore. `nodetool validate` returned ✅ on a workflow whose model id was
+`totally-not-a-real-model-xyz` — it had never checked ids at all, and only a
+deliberately-bogus input revealed it. A check that has only ever been green is
+indistinguishable from one that examines nothing. For an audit that scans
+files, also assert it *found* something, so it cannot pass by matching nothing.
+This is rule 7's sibling in [docs/HARNESS_FIRST.md](docs/HARNESS_FIRST.md).
+
+**Reproduce before you enforce.** Rule 5 requires a bug *fix* to ship a
+reproduction; the same applies to a new *rule*. A validator check was written
+from a log warning plus code reading, shipped as an error, and would have failed
+the examples gate on six shipped workflows — until three reproductions of its
+own criterion passed cleanly and the feature was reverted. Until you have
+watched the failure, report it; do not enforce it.
+
+**"I checked" means you enumerated.** Not one plausible file, and never a
+comment — a comment is a hypothesis about code, not the code. Claims that
+`validateGraph` was ungated in CI, and that six call sites were safe, were both
+made from a sample and both wrong in method. To assert "all X do Y", produce the
+list; if that is too expensive, scope the claim to what you actually read.
+
+**Distrust the measurement before the conclusion.** `pgrep -f` matches the
+shell command that contains the pattern, so a probe can report a dead process as
+running. `cmd | head && echo ok` prints `ok` on failure, because `head` exits 0 —
+capture the exit code of the command you care about. When a result is surprising,
+re-measure with a different tool before believing it.
+
+Two mechanical traps worth naming: after a programmatic edit, byte-count the
+file for stray control characters (a `\u0000` written as the byte it denotes
+got a `.ts` file staged as **binary**), and if the code walks a graph or list,
+run it once on a large input — an `edges.some()` inside a node loop is O(n·m)
+and passed every hand-written fixture before timing out on the 20 000-node
+chain in CI.
+
 ### Code Review for Regressions
 
 Before submitting a PR, review for:

--- a/docs/HARNESS_FIRST.md
+++ b/docs/HARNESS_FIRST.md
@@ -67,6 +67,36 @@ that keeps it true: a registry, an audit, and a gate.
    diff, so edit→verify is a running process, not a fresh full report each
    save.
 
+10. **A harness runs what the runner runs.** Rule 4 keeps the *logic* shared;
+    it does not stop a harness from *constructing* the run differently. That
+    is a distinct failure, and a nastier one: the harness and the product call
+    the same core, so nothing looks reimplemented, and the report is confidently
+    wrong. `nodetool debug` handed `ExecutionSession` a registry but no
+    `resolveNodeType`, which hydrates node flags and leaves `propertyTypes`
+    empty. Correlation analysis reads list-ness only from that map, so every
+    `list[...]` handle read as non-list and a stream arriving on one collapsed
+    to the last value. Same graph, two answers:
+
+    ```
+    workflows run   keyframe=2  animate=2
+    debug           keyframe=2  animate=1
+    ```
+
+    `Directed Film to Timeline` looked like it generated N keyframes and
+    animated one. It does that under `debug` and not under the runner — a
+    debugging session went looking for a kernel bug that did not exist, and a
+    validator rule was written for it before anyone reproduced the claim
+    through the real runner.
+
+    So: when a harness reports a defect, confirm it through the canonical
+    runner before diagnosing; if they disagree, the harness is the first
+    suspect, and the thing to diff is how each *builds* the run, not what the
+    graph contains. Construction differences are auditable —
+    `packages/execution/tests/execution-session-hydration-audit.test.ts` walks
+    every `ExecutionSession.create` and fails on any that passes a registry
+    without a resolver, with a `KNOWN_UNHYDRATED` map for the surfaces that
+    deliberately differ and why.
+
 ## The registry
 
 `packages/cli/src/harness/registry.ts` is the machine-readable inventory:


### PR DESCRIPTION
Two doc changes, each one incident from #4671/#4672 turned into a rule. Nothing here is invented — every claim below was reproduced in those PRs.

## `HARNESS_FIRST.md` — rule 10, harness/runner parity

Rule 4 says a harness cannot drift from the product because both call one shared core. **That holds for logic, not for construction** — and construction is what #4671 actually was.

`nodetool debug` handed `ExecutionSession` a registry and no `resolveNodeType`. That hydrates node flags and leaves `propertyTypes` empty; correlation analysis reads list-ness only from that map, so every `list[...]` handle read as non-list and a stream arriving on one collapsed to its last value. Nothing looked reimplemented — same core, same call — and the report was confidently wrong:

```
workflows run   keyframe=2  animate=2
debug           keyframe=2  animate=1
```

`Directed Film to Timeline` looked like it generated N keyframes and animated one. It does that under `debug` and not under the runner. A debugging session went looking for a kernel bug that did not exist, and a validator rule was written for it before anyone reproduced the claim through the real runner.

Rule 10: confirm a harness's finding through the canonical runner before diagnosing; when they disagree the harness is the first suspect, and the thing to diff is how each *builds* the run. It points at `execution-session-hydration-audit.test.ts` from #4672, which makes that class mechanical instead of remembered.

## `AGENTS.md` — Claims, Checks, and Measurements

Four rules, each paid for in the same two PRs:

- **Prove a new check can fail.** `nodetool validate` returned green on a workflow whose model id was `totally-not-a-real-model-xyz`. It had never checked ids at all, and only a deliberately-bogus input revealed it. Sibling of rule 7.
- **Reproduce before you enforce.** Rule 5 requires a *fix* to ship a reproduction; a new *rule* needs one too. A check written from a log warning plus code reading shipped as an error, would have failed the examples gate on six shipped workflows, and was reverted when three reproductions of its own criterion passed cleanly.
- **"I checked" means you enumerated.** Two claims — that `validateGraph` was ungated in CI, and that six call sites were safe — were made from a sample and a code comment. Both wrong in method; one wrong in fact.
- **Distrust the measurement before the conclusion.** `pgrep -f` matches the shell command containing the pattern, so a probe reported a dead process as running. `cmd | head && echo ok` prints `ok` on failure because `head` exits 0.

Plus two mechanical traps: byte-count after programmatic edits (an escape sequence written as the byte it denotes got a `.ts` staged as **binary** — it recurred four times across this work, including in the PR body describing it), and run graph walks on a large input — an `edges.some()` inside a node loop is O(n*m), passed every hand-written fixture, and spent 40s on CI's 20 000-node chain.

Also amends **Mandatory Post-Change Verification**: per-package suites must follow `nodetool affected`, not memory. Linting `packages/websocket` and never testing it is how two route suites broke, with CI finding it rather than the author.

## Checks

- 75 added lines, clean against `WRITING_STYLE.md`'s forbidden list (the hits elsewhere in `AGENTS.md` are pre-existing)
- Every relative link resolves; the cited audit test exists on `main` and does what the text says it does
- Docs only — no code paths touched

Generated with [Claude Code](https://claude.com/claude-code)
