### PR TITLE
fix: say so when Supabase auth has no anon key, instead of failing silently

### DIFF
--- a/packages/websocket/src/routes/config.ts
+++ b/packages/websocket/src/routes/config.ts
@@ -15,6 +15,33 @@ import { getVersion } from "./health.js";
  * Supabase anon key (`SUPABASE_ANON_KEY`) is designed to ship to clients; the
  * service-role key (`SUPABASE_KEY`) is never returned.
  */
+
+/**
+ * Describe the one misconfiguration this endpoint can serve without noticing:
+ * auth enforced (`SUPABASE_URL` + `SUPABASE_KEY`) but no `SUPABASE_ANON_KEY` to
+ * hand the browser. The response is still well-formed — `supabaseAnonKey` is
+ * just `null` — so the web app falls back to a placeholder key and every login
+ * 401s with nothing in the server log. Returns null when nothing is wrong.
+ *
+ * Pure so the boot-time check can be tested without standing up a server.
+ */
+export const describeMissingAnonKey = (
+  env: Record<string, string | undefined> = process.env
+): string | null => {
+  const url = env["SUPABASE_URL"]?.trim();
+  const serviceKey = env["SUPABASE_KEY"]?.trim();
+  const anonKey = env["SUPABASE_ANON_KEY"]?.trim();
+  if (!url || !serviceKey || anonKey) return null;
+  return (
+    "SUPABASE_ANON_KEY is not set. Auth is enforced (SUPABASE_URL and " +
+    "SUPABASE_KEY are both present), but GET /api/config has no anon key to " +
+    "give the web app, so it falls back to a placeholder and every login " +
+    "fails with 401. Set SUPABASE_ANON_KEY to the project's public anon key — " +
+    "never SUPABASE_KEY, which is the service-role key and must not reach a " +
+    "browser."
+  );
+};
+
 const configRoute: FastifyPluginAsync = async (app) => {
   app.get("/api/config", async (_req, reply) => {
     const supabaseUrl = process.env["SUPABASE_URL"]?.trim() || null;

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -98,7 +98,7 @@ import {
 
 import websocketPlugin from "./plugins/websocket.js";
 import healthRoute, { getVersion } from "./routes/health.js";
-import configRoute from "./routes/config.js";
+import configRoute, { describeMissingAnonKey } from "./routes/config.js";
 import assetsRoutes from "./routes/assets.js";
 import workflowsRoutes from "./routes/workflows.js";
 import nodesRoutes from "./routes/nodes.js";
@@ -756,6 +756,14 @@ const supabaseProvider = supabaseMode
     })
   : null;
 const localProvider = supabaseProvider ? null : new LocalAuthProvider();
+
+// A server that enforces auth but never got an anon key serves a healthy
+// /health and a well-formed /api/config while no user can log in. Say so at
+// boot, where an operator reading the deploy log will see it.
+const missingAnonKey = describeMissingAnonKey();
+if (missingAnonKey) {
+  log.error(missingAnonKey);
+}
 
 // Auth is enforced whenever a remote identity provider is configured.
 const enforceAuth = supabaseMode;

--- a/packages/websocket/tests/config-api.test.ts
+++ b/packages/websocket/tests/config-api.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Fastify, { type FastifyInstance } from "fastify";
-import configRoute from "../src/routes/config.js";
+import configRoute, { describeMissingAnonKey } from "../src/routes/config.js";
 
 const ENV_KEYS = [
   "SUPABASE_URL",
@@ -98,5 +98,54 @@ describe("/api/config endpoint", () => {
     const res = await app.inject({ method: "GET", url: "/api/config" });
     const body = JSON.parse(res.body);
     expect(body.authMode).toBe("local");
+  });
+
+  it("serves supabase mode with a null anon key when the key is missing", async () => {
+    process.env.SUPABASE_URL = "https://x.supabase.co";
+    process.env.SUPABASE_KEY = "service-role-key";
+
+    const body = JSON.parse(
+      (await app.inject({ method: "GET", url: "/api/config" })).body
+    );
+    // The shape that took prod down: auth enforced, nothing for the browser to
+    // authenticate with, and a 200 either way. The service-role key stays out.
+    expect(body.authMode).toBe("supabase");
+    expect(body.supabaseAnonKey).toBeNull();
+    expect(JSON.stringify(body)).not.toContain("service-role-key");
+  });
+});
+
+describe("describeMissingAnonKey", () => {
+  it("flags auth enforced with no anon key", () => {
+    expect(
+      describeMissingAnonKey({
+        SUPABASE_URL: "https://x.supabase.co",
+        SUPABASE_KEY: "service"
+      })
+    ).toContain("SUPABASE_ANON_KEY");
+  });
+
+  it("treats a blank anon key as missing", () => {
+    expect(
+      describeMissingAnonKey({
+        SUPABASE_URL: "https://x.supabase.co",
+        SUPABASE_KEY: "service",
+        SUPABASE_ANON_KEY: "   "
+      })
+    ).toContain("SUPABASE_ANON_KEY");
+  });
+
+  it("is silent once the anon key is set", () => {
+    expect(
+      describeMissingAnonKey({
+        SUPABASE_URL: "https://x.supabase.co",
+        SUPABASE_KEY: "service",
+        SUPABASE_ANON_KEY: "anon"
+      })
+    ).toBeNull();
+  });
+
+  it("is silent in local mode, where Supabase is never called", () => {
+    expect(describeMissingAnonKey({})).toBeNull();
   });
 });

--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -83,6 +83,14 @@ export default {
     "^\\.\\./env$": "<rootDir>/src/__mocks__/envMock.ts",
     "^.*lib/env$": "<rootDir>/src/__mocks__/envMock.ts",
     "^.*lib/supabaseClient$": "<rootDir>/src/__mocks__/supabaseClientMock.ts",
+    // Reads `import.meta.env`, which the CommonJS transform cannot load.
+    // Mapping it lets `supabaseClient.ts` itself be imported and tested.
+    "^\\./supabaseBuildTimeEnv$":
+      "<rootDir>/src/__mocks__/supabaseBuildTimeEnv.ts",
+    "^\\.\\./supabaseBuildTimeEnv$":
+      "<rootDir>/src/__mocks__/supabaseBuildTimeEnv.ts",
+    "^.*lib/supabaseBuildTimeEnv$":
+      "<rootDir>/src/__mocks__/supabaseBuildTimeEnv.ts",
     "^@google/model-viewer$": "<rootDir>/src/__mocks__/modelViewerMock.ts",
     "^react-markdown$": "<rootDir>/src/__mocks__/reactMarkdownMock.tsx",
     "^remark-gfm$": "<rootDir>/src/__mocks__/emptyModule.ts",

--- a/web/src/__mocks__/supabaseBuildTimeEnv.ts
+++ b/web/src/__mocks__/supabaseBuildTimeEnv.ts
@@ -1,0 +1,6 @@
+/**
+ * Under Jest there is no Vite build, so neither build-time fallback exists.
+ * This mirrors production, where the credentials come from `/api/config`.
+ */
+export const buildTimeSupabaseUrl: string | undefined = undefined;
+export const buildTimeSupabaseAnonKey: string | undefined = undefined;

--- a/web/src/lib/__tests__/supabaseClient.test.ts
+++ b/web/src/lib/__tests__/supabaseClient.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression cover for the outage of 2026-08-05: a Supabase-mode backend that
+ * served `supabaseAnonKey: null` left the client holding the placeholder key,
+ * so every login answered 401 while the app looked healthy and logged nothing.
+ *
+ * `jest.config.ts` maps every extensionless specifier for this module to
+ * `__mocks__/supabaseClientMock.ts`, so the tests below import it *with* the
+ * `.ts` extension — the one spelling those patterns don't match — to get the
+ * real implementation under test.
+ */
+jest.mock("@supabase/supabase-js", () => ({
+  createClient: jest.fn(() => ({ auth: {} }))
+}));
+
+type SupabaseClientModule = typeof import("../supabaseClient");
+
+const importReal = (): SupabaseClientModule =>
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require("../supabaseClient.ts") as SupabaseClientModule;
+
+import type { RuntimeConfig } from "../runtimeConfig";
+
+const LOCAL_CONFIG: RuntimeConfig = {
+  authMode: "local",
+  supabaseUrl: null,
+  supabaseAnonKey: null,
+  authRedirectUrl: null,
+  googleWorkspace: false,
+  googleScopes: [],
+  version: null
+};
+
+const SUPABASE_URL = "https://project.supabase.co";
+
+describe("initSupabaseFromConfig", () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("reports an error when Supabase mode ships no anon key", async () => {
+    const mod = importReal();
+
+    mod.initSupabaseFromConfig({
+      ...LOCAL_CONFIG,
+      authMode: "supabase",
+      supabaseUrl: SUPABASE_URL,
+      supabaseAnonKey: null
+    });
+
+    expect(mod.getSupabaseConfigError()).toMatch(/SUPABASE_ANON_KEY/);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays quiet when Supabase mode supplies an anon key", async () => {
+    const mod = importReal();
+
+    mod.initSupabaseFromConfig({
+      ...LOCAL_CONFIG,
+      authMode: "supabase",
+      supabaseUrl: SUPABASE_URL,
+      supabaseAnonKey: "a-real-anon-key"
+    });
+
+    expect(mod.getSupabaseConfigError()).toBeNull();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("stays quiet in Local mode, where Supabase is never called", async () => {
+    const mod = importReal();
+
+    mod.initSupabaseFromConfig(LOCAL_CONFIG);
+
+    expect(mod.getSupabaseConfigError()).toBeNull();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("builds the client with the resolved credentials", async () => {
+    const { createClient } = await import("@supabase/supabase-js");
+    const mod = importReal();
+
+    mod.initSupabaseFromConfig({
+      ...LOCAL_CONFIG,
+      authMode: "supabase",
+      supabaseUrl: SUPABASE_URL,
+      supabaseAnonKey: "a-real-anon-key"
+    });
+
+    expect(createClient).toHaveBeenLastCalledWith(
+      SUPABASE_URL,
+      "a-real-anon-key"
+    );
+  });
+});

--- a/web/src/lib/supabaseBuildTimeEnv.ts
+++ b/web/src/lib/supabaseBuildTimeEnv.ts
@@ -1,0 +1,16 @@
+/**
+ * Build-time Supabase fallbacks, isolated in their own module.
+ *
+ * `import.meta` cannot be loaded by Jest's CommonJS transform, so any module
+ * that reads it directly is untestable and ends up mocked wholesale. Keeping
+ * these two reads here leaves `supabaseClient.ts` free of `import.meta` and
+ * therefore testable; Jest maps this module to a mock that supplies neither.
+ *
+ * These remain a fallback for the dev server and pure-static hosting, where
+ * `GET /api/config` is not reachable.
+ */
+export const buildTimeSupabaseUrl: string | undefined = import.meta.env
+  .VITE_SUPABASE_URL;
+
+export const buildTimeSupabaseAnonKey: string | undefined = import.meta.env
+  .VITE_SUPABASE_ANON_KEY;

--- a/web/src/lib/supabaseClient.ts
+++ b/web/src/lib/supabaseClient.ts
@@ -1,5 +1,9 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { RuntimeConfig } from "./runtimeConfig";
+import {
+  buildTimeSupabaseUrl as buildTimeUrl,
+  buildTimeSupabaseAnonKey as buildTimeAnonKey
+} from "./supabaseBuildTimeEnv";
 
 /**
  * Supabase client for the web app.
@@ -16,10 +20,6 @@ import type { RuntimeConfig } from "./runtimeConfig";
 
 const FALLBACK_URL = "http://localhost";
 const FALLBACK_ANON_KEY = "public-anon-key";
-
-const buildTimeUrl: string | undefined = import.meta.env.VITE_SUPABASE_URL;
-const buildTimeAnonKey: string | undefined =
-  import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 const makeClient = (
   url: string | null | undefined,
@@ -48,6 +48,17 @@ const makeClient = (
 let current = makeClient(null, null);
 let innerClient: SupabaseClient = current.client;
 
+let configError: string | null = null;
+
+/**
+ * The reason Supabase auth cannot work, or null when it can.
+ *
+ * Non-null means the client is holding `FALLBACK_ANON_KEY` while talking to a
+ * backend that enforces auth, so every Supabase request — login included —
+ * answers 401.
+ */
+export const getSupabaseConfigError = (): string | null => configError;
+
 /**
  * Rebuild the Supabase client from runtime config fetched from the backend.
  * Called once at boot after `loadRuntimeConfig()`, before auth initializes.
@@ -56,10 +67,27 @@ export const initSupabaseFromConfig = (config: RuntimeConfig): void => {
   const resolvedUrl = config.supabaseUrl || buildTimeUrl || FALLBACK_URL;
   const resolvedKey =
     config.supabaseAnonKey || buildTimeAnonKey || FALLBACK_ANON_KEY;
+
+  // Falling back to the placeholder key is harmless in Local mode, where
+  // Supabase is never called. In Supabase mode it is fatal *and* invisible: the
+  // URL is real, so the warning in `makeClient` stays quiet, and the app boots
+  // into a login screen that can only ever 401.
+  configError =
+    config.authMode === "supabase" && resolvedKey === FALLBACK_ANON_KEY
+      ? "Supabase auth is enabled but no anon key reached the browser: " +
+        "GET /api/config returned supabaseAnonKey: null and no build-time " +
+        "VITE_SUPABASE_ANON_KEY is set. Login will fail with 401 until the " +
+        "server sets SUPABASE_ANON_KEY (the public anon key — not " +
+        "SUPABASE_KEY, which is the service-role key)."
+      : null;
+  if (configError) {
+    console.error(configError);
+  }
+
   if (current.url === resolvedUrl && current.anonKey === resolvedKey) {
     return;
   }
-  current = makeClient(config.supabaseUrl, config.supabaseAnonKey);
+  current = makeClient(resolvedUrl, resolvedKey);
   innerClient = current.client;
 };
 


### PR DESCRIPTION
## What broke

`nodetool.fly.dev` stopped loading on 2026-08-05 while the backend was entirely healthy — 200 on `/health`, all 58 hashed bundles 200, nothing in the logs.

`GET /api/config` picks `authMode: "supabase"` from `SUPABASE_URL` + `SUPABASE_KEY`, but the key it hands the browser is a **third** variable, `SUPABASE_ANON_KEY`. Only the first two were set on Fly, so the response was well-formed with `supabaseAnonKey: null`. The web app then fell back to the literal placeholder `FALLBACK_ANON_KEY = "public-anon-key"`, built a Supabase client against the *real* project URL, and 401'd on every call including login.

It was invisible because the existing warning in `makeClient` only fires when the **URL** is missing — never when only the key is.

```
apikey: public-anon-key   -> 401
apikey: <real anon key>   -> 200
```

Setting the secret fixed prod. This PR makes the next occurrence say so.

## Change

- **Server**: `describeMissingAnonKey()` in `routes/config.ts`, logged once at boot from `server.ts` — where an operator reading the deploy log will actually see it. Kept pure so it's testable without standing up a server.
- **Web**: `initSupabaseFromConfig` sets and `console.error`s a specific message when `authMode === "supabase"` resolves to the placeholder key, and exposes `getSupabaseConfigError()` for a UI to surface later.
- Also drops the confusing dead code in `initSupabaseFromConfig`, which computed `resolvedUrl`/`resolvedKey` and then passed the raw nulls to `makeClient` anyway.

Neither end invents a key, and the service-role `SUPABASE_KEY` still never reaches `/api/config` — there's now a test pinning that, since the tempting "fix" for this outage is to return it.

## Why `supabaseBuildTimeEnv.ts` exists

`supabaseClient.ts` had no tests, and couldn't: it reads `import.meta.env`, which Jest's CommonJS transform cannot load, so `jest.config.ts` mapped every specifier for it to a mock. (`env.ts` has the same problem — `env.test.ts` works around it by reimplementing the helper inline.) Moving the two build-time reads into their own module leaves `supabaseClient.ts` `import.meta`-free and testable.

## Verification

Both guards watched go red before green — the web test fails if the condition is neutered, the two server tests fail if the helper always returns null.

- `web`: 4 new tests; `src/lib/__tests__` + the suites importing supabaseClient = 185 passed
- `packages/websocket`: 5 new tests, `config-api.test.ts` 10 passed
- `tsc --noEmit` clean for `web` and `packages/websocket`; eslint clean on all changed files
- The 568 pre-existing failures in the full `packages/websocket` suite are identical with and without this change (1466 -> 1471 passing, exactly the 5 added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)