### PR TITLE
Let agents open a document tab instead of failing on a closed one

### DIFF
--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1466,7 +1466,12 @@ export const RESIDENT_TOOL_NAMES: ReadonlySet<string> = new Set([
   "debug_workflow",
   // The app half of the same loop: the only tool that can tell the agent
   // whether a mini app it edited actually works.
-  "debug_app"
+  "debug_app",
+  // Browser sessions only (it is in the manifest a connected UI registers):
+  // opens a document as a tab so the editor `ui_*` tools can act on it.
+  // Resident because it is the answer to "that document is not open", and
+  // hitting that mid-edit should not cost a ToolSearch round-trip.
+  "ui_open_document"
 ]);
 
 /**
@@ -1548,6 +1553,9 @@ function formatUiContext(uiContext?: UiContext | null): string {
 
   lines.push(
     "Every `ui_*` tool requires the id of the document it should act on; pass one of the ids above. These tools act on documents the user has open, so prefer the focused document unless the user points at another one."
+  );
+  lines.push(
+    "A document that is not in that list can be opened: call `ui_open_document` with its type and id (from `list_timelines`, `list_sketches`, `list_storyboards`, `list_scripts`, or a resource link). It opens the document as a tab and returns once its `ui_*` tools work, so never tell the user a document cannot be edited because it is not open."
   );
 
   const hasTimeline =

--- a/packages/websocket/tests/resident-tools.test.ts
+++ b/packages/websocket/tests/resident-tools.test.ts
@@ -18,6 +18,10 @@ describe("resident toolbelt", () => {
     }
   });
 
+  it("keeps opening a document resident, so a closed document is never a dead end", () => {
+    expect(RESIDENT_TOOL_NAMES.has("ui_open_document")).toBe(true);
+  });
+
   it("teaches debug_app in the chat system prompt", () => {
     expect(CHAT_AGENT_SYSTEM_PROMPT).toContain("debug_app");
     // The draft, not the saved row, is what the App Builder must grade.

--- a/web/src/components/appbuilder/puck/puckAgentBridge.ts
+++ b/web/src/components/appbuilder/puck/puckAgentBridge.ts
@@ -112,8 +112,9 @@ export function getPuckAgentHandler(applicationId: string): PuckAgentHandler {
     throw new Error(
       `No app builder is open for application "${applicationId}". ` +
         (open.length > 0
-          ? `Open app builders: ${open.join(", ")}.`
-          : "No app builders are currently open.")
+          ? `Open app builders: ${open.join(", ")}. `
+          : "No app builders are currently open. ") +
+        'Call ui_open_document with type "app" to open it.'
     );
   }
   return handler;

--- a/web/src/components/script/scriptAgentBridge.ts
+++ b/web/src/components/script/scriptAgentBridge.ts
@@ -142,8 +142,9 @@ export function getScriptAgentHandler(scriptId: string): ScriptAgentHandler {
     throw new Error(
       `No script "${scriptId}" is open. ` +
         (open.length > 0
-          ? `Open scripts: ${open.join(", ")}.`
-          : "No scripts are currently open.")
+          ? `Open scripts: ${open.join(", ")}. `
+          : "No scripts are currently open. ") +
+        'Call ui_open_document with type "script" to open it.'
     );
   }
   return handler;

--- a/web/src/components/sketch/sketchAgentBridge.ts
+++ b/web/src/components/sketch/sketchAgentBridge.ts
@@ -223,8 +223,9 @@ export function getSketchAgentHandler(documentId: string): SketchAgentHandler {
     throw new Error(
       `No image document "${documentId}" is open. ` +
         (open.length > 0
-          ? `Open documents: ${open.join(", ")}.`
-          : "No image documents are currently open.")
+          ? `Open documents: ${open.join(", ")}. `
+          : "No image documents are currently open. ") +
+        'Call ui_open_document with type "sketch" to open it.'
     );
   }
   return handler;

--- a/web/src/components/storyboard/storyboardAgentBridge.ts
+++ b/web/src/components/storyboard/storyboardAgentBridge.ts
@@ -140,8 +140,9 @@ export function getStoryboardAgentHandler(
     throw new Error(
       `No storyboard "${boardId}" is open. ` +
         (open.length > 0
-          ? `Open storyboards: ${open.join(", ")}.`
-          : "No storyboards are currently open.")
+          ? `Open storyboards: ${open.join(", ")}. `
+          : "No storyboards are currently open. ") +
+        'Call ui_open_document with type "storyboard" to open it.'
     );
   }
   return handler;

--- a/web/src/components/timeline/timelineAgentBridge.ts
+++ b/web/src/components/timeline/timelineAgentBridge.ts
@@ -359,8 +359,9 @@ export function getTimelineAgentHandler(
     throw new Error(
       `No timeline sequence "${sequenceId}" is open. ` +
         (open.length > 0
-          ? `Open sequences: ${open.join(", ")}.`
-          : "No timeline sequences are currently open.")
+          ? `Open sequences: ${open.join(", ")}. `
+          : "No timeline sequences are currently open. ") +
+        'Call ui_open_document with type "timeline" to open it.'
     );
   }
   return handler;

--- a/web/src/lib/tools/__tests__/openDocument.test.ts
+++ b/web/src/lib/tools/__tests__/openDocument.test.ts
@@ -1,0 +1,167 @@
+import { FrontendToolRegistry } from "../frontendTools";
+import type { FrontendToolState } from "../frontendTools";
+import {
+  useWorkspaceTabsStore,
+  tabId
+} from "../../../stores/WorkspaceTabsStore";
+import { registerAppRouter } from "../../appNavigation";
+import {
+  setTimelineAgentHandler,
+  type TimelineAgentHandler,
+  type TimelineSnapshot
+} from "../../../components/timeline/timelineAgentBridge";
+import "../builtin/openDocument";
+
+const snapshot = (sequenceId: string | null): TimelineSnapshot => ({
+  sequenceId,
+  fps: 30,
+  width: 1920,
+  height: 1080,
+  durationMs: 0,
+  playheadMs: 0,
+  selectedClipIds: [],
+  tracks: [],
+  clips: []
+});
+
+const timelineHandler = (sequenceId: string | null): TimelineAgentHandler =>
+  ({
+    getSnapshot: () => snapshot(sequenceId)
+  }) as unknown as TimelineAgentHandler;
+
+const ctx = {
+  getState: () =>
+    ({
+      getNodeStore: (workflowId: string) =>
+        workflowId === "wf-open" ? ({} as never) : undefined
+    }) as unknown as FrontendToolState
+};
+
+const navigate = jest.fn();
+
+const openDocument = (args: Record<string, unknown>) =>
+  FrontendToolRegistry.call("ui_open_document", args, "tc-1", ctx);
+
+beforeEach(() => {
+  navigate.mockReset();
+  registerAppRouter({ navigate });
+  useWorkspaceTabsStore.setState({ tabs: [], activeTabId: null });
+  setTimelineAgentHandler("seq-1", null);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("ui_open_document", () => {
+  it("is in the manifest with the openable document types", () => {
+    const tool = FrontendToolRegistry.getManifest().find(
+      (t) => t.name === "ui_open_document"
+    );
+    expect(tool).toBeDefined();
+    const schema = tool?.parameters as {
+      properties?: { type?: { enum?: string[] } };
+      required?: string[];
+    };
+    expect(schema.properties?.type?.enum).toEqual([
+      "workflow",
+      "timeline",
+      "storyboard",
+      "script",
+      "sketch",
+      "app"
+    ]);
+    expect(schema.required).toEqual(expect.arrayContaining(["type", "id"]));
+  });
+
+  it("opens a tab and resolves once the editor has loaded the document", async () => {
+    const pending = openDocument({ type: "timeline", id: "seq-1" });
+
+    expect(useWorkspaceTabsStore.getState().tabs.map((tab) => tab.id)).toEqual([
+      tabId("timeline", "seq-1")
+    ]);
+    expect(navigate).toHaveBeenCalledWith("/workspace");
+
+    // The surface mounts and its query resolves.
+    setTimelineAgentHandler("seq-1", timelineHandler("seq-1"));
+
+    await expect(pending).resolves.toEqual({
+      ok: true,
+      type: "timeline",
+      id: "seq-1",
+      already_open: false,
+      url: "timeline://seq-1"
+    });
+    expect(useWorkspaceTabsStore.getState().activeTabId).toBe(
+      tabId("timeline", "seq-1")
+    );
+  });
+
+  it("waits for the document to load, not just for the editor to mount", async () => {
+    jest.useFakeTimers();
+    // Registered but still loading — its snapshot has no sequence yet.
+    setTimelineAgentHandler("seq-1", timelineHandler(null));
+    const pending = openDocument({ type: "timeline", id: "seq-1" });
+    const settled = jest.fn();
+    void pending.then(settled, settled);
+
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(settled).not.toHaveBeenCalled();
+
+    setTimelineAgentHandler("seq-1", timelineHandler("seq-1"));
+    await jest.advanceTimersByTimeAsync(200);
+    await expect(pending).resolves.toMatchObject({ ok: true });
+  });
+
+  it("focuses an already-open document without reopening it", async () => {
+    useWorkspaceTabsStore.getState().openTab({ type: "chat", ref: "t-1" });
+    useWorkspaceTabsStore
+      .getState()
+      .openTab({ type: "timeline", ref: "seq-1", mode: "edit" });
+    useWorkspaceTabsStore.getState().setActiveTab(tabId("chat", "t-1"));
+    setTimelineAgentHandler("seq-1", timelineHandler("seq-1"));
+
+    await expect(
+      openDocument({ type: "timeline", id: "seq-1" })
+    ).resolves.toMatchObject({ already_open: true });
+
+    expect(useWorkspaceTabsStore.getState().tabs).toHaveLength(2);
+    expect(useWorkspaceTabsStore.getState().activeTabId).toBe(
+      tabId("timeline", "seq-1")
+    );
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("leaves the user's tab focused when focus is false", async () => {
+    useWorkspaceTabsStore.getState().openTab({ type: "chat", ref: "t-1" });
+    const pending = openDocument({
+      type: "timeline",
+      id: "seq-1",
+      focus: false
+    });
+    setTimelineAgentHandler("seq-1", timelineHandler("seq-1"));
+    await pending;
+
+    expect(useWorkspaceTabsStore.getState().activeTabId).toBe(
+      tabId("chat", "t-1")
+    );
+  });
+
+  it("resolves a workflow once its node store exists", async () => {
+    await expect(
+      openDocument({ type: "workflow", id: "wf-open" })
+    ).resolves.toMatchObject({ ok: true, type: "workflow", id: "wf-open" });
+  });
+
+  it("closes the tab and explains when the document never loads", async () => {
+    jest.useFakeTimers();
+    const pending = openDocument({ type: "timeline", id: "ghost" });
+    const rejects = expect(pending).rejects.toThrow(
+      'The timeline sequence "ghost" did not open'
+    );
+    await jest.advanceTimersByTimeAsync(21_000);
+    await rejects;
+
+    expect(useWorkspaceTabsStore.getState().tabs).toEqual([]);
+  });
+});

--- a/web/src/lib/tools/builtin/index.ts
+++ b/web/src/lib/tools/builtin/index.ts
@@ -12,7 +12,8 @@
 // Note this is registration, not availability: every editor tool takes a
 // required document id and resolves it against the documents actually open,
 // so registering a tool the user can't currently use is harmless — it fails
-// with a message naming the open ids.
+// with a message naming the open ids, and `ui_open_document` opens one that
+// isn't.
 // -----------------------------------------------------------------
 
 // Graph editor.
@@ -32,6 +33,10 @@ import "./searchModels";
 
 // App-level actions (open/run workflow, switch tab, copy/paste).
 import "./uiActions";
+
+// Opening a document as a workspace tab, so the editor tools below can act
+// on documents the user does not already have open.
+import "./openDocument";
 
 // Editor surfaces.
 import "./timeline";

--- a/web/src/lib/tools/builtin/openDocument.ts
+++ b/web/src/lib/tools/builtin/openDocument.ts
@@ -1,0 +1,214 @@
+// builtin/openDocument.ts
+// -----------------------------------------------------------------
+// `ui_open_document` — open a document as a workspace tab.
+//
+// Every editor `ui_*` tool acts on a document the user has *open*: each
+// mounted editor registers a handler under its document id, and a tool
+// called with an id nothing has registered fails with "No timeline
+// sequence … is open". Before this tool that was a dead end — the agent
+// could find a document id (`list_timelines`, `list_sketches`, a link the
+// user pasted) and still have no way to act on it.
+//
+// Opening a tab mounts that document's surface, which registers the
+// handler, so this is the bridge between "an id exists" and "the ui_*
+// tools work on it". Tabs stay mounted in the background, so opening one
+// does not close or unmount anything else.
+// -----------------------------------------------------------------
+
+import { z } from "zod";
+import {
+  FrontendToolRegistry,
+  type FrontendToolContext
+} from "../frontendTools";
+import {
+  tabId,
+  useWorkspaceTabsStore,
+  type WorkspaceTabType
+} from "../../../stores/WorkspaceTabsStore";
+import { navigateTo } from "../../appNavigation";
+import { docUrl } from "./resourceLinks";
+import {
+  getTimelineAgentHandler,
+  hasTimelineAgentHandler
+} from "../../../components/timeline/timelineAgentBridge";
+import {
+  getStoryboardAgentHandler,
+  hasStoryboardAgentHandler
+} from "../../../components/storyboard/storyboardAgentBridge";
+import {
+  getScriptAgentHandler,
+  hasScriptAgentHandler
+} from "../../../components/script/scriptAgentBridge";
+import {
+  getSketchAgentHandler,
+  hasSketchAgentHandler
+} from "../../../components/sketch/sketchAgentBridge";
+import { hasPuckAgentHandler } from "../../../components/appbuilder/puck/puckAgentBridge";
+
+/**
+ * Document kinds with agent tools behind them, named the way `ui_context`
+ * names them (an app is "app", not "application").
+ */
+const OPENABLE_TYPES = [
+  "workflow",
+  "timeline",
+  "storyboard",
+  "script",
+  "sketch",
+  "app"
+] as const;
+
+type OpenableType = (typeof OPENABLE_TYPES)[number];
+
+const TAB_TYPE: Record<OpenableType, WorkspaceTabType> = {
+  workflow: "workflow",
+  timeline: "timeline",
+  storyboard: "storyboard",
+  script: "script",
+  sketch: "sketch",
+  app: "application"
+};
+
+const LABEL: Record<OpenableType, string> = {
+  workflow: "workflow",
+  timeline: "timeline sequence",
+  storyboard: "storyboard",
+  script: "script",
+  sketch: "image document",
+  app: "app"
+};
+
+/**
+ * True once the document's editor has mounted *and* loaded — the point at
+ * which the `ui_*` tools for it work. Handler presence alone is not enough:
+ * a surface registers its handler while its document query is still in
+ * flight, and an agent that read the snapshot then would see an empty
+ * document. Each probe therefore checks the loaded document's own id.
+ */
+const isReady: Record<
+  OpenableType,
+  (id: string, ctx: FrontendToolContext) => boolean
+> = {
+  workflow: (id, ctx) => ctx.getState().getNodeStore(id) !== undefined,
+  timeline: (id) =>
+    hasTimelineAgentHandler(id) &&
+    getTimelineAgentHandler(id).getSnapshot().sequenceId === id,
+  storyboard: (id) =>
+    hasStoryboardAgentHandler(id) &&
+    getStoryboardAgentHandler(id).getSnapshot().boardId === id,
+  script: (id) =>
+    hasScriptAgentHandler(id) &&
+    getScriptAgentHandler(id).getSnapshot().scriptId === id,
+  sketch: (id) =>
+    hasSketchAgentHandler(id) &&
+    getSketchAgentHandler(id).getSnapshot().documentId === id,
+  app: (id) => hasPuckAgentHandler(id)
+};
+
+const ready = (
+  type: OpenableType,
+  id: string,
+  ctx: FrontendToolContext
+): boolean => {
+  try {
+    return isReady[type](id, ctx);
+  } catch {
+    // A surface mid-mount can throw out of its stores; that just means
+    // "not ready yet".
+    return false;
+  }
+};
+
+/** How long to wait for a freshly-opened surface to mount and load. */
+const READY_TIMEOUT_MS = 20_000;
+const POLL_INTERVAL_MS = 100;
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitUntilReady = async (
+  type: OpenableType,
+  id: string,
+  ctx: FrontendToolContext
+): Promise<boolean> => {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (ready(type, id, ctx)) return true;
+    if (ctx.abortSignal.aborted) return false;
+    await delay(POLL_INTERVAL_MS);
+  }
+  return ready(type, id, ctx);
+};
+
+FrontendToolRegistry.register({
+  name: "ui_open_document",
+  description:
+    "Open a document in the workspace as a tab so the other ui_* tools can act on it. Use this when a ui_* tool reports that the document is not open, or when the user names a document that is not in the open list — do not report a document as unavailable until you have tried to open it. Types: workflow, timeline, storyboard, script, sketch, app. The id is the document's id (from list_timelines, list_sketches, list_storyboards, list_scripts, a resource link, or the user). Documents open in edit mode; already-open documents are focused rather than duplicated. Returns once the editor has loaded and the document's tools are usable.",
+  parameters: z.object({
+    type: z
+      .enum(OPENABLE_TYPES)
+      .describe("Kind of document to open, as named in the ui_context block."),
+    id: z.string().trim().min(1).describe("Id of the document to open."),
+    focus: z
+      .boolean()
+      .optional()
+      .describe(
+        "Switch the workspace to this tab (default true). Pass false to open it in the background and leave the user where they are."
+      )
+  }),
+  async execute({ type, id, focus }, ctx) {
+    const tabs = useWorkspaceTabsStore.getState();
+    const wasOpen = tabs.tabs.some(
+      (tab) => tab.id === tabId(TAB_TYPE[type], id)
+    );
+
+    if (wasOpen && ready(type, id, ctx)) {
+      if (focus !== false) tabs.setActiveTab(tabId(TAB_TYPE[type], id));
+      return {
+        ok: true,
+        type,
+        id,
+        already_open: true,
+        url: docUrl(type, id)
+      };
+    }
+
+    // Tabs only mount inside the workspace shell, so a session driving the
+    // agent from a legacy route has to land there first.
+    if (
+      typeof window !== "undefined" &&
+      !window.location.pathname.startsWith("/workspace")
+    ) {
+      navigateTo("/workspace");
+    }
+
+    // Editors register their agent handler; viewers do not — so always edit.
+    const previousActiveTabId = tabs.activeTabId;
+    tabs.openTab({ type: TAB_TYPE[type], ref: id, mode: "edit" });
+    if (focus === false && previousActiveTabId) {
+      tabs.setActiveTab(previousActiveTabId);
+    }
+
+    if (await waitUntilReady(type, id, ctx)) {
+      return {
+        ok: true,
+        type,
+        id,
+        already_open: wasOpen,
+        url: docUrl(type, id)
+      };
+    }
+
+    // Nothing loaded — leave no broken tab behind for the user to close.
+    if (!wasOpen) {
+      useWorkspaceTabsStore.getState().closeTab(tabId(TAB_TYPE[type], id));
+      if (previousActiveTabId) {
+        useWorkspaceTabsStore.getState().setActiveTab(previousActiveTabId);
+      }
+    }
+    throw new Error(
+      `The ${LABEL[type]} "${id}" did not open. Check that the id is right — ` +
+        `it may have been deleted, or belong to another user.`
+    );
+  }
+});


### PR DESCRIPTION
Every editor `ui_*` tool acts on a document the user has **open**: each mounted editor registers a handler under its document id, and a call naming an id nothing registered fails with

```
{"error":"No timeline sequence \"fcbc78e8…\" is open. No timeline sequences are currently open."}
```

That was a dead end. An agent could get a valid document id — from `list_timelines`, `list_sketches`, a resource link, or the user — and still have no way to act on it.

## What changed

**`ui_open_document` (`web/src/lib/tools/builtin/openDocument.ts`)** opens a document as a workspace tab: `{type, id, focus?}` for `workflow | timeline | storyboard | script | sketch | app`.

- Navigates to the workspace shell first when a legacy route is showing — tabs only mount there.
- Opens in **edit** mode: viewers register no agent handler, editors do.
- Resolves only once the surface has mounted *and* loaded. Handler presence alone is not enough — a surface registers while its document query is still in flight, and an agent reading the snapshot then would see an empty document. Each probe checks the loaded document's own id (a workflow's node store, `snapshot.sequenceId`, `boardId`, `scriptId`, `documentId`).
- A document that never loads (deleted, wrong id) closes its own tab and returns an error saying so, instead of leaving a broken tab for the user to clean up.
- An already-open document is focused, not duplicated; `focus: false` opens in the background and restores the user's tab.

**Discoverability.** The tool is in `RESIDENT_TOOL_NAMES`, so hitting "not open" mid-edit costs no ToolSearch round-trip. The five "… is open" bridge errors (timeline, storyboard, script, sketch, app builder) now name it, and the `ui_context` block in the chat system prompt tells the agent to open a document rather than report it as unavailable.

## Tests

- `web/src/lib/tools/__tests__/openDocument.test.ts` — 7 cases: manifest shape, opens-and-waits, waits for load rather than mount, focuses an already-open doc, honours `focus: false`, workflow readiness, and the timeout path closing its tab.
- `packages/websocket/tests/resident-tools.test.ts` — pins the tool as resident.
- Existing bridge/tool suites pass unchanged (their error assertions are substrings).

`npm run typecheck` (web), eslint on the touched files, and the affected Jest/Vitest suites are green.

## Not covered

Mobile opens documents one-per-screen with no tab store, so its bridge keeps the "ask the user to open one" message. The 3D editor's handler is a singleton with no document id, so `model3d` is not an openable type.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnzUphKhufZGukwCtL8VfE)_