### PR TITLE
feat: version history for timeline sequences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -647,6 +647,26 @@ the verdict is ok. Validation and report rules live in
 `@nodetool-ai/execution/timeline-debug`; the CLI keeps target resolution, the
 interaction script, and the bundle.
 
+`timeline versions` reads and writes a sequence's snapshot history against the
+local database — manual saves, the autosaves `timeline.update` writes at most
+every five minutes, and the pre-restore snapshot that makes a restore undoable.
+All five subcommands take `--json`.
+
+```bash
+npm run dev:nodetool -- timeline versions list <timeline_id> --save-type manual --limit 10
+npm run dev:nodetool -- timeline versions show <timeline_id> 3 --json
+npm run dev:nodetool -- timeline versions create <timeline_id> --name "before the recut"
+npm run dev:nodetool -- timeline versions restore <timeline_id> 3
+npm run dev:nodetool -- timeline versions delete <timeline_id> 3 --yes
+```
+
+`restore` mirrors the tRPC router: it snapshots the current state as a
+`restore` version, CAS-writes the old document and its render settings back
+onto the sequence, then runs the same static check `timeline validate` runs. An
+old document is restored against today's schema, so what it used to pass is not
+what it passes now — a restore whose document no longer validates exits
+non-zero and prints the issues.
+
 ### Script voicing tools (no workflow, no browser)
 
 An agent voices a script and cuts it without authoring a workflow:

--- a/packages/cli/src/commands/timeline-validation-output.ts
+++ b/packages/cli/src/commands/timeline-validation-output.ts
@@ -1,0 +1,39 @@
+/**
+ * Human-readable rendering of a `TimelineValidation`, shared by
+ * `timeline validate` and `timeline versions restore` — a restored document is
+ * checked and reported exactly the way a validated one is.
+ */
+import type {
+  TimelineDebugIssue,
+  TimelineValidation
+} from "@nodetool-ai/execution/timeline-debug";
+
+/** Headline, then one line per issue — errors before warnings. */
+export function renderTimelineValidation(
+  validation: TimelineValidation
+): string[] {
+  const errors = validation.errors.length;
+  const warnings = validation.warnings.length;
+  const mark = validation.ok ? (warnings ? "⚠️" : "✅") : "❌";
+  const lines = ["", `${mark} ${errors} error(s), ${warnings} warning(s)`];
+  if (errors + warnings === 0) return lines;
+
+  lines.push("");
+  for (const issue of [...validation.errors, ...validation.warnings]) {
+    lines.push(`  ${formatTimelineIssue(issue)}`);
+  }
+  return lines;
+}
+
+function formatTimelineIssue(issue: TimelineDebugIssue): string {
+  const tag = issue.severity === "error" ? "error" : "warn ";
+  const where =
+    issue.clipId != null
+      ? ` [clip ${issue.clipId}]`
+      : issue.trackId != null
+        ? ` [track ${issue.trackId}]`
+        : issue.path != null
+          ? ` [${issue.path}]`
+          : "";
+  return `${tag} ${issue.message}${where} (${issue.code})`;
+}

--- a/packages/cli/src/commands/timeline-versions.ts
+++ b/packages/cli/src/commands/timeline-versions.ts
@@ -1,0 +1,497 @@
+/**
+ * `nodetool timeline versions` — the version-history half of the timeline
+ * harness.
+ *
+ * Timeline sequences keep immutable snapshots: manual saves, autosaves the
+ * server writes at most every five minutes, and the pre-restore snapshot that
+ * makes a restore undoable. These commands read and write that history
+ * directly against the local database, the way `timeline validate` and
+ * `timeline debug` read a sequence row, so an agent can inspect, snapshot,
+ * restore and prune without a server.
+ *
+ * `restore` mirrors the tRPC router (`timeline.versions.restore`): snapshot
+ * what is about to be overwritten, then CAS-write the version's document and
+ * render settings back onto the sequence. It then runs the same static check
+ * `timeline validate` runs — an old document is restored against today's
+ * schema, so what it used to pass is not what it passes now.
+ *
+ * The database and the validator core are injected with lazy defaults, so
+ * registration stays light and the actions are unit-testable.
+ */
+import type { Command } from "commander";
+import type {
+  TimelineValidation
+} from "@nodetool-ai/execution/timeline-debug";
+import { printCommandError } from "../command-errors.js";
+import { asJson, confirm, printTable } from "./output.js";
+import { numericOptionParser } from "../numeric-options.js";
+import { renderTimelineValidation } from "./timeline.js";
+
+/** A `timeline_sequences` row as these commands need it. */
+export interface TimelineSequenceRow {
+  id: string;
+  name?: string | null;
+  fps: number;
+  width: number;
+  height: number;
+  duration_ms: number;
+  updated_at: string;
+  document: string;
+}
+
+/** A `timeline_sequence_versions` row. */
+export interface TimelineVersionRow {
+  id: string;
+  timeline_id: string;
+  version: number;
+  name: string | null;
+  save_type: string;
+  fps: number;
+  width: number;
+  height: number;
+  duration_ms: number;
+  created_at: string;
+  document: string;
+}
+
+/** The model calls these commands make — the whole database seam. */
+export interface TimelineVersionStore {
+  loadSequence: (id: string) => Promise<TimelineSequenceRow | null>;
+  listVersions: (
+    timelineId: string,
+    opts: { limit?: number; saveType?: string }
+  ) => Promise<TimelineVersionRow[]>;
+  findVersion: (
+    timelineId: string,
+    version: number
+  ) => Promise<TimelineVersionRow | null>;
+  snapshot: (
+    seq: TimelineSequenceRow,
+    opts: { saveType: "manual" | "restore"; name?: string | null }
+  ) => Promise<TimelineVersionRow>;
+  /**
+   * Write a version's document and render settings back onto the sequence,
+   * compare-and-swap on the `updated_at` it was loaded with. Resolves to null
+   * when someone else wrote first.
+   */
+  restore: (
+    seq: TimelineSequenceRow,
+    version: TimelineVersionRow
+  ) => Promise<TimelineSequenceRow | null>;
+  deleteVersion: (timelineId: string, version: number) => Promise<void>;
+}
+
+export interface TimelineVersionsDeps {
+  /** Defaults to the local database through `@nodetool-ai/models`. */
+  store?: () => Promise<TimelineVersionStore>;
+  /** Defaults to `@nodetool-ai/execution/timeline-debug`. */
+  validate?: (
+    raw: unknown,
+    meta: { fps?: number; width?: number; height?: number }
+  ) => Promise<TimelineValidation> | TimelineValidation;
+  /** Defaults to the interactive prompt in `output.ts`. */
+  confirmDelete?: (message: string, force?: boolean) => Promise<boolean>;
+}
+
+/** The list-item shape, matching the tRPC router's `timelineVersionListItem`. */
+export interface TimelineVersionListItem {
+  id: string;
+  timelineId: string;
+  version: number;
+  name: string | null;
+  saveType: string;
+  fps: number;
+  width: number;
+  height: number;
+  durationMs: number;
+  createdAt: string;
+}
+
+export function toVersionListItem(
+  row: TimelineVersionRow
+): TimelineVersionListItem {
+  return {
+    id: row.id,
+    timelineId: row.timeline_id,
+    version: row.version,
+    name: row.name ?? null,
+    saveType: row.save_type,
+    fps: row.fps,
+    width: row.width,
+    height: row.height,
+    durationMs: row.duration_ms,
+    createdAt: row.created_at
+  };
+}
+
+/** One table row per version: what it is, when it was taken, what it renders. */
+export function versionTableRows(
+  items: TimelineVersionListItem[]
+): Record<string, unknown>[] {
+  return items.map((v) => ({
+    version: v.version,
+    saveType: v.saveType,
+    name: v.name ?? "",
+    createdAt: v.createdAt,
+    fps: v.fps,
+    resolution: `${v.width}x${v.height}`
+  }));
+}
+
+/** Parse a stored document without throwing — an unreadable one is a finding. */
+export function parseVersionDocument(raw: unknown): unknown {
+  if (typeof raw !== "string") return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/** Track / clip / marker counts of whatever a version stored. */
+export function documentCounts(document: unknown): {
+  tracks: number;
+  clips: number;
+  markers: number;
+} {
+  const doc = (document ?? {}) as Record<string, unknown>;
+  const count = (value: unknown): number =>
+    Array.isArray(value) ? value.length : 0;
+  return {
+    tracks: count(doc.tracks),
+    clips: count(doc.clips),
+    markers: count(doc.markers)
+  };
+}
+
+async function defaultStore(): Promise<TimelineVersionStore> {
+  const { initDb, TimelineSequence, TimelineSequenceVersion } = await import(
+    "@nodetool-ai/models"
+  );
+  const { getDefaultDbPath } = await import("@nodetool-ai/config");
+  initDb(getDefaultDbPath());
+
+  type SnapshotArg = Parameters<typeof TimelineSequenceVersion.snapshot>[0];
+
+  return {
+    loadSequence: async (id) =>
+      (await TimelineSequence.findById(id)) as TimelineSequenceRow | null,
+    listVersions: async (timelineId, opts) =>
+      (await TimelineSequenceVersion.listForTimeline(
+        timelineId,
+        opts
+      )) as unknown as TimelineVersionRow[],
+    findVersion: async (timelineId, version) =>
+      (await TimelineSequenceVersion.findByVersion(
+        timelineId,
+        version
+      )) as unknown as TimelineVersionRow | null,
+    snapshot: async (seq, opts) =>
+      (await TimelineSequenceVersion.snapshot(
+        seq as unknown as SnapshotArg,
+        opts
+      )) as unknown as TimelineVersionRow,
+    restore: async (seq, version) =>
+      (await TimelineSequence.updateFieldsIfUnchanged(seq.id, seq.updated_at, {
+        document: version.document,
+        fps: version.fps,
+        width: version.width,
+        height: version.height,
+        duration_ms: version.duration_ms
+      })) as TimelineSequenceRow | null,
+    deleteVersion: async (timelineId, version) => {
+      const row = await TimelineSequenceVersion.findByVersion(
+        timelineId,
+        version
+      );
+      if (row) await row.delete();
+    }
+  };
+}
+
+async function defaultValidate(
+  raw: unknown,
+  meta: { fps?: number; width?: number; height?: number }
+): Promise<TimelineValidation> {
+  const { validateTimelineSequence } = await import(
+    "@nodetool-ai/execution/timeline-debug"
+  );
+  return await validateTimelineSequence(raw, meta);
+}
+
+/** Load a sequence or say which id was not found. */
+async function requireSequence(
+  store: TimelineVersionStore,
+  id: string
+): Promise<TimelineSequenceRow> {
+  const seq = await store.loadSequence(id);
+  if (!seq) throw new Error(`Timeline sequence not found: ${id}`);
+  return seq;
+}
+
+async function requireVersion(
+  store: TimelineVersionStore,
+  timelineId: string,
+  version: number
+): Promise<TimelineVersionRow> {
+  const row = await store.findVersion(timelineId, version);
+  if (!row) {
+    throw new Error(`Timeline version not found: ${timelineId} v${version}`);
+  }
+  return row;
+}
+
+interface JsonOption {
+  json?: boolean;
+}
+
+interface ListOptions extends JsonOption {
+  saveType?: string;
+  limit?: number;
+}
+
+export function registerTimelineVersionsCommands(
+  timeline: Command,
+  deps: TimelineVersionsDeps = {}
+): void {
+  const openStore = deps.store ?? defaultStore;
+  const validate = deps.validate ?? defaultValidate;
+  const confirmDelete =
+    deps.confirmDelete ??
+    ((message: string, force?: boolean) => confirm(message, { force }));
+
+  const versions = timeline
+    .command("versions")
+    .description(
+      "Inspect and restore the snapshot history of a timeline sequence (manual saves, autosaves, pre-restore snapshots)"
+    );
+
+  versions
+    .command("list <timeline_id>")
+    .description("List a timeline's versions, newest first")
+    .option("--save-type <type>", "Only manual, autosave or restore snapshots")
+    .option(
+      "--limit <n>",
+      "Maximum versions to list (default 100)",
+      numericOptionParser("--limit", { integer: true, min: 1 })
+    )
+    .option("--json", "Print the versions as JSON")
+    .action(async (timelineId: string, opts: ListOptions) => {
+      try {
+        const store = await openStore();
+        await requireSequence(store, timelineId);
+        const rows = await store.listVersions(timelineId, {
+          ...(opts.limit !== undefined ? { limit: opts.limit } : {}),
+          ...(opts.saveType ? { saveType: opts.saveType } : {})
+        });
+        const items = rows.map(toVersionListItem);
+
+        if (opts.json) {
+          asJson({ timelineId, versions: items });
+          return;
+        }
+        printTable(versionTableRows(items));
+      } catch (e) {
+        printCommandError(e, opts.json);
+        process.exit(1);
+      }
+    });
+
+  versions
+    .command("show <timeline_id> <version>")
+    .description("Print one version's metadata and the document it stored")
+    .option("--json", "Print the metadata and the full document as JSON")
+    .action(
+      async (timelineId: string, version: string, opts: JsonOption) => {
+        try {
+          const number = parseVersionNumber(version);
+          const store = await openStore();
+          await requireSequence(store, timelineId);
+          const row = await requireVersion(store, timelineId, number);
+          const item = toVersionListItem(row);
+          const document = parseVersionDocument(row.document);
+
+          if (opts.json) {
+            asJson({ ...item, document });
+            return;
+          }
+          const counts = documentCounts(document);
+          printTable([
+            {
+              version: item.version,
+              saveType: item.saveType,
+              name: item.name ?? "",
+              createdAt: item.createdAt,
+              fps: item.fps,
+              resolution: `${item.width}x${item.height}`
+            }
+          ]);
+          console.log(
+            `\n  ${counts.tracks} track(s), ${counts.clips} clip(s), ${counts.markers} marker(s), ${item.durationMs}ms`
+          );
+        } catch (e) {
+          printCommandError(e, opts.json);
+          process.exit(1);
+        }
+      }
+    );
+
+  versions
+    .command("create <timeline_id>")
+    .description("Snapshot the sequence as it stands now (a manual save)")
+    .option("--name <name>", "Label for the snapshot")
+    .option("--json", "Print the created version as JSON")
+    .action(
+      async (timelineId: string, opts: JsonOption & { name?: string }) => {
+        try {
+          const store = await openStore();
+          const seq = await requireSequence(store, timelineId);
+          const row = await store.snapshot(seq, {
+            saveType: "manual",
+            name: opts.name ?? null
+          });
+          const item = toVersionListItem(row);
+
+          if (opts.json) {
+            asJson(item);
+            return;
+          }
+          console.log(
+            `✅ Snapshot saved as v${item.version}${item.name ? ` (${item.name})` : ""}`
+          );
+        } catch (e) {
+          printCommandError(e, opts.json);
+          process.exit(1);
+        }
+      }
+    );
+
+  versions
+    .command("restore <timeline_id> <version>")
+    .description(
+      "Restore a version onto the sequence. The pre-restore state is snapshotted first, and the restored document is validated against the current schema — a restore whose document no longer validates exits non-zero"
+    )
+    .option("--json", "Print the restore result and validation as JSON")
+    .action(
+      async (timelineId: string, version: string, opts: JsonOption) => {
+        // The verdict leaves the try block in a variable: `process.exit`
+        // throws under test, and an exit inside the try would be caught here
+        // as a command failure.
+        let restoredOk = false;
+        try {
+          const number = parseVersionNumber(version);
+          const store = await openStore();
+          const seq = await requireSequence(store, timelineId);
+          const target = await requireVersion(store, timelineId, number);
+
+          // Snapshot what is about to be overwritten first, so the restore is
+          // itself undoable — same order the tRPC router uses.
+          const backup = await store.snapshot(seq, {
+            saveType: "restore",
+            name: `Before restore to v${number}`
+          });
+
+          const updated = await store.restore(seq, target);
+          if (!updated) {
+            throw new Error("Timeline has been modified since last load");
+          }
+
+          const document = parseVersionDocument(target.document);
+          const validation = await validate(document, {
+            fps: target.fps,
+            width: target.width,
+            height: target.height
+          });
+
+          if (opts.json) {
+            asJson({
+              timelineId,
+              restored: toVersionListItem(target),
+              snapshot: toVersionListItem(backup),
+              sequence: {
+                id: updated.id,
+                fps: updated.fps,
+                width: updated.width,
+                height: updated.height,
+                durationMs: updated.duration_ms
+              },
+              validation
+            });
+          } else {
+            const counts = documentCounts(document);
+            console.log(
+              `✅ Restored v${number} onto ${timelineId}: ${counts.tracks} track(s), ${counts.clips} clip(s), ${target.duration_ms}ms @ ${target.fps}fps ${target.width}x${target.height}`
+            );
+            console.log(
+              `  pre-restore state saved as v${backup.version} (${backup.save_type})`
+            );
+            console.log(renderTimelineValidation(validation).join("\n"));
+          }
+          restoredOk = validation.ok;
+        } catch (e) {
+          printCommandError(e, opts.json);
+          process.exit(1);
+        }
+        process.exit(restoredOk ? 0 : 1);
+      }
+    );
+
+  versions
+    .command("delete <timeline_id> <version>")
+    .description("Delete one version from a timeline's history")
+    .option("-y, --yes", "Skip the confirmation prompt")
+    .option("--json", "Print the result as JSON")
+    .action(
+      async (
+        timelineId: string,
+        version: string,
+        opts: JsonOption & { yes?: boolean }
+      ) => {
+        let aborted = false;
+        try {
+          const number = parseVersionNumber(version);
+          const store = await openStore();
+          await requireSequence(store, timelineId);
+          await requireVersion(store, timelineId, number);
+
+          const ok = await confirmDelete(
+            `Delete v${number} of timeline ${timelineId}?`,
+            opts.yes
+          );
+          if (!ok) {
+            aborted = true;
+            if (opts.json) {
+              asJson({
+                timelineId,
+                version: number,
+                deleted: false,
+                aborted: true
+              });
+            } else {
+              console.error("Aborted.");
+            }
+          } else {
+            await store.deleteVersion(timelineId, number);
+            if (opts.json) {
+              asJson({ timelineId, version: number, deleted: true });
+            } else {
+              console.log(`✅ Deleted v${number} of timeline ${timelineId}`);
+            }
+          }
+        } catch (e) {
+          printCommandError(e, opts.json);
+          process.exit(1);
+        }
+        if (aborted) process.exit(1);
+      }
+    );
+}
+
+/** A version is a positive integer; anything else names itself in the error. */
+export function parseVersionNumber(raw: string): number {
+  const value = Number(raw.trim());
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`version must be a positive integer (got "${raw}")`);
+  }
+  return value;
+}

--- a/packages/cli/src/commands/timeline.ts
+++ b/packages/cli/src/commands/timeline.ts
@@ -1,25 +1,26 @@
 /**
- * `nodetool timeline validate` and `nodetool timeline debug` — the timeline
- * harness commands.
+ * `nodetool timeline validate`, `debug` and `versions` — the timeline harness
+ * commands.
  *
  * `validate` checks a timeline document statically: tracks a clip points at,
  * fields a round trip through the schema would strip, timings that cannot
  * render. `debug` additionally replays a scripted `--interact` edit session
  * against the headless `ui_timeline_*` bridge and writes a bundle. Both take a
- * timeline JSON file or a `timeline_sequences` row id.
+ * timeline JSON file or a `timeline_sequences` row id. `versions`
+ * (timeline-versions.ts) reads and restores a sequence's snapshot history.
  *
  * Heavy dependencies (the database, the validator core, the bridge) are
  * imported lazily inside each action, so command registration stays light and
  * unit-testable.
  */
 import type { Command } from "commander";
-import type {
-  TimelineDebugIssue,
-  TimelineDebugReport,
-  TimelineValidation
-} from "@nodetool-ai/execution/timeline-debug";
+import type { TimelineDebugReport } from "@nodetool-ai/execution/timeline-debug";
 import type { TimelineSequenceRecord } from "../timeline-debug/target.js";
 import { printCommandError } from "../command-errors.js";
+import { renderTimelineValidation } from "./timeline-validation-output.js";
+import { registerTimelineVersionsCommands } from "./timeline-versions.js";
+
+export { renderTimelineValidation };
 
 interface TimelineValidateCliOptions {
   json?: boolean;
@@ -142,39 +143,8 @@ export function registerTimelineCommands(program: Command): void {
         process.exit(1);
       }
     });
-}
 
-/** Human-readable validation output: headline, then one line per issue. */
-export function renderTimelineValidation(
-  validation: TimelineValidation
-): string[] {
-  const errors = validation.errors.length;
-  const warnings = validation.warnings.length;
-  const mark = validation.ok ? (warnings ? "⚠️" : "✅") : "❌";
-  const lines = [
-    "",
-    `${mark} ${errors} error(s), ${warnings} warning(s)`
-  ];
-  if (errors + warnings === 0) return lines;
-
-  lines.push("");
-  for (const issue of [...validation.errors, ...validation.warnings]) {
-    lines.push(`  ${formatTimelineIssue(issue)}`);
-  }
-  return lines;
-}
-
-function formatTimelineIssue(issue: TimelineDebugIssue): string {
-  const tag = issue.severity === "error" ? "error" : "warn ";
-  const where =
-    issue.clipId != null
-      ? ` [clip ${issue.clipId}]`
-      : issue.trackId != null
-        ? ` [track ${issue.trackId}]`
-        : issue.path != null
-          ? ` [${issue.path}]`
-          : "";
-  return `${tag} ${issue.message}${where} (${issue.code})`;
+  registerTimelineVersionsCommands(timeline);
 }
 
 function printTimelineSummary(

--- a/packages/cli/src/harness/registry.ts
+++ b/packages/cli/src/harness/registry.ts
@@ -175,6 +175,15 @@ export const HARNESSES: HarnessEntry[] = [
     docs: "CLAUDE.md § nodetool timeline validate / debug"
   },
   {
+    id: "timeline-versions",
+    title: "Timeline version history (snapshot, restore, validate the restore)",
+    command:
+      "nodetool timeline versions list|show|create|restore|delete <id> [<version>]",
+    kind: "execution",
+    capabilities: ["json"],
+    docs: "CLAUDE.md § nodetool timeline validate / debug"
+  },
+  {
     id: "eval",
     title:
       "Agent evaluation suites (graph-planner, graph-e2e, code-gen, task-planner, script-planner, tool-loop×8, app-build)",
@@ -264,9 +273,19 @@ export const SURFACES: SurfaceEntry[] = [
   },
   {
     id: "timeline",
-    title: "Timeline sequences (ui_timeline_* tools)",
-    harnesses: ["timeline-validate", "timeline-debug", "eval"],
-    paths: ["packages/execution/src/timeline-debug/"]
+    title: "Timeline sequences (ui_timeline_* tools, version history)",
+    harnesses: [
+      "timeline-validate",
+      "timeline-debug",
+      "timeline-versions",
+      "eval"
+    ],
+    paths: [
+      "packages/execution/src/timeline-debug/",
+      "packages/cli/src/commands/timeline-versions.ts",
+      "packages/models/src/timeline-sequence-version.ts",
+      "packages/websocket/src/trpc/routers/timeline.ts"
+    ]
   },
   {
     id: "chat-agent",

--- a/packages/cli/tests/harness-registry.test.ts
+++ b/packages/cli/tests/harness-registry.test.ts
@@ -85,6 +85,16 @@ describe("harness gate", () => {
     ]);
   });
 
+  it("maps a timeline version-history change onto the timeline surface", () => {
+    const plan = planGate([
+      "packages/models/src/timeline-sequence-version.ts",
+      "packages/cli/src/commands/timeline-versions.ts"
+    ]);
+    expect(plan.surfaces.map((s) => s.id)).toContain("timeline");
+    expect(plan.manual.map((m) => m.harnessId)).toContain("timeline-versions");
+    expect(plan.unmappedFiles).toEqual([]);
+  });
+
   it("reports files no surface claims", () => {
     const plan = planGate(["README.md"]);
     expect(plan.unmappedFiles).toEqual(["README.md"]);

--- a/packages/cli/tests/timeline-command.test.ts
+++ b/packages/cli/tests/timeline-command.test.ts
@@ -39,6 +39,21 @@ describe("registerTimelineCommands", () => {
     );
   });
 
+  it("registers the versions group with its five subcommands", () => {
+    const versions = timelineSubcommand("versions");
+    expect(versions.commands.map((c) => c.name()).sort()).toEqual([
+      "create",
+      "delete",
+      "list",
+      "restore",
+      "show"
+    ]);
+    const list = versions.commands.find((c) => c.name() === "list")!;
+    expect(list.options.map((o) => o.long)).toEqual(
+      expect.arrayContaining(["--save-type", "--limit", "--json"])
+    );
+  });
+
   it("documents both target kinds on validate", () => {
     const description = timelineSubcommand("validate").description();
     expect(description).toMatch(/JSON file/i);

--- a/packages/cli/tests/timeline-versions-command.test.ts
+++ b/packages/cli/tests/timeline-versions-command.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Action-level tests for `nodetool timeline versions`
+ * (src/commands/timeline-versions.ts).
+ *
+ * The database and the validator core are injected, so these exercise the real
+ * command wiring — argument parsing, JSON shapes, exit codes, and the order a
+ * restore writes in — without a SQLite file or the execution package.
+ */
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { Command } from "commander";
+import {
+  registerTimelineVersionsCommands,
+  toVersionListItem,
+  parseVersionNumber,
+  versionTableRows,
+  documentCounts,
+  type TimelineSequenceRow,
+  type TimelineVersionRow,
+  type TimelineVersionStore
+} from "../src/commands/timeline-versions.js";
+
+const document = JSON.stringify({
+  tracks: [{ id: "t1" }],
+  clips: [{ id: "c1" }, { id: "c2" }],
+  markers: []
+});
+
+const sequence = (): TimelineSequenceRow => ({
+  id: "seq-1",
+  name: "My timeline",
+  fps: 30,
+  width: 1920,
+  height: 1080,
+  duration_ms: 8000,
+  updated_at: "2026-08-01T10:00:00.000Z",
+  document
+});
+
+const versionRow = (
+  overrides: Partial<TimelineVersionRow> = {}
+): TimelineVersionRow => ({
+  id: "ver-1",
+  timeline_id: "seq-1",
+  version: 2,
+  name: "before the cut",
+  save_type: "manual",
+  fps: 24,
+  width: 1280,
+  height: 720,
+  duration_ms: 4000,
+  created_at: "2026-08-01T09:00:00.000Z",
+  document,
+  ...overrides
+});
+
+const clean = { ok: true, errors: [], warnings: [] };
+
+const loadSequence = vi.fn();
+const listVersions = vi.fn();
+const findVersion = vi.fn();
+const snapshot = vi.fn();
+const restore = vi.fn();
+const deleteVersion = vi.fn();
+const validate = vi.fn();
+const confirmDelete = vi.fn();
+
+const store: TimelineVersionStore = {
+  loadSequence,
+  listVersions,
+  findVersion,
+  snapshot,
+  restore,
+  deleteVersion
+};
+
+async function captureOutput(
+  fn: () => Promise<void> | void
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  let stdout = "";
+  let stderr = "";
+  let exitCode: number | null = null;
+  const origLog = console.log;
+  const origErr = console.error;
+  const origExit = process.exit;
+  console.log = (...args: unknown[]) => {
+    stdout += args.map(String).join(" ") + "\n";
+  };
+  console.error = (...args: unknown[]) => {
+    stderr += args.map(String).join(" ") + "\n";
+  };
+  process.exit = ((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`__EXIT__${code ?? 0}`);
+  }) as typeof process.exit;
+  try {
+    await fn();
+  } catch (e) {
+    if (!(e instanceof Error) || !e.message.startsWith("__EXIT__")) throw e;
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+    process.exit = origExit;
+  }
+  return { stdout, stderr, exitCode };
+}
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  const timeline = program.command("timeline");
+  registerTimelineVersionsCommands(timeline, {
+    store: async () => store,
+    validate,
+    confirmDelete
+  });
+  return program;
+}
+
+function run(...argv: string[]) {
+  const program = buildProgram();
+  return captureOutput(() =>
+    program.parseAsync(["node", "cli", "timeline", "versions", ...argv])
+  );
+}
+
+beforeEach(() => {
+  loadSequence.mockReset().mockResolvedValue(sequence());
+  listVersions.mockReset().mockResolvedValue([versionRow()]);
+  findVersion.mockReset().mockResolvedValue(versionRow());
+  snapshot
+    .mockReset()
+    .mockResolvedValue(versionRow({ id: "ver-3", version: 3, save_type: "restore" }));
+  restore.mockReset().mockResolvedValue({
+    ...sequence(),
+    fps: 24,
+    width: 1280,
+    height: 720,
+    duration_ms: 4000
+  });
+  deleteVersion.mockReset().mockResolvedValue(undefined);
+  validate.mockReset().mockResolvedValue(clean);
+  confirmDelete.mockReset().mockResolvedValue(true);
+});
+
+describe("timeline versions list", () => {
+  it("lists a timeline's versions as JSON list items", async () => {
+    const { stdout, exitCode } = await run("list", "seq-1", "--json");
+    expect(exitCode).toBeNull();
+    const parsed = JSON.parse(stdout.trim()) as {
+      timelineId: string;
+      versions: Array<Record<string, unknown>>;
+    };
+    expect(parsed.timelineId).toBe("seq-1");
+    expect(parsed.versions).toHaveLength(1);
+    expect(parsed.versions[0]).toMatchObject({
+      version: 2,
+      saveType: "manual",
+      name: "before the cut",
+      fps: 24,
+      width: 1280,
+      height: 720,
+      durationMs: 4000,
+      createdAt: "2026-08-01T09:00:00.000Z"
+    });
+  });
+
+  it("passes --save-type and --limit through to the store", async () => {
+    await run("list", "seq-1", "--save-type", "autosave", "--limit", "5", "--json");
+    expect(listVersions).toHaveBeenCalledWith("seq-1", {
+      limit: 5,
+      saveType: "autosave"
+    });
+  });
+
+  it("prints a table with version, save type and resolution in human mode", async () => {
+    const { stdout } = await run("list", "seq-1");
+    expect(stdout).toContain("saveType");
+    expect(stdout).toContain("manual");
+    expect(stdout).toContain("1280x720");
+  });
+
+  it("exits non-zero for an unknown timeline id", async () => {
+    loadSequence.mockResolvedValueOnce(null);
+    const { exitCode, stderr } = await run("list", "nope");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Timeline sequence not found: nope");
+    expect(listVersions).not.toHaveBeenCalled();
+  });
+});
+
+describe("timeline versions show", () => {
+  it("prints the metadata and the stored document under --json", async () => {
+    const { stdout } = await run("show", "seq-1", "2", "--json");
+    const parsed = JSON.parse(stdout.trim()) as {
+      version: number;
+      document: { clips: unknown[] };
+    };
+    expect(parsed.version).toBe(2);
+    expect(parsed.document.clips).toHaveLength(2);
+  });
+
+  it("prints track/clip/marker counts in human mode", async () => {
+    const { stdout } = await run("show", "seq-1", "2");
+    expect(stdout).toContain("1 track(s), 2 clip(s), 0 marker(s)");
+  });
+
+  it("exits non-zero for an unknown version", async () => {
+    findVersion.mockResolvedValueOnce(null);
+    const { exitCode, stderr } = await run("show", "seq-1", "9");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Timeline version not found: seq-1 v9");
+  });
+
+  it("rejects a version that is not a positive integer", async () => {
+    const { exitCode, stderr } = await run("show", "seq-1", "latest");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("version must be a positive integer");
+  });
+});
+
+describe("timeline versions create", () => {
+  it("snapshots the current sequence as a manual save", async () => {
+    snapshot.mockResolvedValueOnce(
+      versionRow({ id: "ver-4", version: 4, name: "checkpoint" })
+    );
+    const { stdout } = await run("create", "seq-1", "--name", "checkpoint", "--json");
+    expect(snapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "seq-1" }),
+      { saveType: "manual", name: "checkpoint" }
+    );
+    const parsed = JSON.parse(stdout.trim()) as { version: number; name: string };
+    expect(parsed).toMatchObject({ version: 4, name: "checkpoint" });
+  });
+
+  it("defaults the name to null and reports the new version", async () => {
+    const { stdout } = await run("create", "seq-1");
+    expect(snapshot).toHaveBeenCalledWith(expect.anything(), {
+      saveType: "manual",
+      name: null
+    });
+    expect(stdout).toContain("Snapshot saved as v3");
+  });
+});
+
+describe("timeline versions restore", () => {
+  it("snapshots the pre-restore state before writing the version back", async () => {
+    const { exitCode, stdout } = await run("restore", "seq-1", "2");
+    expect(exitCode).toBe(0);
+
+    expect(snapshot).toHaveBeenCalledWith(expect.objectContaining({ id: "seq-1" }), {
+      saveType: "restore",
+      name: "Before restore to v2"
+    });
+    expect(snapshot.mock.invocationCallOrder[0]!).toBeLessThan(
+      restore.mock.invocationCallOrder[0]!
+    );
+    expect(restore).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "seq-1", updated_at: "2026-08-01T10:00:00.000Z" }),
+      expect.objectContaining({ version: 2, fps: 24, width: 1280, height: 720 })
+    );
+    expect(stdout).toContain("Restored v2 onto seq-1");
+    expect(stdout).toContain("pre-restore state saved as v3");
+    expect(stdout).toContain("0 error(s), 0 warning(s)");
+  });
+
+  it("validates the restored document against the current schema", async () => {
+    await run("restore", "seq-1", "2");
+    expect(validate).toHaveBeenCalledWith(
+      expect.objectContaining({ clips: expect.any(Array) }),
+      { fps: 24, width: 1280, height: 720 }
+    );
+  });
+
+  it("reports the restore, the snapshot and the verdict under --json", async () => {
+    const { stdout, exitCode } = await run("restore", "seq-1", "2", "--json");
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout.trim()) as {
+      timelineId: string;
+      restored: { version: number };
+      snapshot: Record<string, unknown>;
+      sequence: Record<string, unknown>;
+      validation: unknown;
+    };
+    expect(parsed.timelineId).toBe("seq-1");
+    expect(parsed.restored.version).toBe(2);
+    expect(parsed.snapshot).toMatchObject({ version: 3, saveType: "restore" });
+    expect(parsed.sequence).toMatchObject({ fps: 24, width: 1280, height: 720 });
+    expect(parsed.validation).toEqual(clean);
+  });
+
+  it("exits non-zero when the restored document no longer validates", async () => {
+    validate.mockResolvedValueOnce({
+      ok: false,
+      errors: [
+        {
+          severity: "error",
+          code: "clip_track_missing",
+          message: "clip references a track the document does not have",
+          clipId: "c1"
+        }
+      ],
+      warnings: []
+    });
+    const { exitCode, stdout } = await run("restore", "seq-1", "2");
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("clip_track_missing");
+  });
+
+  it("fails when the sequence changed since it was loaded", async () => {
+    restore.mockResolvedValueOnce(null);
+    const { exitCode, stderr } = await run("restore", "seq-1", "2");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Timeline has been modified since last load");
+  });
+
+  it("exits non-zero for an unknown version without snapshotting", async () => {
+    findVersion.mockResolvedValueOnce(null);
+    const { exitCode, stderr } = await run("restore", "seq-1", "7");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Timeline version not found: seq-1 v7");
+    expect(snapshot).not.toHaveBeenCalled();
+    expect(restore).not.toHaveBeenCalled();
+  });
+});
+
+describe("timeline versions delete", () => {
+  it("deletes a confirmed version", async () => {
+    const { stdout } = await run("delete", "seq-1", "2", "--yes", "--json");
+    expect(confirmDelete).toHaveBeenCalledWith(
+      "Delete v2 of timeline seq-1?",
+      true
+    );
+    expect(deleteVersion).toHaveBeenCalledWith("seq-1", 2);
+    expect(JSON.parse(stdout.trim())).toEqual({
+      timelineId: "seq-1",
+      version: 2,
+      deleted: true
+    });
+  });
+
+  it("aborts with exit 1 when the confirmation is declined", async () => {
+    confirmDelete.mockResolvedValueOnce(false);
+    const { exitCode, stdout } = await run("delete", "seq-1", "2", "--json");
+    expect(exitCode).toBe(1);
+    expect(deleteVersion).not.toHaveBeenCalled();
+    expect(JSON.parse(stdout.trim())).toMatchObject({
+      deleted: false,
+      aborted: true
+    });
+  });
+
+  it("exits non-zero for an unknown version", async () => {
+    findVersion.mockResolvedValueOnce(null);
+    const { exitCode, stderr } = await run("delete", "seq-1", "9", "--yes");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Timeline version not found: seq-1 v9");
+    expect(deleteVersion).not.toHaveBeenCalled();
+  });
+
+  it("puts the failure on stdout too under --json", async () => {
+    loadSequence.mockResolvedValueOnce(null);
+    const { stdout } = await run("delete", "gone", "1", "--yes", "--json");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      error: "Timeline sequence not found: gone"
+    });
+  });
+});
+
+describe("timeline versions helpers", () => {
+  it("maps a row to the router's camelCase list item", () => {
+    expect(toVersionListItem(versionRow())).toEqual({
+      id: "ver-1",
+      timelineId: "seq-1",
+      version: 2,
+      name: "before the cut",
+      saveType: "manual",
+      fps: 24,
+      width: 1280,
+      height: 720,
+      durationMs: 4000,
+      createdAt: "2026-08-01T09:00:00.000Z"
+    });
+  });
+
+  it("renders one table row per version with a combined resolution", () => {
+    const [row] = versionTableRows([toVersionListItem(versionRow())]);
+    expect(row).toMatchObject({ version: 2, resolution: "1280x720", name: "before the cut" });
+  });
+
+  it("counts tracks, clips and markers of an unreadable document as zero", () => {
+    expect(documentCounts("not json")).toEqual({
+      tracks: 0,
+      clips: 0,
+      markers: 0
+    });
+  });
+
+  it("rejects non-positive and non-integer versions", () => {
+    expect(parseVersionNumber(" 3 ")).toBe(3);
+    for (const bad of ["0", "-1", "1.5", "v2", ""]) {
+      expect(() => parseVersionNumber(bad)).toThrow(/positive integer/);
+    }
+  });
+});

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -492,6 +492,20 @@ const TABLE_COLUMNS: Record<string, Record<string, string>> = {
     created_at: "text",
     updated_at: "text"
   },
+  timeline_sequence_versions: {
+    id: "text",
+    timeline_id: "text",
+    user_id: "text",
+    name: "text",
+    version: "integer NOT NULL DEFAULT 1",
+    save_type: "text NOT NULL DEFAULT 'manual'",
+    fps: "integer NOT NULL DEFAULT 30",
+    width: "integer NOT NULL DEFAULT 1920",
+    height: "integer NOT NULL DEFAULT 1080",
+    duration_ms: "integer NOT NULL DEFAULT 0",
+    document: "text",
+    created_at: "text"
+  },
   storyboards: {
     id: "text",
     user_id: "text",
@@ -894,6 +908,26 @@ function getCreateSchemaSql(): string {
     CREATE INDEX IF NOT EXISTS "idx_timeline_sequence_user" ON "timeline_sequences" ("user_id");
     CREATE INDEX IF NOT EXISTS "idx_timeline_sequence_project" ON "timeline_sequences" ("project_id");
     CREATE INDEX IF NOT EXISTS "idx_timeline_sequence_updated" ON "timeline_sequences" ("updated_at");
+
+    CREATE TABLE IF NOT EXISTS "timeline_sequence_versions" (
+      "id" text PRIMARY KEY NOT NULL,
+      "timeline_id" text NOT NULL REFERENCES "timeline_sequences" ("id") ON DELETE CASCADE,
+      "user_id" text NOT NULL,
+      "name" text,
+      "version" integer NOT NULL DEFAULT 1,
+      "save_type" text NOT NULL DEFAULT 'manual',
+      "fps" integer NOT NULL DEFAULT 30,
+      "width" integer NOT NULL DEFAULT 1920,
+      "height" integer NOT NULL DEFAULT 1080,
+      "duration_ms" integer NOT NULL DEFAULT 0,
+      "document" text NOT NULL,
+      "created_at" text NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS "idx_tsv_timeline" ON "timeline_sequence_versions" ("timeline_id");
+    CREATE INDEX IF NOT EXISTS "idx_tsv_user" ON "timeline_sequence_versions" ("user_id");
+    CREATE INDEX IF NOT EXISTS "idx_tsv_timeline_save_type_created" ON "timeline_sequence_versions" ("timeline_id", "save_type", "created_at");
+    CREATE UNIQUE INDEX IF NOT EXISTS "idx_tsv_timeline_version" ON "timeline_sequence_versions" ("timeline_id", "version");
+
     CREATE TABLE IF NOT EXISTS "image_documents" (
       "id" text PRIMARY KEY NOT NULL,
       "user_id" text NOT NULL,

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -38,6 +38,7 @@ export {
   teamTasks,
   appSettings,
   timelineSequences,
+  timelineSequenceVersions,
   imageDocuments,
   workerProfiles,
   workerInstances,
@@ -142,6 +143,9 @@ export type {
   TimelineDocument,
   TimelineSequenceMutationResult
 } from "./timeline-sequence.js";
+
+export { TimelineSequenceVersion } from "./timeline-sequence-version.js";
+export type { TimelineSequenceSaveType } from "./timeline-sequence-version.js";
 
 export { ImageDocument, ImageDocumentConflictError } from "./image-document.js";
 export {

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -2445,6 +2445,58 @@ export const migrations: MigrationDef[] = [
     async down() {
       // no-op: SQLite cannot drop columns portably, and leaving it is inert.
     }
+  },
+
+  // ── Timeline version history ───────────────────────────────────────
+  // Snapshots of a timeline sequence: the document plus the render settings it
+  // was written against, so restoring one restores what the editor showed.
+  // `save_type` separates manual saves from autosaves and the snapshot taken
+  // before a restore — only autosaves are pruned. The unique index on
+  // (timeline_id, version) is what keeps two concurrent writers from minting
+  // the same version number; the foreign key keeps a deleted sequence's
+  // history from outliving it.
+  {
+    version: "20260804_000000",
+    name: "create_timeline_sequence_versions",
+    createsTables: ["timeline_sequence_versions"],
+    modifiesTables: [],
+    async up(db) {
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS timeline_sequence_versions (
+          id TEXT PRIMARY KEY NOT NULL,
+          timeline_id TEXT NOT NULL REFERENCES timeline_sequences (id) ON DELETE CASCADE,
+          user_id TEXT NOT NULL,
+          name TEXT,
+          version INTEGER NOT NULL DEFAULT 1,
+          save_type TEXT NOT NULL DEFAULT 'manual',
+          fps INTEGER NOT NULL DEFAULT 30,
+          width INTEGER NOT NULL DEFAULT 1920,
+          height INTEGER NOT NULL DEFAULT 1080,
+          duration_ms INTEGER NOT NULL DEFAULT 0,
+          document TEXT NOT NULL,
+          created_at TEXT NOT NULL
+        )
+      `);
+      await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tsv_timeline ON timeline_sequence_versions (timeline_id)"
+      );
+      await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tsv_user ON timeline_sequence_versions (user_id)"
+      );
+      await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tsv_timeline_save_type_created ON timeline_sequence_versions (timeline_id, save_type, created_at)"
+      );
+      await db.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_tsv_timeline_version ON timeline_sequence_versions (timeline_id, version)"
+      );
+    },
+    async down(db) {
+      await db.execute("DROP INDEX IF EXISTS idx_tsv_timeline_version");
+      await db.execute("DROP INDEX IF EXISTS idx_tsv_timeline_save_type_created");
+      await db.execute("DROP INDEX IF EXISTS idx_tsv_user");
+      await db.execute("DROP INDEX IF EXISTS idx_tsv_timeline");
+      await db.execute("DROP TABLE IF EXISTS timeline_sequence_versions");
+    }
   }
 ];
 

--- a/packages/models/src/schema-pg/index.ts
+++ b/packages/models/src/schema-pg/index.ts
@@ -16,6 +16,7 @@ export { runLeases } from "./run-leases.js";
 export { teamTasks } from "./team-tasks.js";
 export { appSettings } from "./settings.js";
 export { timelineSequences } from "./timeline-sequences.js";
+export { timelineSequenceVersions } from "./timeline-sequence-versions.js";
 export { imageDocuments } from "./image-documents.js";
 export { storyboards } from "./storyboards.js";
 export { applications, applicationVersions } from "./applications.js";

--- a/packages/models/src/schema-pg/timeline-sequence-versions.ts
+++ b/packages/models/src/schema-pg/timeline-sequence-versions.ts
@@ -1,0 +1,41 @@
+import {
+  pgTable,
+  text,
+  integer,
+  index,
+  uniqueIndex
+} from "drizzle-orm/pg-core";
+import { jsonText } from "./helpers.js";
+import { timelineSequences } from "./timeline-sequences.js";
+import type { TimelineDocument } from "../timeline-sequence.js";
+
+/** See the SQLite schema for the column semantics. */
+export const timelineSequenceVersions = pgTable(
+  "timeline_sequence_versions",
+  {
+    id: text("id").primaryKey(),
+    timeline_id: text("timeline_id")
+      .notNull()
+      .references(() => timelineSequences.id, { onDelete: "cascade" }),
+    user_id: text("user_id").notNull(),
+    name: text("name"),
+    version: integer("version").notNull().default(1),
+    save_type: text("save_type").notNull().default("manual"),
+    fps: integer("fps").notNull().default(30),
+    width: integer("width").notNull().default(1920),
+    height: integer("height").notNull().default(1080),
+    duration_ms: integer("duration_ms").notNull().default(0),
+    document: jsonText<TimelineDocument>()("document").notNull(),
+    created_at: text("created_at").notNull()
+  },
+  (table) => [
+    index("idx_tsv_timeline").on(table.timeline_id),
+    index("idx_tsv_user").on(table.user_id),
+    index("idx_tsv_timeline_save_type_created").on(
+      table.timeline_id,
+      table.save_type,
+      table.created_at
+    ),
+    uniqueIndex("idx_tsv_timeline_version").on(table.timeline_id, table.version)
+  ]
+);

--- a/packages/models/src/schema/index.ts
+++ b/packages/models/src/schema/index.ts
@@ -16,6 +16,7 @@ export { runLeases } from "./run-leases.js";
 export { teamTasks } from "./team-tasks.js";
 export { appSettings } from "./settings.js";
 export { timelineSequences } from "./timeline-sequences.js";
+export { timelineSequenceVersions } from "./timeline-sequence-versions.js";
 export { imageDocuments } from "./image-documents.js";
 export { storyboards } from "./storyboards.js";
 export { applications, applicationVersions } from "./applications.js";

--- a/packages/models/src/schema/timeline-sequence-versions.ts
+++ b/packages/models/src/schema/timeline-sequence-versions.ts
@@ -1,0 +1,55 @@
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+  uniqueIndex
+} from "drizzle-orm/sqlite-core";
+import { timelineSequences } from "./timeline-sequences.js";
+
+/**
+ * An immutable snapshot of a timeline sequence: the document plus the render
+ * settings it was written against. Manual saves, autosaves and the snapshot
+ * taken before a restore all live here, told apart by `save_type`.
+ */
+export const timelineSequenceVersions = sqliteTable(
+  "timeline_sequence_versions",
+  {
+    id: text("id").primaryKey(),
+    /**
+     * The sequence this snapshot belongs to. The cascade keeps a deleted
+     * sequence's history from outliving it.
+     */
+    timeline_id: text("timeline_id")
+      .notNull()
+      .references(() => timelineSequences.id, { onDelete: "cascade" }),
+    /**
+     * Owner at snapshot time, copied from the parent. Version reads happen
+     * against a timeline id alone, so the snapshot carries the owner it was
+     * written for rather than trusting whatever row holds that id now.
+     */
+    user_id: text("user_id").notNull(),
+    name: text("name"),
+    /** Monotonic per timeline. */
+    version: integer("version").notNull().default(1),
+    save_type: text("save_type").notNull().default("manual"),
+    fps: integer("fps").notNull().default(30),
+    width: integer("width").notNull().default(1920),
+    height: integer("height").notNull().default(1080),
+    duration_ms: integer("duration_ms").notNull().default(0),
+    document: text("document").notNull(),
+    created_at: text("created_at").notNull()
+  },
+  (table) => [
+    index("idx_tsv_timeline").on(table.timeline_id),
+    index("idx_tsv_user").on(table.user_id),
+    index("idx_tsv_timeline_save_type_created").on(
+      table.timeline_id,
+      table.save_type,
+      table.created_at
+    ),
+    // Two writers that read the same MAX(version) must not both land: the
+    // second insert fails instead of minting a duplicate version number.
+    uniqueIndex("idx_tsv_timeline_version").on(table.timeline_id, table.version)
+  ]
+);

--- a/packages/models/src/timeline-sequence-version.ts
+++ b/packages/models/src/timeline-sequence-version.ts
@@ -1,0 +1,207 @@
+/**
+ * TimelineSequenceVersion model — immutable snapshots of a timeline sequence.
+ *
+ * A snapshot carries the document plus the render settings it was written
+ * against, so restoring one restores what the editor actually showed. Manual
+ * saves, autosaves and the pre-restore snapshot are told apart by `save_type`;
+ * only autosaves are ever pruned.
+ */
+
+import { eq, and, desc, asc, max } from "drizzle-orm";
+import { DBModel, createTimeOrderedUuid } from "./base-model.js";
+import { getDb } from "./db.js";
+import { timelineSequenceVersions } from "./schema/timeline-sequence-versions.js";
+import type { TimelineSequence } from "./timeline-sequence.js";
+
+export type TimelineSequenceSaveType = "manual" | "autosave" | "restore";
+
+/**
+ * Whether an insert lost the race for a version number. SQLite and both
+ * PostgreSQL drivers word it differently; all three mean the unique index on
+ * (timeline_id, version) rejected the row.
+ */
+function isUniqueViolation(error: unknown): boolean {
+  const err = error as { code?: string; message?: string } | null;
+  if (!err) return false;
+  if (err.code === "23505" || err.code === "SQLITE_CONSTRAINT_UNIQUE") {
+    return true;
+  }
+  const message = String(err.message ?? "");
+  return (
+    message.includes("UNIQUE constraint failed") ||
+    message.includes("duplicate key value")
+  );
+}
+
+export class TimelineSequenceVersion extends DBModel {
+  static override table = timelineSequenceVersions;
+
+  declare id: string;
+  declare timeline_id: string;
+  declare user_id: string;
+  declare name: string | null;
+  declare version: number;
+  declare save_type: string;
+  declare fps: number;
+  declare width: number;
+  declare height: number;
+  declare duration_ms: number;
+  declare document: string;
+  declare created_at: string;
+
+  constructor(data: Record<string, unknown>) {
+    super(data);
+    this.id ??= createTimeOrderedUuid();
+    this.name ??= null;
+    this.version ??= 1;
+    this.save_type ??= "manual";
+    this.fps ??= 30;
+    this.width ??= 1920;
+    this.height ??= 1080;
+    this.duration_ms ??= 0;
+    this.created_at ??= new Date().toISOString();
+  }
+
+  /** Versions of a timeline, newest first. */
+  static async listForTimeline(
+    timelineId: string,
+    opts: { limit?: number; saveType?: string } = {}
+  ): Promise<TimelineSequenceVersion[]> {
+    const { limit = 100, saveType } = opts;
+    const db = getDb();
+    const where =
+      saveType === undefined
+        ? eq(timelineSequenceVersions.timeline_id, timelineId)
+        : and(
+            eq(timelineSequenceVersions.timeline_id, timelineId),
+            eq(timelineSequenceVersions.save_type, saveType)
+          );
+    const rows = await db
+      .select()
+      .from(timelineSequenceVersions)
+      .where(where)
+      .orderBy(desc(timelineSequenceVersions.version))
+      .limit(limit);
+    return rows.map(
+      (r: Record<string, unknown>) => new TimelineSequenceVersion(r)
+    );
+  }
+
+  /** One version by timeline id + version number. */
+  static async findByVersion(
+    timelineId: string,
+    version: number
+  ): Promise<TimelineSequenceVersion | null> {
+    const db = getDb();
+    const [row] = await db
+      .select()
+      .from(timelineSequenceVersions)
+      .where(
+        and(
+          eq(timelineSequenceVersions.timeline_id, timelineId),
+          eq(timelineSequenceVersions.version, version)
+        )
+      )
+      .limit(1);
+    return row
+      ? new TimelineSequenceVersion(row as Record<string, unknown>)
+      : null;
+  }
+
+  /** The next version number for a timeline (max existing + 1). */
+  static async nextVersion(timelineId: string): Promise<number> {
+    const db = getDb();
+    const rows = await db
+      .select({ value: max(timelineSequenceVersions.version) })
+      .from(timelineSequenceVersions)
+      .where(eq(timelineSequenceVersions.timeline_id, timelineId));
+    return Number(rows[0]?.value ?? 0) + 1;
+  }
+
+  /**
+   * Snapshot a sequence as the next version.
+   *
+   * The version number is read and written in two steps, so two writers can
+   * pick the same one. The unique index on (timeline_id, version) is what
+   * decides: the loser's insert fails, re-reads the number, and tries once
+   * more before giving up.
+   */
+  static async snapshot(
+    seq: TimelineSequence,
+    opts: {
+      saveType: TimelineSequenceSaveType;
+      name?: string | null;
+    }
+  ): Promise<TimelineSequenceVersion> {
+    const row = {
+      timeline_id: seq.id,
+      user_id: seq.user_id,
+      name: opts.name ?? null,
+      save_type: opts.saveType,
+      fps: seq.fps,
+      width: seq.width,
+      height: seq.height,
+      duration_ms: seq.duration_ms,
+      document: seq.document,
+      created_at: new Date().toISOString()
+    };
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const version = await TimelineSequenceVersion.nextVersion(seq.id);
+      try {
+        return await TimelineSequenceVersion.create<TimelineSequenceVersion>({
+          ...row,
+          id: createTimeOrderedUuid(),
+          version
+        });
+      } catch (error) {
+        if (attempt === 1 || !isUniqueViolation(error)) throw error;
+      }
+    }
+
+    // Unreachable: the loop either returns or rethrows.
+    throw new Error(`Failed to snapshot timeline ${seq.id}`);
+  }
+
+  /**
+   * Drop the oldest autosaves beyond `maxAutosaves`. Manual and restore
+   * snapshots are never touched — they are what a user asked to keep.
+   */
+  static async pruneAutosaves(
+    timelineId: string,
+    maxAutosaves: number
+  ): Promise<void> {
+    const db = getDb();
+    const rows = await db
+      .select({ id: timelineSequenceVersions.id })
+      .from(timelineSequenceVersions)
+      .where(
+        and(
+          eq(timelineSequenceVersions.timeline_id, timelineId),
+          eq(timelineSequenceVersions.save_type, "autosave")
+        )
+      )
+      .orderBy(asc(timelineSequenceVersions.version));
+
+    const excess = rows.length - Math.max(0, maxAutosaves);
+    if (excess <= 0) return;
+
+    for (const row of rows.slice(0, excess) as { id: string }[]) {
+      await db
+        .delete(timelineSequenceVersions)
+        .where(eq(timelineSequenceVersions.id, row.id));
+    }
+  }
+
+  /**
+   * Delete every version of a timeline. Called when the sequence is deleted:
+   * SQLite only enforces the foreign key when `PRAGMA foreign_keys` is on, so
+   * the cascade alone cannot be relied on.
+   */
+  static async deleteForTimeline(timelineId: string): Promise<void> {
+    const db = getDb();
+    await db
+      .delete(timelineSequenceVersions)
+      .where(eq(timelineSequenceVersions.timeline_id, timelineId));
+  }
+}

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 56;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 57;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);

--- a/packages/models/tests/timeline-sequence-version.test.ts
+++ b/packages/models/tests/timeline-sequence-version.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for the TimelineSequenceVersion model.
+ *
+ * Covers: snapshot field copying and version assignment, listForTimeline
+ * ordering/filtering/limit, findByVersion, autosave pruning, bulk delete, and
+ * the unique-index retry when two writers pick the same version number.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ModelObserver } from "../src/base-model.js";
+import { initTestDb } from "../src/db.js";
+import { TimelineSequence } from "../src/timeline-sequence.js";
+import { TimelineSequenceVersion } from "../src/timeline-sequence-version.js";
+
+const DOC = JSON.stringify({
+  tracks: [{ id: "t1" }],
+  clips: [],
+  markers: []
+});
+
+async function createSequence(id = "seq-1"): Promise<TimelineSequence> {
+  return TimelineSequence.create<TimelineSequence>({
+    id,
+    user_id: "user-1",
+    project_id: "proj-1",
+    name: "My sequence",
+    fps: 24,
+    width: 1280,
+    height: 720,
+    duration_ms: 5000,
+    document: DOC
+  });
+}
+
+describe("TimelineSequenceVersion model", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+  afterEach(() => ModelObserver.clear());
+
+  it("snapshot copies the sequence fields and starts at version 1", async () => {
+    const seq = await createSequence();
+    const snap = await TimelineSequenceVersion.snapshot(seq, {
+      saveType: "manual",
+      name: "before edit"
+    });
+
+    expect(snap.timeline_id).toBe(seq.id);
+    expect(snap.user_id).toBe("user-1");
+    expect(snap.name).toBe("before edit");
+    expect(snap.save_type).toBe("manual");
+    expect(snap.fps).toBe(24);
+    expect(snap.width).toBe(1280);
+    expect(snap.height).toBe(720);
+    expect(snap.duration_ms).toBe(5000);
+    expect(snap.document).toBe(DOC);
+    expect(snap.version).toBe(1);
+    expect(snap.id).toBeTruthy();
+    expect(snap.created_at).toBeTruthy();
+  });
+
+  it("snapshot assigns monotonically increasing versions per timeline", async () => {
+    const seq = await createSequence();
+    const other = await createSequence("seq-2");
+
+    const first = await TimelineSequenceVersion.snapshot(seq, {
+      saveType: "manual"
+    });
+    const second = await TimelineSequenceVersion.snapshot(seq, {
+      saveType: "autosave"
+    });
+    const otherFirst = await TimelineSequenceVersion.snapshot(other, {
+      saveType: "manual"
+    });
+
+    expect(first.version).toBe(1);
+    expect(second.version).toBe(2);
+    expect(second.name).toBeNull();
+    // Versions are per timeline, not global.
+    expect(otherFirst.version).toBe(1);
+    expect(await TimelineSequenceVersion.nextVersion(seq.id)).toBe(3);
+  });
+
+  it("retries once when a concurrent writer takes the version number", async () => {
+    const seq = await createSequence();
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "manual" });
+
+    // Stand in for the racing writer: nextVersion() reports 2, but by the time
+    // the insert runs version 2 is already taken, so the unique index rejects
+    // it and the retry lands on 3.
+    const original = TimelineSequenceVersion.nextVersion;
+    let calls = 0;
+    TimelineSequenceVersion.nextVersion = async (timelineId: string) => {
+      const next = await original.call(TimelineSequenceVersion, timelineId);
+      if (calls++ === 0) {
+        await TimelineSequenceVersion.create<TimelineSequenceVersion>({
+          timeline_id: timelineId,
+          user_id: "user-2",
+          version: next,
+          save_type: "manual",
+          document: DOC
+        });
+      }
+      return next;
+    };
+
+    try {
+      const snap = await TimelineSequenceVersion.snapshot(seq, {
+        saveType: "manual"
+      });
+      expect(snap.version).toBe(3);
+      expect(calls).toBe(2);
+    } finally {
+      TimelineSequenceVersion.nextVersion = original;
+    }
+  });
+
+  it("rethrows errors that are not unique-constraint violations", async () => {
+    const seq = await createSequence();
+    const original = TimelineSequenceVersion.nextVersion;
+    TimelineSequenceVersion.nextVersion = async () => {
+      throw new Error("db is on fire");
+    };
+    try {
+      await expect(
+        TimelineSequenceVersion.snapshot(seq, { saveType: "manual" })
+      ).rejects.toThrow("db is on fire");
+    } finally {
+      TimelineSequenceVersion.nextVersion = original;
+    }
+  });
+
+  it("listForTimeline returns newest first and honours limit and saveType", async () => {
+    const seq = await createSequence();
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "manual" });
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "autosave" });
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "autosave" });
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "restore" });
+    // A sibling timeline's versions must not leak in.
+    const other = await createSequence("seq-2");
+    await TimelineSequenceVersion.snapshot(other, { saveType: "manual" });
+
+    const all = await TimelineSequenceVersion.listForTimeline(seq.id);
+    expect(all.map((v: TimelineSequenceVersion) => v.version)).toEqual([
+      4, 3, 2, 1
+    ]);
+
+    const limited = await TimelineSequenceVersion.listForTimeline(seq.id, {
+      limit: 2
+    });
+    expect(limited.map((v: TimelineSequenceVersion) => v.version)).toEqual([
+      4, 3
+    ]);
+
+    const autosaves = await TimelineSequenceVersion.listForTimeline(seq.id, {
+      saveType: "autosave"
+    });
+    expect(autosaves.map((v: TimelineSequenceVersion) => v.version)).toEqual([
+      3, 2
+    ]);
+  });
+
+  it("findByVersion returns the row or null", async () => {
+    const seq = await createSequence();
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "manual" });
+
+    const found = await TimelineSequenceVersion.findByVersion(seq.id, 1);
+    expect(found?.version).toBe(1);
+    expect(found?.timeline_id).toBe(seq.id);
+
+    expect(await TimelineSequenceVersion.findByVersion(seq.id, 99)).toBeNull();
+    expect(await TimelineSequenceVersion.findByVersion("nope", 1)).toBeNull();
+  });
+
+  it("pruneAutosaves drops the oldest autosaves and keeps manual and restore", async () => {
+    const seq = await createSequence();
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "manual" }); // v1
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "autosave" }); // v2
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "autosave" }); // v3
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "restore" }); // v4
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "autosave" }); // v5
+
+    await TimelineSequenceVersion.pruneAutosaves(seq.id, 1);
+
+    const remaining = await TimelineSequenceVersion.listForTimeline(seq.id);
+    expect(remaining.map((v: TimelineSequenceVersion) => v.version)).toEqual([
+      5, 4, 1
+    ]);
+  });
+
+  it("pruneAutosaves is a no-op when under the limit", async () => {
+    const seq = await createSequence();
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "autosave" });
+    await TimelineSequenceVersion.pruneAutosaves(seq.id, 5);
+    expect((await TimelineSequenceVersion.listForTimeline(seq.id)).length).toBe(
+      1
+    );
+  });
+
+  it("deleteForTimeline removes only that timeline's versions", async () => {
+    const seq = await createSequence();
+    const other = await createSequence("seq-2");
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "manual" });
+    await TimelineSequenceVersion.snapshot(seq, { saveType: "autosave" });
+    await TimelineSequenceVersion.snapshot(other, { saveType: "manual" });
+
+    await TimelineSequenceVersion.deleteForTimeline(seq.id);
+
+    expect(await TimelineSequenceVersion.listForTimeline(seq.id)).toEqual([]);
+    expect(
+      (await TimelineSequenceVersion.listForTimeline(other.id)).length
+    ).toBe(1);
+  });
+});

--- a/packages/protocol/src/api-schemas/timeline.ts
+++ b/packages/protocol/src/api-schemas/timeline.ts
@@ -497,3 +497,80 @@ export type CreateClipInput = z.infer<typeof createClipInput>;
 /** Response shape returned by `timeline.clips.create`. */
 export const timelineClipResponse = timelineClip;
 export type TimelineClipResponse = z.infer<typeof timelineClipResponse>;
+
+// ── sequence version history (/api/timeline/:id/versions) ────────────────────
+
+/**
+ * How a snapshot came to exist. `restore` marks the snapshot taken of the
+ * *pre-restore* state, so restoring is itself undoable.
+ */
+export const timelineVersionSaveType = z.enum([
+  "manual",
+  "autosave",
+  "restore"
+]);
+export type TimelineVersionSaveType = z.infer<typeof timelineVersionSaveType>;
+
+/**
+ * Metadata for one snapshot. Deliberately carries no `document`: a timeline
+ * document is large, and the history list renders from metadata alone.
+ */
+export const timelineVersionListItem = z.object({
+  id: z.string(),
+  timelineId: z.string(),
+  version: z.number().int(),
+  name: z.string().nullable().optional(),
+  saveType: timelineVersionSaveType,
+  fps: z.number(),
+  width: z.number(),
+  height: z.number(),
+  durationMs: z.number(),
+  createdAt: z.string()
+});
+export type TimelineVersionListItem = z.infer<typeof timelineVersionListItem>;
+
+/** One snapshot including the document it captured. */
+export const timelineVersionResponse = timelineVersionListItem.extend({
+  document: timelineDocument
+});
+export type TimelineVersionResponse = z.infer<typeof timelineVersionResponse>;
+
+export const listTimelineVersionsInput = z.object({
+  /** Timeline sequence whose history is read. */
+  id: z.string(),
+  limit: z.number().int().positive().max(500).optional(),
+  saveType: timelineVersionSaveType.optional()
+});
+export type ListTimelineVersionsInput = z.infer<
+  typeof listTimelineVersionsInput
+>;
+
+export const getTimelineVersionInput = z.object({
+  id: z.string(),
+  version: z.number().int()
+});
+export type GetTimelineVersionInput = z.infer<typeof getTimelineVersionInput>;
+
+export const createTimelineVersionInput = z.object({
+  id: z.string(),
+  name: z.string().max(200).optional()
+});
+export type CreateTimelineVersionInput = z.infer<
+  typeof createTimelineVersionInput
+>;
+
+export const restoreTimelineVersionInput = z.object({
+  id: z.string(),
+  version: z.number().int()
+});
+export type RestoreTimelineVersionInput = z.infer<
+  typeof restoreTimelineVersionInput
+>;
+
+export const deleteTimelineVersionInput = z.object({
+  id: z.string(),
+  version: z.number().int()
+});
+export type DeleteTimelineVersionInput = z.infer<
+  typeof deleteTimelineVersionInput
+>;

--- a/packages/protocol/tests/timeline.test.ts
+++ b/packages/protocol/tests/timeline.test.ts
@@ -9,7 +9,13 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { timelineClip } from "../src/api-schemas/timeline.js";
+import {
+  createTimelineVersionInput,
+  listTimelineVersionsInput,
+  timelineClip,
+  timelineVersionListItem,
+  timelineVersionResponse
+} from "../src/api-schemas/timeline.js";
 
 const baseClip = {
   id: "c1",
@@ -203,5 +209,61 @@ describe("timelineClip schema", () => {
     };
     const parsed = timelineClip.parse(clip);
     expect(parsed.shapeStyle).toEqual(clip.shapeStyle);
+  });
+});
+
+describe("timeline version schemas", () => {
+  const baseVersion = {
+    id: "v1",
+    timelineId: "seq-1",
+    version: 3,
+    name: null,
+    saveType: "manual" as const,
+    fps: 30,
+    width: 1920,
+    height: 1080,
+    durationMs: 4200,
+    createdAt: "2026-01-01T00:00:00Z"
+  };
+
+  it("keeps the list item free of the document", () => {
+    const parsed = timelineVersionListItem.parse({
+      ...baseVersion,
+      document: { tracks: [], clips: [], markers: [] }
+    });
+    expect(parsed).not.toHaveProperty("document");
+  });
+
+  it("parses a list item with the name omitted entirely", () => {
+    const withoutName: Record<string, unknown> = { ...baseVersion };
+    delete withoutName.name;
+    expect(timelineVersionListItem.safeParse(withoutName).success).toBe(true);
+  });
+
+  it("rejects an unknown saveType", () => {
+    expect(
+      timelineVersionListItem.safeParse({ ...baseVersion, saveType: "bogus" })
+        .success
+    ).toBe(false);
+  });
+
+  it("carries the document on the single-version response", () => {
+    const document = { tracks: [], clips: [], markers: [] };
+    const parsed = timelineVersionResponse.parse({ ...baseVersion, document });
+    expect(parsed.document).toEqual(document);
+  });
+
+  it("bounds the list limit and the manual snapshot name", () => {
+    expect(
+      listTimelineVersionsInput.safeParse({ id: "s", limit: 501 }).success
+    ).toBe(false);
+    expect(
+      listTimelineVersionsInput.safeParse({ id: "s", limit: 0 }).success
+    ).toBe(false);
+    expect(listTimelineVersionsInput.safeParse({ id: "s" }).success).toBe(true);
+    expect(
+      createTimelineVersionInput.safeParse({ id: "s", name: "x".repeat(201) })
+        .success
+    ).toBe(false);
   });
 });

--- a/packages/websocket/src/trpc/routers/timeline.ts
+++ b/packages/websocket/src/trpc/routers/timeline.ts
@@ -7,6 +7,13 @@
  *   create      (mutation) — TimelineSequenceResponse
  *   update      (mutation) — TimelineSequenceResponse (optional baseUpdatedAt for optimistic concurrency)
  *   delete      (mutation) — { ok: true }
+ *   clips.create        (mutation) — TimelineClipResponse
+ *   versions.list       (query)    — TimelineVersionListItem[]
+ *   versions.get        (query)    — TimelineVersionResponse
+ *   versions.create     (mutation) — TimelineVersionListItem (manual snapshot)
+ *   versions.restore    (mutation) — TimelineSequenceResponse (snapshots the
+ *                                    pre-restore state first, so it is undoable)
+ *   versions.delete     (mutation) — { ok: true }
  *
  * Auth: every procedure uses `protectedProcedure`. Ownership is enforced by
  * comparing `seq.user_id` against `ctx.userId`.
@@ -16,6 +23,7 @@ import { z } from "zod";
 import {
   TimelineSequence,
   TimelineSequenceConflictError,
+  TimelineSequenceVersion,
   Workflow,
   createTimeOrderedUuid
 } from "@nodetool-ai/models";
@@ -25,10 +33,17 @@ import { computeDependencyHash } from "@nodetool-ai/timeline/dependencyHash.js";
 import {
   createClipInput,
   createTimelineInput,
+  createTimelineVersionInput,
+  deleteTimelineVersionInput,
+  getTimelineVersionInput,
+  listTimelineVersionsInput,
   patchTimelineInput,
+  restoreTimelineVersionInput,
   timelineClipResponse,
   timelineSequenceListItem,
-  timelineSequenceResponse
+  timelineSequenceResponse,
+  timelineVersionListItem,
+  timelineVersionResponse
 } from "@nodetool-ai/protocol/api-schemas/timeline.js";
 import { ApiErrorCode } from "../../error-codes.js";
 import { router } from "../index.js";
@@ -61,6 +76,58 @@ function toListItem(seq: TimelineSequence) {
     name: seq.name,
     updatedAt: seq.updated_at
   };
+}
+
+/**
+ * A version row carries its document as JSON text on SQLite and as an object on
+ * Postgres, so parse only when it is a string.
+ */
+function parseVersionDocument(raw: unknown): TimelineDocument {
+  const value = typeof raw === "string" ? JSON.parse(raw) : raw;
+  return (value ?? { tracks: [], clips: [], markers: [] }) as TimelineDocument;
+}
+
+function toVersionListItem(
+  version: InstanceType<typeof TimelineSequenceVersion>
+) {
+  return {
+    id: version.id,
+    timelineId: version.timeline_id,
+    version: version.version,
+    name: version.name ?? null,
+    saveType: version.save_type as "manual" | "autosave" | "restore",
+    fps: version.fps,
+    width: version.width,
+    height: version.height,
+    durationMs: version.duration_ms,
+    createdAt: version.created_at
+  };
+}
+
+// ── autosave snapshot cadence ───────────────────────────────────────────────
+
+/** A document write only snapshots when the last autosave is this old. */
+const AUTOSAVE_VERSION_INTERVAL_MS = 5 * 60 * 1000;
+/** Autosave snapshots kept per timeline; older ones are pruned. */
+const MAX_AUTOSAVE_VERSIONS = 20;
+
+const lastAutosaveVersionTime = new Map<string, number>();
+
+// Entries older than the interval can never suppress a snapshot again, so drop
+// them. Without this the map grows one permanent entry per timeline ever saved
+// (including deleted ones) for the lifetime of the process.
+function recordAutosaveVersion(id: string, now: number): void {
+  for (const [key, ts] of lastAutosaveVersionTime) {
+    if (now - ts >= AUTOSAVE_VERSION_INTERVAL_MS) {
+      lastAutosaveVersionTime.delete(key);
+    }
+  }
+  lastAutosaveVersionTime.set(id, now);
+}
+
+/** Test hook: forget the autosave cadence so a suite can drive it from zero. */
+export function __resetTimelineAutosaveVersionState(): void {
+  lastAutosaveVersionTime.clear();
 }
 
 async function loadOwned(
@@ -266,6 +333,29 @@ export const timelineRouter = router({
           "Timeline has been modified since last load"
         );
       }
+
+      if (input.document !== undefined) {
+        // Best-effort history: a snapshot that fails must never fail the save
+        // the user actually asked for (and the versions table may not exist on
+        // an older database).
+        try {
+          const now = Date.now();
+          const last = lastAutosaveVersionTime.get(input.id);
+          if (last === undefined || now - last >= AUTOSAVE_VERSION_INTERVAL_MS) {
+            recordAutosaveVersion(input.id, now);
+            await TimelineSequenceVersion.snapshot(updated, {
+              saveType: "autosave"
+            });
+            await TimelineSequenceVersion.pruneAutosaves(
+              input.id,
+              MAX_AUTOSAVE_VERSIONS
+            );
+          }
+        } catch {
+          // non-fatal — the document write already succeeded
+        }
+      }
+
       return updated.toTimelineSequence();
     }),
 
@@ -275,8 +365,113 @@ export const timelineRouter = router({
     .mutation(async ({ ctx, input }) => {
       const seq = await loadOwned(ctx.userId, input.id);
       await seq.delete();
+      // Belt-and-braces with the FK cascade: version rows outliving their
+      // timeline would be unreachable garbage.
+      await TimelineSequenceVersion.deleteForTimeline(input.id);
+      lastAutosaveVersionTime.delete(input.id);
       return { ok: true as const };
     }),
+
+  versions: router({
+    list: protectedProcedure
+      .input(listTimelineVersionsInput)
+      .output(z.array(timelineVersionListItem))
+      .query(async ({ ctx, input }) => {
+        await loadOwned(ctx.userId, input.id);
+        const versions = await TimelineSequenceVersion.listForTimeline(
+          input.id,
+          { limit: input.limit, saveType: input.saveType }
+        );
+        return versions.map(toVersionListItem);
+      }),
+
+    get: protectedProcedure
+      .input(getTimelineVersionInput)
+      .output(timelineVersionResponse)
+      .query(async ({ ctx, input }) => {
+        await loadOwned(ctx.userId, input.id);
+        const version = await TimelineSequenceVersion.findByVersion(
+          input.id,
+          input.version
+        );
+        if (!version) {
+          throwApiError(ApiErrorCode.NOT_FOUND, "Timeline version not found");
+        }
+        return {
+          ...toVersionListItem(version),
+          document: parseVersionDocument(version.document)
+        };
+      }),
+
+    create: protectedProcedure
+      .input(createTimelineVersionInput)
+      .output(timelineVersionListItem)
+      .mutation(async ({ ctx, input }) => {
+        const seq = await loadOwned(ctx.userId, input.id);
+        const version = await TimelineSequenceVersion.snapshot(seq, {
+          saveType: "manual",
+          name: input.name ?? null
+        });
+        return toVersionListItem(version);
+      }),
+
+    restore: protectedProcedure
+      .input(restoreTimelineVersionInput)
+      .output(timelineSequenceResponse)
+      .mutation(async ({ ctx, input }) => {
+        const seq = await loadOwned(ctx.userId, input.id);
+        const version = await TimelineSequenceVersion.findByVersion(
+          input.id,
+          input.version
+        );
+        if (!version) {
+          throwApiError(ApiErrorCode.NOT_FOUND, "Timeline version not found");
+        }
+
+        // Snapshot what is about to be overwritten first, so a restore is
+        // itself undoable.
+        await TimelineSequenceVersion.snapshot(seq, {
+          saveType: "restore",
+          name: `Before restore to v${input.version}`
+        });
+
+        const document = parseVersionDocument(version.document);
+        const updated = await TimelineSequence.updateFieldsIfUnchanged(
+          input.id,
+          seq.updated_at,
+          {
+            document: JSON.stringify(document),
+            fps: version.fps,
+            width: version.width,
+            height: version.height,
+            duration_ms: version.duration_ms
+          }
+        );
+        if (!updated) {
+          throwApiError(
+            ApiErrorCode.ALREADY_EXISTS,
+            "Timeline has been modified since last load"
+          );
+        }
+        return updated.toTimelineSequence();
+      }),
+
+    delete: protectedProcedure
+      .input(deleteTimelineVersionInput)
+      .output(okOutput)
+      .mutation(async ({ ctx, input }) => {
+        await loadOwned(ctx.userId, input.id);
+        const version = await TimelineSequenceVersion.findByVersion(
+          input.id,
+          input.version
+        );
+        if (!version) {
+          throwApiError(ApiErrorCode.NOT_FOUND, "Timeline version not found");
+        }
+        await version.delete();
+        return { ok: true as const };
+      })
+  }),
 
   clips: router({
     create: protectedProcedure

--- a/packages/websocket/tests/trpc-timeline-versions.test.ts
+++ b/packages/websocket/tests/trpc-timeline-versions.test.ts
@@ -1,0 +1,480 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { appRouter } from "../src/trpc/router.js";
+import { createCallerFactory } from "../src/trpc/index.js";
+import { __resetTimelineAutosaveVersionState } from "../src/trpc/routers/timeline.js";
+import type { Context } from "../src/trpc/context.js";
+import type { TimelineDocument } from "@nodetool-ai/models";
+
+vi.mock("@nodetool-ai/models", async (orig) => {
+  const actual = await orig<typeof import("@nodetool-ai/models")>();
+
+  class StubTimelineSequence {
+    user_id = "user-1";
+    project_id = "p-1";
+    id = "seq-1";
+    name = "Demo";
+    fps = 30;
+    width = 1920;
+    height = 1080;
+    duration_ms = 0;
+    updated_at = "2026-01-01T00:00:00Z";
+    created_at = "2026-01-01T00:00:00Z";
+    document = JSON.stringify({ tracks: [], clips: [], markers: [] });
+    constructor(init: Record<string, unknown> = {}) {
+      Object.assign(this, init);
+    }
+    save = vi.fn().mockResolvedValue(undefined);
+    delete = vi.fn().mockResolvedValue(undefined);
+    toDocument(): TimelineDocument {
+      return JSON.parse(this.document) as TimelineDocument;
+    }
+    toTimelineSequence() {
+      return {
+        id: this.id,
+        projectId: this.project_id,
+        name: this.name,
+        fps: this.fps,
+        width: this.width,
+        height: this.height,
+        durationMs: this.duration_ms,
+        ...this.toDocument(),
+        createdAt: this.created_at,
+        updatedAt: this.updated_at
+      };
+    }
+    static findById = vi.fn();
+    static listByUser = vi.fn();
+    static listByProject = vi.fn();
+    static update = vi.fn();
+
+    // Plain static (not vi.fn) so `vi.resetAllMocks()` doesn't strip the body.
+    static async updateFieldsIfUnchanged(
+      id: string,
+      _expectedUpdatedAt: string,
+      fields: Record<string, unknown>
+    ): Promise<StubTimelineSequence | null> {
+      const seq = (await StubTimelineSequence.findById(
+        id
+      )) as StubTimelineSequence | null;
+      if (!seq) return null;
+      Object.assign(seq, fields);
+      await StubTimelineSequence.update(id, fields);
+      return seq;
+    }
+  }
+
+  class StubTimelineSequenceVersion {
+    id = "ver-1";
+    timeline_id = "seq-1";
+    user_id = "user-1";
+    name: string | null = null;
+    version = 1;
+    save_type = "manual";
+    fps = 30;
+    width = 1920;
+    height = 1080;
+    duration_ms = 0;
+    document = JSON.stringify({ tracks: [], clips: [], markers: [] });
+    created_at = "2026-01-01T00:00:00Z";
+    constructor(init: Record<string, unknown> = {}) {
+      Object.assign(this, init);
+    }
+    delete = vi.fn().mockResolvedValue(undefined);
+
+    static listForTimeline = vi.fn();
+    static findByVersion = vi.fn();
+    static pruneAutosaves = vi.fn();
+    static deleteForTimeline = vi.fn();
+    static snapshotCalls: {
+      seq: StubTimelineSequence;
+      opts: { saveType: string; name?: string | null };
+    }[] = [];
+
+    // Plain static so `vi.resetAllMocks()` doesn't strip the body; calls are
+    // recorded on `snapshotCalls` instead of a spy.
+    static async snapshot(
+      seq: StubTimelineSequence,
+      opts: { saveType: string; name?: string | null }
+    ): Promise<StubTimelineSequenceVersion> {
+      StubTimelineSequenceVersion.snapshotCalls.push({ seq, opts });
+      return new StubTimelineSequenceVersion({
+        id: `ver-${StubTimelineSequenceVersion.snapshotCalls.length}`,
+        timeline_id: seq.id,
+        version: StubTimelineSequenceVersion.snapshotCalls.length,
+        save_type: opts.saveType,
+        name: opts.name ?? null,
+        fps: seq.fps,
+        width: seq.width,
+        height: seq.height,
+        duration_ms: seq.duration_ms,
+        document: seq.document
+      });
+    }
+  }
+
+  return {
+    ...actual,
+    Workflow: { ...actual.Workflow, find: vi.fn() },
+    TimelineSequence: StubTimelineSequence,
+    TimelineSequenceVersion: StubTimelineSequenceVersion,
+    createTimeOrderedUuid: () => "version-id"
+  };
+});
+
+import { TimelineSequence, TimelineSequenceVersion } from "@nodetool-ai/models";
+
+const TS = TimelineSequence as unknown as {
+  findById: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+};
+const TSV = TimelineSequenceVersion as unknown as {
+  listForTimeline: ReturnType<typeof vi.fn>;
+  findByVersion: ReturnType<typeof vi.fn>;
+  pruneAutosaves: ReturnType<typeof vi.fn>;
+  deleteForTimeline: ReturnType<typeof vi.fn>;
+  snapshotCalls: {
+    seq: { id: string };
+    opts: { saveType: string; name?: string | null };
+  }[];
+};
+
+const createCaller = createCallerFactory(appRouter);
+
+function makeCtx(overrides: Partial<Context> = {}): Context {
+  return {
+    userId: "user-1",
+    registry: {} as never,
+    apiOptions: { metadataRoots: [], registry: {} as never } as never,
+    pythonBridge: {} as never,
+    getPythonBridgeReady: () => false,
+    ...overrides
+  };
+}
+
+function makeSeq(over: Record<string, unknown> = {}) {
+  return new (TimelineSequence as unknown as new (
+    init: Record<string, unknown>
+  ) => InstanceType<typeof TimelineSequence>)({ ...over });
+}
+
+function makeVersion(over: Record<string, unknown> = {}) {
+  return new (TimelineSequenceVersion as unknown as new (
+    init: Record<string, unknown>
+  ) => InstanceType<typeof TimelineSequenceVersion>)({ ...over });
+}
+
+const emptyDoc = { tracks: [], clips: [], markers: [] };
+
+describe("timeline.versions router", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    TSV.snapshotCalls.length = 0;
+    __resetTimelineAutosaveVersionState();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  // ── auth triad ────────────────────────────────────────────────────────────
+
+  describe("auth", () => {
+    const cases: [string, (c: ReturnType<typeof createCaller>) => Promise<unknown>][] =
+      [
+        ["list", (c) => c.timeline.versions.list({ id: "seq-1" })],
+        ["create", (c) => c.timeline.versions.create({ id: "seq-1" })],
+        [
+          "restore",
+          (c) => c.timeline.versions.restore({ id: "seq-1", version: 1 })
+        ]
+      ];
+
+    for (const [name, call] of cases) {
+      it(`${name} rejects unauthenticated callers`, async () => {
+        TS.findById.mockResolvedValue(makeSeq());
+        await expect(call(createCaller(makeCtx({ userId: null })))).rejects.toThrow();
+      });
+
+      it(`${name} 404s on an unknown id`, async () => {
+        TS.findById.mockResolvedValue(null);
+        await expect(call(createCaller(makeCtx()))).rejects.toThrow();
+      });
+
+      it(`${name} 404s on another user's timeline`, async () => {
+        TS.findById.mockResolvedValue(makeSeq({ user_id: "other" }));
+        await expect(call(createCaller(makeCtx()))).rejects.toThrow();
+      });
+    }
+  });
+
+  // ── list ──────────────────────────────────────────────────────────────────
+
+  it("list maps rows to metadata and forwards limit + saveType", async () => {
+    TS.findById.mockResolvedValue(makeSeq());
+    TSV.listForTimeline.mockResolvedValue([
+      makeVersion({ id: "v2", version: 2, save_type: "autosave", name: null }),
+      makeVersion({ id: "v1", version: 1, save_type: "manual", name: "First" })
+    ]);
+    const out = await createCaller(makeCtx()).timeline.versions.list({
+      id: "seq-1",
+      limit: 10,
+      saveType: "manual"
+    });
+    expect(TSV.listForTimeline).toHaveBeenCalledWith("seq-1", {
+      limit: 10,
+      saveType: "manual"
+    });
+    expect(out.map((v) => v.version)).toEqual([2, 1]);
+    expect(out[0]).toMatchObject({
+      id: "v2",
+      timelineId: "seq-1",
+      saveType: "autosave",
+      name: null
+    });
+    // metadata only — no document on the wire
+    expect(out[0]).not.toHaveProperty("document");
+  });
+
+  // ── get ───────────────────────────────────────────────────────────────────
+
+  it("get parses a JSON-string document", async () => {
+    TS.findById.mockResolvedValue(makeSeq());
+    TSV.findByVersion.mockResolvedValue(
+      makeVersion({ version: 3, document: JSON.stringify(emptyDoc) })
+    );
+    const out = await createCaller(makeCtx()).timeline.versions.get({
+      id: "seq-1",
+      version: 3
+    });
+    expect(out.version).toBe(3);
+    expect(out.document).toEqual(emptyDoc);
+  });
+
+  it("get accepts an already-parsed document object (Postgres)", async () => {
+    TS.findById.mockResolvedValue(makeSeq());
+    TSV.findByVersion.mockResolvedValue(
+      makeVersion({ version: 3, document: emptyDoc })
+    );
+    const out = await createCaller(makeCtx()).timeline.versions.get({
+      id: "seq-1",
+      version: 3
+    });
+    expect(out.document).toEqual(emptyDoc);
+  });
+
+  it("get 404s on a missing version", async () => {
+    TS.findById.mockResolvedValue(makeSeq());
+    TSV.findByVersion.mockResolvedValue(null);
+    await expect(
+      createCaller(makeCtx()).timeline.versions.get({ id: "seq-1", version: 9 })
+    ).rejects.toThrow();
+  });
+
+  // ── create ────────────────────────────────────────────────────────────────
+
+  it("create snapshots the current sequence as a manual version", async () => {
+    TS.findById.mockResolvedValue(makeSeq({ fps: 24, duration_ms: 5000 }));
+    const out = await createCaller(makeCtx()).timeline.versions.create({
+      id: "seq-1",
+      name: "Before the big cut"
+    });
+    expect(TSV.snapshotCalls).toHaveLength(1);
+    expect(TSV.snapshotCalls[0].opts).toEqual({
+      saveType: "manual",
+      name: "Before the big cut"
+    });
+    expect(out).toMatchObject({
+      version: 1,
+      saveType: "manual",
+      name: "Before the big cut",
+      fps: 24,
+      durationMs: 5000
+    });
+  });
+
+  it("create defaults an omitted name to null", async () => {
+    TS.findById.mockResolvedValue(makeSeq());
+    const out = await createCaller(makeCtx()).timeline.versions.create({
+      id: "seq-1"
+    });
+    expect(TSV.snapshotCalls[0].opts.name).toBeNull();
+    expect(out.name).toBeNull();
+  });
+
+  // ── restore ───────────────────────────────────────────────────────────────
+
+  it("restore writes the version's document and scalars, after a pre-restore snapshot", async () => {
+    const restoredDoc = {
+      tracks: [
+        {
+          id: "t1",
+          name: "V1",
+          type: "video" as const,
+          index: 0,
+          visible: true,
+          locked: false
+        }
+      ],
+      clips: [],
+      markers: []
+    };
+    TS.findById.mockResolvedValue(makeSeq({ updated_at: "2026-02-02T00:00:00Z" }));
+    TSV.findByVersion.mockResolvedValue(
+      makeVersion({
+        version: 7,
+        document: JSON.stringify(restoredDoc),
+        fps: 24,
+        width: 1280,
+        height: 720,
+        duration_ms: 4200
+      })
+    );
+
+    const out = await createCaller(makeCtx()).timeline.versions.restore({
+      id: "seq-1",
+      version: 7
+    });
+
+    // Pre-restore snapshot, so a restore is undoable.
+    expect(TSV.snapshotCalls).toHaveLength(1);
+    expect(TSV.snapshotCalls[0].opts).toEqual({
+      saveType: "restore",
+      name: "Before restore to v7"
+    });
+
+    const [id, fields] = TS.update.mock.calls[0] as [
+      string,
+      Record<string, unknown>
+    ];
+    expect(id).toBe("seq-1");
+    expect(JSON.parse(fields.document as string)).toEqual(restoredDoc);
+    expect(fields).toMatchObject({
+      fps: 24,
+      width: 1280,
+      height: 720,
+      duration_ms: 4200
+    });
+    expect(out.fps).toBe(24);
+    expect(out.tracks).toEqual(restoredDoc.tracks);
+  });
+
+  it("restore 404s on a missing version and writes nothing", async () => {
+    TS.findById.mockResolvedValue(makeSeq());
+    TSV.findByVersion.mockResolvedValue(null);
+    await expect(
+      createCaller(makeCtx()).timeline.versions.restore({
+        id: "seq-1",
+        version: 9
+      })
+    ).rejects.toThrow();
+    expect(TSV.snapshotCalls).toHaveLength(0);
+    expect(TS.update).not.toHaveBeenCalled();
+  });
+
+  it("restore reports a conflict when the sequence changed under it", async () => {
+    TS.findById
+      .mockResolvedValueOnce(makeSeq())
+      // the CAS write re-reads and finds the row gone/changed
+      .mockResolvedValue(null);
+    TSV.findByVersion.mockResolvedValue(
+      makeVersion({ version: 2, document: JSON.stringify(emptyDoc) })
+    );
+    await expect(
+      createCaller(makeCtx()).timeline.versions.restore({
+        id: "seq-1",
+        version: 2
+      })
+    ).rejects.toThrow();
+  });
+
+  // ── delete ────────────────────────────────────────────────────────────────
+
+  it("delete removes the version row", async () => {
+    TS.findById.mockResolvedValue(makeSeq());
+    const version = makeVersion({ version: 4 });
+    TSV.findByVersion.mockResolvedValue(version);
+    const out = await createCaller(makeCtx()).timeline.versions.delete({
+      id: "seq-1",
+      version: 4
+    });
+    expect(version.delete).toHaveBeenCalled();
+    expect(out).toEqual({ ok: true });
+  });
+
+  it("delete 404s on a missing version", async () => {
+    TS.findById.mockResolvedValue(makeSeq());
+    TSV.findByVersion.mockResolvedValue(null);
+    await expect(
+      createCaller(makeCtx()).timeline.versions.delete({
+        id: "seq-1",
+        version: 9
+      })
+    ).rejects.toThrow();
+  });
+});
+
+describe("timeline autosave snapshots", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    TSV.snapshotCalls.length = 0;
+    __resetTimelineAutosaveVersionState();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("snapshots on the first document write and not again within the interval", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-01T00:00:00Z"));
+    TS.findById.mockResolvedValue(makeSeq());
+    const caller = createCaller(makeCtx());
+
+    await caller.timeline.update({ id: "seq-1", document: emptyDoc });
+    expect(TSV.snapshotCalls).toHaveLength(1);
+    expect(TSV.snapshotCalls[0].opts).toEqual({ saveType: "autosave" });
+    expect(TSV.pruneAutosaves).toHaveBeenCalledWith("seq-1", 20);
+
+    vi.advanceTimersByTime(60_000);
+    await caller.timeline.update({ id: "seq-1", document: emptyDoc });
+    expect(TSV.snapshotCalls).toHaveLength(1);
+
+    // Past the 5-minute interval it snapshots again.
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    await caller.timeline.update({ id: "seq-1", document: emptyDoc });
+    expect(TSV.snapshotCalls).toHaveLength(2);
+  });
+
+  it("does not snapshot a scalar-only update", async () => {
+    TS.findById.mockResolvedValue(makeSeq());
+    await createCaller(makeCtx()).timeline.update({
+      id: "seq-1",
+      name: "Renamed"
+    });
+    expect(TSV.snapshotCalls).toHaveLength(0);
+  });
+
+  it("keeps the save when snapshotting throws", async () => {
+    TS.findById.mockResolvedValue(makeSeq());
+    TSV.pruneAutosaves.mockRejectedValue(new Error("no such table"));
+    const out = await createCaller(makeCtx()).timeline.update({
+      id: "seq-1",
+      document: emptyDoc
+    });
+    expect(out.id).toBe("seq-1");
+  });
+
+  it("timeline.delete drops the version rows and the cadence entry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-01T00:00:00Z"));
+    TS.findById.mockResolvedValue(makeSeq());
+    const caller = createCaller(makeCtx());
+
+    await caller.timeline.update({ id: "seq-1", document: emptyDoc });
+    expect(TSV.snapshotCalls).toHaveLength(1);
+
+    await caller.timeline.delete({ id: "seq-1" });
+    expect(TSV.deleteForTimeline).toHaveBeenCalledWith("seq-1");
+
+    // The cadence entry went with it, so the next write snapshots immediately.
+    await caller.timeline.update({ id: "seq-1", document: emptyDoc });
+    expect(TSV.snapshotCalls).toHaveLength(2);
+  });
+});

--- a/packages/websocket/tests/trpc-timeline.test.ts
+++ b/packages/websocket/tests/trpc-timeline.test.ts
@@ -95,6 +95,17 @@ vi.mock("@nodetool-ai/models", async (orig) => {
       return { sequence: seq, result };
     }
   }
+  // Version history is exercised in trpc-timeline-versions.test.ts; here it
+  // only needs to stay off the database. Plain statics so `vi.resetAllMocks()`
+  // doesn't strip their bodies.
+  class StubTimelineSequenceVersion {
+    static async snapshot() {
+      return null;
+    }
+    static async pruneAutosaves() {}
+    static async deleteForTimeline() {}
+  }
+
   return {
     ...actual,
     Workflow: {
@@ -102,6 +113,7 @@ vi.mock("@nodetool-ai/models", async (orig) => {
       find: vi.fn()
     },
     TimelineSequence: StubTimelineSequence,
+    TimelineSequenceVersion: StubTimelineSequenceVersion,
     createTimeOrderedUuid: () => "version-id"
   };
 });

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -36,6 +36,7 @@ import {
   MOTION
 } from "../ui_primitives";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import HistoryOutlinedIcon from "@mui/icons-material/HistoryOutlined";
 import TuneOutlinedIcon from "@mui/icons-material/TuneOutlined";
 
 import { TopBar } from "./TopBar";
@@ -54,6 +55,7 @@ import { TimelineProvider } from "../../stores/timeline/TimelineInstance";
 import { PreviewArea } from "./preview/PreviewArea";
 import { TimelineInspector } from "./Inspector/TimelineInspector";
 import TimelineAgentPanel from "./TimelineAgentPanel";
+import TimelineVersionHistoryPanel from "./TimelineVersionHistoryPanel";
 import { useTimelineAgentBridge } from "../../hooks/timeline/useTimelineAgentBridge";
 import { TranscriptPanel } from "./TranscriptPanel";
 import { useHasScript } from "../../hooks/timeline/useHasScript";
@@ -231,16 +233,18 @@ const PreviewRegion: React.FC<{
 });
 PreviewRegion.displayName = "PreviewRegion";
 
-type InspectorTab = "inspector" | "agent";
+type InspectorTab = "inspector" | "agent" | "history";
 
-const InspectorRegion: React.FC = memo(() => {
+const InspectorRegion: React.FC<{ sequenceId: string | undefined }> = memo(
+  ({ sequenceId }) => {
   const theme = useTheme();
   const [tab, setTab] = useState<InspectorTab>("inspector");
 
   const tabs = useMemo(
     () => [
       { value: "inspector", label: "Inspector", icon: <TuneOutlinedIcon /> },
-      { value: "agent", label: "Assistant", icon: <AutoAwesomeIcon /> }
+      { value: "agent", label: "Assistant", icon: <AutoAwesomeIcon /> },
+      { value: "history", label: "History", icon: <HistoryOutlinedIcon /> }
     ],
     []
   );
@@ -263,11 +267,18 @@ const InspectorRegion: React.FC = memo(() => {
         }}
       />
       <FlexColumn fullWidth sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
-        {tab === "inspector" ? <TimelineInspector /> : <TimelineAgentPanel />}
+        {tab === "inspector" ? (
+          <TimelineInspector />
+        ) : tab === "agent" ? (
+          <TimelineAgentPanel />
+        ) : (
+          <TimelineVersionHistoryPanel sequenceId={sequenceId} />
+        )}
       </FlexColumn>
     </FlexColumn>
   );
-});
+  }
+);
 InspectorRegion.displayName = "InspectorRegion";
 
 const TranscriptRegion: React.FC = memo(() => {
@@ -610,7 +621,7 @@ const TimelineEditorBody: React.FC<
           createSequencePending={createTimeline.isPending}
           createSequenceErrorMessage={createErrorMessage}
         />
-        <InspectorRegion />
+        <InspectorRegion sequenceId={sequenceId} />
       </FlexRow>
 
       {/* ── Horizontal drag handle (mouse + keyboard resizable) ───── */}

--- a/web/src/components/timeline/TimelineVersionHistoryPanel.tsx
+++ b/web/src/components/timeline/TimelineVersionHistoryPanel.tsx
@@ -1,0 +1,364 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * TimelineVersionHistoryPanel
+ *
+ * Version history for the open timeline sequence, mounted as the "History" tab
+ * of the editor's inspector region (alongside Inspector and Assistant).
+ *
+ * Lists snapshots newest first with their save type, name, age, and canvas
+ * settings, and offers three actions: save a manual snapshot, restore one, and
+ * delete one. Restoring rewrites the sequence server-side (after snapshotting
+ * what it overwrites), so it also reloads the editor's store from the response
+ * — see `applyTimelineSequenceToStore`.
+ *
+ * Deliberately no diff/compare view: a timeline document has no useful textual
+ * diff, and the metadata plus a restore is what the history is for.
+ */
+
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import React, { memo, useCallback, useMemo, useState } from "react";
+
+import { useTimelineStoreApi } from "../../stores/timeline/TimelineStore";
+import { applyTimelineSequenceToStore } from "../../hooks/timeline/useLoadTimelineIntoStore";
+import {
+  useTimelineVersions,
+  type TimelineVersionListItem,
+  type TimelineVersionSaveType
+} from "../../serverState/useTimelineVersions";
+import { relativeTime } from "../../utils/formatDateAndTime";
+import { notifyMutationError } from "../../utils/notifyMutationError";
+import PanelToolbar from "../panels/PanelToolbar";
+import {
+  Caption,
+  Chip,
+  Dialog,
+  EditorButton,
+  EmptyState,
+  FlexColumn,
+  FlexRow,
+  LoadingSpinner,
+  ScrollArea,
+  Text,
+  TextInput,
+  BORDER_RADIUS,
+  MOTION,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+
+const SAVE_TYPE_LABEL: Record<TimelineVersionSaveType, string> = {
+  manual: "Manual",
+  autosave: "Auto",
+  restore: "Restore"
+};
+
+const SAVE_TYPE_COLOR: Record<
+  TimelineVersionSaveType,
+  "primary" | "default" | "info"
+> = {
+  manual: "primary",
+  autosave: "default",
+  restore: "info"
+};
+
+const listStyles = (theme: Theme) =>
+  css({
+    ".version-row": {
+      padding: `${getSpacingPx(SPACING.md)} ${getSpacingPx(SPACING.lg)}`,
+      borderBottom: `1px solid ${theme.vars.palette.divider}`,
+      transition: MOTION.background,
+      "&:hover": {
+        backgroundColor: theme.vars.palette.action.hover
+      },
+      "&:hover .version-actions, &:focus-within .version-actions": {
+        opacity: 1
+      }
+    },
+    ".version-actions": {
+      opacity: 0,
+      transition: MOTION.fast,
+      borderRadius: BORDER_RADIUS.sm
+    }
+  });
+
+interface VersionRowProps {
+  version: TimelineVersionListItem;
+  busy: boolean;
+  onRestore: (version: TimelineVersionListItem) => void;
+  onDelete: (version: TimelineVersionListItem) => void;
+}
+
+const VersionRow: React.FC<VersionRowProps> = memo(
+  ({ version, busy, onRestore, onDelete }) => {
+    const handleRestore = useCallback(
+      () => onRestore(version),
+      [onRestore, version]
+    );
+    const handleDelete = useCallback(
+      () => onDelete(version),
+      [onDelete, version]
+    );
+
+    return (
+      <FlexColumn className="version-row" gap={0.5} fullWidth>
+        <FlexRow gap={1} align="center" fullWidth>
+          <Text size="small" weight={600}>
+            v{version.version}
+          </Text>
+          <Chip
+            label={SAVE_TYPE_LABEL[version.saveType]}
+            color={SAVE_TYPE_COLOR[version.saveType]}
+            compact
+            size="small"
+          />
+          {version.name ? (
+            <Text size="small" color="secondary">
+              {version.name}
+            </Text>
+          ) : null}
+          <FlexRow
+            className="version-actions"
+            gap={0.5}
+            align="center"
+            sx={{ marginLeft: "auto" }}
+          >
+            <EditorButton
+              density="compact"
+              variant="text"
+              disabled={busy}
+              onClick={handleRestore}
+              aria-label={`Restore version ${version.version}`}
+            >
+              Restore
+            </EditorButton>
+            <EditorButton
+              density="compact"
+              variant="text"
+              disabled={busy}
+              onClick={handleDelete}
+              aria-label={`Delete version ${version.version}`}
+              sx={{ color: "text.secondary" }}
+            >
+              Delete
+            </EditorButton>
+          </FlexRow>
+        </FlexRow>
+        <Caption size="smaller" color="muted">
+          {relativeTime(version.createdAt)}
+          {" · "}
+          {new Date(version.createdAt).toLocaleString()}
+          {" · "}
+          {version.width}×{version.height} @ {version.fps}fps
+        </Caption>
+      </FlexColumn>
+    );
+  }
+);
+VersionRow.displayName = "VersionRow";
+
+export interface TimelineVersionHistoryPanelProps {
+  /** Sequence whose history is shown. */
+  sequenceId: string | null | undefined;
+}
+
+export const TimelineVersionHistoryPanel: React.FC<
+  TimelineVersionHistoryPanelProps
+> = ({ sequenceId }) => {
+  const theme = useTheme();
+  const store = useTimelineStoreApi();
+  const {
+    versions,
+    isLoading,
+    error,
+    createVersion,
+    restoreVersion,
+    deleteVersion,
+    isCreatingVersion,
+    isRestoringVersion,
+    isDeletingVersion
+  } = useTimelineVersions(sequenceId);
+
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [saveName, setSaveName] = useState("");
+  const [restoreTarget, setRestoreTarget] =
+    useState<TimelineVersionListItem | null>(null);
+  const [deleteTarget, setDeleteTarget] =
+    useState<TimelineVersionListItem | null>(null);
+
+  const busy = isRestoringVersion || isDeletingVersion;
+
+  const openSaveDialog = useCallback(() => {
+    setSaveName("");
+    setSaveDialogOpen(true);
+  }, []);
+  const closeSaveDialog = useCallback(() => setSaveDialogOpen(false), []);
+
+  const handleSaveNameChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) =>
+      setSaveName(event.target.value),
+    []
+  );
+
+  const handleConfirmSave = useCallback(async () => {
+    setSaveDialogOpen(false);
+    try {
+      await createVersion(saveName);
+    } catch (err) {
+      notifyMutationError("save a version", err);
+    }
+  }, [createVersion, saveName]);
+
+  const handleConfirmRestore = useCallback(async () => {
+    const target = restoreTarget;
+    setRestoreTarget(null);
+    if (!target) return;
+    try {
+      const restored = await restoreVersion(target.version);
+      // The editor holds the pre-restore document in memory and autosaves it
+      // 750 ms after any change; without this the next flush would PATCH the
+      // stale state straight back over the restore.
+      applyTimelineSequenceToStore(store, restored);
+    } catch (err) {
+      notifyMutationError("restore that version", err);
+    }
+  }, [restoreTarget, restoreVersion, store]);
+
+  const handleConfirmDelete = useCallback(async () => {
+    const target = deleteTarget;
+    setDeleteTarget(null);
+    if (!target) return;
+    try {
+      await deleteVersion(target.version);
+    } catch (err) {
+      notifyMutationError("delete that version", err);
+    }
+  }, [deleteTarget, deleteVersion]);
+
+  const clearRestoreTarget = useCallback(() => setRestoreTarget(null), []);
+  const clearDeleteTarget = useCallback(() => setDeleteTarget(null), []);
+
+  // Newest first. The server orders by version already; sorting here keeps the
+  // panel correct regardless of the order it is handed.
+  const ordered = useMemo(
+    () => [...versions].sort((a, b) => b.version - a.version),
+    [versions]
+  );
+
+  const toolbarActions = useMemo(
+    () => (
+      <EditorButton
+        density="compact"
+        variant="contained"
+        onClick={openSaveDialog}
+        disabled={!sequenceId || isCreatingVersion}
+      >
+        {isCreatingVersion ? "Saving…" : "Save version"}
+      </EditorButton>
+    ),
+    [openSaveDialog, sequenceId, isCreatingVersion]
+  );
+
+  return (
+    <FlexColumn fullWidth fullHeight sx={{ minHeight: 0, overflow: "hidden" }}>
+      <PanelToolbar
+        title="History"
+        count={ordered.length}
+        actions={toolbarActions}
+      />
+
+      <ScrollArea css={listStyles(theme)} sx={{ flex: 1, minHeight: 0 }}>
+        {isLoading ? (
+          <FlexColumn align="center" justify="center" sx={{ py: 4 }}>
+            <LoadingSpinner size="small" text="Loading versions…" />
+          </FlexColumn>
+        ) : error ? (
+          <FlexColumn gap={0.5} sx={{ p: 2 }}>
+            <Text color="error">Failed to load versions</Text>
+            <Caption size="smaller" color="secondary">
+              {error instanceof Error ? error.message : String(error)}
+            </Caption>
+          </FlexColumn>
+        ) : ordered.length === 0 ? (
+          <FlexColumn align="center" sx={{ py: 4, px: 2 }}>
+            <EmptyState
+              title="No versions yet"
+              description="Save a version to snapshot the sequence you can come back to."
+            />
+          </FlexColumn>
+        ) : (
+          ordered.map((version) => (
+            <VersionRow
+              key={version.id}
+              version={version}
+              busy={busy}
+              onRestore={setRestoreTarget}
+              onDelete={setDeleteTarget}
+            />
+          ))
+        )}
+      </ScrollArea>
+
+      <Dialog
+        open={saveDialogOpen}
+        onClose={closeSaveDialog}
+        title="Save a version"
+        onConfirm={handleConfirmSave}
+        onCancel={closeSaveDialog}
+        confirmText="Save version"
+      >
+        <FlexColumn gap={1} sx={{ minWidth: 320, py: 1 }}>
+          <TextInput
+            label="Name (optional)"
+            value={saveName}
+            onChange={handleSaveNameChange}
+            size="small"
+            autoFocus
+          />
+          <Caption size="smaller" color="secondary">
+            Snapshots the sequence as it is right now.
+          </Caption>
+        </FlexColumn>
+      </Dialog>
+
+      <Dialog
+        open={restoreTarget !== null}
+        onClose={clearRestoreTarget}
+        title={
+          restoreTarget ? `Restore v${restoreTarget.version}?` : "Restore?"
+        }
+        onConfirm={handleConfirmRestore}
+        onCancel={clearRestoreTarget}
+        confirmText="Restore"
+      >
+        <FlexColumn gap={1} sx={{ maxWidth: 420 }}>
+          <Text color="secondary">
+            This replaces the current tracks, clips, and markers with that
+            snapshot.
+          </Text>
+          <Caption size="smaller" color="muted">
+            A snapshot of the current state is saved first, so you can undo the
+            restore from this list.
+          </Caption>
+        </FlexColumn>
+      </Dialog>
+
+      <Dialog
+        open={deleteTarget !== null}
+        onClose={clearDeleteTarget}
+        title={deleteTarget ? `Delete v${deleteTarget.version}?` : "Delete?"}
+        onConfirm={handleConfirmDelete}
+        onCancel={clearDeleteTarget}
+        confirmText="Delete"
+        destructive
+      >
+        <Text color="secondary">This action cannot be undone.</Text>
+      </Dialog>
+    </FlexColumn>
+  );
+};
+
+TimelineVersionHistoryPanel.displayName = "TimelineVersionHistoryPanel";
+
+export default memo(TimelineVersionHistoryPanel);

--- a/web/src/components/timeline/__tests__/TimelineVersionHistoryPanel.test.tsx
+++ b/web/src/components/timeline/__tests__/TimelineVersionHistoryPanel.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * TimelineVersionHistoryPanel tests.
+ *
+ * Covers what the panel owns: the list rendering, the restore confirm →
+ * mutation → store reload path (the one that keeps autosave from writing the
+ * pre-restore document back), and the destructive delete confirm.
+ */
+
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+
+import mockTheme from "../../../__mocks__/themeMock";
+import TimelineVersionHistoryPanel from "../TimelineVersionHistoryPanel";
+import { TimelineProvider } from "../../../stores/timeline/TimelineInstance";
+import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
+
+const createVersion = jest.fn();
+const restoreVersion = jest.fn();
+const deleteVersion = jest.fn();
+
+let hookState: Record<string, unknown> = {};
+
+jest.mock("../../../serverState/useTimelineVersions", () => ({
+  __esModule: true,
+  useTimelineVersions: () => hookState
+}));
+
+const version = (over: Record<string, unknown> = {}) => ({
+  id: "v-1",
+  timelineId: "t-1",
+  version: 1,
+  name: null,
+  saveType: "autosave",
+  fps: 30,
+  width: 1920,
+  height: 1080,
+  durationMs: 4000,
+  createdAt: new Date().toISOString(),
+  ...over
+});
+
+const restoredSequence = {
+  id: "t-1",
+  projectId: "p-1",
+  name: "seq",
+  fps: 24,
+  width: 1280,
+  height: 720,
+  durationMs: 2000,
+  tracks: [
+    {
+      id: "track-restored",
+      name: "Video",
+      type: "video",
+      index: 0,
+      visible: true,
+      locked: false
+    }
+  ],
+  clips: [],
+  markers: [],
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-02-02T00:00:00.000Z"
+};
+
+const renderPanel = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <TimelineProvider>
+        <TimelineVersionHistoryPanel sequenceId="t-1" />
+      </TimelineProvider>
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  restoreVersion.mockResolvedValue(restoredSequence);
+  createVersion.mockResolvedValue(version());
+  deleteVersion.mockResolvedValue({ ok: true });
+  hookState = {
+    versions: [
+      version({ id: "v-2", version: 2, saveType: "manual", name: "before cut" }),
+      version({ id: "v-1", version: 1, saveType: "autosave" })
+    ],
+    isLoading: false,
+    error: null,
+    createVersion,
+    restoreVersion,
+    deleteVersion,
+    isCreatingVersion: false,
+    isRestoringVersion: false,
+    isDeletingVersion: false
+  };
+});
+
+describe("TimelineVersionHistoryPanel", () => {
+  it("lists versions newest first with save type and name", () => {
+    renderPanel();
+    expect(screen.getByText("v2")).toBeInTheDocument();
+    expect(screen.getByText("v1")).toBeInTheDocument();
+    expect(screen.getByText("Manual")).toBeInTheDocument();
+    expect(screen.getByText("Auto")).toBeInTheDocument();
+    expect(screen.getByText("before cut")).toBeInTheDocument();
+
+    const restoreButtons = screen.getAllByRole("button", {
+      name: /Restore version/
+    });
+    expect(restoreButtons[0]).toHaveAccessibleName("Restore version 2");
+  });
+
+  it("shows an empty state when there is no history", () => {
+    hookState = { ...hookState, versions: [] };
+    renderPanel();
+    expect(screen.getByText("No versions yet")).toBeInTheDocument();
+  });
+
+  it("saves a named manual snapshot", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: "Save version" }));
+    await user.type(screen.getByLabelText("Name (optional)"), "keeper");
+    await user.click(screen.getByRole("button", { name: "Save version" }));
+
+    await waitFor(() => expect(createVersion).toHaveBeenCalledWith("keeper"));
+  });
+
+  it("restores after confirming and reloads the store from the response", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(
+      screen.getByRole("button", { name: "Restore version 2" })
+    );
+    expect(screen.getByText("Restore v2?")).toBeInTheDocument();
+    expect(restoreVersion).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Restore" }));
+
+    await waitFor(() => expect(restoreVersion).toHaveBeenCalledWith(2));
+    await waitFor(() => {
+      const state = useTimelineStore.getState();
+      expect(state.sequenceId).toBe("t-1");
+      expect(state.tracks.map((t) => t.id)).toEqual(["track-restored"]);
+      // Rolled to the restore response's token, so the next autosave PATCH
+      // cannot 409 — and cannot carry the pre-restore document.
+      expect(state.baseUpdatedAt).toBe("2026-02-02T00:00:00.000Z");
+      expect(state.fps).toBe(24);
+    });
+  });
+
+  it("does not restore when the confirm dialog is cancelled", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(
+      screen.getByRole("button", { name: "Restore version 1" })
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(restoreVersion).not.toHaveBeenCalled();
+  });
+
+  it("deletes only after the destructive confirm", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: "Delete version 1" }));
+    expect(screen.getByText("Delete v1?")).toBeInTheDocument();
+    expect(deleteVersion).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => expect(deleteVersion).toHaveBeenCalledWith(1));
+  });
+});

--- a/web/src/hooks/timeline/useLoadTimelineIntoStore.ts
+++ b/web/src/hooks/timeline/useLoadTimelineIntoStore.ts
@@ -22,7 +22,30 @@ import type { RouterOutputs } from "../../trpc/client";
  * `easing` to `EasingId`. The compiler tolerates unknown ids at sample time, so
  * the wire→store cast on load is safe.
  */
-type WireSequence = RouterOutputs["timeline"]["get"];
+export type WireSequence = RouterOutputs["timeline"]["get"];
+
+type TimelineStoreApi = ReturnType<typeof useTimelineStoreApi>;
+
+/**
+ * Replace the store's contents with `sequence` and clear undo history.
+ *
+ * Used on first load and after a version restore. Clearing temporal history is
+ * not cosmetic: the load is a tracked `set`, so without it Ctrl+Z would undo
+ * "past" the loaded sequence. `loadSequence` also rolls `baseUpdatedAt` to the
+ * sequence's own token, which re-baselines the autosave subscriber — a restore
+ * that skipped this would be overwritten by the next debounced PATCH of the
+ * stale in-memory document.
+ */
+export function applyTimelineSequenceToStore(
+  store: TimelineStoreApi,
+  sequence: WireSequence
+): void {
+  if ((sequence.transcript?.length ?? 0) > 0) {
+    markTimelineLoadMigrated(sequence.id);
+  }
+  store.getState().loadSequence(sequence as TimelineSequence);
+  timelineTemporalOf(store).clear();
+}
 
 export function useLoadTimelineIntoStore(
   sequence: WireSequence | undefined | null
@@ -39,15 +62,7 @@ export function useLoadTimelineIntoStore(
     if (store.getState().sequenceId === sequence.id) {
       return;
     }
-    if ((sequence.transcript?.length ?? 0) > 0) {
-      // loadSequence folds a legacy transcript onto clips; tell autosave to
-      // persist that migrated document once.
-      markTimelineLoadMigrated(sequence.id);
-    }
-    store.getState().loadSequence(sequence as TimelineSequence);
-    // The load is a tracked `set`; clear history so the first Ctrl+Z can't
-    // undo "past" the loaded sequence into the empty default state.
-    timelineTemporalOf(store).clear();
+    applyTimelineSequenceToStore(store, sequence);
   }, [sequence, store]);
 
   useEffect(() => {

--- a/web/src/serverState/__tests__/useTimelineVersions.test.ts
+++ b/web/src/serverState/__tests__/useTimelineVersions.test.ts
@@ -1,0 +1,188 @@
+import { renderHook } from "@testing-library/react";
+
+jest.mock("@tanstack/react-query", () => ({
+  __esModule: true,
+  useQuery: jest.fn(),
+  useMutation: jest.fn(() => ({ mutateAsync: jest.fn(), isPending: false })),
+  useQueryClient: jest.fn(() => ({ invalidateQueries: jest.fn() }))
+}));
+
+const mockSetData = jest.fn();
+const mockInvalidateGet = jest.fn();
+const mockListQuery = jest.fn();
+const mockCreate = jest.fn();
+const mockRestore = jest.fn();
+const mockDelete = jest.fn();
+
+jest.mock("../../trpc/client", () => ({
+  __esModule: true,
+  trpc: {
+    useUtils: () => ({
+      timeline: { get: { setData: mockSetData, invalidate: mockInvalidateGet } }
+    })
+  },
+  trpcClient: {
+    timeline: {
+      versions: {
+        list: { query: (...args: unknown[]) => mockListQuery(...args) },
+        create: { mutate: (...args: unknown[]) => mockCreate(...args) },
+        restore: { mutate: (...args: unknown[]) => mockRestore(...args) },
+        delete: { mutate: (...args: unknown[]) => mockDelete(...args) }
+      }
+    }
+  }
+}));
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  timelineVersionsQueryKey,
+  useTimelineVersions
+} from "../useTimelineVersions";
+
+const mockUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
+const mockUseMutation = useMutation as jest.MockedFunction<typeof useMutation>;
+const mockUseQueryClient = useQueryClient as jest.MockedFunction<
+  typeof useQueryClient
+>;
+
+const invalidateQueries = jest.fn();
+
+describe("useTimelineVersions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null
+    } as any);
+    mockUseMutation.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: false
+    } as any);
+    mockUseQueryClient.mockReturnValue({ invalidateQueries } as any);
+  });
+
+  describe("timelineVersionsQueryKey", () => {
+    it("keys on timeline id, limit, and save type", () => {
+      expect(timelineVersionsQueryKey("t-1")).toEqual([
+        "timeline",
+        "t-1",
+        "versions",
+        100,
+        "all"
+      ]);
+      expect(timelineVersionsQueryKey("t-1", 20, "manual")).toEqual([
+        "timeline",
+        "t-1",
+        "versions",
+        20,
+        "manual"
+      ]);
+    });
+
+    it("differs per timeline", () => {
+      expect(timelineVersionsQueryKey("a")).not.toEqual(
+        timelineVersionsQueryKey("b")
+      );
+    });
+  });
+
+  it("disables the query without a timeline id", () => {
+    renderHook(() => useTimelineVersions(null));
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+        queryKey: ["timeline", "none", "versions", 100, "all"]
+      })
+    );
+  });
+
+  it("enables the query and keys it on the id", () => {
+    renderHook(() => useTimelineVersions("t-1"));
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        staleTime: 30_000,
+        queryKey: ["timeline", "t-1", "versions", 100, "all"]
+      })
+    );
+  });
+
+  it("fetches the list through trpc with limit and saveType", async () => {
+    renderHook(() => useTimelineVersions("t-1", { limit: 5, saveType: "manual" }));
+    const { queryFn } = mockUseQuery.mock.calls[0][0] as any;
+    await queryFn();
+    expect(mockListQuery).toHaveBeenCalledWith({
+      id: "t-1",
+      limit: 5,
+      saveType: "manual"
+    });
+  });
+
+  it("creates three mutations", () => {
+    renderHook(() => useTimelineVersions("t-1"));
+    expect(mockUseMutation).toHaveBeenCalledTimes(3);
+  });
+
+  it("exposes the mutation wrappers and pending flags", () => {
+    mockUseMutation.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: true
+    } as any);
+    const { result } = renderHook(() => useTimelineVersions("t-1"));
+    expect(result.current.createVersion).toBeDefined();
+    expect(result.current.restoreVersion).toBeDefined();
+    expect(result.current.deleteVersion).toBeDefined();
+    expect(result.current.isCreatingVersion).toBe(true);
+    expect(result.current.isRestoringVersion).toBe(true);
+    expect(result.current.isDeletingVersion).toBe(true);
+    expect(result.current.versions).toEqual([]);
+  });
+
+  it("trims a blank version name to undefined on create", async () => {
+    renderHook(() => useTimelineVersions("t-1"));
+    const createOptions = mockUseMutation.mock.calls[0][0] as any;
+    await createOptions.mutationFn("   ");
+    expect(mockCreate).toHaveBeenCalledWith({ id: "t-1", name: undefined });
+    await createOptions.mutationFn("  before the cut  ");
+    expect(mockCreate).toHaveBeenLastCalledWith({
+      id: "t-1",
+      name: "before the cut"
+    });
+  });
+
+  it("invalidates the versions prefix after create", () => {
+    renderHook(() => useTimelineVersions("t-1"));
+    const createOptions = mockUseMutation.mock.calls[0][0] as any;
+    createOptions.onSuccess();
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["timeline", "t-1", "versions"]
+    });
+  });
+
+  it("restore seeds the timeline.get cache and invalidates both", async () => {
+    renderHook(() => useTimelineVersions("t-1"));
+    const restoreOptions = mockUseMutation.mock.calls[1][0] as any;
+    await restoreOptions.mutationFn(3);
+    expect(mockRestore).toHaveBeenCalledWith({ id: "t-1", version: 3 });
+
+    const restored = { id: "t-1", name: "seq", updatedAt: "2026-01-01" };
+    restoreOptions.onSuccess(restored);
+    expect(mockSetData).toHaveBeenCalledWith({ id: "t-1" }, restored);
+    expect(mockInvalidateGet).toHaveBeenCalledWith({ id: "t-1" });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["timeline", "t-1", "versions"]
+    });
+  });
+
+  it("deletes by version number and invalidates", async () => {
+    renderHook(() => useTimelineVersions("t-1"));
+    const deleteOptions = mockUseMutation.mock.calls[2][0] as any;
+    await deleteOptions.mutationFn(2);
+    expect(mockDelete).toHaveBeenCalledWith({ id: "t-1", version: 2 });
+    deleteOptions.onSuccess();
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["timeline", "t-1", "versions"]
+    });
+  });
+});

--- a/web/src/serverState/useTimelineVersions.ts
+++ b/web/src/serverState/useTimelineVersions.ts
@@ -1,0 +1,117 @@
+/**
+ * useTimelineVersions
+ *
+ * Server state for a timeline sequence's version history
+ * (`trpc.timeline.versions.*`). Mirrors `useWorkflowVersions`: one list query
+ * plus create / restore / delete mutations that invalidate the versions key by
+ * prefix.
+ *
+ * Restore is the odd one out — it rewrites the sequence itself, so its success
+ * handler seeds the `timeline.get` cache with the restored sequence (and
+ * invalidates it) so every other view of that timeline picks the restore up.
+ * Syncing the *open editor's* store is the caller's job: see
+ * `applyTimelineSequenceToStore`.
+ */
+
+import { useCallback } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { trpc, trpcClient } from "../trpc/client";
+
+import type { RouterOutputs } from "../trpc/client";
+
+export type TimelineSequenceData = RouterOutputs["timeline"]["get"];
+export type TimelineVersionListItem =
+  RouterOutputs["timeline"]["versions"]["list"][number];
+export type TimelineVersionSaveType = TimelineVersionListItem["saveType"];
+
+const DEFAULT_LIMIT = 100;
+
+export const timelineVersionsQueryKey = (
+  timelineId: string,
+  limit: number = DEFAULT_LIMIT,
+  saveType?: TimelineVersionSaveType
+) => ["timeline", timelineId, "versions", limit, saveType ?? "all"] as const;
+
+export interface UseTimelineVersionsOptions {
+  limit?: number;
+  saveType?: TimelineVersionSaveType;
+}
+
+export const useTimelineVersions = (
+  timelineId: string | null | undefined,
+  options: UseTimelineVersionsOptions = {}
+) => {
+  const { limit = DEFAULT_LIMIT, saveType } = options;
+  const queryClient = useQueryClient();
+  const utils = trpc.useUtils();
+
+  const query = useQuery({
+    queryKey: timelineId
+      ? timelineVersionsQueryKey(timelineId, limit, saveType)
+      : timelineVersionsQueryKey("none", limit, saveType),
+    queryFn: (): Promise<TimelineVersionListItem[]> =>
+      trpcClient.timeline.versions.list.query({
+        id: timelineId as string,
+        limit,
+        saveType
+      }),
+    enabled: !!timelineId,
+    staleTime: 30 * 1000
+  });
+
+  // Prefix invalidation: every limit / saveType slice of this timeline's
+  // history is stale once a version is added, restored, or removed.
+  const invalidateVersions = useCallback(() => {
+    if (!timelineId) return;
+    queryClient.invalidateQueries({
+      queryKey: ["timeline", timelineId, "versions"]
+    });
+  }, [queryClient, timelineId]);
+
+  const createVersionMutation = useMutation({
+    mutationFn: (name?: string) =>
+      trpcClient.timeline.versions.create.mutate({
+        id: timelineId as string,
+        name: name?.trim() ? name.trim() : undefined
+      }),
+    onSuccess: invalidateVersions
+  });
+
+  const restoreVersionMutation = useMutation({
+    mutationFn: (version: number) =>
+      trpcClient.timeline.versions.restore.mutate({
+        id: timelineId as string,
+        version
+      }),
+    onSuccess: (restored) => {
+      // The restore both rewrote the sequence and appended a pre-restore
+      // snapshot, so the sequence and its history are stale.
+      utils.timeline.get.setData({ id: restored.id }, restored);
+      utils.timeline.get.invalidate({ id: restored.id });
+      invalidateVersions();
+    }
+  });
+
+  const deleteVersionMutation = useMutation({
+    mutationFn: (version: number) =>
+      trpcClient.timeline.versions.delete.mutate({
+        id: timelineId as string,
+        version
+      }),
+    onSuccess: invalidateVersions
+  });
+
+  return {
+    ...query,
+    versions: query.data ?? [],
+    createVersion: createVersionMutation.mutateAsync,
+    restoreVersion: restoreVersionMutation.mutateAsync,
+    deleteVersion: deleteVersionMutation.mutateAsync,
+    isCreatingVersion: createVersionMutation.isPending,
+    isRestoringVersion: restoreVersionMutation.isPending,
+    isDeletingVersion: deleteVersionMutation.isPending
+  };
+};
+
+export default useTimelineVersions;


### PR DESCRIPTION
Adds document-level version history for timeline sequences, end to end: storage, API, editor UI, and headless CLI harness.

## What's in it

**Models** (`packages/models`)
- New `timeline_sequence_versions` table (SQLite + Postgres, migration `20260804_000000`), following the newer unprefixed document-editor tables. Hardened per the `application_versions` precedent: FK cascade to `timeline_sequences`, `user_id` copied at snapshot time, and a unique `(timeline_id, version)` index.
- `TimelineSequenceVersion` model: `snapshot` (max+1 numbering with one retry on a write race), `listForTimeline`, `findByVersion`, `pruneAutosaves` (only touches `save_type: "autosave"` rows), `deleteForTimeline`.

**API** (`packages/protocol`, `packages/websocket`)
- Zod schemas and a nested `timeline.versions` tRPC sub-router: `list`, `get`, `create`, `restore`, `delete` — all owner-scoped through the router's existing `loadOwned`.
- `timeline.update` takes a best-effort autosave snapshot at most every 5 minutes (20 autosaves retained; manual/restore rows are never pruned).
- `restore` snapshots the current state as `save_type: "restore"` before writing, so a restore is itself undoable — closing a gap the workflow-versions precedent has. The write goes through the existing `updateFieldsIfUnchanged` CAS path.
- `timeline.delete` removes the sequence's versions (belt-and-braces with the FK cascade).

**Web** (`web/`)
- A History tab in the timeline editor's inspector region, backed by a new `useTimelineVersions` server-state hook: save named manual snapshots, restore (confirm dialog), delete (destructive confirm). ui_primitives and design tokens throughout.
- Restore applies the mutation response to the open editor via `applyTimelineSequenceToStore` (extracted from `useLoadTimelineIntoStore`): document replaced, fresh `baseUpdatedAt` token set, undo history cleared — so the 750 ms autosave re-arms on the restored state instead of clobbering it with pre-restore in-memory edits.

**CLI + harness** (`packages/cli`)
- `nodetool timeline versions list|show|create|restore|delete`, local-DB with `--json`. `restore` mirrors the router's semantics and prints a static validation verdict on the restored document.
- New `timeline-versions` harness registry entry; `nodetool harness audit` passes with no undocumented gap. Commands documented in CLAUDE.md.

## Testing
- `packages/models`: 792 tests (9 new) · `packages/protocol`: 786 · `packages/websocket`: 2105 (24 new router tests) · `packages/cli`: 507 (24 new)
- `web`: full Jest suite, 1062 suites / 12,500 tests passing (17 new across hook + panel)
- Repo `typecheck` (web, electron) and `lint` clean. The mobile typecheck leg cannot run in this sandbox (its Expo dependency tree is not installed); no mobile files were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFVn8LPnkLRAGYUE3ucuKA

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFVn8LPnkLRAGYUE3ucuKA)_