### PR TITLE
Keep workflow runs alive across WebSocket disconnects

### DIFF
--- a/packages/protocol/src/ws-commands.ts
+++ b/packages/protocol/src/ws-commands.ts
@@ -179,6 +179,15 @@ export const resumeChatDataSchema = z
   })
   .passthrough();
 
+export const reconnectJobDataSchema = z
+  .object({
+    job_id: z.string().optional(),
+    workflow_id: z.string().optional(),
+    /** Highest `job_seq` the client has already received for this job. */
+    last_seq: z.number().optional()
+  })
+  .passthrough();
+
 export const stopDataSchema = z
   .object({
     job_id: z.string().optional(),
@@ -235,8 +244,8 @@ export const transcribeAudioDataSchema = z
  */
 export const commandDataSchemas: Record<UnifiedCommandType, z.ZodTypeAny> = {
   run_job: runJobDataSchema,
-  reconnect_job: looseDataSchema,
-  resume_job: looseDataSchema,
+  reconnect_job: reconnectJobDataSchema,
+  resume_job: reconnectJobDataSchema,
   cancel_job: looseDataSchema,
   update_node_properties: looseDataSchema,
   get_status: looseDataSchema,
@@ -427,11 +436,39 @@ export const chatResumedMessageOutSchema = z
   })
   .passthrough();
 
+/**
+ * Reply to a `reconnect_job` / `resume_job` command. Sent before any
+ * replayed frames.
+ *
+ * `status` reports what the server holds for the job: `"running"` (the run
+ * is still executing on some connection's runner; replay is followed by live
+ * frames) or `"finished"` (the run ended while the client was away; replay
+ * is the whole tail). `"unknown"` is declared for parity with
+ * `chat_resumed` but is never sent today: with no replayable session the
+ * server answers `reconnect_job` with a plain `job_update` carrying the
+ * persisted row's outcome instead of this header.
+ *
+ * `replay_incomplete` is true when the requested `last_seq` predates what the
+ * bounded buffer still holds.
+ */
+export const jobResumedMessageOutSchema = z
+  .object({
+    type: z.literal("job_resumed"),
+    job_id: z.string(),
+    workflow_id: z.string().nullable().optional(),
+    status: z.enum(["running", "finished", "unknown"]),
+    last_seq: z.number(),
+    replay_count: z.number(),
+    replay_incomplete: z.boolean()
+  })
+  .passthrough();
+
 /** Non-`ProcessingMessage` outbound frame schemas, keyed by `type`. */
 export const outboundControlMessageSchemas = {
   pong: pongMessageOutSchema,
   rpc_response: rpcResponseMessageOutSchema,
   system_stats: systemStatsMessageOutSchema,
   resource_change: resourceChangeMessageOutSchema,
-  chat_resumed: chatResumedMessageOutSchema
+  chat_resumed: chatResumedMessageOutSchema,
+  job_resumed: jobResumedMessageOutSchema
 } as const;

--- a/packages/websocket/src/job-run-registry.ts
+++ b/packages/websocket/src/job-run-registry.ts
@@ -1,0 +1,320 @@
+/**
+ * Detachable workflow runs.
+ *
+ * The WebSocket runner is per-connection, so before this module existed a
+ * dropped socket killed every in-flight run (`disconnect()` →
+ * `job.session.cancel()` for each entry of `activeJobs`): a laptop lid-close
+ * threw away minutes of paid GPU work, and `reconnect_job` from a fresh
+ * connection — a fresh `UnifiedWebSocketRunner`, with an empty `activeJobs` —
+ * could only read the persisted row, reporting even a completed run as
+ * `job_update failed` with "replay is unavailable". A {@link JobRunSession}
+ * decouples the run from the socket, exactly as {@link ChatTurnSession} does
+ * for a chat turn: every frame the run emits is stamped with a monotonically
+ * increasing `job_seq` and appended to a bounded buffer, and delivery goes to
+ * whichever connection is currently attached — or nowhere, while the client
+ * is away. On reconnect the client sends
+ * `{command: "reconnect_job", data: {job_id, last_seq}}` and gets the missed
+ * tail replayed, followed by live frames if the run is still going.
+ *
+ * Sessions are keyed by user+job in a process-wide registry. Job ids are
+ * unique per run, so — unlike a chat thread — a new run never supersedes an
+ * existing session; {@link JobRunRegistry.open} replacing an entry means the
+ * same job id was started twice, which is a caller bug, not a turn taking
+ * over.
+ *
+ * Two timers bound a session's life:
+ *   - detach grace: a running job nobody is attached to is cancelled after
+ *     `NODETOOL_JOB_DETACH_GRACE_MS` (default 10 min) so an abandoned client
+ *     cannot leave a workflow burning provider spend forever;
+ *   - retention: a finished session is kept for
+ *     `NODETOOL_JOB_REPLAY_RETENTION_MS` (default 5 min) so a client that
+ *     reconnects just after the run ended still gets the tail, then dropped.
+ *
+ * Terminal state is persisted to the `jobs` table independently of this
+ * buffer, so an expired or truncated replay degrades to `reconnect_job`'s
+ * persisted-row fallback — the run's real status, just without its events.
+ */
+
+import { createLogger } from "@nodetool-ai/config";
+
+const log = createLogger("nodetool.websocket.job-run-registry");
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const MAX_BUFFERED_EVENTS = () =>
+  envInt("NODETOOL_JOB_REPLAY_BUFFER_EVENTS", 2000);
+const DETACH_GRACE_MS = () =>
+  envInt("NODETOOL_JOB_DETACH_GRACE_MS", 10 * 60 * 1000);
+const RETENTION_MS = () =>
+  envInt("NODETOOL_JOB_REPLAY_RETENTION_MS", 5 * 60 * 1000);
+
+/**
+ * A connection that can deliver frames to its client.
+ *
+ * One at a time: {@link JobRunSession.attach} replaces the target rather than
+ * fanning out, so a second tab resubscribing to a run takes the stream from
+ * the first. Same as a chat turn, and the same trade — a client that wants
+ * two views of one run opens them against one socket.
+ */
+export interface JobRunDeliveryTarget {
+  deliver(message: Record<string, unknown>): Promise<void>;
+}
+
+/**
+ * The executing connection's per-run hooks. Kept on the session so a
+ * different connection (post-reconnect) can route a client's `cancel_job` /
+ * `stop` / `stream_input` / `update_node_properties` back to the runner that
+ * actually owns the `ExecutionSession`.
+ */
+export interface JobRunExecutionHooks {
+  cancel(): void;
+  pushInput(input: string, value: unknown, handle?: string): Promise<void>;
+  finishInputStream(input: string, handle?: string): void;
+  updateNodeProperties(
+    nodeId: string,
+    properties: Record<string, unknown>
+  ): boolean;
+}
+
+export interface JobRunAttachResult {
+  /** Frames with `job_seq` greater than the requested `last_seq`. */
+  replay: Array<Record<string, unknown>>;
+  /** True when `last_seq` predates what the bounded buffer still holds. */
+  incomplete: boolean;
+}
+
+interface BufferedEvent {
+  seq: number;
+  message: Record<string, unknown>;
+}
+
+export class JobRunSession {
+  readonly userId: string;
+  readonly jobId: string;
+  readonly workflowId: string | null;
+  status: "running" | "finished" = "running";
+  /** The run's outcome, once known. Reported in the `job_resumed` header. */
+  terminalStatus: string | null = null;
+
+  private seq = 0;
+  private buffer: BufferedEvent[] = [];
+  /** Highest seq evicted from the bounded buffer (0 = nothing evicted). */
+  private evictedThroughSeq = 0;
+  private target: JobRunDeliveryTarget | null = null;
+  /**
+   * Serializes delivery: replayed frames enqueue before any live frame that
+   * arrives after attach, so the client always sees seq order. Unbounded —
+   * a slow socket grows the chain rather than applying backpressure to the
+   * run; the buffer above is what bounds memory. Mirrored from the chat
+   * turn's chain.
+   */
+  private deliveryChain: Promise<void> = Promise.resolve();
+  private detachTimer: NodeJS.Timeout | null = null;
+  private retentionTimer: NodeJS.Timeout | null = null;
+
+  constructor(
+    userId: string,
+    jobId: string,
+    workflowId: string | null,
+    readonly hooks: JobRunExecutionHooks,
+    private readonly onDrop: (session: JobRunSession) => void
+  ) {
+    this.userId = userId;
+    this.jobId = jobId;
+    this.workflowId = workflowId;
+  }
+
+  get lastSeq(): number {
+    return this.seq;
+  }
+
+  /**
+   * Stamp, buffer, and (when a connection is attached) deliver one frame.
+   * Returns the stamped copy.
+   */
+  emit(message: Record<string, unknown>): Record<string, unknown> {
+    this.seq += 1;
+    const stamped = { ...message, job_seq: this.seq };
+    this.buffer.push({ seq: this.seq, message: stamped });
+    const max = MAX_BUFFERED_EVENTS();
+    while (this.buffer.length > max) {
+      const evicted = this.buffer.shift();
+      if (evicted) this.evictedThroughSeq = evicted.seq;
+    }
+    const target = this.target;
+    if (target) {
+      this.enqueueDelivery(() => target.deliver(stamped));
+    }
+    return stamped;
+  }
+
+  /**
+   * Attach a connection and hand back the frames it missed. Live frames
+   * emitted after this call are delivered to the new target, strictly after
+   * the returned replay is delivered (both ride {@link deliveryChain} when
+   * sent via {@link deliverReplay}).
+   */
+  attach(target: JobRunDeliveryTarget, lastSeq: number): JobRunAttachResult {
+    this.clearDetachTimer();
+    this.target = target;
+    const replay = this.buffer
+      .filter((e) => e.seq > lastSeq)
+      .map((e) => e.message);
+    return { replay, incomplete: lastSeq < this.evictedThroughSeq };
+  }
+
+  /** Deliver frames on the session's ordered delivery chain. */
+  deliverReplay(
+    target: JobRunDeliveryTarget,
+    frames: Array<Record<string, unknown>>
+  ): Promise<void> {
+    for (const frame of frames) {
+      this.enqueueDelivery(() => target.deliver(frame));
+    }
+    return this.deliveryChain;
+  }
+
+  /**
+   * The attached connection went away. A running job keeps executing and
+   * buffering; if nobody reattaches within the grace window the run is
+   * cancelled so it cannot burn spend unattended forever.
+   */
+  detach(target?: JobRunDeliveryTarget): void {
+    if (target && this.target !== target) return;
+    this.target = null;
+    if (this.status !== "running") return;
+    this.clearDetachTimer();
+    this.detachTimer = setTimeout(() => {
+      log.info("Detached job run expired, cancelling", { jobId: this.jobId });
+      this.cancel();
+    }, DETACH_GRACE_MS());
+    this.detachTimer.unref?.();
+  }
+
+  /** Cancel the run (client stop, or detach grace elapsed). */
+  cancel(): void {
+    this.hooks.cancel();
+  }
+
+  /**
+   * The run reached a terminal state. The session sticks around (still
+   * replayable) for the retention window, then drops out of the registry.
+   */
+  finish(terminalStatus?: string): void {
+    if (terminalStatus) this.terminalStatus = terminalStatus;
+    if (this.status === "finished") return;
+    this.status = "finished";
+    this.clearDetachTimer();
+    this.retentionTimer = setTimeout(() => this.onDrop(this), RETENTION_MS());
+    this.retentionTimer.unref?.();
+  }
+
+  /** Release timers when the registry drops the session. */
+  dispose(): void {
+    this.clearDetachTimer();
+    if (this.retentionTimer) {
+      clearTimeout(this.retentionTimer);
+      this.retentionTimer = null;
+    }
+  }
+
+  private clearDetachTimer(): void {
+    if (this.detachTimer) {
+      clearTimeout(this.detachTimer);
+      this.detachTimer = null;
+    }
+  }
+
+  private enqueueDelivery(fn: () => Promise<void>): void {
+    this.deliveryChain = this.deliveryChain.then(fn).catch((err) => {
+      log.warn("Job run delivery failed", {
+        jobId: this.jobId,
+        error: err instanceof Error ? err.message : String(err)
+      });
+    });
+  }
+}
+
+export class JobRunRegistry {
+  private sessions = new Map<string, JobRunSession>();
+
+  private key(userId: string, jobId: string): string {
+    return `${userId} ${jobId}`;
+  }
+
+  /**
+   * Open a session for a starting run. Job ids are unique, so an entry that
+   * already exists can only mean the same id was started twice — cancel the
+   * stale run before dropping it. Dropping alone would leave it executing
+   * with nothing that can reach it: no grace timer, no cancel path, no
+   * replay.
+   */
+  open(
+    userId: string,
+    jobId: string,
+    workflowId: string | null,
+    hooks: JobRunExecutionHooks
+  ): JobRunSession {
+    const key = this.key(userId, jobId);
+    const existing = this.sessions.get(key);
+    if (existing) {
+      log.warn("Job session reopened for an id already running", { jobId });
+      if (existing.status === "running") existing.cancel();
+      this.drop(existing);
+    }
+    const session = new JobRunSession(userId, jobId, workflowId, hooks, (s) =>
+      this.drop(s)
+    );
+    this.sessions.set(key, session);
+    return session;
+  }
+
+  get(userId: string, jobId: string): JobRunSession | null {
+    return this.sessions.get(this.key(userId, jobId)) ?? null;
+  }
+
+  /**
+   * Runs still executing for a user, across every connection. The
+   * concurrency caps count runs, not sockets: a detached run still occupies
+   * a slot, or a client could reconnect its way past the cap simply by
+   * abandoning sockets.
+   */
+  countRunning(userId: string): number {
+    let count = 0;
+    for (const session of this.sessions.values()) {
+      if (session.userId === userId && session.status === "running") count += 1;
+    }
+    return count;
+  }
+
+  /** Same, narrowed to one workflow — the per-workflow cap's denominator. */
+  countRunningForWorkflow(userId: string, workflowId: string): number {
+    let count = 0;
+    for (const session of this.sessions.values()) {
+      if (
+        session.userId === userId &&
+        session.workflowId === workflowId &&
+        session.status === "running"
+      ) {
+        count += 1;
+      }
+    }
+    return count;
+  }
+
+  drop(session: JobRunSession): void {
+    const key = this.key(session.userId, session.jobId);
+    if (this.sessions.get(key) === session) {
+      this.sessions.delete(key);
+    }
+    session.dispose();
+  }
+}
+
+/** Process-wide registry: sessions survive their originating connection. */
+export const jobRunRegistry = new JobRunRegistry();

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -3796,17 +3796,28 @@ export class UnifiedWebSocketRunner {
               // against the in-memory set — one DB read per node, not per slot.
               let persistedIndices = persistedIndexByNode.get(nodeId);
               if (persistedIndices === undefined) {
-                const [persisted] = await Asset.paginate(userId, {
-                  jobId: active.jobId,
-                  nodeId,
-                  limit: 1000
-                });
                 persistedIndices = new Set<number>();
-                for (const a of persisted) {
-                  const gi = (
-                    a.metadata as { generation_index?: unknown } | null
-                  )?.generation_index;
-                  if (typeof gi === "number") persistedIndices.add(gi);
+                // Best-effort like every other persistence on this path: a
+                // DB-free run (session persistence in the reliability harness,
+                // a misconfigured deployment) must degrade to skipping the
+                // replay dedupe, not kill the drain loop and fail the job.
+                try {
+                  const [persisted] = await Asset.paginate(userId, {
+                    jobId: active.jobId,
+                    nodeId,
+                    limit: 1000
+                  });
+                  for (const a of persisted) {
+                    const gi = (
+                      a.metadata as { generation_index?: unknown } | null
+                    )?.generation_index;
+                    if (typeof gi === "number") persistedIndices.add(gi);
+                  }
+                } catch (err) {
+                  log.warn("generation replay-dedupe read failed", {
+                    nodeId,
+                    error: err instanceof Error ? err.message : String(err)
+                  });
                 }
                 persistedIndexByNode.set(nodeId, persistedIndices);
               }
@@ -4177,14 +4188,21 @@ export class UnifiedWebSocketRunner {
     }
     active.status = "cancelled";
 
-    // Persist the cancellation to the DB and announce it right away, mirroring
-    // the queued branch and the tRPC jobs.cancel path. The runner's own cleanup
-    // can lag (it drains in-flight messages before its .finally() persists), so
+    // Persist the cancellation to the DB right away, mirroring the queued
+    // branch and the tRPC jobs.cancel path. The runner's own cleanup can lag
+    // (it drains in-flight messages before its .finally() persists), so
     // without this the persisted row stays "running" and jobs.list — which the
     // Queue panel reads from — keeps reporting the job as running even though
-    // the toolbar Stop already fired. Marking it cancelled here, plus the
-    // job_update below, lets clients refetch and reflect the stop immediately.
-    const cancelledWorkflowId = workflowId ?? active.workflowId ?? null;
+    // the toolbar Stop already fired.
+    //
+    // Deliberately NO eager `job_update cancelled` frame here: the kernel's
+    // own terminal frame relays through the drain loop AFTER the node-level
+    // terminal updates, and an out-of-band frame ahead of them tells the
+    // client the job is over while nodes still read "running" — the exact
+    // lifecycle violation the reliability harness's mid-run-cancel journeys
+    // pin (`lifecycle.running-after-job-terminal`), and what left canvas
+    // nodes stuck spinning after a Stop. The `cancel_job` RPC response is the
+    // immediate acknowledgement; the ordered terminal arrives a beat later.
     if (
       (active.executionOptions?.persistence ??
         DEFAULT_RUN_JOB_EXECUTION_OPTIONS.persistence) === "job"
@@ -4199,12 +4217,7 @@ export class UnifiedWebSocketRunner {
         this.logError("cancel persistence failed", err);
       }
     }
-    await this.sendMessage({
-      type: "job_update",
-      status: "cancelled",
-      job_id: jobId,
-      workflow_id: cancelledWorkflowId
-    });
+    const cancelledWorkflowId = workflowId ?? active.workflowId ?? null;
 
     // Do NOT set active.finished = true here. Let the runner's cancellation
     // propagate through executePromise's .finally() callback so that

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -43,6 +43,11 @@ import {
   type ChatTurnSession
 } from "./chat-turn-registry.js";
 import {
+  jobRunRegistry,
+  type JobRunExecutionHooks,
+  type JobRunSession
+} from "./job-run-registry.js";
+import {
   Application,
   Asset,
   ImageDocument,
@@ -1687,10 +1692,22 @@ interface ActiveJob {
     metadata: Record<string, unknown>;
   };
   streamTask?: Promise<void>;
+  /**
+   * The detachable session this run's frames are stamped and buffered into,
+   * so a client that drops mid-run can replay what it missed. Absent for runs
+   * this connection never registered (a chat-triggered workflow run).
+   */
+  runSession?: JobRunSession;
   /** Running sum of node-level provider charges (e.g. kie credits) for this run. */
   providerCostTotal?: number;
   /** Mini app this run belongs to, when one started it. Drives budget settlement. */
   applicationId?: string | null;
+}
+
+/** Highest `job_seq` a resubscribing client claims to already hold. */
+function resumeLastSeq(data: Record<string, unknown>): number {
+  const raw = data["last_seq"];
+  return typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? raw : 0;
 }
 
 function createRelayActivityWaiter(
@@ -1933,7 +1950,10 @@ export class UnifiedWebSocketRunner {
    * whose `cleanup-leaks` invariant can only assert what it can measure.
    */
   get slotCounters(): { activeJobs: number; startingJobs: number } {
-    return { activeJobs: this.activeJobs.size, startingJobs: this.startingJobs };
+    return {
+      activeJobs: this.activeJobs.size,
+      startingJobs: this.startingJobs
+    };
   }
   private currentTask: Promise<void> | null = null;
   private heartbeatTimer: NodeJS.Timeout | null = null;
@@ -1978,6 +1998,28 @@ export class UnifiedWebSocketRunner {
    * still points at THIS connection — never a newer one that reattached.
    */
   private readonly chatDeliveryTarget = {
+    deliver: (message: Record<string, unknown>): Promise<void> =>
+      this.sendToSocket(message)
+  };
+  /**
+   * Job ids of runs still executing on a previous connection's runner that
+   * THIS connection reattached to via `reconnect_job`. Client commands for
+   * them (`cancel_job`, `stop`, `stream_input`, `end_input_stream`,
+   * `update_node_properties`) are forwarded to the executing runner through
+   * the session's hooks.
+   *
+   * Ids, not session objects: holding the session would pin its frame buffer
+   * for this connection's whole life, defeating the registry's retention
+   * drop. Resolved through the registry at every use, so a dropped session
+   * simply resolves to null and its memory goes with it.
+   */
+  private adoptedJobIds = new Set<string>();
+  /**
+   * This connection's identity as a job-run delivery target. Separate object
+   * from {@link chatDeliveryTarget} so a job session's `detach(target)` can
+   * never be confused with a chat session's — both guard on identity.
+   */
+  private readonly jobDeliveryTarget = {
     deliver: (message: Record<string, unknown>): Promise<void> =>
       this.sendToSocket(message)
   };
@@ -2203,12 +2245,26 @@ export class UnifiedWebSocketRunner {
     }
     this.adoptedSessions.clear();
     this.currentTask = null;
+    // A run with a resilient session survives the socket: detach it (frames
+    // keep buffering for replay, and `streamJobMessages` keeps draining on
+    // this now-socketless runner) instead of cancelling. The session's
+    // detach-grace timer bounds how long it may run unattended. A run without
+    // one — a chat-triggered workflow, whose owning turn is cancelled anyway
+    // — is cancelled as before: nobody is left to receive its output.
     for (const [jobId, job] of this.activeJobs) {
-      if (job.session) {
-        job.session.cancel();
+      if (job.runSession) {
+        job.runSession.detach(this.jobDeliveryTarget);
+        continue;
       }
+      job.session?.cancel();
       this.activeJobs.delete(jobId);
     }
+    for (const adoptedId of this.adoptedJobIds) {
+      jobRunRegistry
+        .get(this.userId ?? "1", adoptedId)
+        ?.detach(this.jobDeliveryTarget);
+    }
+    this.adoptedJobIds.clear();
 
     // Drain runs that were still queued (never started): the client is gone,
     // so they will never run. Mark their persisted rows cancelled instead of
@@ -2281,7 +2337,60 @@ export class UnifiedWebSocketRunner {
       session.emit(message);
       return;
     }
+    // Same for a resilient run's frames — including its terminal job_update,
+    // which is the one frame a reconnecting client most needs replayed.
+    // Adopted sessions are checked too so a `cancel_job` this connection
+    // issued against a run owned by another connection still buffers its
+    // acknowledgement into that run's session rather than only this socket.
+    const jobSession = this.resolveJobSession(message.job_id);
+    if (jobSession && jobSession.status === "running") {
+      jobSession.emit(message);
+      return;
+    }
     await this.sendToSocket(message);
+  }
+
+  /**
+   * The resilient session a frame's `job_id` belongs to: one this connection
+   * started, or one it adopted via `reconnect_job`.
+   */
+  private resolveJobSession(jobId: unknown): JobRunSession | null {
+    if (typeof jobId !== "string" || jobId.length === 0) return null;
+    const active = this.activeJobs.get(jobId);
+    if (active?.runSession) return active.runSession;
+    if (!this.adoptedJobIds.has(jobId)) return null;
+    return jobRunRegistry.get(this.userId ?? "1", jobId);
+  }
+
+  /**
+   * Where a client command for `jobId` should act: this connection's own
+   * ExecutionSession, or — for a run this client reconnected to — the hooks
+   * of the session whose runner still owns it. Null when nothing is running.
+   */
+  private resolveJobControl(
+    jobId: string
+  ): { hooks: JobRunExecutionHooks; workflowId: string | null } | null {
+    const active = this.activeJobs.get(jobId);
+    if (active) {
+      const session = active.session;
+      return {
+        workflowId: active.workflowId,
+        hooks: {
+          cancel: () => session.cancel(),
+          pushInput: (input, value, handle) =>
+            session.pushInput(input, value, handle),
+          finishInputStream: (input, handle) =>
+            session.finishInputStream(input, handle),
+          updateNodeProperties: (nodeId, properties) =>
+            session.updateNodeProperties(nodeId, properties)
+        }
+      };
+    }
+    const registered = jobRunRegistry.get(this.userId ?? "1", jobId);
+    if (registered && registered.status === "running") {
+      return { hooks: registered.hooks, workflowId: registered.workflowId };
+    }
+    return null;
   }
 
   /** Raw socket delivery — no chat-turn interception. */
@@ -2607,17 +2716,35 @@ export class UnifiedWebSocketRunner {
     return { value, at: now };
   }
 
-  /** Jobs occupying a concurrency slot: live + reserved-but-not-yet-registered. */
+  /**
+   * Jobs occupying a concurrency slot: live + reserved-but-not-yet-registered.
+   *
+   * The cap counts a *user's* runs, not a socket's. A run detached from a
+   * dropped connection keeps executing, so counting only `activeJobs` would
+   * let a client reconnect its way past the cap — four abandoned sockets and
+   * a fresh one is eight concurrent runs. The registry is the cross-
+   * connection count; `activeJobs` contributes only the entries it does not
+   * already cover (a chat-triggered workflow run, which registers no
+   * session), or the same run would be counted twice.
+   */
   private get inFlightJobCount(): number {
-    return this.activeJobs.size + this.startingJobs;
+    let sessionless = 0;
+    for (const job of this.activeJobs.values()) {
+      if (!job.runSession) sessionless += 1;
+    }
+    return (
+      this.startingJobs +
+      jobRunRegistry.countRunning(this.userId ?? "1") +
+      sessionless
+    );
   }
 
   /**
    * Number of live (unfinished) runs currently executing for a workflow. Used
    * to enforce the per-workflow concurrency limit so non-concurrent runs stay
    * sequential and their live node updates don't clobber each other in the
-   * editor. Safe to check against `activeJobs` alone: commands are processed
-   * one-at-a-time and `startJobInner` registers the job before returning.
+   * editor. Counted the same way as {@link inFlightJobCount}: the registry
+   * across connections, plus this connection's sessionless entries.
    */
   private countActiveJobsForWorkflow(
     workflowId: string | null | undefined
@@ -2625,9 +2752,12 @@ export class UnifiedWebSocketRunner {
     if (!workflowId) {
       return 0;
     }
-    let count = 0;
+    let count = jobRunRegistry.countRunningForWorkflow(
+      this.userId ?? "1",
+      workflowId
+    );
     for (const job of this.activeJobs.values()) {
-      if (job.workflowId === workflowId && !job.finished) {
+      if (!job.runSession && job.workflowId === workflowId && !job.finished) {
         count++;
       }
     }
@@ -3253,11 +3383,43 @@ export class UnifiedWebSocketRunner {
       },
       applicationId: req.application_id ?? null
     };
+    // Decouple the run from this socket: from here on every frame carrying
+    // this job_id is stamped with `job_seq` and buffered, so a client that
+    // drops mid-run can `reconnect_job` from a fresh connection and replay
+    // the tail — including the terminal job_update.
+    //
+    // Keyed on the connection's identity, not `userId`: every lookup
+    // (`reconnect_job`, `cancel_job`, the slot counts) reads
+    // `this.userId ?? "1"`, and a run opened under an explicit differing
+    // `req.user_id` would be unreachable — no replay, and a cancel that
+    // reports the job as not found.
+    const runSession = jobRunRegistry.open(
+      this.userId ?? "1",
+      jobId,
+      workflowId,
+      {
+        cancel: () => session.cancel(),
+        pushInput: (input, value, handle) =>
+          session.pushInput(input, value, handle),
+        finishInputStream: (input, handle) =>
+          session.finishInputStream(input, handle),
+        updateNodeProperties: (nodeId, properties) =>
+          session.updateNodeProperties(nodeId, properties)
+      }
+    );
+    runSession.attach(this.jobDeliveryTarget, runSession.lastSeq);
+    active.runSession = runSession;
     this.activeJobs.set(jobId, active);
-    // Slot ownership transfers from startingJobs to activeJobs now that the
-    // job is registered and counted by activeJobs.size.
+    // Slot ownership transfers from startingJobs to the registry's running
+    // count now that the job is registered. Released before the DB check
+    // below so the reservation and the registry entry never both count.
     releaseSlot();
     log.info("Job started", { jobId, workflowId });
+    await this.settleRunAgainstLostConnection(
+      runSession,
+      jobId,
+      executionOptions
+    );
 
     // The run itself already started inside `ExecutionSession.create()`
     // above — `session.result` is the same never-rejecting terminal-result
@@ -3272,6 +3434,43 @@ export class UnifiedWebSocketRunner {
         this.logError("job stream task failed", error);
       }
     );
+  }
+
+  /**
+   * A run whose start was mid-flight when `disconnect()` fired registers
+   * AFTER that walk of `activeJobs`, so nothing detached it and nothing
+   * armed its grace timer — it would execute unattended forever, delivering
+   * into a dead target. Two fixes, both after registration:
+   *   - no live socket: detach, which starts the detach-grace countdown;
+   *   - the row already reads cancelled: `disconnect()`'s queue drain (or a
+   *     DB-only cancel) settled it while this run was starting, so cancel
+   *     the run rather than let it execute to completion under a row that
+   *     says it never did.
+   */
+  private async settleRunAgainstLostConnection(
+    runSession: JobRunSession,
+    jobId: string,
+    executionOptions: RunJobExecutionOptions
+  ): Promise<void> {
+    const socketGone =
+      !this.websocket ||
+      this.websocket.clientState === "disconnected" ||
+      this.websocket.applicationState === "disconnected";
+    if (socketGone) {
+      runSession.detach(this.jobDeliveryTarget);
+    }
+    if (executionOptions.persistence !== "job") return;
+    try {
+      const job = await Job.get(jobId);
+      if (job?.status === "cancelled") {
+        log.info("Job was cancelled while starting, cancelling the run", {
+          jobId
+        });
+        runSession.cancel();
+      }
+    } catch (error) {
+      this.logError("post-start cancellation check failed", error);
+    }
   }
 
   private async streamJobMessages(
@@ -3319,6 +3518,10 @@ export class UnifiedWebSocketRunner {
       await this.persistTerminalJobStatus(active);
       await this.settleApplicationInvocation(active);
     } finally {
+      // Terminal: the session stops buffering and starts its retention
+      // window, so a client reconnecting shortly after still gets the tail
+      // (and the outcome) before the persisted row becomes the only source.
+      active.runSession?.finish(active.status);
       this.activeJobs.delete(active.jobId);
       this.drainQueue();
     }
@@ -3784,20 +3987,67 @@ export class UnifiedWebSocketRunner {
     // finally, so they run even if the drain loop above throws.
   }
 
-  async reconnectJob(jobId: string, workflowId?: string): Promise<void> {
+  async reconnectJob(
+    jobId: string,
+    workflowId?: string,
+    lastSeq = 0
+  ): Promise<void> {
+    // A resilient session is the authoritative answer: the run may be
+    // executing on another connection's runner right now, or have finished
+    // while this client was away — either way the seq-stamped buffer holds
+    // exactly what was missed. Adopt it so this connection's `cancel_job` /
+    // `stream_input` / `stop` reach the runner that owns the ExecutionSession.
+    const registered = jobRunRegistry.get(this.userId ?? "1", jobId);
+    if (registered) {
+      const { replay, incomplete } = registered.attach(
+        this.jobDeliveryTarget,
+        lastSeq
+      );
+      if (registered.status === "running") {
+        this.adoptedJobIds.add(jobId);
+      }
+      // Header first, then the missed tail; live frames queue behind them on
+      // the session's ordered delivery chain.
+      await registered.deliverReplay(this.jobDeliveryTarget, [
+        {
+          type: "job_resumed",
+          job_id: jobId,
+          workflow_id: workflowId ?? registered.workflowId ?? null,
+          status: registered.status,
+          last_seq: registered.lastSeq,
+          replay_count: replay.length,
+          replay_incomplete: incomplete
+        },
+        ...replay
+      ]);
+      return;
+    }
+
     const active = this.activeJobs.get(jobId);
     if (!active) {
-      // Reconnecting to a job that already finished (or one this server never
-      // had) is a normal client flow after a socket blip. Reply with the job's
-      // terminal state from the persisted row instead of throwing — a throw
-      // here became an unhandled promise rejection (the caller only `void`s
-      // this) and left the client waiting for state that never arrived.
+      // No session and no in-memory job: the run ended long enough ago that
+      // retention elapsed, or this process never had it. A row that already
+      // reached a settled outcome is echoed verbatim — a completed run stays
+      // completed, and the replay-unavailable note rides alongside as an
+      // `error` string explaining only the missing events.
+      //
+      // Every other row status (queued, scheduled, running, recovering,
+      // suspended, paused) is reported as failed: nothing is left that could
+      // ever send this client another frame, and reporting the row as-is
+      // parks the UI in a state that never settles — a `queued` row from a
+      // dead connection's drained queue reads as "running" with a live Stop
+      // button forever.
       const job = (await Job.get(jobId)) as Job | null;
+      const settled =
+        job != null &&
+        (job.status === "completed" ||
+          job.status === "failed" ||
+          job.status === "cancelled");
       const replayUnavailable =
         job != null && job.status !== "failed" && job.status !== "cancelled";
       await this.sendMessage({
         type: "job_update",
-        status: replayUnavailable ? "failed" : (job?.status ?? "failed"),
+        status: settled ? job.status : "failed",
         job_id: jobId,
         workflow_id: workflowId ?? job?.workflow_id ?? null,
         ...(job
@@ -3837,8 +4087,12 @@ export class UnifiedWebSocketRunner {
     }
   }
 
-  async resumeJob(jobId: string, workflowId?: string): Promise<void> {
-    await this.reconnectJob(jobId, workflowId);
+  async resumeJob(
+    jobId: string,
+    workflowId?: string,
+    lastSeq = 0
+  ): Promise<void> {
+    await this.reconnectJob(jobId, workflowId, lastSeq);
   }
 
   async cancelJob(
@@ -3888,6 +4142,29 @@ export class UnifiedWebSocketRunner {
 
     const active = this.activeJobs.get(jobId);
     if (!active) {
+      // Not ours, but possibly still running on the connection that started
+      // it (this client reconnected after a drop). Cancel through the
+      // session's hooks and persist the row here — the owning runner's own
+      // terminal bookkeeping still runs, and its `job_update` reaches this
+      // client over the session it just adopted.
+      const registered = jobRunRegistry.get(this.userId ?? "1", jobId);
+      if (registered && registered.status === "running") {
+        registered.cancel();
+        try {
+          const job = await Job.get(jobId);
+          if (job && job.status !== "cancelled") {
+            job.markCancelled();
+            await job.save();
+          }
+        } catch (err) {
+          this.logError("cancel persistence failed", err);
+        }
+        return {
+          message: "Job cancellation requested",
+          job_id: jobId,
+          workflow_id: workflowId ?? registered.workflowId ?? ""
+        };
+      }
       return {
         error: "Job not found or already completed",
         job_id: jobId,
@@ -7604,9 +7881,11 @@ export class UnifiedWebSocketRunner {
         if (!jobId) return { error: "job_id is required" };
         // Await so an error can't escape as an unhandled rejection; reconnectJob
         // only replays state (it does not run the job), so this stays quick.
-        await this.reconnectJob(jobId, workflowId).catch((err) => {
-          log.warn("reconnect_job failed", { jobId, error: String(err) });
-        });
+        await this.reconnectJob(jobId, workflowId, resumeLastSeq(data)).catch(
+          (err) => {
+            log.warn("reconnect_job failed", { jobId, error: String(err) });
+          }
+        );
         return {
           message: `Reconnecting to job ${jobId}`,
           job_id: jobId,
@@ -7614,9 +7893,11 @@ export class UnifiedWebSocketRunner {
         };
       case "resume_job":
         if (!jobId) return { error: "job_id is required" };
-        await this.resumeJob(jobId, workflowId).catch((err) => {
-          log.warn("resume_job failed", { jobId, error: String(err) });
-        });
+        await this.resumeJob(jobId, workflowId, resumeLastSeq(data)).catch(
+          (err) => {
+            log.warn("resume_job failed", { jobId, error: String(err) });
+          }
+        );
         return {
           message: `Resumption initiated for job ${jobId}`,
           job_id: jobId,
@@ -7625,27 +7906,27 @@ export class UnifiedWebSocketRunner {
       case "stream_input":
         if (!jobId) return { error: "job_id is required" };
         {
-          const active = this.activeJobs.get(jobId);
+          const target = this.resolveJobControl(jobId);
           log.info("stream_input command", {
             jobId,
-            hasActive: !!active,
+            hasActive: !!target,
             inputName: data.input,
             handle: data.handle,
             hasValue: data.value !== undefined,
             activeJobIds: [...this.activeJobs.keys()]
           });
-          if (!active) return { error: "No active job/context" };
+          if (!target) return { error: "No active job/context" };
           const inputName = typeof data.input === "string" ? data.input : "";
           if (!inputName.trim()) return { error: "Invalid input name" };
           const value = data.value;
           const handle =
             typeof data.handle === "string" ? data.handle : undefined;
           try {
-            await active.session.pushInput(inputName, value, handle);
+            await target.hooks.pushInput(inputName, value, handle);
             return {
               message: "Input item streamed",
               job_id: jobId,
-              workflow_id: workflowId ?? active.workflowId
+              workflow_id: workflowId ?? target.workflowId
             };
           } catch (err) {
             log.error("stream_input failed", {
@@ -7654,31 +7935,31 @@ export class UnifiedWebSocketRunner {
             return {
               error: err instanceof Error ? err.message : String(err),
               job_id: jobId,
-              workflow_id: workflowId ?? active.workflowId
+              workflow_id: workflowId ?? target.workflowId
             };
           }
         }
       case "end_input_stream":
         if (!jobId) return { error: "job_id is required" };
         {
-          const active = this.activeJobs.get(jobId);
-          if (!active) return { error: "No active job/context" };
+          const target = this.resolveJobControl(jobId);
+          if (!target) return { error: "No active job/context" };
           const inputName = typeof data.input === "string" ? data.input : "";
           if (!inputName.trim()) return { error: "Invalid input name" };
           const handle =
             typeof data.handle === "string" ? data.handle : undefined;
           try {
-            active.session.finishInputStream(inputName, handle);
+            target.hooks.finishInputStream(inputName, handle);
             return {
               message: "Input stream ended",
               job_id: jobId,
-              workflow_id: workflowId ?? active.workflowId
+              workflow_id: workflowId ?? target.workflowId
             };
           } catch (err) {
             return {
               error: err instanceof Error ? err.message : String(err),
               job_id: jobId,
-              workflow_id: workflowId ?? active.workflowId
+              workflow_id: workflowId ?? target.workflowId
             };
           }
         }
@@ -7698,9 +7979,9 @@ export class UnifiedWebSocketRunner {
         if (properties === null || typeof properties !== "object") {
           return { error: "properties must be an object" };
         }
-        const active = this.activeJobs.get(jobId);
+        const target = this.resolveJobControl(jobId);
         const applied =
-          active?.session.updateNodeProperties(
+          target?.hooks.updateNodeProperties(
             nodeId,
             properties as Record<string, unknown>
           ) ?? false;
@@ -7836,6 +8117,13 @@ export class UnifiedWebSocketRunner {
           if (active) {
             active.session.cancel();
             active.status = "cancelled";
+          } else {
+            // The run may be executing on the connection that started it —
+            // this client reconnected to it. Cancel through its hooks.
+            const registered = jobRunRegistry.get(this.userId ?? "1", jobId);
+            if (registered && registered.status === "running") {
+              registered.cancel();
+            }
           }
         }
         const stopScope = threadId ?? jobId;

--- a/packages/websocket/tests/job-run-registry.test.ts
+++ b/packages/websocket/tests/job-run-registry.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  JobRunRegistry,
+  type JobRunExecutionHooks
+} from "../src/job-run-registry.js";
+
+function makeHooks(): JobRunExecutionHooks & { cancels: number } {
+  const state = { cancels: 0 };
+  return {
+    get cancels() {
+      return state.cancels;
+    },
+    cancel: () => {
+      state.cancels += 1;
+    },
+    pushInput: vi.fn().mockResolvedValue(undefined),
+    finishInputStream: vi.fn(),
+    updateNodeProperties: vi.fn().mockReturnValue(true)
+  };
+}
+
+function makeTarget() {
+  const delivered: Array<Record<string, unknown>> = [];
+  return {
+    delivered,
+    deliver: async (message: Record<string, unknown>) => {
+      delivered.push(message);
+    }
+  };
+}
+
+describe("JobRunSession", () => {
+  let registry: JobRunRegistry;
+
+  beforeEach(() => {
+    registry = new JobRunRegistry();
+  });
+
+  it("stamps emitted frames with increasing job_seq and delivers to the attached target", async () => {
+    const session = registry.open("u1", "j1", "wf1", makeHooks());
+    const target = makeTarget();
+    session.attach(target, session.lastSeq);
+
+    session.emit({ type: "node_update", job_id: "j1", node_id: "n1" });
+    session.emit({ type: "node_update", job_id: "j1", node_id: "n2" });
+    await session.deliverReplay(target, []); // flush the delivery chain
+
+    expect(target.delivered.map((m) => m.job_seq)).toEqual([1, 2]);
+    expect(target.delivered.map((m) => m.node_id)).toEqual(["n1", "n2"]);
+  });
+
+  it("buffers while detached and replays only the missed tail on attach", async () => {
+    const session = registry.open("u1", "j1", "wf1", makeHooks());
+    const target = makeTarget();
+    session.attach(target, 0);
+    session.emit({ type: "node_update", job_id: "j1", node_id: "n1" });
+    await session.deliverReplay(target, []);
+
+    session.detach(target);
+    session.emit({ type: "node_update", job_id: "j1", node_id: "n2" });
+    session.emit({ type: "job_update", job_id: "j1", status: "completed" });
+    expect(target.delivered).toHaveLength(1);
+
+    const reconnected = makeTarget();
+    const { replay, incomplete } = session.attach(reconnected, 1);
+    expect(incomplete).toBe(false);
+    expect(replay.map((m) => m.type)).toEqual(["node_update", "job_update"]);
+
+    await session.deliverReplay(reconnected, replay);
+    session.emit({ type: "node_update", job_id: "j1", node_id: "n3" });
+    await session.deliverReplay(reconnected, []);
+    expect(reconnected.delivered).toHaveLength(3);
+  });
+
+  it("a guarded detach from a stale target does not clear a newer attachment", async () => {
+    const session = registry.open("u1", "j1", "wf1", makeHooks());
+    const oldTarget = makeTarget();
+    session.attach(oldTarget, 0);
+    const newTarget = makeTarget();
+    session.attach(newTarget, session.lastSeq);
+
+    session.detach(oldTarget);
+    session.emit({ type: "node_update", job_id: "j1" });
+    await session.deliverReplay(newTarget, []);
+    expect(newTarget.delivered).toHaveLength(1);
+  });
+
+  it("a delivery that throws does not stall the chain", async () => {
+    const session = registry.open("u1", "j1", "wf1", makeHooks());
+    const dead = {
+      deliver: async () => {
+        throw new Error("socket closed");
+      }
+    };
+    session.attach(dead, 0);
+    session.emit({ type: "node_update", job_id: "j1" });
+
+    const live = makeTarget();
+    const { replay } = session.attach(live, 0);
+    await session.deliverReplay(live, replay);
+    expect(live.delivered).toHaveLength(1);
+  });
+
+  it("reports an incomplete replay when the buffer evicted the requested tail", () => {
+    process.env.NODETOOL_JOB_REPLAY_BUFFER_EVENTS = "3";
+    try {
+      const session = registry.open("u1", "j1", "wf1", makeHooks());
+      for (let i = 0; i < 5; i++) {
+        session.emit({ type: "node_update", job_id: "j1", node_id: String(i) });
+      }
+      const target = makeTarget();
+      const { replay, incomplete } = session.attach(target, 1);
+      expect(incomplete).toBe(true);
+      expect(replay.map((m) => m.node_id)).toEqual(["2", "3", "4"]);
+    } finally {
+      delete process.env.NODETOOL_JOB_REPLAY_BUFFER_EVENTS;
+    }
+  });
+
+  it("records the run's terminal status on finish", () => {
+    const session = registry.open("u1", "j1", "wf1", makeHooks());
+    session.finish("completed");
+    expect(session.status).toBe("finished");
+    expect(session.terminalStatus).toBe("completed");
+  });
+
+  it("cancels a still-running session when its job id is reopened", () => {
+    const first = makeHooks();
+    registry.open("u1", "j1", "wf1", first);
+    const second = registry.open("u1", "j1", "wf1", makeHooks());
+
+    expect(first.cancels).toBe(1);
+    expect(registry.get("u1", "j1")).toBe(second);
+  });
+
+  it("counts running runs per user and per workflow across sessions", () => {
+    registry.open("u1", "j1", "wf1", makeHooks());
+    registry.open("u1", "j2", "wf1", makeHooks());
+    registry.open("u1", "j3", "wf2", makeHooks());
+    const other = registry.open("u2", "j4", "wf1", makeHooks());
+
+    expect(registry.countRunning("u1")).toBe(3);
+    expect(registry.countRunningForWorkflow("u1", "wf1")).toBe(2);
+    expect(registry.countRunning("u2")).toBe(1);
+
+    // A finished run no longer occupies a slot.
+    other.finish("completed");
+    expect(registry.countRunning("u2")).toBe(0);
+    expect(registry.countRunningForWorkflow("u2", "wf1")).toBe(0);
+  });
+
+  it("keys on the full user id even when it contains a space", () => {
+    const a = registry.open("u 1", "j1", "wf1", makeHooks());
+    const b = registry.open("u", "1 j1", "wf1", makeHooks());
+    expect(registry.get("u 1", "j1")).toBe(a);
+    expect(registry.get("u", "1 j1")).toBe(b);
+  });
+
+  it("sessions are scoped per user and per job", () => {
+    const a = registry.open("u1", "j1", "wf1", makeHooks());
+    expect(registry.get("u2", "j1")).toBeNull();
+    expect(registry.get("u1", "j2")).toBeNull();
+    expect(registry.get("u1", "j1")).toBe(a);
+  });
+
+  describe("timers", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("cancels a running job when the detach grace window elapses", () => {
+      const hooks = makeHooks();
+      const session = registry.open("u1", "j1", "wf1", hooks);
+      const target = makeTarget();
+      session.attach(target, 0);
+      session.detach(target);
+
+      vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+      expect(hooks.cancels).toBe(1);
+    });
+
+    it("does not cancel while a target is attached", () => {
+      const hooks = makeHooks();
+      const session = registry.open("u1", "j1", "wf1", hooks);
+      const target = makeTarget();
+      session.attach(target, 0);
+      session.detach(target);
+      session.attach(makeTarget(), session.lastSeq);
+
+      vi.advanceTimersByTime(60 * 60 * 1000);
+      expect(hooks.cancels).toBe(0);
+    });
+
+    it("does not cancel a finished job left detached", () => {
+      const hooks = makeHooks();
+      const session = registry.open("u1", "j1", "wf1", hooks);
+      session.finish("completed");
+      session.detach();
+
+      vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+      expect(hooks.cancels).toBe(0);
+    });
+
+    it("drops a finished session from the registry after the retention window", () => {
+      const session = registry.open("u1", "j1", "wf1", makeHooks());
+      session.finish("completed");
+      expect(registry.get("u1", "j1")).toBe(session);
+
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      expect(registry.get("u1", "j1")).toBeNull();
+    });
+  });
+});

--- a/packages/websocket/tests/job-run-resilience.test.ts
+++ b/packages/websocket/tests/job-run-resilience.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Workflow runs survive a dropped socket.
+ *
+ * A run registers a {@link JobRunSession} at start, so `disconnect()` detaches
+ * it instead of cancelling the run, every frame keeps being seq-stamped and
+ * buffered, and a *different* connection's `reconnect_job` replays the tail —
+ * including the terminal `job_update` — and can then cancel or feed the run
+ * through the session's hooks.
+ *
+ * These tests drive `streamJobMessages` directly against a fake ActiveJob (the
+ * same harness `unified-websocket-runner-runjob-coverage.test.ts` uses) so the
+ * disconnect can be timed precisely mid-run, and wire the session exactly as
+ * `startJobInner` does.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { unpack } from "msgpackr";
+import {
+  UnifiedWebSocketRunner,
+  resolveRunJobExecutionOptions,
+  type WebSocketConnection,
+  type WebSocketReceiveFrame
+} from "../src/unified-websocket-runner.js";
+import {
+  jobRunRegistry,
+  type JobRunExecutionHooks
+} from "../src/job-run-registry.js";
+import { initTestDb, Job } from "@nodetool-ai/models";
+
+class MockWebSocket implements WebSocketConnection {
+  clientState: "connected" | "disconnected" = "connected";
+  applicationState: "connected" | "disconnected" = "connected";
+  sentBytes: Uint8Array[] = [];
+  sentText: string[] = [];
+  queue: Array<WebSocketReceiveFrame> = [];
+  closed = false;
+
+  async accept(): Promise<void> {
+    return;
+  }
+  async receive(): Promise<WebSocketReceiveFrame> {
+    return this.queue.shift() ?? { type: "websocket.disconnect" };
+  }
+  async sendBytes(data: Uint8Array): Promise<void> {
+    this.sentBytes.push(data);
+  }
+  async sendText(data: string): Promise<void> {
+    this.sentText.push(data);
+  }
+  async close(): Promise<void> {
+    this.closed = true;
+    this.clientState = "disconnected";
+    this.applicationState = "disconnected";
+  }
+}
+
+const resolveExecutor = () => ({
+  async process() {
+    return {};
+  }
+});
+
+/** Reach the runner's private job wiring, the way the sibling suites do. */
+const asAny = (r: UnifiedWebSocketRunner) =>
+  r as unknown as Record<string, never> & {
+    activeJobs: Map<string, unknown>;
+    jobDeliveryTarget: { deliver(m: Record<string, unknown>): Promise<void> };
+    streamJobMessages(
+      active: unknown,
+      promise: Promise<unknown>
+    ): Promise<void>;
+  };
+
+function decodeAll(ws: MockWebSocket): Record<string, unknown>[] {
+  return [
+    ...ws.sentBytes.map((b) => unpack(b) as Record<string, unknown>),
+    ...ws.sentText.map((t) => JSON.parse(t) as Record<string, unknown>)
+  ];
+}
+
+function fakeContext() {
+  const q: Record<string, unknown>[] = [];
+  const listeners = new Set<() => void>();
+  return {
+    hasMessages: () => q.length > 0,
+    popMessage: () => q.shift(),
+    addMessageListener: (listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    emit: (message: Record<string, unknown>) => {
+      q.push(message);
+      for (const listener of listeners) listener();
+    },
+    normalizeOutputValue: vi.fn(async (v: unknown) => v),
+    getNodeStatuses: () => ({}),
+    getEdgeStatuses: () => ({})
+  };
+}
+
+function makeHooks(): JobRunExecutionHooks & {
+  cancel: ReturnType<typeof vi.fn>;
+  pushInput: ReturnType<typeof vi.fn>;
+} {
+  return {
+    cancel: vi.fn(),
+    pushInput: vi.fn().mockResolvedValue(undefined),
+    finishInputStream: vi.fn(),
+    updateNodeProperties: vi.fn().mockReturnValue(true)
+  };
+}
+
+/**
+ * Register a running job on `runner` the way `startJobInner` does: a fake
+ * ActiveJob in `activeJobs`, plus a registry session attached to that
+ * connection's job delivery target.
+ */
+function registerRun(
+  runner: UnifiedWebSocketRunner,
+  jobId: string,
+  hooks: JobRunExecutionHooks
+) {
+  const context = fakeContext();
+  const now = performance.now();
+  const active = {
+    jobId,
+    workflowId: "wf",
+    context,
+    session: { cancel: vi.fn() },
+    graph: { nodes: [], edges: [] },
+    finished: false,
+    status: "running" as const,
+    requireTerminalResult: false,
+    executionOptions: resolveRunJobExecutionOptions({ persistence: "job" }),
+    timings: {
+      acceptedAt: now,
+      queueMs: 0,
+      graphLoadedMs: 0,
+      graphHydratedMs: 0,
+      preRunMs: 0,
+      persistenceMs: 0,
+      kernelStartedAt: now
+    },
+    runSession: jobRunRegistry.open("1", jobId, "wf", hooks)
+  };
+  active.runSession.attach(asAny(runner).jobDeliveryTarget, 0);
+  asAny(runner).activeJobs.set(jobId, active);
+  registeredJobIds.push(jobId);
+  return active;
+}
+
+/**
+ * The registry is process-wide, so a run one test leaves executing would
+ * still occupy a concurrency slot in the next. Torn down per test.
+ */
+const registeredJobIds: string[] = [];
+function dropRegisteredRuns(): void {
+  for (const jobId of registeredJobIds.splice(0)) {
+    const session = jobRunRegistry.get("1", jobId);
+    if (session) jobRunRegistry.drop(session);
+  }
+}
+
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (!predicate()) {
+    if (Date.now() > deadline)
+      throw new Error(`timed out waiting for ${label}`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+describe("workflow runs survive a dropped socket", () => {
+  let ws1: MockWebSocket;
+  let runner1: UnifiedWebSocketRunner;
+
+  beforeEach(async () => {
+    await initTestDb();
+    vi.clearAllMocks();
+    ws1 = new MockWebSocket();
+    runner1 = new UnifiedWebSocketRunner({ resolveExecutor });
+    await runner1.connect(ws1);
+  });
+
+  afterEach(async () => {
+    await runner1.disconnect();
+    dropRegisteredRuns();
+  });
+
+  it("keeps a run going after disconnect and replays the missed tail — terminal job_update included — to a second connection", async () => {
+    const jobId = "resilient-job-1";
+    await Job.create({
+      id: jobId,
+      workflow_id: "wf",
+      user_id: "1",
+      status: "running",
+      params: {},
+      graph: { nodes: [], edges: [] }
+    });
+    const hooks = makeHooks();
+    const active = registerRun(runner1, jobId, hooks);
+
+    let settle: (result: { status: "completed" }) => void = () => undefined;
+    const executePromise = new Promise<{ status: "completed" }>((resolve) => {
+      settle = resolve;
+    });
+    const streamTask = asAny(runner1).streamJobMessages(active, executePromise);
+
+    active.context.emit({
+      type: "node_update",
+      node_id: "n1",
+      node_name: "n1",
+      node_type: "test.Node",
+      status: "completed",
+      job_id: jobId
+    });
+    await waitFor(
+      () => decodeAll(ws1).some((m) => m.node_id === "n1"),
+      "the first node_update to reach connection 1"
+    );
+
+    // The socket drops mid-run. The run must NOT be cancelled.
+    await runner1.disconnect();
+    expect(hooks.cancel).not.toHaveBeenCalled();
+    expect(active.session.cancel).not.toHaveBeenCalled();
+
+    const sentBeforeDrop = decodeAll(ws1).length;
+    active.context.emit({
+      type: "node_update",
+      node_id: "n2",
+      node_name: "n2",
+      node_type: "test.Node",
+      status: "completed",
+      job_id: jobId
+    });
+    settle({ status: "completed" });
+    await streamTask;
+    expect(decodeAll(ws1)).toHaveLength(sentBeforeDrop);
+
+    // A fresh connection resubscribes from the last seq it saw.
+    const ws2 = new MockWebSocket();
+    const runner2 = new UnifiedWebSocketRunner({ resolveExecutor });
+    await runner2.connect(ws2);
+    const lastSeq = decodeAll(ws1).at(-1)?.job_seq as number;
+    await runner2.handleCommand({
+      command: "reconnect_job",
+      data: { job_id: jobId, workflow_id: "wf", last_seq: lastSeq }
+    });
+
+    const replayed = decodeAll(ws2);
+    const header = replayed[0];
+    expect(header.type).toBe("job_resumed");
+    expect(header.status).toBe("finished");
+    expect(header.replay_incomplete).toBe(false);
+    expect(replayed.some((m) => m.node_id === "n2")).toBe(true);
+    const terminal = replayed.find(
+      (m) => m.type === "job_update" && m.status === "completed"
+    );
+    expect(terminal).toBeDefined();
+    expect(terminal?.job_id).toBe(jobId);
+    // Nothing before `last_seq` is re-sent.
+    expect(replayed.some((m) => m.node_id === "n1")).toBe(false);
+
+    await runner2.disconnect();
+  });
+
+  it("cancels a detached run from the second connection and persists the cancellation", async () => {
+    const jobId = "resilient-job-2";
+    await Job.create({
+      id: jobId,
+      workflow_id: "wf",
+      user_id: "1",
+      status: "running",
+      params: {},
+      graph: { nodes: [], edges: [] }
+    });
+    const hooks = makeHooks();
+    registerRun(runner1, jobId, hooks);
+    await runner1.disconnect();
+
+    const ws2 = new MockWebSocket();
+    const runner2 = new UnifiedWebSocketRunner({ resolveExecutor });
+    await runner2.connect(ws2);
+    const result = await runner2.handleCommand({
+      command: "cancel_job",
+      data: { job_id: jobId }
+    });
+
+    expect(result?.message).toBe("Job cancellation requested");
+    expect(hooks.cancel).toHaveBeenCalledTimes(1);
+    expect((await Job.get(jobId))?.status).toBe("cancelled");
+    await runner2.disconnect();
+  });
+
+  it("routes stream_input and stop for an adopted run through the owning runner's hooks", async () => {
+    const jobId = "resilient-job-3";
+    const hooks = makeHooks();
+    registerRun(runner1, jobId, hooks);
+    await runner1.disconnect();
+
+    const ws2 = new MockWebSocket();
+    const runner2 = new UnifiedWebSocketRunner({ resolveExecutor });
+    await runner2.connect(ws2);
+    await runner2.handleCommand({
+      command: "reconnect_job",
+      data: { job_id: jobId, workflow_id: "wf" }
+    });
+
+    await runner2.handleCommand({
+      command: "stream_input",
+      data: { job_id: jobId, input: "prompt", value: "hi" }
+    });
+    expect(hooks.pushInput).toHaveBeenCalledWith("prompt", "hi", undefined);
+
+    expect(
+      await runner2.handleCommand({
+        command: "update_node_properties",
+        data: { job_id: jobId, node_id: "n1", properties: { gain: 1 } }
+      })
+    ).toEqual({ applied: true });
+
+    await runner2.handleCommand({ command: "stop", data: { job_id: jobId } });
+    expect(hooks.cancel).toHaveBeenCalled();
+    await runner2.disconnect();
+  });
+
+  it("reports a completed job's real persisted status once its session is gone", async () => {
+    const jobId = "resilient-job-4";
+    const job = await Job.create({
+      id: jobId,
+      workflow_id: "wf",
+      user_id: "1",
+      status: "running",
+      params: {},
+      graph: { nodes: [], edges: [] }
+    });
+    job.markCompleted();
+    await job.save();
+
+    await runner1.handleCommand({
+      command: "reconnect_job",
+      data: { job_id: jobId, workflow_id: "wf" }
+    });
+
+    const update = decodeAll(ws1).find((m) => m.type === "job_update");
+    expect(update?.status).toBe("completed");
+    expect(String(update?.error)).toMatch(/replay is unavailable/i);
+  });
+
+  it("counts a detached run against a fresh connection's concurrency slots", async () => {
+    const jobId = "resilient-job-6";
+    registerRun(runner1, jobId, makeHooks());
+    await runner1.disconnect();
+
+    const ws2 = new MockWebSocket();
+    const runner2 = new UnifiedWebSocketRunner({ resolveExecutor });
+    await runner2.connect(ws2);
+
+    // The run is detached, not this connection's, and still occupies a slot:
+    // otherwise four abandoned sockets plus a fresh one is eight runs.
+    const asCounts = runner2 as unknown as {
+      inFlightJobCount: number;
+      countActiveJobsForWorkflow(workflowId: string | null): number;
+    };
+    expect(asCounts.inFlightJobCount).toBe(1);
+    expect(asCounts.countActiveJobsForWorkflow("wf")).toBe(1);
+    expect(asCounts.countActiveJobsForWorkflow("other-wf")).toBe(0);
+
+    // …and stops occupying one once it settles.
+    jobRunRegistry.get("1", jobId)?.finish("completed");
+    expect(asCounts.inFlightJobCount).toBe(0);
+    expect(asCounts.countActiveJobsForWorkflow("wf")).toBe(0);
+    await runner2.disconnect();
+  });
+
+  it("does not double-count its own running job", async () => {
+    const jobId = "resilient-job-7";
+    registerRun(runner1, jobId, makeHooks());
+    const asCounts = runner1 as unknown as { inFlightJobCount: number };
+    expect(asCounts.inFlightJobCount).toBe(1);
+  });
+
+  it("reports a queued row with no session as failed, not queued", async () => {
+    const jobId = "resilient-job-8";
+    await Job.create({
+      id: jobId,
+      workflow_id: "wf",
+      user_id: "1",
+      status: "queued",
+      params: {},
+      graph: { nodes: [], edges: [] }
+    });
+
+    await runner1.handleCommand({
+      command: "reconnect_job",
+      data: { job_id: jobId, workflow_id: "wf" }
+    });
+
+    // Echoing "queued" parks the editor in a run that nothing can ever
+    // settle — its Stop button would hang forever.
+    const update = decodeAll(ws1).find((m) => m.type === "job_update");
+    expect(update?.status).toBe("failed");
+    expect(String(update?.error)).toMatch(/replay is unavailable/i);
+  });
+
+  it("still reports a row stuck at running with no session as failed", async () => {
+    const jobId = "resilient-job-5";
+    await Job.create({
+      id: jobId,
+      workflow_id: "wf",
+      user_id: "1",
+      status: "running",
+      params: {},
+      graph: { nodes: [], edges: [] }
+    });
+
+    await runner1.handleCommand({
+      command: "reconnect_job",
+      data: { job_id: jobId, workflow_id: "wf" }
+    });
+
+    const update = decodeAll(ws1).find((m) => m.type === "job_update");
+    expect(update?.status).toBe("failed");
+    expect(String(update?.error)).toMatch(/replay is unavailable/i);
+  });
+});

--- a/packages/websocket/tests/job-stream-failure-bookkeeping.test.ts
+++ b/packages/websocket/tests/job-stream-failure-bookkeeping.test.ts
@@ -120,11 +120,22 @@ afterEach(() => {
 
 describe("drain-loop failure bookkeeping", () => {
   it("marks the job failed, emits a terminal job_update, and never orphans the rejection", async () => {
-    vi.spyOn(Asset, "paginate").mockRejectedValue(
-      new Error("storage backend unavailable")
-    );
-
+    // Fault injection: fail the relay of node-level frames. `Asset.paginate`
+    // is no longer a valid injection point — the autosave dedupe read is
+    // best-effort now (see the sibling test below) — but a send failure on
+    // the drain loop's own relay is still fatal by design.
     const runner = makeRunner();
+    const realSend = runner.sendMessage.bind(runner);
+    vi.spyOn(runner, "sendMessage").mockImplementation(async (message) => {
+      if (
+        message.type === "generation_complete" ||
+        message.type === "output_update"
+      ) {
+        throw new Error("relay transport unavailable");
+      }
+      return realSend(message);
+    });
+
     await runner.connect(ws);
     await runner.runJob({
       job_id: "JOBFAIL",
@@ -139,7 +150,7 @@ describe("drain-loop failure bookkeeping", () => {
     );
     expect(terminal).toBeDefined();
     expect(terminal?.job_id).toBe("JOBFAIL");
-    expect(String(terminal?.error)).toContain("storage backend unavailable");
+    expect(String(terminal?.error)).toContain("relay transport unavailable");
 
     // The persisted row must not be stranded at "running".
     let status: string | undefined;
@@ -151,6 +162,39 @@ describe("drain-loop failure bookkeeping", () => {
     expect(status).toBe("failed");
 
     // Let any escaped rejection surface before asserting.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(unhandled).toEqual([]);
+
+    await runner.disconnect();
+  });
+
+  it("completes the run when the autosave dedupe read fails (best-effort, DB-free runs)", async () => {
+    // The reliability harness runs ws-server jobs with no DB at all; an
+    // unavailable Asset store must degrade to skipping replay dedupe, not
+    // fail the job (regression: provider-failure-mid-stream journey died
+    // with "Database not initialized" mid-drain).
+    vi.spyOn(Asset, "paginate").mockRejectedValue(
+      new Error("storage backend unavailable")
+    );
+
+    const runner = makeRunner();
+    await runner.connect(ws);
+    await runner.runJob({
+      job_id: "JOBOK",
+      workflow_id: "WFOK",
+      graph
+    });
+
+    const terminal = await waitFor(() =>
+      sentMsgs(ws).find(
+        (m) =>
+          m.type === "job_update" &&
+          (m.status === "completed" || m.status === "failed")
+      )
+    );
+    expect(terminal).toBeDefined();
+    expect(terminal?.status).toBe("completed");
+
     await new Promise((r) => setTimeout(r, 50));
     expect(unhandled).toEqual([]);
 

--- a/packages/websocket/tests/unified-websocket-runner-lifecycle-coverage.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner-lifecycle-coverage.test.ts
@@ -473,7 +473,7 @@ describe("UnifiedWebSocketRunner lifecycle — job status/cancel/reconnect", () 
     expect(res.workflow_id).toBe("wf");
   });
 
-  it("cancelJob on an active job cancels the runner and announces it", async () => {
+  it("cancelJob on an active job cancels the runner without an eager terminal frame", async () => {
     const cancel = vi.fn();
     asAny(runner).activeJobs.set("J", {
       jobId: "J",
@@ -487,10 +487,14 @@ describe("UnifiedWebSocketRunner lifecycle — job status/cancel/reconnect", () 
     expect(cancel).toHaveBeenCalledOnce();
     // finished is intentionally NOT flipped so the runner drains its messages.
     expect(asAny(runner).activeJobs.get("J").finished).toBe(false);
+    // No out-of-band terminal frame: the kernel's own cancelled job_update
+    // relays through the drain loop after the node-level terminal updates
+    // (lifecycle.running-after-job-terminal). The RPC response above is the
+    // immediate acknowledgement.
     const cancelled = decodeAll(ws).filter(
       (m) => m.type === "job_update" && m.status === "cancelled" && m.job_id === "J"
     );
-    expect(cancelled.length).toBeGreaterThan(0);
+    expect(cancelled.length).toBe(0);
   });
 
   it("reconnectJob reports an unknown job and replays active statuses", async () => {

--- a/packages/websocket/tests/unified-websocket-runner-lifecycle-coverage.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner-lifecycle-coverage.test.ts
@@ -541,7 +541,7 @@ describe("UnifiedWebSocketRunner lifecycle — job status/cancel/reconnect", () 
     await expect(runner.resumeJob("missing")).resolves.toBeUndefined();
   });
 
-  it("reconnectJob fails honestly when completed outputs cannot be replayed", async () => {
+  it("reconnectJob reports a completed job's real status when its events cannot be replayed", async () => {
     await Job.create({
       id: "completed-job",
       workflow_id: "wf",
@@ -551,11 +551,58 @@ describe("UnifiedWebSocketRunner lifecycle — job status/cancel/reconnect", () 
 
     await runner.reconnectJob("completed-job");
 
+    // The missing events are an `error` note, not a verdict: flipping the
+    // status to "failed" here told clients a successful run had crashed.
+    expect(decodeAll(ws)).toContainEqual(
+      expect.objectContaining({
+        type: "job_update",
+        status: "completed",
+        job_id: "completed-job",
+        error:
+          "Job event replay is unavailable after the execution connection was lost."
+      })
+    );
+  });
+
+  it("reconnectJob fails a queued row rather than echoing a status nothing can settle", async () => {
+    await Job.create({
+      id: "queued-job",
+      workflow_id: "wf",
+      user_id: "1",
+      status: "queued"
+    });
+
+    await runner.reconnectJob("queued-job");
+
+    // The queue this row sat in died with its connection. Reporting "queued"
+    // (which the editor renders as running, Stop button and all) leaves the
+    // client waiting on a run that will never start or settle.
     expect(decodeAll(ws)).toContainEqual(
       expect.objectContaining({
         type: "job_update",
         status: "failed",
-        job_id: "completed-job",
+        job_id: "queued-job",
+        error:
+          "Job event replay is unavailable after the execution connection was lost."
+      })
+    );
+  });
+
+  it("reconnectJob still fails a row stuck at running with nothing executing", async () => {
+    await Job.create({
+      id: "orphaned-job",
+      workflow_id: "wf",
+      user_id: "1",
+      status: "running"
+    });
+
+    await runner.reconnectJob("orphaned-job");
+
+    expect(decodeAll(ws)).toContainEqual(
+      expect.objectContaining({
+        type: "job_update",
+        status: "failed",
+        job_id: "orphaned-job",
         error:
           "Job event replay is unavailable after the execution connection was lost."
       })

--- a/packages/websocket/tests/unified-websocket-runner.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner.test.ts
@@ -843,13 +843,15 @@ describe("UnifiedWebSocketRunner", () => {
     }
   });
 
-  it("persists cancellation and emits job_update when cancelling an active job", async () => {
+  it("persists cancellation and delivers an ordered terminal job_update when cancelling an active job", async () => {
     // The toolbar Stop button sends a `cancel_job` command over the websocket.
-    // For an active (running) job this must mark the persisted row cancelled and
-    // emit a cancelled job_update right away — the runner's own cleanup can lag,
-    // so without this jobs.list (the Queue panel's source) keeps reporting the
-    // job as running until that slow cleanup lands. Regression for "toolbar Stop
-    // leaves the running-jobs panel showing the job as running".
+    // For an active (running) job this must mark the persisted row cancelled
+    // right away — the runner's own cleanup can lag, so without this jobs.list
+    // (the Queue panel's source) keeps reporting the job as running until that
+    // slow cleanup lands. The terminal job_update itself is NOT sent eagerly:
+    // it relays from the kernel through the drain loop, after the node-level
+    // terminal updates (lifecycle.running-after-job-terminal — the reliability
+    // harness's mid-run-cancel journeys pin the ordering).
     await initTestDb();
     let release!: () => void;
     const gate = new Promise<void>((r2) => {
@@ -896,15 +898,26 @@ describe("UnifiedWebSocketRunner", () => {
       const job = await Job.get<Job>("RUN_ACTIVE");
       expect(job?.status).toBe("cancelled");
 
-      // A cancelled job_update was announced so clients refetch the job list.
-      const updates = ws.sentBytes
-        .map((b) => unpack(b) as Record<string, unknown>)
-        .filter(
-          (m) => m.type === "job_update" && m.job_id === "RUN_ACTIVE"
-        );
-      expect(
-        updates.some((m) => m.status === "cancelled")
-      ).toBe(true);
+      // The kernel's terminal cancelled job_update arrives through the drain
+      // loop once cancellation propagates — ordered after node terminals, so
+      // it is awaited rather than asserted synchronously. The gated node
+      // ignores the abort signal, so open the gate to let the actor settle;
+      // the run's status stays cancelled regardless.
+      release();
+      const sawCancelled = async (): Promise<boolean> =>
+        ws.sentBytes
+          .map((b) => unpack(b) as Record<string, unknown>)
+          .some(
+            (m) =>
+              m.type === "job_update" &&
+              m.job_id === "RUN_ACTIVE" &&
+              m.status === "cancelled"
+          );
+      const deadline = Date.now() + 5000;
+      while (!(await sawCancelled()) && Date.now() < deadline) {
+        await new Promise((res) => setTimeout(res, 20));
+      }
+      expect(await sawCancelled()).toBe(true);
     } finally {
       release();
       await r.disconnect();

--- a/reliability/harness/src/core/normalize.ts
+++ b/reliability/harness/src/core/normalize.ts
@@ -47,6 +47,18 @@ export const DURATION_FIELDS: readonly string[] = [
 export const NULLABLE_OBJECT_FIELDS: readonly string[] = ["properties"];
 
 /**
+ * Top-level fields the WebSocket transport stamps on a frame so a dropped
+ * client can replay what it missed (`job-run-registry.ts`,
+ * `chat-turn-registry.ts`). They describe the delivery, not the run, and the
+ * raw kernel stream has no counterpart — dropped from the comparison view so
+ * a resumable surface still diffs clean against a non-resumable one.
+ */
+export const TRANSPORT_ONLY_FIELDS: readonly string[] = [
+  "job_seq",
+  "chat_seq"
+];
+
+/**
  * Node type prefixes whose `node_update`/`generation_complete` frames are
  * dropped from comparison (added by C2). This mirrors a real, documented,
  * intentional ws-server behavior (`unified-websocket-runner.ts`: "Skip
@@ -156,10 +168,9 @@ export function normalizeMessage(
   message: Record<string, unknown>,
   mapper: IdMapper
 ): Record<string, unknown> {
-  return normalizeValue(stripJobUpdateResult(message), null, mapper) as Record<
-    string,
-    unknown
-  >;
+  const payload = { ...stripJobUpdateResult(message) };
+  for (const field of TRANSPORT_ONLY_FIELDS) delete payload[field];
+  return normalizeValue(payload, null, mapper) as Record<string, unknown>;
 }
 
 export interface NormalizedRunFrame {

--- a/reliability/harness/tests/journeys/client-reconnect-mid-run.test.ts
+++ b/reliability/harness/tests/journeys/client-reconnect-mid-run.test.ts
@@ -29,23 +29,28 @@
  * `unified-websocket-runner.ts` gives each WS connection its own
  * `UnifiedWebSocketRunner` instance (`test-ui-server.ts`, and production's
  * `plugins/websocket.ts` — same shape), so `reconnect_job` on a genuinely
- * new connection can never hit its in-memory `activeJobs` fast path; it
- * falls through to the persisted `Job` row, which only exists at all when
- * `execution_options.persistence` is `"job"` (every other journey in this
- * suite deliberately uses `"session"` to stay DB-free — this is the one
- * exception, and needs its own `initTestDb()`/`initMasterKey()`).
+ * new connection can never hit that runner's in-memory `activeJobs` map.
+ * What it hits instead is the process-wide `jobRunRegistry`
+ * (`job-run-registry.ts`): a run registers a detachable `JobRunSession` at
+ * start, every frame it emits is stamped with `job_seq` and buffered, and a
+ * dropped socket only *detaches* the session — the run keeps executing and
+ * keeps buffering. Client 2's `reconnect_job` attaches to that session and
+ * gets a `job_resumed` header plus the whole missed tail, terminal
+ * `job_update` included. The run really did complete, and that is what
+ * client 2 is told.
  *
- * That fallback path (`reconnectJob`'s `job != null && job.status !==
- * "failed" && job.status !== "cancelled"` branch) reports a normally-
- * *completed* job as `job_update failed` with `"Job event replay is
- * unavailable after the execution connection was lost."` — a real,
- * currently-shipped gap this journey surfaces rather than papers over:
- * client 2 does observe a terminal state (the run never hangs, satisfying
- * this journey's literal ask), but that terminal state actively
- * misrepresents a successful run as failed. This test pins today's actual
- * behavior and asserts the job's *real* persisted status separately (via
- * `Job.get`) to make the discrepancy explicit rather than asserting the
- * wrong thing as if it were correct.
+ * The persisted `Job` row is now only the fallback for a run whose session
+ * is gone (retention elapsed, or the server restarted); it exists at all
+ * only when `execution_options.persistence` is `"job"` (every other journey
+ * in this suite deliberately uses `"session"` to stay DB-free — this is the
+ * one exception, and needs its own `initTestDb()`/`initMasterKey()`).
+ *
+ * Note the harness kills client 1 with a half-open proxy fault, so the
+ * *server* never observes the disconnect: the session stays attached to a
+ * socket nobody is reading. Client 2's `attach` steals the target from that
+ * dead connection, and any delivery that failed against it was swallowed by
+ * the session's delivery chain rather than stalling it — both are load-
+ * bearing for this test and would regress silently without it.
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { WebSocket } from "ws";
@@ -216,28 +221,50 @@ describe("journey 9: client reconnect mid-run (task D2)", () => {
       const client2 = await connect(proxyPort);
       record("connected", "reconnecting", "connected");
 
+      // last_seq 0: client 2 has seen nothing of this job, so it asks for
+      // the whole buffered stream.
       client2.ws.send(
         packWebSocketMessage({
           command: "reconnect_job",
-          data: { job_id: jobId, workflow_id: WORKFLOW.id }
+          data: { job_id: jobId, workflow_id: WORKFLOW.id, last_seq: 0 }
         })
       );
+
+      const header = await waitFor(
+        client2,
+        (m) => m["type"] === "job_resumed" && m["job_id"] === jobId
+      );
+      expect(header["status"]).toBe("finished");
+      expect(header["replay_incomplete"]).toBe(false);
+      expect(header["replay_count"]).toBeGreaterThan(0);
+
       const resubscribed = await waitFor(
         client2,
-        (m) => m["type"] === "job_update" && m["job_id"] === jobId
+        (m) =>
+          m["type"] === "job_update" &&
+          m["job_id"] === jobId &&
+          ["completed", "failed", "cancelled"].includes(String(m["status"]))
       );
 
-      // The literal ask: the run's terminal state is *observable* after
-      // reconnect — client 2 gets told the job is over, it never hangs.
-      expect(["completed", "failed", "cancelled"]).toContain(resubscribed["status"]);
-      // Today's actual (gap) behavior: a new connection's `reconnect_job`
-      // has no in-memory record of this job (a fresh `UnifiedWebSocketRunner`
-      // per connection) and reports a normally-completed job as "failed"
-      // with a replay-unavailable error, even though `realStatus` above
-      // proves the run genuinely succeeded. Pinned here, not asserted as
-      // correct — see the file-level doc comment.
-      expect(resubscribed["status"]).toBe("failed");
-      expect(resubscribed["error"]).toMatch(/replay is unavailable/i);
+      // The literal ask: the run's terminal state is observable after
+      // reconnect — and it is the run's REAL state, not a replay-unavailable
+      // stand-in. `realStatus` above proves the run succeeded; client 2 is
+      // told exactly that.
+      expect(resubscribed["status"]).toBe("completed");
+      expect(resubscribed["error"]).toBeFalsy();
+
+      // The replay is the run's own event stream, in seq order — client 2
+      // can rebuild the canvas from it, not just learn the outcome.
+      const replayed = client2.messages.filter((m) => m["job_id"] === jobId);
+      const seqs = replayed
+        .map((m) => m["job_seq"])
+        .filter((s): s is number => typeof s === "number");
+      expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+      expect(
+        replayed.some(
+          (m) => m["type"] === "node_update" && m["node_id"] === "n4"
+        )
+      ).toBe(true);
 
       client2.ws.close();
 

--- a/scripts/reliability-ring1.mjs
+++ b/scripts/reliability-ring1.mjs
@@ -53,10 +53,25 @@ const PACKAGED_JOURNEY = "linear-text-pipeline";
 // covered by the harness's own `python-node-workflow.test.ts` /
 // `host-disk-full-write.test.ts` (part of `npm run test`), which call the
 // drivers directly and so don't hit this CLI limitation.
+// `ws-transport-faults` joins them for the same two reasons: its ws-* faults
+// all wrap the one fault proxy, so a bare invocation applies all five at once
+// and the black-hole faults starve the run; and it declares
+// `"surfaces": ["ws-server"]` only (the kernel surface has no WS transport to
+// fault). Its ring block below runs the two recoverable faults per-fault on
+// the declared surface; the three black-hole faults legitimately end
+// client-side as "timeout" (see the journey's doc) — a verdict the CLI can't
+// express as success — and stay covered by the harness's own
+// `ws-transport-faults.test.ts`, which asserts both that symptom and that the
+// server survives it.
 const JOURNEYS_WITH_OWN_RING_HANDLING = new Set([
   "python-node-workflow",
-  "host-disk-full-write"
+  "host-disk-full-write",
+  "ws-transport-faults"
 ]);
+
+// The ws-transport-faults faults that complete with a real terminal frame and
+// so can be asserted through `reliability run`'s pass/fail exit code.
+const WS_TRANSPORT_RECOVERABLE_FAULTS = new Set(["ws-delay", "ws-fragment"]);
 
 function runNodetool(args) {
   return spawnSync("npm", ["run", "nodetool", "--", ...args], {
@@ -124,6 +139,31 @@ for (const faultName of readJourneyFaults("python-node-workflow")) {
     console.error(`FAIL: python-node-workflow --faults ${faultName} (exit ${result.status})`);
   } else {
     console.log(`ok: python-node-workflow --faults ${faultName}`);
+  }
+}
+
+// ws-transport-faults: per-fault (the ws faults stack on one proxy), on its
+// declared ws-server surface only, recoverable faults only (see the doc
+// comment above JOURNEYS_WITH_OWN_RING_HANDLING).
+for (const faultName of readJourneyFaults("ws-transport-faults")) {
+  if (!WS_TRANSPORT_RECOVERABLE_FAULTS.has(faultName)) continue;
+  ringRuns += 1;
+  console.log(`\n=== reliability run ws-transport-faults --faults ${faultName} (ws-server) ===`);
+  const result = runNodetool([
+    "reliability",
+    "run",
+    "ws-transport-faults",
+    "--faults",
+    faultName,
+    "--surface",
+    "ws-server",
+    "--diff"
+  ]);
+  if (result.status !== 0) {
+    failures += 1;
+    console.error(`FAIL: ws-transport-faults --faults ${faultName} (exit ${result.status})`);
+  } else {
+    console.log(`ok: ws-transport-faults --faults ${faultName}`);
   }
 }
 

--- a/web/src/stores/WorkflowRunner.ts
+++ b/web/src/stores/WorkflowRunner.ts
@@ -156,6 +156,12 @@ export type WorkflowRunner = {
   edges: Edge[];
   job_id: string | null;
   /**
+   * Highest `job_seq` seen for `job_id`. Frames of a resilient run are
+   * seq-stamped, so a reconnect asks the server to replay only what the
+   * socket missed. Reset whenever the tracked job changes.
+   */
+  jobReplayCursor: number;
+  /**
    * True while the active run executes in-browser (kernel runner) rather than
    * on the server. Browser runs don't hold a WebSocket connection, so the
    * stuck-state recovery heuristic must not treat a closed socket as a sign
@@ -241,6 +247,7 @@ export const createWorkflowRunnerStore = (
     nodes: [],
     edges: [],
     job_id: null,
+    jobReplayCursor: 0,
     isBrowserRun: false,
     queuePosition: null,
     unsubscribe: null,
@@ -281,6 +288,7 @@ export const createWorkflowRunnerStore = (
         unsubscribe: null,
         state: "idle",
         job_id: null,
+        jobReplayCursor: 0,
         isBrowserRun: false,
         queuePosition: null,
         statusMessage: null,
@@ -301,14 +309,26 @@ export const createWorkflowRunnerStore = (
 
       await get().ensureConnection();
 
-      set({ job_id: jobId, state: "running" });
+      // A different job means the cursor from the previous one must not be
+      // used as a replay floor — it would skip the new job's early frames.
+      const lastSeq = get().job_id === jobId ? get().jobReplayCursor : 0;
+      // Every reconnect targets a server job. A leftover `isBrowserRun` from a
+      // previous in-browser run would make the socket-open auto-resume skip
+      // this store forever.
+      set({
+        job_id: jobId,
+        jobReplayCursor: lastSeq,
+        isBrowserRun: false,
+        state: "running"
+      });
 
       await globalWebSocketManager.send({
         type: "reconnect_job",
         command: "reconnect_job",
         data: {
           job_id: jobId,
-          workflow_id: workflowId
+          workflow_id: workflowId,
+          last_seq: lastSeq
         }
       });
     },
@@ -327,9 +347,13 @@ export const createWorkflowRunnerStore = (
 
       await get().ensureConnection();
 
+      const lastSeq = get().job_id === jobId ? get().jobReplayCursor : 0;
       set({
         workflow,
         job_id: jobId,
+        jobReplayCursor: lastSeq,
+        // See reconnect(): a reconnect always attaches to a server job.
+        isBrowserRun: false,
         state: "connecting",
         statusMessage: "Reconnecting to running job..."
       });
@@ -339,7 +363,8 @@ export const createWorkflowRunnerStore = (
         command: "reconnect_job",
         data: {
           job_id: jobId,
-          workflow_id: workflow.id
+          workflow_id: workflow.id,
+          last_seq: lastSeq
         }
       });
     },
@@ -485,6 +510,7 @@ export const createWorkflowRunnerStore = (
           nodes,
           edges,
           job_id: jobId,
+          jobReplayCursor: 0,
           isBrowserRun: false,
           queuePosition: null,
           statusMessage: "Workflow starting...",
@@ -858,6 +884,7 @@ const defaultWorkflowRunner: WorkflowRunner = {
   nodes: [],
   edges: [],
   job_id: null,
+  jobReplayCursor: 0,
   isBrowserRun: false,
   queuePosition: null,
   unsubscribe: null,

--- a/web/src/stores/__tests__/WorkflowRunner.test.ts
+++ b/web/src/stores/__tests__/WorkflowRunner.test.ts
@@ -211,6 +211,83 @@ describe("WorkflowRunner", () => {
     });
   });
 
+  describe("resume cursor", () => {
+    it("reconnects from the cursor of the job it is already tracking", async () => {
+      store.setState({ job_id: "job-123", jobReplayCursor: 12 });
+
+      await store.getState().reconnect("job-123");
+
+      expect(globalWebSocketManager.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "reconnect_job",
+          data: expect.objectContaining({
+            job_id: "job-123",
+            last_seq: 12,
+          }),
+        })
+      );
+    });
+
+    it("reconnects from zero for a job it was not tracking", async () => {
+      store.setState({ job_id: "job-other", jobReplayCursor: 12 });
+
+      await store.getState().reconnect("job-123");
+
+      expect(globalWebSocketManager.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "reconnect_job",
+          data: expect.objectContaining({ job_id: "job-123", last_seq: 0 }),
+        })
+      );
+      expect(store.getState().jobReplayCursor).toBe(0);
+    });
+
+    it("reconnectWithWorkflow carries the cursor too", async () => {
+      store.setState({ job_id: "job-123", jobReplayCursor: 4 });
+
+      await store.getState().reconnectWithWorkflow("job-123", testWorkflow);
+
+      expect(globalWebSocketManager.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "reconnect_job",
+          data: expect.objectContaining({
+            job_id: "job-123",
+            workflow_id: "test-workflow-id",
+            last_seq: 4,
+          }),
+        })
+      );
+    });
+
+    it.each([
+      ["reconnect", (jobId: string) => store.getState().reconnect(jobId)],
+      [
+        "reconnectWithWorkflow",
+        (jobId: string) =>
+          store.getState().reconnectWithWorkflow(jobId, testWorkflow),
+      ],
+    ] as const)(
+      "%s clears isBrowserRun so the job stays eligible for auto-resume",
+      async (_name, doReconnect) => {
+        // A previous in-browser run left the flag set; the job being attached
+        // to is a server job, and the open-event resume skips browser runs.
+        store.setState({ isBrowserRun: true, job_id: "job-browser" });
+
+        await doReconnect("job-server");
+
+        expect(store.getState().isBrowserRun).toBe(false);
+      }
+    );
+
+    it("starts a fresh run at cursor zero", async () => {
+      store.setState({ jobReplayCursor: 9 });
+
+      await store.getState().run({}, testWorkflow, [], []);
+
+      expect(store.getState().jobReplayCursor).toBe(0);
+    });
+  });
+
   describe("streaming methods", () => {
     beforeEach(async () => {
       await store.getState().ensureConnection();

--- a/web/src/stores/__tests__/workflowUpdates.jobResume.test.ts
+++ b/web/src/stores/__tests__/workflowUpdates.jobResume.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Resilient-run resume: the `job_seq` replay cursor, the `job_resumed` reply,
+ * and the reconnect_job sent when the socket comes back up.
+ */
+import type { JobUpdate, WorkflowAttributes } from "../ApiTypes";
+import {
+  handleUpdate,
+  subscribeToWorkflowUpdates,
+  type JobResumedUpdate
+} from "../workflowUpdates";
+import { globalWebSocketManager } from "../../lib/websocket/GlobalWebSocketManager";
+
+jest.mock("../../lib/websocket/GlobalWebSocketManager", () => ({
+  globalWebSocketManager: {
+    send: jest.fn().mockResolvedValue(undefined),
+    subscribe: jest.fn().mockReturnValue(jest.fn()),
+    subscribeEvent: jest.fn().mockReturnValue(jest.fn())
+  }
+}));
+
+jest.mock("../../lib/workflow/browserWorkflowRunner", () => ({
+  preloadBrowserRunner: jest.fn()
+}));
+
+const mockAddNotification = jest.fn();
+
+type RunnerState = {
+  job_id: string | null;
+  jobReplayCursor: number;
+  state: string;
+  isBrowserRun: boolean;
+  queuePosition: number | null;
+  statusMessage: string | null;
+};
+
+/** Minimal runner store stand-in whose setState mutates the tracked state. */
+const makeRunnerStore = (overrides: Partial<RunnerState> = {}) => {
+  const state: RunnerState = {
+    job_id: null,
+    jobReplayCursor: 0,
+    state: "idle",
+    isBrowserRun: false,
+    queuePosition: null,
+    statusMessage: null,
+    ...overrides
+  };
+  return {
+    state,
+    getState: () => ({ ...state, addNotification: mockAddNotification }),
+    setState: jest.fn((patch: Partial<RunnerState>) => {
+      Object.assign(state, patch);
+    }),
+    subscribe: jest.fn().mockReturnValue(jest.fn())
+  };
+};
+
+const mockWorkflow: WorkflowAttributes = {
+  id: "wf",
+  name: "WF"
+} as WorkflowAttributes;
+
+const jobResumed = (
+  overrides: Partial<JobResumedUpdate> = {}
+): JobResumedUpdate => ({
+  type: "job_resumed",
+  job_id: "A",
+  workflow_id: "wf",
+  status: "running",
+  last_seq: 4,
+  replay_count: 2,
+  replay_incomplete: false,
+  ...overrides
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("job_seq replay cursor", () => {
+  it("tracks the high-water mark for the runner's own job", () => {
+    const runnerStore = makeRunnerStore({ job_id: "A", state: "running" });
+
+    handleUpdate(
+      mockWorkflow,
+      { type: "job_update", job_id: "A", workflow_id: "wf", status: "running", job_seq: 3 } as JobUpdate,
+      runnerStore as never,
+      () => undefined
+    );
+
+    expect(runnerStore.state.jobReplayCursor).toBe(3);
+  });
+
+  it("never moves the cursor backwards", () => {
+    const runnerStore = makeRunnerStore({
+      job_id: "A",
+      state: "running",
+      jobReplayCursor: 7
+    });
+
+    handleUpdate(
+      mockWorkflow,
+      { type: "job_update", job_id: "A", workflow_id: "wf", status: "running", job_seq: 2 } as JobUpdate,
+      runnerStore as never,
+      () => undefined
+    );
+
+    expect(runnerStore.state.jobReplayCursor).toBe(7);
+  });
+
+  it("ignores frames of a concurrent job", () => {
+    const runnerStore = makeRunnerStore({ job_id: "A", state: "running" });
+
+    handleUpdate(
+      mockWorkflow,
+      { type: "job_update", job_id: "B", workflow_id: "wf", status: "running", job_seq: 9 } as JobUpdate,
+      runnerStore as never,
+      () => undefined
+    );
+
+    expect(runnerStore.state.jobReplayCursor).toBe(0);
+  });
+});
+
+describe("job_resumed", () => {
+  it("restores running and clears the reconnect status message", () => {
+    const runnerStore = makeRunnerStore({
+      job_id: "A",
+      state: "connecting",
+      statusMessage: "Reconnecting to running job..."
+    });
+
+    handleUpdate(mockWorkflow, jobResumed(), runnerStore as never, () => undefined);
+
+    expect(runnerStore.state.state).toBe("running");
+    expect(runnerStore.state.statusMessage).toBeNull();
+  });
+
+  it("leaves a run the user cancelled during the gap cancelled", () => {
+    const runnerStore = makeRunnerStore({ job_id: "A", state: "cancelled" });
+
+    handleUpdate(mockWorkflow, jobResumed(), runnerStore as never, () => undefined);
+
+    expect(runnerStore.state.state).toBe("cancelled");
+  });
+
+  it("leaves a finished run with replayed frames to its terminal job_update", () => {
+    const runnerStore = makeRunnerStore({ job_id: "A", state: "running" });
+
+    handleUpdate(
+      mockWorkflow,
+      jobResumed({ status: "finished", replay_count: 2 }),
+      runnerStore as never,
+      () => undefined
+    );
+
+    expect(runnerStore.setState).not.toHaveBeenCalled();
+    expect(runnerStore.state.state).toBe("running");
+  });
+
+  it("settles a finished run that has nothing left to replay", () => {
+    // Our last_seq already covered the terminal frame (e.g. a duplicated
+    // reconnect), so no job_update is coming to end the run.
+    const runnerStore = makeRunnerStore({ job_id: "A", state: "running" });
+
+    handleUpdate(
+      mockWorkflow,
+      jobResumed({ status: "finished", replay_count: 0 }),
+      runnerStore as never,
+      () => undefined
+    );
+
+    expect(runnerStore.state.state).toBe("idle");
+    expect(runnerStore.state.queuePosition).toBeNull();
+    expect(runnerStore.state.statusMessage).toBeNull();
+    // Finishing normally is not an error — no toast.
+    expect(mockAddNotification).not.toHaveBeenCalled();
+  });
+
+  it("does not reopen a run that already settled", () => {
+    const runnerStore = makeRunnerStore({ job_id: "A", state: "cancelled" });
+
+    handleUpdate(
+      mockWorkflow,
+      jobResumed({ status: "finished", replay_count: 0 }),
+      runnerStore as never,
+      () => undefined
+    );
+
+    expect(runnerStore.state.state).toBe("cancelled");
+  });
+
+  it("settles an unknown run instead of hanging in running", () => {
+    const runnerStore = makeRunnerStore({ job_id: "A", state: "running" });
+
+    handleUpdate(
+      mockWorkflow,
+      jobResumed({ status: "unknown", replay_count: 0 }),
+      runnerStore as never,
+      () => undefined
+    );
+
+    expect(runnerStore.state.state).toBe("idle");
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "warning" })
+    );
+  });
+
+  it("warns when the replay was incomplete", () => {
+    const runnerStore = makeRunnerStore({ job_id: "A", state: "running" });
+
+    handleUpdate(
+      mockWorkflow,
+      jobResumed({ replay_incomplete: true }),
+      runnerStore as never,
+      () => undefined
+    );
+
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "warning" })
+    );
+    expect(runnerStore.state.state).toBe("running");
+  });
+
+  it("ignores a frame for another job", () => {
+    const runnerStore = makeRunnerStore({ job_id: "A", state: "running" });
+
+    handleUpdate(
+      mockWorkflow,
+      jobResumed({ job_id: "B", status: "unknown" }),
+      runnerStore as never,
+      () => undefined
+    );
+
+    expect(runnerStore.state.state).toBe("running");
+  });
+});
+
+describe("reconnect on socket open", () => {
+  /** Invoke the "open" listener subscribeToWorkflowUpdates registered. */
+  const fireOpen = () => {
+    const call = (globalWebSocketManager.subscribeEvent as jest.Mock).mock.calls
+      .filter(([event]) => event === "open")
+      .pop();
+    expect(call).toBeDefined();
+    (call?.[1] as () => void)();
+  };
+
+  it("resumes a running job from its cursor", () => {
+    const runnerStore = makeRunnerStore({
+      job_id: "A",
+      state: "running",
+      jobReplayCursor: 5
+    });
+
+    subscribeToWorkflowUpdates("wf", mockWorkflow, runnerStore as never, () => undefined);
+    fireOpen();
+
+    expect(globalWebSocketManager.send).toHaveBeenCalledWith({
+      type: "reconnect_job",
+      command: "reconnect_job",
+      data: { job_id: "A", workflow_id: "wf", last_seq: 5 }
+    });
+  });
+
+  it("sends nothing for an idle runner or an in-browser run", () => {
+    const idle = makeRunnerStore({ job_id: null, state: "idle" });
+    subscribeToWorkflowUpdates("wf", mockWorkflow, idle as never, () => undefined);
+    fireOpen();
+    expect(globalWebSocketManager.send).not.toHaveBeenCalled();
+
+    const browser = makeRunnerStore({
+      job_id: "A",
+      state: "running",
+      isBrowserRun: true
+    });
+    subscribeToWorkflowUpdates("wf", mockWorkflow, browser as never, () => undefined);
+    fireOpen();
+    expect(globalWebSocketManager.send).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/stores/workflowUpdates.ts
+++ b/web/src/stores/workflowUpdates.ts
@@ -393,11 +393,42 @@ export const subscribeToWorkflowUpdates = (
     }
   });
 
+  // After a reconnect, ask the server to replay what the run emitted while the
+  // socket was down. The job keeps running server-side across the drop and its
+  // frames are buffered; `reconnect_job` reattaches this connection and replays
+  // from the job's last seen `job_seq`. In-browser runs hold no socket, so they
+  // have nothing to resume.
+  const resumeInFlightJob = () => {
+    const { job_id, state, isBrowserRun, jobReplayCursor } =
+      runnerStore.getState();
+    if (!job_id || state !== "running" || isBrowserRun) {
+      return;
+    }
+    void globalWebSocketManager
+      .send({
+        type: "reconnect_job",
+        command: "reconnect_job",
+        data: {
+          job_id,
+          workflow_id: workflowId,
+          last_seq: jobReplayCursor
+        }
+      })
+      .catch((e) =>
+        console.error("Failed to send reconnect_job:", job_id, e)
+      );
+  };
+  const unsubscribeOpen = globalWebSocketManager.subscribeEvent(
+    "open",
+    resumeInFlightJob
+  );
+
   workflowSubscriptions.set(workflowId, {
     workflowId,
     unsubscribe: () => {
       unsubscribeWorkflow();
       unsubscribeRunnerStore();
+      unsubscribeOpen();
       if (unsubscribeJob) {
         unsubscribeJob();
         unsubscribeJob = null;
@@ -428,8 +459,25 @@ export const unsubscribeFromWorkflowUpdates = (workflowId: string): void => {
  * runner store so the protocol logic stays decoupled from Zustand wiring.
  */
 
+/**
+ * Reply to a `reconnect_job` command, sent before any replayed frames.
+ * Declared here rather than in ApiTypes (a generated re-export shim) so the
+ * consumer owns the shape; see `jobResumedMessageOutSchema` in
+ * @nodetool-ai/protocol for the contract.
+ */
+export interface JobResumedUpdate {
+  type: "job_resumed";
+  job_id: string;
+  workflow_id: string | null;
+  status: "running" | "finished" | "unknown";
+  last_seq: number;
+  replay_count: number;
+  replay_incomplete: boolean;
+}
+
 export type MsgpackData =
   | JobUpdate
+  | JobResumedUpdate
   | Chunk
   | Prediction
   | NodeProgress
@@ -467,6 +515,94 @@ function isAudioChunkValue(value: unknown): value is Chunk {
     value.content_type === "audio"
   );
 }
+
+/**
+ * Runner states a `job_resumed` reply may still have to settle: the run was
+ * in flight (or mid-handshake) when the socket dropped. A terminal state
+ * (idle/error/cancelled) was already settled by something else and must not be
+ * reopened.
+ */
+const UNSETTLED_RUNNER_STATES: ReadonlySet<string> = new Set([
+  "connecting",
+  "connected",
+  "running",
+  "paused",
+  "suspended"
+]);
+
+/**
+ * Reply to the `reconnect_job` we send after a socket drop.
+ *
+ * "running"/"finished" are followed by the replayed frames, which drive the
+ * runner as usual — a "finished" run's terminal `job_update` is normally among
+ * them. When the server replays nothing ("unknown": retention elapsed or the
+ * server restarted; "finished" with `replay_count: 0`: our `last_seq` already
+ * covered the terminal frame, e.g. a duplicated reconnect) no frame is left to
+ * end the run, so it must be settled here or the store sits in "running"
+ * forever.
+ */
+const handleJobResumed = (
+  data: JobResumedUpdate,
+  runnerStore: WorkflowRunnerStore
+): void => {
+  const runner = runnerStore.getState();
+  if (data.job_id !== runner.job_id) {
+    return;
+  }
+
+  if (data.replay_incomplete) {
+    runner.addNotification({
+      type: "warning",
+      alert: true,
+      content:
+        "Some updates were lost while reconnecting; this run's node results may be incomplete."
+    });
+  }
+
+  if (data.status === "running") {
+    // The run outlived the disconnect. Restore "running" unless the user
+    // cancelled during the gap, and drop the reconnect status text.
+    if (runner.state !== "cancelled") {
+      runnerStore.setState({ state: "running", statusMessage: null });
+    }
+    return;
+  }
+
+  // "finished" with frames to replay: the terminal `job_update` is among them
+  // and drives the store as usual.
+  if (data.status === "finished" && data.replay_count > 0) {
+    return;
+  }
+
+  if (!UNSETTLED_RUNNER_STATES.has(runner.state)) {
+    return;
+  }
+
+  // The persisted job row holds the real outcome in both cases; refresh the
+  // queue view so the run shows its actual terminal status.
+  runnerStore.setState({
+    state: "idle",
+    queuePosition: null,
+    statusMessage: null
+  });
+  queryClient.invalidateQueries({ queryKey: ["jobs"] });
+
+  if (data.status === "unknown") {
+    runner.addNotification({
+      type: "warning",
+      alert: true,
+      content: "Lost track of this run after reconnecting. Check the job queue for its result.",
+      timeout: NOTIFICATION_TIMEOUT_JOB_COMPLETED
+    });
+  } else if (data.replay_count === 0) {
+    // Finished with nothing to replay: the run ended while we were away and we
+    // already had its last frame. Nothing was lost — no toast.
+    console.info(
+      "WorkflowRunner: job finished during the disconnect",
+      data.job_id
+    );
+  }
+};
 
 export const handleUpdate = (
   workflow: WorkflowAttributes,
@@ -518,6 +654,25 @@ export const handleUpdate = (
   // job_id on every data message; if it's absent, skip the per-job write rather
   // than writing a malformed key.
   const messageJobId = extractJobId(data);
+
+  // Frames of a resilient run carry a monotonically increasing `job_seq`.
+  // Track the high-water mark for the runner's OWN job so a reconnect asks
+  // the server to replay only what the dropped socket missed; a concurrent
+  // inline job's frames must not move this store's cursor.
+  const jobSeq = (data as { job_seq?: unknown }).job_seq;
+  if (
+    typeof jobSeq === "number" &&
+    messageJobId &&
+    messageJobId === runnerStore.getState().job_id &&
+    jobSeq > runnerStore.getState().jobReplayCursor
+  ) {
+    runnerStore.setState({ jobReplayCursor: jobSeq });
+  }
+
+  if (data.type === "job_resumed") {
+    handleJobResumed(data, runnerStore);
+    return;
+  }
 
   if (data.type === "edge_update") {
     const currentState = runnerStore.getState().state;


### PR DESCRIPTION
## What

Two related changes to the WebSocket run lifecycle:

1. **Workflow runs survive WebSocket disconnects** the way chat turns already do (commit 1).
2. **The four ws-server bugs holding the Ring 1 deploy gate red are fixed** (commit 2) — the gate (`user-journeys.yml` → `fly-deploy.yml`) has been red since it landed in #4660, blocking every Fly deploy, including the rejected-upgrade fd-leak fix (#4673) whose absence in prod exhausts the machine's file descriptors roughly daily (CLOSE_WAIT pile-up → connection resets → outage).

## Run resilience (commit 1)

Previously, each connection's `UnifiedWebSocketRunner` cancelled every running job in `disconnect()`, and `reconnect_job` from a fresh connection misreported a completed run as `failed` with "Job event replay is unavailable".

Mirrors the `ChatTurnRegistry` design (`resume_chat`) for job runs:

**Server** (`packages/websocket`, `packages/protocol`)
- New `JobRunRegistry` / `JobRunSession` (`job-run-registry.ts`): process-wide sessions keyed by user+job. Every job frame is stamped with a monotonic `job_seq` and appended to a bounded buffer (`NODETOOL_JOB_REPLAY_BUFFER_EVENTS`, default 2000). A running session nobody is attached to is cancelled after a detach grace (`NODETOOL_JOB_DETACH_GRACE_MS`, default 10 min); a finished session is kept for replay (`NODETOOL_JOB_REPLAY_RETENTION_MS`, default 5 min).
- `disconnect()` detaches running jobs instead of cancelling them. Queued (never-started) runs are still drained and cancelled.
- `reconnect_job` / `resume_job` accept `last_seq`, adopt the session onto the new connection, and reply with a `job_resumed` header followed by the missed tail. Cross-connection control (`cancel_job`, `stop`, `stream_input`, `end_input_stream`, `update_node_properties`) routes through the session's execution hooks.
- The persisted-row fallback echoes only settled statuses (`completed`/`failed`/`cancelled`); any non-terminal row with no session reports `failed` instead of leaving the client spinning — and a genuinely completed job is no longer flipped to `failed`.
- Concurrency caps (`MAX_CONCURRENT_JOBS`, per-workflow cap) count runs process-wide through the registry, so detached runs can't be bypassed by reconnecting.

**Web** (`web/src/stores`)
- `WorkflowRunner` tracks a per-job `job_seq` cursor, resends `reconnect_job` with `last_seq` on the socket's `open` event for in-flight server runs (skipping browser-local runs), and handles `job_resumed` — including settling a store whose replay is already complete so it can't hang in "running".

## Ring 1 deploy-gate fixes (commit 2)

- **`cancelJob` no longer sends an eager terminal `job_update`** for an active run. That out-of-band frame told clients the job was over while nodes still read "running" (`lifecycle.running-after-job-terminal`, pinned by the `mid-run-cancel-node`/`mid-run-cancel-streaming` journeys) — the bug that left canvas nodes stuck spinning after Stop. The DB row is still marked cancelled immediately; the kernel's own terminal frame relays through the drain loop after node-level terminals.
- **The generation autosave dedupe read (`Asset.paginate`) in the drain loop is best-effort.** On a DB-free run it threw "Database not initialized", killed the drain loop, and failed a run that had actually completed (`provider-failure-mid-stream` journey).
- **`reliability-ring1.mjs` gives `ws-transport-faults` its own per-fault block** on its declared ws-server surface (like `python-node-workflow`): its ws faults all wrap one proxy, so the bare invocation applied all five simultaneously, and the three black-hole faults legitimately end client-side as "timeout" — covered by the harness's own `ws-transport-faults.test.ts` instead.

## Testing

- **All 15 Ring 1 reliability runs pass locally** (`npm run reliability:ring1`), including the four that fail on main today.
- New `job-run-registry.test.ts` (14 tests) and `job-run-resilience.test.ts` (8 runner-level tests: detach + cross-connection replay incl. terminal frame, cross-connection cancel/control, slot accounting across connections, fallback statuses).
- New `workflowUpdates.jobResume.test.ts` plus extended `WorkflowRunner.test.ts` on the web side (cursor tracking, open-event resubscribe, `job_resumed` paths, `isBrowserRun` reset).
- The `client-reconnect-mid-run` reliability journey now asserts the fixed behavior: replayed node stream, `job_resumed{status:"finished"}`, real `completed` terminal state.
- Full runs: `packages/websocket` 185 files / 2119 tests, reliability harness vitest 153 tests, web suites green; typecheck and lint clean (mobile typecheck fails pre-existing in this sandbox — its Expo tree isn't installed).

An adversarial review pass was run on the diff; the surviving accepted limitations are documented in code: one delivery target per session (a second tab takes the stream, same as chat), and the delivery chain relies on the bounded buffer for memory, not socket backpressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6LtxKGYqd7tnK9MdopkHb