### PR TITLE
docs: agent-first messaging on the home page and entry-point docs

### DIFF
--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -6,7 +6,7 @@ description: "The problems NodeTool solves for creative teams, plus head-to-head
 
 > NodeTool is the open creative AI workspace — every major model, your keys, one canvas.
 
-NodeTool replaces the chatbox with a node canvas where image, video, audio, and LLM models run side by side. Bring your keys, or run everything locally. Open source, AGPL-3.0.
+Ask its agent for what you want and it builds the workflow on a node canvas where image, video, audio, and LLM models run side by side. Then you open that canvas and change it. Bring your keys, or run everything locally. Open source, AGPL-3.0.
 
 ## Head-to-head comparisons
 
@@ -32,7 +32,11 @@ Creative AI is a tab graveyard:
 
 ## How NodeTool solves this
 
-One canvas, every model, your keys:
+Ask for it, then own it:
+
+**An agent that builds the pipeline.** Describe the result and it plans the graph, wires it, picks models, and runs it. Chat tools that write prose hand you instructions; this one hands you a running workflow.
+
+**Nothing generated behind glass.** What the agent builds is the same graph you would have drawn. Open it, rewire it, swap a model, re-run. It edits sketches, timelines, storyboards, and mini apps the same way.
 
 **One canvas for every modality.** Wire Flux to GPT-5.6 to ElevenLabs to Wan in a single graph. Outputs flow as typed edges — image, audio, text, embeddings — not pasted strings.
 
@@ -42,7 +46,7 @@ One canvas, every model, your keys:
 
 **Workflows as files.** Save, share, version. Ship a workflow as a Mini-App with a one-click hide-the-graph mode.
 
-**Agents that drive pipelines.** Built-in planning, tool calling, streaming. Drop an agent node into any graph.
+**Agents inside the pipeline too.** Planning, tool calling, streaming. Drop an Agent node into any graph as one step of it.
 
 **Open source, no markup.** AGPL-3.0. Cloud edition hosts the same code in this repo. Self-host the Docker images any time.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,11 +1,12 @@
 ---
 layout: page
 title: "Quick Start"
-description: "Install NodeTool, run a ready-made example, change it, and turn it into a small app anyone can use."
+description: "Install NodeTool, ask the agent to build a workflow, run a ready-made example, change it, and turn it into a small app anyone can use."
 ---
 
-Install NodeTool, open a ready-made example, run it, change it, and turn it into
-a form anyone can use. About 10 minutes. No account required.
+Install NodeTool, ask its agent to build something, open a ready-made example,
+change it, and turn it into a form anyone can use. About 10 minutes. No account
+required.
 
 This page assumes you have never used a tool like this. Every term is explained
 the first time it appears, and the [Glossary](glossary.md) covers the rest.
@@ -74,7 +75,37 @@ That works too, and it needs a download of several gigabytes per model. See
 
 ---
 
-## Step 2 — Run a ready-made example
+## Step 2 — Ask for what you want
+
+The fastest way in is to describe the result and let the agent build it. Click
+the **Chats** icon in the left rail, start a new thread, pick a model with the
+chip in the composer, and type something like:
+
+> Build me a workflow that takes a product photo and a short brief and writes
+> three ad captions for it.
+
+The agent plans a graph, checks it against the node library, saves it as a
+workflow, and runs it. The thread shows each step as it happens: the plan, every
+tool it calls, and what came back. When it finishes, open the workflow it made
+and you are looking at ordinary nodes and lines, the same as if you had placed
+them yourself.
+
+Three things worth knowing on the first try:
+
+- **The permission chip decides how far it goes on its own.** *Plan* proposes
+  without touching anything, *Default* asks before actions, *Auto* runs
+  everything. It is set per thread.
+- **It works on whatever you have open.** With a workflow, sketch, timeline, or
+  storyboard in front of you, ask for a change to *that* document: "add an
+  upscale step after the image node", "put the voiceover on a new audio track".
+- **You can stop and take over at any point.** Nothing it built is locked.
+
+Full details are in [Chat](global-chat.md) and
+[Chat & Agents](global-chat-agents.md).
+
+---
+
+## Step 3 — Run a ready-made example
 
 Everything you build lives on a **canvas**: a large open work area where you
 place boxes and draw lines between them.
@@ -126,7 +157,7 @@ being made instead of waiting for a finished file.
 
 ---
 
-## Step 3 — Change something
+## Step 4 — Change something
 
 The template is now yours. Change it, run it again, and see what happens. Every
 run uses whatever is on the canvas at that moment, so there is nothing to
@@ -140,6 +171,9 @@ rebuild or recompile.
 4. To watch any value anywhere in the workflow, press `Space` to open the node
    list, search for "Preview", and drop one onto the canvas. Connect a line into
    it and it will show whatever arrives.
+5. Or describe the change instead of making it: with the workflow open, ask the
+   agent in the Chats panel to "add a second image model and preview both".
+   It edits the graph in front of you, and you can undo it like any other edit.
 
 ### Finding more nodes
 
@@ -166,7 +200,7 @@ shared workflows run without setup.
 
 ---
 
-## Step 4 — Turn it into an app
+## Step 5 — Turn it into an app
 
 A **Mini-App** is the same workflow with the boxes and lines hidden. What's left
 is a plain form: fill in the fields, press a button, get the result. Hand it to
@@ -178,6 +212,10 @@ someone who should never have to look at a canvas.
 
 ![A Mini App running](assets/screenshots/mini-app-run.png)
 
+The agent builds these too. In the App Builder, ask it for the form you want —
+"a dropdown for tone, a big text box for the brief, and the result underneath" —
+and it places and wires the widgets.
+
 To design the form yourself, see [Mini Apps](mini-apps.md) for what they are,
 [Building Mini Apps](mini-apps-guide.md) for worked examples, and
 [App Builder](app-builder.md) for the editor.
@@ -186,10 +224,11 @@ To design the form yourself, see [Mini Apps](mini-apps.md) for what they are,
 
 ## What you just learned
 
-The four steps above are the loop NodeTool is built around: gather your files,
-build a workflow, produce something, and share it as a Mini-App.
+The steps above are the loop NodeTool is built around: gather your files, get a
+workflow built (by asking, or by hand), produce something, and share it as a
+Mini-App.
 
-Two other work areas plug into the same loop. The
+Two other work areas plug into the same loop, and the agent works in both. The
 [Sketch Editor](sketch-editor.md) is for still images built from layers, the way
 Photoshop works. The [Video Editor](video-editor.md) is for arranging video and
 audio clips over time. Anything any of them produces is a file NodeTool calls an
@@ -205,6 +244,7 @@ has the full picture with a diagram.
 
 | If you want to | Read |
 |------|------|
+| Get more out of the agent | [Chat](global-chat.md), [Chat & Agents](global-chat-agents.md) |
 | Understand how workflows work | [Key Concepts](key-concepts.md) |
 | Learn the interface | [User Interface](user-interface.md), [Workflow Editor](workflow-editor.md) |
 | See more examples | [Gallery](workflows/), [Cookbook](cookbook.md) |

--- a/docs/global-chat-agents.md
+++ b/docs/global-chat-agents.md
@@ -1,31 +1,60 @@
 ---
 layout: page
 title: "Chat & Agents"
-description: "Run workflows from chat, enable autonomous agents, and expose them through APIs."
+description: "The agent that builds your workflows, sketches, timelines, and apps — in the app, from the CLI, or over the API."
 ---
 
-Chat runs workflows, streams results, and runs the unified agent loop on every turn — the assistant plans and calls tools on its own as a task needs it. Jump to the right reference below.
+The agent is how most work in NodeTool starts. Describe the result, and it plans
+the graph, wires the nodes, picks models, runs it, and edits whatever document
+you have open. Every turn in chat runs the agent loop; there is no mode to
+switch on.
+
+## What it can build
+
+| Ask for | It works on | Reference |
+|---|---|---|
+| A workflow, a change to one, a fix | The node graph | [Workflow Editor](workflow-editor.md) |
+| A layer, a mask, a generated fill | The open sketch | [Sketch Editor](sketch-editor.md) |
+| A track, a cut, an animated clip | The open timeline | [Video Editor](video-editor.md) |
+| Shots, stills, clips, an assembled cut | The storyboard | [Creative Agent](creative-agent.md) |
+| Voiced lines and subtitles | The script | [Creative Agent](creative-agent.md) |
+| A form: fields, buttons, outputs | The mini app | [App Builder](app-builder.md) |
+
+It uses the same actions the interface offers, so every change is visible while
+it happens, and what it leaves behind is an ordinary document you can edit by
+hand.
 
 ## Core guides
 
-- **[Chat](global-chat.md)** — Interface layout, thread management, and how chat invokes workflows or tools.
-- **[NodeTool Agent System](global-chat.md#agent-mode)** — How planning, tool usage, and execution loops work under the hood.
-- **[Agent CLI](agent-cli.md)** — Run autonomous agents from the command line with YAML configuration files.
-- **[Chat CLI](chat-cli.md)** & **[Chat Server](chat-server.md)** — Automate conversations or integrate with custom frontends.
-- **[Chat API](chat-api.md)** — Programmatic access for running chats, streaming outputs, and issuing tool calls.
+- **[Chat](global-chat.md)** — The composer, threads, permission modes, and the agent loop.
+- **[Agent Memory](agent-memory.md)** & **[Long-Term Memory](long-term-memory.md)** — What it carries between turns and between threads.
+- **[Agent Config](agent-config-schema.md)** — The YAML schema behind configured agents.
+- **[Agent CLI](agent-cli.md)** — Run agents from the command line with a config file.
+- **[Chat CLI](chat-cli.md)** & **[Chat Server](chat-server.md)** — Automate conversations or drive a custom frontend.
+- **[Chat API](chat-api.md)** — Run chats, stream output, and issue tool calls from your own code.
 
 ## Typical flows
 
-1. **Run any saved workflow from chat**  
-   Save the workflow in the editor, open Chat, and choose a **workflow** in the composer.
+1. **Have it build a workflow from a description**
+   Open Chat, pick a model, say what the workflow should do. It plans, validates
+   the graph against the node library, saves the workflow, and runs it.
 
-2. **Let the agent plan complex tasks**  
-   The unified agent loop runs on every turn — the LLM decomposes goals into tasks and calls tools as needed. See the [Agent guide](global-chat.md#agent-mode).
+2. **Have it change what is in front of you**
+   With a workflow, sketch, or timeline open, ask for the edit: "add an upscale
+   step", "put the narration on a new audio track". It edits that document.
 
-3. **Run autonomous agents from command line**  
-   Use the [Agent CLI](agent-cli.md) to run agents for fully automated task execution.
+3. **Run a saved workflow from chat**
+   Save the workflow in the editor, then choose it in the composer or ask for it
+   by name. Results stream back into the thread.
 
-4. **Expose agents via APIs**  
-   Use the [Chat API](chat-api.md) from backend services so agents can operate in headless environments.
+4. **Set how much it does unattended**
+   The permission chip is per thread: *Plan* proposes only, *Default* asks
+   before actions, *Auto* runs everything. See
+   [Chat](global-chat.md#permission-modes).
 
-Ready to go deeper? Pair this with the [Cookbook](cookbook.md) for agent patterns or the [Deployment Guide](deployment.md) to move agents into production.
+5. **Run agents headlessly**
+   Use the [Agent CLI](agent-cli.md) for scripted runs, or the
+   [Chat API](chat-api.md) from a backend service.
+
+Pair this with the [Cookbook](cookbook.md) for agent patterns, or the
+[Deployment Guide](deployment.md) to move agents into production.

--- a/docs/global-chat.md
+++ b/docs/global-chat.md
@@ -1,19 +1,20 @@
 ---
 layout: page
 title: "Chat"
-description: "Chat with models, run agents, generate media, and trigger workflows."
+description: "Ask the agent to build workflows and edit your open documents, generate media, and run saved workflows."
 ---
 
-Chat is the always-on chat surface inside NodeTool. It talks to any provider, runs tools, kicks off agents, generates images, video, and speech, and triggers your saved workflows — all from one composer.
+Chat is where you tell NodeTool what to make. The agent behind it plans, calls tools, builds and edits the document you have open, generates images, video, and speech, and runs your saved workflows, all from one composer. It talks to any configured provider.
 
 ---
 
 ## Overview
 
+- Builds and edits workflows, sketches, timelines, storyboards, scripts, and mini apps
+- Every turn runs the agent loop; the assistant plans and calls tools as a task needs them
 - 20+ providers (OpenAI, Anthropic, Gemini, Ollama, …)
 - One composer for chat, image, video, and speech generation
 - Tools: web search, files, code execution, HTTP, and more
-- Every turn runs the agent loop — the assistant plans and calls tools on its own as a task needs it
 - Permission modes (Plan / Default / Auto) set how much the agent may do without asking
 - Run saved workflows from chat
 - Multiple threads, persistent history
@@ -129,6 +130,8 @@ When a request calls for it, the assistant can:
 
 | Capability | Examples |
 |------------|---------|
+| **Building workflows** | Plan a graph, validate it against the node library, save it, run it, debug what failed |
+| **Editing open documents** | Add a node, rewire an edge, add a timeline track, paint a sketch layer, place an app widget |
 | **Web research** | Search the web, browse pages, extract content |
 | **File operations** | Read, write, and organize files in your workspace |
 | **Code execution** | Run JavaScript in a sandboxed environment |
@@ -144,17 +147,42 @@ As the agent runs, the thread shows the task plan, each step's status as it star
 
 ---
 
-## Workflow Integration
+## Building and Editing From Chat
 
-You can ask the agent to run a saved workflow as part of a turn: it calls the workflow with your inputs and streams the results back into the chat. You can also ask it to build or modify workflows — it uses workspace tools to write the workflow configuration for you.
+### Building a workflow
 
-Save a workflow in the [workflow editor](workflow-editor.md) first, then reference it from chat.
+Describe what the workflow should do and the agent runs its build loop: plan the
+graph, validate it against the node library, save it as a workflow, run it, and
+debug whatever failed. The result is a normal workflow in your library, opened
+in the editor like any other.
 
-Inside the editor the same agent is one panel over, with the open graph as its
-subject — ask it to add a node, rewire a connection, or explain what a branch
-does.
+### Editing what you have open
+
+The agent reads the document in front of you and edits it with the same actions
+the interface offers. Ask it to add a node, rewire a connection, or explain what
+a branch does, and watch the change land on the canvas.
 
 ![Workflow assistant panel](assets/screenshots/editor-workflow-assistant.png)
+
+The same holds on every other surface:
+
+| Open document | Ask for |
+|---|---|
+| Workflow | "Add an upscale step after the image node and preview both." |
+| Sketch | "Add a shadow layer at 40% opacity, multiply blend." |
+| Timeline | "Put the narration on a new audio track and fade the last clip out." |
+| Storyboard | "Render stills for every shot, then clips for the ones I picked." |
+| Script | "Voice every draft line with the cast voices and send it to a timeline." |
+| Mini app | "Add a tone dropdown and show the result underneath the button." |
+
+Each editor tool names the document it acts on, so a request that targets
+something you don't have open comes back saying which documents are.
+
+### Running a saved workflow
+
+Choose a workflow in the composer, or ask for it by name. The agent calls it with
+your inputs and streams the results into the thread. Save the workflow in the
+[workflow editor](workflow-editor.md) first.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,13 @@
 ---
 layout: home
-description: "NodeTool — the open creative AI workspace. One node canvas for image, video, audio, and LLM models. Bring your own keys, or run locally."
+description: "NodeTool — the open creative AI workspace. Ask an agent to build the workflow, then take the controls. Image, video, audio, and LLM models on one canvas, with your own keys or local models."
 ---
 
 <section class="home-hero">
   <p class="eyebrow">The open creative AI workspace</p>
-  <h1>Every model. Your keys. Your canvas.</h1>
+  <h1>Ask for it. Then take the controls.</h1>
   <p class="lead">
-   NodeTool replaces the chatbox with a node canvas where image, video, audio, and LLM models run side by side. Bring your keys, or run everything locally. Open source, AGPL-3.0.
+   Describe what you want and NodeTool's agent builds it: a workflow, a layered image, a video cut, a small app. Everything it makes lands on a canvas you can open, inspect, and change by hand. Your keys or your own hardware. Open source, AGPL-3.0.
   </p>
   <img src="{{ '/assets/home.png' | relative_url }}" alt="NodeTool canvas" class="home-screenshot">
   <div class="cta-row">
@@ -16,6 +16,37 @@ description: "NodeTool — the open creative AI workspace. One node canvas for i
     <a href="{{ '/cookbook' | relative_url }}" class="cta-button ghost">Cookbook</a>
   </div>
 </section>
+
+## Start by asking
+
+One agent runs through the whole app. It reads the document you have open and
+edits it with the same actions you would use by hand, so its work is a normal
+workflow, sketch, or timeline afterwards. Nothing it builds is locked, and
+nothing it builds is hidden.
+
+<div class="pattern-grid">
+  <article class="pattern-card">
+    <h5>Say what you want</h5>
+    <p>"Turn this logline into a storyboard and a cut teaser." The agent picks nodes, wires them, chooses models, and runs it.</p>
+    <a href="{{ '/global-chat-agents' | relative_url }}">Chat &amp; Agents →</a>
+  </article>
+  <article class="pattern-card">
+    <h5>Watch it work</h5>
+    <p>Every step streams: the plan, each tool call, each node as it lights up. A permission chip sets whether it asks first.</p>
+    <a href="{{ '/global-chat' | relative_url }}#agent-mode">The agent loop →</a>
+  </article>
+  <article class="pattern-card">
+    <h5>Take over any time</h5>
+    <p>Click a node, change a value, rewire an edge, re-run. The graph is the source of truth for both of you.</p>
+    <a href="{{ '/workflow-editor' | relative_url }}">Workflow editor →</a>
+  </article>
+</div>
+
+The same agent works on every surface: the node graph, the [Sketch
+Editor]({{ '/sketch-editor' | relative_url }}), the [Video
+Editor]({{ '/video-editor' | relative_url }}), scripts and storyboards, and the
+[App Builder]({{ '/app-builder' | relative_url }}). Ask it to add a track, paint
+a layer, revise a shot, or wire a form field, and watch the document change.
 
 ## Featured use cases
 
@@ -58,13 +89,14 @@ story. [See all use cases →]({{ '/use-cases' | relative_url }})
 
 ## What you can do
 
+* **Have the agent build it** — Describe the outcome and it assembles the graph, picks the models, runs it, and reports what came back.
+* **Edit what it built** — Click a node, change a value, re-run. Nothing is generated behind glass; the graph is a file you own.
+* **Put agents inside the pipeline too** — An Agent node plans, calls tools, and streams, as one step of a larger workflow.
 * **Mix models from every vendor** — Wire Flux next to GPT-5.6 next to ElevenLabs in one graph. Pick the best model per step, not per project.
 * **Run frontier models locally** — Ollama, MLX, and GGUF on your hardware. Works offline. Files never leave your disk.
 * **Bring your own keys** — Pay OpenAI, Anthropic, Gemini, Replicate, FAL, and ElevenLabs directly. No credit markup, no provider tax.
 * **Ship a workflow as a Mini-App** — Hide the graph, expose just inputs and outputs. Share a link, no install required.
-* **Build agents that drive workflows** — Multi-step planning, tool calling, streaming. Drop them into any pipeline.
 * **Chat with your documents** — Local SQLite-vec, embeddings, RAG. Your data never leaves the machine.
-* **Iterate visually, not via prompts** — Click a node, change a value, re-run. Watch data flow through every edge.
 
 ## Studio or Cloud
 
@@ -109,7 +141,7 @@ Same code, same workflows. Both AGPL-3.0.
   </article>
   <article class="pattern-card">
     <h5>Agents</h5>
-    <p>Multi-step agents that plan, call tools, and drive pipelines.</p>
+    <p>Agents that plan, call tools, and drive pipelines — in chat or as a node.</p>
     <a href="{{ '/workflows/fetch-papers' | relative_url }}">Fetch Papers →</a>
   </article>
 </div>
@@ -120,14 +152,15 @@ More patterns — pipelines, data, RAG, email — in the [Cookbook]({{ '/cookboo
 
 <ol class="step-sequence">
   <li><a href="{{ '/installation' | relative_url }}">Download NodeTool</a> for macOS, Windows, or Linux.</li>
-  <li><a href="{{ '/getting-started' | relative_url }}#step-2--run-a-ready-made-example">Open a template, press Run.</a></li>
-  <li><a href="{{ '/getting-started' | relative_url }}#step-3--change-something">Edit, re-run, ship as a Mini-App.</a></li>
+  <li><a href="{{ '/getting-started' | relative_url }}#step-2--ask-for-what-you-want">Connect a provider and ask the agent for something.</a></li>
+  <li><a href="{{ '/getting-started' | relative_url }}#step-4--change-something">Open what it built, change it, ship it as a Mini-App.</a></li>
 </ol>
 
 ## Explore
 
 - **New here:** [Getting Started]({{ '/getting-started' | relative_url }}) · [Key Concepts]({{ '/key-concepts' | relative_url }}) · [UI]({{ '/user-interface' | relative_url }})
-- **Building:** [Chat & Agents]({{ '/global-chat-agents' | relative_url }}) · [Cookbook]({{ '/cookbook' | relative_url }}) · [Examples]({{ '/workflows/' | relative_url }})
+- **Working with the agent:** [Chat]({{ '/global-chat' | relative_url }}) · [Chat & Agents]({{ '/global-chat-agents' | relative_url }}) · [Agent Memory]({{ '/agent-memory' | relative_url }})
+- **Building:** [Cookbook]({{ '/cookbook' | relative_url }}) · [Examples]({{ '/workflows/' | relative_url }}) · [Mini Apps]({{ '/mini-apps' | relative_url }})
 - **Self-hosting:** [Deployment]({{ '/deployment' | relative_url }}) · [Configuration]({{ '/configuration' | relative_url }}) · [API]({{ '/api-reference' | relative_url }})
 - **Extending:** [Developer Guide]({{ '/developer/' | relative_url }}) · [Custom Nodes]({{ '/developer/node-reference' | relative_url }}) · [CLI]({{ '/cli' | relative_url }})
 

--- a/docs/key-concepts.md
+++ b/docs/key-concepts.md
@@ -16,6 +16,9 @@ A visual way to use AI. Instead of writing code, you place boxes on a page and
 draw lines between them. Each box does one job, and the lines carry results from
 one box to the next.
 
+- **You can ask instead of place.** An agent lives in the app and builds those
+  boxes and lines for you when you describe what you want. What it produces is
+  the same picture you would have drawn, so you can read it and change it.
 - **It runs on your computer.** Models that run locally use your own hardware,
   and what they produce stays on your disk.
 - **You bring your own accounts.** When a workflow uses an online AI service
@@ -30,6 +33,24 @@ one box to the next.
 ---
 
 ## The building blocks
+
+### The agent
+
+The **agent** is the assistant you talk to in the Chats panel. Give it a goal in
+plain English and it works out the steps, calls tools, and edits your documents:
+it plans a graph, checks it against the node library, saves it as a workflow,
+runs it, and tells you what came back.
+
+Two things make it different from a chatbot that writes instructions for you:
+
+- **It acts on the document you have open.** A workflow, a sketch, a timeline, a
+  storyboard, a script, a mini app. It uses the same actions the interface
+  offers, so you see each change land and can undo it.
+- **It leaves everything editable.** There is no generated artifact you can only
+  regenerate. Whatever it builds, you can open, read, and rewire.
+
+A permission chip on each thread sets how far it may go on its own: propose
+only, ask before acting, or run everything. See [Chat](global-chat.md).
 
 ### Nodes
 
@@ -111,12 +132,13 @@ Timelines are where results become finished media:
 - Regenerate a generated clip after you change its settings.
 - Export the whole sequence as a video asset.
 
-### Agents
+### Agent nodes
 
-An **agent** node takes a goal written in plain English, works out the steps
-itself, and uses tools such as web search, file access, or running code to get
-there. Use one when you can describe the outcome but not the exact steps. A
-normal node does one fixed thing; an agent decides what to do.
+The agent above builds workflows. An **Agent node** is an agent placed *inside*
+one: it takes a goal written in plain English, works out the steps itself, and
+uses tools such as web search, file access, or running code to get there. Use
+one when a step of your pipeline is describable but not scriptable. A normal
+node does one fixed thing; an Agent node decides what to do.
 
 ### Mini-Apps
 
@@ -144,6 +166,8 @@ Most work in NodeTool follows one loop:
 
 The editors are separate because painting an image and cutting a video are
 different problems, but they share one pool of assets and one set of AI services.
+The agent works in every one of them, so any step of the loop is something you
+can do by hand or ask for.
 
 {% mermaid %}
 graph LR
@@ -212,6 +236,8 @@ the one step that needs it while the rest runs locally.
 | **Clip** | One piece of media placed on a timeline track |
 | **Generated clip / layer** | A clip or layer produced by a workflow instead of imported |
 | **Stale** | A generated result whose settings changed since it was last produced |
+| **Agent** | The assistant you ask for changes, and the node that plans its own steps |
+| **Permission mode** | How far the agent may act without asking: Plan, Default, or Auto |
 | **Model** | The trained AI a node calls |
 | **Provider** | Whoever runs the model: your own machine, OpenAI, FAL, and so on |
 
@@ -277,6 +303,7 @@ See the [Developer Guide](developer/) and
 ## Next
 
 - [Quick Start](getting-started.md) — run something in 10 minutes
+- [Chat](global-chat.md) — the agent, its tools, and permission modes
 - [Glossary](glossary.md) — single-word definitions
 - [Workflow Editor](workflow-editor.md)
 - [Asset Management](asset-management.md)

--- a/docs/user-interface.md
+++ b/docs/user-interface.md
@@ -219,13 +219,15 @@ When you select a node, the right panel shows its **configuration**:
 
 ## Chat
 
-AI assistant built into NodeTool.
+The agent that builds and edits your documents, one panel over from whatever you
+have open.
 
 ![Chat Interface](assets/screenshots/global-chat-interface.png)
 
 ### Features
 
-- **Chat** with AI models
+- **Build a workflow** from a description, then open and edit it
+- **Edit the open document** – graph, sketch, timeline, storyboard, script, or mini app
 - **Run workflows** from conversation
 - **Agent loop** for autonomous, multi-step task execution
 - **File sharing** – images, audio, documents


### PR DESCRIPTION
The docs opened with the canvas and treated the agent as one feature among several. That is no longer how people start using NodeTool: the chat agent plans a graph, validates it against the node library, saves it, runs it, and edits whatever document is open (graph, sketch, timeline, storyboard, script, mini app). This reframes the entry points around that, without dropping the canvas story — the point is that what the agent builds stays editable.

## Changes

- **`docs/index.md`** — New hero ("Ask for it. Then take the controls."), a `Start by asking` section above the use cases (say what you want / watch it work / take over), agent-led `What you can do` bullets, get-started steps that begin with asking, and a "Working with the agent" row in Explore.
- **`docs/getting-started.md`** — New **Step 2 — Ask for what you want**: open Chats, pick a model, describe a workflow, watch the build loop. Covers the permission chip and editing the open document. Later steps renumbered (3 run a template, 4 change something, 5 turn it into an app), with asking added as an alternative in step 4 and the App Builder assistant noted in step 5.
- **`docs/key-concepts.md`** — The agent added as a building block (acts on the open document, leaves everything editable); the old "Agents" section becomes "Agent nodes", framed as the in-pipeline case; glossary rows for Agent and permission mode.
- **`docs/global-chat.md`** — Intro and overview lead with building/editing; new "Building and Editing From Chat" section with a per-surface table of what to ask for; capability rows for building workflows and editing open documents.
- **`docs/global-chat-agents.md`** — Rewritten as an agent hub: what it can build per surface, core guides, typical flows.
- **`docs/comparisons.md`**, **`docs/user-interface.md`** — Same framing; no claims added about other products.

## Notes

- Claims are checked against the code: the resident chat toolbelt (`plan_workflow_graph` → `validate_workflow` → `create_workflow` → `debug_workflow` in `packages/websocket/src/unified-websocket-runner.ts`) and the registered frontend tools (`web/src/lib/tools/builtin/index.ts` — graph, timeline, storyboard, sketch, script, 3D, app).
- Anchor links updated together: `index.md` points at the renumbered `#step-2--ask-for-what-you-want` and `#step-4--change-something`; no other file linked those anchors.
- Markdown only, so no code checks apply. Prose follows `docs/WRITING_STYLE.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1DnH5BRzPdjXdpMmdkZ94)_