### PR TITLE
docs: drop the GPU recommendation from install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,13 @@ Download the desktop app, install, and start building — runs fully on your mac
 
 | Platform | Get It | Requirements |
 | :--- | :--- | :--- |
-| **Windows** | [Download](https://nodetool.ai/studio) | NVIDIA GPU recommended, 4GB+ VRAM (local models), 20GB space |
-| **macOS** | [Download](https://nodetool.ai/studio) | M1+ Apple Silicon, 16GB+ RAM (local models) |
-| **Linux** | [Download](https://nodetool.ai/studio) | NVIDIA GPU recommended, 4GB+ VRAM (local models) |
+| **Windows** | [Download](https://nodetool.ai/studio) | Windows 10+, 8GB+ RAM, 20GB space |
+| **macOS** | [Download](https://nodetool.ai/studio) | macOS 13+, Apple Silicon or Intel, 8GB+ RAM |
+| **Linux** | [Download](https://nodetool.ai/studio) | Ubuntu 22+, 8GB+ RAM |
+
+Connect a provider with your own API key and the models run on their servers —
+no GPU involved. A GPU only matters if you later want models to run on your own
+machine.
 
 [Flatpak CI Builds](https://github.com/nodetool-ai/nodetool/actions/workflows/flatpak-ci.yml) are available for Linux.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,12 +26,12 @@ Prefer to watch first? Here is a finished example running. The
 |-----------|---------|-------------|
 | **Memory (RAM)** | 8 GB | 16 GB or more |
 | **Free disk space** | 10 GB | 50 GB if you download AI models |
-| **Graphics card (GPU)** | Not needed | 8 GB or more of video memory |
 | **Operating system** | macOS 13+, Windows 10+, Ubuntu 22+ | The latest version |
 
-A graphics card only matters if you want AI models to run on your own machine.
-Without one, NodeTool sends the work to an online AI service instead, and
-everything on this page still works. See the
+No graphics card needed. The simplest way to use NodeTool is to connect an
+online AI service with your own key, and the models then run on that service's
+machines. A graphics card only enters the picture if you later decide to run
+models on your own machine — see the
 [hardware notes](installation.md#what-different-tasks-need).
 
 ### Install it


### PR DESCRIPTION
Connecting a provider with your own API key is the simplest way to use NodeTool, so the install requirements no longer suggest a GPU.

- `README.md` — the platform table listed "NVIDIA GPU recommended, 4GB+ VRAM" for Windows and Linux and "M1+ Apple Silicon, 16GB+ RAM" for macOS. Those are now plain OS/RAM/disk requirements, with a note that provider models run on the provider's servers and a GPU only matters for local models.
- `docs/getting-started.md` — dropped the "Graphics card (GPU)" row from the "Will it run on my computer?" table and rewrote the paragraph below it to lead with connecting a provider instead of explaining what a GPU buys you.

The local-model hardware guidance in `docs/installation.md` ("What different tasks need") is untouched — that section is about running models on your own machine, where the hardware genuinely matters.

Docs only; no code paths changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_012rLK21wz4DXoTfuz173m6b)_