### PR TITLE
Fix focus, naming, and placeholder issues across editor inputs

### DIFF
--- a/web/src/components/content/Help/ShortcutsSearchableList.tsx
+++ b/web/src/components/content/Help/ShortcutsSearchableList.tsx
@@ -66,6 +66,7 @@ export const ShortcutsSearchableList: React.FC<ShortcutsSearchableListProps> = (
         variant="outlined"
         size="small"
         placeholder={searchPlaceholder}
+        slotProps={{ htmlInput: { "aria-label": searchPlaceholder } }}
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         sx={{

--- a/web/src/components/inputs/Select.tsx
+++ b/web/src/components/inputs/Select.tsx
@@ -268,6 +268,7 @@ const Select: React.FC<SelectProps> = ({
         <div
           ref={selectRef}
           role="combobox"
+          aria-label={typeof label === "string" ? label : undefined}
           aria-expanded={activeSelect === id}
           aria-haspopup="listbox"
           className={`custom-select select-wrapper ${

--- a/web/src/components/menus/PackagesMenu.tsx
+++ b/web/src/components/menus/PackagesMenu.tsx
@@ -223,7 +223,13 @@ const InstallPanel = memo(function InstallPanel({
         <TextInput
           value={spec}
           onChange={(e) => setSpec(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && spec.trim() && status.kind !== "installing") {
+              handleInstall();
+            }
+          }}
           placeholder="@scope/package or package@version"
+          slotProps={{ htmlInput: { "aria-label": "Package to install" } }}
           fullWidth
           disabled={status.kind === "installing"}
         />

--- a/web/src/components/node_menu/TypeFilterChips.tsx
+++ b/web/src/components/node_menu/TypeFilterChips.tsx
@@ -476,6 +476,10 @@ const TypeFilterChips: React.FC<TypeFilterChipsProps> = memo(
                   {...params}
                   size="small"
                   placeholder="Search input type..."
+                  inputProps={{
+                    ...params.inputProps,
+                    "aria-label": "Search input type"
+                  }}
                 />
               )}
               slotProps={{
@@ -523,6 +527,10 @@ const TypeFilterChips: React.FC<TypeFilterChipsProps> = memo(
                   {...params}
                   size="small"
                   placeholder="Search output type..."
+                  inputProps={{
+                    ...params.inputProps,
+                    "aria-label": "Search output type"
+                  }}
                 />
               )}
               slotProps={{

--- a/web/src/components/node_types/code_gen/CodeGenDialog.tsx
+++ b/web/src/components/node_types/code_gen/CodeGenDialog.tsx
@@ -37,6 +37,7 @@ import {
 import CodeAuthoringModelNotice from "../../model_menu/CodeAuthoringModelNotice";
 import { useNodes } from "../../../contexts/NodeContext";
 import { useMonacoEditor } from "../../../hooks/editor/useMonacoEditor";
+import { useAutoFocusEnabled } from "../../../hooks/useAutoFocusEnabled";
 import {
   CODE_AUTHORING_SOURCE_LABEL,
   useCodeAuthoringModel
@@ -163,6 +164,7 @@ const CodeGenDialogInner = ({
     isBlocked
   } = useCodeAuthoringModel();
   const { generate, cancel, reset, result, isPending } = useGenerateCode();
+  const autoFocusEnabled = useAutoFocusEnabled();
 
   const [instruction, setInstruction] = useState("");
   const [isCodeOpen, setIsCodeOpen] = useState(false);
@@ -307,6 +309,9 @@ const CodeGenDialogInner = ({
           onChange={(event) => setInstruction(event.target.value)}
           multiline
           rows={3}
+          // The dialog opens for one purpose: describing the node. Skipped on
+          // touch, where the keyboard would cover the field it just focused.
+          autoFocus={autoFocusEnabled}
           disabled={isPending || isBlocked}
           slotProps={{ htmlInput: { maxLength: MAX_INSTRUCTION_LENGTH } }}
         />

--- a/web/src/components/properties/EnumProperty.tsx
+++ b/web/src/components/properties/EnumProperty.tsx
@@ -66,7 +66,7 @@ const EnumProperty: React.FC<PropertyProps> = ({
         onChange={onChange}
         options={options}
         label={property.name}
-        placeholder={property.name}
+        placeholder="Select…"
         tabIndex={tabIndex}
         changed={changed}
       />

--- a/web/src/components/properties/SelectProperty.tsx
+++ b/web/src/components/properties/SelectProperty.tsx
@@ -53,7 +53,7 @@ const SelectProperty: React.FC<PropertyProps<string>> = ({
         onChange={onChange}
         options={selectOptions}
         label={property.name}
-        placeholder={property.name}
+        placeholder="Select…"
         tabIndex={tabIndex}
         changed={changed}
       />

--- a/web/src/components/timeline/Tracks/ReplaceOutputDialog.tsx
+++ b/web/src/components/timeline/Tracks/ReplaceOutputDialog.tsx
@@ -46,8 +46,17 @@ export const ReplaceOutputDialog: React.FC<ReplaceOutputDialogProps> = memo(
         <TextInput
           value={assetId}
           onChange={(e) => setAssetId(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              handleConfirm();
+            }
+          }}
           placeholder="Asset ID"
           inputProps={{ "aria-label": "Asset ID" }}
+          // The dialog's only field, prefilled — focus it and select the old id
+          // so typing a replacement does not mean clearing it first.
+          autoFocus
+          onFocus={(e) => e.target.select()}
           fullWidth
           size="small"
         />

--- a/web/src/components/ui_primitives/SearchInput.tsx
+++ b/web/src/components/ui_primitives/SearchInput.tsx
@@ -17,6 +17,9 @@ export interface SearchInputProps {
   onChange: (value: string) => void;
   /** Placeholder text */
   placeholder?: string;
+  /** Accessible name. Defaults to the placeholder, which is the only visible
+   * hint these fields carry — without it the input is announced unnamed. */
+  ariaLabel?: string;
   /** Whether to show clear button */
   showClear?: boolean;
   /** Size variant */
@@ -124,6 +127,7 @@ export const SearchInput = memo(forwardRef<HTMLInputElement, SearchInputProps>((
   value,
   onChange,
   placeholder = "Search...",
+  ariaLabel,
   showClear = true,
   size = "small",
   disabled = false,
@@ -159,16 +163,25 @@ export const SearchInput = memo(forwardRef<HTMLInputElement, SearchInputProps>((
   }, [onChange, debounceMs]);
   
   const handleClear = useCallback(() => {
+    // Drop the pending debounced change, or it fires after the clear and puts
+    // the query the user just wiped back into the parent.
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = undefined;
+    }
     setLocalValue("");
     onChange("");
     onClear?.();
   }, [onChange, onClear]);
-  
+
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === "Enter" && onSubmit) {
       onSubmit(localValue);
     }
-    if (e.key === "Escape") {
+    if (e.key === "Escape" && localValue) {
+      // Escape clears the query first; a second Escape reaches the menu or
+      // dialog around us and closes it. One key press must not do both.
+      e.stopPropagation();
       handleClear();
     }
   }, [localValue, onSubmit, handleClear]);
@@ -200,6 +213,7 @@ export const SearchInput = memo(forwardRef<HTMLInputElement, SearchInputProps>((
         sx={sx}
         inputRef={ref}
         slotProps={{
+          htmlInput: { "aria-label": ariaLabel ?? placeholder },
           input: {
             startAdornment: (
               <InputAdornment position="start">

--- a/web/src/components/ui_primitives/__tests__/SearchInput.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/SearchInput.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import { SearchInput } from "../SearchInput";
+
+const renderWithTheme = (component: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{component}</ThemeProvider>);
+
+describe("SearchInput", () => {
+  it("names the input after its placeholder", () => {
+    renderWithTheme(
+      <SearchInput value="" onChange={jest.fn()} placeholder="Search apps" />
+    );
+    expect(screen.getByRole("textbox", { name: "Search apps" })).toBeInTheDocument();
+  });
+
+  it("prefers an explicit ariaLabel over the placeholder", () => {
+    renderWithTheme(
+      <SearchInput
+        value=""
+        onChange={jest.fn()}
+        placeholder="Search…"
+        ariaLabel="Search workflows"
+      />
+    );
+    expect(
+      screen.getByRole("textbox", { name: "Search workflows" })
+    ).toBeInTheDocument();
+  });
+
+  it("drops a pending debounced change when the value is cleared", async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const onChange = jest.fn();
+    renderWithTheme(
+      <SearchInput
+        value=""
+        onChange={onChange}
+        placeholder="Search"
+        debounceMs={200}
+      />
+    );
+
+    await user.type(screen.getByRole("textbox"), "abc");
+    await user.click(screen.getByRole("button", { name: "Clear search" }));
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    // The debounced "abc" must not land after the clear and resurrect the query.
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("");
+    jest.useRealTimers();
+  });
+
+  it("keeps Escape from closing the surface while there is a query to clear", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const onEscape = jest.fn();
+    renderWithTheme(
+      <div onKeyDown={onEscape}>
+        <SearchInput value="abc" onChange={onChange} placeholder="Search" />
+      </div>
+    );
+
+    await user.click(screen.getByRole("textbox"));
+    await user.keyboard("{Escape}");
+
+    expect(onChange).toHaveBeenCalledWith("");
+    expect(onEscape).not.toHaveBeenCalled();
+  });
+
+  it("lets Escape through once the query is empty", async () => {
+    const user = userEvent.setup();
+    const onEscape = jest.fn();
+    renderWithTheme(
+      <div onKeyDown={onEscape}>
+        <SearchInput value="" onChange={jest.fn()} placeholder="Search" />
+      </div>
+    );
+
+    await user.click(screen.getByRole("textbox"));
+    await user.keyboard("{Escape}");
+
+    expect(onEscape).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/workspace/OpenMenu.tsx
+++ b/web/src/components/workspace/OpenMenu.tsx
@@ -548,6 +548,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
                 autoFocus={autoFocusEnabled}
                 fullWidth
                 placeholder="Filter workflows"
+                slotProps={{ htmlInput: { "aria-label": "Filter workflows" } }}
                 value={wfFilter}
                 onChange={(e) => setWfFilter(e.target.value)}
               />
@@ -585,6 +586,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
                 autoFocus={autoFocusEnabled}
                 fullWidth
                 placeholder="Filter chats"
+                slotProps={{ htmlInput: { "aria-label": "Filter chats" } }}
                 value={chatFilter}
                 onChange={(e) => setChatFilter(e.target.value)}
               />
@@ -622,6 +624,7 @@ const OpenMenu = ({ anchorEl, open, onClose }: OpenMenuProps) => {
                 autoFocus={autoFocusEnabled}
                 fullWidth
                 placeholder="Search assets (2+ chars)"
+                slotProps={{ htmlInput: { "aria-label": "Search assets" } }}
                 value={assetQuery}
                 onChange={(e) => setAssetQuery(e.target.value)}
               />


### PR DESCRIPTION
A sweep for low-hanging usability defects in `web/` — focus behavior, missing accessible names, and placeholder text that misleads.

## SearchInput primitive

`ui_primitives/SearchInput` backs ~15 search fields and carried three defects:

- **No accessible name.** The placeholder was the only hint, so every one of those inputs was announced unnamed. It now names itself after the placeholder, with an `ariaLabel` prop for the cases where the two should differ. (The older `search/SearchInput` already did this — the primitive that replaced it did not.)
- **Debounce race on clear.** Clearing while a debounced change was pending let the old query land afterward and put the wiped text back.
- **Escape did two things at once.** The key cleared the query *and* propagated to the surrounding menu or dialog, closing it. It now clears first and only reaches the menu once the field is empty.

Covered by a new `SearchInput.test.tsx` (5 cases).

## Accessible names

- `inputs/Select` — the `role="combobox"` element had no accessible name; `label` only fed a tooltip.
- The pack install field (Packages menu), the three filter fields in the Open menu, the shortcuts search, and the two node-type filter fields had no names.

## Placeholder text

`EnumProperty` and `SelectProperty` passed the property name as the placeholder. Since `Select` renders the placeholder in the value slot, an unset property showed its own label where a value goes — e.g. a "Model" property rendering "Model", indistinguishable from a chosen value. Both say `Select…` now; the label still sits above via `PropertyLabel`.

## Focus and submit

- **Replace Clip** dialog did not focus its only field. It now focuses and selects the prefilled asset id (so typing a replacement does not mean clearing it first) and submits on Enter.
- **Code-gen dialog** did not focus the instruction field it exists to collect. Focus respects `useAutoFocusEnabled`, so touch devices are unaffected.
- The pack install field did not install on Enter.

## Verification

- `npx tsc --noEmit` — no new errors in the touched files (the pre-existing `@nodetool-ai/*` module-resolution errors are unbuilt packages, unrelated).
- `npm run lint` — clean, no new warnings.
- `npx jest` — 1076 suites, 12602 tests passing.

## Not done

Placeholder ellipsis is inconsistent repo-wide (34 files use `...`, 16 use `…`). Normalizing means touching the tests that query by placeholder text, which would bury these fixes in mechanical churn — left as a separate pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DosMJkPfqk12ANefB8C4b5)_