### PR TITLE
Help icons linking each surface to its docs page

### DIFF
--- a/web/src/components/appbuilder/AppBuilderAgentPanel.tsx
+++ b/web/src/components/appbuilder/AppBuilderAgentPanel.tsx
@@ -178,7 +178,11 @@ const AppBuilderAgentPanel: React.FC<AppBuilderAgentPanelProps> = ({
           Build the app layout and bind widgets to workflow inputs and outputs.
         </Caption>
       </Box>
-      <ChatPanelHeader onNewChat={handleNewChat} />
+      <ChatPanelHeader
+        onNewChat={handleNewChat}
+        docsTopic="appBuilder"
+        docsLabel="App builder"
+      />
       <Box sx={{ flex: 1, minHeight: 0 }}>
         <ChatView
           status={viewStatus}

--- a/web/src/components/assets/AssetExplorer.tsx
+++ b/web/src/components/assets/AssetExplorer.tsx
@@ -50,6 +50,7 @@ const AssetExplorer: React.FC = memo(() => {
       icon={<PermMediaOutlinedIcon sx={{ fontSize: 22 }} />}
       title="Assets"
       subtitle="Browse, organize, and preview your images, audio, video, and other files."
+      docsTopic="assets"
       padded={false}
       actions={<StorageAnalytics assets={folderFiles} />}
     >

--- a/web/src/components/chat/containers/ChatPanelHeader.tsx
+++ b/web/src/components/chat/containers/ChatPanelHeader.tsx
@@ -6,6 +6,7 @@ import AddIcon from "@mui/icons-material/Add";
 import ForumOutlinedIcon from "@mui/icons-material/ForumOutlined";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import {
+  DocsHelpLink,
   FlexRow,
   Text,
   ToolbarIconButton,
@@ -14,6 +15,7 @@ import {
   SPACING,
   getSpacingPx
 } from "../../ui_primitives";
+import type { DocsTopic } from "../../../config/docsLinks";
 import useGlobalChatStore from "../../../stores/GlobalChatStore";
 import { useNotificationStore } from "../../../stores/NotificationStore";
 import ThreadList from "../thread/ThreadList";
@@ -28,6 +30,10 @@ interface ChatPanelHeaderProps {
   onSelectThread?: (id: string) => void;
   /** Optional label shown on the left of the header. */
   title?: React.ReactNode;
+  /** Docs page the help icon points at. Defaults to the agents guide. */
+  docsTopic?: DocsTopic;
+  /** Name the help icon's tooltip uses. */
+  docsLabel?: string;
 }
 
 /**
@@ -38,7 +44,9 @@ interface ChatPanelHeaderProps {
 const ChatPanelHeader: React.FC<ChatPanelHeaderProps> = ({
   onNewChat,
   onSelectThread,
-  title
+  title,
+  docsTopic = "agents",
+  docsLabel = "Chat & agents"
 }) => {
   const navigate = useNavigate();
   const openTab = useWorkspaceTabsStore((state) => state.openTab);
@@ -146,6 +154,7 @@ const ChatPanelHeader: React.FC<ChatPanelHeaderProps> = ({
           tooltip="Open in a workspace tab"
           icon={<OpenInNewIcon fontSize="small" />}
         />
+        <DocsHelpLink topic={docsTopic} label={docsLabel} />
       </FlexRow>
 
       <Popover

--- a/web/src/components/collections/CollectionsExplorer.tsx
+++ b/web/src/components/collections/CollectionsExplorer.tsx
@@ -12,7 +12,7 @@ const CollectionsExplorer: React.FC = () => (
     icon={<LibraryBooksOutlinedIcon sx={{ fontSize: 22 }} />}
     title="Collections"
     subtitle="Searchable document collections for RAG workflows — drop in PDFs, Markdown, HTML, or transcripts."
-    docsUrl="https://docs.nodetool.ai/collections.html"
+    docsTopic="collections"
   >
     <CollectionList />
   </ManagerPageLayout>

--- a/web/src/components/hugging_face/model_list/ModelsPage.tsx
+++ b/web/src/components/hugging_face/model_list/ModelsPage.tsx
@@ -12,7 +12,7 @@ const ModelsPage: React.FC = () => (
     icon={<ViewInArOutlinedIcon sx={{ fontSize: 22 }} />}
     title="Model Manager"
     subtitle="Browse, download, and manage local AI models."
-    docsUrl="https://docs.nodetool.ai/models.html"
+    docsTopic="modelsManager"
     padded={false}
   >
     <ModelListIndex />

--- a/web/src/components/menus/APIKeysTab.tsx
+++ b/web/src/components/menus/APIKeysTab.tsx
@@ -62,6 +62,7 @@ import cohereColorIcon from "../../icons/providers/cohere-color.svg";
 import falColorIcon from "../../icons/providers/fal-color.svg";
 import replicateIcon from "../../icons/providers/replicate.svg";
 import elevenlabsIcon from "../../icons/providers/elevenlabs.svg";
+import { docsLink, docsUrl } from "../../config/docsLinks";
 
 // For multi-field credentials, find the parent provider (the one with fields array)
 const getParentProviderMeta = (key: string): ProviderMeta | undefined => {
@@ -1171,19 +1172,19 @@ export const APIKeysRightSidebar = memo(function APIKeysRightSidebar() {
       icon: <ModelTrainingIcon sx={{ fontSize: 18 }} />,
       title: "Supported Models",
       subtitle: "See models by provider",
-      href: "https://docs.nodetool.ai/models-and-providers"
+      href: docsLink("providers")
     },
     {
       icon: <MenuBookIcon sx={{ fontSize: 18 }} />,
       title: "API Documentation",
       subtitle: "Provider guides & links",
-      href: "https://docs.nodetool.ai/providers"
+      href: docsUrl("providers")
     },
     {
       icon: <HelpOutlineIcon sx={{ fontSize: 18 }} />,
       title: "Troubleshooting",
       subtitle: "Common issues & fixes",
-      href: "https://docs.nodetool.ai/troubleshooting.html"
+      href: docsLink("troubleshooting")
     }
   ];
 

--- a/web/src/components/menus/SettingsMenu.tsx
+++ b/web/src/components/menus/SettingsMenu.tsx
@@ -21,8 +21,10 @@ import {
   Box,
   Tabs,
   Tab,
-  SPACING
+  SPACING,
+  DocsHelpLink
 } from "../ui_primitives";
+import type { DocsTopic } from "../../config/docsLinks";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { isLocalhost, isElectron } from "../../lib/env";
 import RemoteSettingsMenuComponent from "./RemoteSettingsMenu";
@@ -55,6 +57,12 @@ const TAB_GENERAL = 0;
 const TAB_API_KEYS = 1;
 const TAB_INTEGRATIONS = 2;
 const aboutTabIndex = 3;
+
+const settingsDocsTopic = (tab: number): DocsTopic =>
+  tab === TAB_API_KEYS ? "providers" : "configuration";
+
+const settingsDocsLabel = (tab: number): string =>
+  tab === TAB_API_KEYS ? "Models & providers" : "Configuration";
 
 const UPDATE_CHANNEL_OPTIONS = [
   { value: "latest", label: "Stable" },
@@ -543,7 +551,13 @@ function SettingsPage() {
       <Box css={settingsStyles(theme)} sx={{ flex: 1, minHeight: 0 }}>
         <header className="settings-page-header">
           <div className="settings-page-header__titles">
-            <h1 className="settings-page-header__title">Settings</h1>
+            <div className="settings-page-header__heading">
+              <h1 className="settings-page-header__title">Settings</h1>
+              <DocsHelpLink
+                topic={settingsDocsTopic(settingsTab)}
+                label={settingsDocsLabel(settingsTab)}
+              />
+            </div>
             <p className="settings-page-header__subtitle">
               {settingsTab === aboutTabIndex
                 ? "About this application."

--- a/web/src/components/menus/settingsMenuStyles.ts
+++ b/web/src/components/menus/settingsMenuStyles.ts
@@ -270,6 +270,12 @@ export const settingsStyles = (theme: Theme): CSSObject => ({
       gap: theme.spacing(0.5),
       minWidth: 0
     },
+    "& .settings-page-header__heading": {
+      display: "flex",
+      flexDirection: "row",
+      alignItems: "center",
+      gap: theme.spacing(0.5)
+    },
     "& .settings-page-header__title": {
       margin: 0,
       color: theme.vars.palette.text.primary,

--- a/web/src/components/node_menu/NodeLibrary.tsx
+++ b/web/src/components/node_menu/NodeLibrary.tsx
@@ -14,7 +14,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import SearchIcon from "@mui/icons-material/Search";
 import ClearIcon from "@mui/icons-material/Clear";
 
-import { Text, thinScrollbarStyles, MOTION, FONT_WEIGHT, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
+import { DocsHelpLink, Text, thinScrollbarStyles, MOTION, FONT_WEIGHT, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 import NodeLibraryRow from "./NodeLibraryRow";
 import NodeInfo from "./NodeInfo";
 import useMetadataStore from "../../stores/MetadataStore";
@@ -59,6 +59,10 @@ const styles = (theme: Theme, isMobile: boolean) =>
       fontWeight: FONT_WEIGHT.semibold,
       letterSpacing: "-0.01em",
       color: theme.vars.palette.text.primary
+    },
+    ".nl-header .docs-help-link": {
+      marginLeft: "auto",
+      padding: 2
     },
     ".nl-count": {
       display: "inline-flex",
@@ -420,6 +424,7 @@ const NodeLibrary = memo<NodeLibraryProps>(
             Node library
           </Text>
           <span className="nl-count">{nodes.length}</span>
+          <DocsHelpLink topic="nodes" label="Node reference" />
         </div>
 
         <div className="nl-search">

--- a/web/src/components/packages/PackagesPage.tsx
+++ b/web/src/components/packages/PackagesPage.tsx
@@ -12,6 +12,7 @@ const PackagesPage: React.FC = () => (
     icon={<Inventory2OutlinedIcon sx={{ fontSize: 22 }} />}
     title="Package Manager"
     subtitle="Install runtimes and node packs in one place."
+    docsTopic="nodePacks"
     padded={false}
   >
     <PackageManager />

--- a/web/src/components/panels/ManagerPageLayout.tsx
+++ b/web/src/components/panels/ManagerPageLayout.tsx
@@ -5,13 +5,16 @@ import type { Theme } from "@mui/material/styles";
 import React, { memo, useMemo } from "react";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { Box, EditorButton, FlexColumn, FlexRow, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
+import { docsLink, type DocsTopic } from "../../config/docsLinks";
 
 interface ManagerPageLayoutProps {
   /** Icon shown in the tinted chip beside the title. */
   icon?: React.ReactNode;
   title: string;
   subtitle?: string;
-  /** Optional docs link rendered as a button in the hero's action row. */
+  /** Documentation page for this manager, rendered as a button in the hero. */
+  docsTopic?: DocsTopic;
+  /** Escape hatch for a docs link outside the registry. */
   docsUrl?: string;
   docsLabel?: string;
   /** Extra controls rendered on the right of the hero header. */
@@ -101,6 +104,7 @@ const ManagerPageLayout: React.FC<ManagerPageLayoutProps> = ({
   icon,
   title,
   subtitle,
+  docsTopic,
   docsUrl,
   docsLabel = "Documentation",
   actions,
@@ -109,6 +113,7 @@ const ManagerPageLayout: React.FC<ManagerPageLayoutProps> = ({
 }) => {
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
+  const resolvedDocsUrl = docsTopic ? docsLink(docsTopic) : docsUrl;
 
   return (
     <Box css={cssStyles} className="manager-page">
@@ -118,16 +123,20 @@ const ManagerPageLayout: React.FC<ManagerPageLayoutProps> = ({
           <h1 className="manager-page-title">{title}</h1>
           {subtitle && <p className="manager-page-subtitle">{subtitle}</p>}
         </FlexColumn>
-        {(docsUrl || actions) && (
+        {(resolvedDocsUrl || actions) && (
           <FlexRow className="manager-page-actions">
             {actions}
-            {docsUrl && (
+            {resolvedDocsUrl && (
               <EditorButton
                 variant="outlined"
                 density="normal"
                 endIcon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
                 onClick={() =>
-                  window.open(docsUrl, "_blank", "noopener,noreferrer")
+                  window.open(
+                    resolvedDocsUrl,
+                    "_blank",
+                    "noopener,noreferrer"
+                  )
                 }
               >
                 {docsLabel}

--- a/web/src/components/panels/PanelBottom.tsx
+++ b/web/src/components/panels/PanelBottom.tsx
@@ -459,7 +459,7 @@ const PanelBodyContent = memo(function PanelBodyContent({
             padding: "0 1em"
           }}
         >
-          <PanelHeadline title="Queue" />
+          <PanelHeadline title="Queue" docsTopic="debugging" />
           <QueuePanel />
         </FlexColumn>
       );

--- a/web/src/components/panels/PanelLeft.tsx
+++ b/web/src/components/panels/PanelLeft.tsx
@@ -331,7 +331,7 @@ const PanelContent = memo(function PanelContent({
             overflow: "hidden"
           }}
         >
-          {!isMobile && <PanelHeadline title="History" />}
+          {!isMobile && <PanelHeadline title="History" docsTopic="nodes" />}
           <HistoryTilesPanel />
         </FlexColumn>
       )}
@@ -344,7 +344,7 @@ const PanelContent = memo(function PanelContent({
             overflow: "hidden"
           }}
         >
-          {!isMobile && <PanelHeadline title="Favorites" />}
+          {!isMobile && <PanelHeadline title="Favorites" docsTopic="nodes" />}
           <ScrollArea fullHeight>
             <FavoritesTiles showEmpty hideHeader />
           </ScrollArea>
@@ -362,6 +362,7 @@ const PanelContent = memo(function PanelContent({
           {!isMobile && (
             <PanelHeadline
               title={currentWorkflow ? "Workflow Output" : "Assets"}
+              docsTopic="assets"
               actions={
                 <Tooltip
                   title="Open the global asset library"
@@ -395,6 +396,7 @@ const PanelContent = memo(function PanelContent({
           {!isMobile && (
             <PanelHeadline
               title="Library"
+              docsTopic="assets"
               actions={
                 <Tooltip title="Open in full page" placement="right-start">
                   <ToolbarIconButton
@@ -425,6 +427,7 @@ const PanelContent = memo(function PanelContent({
           {!isMobile && (
             <PanelHeadline
               title="Workflows"
+              docsTopic="workflows"
               actions={<CreateWorkflowButton />}
             />
           )}
@@ -443,7 +446,11 @@ const PanelContent = memo(function PanelContent({
           }}
         >
           {!isMobile && (
-            <PanelHeadline title="Chats" actions={<CreateChatButton />} />
+            <PanelHeadline
+              title="Chats"
+              docsTopic="chat"
+              actions={<CreateChatButton />}
+            />
           )}
           <ChatListPanel />
         </FlexColumn>
@@ -460,6 +467,7 @@ const PanelContent = memo(function PanelContent({
           {!isMobile && (
             <PanelHeadline
               title="Sketches"
+              docsTopic="sketches"
               actions={<CreateSketchButton />}
             />
           )}
@@ -478,6 +486,7 @@ const PanelContent = memo(function PanelContent({
           {!isMobile && (
             <PanelHeadline
               title="Timelines"
+              docsTopic="timelines"
               actions={<CreateTimelineButton />}
             />
           )}
@@ -496,6 +505,7 @@ const PanelContent = memo(function PanelContent({
           {!isMobile && (
             <PanelHeadline
               title="Storyboards"
+              docsTopic="storyboards"
               actions={<CreateStoryboardButton />}
             />
           )}
@@ -512,7 +522,11 @@ const PanelContent = memo(function PanelContent({
           }}
         >
           {!isMobile && (
-            <PanelHeadline title="Scripts" actions={<CreateScriptButton />} />
+            <PanelHeadline
+              title="Scripts"
+              docsTopic="scripts"
+              actions={<CreateScriptButton />}
+            />
           )}
           <ScriptListPanel />
         </FlexColumn>
@@ -529,6 +543,7 @@ const PanelContent = memo(function PanelContent({
           {!isMobile && (
             <PanelHeadline
               title="Apps"
+              docsTopic="apps"
               actions={
                 <>
                   <CreateApplicationFromWorkflowButton />
@@ -549,7 +564,7 @@ const PanelContent = memo(function PanelContent({
             overflow: "hidden"
           }}
         >
-          {!isMobile && <PanelHeadline title="Settings" />}
+          {!isMobile && <PanelHeadline title="Settings" docsTopic="workflows" />}
           <ScrollArea fullHeight>
             <WorkflowForm workflow={currentWorkflow} onClose={closePanel} />
           </ScrollArea>

--- a/web/src/components/portal/ExamplesPage.tsx
+++ b/web/src/components/portal/ExamplesPage.tsx
@@ -13,6 +13,7 @@ const ExamplesPage: React.FC = () => (
     icon={<AutoAwesomeOutlinedIcon sx={{ fontSize: 22 }} />}
     title="Examples"
     subtitle="Browse example workflows and start from one."
+    docsTopic="examples"
     padded={false}
   >
     <DashboardTemplates fullPage />

--- a/web/src/components/script/ScriptAgentPanel.tsx
+++ b/web/src/components/script/ScriptAgentPanel.tsx
@@ -148,7 +148,11 @@ const ScriptAgentPanel = ({ scriptId }: ScriptAgentPanelProps) => {
 
   return (
     <div css={cssStyles}>
-      <ChatPanelHeader onNewChat={handleNewChat} />
+      <ChatPanelHeader
+        onNewChat={handleNewChat}
+        docsTopic="scripts"
+        docsLabel="Scripts"
+      />
       <div style={{ flex: 1, minHeight: 0 }}>
         <ChatView
           status={chatStatus}

--- a/web/src/components/sketch/SketchAgentPanel.tsx
+++ b/web/src/components/sketch/SketchAgentPanel.tsx
@@ -145,7 +145,11 @@ const SketchAgentPanel = () => {
 
   return (
     <div css={cssStyles}>
-      <ChatPanelHeader onNewChat={handleNewChat} />
+      <ChatPanelHeader
+        onNewChat={handleNewChat}
+        docsTopic="sketches"
+        docsLabel="Sketch editor"
+      />
       <div style={{ flex: 1, minHeight: 0 }}>
         <ChatView
           status={chatStatus}

--- a/web/src/components/storyboard/StoryboardAgentPanel.tsx
+++ b/web/src/components/storyboard/StoryboardAgentPanel.tsx
@@ -151,7 +151,11 @@ const StoryboardAgentPanel = ({ boardId }: StoryboardAgentPanelProps) => {
 
   return (
     <div css={cssStyles}>
-      <ChatPanelHeader onNewChat={handleNewChat} />
+      <ChatPanelHeader
+        onNewChat={handleNewChat}
+        docsTopic="storyboards"
+        docsLabel="Storyboards"
+      />
       <div style={{ flex: 1, minHeight: 0 }}>
         <ChatView
           status={chatStatus}

--- a/web/src/components/timeline/TimelineAgentPanel.tsx
+++ b/web/src/components/timeline/TimelineAgentPanel.tsx
@@ -144,7 +144,11 @@ const TimelineAgentPanel = () => {
 
   return (
     <div css={cssStyles}>
-      <ChatPanelHeader onNewChat={handleNewChat} />
+      <ChatPanelHeader
+        onNewChat={handleNewChat}
+        docsTopic="timelines"
+        docsLabel="Video editor"
+      />
       <div style={{ flex: 1, minHeight: 0 }}>
         <ChatView
           status={chatStatus}

--- a/web/src/components/ui/PanelHeadline.tsx
+++ b/web/src/components/ui/PanelHeadline.tsx
@@ -1,14 +1,17 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
-import { FlexRow } from "../ui_primitives";
+import { DocsHelpLink, FlexRow } from "../ui_primitives";
 import { Text } from "../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { memo } from "react";
+import type { DocsTopic } from "../../config/docsLinks";
 
 interface PanelHeadlineProps {
   title: string;
   actions?: React.ReactNode;
+  /** Renders a help icon beside the title, linking to this docs page. */
+  docsTopic?: DocsTopic;
 }
 
 const styles = (theme: Theme) =>
@@ -21,6 +24,10 @@ const styles = (theme: Theme) =>
       padding: 2,
       "& svg": { fontSize: "var(--fontSizeNormal)" }
     },
+    ".headline-titles .docs-help-link": {
+      padding: 2,
+      "& svg": { fontSize: "var(--fontSizeSmall)" }
+    },
     ".headline-title": {
       letterSpacing: "0.01em",
       lineHeight: "1.4em",
@@ -29,7 +36,11 @@ const styles = (theme: Theme) =>
     }
   });
 
-const PanelHeadline: React.FC<PanelHeadlineProps> = ({ title, actions }) => {
+const PanelHeadline: React.FC<PanelHeadlineProps> = ({
+  title,
+  actions,
+  docsTopic
+}) => {
   const theme = useTheme();
 
   return (
@@ -40,14 +51,17 @@ const PanelHeadline: React.FC<PanelHeadlineProps> = ({ title, actions }) => {
       align="center"
       fullWidth
     >
-      <Text
-        size="normal"
-        weight={600}
-        component="span"
-        className="headline-title"
-      >
-        {title}
-      </Text>
+      <FlexRow className="headline-titles" align="center" gap={0}>
+        <Text
+          size="normal"
+          weight={600}
+          component="span"
+          className="headline-title"
+        >
+          {title}
+        </Text>
+        {docsTopic && <DocsHelpLink topic={docsTopic} label={title} />}
+      </FlexRow>
       {actions && (
         <FlexRow className="headline-actions" align="center" gap={0.5}>
           {actions}

--- a/web/src/components/ui_primitives/DocsHelpLink.tsx
+++ b/web/src/components/ui_primitives/DocsHelpLink.tsx
@@ -1,0 +1,74 @@
+/** @jsxImportSource @emotion/react */
+import React, { memo } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import { IconButton, Tooltip } from "@mui/material";
+import { TOOLTIP_ENTER_DELAY } from "../../config/constants";
+import { docsLink, type DocsTopic } from "../../config/docsLinks";
+import { MOTION } from "./tokens";
+
+export interface DocsHelpLinkProps {
+  /** Documentation page this surface maps to. */
+  topic: DocsTopic;
+  /** What the tooltip names, e.g. "Workflows" → "Workflows documentation". */
+  label: string;
+  size?: "small" | "medium";
+  tooltipPlacement?: "top" | "bottom" | "left" | "right";
+  className?: string;
+}
+
+const styles = (theme: Theme) =>
+  css({
+    color: theme.vars.palette.text.disabled,
+    transition: `color ${MOTION.normal}`,
+    "&:hover": {
+      color: theme.vars.palette.primary.main,
+      backgroundColor: theme.vars.palette.action.hover
+    }
+  });
+
+/**
+ * Small help icon that opens the matching documentation page in a new tab.
+ * Sits in panel headers and page heroes next to the thing it explains.
+ */
+const DocsHelpLinkInternal: React.FC<DocsHelpLinkProps> = ({
+  topic,
+  label,
+  size = "small",
+  tooltipPlacement = "bottom",
+  className
+}) => {
+  const theme = useTheme();
+  const title = `${label} documentation`;
+
+  return (
+    <Tooltip
+      title={title}
+      enterDelay={TOOLTIP_ENTER_DELAY}
+      placement={tooltipPlacement}
+    >
+      <IconButton
+        className={`docs-help-link nodrag${className ? ` ${className}` : ""}`}
+        css={styles(theme)}
+        size={size}
+        component="a"
+        href={docsLink(topic)}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={title}
+        tabIndex={-1}
+        onClick={(event: React.MouseEvent) => event.stopPropagation()}
+      >
+        <HelpOutlineIcon fontSize={size === "medium" ? "medium" : "small"} />
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export const DocsHelpLink = memo(DocsHelpLinkInternal);
+
+DocsHelpLink.displayName = "DocsHelpLink";
+
+export default DocsHelpLink;

--- a/web/src/components/ui_primitives/STRATEGY.md
+++ b/web/src/components/ui_primitives/STRATEGY.md
@@ -68,7 +68,7 @@ These primitives exist but are barely adopted:
 `EditorButton` | `ToolbarIconButton` | `StateIconButton` | `CircularActionButton` | `NavButton` | `CreateFab` | `PlaybackButton` | `RunWorkflowButton` | `ExpandCollapseButton` | `RefreshButton` | `ViewModeToggle` | `LabeledToggle` | `ConfirmButton`
 
 ### Semantic Action Buttons (replace custom icon+tooltip combos)
-`CopyButton` | `CloseButton` | `DeleteButton` | `DownloadButton` | `UploadButton` | `EditButton` | `SettingsButton` | `FavoriteButton` | `HelpButton` | `UndoRedoButtons`
+`CopyButton` | `CloseButton` | `DeleteButton` | `DownloadButton` | `UploadButton` | `EditButton` | `SettingsButton` | `FavoriteButton` | `HelpButton` | `DocsHelpLink` | `UndoRedoButtons`
 
 ### Feedback & Status (replace raw CircularProgress/Alert)
 `LoadingSpinner` | `ProgressBar` | `Skeleton` | `StatusIndicator` | `EmptyState` | `AlertBanner` | `WarningBanner` | `Toast` | `NotificationBadge`

--- a/web/src/components/ui_primitives/__tests__/DocsHelpLink.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/DocsHelpLink.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import { DocsHelpLink } from "../DocsHelpLink";
+import { DOCS_BASE_URL, DOCS_PATHS } from "../../../config/docsLinks";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const renderWithTheme = (component: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{component}</ThemeProvider>);
+
+describe("DocsHelpLink", () => {
+  it("links to the topic's documentation page in a new tab", () => {
+    renderWithTheme(<DocsHelpLink topic="workflows" label="Workflows" />);
+
+    const link = screen.getByRole("link", {
+      name: "Workflows documentation"
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      `${DOCS_BASE_URL}/${DOCS_PATHS.workflows}`
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("names the surface it explains in its accessible label", () => {
+    renderWithTheme(<DocsHelpLink topic="assets" label="Assets" />);
+
+    expect(
+      screen.getByRole("link", { name: "Assets documentation" })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ui_primitives/index.ts
+++ b/web/src/components/ui_primitives/index.ts
@@ -140,6 +140,9 @@ export type { MenuItemPrimitiveProps } from "./MenuItemPrimitive";
 export { HelpButton } from "./HelpButton";
 export type { HelpButtonProps, HelpIconVariant } from "./HelpButton";
 
+export { DocsHelpLink } from "./DocsHelpLink";
+export type { DocsHelpLinkProps } from "./DocsHelpLink";
+
 // New composite/state buttons
 export { StateIconButton } from "./StateIconButton";
 export type { StateIconButtonProps } from "./StateIconButton";

--- a/web/src/components/workspaces/WorkspaceTree.tsx
+++ b/web/src/components/workspaces/WorkspaceTree.tsx
@@ -404,7 +404,7 @@ const WorkspaceTree: React.FC = () => {
   if (!workflowId) {
     return (
       <Box css={workspaceTreeStyles(theme)}>
-        <PanelHeadline title="Workspace Explorer" />
+        <PanelHeadline title="Workspace Explorer" docsTopic="workspaces" />
         <div className="empty-workspace">
           <FolderOpenIcon
             sx={{ fontSize: 40, opacity: 0.3, color: "text.secondary" }}
@@ -424,6 +424,7 @@ const WorkspaceTree: React.FC = () => {
     <Box css={workspaceTreeStyles(theme)}>
       <PanelHeadline
         title="Workspace Explorer"
+        docsTopic="workspaces"
         actions={
           <RefreshButton
             onClick={handleRefresh}

--- a/web/src/components/workspaces/WorkspacesPage.tsx
+++ b/web/src/components/workspaces/WorkspacesPage.tsx
@@ -12,7 +12,7 @@ const WorkspacesPage: React.FC = () => (
     icon={<FolderSpecialOutlinedIcon sx={{ fontSize: 22 }} />}
     title="Workspaces"
     subtitle="Sandboxed folders that agents and workflows can read, write, and organize files in."
-    docsUrl="https://docs.nodetool.ai/workspaces.html"
+    docsTopic="workspaces"
   >
     <WorkspacesManager />
   </ManagerPageLayout>

--- a/web/src/config/__tests__/docsLinks.test.ts
+++ b/web/src/config/__tests__/docsLinks.test.ts
@@ -1,0 +1,29 @@
+import fs from "fs";
+import path from "path";
+import { DOCS_BASE_URL, DOCS_PATHS, docsLink, docsUrl } from "../docsLinks";
+
+const DOCS_DIR = path.resolve(__dirname, "../../../../docs");
+
+describe("docsLinks", () => {
+  it("builds absolute docs URLs", () => {
+    expect(docsUrl("workflow-editor")).toBe(
+      `${DOCS_BASE_URL}/workflow-editor`
+    );
+    expect(docsUrl("/workflow-editor")).toBe(
+      `${DOCS_BASE_URL}/workflow-editor`
+    );
+    expect(docsLink("collections")).toBe(`${DOCS_BASE_URL}/collections`);
+  });
+
+  // A help icon pointing at a page that no longer exists is worse than no icon.
+  it.each(Object.entries(DOCS_PATHS))(
+    "%s resolves to a page that ships in docs/",
+    (_topic, docPath) => {
+      const target = path.join(DOCS_DIR, docPath.replace(/\/$/, ""));
+      const exists =
+        fs.existsSync(`${target}.md`) ||
+        (fs.existsSync(target) && fs.statSync(target).isDirectory());
+      expect(exists).toBe(true);
+    }
+  );
+});

--- a/web/src/config/docsLinks.ts
+++ b/web/src/config/docsLinks.ts
@@ -1,0 +1,54 @@
+/**
+ * Deep links into the documentation site (https://docs.nodetool.ai).
+ *
+ * One entry per surface that shows a help icon, so a page that moves is
+ * renamed here instead of in a dozen components. Paths are extensionless —
+ * the docs site's own navigation links that way.
+ */
+
+export const DOCS_BASE_URL = "https://docs.nodetool.ai";
+
+export const docsUrl = (path: string): string =>
+  `${DOCS_BASE_URL}/${path.replace(/^\//, "")}`;
+
+export const DOCS_PATHS = {
+  gettingStarted: "getting-started",
+  keyConcepts: "key-concepts",
+  userInterface: "user-interface",
+  editorPanels: "editor-panels",
+
+  workflows: "workflow-editor",
+  nodes: "nodes/",
+  nodePacks: "node-packs",
+  packages: "packages",
+  debugging: "workflow-debugging",
+  graphView: "workflow-graph-view",
+  chainEditor: "chain-editor",
+  templates: "templates-gallery",
+  examples: "cookbook",
+
+  chat: "global-chat",
+  agents: "global-chat-agents",
+
+  sketches: "sketch-editor",
+  timelines: "video-editor",
+  storyboards: "creative-agent",
+  scripts: "creative-agent",
+
+  apps: "mini-apps",
+  appBuilder: "app-builder",
+
+  assets: "asset-management",
+  collections: "collections",
+  workspaces: "workspaces",
+  models: "models",
+  modelsManager: "models-manager",
+  providers: "models-and-providers",
+
+  configuration: "configuration",
+  troubleshooting: "troubleshooting"
+} as const;
+
+export type DocsTopic = keyof typeof DOCS_PATHS;
+
+export const docsLink = (topic: DocsTopic): string => docsUrl(DOCS_PATHS[topic]);


### PR DESCRIPTION
Places a small help icon on the surfaces where someone is most likely to be stuck, each one opening the matching page on docs.nodetool.ai in a new tab.

## What's new

- **`web/src/config/docsLinks.ts`** — one registry of doc paths keyed by topic. A page that gets renamed is fixed here, not in a dozen components.
- **`DocsHelpLink`** (`ui_primitives`) — the icon itself: an anchor-based `IconButton` with a tooltip that names the surface ("Workflows documentation").

## Where the icons landed

| Surface | Docs page |
| --- | --- |
| Left panel: Assets, Library | Asset Management |
| Left panel: Workflows, workflow Settings | Workflow Editor |
| Left panel: Chats | Chat |
| Left panel: Sketches / Timelines / Storyboards / Scripts / Apps | Sketch Editor / Video Editor / Creative Agent / Mini Apps |
| Left panel: History, Favorites; Node library header | Node reference |
| Queue panel | Workflow Debugging |
| Workspace explorer | Workspaces |
| Settings header (follows the active tab) | Configuration / Models & Providers |
| Agent chat panels: app builder, timeline, storyboard, sketch, script | that editor's page |
| Manager pages: Assets, Examples, Package Manager | Asset Management / Cookbook / Node Packs |

Most of the left panel comes from a single `docsTopic` prop on `PanelHeadline`. `ManagerPageLayout` gained the same prop, so Workspaces / Models / Collections — which already had a hardcoded docs button — now resolve through the registry, as do the three quick links in the API Keys sidebar.

## Notes

- Registry paths are extensionless, matching how the docs site's own sidebar links; the three existing in-app links that used `.html` are normalized.
- The icon is `tabIndex={-1}` so it stays out of the keyboard path through panel headers, and reachable by its accessible name.

## Testing

- `npm run typecheck:web`, `npm run typecheck:electron`, `web` lint — clean. (Root `npm run typecheck` also runs mobile, which can't resolve its Expo deps in this sandbox; unrelated to this diff.)
- New: `DocsHelpLink.test.tsx` (href, target, accessible name) and `docsLinks.test.ts`, which asserts **every** registered path resolves to a page that ships in `docs/` — so a help icon can't point at a dead link.
- Jest over every touched area: 188 suites / 2593 tests passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnTbfkR56LzbYuz71To3WE)_