### PR TITLE
feat: timeline versioning agent tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -647,6 +647,8 @@ the verdict is ok. Validation and report rules live in
 `@nodetool-ai/execution/timeline-debug`; the CLI keeps target resolution, the
 interaction script, and the bundle.
 
+### nodetool timeline versions (Timeline Version History)
+
 `timeline versions` reads and writes a sequence's snapshot history against the
 local database — manual saves, the autosaves `timeline.update` writes at most
 every five minutes, and the pre-restore snapshot that makes a restore undoable.
@@ -666,6 +668,12 @@ onto the sequence, then runs the same static check `timeline validate` runs. An
 old document is restored against today's schema, so what it used to pass is not
 what it passes now — a restore whose document no longer validates exits
 non-zero and prints the issues.
+
+Agents get the same history headlessly: **`list_timelines`**,
+**`list_timeline_versions`**, **`create_timeline_version`** (manual snapshot),
+and **`restore_timeline_version`**, which snapshots the pre-restore state first
+and returns the post-restore validation. None of them needs an open editor or a
+running server.
 
 ### nodetool sketch validate / debug (Sketch Harness)
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -425,6 +425,13 @@ export {
   RestoreSketchVersionTool,
   SKETCH_VERSION_TOOL_NAMES
 } from "./tools/sketch-version-tools.js";
+export {
+  ListTimelinesTool,
+  ListTimelineVersionsTool,
+  CreateTimelineVersionTool,
+  RestoreTimelineVersionTool,
+  TIMELINE_VERSION_TOOL_NAMES
+} from "./tools/timeline-version-tools.js";
 
 // Plan cache + checkpoint store (opt-in planning/execution persistence)
 export {

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -111,6 +111,12 @@ import {
   CreateSketchVersionTool,
   RestoreSketchVersionTool
 } from "./sketch-version-tools.js";
+import {
+  ListTimelinesTool,
+  ListTimelineVersionsTool,
+  CreateTimelineVersionTool,
+  RestoreTimelineVersionTool
+} from "./timeline-version-tools.js";
 
 export const BUILTIN_TOOL_CLASSES: ReadonlyArray<new () => Tool> = [
   // Filesystem (workspace-relative)
@@ -153,6 +159,12 @@ export const BUILTIN_TOOL_CLASSES: ReadonlyArray<new () => Tool> = [
   ListSketchVersionsTool,
   CreateSketchVersionTool,
   RestoreSketchVersionTool,
+
+  // Timeline snapshot history (find a cut, pin a state, roll one back)
+  ListTimelinesTool,
+  ListTimelineVersionsTool,
+  CreateTimelineVersionTool,
+  RestoreTimelineVersionTool,
 
   // Vision (lazy image loading: handles → pixels on demand)
   ListImagesTool,

--- a/packages/agents/src/tools/timeline-version-tools.ts
+++ b/packages/agents/src/tools/timeline-version-tools.ts
@@ -1,0 +1,394 @@
+/**
+ * Timeline version tools — snapshot history for a timeline sequence, headlessly.
+ *
+ * A sequence keeps immutable snapshots: manual saves, the autosaves a document
+ * write takes at most every five minutes, and the pre-restore snapshot that
+ * makes a restore undoable. Reading and moving through that history was
+ * tRPC-only, so an agent outside the browser could not roll a cut back to a
+ * version the user liked, or pin the current state before a risky recut.
+ *
+ *   list_timelines          — find a sequence to work on
+ *   list_timeline_versions  — its snapshots, newest first
+ *   create_timeline_version — pin the current state as a manual snapshot
+ *   restore_timeline_version — roll the sequence back to one
+ *
+ * The restore mirrors `timeline.versions.restore`: it snapshots what is about
+ * to be overwritten, then compare-and-swaps the old document and render
+ * settings back onto the row. An old document is restored against today's
+ * schema, so what it used to pass is not what it passes now — the restore ends
+ * with `validateTimelineSequence` over the result, the same check
+ * `validate_timeline` and the CLI's `timeline versions restore` make.
+ */
+
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { TimelineSequence, TimelineSequenceVersion } from "@nodetool-ai/models";
+import { validateTimelineSequence } from "@nodetool-ai/execution/timeline-debug";
+import type { TimelineValidation } from "@nodetool-ai/execution/timeline-debug";
+import { Tool } from "./base-tool.js";
+
+/** Versions one call may return, so a long history cannot flood the context. */
+const DEFAULT_VERSION_LIMIT = 20;
+const MAX_VERSION_LIMIT = 100;
+
+type ToolError = { error: string };
+
+const isError = (value: unknown): value is ToolError =>
+  !!value &&
+  typeof value === "object" &&
+  typeof (value as ToolError).error === "string";
+
+async function loadTimeline(
+  context: ProcessingContext,
+  timelineId: unknown
+): Promise<TimelineSequence | ToolError> {
+  if (typeof timelineId !== "string" || !timelineId) {
+    return {
+      error: "timeline_id is required (use list_timelines to find one)."
+    };
+  }
+  const seq = await TimelineSequence.findById(timelineId);
+  // A sequence owned by someone else reads as missing — the same rule the tRPC
+  // router's ownership check applies.
+  if (!seq || seq.user_id !== context.userId) {
+    return { error: `Timeline ${timelineId} was not found.` };
+  }
+  return seq;
+}
+
+/** The list-item shape the tRPC router returns for a snapshot. */
+function toVersionListItem(version: TimelineSequenceVersion) {
+  return {
+    id: version.id,
+    version: version.version,
+    name: version.name,
+    saveType: version.save_type,
+    fps: version.fps,
+    width: version.width,
+    height: version.height,
+    durationMs: version.duration_ms,
+    createdAt: version.created_at
+  };
+}
+
+/**
+ * A snapshot's document is JSON text on SQLite and an object on Postgres, so
+ * parse only when it is a string. A row that is neither is corrupt, and saying
+ * so beats handing back a string the caller will treat as a document.
+ */
+function parseVersionDocument(raw: unknown): unknown | ToolError {
+  if (typeof raw !== "string") return raw;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return { error: "The stored version document is not valid JSON." };
+  }
+}
+
+/** One-line count of what the post-restore validation found. */
+function validationSummary(validation: TimelineValidation): string {
+  const errors = validation.errors.length;
+  const warnings = validation.warnings.length;
+  if (errors === 0 && warnings === 0) return "No issues found.";
+  const parts: string[] = [];
+  if (errors > 0) parts.push(`${errors} error${errors === 1 ? "" : "s"}`);
+  if (warnings > 0)
+    parts.push(`${warnings} warning${warnings === 1 ? "" : "s"}`);
+  return parts.join(", ");
+}
+
+function versionNumber(value: unknown): number | ToolError {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    return {
+      error:
+        "version must be a positive integer (use list_timeline_versions to see the available ones)."
+    };
+  }
+  return n;
+}
+
+const SAVE_TYPE_PROPERTY = {
+  type: "string" as const,
+  enum: ["manual", "autosave", "restore"],
+  description:
+    "Only versions of this kind: 'manual' (a save someone asked for), " +
+    "'autosave' (taken on a document write), 'restore' (the pre-restore " +
+    "snapshot). Omit for all of them."
+};
+
+export class ListTimelinesTool extends Tool {
+  readonly name = "list_timelines";
+  readonly description =
+    "List the caller's timeline sequences, most recently updated first: id, " +
+    "name, frame rate, resolution, duration, and when it last changed. Start " +
+    "here when the user names a timeline but not its id.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      query: {
+        type: "string" as const,
+        description:
+          "Only timelines whose name contains this text (case-insensitive)."
+      },
+      limit: {
+        type: "number" as const,
+        description: "Max timelines to return (default 20)."
+      }
+    }
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    if (!context.userId) return { error: "No user is bound to this session." };
+    const limit = Math.max(1, Math.min(Number(params["limit"]) || 20, 100));
+    const query =
+      typeof params["query"] === "string"
+        ? params["query"].trim().toLowerCase()
+        : "";
+    // Filter after the read: the name filter is not indexed, and the per-user
+    // limit is what bounds the scan.
+    const rows = await TimelineSequence.listByUser(context.userId, 100);
+    const matching = query
+      ? rows.filter((row) => row.name.toLowerCase().includes(query))
+      : rows;
+    return {
+      timelines: matching.slice(0, limit).map((row) => ({
+        id: row.id,
+        name: row.name,
+        project_id: row.project_id,
+        fps: row.fps,
+        width: row.width,
+        height: row.height,
+        duration_ms: row.duration_ms,
+        updated_at: row.updated_at
+      }))
+    };
+  }
+
+  userMessage(): string {
+    return "Listing timelines";
+  }
+}
+
+export class ListTimelineVersionsTool extends Tool {
+  readonly name = "list_timeline_versions";
+  readonly description =
+    "List a timeline sequence's snapshots, newest first: version number, " +
+    "name, save type ('manual', 'autosave', 'restore'), render settings, and " +
+    "when it was taken. Call this before restoring — restore_timeline_version " +
+    "addresses a snapshot by its version number.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      timeline_id: {
+        type: "string" as const,
+        description: "Timeline sequence id."
+      },
+      save_type: SAVE_TYPE_PROPERTY,
+      limit: {
+        type: "number" as const,
+        description: `Max versions to return (default ${DEFAULT_VERSION_LIMIT}, max ${MAX_VERSION_LIMIT}).`
+      }
+    },
+    required: ["timeline_id"]
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const seq = await loadTimeline(context, params["timeline_id"]);
+    if (isError(seq)) return seq;
+
+    const limit = Math.max(
+      1,
+      Math.min(
+        Number(params["limit"]) || DEFAULT_VERSION_LIMIT,
+        MAX_VERSION_LIMIT
+      )
+    );
+    const saveType =
+      typeof params["save_type"] === "string"
+        ? (params["save_type"] as string)
+        : undefined;
+    const versions = await TimelineSequenceVersion.listForTimeline(seq.id, {
+      limit,
+      saveType
+    });
+    return {
+      timeline_id: seq.id,
+      name: seq.name,
+      versions: versions.map(toVersionListItem)
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Listing versions of timeline ${String(params["timeline_id"])}`;
+  }
+}
+
+export class CreateTimelineVersionTool extends Tool {
+  readonly name = "create_timeline_version";
+  readonly description =
+    "Snapshot a timeline sequence's current document as a manual version, so " +
+    "it can be restored later. Manual snapshots are never pruned (autosaves " +
+    "are), so take one before an edit the user may want undone. Returns the " +
+    "new version's number.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      timeline_id: {
+        type: "string" as const,
+        description: "Timeline sequence id."
+      },
+      name: {
+        type: "string" as const,
+        description: "Label for the snapshot, e.g. 'before the recut'."
+      }
+    },
+    required: ["timeline_id"]
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const seq = await loadTimeline(context, params["timeline_id"]);
+    if (isError(seq)) return seq;
+
+    const name =
+      typeof params["name"] === "string" && params["name"]
+        ? (params["name"] as string)
+        : null;
+    const version = await TimelineSequenceVersion.snapshot(seq, {
+      saveType: "manual",
+      name
+    });
+    return {
+      ok: true,
+      timeline_id: seq.id,
+      ...toVersionListItem(version)
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Snapshotting timeline ${String(params["timeline_id"])}`;
+  }
+}
+
+export class RestoreTimelineVersionTool extends Tool {
+  readonly name = "restore_timeline_version";
+  readonly description =
+    "Roll a timeline sequence's document and render settings back to one of " +
+    "its snapshots, addressed by version number (from " +
+    "list_timeline_versions). The state being overwritten is snapshotted " +
+    "first, so the restore is itself undoable — restore that snapshot to come " +
+    "back. An old document is restored against today's schema, so the result " +
+    "is validated afterwards and the findings are returned with it.";
+  readonly jsonSchema = {
+    type: "object" as const,
+    properties: {
+      timeline_id: {
+        type: "string" as const,
+        description: "Timeline sequence id."
+      },
+      version: {
+        type: "number" as const,
+        description: "Version number to restore, from list_timeline_versions."
+      }
+    },
+    required: ["timeline_id", "version"]
+  };
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const seq = await loadTimeline(context, params["timeline_id"]);
+    if (isError(seq)) return seq;
+
+    const number = versionNumber(params["version"]);
+    if (isError(number)) return number;
+
+    const version = await TimelineSequenceVersion.findByVersion(seq.id, number);
+    if (!version) {
+      return {
+        error: `Timeline ${seq.id} has no version ${number}. Call list_timeline_versions to see the available ones.`
+      };
+    }
+
+    const document = parseVersionDocument(version.document);
+    if (isError(document)) return document;
+
+    // Snapshot what is about to be overwritten first, so a restore is itself
+    // undoable.
+    const undo = await TimelineSequenceVersion.snapshot(seq, {
+      saveType: "restore",
+      name: `Before restore to v${number}`
+    });
+
+    let updated: TimelineSequence | null;
+    try {
+      updated = await TimelineSequence.updateFieldsIfUnchanged(
+        seq.id,
+        seq.updated_at,
+        {
+          document: JSON.stringify(document),
+          fps: version.fps,
+          width: version.width,
+          height: version.height,
+          duration_ms: version.duration_ms
+        }
+      );
+    } catch (error) {
+      // The write rejects a document without tracks/clips/markers arrays. That
+      // is a snapshot too old or too broken to restore, not a failed call.
+      return {
+        error: `Version ${number} of timeline ${seq.id} cannot be restored: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        undo_version: undo.version
+      };
+    }
+    if (!updated) {
+      return {
+        error: `Timeline ${seq.id} was modified since it was read (optimistic concurrency conflict); nothing was restored. Retry the call.`,
+        undo_version: undo.version
+      };
+    }
+
+    const validation = validateTimelineSequence(document, {
+      fps: version.fps,
+      width: version.width,
+      height: version.height
+    });
+
+    return {
+      ok: true,
+      timeline_id: seq.id,
+      restored_version: number,
+      undo_version: undo.version,
+      fps: updated.fps,
+      width: updated.width,
+      height: updated.height,
+      duration_ms: updated.duration_ms,
+      updated_at: updated.updated_at,
+      validation,
+      summary: validationSummary(validation)
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    return `Restoring timeline ${String(params["timeline_id"])} to v${String(params["version"])}`;
+  }
+}
+
+/** Every tool in this module, for toolbelt assembly and docs. */
+export const TIMELINE_VERSION_TOOL_NAMES = [
+  "list_timelines",
+  "list_timeline_versions",
+  "create_timeline_version",
+  "restore_timeline_version"
+] as const;

--- a/packages/agents/src/tools/tool-permissions.ts
+++ b/packages/agents/src/tools/tool-permissions.ts
@@ -79,6 +79,8 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   validate_sketch: "read",
   list_sketches: "read",
   list_sketch_versions: "read",
+  list_timelines: "read",
+  list_timeline_versions: "read",
   list_storyboards: "read",
   get_storyboard: "read",
   get_example_workflow: "read",
@@ -180,6 +182,10 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   // document itself (undoably — it snapshots first).
   create_sketch_version: "write",
   restore_sketch_version: "write",
+  // Same for a timeline sequence's history: a restore rewrites the cut, after
+  // snapshotting the state it replaces.
+  create_timeline_version: "write",
+  restore_timeline_version: "write",
   transcribe_audio: "write",
   embed_text: "write",
   openai_image_generation: "write",

--- a/packages/agents/tests/timeline-version-tools.test.ts
+++ b/packages/agents/tests/timeline-version-tools.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  ModelObserver,
+  TimelineSequence,
+  TimelineSequenceVersion,
+  initTestDb
+} from "@nodetool-ai/models";
+import {
+  ListTimelinesTool,
+  ListTimelineVersionsTool,
+  CreateTimelineVersionTool,
+  RestoreTimelineVersionTool
+} from "../src/tools/timeline-version-tools.js";
+import { permissionCategoryFor } from "../src/tools/tool-permissions.js";
+import { BUILTIN_TOOL_CLASSES } from "../src/tools/builtin-tools.js";
+
+const ctx = (userId = "u1") => ({ userId }) as unknown as ProcessingContext;
+
+const track = (overrides: Record<string, unknown> = {}) => ({
+  id: "track-1",
+  name: "Video 1",
+  type: "video",
+  index: 0,
+  visible: true,
+  locked: false,
+  ...overrides
+});
+
+const clip = (overrides: Record<string, unknown> = {}) => ({
+  id: "clip-1",
+  trackId: "track-1",
+  name: "Shot 1",
+  startMs: 0,
+  durationMs: 2000,
+  mediaType: "video",
+  sourceType: "imported",
+  status: "generated",
+  locked: false,
+  versions: [],
+  ...overrides
+});
+
+const document = (trackId = "track-1") =>
+  JSON.stringify({
+    tracks: [track()],
+    clips: [clip({ trackId })],
+    markers: []
+  });
+
+async function makeTimeline(
+  overrides: Record<string, unknown> = {}
+): Promise<TimelineSequence> {
+  return TimelineSequence.create<TimelineSequence>({
+    user_id: "u1",
+    project_id: "default",
+    name: "Trailer cut",
+    fps: 30,
+    width: 1920,
+    height: 1080,
+    duration_ms: 2000,
+    document: document(),
+    ...overrides
+  });
+}
+
+describe("timeline version tools", () => {
+  beforeEach(() => initTestDb());
+  afterEach(() => ModelObserver.clear());
+
+  it("registers as built-ins with sane permissions", () => {
+    const names = BUILTIN_TOOL_CLASSES.map((Cls) => new Cls().name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "list_timelines",
+        "list_timeline_versions",
+        "create_timeline_version",
+        "restore_timeline_version"
+      ])
+    );
+    expect(permissionCategoryFor("list_timelines")).toBe("read");
+    expect(permissionCategoryFor("list_timeline_versions")).toBe("read");
+    expect(permissionCategoryFor("create_timeline_version")).toBe("write");
+    expect(permissionCategoryFor("restore_timeline_version")).toBe("write");
+  });
+
+  it("lists the caller's timelines and filters by name", async () => {
+    const trailer = await makeTimeline();
+    await makeTimeline({ name: "Behind the scenes" });
+
+    const all = (await new ListTimelinesTool().process(ctx(), {})) as {
+      timelines: Array<{ id: string; name: string }>;
+    };
+    expect(all.timelines).toHaveLength(2);
+
+    const filtered = (await new ListTimelinesTool().process(ctx(), {
+      query: "trail"
+    })) as { timelines: Array<{ id: string; fps: number }> };
+    expect(filtered.timelines).toHaveLength(1);
+    expect(filtered.timelines[0]).toMatchObject({ id: trailer.id, fps: 30 });
+  });
+
+  it("hides another user's timelines", async () => {
+    const row = await makeTimeline();
+    const listed = (await new ListTimelinesTool().process(ctx("other"), {})) as {
+      timelines: unknown[];
+    };
+    expect(listed.timelines).toEqual([]);
+
+    const versions = (await new ListTimelineVersionsTool().process(
+      ctx("other"),
+      { timeline_id: row.id }
+    )) as { error: string };
+    expect(versions.error).toContain("was not found");
+  });
+
+  it("creates a manual snapshot and lists it", async () => {
+    const row = await makeTimeline();
+
+    const created = (await new CreateTimelineVersionTool().process(ctx(), {
+      timeline_id: row.id,
+      name: "before the recut"
+    })) as { ok: boolean; version: number; saveType: string; name: string };
+    expect(created).toMatchObject({
+      ok: true,
+      version: 1,
+      saveType: "manual",
+      name: "before the recut",
+      fps: 30,
+      durationMs: 2000
+    });
+
+    await TimelineSequenceVersion.snapshot(row, { saveType: "autosave" });
+
+    const listed = (await new ListTimelineVersionsTool().process(ctx(), {
+      timeline_id: row.id
+    })) as { versions: Array<{ version: number; saveType: string }> };
+    // Newest first.
+    expect(listed.versions.map((v) => [v.version, v.saveType])).toEqual([
+      [2, "autosave"],
+      [1, "manual"]
+    ]);
+
+    const manualOnly = (await new ListTimelineVersionsTool().process(ctx(), {
+      timeline_id: row.id,
+      save_type: "manual"
+    })) as { versions: Array<{ version: number }> };
+    expect(manualOnly.versions.map((v) => v.version)).toEqual([1]);
+  });
+
+  it("restores a version, snapshots the overwritten state, and validates the result", async () => {
+    const row = await makeTimeline();
+    await new CreateTimelineVersionTool().process(ctx(), {
+      timeline_id: row.id,
+      name: "the good cut"
+    });
+
+    // Move the sequence on, so the restore has something to undo.
+    const edited = (await TimelineSequence.findById(row.id))!;
+    await TimelineSequence.updateFieldsIfUnchanged(row.id, edited.updated_at, {
+      document: JSON.stringify({ tracks: [], clips: [], markers: [] }),
+      width: 1280,
+      duration_ms: 0
+    });
+
+    const result = (await new RestoreTimelineVersionTool().process(ctx(), {
+      timeline_id: row.id,
+      version: 1
+    })) as {
+      ok: boolean;
+      restored_version: number;
+      undo_version: number;
+      width: number;
+      validation: { ok: boolean };
+      summary: string;
+    };
+
+    expect(result).toMatchObject({
+      ok: true,
+      restored_version: 1,
+      undo_version: 2,
+      width: 1920,
+      duration_ms: 2000
+    });
+    expect(result.validation.ok).toBe(true);
+    expect(result.summary).toBe("No issues found.");
+
+    const restored = (await TimelineSequence.findById(row.id))!;
+    expect(restored.width).toBe(1920);
+    expect(JSON.parse(restored.document).clips).toHaveLength(1);
+
+    // The restore is undoable: v2 holds the state it overwrote.
+    const undo = (await TimelineSequenceVersion.findByVersion(row.id, 2))!;
+    expect(undo.save_type).toBe("restore");
+    expect(undo.name).toBe("Before restore to v1");
+    expect(undo.width).toBe(1280);
+  });
+
+  it("reports the findings when the restored document no longer validates", async () => {
+    const row = await makeTimeline({ document: document("ghost") });
+    await new CreateTimelineVersionTool().process(ctx(), {
+      timeline_id: row.id
+    });
+
+    const result = (await new RestoreTimelineVersionTool().process(ctx(), {
+      timeline_id: row.id,
+      version: 1
+    })) as {
+      ok: boolean;
+      validation: { ok: boolean; errors: Array<{ code: string }> };
+      summary: string;
+    };
+
+    expect(result.ok).toBe(true);
+    expect(result.validation.ok).toBe(false);
+    expect(result.validation.errors.map((e) => e.code)).toContain(
+      "clip_track_missing"
+    );
+    expect(result.summary).toContain("1 error");
+  });
+
+  it("refuses to restore a version the timeline does not have", async () => {
+    const row = await makeTimeline();
+    const result = (await new RestoreTimelineVersionTool().process(ctx(), {
+      timeline_id: row.id,
+      version: 7
+    })) as { error: string };
+    expect(result.error).toContain("no version 7");
+    expect(result.error).toContain("list_timeline_versions");
+  });
+
+  it("refuses to restore another user's timeline", async () => {
+    const row = await makeTimeline();
+    await new CreateTimelineVersionTool().process(ctx(), {
+      timeline_id: row.id
+    });
+
+    const result = (await new RestoreTimelineVersionTool().process(ctx("other"), {
+      timeline_id: row.id,
+      version: 1
+    })) as { error: string };
+    expect(result.error).toContain("was not found");
+  });
+
+  it("reports a snapshot the sequence write refuses instead of throwing", async () => {
+    const row = await makeTimeline();
+    // A document from before tracks/clips/markers were required — the write
+    // rejects it, and the tool has to say so rather than fail the call.
+    await TimelineSequenceVersion.create<TimelineSequenceVersion>({
+      timeline_id: row.id,
+      user_id: row.user_id,
+      version: 1,
+      save_type: "manual",
+      fps: 30,
+      width: 1920,
+      height: 1080,
+      duration_ms: 0,
+      document: JSON.stringify({ tracks: [] })
+    });
+
+    const result = (await new RestoreTimelineVersionTool().process(ctx(), {
+      timeline_id: row.id,
+      version: 1
+    })) as { error: string; undo_version: number };
+    expect(result.error).toContain("cannot be restored");
+    expect(result.undo_version).toBe(2);
+  });
+});

--- a/packages/cli/src/harness/registry.ts
+++ b/packages/cli/src/harness/registry.ts
@@ -181,7 +181,8 @@ export const HARNESSES: HarnessEntry[] = [
       "nodetool timeline versions list|show|create|restore|delete <id> [<version>]",
     kind: "execution",
     capabilities: ["json"],
-    docs: "CLAUDE.md § nodetool timeline validate / debug"
+    agentTool: "restore_timeline_version",
+    docs: "CLAUDE.md § nodetool timeline versions"
   },
   {
     id: "sketch-validate",
@@ -207,6 +208,7 @@ export const HARNESSES: HarnessEntry[] = [
       "nodetool sketch versions list|show|create|restore|delete <id> [<version>]",
     kind: "execution",
     capabilities: ["json"],
+    agentTool: "restore_sketch_version",
     docs: "CLAUDE.md § nodetool sketch versions"
   },
   {
@@ -308,7 +310,9 @@ export const SURFACES: SurfaceEntry[] = [
     ],
     paths: [
       "packages/execution/src/timeline-debug/",
+      "packages/cli/src/timeline-debug/",
       "packages/cli/src/commands/timeline-versions.ts",
+      "packages/agents/src/tools/timeline-version-tools.ts",
       "packages/models/src/timeline-sequence-version.ts",
       "packages/websocket/src/trpc/routers/timeline.ts"
     ]

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1310,7 +1310,11 @@ forward is a workflow.
   workflow or an open editor. The \`+ui_script\` family edits the open one.
 - **timeline** — tracks and clips that render to video. Family \`+timeline\`
   for tracks, clips, trims, and animations; \`validate_timeline\` statically
-  checks a sequence before the user renders it.
+  checks a sequence before the user renders it. \`list_timelines\` finds one;
+  every sequence also keeps a snapshot history, read with
+  \`list_timeline_versions\`, pinned with \`create_timeline_version\` and
+  rolled back with \`restore_timeline_version\` — none of which needs an open
+  editor.
 - **sketch** — a layered image document. Family \`+sketch\`: layers, drawing
   tools, generating into a layer, rendering the result to an asset.
   \`validate_sketch\` statically checks a document — the open one or any saved


### PR DESCRIPTION
A timeline sequence's snapshot history was tRPC-only on the read/write side, so an agent outside the browser could not roll a cut back to a version the user liked, or pin the current state before a risky recut. The CLI (`nodetool timeline versions`) and the harness were already there; the agent surface was the gap.

Mirrors the sketch version tools (#4720) for timelines.

## Tools

| Tool | Does |
|---|---|
| `list_timelines` | The caller's sequences, most recently updated first |
| `list_timeline_versions` | Its snapshots, newest first, filterable by save type |
| `create_timeline_version` | Pin the current state as a manual snapshot |
| `restore_timeline_version` | Roll the sequence back to one |

## Behavior

- **Restore mirrors `timeline.versions.restore`**: snapshot what is about to be overwritten (so the restore is itself undoable), CAS-write the old document and render settings back onto the row, then run the same static check `validate_timeline` runs. An old document is restored against today's schema, so what it used to pass is not what it passes now — the findings come back with the result.
- A snapshot the row write refuses — one predating the tracks/clips/markers requirement — comes back as an error naming the undo snapshot, not a thrown call.
- A conflicting concurrent write returns the CAS conflict and the undo version instead of clobbering.
- Ownership follows the router's rule: a sequence belonging to another user reads as missing.
- Permissions: the two list tools are `read`, snapshot and restore are `write`.

## Wiring

The tools are built-ins, so the MCP bridge picks them up from `getBuiltinTools()` with no hand-listing (the coverage test already asserts every built-in is exposed). The timeline surface's harness registry entry now names the agent tool and the tools file, `sketch-versions` gets the same `agentTool` pointer for symmetry, and the chat prompt tells the assistant the history exists.

## Tests

`packages/agents/tests/timeline-version-tools.test.ts` — 9 cases over an in-memory DB: registration and permissions, listing and name filtering, cross-user isolation on both list and restore, manual snapshot + save-type filter, a restore that validates clean and leaves an undo snapshot holding the overwritten render settings, a restore whose document no longer validates, an unknown version number, and a snapshot the write refuses.

Full `packages/agents` suite green (2061 passed), plus `harness-registry` and `mcp-server-coverage`. `npm run lint` clean; `typecheck` passes for web/electron/packages (mobile's failures are missing `mobile/node_modules` in this environment, unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnhxdQiZ8qNf4R2HBbFjJz)_