### PR TITLE
feat: sketch validate/debug harness and headless agent tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -667,6 +667,49 @@ old document is restored against today's schema, so what it used to pass is not
 what it passes now — a restore whose document no longer validates exits
 non-zero and prints the issues.
 
+### nodetool sketch validate / debug (Sketch Harness)
+
+Checks a sketch (image document) without opening an editor, and replays a
+scripted edit session against it. The target is an image document JSON file — a
+bare `{sketch, layerBindings}` object or anything carrying one, so a
+`sketch.get` response or an `image_documents` row works as-is — or an
+`image_documents` row id. A path that exists on disk wins over an id.
+
+```bash
+npm run dev:nodetool -- sketch validate <image_document_id>
+npm run dev:nodetool -- sketch validate sketch.json --json
+npm run dev:nodetool -- sketch validate <id> --warnings-as-errors
+
+npm run dev:nodetool -- sketch debug sketch.json \
+  --interact '[{"tool":"add_layer","input":{"name":"Shadow"}},
+               {"tool":"set_layer_props","input":{"target":"Shadow","opacity":0.4,"blendMode":"multiply"}}]'
+npm run dev:nodetool -- sketch debug <id> --out ./mydebug --json
+```
+
+`validate` reads what a headless check can decide: a duplicate layer id, an
+`activeLayerId` or binding pointing at a layer the document lacks, opacity or a
+blend mode no compositor ships, a binding with no workflow or prompt behind it,
+and fields a schema round trip would strip. `debug` runs the same check, then
+executes each `--interact` step against the headless `ui_sketch_*` bridge — the
+one the `sketch-tools` eval drives — and validates the document the session
+left behind. A failing step is recorded and the script continues. Pixels,
+painting, rendering, generation, and asset I/O are not simulated; the report
+lists that under `notSimulated`. Layer bitmaps stay opaque throughout.
+
+The same static check is exposed to agents through the **`validate_sketch`**
+tool: pass an inline `document` to check a sketch being built, or an
+`image_document_id` to validate a saved one (scoped to the requesting user).
+Agents also get the version history headlessly: **`list_sketches`**,
+**`list_sketch_versions`**, **`create_sketch_version`** (manual snapshot), and
+**`restore_sketch_version`**, which snapshots the pre-restore state first and
+returns the post-restore validation.
+
+The bundle (`nodetool-debug/sketch-<id>-<ts>/`) holds `report.json`,
+`report.md`, and `sketch.json` (the input document). Exit code 0 only when the
+verdict is ok. Validation and report rules live in
+`@nodetool-ai/execution/sketch-debug`; the CLI keeps target resolution, the
+interaction script, and the bundle.
+
 ### nodetool sketch versions (Sketch Version History)
 
 `sketch versions` reads and writes an image document's snapshot history against
@@ -685,11 +728,12 @@ npm run dev:nodetool -- sketch versions delete <image_document_id> 3 --yes
 ```
 
 `restore` mirrors the tRPC router (`sketch.documentVersions.restore`): it
-snapshots the current state as a `restore` version, then CAS-writes the old
-document and its canvas settings back onto the image document. A sketch has no
-validator harness, so the check afterwards is the one a headless run can make —
-the restored document must still parse as a JSON object; one that no longer
-does exits non-zero. Layer bitmaps stay opaque to that check.
+snapshots the current state as a `restore` version, CAS-writes the old document
+and its canvas settings back onto the image document, then runs the same static
+check `sketch validate` runs. An old document is restored against today's
+schema, so what it used to pass is not what it passes now — a restore whose
+document no longer validates exits non-zero and prints the issues. Layer
+bitmaps stay opaque to that check.
 
 ### Script voicing tools (no workflow, no browser)
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -113,6 +113,7 @@ export {
   DebugAppTool,
   ValidateWorkflowTool,
   ValidateTimelineTool,
+  ValidateSketchTool,
   PlanWorkflowGraphTool,
   GetExampleWorkflowTool,
   ExportWorkflowDigraphTool,
@@ -132,7 +133,9 @@ export {
 export type {
   PlanWorkflowGraphToolOptions,
   TimelineLoader,
-  TimelineToolRecord
+  TimelineToolRecord,
+  SketchLoader,
+  SketchToolRecord
 } from "./tools/mcp-tools.js";
 export {
   ExtractPDFTextTool,
@@ -415,6 +418,13 @@ export {
   AssembleStoryboardTimelineTool,
   STORYBOARD_RENDER_TOOL_NAMES
 } from "./tools/storyboard-render-tools.js";
+export {
+  ListSketchesTool,
+  ListSketchVersionsTool,
+  CreateSketchVersionTool,
+  RestoreSketchVersionTool,
+  SKETCH_VERSION_TOOL_NAMES
+} from "./tools/sketch-version-tools.js";
 
 // Plan cache + checkpoint store (opt-in planning/execution persistence)
 export {

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -105,6 +105,12 @@ import {
   ReviseStoryboardClipTool,
   AssembleStoryboardTimelineTool
 } from "./storyboard-render-tools.js";
+import {
+  ListSketchesTool,
+  ListSketchVersionsTool,
+  CreateSketchVersionTool,
+  RestoreSketchVersionTool
+} from "./sketch-version-tools.js";
 
 export const BUILTIN_TOOL_CLASSES: ReadonlyArray<new () => Tool> = [
   // Filesystem (workspace-relative)
@@ -141,6 +147,12 @@ export const BUILTIN_TOOL_CLASSES: ReadonlyArray<new () => Tool> = [
   RenderStoryboardClipsTool,
   ReviseStoryboardClipTool,
   AssembleStoryboardTimelineTool,
+
+  // Sketch snapshot history (find a sketch, pin a state, roll one back)
+  ListSketchesTool,
+  ListSketchVersionsTool,
+  CreateSketchVersionTool,
+  RestoreSketchVersionTool,
 
   // Vision (lazy image loading: handles → pixels on demand)
   ListImagesTool,

--- a/packages/agents/src/tools/mcp-tools.ts
+++ b/packages/agents/src/tools/mcp-tools.ts
@@ -21,10 +21,8 @@ import {
   collectModelSelectionIssues,
   validateGraph
 } from "@nodetool-ai/node-sdk";
-import {
-  validateTimelineSequence,
-  type TimelineValidation
-} from "@nodetool-ai/execution/timeline-debug";
+import { validateTimelineSequence } from "@nodetool-ai/execution/timeline-debug";
+import { validateSketchDocument } from "@nodetool-ai/execution/sketch-debug";
 import { Tool } from "./base-tool.js";
 import { LocalListNodesTool } from "./local-list-nodes-tool.js";
 import { LocalSearchNodesTool } from "./local-search-nodes-tool.js";
@@ -1247,7 +1245,7 @@ function numberParam(value: unknown): number | undefined {
 }
 
 /** Unwrap a stored document that may still be JSON text. */
-function parseTimelineDocument(document: unknown): unknown {
+function parseStoredDocument(document: unknown): unknown {
   if (typeof document !== "string") return document;
   try {
     return JSON.parse(document);
@@ -1256,7 +1254,11 @@ function parseTimelineDocument(document: unknown): unknown {
   }
 }
 
-function timelineSummary(validation: TimelineValidation): string {
+/** One-line count of what a static validation found. */
+function issueSummary(validation: {
+  errors: unknown[];
+  warnings: unknown[];
+}): string {
   const errors = validation.errors.length;
   const warnings = validation.warnings.length;
   if (errors === 0 && warnings === 0) return "No issues found.";
@@ -1347,7 +1349,7 @@ export class ValidateTimelineTool extends Tool {
           validated: false
         };
       }
-      document = parseTimelineDocument(record.document);
+      document = parseStoredDocument(record.document);
       meta = { fps: record.fps, width: record.width, height: record.height };
       name = record.name;
     }
@@ -1364,7 +1366,7 @@ export class ValidateTimelineTool extends Tool {
       ...validation,
       ...(timelineId ? { timeline_id: timelineId } : {}),
       ...(name ? { name } : {}),
-      summary: timelineSummary(validation)
+      summary: issueSummary(validation)
     };
   }
 
@@ -1372,6 +1374,144 @@ export class ValidateTimelineTool extends Tool {
     return params["timeline_id"]
       ? `Validating timeline ${params["timeline_id"]}`
       : "Validating timeline document";
+  }
+}
+
+export interface SketchToolRecord {
+  /** The stored document — a JSON string or an already-parsed object. */
+  document: unknown;
+  width?: number;
+  height?: number;
+  backgroundColor?: string;
+  name?: string;
+}
+
+/** Reads an `image_documents` row for the caller. */
+export type SketchLoader = (
+  context: ProcessingContext,
+  id: string
+) => Promise<SketchToolRecord | null>;
+
+export class ValidateSketchTool extends Tool {
+  readonly name = "validate_sketch";
+  readonly description =
+    "Statically validate a sketch (image document) WITHOUT rendering it: " +
+    "duplicate layer ids, an active or mask layer the stack lacks, unknown " +
+    "blend modes, opacities and transforms that cannot render, generation " +
+    "bindings pointing at missing layers, unknown binding kinds and statuses, " +
+    "canvas settings that disagree with the stored ones, and fields a schema " +
+    "round trip would strip. Pass an inline `document` to check one you are " +
+    "building, or `image_document_id` to validate a saved sketch. Run it after " +
+    "sketch edits and before handing the document back.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      image_document_id: {
+        type: "string" as const,
+        description: "The ID of a saved sketch (image document) to validate"
+      },
+      document: {
+        type: "object" as const,
+        description:
+          "Inline ImageDocumentData to validate ({ sketch, layerBindings }). " +
+          "Takes precedence over image_document_id."
+      },
+      width: {
+        type: "number" as const,
+        description:
+          "Canvas width the inline document is stored against. The canvas " +
+          "size lives on the row, not in the document, so without it a " +
+          "mismatch between the two cannot be reported. Ignored for " +
+          "image_document_id."
+      },
+      height: {
+        type: "number" as const,
+        description:
+          "Canvas height the inline document is stored against. Ignored for image_document_id."
+      },
+      background_color: {
+        type: "string" as const,
+        description:
+          "Canvas background color the inline document is stored against. Ignored for image_document_id."
+      }
+    }
+  };
+
+  // The sketch API is tRPC-only, so there is no REST route to fall back on:
+  // a host that wants the `image_document_id` path injects a loader. Without
+  // one the tool still validates inline documents.
+  constructor(private readonly loadSketch?: SketchLoader) {
+    super();
+  }
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const inline = params["document"];
+    const sketchId = params["image_document_id"] as string | undefined;
+
+    let document = inline;
+    // An inline document carries no stored canvas settings, so the caller
+    // supplies them; the image_document_id path overwrites these from the row.
+    let meta: {
+      width?: number;
+      height?: number;
+      backgroundColor?: string;
+    } = {
+      width: numberParam(params["width"]),
+      height: numberParam(params["height"]),
+      backgroundColor:
+        typeof params["background_color"] === "string"
+          ? (params["background_color"] as string)
+          : undefined
+    };
+    let name: string | undefined;
+
+    if (document === undefined && sketchId) {
+      if (!this.loadSketch) {
+        return {
+          error:
+            "Cannot load a saved sketch in this process: no sketch loader is available. Pass the document inline as `document`, or call this tool from a server-side context.",
+          validated: false
+        };
+      }
+      const record = await this.loadSketch(context, sketchId);
+      if (!record) {
+        return {
+          error: `Sketch ${sketchId} was not found.`,
+          validated: false
+        };
+      }
+      document = parseStoredDocument(record.document);
+      meta = {
+        width: record.width,
+        height: record.height,
+        backgroundColor: record.backgroundColor
+      };
+      name = record.name;
+    }
+
+    if (document === undefined || document === null) {
+      return {
+        error:
+          "No sketch to validate — pass an inline `document` ({sketch, layerBindings}) or a valid `image_document_id`."
+      };
+    }
+
+    const validation = validateSketchDocument(document, meta);
+    return {
+      ...validation,
+      ...(sketchId ? { image_document_id: sketchId } : {}),
+      ...(name ? { name } : {}),
+      summary: issueSummary(validation)
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    return params["image_document_id"]
+      ? `Validating sketch ${params["image_document_id"]}`
+      : "Validating sketch document";
   }
 }
 

--- a/packages/agents/src/tools/sketch-version-tools.ts
+++ b/packages/agents/src/tools/sketch-version-tools.ts
@@ -1,0 +1,377 @@
+/**
+ * Sketch version tools — snapshot history for an image document, headlessly.
+ *
+ * The sketch editor keeps a whole-document history: manual saves, the autosaves
+ * a document write takes at most every five minutes, and the pre-restore
+ * snapshot that makes a restore undoable. Reading and moving through it was
+ * tRPC-only, so an agent outside the browser could not roll a sketch back to a
+ * version the user liked, or pin the current state before a risky edit.
+ *
+ *   list_sketches          — find a sketch to work on
+ *   list_sketch_versions   — its snapshots, newest first
+ *   create_sketch_version  — pin the current state as a manual snapshot
+ *   restore_sketch_version — roll the document back to one
+ *
+ * The restore mirrors `sketch.documentVersions.restore`: it snapshots what is
+ * about to be overwritten, then compare-and-swaps the old document and canvas
+ * settings back onto the row. An old document is restored against today's
+ * schema, so what it used to pass is not what it passes now — the restore ends
+ * with `validateSketchDocument` over the result, the same check the CLI's
+ * `sketch versions restore` makes.
+ *
+ * Per-layer generation history (`sketch.versions.*`) is a different thing:
+ * those record one generated image on one layer, these snapshot the document.
+ */
+
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { ImageDocument, ImageDocumentVersion } from "@nodetool-ai/models";
+import { validateSketchDocument } from "@nodetool-ai/execution/sketch-debug";
+import type { SketchValidation } from "@nodetool-ai/execution/sketch-debug";
+import { Tool } from "./base-tool.js";
+
+/** Versions one call may return, so a long history cannot flood the context. */
+const DEFAULT_VERSION_LIMIT = 20;
+const MAX_VERSION_LIMIT = 100;
+
+type ToolError = { error: string };
+
+const isError = (value: unknown): value is ToolError =>
+  !!value &&
+  typeof value === "object" &&
+  typeof (value as ToolError).error === "string";
+
+async function loadSketch(
+  context: ProcessingContext,
+  sketchId: unknown
+): Promise<ImageDocument | ToolError> {
+  if (typeof sketchId !== "string" || !sketchId) {
+    return {
+      error:
+        "image_document_id is required (use list_sketches to find one)."
+    };
+  }
+  const doc = await ImageDocument.findById(sketchId);
+  // A sketch owned by someone else reads as missing — the same rule the tRPC
+  // router's ownership check applies.
+  if (!doc || doc.user_id !== context.userId) {
+    return { error: `Sketch ${sketchId} was not found.` };
+  }
+  return doc;
+}
+
+/** The list-item shape the tRPC router returns for a snapshot. */
+function toVersionListItem(version: ImageDocumentVersion) {
+  return {
+    id: version.id,
+    version: version.version,
+    name: version.name,
+    saveType: version.save_type,
+    width: version.width,
+    height: version.height,
+    backgroundColor: version.background_color,
+    createdAt: version.created_at
+  };
+}
+
+/**
+ * A snapshot's document is JSON text on SQLite and an object on Postgres, so
+ * parse only when it is a string. A row that is neither is corrupt, and saying
+ * so beats handing back a string the caller will treat as a document.
+ */
+function parseVersionDocument(raw: unknown): unknown | ToolError {
+  if (typeof raw !== "string") return raw;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return { error: "The stored version document is not valid JSON." };
+  }
+}
+
+/** One-line count of what the post-restore validation found. */
+function validationSummary(validation: SketchValidation): string {
+  const errors = validation.errors.length;
+  const warnings = validation.warnings.length;
+  if (errors === 0 && warnings === 0) return "No issues found.";
+  const parts: string[] = [];
+  if (errors > 0) parts.push(`${errors} error${errors === 1 ? "" : "s"}`);
+  if (warnings > 0)
+    parts.push(`${warnings} warning${warnings === 1 ? "" : "s"}`);
+  return parts.join(", ");
+}
+
+function versionNumber(value: unknown): number | ToolError {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    return {
+      error:
+        "version must be a positive integer (use list_sketch_versions to see the available ones)."
+    };
+  }
+  return n;
+}
+
+const SAVE_TYPE_PROPERTY = {
+  type: "string" as const,
+  enum: ["manual", "autosave", "restore"],
+  description:
+    "Only versions of this kind: 'manual' (a save someone asked for), " +
+    "'autosave' (taken on a document write), 'restore' (the pre-restore " +
+    "snapshot). Omit for all of them."
+};
+
+export class ListSketchesTool extends Tool {
+  readonly name = "list_sketches";
+  readonly description =
+    "List the caller's sketches (image documents), most recently updated " +
+    "first: id, name, canvas size, and when it last changed. Start here when " +
+    "the user names a sketch but not its id.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      query: {
+        type: "string" as const,
+        description: "Only sketches whose name contains this text (case-insensitive)."
+      },
+      limit: {
+        type: "number" as const,
+        description: "Max sketches to return (default 20)."
+      }
+    }
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    if (!context.userId) return { error: "No user is bound to this session." };
+    const limit = Math.max(1, Math.min(Number(params["limit"]) || 20, 100));
+    const query =
+      typeof params["query"] === "string"
+        ? params["query"].trim().toLowerCase()
+        : "";
+    // Filter after the read: the name filter is not indexed, and the per-user
+    // limit is what bounds the scan.
+    const rows = await ImageDocument.listByUser(context.userId, 100);
+    const matching = query
+      ? rows.filter((row) => row.name.toLowerCase().includes(query))
+      : rows;
+    return {
+      sketches: matching.slice(0, limit).map((row) => ({
+        id: row.id,
+        name: row.name,
+        width: row.width,
+        height: row.height,
+        updated_at: row.updated_at
+      }))
+    };
+  }
+
+  userMessage(): string {
+    return "Listing sketches";
+  }
+}
+
+export class ListSketchVersionsTool extends Tool {
+  readonly name = "list_sketch_versions";
+  readonly description =
+    "List a sketch's whole-document snapshots, newest first: version number, " +
+    "name, save type ('manual', 'autosave', 'restore'), canvas settings, and " +
+    "when it was taken. These are document snapshots, not the per-layer " +
+    "generation history. Call this before restoring — restore_sketch_version " +
+    "addresses a snapshot by its version number.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      image_document_id: {
+        type: "string" as const,
+        description: "Sketch (image document) id."
+      },
+      save_type: SAVE_TYPE_PROPERTY,
+      limit: {
+        type: "number" as const,
+        description: `Max versions to return (default ${DEFAULT_VERSION_LIMIT}, max ${MAX_VERSION_LIMIT}).`
+      }
+    },
+    required: ["image_document_id"]
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const doc = await loadSketch(context, params["image_document_id"]);
+    if (isError(doc)) return doc;
+
+    const limit = Math.max(
+      1,
+      Math.min(Number(params["limit"]) || DEFAULT_VERSION_LIMIT, MAX_VERSION_LIMIT)
+    );
+    const saveType =
+      typeof params["save_type"] === "string"
+        ? (params["save_type"] as string)
+        : undefined;
+    const versions = await ImageDocumentVersion.listForDocument(doc.id, {
+      limit,
+      saveType
+    });
+    return {
+      image_document_id: doc.id,
+      name: doc.name,
+      versions: versions.map(toVersionListItem)
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Listing versions of sketch ${String(params["image_document_id"])}`;
+  }
+}
+
+export class CreateSketchVersionTool extends Tool {
+  readonly name = "create_sketch_version";
+  readonly description =
+    "Snapshot a sketch's current document as a manual version, so it can be " +
+    "restored later. Manual snapshots are never pruned (autosaves are), so " +
+    "take one before an edit the user may want undone. Returns the new " +
+    "version's number.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      image_document_id: {
+        type: "string" as const,
+        description: "Sketch (image document) id."
+      },
+      name: {
+        type: "string" as const,
+        description: "Label for the snapshot, e.g. 'before the repaint'."
+      }
+    },
+    required: ["image_document_id"]
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const doc = await loadSketch(context, params["image_document_id"]);
+    if (isError(doc)) return doc;
+
+    const name =
+      typeof params["name"] === "string" && params["name"]
+        ? (params["name"] as string)
+        : null;
+    const version = await ImageDocumentVersion.snapshot(doc, {
+      saveType: "manual",
+      name
+    });
+    return {
+      ok: true,
+      image_document_id: doc.id,
+      ...toVersionListItem(version)
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Snapshotting sketch ${String(params["image_document_id"])}`;
+  }
+}
+
+export class RestoreSketchVersionTool extends Tool {
+  readonly name = "restore_sketch_version";
+  readonly description =
+    "Roll a sketch's document and canvas settings back to one of its " +
+    "snapshots, addressed by version number (from list_sketch_versions). The " +
+    "state being overwritten is snapshotted first, so the restore is itself " +
+    "undoable — restore that snapshot to come back. An old document is " +
+    "restored against today's schema, so the result is validated afterwards " +
+    "and the findings are returned with it.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      image_document_id: {
+        type: "string" as const,
+        description: "Sketch (image document) id."
+      },
+      version: {
+        type: "number" as const,
+        description: "Version number to restore, from list_sketch_versions."
+      }
+    },
+    required: ["image_document_id", "version"]
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const doc = await loadSketch(context, params["image_document_id"]);
+    if (isError(doc)) return doc;
+
+    const number = versionNumber(params["version"]);
+    if (isError(number)) return number;
+
+    const version = await ImageDocumentVersion.findByVersion(doc.id, number);
+    if (!version) {
+      return {
+        error: `Sketch ${doc.id} has no version ${number}. Call list_sketch_versions to see the available ones.`
+      };
+    }
+
+    const document = parseVersionDocument(version.document);
+    if (isError(document)) return document;
+
+    // Snapshot what is about to be overwritten first, so a restore is itself
+    // undoable.
+    const undo = await ImageDocumentVersion.snapshot(doc, {
+      saveType: "restore",
+      name: `Before restore to v${number}`
+    });
+
+    const updated = await ImageDocument.updateFieldsIfUnchanged(
+      doc.id,
+      doc.updated_at,
+      {
+        document: JSON.stringify(document),
+        width: version.width,
+        height: version.height,
+        background_color: version.background_color
+      }
+    );
+    if (!updated) {
+      return {
+        error: `Sketch ${doc.id} was modified since it was read (optimistic concurrency conflict); nothing was restored. Retry the call.`,
+        undo_version: undo.version
+      };
+    }
+
+    const validation = validateSketchDocument(document, {
+      width: version.width,
+      height: version.height,
+      backgroundColor: version.background_color
+    });
+
+    return {
+      ok: true,
+      image_document_id: doc.id,
+      restored_version: number,
+      undo_version: undo.version,
+      width: updated.width,
+      height: updated.height,
+      backgroundColor: updated.background_color,
+      updated_at: updated.updated_at,
+      validation,
+      summary: validationSummary(validation)
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Restoring sketch ${String(params["image_document_id"])} to v${String(params["version"])}`;
+  }
+}
+
+/** Every tool in this module, for toolbelt assembly and docs. */
+export const SKETCH_VERSION_TOOL_NAMES = [
+  "list_sketches",
+  "list_sketch_versions",
+  "create_sketch_version",
+  "restore_sketch_version"
+] as const;

--- a/packages/agents/src/tools/tool-permissions.ts
+++ b/packages/agents/src/tools/tool-permissions.ts
@@ -76,6 +76,9 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   list_scripts: "read",
   get_script: "read",
   validate_timeline: "read",
+  validate_sketch: "read",
+  list_sketches: "read",
+  list_sketch_versions: "read",
   list_storyboards: "read",
   get_storyboard: "read",
   get_example_workflow: "read",
@@ -173,6 +176,10 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   // assembly writes a timeline row.
   voice_script_lines: "write",
   assemble_script_timeline: "write",
+  // Both write the sketch's snapshot history; a restore also rewrites the
+  // document itself (undoably — it snapshots first).
+  create_sketch_version: "write",
+  restore_sketch_version: "write",
   transcribe_audio: "write",
   embed_text: "write",
   openai_image_generation: "write",

--- a/packages/agents/tests/mcp-tools.test.ts
+++ b/packages/agents/tests/mcp-tools.test.ts
@@ -12,6 +12,7 @@ import {
   DebugAppTool,
   ValidateWorkflowTool,
   ValidateTimelineTool,
+  ValidateSketchTool,
   GetExampleWorkflowTool,
   ExportWorkflowDigraphTool,
   ListNodesTool,
@@ -744,6 +745,119 @@ describe("ValidateTimelineTool", () => {
 
     expect(result.error).toContain("no timeline loader");
     expect(result.validated).toBe(false);
+  });
+});
+
+describe("ValidateSketchTool", () => {
+  const layer = (overrides: Record<string, unknown> = {}) => ({
+    id: "layer-1",
+    name: "Background",
+    type: "raster",
+    visible: true,
+    locked: false,
+    opacity: 1,
+    blendMode: "normal",
+    data: null,
+    ...overrides
+  });
+  const doc = (activeLayerId = "layer-1") => ({
+    sketch: {
+      version: 3,
+      canvas: { width: 1024, height: 768, backgroundColor: "#ffffff" },
+      layers: [layer()],
+      activeLayerId,
+      maskLayerId: null
+    },
+    layerBindings: []
+  });
+
+  it("validates an inline document and summarizes a clean result", async () => {
+    const tool = new ValidateSketchTool();
+    const result = (await tool.process(ctx, { document: doc() })) as {
+      ok: boolean;
+      errors: unknown[];
+      summary: string;
+    };
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.summary).toBe("No issues found.");
+  });
+
+  it("reports an active layer the stack lacks", async () => {
+    const tool = new ValidateSketchTool();
+    const result = (await tool.process(ctx, { document: doc("gone") })) as {
+      ok: boolean;
+      errors: Array<{ code: string }>;
+      summary: string;
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.map((e) => e.code)).toContain("active_layer_missing");
+    expect(result.summary).toContain("1 error");
+  });
+
+  it("checks the inline document against the canvas meta it is given", async () => {
+    const tool = new ValidateSketchTool();
+    const result = (await tool.process(ctx, {
+      document: doc(),
+      width: 512,
+      height: 768,
+      background_color: "#ffffff"
+    })) as { ok: boolean; warnings: Array<{ code: string }> };
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings.map((w) => w.code)).toContain("canvas_size_mismatch");
+  });
+
+  it("loads a saved sketch through the injected loader", async () => {
+    const loader = vi.fn().mockResolvedValue({
+      // Stored documents are JSON text; the tool parses them.
+      document: JSON.stringify(doc("gone")),
+      width: 1024,
+      height: 768,
+      backgroundColor: "#ffffff",
+      name: "My sketch"
+    });
+    const tool = new ValidateSketchTool(loader);
+    const result = (await tool.process(ctx, { image_document_id: "img-1" })) as {
+      ok: boolean;
+      image_document_id: string;
+      name: string;
+    };
+
+    expect(loader).toHaveBeenCalledWith(ctx, "img-1");
+    expect(result.ok).toBe(false);
+    expect(result.image_document_id).toBe("img-1");
+    expect(result.name).toBe("My sketch");
+  });
+
+  it("reports a sketch the loader cannot find", async () => {
+    const tool = new ValidateSketchTool(vi.fn().mockResolvedValue(null));
+    const result = (await tool.process(ctx, { image_document_id: "img-1" })) as {
+      error: string;
+      validated: boolean;
+    };
+
+    expect(result.error).toContain("was not found");
+    expect(result.validated).toBe(false);
+  });
+
+  it("reports an error when given an id but wired with no loader", async () => {
+    const tool = new ValidateSketchTool();
+    const result = (await tool.process(ctx, { image_document_id: "img-1" })) as {
+      error: string;
+      validated: boolean;
+    };
+
+    expect(result.error).toContain("no sketch loader");
+    expect(result.validated).toBe(false);
+  });
+
+  it("reports having nothing to validate", async () => {
+    const tool = new ValidateSketchTool();
+    const result = (await tool.process(ctx, {})) as { error: string };
+    expect(result.error).toContain("No sketch to validate");
   });
 });
 

--- a/packages/agents/tests/sketch-version-tools.test.ts
+++ b/packages/agents/tests/sketch-version-tools.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  ImageDocument,
+  ImageDocumentVersion,
+  ModelObserver,
+  initTestDb
+} from "@nodetool-ai/models";
+import {
+  ListSketchesTool,
+  ListSketchVersionsTool,
+  CreateSketchVersionTool,
+  RestoreSketchVersionTool
+} from "../src/tools/sketch-version-tools.js";
+import { permissionCategoryFor } from "../src/tools/tool-permissions.js";
+import { BUILTIN_TOOL_CLASSES } from "../src/tools/builtin-tools.js";
+
+const ctx = (userId = "u1") => ({ userId }) as unknown as ProcessingContext;
+
+const layer = (overrides: Record<string, unknown> = {}) => ({
+  id: "layer-1",
+  name: "Background",
+  type: "raster",
+  visible: true,
+  locked: false,
+  opacity: 1,
+  blendMode: "normal",
+  data: null,
+  ...overrides
+});
+
+const document = (activeLayerId = "layer-1") =>
+  JSON.stringify({
+    sketch: {
+      version: 3,
+      canvas: { width: 1024, height: 768, backgroundColor: "#ffffff" },
+      layers: [layer()],
+      activeLayerId,
+      maskLayerId: null
+    },
+    layerBindings: []
+  });
+
+async function makeSketch(
+  overrides: Record<string, unknown> = {}
+): Promise<ImageDocument> {
+  return ImageDocument.create<ImageDocument>({
+    user_id: "u1",
+    project_id: "default",
+    name: "Poster",
+    width: 1024,
+    height: 768,
+    background_color: "#ffffff",
+    document: document(),
+    ...overrides
+  });
+}
+
+describe("sketch version tools", () => {
+  beforeEach(() => initTestDb());
+  afterEach(() => ModelObserver.clear());
+
+  it("registers as built-ins with sane permissions", () => {
+    const names = BUILTIN_TOOL_CLASSES.map((Cls) => new Cls().name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "list_sketches",
+        "list_sketch_versions",
+        "create_sketch_version",
+        "restore_sketch_version"
+      ])
+    );
+    expect(permissionCategoryFor("list_sketch_versions")).toBe("read");
+    expect(permissionCategoryFor("restore_sketch_version")).toBe("write");
+    expect(permissionCategoryFor("validate_sketch")).toBe("read");
+  });
+
+  it("lists the caller's sketches and filters by name", async () => {
+    const poster = await makeSketch();
+    await makeSketch({ name: "Storyboard frame" });
+
+    const all = (await new ListSketchesTool().process(ctx(), {})) as {
+      sketches: Array<{ id: string; name: string; width: number }>;
+    };
+    expect(all.sketches).toHaveLength(2);
+
+    const filtered = (await new ListSketchesTool().process(ctx(), {
+      query: "post"
+    })) as { sketches: Array<{ id: string; width: number }> };
+    expect(filtered.sketches).toHaveLength(1);
+    expect(filtered.sketches[0]).toMatchObject({ id: poster.id, width: 1024 });
+  });
+
+  it("hides another user's sketches", async () => {
+    await makeSketch();
+    const listed = (await new ListSketchesTool().process(ctx("other"), {})) as {
+      sketches: unknown[];
+    };
+    expect(listed.sketches).toEqual([]);
+
+    const versions = (await new ListSketchVersionsTool().process(ctx("other"), {
+      image_document_id: (await ImageDocument.listByUser("u1"))[0].id
+    })) as { error: string };
+    expect(versions.error).toContain("was not found");
+  });
+
+  it("creates a manual snapshot and lists it", async () => {
+    const row = await makeSketch();
+
+    const created = (await new CreateSketchVersionTool().process(ctx(), {
+      image_document_id: row.id,
+      name: "before the repaint"
+    })) as { ok: boolean; version: number; saveType: string; name: string };
+    expect(created).toMatchObject({
+      ok: true,
+      version: 1,
+      saveType: "manual",
+      name: "before the repaint",
+      backgroundColor: "#ffffff"
+    });
+
+    await ImageDocumentVersion.snapshot(row, { saveType: "autosave" });
+
+    const listed = (await new ListSketchVersionsTool().process(ctx(), {
+      image_document_id: row.id
+    })) as { versions: Array<{ version: number; saveType: string }> };
+    // Newest first.
+    expect(listed.versions.map((v) => [v.version, v.saveType])).toEqual([
+      [2, "autosave"],
+      [1, "manual"]
+    ]);
+
+    const manualOnly = (await new ListSketchVersionsTool().process(ctx(), {
+      image_document_id: row.id,
+      save_type: "manual"
+    })) as { versions: Array<{ version: number }> };
+    expect(manualOnly.versions.map((v) => v.version)).toEqual([1]);
+  });
+
+  it("restores a version, snapshots the overwritten state, and validates the result", async () => {
+    const row = await makeSketch();
+    await new CreateSketchVersionTool().process(ctx(), {
+      image_document_id: row.id,
+      name: "the good one"
+    });
+
+    // Move the document on, so the restore has something to undo.
+    const edited = (await ImageDocument.findById(row.id))!;
+    edited.document = document("layer-2");
+    edited.width = 512;
+    await edited.save();
+
+    const result = (await new RestoreSketchVersionTool().process(ctx(), {
+      image_document_id: row.id,
+      version: 1
+    })) as {
+      ok: boolean;
+      restored_version: number;
+      undo_version: number;
+      width: number;
+      validation: { ok: boolean; errors: unknown[] };
+      summary: string;
+    };
+
+    expect(result).toMatchObject({
+      ok: true,
+      restored_version: 1,
+      undo_version: 2,
+      width: 1024
+    });
+    expect(result.validation.ok).toBe(true);
+    expect(result.summary).toBe("No issues found.");
+
+    const restored = (await ImageDocument.findById(row.id))!;
+    expect(restored.width).toBe(1024);
+    expect(JSON.parse(restored.document).sketch.activeLayerId).toBe("layer-1");
+
+    // The restore is undoable: v2 holds the state it overwrote.
+    const undo = (await ImageDocumentVersion.findByVersion(row.id, 2))!;
+    expect(undo.save_type).toBe("restore");
+    expect(undo.name).toBe("Before restore to v1");
+    expect(undo.width).toBe(512);
+  });
+
+  it("reports the findings when the restored document no longer validates", async () => {
+    const row = await makeSketch({ document: document("gone") });
+    await new CreateSketchVersionTool().process(ctx(), {
+      image_document_id: row.id
+    });
+
+    const result = (await new RestoreSketchVersionTool().process(ctx(), {
+      image_document_id: row.id,
+      version: 1
+    })) as {
+      ok: boolean;
+      validation: { ok: boolean; errors: Array<{ code: string }> };
+      summary: string;
+    };
+
+    expect(result.ok).toBe(true);
+    expect(result.validation.ok).toBe(false);
+    expect(result.validation.errors.map((e) => e.code)).toContain(
+      "active_layer_missing"
+    );
+    expect(result.summary).toContain("1 error");
+  });
+
+  it("refuses to restore a version the sketch does not have", async () => {
+    const row = await makeSketch();
+    const result = (await new RestoreSketchVersionTool().process(ctx(), {
+      image_document_id: row.id,
+      version: 7
+    })) as { error: string };
+    expect(result.error).toContain("no version 7");
+    expect(result.error).toContain("list_sketch_versions");
+  });
+
+  it("refuses to restore another user's sketch", async () => {
+    const row = await makeSketch();
+    await new CreateSketchVersionTool().process(ctx(), {
+      image_document_id: row.id
+    });
+
+    const result = (await new RestoreSketchVersionTool().process(ctx("other"), {
+      image_document_id: row.id,
+      version: 1
+    })) as { error: string };
+    expect(result.error).toContain("was not found");
+  });
+});

--- a/packages/base-nodes/vitest.config.ts
+++ b/packages/base-nodes/vitest.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
         __dirname,
         "../execution/src/timeline-debug/index.ts"
       ),
+      "@nodetool-ai/execution/sketch-debug": resolve(
+        __dirname,
+        "../execution/src/sketch-debug/index.ts"
+      ),
       "@nodetool-ai/execution": resolve(__dirname, "../execution/src/index.ts"),
       "@nodetool-ai/kernel": resolve(__dirname, "../kernel/src/index.ts"),
       "@nodetool-ai/protocol": resolve(__dirname, "../protocol/src"),

--- a/packages/cli/src/commands/sketch-validation-output.ts
+++ b/packages/cli/src/commands/sketch-validation-output.ts
@@ -1,0 +1,35 @@
+/**
+ * Human-readable rendering of a `SketchValidation`, kept beside the sketch
+ * commands the way `timeline-validation-output.ts` sits beside the timeline
+ * ones. Split out so more than one command can print a check the same way.
+ */
+import type {
+  SketchDebugIssue,
+  SketchValidation
+} from "@nodetool-ai/execution/sketch-debug";
+
+/** Headline, then one line per issue — errors before warnings. */
+export function renderSketchValidation(validation: SketchValidation): string[] {
+  const errors = validation.errors.length;
+  const warnings = validation.warnings.length;
+  const mark = validation.ok ? (warnings ? "⚠️" : "✅") : "❌";
+  const lines = ["", `${mark} ${errors} error(s), ${warnings} warning(s)`];
+  if (errors + warnings === 0) return lines;
+
+  lines.push("");
+  for (const issue of [...validation.errors, ...validation.warnings]) {
+    lines.push(`  ${formatSketchIssue(issue)}`);
+  }
+  return lines;
+}
+
+function formatSketchIssue(issue: SketchDebugIssue): string {
+  const tag = issue.severity === "error" ? "error" : "warn ";
+  const where =
+    issue.layerId != null
+      ? ` [layer ${issue.layerId}]`
+      : issue.path != null
+        ? ` [${issue.path}]`
+        : "";
+  return `${tag} ${issue.message}${where} (${issue.code})`;
+}

--- a/packages/cli/src/commands/sketch-versions.ts
+++ b/packages/cli/src/commands/sketch-versions.ts
@@ -10,17 +10,21 @@
  *
  * `restore` mirrors the tRPC router (`sketch.documentVersions.restore`):
  * snapshot what is about to be overwritten, then CAS-write the version's
- * document and canvas settings back onto the image document. A sketch has no
- * validator harness, so the check afterwards is the one a headless run can
- * make — the restored document must still parse as a JSON object.
+ * document and canvas settings back onto the image document, then run the same
+ * static check `sketch validate` runs. An old document is restored against
+ * today's schema, so what it used to pass is not what it passes now — a
+ * restore whose document no longer validates exits non-zero and prints the
+ * issues.
  *
- * The database is injected with a lazy default, so registration stays light and
- * the actions are unit-testable.
+ * The database and the validator core are injected with lazy defaults, so
+ * registration stays light and the actions are unit-testable.
  */
 import type { Command } from "commander";
+import type { SketchValidation } from "@nodetool-ai/execution/sketch-debug";
 import { printCommandError } from "../command-errors.js";
 import { asJson, confirm, printTable } from "./output.js";
 import { numericOptionParser } from "../numeric-options.js";
+import { renderSketchValidation } from "./sketch-validation-output.js";
 
 /** An `image_documents` row as these commands need it. */
 export interface ImageDocumentRow {
@@ -77,6 +81,11 @@ export interface SketchVersionStore {
 export interface SketchVersionsDeps {
   /** Defaults to the local database through `@nodetool-ai/models`. */
   store?: () => Promise<SketchVersionStore>;
+  /** Defaults to `validateSketchDocument` from the sketch-debug core. */
+  validate?: (
+    document: unknown,
+    meta: { width?: number; height?: number; backgroundColor?: string }
+  ) => Promise<SketchValidation> | SketchValidation;
   /** Defaults to the interactive prompt in `output.ts`. */
   confirmDelete?: (message: string, force?: boolean) => Promise<boolean>;
 }
@@ -147,25 +156,14 @@ export function documentCounts(document: unknown): {
   };
 }
 
-/**
- * What a headless check can decide about a restored sketch: it has to still be
- * a JSON object. Layer bitmaps are opaque here — nothing offline can say
- * whether they still decode.
- */
-export function checkRestoredDocument(document: unknown): {
-  ok: boolean;
-  error?: string;
-} {
-  if (typeof document !== "object" || document === null) {
-    return {
-      ok: false,
-      error: "restored document is not valid JSON (expected an object)"
-    };
-  }
-  if (Array.isArray(document)) {
-    return { ok: false, error: "restored document is an array, not an object" };
-  }
-  return { ok: true };
+async function defaultValidate(
+  document: unknown,
+  meta: { width?: number; height?: number; backgroundColor?: string }
+): Promise<SketchValidation> {
+  const { validateSketchDocument } = await import(
+    "@nodetool-ai/execution/sketch-debug"
+  );
+  return validateSketchDocument(document, meta);
 }
 
 async function defaultStore(): Promise<SketchVersionStore> {
@@ -247,6 +245,7 @@ export function registerSketchVersionsCommands(
   deps: SketchVersionsDeps = {}
 ): void {
   const openStore = deps.store ?? defaultStore;
+  const validate = deps.validate ?? defaultValidate;
   const confirmDelete =
     deps.confirmDelete ??
     ((message: string, force?: boolean) => confirm(message, { force }));
@@ -358,7 +357,7 @@ export function registerSketchVersionsCommands(
   versions
     .command("restore <image_document_id> <version>")
     .description(
-      "Restore a version onto the sketch. The pre-restore state is snapshotted first, and the restored document must still parse as a JSON object — a restore that no longer does exits non-zero"
+      "Restore a version onto the sketch. The pre-restore state is snapshotted first, and the restored document is validated against the current schema — a restore whose document no longer validates exits non-zero"
     )
     .option("--json", "Print the restore result as JSON")
     .action(async (documentId: string, version: string, opts: JsonOption) => {
@@ -385,7 +384,11 @@ export function registerSketchVersionsCommands(
         }
 
         const document = parseVersionDocument(target.document);
-        const check = checkRestoredDocument(document);
+        const validation = await validate(document, {
+          width: target.width,
+          height: target.height,
+          backgroundColor: target.background_color
+        });
 
         if (opts.json) {
           asJson({
@@ -398,7 +401,7 @@ export function registerSketchVersionsCommands(
               height: updated.height,
               backgroundColor: updated.background_color
             },
-            check
+            validation
           });
         } else {
           const counts = documentCounts(document);
@@ -408,13 +411,9 @@ export function registerSketchVersionsCommands(
           console.log(
             `  pre-restore state saved as v${backup.version} (${backup.save_type})`
           );
-          if (check.ok) {
-            console.log("  document parses cleanly");
-          } else {
-            console.log(`❌ ${check.error}`);
-          }
+          console.log(renderSketchValidation(validation).join("\n"));
         }
-        restoredOk = check.ok;
+        restoredOk = validation.ok;
       } catch (e) {
         printCommandError(e, opts.json);
         process.exit(1);

--- a/packages/cli/src/commands/sketch.ts
+++ b/packages/cli/src/commands/sketch.ts
@@ -1,17 +1,173 @@
 /**
- * `nodetool sketch` — the image-editor commands.
+ * `nodetool sketch validate`, `debug` and `versions` — the sketch harness
+ * commands.
  *
- * Only the snapshot history lives here so far (sketch-versions.ts): a sketch's
- * manual saves, the autosaves the server writes, and the pre-restore snapshot
- * that makes a restore undoable.
+ * `validate` checks an image document statically: layers a binding points at,
+ * fields a round trip through the schema would strip, canvas and layer values
+ * nothing can composite. `debug` additionally replays a scripted `--interact`
+ * edit session against the headless `ui_sketch_*` bridge and writes a bundle.
+ * Both take an image-document JSON file or an `image_documents` row id.
+ * `versions` (sketch-versions.ts) reads and restores a document's snapshot
+ * history.
+ *
+ * Heavy dependencies (the database, the validator core, the bridge) are
+ * imported lazily inside each action, so command registration stays light and
+ * unit-testable.
  */
 import type { Command } from "commander";
+import type { SketchDebugReport } from "@nodetool-ai/execution/sketch-debug";
+import type { ImageDocumentRecord } from "../sketch-debug/target.js";
+import { printCommandError } from "../command-errors.js";
+import { renderSketchValidation } from "./sketch-validation-output.js";
 import { registerSketchVersionsCommands } from "./sketch-versions.js";
+
+export { renderSketchValidation };
+
+interface SketchValidateCliOptions {
+  json?: boolean;
+  warningsAsErrors?: boolean;
+}
+
+interface SketchDebugCliOptions {
+  interact?: string;
+  out?: string;
+  json?: boolean;
+}
+
+/** Read an image document row through the local database. */
+async function documentLoader(): Promise<
+  (id: string) => Promise<ImageDocumentRecord | null>
+> {
+  const { initDb, ImageDocument } = await import("@nodetool-ai/models");
+  const { getDefaultDbPath } = await import("@nodetool-ai/config");
+  let ready = false;
+  return async (id: string) => {
+    if (!ready) {
+      initDb(getDefaultDbPath());
+      ready = true;
+    }
+    const row = await ImageDocument.findById(id);
+    return row
+      ? {
+          id: row.id,
+          name: row.name,
+          width: row.width,
+          height: row.height,
+          background_color: row.background_color,
+          document: row.document
+        }
+      : null;
+  };
+}
 
 export function registerSketchCommands(program: Command): void {
   const sketch = program
     .command("sketch")
     .description("Work with sketches (image documents)");
 
+  sketch
+    .command("validate <sketch_id_or_file>")
+    .description(
+      "Validate an image document without rendering it: bindings on missing layers, fields a schema round trip would strip, canvas and layer values nothing can composite. Takes an image-document JSON file or an image_documents row id"
+    )
+    .option("--json", "Print the full SketchValidation as JSON")
+    .option(
+      "--warnings-as-errors",
+      "Exit non-zero when there are warnings (not just errors)"
+    )
+    .action(async (ref: string, opts: SketchValidateCliOptions) => {
+      try {
+        const { runSketchValidate } = await import("../sketch-debug/index.js");
+        const { target, validation } = await runSketchValidate(ref, {
+          loadDocument: await documentLoader()
+        });
+
+        if (opts.json) {
+          console.log(JSON.stringify({ target, validation }, null, 2));
+        } else {
+          console.log(renderSketchValidation(validation).join("\n"));
+        }
+
+        const failed =
+          !validation.ok ||
+          (opts.warningsAsErrors === true && validation.warnings.length > 0);
+        process.exit(failed ? 1 : 0);
+      } catch (e) {
+        printCommandError(e, opts.json);
+        process.exit(1);
+      }
+    });
+
+  sketch
+    .command("debug <sketch_id_or_file>")
+    .description(
+      "Replay a scripted edit session against a sketch headlessly and collect a debug bundle (the document, the report, every step's result)"
+    )
+    .option(
+      "--interact <json>",
+      'Scripted steps: [{"tool":"add_layer","input":{"name":"Glow"}}] — the ui_sketch_ prefix is optional'
+    )
+    .option(
+      "--out <dir>",
+      "Bundle output directory (default: nodetool-debug/sketch-<id>-<timestamp>)"
+    )
+    .option("--json", "Print the full SketchDebugReport as JSON to stdout")
+    .action(async (ref: string, opts: SketchDebugCliOptions) => {
+      try {
+        const { parseInteractionScript, runSketchDebug } = await import(
+          "../sketch-debug/index.js"
+        );
+        const interact = opts.interact
+          ? parseInteractionScript(opts.interact)
+          : undefined;
+
+        const { report, bundleDir } = await runSketchDebug(
+          ref,
+          {
+            ...(interact ? { interact } : {}),
+            ...(opts.out ? { outDir: opts.out } : {})
+          },
+          {
+            loadDocument: await documentLoader(),
+            onLog: (line) => console.error(line)
+          }
+        );
+
+        if (opts.json) {
+          console.log(JSON.stringify(report, null, 2));
+        } else {
+          printSketchSummary(report, bundleDir);
+        }
+        process.exit(report.verdict.ok ? 0 : 1);
+      } catch (e) {
+        printCommandError(e, opts.json);
+        process.exit(1);
+      }
+    });
+
   registerSketchVersionsCommands(sketch);
+}
+
+function printSketchSummary(report: SketchDebugReport, bundleDir: string): void {
+  const mark = report.verdict.ok ? "✅" : "❌";
+  console.log(`\n${mark} ${report.verdict.headline}`);
+  console.log(
+    `  sketch:  ${report.meta.layerCount} layer(s), ${report.meta.bindingCount} binding(s), ${report.meta.width}x${report.meta.height}`
+  );
+  const failed = report.interactions.filter((i) => !i.ok).length;
+  if (report.interactions.length > 0) {
+    console.log(
+      `  session: ${report.interactions.length} step(s), ${failed} failed`
+    );
+  }
+  if (report.verdict.issues.length > 0) {
+    console.log("\nIssues:");
+    for (const issue of report.verdict.issues) console.log(`  - ${issue}`);
+  }
+  if (report.verdict.warnings && report.verdict.warnings.length > 0) {
+    console.log("\nWarnings:");
+    for (const warning of report.verdict.warnings) console.log(`  - ${warning}`);
+  }
+  console.log(`\nDebug bundle: ${bundleDir}`);
+  console.log("  report.md / report.json · sketch.json");
 }

--- a/packages/cli/src/harness/registry.ts
+++ b/packages/cli/src/harness/registry.ts
@@ -184,8 +184,25 @@ export const HARNESSES: HarnessEntry[] = [
     docs: "CLAUDE.md § nodetool timeline validate / debug"
   },
   {
+    id: "sketch-validate",
+    title: "Sketch static check",
+    command: "nodetool sketch validate <id|file.json>",
+    kind: "static",
+    capabilities: ["json", "no-db"],
+    agentTool: "validate_sketch",
+    docs: "CLAUDE.md § nodetool sketch validate / debug"
+  },
+  {
+    id: "sketch-debug",
+    title: "Sketch edit-session replay",
+    command: "nodetool sketch debug <id|file.json> --interact '[...]'",
+    kind: "execution",
+    capabilities: ["json", "interact", "no-db"],
+    docs: "CLAUDE.md § nodetool sketch validate / debug"
+  },
+  {
     id: "sketch-versions",
-    title: "Sketch version history (snapshot, restore, check the restore)",
+    title: "Sketch version history (snapshot, restore, validate the restore)",
     command:
       "nodetool sketch versions list|show|create|restore|delete <id> [<version>]",
     kind: "execution",
@@ -298,11 +315,14 @@ export const SURFACES: SurfaceEntry[] = [
   },
   {
     id: "sketch",
-    title: "Sketches (image documents, version history)",
-    harnesses: ["sketch-versions", "eval"],
+    title: "Sketches (image documents, ui_sketch_* tools, version history)",
+    harnesses: ["sketch-validate", "sketch-debug", "sketch-versions", "eval"],
     paths: [
+      "packages/execution/src/sketch-debug/",
+      "packages/cli/src/sketch-debug/",
       "packages/cli/src/commands/sketch-versions.ts",
       "packages/cli/src/commands/sketch.ts",
+      "packages/agents/src/tools/sketch-version-tools.ts",
       "packages/models/src/image-document-version.ts",
       "packages/websocket/src/trpc/routers/sketch.ts"
     ]

--- a/packages/cli/src/sketch-debug/harness.ts
+++ b/packages/cli/src/sketch-debug/harness.ts
@@ -1,0 +1,286 @@
+/**
+ * The sketch debug harness: the CLI host around the shared validator.
+ *
+ * `runSketchValidate` is the cheap pre-flight — load an image document, check
+ * it, report. `runSketchDebug` additionally replays a scripted edit session
+ * against the headless `ui_sketch_*` bridge (the one the tool-loop eval
+ * drives), validates the document the session left behind, and writes a
+ * self-contained bundle.
+ *
+ * Everything that could pull in a heavy package is injected with a lazy
+ * default: the validator core (`@nodetool-ai/execution/sketch-debug`) and the
+ * bridge factory (`@nodetool-ai/agents`). Tests supply their own and load
+ * neither.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import type {
+  SketchDebugReport,
+  SketchInteractionRecord,
+  SketchValidation
+} from "@nodetool-ai/execution/sketch-debug";
+import type { SketchInteractionStep } from "./interactions.js";
+import {
+  resolveSketchTarget,
+  type ResolvedSketchTarget,
+  type SketchCanvasSettings,
+  type SketchTargetDeps
+} from "./target.js";
+
+/** The pieces of the shared core this host calls. */
+export interface SketchDebugCore {
+  validateSketchDocument: (
+    raw: unknown,
+    meta?: SketchCanvasSettings
+  ) => SketchValidation | Promise<SketchValidation>;
+  buildSketchDebugReport: (input: {
+    target: SketchDebugReport["target"];
+    document: unknown;
+    meta?: SketchCanvasSettings;
+    interactions?: SketchInteractionRecord[];
+    finalState?: unknown;
+    finalDocument?: unknown;
+  }) => SketchDebugReport | Promise<SketchDebugReport>;
+  renderSketchReportMarkdown: (report: SketchDebugReport) => string;
+}
+
+/** The bridge surface this host drives — one tool per `ui_sketch_*` name. */
+export interface SketchBridgeTool {
+  name: string;
+  execute: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+/** One layer of the bridge's snapshot. */
+export interface SketchBridgeLayer {
+  id: string;
+  name: string;
+  type: "raster" | "mask" | "group";
+  visible: boolean;
+  opacity: number;
+  blendMode: string;
+  hasBinding?: boolean;
+}
+
+/** The bridge's snapshot after a session (`SketchBridgeFinalState`). */
+export interface SketchBridgeSnapshot {
+  width?: number;
+  height?: number;
+  backgroundColor?: string;
+  activeLayerId?: string | null;
+  layers?: SketchBridgeLayer[];
+}
+
+export interface SketchBridge {
+  tools: SketchBridgeTool[];
+  finalState: () => SketchBridgeSnapshot;
+}
+
+export type CreateSketchBridge = (initial: {
+  name?: string;
+  width?: number;
+  height?: number;
+  layers?: { name: string; type?: "raster" | "mask" }[];
+}) => SketchBridge;
+
+export interface SketchDebugDeps extends SketchTargetDeps {
+  /** Defaults to `@nodetool-ai/execution/sketch-debug`. */
+  core?: SketchDebugCore;
+  /** Defaults to `createSketchToolBridge` from `@nodetool-ai/agents`. */
+  createBridge?: CreateSketchBridge;
+  onLog?: (line: string) => void;
+}
+
+export interface SketchDebugOptions {
+  interact?: SketchInteractionStep[];
+  outDir?: string;
+}
+
+export interface SketchValidateResult {
+  target: ResolvedSketchTarget["target"];
+  validation: SketchValidation;
+}
+
+export interface SketchDebugResult {
+  report: SketchDebugReport;
+  bundleDir: string;
+}
+
+async function loadCore(): Promise<SketchDebugCore> {
+  const core = await import("@nodetool-ai/execution/sketch-debug");
+  return {
+    validateSketchDocument: (raw, meta) => core.validateSketchDocument(raw, meta),
+    buildSketchDebugReport: (input) => core.buildSketchDebugReport(input),
+    renderSketchReportMarkdown: (report) => core.renderSketchReportMarkdown(report)
+  };
+}
+
+async function loadBridgeFactory(): Promise<CreateSketchBridge> {
+  const { createSketchToolBridge } = await import("@nodetool-ai/agents");
+  return (initial) =>
+    createSketchToolBridge(
+      initial as Parameters<typeof createSketchToolBridge>[0]
+    ) as unknown as SketchBridge;
+}
+
+function defaultOutDir(ref: string): string {
+  const slug =
+    ref.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40) ||
+    "sketch";
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return resolve(`nodetool-debug/sketch-${slug}-${stamp}`);
+}
+
+/** Load a sketch and validate it — no bridge, no bundle. */
+export async function runSketchValidate(
+  ref: string,
+  deps: SketchDebugDeps
+): Promise<SketchValidateResult> {
+  const resolved = await resolveSketchTarget(ref, deps);
+  const core = deps.core ?? (await loadCore());
+  const validation = await core.validateSketchDocument(resolved.raw, resolved.meta);
+  return { target: resolved.target, validation };
+}
+
+/**
+ * The document the session left behind, rebuilt from the bridge snapshot.
+ *
+ * The bridge models a flat raster/mask stack with its own layer ids and no
+ * pixels, so the reconstruction carries structure only: bitmaps are absent,
+ * lock state is not tracked, and generation bindings are dropped — the bridge
+ * records a layer's prompt/provider/model, not the persisted binding record.
+ * The report's `notSimulated` says so.
+ */
+function reconstructDocument(
+  snapshot: SketchBridgeSnapshot,
+  resolved: ResolvedSketchTarget
+): unknown {
+  const layers = (snapshot.layers ?? []).map((layer) => ({
+    id: layer.id,
+    name: layer.name,
+    type: layer.type,
+    visible: layer.visible,
+    locked: false,
+    opacity: layer.opacity,
+    blendMode: layer.blendMode,
+    data: null
+  }));
+  const activeLayerId =
+    typeof snapshot.activeLayerId === "string" ? snapshot.activeLayerId : "";
+  const background =
+    snapshot.backgroundColor ??
+    resolved.document.canvas.backgroundColor ??
+    resolved.meta.backgroundColor;
+
+  return {
+    sketch: {
+      version: resolved.document.version,
+      canvas: {
+        width: snapshot.width ?? resolved.document.canvas.width ?? 0,
+        height: snapshot.height ?? resolved.document.canvas.height ?? 0,
+        ...(background !== undefined ? { backgroundColor: background } : {})
+      },
+      layers,
+      activeLayerId,
+      maskLayerId: null
+    },
+    layerBindings: []
+  };
+}
+
+/**
+ * Replay `--interact` against the headless bridge and write the bundle.
+ *
+ * A failing step is recorded and the script continues: a run that stops at the
+ * first error hides every problem behind it, and the report is what the caller
+ * came for.
+ */
+export async function runSketchDebug(
+  ref: string,
+  options: SketchDebugOptions,
+  deps: SketchDebugDeps
+): Promise<SketchDebugResult> {
+  const resolved = await resolveSketchTarget(ref, deps);
+  const core = deps.core ?? (await loadCore());
+
+  const steps = options.interact ?? [];
+  const interactions: SketchInteractionRecord[] = [];
+  let snapshot: SketchBridgeSnapshot | undefined;
+
+  if (steps.length > 0) {
+    const createBridge = deps.createBridge ?? (await loadBridgeFactory());
+    const bridge = createBridge({
+      ...(resolved.target.name ? { name: resolved.target.name } : {}),
+      ...(resolved.document.canvas.width !== undefined
+        ? { width: resolved.document.canvas.width }
+        : {}),
+      ...(resolved.document.canvas.height !== undefined
+        ? { height: resolved.document.canvas.height }
+        : {}),
+      // The bridge seeds names and types only; a group layer has no headless
+      // equivalent, so it enters the stack as a raster.
+      layers: resolved.document.layers.map((layer) => ({
+        name: layer.name,
+        type: layer.type === "mask" ? ("mask" as const) : ("raster" as const)
+      }))
+    });
+    const byName = new Map(bridge.tools.map((t) => [t.name, t]));
+
+    for (const step of steps) {
+      const tool = byName.get(step.tool);
+      if (!tool) {
+        const known = [...byName.keys()].sort().join(", ");
+        interactions.push({
+          tool: step.tool,
+          input: step.input,
+          ok: false,
+          error: `No sketch tool named "${step.tool}". Available: ${known}.`
+        });
+        deps.onLog?.(`✗ ${step.tool}: unknown tool`);
+        continue;
+      }
+      try {
+        const result = await tool.execute(step.input);
+        interactions.push({ tool: step.tool, input: step.input, ok: true, result });
+        deps.onLog?.(`✓ ${step.tool}`);
+      } catch (e) {
+        const error = e instanceof Error ? e.message : String(e);
+        interactions.push({ tool: step.tool, input: step.input, ok: false, error });
+        deps.onLog?.(`✗ ${step.tool}: ${error}`);
+      }
+    }
+    snapshot = bridge.finalState();
+  }
+
+  const finalDocument = snapshot
+    ? reconstructDocument(snapshot, resolved)
+    : undefined;
+
+  const report = await core.buildSketchDebugReport({
+    target: resolved.target,
+    document: resolved.raw,
+    meta: resolved.meta,
+    interactions,
+    ...(snapshot ? { finalState: snapshot } : {}),
+    ...(finalDocument ? { finalDocument } : {})
+  });
+
+  const bundleDir = options.outDir ? resolve(options.outDir) : defaultOutDir(ref);
+  await mkdir(bundleDir, { recursive: true });
+  await writeFile(
+    join(bundleDir, "sketch.json"),
+    JSON.stringify(resolved.raw, null, 2),
+    "utf8"
+  );
+  await writeFile(
+    join(bundleDir, "report.json"),
+    JSON.stringify(report, null, 2),
+    "utf8"
+  );
+  await writeFile(
+    join(bundleDir, "report.md"),
+    core.renderSketchReportMarkdown(report),
+    "utf8"
+  );
+
+  return { report, bundleDir };
+}

--- a/packages/cli/src/sketch-debug/index.ts
+++ b/packages/cli/src/sketch-debug/index.ts
@@ -1,0 +1,33 @@
+/**
+ * The CLI host for the sketch debug harness: target resolution, the
+ * `--interact` script, and the bundle writer. The rules themselves live in
+ * `@nodetool-ai/execution/sketch-debug`.
+ */
+export {
+  runSketchDebug,
+  runSketchValidate,
+  type CreateSketchBridge,
+  type SketchBridge,
+  type SketchBridgeLayer,
+  type SketchBridgeSnapshot,
+  type SketchBridgeTool,
+  type SketchDebugCore,
+  type SketchDebugDeps,
+  type SketchDebugOptions,
+  type SketchDebugResult,
+  type SketchValidateResult
+} from "./harness.js";
+export {
+  normalizeToolName,
+  parseInteractionScript,
+  type SketchInteractionStep
+} from "./interactions.js";
+export {
+  resolveSketchTarget,
+  type ImageDocumentRecord,
+  type ResolvedSketchTarget,
+  type SketchCanvasSettings,
+  type SketchDocumentView,
+  type SketchLayerView,
+  type SketchTargetDeps
+} from "./target.js";

--- a/packages/cli/src/sketch-debug/interactions.ts
+++ b/packages/cli/src/sketch-debug/interactions.ts
@@ -1,0 +1,58 @@
+/**
+ * The `--interact` script for `nodetool sketch debug`.
+ *
+ * A step names one sketch tool and the input to call it with:
+ *
+ * ```json
+ * [{"tool": "add_layer", "input": {"name": "Glow", "type": "raster"}},
+ *  {"tool": "ui_sketch_set_layer_props",
+ *   "input": {"target": "Glow", "opacity": 0.5, "blendMode": "multiply"}}]
+ * ```
+ *
+ * Both spellings resolve to the same tool: the `ui_sketch_` prefix is what the
+ * bridge and the browser call it, and typing it for every step is noise.
+ */
+
+/** One parsed step, with the tool name in its canonical `ui_sketch_*` form. */
+export interface SketchInteractionStep {
+  tool: string;
+  input: Record<string, unknown>;
+}
+
+const PREFIX = "ui_sketch_";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** `add_layer`, `ui_sketch_add_layer`, and `ui_add_layer` all normalize alike. */
+export function normalizeToolName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.startsWith(PREFIX)) return trimmed;
+  const bare = trimmed.startsWith("ui_") ? trimmed.slice("ui_".length) : trimmed;
+  return `${PREFIX}${bare}`;
+}
+
+/** Parse a `--interact` argument, naming the offending step on bad input. */
+export function parseInteractionScript(json: string): SketchInteractionStep[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (e) {
+    throw new Error(`--interact is not valid JSON: ${(e as Error).message}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      '--interact must be a JSON array of steps, e.g. \'[{"tool":"add_layer","input":{"name":"Glow"}}]\''
+    );
+  }
+  return parsed.map((step, index) => {
+    if (!isRecord(step) || typeof step.tool !== "string" || step.tool.trim() === "") {
+      throw new Error(`--interact step ${index + 1} has no \`tool\` name.`);
+    }
+    const input = step.input ?? {};
+    if (!isRecord(input)) {
+      throw new Error(`--interact step ${index + 1}: \`input\` must be an object.`);
+    }
+    return { tool: normalizeToolName(step.tool), input: { ...input } };
+  });
+}

--- a/packages/cli/src/sketch-debug/target.ts
+++ b/packages/cli/src/sketch-debug/target.ts
@@ -1,0 +1,189 @@
+/**
+ * Resolves a sketch debug target into an image document plus its canvas
+ * settings.
+ *
+ * A sketch is named two ways, and both end up in the same shape:
+ *
+ * - a **JSON file** — either a bare `ImageDocumentData` (`sketch` +
+ *   `layerBindings`) or a wrapper carrying one under `document`, as the
+ *   `image_documents` row and the `sketch.get` response do;
+ * - an **image_documents row id**, read through an injected loader so this
+ *   module needs no database.
+ *
+ * A path that exists on disk wins over an id, so a file named like an id is
+ * still readable.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import type { SketchDebugTarget } from "@nodetool-ai/execution/sketch-debug";
+
+/** An `image_documents` row as the harness needs it. */
+export interface ImageDocumentRecord {
+  id: string;
+  name?: string | null;
+  width?: number;
+  height?: number;
+  /** camelCase on the API response, snake_case on the row. */
+  backgroundColor?: string;
+  background_color?: string;
+  /** The stored document — a JSON string or an already-parsed object. */
+  document: unknown;
+}
+
+export interface SketchTargetDeps {
+  /** Load an image document by DB id. */
+  loadDocument: (id: string) => Promise<ImageDocumentRecord | null>;
+}
+
+/** The canvas settings the row carries beside the document. */
+export interface SketchCanvasSettings {
+  width?: number;
+  height?: number;
+  backgroundColor?: string;
+}
+
+/** The layer stack, read down to what the headless bridge can be seeded with. */
+export interface SketchLayerView {
+  id: string;
+  name: string;
+  type: "raster" | "mask" | "group";
+}
+
+/** The document read as a canvas plus a layer stack. */
+export interface SketchDocumentView {
+  version: number;
+  canvas: SketchCanvasSettings;
+  layers: SketchLayerView[];
+  activeLayerId: string;
+  maskLayerId: string | null;
+}
+
+export interface ResolvedSketchTarget {
+  target: SketchDebugTarget;
+  /** The document exactly as loaded — validation's input, unrepaired. */
+  raw: unknown;
+  /** The same document, read as a canvas + layer stack. */
+  document: SketchDocumentView;
+  meta: SketchCanvasSettings;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const numberOr = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+/** Read width/height/background off whatever wrapper carried the document. */
+function settingsOf(raw: unknown): SketchCanvasSettings {
+  if (!isRecord(raw)) return {};
+  const settings: SketchCanvasSettings = {};
+  const width = numberOr(raw.width);
+  const height = numberOr(raw.height);
+  const background =
+    typeof raw.backgroundColor === "string"
+      ? raw.backgroundColor
+      : typeof raw.background_color === "string"
+        ? raw.background_color
+        : undefined;
+  if (width !== undefined) settings.width = width;
+  if (height !== undefined) settings.height = height;
+  if (background !== undefined) settings.backgroundColor = background;
+  return settings;
+}
+
+/** A document is anything with a `sketch` object and a `layerBindings` array. */
+const looksLikeDocument = (value: unknown): boolean =>
+  isRecord(value) && isRecord(value.sketch) && Array.isArray(value.layerBindings);
+
+/**
+ * The document a target carries, unwrapping a `document` field (string or
+ * object) when there is one. Never throws — an unreadable document is a
+ * validation finding, not a crash.
+ */
+function documentOf(raw: unknown): unknown {
+  if (!isRecord(raw)) return raw;
+  const inner = raw.document;
+  if (typeof inner === "string") {
+    try {
+      return JSON.parse(inner);
+    } catch {
+      return inner;
+    }
+  }
+  if (inner !== undefined) return inner;
+  return raw;
+}
+
+const layerType = (value: unknown): SketchLayerView["type"] =>
+  value === "mask" || value === "group" ? value : "raster";
+
+/** Read a document as a canvas + layer stack, defaulting what is missing. */
+function asDocument(raw: unknown): SketchDocumentView {
+  const record = isRecord(raw) ? raw : {};
+  const sketch = isRecord(record.sketch) ? record.sketch : {};
+  const layers: SketchLayerView[] = [];
+  for (const entry of Array.isArray(sketch.layers) ? sketch.layers : []) {
+    if (!isRecord(entry) || typeof entry.id !== "string") continue;
+    layers.push({
+      id: entry.id,
+      name: typeof entry.name === "string" ? entry.name : entry.id,
+      type: layerType(entry.type)
+    });
+  }
+  return {
+    version: numberOr(sketch.version) ?? 1,
+    canvas: settingsOf(sketch.canvas),
+    layers,
+    activeLayerId:
+      typeof sketch.activeLayerId === "string" ? sketch.activeLayerId : "",
+    maskLayerId: typeof sketch.maskLayerId === "string" ? sketch.maskLayerId : null
+  };
+}
+
+/** Resolve a sketch target: a JSON file path or an image document row id. */
+export async function resolveSketchTarget(
+  ref: string,
+  deps: SketchTargetDeps
+): Promise<ResolvedSketchTarget> {
+  if (existsSync(ref)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(ref, "utf8"));
+    } catch (e) {
+      throw new Error(`${ref} is not valid JSON: ${(e as Error).message}`);
+    }
+    const raw = documentOf(parsed);
+    if (!looksLikeDocument(raw)) {
+      throw new Error(
+        `${ref} is not an image document (no \`sketch\`/\`layerBindings\`, and no \`document\` field carrying them).`
+      );
+    }
+    const name =
+      isRecord(parsed) && typeof parsed.name === "string" ? parsed.name : undefined;
+    const document = asDocument(raw);
+    return {
+      target: { kind: "file", ref, ...(name ? { name } : {}) },
+      raw,
+      document,
+      // The wrapper's own width/height, never the canvas's: the validator
+      // compares the two, so folding one into the other hides the mismatch.
+      meta: settingsOf(parsed)
+    };
+  }
+
+  const record = await deps.loadDocument(ref);
+  if (!record) {
+    throw new Error(`Image document not found: ${ref}`);
+  }
+  const raw = documentOf(record);
+  const document = asDocument(raw);
+  return {
+    target: {
+      kind: "id",
+      ref,
+      ...(record.name ? { name: record.name } : {})
+    },
+    raw,
+    document,
+    meta: settingsOf(record)
+  };
+}

--- a/packages/cli/tests/sketch-command.test.ts
+++ b/packages/cli/tests/sketch-command.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the `nodetool sketch` command registration (src/commands/sketch.ts)
+ * and its human-readable validation output. Heavy dependencies are only
+ * imported lazily inside the actions, so registration is testable without them.
+ */
+import { describe, expect, it } from "vitest";
+import { Command } from "commander";
+import {
+  registerSketchCommands,
+  renderSketchValidation
+} from "../src/commands/sketch.js";
+
+function sketchSubcommand(name: string) {
+  const program = new Command();
+  registerSketchCommands(program);
+  const sketch = program.commands.find((c) => c.name() === "sketch");
+  if (!sketch) throw new Error("sketch command not registered");
+  const cmd = sketch.commands.find((c) => c.name() === name);
+  if (!cmd) throw new Error(`sketch ${name} not registered`);
+  return cmd;
+}
+
+describe("registerSketchCommands", () => {
+  it("registers validate with its options and target argument", () => {
+    const cmd = sketchSubcommand("validate");
+    expect(cmd.options.map((o) => o.long)).toEqual(
+      expect.arrayContaining(["--json", "--warnings-as-errors"])
+    );
+    expect(cmd.registeredArguments.map((a) => a.name())).toContain(
+      "sketch_id_or_file"
+    );
+  });
+
+  it("registers debug with the interact, out and json options", () => {
+    const cmd = sketchSubcommand("debug");
+    expect(cmd.options.map((o) => o.long)).toEqual(
+      expect.arrayContaining(["--interact", "--out", "--json"])
+    );
+  });
+
+  it("keeps the versions group beside them", () => {
+    const versions = sketchSubcommand("versions");
+    expect(versions.commands.map((c) => c.name()).sort()).toEqual([
+      "create",
+      "delete",
+      "list",
+      "restore",
+      "show"
+    ]);
+  });
+
+  it("documents both target kinds on validate", () => {
+    const description = sketchSubcommand("validate").description();
+    expect(description).toMatch(/JSON file/i);
+    expect(description).toMatch(/image_documents/);
+  });
+});
+
+describe("renderSketchValidation", () => {
+  it("reports a clean document with a check mark and no issue lines", () => {
+    const lines = renderSketchValidation({ ok: true, errors: [], warnings: [] });
+    expect(lines.join("\n")).toContain("✅ 0 error(s), 0 warning(s)");
+    expect(lines).toHaveLength(2);
+  });
+
+  it("lists errors before warnings, each with its code and location", () => {
+    const lines = renderSketchValidation({
+      ok: false,
+      errors: [
+        {
+          severity: "error",
+          code: "binding_layer_missing",
+          message: "binding generates a layer the document does not contain",
+          layerId: "layer-9"
+        }
+      ],
+      warnings: [
+        {
+          severity: "warning",
+          code: "field_stripped",
+          message: "field is dropped by the schema",
+          path: "sketch.notes"
+        }
+      ]
+    });
+
+    expect(lines[3]).toContain("error");
+    expect(lines[3]).toContain("[layer layer-9]");
+    expect(lines[3]).toContain("(binding_layer_missing)");
+    expect(lines[4]).toContain("warn");
+    expect(lines[4]).toContain("[sketch.notes]");
+  });
+
+  it("marks a warning-only document as a warning, not a failure", () => {
+    const lines = renderSketchValidation({
+      ok: true,
+      errors: [],
+      warnings: [
+        {
+          severity: "warning",
+          code: "document_empty",
+          message: "the sketch has no layers"
+        }
+      ]
+    });
+    expect(lines[1]).toContain("⚠️ 0 error(s), 1 warning(s)");
+  });
+});

--- a/packages/cli/tests/sketch-harness.test.ts
+++ b/packages/cli/tests/sketch-harness.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for the sketch debug harness (src/sketch-debug/): the `--interact`
+ * script parser and the orchestrator, with the validator core and the headless
+ * bridge injected — neither the execution core nor `@nodetool-ai/agents` is
+ * loaded here.
+ */
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  normalizeToolName,
+  parseInteractionScript
+} from "../src/sketch-debug/interactions.js";
+import {
+  runSketchDebug,
+  runSketchValidate,
+  type SketchDebugCore
+} from "../src/sketch-debug/harness.js";
+
+const layer = {
+  id: "layer-1",
+  name: "Background",
+  type: "raster",
+  visible: true,
+  locked: false,
+  opacity: 1,
+  blendMode: "normal",
+  data: null
+};
+
+const document = {
+  sketch: {
+    version: 3,
+    canvas: { width: 1024, height: 768, backgroundColor: "#ffffff" },
+    layers: [layer],
+    activeLayerId: "layer-1",
+    maskLayerId: null
+  },
+  layerBindings: []
+};
+
+const sketchFile = (): string => {
+  const file = join(mkdtempSync(join(tmpdir(), "sketch-harness-")), "sketch.json");
+  writeFileSync(
+    file,
+    JSON.stringify({
+      id: "img-1",
+      name: "Poster",
+      width: 2048,
+      height: 768,
+      backgroundColor: "#000000",
+      document
+    }),
+    "utf8"
+  );
+  return file;
+};
+
+const outDir = (): string => join(mkdtempSync(join(tmpdir(), "sketch-out-")), "bundle");
+
+const cleanValidation = { ok: true, errors: [], warnings: [] };
+
+/** A core that records what it was handed and answers with a fixed report. */
+function fakeCore(): SketchDebugCore & {
+  calls: { validate: unknown[]; build: unknown[] };
+} {
+  const calls = { validate: [] as unknown[], build: [] as unknown[] };
+  return {
+    calls,
+    validateSketchDocument: (raw, meta) => {
+      calls.validate.push({ raw, meta });
+      return cleanValidation;
+    },
+    buildSketchDebugReport: (input) => {
+      calls.build.push(input);
+      return {
+        target: input.target,
+        meta: {
+          width: 1024,
+          height: 768,
+          backgroundColor: "#ffffff",
+          layerCount: 1,
+          bindingCount: 0
+        },
+        validation: cleanValidation,
+        interactions: input.interactions ?? [],
+        ...(input.finalState ? { finalState: input.finalState } : {}),
+        notSimulated: ["pixels"],
+        verdict: { ok: true, headline: "sketch ok", issues: [] }
+      };
+    },
+    renderSketchReportMarkdown: (report) => `# ${report.verdict.headline}\n`
+  };
+}
+
+/** A bridge whose one tool succeeds and whose other always throws. */
+function fakeBridge() {
+  const layers = [
+    {
+      id: "layer_1",
+      name: "Background",
+      type: "raster" as const,
+      visible: true,
+      opacity: 1,
+      blendMode: "normal"
+    }
+  ];
+  return {
+    tools: [
+      {
+        name: "ui_sketch_add_layer",
+        execute: async (args: Record<string, unknown>) => {
+          layers.push({
+            id: `layer_${layers.length + 1}`,
+            name: String(args.name ?? "Layer"),
+            type: "raster" as const,
+            visible: true,
+            opacity: 1,
+            blendMode: "normal"
+          });
+          return { ok: true };
+        }
+      },
+      {
+        name: "ui_sketch_remove_layer",
+        execute: async () => {
+          throw new Error('No layer found matching "nope".');
+        }
+      }
+    ],
+    finalState: () => ({
+      width: 1024,
+      height: 768,
+      backgroundColor: "#ffffff",
+      activeLayerId: layers[layers.length - 1]?.id ?? null,
+      layers
+    })
+  };
+}
+
+describe("parseInteractionScript", () => {
+  it("normalizes bare and prefixed tool names alike", () => {
+    const steps = parseInteractionScript(
+      JSON.stringify([
+        { tool: "add_layer", input: { name: "Glow" } },
+        { tool: "ui_sketch_set_color", input: { foreground: "#ff0000" } },
+        { tool: "ui_select_layer" }
+      ])
+    );
+    expect(steps.map((s) => s.tool)).toEqual([
+      "ui_sketch_add_layer",
+      "ui_sketch_set_color",
+      "ui_sketch_select_layer"
+    ]);
+    expect(steps[2].input).toEqual({});
+  });
+
+  it("rejects invalid JSON with the parser's own message", () => {
+    expect(() => parseInteractionScript("[{")).toThrow(/--interact is not valid JSON/);
+  });
+
+  it("rejects a non-array script", () => {
+    expect(() => parseInteractionScript('{"tool":"add_layer"}')).toThrow(
+      /must be a JSON array/
+    );
+  });
+
+  it("names the step that has no tool", () => {
+    expect(() =>
+      parseInteractionScript(JSON.stringify([{ tool: "add_layer" }, { input: {} }]))
+    ).toThrow(/step 2 has no `tool` name/);
+  });
+
+  it("rejects a non-object input", () => {
+    expect(() =>
+      parseInteractionScript(JSON.stringify([{ tool: "add_layer", input: 5 }]))
+    ).toThrow(/step 1: `input` must be an object/);
+  });
+
+  it("leaves an already-canonical name alone", () => {
+    expect(normalizeToolName("ui_sketch_add_layer")).toBe("ui_sketch_add_layer");
+  });
+});
+
+describe("runSketchValidate", () => {
+  it("validates the raw document with the row's canvas settings", async () => {
+    const core = fakeCore();
+    const { target, validation } = await runSketchValidate(sketchFile(), {
+      loadDocument: async () => null,
+      core
+    });
+
+    expect(target.kind).toBe("file");
+    expect(validation).toEqual(cleanValidation);
+    expect(core.calls.validate).toHaveLength(1);
+    expect((core.calls.validate[0] as { meta: unknown }).meta).toEqual({
+      width: 2048,
+      height: 768,
+      backgroundColor: "#000000"
+    });
+  });
+});
+
+describe("runSketchDebug", () => {
+  it("seeds the bridge from the document and records each step", async () => {
+    const createBridge = vi.fn(() => fakeBridge());
+    const { report } = await runSketchDebug(
+      sketchFile(),
+      {
+        interact: parseInteractionScript(
+          JSON.stringify([{ tool: "add_layer", input: { name: "Glow" } }])
+        ),
+        outDir: outDir()
+      },
+      { loadDocument: async () => null, core: fakeCore(), createBridge }
+    );
+
+    expect(createBridge).toHaveBeenCalledWith({
+      name: "Poster",
+      width: 1024,
+      height: 768,
+      layers: [{ name: "Background", type: "raster" }]
+    });
+    expect(report.interactions).toEqual([
+      {
+        tool: "ui_sketch_add_layer",
+        input: { name: "Glow" },
+        ok: true,
+        result: { ok: true }
+      }
+    ]);
+  });
+
+  it("records a failing step and keeps going", async () => {
+    const { report } = await runSketchDebug(
+      sketchFile(),
+      {
+        interact: parseInteractionScript(
+          JSON.stringify([
+            { tool: "remove_layer", input: { target: "nope" } },
+            { tool: "not_a_tool" },
+            { tool: "add_layer", input: { name: "Glow" } }
+          ])
+        ),
+        outDir: outDir()
+      },
+      {
+        loadDocument: async () => null,
+        core: fakeCore(),
+        createBridge: () => fakeBridge()
+      }
+    );
+
+    expect(report.interactions.map((i) => i.ok)).toEqual([false, false, true]);
+    expect(report.interactions[0].error).toMatch(/No layer found/);
+    expect(report.interactions[1].error).toMatch(/No sketch tool named/);
+  });
+
+  it("rebuilds the post-edit document from the bridge snapshot", async () => {
+    const core = fakeCore();
+    await runSketchDebug(
+      sketchFile(),
+      {
+        interact: parseInteractionScript(
+          JSON.stringify([{ tool: "add_layer", input: { name: "Glow" } }])
+        ),
+        outDir: outDir()
+      },
+      { loadDocument: async () => null, core, createBridge: () => fakeBridge() }
+    );
+
+    const built = core.calls.build[0] as {
+      finalDocument?: {
+        sketch: {
+          canvas: { width: number; height: number };
+          layers: { id: string; name: string }[];
+          activeLayerId: string;
+        };
+        layerBindings: unknown[];
+      };
+      finalState?: unknown;
+    };
+    expect(built.finalDocument?.sketch.layers.map((l) => l.name)).toEqual([
+      "Background",
+      "Glow"
+    ]);
+    expect(built.finalDocument?.sketch.activeLayerId).toBe("layer_2");
+    expect(built.finalDocument?.sketch.canvas).toEqual({
+      width: 1024,
+      height: 768,
+      backgroundColor: "#ffffff"
+    });
+    // The bridge tracks no persisted binding record, so the rebuild drops them.
+    expect(built.finalDocument?.layerBindings).toEqual([]);
+    expect(built.finalState).toBeDefined();
+  });
+
+  it("runs no bridge at all without an interact script", async () => {
+    const createBridge = vi.fn(() => fakeBridge());
+    const core = fakeCore();
+    const { report } = await runSketchDebug(
+      sketchFile(),
+      { outDir: outDir() },
+      { loadDocument: async () => null, core, createBridge }
+    );
+
+    expect(createBridge).not.toHaveBeenCalled();
+    expect(report.interactions).toEqual([]);
+    expect((core.calls.build[0] as { finalState?: unknown }).finalState).toBeUndefined();
+  });
+
+  it("writes the bundle: report.json, report.md and the input document", async () => {
+    const dir = outDir();
+    const { bundleDir } = await runSketchDebug(
+      sketchFile(),
+      { outDir: dir },
+      { loadDocument: async () => null, core: fakeCore() }
+    );
+
+    expect(bundleDir).toBe(dir);
+    for (const name of ["report.json", "report.md", "sketch.json"]) {
+      expect(existsSync(join(dir, name))).toBe(true);
+    }
+    expect(readFileSync(join(dir, "report.md"), "utf8")).toContain("sketch ok");
+    const written = JSON.parse(readFileSync(join(dir, "sketch.json"), "utf8"));
+    expect(written.sketch.layers).toEqual([layer]);
+  });
+});

--- a/packages/cli/tests/sketch-target.test.ts
+++ b/packages/cli/tests/sketch-target.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the sketch debug target loader (src/sketch-debug/target.ts): file
+ * vs. row-id precedence, the document shapes a file can carry, and where the
+ * canvas settings come from.
+ */
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { resolveSketchTarget } from "../src/sketch-debug/target.js";
+
+const document = {
+  sketch: {
+    version: 3,
+    canvas: { width: 1024, height: 768, backgroundColor: "#ffffff" },
+    layers: [
+      {
+        id: "layer-1",
+        name: "Background",
+        type: "raster",
+        visible: true,
+        locked: false,
+        opacity: 1,
+        blendMode: "normal",
+        data: null
+      }
+    ],
+    activeLayerId: "layer-1",
+    maskLayerId: null
+  },
+  layerBindings: []
+};
+
+const writeJson = (name: string, value: unknown): string => {
+  const file = join(mkdtempSync(join(tmpdir(), "sketch-target-")), name);
+  writeFileSync(file, JSON.stringify(value), "utf8");
+  return file;
+};
+
+const noDocuments = vi.fn(async () => null);
+
+describe("resolveSketchTarget", () => {
+  it("reads a bare ImageDocumentData file", async () => {
+    const file = writeJson("sketch.json", document);
+    const resolved = await resolveSketchTarget(file, {
+      loadDocument: noDocuments
+    });
+
+    expect(resolved.target).toEqual({ kind: "file", ref: file });
+    expect(resolved.document.layers).toEqual([
+      { id: "layer-1", name: "Background", type: "raster" }
+    ]);
+    expect(resolved.document.activeLayerId).toBe("layer-1");
+    expect(resolved.meta).toEqual({});
+    expect(noDocuments).not.toHaveBeenCalled();
+  });
+
+  it("unwraps a sketch.get response and keeps its canvas settings apart", async () => {
+    const file = writeJson("response.json", {
+      id: "img-1",
+      name: "Poster",
+      width: 2048,
+      height: 768,
+      backgroundColor: "#000000",
+      document
+    });
+    const resolved = await resolveSketchTarget(file, {
+      loadDocument: noDocuments
+    });
+
+    expect(resolved.target).toEqual({ kind: "file", ref: file, name: "Poster" });
+    expect(resolved.meta).toEqual({
+      width: 2048,
+      height: 768,
+      backgroundColor: "#000000"
+    });
+    expect(resolved.document.canvas).toEqual({
+      width: 1024,
+      height: 768,
+      backgroundColor: "#ffffff"
+    });
+  });
+
+  it("unwraps a document stored as a JSON string", async () => {
+    const file = writeJson("row.json", {
+      id: "img-1",
+      document: JSON.stringify(document)
+    });
+    const resolved = await resolveSketchTarget(file, {
+      loadDocument: noDocuments
+    });
+
+    expect(resolved.document.layers).toHaveLength(1);
+  });
+
+  it("rejects a file that carries no image document", async () => {
+    const file = writeJson("nope.json", { tracks: [], clips: [] });
+    await expect(
+      resolveSketchTarget(file, { loadDocument: noDocuments })
+    ).rejects.toThrow(/is not an image document/);
+  });
+
+  it("rejects a file that is not JSON", async () => {
+    const file = join(mkdtempSync(join(tmpdir(), "sketch-target-")), "bad.json");
+    writeFileSync(file, "{oops", "utf8");
+    await expect(
+      resolveSketchTarget(file, { loadDocument: noDocuments })
+    ).rejects.toThrow(/is not valid JSON/);
+  });
+
+  it("reads a row id through the loader, snake_case background included", async () => {
+    const resolved = await resolveSketchTarget("img-1", {
+      loadDocument: async (id) => ({
+        id,
+        name: "Poster",
+        width: 1024,
+        height: 768,
+        background_color: "#101010",
+        document: JSON.stringify(document)
+      })
+    });
+
+    expect(resolved.target).toEqual({ kind: "id", ref: "img-1", name: "Poster" });
+    expect(resolved.meta).toEqual({
+      width: 1024,
+      height: 768,
+      backgroundColor: "#101010"
+    });
+    expect(resolved.raw).toEqual(document);
+  });
+
+  it("names the id that has no row", async () => {
+    await expect(
+      resolveSketchTarget("img-9", { loadDocument: async () => null })
+    ).rejects.toThrow(/Image document not found: img-9/);
+  });
+});

--- a/packages/cli/tests/sketch-versions-command.test.ts
+++ b/packages/cli/tests/sketch-versions-command.test.ts
@@ -14,7 +14,6 @@ import {
   parseVersionNumber,
   versionTableRows,
   documentCounts,
-  checkRestoredDocument,
   type ImageDocumentRow,
   type SketchVersionRow,
   type SketchVersionStore
@@ -63,6 +62,7 @@ const snapshot = vi.fn();
 const restore = vi.fn();
 const deleteVersion = vi.fn();
 const confirmDelete = vi.fn();
+const validate = vi.fn();
 
 const store: SketchVersionStore = {
   loadDocument,
@@ -110,6 +110,7 @@ function buildProgram(): Command {
   const sketch = program.command("sketch");
   registerSketchVersionsCommands(sketch, {
     store: async () => store,
+    validate,
     confirmDelete
   });
   return program;
@@ -139,6 +140,7 @@ beforeEach(() => {
   });
   deleteVersion.mockReset().mockResolvedValue(undefined);
   confirmDelete.mockReset().mockResolvedValue(true);
+  validate.mockReset().mockResolvedValue({ ok: true, errors: [], warnings: [] });
 });
 
 describe("sketch versions list", () => {
@@ -283,10 +285,15 @@ describe("sketch versions restore", () => {
     );
     expect(stdout).toContain("Restored v2 onto doc-1");
     expect(stdout).toContain("pre-restore state saved as v3");
-    expect(stdout).toContain("document parses cleanly");
+    expect(stdout).toContain("0 error(s), 0 warning(s)");
+    expect(validate).toHaveBeenCalledWith(expect.objectContaining({}), {
+      width: 1280,
+      height: 720,
+      backgroundColor: "#101010"
+    });
   });
 
-  it("reports the restore, the snapshot and the check under --json", async () => {
+  it("reports the restore, the snapshot and the validation under --json", async () => {
     const { stdout, exitCode } = await run("restore", "doc-1", "2", "--json");
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout.trim()) as {
@@ -294,7 +301,7 @@ describe("sketch versions restore", () => {
       restored: { version: number };
       snapshot: Record<string, unknown>;
       document: Record<string, unknown>;
-      check: { ok: boolean };
+      validation: { ok: boolean };
     };
     expect(parsed.imageDocumentId).toBe("doc-1");
     expect(parsed.restored.version).toBe(2);
@@ -304,14 +311,28 @@ describe("sketch versions restore", () => {
       height: 720,
       backgroundColor: "#101010"
     });
-    expect(parsed.check).toEqual({ ok: true });
+    expect(parsed.validation).toEqual({ ok: true, errors: [], warnings: [] });
   });
 
-  it("exits non-zero when the restored document is no longer readable JSON", async () => {
+  it("exits non-zero when the restored document no longer validates", async () => {
+    validate.mockResolvedValueOnce({
+      ok: false,
+      errors: [
+        {
+          severity: "error",
+          code: "document_invalid",
+          message: "Document is a string — expected an object."
+        }
+      ],
+      warnings: []
+    });
     findVersion.mockResolvedValueOnce(versionRow({ document: "{not json" }));
     const { exitCode, stdout } = await run("restore", "doc-1", "2");
     expect(exitCode).toBe(1);
-    expect(stdout).toContain("restored document is not valid JSON");
+    expect(stdout).toContain("1 error(s), 0 warning(s)");
+    // parseVersionDocument hands the unparseable text through as-is, so the
+    // validator sees the raw string rather than a silent undefined.
+    expect(validate).toHaveBeenCalledWith("{not json", expect.anything());
   });
 
   it("fails when the document changed since it was loaded", async () => {
@@ -400,13 +421,6 @@ describe("sketch versions helpers", () => {
 
   it("counts layers and bindings of an unreadable document as zero", () => {
     expect(documentCounts("not json")).toEqual({ layers: 0, bindings: 0 });
-  });
-
-  it("accepts an object document and rejects anything else", () => {
-    expect(checkRestoredDocument({ sketch: {} })).toEqual({ ok: true });
-    expect(checkRestoredDocument("{not json").ok).toBe(false);
-    expect(checkRestoredDocument(null).ok).toBe(false);
-    expect(checkRestoredDocument([]).error).toContain("array");
   });
 
   it("rejects non-positive and non-integer versions", () => {

--- a/packages/execution/package.json
+++ b/packages/execution/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@nodetool-ai/app-runtime": "*",
     "@nodetool-ai/config": "*",
+    "@nodetool-ai/gpu": "*",
     "@nodetool-ai/kernel": "*",
     "@nodetool-ai/node-sdk": "*",
     "@nodetool-ai/protocol": "*",
@@ -52,6 +53,12 @@
       "types": "./dist/timeline-debug/index.d.ts",
       "import": "./dist/timeline-debug/index.js",
       "default": "./dist/timeline-debug/index.js"
+    },
+    "./sketch-debug": {
+      "nodetool-dev": "./src/sketch-debug/index.ts",
+      "types": "./dist/sketch-debug/index.d.ts",
+      "import": "./dist/sketch-debug/index.js",
+      "default": "./dist/sketch-debug/index.js"
     }
   },
   "license": "MIT",

--- a/packages/execution/src/sketch-debug/index.ts
+++ b/packages/execution/src/sketch-debug/index.ts
@@ -1,0 +1,22 @@
+/**
+ * `@nodetool-ai/execution/sketch-debug` — sketch validation + debug report.
+ *
+ * Pure, dependency-injected core: no DB, no canvas, no browser. Hosts (the CLI
+ * `sketch` command today) resolve the target and write the bundle.
+ */
+
+export type {
+  SketchDebugIssue,
+  SketchValidation,
+  SketchInteractionRecord,
+  SketchDebugTarget,
+  SketchDocumentMeta,
+  SketchDebugReport
+} from "./types.js";
+
+export { validateSketchDocument, type SketchValidationMeta } from "./validate.js";
+export {
+  buildSketchDebugReport,
+  type SketchDebugReportInput
+} from "./report.js";
+export { renderSketchReportMarkdown } from "./markdown.js";

--- a/packages/execution/src/sketch-debug/markdown.ts
+++ b/packages/execution/src/sketch-debug/markdown.ts
@@ -1,0 +1,136 @@
+/**
+ * Renders a `SketchDebugReport` as human-readable Markdown for the bundle.
+ */
+import type { SketchDebugIssue, SketchDebugReport } from "./types.js";
+
+const short = (value: unknown, max = 120): string => {
+  if (value === undefined) return "—";
+  let s: string;
+  try {
+    s = typeof value === "string" ? value : JSON.stringify(value);
+  } catch {
+    s = String(value);
+  }
+  s = (s ?? "null").replace(/\s+/g, " ");
+  return s.length > max ? `${s.slice(0, max)}…` : s;
+};
+
+const where = (issue: SketchDebugIssue): string => {
+  const parts = [
+    issue.layerId ? `layer \`${issue.layerId}\`` : null,
+    issue.path ? `\`${issue.path}\`` : null
+  ].filter((part): part is string => part !== null);
+  return parts.length > 0 ? parts.join(" · ") : "—";
+};
+
+function issueTable(
+  title: string,
+  issues: ReadonlyArray<SketchDebugIssue>,
+  lines: string[]
+): void {
+  if (issues.length === 0) return;
+  lines.push("", `## ${title}`, "");
+  lines.push("| Severity | Code | Where | Message |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const issue of issues) {
+    lines.push(
+      `| ${issue.severity} | \`${issue.code}\` | ${where(issue)} | ${short(issue.message, 300)} |`
+    );
+  }
+}
+
+interface SnapshotLayer {
+  id?: string;
+  name?: string;
+  type?: string;
+  visible?: boolean;
+  opacity?: number;
+  blendMode?: string;
+  hasBinding?: boolean;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+
+/**
+ * The snapshot carries the whole layer stack; the markdown wants one line per
+ * layer, top of the stack first, rather than a JSON dump.
+ */
+function finalStateLines(state: unknown): string[] {
+  const record = asRecord(state);
+  const layers = Array.isArray(record?.layers)
+    ? (record.layers as SnapshotLayer[])
+    : null;
+  if (!layers) return [`- ${short(state, 600)}`];
+
+  const lines: string[] = [];
+  const canvas = `${String(record?.width ?? "?")}×${String(record?.height ?? "?")}`;
+  lines.push(`- canvas ${canvas}, active layer \`${String(record?.activeLayerId ?? "none")}\``);
+  for (const layer of [...layers].reverse()) {
+    lines.push(
+      `- \`${layer.id ?? "?"}\`${layer.name ? ` "${layer.name}"` : ""} ` +
+        `${layer.type ?? "?"} · opacity ${layer.opacity ?? 1} · ${layer.blendMode ?? "normal"}` +
+        `${layer.visible === false ? " · hidden" : ""}${layer.hasBinding ? " · bound" : ""}`
+    );
+  }
+  return lines;
+}
+
+export function renderSketchReportMarkdown(report: SketchDebugReport): string {
+  const lines: string[] = [];
+  const title = report.target.name ?? report.target.ref;
+  lines.push(`# Sketch debug: ${title}`);
+  lines.push("");
+  lines.push(`${report.verdict.ok ? "✅" : "❌"} ${report.verdict.headline}`);
+  lines.push("");
+  lines.push(`Target: \`${report.target.ref}\` (${report.target.kind})`);
+  lines.push(
+    `Document: ${report.meta.width}×${report.meta.height} on ${report.meta.backgroundColor} · ` +
+      `${report.meta.layerCount} layer(s), ${report.meta.bindingCount} binding(s)`
+  );
+
+  if (report.verdict.issues.length > 0) {
+    lines.push("", "## Issues", "");
+    for (const issue of report.verdict.issues) lines.push(`- ${issue}`);
+  }
+
+  issueTable(
+    "Validation",
+    [...report.validation.errors, ...report.validation.warnings],
+    lines
+  );
+
+  if (report.interactions.length > 0) {
+    lines.push("", "## Interactions", "");
+    lines.push("| Tool | OK | Input | Error |");
+    lines.push("| --- | --- | --- | --- |");
+    for (const step of report.interactions) {
+      lines.push(
+        `| \`${step.tool}\` | ${step.ok ? "✅" : "❌"} | ${short(step.input)} | ${
+          step.error ? short(step.error, 200) : "—"
+        } |`
+      );
+    }
+  }
+
+  if (report.finalValidation) {
+    issueTable(
+      "Validation after edits",
+      [...report.finalValidation.errors, ...report.finalValidation.warnings],
+      lines
+    );
+  }
+
+  if (report.finalState !== undefined) {
+    lines.push("", "## Final state", "");
+    lines.push(...finalStateLines(report.finalState));
+  }
+
+  if (report.notSimulated.length > 0) {
+    lines.push("", "## Not simulated", "");
+    for (const entry of report.notSimulated) lines.push(`- ${entry}`);
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}

--- a/packages/execution/src/sketch-debug/report.ts
+++ b/packages/execution/src/sketch-debug/report.ts
@@ -1,0 +1,139 @@
+/**
+ * Assembles a `SketchDebugReport` from a document, an optional scripted edit
+ * session, and the document that session left behind.
+ *
+ * Pure: the host resolves the target (file, id) and writes the bundle; this
+ * decides what the run means.
+ */
+import type { DebugVerdict } from "../debug/types.js";
+import type {
+  SketchDebugIssue,
+  SketchDebugReport,
+  SketchDebugTarget,
+  SketchDocumentMeta,
+  SketchInteractionRecord,
+  SketchValidation
+} from "./types.js";
+import { validateSketchDocument, type SketchValidationMeta } from "./validate.js";
+
+const DEFAULTS = { width: 1024, height: 1024, backgroundColor: "#ffffff" } as const;
+
+/**
+ * What a headless sketch run cannot answer. Fixed, because the boundary is a
+ * property of the harness, not of the document it was pointed at.
+ */
+const NOT_SIMULATED: ReadonlyArray<string> = [
+  "Pixels — layer bitmaps are never decoded, composited, or diffed.",
+  "Rendering and flattening — no canvas exists, so blend modes and effects produce nothing to look at.",
+  "Painting tools — brush, eraser, fill, gradient and transform strokes leave no marks headlessly.",
+  "Generation providers — no imagery is produced; bindings are checked structurally only.",
+  "Asset I/O — asset ids are never resolved, fetched, or uploaded.",
+  "Generation bindings after edits — the headless bridge tracks a layer's prompt/provider/model but not the persisted binding record, so a post-edit document is validated with no bindings."
+];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const count = (value: unknown): number => (Array.isArray(value) ? value.length : 0);
+
+function describeDocument(
+  document: unknown,
+  meta: SketchValidationMeta | undefined
+): SketchDocumentMeta {
+  const record = isRecord(document) ? document : {};
+  const sketch = isRecord(record.sketch) ? record.sketch : {};
+  const canvas = isRecord(sketch.canvas) ? sketch.canvas : {};
+  const pick = (value: unknown, fallback: number): number =>
+    typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+  const background =
+    typeof canvas.backgroundColor === "string"
+      ? canvas.backgroundColor
+      : (meta?.backgroundColor ?? DEFAULTS.backgroundColor);
+
+  return {
+    width: pick(canvas.width, pick(meta?.width, DEFAULTS.width)),
+    height: pick(canvas.height, pick(meta?.height, DEFAULTS.height)),
+    backgroundColor: background,
+    layerCount: count(sketch.layers),
+    bindingCount: count(record.layerBindings)
+  };
+}
+
+const describe = (issue: SketchDebugIssue): string => {
+  const where = issue.layerId ?? issue.path;
+  return where
+    ? `[${issue.code}] ${where}: ${issue.message}`
+    : `[${issue.code}] ${issue.message}`;
+};
+
+function buildSketchVerdict(
+  validation: SketchValidation,
+  interactions: ReadonlyArray<SketchInteractionRecord>,
+  finalValidation: SketchValidation | undefined
+): DebugVerdict {
+  const failedSteps = interactions.filter((step) => !step.ok);
+  const issues: string[] = [
+    ...validation.errors.map(describe),
+    ...failedSteps.map(
+      (step) => `Interaction \`${step.tool}\` failed${step.error ? `: ${step.error}` : ""}`
+    ),
+    ...(finalValidation?.errors ?? []).map((issue) => `After edits — ${describe(issue)}`)
+  ];
+  const warnings: string[] = [
+    ...validation.warnings.map(describe),
+    ...(finalValidation?.warnings ?? []).map((issue) => `After edits — ${describe(issue)}`)
+  ];
+
+  const ok = issues.length === 0;
+  const warningCount = warnings.length;
+  const headline = ok
+    ? `Sketch is sound — ${interactions.length} interaction(s) ran clean` +
+      (warningCount > 0 ? `, ${warningCount} warning(s)` : "") +
+      "."
+    : `Sketch has ${issues.length} problem(s)` +
+      (failedSteps.length > 0 ? `, ${failedSteps.length} failed interaction(s)` : "") +
+      (warningCount > 0 ? `, ${warningCount} warning(s)` : "") +
+      ` — ${issues[0]}`;
+
+  return warningCount > 0 ? { ok, headline, issues, warnings } : { ok, headline, issues };
+}
+
+export interface SketchDebugReportInput {
+  target: SketchDebugTarget;
+  /** The document as loaded — untrusted, validated here. */
+  document: unknown;
+  meta?: SketchValidationMeta;
+  interactions?: SketchInteractionRecord[];
+  /** Bridge snapshot after the scripted session (`SketchBridgeFinalState`). */
+  finalState?: unknown;
+  /** Document reconstructed from the final state, validated as a second pass. */
+  finalDocument?: unknown;
+}
+
+export function buildSketchDebugReport(
+  input: SketchDebugReportInput
+): SketchDebugReport {
+  const validation = validateSketchDocument(input.document, input.meta);
+  // The post-edit pass runs without `meta`: a session may have resized the
+  // canvas, and the stored row's size is then the stale number, not the bug.
+  const finalValidation =
+    input.finalDocument === undefined
+      ? undefined
+      : validateSketchDocument(input.finalDocument);
+  const interactions = input.interactions ?? [];
+
+  // The final document is what the session left behind, so it — not the input
+  // — describes the sketch the report is about.
+  const meta = describeDocument(input.finalDocument ?? input.document, input.meta);
+
+  return {
+    target: input.target,
+    meta,
+    validation,
+    interactions,
+    ...(input.finalState !== undefined ? { finalState: input.finalState } : {}),
+    ...(finalValidation ? { finalValidation } : {}),
+    notSimulated: [...NOT_SIMULATED],
+    verdict: buildSketchVerdict(validation, interactions, finalValidation)
+  };
+}

--- a/packages/execution/src/sketch-debug/types.ts
+++ b/packages/execution/src/sketch-debug/types.ts
@@ -1,0 +1,68 @@
+/**
+ * Sketch debug vocabulary.
+ *
+ * One report shape for "is this image document sound, and what did a scripted
+ * edit session leave behind" — shared by the CLI `sketch validate` /
+ * `sketch debug` commands and any future server surface, the same way
+ * `../timeline-debug/types.ts` is shared by the timeline surfaces.
+ */
+
+import type { DebugVerdict } from "../debug/types.js";
+
+/** One finding against an image document. */
+export interface SketchDebugIssue {
+  severity: "error" | "warning";
+  /** Stable machine code, e.g. `field_stripped`, `binding_layer_missing`. */
+  code: string;
+  message: string;
+  layerId?: string;
+  /** JSON path of the offending field, for schema/round-trip findings. */
+  path?: string;
+}
+
+export interface SketchValidation {
+  /** True when there are no errors. Warnings do not clear `ok`. */
+  ok: boolean;
+  errors: SketchDebugIssue[];
+  warnings: SketchDebugIssue[];
+}
+
+/** One executed step of a `--interact` script. */
+export interface SketchInteractionRecord {
+  /** Tool name as invoked (canonical `ui_sketch_*` form). */
+  tool: string;
+  input: unknown;
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+export interface SketchDebugTarget {
+  kind: "file" | "id";
+  ref: string;
+  name?: string;
+}
+
+export interface SketchDocumentMeta {
+  width: number;
+  height: number;
+  backgroundColor: string;
+  layerCount: number;
+  bindingCount: number;
+}
+
+export interface SketchDebugReport {
+  target: SketchDebugTarget;
+  meta: SketchDocumentMeta;
+  /** Static validation of the input document. */
+  validation: SketchValidation;
+  /** Scripted edit session, when one ran. */
+  interactions: SketchInteractionRecord[];
+  /** Bridge snapshot after the script (SketchBridgeFinalState shape). */
+  finalState?: unknown;
+  /** Validation of the document reconstructed from the final state. */
+  finalValidation?: SketchValidation;
+  /** What a headless run cannot answer (pixels, rendering, assets …). */
+  notSimulated: string[];
+  verdict: DebugVerdict;
+}

--- a/packages/execution/src/sketch-debug/validate.ts
+++ b/packages/execution/src/sketch-debug/validate.ts
@@ -1,0 +1,578 @@
+/**
+ * Static validation of a sketch (image document).
+ *
+ * Pure and structural: everything here is decidable from the document alone —
+ * no database, no assets, no canvas. Layer bitmaps stay opaque: a layer's
+ * `data` is a serialized raster payload or a data URL, and nothing offline
+ * decides whether it still decodes, so pixel decode is out of scope.
+ *
+ * Unlike the timeline validator, a schema failure does not stop the structural
+ * pass. `imageDocumentData` leaves layers as `z.array(z.unknown())`, so almost
+ * everything checked here is read by this module anyway; a document that fails
+ * on one binding field should still report the layer stack around it.
+ */
+import { BLEND_MODE_TUPLE } from "@nodetool-ai/gpu";
+import {
+  imageDocumentData,
+  sketchLayerLike
+} from "@nodetool-ai/protocol/api-schemas/sketch.js";
+
+import type { SketchDebugIssue, SketchValidation } from "./types.js";
+
+/** Canvas settings the row carries beside the document. */
+export interface SketchValidationMeta {
+  width?: number;
+  height?: number;
+  backgroundColor?: string;
+}
+
+const BLEND_MODES = new Set<string>(BLEND_MODE_TUPLE);
+
+const BINDING_KINDS = new Set([
+  "workflow",
+  "text-to-image",
+  "image-to-image",
+  "inpaint"
+]);
+
+const BINDING_STATUSES = new Set([
+  "draft",
+  "queued",
+  "generating",
+  "generated",
+  "stale",
+  "failed",
+  "locked",
+  "missing"
+]);
+
+const VERSION_STATUSES = new Set(["success", "failed", "cancelled"]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const asArray = (value: unknown): unknown[] =>
+  Array.isArray(value) ? value : [];
+
+const positive = (value: unknown): boolean =>
+  typeof value === "number" && Number.isFinite(value) && value > 0;
+
+/** Collect every leaf/branch path the parse output dropped from the input. */
+function collectStrippedPaths(
+  input: unknown,
+  output: unknown,
+  path: string,
+  found: Set<string>
+): void {
+  if (Array.isArray(input)) {
+    if (!Array.isArray(output)) return;
+    input.forEach((item, index) => {
+      collectStrippedPaths(item, output[index], `${path}[*]`, found);
+    });
+    return;
+  }
+  if (!isRecord(input) || !isRecord(output)) return;
+  for (const [key, value] of Object.entries(input)) {
+    // An explicit `undefined` carries nothing, so its absence loses nothing.
+    if (value === undefined) continue;
+    const childPath = path ? `${path}.${key}` : key;
+    if (!(key in output) || output[key] === undefined) {
+      found.add(childPath);
+      continue;
+    }
+    collectStrippedPaths(value, output[key], childPath, found);
+  }
+}
+
+/**
+ * Fields the schema silently drops. A stripped field survives in memory and
+ * disappears on the next autosave round trip, so it never fails loudly — the
+ * only way to see it is to diff the input against what Zod handed back.
+ *
+ * The document schema keeps layers as `unknown`, so nothing inside a layer is
+ * ever reported here; layer fields are checked directly instead.
+ */
+function checkFieldStripping(raw: unknown, parsed: unknown): SketchDebugIssue[] {
+  const paths = new Set<string>();
+  collectStrippedPaths(raw, parsed, "", paths);
+  return [...paths].sort().map((path) => ({
+    severity: "warning" as const,
+    code: "field_stripped",
+    path,
+    message: `\`${path}\` is present in the document but absent after schema parse — the schema strips it, so it is lost on the next save.`
+  }));
+}
+
+function checkSchema(raw: unknown): {
+  issues: SketchDebugIssue[];
+  parsed: unknown;
+} {
+  const result = imageDocumentData.safeParse(raw);
+  if (result.success) {
+    return { issues: checkFieldStripping(raw, result.data), parsed: result.data };
+  }
+  const issues: SketchDebugIssue[] = result.error.issues
+    .slice(0, 25)
+    .map((issue) => {
+      const path = issue.path.map((part) => String(part)).join(".");
+      return {
+        severity: "error" as const,
+        code: "schema_invalid",
+        message: `${path || "(root)"}: ${issue.message}`,
+        ...(path ? { path } : {})
+      };
+    });
+  if (issues.length === 0) {
+    issues.push({
+      severity: "error",
+      code: "schema_invalid",
+      message: "Document does not match the image-document schema."
+    });
+  }
+  return { issues, parsed: undefined };
+}
+
+function checkCanvas(
+  sketch: Record<string, unknown>,
+  meta: SketchValidationMeta | undefined
+): SketchDebugIssue[] {
+  const issues: SketchDebugIssue[] = [];
+  const canvas = isRecord(sketch.canvas) ? sketch.canvas : undefined;
+  if (!canvas) {
+    issues.push({
+      severity: "error",
+      code: "canvas_missing",
+      message: "The sketch has no `canvas` — nothing declares the artboard size.",
+      path: "sketch.canvas"
+    });
+    return issues;
+  }
+
+  for (const axis of ["width", "height"] as const) {
+    if (!positive(canvas[axis])) {
+      issues.push({
+        severity: "error",
+        code: "canvas_invalid",
+        message: `Canvas ${axis} is ${JSON.stringify(canvas[axis])} — the artboard must have a positive ${axis}.`,
+        path: `sketch.canvas.${axis}`
+      });
+    }
+  }
+
+  if (
+    canvas.backgroundColor !== undefined &&
+    typeof canvas.backgroundColor !== "string"
+  ) {
+    issues.push({
+      severity: "error",
+      code: "canvas_invalid",
+      message: `Canvas backgroundColor is ${JSON.stringify(canvas.backgroundColor)} — expected a color string.`,
+      path: "sketch.canvas.backgroundColor"
+    });
+  }
+
+  // The row's width/height are what the editor opens and what thumbnails are
+  // cut at; a document that disagrees renders at one size and is stored at
+  // another.
+  for (const axis of ["width", "height"] as const) {
+    const outer = meta?.[axis];
+    if (positive(outer) && positive(canvas[axis]) && outer !== canvas[axis]) {
+      issues.push({
+        severity: "warning",
+        code: "canvas_size_mismatch",
+        message: `Canvas ${axis} is ${String(canvas[axis])} but the image document records ${String(outer)}.`,
+        path: `sketch.canvas.${axis}`
+      });
+    }
+  }
+
+  return issues;
+}
+
+interface LayerRead {
+  id: string;
+  label: string;
+  type: string;
+  record: Record<string, unknown>;
+}
+
+function readLayers(sketch: Record<string, unknown>): {
+  layers: LayerRead[];
+  issues: SketchDebugIssue[];
+} {
+  const issues: SketchDebugIssue[] = [];
+  const layers: LayerRead[] = [];
+  const seen = new Set<string>();
+
+  asArray(sketch.layers).forEach((entry, index) => {
+    const path = `sketch.layers[${index}]`;
+    if (!isRecord(entry)) {
+      issues.push({
+        severity: "error",
+        code: "layer_invalid",
+        message: `Layer at index ${index} is ${JSON.stringify(entry)} — expected an object.`,
+        path
+      });
+      return;
+    }
+
+    const parsed = sketchLayerLike.safeParse(entry);
+    if (!parsed.success) {
+      for (const issue of parsed.error.issues.slice(0, 5)) {
+        const field = issue.path.map((part) => String(part)).join(".");
+        issues.push({
+          severity: "error",
+          code: "layer_invalid",
+          message: `Layer at index ${index}: ${field || "(root)"}: ${issue.message}`,
+          path: field ? `${path}.${field}` : path,
+          ...(typeof entry.id === "string" ? { layerId: entry.id } : {})
+        });
+      }
+      if (typeof entry.id !== "string" || entry.id === "") return;
+    }
+
+    const id = String(entry.id);
+    const label = typeof entry.name === "string" && entry.name ? entry.name : id;
+    if (seen.has(id)) {
+      issues.push({
+        severity: "error",
+        code: "duplicate_layer_id",
+        message: `Duplicate layer id "${id}" — every reference to it is ambiguous.`,
+        layerId: id,
+        path
+      });
+    }
+    seen.add(id);
+    layers.push({
+      id,
+      label,
+      type: typeof entry.type === "string" ? entry.type : "raster",
+      record: entry
+    });
+  });
+
+  return { layers, issues };
+}
+
+function checkLayer(layer: LayerRead, ids: ReadonlySet<string>): SketchDebugIssue[] {
+  const issues: SketchDebugIssue[] = [];
+  const { record, id, label } = layer;
+
+  const { opacity } = record;
+  if (opacity !== undefined) {
+    if (typeof opacity !== "number" || !Number.isFinite(opacity) || opacity < 0 || opacity > 1) {
+      issues.push({
+        severity: "error",
+        code: "layer_opacity_invalid",
+        message: `Layer "${label}" has opacity ${JSON.stringify(opacity)} — compositing expects a number in [0, 1].`,
+        layerId: id,
+        path: "opacity"
+      });
+    }
+  }
+
+  const { blendMode } = record;
+  if (blendMode !== undefined && !BLEND_MODES.has(String(blendMode))) {
+    issues.push({
+      severity: "error",
+      code: "unknown_blend_mode",
+      message: `Layer "${label}" blends with "${String(blendMode)}", which no NodeTool compositor ships.`,
+      layerId: id,
+      path: "blendMode"
+    });
+  }
+
+  const bounds = record.contentBounds;
+  if (bounds !== undefined) {
+    if (!isRecord(bounds)) {
+      issues.push({
+        severity: "error",
+        code: "content_bounds_invalid",
+        message: `Layer "${label}" has contentBounds ${JSON.stringify(bounds)} — expected an object.`,
+        layerId: id,
+        path: "contentBounds"
+      });
+    } else {
+      for (const axis of ["width", "height"] as const) {
+        const value = bounds[axis];
+        if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+          issues.push({
+            severity: "error",
+            code: "content_bounds_invalid",
+            message: `Layer "${label}" has contentBounds.${axis} ${JSON.stringify(value)} — a backing raster cannot be smaller than nothing.`,
+            layerId: id,
+            path: `contentBounds.${axis}`
+          });
+        }
+      }
+    }
+  }
+
+  const { parentId } = record;
+  if (typeof parentId === "string" && parentId !== "" && !ids.has(parentId)) {
+    issues.push({
+      severity: "warning",
+      code: "layer_parent_missing",
+      message: `Layer "${label}" names parent "${parentId}", which the document does not contain — it renders at the root.`,
+      layerId: id,
+      path: "parentId"
+    });
+  }
+
+  return issues;
+}
+
+function checkSelection(
+  sketch: Record<string, unknown>,
+  layers: ReadonlyArray<LayerRead>,
+  ids: ReadonlySet<string>
+): SketchDebugIssue[] {
+  const issues: SketchDebugIssue[] = [];
+
+  if (layers.length === 0) {
+    issues.push({
+      severity: "warning",
+      code: "document_empty",
+      message: "The sketch has no layers — nothing composites onto the canvas.",
+      path: "sketch.layers"
+    });
+  }
+
+  const active = sketch.activeLayerId;
+  if (layers.length > 0) {
+    if (typeof active !== "string" || active === "") {
+      issues.push({
+        severity: "error",
+        code: "active_layer_missing",
+        message: `activeLayerId is ${JSON.stringify(active)} — edits have no layer to land on.`,
+        path: "sketch.activeLayerId"
+      });
+    } else if (!ids.has(active)) {
+      issues.push({
+        severity: "error",
+        code: "active_layer_missing",
+        message: `activeLayerId "${active}" names a layer the document does not contain.`,
+        layerId: active,
+        path: "sketch.activeLayerId"
+      });
+    }
+  }
+
+  const mask = sketch.maskLayerId;
+  if (typeof mask === "string" && mask !== "" && !ids.has(mask)) {
+    issues.push({
+      severity: "warning",
+      code: "mask_layer_missing",
+      message: `maskLayerId "${mask}" names a layer the document does not contain — masked edits fall back to the whole canvas.`,
+      layerId: mask,
+      path: "sketch.maskLayerId"
+    });
+  }
+
+  return issues;
+}
+
+function checkBindings(
+  document: Record<string, unknown>,
+  ids: ReadonlySet<string>
+): SketchDebugIssue[] {
+  const issues: SketchDebugIssue[] = [];
+  const raw = document.layerBindings;
+  if (raw === undefined || !Array.isArray(raw)) {
+    issues.push({
+      severity: "error",
+      code: "bindings_missing",
+      message: "`layerBindings` is missing or not an array — the document does not declare how any layer generates.",
+      path: "layerBindings"
+    });
+    return issues;
+  }
+
+  const bound = new Set<string>();
+  raw.forEach((entry, index) => {
+    const path = `layerBindings[${index}]`;
+    if (!isRecord(entry)) {
+      issues.push({
+        severity: "error",
+        code: "binding_invalid",
+        message: `Binding at index ${index} is ${JSON.stringify(entry)} — expected an object.`,
+        path
+      });
+      return;
+    }
+
+    const layerId = typeof entry.layerId === "string" ? entry.layerId : "";
+    if (layerId === "") {
+      issues.push({
+        severity: "error",
+        code: "binding_invalid",
+        message: `Binding at index ${index} has no \`layerId\` — nothing says which layer it generates.`,
+        path: `${path}.layerId`
+      });
+    } else if (!ids.has(layerId)) {
+      issues.push({
+        severity: "error",
+        code: "binding_layer_missing",
+        message: `Binding at index ${index} generates layer "${layerId}", which the document does not contain.`,
+        layerId,
+        path: `${path}.layerId`
+      });
+    } else if (bound.has(layerId)) {
+      issues.push({
+        severity: "error",
+        code: "duplicate_binding",
+        message: `Layer "${layerId}" carries more than one binding — which one generates it is undefined.`,
+        layerId,
+        path: `${path}.layerId`
+      });
+    }
+    if (layerId !== "") bound.add(layerId);
+
+    // Absent `kind` is legacy data, which the editor reads as "workflow".
+    const kind = entry.kind === undefined ? "workflow" : String(entry.kind);
+    if (!BINDING_KINDS.has(kind)) {
+      issues.push({
+        severity: "error",
+        code: "binding_kind_invalid",
+        message: `Binding for "${layerId}" has kind "${kind}" — expected one of ${[...BINDING_KINDS].join(", ")}.`,
+        ...(layerId ? { layerId } : {}),
+        path: `${path}.kind`
+      });
+    }
+
+    if (kind === "workflow") {
+      const workflowId = entry.workflowId;
+      if (typeof workflowId !== "string" || workflowId === "") {
+        issues.push({
+          severity: "error",
+          code: "binding_workflow_missing",
+          message: `Workflow binding for "${layerId}" names no workflowId — nothing can produce its pixels.`,
+          ...(layerId ? { layerId } : {}),
+          path: `${path}.workflowId`
+        });
+      }
+    } else {
+      const prompt = entry.prompt;
+      if (typeof prompt !== "string" || prompt.trim() === "") {
+        issues.push({
+          severity: "warning",
+          code: "binding_incomplete",
+          message: `${kind} binding for "${layerId}" carries no prompt — a generation would run on nothing.`,
+          ...(layerId ? { layerId } : {}),
+          path: `${path}.prompt`
+        });
+      }
+      const source = entry.sourceLayerId;
+      if (
+        (kind === "image-to-image" || kind === "inpaint") &&
+        typeof source === "string" &&
+        source !== "" &&
+        !ids.has(source)
+      ) {
+        issues.push({
+          severity: "warning",
+          code: "binding_source_layer_missing",
+          message: `${kind} binding for "${layerId}" reads source layer "${source}", which the document does not contain.`,
+          ...(layerId ? { layerId } : {}),
+          path: `${path}.sourceLayerId`
+        });
+      }
+    }
+
+    const status = entry.status;
+    if (typeof status !== "string" || !BINDING_STATUSES.has(status)) {
+      issues.push({
+        severity: "error",
+        code: "binding_status_invalid",
+        message: `Binding for "${layerId}" has status ${JSON.stringify(status)} — expected one of ${[...BINDING_STATUSES].join(", ")}.`,
+        ...(layerId ? { layerId } : {}),
+        path: `${path}.status`
+      });
+    }
+
+    const versions = entry.versions;
+    if (versions !== undefined && !Array.isArray(versions)) {
+      issues.push({
+        severity: "error",
+        code: "binding_invalid",
+        message: `Binding for "${layerId}" has \`versions\` ${JSON.stringify(versions)} — expected an array.`,
+        ...(layerId ? { layerId } : {}),
+        path: `${path}.versions`
+      });
+    }
+    asArray(versions).forEach((version, versionIndex) => {
+      if (!isRecord(version)) return;
+      const versionStatus = version.status;
+      if (typeof versionStatus !== "string" || !VERSION_STATUSES.has(versionStatus)) {
+        issues.push({
+          severity: "error",
+          code: "version_status_invalid",
+          message: `Version ${versionIndex} of the binding for "${layerId}" has status ${JSON.stringify(versionStatus)} — expected one of ${[...VERSION_STATUSES].join(", ")}.`,
+          ...(layerId ? { layerId } : {}),
+          path: `${path}.versions[${versionIndex}].status`
+        });
+      }
+    });
+  });
+
+  return issues;
+}
+
+/**
+ * Validate a parsed-JSON image document (`{sketch, layerBindings}`). `raw` is
+ * untrusted: a document that is not an object, or has no `sketch`, is reported
+ * and the rest of the pass is skipped, since there is nothing left to read.
+ */
+export function validateSketchDocument(
+  raw: unknown,
+  meta?: SketchValidationMeta
+): SketchValidation {
+  if (!isRecord(raw)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          severity: "error",
+          code: "document_invalid",
+          message: `Document is ${JSON.stringify(raw)} — expected an object carrying \`sketch\` and \`layerBindings\`.`
+        }
+      ],
+      warnings: []
+    };
+  }
+
+  const { issues: schemaIssues } = checkSchema(raw);
+
+  if (!isRecord(raw.sketch)) {
+    return {
+      ok: false,
+      errors: [
+        ...schemaIssues.filter((issue) => issue.severity === "error"),
+        {
+          severity: "error",
+          code: "sketch_missing",
+          message: "Document has no `sketch` object — there is no layer stack to check.",
+          path: "sketch"
+        }
+      ],
+      warnings: schemaIssues.filter((issue) => issue.severity === "warning")
+    };
+  }
+
+  const sketch = raw.sketch;
+  const { layers, issues: layerIssues } = readLayers(sketch);
+  const ids = new Set(layers.map((layer) => layer.id));
+
+  const issues: SketchDebugIssue[] = [
+    ...schemaIssues,
+    ...checkCanvas(sketch, meta),
+    ...layerIssues,
+    ...layers.flatMap((layer) => checkLayer(layer, ids)),
+    ...checkSelection(sketch, layers, ids),
+    ...checkBindings(raw, ids)
+  ];
+
+  const errors = issues.filter((issue) => issue.severity === "error");
+  const warnings = issues.filter((issue) => issue.severity === "warning");
+  return { ok: errors.length === 0, errors, warnings };
+}

--- a/packages/execution/tests/sketch-debug.test.ts
+++ b/packages/execution/tests/sketch-debug.test.ts
@@ -1,0 +1,406 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSketchDebugReport,
+  renderSketchReportMarkdown,
+  validateSketchDocument,
+  type SketchDebugIssue,
+  type SketchInteractionRecord
+} from "../src/sketch-debug/index.js";
+
+type Json = Record<string, unknown>;
+
+const layer = (overrides: Json = {}): Json => ({
+  id: "layer-1",
+  name: "Background",
+  type: "raster",
+  visible: true,
+  locked: false,
+  opacity: 1,
+  blendMode: "normal",
+  data: null,
+  ...overrides
+});
+
+const binding = (overrides: Json = {}): Json => ({
+  layerId: "layer-1",
+  kind: "workflow",
+  workflowId: "wf-1",
+  status: "generated",
+  versions: [],
+  ...overrides
+});
+
+const doc = (sketch: Json = {}, overrides: Json = {}): Json => ({
+  sketch: {
+    version: 3,
+    canvas: { width: 1024, height: 768, backgroundColor: "#ffffff" },
+    layers: [layer()],
+    activeLayerId: "layer-1",
+    maskLayerId: null,
+    ...sketch
+  },
+  layerBindings: [],
+  ...overrides
+});
+
+const codes = (issues: ReadonlyArray<SketchDebugIssue>): string[] =>
+  issues.map((issue) => issue.code);
+
+describe("validateSketchDocument — document shape", () => {
+  it("accepts a minimal sound document", () => {
+    const result = validateSketchDocument(doc());
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a non-object document", () => {
+    const result = validateSketchDocument("not a sketch");
+    expect(result.ok).toBe(false);
+    expect(codes(result.errors)).toEqual(["document_invalid"]);
+  });
+
+  it("reports a document with no sketch and stops there", () => {
+    const result = validateSketchDocument({ layerBindings: [] });
+    expect(codes(result.errors)).toContain("sketch_missing");
+  });
+
+  it("reports layerBindings that is not an array", () => {
+    const result = validateSketchDocument(doc({}, { layerBindings: {} }));
+    expect(codes(result.errors)).toContain("bindings_missing");
+  });
+
+  it("reports schema_invalid but still checks the structure around it", () => {
+    const result = validateSketchDocument(
+      doc({ version: "three", layers: [layer({ opacity: 4 })] })
+    );
+    expect(codes(result.errors)).toContain("schema_invalid");
+    expect(codes(result.errors)).toContain("layer_opacity_invalid");
+  });
+});
+
+describe("validateSketchDocument — field_stripped", () => {
+  it("flags a key the schema drops", () => {
+    const result = validateSketchDocument(doc({ notes: "keep me" }));
+    const stripped = result.warnings.filter((w) => w.code === "field_stripped");
+    expect(stripped.map((w) => w.path)).toEqual(["sketch.notes"]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("says nothing about layer fields, which the schema keeps opaque", () => {
+    const result = validateSketchDocument(
+      doc({ layers: [layer({ segmentationMeta: { source: "sam" } })] })
+    );
+    expect(codes(result.warnings)).not.toContain("field_stripped");
+  });
+});
+
+describe("validateSketchDocument — canvas", () => {
+  it("reports a canvas with no positive size", () => {
+    const result = validateSketchDocument(
+      doc({ canvas: { width: 0, height: -10 } })
+    );
+    expect(codes(result.errors)).toEqual(["canvas_invalid", "canvas_invalid"]);
+  });
+
+  it("reports a missing canvas", () => {
+    const result = validateSketchDocument(doc({ canvas: undefined }));
+    expect(codes(result.errors)).toContain("canvas_missing");
+  });
+
+  it("reports a non-string backgroundColor", () => {
+    const result = validateSketchDocument(
+      doc({ canvas: { width: 8, height: 8, backgroundColor: 16777215 } })
+    );
+    expect(codes(result.errors)).toContain("canvas_invalid");
+  });
+
+  it("warns when the row's size disagrees with the canvas", () => {
+    const result = validateSketchDocument(doc(), { width: 2048, height: 768 });
+    const mismatch = result.warnings.filter(
+      (w) => w.code === "canvas_size_mismatch"
+    );
+    expect(mismatch).toHaveLength(1);
+    expect(mismatch[0]?.path).toBe("sketch.canvas.width");
+  });
+});
+
+describe("validateSketchDocument — layers", () => {
+  it("reports a duplicate layer id", () => {
+    const result = validateSketchDocument(
+      doc({ layers: [layer(), layer({ name: "Copy" })] })
+    );
+    expect(codes(result.errors)).toContain("duplicate_layer_id");
+  });
+
+  it("reports a layer missing its required fields", () => {
+    const result = validateSketchDocument(
+      doc({ layers: [{ id: "layer-1", name: "Background" }] })
+    );
+    expect(codes(result.errors)).toContain("layer_invalid");
+  });
+
+  it("reports an opacity outside [0, 1]", () => {
+    const result = validateSketchDocument(
+      doc({ layers: [layer({ opacity: -0.5 })] })
+    );
+    expect(codes(result.errors)).toContain("layer_opacity_invalid");
+  });
+
+  it("reports a blend mode no compositor ships", () => {
+    const result = validateSketchDocument(
+      doc({ layers: [layer({ blendMode: "vivid-light" })] })
+    );
+    const issue = result.errors.find((e) => e.code === "unknown_blend_mode");
+    expect(issue?.layerId).toBe("layer-1");
+  });
+
+  it("reports negative content bounds", () => {
+    const result = validateSketchDocument(
+      doc({
+        layers: [layer({ contentBounds: { x: 0, y: 0, width: -4, height: 10 } })]
+      })
+    );
+    expect(codes(result.errors)).toEqual(["content_bounds_invalid"]);
+  });
+
+  it("warns about a parent the document does not contain", () => {
+    const result = validateSketchDocument(
+      doc({ layers: [layer({ parentId: "group-9" })] })
+    );
+    expect(codes(result.warnings)).toContain("layer_parent_missing");
+  });
+});
+
+describe("validateSketchDocument — selection", () => {
+  it("reports an activeLayerId naming a missing layer", () => {
+    const result = validateSketchDocument(doc({ activeLayerId: "layer-9" }));
+    const issue = result.errors.find((e) => e.code === "active_layer_missing");
+    expect(issue?.layerId).toBe("layer-9");
+  });
+
+  it("warns about a maskLayerId naming a missing layer", () => {
+    const result = validateSketchDocument(doc({ maskLayerId: "layer-9" }));
+    expect(codes(result.warnings)).toContain("mask_layer_missing");
+  });
+
+  it("warns about a document with no layers at all", () => {
+    const result = validateSketchDocument(
+      doc({ layers: [], activeLayerId: "" })
+    );
+    expect(codes(result.warnings)).toContain("document_empty");
+    expect(codes(result.errors)).not.toContain("active_layer_missing");
+  });
+});
+
+describe("validateSketchDocument — bindings", () => {
+  it("accepts a workflow binding on a layer the document has", () => {
+    const result = validateSketchDocument(doc({}, { layerBindings: [binding()] }));
+    expect(result.ok).toBe(true);
+  });
+
+  it("reports a binding on a layer the document lacks", () => {
+    const result = validateSketchDocument(
+      doc({}, { layerBindings: [binding({ layerId: "layer-9" })] })
+    );
+    expect(codes(result.errors)).toContain("binding_layer_missing");
+  });
+
+  it("reports two bindings for one layer", () => {
+    const result = validateSketchDocument(
+      doc({}, { layerBindings: [binding(), binding({ workflowId: "wf-2" })] })
+    );
+    expect(codes(result.errors)).toContain("duplicate_binding");
+  });
+
+  it("reports a workflow binding with no workflowId", () => {
+    const result = validateSketchDocument(
+      doc({}, { layerBindings: [binding({ workflowId: "" })] })
+    );
+    expect(codes(result.errors)).toContain("binding_workflow_missing");
+  });
+
+  it("reports a status outside the enum", () => {
+    const result = validateSketchDocument(
+      doc({}, { layerBindings: [binding({ status: "rendering" })] })
+    );
+    expect(codes(result.errors)).toContain("binding_status_invalid");
+  });
+
+  it("reports a version status outside the enum", () => {
+    const result = validateSketchDocument(
+      doc(
+        {},
+        {
+          layerBindings: [
+            binding({
+              versions: [
+                {
+                  id: "v1",
+                  createdAt: "2026-01-01T00:00:00.000Z",
+                  jobId: "job-1",
+                  assetId: "asset-1",
+                  workflowUpdatedAt: "2026-01-01T00:00:00.000Z",
+                  dependencyHash: "abc",
+                  paramOverridesSnapshot: {},
+                  status: "done"
+                }
+              ]
+            })
+          ]
+        }
+      )
+    );
+    expect(codes(result.errors)).toContain("version_status_invalid");
+  });
+
+  it("reports an unknown binding kind", () => {
+    const result = validateSketchDocument(
+      doc({}, { layerBindings: [binding({ kind: "video" })] })
+    );
+    expect(codes(result.errors)).toContain("binding_kind_invalid");
+  });
+
+  it("warns about a direct-gen binding with no prompt", () => {
+    const result = validateSketchDocument(
+      doc(
+        {},
+        {
+          layerBindings: [
+            binding({ kind: "text-to-image", workflowId: undefined, prompt: "" })
+          ]
+        }
+      )
+    );
+    expect(codes(result.warnings)).toContain("binding_incomplete");
+  });
+
+  it("warns about an image-to-image source layer that is gone", () => {
+    const result = validateSketchDocument(
+      doc(
+        {},
+        {
+          layerBindings: [
+            binding({
+              kind: "image-to-image",
+              workflowId: undefined,
+              prompt: "restyle",
+              sourceLayerId: "layer-9"
+            })
+          ]
+        }
+      )
+    );
+    expect(codes(result.warnings)).toContain("binding_source_layer_missing");
+  });
+});
+
+const interaction = (
+  overrides: Partial<SketchInteractionRecord> = {}
+): SketchInteractionRecord => ({
+  tool: "ui_sketch_add_layer",
+  input: { name: "Glow" },
+  ok: true,
+  ...overrides
+});
+
+describe("buildSketchDebugReport", () => {
+  it("describes a clean document and lists what is not simulated", () => {
+    const report = buildSketchDebugReport({
+      target: { kind: "file", ref: "sketch.json" },
+      document: doc({}, { layerBindings: [binding()] })
+    });
+
+    expect(report.verdict.ok).toBe(true);
+    expect(report.meta).toEqual({
+      width: 1024,
+      height: 768,
+      backgroundColor: "#ffffff",
+      layerCount: 1,
+      bindingCount: 1
+    });
+    expect(report.notSimulated.join(" ")).toMatch(/Pixels/);
+  });
+
+  it("fails the verdict on a failed interaction", () => {
+    const report = buildSketchDebugReport({
+      target: { kind: "id", ref: "img-1" },
+      document: doc(),
+      interactions: [interaction({ ok: false, error: 'No layer found matching "nope".' })]
+    });
+
+    expect(report.verdict.ok).toBe(false);
+    expect(report.verdict.issues[0]).toMatch(/ui_sketch_add_layer` failed/);
+  });
+
+  it("validates the post-edit document and describes it, not the input", () => {
+    const report = buildSketchDebugReport({
+      target: { kind: "file", ref: "sketch.json" },
+      document: doc(),
+      interactions: [interaction()],
+      finalState: { layers: [] },
+      finalDocument: doc({
+        layers: [layer(), layer({ id: "layer-2", name: "Glow", opacity: 9 })]
+      })
+    });
+
+    expect(report.meta.layerCount).toBe(2);
+    expect(codes(report.finalValidation?.errors ?? [])).toContain(
+      "layer_opacity_invalid"
+    );
+    expect(report.verdict.issues.some((i) => i.startsWith("After edits"))).toBe(true);
+  });
+
+  it("keeps warnings out of the ok verdict", () => {
+    const report = buildSketchDebugReport({
+      target: { kind: "file", ref: "sketch.json" },
+      document: doc({ maskLayerId: "layer-9" })
+    });
+
+    expect(report.verdict.ok).toBe(true);
+    expect(report.verdict.warnings?.[0]).toMatch(/mask_layer_missing/);
+  });
+});
+
+describe("renderSketchReportMarkdown", () => {
+  it("renders the verdict, the issue table, the steps and the final stack", () => {
+    const report = buildSketchDebugReport({
+      target: { kind: "file", ref: "sketch.json", name: "Poster" },
+      document: doc({ activeLayerId: "layer-9" }),
+      interactions: [interaction()],
+      finalState: {
+        width: 1024,
+        height: 768,
+        activeLayerId: "layer-2",
+        layers: [
+          {
+            id: "layer-1",
+            name: "Background",
+            type: "raster",
+            visible: true,
+            opacity: 1,
+            blendMode: "normal"
+          },
+          {
+            id: "layer-2",
+            name: "Glow",
+            type: "raster",
+            visible: true,
+            opacity: 0.5,
+            blendMode: "multiply",
+            hasBinding: true
+          }
+        ]
+      }
+    });
+
+    const md = renderSketchReportMarkdown(report);
+    expect(md).toContain("# Sketch debug: Poster");
+    expect(md).toContain("❌");
+    expect(md).toContain("`active_layer_missing`");
+    expect(md).toContain("| `ui_sketch_add_layer` | ✅ |");
+    expect(md).toContain('`layer-2` "Glow"');
+    expect(md).toContain("## Not simulated");
+  });
+});

--- a/packages/execution/tsconfig.json
+++ b/packages/execution/tsconfig.json
@@ -15,6 +15,9 @@
       "path": "../config"
     },
     {
+      "path": "../gpu"
+    },
+    {
       "path": "../protocol"
     },
     {

--- a/packages/websocket/src/mcp-agent-tools.ts
+++ b/packages/websocket/src/mcp-agent-tools.ts
@@ -25,6 +25,7 @@ import { ProcessingContext as ProcessingContextImpl } from "@nodetool-ai/runtime
 import {
   Tool,
   ValidateTimelineTool,
+  ValidateSketchTool,
   FindModelTool,
   GenerateImageTool,
   EditImageTool,
@@ -39,8 +40,13 @@ import {
 } from "@nodetool-ai/agents";
 import { FileStorageAdapter } from "@nodetool-ai/runtime";
 import type { BaseProvider } from "@nodetool-ai/runtime";
-import type { TimelineLoader } from "@nodetool-ai/agents";
-import { getSecret, Asset, TimelineSequence } from "@nodetool-ai/models";
+import type { SketchLoader, TimelineLoader } from "@nodetool-ai/agents";
+import {
+  getSecret,
+  Asset,
+  ImageDocument,
+  TimelineSequence
+} from "@nodetool-ai/models";
 import { WORKFLOW_DOCUMENT_TOOL_NAMES } from "@nodetool-ai/node-sdk";
 import {
   createLogger,
@@ -168,6 +174,24 @@ const loadTimelineForUser: TimelineLoader = async (context, id) => {
     fps: row.fps,
     width: row.width,
     height: row.height,
+    name: row.name
+  };
+};
+
+/**
+ * Read an `image_documents` row for `validate_sketch`. There is no REST route
+ * for sketches (the API is tRPC-only), so the tool takes this loader instead of
+ * fetching. Ownership is checked the same way the tRPC router's `loadOwned`
+ * does — a row belonging to another user reads as not found.
+ */
+const loadSketchForUser: SketchLoader = async (context, id) => {
+  const row = await ImageDocument.findById(id);
+  if (!row || row.user_id !== context.userId) return null;
+  return {
+    document: row.document,
+    width: row.width,
+    height: row.height,
+    backgroundColor: row.background_color,
     name: row.name
   };
 };
@@ -326,6 +350,9 @@ function collectBridgedTools(
     // Timelines have no REST route (the API is tRPC-only), so this tool takes a
     // loader instead of fetching, and `getAllMcpTools` cannot construct it.
     new ValidateTimelineTool(loadTimelineForUser),
+    // Sketches are tRPC-only too, so this one takes a loader for the same
+    // reason and `getAllMcpTools` cannot construct it either.
+    new ValidateSketchTool(loadSketchForUser),
     // `getAllMcpTools` only offers the media tools when handed a populated
     // provider map. Here they resolve providers from the scoped user's secrets
     // at call time, so offer them unconditionally rather than probing every

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1313,6 +1313,11 @@ forward is a workflow.
   checks a sequence before the user renders it.
 - **sketch** — a layered image document. Family \`+sketch\`: layers, drawing
   tools, generating into a layer, rendering the result to an asset.
+  \`validate_sketch\` statically checks a document — the open one or any saved
+  one by id. \`list_sketches\` finds one; every sketch also keeps a snapshot
+  history, read with \`list_sketch_versions\`, pinned with
+  \`create_sketch_version\` and rolled back with \`restore_sketch_version\` —
+  none of which needs an open editor.
 - **model3d** — a 3D scene. Family \`+ui_3d\`: add and transform objects, set
   materials, capture a view as an image.
 - **collection** — a vector store for RAG. \`list_collections\`,
@@ -1539,6 +1544,14 @@ function formatUiContext(uiContext?: UiContext | null): string {
   if (hasTimeline) {
     lines.push(
       "After editing a timeline sequence, call `validate_timeline` with its id. It statically catches clips on missing tracks, overlaps, fades longer than their clip, and timings that cannot render — before the user renders."
+    );
+  }
+
+  const hasSketch =
+    focused?.type === "sketch" || open.some((ref) => ref.type === "sketch");
+  if (hasSketch) {
+    lines.push(
+      "After editing a sketch, call `validate_sketch` with its id. It statically catches duplicate layer ids, an active or mask layer the stack lacks, unknown blend modes, bindings pointing at missing layers, and fields a save would strip — before you hand the document back."
     );
   }
 

--- a/packages/websocket/tests/mcp-server-coverage.test.ts
+++ b/packages/websocket/tests/mcp-server-coverage.test.ts
@@ -551,6 +551,7 @@ describe("bridged agent tools (the full agent toolbelt)", () => {
       "debug_app",
       "validate_workflow",
       "validate_timeline",
+      "validate_sketch",
       "list_models",
       "get_example_workflow",
       "export_workflow_digraph",
@@ -692,6 +693,53 @@ describe("bridged agent tools (the full agent toolbelt)", () => {
     };
     expect(body.ok).toBe(true);
     expect(body.summary).toBe("No issues found.");
+  });
+
+  it("validate_sketch validates an inline document", async () => {
+    const server = createMcpServer({ agentToolsScope: scope });
+    const res = await callTool(server, "validate_sketch", {
+      document: {
+        sketch: {
+          version: 3,
+          canvas: { width: 1024, height: 768, backgroundColor: "#ffffff" },
+          layers: [
+            {
+              id: "layer-1",
+              name: "Background",
+              type: "raster",
+              visible: true,
+              locked: false,
+              opacity: 1,
+              blendMode: "normal",
+              data: null
+            }
+          ],
+          activeLayerId: "layer-1",
+          maskLayerId: null
+        },
+        layerBindings: []
+      }
+    });
+    const body = JSON.parse(res.content[0].text!) as {
+      ok: boolean;
+      summary: string;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.summary).toBe("No issues found.");
+  });
+
+  it("validate_sketch reads a saved sketch through the bridged loader", async () => {
+    const server = createMcpServer({ agentToolsScope: scope });
+    const res = await callTool(server, "validate_sketch", {
+      image_document_id: "no-such-sketch"
+    });
+    const body = JSON.parse(res.content[0].text!) as {
+      error: string;
+      validated: boolean;
+    };
+    // The loader is wired (no "no sketch loader" error) and reports the miss.
+    expect(body.error).toContain("was not found");
+    expect(body.validated).toBe(false);
   });
 
   it("save_asset reports an actionable error when nothing to save", async () => {


### PR DESCRIPTION
Follow-up to #4719: sketches get the harness and agent-tool surface timelines already have.

## Validation core (`@nodetool-ai/execution/sketch-debug`)

`validateSketchDocument(raw, meta?)` decides what a headless check can: a document that is not `{sketch, layerBindings}`, canvas dimensions that cannot render, duplicate layer ids, an `activeLayerId`/`maskLayerId`/binding pointing at a layer the document lacks, opacity outside [0,1], blend modes no compositor ships (checked against `BLEND_MODE_TUPLE` from `@nodetool-ai/gpu`), workflow bindings naming no workflow, direct-gen bindings with no prompt or a missing source layer, statuses outside their enums, and fields a schema round trip would strip. Layer bitmaps stay opaque — pixel decode is out of scope. Report builder + markdown renderer mirror `timeline-debug`.

## CLI harness

- `nodetool sketch validate <id|file.json>` (`--json`, `--warnings-as-errors`) — the cheap static pre-flight; file targets need no database.
- `nodetool sketch debug <id|file.json> --interact '[...]'` — replays a scripted edit session against the headless `ui_sketch_*` bridge (the one the `sketch-tools` eval drives), validates the document the session left behind, and writes a `report.json`/`report.md`/`sketch.json` bundle. A failing step is recorded and the script continues. Pixels, painting, rendering, generation, and asset I/O are listed under `notSimulated`.
- `nodetool sketch versions restore` now runs the same static check instead of the JSON-object-only test, matching `timeline versions restore`: a restore whose document no longer validates exits non-zero and prints the issues.

## Agent tools

- `validate_sketch` — the static check as a tool: inline `document` or `image_document_id` (loader injected server-side with the same ownership check the tRPC router makes).
- `list_sketches`, `list_sketch_versions`, `create_sketch_version`, `restore_sketch_version` — the version history headlessly, mirroring the tRPC semantics: restore snapshots the pre-restore state first (undoable), CAS-writes the version back, and returns the post-restore validation.
- Registered in the builtin toolbelt and the MCP bridge; the chat system prompt names them beside the timeline guidance.

## Harness registry + docs

`sketch-validate` and `sketch-debug` join `sketch-versions` on the sketch surface (`nodetool harness audit`: 9/11 covered, no new gaps); CLAUDE.md documents the harness and the tools.

## Verification

- Package suites all green: execution 177, cli 558+, agents, websocket (final counts in CI).
- `npm run typecheck` clean for web/electron/packages; `npm run lint` clean.
- Smoke: `sketch validate` on a `sketch.get`-shaped file → 0 errors; `sketch debug` with a three-step script against the real bridge → failing step recorded, bundle written, verdict as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yzrorMvguPf5DMZjMRNP8

---
_Generated by [Claude Code](https://claude.ai/code/session_018yzrorMvguPf5DMZjMRNP8)_