### PR TITLE
Require a selected model to send a chat turn

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -10,6 +10,7 @@ export * from "./graph.js";
 export * from "./api-types.js";
 export * from "./package-assets.js";
 export * from "./resource-uri.js";
+export * from "./model-selection.js";
 export { TypeMetadata } from "./type-metadata.js";
 export { validateType, type ValidationResult } from "./typecheck.js";
 export {

--- a/packages/protocol/src/model-selection.ts
+++ b/packages/protocol/src/model-selection.ts
@@ -1,0 +1,43 @@
+/**
+ * Whether a model reference names a model the user actually picked.
+ *
+ * Every model field starts out as a placeholder whose provider is `"empty"` —
+ * the repo-wide sentinel for "nothing chosen yet". A selection counts only
+ * when both a provider and a model id are present and the provider is not that
+ * sentinel, so a placeholder never reaches provider resolution.
+ */
+
+export const UNSET_PROVIDER = "empty";
+
+export interface ModelSelection {
+  provider?: string | null;
+  id?: string | null;
+}
+
+export function isModelSelection(provider: unknown, id: unknown): boolean {
+  return (
+    typeof provider === "string" &&
+    provider.length > 0 &&
+    provider !== UNSET_PROVIDER &&
+    typeof id === "string" &&
+    id.length > 0 &&
+    // A client that stringified an absent id sends the literal "undefined".
+    id !== "undefined"
+  );
+}
+
+export function isModelSelected(
+  model: ModelSelection | null | undefined
+): boolean {
+  return isModelSelection(model?.provider, model?.id);
+}
+
+/** Guidance for a chat turn submitted with no language model selected. */
+export const NO_MODEL_SELECTED_MESSAGE =
+  "No model selected. Pick a language model in the composer's model menu, " +
+  "or add a provider API key under Settings → Models & Providers.";
+
+/** Guidance for a media generation submitted with no model selected. */
+export const noMediaModelSelectedMessage = (mode: string): string =>
+  `No ${mode.replace(/_/g, " ")} model selected. Pick one in the composer's ` +
+  "model menu, or add a provider API key under Settings → Models & Providers.";

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -96,7 +96,12 @@ import {
   isProviderSessionUpdate,
   isProviderMessageEvent
 } from "@nodetool-ai/runtime";
-import { isRawRgbaImage } from "@nodetool-ai/protocol";
+import {
+  isRawRgbaImage,
+  isModelSelection,
+  NO_MODEL_SELECTED_MESSAGE,
+  noMediaModelSelectedMessage
+} from "@nodetool-ai/protocol";
 import type {
   Chunk,
   GraphData,
@@ -4963,6 +4968,32 @@ export class UnifiedWebSocketRunner {
     );
     data.thread_id = threadId;
 
+    // Route this turn takes: a workflow chatbot and a media generation carry
+    // their own model selection (checked in their handlers), a plain chat turn
+    // is served by the language model the composer picked.
+    const workflowTargetHint =
+      typeof data.workflow_target === "string" ? data.workflow_target : null;
+    const mediaModeHint =
+      data.media_generation && typeof data.media_generation === "object"
+        ? (data.media_generation as Record<string, unknown>).mode
+        : null;
+    const isPlainChatTurn =
+      workflowTargetHint !== "workflow" &&
+      (typeof mediaModeHint !== "string" || mediaModeHint === "chat");
+
+    // A plain chat turn without a chosen model used to fall through to the
+    // built-in default and die deep in provider resolution ("No provider
+    // registered for \"empty\"") — after the user's message had been
+    // persisted. Reject it up front and say what to do instead.
+    if (isPlainChatTurn && !isModelSelection(data.provider, data.model)) {
+      await this.sendMessage({
+        type: "error",
+        message: NO_MODEL_SELECTED_MESSAGE,
+        thread_id: threadId
+      });
+      return;
+    }
+
     // Apply defaults — matches Python's handle_chat_message
     if (!data.model) data.model = this.defaultModel;
     if (!data.provider) data.provider = this.defaultProvider;
@@ -6165,12 +6196,12 @@ export class UnifiedWebSocketRunner {
       typeof data.workflow_id === "string" ? data.workflow_id : null;
     const userId = this.userId ?? "1";
     const mode = String(mediaGeneration.mode ?? "");
-    const providerId = String(
-      mediaGeneration.provider ?? data.provider ?? this.defaultProvider
-    );
-    const modelId = String(
-      mediaGeneration.model ?? data.model ?? this.defaultModel
-    );
+    // The media composer's own selection first; a client without a separate
+    // media picker (mobile) sends only the message-level one. The built-in
+    // chat default is not in the chain — a text model can never serve a
+    // generation, so falling back to it only buys an obscure provider error.
+    const providerId = String(mediaGeneration.provider ?? data.provider ?? "");
+    const modelId = String(mediaGeneration.model ?? data.model ?? "");
     const prompt = this.extractTextContent(data.content);
 
     /**
@@ -6200,10 +6231,10 @@ export class UnifiedWebSocketRunner {
       return;
     }
 
-    if (!modelId || modelId === "undefined") {
+    if (!isModelSelection(providerId, modelId)) {
       await this.sendMessage({
         type: "error",
-        message: `Please select a ${mode} model before generating`,
+        message: noMediaModelSelectedMessage(mode),
         thread_id: threadId
       });
       return;

--- a/packages/websocket/tests/unified-websocket-runner-model-required.test.ts
+++ b/packages/websocket/tests/unified-websocket-runner-model-required.test.ts
@@ -1,0 +1,105 @@
+/**
+ * A chat turn needs a model. Without one the runner used to fall back to a
+ * built-in default and die in provider resolution — after persisting the user's
+ * message. It now rejects the turn with guidance instead.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { unpack } from "msgpackr";
+import { initTestDb, Message } from "@nodetool-ai/models";
+import {
+  UnifiedWebSocketRunner,
+  type WebSocketConnection,
+  type WebSocketReceiveFrame
+} from "../src/unified-websocket-runner.js";
+
+class MockWS implements WebSocketConnection {
+  clientState: "connected" | "disconnected" = "connected";
+  applicationState: "connected" | "disconnected" = "connected";
+  sentBytes: Uint8Array[] = [];
+  async accept() {}
+  async receive(): Promise<WebSocketReceiveFrame> {
+    return { type: "websocket.disconnect" };
+  }
+  async sendBytes(data: Uint8Array) {
+    this.sentBytes.push(data);
+  }
+  async sendText() {}
+  async close() {
+    this.clientState = "disconnected";
+    this.applicationState = "disconnected";
+  }
+}
+
+const noopExecutor = () => ({
+  async process() {
+    return {};
+  }
+});
+
+function sentMsgs(ws: MockWS): Record<string, unknown>[] {
+  return ws.sentBytes.map((b) => unpack(b) as Record<string, unknown>);
+}
+
+async function sendChat(
+  data: Record<string, unknown>
+): Promise<{ ws: MockWS; resolveProvider: ReturnType<typeof vi.fn> }> {
+  const resolveProvider = vi.fn();
+  const runner = new UnifiedWebSocketRunner({
+    resolveExecutor: noopExecutor,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolveProvider: resolveProvider as any
+  });
+  const ws = new MockWS();
+  await runner.connect(ws);
+  await runner.handleCommand({ command: "chat_message", data });
+  await vi.waitFor(() => {
+    expect(sentMsgs(ws).some((m) => m.type === "error")).toBe(true);
+  });
+  return { ws, resolveProvider };
+}
+
+describe("chat_message without a selected model", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("rejects a chat turn whose provider is the unset sentinel", async () => {
+    const threadId = `t-nomodel-${Date.now()}-${Math.random()}`;
+    const { ws, resolveProvider } = await sendChat({
+      thread_id: threadId,
+      content: "hi",
+      provider: "empty",
+      model: "gpt-oss:20b"
+    });
+
+    const error = sentMsgs(ws).find((m) => m.type === "error")!;
+    expect(error.message).toMatch(/No model selected/i);
+    expect(error.message).toMatch(/model menu/i);
+    expect(error.thread_id).toBe(threadId);
+    expect(resolveProvider).not.toHaveBeenCalled();
+
+    // The turn never happened, so the user message is not persisted.
+    const [rows] = await Message.paginate(threadId, { limit: 10 });
+    expect(rows).toHaveLength(0);
+  });
+
+  it("rejects a chat turn with no model at all", async () => {
+    const threadId = `t-nomodel2-${Date.now()}-${Math.random()}`;
+    const { ws } = await sendChat({ thread_id: threadId, content: "hi" });
+    const error = sentMsgs(ws).find((m) => m.type === "error")!;
+    expect(error.message).toMatch(/No model selected/i);
+  });
+
+  it("rejects a media generation with no model picked", async () => {
+    const threadId = `t-nomedia-${Date.now()}-${Math.random()}`;
+    const { ws } = await sendChat({
+      thread_id: threadId,
+      content: "a red fox",
+      provider: "empty",
+      model: "gpt-oss:20b",
+      media_generation: { mode: "image", provider: null, model: null }
+    });
+    const error = sentMsgs(ws).find((m) => m.type === "error")!;
+    expect(error.message).toMatch(/No image model selected/i);
+  });
+});

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -45,6 +45,7 @@ import type {
 import MediaControlChip from "./MediaControlChip";
 import MediaModeMenu from "./MediaModeMenu";
 import ModeProviderSetupBanner from "./ModeProviderSetupBanner";
+import SelectModelBanner from "./SelectModelBanner";
 import { useModeProviderSetup } from "./useModeProviderSetup";
 import PiComposerControls, { piModeAvailable } from "./PiComposerControls";
 import SmartToyOutlinedIcon from "@mui/icons-material/SmartToyOutlined";
@@ -72,7 +73,11 @@ import type {
   TTSModel,
   VideoModel
 } from "../../../stores/ApiTypes";
-import type { Entity } from "@nodetool-ai/protocol";
+import {
+  isModelSelected,
+  type Entity,
+  type ModelSelection
+} from "@nodetool-ai/protocol";
 import type { MediaGenerationRequest } from "../types/media.types";
 import { assetToUri } from "../../node_types/editing/promptComposer/promptTokens";
 import { resolveAssetUri } from "../../node/output";
@@ -522,6 +527,66 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     mode === "image_to_video" ||
     mode === "audio";
 
+  const chatModel = selectedModel ?? languageModel;
+
+  const modelGate = useMemo((): {
+    model: ModelSelection | null | undefined;
+    label: string;
+    open: () => void;
+  } | null => {
+    if (isPi) return null;
+    if (mode === "chat")
+      return {
+        model: chatModel,
+        label: "language",
+        open: () => setLanguageModelOpen(true)
+      };
+    if (mode === "image")
+      return {
+        model: imageParams.model,
+        label: "image",
+        open: () => setImageModelOpen(true)
+      };
+    if (mode === "image_edit")
+      return {
+        model: imageEditParams.model,
+        label: "image edit",
+        open: () => setImageModelOpen(true)
+      };
+    if (mode === "video")
+      return {
+        model: videoParams.model,
+        label: "video",
+        open: () => setVideoModelOpen(true)
+      };
+    if (mode === "image_to_video")
+      return {
+        model: imageToVideoParams.model,
+        label: "image to video",
+        open: () => setVideoModelOpen(true)
+      };
+    if (mode === "audio")
+      return {
+        model: audioParams.model,
+        label: "speech",
+        open: () => setTtsModelOpen(true)
+      };
+    return null;
+  }, [
+    isPi,
+    mode,
+    chatModel,
+    imageParams.model,
+    imageEditParams.model,
+    videoParams.model,
+    imageToVideoParams.model,
+    audioParams.model
+  ]);
+
+  // A send with no model picked can only fail on the server, so the composer
+  // refuses it and opens the picker instead.
+  const needsModel = !!modelGate && !isModelSelected(modelGate.model);
+
   const canGenerate = prompt.trim().length > 0 || droppedFiles.length > 0;
 
   const handleSend = useCallback(() => {
@@ -532,6 +597,12 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     // the server. Keep the prompt and guide the user through provider setup.
     if (providerSetup.needsSetup) {
       providerSetup.openSetup();
+      return;
+    }
+    // Nothing is picked for this mode. The server rejects such a turn, so keep
+    // the prompt and open the picker instead of sending.
+    if (needsModel) {
+      modelGate?.open();
       return;
     }
     const content: MessageContent[] = [];
@@ -554,7 +625,9 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     sendMessage,
     clearFiles,
     recordHistory,
-    providerSetup
+    providerSetup,
+    needsModel,
+    modelGate
   ]);
 
   const handlePaste = useCallback(
@@ -871,10 +944,9 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
   const { strengthOptions, stepsOptions } = useMemo(buildImageEditOptions, []);
 
   const chatProviderLabel = useMemo(() => {
-    const m = selectedModel ?? languageModel;
-    if (!m?.id) return "Select model";
-    return m.name || m.id;
-  }, [selectedModel, languageModel]);
+    if (!isModelSelected(chatModel)) return "Select model";
+    return chatModel.name || chatModel.id;
+  }, [chatModel]);
 
   const isBusy = isLoading || isStreaming;
   const isDisabled = disabled || isBusy;
@@ -928,6 +1000,15 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
           <ModeProviderSetupBanner
             reason={providerSetup.reason}
             onConnect={providerSetup.openSetup}
+          />
+        )}
+
+        {!providerSetup.needsSetup && needsModel && modelGate && (
+          <SelectModelBanner
+            reason={`Pick a ${modelGate.label} model to ${
+              isMediaMode ? "generate" : "send"
+            }.`}
+            onSelect={modelGate.open}
           />
         )}
 

--- a/web/src/components/chat/composer/SelectModelBanner.tsx
+++ b/web/src/components/chat/composer/SelectModelBanner.tsx
@@ -1,0 +1,38 @@
+import React, { memo } from "react";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import { AlertBanner, EditorButton } from "../../ui_primitives";
+
+interface SelectModelBannerProps {
+  reason: string;
+  onSelect: () => void;
+}
+
+/**
+ * Inline callout shown in the composer when the current mode has no model
+ * picked. Sending is refused until one is, so the banner carries the picker.
+ */
+const SelectModelBanner: React.FC<SelectModelBannerProps> = ({
+  reason,
+  onSelect
+}) => (
+  <AlertBanner
+    severity="info"
+    compact
+    icon={<AutoAwesomeIcon fontSize="small" />}
+    action={
+      <EditorButton
+        variant="outlined"
+        color="primary"
+        size="small"
+        onClick={onSelect}
+      >
+        Select a model
+      </EditorButton>
+    }
+    sx={{ mx: 1, mb: 0.5, alignItems: "center" }}
+  >
+    {reason}
+  </AlertBanner>
+);
+
+export default memo(SelectModelBanner);

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -40,6 +40,11 @@ import {
   isTRPCErrorWithCode,
   ApiErrorCode
 } from "@nodetool-ai/protocol/api-schemas";
+import {
+  isModelSelected,
+  NO_MODEL_SELECTED_MESSAGE,
+  noMediaModelSelectedMessage
+} from "@nodetool-ai/protocol";
 import { DEFAULT_MODEL } from "../config/constants";
 import { ConnectionState } from "../lib/websocket/WebSocketManager";
 import { globalWebSocketManager } from "../lib/websocket/GlobalWebSocketManager";
@@ -875,8 +880,33 @@ const useGlobalChatStore = create<GlobalChatState>()(
         // `agent_planner` are no longer sent on the wire.
         const outgoing = message as ChatOutgoingMessage;
         const mediaGeneration = outgoing.media_generation ?? null;
+        const isMediaGeneration =
+          !!mediaGeneration && mediaGeneration.mode !== "chat";
 
         set({ error: null });
+
+        // Nothing is picked yet — the default selection carries the "empty"
+        // provider sentinel. Sending would persist the user's turn and then
+        // fail in provider resolution, so stop here and say what to do.
+        const modelForSend = isMediaGeneration
+          ? {
+              provider: mediaGeneration?.provider ?? message.provider,
+              id: mediaGeneration?.model ?? message.model
+            }
+          : selectedModel;
+        if (!isModelSelected(modelForSend)) {
+          const reason = isMediaGeneration
+            ? noMediaModelSelectedMessage(mediaGeneration?.mode ?? "media")
+            : NO_MODEL_SELECTED_MESSAGE;
+          const knownThreadId = targetThreadId ?? currentThreadId;
+          set((state) => ({
+            error: reason,
+            ...(knownThreadId
+              ? threadRuntimeUpdate(state, knownThreadId, { error: reason })
+              : {})
+          }));
+          return;
+        }
 
         // Ensure WebSocket connection is established before sending
         try {
@@ -970,8 +1000,6 @@ const useGlobalChatStore = create<GlobalChatState>()(
         // use the provider/model chosen in the media composer instead of the
         // default language model so text-to-image / text-to-video calls are
         // routed correctly on the server.
-        const isMediaGeneration =
-          !!mediaGeneration && mediaGeneration.mode !== "chat";
         // The client no longer drives the toolbelt: `tools` and `collections`
         // are dropped from the send path. The active per-thread permission
         // mode is sent instead and governs how the agent's gated tool calls

--- a/web/src/stores/__tests__/GlobalChatStore.test.ts
+++ b/web/src/stores/__tests__/GlobalChatStore.test.ts
@@ -152,6 +152,14 @@ describe("GlobalChatStore", () => {
       currentThreadId: null,
       status: "disconnected",
       error: null,
+      // The shipped default carries the "empty" provider sentinel, which
+      // sendMessage refuses; these tests exercise the sending path.
+      selectedModel: {
+        type: "language_model",
+        provider: "openai",
+        id: "gpt-5.4-mini",
+        name: "gpt-5.4-mini"
+      },
       progress: { current: 0, total: 0 }
     } as any);
   });
@@ -210,8 +218,8 @@ describe("GlobalChatStore", () => {
           workflow_id: null,
           thread_id: threadId,
           memory_enabled: false,
-          model: "gpt-oss:20b",
-          provider: "empty",
+          model: "gpt-5.4-mini",
+          provider: "openai",
           permission_mode: "default",
           media_generation: null
         }
@@ -220,6 +228,32 @@ describe("GlobalChatStore", () => {
       if (mockServer) {mockServer.stop();}
       store.getState().disconnect();
     }
+  });
+
+  it("sendMessage refuses to send when no model is selected", async () => {
+    mockGlobalWebSocketManager.send.mockClear();
+    const threadId = await store.getState().createNewThread();
+    store.setState({
+      selectedModel: {
+        type: "language_model",
+        provider: "empty",
+        id: "gpt-oss:20b",
+        name: "gpt-oss:20b"
+      }
+    } as any);
+
+    await store.getState().sendMessage({
+      role: "user",
+      type: "message",
+      content: "hello"
+    } as Message);
+
+    expect(mockGlobalWebSocketManager.send).not.toHaveBeenCalled();
+    expect(store.getState().error).toMatch(/No model selected/i);
+    expect(store.getState().threadRuntime[threadId]?.error).toMatch(
+      /No model selected/i
+    );
+    expect(store.getState().messageCache[threadId] ?? []).toEqual([]);
   });
 
   it("switchThread does nothing for invalid id", () => {
@@ -899,8 +933,8 @@ describe("GlobalChatStore", () => {
           workflow_id: "test-workflow",
           thread_id: threadId,
           memory_enabled: false,
-          model: "gpt-oss:20b",
-          provider: "empty",
+          model: "gpt-5.4-mini",
+          provider: "openai",
           permission_mode: "default",
           media_generation: null
         }


### PR DESCRIPTION
## What

A chat send with no model picked used to sail all the way through. The composer's default selection is `{ provider: "empty", id: "gpt-oss:20b" }` — `"empty"` being the repo's "nothing chosen" sentinel — nothing on the client checked it, and `handleChatMessage` papered over the gap with a built-in default (`gpt-oss:20b` / ollama) before dying in provider resolution with `No provider registered for "empty"`. By then the user's message was already persisted.

Three gates now, so the failure is caught where it can be fixed:

- **`MediaChatComposer`** refuses the send, keeps the prompt and attachments, and opens the picker for the current mode (language / image / image edit / video / image→video / speech). An inline `SelectModelBanner` carries the same action. This mirrors the existing provider-setup gate right above it. Pi mode is exempt — it has its own model controls.
- **`GlobalChatStore.sendMessage`** refuses any send whose model is unset and reports it on the thread, so the composers without a model chip (the `simple` variant, `WorkspaceEmptyView`) are covered too. A media send is checked against the media picker's own model, not the chat language model.
- **`handleChatMessage`** rejects a plain chat turn with no model *before* persisting anything, and returns guidance instead of a raw provider error. The media path's fallback chain no longer ends at the chat default — a text model can never serve a generation, so falling back to it only bought an obscure provider failure.

`isModelSelection` / `isModelSelected` and the two guidance strings live in `@nodetool-ai/protocol` (`model-selection.ts`), so client and server read the sentinel the same way.

## Why

The old path spent a DB write and a round trip to produce an error naming an internal sentinel. Nothing about `No provider registered for "empty"` tells a user to open the model menu.

## Testing

- `packages/websocket/tests/unified-websocket-runner-model-required.test.ts` (new): the sentinel provider, a turn with no model at all, and a media turn with nothing picked — each gets the guidance error, `resolveProvider` is never called, and no message row is written.
- `web/src/stores/__tests__/GlobalChatStore.test.ts`: new case asserting the store sends nothing and surfaces the reason on the thread. The existing send-path cases now seed a real `selectedModel` (they were asserting the `provider: "empty"` payload).
- `npm run lint`, `npm run typecheck` (web + electron), full web Jest suite (12,593 passed), full `packages/websocket` Vitest suite (2,210 passed). Mobile typecheck fails identically before and after this change — its Expo dependencies aren't installed in this environment.

---
_Generated by [Claude Code](https://claude.ai/code/session_016AtcqSjnPFzsMmnNgGnh7o)_