### PR TITLE
Drop host-filesystem nodes from the production node surface

### DIFF
--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -119,14 +119,56 @@ export const CLOUD_NODE_ALLOWLIST: readonly string[] = [
 ];
 
 /**
- * Node types removed even though their namespace is allowed. Two groups:
+ * Nodes that read or write a path on the server's own filesystem and sit
+ * inside an otherwise-allowed namespace, so only naming them keeps them out.
  *
+ * Two shapes end up here. Most declare a path property the editor renders as a
+ * native file/folder picker (`json_schema_extra: { type: "file_path" }`) —
+ * `nodetool.input.DocumentFileInput` is the one users hit first. The rest take
+ * a plain string path and call `fs` in `process()`; nothing in their metadata
+ * distinguishes them, which is why this list is written out rather than
+ * derived.
+ *
+ * Split out from {@link CLOUD_NODE_DENYLIST} so the "no host filesystem in the
+ * cloud" rule is one reviewable list instead of entries scattered by namespace.
+ */
+export const CLOUD_HOST_FILE_NODES: readonly string[] = [
+  // Path pickers — a local path typed into a browser tab points at the
+  // container's disk, not the user's machine.
+  "nodetool.input.DocumentFileInput",
+  "nodetool.input.FilePathInput",
+  "nodetool.input.FolderPathInput",
+  // Media loaders/savers that go to disk. Their asset-store siblings
+  // (LoadImageAssets, SaveImage, SaveAudio, SaveVideo, …) stay.
+  "nodetool.audio.LoadAudioFile",
+  "nodetool.audio.LoadAudioFolder",
+  "nodetool.audio.SaveAudioFile",
+  "nodetool.image.LoadImageFile",
+  "nodetool.image.LoadImageFolder",
+  "nodetool.image.SaveImageFile",
+  "nodetool.video.LoadVideoFile",
+  "nodetool.video.SaveVideoFile",
+  "nodetool.model3d.LoadModel3DFile",
+  "nodetool.model3d.SaveModel3DFile"
+];
+
+/**
+ * Node types removed even though their namespace is allowed. Three groups:
+ *
+ * - Host-filesystem nodes — {@link CLOUD_HOST_FILE_NODES} above, which this
+ *   list embeds. A node that reads or writes a path on the server's own disk
+ *   has no meaning in a managed multi-tenant cloud: the path belongs to the
+ *   container, not to the user sitting in the browser. The matching HTTP
+ *   surfaces are already refused in production (`/api/files/local`, the
+ *   workspace routes, tRPC `files.list`), so leaving the nodes in the palette
+ *   only offers a picker that cannot pick and a run that cannot resolve.
+ *   Assets are the cloud's file story: the `*Assets` loaders and the plain
+ *   `SaveImage`/`SaveAudio`/`SaveVideo`/`SaveDataframe` savers go through the
+ *   asset store and stay.
  * - `nodetool.text.*` file I/O — `nodetool.text` is whole-listed for its
  *   creative-text toolkit and ASR, but the folder/asset loaders and the two
  *   filesystem writers (`SaveText`, `SaveTextFile` — both call fs.writeFile on
- *   an unsandboxed host path) are dropped: arbitrary host-filesystem access
- *   isn't appropriate for a managed multi-tenant cloud (same reason the
- *   shell/Docker code runners stay out).
+ *   an unsandboxed host path) are dropped, for the same reason.
  * - `nodetool.agents.*` — the developer/automation-flavored agents that wrap
  *   the very integrations the cloud profile drops (shell, git, sqlite,
  *   supabase, http, filesystem, browser, office docs). Kept agents: Agent,
@@ -134,6 +176,7 @@ export const CLOUD_NODE_ALLOWLIST: readonly string[] = [
  *   FfmpegAgent, DocumentAgent.
  */
 export const CLOUD_NODE_DENYLIST: readonly string[] = [
+  ...CLOUD_HOST_FILE_NODES,
   "nodetool.text.LoadTextFolder",
   "nodetool.text.LoadTextAssets",
   "nodetool.text.SaveText",

--- a/packages/protocol/tests/cloud-profile.test.ts
+++ b/packages/protocol/tests/cloud-profile.test.ts
@@ -3,6 +3,7 @@ import {
   CLOUD_NODE_NAMESPACES,
   CLOUD_NODE_ALLOWLIST,
   CLOUD_NODE_DENYLIST,
+  CLOUD_HOST_FILE_NODES,
   CLOUD_PROVIDER_IDS,
   CLOUD_BUILTIN_PACK_IDS,
   isCloudNodeType,
@@ -133,6 +134,31 @@ describe("code is node-level trimmed; text is whole-listed minus file I/O", () =
       "nodetool.text.SaveTextFile"
     ]) {
       expect(isCloudNodeType(nodeType)).toBe(false);
+    }
+  });
+
+  it("drops the host-filesystem nodes from the managed cloud", () => {
+    for (const nodeType of CLOUD_HOST_FILE_NODES) {
+      expect(isCloudNodeType(nodeType)).toBe(false);
+    }
+    // The node users reach for first — a local path picker in the browser.
+    expect(CLOUD_HOST_FILE_NODES).toContain(
+      "nodetool.input.DocumentFileInput"
+    );
+  });
+
+  it("keeps the asset-store counterparts of the dropped file nodes", () => {
+    // Assets, not host paths, are how the cloud moves files around. Dropping
+    // the disk nodes must not take these with them.
+    for (const nodeType of [
+      "nodetool.input.AssetFolderInput",
+      "nodetool.input.DocumentInput",
+      "nodetool.image.LoadImageAssets",
+      "nodetool.image.SaveImage",
+      "nodetool.audio.SaveAudio",
+      "nodetool.video.SaveVideo"
+    ]) {
+      expect(isCloudNodeType(nodeType)).toBe(true);
     }
   });
 

--- a/packages/websocket/tests/node-registry-setup.test.ts
+++ b/packages/websocket/tests/node-registry-setup.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { NodeRegistry } from "@nodetool-ai/node-sdk";
 import {
   BUILTIN_NODE_PACKS,
+  CLOUD_HOST_FILE_NODES,
   CLOUD_PROFILE_ENV,
   NODE_ENV_VAR,
   isCloudNodeType
@@ -261,9 +262,37 @@ describe("applyCloudNodePolicy", () => {
     expect(remaining).not.toContain("nodetool.text.LoadTextFolder");
     expect(remaining).not.toContain("nodetool.text.SaveText");
     expect(remaining).not.toContain("nodetool.text.SaveTextFile");
+    // …the same goes for every node that reads or writes a host path,
+    // including the file/folder pickers in the otherwise-allowed input
+    // namespace…
+    for (const nodeType of CLOUD_HOST_FILE_NODES) {
+      expect(remaining).not.toContain(nodeType);
+    }
+    // …while the asset-store equivalents stay, since assets are how the cloud
+    // moves files…
+    expect(remaining).toContain("nodetool.input.AssetFolderInput");
+    expect(remaining).toContain("nodetool.image.LoadImageAssets");
+    expect(remaining).toContain("nodetool.image.SaveImage");
     // …while the creative media core stays.
     expect(remaining.some((t) => t.startsWith("nodetool.image."))).toBe(true);
     expect(remaining.some((t) => t.startsWith("nodetool.audio."))).toBe(true);
+  }
+
+  /**
+   * Drift guard. A path property the editor renders as a native picker is the
+   * one host-filesystem shape that is visible in metadata, so a node added
+   * later inside an allowed namespace is caught here rather than in
+   * production. Nodes taking a plain string path look like any other string
+   * node and can only be caught by naming them in CLOUD_HOST_FILE_NODES.
+   */
+  function expectNoNativePathPickers(registry: NodeRegistry): void {
+    const offenders = registry.list().filter((nodeType) =>
+      (registry.getMetadata(nodeType)?.properties ?? []).some((property) => {
+        const kind = property.json_schema_extra?.["type"];
+        return kind === "file_path" || kind === "folder_path";
+      })
+    );
+    expect(offenders).toEqual([]);
   }
 
   it("is a no-op when the cloud profile is off", () => {
@@ -293,5 +322,16 @@ describe("applyCloudNodePolicy", () => {
     const registry = fullRegistry();
     applyCloudNodePolicy(registry);
     expectCuratedSurface(registry);
+  });
+
+  it("leaves no native file/folder picker in the cloud surface", () => {
+    delete process.env[CLOUD_PROFILE_ENV];
+    process.env[NODE_ENV_VAR] = "production";
+    const registry = fullRegistry();
+    // The pickers exist before the policy runs — otherwise this guard would
+    // pass for the wrong reason.
+    expect(registry.list()).toContain("nodetool.input.DocumentFileInput");
+    applyCloudNodePolicy(registry);
+    expectNoNativePathPickers(registry);
   });
 });


### PR DESCRIPTION
## Problem

In production we don't want file-access nodes like the document file input.

The cloud profile (`NODETOOL_ENV=production` → cloud, unless `NODETOOL_NODE_PROFILE=full`) already curates the catalog down to the creative node set, but it whole-lists `nodetool.input`, `nodetool.image`, `nodetool.audio`, `nodetool.video`, and `nodetool.model3d`. The nodes inside those namespaces that read and write paths on the **server's own disk** therefore survived.

`nodetool.input.DocumentFileInput` is the one users hit first: a native file picker rendered in a browser tab that can only ever point at the container's filesystem, not the user's machine.

The matching HTTP surfaces are already refused in production — `/api/files/local` (`file-api.ts:163`), the workspace routes (`workspace-api.ts:76`), tRPC `files.list` (`trpc/routers/files.ts:46`). So these nodes were offering a picker that cannot pick and a run that cannot resolve.

## Change

Collect the offenders in a new `CLOUD_HOST_FILE_NODES` and embed it in the existing `CLOUD_NODE_DENYLIST` (`packages/protocol/src/cloud-profile.ts`). `applyCloudNodePolicy` already unregisters denied types at bootstrap, so the palette, `/api/nodes/metadata`, and the runner all agree with no new mechanism.

Thirteen node types, all verified to exist in the registry (a typo here would be a silent no-op):

| | |
|---|---|
| Path pickers | `nodetool.input.DocumentFileInput`, `FilePathInput`, `FolderPathInput` |
| Audio | `LoadAudioFile`, `LoadAudioFolder`, `SaveAudioFile` |
| Image | `LoadImageFile`, `LoadImageFolder`, `SaveImageFile` |
| Video | `LoadVideoFile`, `SaveVideoFile` |
| 3D | `LoadModel3DFile`, `SaveModel3DFile` |

**Assets stay.** They're how the cloud moves files: the `*Assets` loaders, `AssetFolderInput`, `DocumentInput`, and the plain `SaveImage`/`SaveAudio`/`SaveVideo`/`SaveModel3D` savers are untouched, and a test pins that.

## Why the list is written out rather than derived

Two shapes needed naming, and only one is visible in metadata:

- Most declare a picker property (`json_schema_extra: { type: "file_path" }`) — detectable.
- The rest (`LoadAudioFile` and friends) take a plain `str` prop and call `fs` in `process()`. Nothing in their metadata distinguishes them from any other string node.

So the list is explicit, and a **registry-level drift guard** covers the detectable half: a test asserts no node with a file/folder picker property survives the policy, so one added later inside an allowed namespace fails CI instead of shipping. I verified the guard actually fails by temporarily removing `DocumentFileInput` from the list — it caught it — then restored.

Nodes that use scratch files under `os.tmpdir()` (ffmpeg work in `nodetool.video.*` and `nodetool.timeline.*`) are **not** host file access and correctly stay; I checked each against its source rather than trusting an `fs` grep.

## Scope

Self-hosted deployments running `NODETOOL_NODE_PROFILE=full` are unaffected, consistent with the rest of the cloud curation. I deliberately did not gate on bare `NODETOOL_ENV=production`, which would override that documented opt-out — say the word if you'd rather these nodes be gone on every production server regardless of profile.

No shipped example workflow references any of the removed nodes (checked). Existing user workflows in the cloud that contain one will now fail validation up front rather than at the node — those runs could not have resolved a host path anyway.

## Testing

- `packages/protocol`: 794 tests pass; added coverage that the host-file nodes are denied and their asset counterparts are kept.
- `packages/websocket` `node-registry-setup`: 19 pass, including the new drift guard.
- `npm run lint` passes; root `npm run typecheck` passes.

Two pre-existing environment failures, confirmed identical on a clean tree via `git stash`: electron's typecheck and 26 websocket test files fail to import because `packages/websocket/dist` and `@nodetool-ai/dsl` aren't built in this sandbox. All 1918 collected websocket tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfkxHL5wPA3ZPKAvie8rbh)_