### PR TITLE
web: dismiss the mobile keyboard after sending a chat message

### DIFF
--- a/web/src/hooks/__tests__/useMessageQueue.test.ts
+++ b/web/src/hooks/__tests__/useMessageQueue.test.ts
@@ -7,9 +7,24 @@ describe("useMessageQueue", () => {
   const mockOnStop = jest.fn();
   const mockTextareaRef = {
     current: {
-      focus: jest.fn()
+      focus: jest.fn(),
+      blur: jest.fn()
     } as unknown as HTMLTextAreaElement
   };
+
+  const mockPointer = (coarse: boolean) => {
+    window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+      matches: query.includes("pointer: coarse") ? coarse : false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn()
+    })) as unknown as typeof window.matchMedia;
+  };
+  const originalMatchMedia = window.matchMedia;
 
   const createMockContent = (text: string): MessageContent[] => [
     { type: "text", text }
@@ -22,6 +37,7 @@ describe("useMessageQueue", () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    window.matchMedia = originalMatchMedia;
   });
 
   describe("initial state", () => {
@@ -162,6 +178,34 @@ describe("useMessageQueue", () => {
       });
 
       expect(mockTextareaRef.current.focus).toHaveBeenCalled();
+    });
+
+    it("blurs the textarea after sending on a touch device", () => {
+      mockPointer(true);
+
+      const { result } = renderHook(() =>
+        useMessageQueue({
+          isLoading: false,
+          isStreaming: false,
+          onSendMessage: mockOnSendMessage,
+          textareaRef: mockTextareaRef
+        })
+      );
+
+      act(() => {
+        result.current.sendMessage(
+          createMockContent("test message"),
+          "test message"
+        );
+      });
+
+      expect(mockTextareaRef.current.blur).toHaveBeenCalled();
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(mockTextareaRef.current.focus).not.toHaveBeenCalled();
     });
   });
 

--- a/web/src/hooks/useMessageQueue.ts
+++ b/web/src/hooks/useMessageQueue.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { MessageContent } from "../stores/ApiTypes";
+import { useAutoFocusEnabled } from "./useAutoFocusEnabled";
 
 interface QueuedMessage {
   content: MessageContent[];
@@ -36,6 +37,7 @@ export function useMessageQueue({
 }: UseMessageQueueOptions): UseMessageQueueReturn {
   const [queuedMessage, setQueuedMessage] = useState<QueuedMessage | null>(null);
   const sendMessageRef = useRef(onSendMessage);
+  const keepFocusAfterSend = useAutoFocusEnabled();
 
   useEffect(() => {
     sendMessageRef.current = onSendMessage;
@@ -44,14 +46,22 @@ export function useMessageQueue({
   const sendMessageNow = useCallback(
     (content: MessageContent[], messagePrompt: string) => {
       sendMessageRef.current(content, messagePrompt);
-      // Keep focus in the textarea after sending
-      if (textareaRef?.current) {
+      if (!textareaRef?.current) {
+        return;
+      }
+      if (keepFocusAfterSend) {
+        // Keep focus in the textarea after sending
         requestAnimationFrame(() => {
           textareaRef.current?.focus();
         });
+        return;
       }
+      // On touch the focus holds the virtual keyboard open over the reply that
+      // just started streaming. Drop it synchronously so the dismissal still
+      // rides the send gesture (iOS Safari ignores a deferred blur).
+      textareaRef.current.blur();
     },
-    [textareaRef]
+    [textareaRef, keepFocusAfterSend]
   );
 
   const sendMessage = useCallback(


### PR DESCRIPTION
On mobile web the virtual keyboard stayed up after sending a chat message, eating most of the screen while the reply streamed in.

`useMessageQueue.sendMessageNow` re-focused the composer textarea on every send (in a `requestAnimationFrame`) so the caret stays put between turns on desktop. On touch that same refocus pulls the keyboard back open even when the send came from tapping the send button.

The refocus now only happens on a fine pointer. On a coarse one the textarea is blurred instead, synchronously rather than in the next frame — iOS Safari ignores a deferred blur, the dismissal has to ride the send gesture. The device check reuses the existing `useAutoFocusEnabled` hook, which is already the repo's signal for "don't raise the keyboard the user didn't ask for".

Both composers (`ChatComposer`, `MediaChatComposer`) go through this hook, so one change covers the simple and media chat inputs, the Enter-key and send-button paths, and the deferred send of a queued message.

Tests: added a coarse-pointer case to `useMessageQueue.test.ts` asserting the textarea is blurred and never refocused; the existing fine-pointer focus test still passes. `npx jest src/components/chat src/hooks` — 157 suites, 1364 tests, all green. Lint clean on the changed files. `npm run typecheck` reports only pre-existing `TS2307` module-not-found errors from unbuilt `@nodetool-ai/*-nodes` packages in `browserRunnerCore.ts`, untouched by this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpmuVmPASKWsiR1oVa3M8w)_