### PR TITLE
fix(web): stop output action buttons ballooning on mobile

### DIFF
--- a/web/src/styles/mobile.css
+++ b/web/src/styles/mobile.css
@@ -579,6 +579,30 @@
     min-width: 44px !important;
   }
 
+  /* Output/preview action buttons (download, add to assets, copy) overlay the
+     rendered output and size their icon to fill the button, so the blanket
+     44px rule above turned them into full-width icons. Give them a tappable
+     32px box with a fixed icon instead. */
+  .mobile .actions .action-button,
+  .mobile .actions .copy-button,
+  .mobile .video-preview-actions .MuiIconButton-root,
+  .mobile .dataframe-action-buttons .MuiIconButton-root {
+    width: 32px !important;
+    height: 32px !important;
+    min-width: 32px !important;
+    min-height: 32px !important;
+    padding: 0 !important;
+  }
+
+  .mobile .actions .action-button svg,
+  .mobile .actions .copy-button svg,
+  .mobile .video-preview-actions .MuiIconButton-root svg,
+  .mobile .dataframe-action-buttons .MuiIconButton-root svg {
+    width: 18px !important;
+    height: 18px !important;
+    font-size: 18px !important;
+  }
+
   .mobile .main-container {
     height: 100dvh !important;
     max-height: 100dvh !important;


### PR DESCRIPTION
## What

The download, add-to-assets, and copy buttons in the output/preview renderers rendered enormous on mobile web.

## Why

`web/src/styles/mobile.css` applies a blanket touch-target rule:

```css
.mobile button, .mobile .MuiIconButton-root, .mobile .MuiButton-root {
  min-height: 44px !important;
  min-width: 44px !important;
}
```

`PreviewActions` and the `.actions` row in `PreviewNode`/`OutputNode` style these buttons at `17px` square with `& svg { width: 100%; height: 100% }`. The `!important` minimum wins over the emotion `sx`, so the button grew to 44px and the icon grew with it — three 44px glyphs sitting on top of the rendered output.

## How

Added a scoped override right after the blanket rule: the small inline action buttons get an explicit 32px box with a fixed 18px icon. Still a comfortable touch target (larger than the 17px desktop size), no longer covering the output.

Covered selectors: `.actions .action-button`, `.actions .copy-button`, `.video-preview-actions .MuiIconButton-root` (ContentCardBody's video download / save-to-assets), `.dataframe-action-buttons .MuiIconButton-root`. Deliberately excluded `.action-bar .action-button` — that one is a labeled "Compare" button in `PreviewImageGrid` and a fixed square would break it.

## Testing

- `npm run lint` (web) passes — warnings only, all pre-existing.
- `npm run typecheck` (web) fails in this sandbox, but only with `Cannot find module '@nodetool-ai/node-sdk'` cascades because the backend packages were never built here (`packages/node-sdk/dist` is absent). The change touches a single `.css` file, which `tsc` does not read.
- Not verified in a real mobile browser from this environment.