### PR TITLE
feat(web): show getting-started onboarding in the empty workspace

### DIFF
--- a/web/src/components/portal/GettingStartedChecklist.tsx
+++ b/web/src/components/portal/GettingStartedChecklist.tsx
@@ -10,11 +10,13 @@ import useOnboardingStore, {
 import { wrapStyles } from "./dashboardChrome";
 import { BORDER_RADIUS, MOTION, SPACING, getSpacingPx } from "../ui_primitives";
 
-const styles = (theme: Theme) =>
+const styles = (theme: Theme, inline: boolean) =>
   css({
-    borderBottom: `1px solid ${theme.vars.palette.divider}`,
+    borderBottom: inline ? "none" : `1px solid ${theme.vars.palette.divider}`,
+    width: "100%",
 
     ".checklist-inner": {
+      justifyContent: inline ? "center" : "flex-start",
       display: "flex",
       alignItems: "center",
       gap: 10,
@@ -69,7 +71,7 @@ const styles = (theme: Theme) =>
       }
     },
     ".checklist-dismiss": {
-      marginLeft: "auto",
+      marginLeft: inline ? 0 : "auto",
       background: "none",
       border: "none",
       padding: `${getSpacingPx(SPACING.xs)} ${getSpacingPx(SPACING.md)}`,
@@ -96,19 +98,26 @@ interface GettingStartedChecklistProps {
   onConnectProvider: () => void;
   onOpenTemplates: () => void;
   onCreateWorkflow: () => void;
+  /**
+   * "dashboard" keeps the section chrome (centered wrap, bottom rule);
+   * "inline" drops it for hosts that place the checklist themselves, such as
+   * the empty workspace.
+   */
+  variant?: "dashboard" | "inline";
 }
 
 /**
- * Slim first-run checklist under the dashboard hero: connect a provider,
- * open a template, run it, build your own. Steps complete via
- * OnboardingStore markers (provider state is derived live from secrets).
- * Hidden once every step is done or the user dismisses it.
+ * Slim first-run checklist: connect a provider, open a template, run it, build
+ * your own. Steps complete via OnboardingStore markers (provider state is
+ * derived live from secrets). Hidden once every step is done or the user
+ * dismisses it — so a host can mount it unconditionally.
  */
 const GettingStartedChecklist: React.FC<GettingStartedChecklistProps> = ({
   hasConfiguredProvider,
   onConnectProvider,
   onOpenTemplates,
-  onCreateWorkflow
+  onCreateWorkflow,
+  variant = "dashboard"
 }) => {
   const theme = useTheme();
   const { completedSteps, dismissed, dismiss } = useOnboardingStore(
@@ -152,9 +161,14 @@ const GettingStartedChecklist: React.FC<GettingStartedChecklistProps> = ({
     return null;
   }
 
+  const inline = variant === "inline";
+
   return (
-    <section css={styles(theme)} aria-label="Getting started checklist">
-      <div css={wrapStyles(theme)}>
+    <section
+      css={styles(theme, inline)}
+      aria-label="Getting started checklist"
+    >
+      <div css={inline ? undefined : wrapStyles(theme)}>
         <div className="checklist-inner">
           <span className="checklist-label">
             Getting started · {doneCount}/{steps.length}

--- a/web/src/components/portal/Portal.tsx
+++ b/web/src/components/portal/Portal.tsx
@@ -3,12 +3,12 @@
 import { css } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
 import { useTheme } from "@mui/material/styles";
-import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
+import React, { memo, useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { usePortalChat } from "./usePortalChat";
 import { useDashboardData } from "../../hooks/useDashboardData";
 import { useWorkflowActions } from "../../hooks/useWorkflowActions";
-import useSecretsStore from "../../stores/SecretsStore";
+import { useHasConfiguredProvider } from "../../hooks/useHasConfiguredProvider";
 import { usePanelStore } from "../../stores/PanelStore";
 import { LanguageModel } from "../../stores/ApiTypes";
 import PortalSetupFlow from "./PortalSetupFlow";
@@ -22,17 +22,6 @@ import DashboardFooter from "./DashboardFooter";
 import { useCreateStarterWorkflow } from "../../hooks/useCreateStarterWorkflow";
 import { WELCOME_TRACKS, type WelcomeTrackId } from "./welcomeTracks";
 import { Box, SPACING, getSpacingPx } from "../ui_primitives";
-
-// Secret keys the runtime providers actually read (see
-// packages/runtime/src/providers — e.g. GeminiProvider requires
-// GEMINI_API_KEY, HuggingFaceProvider requires HF_TOKEN).
-const KNOWN_PROVIDER_KEYS = [
-  "OPENAI_API_KEY",
-  "ANTHROPIC_API_KEY",
-  "GEMINI_API_KEY",
-  "OPENROUTER_API_KEY",
-  "HF_TOKEN"
-];
 
 type PortalState = "idle" | "setup";
 
@@ -86,21 +75,8 @@ const Portal: React.FC = () => {
   const { sortedWorkflows, isLoadingWorkflows } = useDashboardData();
   const { handleCreateNewWorkflow } = useWorkflowActions();
 
-  const fetchSecrets = useSecretsStore((s) => s.fetchSecrets);
-  const secrets = useSecretsStore((s) => s.secrets);
   const createStarterWorkflow = useCreateStarterWorkflow();
-
-  useEffect(() => {
-    fetchSecrets();
-  }, [fetchSecrets]);
-
-  const hasConfiguredProvider = useMemo(
-    () =>
-      secrets.some(
-        (s) => KNOWN_PROVIDER_KEYS.includes(s.key) && s.is_configured
-      ),
-    [secrets]
-  );
+  const hasConfiguredProvider = useHasConfiguredProvider();
 
   const handlePickTrack = useCallback(
     (trackId: WelcomeTrackId) => {

--- a/web/src/components/workspace/WorkspaceEmptyView.tsx
+++ b/web/src/components/workspace/WorkspaceEmptyView.tsx
@@ -7,8 +7,14 @@ import { useShallow } from "zustand/react/shallow";
 
 import useGlobalChatStore from "../../stores/GlobalChatStore";
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
+import { openProviderOnboarding } from "../../stores/ProviderOnboardingStore";
+import useOnboardingStore from "../../stores/OnboardingStore";
+import { useHasConfiguredProvider } from "../../hooks/useHasConfiguredProvider";
 import type { Message, MessageContent } from "../../stores/ApiTypes";
 import ChatInputSection from "../chat/containers/ChatInputSection";
+import GettingStartedChecklist from "../portal/GettingStartedChecklist";
+import { PAGE_TAB_TITLES } from "./pageTabs";
 import { Caption, SPACING, getSpacingPx } from "../ui_primitives";
 
 const styles = (theme: Theme) =>
@@ -29,19 +35,28 @@ const styles = (theme: Theme) =>
       maxWidth: 720,
       display: "flex",
       justifyContent: "center"
+    },
+    ".empty-onboarding": {
+      width: "100%",
+      maxWidth: 720
     }
   });
 
 /**
  * Shown in the workspace when no tabs are open. Carries the chat composer that
  * used to live on the dashboard hero: a message sent here creates a thread,
- * opens it as a chat tab, and delivers the message to that tab.
+ * opens it as a chat tab, and delivers the message to that tab. Above it sits
+ * the getting-started checklist, which renders itself only while first-run
+ * steps are still open — the workspace is where a first-time user lands, so
+ * onboarding has to be reachable without a trip to the dashboard.
  */
 const WorkspaceEmptyView = () => {
   const theme = useTheme();
   const emptyStyles = useMemo(() => styles(theme), [theme]);
 
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const createNewWorkflow = useWorkflowManager((state) => state.createNew);
+  const hasConfiguredProvider = useHasConfiguredProvider();
 
   const { status, selectedModel, setSelectedModel, stopGeneration } =
     useGlobalChatStore(
@@ -87,11 +102,51 @@ const WorkspaceEmptyView = () => {
     [openTab]
   );
 
+  const handleConnectProvider = useCallback(() => {
+    openProviderOnboarding({
+      capability: "generate_message",
+      reason: "Connect an AI provider to run workflows and chat."
+    });
+  }, []);
+
+  const handleOpenTemplates = useCallback(() => {
+    openTab({
+      type: "page",
+      ref: "examples",
+      mode: "view",
+      title: PAGE_TAB_TITLES.examples
+    });
+  }, [openTab]);
+
+  const handleCreateWorkflow = useCallback(async () => {
+    useOnboardingStore.getState().markStep("create-workflow");
+    try {
+      const workflow = await createNewWorkflow();
+      openTab({
+        type: "workflow",
+        ref: workflow.id,
+        mode: "edit",
+        title: workflow.name
+      });
+    } catch (error) {
+      console.error("Failed to create workflow:", error);
+    }
+  }, [createNewWorkflow, openTab]);
+
   // ChatInputSection has no "stopping" state; the composer treats it as idle.
   const inputStatus = status === "stopping" ? "connected" : status;
 
   return (
     <div css={emptyStyles} className="workspace-empty">
+      <div className="empty-onboarding">
+        <GettingStartedChecklist
+          variant="inline"
+          hasConfiguredProvider={hasConfiguredProvider}
+          onConnectProvider={handleConnectProvider}
+          onOpenTemplates={handleOpenTemplates}
+          onCreateWorkflow={() => void handleCreateWorkflow()}
+        />
+      </div>
       <Caption color="secondary">
         No tabs open — ask below to start a chat, or use + to open a document.
       </Caption>

--- a/web/src/components/workspace/__tests__/WorkspaceEmptyView.test.tsx
+++ b/web/src/components/workspace/__tests__/WorkspaceEmptyView.test.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "@mui/material/styles";
 
 import WorkspaceEmptyView from "../WorkspaceEmptyView";
 import mockTheme from "../../../__mocks__/themeMock";
+import useOnboardingStore from "../../../stores/OnboardingStore";
 import type { MessageContent } from "../../../stores/ApiTypes";
 
 const openTab = jest.fn();
@@ -36,6 +37,34 @@ jest.mock("../../../stores/WorkspaceTabsStore", () => ({
     selector({ openTab })
 }));
 
+const createNew = jest
+  .fn()
+  .mockResolvedValue({ id: "wf-1", name: "Untitled workflow" });
+
+jest.mock("../../../contexts/WorkflowManagerContext", () => ({
+  __esModule: true,
+  useWorkflowManager: (selector: (state: unknown) => unknown) =>
+    selector({ createNew })
+}));
+
+const fetchSecrets = jest.fn().mockResolvedValue([]);
+const secretsState = { fetchSecrets, secrets: [] as unknown[] };
+
+jest.mock("../../../stores/SecretsStore", () => {
+  const useStore = (selector: (state: unknown) => unknown) =>
+    selector(secretsState);
+  useStore.getState = () => secretsState;
+  return { __esModule: true, default: useStore };
+});
+
+const showProviderOnboarding = jest.fn();
+
+jest.mock("../../../stores/ProviderOnboardingStore", () => ({
+  __esModule: true,
+  openProviderOnboarding: (options?: unknown) =>
+    showProviderOnboarding(options)
+}));
+
 jest.mock("../../chat/containers/ChatInputSection", () => ({
   __esModule: true,
   default: ({
@@ -62,6 +91,7 @@ const renderEmptyView = () =>
 describe("WorkspaceEmptyView", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useOnboardingStore.setState({ completedSteps: [], dismissed: false });
   });
 
   it("renders the composer with the empty-workspace hint", () => {
@@ -92,6 +122,60 @@ describe("WorkspaceEmptyView", () => {
         }),
         "thread-1"
       )
+    );
+  });
+
+  it("shows the getting started checklist while steps are open", () => {
+    renderEmptyView();
+    expect(screen.getByText(/getting started · 0\/4/i)).toBeInTheDocument();
+  });
+
+  it("hides the checklist once onboarding is dismissed", () => {
+    useOnboardingStore.setState({ dismissed: true });
+    renderEmptyView();
+    expect(screen.queryByText(/getting started/i)).not.toBeInTheDocument();
+  });
+
+  it("opens the provider dialog from the connect step", async () => {
+    const user = userEvent.setup();
+    renderEmptyView();
+
+    await user.click(screen.getByText("Connect an AI provider"));
+
+    expect(showProviderOnboarding).toHaveBeenCalledWith(
+      expect.objectContaining({ capability: "generate_message" })
+    );
+  });
+
+  it("opens the examples page as a tab from the template step", async () => {
+    const user = userEvent.setup();
+    renderEmptyView();
+
+    await user.click(screen.getByText("Open a starter or template"));
+
+    expect(openTab).toHaveBeenCalledWith({
+      type: "page",
+      ref: "examples",
+      mode: "view",
+      title: "Examples"
+    });
+  });
+
+  it("creates a workflow tab from the build-your-own step", async () => {
+    const user = userEvent.setup();
+    renderEmptyView();
+
+    await user.click(screen.getByText("Build your own"));
+
+    await waitFor(() => expect(createNew).toHaveBeenCalled());
+    expect(openTab).toHaveBeenCalledWith({
+      type: "workflow",
+      ref: "wf-1",
+      mode: "edit",
+      title: "Untitled workflow"
+    });
+    expect(useOnboardingStore.getState().completedSteps).toContain(
+      "create-workflow"
     );
   });
 });

--- a/web/src/hooks/useHasConfiguredProvider.ts
+++ b/web/src/hooks/useHasConfiguredProvider.ts
@@ -1,0 +1,37 @@
+import { useEffect, useMemo } from "react";
+import useSecretsStore from "../stores/SecretsStore";
+
+// Secret keys the runtime providers actually read (see
+// packages/runtime/src/providers — e.g. GeminiProvider requires
+// GEMINI_API_KEY, HuggingFaceProvider requires HF_TOKEN).
+export const KNOWN_PROVIDER_KEYS = [
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GEMINI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "HF_TOKEN"
+];
+
+/**
+ * Whether at least one AI provider is configured. Drives the "connect a
+ * provider" onboarding step wherever it is shown (dashboard checklist, empty
+ * workspace), so both surfaces read the same secrets.
+ */
+export const useHasConfiguredProvider = (): boolean => {
+  const fetchSecrets = useSecretsStore((s) => s.fetchSecrets);
+  const secrets = useSecretsStore((s) => s.secrets);
+
+  useEffect(() => {
+    fetchSecrets();
+  }, [fetchSecrets]);
+
+  return useMemo(
+    () =>
+      secrets.some(
+        (s) => KNOWN_PROVIDER_KEYS.includes(s.key) && s.is_configured
+      ),
+    [secrets]
+  );
+};
+
+export default useHasConfiguredProvider;


### PR DESCRIPTION
The workspace is where a first-time user lands, but the getting-started checklist only lived on the dashboard — a fresh install with no tabs open showed nothing but a chat composer.

## Changes

- `WorkspaceEmptyView` renders `GettingStartedChecklist` above the composer, wired to workspace-native actions:
  - **Connect an AI provider** → the global provider-onboarding dialog (`openProviderOnboarding`, capability `generate_message`)
  - **Open a starter or template** → opens the Examples page as a tab
  - **Build your own** → creates a workflow, marks the `create-workflow` step, opens it as a tab
- `GettingStartedChecklist` gains a `variant` prop; `"inline"` drops the dashboard section chrome (bottom rule, centered wrap) and centers the steps. Default stays `"dashboard"`.
- The provider-configured derivation moves out of `Portal.tsx` into a new `useHasConfiguredProvider` hook, so both surfaces read the same secrets and key list.

The checklist already returns `null` once every step is done or the user dismisses it, so the empty view stays clean for returning users — "if applicable" needs no extra gate.

## Testing

- `web/src/components/workspace/__tests__/WorkspaceEmptyView.test.tsx`: new cases for the checklist showing while steps are open, hiding when dismissed, and each of the three actions.
- `npx jest src/components/workspace src/components/portal` — pass.
- `npm run lint` — clean (only pre-existing warnings elsewhere).
- `npm run typecheck` — the only errors are pre-existing `TS2307`s in `src/lib/workflow/browserRunnerCore.ts` from unbuilt node packages in this environment; none in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wTaqMNqkSKdUTb8EuWNtB

---
_Generated by [Claude Code](https://claude.ai/code/session_017wTaqMNqkSKdUTb8EuWNtB)_