### PR TITLE
Reconcile in-flight workflow runs after a page reload

### DIFF
--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -4076,7 +4076,11 @@ export class UnifiedWebSocketRunner {
       // parks the UI in a state that never settles — a `queued` row from a
       // dead connection's drained queue reads as "running" with a live Stop
       // button forever.
-      const job = (await Job.get(jobId)) as Job | null;
+      // Ownership rule as in the jobs router: another user's row is
+      // indistinguishable from a missing one — it must be neither reported
+      // nor settled below.
+      const row = (await Job.get(jobId)) as Job | null;
+      const job = row && row.user_id === (this.userId ?? "1") ? row : null;
       const settled =
         job != null &&
         (job.status === "completed" ||
@@ -4084,6 +4088,31 @@ export class UnifiedWebSocketRunner {
           job.status === "cancelled");
       const replayUnavailable =
         job != null && job.status !== "failed" && job.status !== "cancelled";
+      // A non-settled row with no session and no in-memory job is a zombie:
+      // nothing is left that could ever finish it. Persist the failure when
+      // this instance owns the row (or nothing claims it), so the row stops
+      // advertising an in-flight run — otherwise every reload rediscovers it,
+      // reattaches, and re-reports the same loss forever. A row claimed by
+      // another instance is left alone: on a multi-instance deployment this
+      // connection may simply have been balanced away from a run that is
+      // still executing. Suspended rows are durable by design — never touched.
+      if (job && !settled && job.status !== "suspended") {
+        const instanceId = getInstanceId();
+        const ownedHere =
+          !job.runner_instance ||
+          !instanceId ||
+          job.runner_instance === instanceId;
+        if (ownedHere) {
+          try {
+            job.markFailed(
+              "Run was lost after the execution connection went away."
+            );
+            await job.save();
+          } catch (error) {
+            this.logError("stale job row cleanup failed", error);
+          }
+        }
+      }
       await this.sendMessage({
         type: "job_update",
         status: settled ? job.status : "failed",

--- a/packages/websocket/tests/job-run-resilience.test.ts
+++ b/packages/websocket/tests/job-run-resilience.test.ts
@@ -421,5 +421,85 @@ describe("workflow runs survive a dropped socket", () => {
     const update = decodeAll(ws1).find((m) => m.type === "job_update");
     expect(update?.status).toBe("failed");
     expect(String(update?.error)).toMatch(/replay is unavailable/i);
+
+    // …and settles the row itself: an unclaimed zombie row that kept reading
+    // "running" would be rediscovered by reload reconciliation on every page
+    // load, re-reporting the same loss forever.
+    const row = (await Job.get(jobId)) as Job | null;
+    expect(row?.status).toBe("failed");
+  });
+
+  it("leaves a running row claimed by another instance untouched", async () => {
+    const jobId = "resilient-job-9";
+    process.env["NODETOOL_INSTANCE_ID"] = "instance-a";
+    try {
+      await Job.create({
+        id: jobId,
+        workflow_id: "wf",
+        user_id: "1",
+        status: "running",
+        runner_instance: "instance-b",
+        params: {},
+        graph: { nodes: [], edges: [] }
+      });
+
+      await runner1.handleCommand({
+        command: "reconnect_job",
+        data: { job_id: jobId, workflow_id: "wf" }
+      });
+
+      // Reported failed to THIS client (no replay is possible here), but the
+      // row stays running: the run may well be alive on instance-b.
+      const update = decodeAll(ws1).find((m) => m.type === "job_update");
+      expect(update?.status).toBe("failed");
+      const row = (await Job.get(jobId)) as Job | null;
+      expect(row?.status).toBe("running");
+    } finally {
+      delete process.env["NODETOOL_INSTANCE_ID"];
+    }
+  });
+
+  it("treats another user's row as missing and leaves it untouched", async () => {
+    const jobId = "resilient-job-11";
+    await Job.create({
+      id: jobId,
+      workflow_id: "wf",
+      user_id: "2",
+      status: "running",
+      params: {},
+      graph: { nodes: [], edges: [] }
+    });
+
+    await runner1.handleCommand({
+      command: "reconnect_job",
+      data: { job_id: jobId, workflow_id: "wf" }
+    });
+
+    const update = decodeAll(ws1).find((m) => m.type === "job_update");
+    expect(String(update?.error)).toMatch(/not found/i);
+    const row = (await Job.get(jobId)) as Job | null;
+    expect(row?.status).toBe("running");
+  });
+
+  it("never settles a suspended row", async () => {
+    const jobId = "resilient-job-10";
+    await Job.create({
+      id: jobId,
+      workflow_id: "wf",
+      user_id: "1",
+      status: "suspended",
+      params: {},
+      graph: { nodes: [], edges: [] }
+    });
+
+    await runner1.handleCommand({
+      command: "reconnect_job",
+      data: { job_id: jobId, workflow_id: "wf" }
+    });
+
+    // Suspended is a durable, resumable state — replay being gone does not
+    // make the run dead.
+    const row = (await Job.get(jobId)) as Job | null;
+    expect(row?.status).toBe("suspended");
   });
 });

--- a/web/src/stores/WorkflowManagerStore.ts
+++ b/web/src/stores/WorkflowManagerStore.ts
@@ -30,6 +30,10 @@ import {
   getWorkflowRunnerStore
 } from "./WorkflowRunner";
 import {
+  startRunReconciliation,
+  stopRunReconciliation
+} from "./runReconciliation";
+import {
   disposeAppRuntimeStore,
   workflowInstanceId
 } from "../components/appbuilder/runtime/appRuntimeStore";
@@ -702,6 +706,12 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
           get().getNodeStore
         );
 
+        // A server run survives a page reload (the run detaches from its
+        // socket and keeps executing), but the reloaded client no longer
+        // remembers it. Reattach any in-flight run and replay its frames so
+        // the canvas reconciles from the server instead of coming back blank.
+        startRunReconciliation(workflow.id, workflow, runnerStore);
+
         // Refresh live FAL pricing for the FAL nodes in this workflow.
         // Subscribes to MetadataStore so we still fire once metadata loads
         // (workflows restored from localStorage open before metadata fetch).
@@ -812,6 +822,7 @@ export const createWorkflowManagerStore = (queryClient: QueryClient) => {
        * @param {string} workflowId The ID of the workflow to remove
        */
       removeWorkflow: (workflowId: string) => {
+        stopRunReconciliation(workflowId);
         unsubscribeFromWorkflowUpdates(workflowId);
         releasePricingUnsubs(workflowId);
 

--- a/web/src/stores/__tests__/runReconciliation.test.ts
+++ b/web/src/stores/__tests__/runReconciliation.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Reload-time run reconciliation: a workflow opened with an idle runner
+ * discovers the server's in-flight jobs and reattaches, so a page reload
+ * neither kills the run nor comes back blank.
+ */
+import {
+  startRunReconciliation,
+  stopRunReconciliation
+} from "../runReconciliation";
+import { getPendingResumeJobId } from "../resumeJobHint";
+import { trpcClient } from "../../trpc/client";
+import { globalWebSocketManager } from "../../lib/websocket/GlobalWebSocketManager";
+import { isAuthRequired } from "../../lib/runtimeConfig";
+import { useAuth } from "../useAuth";
+import type { WorkflowAttributes } from "../ApiTypes";
+
+jest.mock("../../trpc/client", () => ({
+  trpcClient: {
+    jobs: {
+      list: { query: jest.fn() }
+    }
+  }
+}));
+
+jest.mock("../../lib/websocket/GlobalWebSocketManager", () => ({
+  globalWebSocketManager: {
+    send: jest.fn().mockResolvedValue(undefined)
+  }
+}));
+
+jest.mock("../../lib/runtimeConfig", () => ({
+  isAuthRequired: jest.fn(() => false)
+}));
+
+jest.mock("../useAuth", () => ({
+  useAuth: {
+    getState: jest.fn(() => ({ state: "logged_in" })),
+    subscribe: jest.fn(() => jest.fn())
+  }
+}));
+
+const mockListQuery = trpcClient.jobs.list.query as jest.Mock;
+const mockSend = globalWebSocketManager.send as jest.Mock;
+const mockIsAuthRequired = isAuthRequired as jest.Mock;
+const mockAuthGetState = useAuth.getState as jest.Mock;
+const mockAuthSubscribe = useAuth.subscribe as unknown as jest.Mock;
+
+const workflow: WorkflowAttributes = {
+  id: "wf",
+  name: "WF"
+} as WorkflowAttributes;
+
+type RunnerState = { job_id: string | null; state: string };
+
+const makeRunnerStore = (overrides: Partial<RunnerState> = {}) => {
+  const state: RunnerState = { job_id: null, state: "idle", ...overrides };
+  const reconnectWithWorkflow = jest.fn(async (jobId: string) => {
+    state.job_id = jobId;
+    state.state = "connecting";
+  });
+  return {
+    state,
+    reconnectWithWorkflow,
+    getState: () => ({ ...state, reconnectWithWorkflow })
+  };
+};
+
+const job = (id: string, status: string) => ({
+  id,
+  status,
+  workflow_id: "wf"
+});
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  stopRunReconciliation("wf");
+  mockIsAuthRequired.mockReturnValue(false);
+  mockAuthGetState.mockReturnValue({ state: "logged_in" });
+  mockListQuery.mockResolvedValue({ jobs: [] });
+});
+
+it("reattaches the newest in-flight job through the runner store", async () => {
+  mockListQuery.mockResolvedValue({
+    jobs: [job("new", "running"), job("done", "completed"), job("old", "running")]
+  });
+  const runnerStore = makeRunnerStore();
+
+  startRunReconciliation("wf", workflow, runnerStore as never);
+  await flush();
+
+  expect(mockListQuery).toHaveBeenCalledWith({ workflow_id: "wf", limit: 20 });
+  expect(runnerStore.reconnectWithWorkflow).toHaveBeenCalledWith(
+    "new",
+    workflow
+  );
+});
+
+it("parks the handshake resume hint while reattaching, then clears it", async () => {
+  mockListQuery.mockResolvedValue({ jobs: [job("A", "running")] });
+  const runnerStore = makeRunnerStore();
+  let hintDuringReconnect: string | null = null;
+  runnerStore.reconnectWithWorkflow.mockImplementation(async () => {
+    hintDuringReconnect = getPendingResumeJobId();
+  });
+
+  startRunReconciliation("wf", workflow, runnerStore as never);
+  await flush();
+
+  expect(hintDuringReconnect).toBe("A");
+  expect(getPendingResumeJobId()).toBeNull();
+});
+
+it("adopts concurrent siblings with a bare reconnect_job replaying from 0", async () => {
+  mockListQuery.mockResolvedValue({
+    jobs: [job("A", "running"), job("B", "running"), job("C", "queued")]
+  });
+  const runnerStore = makeRunnerStore();
+
+  startRunReconciliation("wf", workflow, runnerStore as never);
+  await flush();
+
+  expect(runnerStore.reconnectWithWorkflow).toHaveBeenCalledWith(
+    "A",
+    workflow
+  );
+  expect(mockSend).toHaveBeenCalledWith({
+    type: "reconnect_job",
+    command: "reconnect_job",
+    data: { job_id: "B", workflow_id: "wf", last_seq: 0 }
+  });
+  expect(mockSend).toHaveBeenCalledWith({
+    type: "reconnect_job",
+    command: "reconnect_job",
+    data: { job_id: "C", workflow_id: "wf", last_seq: 0 }
+  });
+});
+
+it("does nothing when every job already settled", async () => {
+  mockListQuery.mockResolvedValue({
+    jobs: [job("A", "completed"), job("B", "cancelled"), job("C", "failed")]
+  });
+  const runnerStore = makeRunnerStore();
+
+  startRunReconciliation("wf", workflow, runnerStore as never);
+  await flush();
+
+  expect(runnerStore.reconnectWithWorkflow).not.toHaveBeenCalled();
+  expect(mockSend).not.toHaveBeenCalled();
+});
+
+it("never reattaches a suspended row", async () => {
+  // Suspended is durable and resumable through its own flow; a reattach whose
+  // session is gone would only report it failed.
+  mockListQuery.mockResolvedValue({ jobs: [job("A", "suspended")] });
+  const runnerStore = makeRunnerStore();
+
+  startRunReconciliation("wf", workflow, runnerStore as never);
+  await flush();
+
+  expect(runnerStore.reconnectWithWorkflow).not.toHaveBeenCalled();
+});
+
+it("leaves a runner that already tracks a job alone", async () => {
+  const runnerStore = makeRunnerStore({ job_id: "live", state: "running" });
+
+  startRunReconciliation("wf", workflow, runnerStore as never);
+  await flush();
+
+  expect(mockListQuery).not.toHaveBeenCalled();
+});
+
+it("yields to a run that started while the job list was in flight", async () => {
+  const runnerStore = makeRunnerStore();
+  mockListQuery.mockImplementation(async () => {
+    runnerStore.state.job_id = "fresh";
+    runnerStore.state.state = "connecting";
+    return { jobs: [job("A", "running")] };
+  });
+
+  startRunReconciliation("wf", workflow, runnerStore as never);
+  await flush();
+
+  expect(runnerStore.reconnectWithWorkflow).not.toHaveBeenCalled();
+});
+
+it("stopRunReconciliation cancels a pending reconcile", async () => {
+  mockListQuery.mockResolvedValue({ jobs: [job("A", "running")] });
+  const runnerStore = makeRunnerStore();
+
+  startRunReconciliation("wf", workflow, runnerStore as never);
+  stopRunReconciliation("wf");
+  await flush();
+
+  expect(runnerStore.reconnectWithWorkflow).not.toHaveBeenCalled();
+});
+
+it("waits for login when auth is required and still settling", async () => {
+  mockIsAuthRequired.mockReturnValue(true);
+  mockAuthGetState.mockReturnValue({ state: "init" });
+  let authListener: ((auth: { state: string }) => void) | undefined;
+  mockAuthSubscribe.mockImplementation((listener) => {
+    authListener = listener;
+    return jest.fn();
+  });
+  mockListQuery.mockResolvedValue({ jobs: [job("A", "running")] });
+  const runnerStore = makeRunnerStore();
+
+  startRunReconciliation("wf", workflow, runnerStore as never);
+  await flush();
+  expect(mockListQuery).not.toHaveBeenCalled();
+
+  authListener?.({ state: "logged_in" });
+  await flush();
+
+  expect(runnerStore.reconnectWithWorkflow).toHaveBeenCalledWith(
+    "A",
+    workflow
+  );
+});
+
+it("gives up when auth settles logged out", async () => {
+  mockIsAuthRequired.mockReturnValue(true);
+  mockAuthGetState.mockReturnValue({ state: "loading" });
+  const unsubscribe = jest.fn();
+  let authListener: ((auth: { state: string }) => void) | undefined;
+  mockAuthSubscribe.mockImplementation((listener) => {
+    authListener = listener;
+    return unsubscribe;
+  });
+  const runnerStore = makeRunnerStore();
+
+  startRunReconciliation("wf", workflow, runnerStore as never);
+  authListener?.({ state: "logged_out" });
+  await flush();
+
+  expect(mockListQuery).not.toHaveBeenCalled();
+  expect(unsubscribe).toHaveBeenCalled();
+});

--- a/web/src/stores/resumeJobHint.ts
+++ b/web/src/stores/resumeJobHint.ts
@@ -1,0 +1,18 @@
+/**
+ * One-shot `resume_job` handshake hint for reload-time run reconciliation.
+ *
+ * The socket's resume hint normally comes from scanning the runner stores
+ * (`setResumeJobIdProvider` in workflowUpdates.ts), which only works for a run
+ * the client still remembers. After a full page reload the stores are empty,
+ * but run reconciliation (runReconciliation.ts) knows the job id it is about
+ * to reattach before any connection exists. It parks the id here so the
+ * handshake can carry `?resume_job=<id>` and a multi-instance server routes
+ * the connection at the instance that owns the run's replay buffer.
+ */
+let pendingResumeJobId: string | null = null;
+
+export const setPendingResumeJobId = (jobId: string | null): void => {
+  pendingResumeJobId = jobId;
+};
+
+export const getPendingResumeJobId = (): string | null => pendingResumeJobId;

--- a/web/src/stores/runReconciliation.ts
+++ b/web/src/stores/runReconciliation.ts
@@ -1,0 +1,176 @@
+/**
+ * Reload-time run reconciliation.
+ *
+ * A server run outlives its socket: on disconnect the JobRunSession detaches
+ * and keeps executing, buffering seq-stamped frames for the detach grace
+ * window (packages/websocket/src/job-run-registry.ts). A mid-session socket
+ * drop is already covered — `resumeInFlightJob` (workflowUpdates.ts) replays
+ * from the in-memory cursor — but a page reload wipes every store, so nothing
+ * remembered the job: the run kept executing server-side while the client came
+ * back blank, and the grace timer eventually cancelled it as abandoned.
+ *
+ * This module closes that gap. When a workflow is opened and its runner is
+ * idle, it asks the server for the workflow's in-flight jobs and reattaches:
+ * the newest one through the runner store (`reconnectWithWorkflow`, so the
+ * Stop/pause controls and `job_resumed` settling apply as usual), any
+ * concurrent siblings through a bare `reconnect_job`. Every reattach replays
+ * from `last_seq: 0`, so the run's whole buffered stream flows back through
+ * `handleUpdate` and rebuilds the per-node state (statuses, results, progress,
+ * edges) the reload discarded — the client reconciles from the server instead
+ * of restarting.
+ */
+import type { Job, WorkflowAttributes } from "./ApiTypes";
+import type { WorkflowRunnerStore } from "./WorkflowRunner";
+import { trpcClient } from "../trpc/client";
+import { globalWebSocketManager } from "../lib/websocket/GlobalWebSocketManager";
+import { useAuth } from "./useAuth";
+import { isAuthRequired } from "../lib/runtimeConfig";
+import { setPendingResumeJobId } from "./resumeJobHint";
+
+/**
+ * Row statuses that can still have a live run behind them. "suspended" is
+ * deliberately absent: a suspended row is a durable, resumable state that can
+ * outlive any session, and reattaching to one whose session is gone would
+ * only report it failed.
+ */
+const IN_FLIGHT_JOB_STATUSES: ReadonlySet<string> = new Set([
+  "scheduled",
+  "queued",
+  "running",
+  "paused",
+  "recovering"
+]);
+
+/** How many recent jobs to inspect for in-flight runs of one workflow. */
+const RECONCILE_JOB_LIMIT = 20;
+
+const reconciliations = new Map<string, () => void>();
+
+/**
+ * Discover and reattach this workflow's in-flight server runs. Runs once per
+ * call; a repeat call for the same workflow cancels the previous attempt.
+ * Does nothing when the runner already tracks a job.
+ */
+export const startRunReconciliation = (
+  workflowId: string,
+  workflow: WorkflowAttributes,
+  runnerStore: WorkflowRunnerStore
+): void => {
+  stopRunReconciliation(workflowId);
+
+  let cancelled = false;
+  let unsubscribeAuth: (() => void) | null = null;
+  reconciliations.set(workflowId, () => {
+    cancelled = true;
+    unsubscribeAuth?.();
+    unsubscribeAuth = null;
+  });
+
+  const runnerIsIdle = (): boolean => {
+    const { job_id, state } = runnerStore.getState();
+    return job_id === null && state === "idle";
+  };
+
+  const reconcile = async (): Promise<void> => {
+    if (cancelled || !runnerIsIdle()) {
+      return;
+    }
+
+    let jobs: Job[];
+    try {
+      const result = await trpcClient.jobs.list.query({
+        workflow_id: workflowId,
+        limit: RECONCILE_JOB_LIMIT
+      });
+      jobs = result.jobs ?? [];
+    } catch (error) {
+      console.warn(
+        `[runReconciliation] Failed to list jobs for ${workflowId}`,
+        error
+      );
+      return;
+    }
+
+    // A run may have started, or the workflow closed, while the list was in
+    // flight — the fresh run owns the runner now.
+    if (cancelled || !runnerIsIdle()) {
+      return;
+    }
+
+    const inFlight = jobs.filter(
+      (job) => job.status != null && IN_FLIGHT_JOB_STATUSES.has(job.status)
+    );
+    if (inFlight.length === 0) {
+      return;
+    }
+
+    // jobs.list is newest-first; the head is the run the runner tracks. Park
+    // its id as the handshake hint so a multi-instance server routes the
+    // connection at the instance holding the run's replay buffer.
+    const [primary, ...siblings] = inFlight;
+    console.info(
+      `[runReconciliation] Reattaching ${inFlight.length} in-flight run(s) for workflow ${workflowId}`,
+      { jobId: primary.id }
+    );
+    setPendingResumeJobId(primary.id);
+    try {
+      await runnerStore.getState().reconnectWithWorkflow(primary.id, workflow);
+    } catch (error) {
+      console.warn(
+        `[runReconciliation] Failed to reattach job ${primary.id}`,
+        error
+      );
+      return;
+    } finally {
+      // The handshake (if one was needed) has read the hint by now; from here
+      // on the runner store itself names the resumable job.
+      setPendingResumeJobId(null);
+    }
+
+    // Concurrent siblings reattach without claiming the runner: their replayed
+    // frames land in their own per-job slices, and the reattach clears the
+    // server's detach-grace timer so they aren't cancelled as abandoned.
+    for (const job of siblings) {
+      globalWebSocketManager
+        .send({
+          type: "reconnect_job",
+          command: "reconnect_job",
+          data: { job_id: job.id, workflow_id: workflowId, last_seq: 0 }
+        })
+        .catch((error) =>
+          console.warn(
+            `[runReconciliation] Failed to reattach job ${job.id}`,
+            error
+          )
+        );
+    }
+  };
+
+  const authState = useAuth.getState().state;
+  if (!isAuthRequired() || authState === "logged_in") {
+    void reconcile();
+  } else if (authState === "init" || authState === "loading") {
+    // Auth is still settling (Supabase restoring the session right after the
+    // reload). Wait for the outcome; anything but logged_in means the jobs
+    // list cannot be read.
+    unsubscribeAuth = useAuth.subscribe((auth) => {
+      if (auth.state === "logged_in") {
+        unsubscribeAuth?.();
+        unsubscribeAuth = null;
+        void reconcile();
+      } else if (auth.state === "logged_out" || auth.state === "error") {
+        unsubscribeAuth?.();
+        unsubscribeAuth = null;
+      }
+    });
+  }
+};
+
+/** Cancel a pending reconciliation (workflow closed or resubscribed). */
+export const stopRunReconciliation = (workflowId: string): void => {
+  const cancel = reconciliations.get(workflowId);
+  if (cancel) {
+    reconciliations.delete(workflowId);
+    cancel();
+  }
+};

--- a/web/src/stores/workflowUpdates.ts
+++ b/web/src/stores/workflowUpdates.ts
@@ -53,6 +53,7 @@ import { getRunSignature, clearRunSignatures } from "./runSignatures";
 import { computeStampSignature } from "../utils/computeRunSignatures";
 import { getNodeGenerations } from "./nodeGenerationAccessor";
 import useMetadataStore from "./MetadataStore";
+import { getPendingResumeJobId } from "./resumeJobHint";
 
 /**
  * Pending audio-chunk store appends, coalesced per node and flushed on a
@@ -207,6 +208,10 @@ const resumableJobId = (runnerStore: WorkflowRunnerStore): string | null => {
  * status, no replayed frames.
  */
 globalWebSocketManager.setResumeJobIdProvider(() => {
+  // Reload-time reconciliation parks the id it is about to reattach here
+  // before any runner store knows about it (see runReconciliation.ts).
+  const pending = getPendingResumeJobId();
+  if (pending) return pending;
   for (const { runnerStore } of workflowSubscriptions.values()) {
     const jobId = resumableJobId(runnerStore);
     if (jobId) return jobId;


### PR DESCRIPTION
## What

When a workflow is running, a page reload no longer kills the run or leaves the editor blank: the run keeps executing server-side, and the reloaded client discovers it and reconciles the runner state from the server.

## How

The server half already existed: on disconnect a run's `JobRunSession` detaches instead of cancelling, keeps buffering seq-stamped frames, and `reconnect_job` replays the missed tail (`job-run-registry.ts`). What was missing was reload-time discovery — the client only resumed jobs it still remembered in memory, and a reload wipes every store, so the detach-grace timer eventually cancelled the abandoned run.

**Client**

- `web/src/stores/runReconciliation.ts` (new): when a workflow is opened (`WorkflowManagerStore.addWorkflow`) and its runner is idle, list the workflow's jobs over tRPC and reattach the newest in-flight one through the existing `reconnectWithWorkflow`. Replaying from `last_seq: 0` pushes the run's whole buffered stream back through `handleUpdate`, rebuilding per-node statuses, results, progress and edge animations the reload discarded. Concurrent sibling runs reattach through a bare `reconnect_job` so their detach-grace timers clear too. Suspended rows are never reattached (durable, resumable state with its own flow).
- `web/src/stores/resumeJobHint.ts` (new): parks the job id as a one-shot `?resume_job=` handshake hint, so on a multi-instance deployment the fresh connection is routed (fly-replay) at the instance holding the run's replay buffer.

**Server**

- `reconnectJob`'s persisted-row fallback now settles zombie rows — non-settled status, no session, no in-memory job, owned by this instance (or unclaimed) — as `failed`, so a lost run is reported once instead of being rediscovered and re-reported on every reload. Rows claimed by another instance and suspended rows are never touched.
- The fallback now treats another user's row as missing, matching the jobs router's ownership rule (previously it echoed status to any authenticated caller; with the new persistence that gap would have allowed cross-user writes).

## Tests

- `web/src/stores/__tests__/runReconciliation.test.ts` (new, 10 cases): newest-job reattach, hint park/clear, sibling adoption, settled/suspended filtering, busy-runner and mid-fetch-race yields, cancellation, auth gating.
- `packages/websocket/tests/job-run-resilience.test.ts` (+3 cases): zombie row persisted as failed, foreign-instance row untouched, suspended row untouched, cross-user row treated as missing.
- `npm run typecheck` and lint clean on web and websocket; all 16 workflowUpdates/WorkflowRunner store suites (127 tests) and the websocket job suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNztvceWuskCW5qLZEcSzo

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNztvceWuskCW5qLZEcSzo)_