### PR TITLE
Fix the tutorials page layout on narrow screens

### DIFF
--- a/web/src/components/tutorials/TutorialCard.tsx
+++ b/web/src/components/tutorials/TutorialCard.tsx
@@ -7,10 +7,11 @@ import PlayArrowRoundedIcon from "@mui/icons-material/PlayArrowRounded";
 import { MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 import type { Tutorial } from "./tutorialsData";
 
-const styles = (theme: Theme, accent: string, active: boolean) =>
+const styles = (theme: Theme, accent: string, active: boolean, compact: boolean) =>
   css({
     display: "flex",
-    flexDirection: "column",
+    flexDirection: compact ? "row" : "column",
+    alignItems: compact ? "stretch" : undefined,
     textAlign: "left",
     width: "100%",
     padding: 0,
@@ -25,10 +26,16 @@ const styles = (theme: Theme, accent: string, active: boolean) =>
     overflow: "hidden",
     transition: `border-color ${MOTION.fast}, transform ${MOTION.fast}, box-shadow ${MOTION.fast}`,
     boxShadow: active ? `0 0 0 1px ${accent}` : "none",
-    "&:hover": {
-      borderColor: accent,
-      transform: "translateY(-2px)",
-      boxShadow: "0 10px 24px rgba(0,0,0,0.28)"
+    // Touch devices keep :hover styles latched after a tap, so gate them on a
+    // real pointer.
+    "@media (hover: hover)": {
+      "&:hover": {
+        borderColor: accent,
+        transform: "translateY(-2px)",
+        boxShadow: "0 10px 24px rgba(0,0,0,0.28)"
+      },
+      "&:hover .thumb img": { transform: "scale(1.03)", opacity: 1 },
+      "&:hover .play-dot": { transform: "scale(1.08)" }
     },
     "&:focus-visible": {
       outline: `2px solid ${accent}`,
@@ -37,7 +44,10 @@ const styles = (theme: Theme, accent: string, active: boolean) =>
     ".thumb": {
       position: "relative",
       aspectRatio: "16 / 9",
-      width: "100%",
+      width: compact ? 132 : "100%",
+      // Row layout: hold the thumbnail width. Column layout it must be able to
+      // shrink, or the card body gets squeezed out in the scrolling sidebar.
+      flexShrink: compact ? 0 : 1,
       overflow: "hidden",
       background: theme.vars.palette.common.black
     },
@@ -49,10 +59,6 @@ const styles = (theme: Theme, accent: string, active: boolean) =>
       opacity: 0.92,
       transition: `transform ${MOTION.normal}, opacity ${MOTION.fast}`
     },
-    "&:hover .thumb img": {
-      transform: "scale(1.03)",
-      opacity: 1
-    },
     ".play": {
       position: "absolute",
       inset: 0,
@@ -62,16 +68,15 @@ const styles = (theme: Theme, accent: string, active: boolean) =>
     ".play-dot": {
       display: "grid",
       placeItems: "center",
-      width: 44,
-      height: 44,
+      width: compact ? 28 : 44,
+      height: compact ? 28 : 44,
       borderRadius: BORDER_RADIUS.circle,
       color: theme.vars.palette.common.white,
       background: `${accent}e6`,
       boxShadow: "0 4px 16px rgba(0,0,0,0.4)",
       transition: `transform ${MOTION.fast}`,
-      "& svg": { fontSize: 28 }
+      "& svg": { fontSize: compact ? 18 : 28 }
     },
-    "&:hover .play-dot": { transform: "scale(1.08)" },
     ".duration": {
       position: "absolute",
       right: 8,
@@ -87,16 +92,28 @@ const styles = (theme: Theme, accent: string, active: boolean) =>
     ".body": {
       display: "flex",
       flexDirection: "column",
+      justifyContent: "center",
+      minWidth: 0,
       gap: 4,
       padding: `${theme.spacing(SPACING.sm)} ${theme.spacing(1.5)}`
     },
+    ".meta": {
+      display: "flex",
+      alignItems: "baseline",
+      gap: theme.spacing(SPACING.xs)
+    },
     ".level": {
-      alignSelf: "flex-start",
       fontSize: "var(--fontSizeSmaller)",
       fontWeight: 600,
       letterSpacing: "0.04em",
       textTransform: "uppercase",
       color: accent
+    },
+    ".meta .duration-inline": {
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.secondary,
+      fontVariantNumeric: "tabular-nums"
     },
     ".title": {
       margin: 0,
@@ -108,26 +125,37 @@ const styles = (theme: Theme, accent: string, active: boolean) =>
       margin: 0,
       fontSize: "var(--fontSizeSmall)",
       color: theme.vars.palette.text.secondary,
-      lineHeight: 1.4
+      lineHeight: 1.4,
+      ...(compact
+        ? {
+            display: "-webkit-box",
+            WebkitBoxOrient: "vertical" as const,
+            WebkitLineClamp: 2,
+            overflow: "hidden"
+          }
+        : {})
     }
   });
 
 export interface TutorialCardProps {
   tutorial: Tutorial;
   active?: boolean;
+  /** Row layout with a small thumbnail — for narrow viewports. */
+  compact?: boolean;
   onClick: (id: string) => void;
 }
 
 const TutorialCardInner: React.FC<TutorialCardProps> = ({
   tutorial,
   active = false,
+  compact = false,
   onClick
 }) => {
   const theme = useTheme();
   return (
     <button
       type="button"
-      css={styles(theme, tutorial.accent, active)}
+      css={styles(theme, tutorial.accent, active, compact)}
       onClick={() => onClick(tutorial.id)}
       aria-label={`Play tutorial: ${tutorial.title}`}
       aria-pressed={active}
@@ -139,10 +167,17 @@ const TutorialCardInner: React.FC<TutorialCardProps> = ({
             <PlayArrowRoundedIcon />
           </span>
         </span>
-        <span className="duration">{tutorial.durationLabel}</span>
+        {!compact && (
+          <span className="duration">{tutorial.durationLabel}</span>
+        )}
       </span>
       <span className="body">
-        <span className="level">{tutorial.level}</span>
+        <span className="meta">
+          <span className="level">{tutorial.level}</span>
+          {compact && (
+            <span className="duration-inline">{tutorial.durationLabel}</span>
+          )}
+        </span>
         <h3 className="title">{tutorial.title}</h3>
         <p className="tagline">{tutorial.tagline}</p>
       </span>

--- a/web/src/components/tutorials/TutorialsPage.tsx
+++ b/web/src/components/tutorials/TutorialsPage.tsx
@@ -2,7 +2,8 @@
 import { css } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
 import { useTheme } from "@mui/material/styles";
-import { memo, useCallback } from "react";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { memo, useCallback, useRef } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
 import CheckRoundedIcon from "@mui/icons-material/CheckRounded";
@@ -34,9 +35,17 @@ const styles = (theme: Theme) =>
       gap: theme.spacing(1.5),
       padding: `${getSpacingPx(4)} ${getSpacingPx(6)}`,
       borderBottom: `1px solid ${theme.vars.palette.divider}`,
-      flexShrink: 0
+      flexShrink: 0,
+      [theme.breakpoints.down("md")]: {
+        padding: `${getSpacingPx(SPACING.lg)} ${getSpacingPx(SPACING.lg)}`
+      }
     },
-    ".tut-header .titles": { display: "flex", flexDirection: "column", gap: 2 },
+    ".tut-header .titles": {
+      display: "flex",
+      flexDirection: "column",
+      gap: 2,
+      minWidth: 0
+    },
     ".tut-header h1": {
       margin: 0,
       fontSize: "var(--fontSizeBig)",
@@ -45,7 +54,8 @@ const styles = (theme: Theme) =>
     },
     ".tut-header .sub": {
       fontSize: "var(--fontSizeSmall)",
-      color: theme.vars.palette.text.secondary
+      color: theme.vars.palette.text.secondary,
+      [theme.breakpoints.down("md")]: { display: "none" }
     },
     ".tut-header .spacer": { flex: 1 },
     ".back": {
@@ -59,7 +69,8 @@ const styles = (theme: Theme) =>
       cursor: "pointer",
       transition: `color ${MOTION.fast}`,
       "&:hover": { color: theme.vars.palette.text.primary },
-      "& svg": { fontSize: 18 }
+      "& svg": { fontSize: 18 },
+      "@media (pointer: coarse)": { minHeight: 44, paddingLeft: 0 }
     },
 
     ".tut-body": {
@@ -67,7 +78,14 @@ const styles = (theme: Theme) =>
       minHeight: 0,
       display: "grid",
       gridTemplateColumns: "320px 1fr",
-      [theme.breakpoints.down("md")]: { gridTemplateColumns: "1fr" }
+      // Stacked: one scroll container for the whole page instead of two
+      // competing ones squeezed into a viewport-height grid.
+      [theme.breakpoints.down("md")]: {
+        display: "flex",
+        flexDirection: "column",
+        overflowY: "auto",
+        WebkitOverflowScrolling: "touch"
+      }
     },
 
     ".tut-sidebar": {
@@ -78,19 +96,40 @@ const styles = (theme: Theme) =>
       flexDirection: "column",
       gap: getSpacingPx(3),
       [theme.breakpoints.down("md")]: {
+        // The player leads; the list follows it, one column per phone-width
+        // track so a tablet gets two abreast.
+        order: 2,
         borderRight: "none",
-        borderBottom: `1px solid ${theme.vars.palette.divider}`
+        borderTop: `1px solid ${theme.vars.palette.divider}`,
+        overflow: "visible",
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+        alignItems: "start",
+        padding: getSpacingPx(SPACING.lg),
+        gap: getSpacingPx(SPACING.md)
       }
     },
+    // Cards keep their natural height; the sidebar scrolls instead of
+    // squeezing them until the titles disappear.
+    ".tut-sidebar > *": { flexShrink: 0 },
     ".tut-sidebar .sidebar-label": {
       fontSize: "var(--fontSizeSmaller)",
       fontWeight: 600,
       letterSpacing: "0.06em",
       textTransform: "uppercase",
-      color: theme.vars.palette.text.disabled
+      color: theme.vars.palette.text.disabled,
+      [theme.breakpoints.down("md")]: { gridColumn: "1 / -1" }
     },
 
-    ".tut-main": { overflowY: "auto", padding: getSpacingPx(8) },
+    ".tut-main": {
+      overflowY: "auto",
+      padding: getSpacingPx(8),
+      [theme.breakpoints.down("md")]: {
+        order: 1,
+        overflow: "visible",
+        padding: getSpacingPx(SPACING.lg)
+      }
+    },
     ".tut-main .stage": { maxWidth: 920, margin: "0 auto" },
     ".tut-player": {
       width: "100%",
@@ -99,13 +138,15 @@ const styles = (theme: Theme) =>
       overflow: "hidden",
       border: `1px solid ${theme.vars.palette.divider}`,
       background: theme.vars.palette.common.black,
-      boxShadow: "0 20px 50px rgba(0,0,0,0.4)"
+      boxShadow: "0 20px 50px rgba(0,0,0,0.4)",
+      [theme.breakpoints.down("md")]: { boxShadow: "none" }
     },
     ".tut-meta": {
       display: "flex",
       alignItems: "center",
       gap: theme.spacing(SPACING.sm),
-      marginTop: getSpacingPx(5)
+      marginTop: getSpacingPx(5),
+      [theme.breakpoints.down("md")]: { marginTop: getSpacingPx(SPACING.lg) }
     },
     ".tut-meta .pill": {
       fontSize: "var(--fontSizeSmaller)",
@@ -137,6 +178,7 @@ const styles = (theme: Theme) =>
 
     ".tut-learn": {
       marginTop: getSpacingPx(6),
+      [theme.breakpoints.down("md")]: { marginTop: getSpacingPx(SPACING.xl) },
       display: "flex",
       flexDirection: "column",
       gap: getSpacingPx(2)
@@ -166,7 +208,11 @@ const styles = (theme: Theme) =>
       display: "flex",
       gap: theme.spacing(1.5),
       marginTop: getSpacingPx(8),
-      flexWrap: "wrap"
+      flexWrap: "wrap",
+      [theme.breakpoints.down("md")]: {
+        marginTop: getSpacingPx(SPACING.xl),
+        "& > button": { flex: 1, minHeight: 44 }
+      }
     }
   });
 
@@ -174,14 +220,20 @@ const TutorialsPage: React.FC = () => {
   const theme = useTheme();
   const navigate = useNavigate();
   const [params, setParams] = useSearchParams();
+  const stacked = useMediaQuery(theme.breakpoints.down("md"));
+  const bodyRef = useRef<HTMLDivElement>(null);
 
   const active = getTutorial(params.get("id"));
 
   const select = useCallback(
     (id: string) => {
       setParams({ id }, { replace: true });
+      // Stacked, the list sits below the player — bring the player back up.
+      if (stacked) {
+        bodyRef.current?.scrollTo?.({ top: 0, behavior: "smooth" });
+      }
     },
-    [setParams]
+    [setParams, stacked]
   );
 
   return (
@@ -199,7 +251,7 @@ const TutorialsPage: React.FC = () => {
         </button>
       </header>
 
-      <div className="tut-body">
+      <div className="tut-body" ref={bodyRef}>
         <aside className="tut-sidebar">
           <span className="sidebar-label">{TUTORIALS.length} tutorials</span>
           {TUTORIALS.map((tutorial) => (
@@ -207,6 +259,7 @@ const TutorialsPage: React.FC = () => {
               key={tutorial.id}
               tutorial={tutorial}
               active={tutorial.id === active.id}
+              compact={stacked}
               onClick={select}
             />
           ))}

--- a/web/src/components/tutorials/__tests__/TutorialsPage.test.tsx
+++ b/web/src/components/tutorials/__tests__/TutorialsPage.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import { MemoryRouter } from "react-router-dom";
+import mockTheme from "../../../__mocks__/themeMock";
+import TutorialsPage from "../TutorialsPage";
+import { TUTORIALS } from "../tutorialsData";
+
+const MAX_WIDTH_QUERY = /max-width/;
+
+/** Drive MUI's useMediaQuery: only max-width queries match on "narrow". */
+const setViewport = (narrow: boolean) => {
+  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches: narrow && MAX_WIDTH_QUERY.test(query),
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  })) as unknown as typeof window.matchMedia;
+};
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <ThemeProvider theme={mockTheme}>
+        <TutorialsPage />
+      </ThemeProvider>
+    </MemoryRouter>
+  );
+
+describe("TutorialsPage responsive layout", () => {
+  const originalMatchMedia = window.matchMedia;
+  const second = TUTORIALS[1];
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    jest.restoreAllMocks();
+  });
+
+  it("stacks the list under the player and scrolls back up on select", async () => {
+    setViewport(true);
+    const scrollTo = jest.fn();
+    Element.prototype.scrollTo = scrollTo as unknown as Element["scrollTo"];
+
+    const { container } = renderPage();
+
+    const body = container.querySelector(".tut-body");
+    const main = container.querySelector(".tut-main");
+    const sidebar = container.querySelector(".tut-sidebar");
+    expect(body).toContainElement(main as HTMLElement);
+    expect(body).toContainElement(sidebar as HTMLElement);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: `Play tutorial: ${second.title}` })
+    );
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+    expect(
+      screen.getByRole("button", { name: `Play tutorial: ${second.title}` })
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("keeps the two-column layout put on a wide viewport", async () => {
+    setViewport(false);
+    const scrollTo = jest.fn();
+    Element.prototype.scrollTo = scrollTo as unknown as Element["scrollTo"];
+
+    renderPage();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: `Play tutorial: ${second.title}` })
+    );
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/ui_primitives/VideoPlayer.tsx
+++ b/web/src/components/ui_primitives/VideoPlayer.tsx
@@ -71,7 +71,13 @@ const styles = (theme: Theme, controlsVisible: boolean) =>
     ".play-button": {
       width: 28,
       height: 28,
+      flexShrink: 0,
       padding: 0,
+      "@media (pointer: coarse)": {
+        width: 40,
+        height: 40,
+        "& svg": { fontSize: 24 }
+      },
       color: theme.vars.palette.common.white,
       "& svg": { fontSize: 20 },
       "&:hover": {
@@ -81,11 +87,17 @@ const styles = (theme: Theme, controlsVisible: boolean) =>
     },
     ".seek": {
       flex: 1,
+      minWidth: 0,
       height: 4,
       appearance: "none",
       background: "rgba(255, 255, 255, 0.25)",
       borderRadius: 2,
       cursor: "pointer",
+      "@media (pointer: coarse)": {
+        height: 6,
+        "&::-webkit-slider-thumb": { width: 16, height: 16 },
+        "&::-moz-range-thumb": { width: 16, height: 16 }
+      },
       "&::-webkit-slider-thumb": {
         appearance: "none",
         width: 10,
@@ -235,6 +247,9 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
       onMouseMove={showControls}
       onMouseEnter={showControls}
       onMouseLeave={() => setControlsVisible(false)}
+      // Touch has no hover, so without this the controls never come back once
+      // they auto-hide.
+      onTouchStart={showControls}
     >
       <video
         ref={videoRef}


### PR DESCRIPTION
Below the `md` breakpoint the tutorials page stacked two independently scrolling regions inside a viewport-height grid: a full-height list of 16:9 cards on top, the player squeezed underneath. On a phone you scrolled a list to find the video, then scrolled a second box to read anything about it.

## What changed

- **One scroll for the page when stacked.** `.tut-body` becomes a flex column that owns the scroll; the sidebar and main no longer scroll independently. The player comes first, the list follows, and selecting a tutorial scrolls back up to the player.
- **The list becomes rows** (`TutorialCard` gains a `compact` prop): 132px thumbnail, level + duration + title + 2-line tagline beside it. Laid out `repeat(auto-fill, minmax(280px, 1fr))`, so a phone gets one column and a tablet two abreast.
- **Narrow-width trim**: smaller header padding, subtitle hidden, main padding down to 12px, CTA buttons split the row at 44px tall, player drop-shadow off.
- **Sidebar cards no longer shrink to fit.** In the scrolling flex column they were being squeezed until their titles disappeared — visible on desktop too (see before/after below).
- **VideoPlayer**: controls reveal on `touchstart` (they auto-hide after a delay and there is no hover to bring them back on a phone), the play button grows to 40px and the seek thumb to 16px on coarse pointers, and hover-only effects are gated behind `@media (hover: hover)` so they don't latch after a tap.

## Verification

- `npx eslint` clean on the touched files; `tsc --noEmit` reports nothing new (the pre-existing errors are unbuilt node packages).
- New `TutorialsPage.test.tsx` covers the stacked layout and the scroll-to-player behavior; `jest src/components/tutorials src/components/ui_primitives` — 825 tests pass.
- Checked in a real browser against the dev server at 320px, 390px, 768px, and 1280px: no horizontal overflow at any width, no console errors, and the desktop two-column layout is unchanged apart from the card-squeeze fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub9An6cR1rk4ok1j7HFEe4)_