### PR TITLE
fix(chat): reattach to a running agent turn after a page reload

### DIFF
--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -658,6 +658,7 @@ export type UnifiedCommandType =
   | "end_input_stream"
   | "chat_message"
   | "resume_chat"
+  | "list_chat_turns"
   | "inference"
   | "stop"
   | "list_workflows"

--- a/packages/protocol/src/ws-commands.ts
+++ b/packages/protocol/src/ws-commands.ts
@@ -47,6 +47,7 @@ export const UNIFIED_COMMAND_TYPES = [
   "end_input_stream",
   "chat_message",
   "resume_chat",
+  "list_chat_turns",
   "inference",
   "stop",
   "list_workflows",
@@ -174,7 +175,13 @@ export const chatMessageDataSchema = z
 export const resumeChatDataSchema = z
   .object({
     thread_id: z.string().optional(),
-    /** Highest `chat_seq` the client has already received for this thread. */
+    /**
+     * Highest `chat_seq` the client has already received for this thread.
+     * `0` (or omitted) declares a fresh client with no frame state — a page
+     * that just reloaded. The server then replays only what persisted
+     * history cannot provide (frames after the turn's last `message` frame)
+     * and flags `replay_incomplete` so the client reconciles over REST.
+     */
     last_seq: z.number().optional()
   })
   .passthrough();
@@ -255,6 +262,7 @@ export const commandDataSchemas: Record<UnifiedCommandType, z.ZodTypeAny> = {
   end_input_stream: looseDataSchema,
   chat_message: looseDataSchema,
   resume_chat: resumeChatDataSchema,
+  list_chat_turns: looseDataSchema,
   inference: looseDataSchema,
   stop: looseDataSchema,
   list_workflows: looseDataSchema,
@@ -437,6 +445,22 @@ export const chatResumedMessageOutSchema = z
   .passthrough();
 
 /**
+ * Reply to a `list_chat_turns` command, one frame per chat turn still
+ * running for the requesting user. A client that starts with no local state
+ * (a fresh page after a reload) sends `list_chat_turns` to discover threads
+ * whose agent turn survived on the server, then reattaches each with
+ * `resume_chat`. Routed by `thread_id` like every other chat frame.
+ */
+export const chatTurnActiveMessageOutSchema = z
+  .object({
+    type: z.literal("chat_turn_active"),
+    thread_id: z.string(),
+    status: z.literal("running"),
+    last_seq: z.number()
+  })
+  .passthrough();
+
+/**
  * Reply to a `reconnect_job` / `resume_job` command. Sent before any
  * replayed frames.
  *
@@ -470,5 +494,6 @@ export const outboundControlMessageSchemas = {
   system_stats: systemStatsMessageOutSchema,
   resource_change: resourceChangeMessageOutSchema,
   chat_resumed: chatResumedMessageOutSchema,
+  chat_turn_active: chatTurnActiveMessageOutSchema,
   job_resumed: jobResumedMessageOutSchema
 } as const;

--- a/packages/websocket/src/chat-turn-registry.ts
+++ b/packages/websocket/src/chat-turn-registry.ts
@@ -111,6 +111,25 @@ export class ChatTurnSession {
   }
 
   /**
+   * Where a client with no frame state (a freshly reloaded page) should
+   * start its replay: after the turn's last `message` frame. Everything up
+   * to and including that frame is persisted to the DB and reachable over
+   * REST; what follows — stream chunks of the in-progress reply, status
+   * updates, pending tool/approval requests — exists only in this buffer.
+   * With no `message` frame buffered yet, replay starts at the oldest
+   * frame still held.
+   */
+  freshAttachSeq(): number {
+    for (let i = this.buffer.length - 1; i >= 0; i--) {
+      const entry = this.buffer[i];
+      if ((entry.message as { type?: unknown }).type === "message") {
+        return entry.seq;
+      }
+    }
+    return this.evictedThroughSeq;
+  }
+
+  /**
    * Stamp, buffer, and (when a connection is attached) deliver one frame.
    * Returns the stamped copy.
    */
@@ -265,6 +284,13 @@ export class ChatTurnRegistry {
 
   get(userId: string, threadId: string): ChatTurnSession | null {
     return this.sessions.get(this.key(userId, threadId)) ?? null;
+  }
+
+  /** Sessions still running for a user — what a fresh client can reattach to. */
+  listRunningForUser(userId: string): ChatTurnSession[] {
+    return [...this.sessions.values()].filter(
+      (s) => s.userId === userId && s.status === "running"
+    );
   }
 
   drop(session: ChatTurnSession): void {

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -8090,6 +8090,23 @@ export class UnifiedWebSocketRunner {
           thread_id: threadId
         };
       }
+      case "list_chat_turns": {
+        // Discovery for a client that starts with no local state (a page
+        // reload): report every turn of this user still running so the
+        // client can reattach each thread with `resume_chat`.
+        const sessions = chatTurnRegistry.listRunningForUser(
+          this.userId ?? "1"
+        );
+        for (const s of sessions) {
+          await this.sendToSocket({
+            type: "chat_turn_active",
+            thread_id: s.threadId,
+            status: "running",
+            last_seq: s.lastSeq
+          });
+        }
+        return { message: "Chat turns listed", count: sessions.length };
+      }
       case "resume_chat": {
         const threadId =
           typeof data.thread_id === "string" ? data.thread_id : "";
@@ -8114,9 +8131,15 @@ export class UnifiedWebSocketRunner {
           });
           return { message: "No chat turn to resume", thread_id: threadId };
         }
+        // last_seq <= 0 is a fresh client (page reload): it has no frame
+        // state, but the persisted head of the turn is reachable over REST.
+        // Replay only what REST cannot provide — frames after the turn's
+        // last `message` frame — and flag the replay incomplete so the
+        // client reconciles history from REST.
+        const fresh = lastSeq <= 0;
         const { replay, incomplete } = session.attach(
           this.chatDeliveryTarget,
-          lastSeq
+          fresh ? session.freshAttachSeq() : lastSeq
         );
         if (session.status === "running" && this.chatTurnSession !== session) {
           this.adoptedSessions.set(threadId, session);
@@ -8130,7 +8153,7 @@ export class UnifiedWebSocketRunner {
             status: session.status,
             last_seq: session.lastSeq,
             replay_count: replay.length,
-            replay_incomplete: incomplete
+            replay_incomplete: fresh || incomplete
           },
           ...replay
         ]);

--- a/packages/websocket/tests/unified-websocket-runner-chat-resume.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner-chat-resume.test.ts
@@ -166,6 +166,130 @@ describe("chat turn resilience across disconnect", () => {
     await runnerB.disconnect();
   });
 
+  it("lets a fresh client (page reload) discover and reattach a running turn", async () => {
+    // Reproduces the reported bug: the agent keeps running server-side, but a
+    // reloaded page has no threadRuntime/cursor state, so before
+    // `list_chat_turns` existed it never learned a turn was in flight and
+    // never reattached — the turn streamed to nobody until the detach grace
+    // aborted it.
+    const threadId = `t-reload-${Date.now()}-${Math.random()}`;
+    const { provider, release } = gatedProvider();
+
+    const runnerA = new UnifiedWebSocketRunner({
+      resolveExecutor: noopExecutor,
+      resolveProvider: provider
+    });
+    const wsA = new MockWS();
+    await runnerA.connect(wsA);
+    await runnerA.handleCommand({
+      command: "chat_message",
+      data: { thread_id: threadId, content: "hi", provider: "mock", model: "m" }
+    });
+    await vi.waitFor(() => {
+      expect(
+        sentMsgs(wsA).some((m) => m.type === "chunk" && m.content === "hello ")
+      ).toBe(true);
+    });
+
+    // The page reloads: old socket gone, new connection with zero state.
+    await runnerA.disconnect();
+    const runnerB = new UnifiedWebSocketRunner({
+      resolveExecutor: noopExecutor,
+      resolveProvider: provider
+    });
+    const wsB = new MockWS();
+    await runnerB.connect(wsB);
+
+    // Discovery: the fresh client learns which threads still have a turn.
+    await runnerB.handleCommand({ command: "list_chat_turns", data: {} });
+    const active = sentMsgs(wsB).find((m) => m.type === "chat_turn_active");
+    expect(active).toBeDefined();
+    expect(active!.thread_id).toBe(threadId);
+    expect(active!.status).toBe("running");
+
+    // Reattach with no cursor: replay starts after the last persisted
+    // message frame (none yet mid-turn, so the streamed chunk is replayed
+    // and the client can rebuild the in-progress reply), and the header
+    // tells the client to reconcile persisted history over REST.
+    await runnerB.handleCommand({
+      command: "resume_chat",
+      data: { thread_id: threadId, last_seq: 0 }
+    });
+    const header = sentMsgs(wsB).find((m) => m.type === "chat_resumed");
+    expect(header).toBeDefined();
+    expect(header!.status).toBe("running");
+    expect(header!.replay_incomplete).toBe(true);
+    expect(
+      sentMsgs(wsB).some((m) => m.type === "chunk" && m.content === "hello ")
+    ).toBe(true);
+
+    // The turn finishes against the reattached connection.
+    release();
+    await vi.waitFor(() => {
+      expect(
+        sentMsgs(wsB).some(
+          (m) => m.type === "message" && m.role === "assistant"
+        )
+      ).toBe(true);
+    });
+    expect(
+      sentMsgs(wsB).some((m) => m.type === "chunk" && m.content === "world")
+    ).toBe(true);
+    await runnerB.disconnect();
+  });
+
+  it("fresh reattach after the reply finalized replays no stale chunks", async () => {
+    const threadId = `t-reload-late-${Date.now()}-${Math.random()}`;
+    const { provider, release } = gatedProvider();
+
+    const runnerA = new UnifiedWebSocketRunner({
+      resolveExecutor: noopExecutor,
+      resolveProvider: provider
+    });
+    const wsA = new MockWS();
+    await runnerA.connect(wsA);
+    await runnerA.handleCommand({
+      command: "chat_message",
+      data: { thread_id: threadId, content: "hi", provider: "mock", model: "m" }
+    });
+    await vi.waitFor(() => {
+      expect(sentMsgs(wsA).some((m) => m.type === "chunk")).toBe(true);
+    });
+    await runnerA.disconnect();
+    release();
+    await vi.waitFor(() => {
+      expect(chatTurnRegistry.get("1", threadId)!.status).toBe("finished");
+    });
+
+    // Reload after the turn finished (within retention). The assistant
+    // message is persisted, so a fresh attach must not replay the chunks
+    // that built it — REST history already carries the final text and a
+    // chunk replay would render it twice.
+    const runnerB = new UnifiedWebSocketRunner({
+      resolveExecutor: noopExecutor,
+      resolveProvider: provider
+    });
+    const wsB = new MockWS();
+    await runnerB.connect(wsB);
+    await runnerB.handleCommand({
+      command: "resume_chat",
+      data: { thread_id: threadId, last_seq: 0 }
+    });
+    const header = sentMsgs(wsB).find((m) => m.type === "chat_resumed");
+    expect(header).toBeDefined();
+    expect(header!.status).toBe("finished");
+    expect(header!.replay_incomplete).toBe(true);
+    // Only the terminal done-chunk may follow the persisted message; the
+    // text chunks that built the reply must not be replayed.
+    expect(
+      sentMsgs(wsB).some((m) => m.type === "chunk" && m.content !== "")
+    ).toBe(false);
+    expect(
+      sentMsgs(wsB).some((m) => m.type === "message" && m.role === "assistant")
+    ).toBe(false);
+    await runnerB.disconnect();
+  });
+
   it("answers resume_chat for an unknown thread with status unknown", async () => {
     const runner = new UnifiedWebSocketRunner({
       resolveExecutor: noopExecutor

--- a/web/src/core/chat/__tests__/chatResume.test.ts
+++ b/web/src/core/chat/__tests__/chatResume.test.ts
@@ -58,6 +58,10 @@ const makeHarness = (threadRuntimeStatus = "streaming") => {
 };
 
 describe("chat resume protocol", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("tracks the chat_seq high-water mark per thread", async () => {
     const h = makeHarness();
     await handleChatWebSocketMessage(
@@ -92,7 +96,7 @@ describe("chat resume protocol", () => {
     expect(h.state().loadMessages).toHaveBeenCalledWith("thread-1");
   });
 
-  it("chat_resumed incomplete replay also reconciles from history", async () => {
+  it("chat_resumed incomplete replay reconciles from history, staying busy while running", async () => {
     const h = makeHarness("streaming");
     await handleChatWebSocketMessage(
       {
@@ -106,8 +110,71 @@ describe("chat resume protocol", () => {
       h.set,
       h.get
     );
+    // The turn is still running server-side — the runtime must keep showing
+    // the agent at work while history reloads, not flash back to idle.
+    expect(h.state().threadRuntime["thread-1"].status).toBe("loading");
+    expect(h.state().loadMessages).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("chat_resumed incomplete replay of a finished turn resets to idle", async () => {
+    const h = makeHarness("streaming");
+    await handleChatWebSocketMessage(
+      {
+        type: "chat_resumed",
+        thread_id: "thread-1",
+        status: "finished",
+        last_seq: 40,
+        replay_count: 0,
+        replay_incomplete: true
+      } as any,
+      h.set,
+      h.get
+    );
     expect(h.state().threadRuntime["thread-1"].status).toBe("idle");
     expect(h.state().loadMessages).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("chat_turn_active on an idle thread reattaches it (the page-reload path)", async () => {
+    // After a reload the runtime is empty even though the server still runs
+    // the turn: discovery must mark the thread busy and send resume_chat.
+    const h = makeHarness("idle");
+    await handleChatWebSocketMessage(
+      {
+        type: "chat_turn_active",
+        thread_id: "thread-1",
+        status: "running",
+        last_seq: 57
+      } as any,
+      h.set,
+      h.get
+    );
+    expect(h.state().threadRuntime["thread-1"].status).toBe("loading");
+    const { globalWebSocketManager } = jest.requireMock(
+      "../../../lib/websocket/GlobalWebSocketManager"
+    );
+    expect(globalWebSocketManager.send).toHaveBeenCalledWith({
+      command: "resume_chat",
+      data: { thread_id: "thread-1", last_seq: 0 }
+    });
+  });
+
+  it("chat_turn_active on an already-streaming thread does nothing", async () => {
+    const h = makeHarness("streaming");
+    await handleChatWebSocketMessage(
+      {
+        type: "chat_turn_active",
+        thread_id: "thread-1",
+        status: "running",
+        last_seq: 57
+      } as any,
+      h.set,
+      h.get
+    );
+    expect(h.state().threadRuntime["thread-1"].status).toBe("streaming");
+    const { globalWebSocketManager } = jest.requireMock(
+      "../../../lib/websocket/GlobalWebSocketManager"
+    );
+    expect(globalWebSocketManager.send).not.toHaveBeenCalled();
   });
 
   it("chat_resumed running leaves the streaming runtime alone", async () => {

--- a/web/src/core/chat/chatProtocol.ts
+++ b/web/src/core/chat/chatProtocol.ts
@@ -125,6 +125,18 @@ export interface ChatResumedUpdate {
   replay_incomplete: boolean;
 }
 
+/**
+ * Reply to a `list_chat_turns` command: this thread's agent turn is still
+ * running on the server. Sent once per running turn so a client that starts
+ * with no local state (a page reload) can reattach with `resume_chat`.
+ */
+export interface ChatTurnActiveUpdate {
+  type: "chat_turn_active";
+  thread_id: string;
+  status: "running";
+  last_seq: number;
+}
+
 export type MsgpackData =
   | JobUpdate
   | Chunk
@@ -148,6 +160,7 @@ export type MsgpackData =
   | ToolApprovalRequestMessage
   | PlanApprovalRequestMessage
   | ChatResumedUpdate
+  | ChatTurnActiveUpdate
   | ErrorMessage;
 
 export interface ToolResultMessage {
@@ -1439,18 +1452,49 @@ export async function handleChatWebSocketMessage(
       }));
     }
     console.debug(`${data.type}:`, data.workflow_id);
+  } else if (data.type === "chat_turn_active") {
+    // Reply to our list_chat_turns: this thread's turn is still running on
+    // the server. If the runtime already tracks it (same-page reconnect,
+    // resume already sent with a real cursor) there is nothing to do; a
+    // fresh page has no runtime state, so mark the thread busy and reattach
+    // from scratch — the chat_resumed reply then reconciles history.
+    if (tid) {
+      const runtimeStatus = getThreadRuntime(get(), tid).status;
+      if (
+        runtimeStatus !== "loading" &&
+        runtimeStatus !== "streaming" &&
+        runtimeStatus !== "stopping"
+      ) {
+        set((state) => threadRuntimeUpdate(state, tid, { status: "loading" }));
+        void globalWebSocketManager
+          .send({
+            command: "resume_chat",
+            data: {
+              thread_id: tid,
+              last_seq: get().chatReplayCursors[tid] ?? 0
+            }
+          })
+          .catch((err) =>
+            console.error("Failed to send resume_chat:", tid, err)
+          );
+      }
+    }
   } else if (data.type === "chat_resumed") {
     // Reply to our resume_chat after a reconnect. "running"/"finished" are
     // followed by the replayed frames, which drive the runtime as usual. If
     // the server has nothing to replay ("unknown": no turn survived, or the
-    // retention window elapsed) or the bounded buffer lost our tail
-    // (replay_incomplete), reconcile from persisted history instead: reset
-    // the runtime and reload the thread's messages over REST.
+    // retention window elapsed) or the replay doesn't reach back to what we
+    // last saw (replay_incomplete — the buffer lost our tail, or we are a
+    // fresh page with no frame state at all), reconcile from persisted
+    // history: reload the thread's messages over REST. The runtime stays
+    // busy while the turn is still running so the UI keeps showing the
+    // agent at work; otherwise it resets to idle.
     if (tid && (data.status === "unknown" || data.replay_incomplete)) {
       clearSendTimeout();
+      const stillRunning = data.status === "running";
       set((state) =>
         threadRuntimeUpdate(state, tid, {
-          status: "idle",
+          status: stillRunning ? "loading" : "idle",
           statusMessage: null,
           progress: { current: 0, total: 0 }
         })

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -748,8 +748,26 @@ const useGlobalChatStore = create<GlobalChatState>()(
           globalWebSocketManager.subscribeEvent("open", resumeInFlightThreads)
         );
 
+        // Discover turns this client knows nothing about. A page reload
+        // wipes threadRuntime and the replay cursors, so the loop above
+        // finds nothing even though the server kept the agent turn running.
+        // `list_chat_turns` answers with one `chat_turn_active` frame per
+        // running turn; the protocol handler reattaches each thread.
+        const discoverRunningTurns = () => {
+          void globalWebSocketManager
+            .send({ command: "list_chat_turns", data: {} })
+            .catch((e) => console.error("Failed to send list_chat_turns:", e));
+        };
+        eventUnsubscribes.push(
+          globalWebSocketManager.subscribeEvent("open", discoverRunningTurns)
+        );
+
         if (globalWebSocketManager.isConnectionOpen()) {
           sendManifest();
+          // The initial connection's "open" fired before these subscribers
+          // existed — run discovery for it now that the per-thread handlers
+          // are registered.
+          discoverRunningTurns();
         }
 
         eventUnsubscribes.push(
@@ -1377,9 +1395,21 @@ const useGlobalChatStore = create<GlobalChatState>()(
 
             set((state) => {
               const existingMessages = state.messageCache[threadId] || [];
+              // A full refresh replaces the cache with persisted history —
+              // but the trailing `local-stream-*` placeholder holds streamed
+              // text of a reply that is not persisted yet (it exists while a
+              // resume replay and this REST load race), so carry it over
+              // instead of wiping it.
               const updatedMessages = cursor
                 ? [...existingMessages, ...messages]
-                : messages;
+                : [
+                    ...messages,
+                    ...existingMessages.filter(
+                      (m) =>
+                        typeof m.id === "string" &&
+                        m.id.startsWith("local-stream-")
+                    )
+                  ];
 
               return {
                 messageCache: {


### PR DESCRIPTION
## Problem

Start a chat, kick off a long agent task, reload the page: the agent keeps running on the server, but the reloaded page shows an idle thread and nothing ever streams in. After the 10-minute detach grace the turn is aborted outright.

#4711 made chat turns survive *socket* drops, but the resume path depended entirely on client memory: only threads whose in-memory `threadRuntime` was in flight sent `resume_chat`, using the in-memory `chatReplayCursors` high-water mark. A page reload wipes both, so the fresh page never learns a turn is running and never reattaches.

Reproduced in `packages/websocket/tests/unified-websocket-runner-chat-resume.test.ts` ("lets a fresh client (page reload) discover and reattach a running turn"): a second runner connecting with zero state — exactly what a reloaded page is — previously had no way to find the running session.

## Fix

**Server** (`packages/websocket`, `packages/protocol`):
- New `list_chat_turns` command: answers with one `chat_turn_active {thread_id, status, last_seq}` frame per turn still running for the user (routed by `thread_id` like every other chat frame).
- `resume_chat` with `last_seq <= 0` now means "fresh client". Replay starts after the turn's last persisted `message` frame (`ChatTurnSession.freshAttachSeq()`): everything before it is reachable over REST, so the client gets the in-progress reply's chunks — and any pending tool-call / approval frames, which are emitted after the message that carries their tool_calls — without duplicating persisted history. The header sets `replay_incomplete` so the client reconciles the persisted head over REST.

**Web** (`web/src`):
- `GlobalChatStore.connect` sends `list_chat_turns` on every socket open, and once immediately on the initial connect (whose `open` event fires before the subscribers exist).
- The protocol handler reattaches any `chat_turn_active` thread whose runtime is idle: marks it `loading` and sends `resume_chat` (threads already tracked by the same-page reconnect path are left alone).
- `chat_resumed` with `replay_incomplete` on a still-running turn now keeps the runtime busy (`loading`) instead of flashing back to idle while history reloads.
- A full `loadMessages` refresh carries over the trailing `local-stream-*` placeholder instead of wiping the streamed text a resume replay just rebuilt (the REST snapshot and the replay race).

## Tests

- `packages/websocket`: two new tests — fresh-client discovery + reattach mid-turn (chunks replayed, turn finishes against the new connection), and fresh reattach after the reply finalized (no stale text chunks replayed, history comes from REST). Full websocket suite passes (189 files, 2191 tests).
- `web`: new `chat_turn_active` handler tests (idle → reattach, streaming → untouched) and updated `chat_resumed` expectations. Chat core + GlobalChatStore suites pass.
- `npm run typecheck` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016z6aTq8TSKVZ1anC2E67SJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016z6aTq8TSKVZ1anC2E67SJ)_