### PR TITLE
kie: pick up the recent models from the KIE docs

### DIFF
--- a/packages/kie-codegen/src/configs/audio.ts
+++ b/packages/kie-codegen/src/configs/audio.ts
@@ -504,6 +504,108 @@ export const audioConfig: ModuleConfig = {
       ]
     },
     {
+      "className": "Gemini31FlashTts",
+      "modelId": "google/gemini-3-1-flash-tts",
+      "title": "Gemini 3.1 Flash Text to speech",
+      "description": "Gemini 3.1 Flash Text to speech via Kie.ai.\n\n    kie, audio, ai\n\n    Content generation using elevenlabs/audio-isolation",
+      "outputType": "audio",
+      "fields": [
+        {
+          "name": "temperature",
+          "type": "float",
+          "default": 1,
+          "title": "Temperature",
+          "description": "Sampling temperature, e.g., 1",
+          "required": false,
+          "min": 0,
+          "max": 2
+        },
+        {
+          "name": "scene",
+          "type": "str",
+          "default": "",
+          "title": "Scene",
+          "description": "Scene description, e.g., \"A quiet, warm room with a fireplace crackling softly.\"",
+          "required": false
+        },
+        {
+          "name": "sample_context",
+          "type": "str",
+          "default": "",
+          "title": "Sample Context",
+          "description": "Sample context/overall tone, e.g., \"Audiobook style narration. Tone is gentle and inviting.\"",
+          "required": false
+        },
+        {
+          "name": "speakers",
+          "type": "list[image]",
+          "default": [],
+          "title": "Speakers",
+          "description": "List of speaker configurations",
+          "required": true
+        },
+        {
+          "name": "dialogue_turns",
+          "type": "list[image]",
+          "default": [],
+          "title": "Dialogue Turns",
+          "description": "List of dialogue turns, output in sequential order",
+          "required": true
+        }
+      ]
+    },
+    {
+      "className": "Gemini25ProTts",
+      "modelId": "google/gemini-2-5-pro-tts",
+      "title": "Gemini 2.5 Pro Text to Speech",
+      "description": "Gemini 2.5 Pro Text to Speech via Kie.ai.\n\n    kie, audio, ai\n\n    Content generation using elevenlabs/audio-isolation",
+      "outputType": "audio",
+      "fields": [
+        {
+          "name": "temperature",
+          "type": "float",
+          "default": 1,
+          "title": "Temperature",
+          "description": "Sampling temperature, e.g., 1",
+          "required": false,
+          "min": 0,
+          "max": 2
+        },
+        {
+          "name": "scene",
+          "type": "str",
+          "default": "",
+          "title": "Scene",
+          "description": "Scene description, e.g., \"A quiet, warm room with a fireplace crackling softly.\"",
+          "required": false
+        },
+        {
+          "name": "sample_context",
+          "type": "str",
+          "default": "",
+          "title": "Sample Context",
+          "description": "Sample context/overall tone, e.g., \"Audiobook style narration. Tone is gentle and inviting.\"",
+          "required": false
+        },
+        {
+          "name": "speakers",
+          "type": "list[image]",
+          "default": [],
+          "title": "Speakers",
+          "description": "List of speaker configurations",
+          "required": true
+        },
+        {
+          "name": "dialogue_turns",
+          "type": "list[image]",
+          "default": [],
+          "title": "Dialogue Turns",
+          "description": "List of dialogue turns, output in sequential order",
+          "required": true
+        }
+      ]
+    },
+    {
       "className": "GenerateMusic",
       "modelId": "generate-music",
       "title": "Generate Music",
@@ -692,8 +794,8 @@ export const audioConfig: ModuleConfig = {
           "type": "str",
           "default": "",
           "title": "Prompt",
-          "description": "Description of the desired audio extension content. - Required when `defaultParamFlag` is `true`. - Character limits by model: - **V4**: Maximum 3000 characters - **V4_5 & V4_5PLUS**: Maximum 5000 characters - **V4_5ALL**: Maximum 5000 characters - **V5_5 & V5**: Maximum 5000 characters - Describes how the music should continue or change in the extension.",
-          "required": true
+          "description": "Prompt describing the desired audio extension content. - Required when `defaultParamFlag` is `true` (this parameter is not needed if `instrumental` is `true`). - Character limits by model: - **V4**: Max 3,000 characters - **V4_5 and V4_5PLUS**: Max 5,000 characters - **V4_5ALL**: Max 5,000 characters - **V5_5 and V5**: Max 5,000 characters - Describe how the music should continue or evolve in the extended section.",
+          "required": false
         },
         {
           "name": "style",
@@ -748,7 +850,7 @@ export const audioConfig: ModuleConfig = {
           "type": "enum",
           "default": "",
           "title": "Vocal Gender",
-          "description": "Vocal gender preference for the singing voice. Optional. Use 'm' for male and 'f' for female. Based on practice, this parameter can only increase the probability but cannot guarantee adherence to male/female voice instructions.",
+          "description": "Vocal gender preference. Optional. 'm' denotes a male voice, and 'f' denotes a female voice. In practice, this parameter only influences the probability and does not guarantee strict adherence to the gender instruction. This parameter is not required if `instrumental` is set to `true`.",
           "required": false,
           "values": [
             "m",
@@ -810,7 +912,7 @@ export const audioConfig: ModuleConfig = {
           "type": "bool",
           "default": false,
           "title": "Instrumental",
-          "description": "Is it an instrumental track? The prompt parameter is required only if false. If true, do not include it.",
+          "description": "Indicates whether it is an instrumental track. If true, passing the `prompt` and `vocalGender` parameters is prohibited.",
           "required": false
         }
       ],
@@ -819,11 +921,6 @@ export const audioConfig: ModuleConfig = {
           "field": "audioId",
           "rule": "not_empty",
           "message": "Audio Id is required"
-        },
-        {
-          "field": "prompt",
-          "rule": "not_empty",
-          "message": "Prompt is required"
         },
         {
           "field": "model",
@@ -1016,7 +1113,7 @@ export const audioConfig: ModuleConfig = {
       "className": "UploadAndExtendAudio",
       "modelId": "upload-and-extend-audio",
       "title": "Upload And Extend Audio",
-      "description": "Upload And Extend Audio via Kie.ai.\n\n    kie, audio, ai\n\n    > This API extends audio tracks while preserving their original style. It includes Suno's upload functionality, allowing users to upload audio files for processing. The expected result is a longer track that seamlessly continues the input style.",
+      "description": "Upload And Extend Audio via Kie.ai.\n\n    kie, audio, ai\n\n    # Upload and Extend Music",
       "outputType": "audio",
       "useSuno": true,
       "sunoEndpoint": "/api/v1/generate/upload-extend",
@@ -1048,15 +1145,15 @@ export const audioConfig: ModuleConfig = {
           "type": "bool",
           "default": false,
           "title": "Instrumental",
-          "description": "Determines whether the audio is instrumental (without lyrics). - In custom parameter mode (`customMode: true`): - If `true`: only `style`, `title`, and `uploadUrl` are required. - If `false`: `style`, `title`, `prompt` (`prompt` will be used as exact lyrics), and `uploadUrl` are required. - In non-custom parameter mode (`defaultParamFlag: false`): does not affect required fields (only `uploadUrl` needed). If `false`, lyrics will be automatically generated.",
-          "required": true
+          "description": "Determines whether the audio is instrumental (without lyrics). - In custom parameter mode (`defaultParamFlag: true`): - If `true`: Only `style`, `title`, and `uploadUrl` are required; `prompt` and `vocalGender` do not need to be specified. - If `false`: `style`, `title`, and `uploadUrl` are required; `prompt` is optional (if provided, it serves as a prompt); `vocalGender` does not need to be specified. - In non-custom parameter mode (`defaultParamFlag: false`): Does not affect mandatory fields (only `uploadUrl` is required); `prompt` is optional. If set to `false`, lyrics will be automatically generated. Optional; defaults to `false`.",
+          "required": false
         },
         {
           "name": "prompt",
           "type": "str",
           "default": "",
           "title": "Prompt",
-          "description": "Description of how the music should be extended. Required when defaultParamFlag is true. Character limits by model: - **V5_5 & V5**: Maximum 5000 characters - **V4_5PLUS & V4_5**: Maximum 5000 characters - **V4_5ALL**: Maximum 5000 characters - **V4**: Maximum 3000 characters",
+          "description": "Describe how the music should be extended. Optional; if provided, it will be used as a prompt. Subject to model character limits: - **V5_5 & V5**: Max 5,000 characters - **V4_5PLUS & V4_5**: Max 5,000 characters - **V4_5ALL**: Max 5,000 characters - **V4**: Max 3,000 characters",
           "required": false
         },
         {
@@ -1700,6 +1797,97 @@ export const audioConfig: ModuleConfig = {
           "field": "audioId",
           "rule": "not_empty",
           "message": "Audio Id is required"
+        }
+      ]
+    },
+    {
+      "className": "GeneratePersona",
+      "modelId": "generate-persona",
+      "title": "Generate Persona",
+      "description": "Generate Persona via Kie.ai.\n\n    kie, audio, ai\n\n    Generate Persona",
+      "outputType": "audio",
+      "useSuno": true,
+      "sunoEndpoint": "/api/v1/generate/generate-persona",
+      "fields": [
+        {
+          "name": "taskId",
+          "type": "str",
+          "default": "",
+          "title": "Task Id",
+          "description": "Unique identifier of the original music generation task. This can be a taskId returned from any of the following endpoints: - Generate Music (/api/v1/generate) - Extend Music (/api/v1/generate/extend)",
+          "required": true
+        },
+        {
+          "name": "audioId",
+          "type": "str",
+          "default": "",
+          "title": "Audio Id",
+          "description": "Unique identifier of the audio track to create Persona for. This ID is returned in the callback data after music generation completes.",
+          "required": true
+        },
+        {
+          "name": "name",
+          "type": "str",
+          "default": "",
+          "title": "Name",
+          "description": "Name for the Persona. A descriptive name that captures the essence of the musical style or character.",
+          "required": true
+        },
+        {
+          "name": "description",
+          "type": "str",
+          "default": "",
+          "title": "Description",
+          "description": "Detailed description of the Persona's musical characteristics, style, and personality. Be specific about genre, mood, instrumentation, and vocal qualities.",
+          "required": true
+        },
+        {
+          "name": "vocalStart",
+          "type": "float",
+          "default": 0,
+          "title": "Vocal Start",
+          "description": "Start time (in seconds) for Persona analysis segment extraction. Used to specify the time point in the audio from which to extract the segment for Persona analysis. Must be less than vocalEnd, and vocalEnd - vocalStart must be between 10–30 seconds. Defaults to 0.0.",
+          "required": false,
+          "min": 0
+        },
+        {
+          "name": "vocalEnd",
+          "type": "float",
+          "default": 30,
+          "title": "Vocal End",
+          "description": "End time (in seconds) for Persona analysis segment extraction. Together with vocalStart, used to specify the time range for analysis. vocalEnd - vocalStart must be between 10–30 seconds. Defaults to 30.0.",
+          "required": false,
+          "min": 0
+        },
+        {
+          "name": "style",
+          "type": "str",
+          "default": "",
+          "title": "Style",
+          "description": "Optional. Used to supplement the description of the music style tag corresponding to the Persona, such as \"Electronic Pop\", \"Jazz Trio\", etc.",
+          "required": false
+        }
+      ],
+      "validation": [
+        {
+          "field": "taskId",
+          "rule": "not_empty",
+          "message": "Task Id is required"
+        },
+        {
+          "field": "audioId",
+          "rule": "not_empty",
+          "message": "Audio Id is required"
+        },
+        {
+          "field": "name",
+          "rule": "not_empty",
+          "message": "Name is required"
+        },
+        {
+          "field": "description",
+          "rule": "not_empty",
+          "message": "Description is required"
         }
       ]
     },

--- a/packages/kie-codegen/src/configs/image.ts
+++ b/packages/kie-codegen/src/configs/image.ts
@@ -1282,15 +1282,15 @@ export const imageConfig: ModuleConfig = {
           "required": false,
           "values": [
             "1:1",
-            "1:4",
-            "1:8",
             "2:3",
             "3:2",
-            "3:4",
+            "1:4",
             "4:1",
+            "3:4",
             "4:3",
             "4:5",
             "5:4",
+            "1:8",
             "8:1",
             "9:16",
             "16:9",
@@ -2146,8 +2146,7 @@ export const imageConfig: ModuleConfig = {
           "values": [
             "1",
             "2",
-            "4",
-            "8"
+            "4"
           ]
         }
       ],
@@ -3359,6 +3358,14 @@ export const imageConfig: ModuleConfig = {
           "description": "The negative prompt for the generation Default value: \" \" (Max length: 500 characters)",
           "required": false,
           "max": 500
+        },
+        {
+          "name": "nsfw_checker",
+          "type": "bool",
+          "default": false,
+          "title": "Nsfw Checker",
+          "description": "Defaults to false. You can set it to false based on your needs. If set to false, our content filtering will be disabled, and all results will be returned directly by the model itself. Note: There is no guarantee that everything can be filtered out; if you are not satisfied with the results, you will need to make your own arrangements.",
+          "required": false
         }
       ],
       "uploads": [
@@ -3443,6 +3450,14 @@ export const imageConfig: ModuleConfig = {
             "jpeg",
             "png"
           ]
+        },
+        {
+          "name": "nsfw_checker",
+          "type": "bool",
+          "default": false,
+          "title": "Nsfw Checker",
+          "description": "Defaults to false. You can set it to false based on your needs. If set to false, our content filtering will be disabled, and all results will be returned directly by the model itself. Note: There is no guarantee that everything can be filtered out; if you are not satisfied with the results, you will need to make your own arrangements.",
+          "required": false
         }
       ],
       "uploads": [
@@ -3518,6 +3533,458 @@ export const imageConfig: ModuleConfig = {
           "title": "Nsfw Checker",
           "description": "Defaults to false. You can set it to false based on your needs. If set to false, our content filtering will be disabled, and all results will be returned directly by the model itself. Note: There is no guarantee that everything can be filtered out; if you are not satisfied with the results, you will need to make your own arrangements.",
           "required": false
+        }
+      ],
+      "validation": [
+        {
+          "field": "prompt",
+          "rule": "not_empty",
+          "message": "Prompt is required"
+        }
+      ]
+    },
+    {
+      "className": "Qwen3ProTextToImage",
+      "modelId": "qwen3/pro-text-to-image",
+      "title": "Qwen3 Pro Text to Image",
+      "description": "Qwen3 Pro Text to Image via Kie.ai.\n\n    kie, image, ai\n\n    ## Create Task",
+      "outputType": "image",
+      "fields": [
+        {
+          "name": "prompt",
+          "type": "str",
+          "default": "",
+          "title": "Prompt",
+          "description": "The positive prompt that describes the image content, style, and composition you want to generate or edit. Both Chinese and English are supported.",
+          "required": true,
+          "min": 0,
+          "max": 800
+        },
+        {
+          "name": "resolution",
+          "type": "enum",
+          "default": "",
+          "title": "Resolution",
+          "description": "The output image resolution.",
+          "required": false,
+          "values": [
+            "1K",
+            "2K"
+          ]
+        },
+        {
+          "name": "image_size",
+          "type": "enum",
+          "default": "16:9",
+          "title": "Image Size",
+          "description": "The output image size.",
+          "required": false,
+          "values": [
+            "1:1",
+            "3:2",
+            "2:3",
+            "4:3",
+            "3:4",
+            "16:9",
+            "9:16",
+            "21:9"
+          ]
+        },
+        {
+          "name": "output_format",
+          "type": "enum",
+          "default": "png",
+          "title": "Output Format",
+          "description": "The generated image format.",
+          "required": false,
+          "values": [
+            "png",
+            "jpeg"
+          ]
+        },
+        {
+          "name": "prompt_extend",
+          "type": "bool",
+          "default": true,
+          "title": "Prompt Extend",
+          "description": "Whether to enable intelligent prompt rewriting. Default: true (recommended). When enabled, the model optimizes the positive prompt, which significantly improves results for simple descriptions.",
+          "required": false
+        },
+        {
+          "name": "nsfw_checker",
+          "type": "bool",
+          "default": false,
+          "title": "Nsfw Checker",
+          "description": "Whether to enable content filtering. Optional. Defaults to false. When set to false, content filtering is disabled and all results are returned directly by the model. Note: Content filtering cannot guarantee that all inappropriate content will be detected. If the filtering results do not meet your requirements, you must implement additional content moderation measures.",
+          "required": false
+        },
+        {
+          "name": "negative_prompt",
+          "type": "str",
+          "default": "",
+          "title": "Negative Prompt",
+          "description": "The negative prompt that describes content you do not want to appear in the image.",
+          "required": false,
+          "min": 0,
+          "max": 5000
+        },
+        {
+          "name": "seed",
+          "type": "int",
+          "default": 1,
+          "title": "Seed",
+          "description": "The random seed. Value range: [0, 2147483647]. A fixed seed helps maintain relatively stable results.",
+          "required": false,
+          "min": 0,
+          "max": 2147483647
+        }
+      ],
+      "validation": [
+        {
+          "field": "prompt",
+          "rule": "not_empty",
+          "message": "Prompt is required"
+        }
+      ]
+    },
+    {
+      "className": "Qwen3TextToImage",
+      "modelId": "qwen3/text-to-image",
+      "title": "Qwen3 Text to Image",
+      "description": "Qwen3 Text to Image via Kie.ai.\n\n    kie, image, ai\n\n    ## Create Task",
+      "outputType": "image",
+      "fields": [
+        {
+          "name": "prompt",
+          "type": "str",
+          "default": "",
+          "title": "Prompt",
+          "description": "The positive prompt that describes the image content, style, and composition you want to generate or edit. Both Chinese and English are supported.",
+          "required": true,
+          "min": 0,
+          "max": 800
+        },
+        {
+          "name": "resolution",
+          "type": "enum",
+          "default": "",
+          "title": "Resolution",
+          "description": "The output image resolution.",
+          "required": false,
+          "values": [
+            "1K",
+            "2K"
+          ]
+        },
+        {
+          "name": "image_size",
+          "type": "enum",
+          "default": "16:9",
+          "title": "Image Size",
+          "description": "The output image size.",
+          "required": false,
+          "values": [
+            "1:1",
+            "3:2",
+            "2:3",
+            "4:3",
+            "3:4",
+            "16:9",
+            "9:16",
+            "21:9"
+          ]
+        },
+        {
+          "name": "output_format",
+          "type": "enum",
+          "default": "png",
+          "title": "Output Format",
+          "description": "The generated image format.",
+          "required": false,
+          "values": [
+            "png",
+            "jpeg"
+          ]
+        },
+        {
+          "name": "prompt_extend",
+          "type": "bool",
+          "default": true,
+          "title": "Prompt Extend",
+          "description": "Whether to enable intelligent prompt rewriting. Default: true (recommended). When enabled, the model optimizes the positive prompt, which significantly improves results for simple descriptions.",
+          "required": false
+        },
+        {
+          "name": "nsfw_checker",
+          "type": "bool",
+          "default": false,
+          "title": "Nsfw Checker",
+          "description": "Whether to enable content filtering. Optional. Defaults to false. When set to false, content filtering is disabled and all results are returned directly by the model. Note: Content filtering cannot guarantee that all inappropriate content will be detected. If the filtering results do not meet your requirements, you must implement additional content moderation measures.",
+          "required": false
+        },
+        {
+          "name": "negative_prompt",
+          "type": "str",
+          "default": "",
+          "title": "Negative Prompt",
+          "description": "The negative prompt that describes content you do not want to appear in the image.",
+          "required": false,
+          "min": 0,
+          "max": 5000
+        },
+        {
+          "name": "seed",
+          "type": "int",
+          "default": 1,
+          "title": "Seed",
+          "description": "The random seed. Value range: [0, 2147483647]. A fixed seed helps maintain relatively stable results.",
+          "required": false,
+          "min": 0,
+          "max": 2147483647
+        }
+      ],
+      "validation": [
+        {
+          "field": "prompt",
+          "rule": "not_empty",
+          "message": "Prompt is required"
+        }
+      ]
+    },
+    {
+      "className": "Qwen3ProImageToImage",
+      "modelId": "qwen3/pro-image-to-image",
+      "title": "Qwen3 Pro Image to Image",
+      "description": "Qwen3 Pro Image to Image via Kie.ai.\n\n    kie, image, ai\n\n    ## Create Task",
+      "outputType": "image",
+      "fields": [
+        {
+          "name": "images",
+          "type": "list[image]",
+          "default": [],
+          "title": "Images",
+          "description": "Input image URL array. Upload images and provide their URLs rather than the file content. Supports up to 3 images. Supported file types: `image/jpeg`, `image/png`, `image/webp`, `image/bmp`, and `image/gif`,`image/tiff`. Maximum file size: 10 MB per image.",
+          "required": true,
+          "min": 1,
+          "max": 3
+        },
+        {
+          "name": "prompt",
+          "type": "str",
+          "default": "",
+          "title": "Prompt",
+          "description": "The positive prompt that describes the image content, style, and composition you want to generate or edit. Both Chinese and English are supported.",
+          "required": true,
+          "min": 0,
+          "max": 800
+        },
+        {
+          "name": "resolution",
+          "type": "enum",
+          "default": "1K",
+          "title": "Resolution",
+          "description": "The output image resolution.",
+          "required": false,
+          "values": [
+            "1K",
+            "2K"
+          ]
+        },
+        {
+          "name": "image_size",
+          "type": "enum",
+          "default": "16:9",
+          "title": "Image Size",
+          "description": "The output image size.",
+          "required": false,
+          "values": [
+            "1:1",
+            "3:2",
+            "2:3",
+            "4:3",
+            "3:4",
+            "16:9",
+            "9:16",
+            "21:9"
+          ]
+        },
+        {
+          "name": "output_format",
+          "type": "enum",
+          "default": "png",
+          "title": "Output Format",
+          "description": "The generated image format.",
+          "required": false,
+          "values": [
+            "png",
+            "jpeg"
+          ]
+        },
+        {
+          "name": "prompt_extend",
+          "type": "bool",
+          "default": true,
+          "title": "Prompt Extend",
+          "description": "Whether to enable intelligent prompt rewriting. Default: true (recommended). When enabled, the model optimizes the positive prompt, which significantly improves results for simple descriptions.",
+          "required": false
+        },
+        {
+          "name": "nsfw_checker",
+          "type": "bool",
+          "default": false,
+          "title": "Nsfw Checker",
+          "description": "Whether to enable content filtering. Optional. Defaults to false. When set to false, content filtering is disabled and all results are returned directly by the model. Note: Content filtering cannot guarantee that all inappropriate content will be detected. If the filtering results do not meet your requirements, you must implement additional content moderation measures.",
+          "required": false
+        },
+        {
+          "name": "negative_prompt",
+          "type": "str",
+          "default": "",
+          "title": "Negative Prompt",
+          "description": "The negative prompt that describes content you do not want to appear in the image.",
+          "required": false,
+          "min": 0,
+          "max": 5000
+        },
+        {
+          "name": "seed",
+          "type": "int",
+          "default": 1,
+          "title": "Seed",
+          "description": "The random seed. Value range: [0, 2147483647]. A fixed seed helps maintain relatively stable results.",
+          "required": false,
+          "min": 0,
+          "max": 2147483647
+        }
+      ],
+      "uploads": [
+        {
+          "field": "images",
+          "kind": "image",
+          "isList": true,
+          "paramName": "image_urls"
+        }
+      ],
+      "validation": [
+        {
+          "field": "prompt",
+          "rule": "not_empty",
+          "message": "Prompt is required"
+        }
+      ]
+    },
+    {
+      "className": "Qwen3ImageToImage",
+      "modelId": "qwen3/image-to-image",
+      "title": "Qwen3 Image to Image",
+      "description": "Qwen3 Image to Image via Kie.ai.\n\n    kie, image, ai\n\n    ## Create Task",
+      "outputType": "image",
+      "fields": [
+        {
+          "name": "images",
+          "type": "list[image]",
+          "default": [],
+          "title": "Images",
+          "description": "Input image URL array. Upload images and provide their URLs rather than the file content. Supports up to 3 images. Supported file types: `image/jpeg`, `image/png`, `image/webp`, `image/bmp`, and `image/gif`,`image/tiff`. Maximum file size: 10 MB per image.",
+          "required": true,
+          "min": 1,
+          "max": 3
+        },
+        {
+          "name": "prompt",
+          "type": "str",
+          "default": "",
+          "title": "Prompt",
+          "description": "The positive prompt that describes the image content, style, and composition you want to generate or edit. Both Chinese and English are supported.",
+          "required": true,
+          "min": 0,
+          "max": 800
+        },
+        {
+          "name": "resolution",
+          "type": "enum",
+          "default": "1K",
+          "title": "Resolution",
+          "description": "The output image resolution.",
+          "required": false,
+          "values": [
+            "1K",
+            "2K"
+          ]
+        },
+        {
+          "name": "image_size",
+          "type": "enum",
+          "default": "16:9",
+          "title": "Image Size",
+          "description": "The output image size.",
+          "required": false,
+          "values": [
+            "1:1",
+            "3:2",
+            "2:3",
+            "4:3",
+            "3:4",
+            "16:9",
+            "9:16",
+            "21:9"
+          ]
+        },
+        {
+          "name": "output_format",
+          "type": "enum",
+          "default": "png",
+          "title": "Output Format",
+          "description": "The generated image format.",
+          "required": false,
+          "values": [
+            "png",
+            "jpeg"
+          ]
+        },
+        {
+          "name": "prompt_extend",
+          "type": "bool",
+          "default": true,
+          "title": "Prompt Extend",
+          "description": "Whether to enable intelligent prompt rewriting. Default: true (recommended). When enabled, the model optimizes the positive prompt, which significantly improves results for simple descriptions.",
+          "required": false
+        },
+        {
+          "name": "nsfw_checker",
+          "type": "bool",
+          "default": false,
+          "title": "Nsfw Checker",
+          "description": "Whether to enable content filtering. Optional. Defaults to false. When set to false, content filtering is disabled and all results are returned directly by the model. Note: Content filtering cannot guarantee that all inappropriate content will be detected. If the filtering results do not meet your requirements, you must implement additional content moderation measures.",
+          "required": false
+        },
+        {
+          "name": "negative_prompt",
+          "type": "str",
+          "default": "",
+          "title": "Negative Prompt",
+          "description": "The negative prompt that describes content you do not want to appear in the image.",
+          "required": false,
+          "min": 0,
+          "max": 5000
+        },
+        {
+          "name": "seed",
+          "type": "int",
+          "default": 1,
+          "title": "Seed",
+          "description": "The random seed. Value range: [0, 2147483647]. A fixed seed helps maintain relatively stable results.",
+          "required": false,
+          "min": 0,
+          "max": 2147483647
+        }
+      ],
+      "uploads": [
+        {
+          "field": "images",
+          "kind": "image",
+          "isList": true,
+          "paramName": "image_urls"
         }
       ],
       "validation": [

--- a/packages/kie-codegen/src/configs/video.ts
+++ b/packages/kie-codegen/src/configs/video.ts
@@ -67,7 +67,8 @@ export const videoConfig: ModuleConfig = {
           "required": false,
           "values": [
             "480p",
-            "720p"
+            "720p",
+            "1080p"
           ]
         },
         {
@@ -99,7 +100,7 @@ export const videoConfig: ModuleConfig = {
           "type": "list[image]",
           "default": [],
           "title": "Images",
-          "description": "Provide an external image URL as a reference for video generation. Up to 7 images are supported. Do not use it simultaneously with task_id. In your prompt, reference an uploaded image by typing @image(n) followed by a space (for example: @image1 a sunset over the ocean). - Supports JPEG, PNG, and WEBP formats - Maximum file size for each image: 10MB - The Spicy mode is not available when using external images - The array can contain a maximum of seven URLs",
+          "description": "Provide an external image URL as a reference for video generation. Up to 7 images are supported. Do not use it simultaneously with task_id. In your prompt, reference an uploaded image by typing @image(n) followed by a space (for example: @image1 a sunset over the ocean). - Supports JPEG, PNG, and WEBP formats - Maximum file size for each image: 10MB - The Spicy mode is not available when using external images - The array can contain a maximum of seven URLs - Only one is supported when the resolution is 1080p.",
           "required": false,
           "max": 7
         },
@@ -162,7 +163,8 @@ export const videoConfig: ModuleConfig = {
           "required": false,
           "values": [
             "480p",
-            "720p"
+            "720p",
+            "1080p"
           ]
         },
         {
@@ -213,6 +215,18 @@ export const videoConfig: ModuleConfig = {
           "description": "Task ID from a previously successful video generation task. Required field. - Must be from a Kie AI video generation model (e.g., grok-imagine/text-to-video) - The original video generation must have completed successfully - Only Kie AI–generated task IDs are supported",
           "required": true,
           "max": 100
+        },
+        {
+          "name": "resolution",
+          "type": "enum",
+          "default": "720p",
+          "title": "Resolution",
+          "description": "Video generation resolution.",
+          "required": false,
+          "values": [
+            "720p",
+            "1080p"
+          ]
         }
       ],
       "validation": [
@@ -299,7 +313,7 @@ export const videoConfig: ModuleConfig = {
           "type": "list[image]",
           "default": [],
           "title": "Images",
-          "description": "Upload image files to be used as API input. Supported file types: image/jpeg, image/png, image/webp, image/jpg. Maximum file size: 20MB. Supports multi-file upload, up to 7 file.",
+          "description": "Upload image files to be used as API input. Supported file types: image/jpeg, image/png, image/webp, image/jpg. Maximum file size: 20MB. Supports multi-file upload, up to 7 file.Only one is supported when the resolution is 1080p.",
           "required": false,
           "max": 7
         },
@@ -328,7 +342,8 @@ export const videoConfig: ModuleConfig = {
           "required": false,
           "values": [
             "480p",
-            "720p"
+            "720p",
+            "1080p"
           ]
         },
         {
@@ -525,6 +540,20 @@ export const videoConfig: ModuleConfig = {
           "required": true
         },
         {
+          "name": "tail_image",
+          "type": "image",
+          "default": {
+            "type": "image",
+            "uri": "",
+            "asset_id": null,
+            "data": null,
+            "metadata": null
+          },
+          "title": "Tail Image",
+          "description": "Tail frame image of video (File URL after upload, not file content; Accepted types: image/jpeg, image/png; Max size: 10.0MB)",
+          "required": false
+        },
+        {
           "name": "duration",
           "type": "enum",
           "default": "5",
@@ -554,20 +583,6 @@ export const videoConfig: ModuleConfig = {
           "required": false,
           "min": 0,
           "max": 1
-        },
-        {
-          "name": "tail_image",
-          "type": "image",
-          "default": {
-            "type": "image",
-            "uri": "",
-            "asset_id": null,
-            "data": null,
-            "metadata": null
-          },
-          "title": "Tail Image",
-          "description": "Tail frame image of video (File URL after upload, not file content; Accepted types: image/jpeg, image/png; Max size: 10.0MB)",
-          "required": false
         }
       ],
       "uploads": [
@@ -1138,7 +1153,7 @@ export const videoConfig: ModuleConfig = {
           "type": "list[video]",
           "default": [],
           "title": "Videos",
-          "description": "An array containing a single video URL. The duration must be between 3 to 30 seconds, and the video must clearly show the subject's head, shoulders, and torso. (File URL after upload, not file content; Accepted types: video/mp4, video/quicktime, video/x-matroska; Max size: 100.0MB)",
+          "description": "An array containing a single video URL. The duration must be between 3 to 30 seconds, and the video must clearly show the subject's head, shoulders, and torso. (File URL after upload, not file content; Accepted types: video/mp4, video/quicktime; Max size: 100.0MB)",
           "required": true,
           "min": 3,
           "max": 1
@@ -1267,6 +1282,147 @@ export const videoConfig: ModuleConfig = {
       ]
     },
     {
+      "className": "Kling30",
+      "modelId": "kling-3.0/video",
+      "title": "Kling 3.0",
+      "description": "Kling 3.0 via Kie.ai.\n\n    kie, video, ai\n\n    Generate high-quality videos with advanced multi-shot capabilities and element references using Kling 3.0 AI",
+      "outputType": "video",
+      "fields": [
+        {
+          "name": "prompt",
+          "type": "str",
+          "default": "",
+          "title": "Prompt",
+          "description": "Video generation prompt. Takes effect when multi_shots is false.",
+          "required": true
+        },
+        {
+          "name": "images",
+          "type": "list[image]",
+          "default": [],
+          "title": "Images",
+          "description": "First and last frame image URLs. Required when elements are referenced in the prompt (using @element_name syntax). When multi_shots is false: if length is 2, index 0 is the first frame and index 1 is the last frame; if length is 1, the array item serves as the first frame. When multi_shots is true: only the first frame is supported.",
+          "required": false
+        },
+        {
+          "name": "sound",
+          "type": "bool",
+          "default": false,
+          "title": "Sound",
+          "description": "Whether to enable sound effects. true enables sound effects, false disables them. When multi_shots is true, this field defaults to true.",
+          "required": true
+        },
+        {
+          "name": "duration",
+          "type": "enum",
+          "default": "5",
+          "title": "Duration",
+          "description": "Total video duration in seconds. Integer value, range: 3 to 15.",
+          "required": true,
+          "values": [
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15"
+          ],
+          "min": 3,
+          "max": 15
+        },
+        {
+          "name": "aspect_ratio",
+          "type": "enum",
+          "default": "16:9",
+          "title": "Aspect Ratio",
+          "description": "Video aspect ratio. Options: 16:9, 9:16, 1:1. When image_urls(first and last frame images) is provided, this parameter is optional and the aspect ratio will be automatically adapted based on the uploaded images.",
+          "required": true,
+          "values": [
+            "16:9",
+            "9:16",
+            "1:1"
+          ]
+        },
+        {
+          "name": "mode",
+          "type": "enum",
+          "default": "pro",
+          "title": "Mode",
+          "description": "Generation mode. std has standard resolution, pro has higher resolution, 4K has 4K resolution. Resolution mapping: - **std mode**: 16:9 (1280×720), 9:16 (720×1280), 1:1 (720×720) - **pro mode**: 16:9 (1920×1080), 9:16 (1080×1920), 1:1 (1080×1080) - **4K mode**: 16:9 (3840×2160), 9:16 (2160×3840), 1:1 (2160×2160)",
+          "required": true,
+          "values": [
+            "std",
+            "pro",
+            "4K"
+          ]
+        },
+        {
+          "name": "multi_shots",
+          "type": "bool",
+          "default": false,
+          "title": "Multi Shots",
+          "description": "Whether to use multi-shot mode. true enables multi-shot mode, false enables single-shot mode.",
+          "required": true
+        },
+        {
+          "name": "multi_prompt",
+          "type": "list[image]",
+          "default": [],
+          "title": "Multi Prompt",
+          "description": "Shot prompts. Takes effect when multi_shots is true. Used to describe the text and duration of each shot. Supports up to 5 shots. Each shot duration is 1-12 seconds. If you need to use elements, add them after the prompt.",
+          "required": true,
+          "min": 1,
+          "max": 12
+        },
+        {
+          "name": "kling_elements",
+          "type": "list[image]",
+          "default": [],
+          "title": "Kling Elements",
+          "description": "Referenced elements. Detailed information about elements referenced in the prompt. A single task can reference a maximum of three elements.",
+          "required": false,
+          "max": 3
+        }
+      ],
+      "uploads": [
+        {
+          "field": "images",
+          "kind": "image",
+          "isList": true,
+          "paramName": "image_urls"
+        }
+      ],
+      "validation": [
+        {
+          "field": "prompt",
+          "rule": "not_empty",
+          "message": "Prompt is required"
+        },
+        {
+          "field": "duration",
+          "rule": "not_empty",
+          "message": "Duration is required"
+        },
+        {
+          "field": "aspect_ratio",
+          "rule": "not_empty",
+          "message": "Aspect Ratio is required"
+        },
+        {
+          "field": "mode",
+          "rule": "not_empty",
+          "message": "Mode is required"
+        }
+      ]
+    },
+    {
       "className": "KlingV3TurboTextToVideo",
       "modelId": "kling/v3-turbo-text-to-video",
       "title": "Kling - V3 Turbo Text to Video",
@@ -1356,14 +1512,6 @@ export const videoConfig: ModuleConfig = {
           "max": 2500
         },
         {
-          "name": "images",
-          "type": "list[image]",
-          "default": [],
-          "title": "Images",
-          "description": "URL of the image to be used for the video (File URL after upload, not file content; Accepted types: image/jpeg, image/png; Max size: 10.0MB)",
-          "required": true
-        },
-        {
           "name": "duration",
           "type": "str",
           "default": "5",
@@ -1382,6 +1530,14 @@ export const videoConfig: ModuleConfig = {
             "720p",
             "1080p"
           ]
+        },
+        {
+          "name": "images",
+          "type": "list[image]",
+          "default": [],
+          "title": "Images",
+          "description": "URL of the image to be used for the video (File URL after upload, not file content; Accepted types: image/jpeg, image/png; Max size: 10.0MB)",
+          "required": true
         }
       ],
       "uploads": [
@@ -2294,6 +2450,14 @@ export const videoConfig: ModuleConfig = {
           "default": false,
           "title": "Enable Safety Checker",
           "description": "The safety checker is always enabled in Playground. It can only be disabled by setting false through the API. (Boolean value (true/false))",
+          "required": false
+        },
+        {
+          "name": "nsfw_checker",
+          "type": "bool",
+          "default": false,
+          "title": "Nsfw Checker",
+          "description": "Defaults to false. You can set it to false based on your needs. If set to false, our content filtering will be disabled, and all results will be returned directly by the model itself. Note: There is no guarantee that everything can be filtered out; if you are not satisfied with the results, you will need to make your own arrangements.",
           "required": false
         }
       ],
@@ -3494,6 +3658,14 @@ export const videoConfig: ModuleConfig = {
           ]
         },
         {
+          "name": "multi_shots",
+          "type": "bool",
+          "default": false,
+          "title": "Multi Shots",
+          "description": "The multi shots parameter controls the shot composition style during AI video generation, determining whether the generated video is a single continuous shot or multiple shots with transitions.",
+          "required": false
+        },
+        {
           "name": "nsfw_checker",
           "type": "bool",
           "default": false,
@@ -3560,6 +3732,14 @@ export const videoConfig: ModuleConfig = {
           ]
         },
         {
+          "name": "multi_shots",
+          "type": "bool",
+          "default": false,
+          "title": "Multi Shots",
+          "description": "The multi shots parameter controls the shot composition style during AI video generation, determining whether the generated video is a single continuous shot or multiple shots with transitions.",
+          "required": false
+        },
+        {
           "name": "nsfw_checker",
           "type": "bool",
           "default": false,
@@ -3624,6 +3804,14 @@ export const videoConfig: ModuleConfig = {
             "720p",
             "1080p"
           ]
+        },
+        {
+          "name": "multi_shots",
+          "type": "bool",
+          "default": false,
+          "title": "Multi Shots",
+          "description": "The multi shots parameter controls the shot composition style during AI video generation, determining whether the generated video is a single continuous shot or multiple shots with transitions.",
+          "required": false
         },
         {
           "name": "nsfw_checker",
@@ -5389,6 +5577,277 @@ export const videoConfig: ModuleConfig = {
       ]
     },
     {
+      "className": "MinimaxH3TextToVideo",
+      "modelId": "minimax-h3/text-to-video",
+      "title": "MiniMax H3 Text-to-Video",
+      "description": "MiniMax H3 Text-to-Video via Kie.ai.\n\n    kie, video, ai\n\n    ## Query Task Status",
+      "outputType": "video",
+      "fields": [
+        {
+          "name": "prompt",
+          "type": "str",
+          "default": "",
+          "title": "Prompt",
+          "description": "Video generation prompt, length is between 1 and 7000 characters.",
+          "required": true,
+          "min": 1,
+          "max": 7000
+        },
+        {
+          "name": "aspect_ratio",
+          "type": "enum",
+          "default": "",
+          "title": "Aspect Ratio",
+          "description": "Video aspect ratio. Required for text-to-video, adaptive is not supported.",
+          "required": true,
+          "values": [
+            "21:9",
+            "16:9",
+            "4:3",
+            "1:1",
+            "3:4",
+            "9:16"
+          ]
+        },
+        {
+          "name": "duration",
+          "type": "int",
+          "default": 6,
+          "title": "Duration",
+          "description": "Generated video duration, supports integer values from 4 to 15 seconds.",
+          "required": true,
+          "min": 4,
+          "max": 15
+        },
+        {
+          "name": "resolution",
+          "type": "enum",
+          "default": "2K",
+          "title": "Resolution",
+          "description": "Video resolution.",
+          "required": false,
+          "values": [
+            "768P",
+            "2K"
+          ]
+        }
+      ],
+      "validation": [
+        {
+          "field": "prompt",
+          "rule": "not_empty",
+          "message": "Prompt is required"
+        },
+        {
+          "field": "aspect_ratio",
+          "rule": "not_empty",
+          "message": "Aspect Ratio is required"
+        }
+      ]
+    },
+    {
+      "className": "MinimaxH3ImageToVideo",
+      "modelId": "minimax-h3/image-to-video",
+      "title": "MiniMax H3 Image-to-Video",
+      "description": "MiniMax H3 Image-to-Video via Kie.ai.\n\n    kie, video, ai\n\n    ## Query Task Status",
+      "outputType": "video",
+      "fields": [
+        {
+          "name": "prompt",
+          "type": "str",
+          "default": "",
+          "title": "Prompt",
+          "description": "Video generation prompt, length is between 1 and 7000 characters.",
+          "required": true,
+          "min": 1,
+          "max": 7000
+        },
+        {
+          "name": "first_frame",
+          "type": "image",
+          "default": {
+            "type": "image",
+            "uri": "",
+            "asset_id": null,
+            "data": null,
+            "metadata": null
+          },
+          "title": "First Frame",
+          "description": "First frame image URL. Note: Either first_frame_url or last_frame_url must be provided. Supports HTTP, HTTPS, and OSS addresses; supports JPG, JPEG, PNG, WEBP, HEIC, HEIF formats; single image size not exceeding 30 MB, image side length between 256 and 5760 pixels, aspect ratio between 0.4 and 2.5.",
+          "required": false
+        },
+        {
+          "name": "last_frame",
+          "type": "image",
+          "default": {
+            "type": "image",
+            "uri": "",
+            "asset_id": null,
+            "data": null,
+            "metadata": null
+          },
+          "title": "Last Frame",
+          "description": "Last frame image URL. Note: Either first_frame_url or last_frame_url must be provided. Image restrictions are the same as first_frame_url.",
+          "required": false
+        },
+        {
+          "name": "duration",
+          "type": "int",
+          "default": 6,
+          "title": "Duration",
+          "description": "Generated video duration, supporting integer values from 4 to 15 seconds.",
+          "required": true,
+          "min": 4,
+          "max": 15
+        },
+        {
+          "name": "resolution",
+          "type": "enum",
+          "default": "2K",
+          "title": "Resolution",
+          "description": "Video resolution.",
+          "required": false,
+          "values": [
+            "768P",
+            "2K"
+          ]
+        }
+      ],
+      "uploads": [
+        {
+          "field": "first_frame",
+          "kind": "image",
+          "paramName": "first_frame_url"
+        },
+        {
+          "field": "last_frame",
+          "kind": "image",
+          "paramName": "last_frame_url"
+        }
+      ],
+      "validation": [
+        {
+          "field": "prompt",
+          "rule": "not_empty",
+          "message": "Prompt is required"
+        }
+      ]
+    },
+    {
+      "className": "MinimaxH3ReferenceToVideo",
+      "modelId": "minimax-h3/reference-to-video",
+      "title": "MiniMax H3 Reference-to-Video",
+      "description": "MiniMax H3 Reference-to-Video via Kie.ai.\n\n    kie, video, ai\n\n    ## Query Task Status",
+      "outputType": "video",
+      "fields": [
+        {
+          "name": "prompt",
+          "type": "str",
+          "default": "",
+          "title": "Prompt",
+          "description": "Video generation prompt, length is between 1 and 7000 characters.",
+          "required": true,
+          "min": 1,
+          "max": 7000
+        },
+        {
+          "name": "reference_images",
+          "type": "list[image]",
+          "default": [],
+          "title": "Reference Images",
+          "description": "Array of reference image URLs. Supports up to 9 images. Supports HTTP, HTTPS, and OSS addresses; supported image formats include JPG, JPEG, PNG, WEBP, HEIC, and HEIF; a single image size cannot exceed 30 MB; the side length of the image must be between 256 and 5760 pixels, and the aspect ratio must be between 0.4 and 2.5.",
+          "required": false,
+          "max": 9
+        },
+        {
+          "name": "reference_videos",
+          "type": "list[video]",
+          "default": [],
+          "title": "Reference Videos",
+          "description": "Array of reference video URLs. Supports up to 3 videos. Supports MP4, MOV; video encoding supports H.264, H.265, audio encoding supports AAC, MP3; a single file size cannot exceed 50 MB; the duration of a single segment is 2 to 15 seconds, and the total duration of all reference videos cannot exceed 15 seconds; the video side length must be between 256 and 5760 pixels, the aspect ratio must be between 0.4 and 2.5, and the frame rate must be between 23.976 and 60.",
+          "required": false,
+          "min": 2,
+          "max": 3
+        },
+        {
+          "name": "reference_audios",
+          "type": "list[audio]",
+          "default": [],
+          "title": "Reference Audios",
+          "description": "Array of reference audio URLs. Supports up to 3 audios. Supports WAV, MP3; a single file size cannot exceed 15 MB; the duration of a single segment is 2 to 15 seconds, and the total duration of all reference audios cannot exceed 15 seconds. reference_audio cannot be used alone, it must be accompanied by reference_image or reference_video.",
+          "required": false,
+          "min": 2,
+          "max": 3
+        },
+        {
+          "name": "aspect_ratio",
+          "type": "enum",
+          "default": "adaptive",
+          "title": "Aspect Ratio",
+          "description": "Video aspect ratio. The default is adaptive, or a specific ratio can be specified.",
+          "required": false,
+          "values": [
+            "adaptive",
+            "21:9",
+            "16:9",
+            "4:3",
+            "1:1",
+            "3:4",
+            "9:16"
+          ]
+        },
+        {
+          "name": "duration",
+          "type": "int",
+          "default": 6,
+          "title": "Duration",
+          "description": "The duration of the generated video, supporting integer values from 4 to 15 seconds.",
+          "required": true,
+          "min": 4,
+          "max": 15
+        },
+        {
+          "name": "resolution",
+          "type": "enum",
+          "default": "2K",
+          "title": "Resolution",
+          "description": "Video resolution.",
+          "required": false,
+          "values": [
+            "768P",
+            "2K"
+          ]
+        }
+      ],
+      "uploads": [
+        {
+          "field": "reference_images",
+          "kind": "image",
+          "isList": true,
+          "paramName": "reference_image_urls"
+        },
+        {
+          "field": "reference_videos",
+          "kind": "video",
+          "isList": true,
+          "paramName": "reference_video_urls"
+        },
+        {
+          "field": "reference_audios",
+          "kind": "audio",
+          "isList": true,
+          "paramName": "reference_audio_urls"
+        }
+      ],
+      "validation": [
+        {
+          "field": "prompt",
+          "rule": "not_empty",
+          "message": "Prompt is required"
+        }
+      ]
+    },
+    {
       "className": "HappyhorseTextToVideo",
       "modelId": "happyhorse/text-to-video",
       "title": "happyhorse-text-to-video",
@@ -5535,6 +5994,25 @@ export const videoConfig: ModuleConfig = {
       "outputType": "video",
       "fields": [
         {
+          "name": "prompt",
+          "type": "str",
+          "default": "",
+          "title": "Prompt",
+          "description": "Text prompt describing the video to generate (any language). Max 5,000 non‑Chinese characters or 2,500 Chinese characters; extra content is truncated.",
+          "required": true,
+          "max": 5000
+        },
+        {
+          "name": "reference_image",
+          "type": "list[image]",
+          "default": [],
+          "title": "Reference Image",
+          "description": "Reference image URL list. Provide 1–9 images. The order defines which image is character1, character2, etc. Image limits: Format: JPEG, JPG, PNG, and WEBP. Resolution: shortest side at least 400 px. 720P or higher recommended. Avoid small, blurry, or heavily compressed images, as they degrade output quality. File size: 10 MB maximum.",
+          "required": true,
+          "min": 1,
+          "max": 9
+        },
+        {
           "name": "resolution",
           "type": "enum",
           "default": "1080p",
@@ -5545,35 +6023,6 @@ export const videoConfig: ModuleConfig = {
             "720p",
             "1080p"
           ]
-        },
-        {
-          "name": "duration",
-          "type": "int",
-          "default": 5,
-          "title": "Duration",
-          "description": "Output duration in seconds (integer). Must be between 3 and 15. Defaults to 5.",
-          "required": false,
-          "min": 3,
-          "max": 15
-        },
-        {
-          "name": "prompt",
-          "type": "str",
-          "default": "",
-          "title": "Prompt",
-          "description": "Text prompt describing the video to generate (any language). Max 5,000 non‑Chinese characters or 2,500 Chinese characters; extra content is truncated.",
-          "required": true,
-          "max": 5000
-        },
-        {
-          "name": "seed",
-          "type": "int",
-          "default": 0,
-          "title": "Seed",
-          "description": "Random seed for reproducibility (if supported).",
-          "required": false,
-          "min": 0,
-          "max": 2147483647
         },
         {
           "name": "aspect_ratio",
@@ -5591,14 +6040,24 @@ export const videoConfig: ModuleConfig = {
           ]
         },
         {
-          "name": "reference_image",
-          "type": "list[image]",
-          "default": [],
-          "title": "Reference Image",
-          "description": "Reference image URL list. Provide 1–9 images. The order defines which image is character1, character2, etc. Image limits: Format: JPEG, JPG, PNG, and WEBP. Resolution: shortest side at least 400 px. 720P or higher recommended. Avoid small, blurry, or heavily compressed images, as they degrade output quality. File size: 10 MB maximum.",
-          "required": true,
-          "min": 1,
-          "max": 9
+          "name": "duration",
+          "type": "int",
+          "default": 5,
+          "title": "Duration",
+          "description": "Output duration in seconds (integer). Must be between 3 and 15. Defaults to 5.",
+          "required": false,
+          "min": 3,
+          "max": 15
+        },
+        {
+          "name": "seed",
+          "type": "int",
+          "default": 0,
+          "title": "Seed",
+          "description": "Random seed for reproducibility (if supported).",
+          "required": false,
+          "min": 0,
+          "max": 2147483647
         }
       ],
       "validation": [
@@ -6204,7 +6663,7 @@ export const videoConfig: ModuleConfig = {
           "title": "Prompt",
           "description": "Optional prompt text. Limited to Chinese, English, Japanese, Korean, Spanish, and Indonesian. Recommended 300 characters or less. Maximum length: 1000 characters.",
           "required": false,
-          "max": 1000
+          "max": 300
         },
         {
           "name": "output_resolution",

--- a/packages/kie-codegen/src/schema-parser.ts
+++ b/packages/kie-codegen/src/schema-parser.ts
@@ -126,7 +126,12 @@ function moduleFromCategory(category: string): ModuleConfig["moduleName"] | null
   if (lower.includes("video models")) {
     return "video";
   }
-  if (lower.includes("audio") || lower.includes("suno") || lower.includes("elevenlabs")) {
+  if (
+    lower.includes("audio") ||
+    lower.includes("music models") ||
+    lower.includes("suno") ||
+    lower.includes("elevenlabs")
+  ) {
     return "audio";
   }
   if (!lower.includes("image models")) {
@@ -387,8 +392,15 @@ function mapField(paramName: string, schema: JsonRecord, required: boolean): {
   return { field };
 }
 
+/**
+ * Read the page's OpenAPI YAML block. Descriptions inside the spec sometimes
+ * embed their own fenced examples (```json …```), always indented; only the
+ * block's own closing fence sits at column 0. Matching the first ``` of any
+ * kind truncates the spec mid-operation, and the half-document still parses as
+ * YAML — the model then drops out of the manifest with no error.
+ */
 function extractOpenApi(markdown: string): JsonRecord | null {
-  const match = markdown.match(/```ya?ml\s*([\s\S]*?)```/i);
+  const match = markdown.match(/```ya?ml\s*\n([\s\S]*?)\n```[ \t]*(?:\n|$)/i);
   if (!match) {
     return null;
   }

--- a/packages/kie-nodes/src/generated/kie-node-type-pricing.json
+++ b/packages/kie-nodes/src/generated/kie-node-type-pricing.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "writtenAt": "2026-07-28T07:24:10.138Z",
+  "writtenAt": "2026-08-06T06:00:22.535Z",
   "byNodeType": {
     "kie.image.Seedream45TextToImage": {
       "model_id": "seedream/4.5-text-to-image",
@@ -299,6 +299,42 @@
       "tier_count": 1,
       "pricing_url": "https://kie.ai/qwen/image-edit"
     },
+    "kie.image.Qwen3ProTextToImage": {
+      "model_id": "qwen3/pro-text-to-image",
+      "unit_price": 6.4,
+      "billing_unit": "image",
+      "currency": "credits",
+      "usd_price": 0.032,
+      "tier_count": 2,
+      "pricing_url": "https://kie.ai/qwen-image-3"
+    },
+    "kie.image.Qwen3TextToImage": {
+      "model_id": "qwen3/text-to-image",
+      "unit_price": 4.8,
+      "billing_unit": "image",
+      "currency": "credits",
+      "usd_price": 0.024,
+      "tier_count": 2,
+      "pricing_url": "https://kie.ai/qwen-image-3"
+    },
+    "kie.image.Qwen3ProImageToImage": {
+      "model_id": "qwen3/pro-image-to-image",
+      "unit_price": 0.5,
+      "billing_unit": "image",
+      "currency": "credits",
+      "usd_price": 0.0025,
+      "tier_count": 4,
+      "pricing_url": "https://kie.ai/qwen-image-3"
+    },
+    "kie.image.Qwen3ImageToImage": {
+      "model_id": "qwen3/image-to-image",
+      "unit_price": 0.5,
+      "billing_unit": "image",
+      "currency": "credits",
+      "usd_price": 0.0025,
+      "tier_count": 4,
+      "pricing_url": "https://kie.ai/qwen-image-3"
+    },
     "kie.image.Wan27Image": {
       "model_id": "wan-2-7-image",
       "unit_price": 4.8,
@@ -463,20 +499,20 @@
     },
     "kie.video.GrokImagineTextToVideo": {
       "model_id": "grok-imagine/text-to-video",
-      "unit_price": 1.6,
+      "unit_price": 2.4,
       "billing_unit": "varies",
       "currency": "credits",
-      "usd_price": 0.008,
-      "tier_count": 3,
+      "usd_price": 0.012,
+      "tier_count": 4,
       "pricing_url": "https://kie.ai/grok-imagine"
     },
     "kie.video.GrokImagineImageToVideo": {
       "model_id": "grok-imagine/image-to-video",
-      "unit_price": 1.6,
+      "unit_price": 2.4,
       "billing_unit": "second",
       "currency": "credits",
-      "usd_price": 0.008,
-      "tier_count": 2,
+      "usd_price": 0.012,
+      "tier_count": 3,
       "pricing_url": "https://kie.ai/grok-imagine"
     },
     "kie.video.GrokImagineUpscale": {
@@ -485,24 +521,24 @@
       "billing_unit": "upscale",
       "currency": "credits",
       "usd_price": 0.05,
-      "tier_count": 1,
+      "tier_count": 3,
       "pricing_url": "https://kie.ai/grok-imagine"
     },
     "kie.video.GrokImagineExtend": {
       "model_id": "grok-imagine/extend",
-      "unit_price": 10,
+      "unit_price": 14.4,
       "billing_unit": "run",
       "currency": "credits",
-      "usd_price": 0.05,
+      "usd_price": 0.072,
       "tier_count": 4,
       "pricing_url": "https://kie.ai/grok-imagine"
     },
     "kie.video.GrokImagineVideo15PreviewCreateTask": {
       "model_id": "grok-imagine-video-1-5-preview",
-      "unit_price": 1.6,
+      "unit_price": 2.4,
       "billing_unit": "second",
       "currency": "credits",
-      "usd_price": 0.008,
+      "usd_price": 0.012,
       "tier_count": 2,
       "pricing_url": "https://kie.ai/grok-imagine-video-1.5"
     },
@@ -629,7 +665,8 @@
       "billing_unit": "second",
       "currency": "credits",
       "usd_price": 0.03,
-      "tier_count": 4
+      "tier_count": 4,
+      "pricing_url": "https://kie.ai/seedance-2-0-mini"
     },
     "kie.video.BytedanceSeedance15Pro": {
       "model_id": "bytedance/seedance-1.5-pro",
@@ -792,6 +829,33 @@
       "usd_price": 0.08,
       "tier_count": 2,
       "pricing_url": "https://kie.ai/wan-2-7-video"
+    },
+    "kie.video.MinimaxH3TextToVideo": {
+      "model_id": "minimax-h3/text-to-video",
+      "unit_price": 22.5,
+      "billing_unit": "second",
+      "currency": "credits",
+      "usd_price": 0.1125,
+      "tier_count": 2,
+      "pricing_url": "https://kie.ai/minimax-h3"
+    },
+    "kie.video.MinimaxH3ImageToVideo": {
+      "model_id": "minimax-h3/image-to-video",
+      "unit_price": 22.5,
+      "billing_unit": "second",
+      "currency": "credits",
+      "usd_price": 0.1125,
+      "tier_count": 2,
+      "pricing_url": "https://kie.ai/minimax-h3"
+    },
+    "kie.video.MinimaxH3ReferenceToVideo": {
+      "model_id": "minimax-h3/reference-to-video",
+      "unit_price": 22.5,
+      "billing_unit": "second",
+      "currency": "credits",
+      "usd_price": 0.1125,
+      "tier_count": 2,
+      "pricing_url": "https://kie.ai/minimax-h3"
     },
     "kie.video.HappyhorseTextToVideo": {
       "model_id": "happyhorse/text-to-video",

--- a/packages/kie-nodes/src/generated/kie-unit-pricing.json
+++ b/packages/kie-nodes/src/generated/kie-unit-pricing.json
@@ -1,7 +1,70 @@
 {
   "schemaVersion": 1,
-  "writtenAt": "2026-07-28T07:24:10.138Z",
+  "writtenAt": "2026-08-06T06:00:22.535Z",
   "prices": {
+    "qwen3/pro-image-to-image": {
+      "model_id": "qwen3/pro-image-to-image",
+      "unit_price": 0.5,
+      "billing_unit": "image",
+      "currency": "credits",
+      "usd_price": 0.0025,
+      "tier_count": 4,
+      "pricing_url": "https://kie.ai/qwen-image-3"
+    },
+    "qwen3/pro-text-to-image": {
+      "model_id": "qwen3/pro-text-to-image",
+      "unit_price": 6.4,
+      "billing_unit": "image",
+      "currency": "credits",
+      "usd_price": 0.032,
+      "tier_count": 2,
+      "pricing_url": "https://kie.ai/qwen-image-3"
+    },
+    "qwen3/image-to-image": {
+      "model_id": "qwen3/image-to-image",
+      "unit_price": 0.5,
+      "billing_unit": "image",
+      "currency": "credits",
+      "usd_price": 0.0025,
+      "tier_count": 4,
+      "pricing_url": "https://kie.ai/qwen-image-3"
+    },
+    "qwen3/text-to-image": {
+      "model_id": "qwen3/text-to-image",
+      "unit_price": 4.8,
+      "billing_unit": "image",
+      "currency": "credits",
+      "usd_price": 0.024,
+      "tier_count": 2,
+      "pricing_url": "https://kie.ai/qwen-image-3"
+    },
+    "minimax-h3/reference-to-video": {
+      "model_id": "minimax-h3/reference-to-video",
+      "unit_price": 22.5,
+      "billing_unit": "second",
+      "currency": "credits",
+      "usd_price": 0.1125,
+      "tier_count": 2,
+      "pricing_url": "https://kie.ai/minimax-h3"
+    },
+    "minimax-h3/image-to-video": {
+      "model_id": "minimax-h3/image-to-video",
+      "unit_price": 22.5,
+      "billing_unit": "second",
+      "currency": "credits",
+      "usd_price": 0.1125,
+      "tier_count": 2,
+      "pricing_url": "https://kie.ai/minimax-h3"
+    },
+    "minimax-h3/text-to-video": {
+      "model_id": "minimax-h3/text-to-video",
+      "unit_price": 22.5,
+      "billing_unit": "second",
+      "currency": "credits",
+      "usd_price": 0.1125,
+      "tier_count": 2,
+      "pricing_url": "https://kie.ai/minimax-h3"
+    },
     "seedream/5-pro-text-to-image": {
       "model_id": "seedream/5-pro-text-to-image",
       "unit_price": 7,
@@ -35,7 +98,8 @@
       "billing_unit": "second",
       "currency": "credits",
       "usd_price": 0.03,
-      "tier_count": 4
+      "tier_count": 4,
+      "pricing_url": "https://kie.ai/seedance-2-0-mini"
     },
     "happyhorse-1-1/image-to-video": {
       "model_id": "happyhorse-1-1/image-to-video",
@@ -102,10 +166,10 @@
     },
     "grok-imagine-video-1-5-preview": {
       "model_id": "grok-imagine-video-1-5-preview",
-      "unit_price": 1.6,
+      "unit_price": 2.4,
       "billing_unit": "second",
       "currency": "credits",
-      "usd_price": 0.008,
+      "usd_price": 0.012,
       "tier_count": 2,
       "pricing_url": "https://kie.ai/grok-imagine-video-1.5"
     },
@@ -246,10 +310,10 @@
     },
     "grok-imagine/extend": {
       "model_id": "grok-imagine/extend",
-      "unit_price": 10,
+      "unit_price": 14.4,
       "billing_unit": "run",
       "currency": "credits",
-      "usd_price": 0.05,
+      "usd_price": 0.072,
       "tier_count": 4,
       "pricing_url": "https://kie.ai/grok-imagine"
     },
@@ -460,6 +524,33 @@
       "tier_count": 2,
       "pricing_url": "https://kie.ai/nano-banana-pro"
     },
+    "grok-imagine/upscale": {
+      "model_id": "grok-imagine/upscale",
+      "unit_price": 10,
+      "billing_unit": "upscale",
+      "currency": "credits",
+      "usd_price": 0.05,
+      "tier_count": 3,
+      "pricing_url": "https://kie.ai/grok-imagine"
+    },
+    "grok-imagine/text-to-video": {
+      "model_id": "grok-imagine/text-to-video",
+      "unit_price": 2.4,
+      "billing_unit": "varies",
+      "currency": "credits",
+      "usd_price": 0.012,
+      "tier_count": 4,
+      "pricing_url": "https://kie.ai/grok-imagine"
+    },
+    "grok-imagine/image-to-video": {
+      "model_id": "grok-imagine/image-to-video",
+      "unit_price": 2.4,
+      "billing_unit": "second",
+      "currency": "credits",
+      "usd_price": 0.012,
+      "tier_count": 3,
+      "pricing_url": "https://kie.ai/grok-imagine"
+    },
     "grok-imagine/text-to-image": {
       "model_id": "grok-imagine/text-to-image",
       "unit_price": 5,
@@ -469,39 +560,12 @@
       "tier_count": 1,
       "pricing_url": "https://kie.ai/grok-imagine"
     },
-    "grok-imagine/image-to-video": {
-      "model_id": "grok-imagine/image-to-video",
-      "unit_price": 1.6,
-      "billing_unit": "second",
-      "currency": "credits",
-      "usd_price": 0.008,
-      "tier_count": 2,
-      "pricing_url": "https://kie.ai/grok-imagine"
-    },
-    "grok-imagine/text-to-video": {
-      "model_id": "grok-imagine/text-to-video",
-      "unit_price": 1.6,
-      "billing_unit": "varies",
-      "currency": "credits",
-      "usd_price": 0.008,
-      "tier_count": 3,
-      "pricing_url": "https://kie.ai/grok-imagine"
-    },
     "grok-imagine/image-to-image": {
       "model_id": "grok-imagine/image-to-image",
       "unit_price": 4,
       "billing_unit": "image",
       "currency": "credits",
       "usd_price": 0.02,
-      "tier_count": 1,
-      "pricing_url": "https://kie.ai/grok-imagine"
-    },
-    "grok-imagine/upscale": {
-      "model_id": "grok-imagine/upscale",
-      "unit_price": 10,
-      "billing_unit": "upscale",
-      "currency": "credits",
-      "usd_price": 0.05,
       "tier_count": 1,
       "pricing_url": "https://kie.ai/grok-imagine"
     },

--- a/packages/kie-nodes/src/kie-manifest.json
+++ b/packages/kie-nodes/src/kie-manifest.json
@@ -1327,15 +1327,15 @@
         "required": false,
         "values": [
           "1:1",
-          "1:4",
-          "1:8",
           "2:3",
           "3:2",
-          "3:4",
+          "1:4",
           "4:1",
+          "3:4",
           "4:3",
           "4:5",
           "5:4",
+          "1:8",
           "8:1",
           "9:16",
           "16:9",
@@ -2227,8 +2227,7 @@
         "values": [
           "1",
           "2",
-          "4",
-          "8"
+          "4"
         ]
       }
     ],
@@ -3473,6 +3472,14 @@
         "description": "The negative prompt for the generation Default value: \" \" (Max length: 500 characters)",
         "required": false,
         "max": 500
+      },
+      {
+        "name": "nsfw_checker",
+        "type": "bool",
+        "default": false,
+        "title": "Nsfw Checker",
+        "description": "Defaults to false. You can set it to false based on your needs. If set to false, our content filtering will be disabled, and all results will be returned directly by the model itself. Note: There is no guarantee that everything can be filtered out; if you are not satisfied with the results, you will need to make your own arrangements.",
+        "required": false
       }
     ],
     "uploads": [
@@ -3560,6 +3567,14 @@
           "jpeg",
           "png"
         ]
+      },
+      {
+        "name": "nsfw_checker",
+        "type": "bool",
+        "default": false,
+        "title": "Nsfw Checker",
+        "description": "Defaults to false. You can set it to false based on your needs. If set to false, our content filtering will be disabled, and all results will be returned directly by the model itself. Note: There is no guarantee that everything can be filtered out; if you are not satisfied with the results, you will need to make your own arrangements.",
+        "required": false
       }
     ],
     "uploads": [
@@ -3638,6 +3653,470 @@
         "title": "Nsfw Checker",
         "description": "Defaults to false. You can set it to false based on your needs. If set to false, our content filtering will be disabled, and all results will be returned directly by the model itself. Note: There is no guarantee that everything can be filtered out; if you are not satisfied with the results, you will need to make your own arrangements.",
         "required": false
+      }
+    ],
+    "validation": [
+      {
+        "field": "prompt",
+        "rule": "not_empty",
+        "message": "Prompt is required"
+      }
+    ]
+  },
+  {
+    "className": "Qwen3ProTextToImage",
+    "moduleName": "image",
+    "modelId": "qwen3/pro-text-to-image",
+    "title": "Qwen3 Pro Text to Image",
+    "description": "Qwen3 Pro Text to Image via Kie.ai.\n\n    kie, image, ai\n\n    ## Create Task",
+    "outputType": "image",
+    "pollInterval": 1500,
+    "maxAttempts": 400,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt that describes the image content, style, and composition you want to generate or edit. Both Chinese and English are supported.",
+        "required": true,
+        "min": 0,
+        "max": 800
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "",
+        "title": "Resolution",
+        "description": "The output image resolution.",
+        "required": false,
+        "values": [
+          "1K",
+          "2K"
+        ]
+      },
+      {
+        "name": "image_size",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Image Size",
+        "description": "The output image size.",
+        "required": false,
+        "values": [
+          "1:1",
+          "3:2",
+          "2:3",
+          "4:3",
+          "3:4",
+          "16:9",
+          "9:16",
+          "21:9"
+        ]
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "png",
+        "title": "Output Format",
+        "description": "The generated image format.",
+        "required": false,
+        "values": [
+          "png",
+          "jpeg"
+        ]
+      },
+      {
+        "name": "prompt_extend",
+        "type": "bool",
+        "default": true,
+        "title": "Prompt Extend",
+        "description": "Whether to enable intelligent prompt rewriting. Default: true (recommended). When enabled, the model optimizes the positive prompt, which significantly improves results for simple descriptions.",
+        "required": false
+      },
+      {
+        "name": "nsfw_checker",
+        "type": "bool",
+        "default": false,
+        "title": "Nsfw Checker",
+        "description": "Whether to enable content filtering. Optional. Defaults to false. When set to false, content filtering is disabled and all results are returned directly by the model. Note: Content filtering cannot guarantee that all inappropriate content will be detected. If the filtering results do not meet your requirements, you must implement additional content moderation measures.",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "The negative prompt that describes content you do not want to appear in the image.",
+        "required": false,
+        "min": 0,
+        "max": 5000
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": 1,
+        "title": "Seed",
+        "description": "The random seed. Value range: [0, 2147483647]. A fixed seed helps maintain relatively stable results.",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      }
+    ],
+    "validation": [
+      {
+        "field": "prompt",
+        "rule": "not_empty",
+        "message": "Prompt is required"
+      }
+    ]
+  },
+  {
+    "className": "Qwen3TextToImage",
+    "moduleName": "image",
+    "modelId": "qwen3/text-to-image",
+    "title": "Qwen3 Text to Image",
+    "description": "Qwen3 Text to Image via Kie.ai.\n\n    kie, image, ai\n\n    ## Create Task",
+    "outputType": "image",
+    "pollInterval": 1500,
+    "maxAttempts": 400,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt that describes the image content, style, and composition you want to generate or edit. Both Chinese and English are supported.",
+        "required": true,
+        "min": 0,
+        "max": 800
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "",
+        "title": "Resolution",
+        "description": "The output image resolution.",
+        "required": false,
+        "values": [
+          "1K",
+          "2K"
+        ]
+      },
+      {
+        "name": "image_size",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Image Size",
+        "description": "The output image size.",
+        "required": false,
+        "values": [
+          "1:1",
+          "3:2",
+          "2:3",
+          "4:3",
+          "3:4",
+          "16:9",
+          "9:16",
+          "21:9"
+        ]
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "png",
+        "title": "Output Format",
+        "description": "The generated image format.",
+        "required": false,
+        "values": [
+          "png",
+          "jpeg"
+        ]
+      },
+      {
+        "name": "prompt_extend",
+        "type": "bool",
+        "default": true,
+        "title": "Prompt Extend",
+        "description": "Whether to enable intelligent prompt rewriting. Default: true (recommended). When enabled, the model optimizes the positive prompt, which significantly improves results for simple descriptions.",
+        "required": false
+      },
+      {
+        "name": "nsfw_checker",
+        "type": "bool",
+        "default": false,
+        "title": "Nsfw Checker",
+        "description": "Whether to enable content filtering. Optional. Defaults to false. When set to false, content filtering is disabled and all results are returned directly by the model. Note: Content filtering cannot guarantee that all inappropriate content will be detected. If the filtering results do not meet your requirements, you must implement additional content moderation measures.",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "The negative prompt that describes content you do not want to appear in the image.",
+        "required": false,
+        "min": 0,
+        "max": 5000
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": 1,
+        "title": "Seed",
+        "description": "The random seed. Value range: [0, 2147483647]. A fixed seed helps maintain relatively stable results.",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      }
+    ],
+    "validation": [
+      {
+        "field": "prompt",
+        "rule": "not_empty",
+        "message": "Prompt is required"
+      }
+    ]
+  },
+  {
+    "className": "Qwen3ProImageToImage",
+    "moduleName": "image",
+    "modelId": "qwen3/pro-image-to-image",
+    "title": "Qwen3 Pro Image to Image",
+    "description": "Qwen3 Pro Image to Image via Kie.ai.\n\n    kie, image, ai\n\n    ## Create Task",
+    "outputType": "image",
+    "pollInterval": 1500,
+    "maxAttempts": 400,
+    "fields": [
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": [],
+        "title": "Images",
+        "description": "Input image URL array. Upload images and provide their URLs rather than the file content. Supports up to 3 images. Supported file types: `image/jpeg`, `image/png`, `image/webp`, `image/bmp`, and `image/gif`,`image/tiff`. Maximum file size: 10 MB per image.",
+        "required": true,
+        "min": 1,
+        "max": 3
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt that describes the image content, style, and composition you want to generate or edit. Both Chinese and English are supported.",
+        "required": true,
+        "min": 0,
+        "max": 800
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1K",
+        "title": "Resolution",
+        "description": "The output image resolution.",
+        "required": false,
+        "values": [
+          "1K",
+          "2K"
+        ]
+      },
+      {
+        "name": "image_size",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Image Size",
+        "description": "The output image size.",
+        "required": false,
+        "values": [
+          "1:1",
+          "3:2",
+          "2:3",
+          "4:3",
+          "3:4",
+          "16:9",
+          "9:16",
+          "21:9"
+        ]
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "png",
+        "title": "Output Format",
+        "description": "The generated image format.",
+        "required": false,
+        "values": [
+          "png",
+          "jpeg"
+        ]
+      },
+      {
+        "name": "prompt_extend",
+        "type": "bool",
+        "default": true,
+        "title": "Prompt Extend",
+        "description": "Whether to enable intelligent prompt rewriting. Default: true (recommended). When enabled, the model optimizes the positive prompt, which significantly improves results for simple descriptions.",
+        "required": false
+      },
+      {
+        "name": "nsfw_checker",
+        "type": "bool",
+        "default": false,
+        "title": "Nsfw Checker",
+        "description": "Whether to enable content filtering. Optional. Defaults to false. When set to false, content filtering is disabled and all results are returned directly by the model. Note: Content filtering cannot guarantee that all inappropriate content will be detected. If the filtering results do not meet your requirements, you must implement additional content moderation measures.",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "The negative prompt that describes content you do not want to appear in the image.",
+        "required": false,
+        "min": 0,
+        "max": 5000
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": 1,
+        "title": "Seed",
+        "description": "The random seed. Value range: [0, 2147483647]. A fixed seed helps maintain relatively stable results.",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      }
+    ],
+    "uploads": [
+      {
+        "field": "images",
+        "kind": "image",
+        "isList": true,
+        "paramName": "image_urls"
+      }
+    ],
+    "validation": [
+      {
+        "field": "prompt",
+        "rule": "not_empty",
+        "message": "Prompt is required"
+      }
+    ]
+  },
+  {
+    "className": "Qwen3ImageToImage",
+    "moduleName": "image",
+    "modelId": "qwen3/image-to-image",
+    "title": "Qwen3 Image to Image",
+    "description": "Qwen3 Image to Image via Kie.ai.\n\n    kie, image, ai\n\n    ## Create Task",
+    "outputType": "image",
+    "pollInterval": 1500,
+    "maxAttempts": 400,
+    "fields": [
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": [],
+        "title": "Images",
+        "description": "Input image URL array. Upload images and provide their URLs rather than the file content. Supports up to 3 images. Supported file types: `image/jpeg`, `image/png`, `image/webp`, `image/bmp`, and `image/gif`,`image/tiff`. Maximum file size: 10 MB per image.",
+        "required": true,
+        "min": 1,
+        "max": 3
+      },
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "The positive prompt that describes the image content, style, and composition you want to generate or edit. Both Chinese and English are supported.",
+        "required": true,
+        "min": 0,
+        "max": 800
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "1K",
+        "title": "Resolution",
+        "description": "The output image resolution.",
+        "required": false,
+        "values": [
+          "1K",
+          "2K"
+        ]
+      },
+      {
+        "name": "image_size",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Image Size",
+        "description": "The output image size.",
+        "required": false,
+        "values": [
+          "1:1",
+          "3:2",
+          "2:3",
+          "4:3",
+          "3:4",
+          "16:9",
+          "9:16",
+          "21:9"
+        ]
+      },
+      {
+        "name": "output_format",
+        "type": "enum",
+        "default": "png",
+        "title": "Output Format",
+        "description": "The generated image format.",
+        "required": false,
+        "values": [
+          "png",
+          "jpeg"
+        ]
+      },
+      {
+        "name": "prompt_extend",
+        "type": "bool",
+        "default": true,
+        "title": "Prompt Extend",
+        "description": "Whether to enable intelligent prompt rewriting. Default: true (recommended). When enabled, the model optimizes the positive prompt, which significantly improves results for simple descriptions.",
+        "required": false
+      },
+      {
+        "name": "nsfw_checker",
+        "type": "bool",
+        "default": false,
+        "title": "Nsfw Checker",
+        "description": "Whether to enable content filtering. Optional. Defaults to false. When set to false, content filtering is disabled and all results are returned directly by the model. Note: Content filtering cannot guarantee that all inappropriate content will be detected. If the filtering results do not meet your requirements, you must implement additional content moderation measures.",
+        "required": false
+      },
+      {
+        "name": "negative_prompt",
+        "type": "str",
+        "default": "",
+        "title": "Negative Prompt",
+        "description": "The negative prompt that describes content you do not want to appear in the image.",
+        "required": false,
+        "min": 0,
+        "max": 5000
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": 1,
+        "title": "Seed",
+        "description": "The random seed. Value range: [0, 2147483647]. A fixed seed helps maintain relatively stable results.",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
+      }
+    ],
+    "uploads": [
+      {
+        "field": "images",
+        "kind": "image",
+        "isList": true,
+        "paramName": "image_urls"
       }
     ],
     "validation": [
@@ -4451,6 +4930,114 @@
     ]
   },
   {
+    "className": "Gemini31FlashTts",
+    "moduleName": "audio",
+    "modelId": "google/gemini-3-1-flash-tts",
+    "title": "Gemini 3.1 Flash Text to speech",
+    "description": "Gemini 3.1 Flash Text to speech via Kie.ai.\n\n    kie, audio, ai\n\n    Content generation using elevenlabs/audio-isolation",
+    "outputType": "audio",
+    "pollInterval": 4000,
+    "maxAttempts": 120,
+    "fields": [
+      {
+        "name": "temperature",
+        "type": "float",
+        "default": 1,
+        "title": "Temperature",
+        "description": "Sampling temperature, e.g., 1",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "scene",
+        "type": "str",
+        "default": "",
+        "title": "Scene",
+        "description": "Scene description, e.g., \"A quiet, warm room with a fireplace crackling softly.\"",
+        "required": false
+      },
+      {
+        "name": "sample_context",
+        "type": "str",
+        "default": "",
+        "title": "Sample Context",
+        "description": "Sample context/overall tone, e.g., \"Audiobook style narration. Tone is gentle and inviting.\"",
+        "required": false
+      },
+      {
+        "name": "speakers",
+        "type": "list[image]",
+        "default": [],
+        "title": "Speakers",
+        "description": "List of speaker configurations",
+        "required": true
+      },
+      {
+        "name": "dialogue_turns",
+        "type": "list[image]",
+        "default": [],
+        "title": "Dialogue Turns",
+        "description": "List of dialogue turns, output in sequential order",
+        "required": true
+      }
+    ]
+  },
+  {
+    "className": "Gemini25ProTts",
+    "moduleName": "audio",
+    "modelId": "google/gemini-2-5-pro-tts",
+    "title": "Gemini 2.5 Pro Text to Speech",
+    "description": "Gemini 2.5 Pro Text to Speech via Kie.ai.\n\n    kie, audio, ai\n\n    Content generation using elevenlabs/audio-isolation",
+    "outputType": "audio",
+    "pollInterval": 4000,
+    "maxAttempts": 120,
+    "fields": [
+      {
+        "name": "temperature",
+        "type": "float",
+        "default": 1,
+        "title": "Temperature",
+        "description": "Sampling temperature, e.g., 1",
+        "required": false,
+        "min": 0,
+        "max": 2
+      },
+      {
+        "name": "scene",
+        "type": "str",
+        "default": "",
+        "title": "Scene",
+        "description": "Scene description, e.g., \"A quiet, warm room with a fireplace crackling softly.\"",
+        "required": false
+      },
+      {
+        "name": "sample_context",
+        "type": "str",
+        "default": "",
+        "title": "Sample Context",
+        "description": "Sample context/overall tone, e.g., \"Audiobook style narration. Tone is gentle and inviting.\"",
+        "required": false
+      },
+      {
+        "name": "speakers",
+        "type": "list[image]",
+        "default": [],
+        "title": "Speakers",
+        "description": "List of speaker configurations",
+        "required": true
+      },
+      {
+        "name": "dialogue_turns",
+        "type": "list[image]",
+        "default": [],
+        "title": "Dialogue Turns",
+        "description": "List of dialogue turns, output in sequential order",
+        "required": true
+      }
+    ]
+  },
+  {
     "className": "GenerateMusic",
     "moduleName": "audio",
     "modelId": "generate-music",
@@ -4643,8 +5230,8 @@
         "type": "str",
         "default": "",
         "title": "Prompt",
-        "description": "Description of the desired audio extension content. - Required when `defaultParamFlag` is `true`. - Character limits by model: - **V4**: Maximum 3000 characters - **V4_5 & V4_5PLUS**: Maximum 5000 characters - **V4_5ALL**: Maximum 5000 characters - **V5_5 & V5**: Maximum 5000 characters - Describes how the music should continue or change in the extension.",
-        "required": true
+        "description": "Prompt describing the desired audio extension content. - Required when `defaultParamFlag` is `true` (this parameter is not needed if `instrumental` is `true`). - Character limits by model: - **V4**: Max 3,000 characters - **V4_5 and V4_5PLUS**: Max 5,000 characters - **V4_5ALL**: Max 5,000 characters - **V5_5 and V5**: Max 5,000 characters - Describe how the music should continue or evolve in the extended section.",
+        "required": false
       },
       {
         "name": "style",
@@ -4699,7 +5286,7 @@
         "type": "enum",
         "default": "",
         "title": "Vocal Gender",
-        "description": "Vocal gender preference for the singing voice. Optional. Use 'm' for male and 'f' for female. Based on practice, this parameter can only increase the probability but cannot guarantee adherence to male/female voice instructions.",
+        "description": "Vocal gender preference. Optional. 'm' denotes a male voice, and 'f' denotes a female voice. In practice, this parameter only influences the probability and does not guarantee strict adherence to the gender instruction. This parameter is not required if `instrumental` is set to `true`.",
         "required": false,
         "values": [
           "m",
@@ -4761,7 +5348,7 @@
         "type": "bool",
         "default": false,
         "title": "Instrumental",
-        "description": "Is it an instrumental track? The prompt parameter is required only if false. If true, do not include it.",
+        "description": "Indicates whether it is an instrumental track. If true, passing the `prompt` and `vocalGender` parameters is prohibited.",
         "required": false
       }
     ],
@@ -4772,11 +5359,6 @@
         "field": "audioId",
         "rule": "not_empty",
         "message": "Audio Id is required"
-      },
-      {
-        "field": "prompt",
-        "rule": "not_empty",
-        "message": "Prompt is required"
       },
       {
         "field": "model",
@@ -4973,7 +5555,7 @@
     "moduleName": "audio",
     "modelId": "upload-and-extend-audio",
     "title": "Upload And Extend Audio",
-    "description": "Upload And Extend Audio via Kie.ai.\n\n    kie, audio, ai\n\n    > This API extends audio tracks while preserving their original style. It includes Suno's upload functionality, allowing users to upload audio files for processing. The expected result is a longer track that seamlessly continues the input style.",
+    "description": "Upload And Extend Audio via Kie.ai.\n\n    kie, audio, ai\n\n    # Upload and Extend Music",
     "outputType": "audio",
     "pollInterval": 4000,
     "maxAttempts": 120,
@@ -5005,15 +5587,15 @@
         "type": "bool",
         "default": false,
         "title": "Instrumental",
-        "description": "Determines whether the audio is instrumental (without lyrics). - In custom parameter mode (`customMode: true`): - If `true`: only `style`, `title`, and `uploadUrl` are required. - If `false`: `style`, `title`, `prompt` (`prompt` will be used as exact lyrics), and `uploadUrl` are required. - In non-custom parameter mode (`defaultParamFlag: false`): does not affect required fields (only `uploadUrl` needed). If `false`, lyrics will be automatically generated.",
-        "required": true
+        "description": "Determines whether the audio is instrumental (without lyrics). - In custom parameter mode (`defaultParamFlag: true`): - If `true`: Only `style`, `title`, and `uploadUrl` are required; `prompt` and `vocalGender` do not need to be specified. - If `false`: `style`, `title`, and `uploadUrl` are required; `prompt` is optional (if provided, it serves as a prompt); `vocalGender` does not need to be specified. - In non-custom parameter mode (`defaultParamFlag: false`): Does not affect mandatory fields (only `uploadUrl` is required); `prompt` is optional. If set to `false`, lyrics will be automatically generated. Optional; defaults to `false`.",
+        "required": false
       },
       {
         "name": "prompt",
         "type": "str",
         "default": "",
         "title": "Prompt",
-        "description": "Description of how the music should be extended. Required when defaultParamFlag is true. Character limits by model: - **V5_5 & V5**: Maximum 5000 characters - **V4_5PLUS & V4_5**: Maximum 5000 characters - **V4_5ALL**: Maximum 5000 characters - **V4**: Maximum 3000 characters",
+        "description": "Describe how the music should be extended. Optional; if provided, it will be used as a prompt. Subject to model character limits: - **V5_5 & V5**: Max 5,000 characters - **V4_5PLUS & V4_5**: Max 5,000 characters - **V4_5ALL**: Max 5,000 characters - **V4**: Max 3,000 characters",
         "required": false
       },
       {
@@ -5677,6 +6259,100 @@
         "field": "audioId",
         "rule": "not_empty",
         "message": "Audio Id is required"
+      }
+    ]
+  },
+  {
+    "className": "GeneratePersona",
+    "moduleName": "audio",
+    "modelId": "generate-persona",
+    "title": "Generate Persona",
+    "description": "Generate Persona via Kie.ai.\n\n    kie, audio, ai\n\n    Generate Persona",
+    "outputType": "audio",
+    "pollInterval": 4000,
+    "maxAttempts": 120,
+    "fields": [
+      {
+        "name": "taskId",
+        "type": "str",
+        "default": "",
+        "title": "Task Id",
+        "description": "Unique identifier of the original music generation task. This can be a taskId returned from any of the following endpoints: - Generate Music (/api/v1/generate) - Extend Music (/api/v1/generate/extend)",
+        "required": true
+      },
+      {
+        "name": "audioId",
+        "type": "str",
+        "default": "",
+        "title": "Audio Id",
+        "description": "Unique identifier of the audio track to create Persona for. This ID is returned in the callback data after music generation completes.",
+        "required": true
+      },
+      {
+        "name": "name",
+        "type": "str",
+        "default": "",
+        "title": "Name",
+        "description": "Name for the Persona. A descriptive name that captures the essence of the musical style or character.",
+        "required": true
+      },
+      {
+        "name": "description",
+        "type": "str",
+        "default": "",
+        "title": "Description",
+        "description": "Detailed description of the Persona's musical characteristics, style, and personality. Be specific about genre, mood, instrumentation, and vocal qualities.",
+        "required": true
+      },
+      {
+        "name": "vocalStart",
+        "type": "float",
+        "default": 0,
+        "title": "Vocal Start",
+        "description": "Start time (in seconds) for Persona analysis segment extraction. Used to specify the time point in the audio from which to extract the segment for Persona analysis. Must be less than vocalEnd, and vocalEnd - vocalStart must be between 10–30 seconds. Defaults to 0.0.",
+        "required": false,
+        "min": 0
+      },
+      {
+        "name": "vocalEnd",
+        "type": "float",
+        "default": 30,
+        "title": "Vocal End",
+        "description": "End time (in seconds) for Persona analysis segment extraction. Together with vocalStart, used to specify the time range for analysis. vocalEnd - vocalStart must be between 10–30 seconds. Defaults to 30.0.",
+        "required": false,
+        "min": 0
+      },
+      {
+        "name": "style",
+        "type": "str",
+        "default": "",
+        "title": "Style",
+        "description": "Optional. Used to supplement the description of the music style tag corresponding to the Persona, such as \"Electronic Pop\", \"Jazz Trio\", etc.",
+        "required": false
+      }
+    ],
+    "useSuno": true,
+    "sunoEndpoint": "/api/v1/generate/generate-persona",
+    "validation": [
+      {
+        "field": "taskId",
+        "rule": "not_empty",
+        "message": "Task Id is required"
+      },
+      {
+        "field": "audioId",
+        "rule": "not_empty",
+        "message": "Audio Id is required"
+      },
+      {
+        "field": "name",
+        "rule": "not_empty",
+        "message": "Name is required"
+      },
+      {
+        "field": "description",
+        "rule": "not_empty",
+        "message": "Description is required"
       }
     ]
   },
@@ -6569,7 +7245,8 @@
         "required": false,
         "values": [
           "480p",
-          "720p"
+          "720p",
+          "1080p"
         ]
       },
       {
@@ -6604,7 +7281,7 @@
         "type": "list[image]",
         "default": [],
         "title": "Images",
-        "description": "Provide an external image URL as a reference for video generation. Up to 7 images are supported. Do not use it simultaneously with task_id. In your prompt, reference an uploaded image by typing @image(n) followed by a space (for example: @image1 a sunset over the ocean). - Supports JPEG, PNG, and WEBP formats - Maximum file size for each image: 10MB - The Spicy mode is not available when using external images - The array can contain a maximum of seven URLs",
+        "description": "Provide an external image URL as a reference for video generation. Up to 7 images are supported. Do not use it simultaneously with task_id. In your prompt, reference an uploaded image by typing @image(n) followed by a space (for example: @image1 a sunset over the ocean). - Supports JPEG, PNG, and WEBP formats - Maximum file size for each image: 10MB - The Spicy mode is not available when using external images - The array can contain a maximum of seven URLs - Only one is supported when the resolution is 1080p.",
         "required": false,
         "max": 7
       },
@@ -6667,7 +7344,8 @@
         "required": false,
         "values": [
           "480p",
-          "720p"
+          "720p",
+          "1080p"
         ]
       },
       {
@@ -6721,6 +7399,18 @@
         "description": "Task ID from a previously successful video generation task. Required field. - Must be from a Kie AI video generation model (e.g., grok-imagine/text-to-video) - The original video generation must have completed successfully - Only Kie AI–generated task IDs are supported",
         "required": true,
         "max": 100
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "720p",
+        "title": "Resolution",
+        "description": "Video generation resolution.",
+        "required": false,
+        "values": [
+          "720p",
+          "1080p"
+        ]
       }
     ],
     "validation": [
@@ -6813,7 +7503,7 @@
         "type": "list[image]",
         "default": [],
         "title": "Images",
-        "description": "Upload image files to be used as API input. Supported file types: image/jpeg, image/png, image/webp, image/jpg. Maximum file size: 20MB. Supports multi-file upload, up to 7 file.",
+        "description": "Upload image files to be used as API input. Supported file types: image/jpeg, image/png, image/webp, image/jpg. Maximum file size: 20MB. Supports multi-file upload, up to 7 file.Only one is supported when the resolution is 1080p.",
         "required": false,
         "max": 7
       },
@@ -6842,7 +7532,8 @@
         "required": false,
         "values": [
           "480p",
-          "720p"
+          "720p",
+          "1080p"
         ]
       },
       {
@@ -7048,6 +7739,20 @@
         "required": true
       },
       {
+        "name": "tail_image",
+        "type": "image",
+        "default": {
+          "type": "image",
+          "uri": "",
+          "asset_id": null,
+          "data": null,
+          "metadata": null
+        },
+        "title": "Tail Image",
+        "description": "Tail frame image of video (File URL after upload, not file content; Accepted types: image/jpeg, image/png; Max size: 10.0MB)",
+        "required": false
+      },
+      {
         "name": "duration",
         "type": "enum",
         "default": "5",
@@ -7077,20 +7782,6 @@
         "required": false,
         "min": 0,
         "max": 1
-      },
-      {
-        "name": "tail_image",
-        "type": "image",
-        "default": {
-          "type": "image",
-          "uri": "",
-          "asset_id": null,
-          "data": null,
-          "metadata": null
-        },
-        "title": "Tail Image",
-        "description": "Tail frame image of video (File URL after upload, not file content; Accepted types: image/jpeg, image/png; Max size: 10.0MB)",
-        "required": false
       }
     ],
     "uploads": [
@@ -7685,7 +8376,7 @@
         "type": "list[video]",
         "default": [],
         "title": "Videos",
-        "description": "An array containing a single video URL. The duration must be between 3 to 30 seconds, and the video must clearly show the subject's head, shoulders, and torso. (File URL after upload, not file content; Accepted types: video/mp4, video/quicktime, video/x-matroska; Max size: 100.0MB)",
+        "description": "An array containing a single video URL. The duration must be between 3 to 30 seconds, and the video must clearly show the subject's head, shoulders, and torso. (File URL after upload, not file content; Accepted types: video/mp4, video/quicktime; Max size: 100.0MB)",
         "required": true,
         "min": 3,
         "max": 1
@@ -7817,6 +8508,150 @@
     ]
   },
   {
+    "className": "Kling30",
+    "moduleName": "video",
+    "modelId": "kling-3.0/video",
+    "title": "Kling 3.0",
+    "description": "Kling 3.0 via Kie.ai.\n\n    kie, video, ai\n\n    Generate high-quality videos with advanced multi-shot capabilities and element references using Kling 3.0 AI",
+    "outputType": "video",
+    "pollInterval": 8000,
+    "maxAttempts": 450,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Video generation prompt. Takes effect when multi_shots is false.",
+        "required": true
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": [],
+        "title": "Images",
+        "description": "First and last frame image URLs. Required when elements are referenced in the prompt (using @element_name syntax). When multi_shots is false: if length is 2, index 0 is the first frame and index 1 is the last frame; if length is 1, the array item serves as the first frame. When multi_shots is true: only the first frame is supported.",
+        "required": false
+      },
+      {
+        "name": "sound",
+        "type": "bool",
+        "default": false,
+        "title": "Sound",
+        "description": "Whether to enable sound effects. true enables sound effects, false disables them. When multi_shots is true, this field defaults to true.",
+        "required": true
+      },
+      {
+        "name": "duration",
+        "type": "enum",
+        "default": "5",
+        "title": "Duration",
+        "description": "Total video duration in seconds. Integer value, range: 3 to 15.",
+        "required": true,
+        "values": [
+          "3",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8",
+          "9",
+          "10",
+          "11",
+          "12",
+          "13",
+          "14",
+          "15"
+        ],
+        "min": 3,
+        "max": 15
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "16:9",
+        "title": "Aspect Ratio",
+        "description": "Video aspect ratio. Options: 16:9, 9:16, 1:1. When image_urls(first and last frame images) is provided, this parameter is optional and the aspect ratio will be automatically adapted based on the uploaded images.",
+        "required": true,
+        "values": [
+          "16:9",
+          "9:16",
+          "1:1"
+        ]
+      },
+      {
+        "name": "mode",
+        "type": "enum",
+        "default": "pro",
+        "title": "Mode",
+        "description": "Generation mode. std has standard resolution, pro has higher resolution, 4K has 4K resolution. Resolution mapping: - **std mode**: 16:9 (1280×720), 9:16 (720×1280), 1:1 (720×720) - **pro mode**: 16:9 (1920×1080), 9:16 (1080×1920), 1:1 (1080×1080) - **4K mode**: 16:9 (3840×2160), 9:16 (2160×3840), 1:1 (2160×2160)",
+        "required": true,
+        "values": [
+          "std",
+          "pro",
+          "4K"
+        ]
+      },
+      {
+        "name": "multi_shots",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shots",
+        "description": "Whether to use multi-shot mode. true enables multi-shot mode, false enables single-shot mode.",
+        "required": true
+      },
+      {
+        "name": "multi_prompt",
+        "type": "list[image]",
+        "default": [],
+        "title": "Multi Prompt",
+        "description": "Shot prompts. Takes effect when multi_shots is true. Used to describe the text and duration of each shot. Supports up to 5 shots. Each shot duration is 1-12 seconds. If you need to use elements, add them after the prompt.",
+        "required": true,
+        "min": 1,
+        "max": 12
+      },
+      {
+        "name": "kling_elements",
+        "type": "list[image]",
+        "default": [],
+        "title": "Kling Elements",
+        "description": "Referenced elements. Detailed information about elements referenced in the prompt. A single task can reference a maximum of three elements.",
+        "required": false,
+        "max": 3
+      }
+    ],
+    "uploads": [
+      {
+        "field": "images",
+        "kind": "image",
+        "isList": true,
+        "paramName": "image_urls"
+      }
+    ],
+    "validation": [
+      {
+        "field": "prompt",
+        "rule": "not_empty",
+        "message": "Prompt is required"
+      },
+      {
+        "field": "duration",
+        "rule": "not_empty",
+        "message": "Duration is required"
+      },
+      {
+        "field": "aspect_ratio",
+        "rule": "not_empty",
+        "message": "Aspect Ratio is required"
+      },
+      {
+        "field": "mode",
+        "rule": "not_empty",
+        "message": "Mode is required"
+      }
+    ]
+  },
+  {
     "className": "KlingV3TurboTextToVideo",
     "moduleName": "video",
     "modelId": "kling/v3-turbo-text-to-video",
@@ -7912,14 +8747,6 @@
         "max": 2500
       },
       {
-        "name": "images",
-        "type": "list[image]",
-        "default": [],
-        "title": "Images",
-        "description": "URL of the image to be used for the video (File URL after upload, not file content; Accepted types: image/jpeg, image/png; Max size: 10.0MB)",
-        "required": true
-      },
-      {
         "name": "duration",
         "type": "str",
         "default": "5",
@@ -7938,6 +8765,14 @@
           "720p",
           "1080p"
         ]
+      },
+      {
+        "name": "images",
+        "type": "list[image]",
+        "default": [],
+        "title": "Images",
+        "description": "URL of the image to be used for the video (File URL after upload, not file content; Accepted types: image/jpeg, image/png; Max size: 10.0MB)",
+        "required": true
       }
     ],
     "uploads": [
@@ -8871,6 +9706,14 @@
         "default": false,
         "title": "Enable Safety Checker",
         "description": "The safety checker is always enabled in Playground. It can only be disabled by setting false through the API. (Boolean value (true/false))",
+        "required": false
+      },
+      {
+        "name": "nsfw_checker",
+        "type": "bool",
+        "default": false,
+        "title": "Nsfw Checker",
+        "description": "Defaults to false. You can set it to false based on your needs. If set to false, our content filtering will be disabled, and all results will be returned directly by the model itself. Note: There is no guarantee that everything can be filtered out; if you are not satisfied with the results, you will need to make your own arrangements.",
         "required": false
       }
     ],
@@ -10113,6 +10956,14 @@
         ]
       },
       {
+        "name": "multi_shots",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shots",
+        "description": "The multi shots parameter controls the shot composition style during AI video generation, determining whether the generated video is a single continuous shot or multiple shots with transitions.",
+        "required": false
+      },
+      {
         "name": "nsfw_checker",
         "type": "bool",
         "default": false,
@@ -10182,6 +11033,14 @@
         ]
       },
       {
+        "name": "multi_shots",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shots",
+        "description": "The multi shots parameter controls the shot composition style during AI video generation, determining whether the generated video is a single continuous shot or multiple shots with transitions.",
+        "required": false
+      },
+      {
         "name": "nsfw_checker",
         "type": "bool",
         "default": false,
@@ -10249,6 +11108,14 @@
           "720p",
           "1080p"
         ]
+      },
+      {
+        "name": "multi_shots",
+        "type": "bool",
+        "default": false,
+        "title": "Multi Shots",
+        "description": "The multi shots parameter controls the shot composition style during AI video generation, determining whether the generated video is a single continuous shot or multiple shots with transitions.",
+        "required": false
       },
       {
         "name": "nsfw_checker",
@@ -12059,6 +12926,286 @@
     ]
   },
   {
+    "className": "MinimaxH3TextToVideo",
+    "moduleName": "video",
+    "modelId": "minimax-h3/text-to-video",
+    "title": "MiniMax H3 Text-to-Video",
+    "description": "MiniMax H3 Text-to-Video via Kie.ai.\n\n    kie, video, ai\n\n    ## Query Task Status",
+    "outputType": "video",
+    "pollInterval": 8000,
+    "maxAttempts": 450,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Video generation prompt, length is between 1 and 7000 characters.",
+        "required": true,
+        "min": 1,
+        "max": 7000
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "",
+        "title": "Aspect Ratio",
+        "description": "Video aspect ratio. Required for text-to-video, adaptive is not supported.",
+        "required": true,
+        "values": [
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 6,
+        "title": "Duration",
+        "description": "Generated video duration, supports integer values from 4 to 15 seconds.",
+        "required": true,
+        "min": 4,
+        "max": 15
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "2K",
+        "title": "Resolution",
+        "description": "Video resolution.",
+        "required": false,
+        "values": [
+          "768P",
+          "2K"
+        ]
+      }
+    ],
+    "validation": [
+      {
+        "field": "prompt",
+        "rule": "not_empty",
+        "message": "Prompt is required"
+      },
+      {
+        "field": "aspect_ratio",
+        "rule": "not_empty",
+        "message": "Aspect Ratio is required"
+      }
+    ]
+  },
+  {
+    "className": "MinimaxH3ImageToVideo",
+    "moduleName": "video",
+    "modelId": "minimax-h3/image-to-video",
+    "title": "MiniMax H3 Image-to-Video",
+    "description": "MiniMax H3 Image-to-Video via Kie.ai.\n\n    kie, video, ai\n\n    ## Query Task Status",
+    "outputType": "video",
+    "pollInterval": 8000,
+    "maxAttempts": 450,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Video generation prompt, length is between 1 and 7000 characters.",
+        "required": true,
+        "min": 1,
+        "max": 7000
+      },
+      {
+        "name": "first_frame",
+        "type": "image",
+        "default": {
+          "type": "image",
+          "uri": "",
+          "asset_id": null,
+          "data": null,
+          "metadata": null
+        },
+        "title": "First Frame",
+        "description": "First frame image URL. Note: Either first_frame_url or last_frame_url must be provided. Supports HTTP, HTTPS, and OSS addresses; supports JPG, JPEG, PNG, WEBP, HEIC, HEIF formats; single image size not exceeding 30 MB, image side length between 256 and 5760 pixels, aspect ratio between 0.4 and 2.5.",
+        "required": false
+      },
+      {
+        "name": "last_frame",
+        "type": "image",
+        "default": {
+          "type": "image",
+          "uri": "",
+          "asset_id": null,
+          "data": null,
+          "metadata": null
+        },
+        "title": "Last Frame",
+        "description": "Last frame image URL. Note: Either first_frame_url or last_frame_url must be provided. Image restrictions are the same as first_frame_url.",
+        "required": false
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 6,
+        "title": "Duration",
+        "description": "Generated video duration, supporting integer values from 4 to 15 seconds.",
+        "required": true,
+        "min": 4,
+        "max": 15
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "2K",
+        "title": "Resolution",
+        "description": "Video resolution.",
+        "required": false,
+        "values": [
+          "768P",
+          "2K"
+        ]
+      }
+    ],
+    "uploads": [
+      {
+        "field": "first_frame",
+        "kind": "image",
+        "paramName": "first_frame_url"
+      },
+      {
+        "field": "last_frame",
+        "kind": "image",
+        "paramName": "last_frame_url"
+      }
+    ],
+    "validation": [
+      {
+        "field": "prompt",
+        "rule": "not_empty",
+        "message": "Prompt is required"
+      }
+    ]
+  },
+  {
+    "className": "MinimaxH3ReferenceToVideo",
+    "moduleName": "video",
+    "modelId": "minimax-h3/reference-to-video",
+    "title": "MiniMax H3 Reference-to-Video",
+    "description": "MiniMax H3 Reference-to-Video via Kie.ai.\n\n    kie, video, ai\n\n    ## Query Task Status",
+    "outputType": "video",
+    "pollInterval": 8000,
+    "maxAttempts": 450,
+    "fields": [
+      {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Video generation prompt, length is between 1 and 7000 characters.",
+        "required": true,
+        "min": 1,
+        "max": 7000
+      },
+      {
+        "name": "reference_images",
+        "type": "list[image]",
+        "default": [],
+        "title": "Reference Images",
+        "description": "Array of reference image URLs. Supports up to 9 images. Supports HTTP, HTTPS, and OSS addresses; supported image formats include JPG, JPEG, PNG, WEBP, HEIC, and HEIF; a single image size cannot exceed 30 MB; the side length of the image must be between 256 and 5760 pixels, and the aspect ratio must be between 0.4 and 2.5.",
+        "required": false,
+        "max": 9
+      },
+      {
+        "name": "reference_videos",
+        "type": "list[video]",
+        "default": [],
+        "title": "Reference Videos",
+        "description": "Array of reference video URLs. Supports up to 3 videos. Supports MP4, MOV; video encoding supports H.264, H.265, audio encoding supports AAC, MP3; a single file size cannot exceed 50 MB; the duration of a single segment is 2 to 15 seconds, and the total duration of all reference videos cannot exceed 15 seconds; the video side length must be between 256 and 5760 pixels, the aspect ratio must be between 0.4 and 2.5, and the frame rate must be between 23.976 and 60.",
+        "required": false,
+        "min": 2,
+        "max": 3
+      },
+      {
+        "name": "reference_audios",
+        "type": "list[audio]",
+        "default": [],
+        "title": "Reference Audios",
+        "description": "Array of reference audio URLs. Supports up to 3 audios. Supports WAV, MP3; a single file size cannot exceed 15 MB; the duration of a single segment is 2 to 15 seconds, and the total duration of all reference audios cannot exceed 15 seconds. reference_audio cannot be used alone, it must be accompanied by reference_image or reference_video.",
+        "required": false,
+        "min": 2,
+        "max": 3
+      },
+      {
+        "name": "aspect_ratio",
+        "type": "enum",
+        "default": "adaptive",
+        "title": "Aspect Ratio",
+        "description": "Video aspect ratio. The default is adaptive, or a specific ratio can be specified.",
+        "required": false,
+        "values": [
+          "adaptive",
+          "21:9",
+          "16:9",
+          "4:3",
+          "1:1",
+          "3:4",
+          "9:16"
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "int",
+        "default": 6,
+        "title": "Duration",
+        "description": "The duration of the generated video, supporting integer values from 4 to 15 seconds.",
+        "required": true,
+        "min": 4,
+        "max": 15
+      },
+      {
+        "name": "resolution",
+        "type": "enum",
+        "default": "2K",
+        "title": "Resolution",
+        "description": "Video resolution.",
+        "required": false,
+        "values": [
+          "768P",
+          "2K"
+        ]
+      }
+    ],
+    "uploads": [
+      {
+        "field": "reference_images",
+        "kind": "image",
+        "isList": true,
+        "paramName": "reference_image_urls"
+      },
+      {
+        "field": "reference_videos",
+        "kind": "video",
+        "isList": true,
+        "paramName": "reference_video_urls"
+      },
+      {
+        "field": "reference_audios",
+        "kind": "audio",
+        "isList": true,
+        "paramName": "reference_audio_urls"
+      }
+    ],
+    "validation": [
+      {
+        "field": "prompt",
+        "rule": "not_empty",
+        "message": "Prompt is required"
+      }
+    ]
+  },
+  {
     "className": "HappyhorseTextToVideo",
     "moduleName": "video",
     "modelId": "happyhorse/text-to-video",
@@ -12214,6 +13361,25 @@
     "maxAttempts": 450,
     "fields": [
       {
+        "name": "prompt",
+        "type": "str",
+        "default": "",
+        "title": "Prompt",
+        "description": "Text prompt describing the video to generate (any language). Max 5,000 non‑Chinese characters or 2,500 Chinese characters; extra content is truncated.",
+        "required": true,
+        "max": 5000
+      },
+      {
+        "name": "reference_image",
+        "type": "list[image]",
+        "default": [],
+        "title": "Reference Image",
+        "description": "Reference image URL list. Provide 1–9 images. The order defines which image is character1, character2, etc. Image limits: Format: JPEG, JPG, PNG, and WEBP. Resolution: shortest side at least 400 px. 720P or higher recommended. Avoid small, blurry, or heavily compressed images, as they degrade output quality. File size: 10 MB maximum.",
+        "required": true,
+        "min": 1,
+        "max": 9
+      },
+      {
         "name": "resolution",
         "type": "enum",
         "default": "1080p",
@@ -12224,35 +13390,6 @@
           "720p",
           "1080p"
         ]
-      },
-      {
-        "name": "duration",
-        "type": "int",
-        "default": 5,
-        "title": "Duration",
-        "description": "Output duration in seconds (integer). Must be between 3 and 15. Defaults to 5.",
-        "required": false,
-        "min": 3,
-        "max": 15
-      },
-      {
-        "name": "prompt",
-        "type": "str",
-        "default": "",
-        "title": "Prompt",
-        "description": "Text prompt describing the video to generate (any language). Max 5,000 non‑Chinese characters or 2,500 Chinese characters; extra content is truncated.",
-        "required": true,
-        "max": 5000
-      },
-      {
-        "name": "seed",
-        "type": "int",
-        "default": 0,
-        "title": "Seed",
-        "description": "Random seed for reproducibility (if supported).",
-        "required": false,
-        "min": 0,
-        "max": 2147483647
       },
       {
         "name": "aspect_ratio",
@@ -12270,14 +13407,24 @@
         ]
       },
       {
-        "name": "reference_image",
-        "type": "list[image]",
-        "default": [],
-        "title": "Reference Image",
-        "description": "Reference image URL list. Provide 1–9 images. The order defines which image is character1, character2, etc. Image limits: Format: JPEG, JPG, PNG, and WEBP. Resolution: shortest side at least 400 px. 720P or higher recommended. Avoid small, blurry, or heavily compressed images, as they degrade output quality. File size: 10 MB maximum.",
-        "required": true,
-        "min": 1,
-        "max": 9
+        "name": "duration",
+        "type": "int",
+        "default": 5,
+        "title": "Duration",
+        "description": "Output duration in seconds (integer). Must be between 3 and 15. Defaults to 5.",
+        "required": false,
+        "min": 3,
+        "max": 15
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "default": 0,
+        "title": "Seed",
+        "description": "Random seed for reproducibility (if supported).",
+        "required": false,
+        "min": 0,
+        "max": 2147483647
       }
     ],
     "validation": [
@@ -12904,7 +14051,7 @@
         "title": "Prompt",
         "description": "Optional prompt text. Limited to Chinese, English, Japanese, Korean, Spanish, and Indonesian. Recommended 300 characters or less. Maximum length: 1000 characters.",
         "required": false,
-        "max": 1000
+        "max": 300
       },
       {
         "name": "output_resolution",


### PR DESCRIPTION
Regenerates the KIE configs, manifest, and pricing bundles from `docs.kie.ai` (`npm run generate:kie`), and fixes two parser rules that were silently dropping models from the docs index.

## New nodes (11)

| Module | Node | Model id |
|---|---|---|
| image | `Qwen3TextToImage`, `Qwen3ImageToImage` | `qwen3/text-to-image`, `qwen3/image-to-image` |
| image | `Qwen3ProTextToImage`, `Qwen3ProImageToImage` | `qwen3/pro-text-to-image`, `qwen3/pro-image-to-image` |
| video | `MinimaxH3TextToVideo`, `MinimaxH3ImageToVideo`, `MinimaxH3ReferenceToVideo` | `minimax-h3/*` |
| video | `Kling30` | `kling-3.0/video` |
| audio | `Gemini31FlashTts`, `Gemini25ProTts` | `google/gemini-3-1-flash-tts`, `google/gemini-2-5-pro-tts` |
| audio | `GeneratePersona` | `generate-persona` (Suno) |

Nineteen existing nodes pick up upstream schema changes — new fields (Wan 2.6 `multi_shots`, Qwen `nsfw_checker`, Grok Imagine upscale `resolution`, Bytedance V1 Pro), reordered enum values. No node was removed. Manifest goes 140 → 151 entries.

## Parser fixes

Both were dropping documented models with no error, which is why a plain regenerate had not picked them up:

- **Truncated OpenAPI block.** `extractOpenApi` matched the YAML fence non-greedily, so a spec whose descriptions embed their own indented ` ```json ` examples was cut off at the first inner fence. The half-document still parsed as YAML, so the model fell out at the `requestBody` check instead of raising. The closing fence is now required at column 0. This is what hid Kling 3.0.
- **`Music Models > …` category.** `moduleFromCategory` matched `audio`/`suno`/`elevenlabs` but not `music models`, so both Gemini TTS pages mapped to no module. Now treated as audio.

## Pricing

`kie-unit-pricing.json` / `kie-node-type-pricing.json` move with the upstream KIE catalog: 7 new entries, none removed, and the Grok Imagine video models repriced (`text-to-video`/`image-to-video`/`1-5-preview` $0.008 → $0.012 per second, `extend` $0.05 → $0.072). Worth a second look since these gate a run's budget.

## Known limitation (pre-existing)

The parser's array fallback types every non-URL object array as `list[image]`, so `Kling30.multi_prompt` / `kling_elements` and the TTS `speakers` / `dialogue_turns` come out as image lists. Same shape already shipped for `Wan27Image.bbox_list` and `ElevenlabsTextToDialogueV3.dialogue`, so this change does not make it worse — left alone rather than reshaping existing nodes here.

## Verification

- `npm run generate:kie`
- `npm run lint --workspace=packages/kie-codegen`
- `npm run test --workspace=packages/kie-codegen` — 73 passed
- `npm run test --workspace=packages/websocket` — 2210 passed
- `npx vitest run --root packages/runtime kie` — 58 passed
- `npm run build --workspace=packages/kie-nodes`

Chat models needed no change: every model under `Chat Models` in `llms.txt` is already in `KIE_CHAT_MODELS`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEmPbW6HtAxCehrtRCtaKt)_