### PR TITLE
fix(web): show every left-panel view in the mobile sheet

### DIFF
--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -36,7 +36,6 @@ import QuickAccessSidebar from "../node_menu/QuickAccessSidebar";
 import NodeLibrary from "../node_menu/NodeLibrary";
 import RailAppMenu from "./RailAppMenu";
 
-import { IconForType } from "../../config/IconForType";
 import {
   LeftPanelView,
   NodeCategoryId,
@@ -49,6 +48,7 @@ import {
   LEFT_PANEL_TOP_LEVEL,
   getTopLevelCategory
 } from "../../config/quickAccessCategories";
+import type { LeftPanelTopLevelCategory } from "../../config/quickAccessCategories";
 import { ContextMenuProvider } from "../../providers/ContextMenuProvider";
 import ContextMenus from "../context_menus/ContextMenus";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -63,8 +63,6 @@ import PanelHeadline from "../ui/PanelHeadline";
 import { ScrollArea, Tooltip, MobileBottomSheet, MOTION } from "../ui_primitives";
 import MenuIcon from "@mui/icons-material/Menu";
 import CodeIcon from "@mui/icons-material/Code";
-import GridViewIcon from "@mui/icons-material/GridView";
-import CollectionsOutlinedIcon from "@mui/icons-material/CollectionsOutlined";
 
 import Fullscreen from "@mui/icons-material/Fullscreen";
 
@@ -612,12 +610,15 @@ const mobileLauncherStyles = (theme: Theme) =>
 const mobileHeaderExtrasStyles = (theme: Theme) =>
   css({
     display: "flex",
-    flexWrap: "wrap",
+    // Every top-level view gets a tab, so the row scrolls sideways rather than
+    // wrapping into several rows of icons above the sheet content.
+    flexWrap: "nowrap",
     gap: getSpacingPx(SPACING.xs),
     padding: `${getSpacingPx(SPACING.md)} ${getSpacingPx(SPACING.lg)}`,
     overflowX: "auto",
     WebkitOverflowScrolling: "touch",
     "& .tab-button": {
+      flexShrink: 0,
       padding: `${getSpacingPx(SPACING.sm)} ${getSpacingPx(SPACING.lg)}`, // was 6px 10px
       borderRadius: BORDER_RADIUS.lg,
       color: theme.vars.palette.text.secondary,
@@ -633,6 +634,18 @@ const mobileHeaderExtrasStyles = (theme: Theme) =>
     }
   });
 
+// The create action each list view offers, mirroring the desktop panel
+// headlines (which mobile hides in favour of the sheet header).
+const MOBILE_CREATE_ACTIONS: Partial<Record<LeftPanelView, React.FC>> = {
+  workflows: CreateWorkflowButton,
+  chats: CreateChatButton,
+  sketches: CreateSketchButton,
+  timelines: CreateTimelineButton,
+  storyboards: CreateStoryboardButton,
+  scripts: CreateScriptButton,
+  apps: CreateApplicationButton
+};
+
 const MobilePanelLeft: React.FC<{
   activeView: LeftPanelView;
   activeNodeCategory: NodeCategoryId;
@@ -643,6 +656,8 @@ const MobilePanelLeft: React.FC<{
   onClose: () => void;
   onViewChange: (view: LeftPanelView) => void;
   handlePanelToggle: (view: LeftPanelView) => void;
+  /** Top-level views to omit, same as the desktop rail. */
+  hiddenViews?: readonly LeftPanelView[];
   /**
    * In the workspace shell the top row carries the launcher buttons
    * (MobileRailLauncher), so this variant renders only the sheet.
@@ -658,6 +673,7 @@ const MobilePanelLeft: React.FC<{
   onClose,
   onViewChange,
   handlePanelToggle,
+  hiddenViews,
   hideLauncher = false
 }) => {
   const theme = useTheme();
@@ -668,6 +684,13 @@ const MobilePanelLeft: React.FC<{
     },
     [onViewChange]
   );
+
+  const categories = useMemo<readonly LeftPanelTopLevelCategory[]>(
+    () => LEFT_PANEL_TOP_LEVEL.filter((cat) => !hiddenViews?.includes(cat.id)),
+    [hiddenViews]
+  );
+
+  const CreateAction = MOBILE_CREATE_ACTIONS[activeView];
 
   const launcherTitle =
     getTopLevelCategory(activeView)?.label ?? "Workflows";
@@ -695,56 +718,25 @@ const MobilePanelLeft: React.FC<{
         ariaLabel="Workflows, sketches, timelines, and assets panel"
         headerExtras={
           <div css={mobileHeaderExtrasStyles(theme)}>
-            <Tooltip title="Workflows" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
-              <ToolbarIconButton
-                className={`tab-button ${activeView === "workflows" ? "active" : ""}`}
-                onClick={() => handleSheetViewChange("workflows")}
-                ariaLabel="Show workflows"
-                tabIndex={-1}
-                icon={<GridViewIcon />}
-              />
-            </Tooltip>
-            <Tooltip title="Sketches" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
-              <ToolbarIconButton
-                className={`tab-button ${activeView === "sketches" ? "active" : ""}`}
-                onClick={() => handleSheetViewChange("sketches")}
-                ariaLabel="Show sketches"
-                tabIndex={-1}
-                icon={<IconForType iconName="image" showTooltip={false} iconSize="small" />}
-              />
-            </Tooltip>
-            <Tooltip title="Timelines" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
-              <ToolbarIconButton
-                className={`tab-button ${activeView === "timelines" ? "active" : ""}`}
-                onClick={() => handleSheetViewChange("timelines")}
-                ariaLabel="Show timelines"
-                tabIndex={-1}
-                icon={<IconForType iconName="video" showTooltip={false} iconSize="small" />}
-              />
-            </Tooltip>
-            <Tooltip title="Assets" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
-              <ToolbarIconButton
-                className={`tab-button ${activeView === "assets" ? "active" : ""}`}
-                onClick={() => handleSheetViewChange("assets")}
-                ariaLabel="Show assets"
-                tabIndex={-1}
-                icon={<IconForType iconName="asset" showTooltip={false} iconSize="small" />}
-              />
-            </Tooltip>
-            <Tooltip title="Library" placement="bottom" delay={TOOLTIP_ENTER_DELAY}>
-              <ToolbarIconButton
-                className={`tab-button ${activeView === "library" ? "active" : ""}`}
-                onClick={() => handleSheetViewChange("library")}
-                ariaLabel="Show library"
-                tabIndex={-1}
-                icon={<CollectionsOutlinedIcon fontSize="small" />}
-              />
-            </Tooltip>
+            {categories.map((cat) => (
+              <Tooltip
+                key={cat.id}
+                title={cat.label}
+                placement="bottom"
+                delay={TOOLTIP_ENTER_DELAY}
+              >
+                <ToolbarIconButton
+                  className={`tab-button ${activeView === cat.id ? "active" : ""}`}
+                  onClick={() => handleSheetViewChange(cat.id)}
+                  ariaLabel={cat.label}
+                  tabIndex={-1}
+                  icon={cat.icon}
+                />
+              </Tooltip>
+            ))}
 
             <Box sx={{ flex: 1 }} />
-            {activeView === "workflows" && <CreateWorkflowButton />}
-            {activeView === "sketches" && <CreateSketchButton />}
-            {activeView === "timelines" && <CreateTimelineButton />}
+            {CreateAction && <CreateAction />}
           </div>
         }
       >
@@ -874,6 +866,7 @@ const PanelLeft: React.FC = () => {
         onClose={handleMobileClose}
         onViewChange={onViewChange}
         handlePanelToggle={handlePanelToggle}
+        hiddenViews={hiddenViews}
         hideLauncher={isWorkspace}
       />
     );

--- a/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
+++ b/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * PanelLeft — mobile bottom sheet tests
+ *
+ * The sheet's tab row is the only way to reach a left-panel view on a phone,
+ * so it must offer the same top-level views the desktop rail does, minus the
+ * ones that only make sense while a workflow is open for editing.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+
+import PanelLeft from "../PanelLeft";
+import mockTheme from "../../../__mocks__/themeMock";
+import { usePanelStore } from "../../../stores/PanelStore";
+import { LEFT_PANEL_TOP_LEVEL } from "../../../config/quickAccessCategories";
+
+jest.mock("@mui/material/useMediaQuery", () => () => true);
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => jest.fn(),
+  useLocation: () => ({ pathname: "/workspace" })
+}));
+
+jest.mock("../../../hooks/handlers/useResizePanel", () => ({
+  useResizePanel: () => ({
+    ref: { current: null },
+    size: 300,
+    isVisible: true,
+    isDragging: false,
+    handleMouseDown: jest.fn(),
+    handlePanelToggle: (view: string) =>
+      usePanelStore.getState().setActiveView(view as never)
+  })
+}));
+
+jest.mock("../../../contexts/WorkflowManagerContext", () => ({
+  useWorkflowManager: () => null
+}));
+
+jest.mock("../../../stores/WorkspaceTabsStore", () => ({
+  useWorkspaceTabsStore: (selector: (state: unknown) => unknown) =>
+    selector({ tabs: [], activeTabId: null, openTab: jest.fn() })
+}));
+
+jest.mock("../../assets/AssetGrid", () => () => <div data-testid="asset-grid" />);
+jest.mock("../../workflows/WorkflowList", () => () => (
+  <div data-testid="workflow-list" />
+));
+jest.mock("../../workflows/WorkflowForm", () => () => (
+  <div data-testid="workflow-form" />
+));
+jest.mock("../../workflows/CreateWorkflowButton", () => () => (
+  <div data-testid="create-workflow" />
+));
+jest.mock("../../node_menu/NodeLibrary", () => () => (
+  <div data-testid="node-library" />
+));
+jest.mock("../../node_menu/HistoryTilesPanel", () => () => (
+  <div data-testid="history-tiles" />
+));
+jest.mock("../../node_menu/FavoritesTiles", () => () => (
+  <div data-testid="favorites-tiles" />
+));
+jest.mock("../RailAppMenu", () => () => <div data-testid="rail-app-menu" />);
+jest.mock("../../ui/ThemeToggle", () => () => (
+  <div data-testid="theme-toggle" />
+));
+jest.mock("../../context_menus/ContextMenus", () => () => (
+  <div data-testid="context-menus" />
+));
+
+jest.mock("../../timeline/TimelineListPanel", () => ({
+  __esModule: true,
+  default: () => <div data-testid="timeline-list" />,
+  CreateTimelineButton: () => <div data-testid="create-timeline" />
+}));
+jest.mock("../../sketch/SketchListPanel", () => ({
+  __esModule: true,
+  default: () => <div data-testid="sketch-list" />,
+  CreateSketchButton: () => <div data-testid="create-sketch" />
+}));
+jest.mock("../../storyboard/StoryboardListPanel", () => ({
+  __esModule: true,
+  default: () => <div data-testid="storyboard-list" />,
+  CreateStoryboardButton: () => <div data-testid="create-storyboard" />
+}));
+jest.mock("../../script/ScriptListPanel", () => ({
+  __esModule: true,
+  default: () => <div data-testid="script-list" />,
+  CreateScriptButton: () => <div data-testid="create-script" />
+}));
+jest.mock("../../chat/ChatListPanel", () => ({
+  __esModule: true,
+  default: () => <div data-testid="chat-list" />,
+  CreateChatButton: () => <div data-testid="create-chat" />
+}));
+jest.mock("../../applications/ApplicationListPanel", () => ({
+  __esModule: true,
+  default: () => <div data-testid="application-list" />,
+  CreateApplicationButton: () => <div data-testid="create-application" />,
+  CreateApplicationFromWorkflowButton: () => (
+    <div data-testid="create-application-from-workflow" />
+  )
+}));
+
+const WORKFLOW_EDIT_ONLY = ["nodes", "settings", "history", "favorites"];
+
+const renderPanel = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <PanelLeft />
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  usePanelStore.getState().setVisibility(true);
+  usePanelStore.getState().setActiveView("workflows");
+});
+
+it("offers every non-workflow-edit top-level view as a tab", () => {
+  renderPanel();
+
+  for (const category of LEFT_PANEL_TOP_LEVEL) {
+    const tab = screen.queryByLabelText(category.label);
+    if (WORKFLOW_EDIT_ONLY.includes(category.id)) {
+      expect(tab).not.toBeInTheDocument();
+    } else {
+      expect(tab).toBeInTheDocument();
+    }
+  }
+});
+
+it("switches the sheet to the view whose tab was tapped", async () => {
+  const user = userEvent.setup();
+  renderPanel();
+
+  await user.click(screen.getByLabelText("Chats"));
+  expect(usePanelStore.getState().panel.activeView).toBe("chats");
+  expect(screen.getByTestId("chat-list")).toBeInTheDocument();
+
+  await user.click(screen.getByLabelText("Apps"));
+  expect(usePanelStore.getState().panel.activeView).toBe("apps");
+  expect(screen.getByTestId("application-list")).toBeInTheDocument();
+});
+
+it("shows the create action for the active list view", async () => {
+  const user = userEvent.setup();
+  renderPanel();
+
+  expect(screen.getByTestId("create-workflow")).toBeInTheDocument();
+
+  await user.click(screen.getByLabelText("Storyboards"));
+  expect(screen.getByTestId("create-storyboard")).toBeInTheDocument();
+
+  await user.click(screen.getByLabelText("Assets"));
+  expect(screen.queryByTestId("create-storyboard")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## What

The mobile left panel (`MobilePanelLeft` in `web/src/components/panels/PanelLeft.tsx`) hard-coded five tabs in its bottom-sheet header: Workflows, Sketches, Timelines, Assets, Library. The desktop rail renders all of `LEFT_PANEL_TOP_LEVEL`, so on a phone these views had no entry point at all:

- Chats
- Storyboards
- Scripts
- Apps
- Nodes / History / Favorites / Settings (workflow-edit views)

`PanelContent` already rendered every one of them — only the way in was missing.

## Changes

- The sheet's tab row now maps over `LEFT_PANEL_TOP_LEVEL`, the same config `QuickAccessSidebar` uses for the desktop rail, using each category's own icon and label.
- `hiddenViews` is passed through to the mobile variant, so the workflow-edit-only views (nodes, settings, history, favorites) appear on a phone exactly when they appear on desktop — while a workflow is open for editing.
- The create action in the sheet header follows the active view via a `MOBILE_CREATE_ACTIONS` map, covering chats, storyboards, scripts and apps in addition to the three it handled before.
- The tab row is `nowrap` and scrolls sideways instead of wrapping into several rows of icons above the content.
- Dropped the now-unused `IconForType`, `GridViewIcon` and `CollectionsOutlinedIcon` imports.

## Tests

New `web/src/components/panels/__tests__/PanelLeftMobile.test.tsx` renders `PanelLeft` at a mobile breakpoint and asserts:

- every non-workflow-edit top-level view has a tab, and the workflow-edit ones do not;
- tapping a tab switches the sheet to that view's panel;
- the create action tracks the active view.

`npx jest src/components/panels` passes; `eslint` is clean on both files; `tsc` reports nothing under `src/components/panels/` (the remaining repo-wide errors are pre-existing missing `dist/` output from unbuilt packages).

---
_Generated by [Claude Code](https://claude.ai/code/session_016GdCgMqLFojARSx8Pv22PA)_