### PR TITLE
Fix the chat shimmer clipping truncated labels

### DIFF
--- a/web/src/components/ui_primitives/ShimmerText.tsx
+++ b/web/src/components/ui_primitives/ShimmerText.tsx
@@ -19,9 +19,14 @@ const sweep = keyframes`
 `;
 
 const shimmerCss = css({
-  display: "inline-block",
+  // `inline`, not `inline-block`: an atomic inline is not ellipsized, so a
+  // shimmering label inside a truncating parent (the tool-call name) gets
+  // hard-clipped mid-character instead of ending in `…`.
+  display: "inline",
+  // The dim stops stay legible on their own — the sweep is a highlight
+  // passing over readable text, not a fade to near-invisible.
   background:
-    "linear-gradient(90deg, color-mix(in srgb, currentColor 45%, transparent) 0%, currentColor 50%, color-mix(in srgb, currentColor 45%, transparent) 100%)",
+    "linear-gradient(90deg, color-mix(in srgb, currentColor 70%, transparent) 0%, currentColor 50%, color-mix(in srgb, currentColor 70%, transparent) 100%)",
   backgroundSize: "200% 100%",
   WebkitBackgroundClip: "text",
   backgroundClip: "text",

--- a/web/src/components/ui_primitives/__tests__/ShimmerText.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/ShimmerText.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import { ShimmerText } from "../ShimmerText";
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
+
+describe("ShimmerText", () => {
+  it("renders its children as text", () => {
+    renderWithTheme(<ShimmerText>Thinking…</ShimmerText>);
+    expect(screen.getByText("Thinking…")).toBeInTheDocument();
+  });
+
+  it("stays inline so a truncating parent can still ellipsize it", () => {
+    const { container } = renderWithTheme(
+      <ShimmerText>search_the_web</ShimmerText>
+    );
+    const span = container.querySelector("span") as HTMLElement;
+    expect(getComputedStyle(span).display).toBe("inline");
+  });
+
+  it("forwards span attributes", () => {
+    renderWithTheme(
+      <ShimmerText aria-label="working" data-testid="shimmer">
+        Responding…
+      </ShimmerText>
+    );
+    expect(screen.getByTestId("shimmer")).toHaveAttribute(
+      "aria-label",
+      "working"
+    );
+  });
+});


### PR DESCRIPTION
## The bug

`ShimmerText` (added in #4742 to replace the chat circle spinners) was `display: inline-block`. An atomic inline cannot be ellipsized, so a running tool call's name — which sits inside a truncating `Text` (`.tool-call-name` is `white-space: nowrap` under `text-overflow: ellipsis`) — was hard-clipped mid-character instead of ending in `…`.

Reproduced in Chromium against the real component through the app's Vite pipeline. Same string, same 220px truncating box:

- plain text → `search_the_web_for_recent_art…`
- shimmering → `search_the_web_for_recent_articl` (clipped, no ellipsis)

## The fix

`display: inline`. The `background-clip: text` sweep still works — it animates on a single line and across a wrapped one — and truncation is restored (the ellipsis renders in the parent's solid color, which is what it did before the shimmer landed).

Also raised the gradient's dim stops from 45% to 70% of `currentColor`. At 45% a `text.secondary` status label spent most of the 2s cycle at ~0.31 effective alpha, which read as washed out rather than shimmering. At 70% the sweep is a highlight passing over text that stays readable on its own.

## Verification

- Browser: ellipsis restored, 4/4 sampled frames distinct (animation running), multi-line wrapping unchanged.
- New `ShimmerText.test.tsx` — renders children, stays `inline`, forwards span attributes.
- `web/src/components/chat` + `ui_primitives` suites: 168 tests, all passing.
- `tsc --noEmit` reports nothing on the touched files. The repo-wide typecheck has pre-existing `@nodetool-ai/audio-nodes` / `image-nodes` module-resolution errors in `browserRunnerCore.ts` from unbuilt package `dist/`, untouched by this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4mYLeZJRc9TKMrwMEATDs)_