### PR TITLE
fix(reliability): anchor the lifecycle check on the final job terminal; give ws-transport-faults its own ring handling

### DIFF
--- a/reliability/harness/src/core/invariants/lifecycle.ts
+++ b/reliability/harness/src/core/invariants/lifecycle.ts
@@ -6,12 +6,20 @@
  *   that invocation — a node can run more than once in a record (loops,
  *   re-entrant control events), so pairing is tracked as a per-node stack,
  *   not a single flag.
- * - No node is left `running` after the `job_update` terminal.
+ * - No node is left `running` after the FINAL `job_update` terminal. A surface
+ *   may answer a cancel with an eager terminal ack and keep draining — the
+ *   ws-server relay does exactly that (`unified-websocket-runner.ts`'s
+ *   `cancelJob` announces the stop immediately and deliberately leaves
+ *   `active.finished` unset so the node terminals still arrive) — so the
+ *   authoritative terminal is the last one, not the first. Anchoring on the
+ *   first would call a run dirty for converging after an ack the protocol
+ *   sends before convergence.
  *
  * `terminal-uniqueness.ts` covers the job-level "exactly one terminal
  * `job_update`" and precedence rules — kept separate so each §6 bullet has
  * its own attributable module, per the task's "may fold into lifecycle if
- * cleaner, but keep the checks individually attributable" note.
+ * cleaner, but keep the checks individually attributable" note. Duplicate
+ * terminals stay its business: this module only asks where the run ended.
  */
 import type { RunRecord } from "../record.js";
 import type { Violation } from "./types.js";
@@ -29,11 +37,10 @@ export function checkLifecycle(record: RunRecord): Violation[] {
 
     if (type === "job_update") {
       const status = asString(message, "status");
-      if (
-        jobTerminalIndex === undefined &&
-        status !== undefined &&
-        JOB_TERMINAL_STATUSES.has(status)
-      ) {
+      // Last terminal wins (see the header note). Redundant-tagged frames
+      // count: the ws driver tags the SECOND cancelled frame, so skipping
+      // tagged ones would re-select the eager ack.
+      if (status !== undefined && JOB_TERMINAL_STATUSES.has(status)) {
         jobTerminalIndex = index;
       }
       return;
@@ -104,7 +111,7 @@ export function checkLifecycle(record: RunRecord): Violation[] {
       if (openCount <= 0) continue;
       violations.push({
         invariant: "lifecycle.running-after-job-terminal",
-        message: `node "${nodeId}" is still "running" at the job_update terminal (frame ${jobTerminalIndex})`,
+        message: `node "${nodeId}" is still "running" at the final job_update terminal (frame ${jobTerminalIndex})`,
         nodeId,
         frameIndex: jobTerminalIndex,
         details: { openCount }

--- a/reliability/harness/tests/invariants/lifecycle.test.ts
+++ b/reliability/harness/tests/invariants/lifecycle.test.ts
@@ -73,3 +73,54 @@ describe("checkLifecycle: failing fixtures", () => {
     ]);
   });
 });
+
+/**
+ * The ws-server cancel shape. `cancelJob` answers the command with a terminal
+ * `job_update` straight away (`unified-websocket-runner.ts`, "announce it right
+ * away") and deliberately does NOT set `active.finished`, so the drain keeps
+ * running and the node terminals follow it. Judging node state against that
+ * eager ack calls a converged run dirty — the authoritative terminal is the
+ * last one. Duplicate terminals stay `terminal-uniqueness.ts`'s business.
+ */
+describe("checkLifecycle: a surface that emits an eager terminal ack", () => {
+  it("judges node state against the final job_update terminal, not the eager ack", () => {
+    const record = baseRecord([
+      makeFrame(0, "ws-server", "server_to_client", { type: "job_update", status: "running", job_id: "job-1" }),
+      makeFrame(1, "ws-server", "server_to_client", { type: "node_update", node_id: "n1", status: "running" }),
+      // The eager cancel ack. Untagged — the driver tags the *second*
+      // occurrence redundant, not the first, so "last non-redundant" would
+      // re-select this frame and keep the bug.
+      makeFrame(2, "ws-server", "server_to_client", { type: "job_update", status: "cancelled", job_id: "job-1" }),
+      makeFrame(3, "ws-server", "server_to_client", { type: "node_update", node_id: "n1", status: "cancelled" }),
+      {
+        ...makeFrame(4, "ws-server", "server_to_client", {
+          type: "job_update",
+          status: "cancelled",
+          job_id: "job-1"
+        }),
+        redundant: "ws-eager-cancel-ack"
+      }
+    ]);
+
+    expect(checkLifecycle(record)).toEqual([]);
+  });
+
+  it("still flags a node that never closes, even with duplicate terminals", () => {
+    const record = baseRecord([
+      makeFrame(0, "ws-server", "server_to_client", { type: "node_update", node_id: "n1", status: "running" }),
+      makeFrame(1, "ws-server", "server_to_client", { type: "job_update", status: "cancelled", job_id: "job-1" }),
+      {
+        ...makeFrame(2, "ws-server", "server_to_client", {
+          type: "job_update",
+          status: "cancelled",
+          job_id: "job-1"
+        }),
+        redundant: "ws-eager-cancel-ack"
+      }
+    ]);
+
+    const invariantIds = checkLifecycle(record).map((v) => v.invariant);
+    expect(invariantIds).toContain("lifecycle.unmatched-running");
+    expect(invariantIds).toContain("lifecycle.running-after-job-terminal");
+  });
+});

--- a/scripts/reliability-ring1.mjs
+++ b/scripts/reliability-ring1.mjs
@@ -53,9 +53,25 @@ const PACKAGED_JOURNEY = "linear-text-pipeline";
 // covered by the harness's own `python-node-workflow.test.ts` /
 // `host-disk-full-write.test.ts` (part of `npm run test`), which call the
 // drivers directly and so don't hit this CLI limitation.
+// `ws-transport-faults` is excluded for the same stacking reason, with a
+// twist: its five ws faults share ONE process-wide proxy slot
+// (`faults/ws-proxy.ts`), so a bare invocation doesn't merely apply them
+// together, it applies only the last — `ws-abrupt-close`, which destroys the
+// socket on the first client->server frame. The client then never sees a
+// terminal and the driver's 4000ms wait expires. That timeout is the
+// journey's DESIGNED outcome under a black-hole fault, not a slow path (an
+// unfaulted run finishes in ~8ms), so the bare run reported a failure for
+// behaving correctly. It also declares `"surfaces": ["ws-server"]` only, and
+// unlike the two above it can't be rescued by a per-fault block here: `cli.ts`
+// always injects the kernel oracle, and a kernel that completes necessarily
+// diverges from a black-holed client. Its per-fault coverage — including
+// post-fault server health — is
+// `reliability/harness/tests/journeys/ws-transport-faults.test.ts`, which runs
+// in the Quality Gate's `test-packages` leg.
 const JOURNEYS_WITH_OWN_RING_HANDLING = new Set([
   "python-node-workflow",
-  "host-disk-full-write"
+  "host-disk-full-write",
+  "ws-transport-faults"
 ]);
 
 function runNodetool(args) {


### PR DESCRIPTION
Three of the four red Ring 1 journeys. Both are harness/CI defects — no product code changes.

## 1. `mid-run-cancel-node` + `mid-run-cancel-streaming`

`cancelJob` answers the command with a terminal `job_update{status:"cancelled"}` immediately (`packages/websocket/src/unified-websocket-runner.ts:3827-3832`) and deliberately does not set `active.finished` — the comment at `:3834` says to let the drain deliver what's left. The node terminals follow. Proof they arrive: CI reports `lifecycle.running-after-job-terminal` but never `unmatched-running`, so the pairing closes by end of record.

`checkLifecycle` anchored on the FIRST terminal `job_update` (`lifecycle.ts:33`, guard `jobTerminalIndex === undefined`), which on cancel is the eager ack. It judged a converged run against a frame the protocol emits before convergence. Now it anchors on the last.

Duplicate terminals remain `terminal-uniqueness.ts`'s job — that separation is the stated design (`lifecycle.ts:11-14`).

**Why this doesn't blind the check.** A node with no terminal at all is still caught twice: by the anchor-independent end-of-record `unmatched-running` sweep (`:72-83`), and by being open at the last terminal. The only shape that stops being flagged is "node closes between two terminal `job_update`s" — which is either the documented eager-ack protocol or an undocumented duplicate terminal, and `terminal-uniqueness.multiple` catches the latter because untagged duplicates are counted. No violation class becomes unreachable.

Note the anchor must include `redundant`-tagged frames: the driver tags the *second* cancelled frame (`ws-server.ts:290-301`), so "last non-redundant" would re-select the eager ack and keep the bug.

## 2. `ws-transport-faults`

`reliability-ring1.mjs` ran it bare. A bare invocation applies every declared fault at once (`cli.ts:147-158` falls back to the full matrix), and the ws faults share one process-wide proxy slot (`faults/ws-proxy.ts:14-19`), so last-write-wins leaves a black-hole fault active — the client never sees a terminal and the driver's 4000ms timeout fires. That timeout is the designed behavior, not a slow path: an unfaulted run finishes in ~8ms.

The journey declares `["ws-server"]` only, and a per-fault ring loop cannot work either — `cli.ts:181` always injects the kernel oracle, which by design diverges from a black-holed client. Exclusion plus the existing per-fault vitest suite (`tests/journeys/ws-transport-faults.test.ts`, already in the Quality Gate) is the only correct shape. Added to `JOURNEYS_WITH_OWN_RING_HANDLING` alongside the two journeys already there for this reason.

## Red first

Two pushes on this branch:
- **Push 1** — tests only. `test-packages` fails with `lifecycle.running-after-job-terminal` on the converged-cancel record.
- **Push 2** — the fix. Green.

Run URLs in a comment below, so the flip is inspectable rather than asserted.

## Expected Ring 1 after this

`ok: mid-run-cancel-node`, `ok: mid-run-cancel-streaming`, and the `ws-transport-faults` block gone.

**`provider-failure-mid-stream` still fails** — separate root cause (`WsServerDriver` never calls `initTestDb`, so the autosave dedupe read throws and aborts the drain). Fixed in the next PR. Do not read that line as a failure of this one.

## Blast radius

`checkLifecycle` consumers: Ring 0 (kernel-only, single terminal — unaffected), Ring 1, `harness gate`. Every existing fixture in `tests/journeys/` and `tests/invariants/` has exactly one terminal `job_update`, so first == last and nothing flips. `tests/drivers/cli.test.ts` and `browser.test.ts` load the cancel journeys but assert status, not invariants.