### PR TITLE
Keep agent chat turns alive across websocket disconnects, replay on reconnect

### DIFF
--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -657,6 +657,7 @@ export type UnifiedCommandType =
   | "stream_input"
   | "end_input_stream"
   | "chat_message"
+  | "resume_chat"
   | "inference"
   | "stop"
   | "list_workflows"

--- a/packages/protocol/src/ws-commands.ts
+++ b/packages/protocol/src/ws-commands.ts
@@ -46,6 +46,7 @@ export const UNIFIED_COMMAND_TYPES = [
   "stream_input",
   "end_input_stream",
   "chat_message",
+  "resume_chat",
   "inference",
   "stop",
   "list_workflows",
@@ -170,6 +171,14 @@ export const chatMessageDataSchema = z
   })
   .passthrough();
 
+export const resumeChatDataSchema = z
+  .object({
+    thread_id: z.string().optional(),
+    /** Highest `chat_seq` the client has already received for this thread. */
+    last_seq: z.number().optional()
+  })
+  .passthrough();
+
 export const stopDataSchema = z
   .object({
     job_id: z.string().optional(),
@@ -236,6 +245,7 @@ export const commandDataSchemas: Record<UnifiedCommandType, z.ZodTypeAny> = {
   stream_input: looseDataSchema,
   end_input_stream: looseDataSchema,
   chat_message: looseDataSchema,
+  resume_chat: resumeChatDataSchema,
   inference: looseDataSchema,
   stop: looseDataSchema,
   list_workflows: looseDataSchema,
@@ -395,10 +405,33 @@ export const resourceChangeMessageOutSchema = z
   })
   .passthrough();
 
+/**
+ * Reply to a `resume_chat` command. Sent before any replayed frames.
+ *
+ * `status` reports what the server holds for the thread's latest turn:
+ * `"running"` (turn still executing; replay is followed by live frames),
+ * `"finished"` (turn completed while the client was away; replay is the
+ * whole tail), or `"unknown"` (nothing to replay — either no turn ran, or
+ * the retention window elapsed; the client should refetch thread history).
+ * `replay_incomplete` is true when the requested `last_seq` predates what
+ * the bounded buffer still holds.
+ */
+export const chatResumedMessageOutSchema = z
+  .object({
+    type: z.literal("chat_resumed"),
+    thread_id: z.string(),
+    status: z.enum(["running", "finished", "unknown"]),
+    last_seq: z.number(),
+    replay_count: z.number(),
+    replay_incomplete: z.boolean()
+  })
+  .passthrough();
+
 /** Non-`ProcessingMessage` outbound frame schemas, keyed by `type`. */
 export const outboundControlMessageSchemas = {
   pong: pongMessageOutSchema,
   rpc_response: rpcResponseMessageOutSchema,
   system_stats: systemStatsMessageOutSchema,
-  resource_change: resourceChangeMessageOutSchema
+  resource_change: resourceChangeMessageOutSchema,
+  chat_resumed: chatResumedMessageOutSchema
 } as const;

--- a/packages/websocket/src/chat-turn-registry.ts
+++ b/packages/websocket/src/chat-turn-registry.ts
@@ -1,0 +1,291 @@
+/**
+ * Detachable chat/agent turns.
+ *
+ * The WebSocket runner is per-connection, so before this module existed a
+ * dropped socket aborted the in-flight chat turn (`disconnect()` →
+ * `cancelChatTurn()`): a laptop lid-close killed the agent mid-work and the
+ * client had nothing to reattach to. A {@link ChatTurnSession} decouples the
+ * turn from the socket: every frame the turn emits is stamped with a
+ * monotonically increasing `chat_seq` and appended to a bounded buffer, and
+ * delivery goes to whichever connection is currently attached — or nowhere,
+ * while the client is away. On reconnect the client sends
+ * `{command: "resume_chat", data: {thread_id, last_seq}}` and gets the missed
+ * tail replayed, followed by live frames if the turn is still running.
+ *
+ * Sessions are keyed by user+thread in a process-wide registry (one turn per
+ * thread; a new turn supersedes and aborts the previous one, matching the
+ * single-turn semantics `beginChatTurn` already enforces per connection).
+ * Two timers bound a session's life:
+ *   - detach grace: a running turn nobody is attached to is aborted after
+ *     `NODETOOL_CHAT_DETACH_GRACE_MS` (default 10 min) so an abandoned client
+ *     cannot leave an agent working forever;
+ *   - retention: a finished session is kept for
+ *     `NODETOOL_CHAT_REPLAY_RETENTION_MS` (default 5 min) so a client that
+ *     reconnects just after the turn ended still gets the tail, then dropped.
+ *
+ * Assistant/tool messages are persisted to the DB independently of this
+ * buffer, so an expired or truncated replay degrades to the client refetching
+ * thread history over REST — nothing is lost except unpersisted stream chunks.
+ */
+
+import { createLogger } from "@nodetool-ai/config";
+
+const log = createLogger("nodetool.websocket.chat-turn-registry");
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const MAX_BUFFERED_EVENTS = () =>
+  envInt("NODETOOL_CHAT_REPLAY_BUFFER_EVENTS", 2000);
+const DETACH_GRACE_MS = () =>
+  envInt("NODETOOL_CHAT_DETACH_GRACE_MS", 10 * 60 * 1000);
+const RETENTION_MS = () =>
+  envInt("NODETOOL_CHAT_REPLAY_RETENTION_MS", 5 * 60 * 1000);
+
+/** A connection that can deliver frames to its client. */
+export interface ChatTurnDeliveryTarget {
+  deliver(message: Record<string, unknown>): Promise<void>;
+}
+
+/**
+ * The executing connection's per-turn hooks. Kept on the session so a
+ * different connection (post-reconnect) can route a client's `tool_result` /
+ * approval / `stop` back to the runner that actually owns the turn.
+ */
+export interface ChatTurnExecutionHooks {
+  resolveToolResult(toolCallId: string, payload: Record<string, unknown>): void;
+  resolveApproval(approvalId: string, payload: Record<string, unknown>): void;
+  cancelPendingCalls(threadId: string): void;
+}
+
+export interface ChatTurnAttachResult {
+  /** Frames with `chat_seq` greater than the requested `last_seq`. */
+  replay: Array<Record<string, unknown>>;
+  /** True when `last_seq` predates what the bounded buffer still holds. */
+  incomplete: boolean;
+}
+
+interface BufferedEvent {
+  seq: number;
+  message: Record<string, unknown>;
+}
+
+export class ChatTurnSession {
+  readonly userId: string;
+  readonly threadId: string;
+  status: "running" | "finished" = "running";
+
+  private seq: number;
+  private buffer: BufferedEvent[] = [];
+  /** Highest seq evicted from the bounded buffer (0 = nothing evicted). */
+  private evictedThroughSeq: number;
+  private target: ChatTurnDeliveryTarget | null = null;
+  /**
+   * Serializes delivery: replayed frames enqueue before any live frame that
+   * arrives after attach, so the client always sees seq order.
+   */
+  private deliveryChain: Promise<void> = Promise.resolve();
+  private detachTimer: NodeJS.Timeout | null = null;
+  private retentionTimer: NodeJS.Timeout | null = null;
+
+  constructor(
+    userId: string,
+    threadId: string,
+    private readonly controller: AbortController,
+    readonly hooks: ChatTurnExecutionHooks,
+    private readonly onDrop: (session: ChatTurnSession) => void,
+    startSeq: number
+  ) {
+    this.userId = userId;
+    this.threadId = threadId;
+    this.seq = startSeq;
+    this.evictedThroughSeq = startSeq;
+  }
+
+  get lastSeq(): number {
+    return this.seq;
+  }
+
+  /**
+   * Stamp, buffer, and (when a connection is attached) deliver one frame.
+   * Returns the stamped copy.
+   */
+  emit(message: Record<string, unknown>): Record<string, unknown> {
+    this.seq += 1;
+    const stamped = { ...message, chat_seq: this.seq };
+    this.buffer.push({ seq: this.seq, message: stamped });
+    const max = MAX_BUFFERED_EVENTS();
+    while (this.buffer.length > max) {
+      const evicted = this.buffer.shift();
+      if (evicted) this.evictedThroughSeq = evicted.seq;
+    }
+    const target = this.target;
+    if (target) {
+      this.enqueueDelivery(() => target.deliver(stamped));
+    }
+    return stamped;
+  }
+
+  /**
+   * Attach a connection and hand back the frames it missed. Live frames
+   * emitted after this call are delivered to the new target, strictly after
+   * the returned replay is delivered (both ride {@link deliveryChain} when
+   * sent via {@link deliverReplay}).
+   */
+  attach(target: ChatTurnDeliveryTarget, lastSeq: number): ChatTurnAttachResult {
+    this.clearDetachTimer();
+    this.target = target;
+    const replay = this.buffer
+      .filter((e) => e.seq > lastSeq)
+      .map((e) => e.message);
+    return { replay, incomplete: lastSeq < this.evictedThroughSeq };
+  }
+
+  /** Deliver frames on the session's ordered delivery chain. */
+  deliverReplay(
+    target: ChatTurnDeliveryTarget,
+    frames: Array<Record<string, unknown>>
+  ): Promise<void> {
+    for (const frame of frames) {
+      this.enqueueDelivery(() => target.deliver(frame));
+    }
+    return this.deliveryChain;
+  }
+
+  /**
+   * The attached connection went away. A running turn keeps executing and
+   * buffering; if nobody reattaches within the grace window the turn is
+   * aborted so it cannot run unattended forever.
+   */
+  detach(target?: ChatTurnDeliveryTarget): void {
+    if (target && this.target !== target) return;
+    this.target = null;
+    if (this.status !== "running") return;
+    this.clearDetachTimer();
+    this.detachTimer = setTimeout(() => {
+      log.info("Detached chat turn expired, aborting", {
+        threadId: this.threadId
+      });
+      this.abort();
+    }, DETACH_GRACE_MS());
+    this.detachTimer.unref?.();
+  }
+
+  /** Abort the turn (superseded, stopped, or detach grace elapsed). */
+  abort(): void {
+    this.controller.abort();
+    this.hooks.cancelPendingCalls(this.threadId);
+  }
+
+  /**
+   * The turn's promise settled. The session sticks around (still replayable)
+   * for the retention window, then drops out of the registry.
+   */
+  finish(): void {
+    if (this.status === "finished") return;
+    this.status = "finished";
+    this.clearDetachTimer();
+    this.retentionTimer = setTimeout(() => this.onDrop(this), RETENTION_MS());
+    this.retentionTimer.unref?.();
+  }
+
+  /** Release timers when the registry drops the session. */
+  dispose(): void {
+    this.clearDetachTimer();
+    if (this.retentionTimer) {
+      clearTimeout(this.retentionTimer);
+      this.retentionTimer = null;
+    }
+  }
+
+  private clearDetachTimer(): void {
+    if (this.detachTimer) {
+      clearTimeout(this.detachTimer);
+      this.detachTimer = null;
+    }
+  }
+
+  private enqueueDelivery(fn: () => Promise<void>): void {
+    this.deliveryChain = this.deliveryChain.then(fn).catch((err) => {
+      log.warn("Chat turn delivery failed", {
+        threadId: this.threadId,
+        error: err instanceof Error ? err.message : String(err)
+      });
+    });
+  }
+}
+
+export class ChatTurnRegistry {
+  private sessions = new Map<string, ChatTurnSession>();
+  /**
+   * Per-thread seq high-water marks, so a new turn continues numbering where
+   * the previous one left off and a client's `last_seq` from an older turn
+   * can never accidentally skip a newer turn's frames. Bounded: oldest
+   * entries are evicted past {@link MAX_SEQ_ENTRIES}.
+   */
+  private lastSeqByThread = new Map<string, number>();
+  private static readonly MAX_SEQ_ENTRIES = 10_000;
+
+  private key(userId: string, threadId: string): string {
+    return `${userId}\u0000${threadId}`;
+  }
+
+  /**
+   * Open a session for a new turn. An existing session for the same thread is
+   * superseded: aborted (if still running) and dropped, exactly as a new
+   * `chat_message` on a live connection cancels the previous turn.
+   */
+  open(
+    userId: string,
+    threadId: string,
+    controller: AbortController,
+    hooks: ChatTurnExecutionHooks
+  ): ChatTurnSession {
+    const key = this.key(userId, threadId);
+    const existing = this.sessions.get(key);
+    if (existing) {
+      if (existing.status === "running") existing.abort();
+      this.drop(existing);
+    }
+    const session = new ChatTurnSession(
+      userId,
+      threadId,
+      controller,
+      hooks,
+      (s) => this.drop(s),
+      this.lastSeqByThread.get(key) ?? 0
+    );
+    this.sessions.set(key, session);
+    return session;
+  }
+
+  get(userId: string, threadId: string): ChatTurnSession | null {
+    return this.sessions.get(this.key(userId, threadId)) ?? null;
+  }
+
+  drop(session: ChatTurnSession): void {
+    const key = this.key(session.userId, session.threadId);
+    if (this.sessions.get(key) === session) {
+      this.sessions.delete(key);
+    }
+    // max(): a superseded session's late retention-drop must not lower the
+    // high-water mark below what its successor already emitted.
+    this.lastSeqByThread.set(
+      key,
+      Math.max(this.lastSeqByThread.get(key) ?? 0, session.lastSeq)
+    );
+    while (this.lastSeqByThread.size > ChatTurnRegistry.MAX_SEQ_ENTRIES) {
+      const oldest = this.lastSeqByThread.keys().next().value;
+      if (oldest === undefined) break;
+      this.lastSeqByThread.delete(oldest);
+    }
+    session.dispose();
+  }
+}
+
+/** Process-wide registry: sessions survive their originating connection. */
+export const chatTurnRegistry = new ChatTurnRegistry();

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -38,6 +38,11 @@ import {
 } from "@nodetool-ai/execution";
 import { createRunSupervisor } from "./run-supervisor.js";
 import {
+  chatTurnRegistry,
+  type ChatTurnExecutionHooks,
+  type ChatTurnSession
+} from "./chat-turn-registry.js";
+import {
   Application,
   Asset,
   ImageDocument,
@@ -1806,6 +1811,21 @@ class ToolBridge {
       }
     }
   }
+
+  /**
+   * Cancel every pending call except those scoped to `scope`. Used on
+   * disconnect when a detached chat turn stays alive: its client tool calls
+   * survive (the replay re-delivers the `tool_call` frames, so a reconnecting
+   * client can still answer them) while everything else is rejected.
+   */
+  cancelAllExcept(scope: string): void {
+    const error = new Error("All pending tool calls cancelled");
+    for (const [id, waiter] of this.waiters) {
+      if (waiter.scope === scope) continue;
+      waiter.reject(error);
+      this.waiters.delete(id);
+    }
+  }
 }
 
 export interface UnifiedWebSocketRunnerOptions {
@@ -1937,6 +1957,30 @@ export class UnifiedWebSocketRunner {
    */
   private chatSessionAllow = new Map<string, Set<string>>();
   private observerRegistered = false;
+  /**
+   * The detachable session for the chat turn THIS connection is executing.
+   * While set (and running), every outbound frame carrying its thread_id is
+   * routed through the session: stamped with `chat_seq`, buffered for replay,
+   * and delivered to whichever connection is currently attached — which stops
+   * being this one if the socket drops mid-turn.
+   */
+  private chatTurnSession: ChatTurnSession | null = null;
+  /**
+   * Turns still executing on a previous connection's runner that THIS
+   * connection reattached to via `resume_chat`, keyed by thread id. Client
+   * frames for them (`tool_result`, approvals, `stop`) are forwarded to the
+   * executing runner through the session's hooks.
+   */
+  private adoptedSessions = new Map<string, ChatTurnSession>();
+  /**
+   * This connection's identity as a chat-turn delivery target. A stable
+   * object so `detach(target)` only clears the session's attachment when it
+   * still points at THIS connection — never a newer one that reattached.
+   */
+  private readonly chatDeliveryTarget = {
+    deliver: (message: Record<string, unknown>): Promise<void> =>
+      this.sendToSocket(message)
+  };
 
   private logError(context: string, error: unknown): void {
     log.error(context, formatSanitizedError(error));
@@ -1959,6 +2003,24 @@ export class UnifiedWebSocketRunner {
       seq: this.chatRequestSeq,
       signal: this.chatAbort.signal,
       controller: this.chatAbort
+    };
+  }
+
+  /**
+   * Hooks a resilient chat-turn session carries so a LATER connection that
+   * reattaches can route the client's `tool_result` / approvals / `stop`
+   * back to this runner — the one whose bridges own the pending waiters.
+   */
+  private buildChatTurnHooks(): ChatTurnExecutionHooks {
+    return {
+      resolveToolResult: (toolCallId, payload) =>
+        this.toolBridge.resolveResult(toolCallId, payload),
+      resolveApproval: (approvalId, payload) =>
+        this.approvalBridge.resolveResult(approvalId, payload),
+      cancelPendingCalls: (threadId) => {
+        this.toolBridge.cancelScope(threadId);
+        this.approvalBridge.cancelScope(threadId);
+      }
     };
   }
 
@@ -2115,13 +2177,31 @@ export class UnifiedWebSocketRunner {
     this.stopHeartbeat();
     this.stopStatsBroadcast();
     this.unregisterObserver();
-    this.toolBridge.cancelAll();
-    this.approvalBridge.cancelAll();
 
-    // Dropping the reference does not stop the work — abort the turn or a
-    // dropped socket leaves an inference request (or a Claude SDK subprocess)
-    // running with nobody left to receive its output.
-    this.cancelChatTurn();
+    // A resilient chat turn survives the socket: detach it (frames keep
+    // buffering in the session for replay) instead of aborting. The session's
+    // detach-grace timer bounds how long it may run unattended. Its pending
+    // client tool calls stay alive too — replay re-delivers the `tool_call`
+    // frames, so a reconnecting client can still answer them. Everything
+    // else (a sessionless `inference` turn, other pending calls) is cancelled
+    // as before: nobody is left to receive its output.
+    const detachedThreadId =
+      this.chatTurnSession?.status === "running"
+        ? this.chatTurnSession.threadId
+        : null;
+    if (detachedThreadId) {
+      this.chatTurnSession?.detach(this.chatDeliveryTarget);
+      this.toolBridge.cancelAllExcept(detachedThreadId);
+      this.approvalBridge.cancelAllExcept(detachedThreadId);
+    } else {
+      this.toolBridge.cancelAll();
+      this.approvalBridge.cancelAll();
+      this.cancelChatTurn();
+    }
+    for (const session of this.adoptedSessions.values()) {
+      session.detach(this.chatDeliveryTarget);
+    }
+    this.adoptedSessions.clear();
     this.currentTask = null;
     for (const [jobId, job] of this.activeJobs) {
       if (job.session) {
@@ -2188,6 +2268,24 @@ export class UnifiedWebSocketRunner {
   }
 
   async sendMessage(message: Record<string, unknown>): Promise<void> {
+    // Frames belonging to this connection's resilient chat turn go through the
+    // session: seq-stamped, buffered for replay, delivered to the attached
+    // connection (possibly a later one than this).
+    const session = this.chatTurnSession;
+    if (
+      session &&
+      session.status === "running" &&
+      typeof message.thread_id === "string" &&
+      message.thread_id === session.threadId
+    ) {
+      session.emit(message);
+      return;
+    }
+    await this.sendToSocket(message);
+  }
+
+  /** Raw socket delivery — no chat-turn interception. */
+  async sendToSocket(message: Record<string, unknown>): Promise<void> {
     if (!this.websocket) return;
     if (
       this.websocket.clientState === "disconnected" ||
@@ -7624,19 +7722,89 @@ export class UnifiedWebSocketRunner {
           return { error: "thread_id is required for chat_message command" };
         }
         const { seq, signal, controller } = this.beginChatTurn();
-        this.currentTask = this.handleChatMessage(data, seq, signal).finally(
-          () => this.endChatTurn(controller)
+        // A resilient session decouples the turn from this socket: frames are
+        // seq-stamped and buffered so a client that disconnects mid-turn can
+        // replay what it missed. Opening supersedes (aborts) any prior turn
+        // still running for this thread — including one detached from a dead
+        // connection.
+        const session = chatTurnRegistry.open(
+          this.userId ?? "1",
+          threadId,
+          controller,
+          this.buildChatTurnHooks()
         );
-        void this.currentTask.catch(async (err) => {
-          this.logError("chat_message processing failed", err);
-          await this.sendMessage({
-            type: "error",
-            message: err instanceof Error ? err.message : String(err)
+        session.attach(this.chatDeliveryTarget, session.lastSeq);
+        this.adoptedSessions.delete(threadId);
+        this.chatTurnSession = session;
+        // Error frames must be sent (and buffered) before the session
+        // finishes, so the catch runs inside the chain the finally closes.
+        this.currentTask = this.handleChatMessage(data, seq, signal)
+          .catch(async (err) => {
+            this.logError("chat_message processing failed", err);
+            await this.sendMessage({
+              type: "error",
+              message: err instanceof Error ? err.message : String(err),
+              thread_id: threadId
+            });
+          })
+          .finally(() => {
+            this.endChatTurn(controller);
+            session.finish();
+            if (this.chatTurnSession === session) this.chatTurnSession = null;
           });
-        });
         return {
           message: "Chat message processing started",
           thread_id: threadId
+        };
+      }
+      case "resume_chat": {
+        const threadId =
+          typeof data.thread_id === "string" ? data.thread_id : "";
+        if (!threadId) {
+          return { error: "thread_id is required for resume_chat command" };
+        }
+        const lastSeq =
+          typeof data.last_seq === "number" && Number.isFinite(data.last_seq)
+            ? data.last_seq
+            : 0;
+        const session = chatTurnRegistry.get(this.userId ?? "1", threadId);
+        if (!session) {
+          // Nothing to replay: no turn ran here, or retention elapsed. The
+          // persisted thread history over REST is the client's fallback.
+          await this.sendToSocket({
+            type: "chat_resumed",
+            thread_id: threadId,
+            status: "unknown",
+            last_seq: 0,
+            replay_count: 0,
+            replay_incomplete: false
+          });
+          return { message: "No chat turn to resume", thread_id: threadId };
+        }
+        const { replay, incomplete } = session.attach(
+          this.chatDeliveryTarget,
+          lastSeq
+        );
+        if (session.status === "running" && this.chatTurnSession !== session) {
+          this.adoptedSessions.set(threadId, session);
+        }
+        // Header first, then the missed tail; live frames queue behind them
+        // on the session's ordered delivery chain.
+        await session.deliverReplay(this.chatDeliveryTarget, [
+          {
+            type: "chat_resumed",
+            thread_id: threadId,
+            status: session.status,
+            last_seq: session.lastSeq,
+            replay_count: replay.length,
+            replay_incomplete: incomplete
+          },
+          ...replay
+        ]);
+        return {
+          message: "Chat resumed",
+          thread_id: threadId,
+          replay_count: replay.length
         };
       }
       case "inference": {
@@ -7674,6 +7842,14 @@ export class UnifiedWebSocketRunner {
         if (stopScope) {
           this.toolBridge.cancelScope(stopScope);
           this.approvalBridge.cancelScope(stopScope);
+        }
+        // The thread's turn may be executing on a previous connection's
+        // runner (detached or adopted after a reconnect) — abort it there.
+        if (threadId) {
+          const registered = chatTurnRegistry.get(this.userId ?? "1", threadId);
+          if (registered && registered.status === "running") {
+            registered.abort();
+          }
         }
         await this.sendMessage({
           type: "generation_stopped",
@@ -8033,6 +8209,11 @@ export class UnifiedWebSocketRunner {
           typeof data.tool_call_id === "string" ? data.tool_call_id : null;
         if (toolCallId) {
           this.toolBridge.resolveResult(toolCallId, data);
+          // The waiter may live on the runner executing an adopted turn.
+          // resolveResult no-ops on unknown ids, so forwarding is safe.
+          for (const session of this.adoptedSessions.values()) {
+            session.hooks.resolveToolResult(toolCallId, data);
+          }
         }
         continue;
       }
@@ -8042,6 +8223,9 @@ export class UnifiedWebSocketRunner {
           typeof data.approval_id === "string" ? data.approval_id : null;
         if (approvalId) {
           this.approvalBridge.resolveResult(approvalId, data);
+          for (const session of this.adoptedSessions.values()) {
+            session.hooks.resolveApproval(approvalId, data);
+          }
         }
         continue;
       }
@@ -8051,6 +8235,9 @@ export class UnifiedWebSocketRunner {
           typeof data.approval_id === "string" ? data.approval_id : null;
         if (approvalId) {
           this.approvalBridge.resolveResult(approvalId, data);
+          for (const session of this.adoptedSessions.values()) {
+            session.hooks.resolveApproval(approvalId, data);
+          }
         }
         continue;
       }

--- a/packages/websocket/tests/chat-turn-registry.test.ts
+++ b/packages/websocket/tests/chat-turn-registry.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  ChatTurnRegistry,
+  type ChatTurnExecutionHooks
+} from "../src/chat-turn-registry.js";
+
+function makeHooks(): ChatTurnExecutionHooks & {
+  cancelled: string[];
+} {
+  const cancelled: string[] = [];
+  return {
+    cancelled,
+    resolveToolResult: vi.fn(),
+    resolveApproval: vi.fn(),
+    cancelPendingCalls: (threadId: string) => {
+      cancelled.push(threadId);
+    }
+  };
+}
+
+function makeTarget() {
+  const delivered: Array<Record<string, unknown>> = [];
+  return {
+    delivered,
+    deliver: async (message: Record<string, unknown>) => {
+      delivered.push(message);
+    }
+  };
+}
+
+describe("ChatTurnSession", () => {
+  let registry: ChatTurnRegistry;
+
+  beforeEach(() => {
+    registry = new ChatTurnRegistry();
+  });
+
+  it("stamps emitted frames with increasing chat_seq and delivers to the attached target", async () => {
+    const session = registry.open("u1", "t1", new AbortController(), makeHooks());
+    const target = makeTarget();
+    session.attach(target, session.lastSeq);
+
+    session.emit({ type: "chunk", thread_id: "t1", content: "a" });
+    session.emit({ type: "chunk", thread_id: "t1", content: "b" });
+    await session.deliverReplay(target, []); // flush the delivery chain
+
+    expect(target.delivered.map((m) => m.chat_seq)).toEqual([1, 2]);
+    expect(target.delivered.map((m) => m.content)).toEqual(["a", "b"]);
+  });
+
+  it("buffers while detached and replays only the missed tail on attach", async () => {
+    const session = registry.open("u1", "t1", new AbortController(), makeHooks());
+    const target = makeTarget();
+    session.attach(target, 0);
+    session.emit({ type: "chunk", thread_id: "t1", content: "a" });
+    await session.deliverReplay(target, []);
+
+    session.detach(target);
+    session.emit({ type: "chunk", thread_id: "t1", content: "b" });
+    session.emit({ type: "chunk", thread_id: "t1", content: "c" });
+    expect(target.delivered).toHaveLength(1);
+
+    const reconnected = makeTarget();
+    const { replay, incomplete } = session.attach(reconnected, 1);
+    expect(incomplete).toBe(false);
+    expect(replay.map((m) => m.content)).toEqual(["b", "c"]);
+
+    // Live frames after reattach flow to the new target, after the replay.
+    await session.deliverReplay(reconnected, replay);
+    session.emit({ type: "chunk", thread_id: "t1", content: "d" });
+    await session.deliverReplay(reconnected, []);
+    expect(reconnected.delivered.map((m) => m.content)).toEqual(["b", "c", "d"]);
+  });
+
+  it("a guarded detach from a stale target does not clear a newer attachment", async () => {
+    const session = registry.open("u1", "t1", new AbortController(), makeHooks());
+    const oldTarget = makeTarget();
+    session.attach(oldTarget, 0);
+    const newTarget = makeTarget();
+    session.attach(newTarget, session.lastSeq);
+
+    session.detach(oldTarget);
+    session.emit({ type: "chunk", thread_id: "t1", content: "x" });
+    await session.deliverReplay(newTarget, []);
+    expect(newTarget.delivered).toHaveLength(1);
+  });
+
+  it("reports an incomplete replay when the buffer evicted the requested tail", () => {
+    process.env.NODETOOL_CHAT_REPLAY_BUFFER_EVENTS = "3";
+    try {
+      const session = registry.open(
+        "u1",
+        "t1",
+        new AbortController(),
+        makeHooks()
+      );
+      for (let i = 0; i < 5; i++) {
+        session.emit({ type: "chunk", thread_id: "t1", content: String(i) });
+      }
+      const target = makeTarget();
+      const { replay, incomplete } = session.attach(target, 1);
+      expect(incomplete).toBe(true);
+      expect(replay.map((m) => m.content)).toEqual(["2", "3", "4"]);
+    } finally {
+      delete process.env.NODETOOL_CHAT_REPLAY_BUFFER_EVENTS;
+    }
+  });
+
+  it("opening a new turn supersedes and aborts the previous session for the thread", () => {
+    const controller = new AbortController();
+    const hooks = makeHooks();
+    registry.open("u1", "t1", controller, hooks);
+    const next = registry.open("u1", "t1", new AbortController(), makeHooks());
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(hooks.cancelled).toEqual(["t1"]);
+    expect(registry.get("u1", "t1")).toBe(next);
+  });
+
+  it("continues seq numbering across turns on the same thread", () => {
+    const first = registry.open("u1", "t1", new AbortController(), makeHooks());
+    first.emit({ type: "chunk", thread_id: "t1", content: "a" });
+    first.emit({ type: "chunk", thread_id: "t1", content: "b" });
+    first.finish();
+    registry.drop(first);
+
+    const second = registry.open("u1", "t1", new AbortController(), makeHooks());
+    const stamped = second.emit({
+      type: "chunk",
+      thread_id: "t1",
+      content: "c"
+    });
+    expect(stamped.chat_seq).toBe(3);
+  });
+
+  it("sessions are scoped per user", () => {
+    const a = registry.open("u1", "t1", new AbortController(), makeHooks());
+    expect(registry.get("u2", "t1")).toBeNull();
+    expect(registry.get("u1", "t1")).toBe(a);
+  });
+
+  describe("timers", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("aborts a running turn when the detach grace window elapses", () => {
+      const controller = new AbortController();
+      const session = registry.open("u1", "t1", controller, makeHooks());
+      const target = makeTarget();
+      session.attach(target, 0);
+      session.detach(target);
+
+      vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+      expect(controller.signal.aborted).toBe(true);
+    });
+
+    it("does not abort while a target is attached", () => {
+      const controller = new AbortController();
+      const session = registry.open("u1", "t1", controller, makeHooks());
+      const target = makeTarget();
+      session.attach(target, 0);
+      session.detach(target);
+      session.attach(makeTarget(), session.lastSeq);
+
+      vi.advanceTimersByTime(60 * 60 * 1000);
+      expect(controller.signal.aborted).toBe(false);
+    });
+
+    it("drops a finished session from the registry after the retention window", () => {
+      const session = registry.open("u1", "t1", new AbortController(), makeHooks());
+      session.finish();
+      expect(registry.get("u1", "t1")).toBe(session);
+
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      expect(registry.get("u1", "t1")).toBeNull();
+    });
+  });
+});

--- a/packages/websocket/tests/unified-websocket-runner-chat-resume.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner-chat-resume.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Chat-turn resilience: a turn keeps executing when its socket disconnects,
+ * and a later connection replays the missed frames via `resume_chat`.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { unpack } from "msgpackr";
+import { initTestDb } from "@nodetool-ai/models";
+import { BaseProvider } from "@nodetool-ai/runtime";
+import {
+  UnifiedWebSocketRunner,
+  type WebSocketConnection,
+  type WebSocketReceiveFrame
+} from "../src/unified-websocket-runner.js";
+import { chatTurnRegistry } from "../src/chat-turn-registry.js";
+
+class MockWS implements WebSocketConnection {
+  clientState: "connected" | "disconnected" = "connected";
+  applicationState: "connected" | "disconnected" = "connected";
+  sentBytes: Uint8Array[] = [];
+  queue: Array<WebSocketReceiveFrame> = [];
+  async accept() {}
+  async receive(): Promise<WebSocketReceiveFrame> {
+    return this.queue.shift() ?? { type: "websocket.disconnect" };
+  }
+  async sendBytes(data: Uint8Array) {
+    this.sentBytes.push(data);
+  }
+  async sendText() {}
+  async close() {
+    this.clientState = "disconnected";
+    this.applicationState = "disconnected";
+  }
+}
+
+const noopExecutor = () => ({
+  async process() {
+    return {};
+  }
+});
+
+function sentMsgs(ws: MockWS): Record<string, unknown>[] {
+  return ws.sentBytes.map((b) => unpack(b) as Record<string, unknown>);
+}
+
+/** Provider that streams "hello " then blocks until released, then "world". */
+function gatedProvider() {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // Real providers abort the in-flight request when the turn's signal fires;
+  // the mock mirrors that by racing the gate against the abort.
+  async function* generate(opts?: { signal?: AbortSignal }) {
+    yield { type: "chunk" as const, content: "hello " };
+    const aborted = new Promise<never>((_, reject) => {
+      opts?.signal?.addEventListener(
+        "abort",
+        () => reject(new Error("aborted")),
+        { once: true }
+      );
+    });
+    await Promise.race([gate, aborted]);
+    yield { type: "chunk" as const, content: "world" };
+  }
+  const provider = async () =>
+    ({
+      provider: "mock",
+      generateMessages: generate,
+      generateMessagesTraced: generate,
+      async generateMessageTraced() {
+        return {};
+      },
+      generateMessage: vi.fn(),
+      hasToolSupport: async () => false,
+      getAvailableLanguageModels: async () => [],
+      getAvailableImageModels: async () => [],
+      getAvailableVideoModels: async () => [],
+      getAvailableTTSModels: async () => [],
+      getAvailableASRModels: async () => [],
+      getAvailableEmbeddingModels: async () => [],
+      getContainerEnv: () => ({}),
+      generateLoop: BaseProvider.prototype.generateLoop
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+  return { provider, release: () => release() };
+}
+
+describe("chat turn resilience across disconnect", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("keeps the turn running after disconnect and replays it on resume_chat", async () => {
+    const threadId = `t-resume-${Date.now()}-${Math.random()}`;
+    const { provider, release } = gatedProvider();
+
+    const runnerA = new UnifiedWebSocketRunner({
+      resolveExecutor: noopExecutor,
+      resolveProvider: provider
+    });
+    const wsA = new MockWS();
+    await runnerA.connect(wsA);
+    await runnerA.handleCommand({
+      command: "chat_message",
+      data: { thread_id: threadId, content: "hi", provider: "mock", model: "m" }
+    });
+
+    // Wait for the first chunk to reach client A, then note its seq.
+    await vi.waitFor(() => {
+      expect(
+        sentMsgs(wsA).some((m) => m.type === "chunk" && m.content === "hello ")
+      ).toBe(true);
+    });
+    const firstChunk = sentMsgs(wsA).find(
+      (m) => m.type === "chunk" && m.content === "hello "
+    )!;
+    expect(typeof firstChunk.chat_seq).toBe("number");
+    const lastSeq = firstChunk.chat_seq as number;
+
+    // Socket drops mid-turn: the turn must keep running (not be aborted).
+    await runnerA.disconnect();
+    const session = chatTurnRegistry.get("1", threadId);
+    expect(session).not.toBeNull();
+    expect(session!.status).toBe("running");
+
+    // The provider finishes while nobody is connected.
+    release();
+    await vi.waitFor(() => {
+      expect(chatTurnRegistry.get("1", threadId)!.status).toBe("finished");
+    });
+
+    // A fresh connection resumes and receives everything after lastSeq.
+    const runnerB = new UnifiedWebSocketRunner({
+      resolveExecutor: noopExecutor,
+      resolveProvider: provider
+    });
+    const wsB = new MockWS();
+    await runnerB.connect(wsB);
+    await runnerB.handleCommand({
+      command: "resume_chat",
+      data: { thread_id: threadId, last_seq: lastSeq }
+    });
+
+    const replayed = sentMsgs(wsB);
+    const header = replayed.find((m) => m.type === "chat_resumed");
+    expect(header).toBeDefined();
+    expect(header!.status).toBe("finished");
+    expect(header!.replay_incomplete).toBe(false);
+    expect(header!.thread_id).toBe(threadId);
+
+    // The second chunk and the terminal frames arrived, none re-sent from
+    // before lastSeq.
+    const chunks = replayed.filter((m) => m.type === "chunk");
+    expect(chunks.some((m) => m.content === "world")).toBe(true);
+    expect(chunks.some((m) => m.content === "hello ")).toBe(false);
+    expect(chunks.some((m) => m.done === true)).toBe(true);
+    expect(
+      replayed.some((m) => m.type === "message" && m.role === "assistant")
+    ).toBe(true);
+    for (const m of replayed) {
+      if (typeof m.chat_seq === "number") {
+        expect(m.chat_seq).toBeGreaterThan(lastSeq);
+      }
+    }
+
+    await runnerB.disconnect();
+  });
+
+  it("answers resume_chat for an unknown thread with status unknown", async () => {
+    const runner = new UnifiedWebSocketRunner({
+      resolveExecutor: noopExecutor
+    });
+    const ws = new MockWS();
+    await runner.connect(ws);
+    await runner.handleCommand({
+      command: "resume_chat",
+      data: { thread_id: "never-ran", last_seq: 0 }
+    });
+    const out = sentMsgs(ws).find((m) => m.type === "chat_resumed");
+    expect(out).toBeDefined();
+    expect(out!.status).toBe("unknown");
+    await runner.disconnect();
+  });
+
+  it("stop from a later connection aborts a detached turn", async () => {
+    const threadId = `t-stop-${Date.now()}-${Math.random()}`;
+    const { provider } = gatedProvider();
+
+    const runnerA = new UnifiedWebSocketRunner({
+      resolveExecutor: noopExecutor,
+      resolveProvider: provider
+    });
+    const wsA = new MockWS();
+    await runnerA.connect(wsA);
+    await runnerA.handleCommand({
+      command: "chat_message",
+      data: { thread_id: threadId, content: "hi", provider: "mock", model: "m" }
+    });
+    await vi.waitFor(() => {
+      expect(sentMsgs(wsA).some((m) => m.type === "chunk")).toBe(true);
+    });
+    await runnerA.disconnect();
+    expect(chatTurnRegistry.get("1", threadId)!.status).toBe("running");
+
+    const runnerB = new UnifiedWebSocketRunner({
+      resolveExecutor: noopExecutor,
+      resolveProvider: provider
+    });
+    const wsB = new MockWS();
+    await runnerB.connect(wsB);
+    await runnerB.handleCommand({
+      command: "stop",
+      data: { thread_id: threadId }
+    });
+
+    await vi.waitFor(() => {
+      const session = chatTurnRegistry.get("1", threadId);
+      expect(session === null || session.status === "finished").toBe(true);
+    });
+    await runnerB.disconnect();
+  });
+});

--- a/web/src/core/chat/__tests__/chatResume.test.ts
+++ b/web/src/core/chat/__tests__/chatResume.test.ts
@@ -1,0 +1,130 @@
+import { handleChatWebSocketMessage } from "../chatProtocol";
+
+jest.mock("../../../lib/tools/frontendTools", () => ({
+  FrontendToolRegistry: {
+    has: jest.fn(),
+    call: jest.fn()
+  }
+}));
+
+jest.mock("../../../lib/websocket/GlobalWebSocketManager", () => ({
+  globalWebSocketManager: {
+    send: jest.fn().mockResolvedValue(undefined),
+    ensureConnection: jest.fn().mockResolvedValue(undefined)
+  }
+}));
+
+const makeState = (threadRuntimeStatus: string) => ({
+  status: "streaming",
+  currentThreadId: "thread-1",
+  threads: {
+    "thread-1": {
+      id: "thread-1",
+      title: "T",
+      updated_at: new Date().toISOString()
+    }
+  },
+  threadRuntime: {
+    "thread-1": {
+      status: threadRuntimeStatus,
+      statusMessage: null,
+      progress: { current: 0, total: 0 },
+      error: null,
+      planningUpdate: null,
+      taskUpdate: null,
+      logUpdate: null,
+      runningToolCallId: null,
+      toolMessage: null,
+      sendMessageTimeoutId: null
+    }
+  },
+  messageCache: { "thread-1": [] },
+  chatReplayCursors: {},
+  loadMessages: jest.fn().mockResolvedValue([]),
+  selectedModel: { provider: "", id: "" },
+  summarizeThread: jest.fn(),
+  updateThreadTitle: jest.fn()
+});
+
+const makeHarness = (threadRuntimeStatus = "streaming") => {
+  let state: any = makeState(threadRuntimeStatus);
+  const set = jest.fn((updater) => {
+    state = {
+      ...state,
+      ...(typeof updater === "function" ? updater(state) : updater)
+    };
+  });
+  return { set, get: () => state, state: () => state };
+};
+
+describe("chat resume protocol", () => {
+  it("tracks the chat_seq high-water mark per thread", async () => {
+    const h = makeHarness();
+    await handleChatWebSocketMessage(
+      {
+        type: "chunk",
+        thread_id: "thread-1",
+        content: "hi",
+        done: false,
+        chat_seq: 7
+      } as any,
+      h.set,
+      h.get
+    );
+    expect(h.state().chatReplayCursors["thread-1"]).toBe(7);
+  });
+
+  it("chat_resumed unknown resets the runtime and reloads history", async () => {
+    const h = makeHarness("streaming");
+    await handleChatWebSocketMessage(
+      {
+        type: "chat_resumed",
+        thread_id: "thread-1",
+        status: "unknown",
+        last_seq: 0,
+        replay_count: 0,
+        replay_incomplete: false
+      } as any,
+      h.set,
+      h.get
+    );
+    expect(h.state().threadRuntime["thread-1"].status).toBe("idle");
+    expect(h.state().loadMessages).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("chat_resumed incomplete replay also reconciles from history", async () => {
+    const h = makeHarness("streaming");
+    await handleChatWebSocketMessage(
+      {
+        type: "chat_resumed",
+        thread_id: "thread-1",
+        status: "running",
+        last_seq: 40,
+        replay_count: 12,
+        replay_incomplete: true
+      } as any,
+      h.set,
+      h.get
+    );
+    expect(h.state().threadRuntime["thread-1"].status).toBe("idle");
+    expect(h.state().loadMessages).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("chat_resumed running leaves the streaming runtime alone", async () => {
+    const h = makeHarness("streaming");
+    await handleChatWebSocketMessage(
+      {
+        type: "chat_resumed",
+        thread_id: "thread-1",
+        status: "running",
+        last_seq: 40,
+        replay_count: 12,
+        replay_incomplete: false
+      } as any,
+      h.set,
+      h.get
+    );
+    expect(h.state().threadRuntime["thread-1"].status).toBe("streaming");
+    expect(h.state().loadMessages).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/core/chat/chatProtocol.ts
+++ b/web/src/core/chat/chatProtocol.ts
@@ -112,6 +112,19 @@ export interface ToolCallMessage {
   thread_id: string;
 }
 
+/**
+ * Reply to a `resume_chat` command, sent before any replayed frames. See
+ * `chatResumedMessageOutSchema` in @nodetool-ai/protocol for the contract.
+ */
+export interface ChatResumedUpdate {
+  type: "chat_resumed";
+  thread_id: string;
+  status: "running" | "finished" | "unknown";
+  last_seq: number;
+  replay_count: number;
+  replay_incomplete: boolean;
+}
+
 export type MsgpackData =
   | JobUpdate
   | Chunk
@@ -134,6 +147,7 @@ export type MsgpackData =
   | ToolResultMessage
   | ToolApprovalRequestMessage
   | PlanApprovalRequestMessage
+  | ChatResumedUpdate
   | ErrorMessage;
 
 export interface ToolResultMessage {
@@ -1262,6 +1276,16 @@ export async function handleChatWebSocketMessage(
     currentState.currentThreadId ??
     null;
 
+  // Frames from a resilient chat turn are stamped with a monotonically
+  // increasing `chat_seq`. Track the high-water mark per thread so a
+  // reconnect can ask the server to replay only what was missed.
+  const chatSeq = (msg as Record<string, unknown>).chat_seq;
+  if (tid && typeof chatSeq === "number") {
+    set((state) => ({
+      chatReplayCursors: { ...state.chatReplayCursors, [tid]: chatSeq }
+    }));
+  }
+
   // Swallow stragglers for a thread the user is stopping. The top-level
   // status check covers the pi transport, which drives the mirror directly.
   const isStopping =
@@ -1415,6 +1439,28 @@ export async function handleChatWebSocketMessage(
       }));
     }
     console.debug(`${data.type}:`, data.workflow_id);
+  } else if (data.type === "chat_resumed") {
+    // Reply to our resume_chat after a reconnect. "running"/"finished" are
+    // followed by the replayed frames, which drive the runtime as usual. If
+    // the server has nothing to replay ("unknown": no turn survived, or the
+    // retention window elapsed) or the bounded buffer lost our tail
+    // (replay_incomplete), reconcile from persisted history instead: reset
+    // the runtime and reload the thread's messages over REST.
+    if (tid && (data.status === "unknown" || data.replay_incomplete)) {
+      clearSendTimeout();
+      set((state) =>
+        threadRuntimeUpdate(state, tid, {
+          status: "idle",
+          statusMessage: null,
+          progress: { current: 0, total: 0 }
+        })
+      );
+      void get()
+        .loadMessages(tid)
+        .catch((err) =>
+          console.error("Failed to reload messages after chat resume:", err)
+        );
+    }
   } else if (data.type === "error") {
     // Clear the safety timeout on error
     clearSendTimeout();

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -210,6 +210,14 @@ export interface GlobalChatState extends ChatPiSlice {
   messageCursors: Record<string, string | null>; // threadId -> next cursor
   isLoadingMessages: boolean;
 
+  /**
+   * Per-thread `chat_seq` high-water marks from resilient chat turns. On
+   * reconnect, threads with a generation in flight send `resume_chat` with
+   * this cursor and the server replays only what was missed. In-memory only:
+   * after a full page reload the cache is rebuilt from REST history instead.
+   */
+  chatReplayCursors: Record<string, number>;
+
   // Long-term memory opt-in
   /**
    * When true, the server resolves a per-user, per-thread `LongTermMemory`
@@ -492,6 +500,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
       messageCache: {},
       messageCursors: {},
       isLoadingMessages: false,
+      chatReplayCursors: {},
 
       memoryEnabled: false,
       setMemoryEnabled: (enabled: boolean) => set({ memoryEnabled: enabled }),
@@ -704,6 +713,39 @@ const useGlobalChatStore = create<GlobalChatState>()(
 
         eventUnsubscribes.push(
           globalWebSocketManager.subscribeEvent("open", sendManifest)
+        );
+
+        // After a reconnect, ask the server to replay what each in-flight
+        // generation emitted while the socket was down. The server keeps the
+        // agent turn running across the disconnect and buffers its frames;
+        // `resume_chat` reattaches this connection and replays from the
+        // thread's last seen `chat_seq`. Registered after sendManifest so the
+        // tools manifest lands before any replayed `tool_call` frames.
+        const resumeInFlightThreads = () => {
+          const s = get();
+          for (const [threadId, runtime] of Object.entries(s.threadRuntime)) {
+            if (
+              runtime.status !== "loading" &&
+              runtime.status !== "streaming" &&
+              runtime.status !== "stopping"
+            ) {
+              continue;
+            }
+            void globalWebSocketManager
+              .send({
+                command: "resume_chat",
+                data: {
+                  thread_id: threadId,
+                  last_seq: s.chatReplayCursors[threadId] ?? 0
+                }
+              })
+              .catch((e) =>
+                console.error("Failed to send resume_chat:", threadId, e)
+              );
+          }
+        };
+        eventUnsubscribes.push(
+          globalWebSocketManager.subscribeEvent("open", resumeInFlightThreads)
         );
 
         if (globalWebSocketManager.isConnectionOpen()) {
@@ -1194,6 +1236,8 @@ const useGlobalChatStore = create<GlobalChatState>()(
             threadUnsubscribe?.();
             const { [threadId]: _deletedTodos, ...remainingTodos } =
               state.todosByThread;
+            const { [threadId]: _deletedReplayCursor, ...remainingReplayCursors } =
+              state.chatReplayCursors;
             const { [threadId]: deletedRuntime, ...remainingRuntime } =
               state.threadRuntime;
             if (deletedRuntime?.sendMessageTimeoutId != null) {
@@ -1206,7 +1250,8 @@ const useGlobalChatStore = create<GlobalChatState>()(
               messageCursors: remainingCursors,
               wsThreadSubscriptions: remainingSubscriptions,
               todosByThread: remainingTodos,
-              threadRuntime: remainingRuntime
+              threadRuntime: remainingRuntime,
+              chatReplayCursors: remainingReplayCursors
             };
 
             // If deleting current thread, switch to another or create new


### PR DESCRIPTION
## Problem

A dropped websocket aborted the in-flight chat/agent turn (`disconnect()` → `cancelChatTurn()`), so a laptop lid-close or network blip killed the agent mid-work. The client had no way to see what happened while it was away: chat frames carried no sequence numbers and the server kept no event buffer.

## What changed

**Server — detachable chat-turn sessions** (`packages/websocket/src/chat-turn-registry.ts`)
- Each `chat_message` turn now runs inside a `ChatTurnSession`, keyed by user+thread in a process-wide registry. Every outbound frame is stamped with a monotonic `chat_seq` and kept in a bounded replay buffer (`NODETOOL_CHAT_REPLAY_BUFFER_EVENTS`, default 2000); delivery goes to whichever connection is attached.
- On disconnect the session **detaches instead of aborting**: the agent keeps executing and buffering. A grace timer (`NODETOOL_CHAT_DETACH_GRACE_MS`, default 10 min) aborts a turn nobody reclaims. Sessionless `inference` turns and job behavior are unchanged.
- New `resume_chat {thread_id, last_seq}` command: the server replies with a `chat_resumed` header (status `running` / `finished` / `unknown`, `replay_incomplete` when the buffer evicted the requested tail) and replays the missed frames, then live frames follow in seq order. Finished turns stay replayable for a retention window (`NODETOOL_CHAT_REPLAY_RETENTION_MS`, default 5 min); after that the client reconciles from persisted REST history.
- `tool_result` / approval / `stop` frames arriving on the new connection are routed to the runner executing the adopted turn, and a detached turn's pending client tool calls survive the disconnect (replay re-delivers the `tool_call` frames so the reconnected client can still answer them).
- Seq numbering continues across turns on a thread, so a stale `last_seq` can never skip newer frames. A new turn supersedes and aborts a detached one, matching existing single-turn semantics.

**Web client**
- `GlobalChatStore` tracks the per-thread `chat_seq` high-water mark and, on every socket reopen, sends `resume_chat` for threads with a generation in flight (registered after the tools manifest so replayed `tool_call` frames find the manifest in place).
- `chat_resumed` with status `unknown` or an incomplete replay resets the thread runtime to idle and reloads the thread's messages over REST.

**Protocol**
- `resume_chat` added to `UnifiedCommandType` / command schemas; `chat_resumed` added to the outbound frame schemas. All schemas passthrough, so older clients ignore the new `chat_seq` field.

## Tests

- `packages/websocket/tests/chat-turn-registry.test.ts` — seq stamping, detach/attach replay ordering, stale-target guard, buffer eviction → `replay_incomplete`, supersede-abort, cross-turn seq continuity, detach-grace and retention timers.
- `packages/websocket/tests/unified-websocket-runner-chat-resume.test.ts` — end-to-end: turn survives `disconnect()`, finishes unattended, replays on a fresh connection with no duplicates; `resume_chat` for an unknown thread; `stop` from a later connection aborts a detached turn.
- `web/src/core/chat/__tests__/chatResume.test.ts` — cursor tracking and `chat_resumed` handling.
- Full websocket suite (183 files / 2094 tests), protocol suite, and web chat/websocket suites pass; `npm run lint` and web+electron typecheck clean (mobile typecheck fails only on uninstalled Expo deps in this sandbox, unrelated).

## Notes / scope

- Workflow jobs keep their existing lifecycle (cancelled on disconnect, `reconnect_job` unchanged); this PR covers chat/agent turns. A chat turn that routes into a workflow run still loses that job on disconnect.
- Resume is in-memory per page session: after a full reload the client rebuilds from REST history instead of replaying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWpARdXPyxfxgJnLR7SV6C

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWpARdXPyxfxgJnLR7SV6C)_