### PR TITLE
chat: teach the agent what NodeTool resources exist

### DIFF
--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1255,9 +1255,10 @@ You start with a resident core, always available without loading:
 Everything else is a DEFERRED tool you load on demand with \`ToolSearch\` (see
 "Deferred tools" below) — web search and browsing, reading knowledge
 collections, files, code execution, media generation, document conversion, and
-any editor / app-builder (\`ui_*\`) actions. The deferred tools are listed by
-name in a \`<system-reminder>\` — that list is authoritative, so load only what
-appears there, and load the ones you need before calling them.
+every resource-editing (\`ui_*\`) action: storyboards, scripts, timelines,
+sketches, 3D scenes, and apps (see "NodeTool resources"). The deferred tools
+are listed by name in a \`<system-reminder>\` — that list is authoritative, so
+load only what appears there, and load the ones you need before calling them.
 
 # Deferred tools
 Some tools are not loaded up front — they appear by name only, listed in a
@@ -1272,6 +1273,47 @@ with the \`ToolSearch\` tool.
   - \`+substr words\` — require \`substr\` in the tool name, rank by the rest.
 - Load every tool you intend to use before calling it; one search can load
   several. If a call fails because a tool is unknown, ToolSearch it first.
+- \`max_results\` defaults to 5. A resource family has more tools than that, so
+  raise it (\`+timeline\` with \`max_results: 20\`) to see the whole family
+  rather than concluding a capability is missing.
+
+# NodeTool resources
+NodeTool is not only workflows. A user's work lives in typed resources, and
+most of them have a dedicated tool family that is DEFERRED — so when a request
+names one, ToolSearch that family first instead of assuming the only way
+forward is a workflow.
+- **workflow** — a node graph that runs. Resident tools; see "Building
+  workflows".
+- **app** — a mini app: widgets bound to workflow operations and variables.
+  Author with the \`ui_app_*\` family (\`+ui_app\`), verify with \`debug_app\`,
+  or generate a whole one from a prompt with \`build_app\`.
+- **storyboard** — a brief or screenplay broken into shots, each with a
+  keyframe image and a generated clip. Family \`+storyboard\`: read the state,
+  set the screenplay, add and revise shots, generate a shot's keyframe or
+  clip, assemble the shots into a timeline.
+- **script** — speakers, lines, and a voice take per line. \`list_scripts\` and
+  \`get_script\` read any script by id and report which lines still need
+  voicing; \`voice_script_lines\` synthesizes the takes and
+  \`assemble_script_timeline\` cuts them into a timeline — neither needs a
+  workflow or an open editor. The \`+ui_script\` family edits the open one.
+- **timeline** — tracks and clips that render to video. Family \`+timeline\`
+  for tracks, clips, trims, and animations; \`validate_timeline\` statically
+  checks a sequence before the user renders it.
+- **sketch** — a layered image document. Family \`+sketch\`: layers, drawing
+  tools, generating into a layer, rendering the result to an asset.
+- **model3d** — a 3D scene. Family \`+ui_3d\`: add and transform objects, set
+  materials, capture a view as an image.
+- **collection** — a vector store for RAG. \`list_collections\`,
+  \`query_collection\`, and the \`vector_*\` indexing tools.
+- **asset** — stored media (images, video, audio, documents). \`asset_search\`,
+  \`asset_list\`, \`get_asset\`.
+- **thread** — this conversation and its memory; see "Memory and resources".
+The \`ui_*\` families act on a document the user has open and take its id — the
+open ids are listed under "What the user is looking at", and the exact tools in
+a family differ per surface, so ToolSearch rather than guessing names. Chat has
+no tool that creates a storyboard, script, timeline, sketch, or 3D scene from
+nothing: when none is open, name the one you need and ask the user to open or
+create it, instead of falling back to a workflow that approximates it.
 
 # Building workflows
 When the user wants a workflow built, drive this loop:

--- a/packages/websocket/tests/resident-tools.test.ts
+++ b/packages/websocket/tests/resident-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { RESOURCE_KINDS } from "@nodetool-ai/protocol";
 import {
   RESIDENT_TOOL_NAMES,
   CHAT_AGENT_SYSTEM_PROMPT
@@ -21,5 +22,13 @@ describe("resident toolbelt", () => {
     expect(CHAT_AGENT_SYSTEM_PROMPT).toContain("debug_app");
     // The draft, not the saved row, is what the App Builder must grade.
     expect(CHAT_AGENT_SYSTEM_PROMPT).toContain("document");
+  });
+
+  it("describes every resource kind, not just workflows", () => {
+    const section = CHAT_AGENT_SYSTEM_PROMPT.split("# NodeTool resources")[1];
+    expect(section).toBeDefined();
+    for (const kind of RESOURCE_KINDS) {
+      expect(section).toContain(`**${kind}**`);
+    }
   });
 });


### PR DESCRIPTION
## Problem

`CHAT_AGENT_SYSTEM_PROMPT` taught workflows, mini apps, assets and thread
memory. It never said that storyboards, scripts, timelines, sketches, 3D
scenes and collections are first-class NodeTool resources with their own tool
families — they appeared only as bare words in the "Linking resources" kind
list.

Those families are all deferred, so they reach the model as names in a
`<system-reminder>` and nothing else. An agent that does not know a storyboard
is a thing you can edit never runs the ToolSearch that would reveal
`ui_storyboard_*`; asked for one, it falls back to authoring a workflow.

## Change

`packages/websocket/src/unified-websocket-runner.ts`

- New **`# NodeTool resources`** section: every kind in `ResourceKind`
  (workflow, app, storyboard, script, timeline, sketch, model3d, collection,
  asset, thread), what it is, and the tools or ToolSearch query that reach it.
  Families are named by prefix (`+storyboard`, `+timeline`, `+ui_3d`) rather
  than by exact tool name, because web and mobile register different tools
  under the same prefix.
- States the constraint the `ui_*` tools impose: they act on a document the
  user has open and take its id, and chat has no tool that creates a
  storyboard, script, timeline, sketch or 3D scene — so ask the user to open
  one instead of approximating it with a workflow.
- Notes the server-side paths that need no open editor: `list_scripts` /
  `get_script` / `voice_script_lines` / `assemble_script_timeline`,
  `validate_timeline`, the collection and asset tools.
- `# Deferred tools`: `max_results` defaults to 5, which silently truncates a
  family of 9–18 tools. Says to raise it.

`packages/websocket/tests/resident-tools.test.ts`

- New test iterating `RESOURCE_KINDS` from `@nodetool-ai/protocol` and
  asserting each appears in the section, so a kind added to the union cannot
  be left undocumented.

## Verification

- `npx vitest run tests/resident-tools.test.ts --root packages/websocket` — 3 passed
- `npm run lint --workspace=packages/websocket` (tsc --noEmit) — clean

Prompt-only change plus its guard test; no behavior outside the system prompt string.

---
_Generated by [Claude Code](https://claude.ai/code/session_0184ECreZPFZcGApFhcE57st)_