### PR TITLE
Inherit the calling agent's model in build_app by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,8 +551,12 @@ The same `buildApp` runs on the server:
 `POST /api/applications/build {prompt | spec, provider, model, workflow_ids,
 max_repairs, cost_cap_usd, timeout_ms}` returns the `BuildReport`, and an agent
 reaches it through the **`build_app`** tool. Provider and model come from the
-body, or from `NODETOOL_APP_BUILD_PROVIDER` / `NODETOOL_APP_BUILD_MODEL`; the
-cost cap defaults to the harness's own $2.
+body; a `build_app` call that omits them inherits the calling agent's own
+provider/model (stamped on the ProcessingContext under
+`ACTIVE_MODEL_CONTEXT_KEY` by every tool-calling loop — chat turns and
+`StepExecutor` sub-agents alike), and the server falls back to
+`NODETOOL_APP_BUILD_PROVIDER` / `NODETOOL_APP_BUILD_MODEL`. The cost cap
+defaults to the harness's own $2.
 
 A build runs for minutes, so `poll: true` returns a session id immediately and
 the caller reads `GET /api/debug/sessions/:id` until it settles, or cancels with

--- a/packages/agents/src/step-executor.ts
+++ b/packages/agents/src/step-executor.ts
@@ -20,7 +20,12 @@ import type {
   ProviderStreamItem
 } from "@nodetool-ai/runtime";
 import type { TurnBudget } from "@nodetool-ai/runtime";
-import { memoryKeys, withAgentSpanGen } from "@nodetool-ai/runtime";
+import {
+  ACTIVE_MODEL_CONTEXT_KEY,
+  memoryKeys,
+  withAgentSpanGen,
+  type ActiveModelSelection
+} from "@nodetool-ai/runtime";
 import { linkAbort } from "./utils/link-abort.js";
 import { createLogger } from "@nodetool-ai/config";
 import {
@@ -886,6 +891,13 @@ export class StepExecutor {
       stepId: this.step.id,
       instructions: this.step.instructions.slice(0, 60)
     });
+
+    // Stamp the loop's own selection so harness-launching tools (build_app)
+    // inherit this agent's provider/model when the call doesn't name one.
+    this.context.set(ACTIVE_MODEL_CONTEXT_KEY, {
+      provider: this.provider.provider,
+      model: this.model
+    } satisfies ActiveModelSelection);
 
     this.history.push({ role: "system" as const, content: this.systemPrompt });
 

--- a/packages/agents/src/tools/mcp-tools.ts
+++ b/packages/agents/src/tools/mcp-tools.ts
@@ -9,8 +9,10 @@
 
 import type { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
 import {
+  ACTIVE_MODEL_CONTEXT_KEY,
   listOfflineModelIds,
-  listRegisteredProviderIds
+  listRegisteredProviderIds,
+  type ActiveModelSelection
 } from "@nodetool-ai/runtime";
 import type {
   GraphValidationIssue,
@@ -954,7 +956,10 @@ export class BuildAppTool extends Tool {
     "fixed, the simulated run of every interaction, a pass/fail verdict, and " +
     "— only behind a passing verdict — the ApplicationBundle. The bundle is " +
     "offered, not installed: show the user the verdict and install it with " +
-    "POST /api/applications/import-bundle once they agree. A build takes " +
+    "POST /api/applications/import-bundle once they agree. The build's own " +
+    "model calls default to the provider and model YOU are running on — omit " +
+    "provider/model to inherit them; pass both only to build with a " +
+    "different model. A build takes " +
     "minutes; pass poll=true to get a session id back immediately, then read " +
     "GET /api/debug/sessions/<id> until it settles or cancel it with POST " +
     "/api/debug/sessions/<id>/cancel.";
@@ -972,11 +977,15 @@ export class BuildAppTool extends Tool {
       },
       provider: {
         type: "string" as const,
-        description: "Provider id for the build's own model calls"
+        description:
+          "Provider id for the build's own model calls. Defaults to the " +
+          "provider of the agent making this call."
       },
       model: {
         type: "string" as const,
-        description: "Model id the build authors with"
+        description:
+          "Model id the build authors with. Defaults to the model of the " +
+          "agent making this call."
       },
       workflow_ids: {
         type: "array" as const,
@@ -1011,7 +1020,15 @@ export class BuildAppTool extends Tool {
     context: ProcessingContext,
     params: Record<string, unknown>
   ): Promise<unknown> {
-    return apiPost(context, "/api/applications/build", params);
+    const inherited = context.get<ActiveModelSelection | undefined>(
+      ACTIVE_MODEL_CONTEXT_KEY
+    );
+    const body = { ...params };
+    if (inherited) {
+      body["provider"] ??= inherited.provider;
+      body["model"] ??= inherited.model;
+    }
+    return apiPost(context, "/api/applications/build", body);
   }
 
   userMessage(params: Record<string, unknown>): string {

--- a/packages/agents/tests/mcp-tools.test.ts
+++ b/packages/agents/tests/mcp-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { BaseProvider, ProcessingContext } from "@nodetool-ai/runtime";
+import { ACTIVE_MODEL_CONTEXT_KEY } from "@nodetool-ai/runtime";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
 import {
   PlanWorkflowGraphTool,
@@ -9,6 +10,7 @@ import {
   RunWorkflowTool,
   DebugWorkflowTool,
   ResolveWorkflowEscalationTool,
+  BuildAppTool,
   DebugAppTool,
   ValidateWorkflowTool,
   ValidateTimelineTool,
@@ -31,10 +33,15 @@ import {
 const API_URL = "http://test-api:7777";
 
 function makeMockContext(): ProcessingContext {
+  const variables: Record<string, unknown> = {};
   return {
     userId: "user-1",
     authToken: "access-token",
-    environment: { NODETOOL_API_URL: API_URL }
+    environment: { NODETOOL_API_URL: API_URL },
+    get: (key: string) => variables[key],
+    set: (key: string, value: unknown) => {
+      variables[key] = value;
+    }
   } as unknown as ProcessingContext;
 }
 
@@ -565,6 +572,51 @@ describe("ResolveWorkflowEscalationTool", () => {
       action: "skip"
     })) as Record<string, unknown>;
     expect(String(result.next_tool)).toContain("resolve_workflow_escalation");
+  });
+});
+
+describe("BuildAppTool", () => {
+  const tool = new BuildAppTool();
+
+  it("inherits the calling agent's provider/model when the call omits them", async () => {
+    ctx.set(ACTIVE_MODEL_CONTEXT_KEY, {
+      provider: "anthropic",
+      model: "claude-sonnet-5"
+    });
+    await tool.process(ctx, { prompt: "a note-drafting app" });
+    expect(lastFetchUrl()).toContain("/api/applications/build");
+    const body = JSON.parse(lastFetchOpts().body as string);
+    expect(body.provider).toBe("anthropic");
+    expect(body.model).toBe("claude-sonnet-5");
+  });
+
+  it("keeps an explicit provider/model over the inherited one", async () => {
+    ctx.set(ACTIVE_MODEL_CONTEXT_KEY, {
+      provider: "anthropic",
+      model: "claude-sonnet-5"
+    });
+    await tool.process(ctx, {
+      prompt: "a note-drafting app",
+      provider: "openai",
+      model: "gpt-5.4-mini"
+    });
+    const body = JSON.parse(lastFetchOpts().body as string);
+    expect(body.provider).toBe("openai");
+    expect(body.model).toBe("gpt-5.4-mini");
+  });
+
+  it("passes the params through unchanged when nothing is stamped", async () => {
+    await tool.process(ctx, { prompt: "a note-drafting app" });
+    const body = JSON.parse(lastFetchOpts().body as string);
+    expect(body.provider).toBeUndefined();
+    expect(body.model).toBeUndefined();
+  });
+
+  it("documents the inheritance in the tool and parameter descriptions", () => {
+    expect(tool.description).toContain("default to the provider and model");
+    const props = tool.jsonSchema.properties;
+    expect(props.provider.description).toContain("agent making this call");
+    expect(props.model.description).toContain("agent making this call");
   });
 });
 

--- a/packages/chat/src/message-processor.ts
+++ b/packages/chat/src/message-processor.ts
@@ -12,8 +12,10 @@ import type {
   ProviderSession
 } from "@nodetool-ai/runtime";
 import {
+  ACTIVE_MODEL_CONTEXT_KEY,
   isProviderSessionUpdate,
-  isProviderMessageEvent
+  isProviderMessageEvent,
+  type ActiveModelSelection
 } from "@nodetool-ai/runtime";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import type { Chunk } from "@nodetool-ai/protocol";
@@ -151,6 +153,13 @@ export async function processChat(opts: {
     maxIterations = 25,
     longTermMemory
   } = opts;
+
+  // Stamp the turn's own selection so harness-launching tools (build_app)
+  // inherit this chat's provider/model when the call doesn't name one.
+  context.set(ACTIVE_MODEL_CONTEXT_KEY, {
+    provider: provider.provider,
+    model
+  } satisfies ActiveModelSelection);
 
   // Recall memory before pushing the user message — keep the recall fresh
   // (relevant to the new query) and avoid leaking the system block into the

--- a/packages/chat/tests/message-processor.test.ts
+++ b/packages/chat/tests/message-processor.test.ts
@@ -99,7 +99,13 @@ function createMockProvider(sequences: ProviderStreamItem[][]) {
 }
 
 function createMockContext(): ProcessingContext {
-  return {} as any;
+  const variables: Record<string, unknown> = {};
+  return {
+    get: (key: string) => variables[key],
+    set: (key: string, value: unknown) => {
+      variables[key] = value;
+    }
+  } as any;
 }
 
 function chunk(content: string): Chunk {

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -43,6 +43,21 @@ import { importNodeBuiltin } from "@nodetool-ai/config";
  */
 const MIN_MASKABLE_SECRET_LENGTH = 8;
 
+/**
+ * ProcessingContext variable key carrying the provider/model the currently
+ * running agent loop is itself talking to. Every loop that executes tools
+ * (chat turns, `StepExecutor` sub-agents) stamps it, so a tool that launches
+ * another harness — `build_app` and friends — inherits the caller's model by
+ * default instead of demanding one or falling back to a server env default.
+ */
+export const ACTIVE_MODEL_CONTEXT_KEY = "active_agent_model";
+
+/** The value stored under {@link ACTIVE_MODEL_CONTEXT_KEY}. */
+export interface ActiveModelSelection {
+  provider: string;
+  model: string;
+}
+
 const nodeCrypto =
   await importNodeBuiltin<typeof import("node:crypto")>("node:crypto");
 const nodeFsP =

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -4,6 +4,8 @@
 
 export {
   ProcessingContext,
+  ACTIVE_MODEL_CONTEXT_KEY,
+  type ActiveModelSelection,
   MemoryCache,
   InMemoryStorageAdapter,
   FileStorageAdapter,

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -91,10 +91,12 @@ import type {
 } from "@nodetool-ai/runtime";
 import {
   ProcessingContext as RuntimeProcessingContext,
+  ACTIVE_MODEL_CONTEXT_KEY,
   encodeRawRgbaToPng,
   getCostReconciler,
   isProviderSessionUpdate,
-  isProviderMessageEvent
+  isProviderMessageEvent,
+  type ActiveModelSelection
 } from "@nodetool-ai/runtime";
 import { isRawRgbaImage } from "@nodetool-ai/protocol";
 import type {
@@ -5412,6 +5414,12 @@ export class UnifiedWebSocketRunner {
     // Any agent planning inside this turn (e.g. via run_node spawning an
     // Agent node in plan mode) pauses for user plan approval.
     this.attachPlanApproval(ctx, threadId || null);
+    // Stamp the turn's own selection so harness-launching tools (build_app)
+    // inherit this chat's provider/model when the call doesn't name one.
+    ctx.set(ACTIVE_MODEL_CONTEXT_KEY, {
+      provider: providerId,
+      model
+    } satisfies ActiveModelSelection);
 
     // Prepend system prompt if first message isn't system role — matches Python
     if (chatHistory.length === 0 || chatHistory[0].role !== "system") {


### PR DESCRIPTION
## What

When an agent calls the app-build harness through the `build_app` tool, the call now inherits the calling agent's own provider/model by default, and the tool description says so.

## How

- **`ACTIVE_MODEL_CONTEXT_KEY` + `ActiveModelSelection`** (`@nodetool-ai/runtime`): a ProcessingContext variable carrying the provider/model the currently running agent loop is itself talking to.
- Every tool-calling loop stamps it: the websocket runner's chat turn, `processChat` in `@nodetool-ai/chat`, and `StepExecutor` sub-agents.
- `BuildAppTool.process` fills omitted `provider`/`model` params from the stamped selection. Explicit params still win, and the server-side `NODETOOL_APP_BUILD_PROVIDER` / `NODETOOL_APP_BUILD_MODEL` fallback remains for callers with no stamped selection (e.g. external MCP clients on `/mcp`).
- The tool description and the `provider`/`model` parameter descriptions now explain the inheritance, so the model driving the tool knows it can omit them.
- CLAUDE.md's `build_app` section documents the new resolution order.

## Tests

- `packages/agents/tests/mcp-tools.test.ts`: new `BuildAppTool` suite — inherits when omitted, explicit wins, passes through untouched when nothing is stamped, and the descriptions document the behavior.
- Full suites green: agents (2067), chat (30), websocket (2206), runtime (2699). Lint and web/electron typecheck pass; the mobile typecheck failure is missing Expo deps in this sandbox, unrelated to the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4Px39VmiyrGyanqioq6GL

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4Px39VmiyrGyanqioq6GL)_