### PR TITLE
docs+marketing: retell "Why NodeTool" and the /vs pages around the agent-first story

### DIFF
--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,12 +1,36 @@
 ---
 layout: page
 title: "Why NodeTool: Comparisons vs ComfyUI, n8n & More"
-description: "The problems NodeTool solves for creative teams, plus head-to-head comparisons: NodeTool vs ComfyUI, Dify, Flowise, Langflow, n8n, and Figma Weave (formerly Weavy)."
+description: "Why NodeTool exists, what agent-first means, and head-to-head comparisons: NodeTool vs ComfyUI, Dify, Flowise, Langflow, n8n, and Figma Weave (formerly Weavy)."
 ---
 
-> NodeTool is the open creative AI workspace — every major model, your keys, one canvas.
+> NodeTool is the open-source, agent-first creative AI workspace — every major model, your keys, one canvas.
 
-NodeTool replaces the chatbox with a node canvas where image, video, audio, and LLM models run side by side. Bring your keys, or run everything locally. Open source, AGPL-3.0.
+## The day NodeTool replaces
+
+Say you're making a thirty-second product video. The storyboard prompts live in a ChatGPT tab. The stills come from a Flux tab, downloaded one by one. You upload each still to a video model, download the clips, drag them into an editor on your desktop, then open a fourth tab for music. Four subscriptions, a downloads folder full of `final_v3.png`, and when the client asks for a warmer version next Tuesday, the recipe exists only in your chat history and your memory.
+
+None of those tools is bad. They just don't compose:
+
+* **Every model lives behind its own UI.** Moving between them means downloading, re-uploading, and re-explaining context. Outputs don't flow into inputs.
+* **SaaS canvases tax every token.** Hosted creative tools mark up provider credits 2–5x. You pay for the same OpenAI call twice.
+* **Local-only tools are model-narrow.** ComfyUI gives you diffusion internals but treats LLMs, agents, and cloud APIs as second-class.
+* **Nothing is reproducible.** Prompts in chat history, settings in screenshots, the pipeline in your head.
+* **Privacy is a yes/no toggle.** Either everything goes to a vendor, or nothing leaves your machine. No mixed mode.
+
+## The same day on one canvas
+
+In NodeTool, that video is one graph. The script prompt feeds GPT-5.6, the shot descriptions feed Flux, the stills feed Wan, the voiceover comes from ElevenLabs, and every hop is a typed edge — image, audio, text, embeddings — not a paste. Warmer version? Change one prompt node and rerun. The whole pipeline is a file you can save, version, share, or hand to a client as a Mini-App with the graph hidden.
+
+Your keys stay yours. OpenAI, Anthropic, Gemini, Replicate, FAL, Kie, ElevenLabs, MiniMax, HuggingFace — you pay each provider its list price, with no credit markup. And local and cloud mix per node: run Llama on MLX for the script, route the render to FAL, keep the client's source footage on disk.
+
+## You don't have to wire it yourself
+
+Here is the part the comparison tables miss. NodeTool is agent-first: every editor — the node canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools, around 120 in all. Describe the pipeline and an agent authors the graph: picks the nodes, wires the edges, selects the models, and validates the result before anything runs. What it leaves behind is a workflow you can inspect, edit, and rerun, not a chat transcript.
+
+The agent stays on the job after the build. Supervised runs put it on the failure path — when a step fails mid-run it decides whether to retry, repair the output, skip the item, or stop, inside a decision and cost budget you set, with every intervention logged. And the toolbelt speaks MCP, so Claude Desktop, Claude Code, or any MCP-aware agent can drive the same surfaces you click.
+
+Other tools bolt a chat panel onto an editor. NodeTool built the editor as something an agent can operate.
 
 ## Head-to-head comparisons
 
@@ -19,34 +43,6 @@ Full write-ups against specific tools:
 - [NodeTool vs n8n](https://nodetool.ai/vs/n8n) — app-to-app automation vs workflows built to generate media and run agents.
 - [NodeTool vs Weavy](https://nodetool.ai/vs/weavy) — SaaS credits and a curated model roster vs open source, BYOK, no lock-in.
 - [NodeTool vs Figma Weave](https://nodetool.ai/vs/figma-weave) — Weavy's new life inside Figma: hosted, credit-billed, ecosystem-bound vs open source and BYOK.
-
-## The problem
-
-Creative AI is a tab graveyard:
-
-* **Every model lives behind its own UI.** Switching between Flux, ElevenLabs, Sora, and a chatbot means losing context every time. Outputs don't compose.
-* **SaaS canvases tax every token.** Hosted creative tools mark up provider credits 2–5x. You pay for the same OpenAI call twice.
-* **Local-only tools are model-narrow.** ComfyUI nails diffusion internals but treats LLMs, agents, and cloud APIs as second-class.
-* **Workflows aren't portable.** Prompts in chat history, settings in screenshots, pipelines in your head. Nothing is reproducible.
-* **Privacy is a yes/no toggle.** Either everything goes to a vendor, or nothing leaves your machine. No mixed mode.
-
-## How NodeTool solves this
-
-One canvas, every model, your keys:
-
-**One canvas for every modality.** Wire Flux to GPT-5.6 to ElevenLabs to Wan in a single graph. Outputs flow as typed edges — image, audio, text, embeddings — not pasted strings.
-
-**BYOK to every provider.** OpenAI, Anthropic, Gemini, Replicate, FAL, Kie, ElevenLabs, MiniMax, HuggingFace. Pay them directly. No credit markup, no provider lock-in.
-
-**Local + cloud, mixed.** Run Llama on MLX, route image gen to FAL, send audio to ElevenLabs — in one workflow. Toggle per node.
-
-**Workflows as files.** Save, share, version. Ship a workflow as a Mini-App with a one-click hide-the-graph mode.
-
-**Agents that drive pipelines.** Built-in planning, tool calling, streaming. Drop an agent node into any graph.
-
-**Open source, no markup.** AGPL-3.0. Cloud edition hosts the same code in this repo. Self-host the Docker images any time.
-
----
 
 ## Feature Comparison
 
@@ -62,7 +58,9 @@ One canvas, every model, your keys:
 | **Video generation** | Local: Wan · API: FAL, Kie, Sora, Veo, Kling | Cloud: Kling, Veo, Runway, etc. | Local diffusion video (AnimateDiff, etc.) |
 | **Audio & music** | Local: MusicGen, AudioLDM, Stable Audio · API: Kie, ElevenLabs, MiniMax | Cloud: Suno, ElevenLabs, etc. | ⚠️ Via custom nodes |
 | **TTS / ASR** | Local: Kokoro, Sesame, Whisper · API: OpenAI, ElevenLabs | Cloud only | ⚠️ Via custom nodes |
+| **Agent-first editing** | ✅ Every editor exposed as agent tools (~120); agents build, run, and repair workflows | ❌ | ❌ |
 | **LLMs & agents** | Built-in agent nodes, tool calling, streaming, Ollama, MLX | Limited LLM nodes | ⚠️ Via custom nodes |
+| **MCP server** | ✅ Claude Desktop, Claude Code, any MCP agent | ❌ | ❌ |
 | **Diffusion control** | Standard parameters | ❌ Hidden behind presets | ✅ Latents, VAE, samplers, ControlNet |
 | **RAG / vector search** | ✅ Local SQLite-vec, plus Pinecone & Supabase pgvector | ❌ | ❌ |
 | **Mini-apps from workflows** | ✅ Turn a graph into a simple UI | ⚠️ Share-as-template | ❌ |
@@ -71,7 +69,7 @@ One canvas, every model, your keys:
 
 ### When to pick each
 
-**NodeTool** — every modality, every provider, on one canvas. Local, cloud, or mixed.
+**NodeTool** — every modality, every provider, on one canvas, with an agent that can build and repair the pipeline for you. Local, cloud, or mixed.
 
 **Figma Weave** (formerly Weavy) — hosted SaaS if you want a managed product with credits inside the Figma ecosystem and don't need BYOK, local execution, or open source.
 

--- a/marketing/src/data/competitorEntries.ts
+++ b/marketing/src/data/competitorEntries.ts
@@ -10,9 +10,11 @@ import type { OgAccent } from "../lib/og";
  * tool list, the same feature table, and a visible FAQ).
  *
  * The six original competitors (comfyui, weavy, langflow, n8n, flowise, dify)
- * are transcribed verbatim from the hand-built pages they replaced — content
- * parity was the review bar. The first-wave additions (`isNew`) are drafted
- * from the same pattern and carry at least one honest concession row.
+ * started as verbatim transcriptions of the hand-built pages they replaced;
+ * the prose has since been rewritten for narrative flow and the agent-first
+ * positioning (an agent builds, runs, and repairs workflows on the same
+ * editors you use). The first-wave additions (`isNew`) follow the same
+ * pattern and carry at least one honest concession row.
  */
 
 /** Page accent — full literal Tailwind fragments so the JIT compiler keeps them. */
@@ -153,7 +155,7 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "The open creative AI workspace, not just a diffusion editor.",
     heroParagraph:
-      "ComfyUI is a node editor for Stable Diffusion, built with an an interface built for engineers. NodeTool is the studio around it: image, video, music, and words on one canvas, a far wider list of models, and the editing tools creatives reach for — called with your own keys at provider prices. Both are open source, and both work by connecting blocks on a canvas.",
+      "ComfyUI will hand you the sampler, the VAE, and the latents — if your project ends at a diffusion image, nothing goes deeper. Most projects don't end there. The still becomes a clip, the clip needs a voice, the voice needs music, and suddenly you're out of the graph and back in the tab-switching business. NodeTool is the studio for that whole arc: image, video, music, and words on one canvas, every major provider on your own keys at provider prices, and an agent that can wire the graph for you. Both are open source.",
     competitorTagline: "Node editor for diffusion images",
     competitorBullets: [
       "Deep control over Stable Diffusion pipelines",
@@ -166,7 +168,8 @@ export const competitors: Competitor[] = [
       "Image, video, audio, and text on one canvas",
       "Every major model from every major provider",
       "Editing tools: masks, inpaint, relight, layers",
-      "your own keys at provider prices — no credits, no markup",
+      "Agent-first: describe the pipeline and an agent builds and runs it",
+      "Your own keys at provider prices — no credits, no markup",
     ],
     rows: [
       { label: "Media types", competitor: "Diffusion images", nodetool: "Image, video, audio, text" },
@@ -179,7 +182,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "One canvas for everything, not just images",
     explainerParagraph:
-      "If your work starts and ends with Stable Diffusion images, ComfyUI gives you fine-grained control. But most creative projects span more than one medium — image into video, voice and music into a cut, words into everything. NodeTool keeps all of it on one visual canvas with masks, inpaint, outpaint, relight, upscale, layers, and compositing built in. You call every major model with your own keys at provider prices, and run locally via Ollama, MLX, and llama.cpp.",
+      "If your work starts and ends with Stable Diffusion images, ComfyUI gives you fine-grained control, and nothing here will pry it from your hands. But most creative projects span more than one medium: image into video, voice and music into a cut, words into everything. NodeTool keeps all of it on one visual canvas with masks, inpaint, outpaint, relight, upscale, layers, and compositing built in. And you don't have to place every node yourself — NodeTool is agent-first, so you can describe the pipeline and an agent authors the graph, picks the models, and repairs what fails, leaving behind a workflow you can inspect and rerun. You call every major model with your own keys at provider prices, and run locally via Ollama, MLX, and llama.cpp.",
     ctaHeading: "Open, complete, and yours.",
     ctaParagraph:
       "Download Studio and build across image, video, audio, and text in one place.",
@@ -187,7 +190,7 @@ export const competitors: Competitor[] = [
       {
         question: "What is the difference between NodeTool and ComfyUI?",
         answer:
-          "ComfyUI is a node editor focused on Stable Diffusion and diffusion image generation with an an interface built for engineers. NodeTool is the studio around it: image, video, music, and text on one visual canvas, a much wider list of models across providers and media types, and editing tools creatives actually use — called with your own keys at provider prices. Both are open source, and both work by connecting blocks on a canvas.",
+          "ComfyUI is a node editor focused on Stable Diffusion and diffusion image generation with an interface built for engineers. NodeTool is the studio around it: image, video, music, and text on one visual canvas, a much wider list of models across providers and media types, and editing tools creatives actually use — called with your own keys at provider prices. Both are open source, and both work by connecting blocks on a canvas.",
       },
       {
         question: "Is NodeTool open source like ComfyUI?",
@@ -227,7 +230,7 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Open source and your own keys. No credits, no lock-in.",
     heroParagraph:
-      "Weavy is now Figma Weave — Figma acquired it in October 2025 — and it remains a closed SaaS canvas with a credit system and a curated list of models. NodeTool is open source and runs on your own keys: every provider, your keys, provider prices, and you own your workflows and files. Cloud is just managed hosting of the same open-source code you can self-host.",
+      "One morning in October 2025, Weavy users woke up to a new name, a new owner, and the same old credit meter. Figma acquired Weavy, renamed it Figma Weave, and the canvas stayed what it always was: closed, hosted, and billed in credits, with a model list someone else curates. NodeTool takes the opposite bet — open source, your own keys at provider prices, workflows and files you own, and an agent-first workspace where an agent can build the pipeline for you. Cloud is just managed hosting of the same code you can self-host.",
     competitorTagline: "Closed SaaS canvas, now Figma Weave",
     competitorBullets: [
       "Credit system you top up and burn",
@@ -238,9 +241,10 @@ export const competitors: Competitor[] = [
     competitorBulletTone: "negative",
     nodetoolTagline: "Open source · your keys",
     nodetoolBullets: [
-      "your own keys — pay providers directly at list prices",
+      "Your own keys — pay providers directly at list prices",
       "Every major model from every major provider",
       "Open source under AGPL-3.0, self-hostable",
+      "Agent-first: an agent builds, runs, and repairs workflows",
       "You own your workflows and files",
     ],
     rows: [
@@ -253,7 +257,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "Pay providers, not credits — and keep your work",
     explainerParagraph:
-      "Credit systems and hand-picked list of modelss decide which models you can use and what each call costs. NodeTool flips that: you add your own API keys and pay each provider their published list price. The whole workspace is open source under AGPL-3.0, so you can run it as a desktop app or self-host it, and your workflows and files stay yours. NodeTool Cloud is managed hosting of the same code.",
+      "Credit systems and curated model lists decide which models you can use and what each call costs — and after an acquisition, someone else's roadmap decides everything else. NodeTool flips that: you add your own API keys and pay each provider their published list price. The workspace is agent-first, so you can describe what you want and an agent authors the workflow, runs it, and repairs what fails on the same canvas you use. All of it is open source under AGPL-3.0 — run it as a desktop app or self-host it, and your workflows and files stay yours. NodeTool Cloud is managed hosting of the same code.",
     ctaHeading: "Own your canvas.",
     ctaParagraph:
       "Download Studio and build with every provider, at provider prices.",
@@ -271,7 +275,7 @@ export const competitors: Competitor[] = [
       {
         question: "Does NodeTool use credits?",
         answer:
-          "No. NodeTool runs on your own keys — you bring your own API keys and pay each provider their list price directly. There are no credits, no markup, and no hand-picked list of models of models.",
+          "No. NodeTool runs on your own keys — you bring your own API keys and pay each provider their list price directly. There are no credits, no markup, and no hand-picked model list.",
       },
       {
         question: "Can I self-host NodeTool?",
@@ -305,7 +309,7 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "The open-source alternative to Figma Weave.",
     heroParagraph:
-      "Figma Weave — the canvas formerly known as Weavy — is a polished hosted tool with a curated frontier-list of models, billed in its own AI credits and moving deeper into the Figma platform. NodeTool covers the same visual media workflows in the open: AGPL-3.0 source, your own keys at provider prices, a desktop app you can run offline with local models, and workflows and files that stay yours.",
+      "Figma Weave — the canvas formerly known as Weavy — is a polished hosted tool with a curated frontier model list, billed in its own AI credits and moving deeper into the Figma platform with every release. That's fine until the day a model you rely on drops off the list, or the credit math changes, or the roadmap bends toward Figma's plans instead of yours. NodeTool covers the same visual media workflows in the open: AGPL-3.0 source, your own keys at provider prices, an agent that can build the pipeline for you, a desktop app that runs offline with local models, and workflows and files that stay yours.",
     competitorTagline: "Hosted AI canvas in the Figma ecosystem",
     competitorBullets: [
       "Billed in Figma Weave AI credits",
@@ -316,9 +320,10 @@ export const competitors: Competitor[] = [
     competitorBulletTone: "negative",
     nodetoolTagline: "Open source · your keys",
     nodetoolBullets: [
-      "your own keys — pay providers directly at list prices",
+      "Your own keys — pay providers directly at list prices",
       "Every major model from every major provider",
       "Open source under AGPL-3.0 — desktop app or self-host",
+      "Agent-first: an agent builds, runs, and repairs workflows",
       "Local models via Ollama, MLX, and llama.cpp",
     ],
     rows: [
@@ -332,7 +337,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "Own the canvas, not a seat in an ecosystem",
     explainerParagraph:
-      "Acquisitions change products: pricing, list of modelss, and roadmaps for Figma Weave now follow Figma's platform strategy, and your workflows live on their servers either way. NodeTool takes the opposite bet. The whole workspace is open source under AGPL-3.0, workflows are files you own, and models are called with your own API keys at each provider's published price — or run locally with Ollama, MLX, and llama.cpp. If the tool changes direction, you keep the code, the graphs, and the keys.",
+      "Acquisitions change products: pricing, model lists, and roadmaps for Figma Weave now follow Figma's platform strategy, and your workflows live on their servers either way. NodeTool takes the opposite bet. The whole workspace is open source under AGPL-3.0, workflows are files you own, and models are called with your own API keys at each provider's published price — or run locally with Ollama, MLX, and llama.cpp. It is also agent-first: every editor is exposed to agents as tools, so you can describe a pipeline and an agent wires it, runs it, and repairs what fails. If the tool changes direction, you keep the code, the graphs, and the keys.",
     ctaHeading: "Build on a canvas nobody can acquire.",
     ctaParagraph:
       "Download Studio — open source, your own keys, every provider at provider prices.",
@@ -380,7 +385,7 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Agents that ship media, not just messages.",
     heroParagraph:
-      "Langflow is a drag-and-drop builder for chatbot and agent apps, covering chat, document search, and agents, rooted in Python and LangChain. NodeTool covers that same ground and adds what Langflow leaves to external APIs: native image, video, and music generation with editing tools on the same canvas. Open source, your own keys at provider prices, local models included.",
+      "Your Langflow agent can answer from a thousand documents. Now ask it for a storyboard, and watch the flow end at a blank HTTP node waiting for an API you'll wire by hand. Langflow is a capable drag-and-drop builder for chat, document search, and agents, rooted in Python and LangChain — but its agents ship messages, not media. NodeTool covers that same ground and keeps going: native image, video, and music generation with editing tools on the same canvas, and an agent that can build the whole pipeline itself. Open source, your own keys at provider prices, local models included.",
     competitorTagline: "Drag-and-drop builder for chatbot and agent apps",
     competitorBullets: [
       "Visual flows for chatbots, document search, and agents",
@@ -393,7 +398,8 @@ export const competitors: Competitor[] = [
       "Agents, document search, and chat on the same canvas",
       "Native image, video, and music generation nodes",
       "Editing tools: masks, inpaint, relight, layers",
-      "your own keys at provider prices — local models via Ollama, MLX, llama.cpp",
+      "Agent-first: describe the pipeline and an agent builds and runs it",
+      "Your own keys at provider prices — local models via Ollama, MLX, llama.cpp",
     ],
     rows: [
       { label: "Focus", competitor: "chatbot and agent apps: chat, document search, agents", nodetool: "Agents + image, video, audio, text" },
@@ -407,7 +413,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "The pipeline and the picture, on one canvas",
     explainerParagraph:
-      "If your project ends at a chatbot or a document question-answering, Langflow is a solid choice — visual flows, Python extensibility, a mature LangChain ecosystem. But the moment an agent needs to produce something you can look at or listen to — a storyboard, a product video, a soundtrack — Langflow hands you an API key form and a blank HTTP node. NodeTool keeps going: generation nodes for image, video, and music from every major provider sit on the same canvas as your agents and retrieval, with masks, inpaint, relight, upscale, and layers built in. You bring your own keys and pay provider list prices — no credits, no markup — and run local models via Ollama, MLX, and llama.cpp on the desktop.",
+      "If your project ends at a chatbot or document question-answering, Langflow is a solid choice — visual flows, Python extensibility, a mature LangChain community. But the moment an agent needs to produce something you can look at or listen to — a storyboard, a product video, a soundtrack — Langflow hands you an API key form and a blank HTTP node. NodeTool keeps going: generation nodes for image, video, and music from every major provider sit on the same canvas as your agents and retrieval, with masks, inpaint, relight, upscale, and layers built in. And the agents don't just live in the workflow, they build it: NodeTool is agent-first, so you can describe a pipeline and an agent authors the graph, validates it, and repairs what fails. You bring your own keys and pay provider list prices — no credits, no markup — and run local models via Ollama, MLX, and llama.cpp on the desktop.",
     ctaHeading: "Build agents that make things.",
     ctaParagraph:
       "Download Studio and put generation on the same canvas as your agents.",
@@ -454,7 +460,7 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Workflows that create, not just connect.",
     heroParagraph:
-      "n8n moves data between hundreds of business apps — schedules, retries, branching. NodeTool is built for workflows where the AI work is the point: native image, video, and music generation, agents, and editing tools on one canvas. Open source under AGPL-3.0, your own keys at provider prices, with a desktop app and local models.",
+      "n8n is what you reach for when a record has to travel from Salesforce to Slack to a spreadsheet, every night, without fail. But try to make the workflow produce something — a product video, a batch of campaign images, a soundtrack — and the creative step collapses into a generic HTTP node calling an API you configured by hand. NodeTool is built for workflows where the AI work is the point: native image, video, and music generation, agents, and editing tools on one canvas, with an agent that can author the pipeline for you. Open source under AGPL-3.0, your own keys at provider prices, with a desktop app and local models.",
     competitorTagline: "Workflow automation platform",
     competitorBullets: [
       "400+ integrations for business apps",
@@ -466,8 +472,9 @@ export const competitors: Competitor[] = [
     nodetoolBullets: [
       "Native image, video, and music generation nodes",
       "Agents and document search on the same canvas as generation",
+      "Agent-first: describe the pipeline and an agent builds and runs it",
       "Open source under AGPL-3.0, desktop app included",
-      "your own keys at provider prices — no credits, no markup",
+      "Your own keys at provider prices — no credits, no markup",
     ],
     rows: [
       { label: "Focus", competitor: "App-to-app automation", nodetool: "AI generation + agents" },
@@ -481,7 +488,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "Plumbing is solved. Production isn't.",
     explainerParagraph:
-      "If the hard part of your workflow is moving records between Salesforce, Slack, and a spreadsheet on a schedule, n8n is built for exactly that. But when the workflow's output is the thing itself — a product video, a batch of campaign images, a soundtrack, an agent's research report — the generation can't live in a generic HTTP node. NodeTool makes it native: image, video, and music models from every major provider as built-in blocks, agents and retrieval on the same canvas, and editing tools — masks, inpaint, relight, upscale, layers — built in. It's open source under AGPL-3.0 rather than fair-code, runs as a desktop app on macOS, Windows, and Linux, and calls models with your own keys at provider list prices.",
+      "If the hard part of your workflow is moving records between Salesforce, Slack, and a spreadsheet on a schedule, n8n is built for exactly that. But when the workflow's output is the thing itself — a product video, a batch of campaign images, a soundtrack, an agent's research report — the generation can't live in a generic HTTP node. NodeTool makes it native: image, video, and music models from every major provider as built-in blocks, agents and retrieval on the same canvas, and editing tools — masks, inpaint, relight, upscale, layers — built in. It is also agent-first: describe the pipeline and an agent authors the graph, runs it, and repairs what fails, so the automation can build itself. Open source under AGPL-3.0 rather than fair-code, it runs as a desktop app on macOS, Windows, and Linux and calls models with your own keys at provider list prices.",
     ctaHeading: "Make the workflow the studio.",
     ctaParagraph:
       "Download Studio and generate image, video, and music where your agents already work.",
@@ -528,7 +535,7 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "The chatbot, plus everything it needs to produce.",
     heroParagraph:
-      "Flowise is the fastest drag-and-drop path to a LangChain chatbot that answers from your documents. NodeTool covers the same agent and retrieval ground, then adds native image, video, and music generation and editing tools on the same canvas — open source under AGPL-3.0, your own keys at provider prices, with a desktop app and local models.",
+      "Flowise gets you from zero to a document-answering chatbot in an afternoon: vector store, retriever, LLM node, done. Then the client asks for the demo video, the launch images, a voice for the assistant — and every one of those lands outside the flow, in a raw HTTP node or another tool entirely. NodeTool covers the same agent and retrieval ground, then keeps the whole deliverable on one canvas: native image, video, and music generation, editing tools, and an agent that can build the pipeline itself. Open source under AGPL-3.0, your own keys at provider prices, with a desktop app and local models.",
     competitorTagline: "Drag-and-drop LangChain builder",
     competitorBullets: [
       "Fastest path to a chatbot that answers from your documents",
@@ -540,8 +547,9 @@ export const competitors: Competitor[] = [
     nodetoolBullets: [
       "Agents, document search, and native image/video/music generation",
       "Built-in editing tools — masks, inpaint, relight, layers",
+      "Agent-first: describe the pipeline and an agent builds and runs it",
       "Open source under AGPL-3.0, desktop app included",
-      "your own keys at provider prices — no credits, no markup",
+      "Your own keys at provider prices — no credits, no markup",
     ],
     rows: [
       { label: "Focus", competitor: "LangChain chatbots & document search", nodetool: "AI generation + agents" },
@@ -555,7 +563,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "A chatbot is often just the front door.",
     explainerParagraph:
-      "Flowise is genuinely fast at what it's built for: wire a vector store, a retriever, and an language model node into a working chatbot that answers from your documents in minutes. But the moment the workflow needs to produce something — a rendered image, a video cut, a voice line — that step lands in a generic HTTP node calling an external API by hand. In NodeTool, image, video, and music models from every major provider sit on the same canvas as the agent and retrieval nodes, with masks, inpaint, relight, upscale, and layers built in — every call on your own keys at list price, no credit tiers on top.",
+      "Flowise is genuinely fast at what it's built for: wire a vector store, a retriever, and a language model node into a working chatbot that answers from your documents in minutes. But the moment the workflow needs to produce something — a rendered image, a video cut, a voice line — that step lands in a generic HTTP node calling an external API by hand. In NodeTool, image, video, and music models from every major provider sit on the same canvas as the agent and retrieval nodes, with masks, inpaint, relight, upscale, and layers built in. The workspace is agent-first too: describe what the chatbot and its media pipeline should do, and an agent wires the graph, validates it, and repairs what fails. Every call runs on your own keys at list price, no credit tiers on top.",
     ctaHeading: "Build the chatbot. Ship the media too.",
     ctaParagraph:
       "Download Studio and put generation on the same canvas as your agents and retrieval.",
@@ -602,7 +610,7 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Text apps are the floor, not the ceiling.",
     heroParagraph:
-      "Dify is a strong platform for text-first chatbot and agent apps — prompt management, knowledge bases, agent debugging. NodeTool starts from the same agent and document-search ground, then puts native image, video, and music generation and editing tools on the same canvas — open source under AGPL-3.0, your own keys at provider prices, with a desktop app and local models.",
+      "Dify earns its reputation on the text side: prompt management, knowledge bases, agent debugging — everything a support bot or internal copilot needs. But the day the deliverable includes a rendered image, a video cut, or a synthesized voice, the work has to leave the platform. NodeTool starts from the same agent and document-search ground and keeps the whole job on one canvas: native image, video, and music generation, editing tools, and an agent that can build the pipeline for you. Open source under AGPL-3.0, your own keys at provider prices, with a desktop app and local models.",
     competitorTagline: "language model app development platform",
     competitorBullets: [
       "Prompt management and app-store-style deployment",
@@ -614,8 +622,9 @@ export const competitors: Competitor[] = [
     nodetoolBullets: [
       "Agents, document search, and native image/video/music generation",
       "Built-in editing tools — masks, inpaint, relight, layers",
+      "Agent-first: describe the pipeline and an agent builds and runs it",
       "Open source under AGPL-3.0, desktop app included",
-      "your own keys at provider prices — no credits, no markup",
+      "Your own keys at provider prices — no credits, no markup",
     ],
     rows: [
       { label: "Focus", competitor: "Text-first chatbot and agent apps & knowledge bases", nodetool: "AI generation + agents" },
@@ -629,7 +638,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "Great for the chatbot. Not built for the render.",
     explainerParagraph:
-      "Dify earns its reputation on debugging and knowledge-base tooling for text-first chatbot and agent apps — a support bot, an internal copilot, a document Q&A assistant. But when the deliverable includes a generated image, a video cut, or a synthesized voice line, that step has to leave the platform. NodeTool puts image, video, and music models from every major provider on the same canvas as its agent and retrieval nodes, with masks, inpaint, relight, upscale, and layers built in — every call on your own keys at list price.",
+      "Dify earns its reputation on debugging and knowledge-base tooling for text-first chatbot and agent apps — a support bot, an internal copilot, a document Q&A assistant. But when the deliverable includes a generated image, a video cut, or a synthesized voice line, that step has to leave the platform. NodeTool puts image, video, and music models from every major provider on the same canvas as its agent and retrieval nodes, with masks, inpaint, relight, upscale, and layers built in. And because the workspace is agent-first, an agent can author that canvas itself — build the workflow, run it, and repair what fails — with every call on your own keys at list price.",
     ctaHeading: "Build past the chatbot.",
     ctaParagraph:
       "Download Studio and put generation on the same canvas as your agents and knowledge base.",
@@ -679,7 +688,7 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "The creative canvas, open source and yours.",
     heroParagraph:
-      "Flora is a beautifully designed hosted canvas for AI image and video, sold on credits. NodeTool is the open version of that idea: image, video, music, and text on one visual canvas, every model called with your own keys at provider prices, and workflows and files you own and can self-host.",
+      "Flora is a beautifully designed hosted canvas for AI image and video — and every render on it burns credits, on a model list someone else curates, on servers where your work lives. NodeTool is the open version of that idea: image, video, music, and text on one visual canvas, every model called with your own keys at provider prices, an agent that can build the pipeline for you, and workflows and files you own and can self-host.",
     competitorTagline: "Hosted infinite canvas",
     competitorBullets: [
       "Polished, purpose-built creative canvas UX",
@@ -693,7 +702,8 @@ export const competitors: Competitor[] = [
       "Image, video, audio, and text on one canvas",
       "Every major model from every major provider",
       "Open source under AGPL-3.0, self-hostable",
-      "your own keys at provider prices — no credits, no markup",
+      "Agent-first: describe the pipeline and an agent builds and runs it",
+      "Your own keys at provider prices — no credits, no markup",
     ],
     rows: [
       { label: "Design / onboarding polish", competitor: "Purpose-built creative interface", nodetool: "A visual canvas built for depth" },
@@ -706,7 +716,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "A canvas you can take with you",
     explainerParagraph:
-      "Flora is genuinely pleasant to use — the onboarding and the canvas feel designed, and for a quick hosted image or video it's fast to reach for. But it's closed and credit-metered: the list of models is curated, each render burns credits, and your work lives on their platform. NodeTool trades some of that turnkey polish for control — image, video, music, and text on one canvas, every provider at list price with your own keys, local models via Ollama, MLX, and llama.cpp, and the whole thing open source under AGPL-3.0 so you can self-host it and keep your files.",
+      "Flora is genuinely pleasant to use — the onboarding and the canvas feel designed, and for a quick hosted image or video it's fast to reach for. But it's closed and credit-metered: the model list is curated, each render burns credits, and your work lives on their platform. NodeTool trades some of that turnkey polish for control. Image, video, music, and text share one canvas, every provider is called at list price with your own keys, and local models run via Ollama, MLX, and llama.cpp. It's agent-first too — describe what you want and an agent wires the graph and runs it — and the whole thing is open source under AGPL-3.0, so you can self-host it and keep your files.",
     ctaHeading: "Create on a canvas you own.",
     ctaParagraph:
       "Download Studio and build across image, video, audio, and text — your keys, your files.",
@@ -714,7 +724,7 @@ export const competitors: Competitor[] = [
       {
         question: "What is the difference between NodeTool and Flora?",
         answer:
-          "Flora is a hosted, closed-source creative canvas for AI image and video, billed in credits. NodeTool is an open-source (AGPL-3.0) visual canvas that runs on your own keys that spans image, video, audio, and text, connects to every major provider at list price, and can be self-hosted or run as a desktop app with local models.",
+          "Flora is a hosted, closed-source creative canvas for AI image and video, billed in credits. NodeTool is an open-source (AGPL-3.0) visual canvas, run on your own keys, that spans image, video, audio, and text, connects to every major provider at list price, and can be self-hosted or run as a desktop app with local models.",
       },
       {
         question: "Is NodeTool a free alternative to Flora?",
@@ -749,7 +759,7 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Instant renders, or the whole pipeline?",
     heroParagraph:
-      "Krea is a hosted studio built around real-time image generation and enhancement, sold on subscription and credits. NodeTool is the open-source, bring-your-own-key canvas around that: image, video, music, and text on one visual canvas, every model at provider prices, self-hostable, with editing built in.",
+      "Krea's party trick is real: sketch, and the image resolves under your cursor. For a single instant render, it's hard to beat. But a finished piece is rarely a single render — it's a pipeline of steps across image, video, music, and text, and that's where a hosted, credit-billed studio runs out of canvas. NodeTool is the open-source, bring-your-own-key workspace for the pipeline: every model at provider prices, editing built in, an agent that can wire the steps for you, and the whole thing self-hostable.",
     competitorTagline: "Hosted real-time studio",
     competitorBullets: [
       "Real-time, instant image generation and enhance",
@@ -763,7 +773,8 @@ export const competitors: Competitor[] = [
       "Image, video, audio, and text on one canvas",
       "Compose and edit — masks, inpaint, relight, layers",
       "Every major model from every major provider",
-      "your own keys at provider prices — self-hostable, local models",
+      "Agent-first: describe the pipeline and an agent builds and runs it",
+      "Your own keys at provider prices — self-hostable, local models",
     ],
     rows: [
       { label: "Real-time / instant generation", competitor: "Built-in, real-time", nodetool: "Batch & workflow, not real-time" },
@@ -776,7 +787,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "Speed at one step, or control across all of them",
     explainerParagraph:
-      "Krea's real-time canvas is legitimately great: type or sketch and watch the image resolve instantly, then enhance and upscale — all hosted, nothing to install. If a fast, interactive single render is the job, Krea is hard to beat. NodeTool optimizes for the opposite end: composing multi-step pipelines that mix image, video, music, and text, editing on the same canvas with masks and layers, calling every provider with your own keys at list price, and running local models — open source and self-hostable so the whole pipeline is yours.",
+      "Krea's real-time canvas is legitimately great: type or sketch and watch the image resolve instantly, then enhance and upscale — all hosted, nothing to install. If a fast, interactive single render is the job, Krea is hard to beat. NodeTool optimizes for the opposite end: composing multi-step pipelines that mix image, video, music, and text, editing on the same canvas with masks and layers, calling every provider with your own keys at list price, and running local models. It's agent-first, so an agent can author those pipelines from a description, run them, and repair what fails — and it's open source and self-hostable, so the whole pipeline is yours.",
     ctaHeading: "Own the whole pipeline.",
     ctaParagraph:
       "Download Studio and compose image, video, audio, and text on one open canvas.",
@@ -819,7 +830,7 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Run local models — then build the workflow.",
     heroParagraph:
-      "LM Studio is a superb desktop runtime for local GGUF language models: a clean chat UI, a great model browser, and an OpenAI-compatible local server. NodeTool runs local models too — via Ollama, MLX, and llama.cpp — but on a visual canvas that also generates image, video, and music and builds agents and document search around them.",
+      "LM Studio nails the first hour of local AI: browse a model, download it, chat with it, serve it over an OpenAI-compatible endpoint. The question is the second hour — when you want that model to read your documents, drive an agent, or feed a prompt into image and video generation, and the chat window has no answer. NodeTool runs local models too, via Ollama, MLX, and llama.cpp, but on a visual canvas that builds whole workflows around them — with an agent that can do the building.",
     competitorTagline: "Desktop local-language model runtime",
     competitorBullets: [
       "Polished model browser and one-click local language models",
@@ -832,6 +843,7 @@ export const competitors: Competitor[] = [
       "Local models via Ollama, MLX, and llama.cpp",
       "Plus native image, video, and music generation",
       "Agents, document search, and multi-step workflows on one canvas",
+      "Agent-first: describe the workflow and an agent builds and runs it",
       "Open source under AGPL-3.0, your own keys for cloud models",
     ],
     rows: [
@@ -845,7 +857,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "The runtime, and the workflow around it",
     explainerParagraph:
-      "For downloading a local model and chatting with it, LM Studio is excellent — the model browser is the best in class, and the OpenAI-compatible server makes it easy to point other tools at a local endpoint. If that's the whole job, LM Studio is more specialized than NodeTool and a great pick. But once you want the model to do something in a pipeline — retrieve from your documents, drive an agent, feed a prompt into image or video generation — you need a canvas. NodeTool runs the same class of local models via Ollama, MLX, and llama.cpp and puts them next to native generation nodes, agents, and document search, open source and runs on your own keys for any cloud models you add.",
+      "For downloading a local model and chatting with it, LM Studio is excellent — the model browser is best in class, and the OpenAI-compatible server makes it easy to point other tools at a local endpoint. If that's the whole job, LM Studio is more specialized than NodeTool and a great pick. But once you want the model to do something in a pipeline — retrieve from your documents, drive an agent, feed a prompt into image or video generation — you need a canvas. NodeTool runs the same class of local models via Ollama, MLX, and llama.cpp and puts them next to native generation nodes, agents, and document search. It's agent-first, so you can describe the workflow and an agent wires it and runs it — open source, with your own keys for any cloud models you add.",
     ctaHeading: "From local chat to full workflow.",
     ctaParagraph:
       "Download Studio and put your local models on a canvas with generation, agents, and document search.",
@@ -888,7 +900,7 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Open and local — plus everything past chat.",
     heroParagraph:
-      "Jan is an open source, offline-first desktop app for chatting with local language models — a clean, private local ChatGPT alternative. NodeTool is open source too, but a visual canvas: it runs local models via Ollama, MLX, and llama.cpp and adds native image, video, and music generation, agents, and document search on the same graph.",
+      "Jan makes one promise and keeps it: a private, offline chat with a local model, in an app that's fully open source. NodeTool shares the open, local-first values and asks a bigger question — what happens after the chat? On its canvas the same local models, run via Ollama, MLX, and llama.cpp, drive image, video, and music generation, agents, and document search on one graph, and an agent can build that graph for you.",
     competitorTagline: "Open source local chat app",
     competitorBullets: [
       "Offline-first, private local language model chat",
@@ -901,6 +913,7 @@ export const competitors: Competitor[] = [
       "Local models via Ollama, MLX, and llama.cpp",
       "Native image, video, and music generation",
       "Agents, document search, and multi-step workflows on one canvas",
+      "Agent-first: describe the workflow and an agent builds and runs it",
       "Open source under AGPL-3.0, your own keys for cloud models",
     ],
     rows: [
@@ -914,7 +927,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "A great chat app, or a whole canvas",
     explainerParagraph:
-      "Jan does one thing well and openly: private, offline-first chat with local models, with a UI that feels like a local ChatGPT. If that's what you want, Jan is a lovely, focused choice and fully open source. NodeTool aims wider: it runs the same local models via Ollama, MLX, and llama.cpp, but puts them on a visual canvas alongside native image, video, and music generation, agents, and document search — so a local model can drive a whole workflow, not just a chat window. Both are open source; the difference is scope.",
+      "Jan does one thing well and openly: private, offline-first chat with local models, with a UI that feels like a local ChatGPT. If that's what you want, Jan is a lovely, focused choice and fully open source. NodeTool aims wider: it runs the same local models via Ollama, MLX, and llama.cpp, but puts them on a visual canvas alongside native image, video, and music generation, agents, and document search — so a local model can drive a whole workflow, not just a chat window. It's agent-first too: describe the workflow and an agent builds it, runs it, and repairs what fails. Both are open source; the difference is scope.",
     ctaHeading: "Take local models past the chat window.",
     ctaParagraph:
       "Download Studio and build workflows around your local and cloud models.",
@@ -957,7 +970,7 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Agents that produce, not just operate.",
     heroParagraph:
-      "Lindy is a polished hosted platform for AI assistants built without code that automate business operations — inbox, scheduling, CRM. NodeTool is an open-source, bring-your-own-key canvas where the AI work is the deliverable: native image, video, and music generation, agents, and document search on one visual canvas.",
+      "Lindy's agents live in your inbox, your calendar, and your CRM, quietly handling the operations work nobody wants. But ask one for the campaign itself — the images, the video, the soundtrack — and you've left what the platform is built for. NodeTool is an open-source, bring-your-own-key canvas where the AI work is the deliverable: native image, video, and music generation, agents, and document search on one visual canvas, with an agent that builds the pipeline from your description.",
     competitorTagline: "Hosted business-ops agents",
     competitorBullets: [
       "Assistants for operations work, built without code",
@@ -970,8 +983,9 @@ export const competitors: Competitor[] = [
     nodetoolBullets: [
       "Native image, video, and music generation",
       "Agents and document search on the same canvas as generation",
+      "Agent-first: describe the pipeline and an agent builds and runs it",
       "Open source under AGPL-3.0, desktop app included",
-      "your own keys at provider prices — local models supported",
+      "Your own keys at provider prices — local models supported",
     ],
     rows: [
       { label: "Focus", competitor: "Business-ops automation", nodetool: "AI generation + agents" },
@@ -984,7 +998,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "Ops plumbing, or creative production",
     explainerParagraph:
-      "Lindy is strong where its integrations are strong: wiring an assistant into your inbox, calendar, and CRM to handle repetitive operations, all hosted and built without code. If the job is ops automation across business apps, that prebuilt depth is a real advantage. NodeTool is built for a different job — producing things with AI. Image, video, and music models sit on the same canvas as agents and document search, with editing tools built in, every call made with your own keys at provider prices, and the whole workspace open source under AGPL-3.0 with local-model support and a desktop app.",
+      "Lindy is strong where its integrations are strong: wiring an assistant into your inbox, calendar, and CRM to handle repetitive operations, all hosted and built without code. If the job is ops automation across business apps, that prebuilt depth is a real advantage. NodeTool is built for a different job — producing things with AI. Image, video, and music models sit on the same canvas as agents and document search, with editing tools built in, and the workspace is agent-first: describe the pipeline and an agent authors it, runs it, and repairs what fails. Every call is made with your own keys at provider prices, and the whole workspace is open source under AGPL-3.0 with local-model support and a desktop app.",
     ctaHeading: "Put creation on the canvas.",
     ctaParagraph:
       "Download Studio and build agents that generate image, video, and music.",
@@ -992,7 +1006,7 @@ export const competitors: Competitor[] = [
       {
         question: "What is the difference between NodeTool and Lindy?",
         answer:
-          "Lindy is a hosted, closed-source hosted platform for AI assistants that automate business operations like email, scheduling, and CRM. NodeTool is an open-source (AGPL-3.0) visual canvas that runs on your own keys focused on AI generation — image, video, and music — plus agents and document search, with a desktop app and local-model support.",
+          "Lindy is a hosted, closed-source platform for AI assistants that automate business operations like email, scheduling, and CRM. NodeTool is an open-source (AGPL-3.0) visual canvas, run on your own keys, focused on AI generation — image, video, and music — plus agents and document search, with a desktop app and local-model support.",
       },
       {
         question: "When should I pick Lindy instead of NodeTool?",
@@ -1000,7 +1014,7 @@ export const competitors: Competitor[] = [
           "When the job is automating business operations with deep prebuilt integrations into your inbox, calendar, and CRM. That's what Lindy is built for. NodeTool is the better fit when the workflow's output is AI-generated media or creative agent work.",
       },
       {
-        question: "Is NodeTool open source and runs on your own keys?",
+        question: "Is NodeTool open source, and does it run on your own keys?",
         answer:
           "Yes. NodeTool is open source under AGPL-3.0 and your own keys — you connect your own provider keys and pay list prices, with no per-task credits or platform markup, and you can run local models on your own hardware.",
       },
@@ -1027,7 +1041,7 @@ export const competitors: Competitor[] = [
     },
     heroHeading: "Automation that generates, not just processes.",
     heroParagraph:
-      "Gumloop is a hosted platform that needs no code for AI-powered business automation, with a deep library of prebuilt nodes and integrations. NodeTool is an open-source, bring-your-own-key canvas built for the case where the AI work is the deliverable: native image, video, and music generation, agents, and document search on one visual canvas.",
+      "Gumloop will move your data through a business process without a line of code — prebuilt nodes, broad SaaS integrations, all hosted. But a process that ends in a spreadsheet is a different job from a workflow that ends in a finished video. NodeTool is an open-source, bring-your-own-key canvas built for the second job: native image, video, and music generation, agents, and document search on one visual canvas, with an agent that builds the pipeline from your description.",
     competitorTagline: "Hosted automation, no code required",
     competitorBullets: [
       "Prebuilt nodes for business automation",
@@ -1040,8 +1054,9 @@ export const competitors: Competitor[] = [
     nodetoolBullets: [
       "Native image, video, and music generation",
       "Agents and document search on the same canvas as generation",
+      "Agent-first: describe the pipeline and an agent builds and runs it",
       "Open source under AGPL-3.0, desktop app included",
-      "your own keys at provider prices — local models supported",
+      "Your own keys at provider prices — local models supported",
     ],
     rows: [
       { label: "Focus", competitor: "Business-process automation", nodetool: "AI generation + agents" },
@@ -1054,7 +1069,7 @@ export const competitors: Competitor[] = [
     ],
     explainerHeading: "Process automation, or media production",
     explainerParagraph:
-      "Gumloop is good at what it's built for: automating business processes without writing code, with prebuilt nodes and broad SaaS integrations that get an ops workflow running fast and hosted. If that's the job, its integration library is a real edge. NodeTool is built to produce, not just process — image, video, and music models on the same canvas as agents and document search, editing tools built in, every call made with your own keys at provider prices, and the whole workspace open source under AGPL-3.0 with local models and a desktop app.",
+      "Gumloop is good at what it's built for: automating business processes without writing code, with prebuilt nodes and broad SaaS integrations that get an ops workflow running fast and hosted. If that's the job, its integration library is a real edge. NodeTool is built to produce, not just process — image, video, and music models on the same canvas as agents and document search, editing tools built in, and an agent-first workspace where an agent authors the workflow, runs it, and repairs what fails. Every call is made with your own keys at provider prices, and the whole workspace is open source under AGPL-3.0 with local models and a desktop app.",
     ctaHeading: "Automate the creation itself.",
     ctaParagraph:
       "Download Studio and build workflows that generate image, video, and music.",
@@ -1062,7 +1077,7 @@ export const competitors: Competitor[] = [
       {
         question: "What is the difference between NodeTool and Gumloop?",
         answer:
-          "Gumloop is a hosted, closed-source hosted platform for business-process automation with prebuilt nodes and SaaS integrations. NodeTool is an open-source (AGPL-3.0) visual canvas that runs on your own keys focused on AI generation — image, video, and music — plus agents and document search, with a desktop app and local-model support.",
+          "Gumloop is a hosted, closed-source platform for business-process automation with prebuilt nodes and SaaS integrations. NodeTool is an open-source (AGPL-3.0) visual canvas, run on your own keys, focused on AI generation — image, video, and music — plus agents and document search, with a desktop app and local-model support.",
       },
       {
         question: "When should I pick Gumloop instead of NodeTool?",


### PR DESCRIPTION
## What

The "Why NodeTool" docs page (`docs/comparisons.md`) had the right facts but read like a spec sheet, and it never mentioned the agent-first positioning that leads the README and the whole marketing site. This PR rewrites it as a narrative and runs the same storytelling pass over the comparison pages.

### `docs/comparisons.md`
- Opens on a concrete scene: the tab-graveyard day a creative actually lives (storyboard in one tab, stills in another, `final_v3.png` in the downloads folder, the recipe gone by Tuesday), then the same job as one graph.
- New section, "You don't have to wire it yourself", integrates the agent-first strategy: every editor exposed to agents as ~120 tools, agents that author/validate/repair workflows, supervised runs on the failure path, and the MCP toolbelt for Claude Desktop / Claude Code.
- Feature table gains **Agent-first editing** and **MCP server** rows; "when to pick each" now names the agent as part of the NodeTool pitch.
- Stays inside `docs/WRITING_STYLE.md`: concrete claims, no slop vocabulary.

### `marketing/src/data/competitorEntries.ts` (drives all `/vs/*` and `/alternatives/*` pages)
- Every hero paragraph now opens on the moment the competitor's model runs out — the Langflow flow ending at a blank HTTP node, Weavy users waking up in October 2025 to a new owner and the same credit meter, LM Studio's second hour, Krea's single perfect render vs the pipeline around it.
- Each explainer and each NodeTool at-a-glance card carries the agent-first line ("describe the pipeline and an agent builds, runs, and repairs it"), phrased as claims about NodeTool only — no new claims about competitors, and every honest concession is kept.
- Fixes long-standing copy defects that shipped verbatim from the old hand-built pages: "an an interface", "hand-picked list of modelss", "no hand-picked list of models of models", doubled "hosted", lowercase bullet openers, "runs on your own keys that spans…". Updated the file's header comment, which claimed verbatim parity with those pages.

## Verification
- `npm run lint` passes (exit 0).
- `npm run typecheck` fails identically with and without this diff (mobile Expo deps absent in the sandbox; verified via stash/compare) — no new errors.
- The edited TS data file parses clean (0 diagnostics via the TypeScript compiler API); all edits are string-literal copy inside the existing `Competitor` shape, so the `/vs` + `/alternatives` templates and JSON-LD FAQ consume it unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxYB42c2v6a3UfxmifwynH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxYB42c2v6a3UfxmifwynH)_