### PR TITLE
feat(studio): beginner shell for agentic video creation

### DIFF
--- a/docs/agentic-video-product.md
+++ b/docs/agentic-video-product.md
@@ -1,0 +1,102 @@
+# Studio: the agentic-video carve-out
+
+A niche product on the NodeTool platform: agentic video creation and editing
+for absolute beginners. One shell, two creation paths (storyboard and script),
+one finishing surface (the timeline editor), a curated model list, and a
+credits display instead of provider pricing. Everything below the shell is
+reused NodeTool.
+
+> Status: prototype. The shell ships inside the main web app at `/studio`;
+> carving it into a standalone deployable is a later step (see
+> "From prototype to product").
+
+## What the user sees
+
+- **`/studio`** — home. Two cards: *Start with a storyboard* (describe an
+  idea; the director agent breaks it into shots, renders stills, animates
+  clips) and *Start with a script* (write or generate lines, cast voices,
+  voice them). Below: recent projects across all three document types. The
+  header always shows the credit balance.
+- **`/studio/storyboard/:id`** — the storyboard editor (board + agent panel +
+  generation queue) without the workspace sidebar or tabs. *Assemble*
+  navigates to the Studio timeline page.
+- **`/studio/script/:id`** — the script editor (document pane + cast /
+  assistant dock). *Create video* in the header assembles the voiced takes
+  into a timeline and navigates there.
+- **`/studio/timeline/:id`** — the full timeline editor, the one finishing
+  surface. Preview, tracks, inspector, agent panel and export all come from
+  the platform editor unchanged.
+
+## What is reused (all of it)
+
+| Product piece | Platform code |
+|---|---|
+| Storyboard editing + agent | `web/src/components/storyboard/*`, `ui_storyboard_*` tools, `StoryboardStore`, server sync |
+| Script editing + voicing | `web/src/components/script/*`, `ui_script_*` tools, `ScriptStore`, server sync |
+| Timeline editing | `web/src/components/timeline/TimelineEditor`, `ui_timeline_*` tools |
+| Storyboard → timeline | `useAssembleTimeline` → `buildStoryboardTimeline` (`@nodetool-ai/timeline`) |
+| Script → timeline | `useAssembleScriptTimeline` → `buildScriptTimeline` (`@nodetool-ai/timeline`) |
+| Agent chat in every editor | `ChatView` + per-document agent panels and bridges |
+| Persistence | tRPC `storyboards` / `scripts` / `timeline` routers, autosave hooks |
+| Cost data | prediction ledger (`nodetool_predictions`) via `costs.dashboard` |
+| Headless QA | `nodetool timeline validate`, `storyboard`/`script` render tools, the tool-loop evals |
+
+The Studio module itself is five small files in `web/src/studio/` plus four
+routes in `web/src/index.tsx`. Nothing under `web/src/components/` changed.
+
+## Curated models
+
+`web/src/studio/curatedModels.ts` is the entire model policy: one language
+model (screenplay direction + assistants), one still model, one clip model.
+New Studio storyboards get them stamped on before the first generation, so
+beginners never meet a model picker; the platform pickers still exist inside
+the reused editors for users who dig, and `validate_workflow`'s
+provider/model check rejects any id the catalogs don't know.
+
+Changing the lineup is editing that file. If the product later needs per-plan
+lineups (e.g. faster models on the free tier), the same shape can move to a
+server-delivered config.
+
+## Credits
+
+Prototype semantics, in `web/src/studio/useStudioCredits.ts`:
+
+- 1 credit = $0.01 of provider spend.
+- Balance = flat grant (1,000 credits) minus everything in the prediction
+  ledger for the last 90 days, read from `costs.dashboard`.
+- Display-only: the chip in the Studio header. Nothing is blocked
+  client-side.
+
+The path to real enforcement already exists in the platform and is the next
+step after the prototype validates:
+
+1. **Server gate.** The `application_budgets` machinery
+   (`packages/models/src/application-budget.ts`, enforced in
+   `unified-websocket-runner.ts` with `BUDGET_EXCEEDED`) already does
+   estimate → reserve → settle per invocation. Generalize the key from
+   `application_id` to a user-scoped budget row and every generation path —
+   storyboard stills/clips, voicing, timeline generate — is gated by the same
+   code.
+2. **Purchases.** A `credits` tRPC router (alongside `costsRouter`) exposing
+   balance + top-ups; grants become ledger rows instead of a client constant.
+3. **Estimates before spend.** `@nodetool-ai/model-pricing`
+   (`getModelUnitPrice`) prices the curated models per unit, so shot cards
+   and the voice-all button can show "≈ 3 credits" before the click.
+
+## From prototype to product
+
+- **Standalone shell.** The Studio routes live in the main bundle today. To
+  ship a separate product surface: a `studio.html` Vite entry (the
+  `app-preview.html` pattern) with only the Studio routes, or keep one bundle
+  and gate by hostname/runtime config. The second is cheaper and keeps one
+  deploy pipeline (the GHCR image).
+- **Access control.** A Studio-only auth mode hides `/workspace`, the node
+  editor, and settings; the reused editors already work without them.
+- **Curated voices.** Script casting still offers the full TTS catalog;
+  curate it the same way the image/video models are curated.
+- **Known prototype seams.**
+  - The reused assemble hooks also open a workspace tab (harmless in Studio;
+    the tab is simply there if the user ever visits `/workspace`).
+  - Model stamping re-applies if a user clears all three storyboard models.
+  - The storyboard/script pages are desktop-first; the workspace surfaces'
+    mobile pane-switchers were not carried over.

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -136,6 +136,15 @@ const SketchEditorPage = React.lazy(
 const WorkspaceShell = React.lazy(
   () => import("./components/workspace/WorkspaceShell")
 );
+// Studio — the beginner-facing agentic-video shell (see docs/agentic-video-product.md)
+const StudioHome = React.lazy(() => import("./studio/StudioHome"));
+const StudioStoryboardPage = React.lazy(
+  () => import("./studio/StudioStoryboardPage")
+);
+const StudioScriptPage = React.lazy(() => import("./studio/StudioScriptPage"));
+const StudioTimelinePage = React.lazy(
+  () => import("./studio/StudioTimelinePage")
+);
 import {
   ChatThreadRedirect,
   WorkflowEditorRedirect
@@ -425,6 +434,33 @@ function getRoutes() {
         </ProtectedRoute>
       )
     },
+    // Studio: the beginner shell for agentic video creation. Two creation
+    // paths (storyboard, script) that both finish in the timeline editor.
+    ...(
+      [
+        { path: "/studio", el: <StudioHome /> },
+        { path: "/studio/storyboard/:boardId", el: <StudioStoryboardPage /> },
+        { path: "/studio/script/:scriptId", el: <StudioScriptPage /> },
+        { path: "/studio/timeline/:sequenceId", el: <StudioTimelinePage /> }
+      ] as const
+    ).map(({ path, el }) => ({
+      path,
+      element: (
+        <ProtectedRoute>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              width: "100%",
+              height: "100%"
+            }}
+          >
+            <SkipLinks />
+            <React.Suspense fallback={<LoadingSpinner />}>{el}</React.Suspense>
+          </div>
+        </ProtectedRoute>
+      )
+    })),
     {
       // New tabbed-document workspace (in progress). Lives alongside the
       // existing routes; will become the default once all document types

--- a/web/src/studio/StudioHome.tsx
+++ b/web/src/studio/StudioHome.tsx
@@ -1,0 +1,220 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * Studio home: two creation paths and the recent projects that came out of
+ * them. A storyboard project starts visual (shots → stills → clips); a script
+ * project starts spoken (lines → voices → takes). Both end in the timeline
+ * editor, which is the one finishing surface the product has.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTheme } from "@mui/material/styles";
+import TheatersRoundedIcon from "@mui/icons-material/TheatersRounded";
+import RecordVoiceOverRoundedIcon from "@mui/icons-material/RecordVoiceOverRounded";
+import MovieRoundedIcon from "@mui/icons-material/MovieRounded";
+import {
+  BORDER_RADIUS,
+  Card,
+  Chip,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  SPACING,
+  Text
+} from "../components/ui_primitives";
+import { useCreateStoryboard, useStoryboards } from "../hooks/storyboard/useStoryboards";
+import { useCreateScript, useScripts } from "../hooks/script/useScripts";
+import { useTimelines } from "../hooks/useTimelineSequence";
+import StudioShell from "./StudioShell";
+
+type ProjectKind = "storyboard" | "script" | "timeline";
+
+interface RecentProject {
+  kind: ProjectKind;
+  id: string;
+  name: string;
+  updatedAt: string;
+}
+
+const KIND_LABEL: Record<ProjectKind, string> = {
+  storyboard: "Storyboard",
+  script: "Script",
+  timeline: "Video"
+};
+
+const KIND_ICON: Record<ProjectKind, React.ReactNode> = {
+  storyboard: <TheatersRoundedIcon fontSize="small" />,
+  script: <RecordVoiceOverRoundedIcon fontSize="small" />,
+  timeline: <MovieRoundedIcon fontSize="small" />
+};
+
+const projectRoute = (p: RecentProject) => `/studio/${p.kind}/${p.id}`;
+
+const PathCard = ({
+  icon,
+  title,
+  description,
+  cta,
+  busy,
+  onStart
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  cta: string;
+  busy: boolean;
+  onStart: () => void;
+}) => (
+  <Card
+    variant="outlined"
+    padding="comfortable"
+    sx={{ flex: 1, minWidth: 260, maxWidth: 420 }}
+  >
+    <FlexColumn gap={SPACING.md} align="flex-start">
+      {icon}
+      <Text size="big" weight={600}>
+        {title}
+      </Text>
+      <Text size="small" color="secondary">
+        {description}
+      </Text>
+      <EditorButton variant="contained" onClick={onStart} disabled={busy}>
+        {busy ? "Creating…" : cta}
+      </EditorButton>
+    </FlexColumn>
+  </Card>
+);
+
+const StudioHome = () => {
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const createStoryboard = useCreateStoryboard();
+  const createScript = useCreateScript();
+  const [creating, setCreating] = useState<ProjectKind | null>(null);
+
+  const storyboards = useStoryboards();
+  const scripts = useScripts();
+  const timelines = useTimelines("default");
+
+  const recent = useMemo<RecentProject[]>(() => {
+    const rows: RecentProject[] = [
+      ...(storyboards.data ?? []).map((s) => ({
+        kind: "storyboard" as const,
+        id: s.id,
+        name: s.name,
+        updatedAt: s.updatedAt
+      })),
+      ...(scripts.data ?? []).map((s) => ({
+        kind: "script" as const,
+        id: s.id,
+        name: s.name,
+        updatedAt: s.updatedAt
+      })),
+      ...(timelines.data ?? []).map((t) => ({
+        kind: "timeline" as const,
+        id: t.id,
+        name: t.name,
+        updatedAt: t.updatedAt
+      }))
+    ];
+    return rows
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      .slice(0, 12);
+  }, [storyboards.data, scripts.data, timelines.data]);
+
+  const startStoryboard = useCallback(() => {
+    setCreating("storyboard");
+    createStoryboard
+      .mutateAsync({ name: "Untitled storyboard", projectId: "default" })
+      .then((created) => navigate(`/studio/storyboard/${created.id}`))
+      .finally(() => setCreating(null));
+  }, [createStoryboard, navigate]);
+
+  const startScript = useCallback(() => {
+    setCreating("script");
+    createScript
+      .mutateAsync({ name: "Untitled script", projectId: "default" })
+      .then((created) => navigate(`/studio/script/${created.id}`))
+      .finally(() => setCreating(null));
+  }, [createScript, navigate]);
+
+  return (
+    <StudioShell showBack={false}>
+      <FlexColumn
+        align="center"
+        gap={SPACING.xl}
+        sx={{ flex: 1, minHeight: 0, overflowY: "auto", p: SPACING.xl }}
+      >
+        <FlexColumn align="center" gap={SPACING.sm} sx={{ pt: SPACING.xl }}>
+          <Text size="giant" weight={600}>
+            Make a video
+          </Text>
+          <Text size="normal" color="secondary">
+            Pick a starting point — the agent handles the models, you direct.
+          </Text>
+        </FlexColumn>
+
+        <FlexRow gap={SPACING.lg} wrap justify="center" fullWidth>
+          <PathCard
+            icon={<TheatersRoundedIcon />}
+            title="Start with a storyboard"
+            description="Describe your idea. The director agent breaks it into shots, renders stills, animates them into clips, and cuts them together."
+            cta="New storyboard"
+            busy={creating === "storyboard"}
+            onStart={startStoryboard}
+          />
+          <PathCard
+            icon={<RecordVoiceOverRoundedIcon />}
+            title="Start with a script"
+            description="Write or generate a script, cast a voice for every speaker, and turn the voiced lines into a video with captions."
+            cta="New script"
+            busy={creating === "script"}
+            onStart={startScript}
+          />
+        </FlexRow>
+
+        {recent.length > 0 && (
+          <FlexColumn gap={SPACING.sm} sx={{ width: "100%", maxWidth: 880 }}>
+            <Text size="small" weight={600} color="secondary">
+              Recent projects
+            </Text>
+            {recent.map((p) => (
+              <FlexRow
+                key={`${p.kind}:${p.id}`}
+                component="button"
+                align="center"
+                gap={SPACING.md}
+                onClick={() => navigate(projectRoute(p))}
+                sx={{
+                  width: "100%",
+                  textAlign: "left",
+                  cursor: "pointer",
+                  background: "none",
+                  border: `1px solid ${theme.vars.palette.divider}`,
+                  borderRadius: BORDER_RADIUS.md,
+                  px: SPACING.md,
+                  py: SPACING.sm,
+                  color: "inherit",
+                  "&:hover": {
+                    backgroundColor: theme.vars.palette.action.hover
+                  }
+                }}
+              >
+                {KIND_ICON[p.kind]}
+                <Text size="normal" truncate sx={{ flex: 1 }}>
+                  {p.name}
+                </Text>
+                <Chip compact label={KIND_LABEL[p.kind]} />
+                <Text size="smaller" color="secondary">
+                  {new Date(p.updatedAt).toLocaleDateString()}
+                </Text>
+              </FlexRow>
+            ))}
+          </FlexColumn>
+        )}
+      </FlexColumn>
+    </StudioShell>
+  );
+};
+
+export default StudioHome;

--- a/web/src/studio/StudioScriptPage.tsx
+++ b/web/src/studio/StudioScriptPage.tsx
@@ -1,0 +1,137 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * Studio script page: the existing script editor (document pane + cast /
+ * assistant dock) inside the Studio chrome. The header carries the one Studio
+ * addition — "Create video" assembles the voiced takes into a timeline and
+ * navigates to `/studio/timeline/:id`.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useTheme } from "@mui/material/styles";
+import GroupsIcon from "@mui/icons-material/Groups";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import MovieRoundedIcon from "@mui/icons-material/MovieRounded";
+import {
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  TabGroup,
+  Tooltip
+} from "../components/ui_primitives";
+import ScriptDocumentPane from "../components/script/ScriptDocumentPane";
+import ScriptCastPanel from "../components/script/ScriptCastPanel";
+import ScriptAgentPanel from "../components/script/ScriptAgentPanel";
+import {
+  useScriptStore,
+  useScriptCast,
+  useScriptTitle
+} from "../stores/script/ScriptStore";
+import { useScriptServerSync } from "../hooks/script/useScriptServerSync";
+import { useScriptAgentBridge } from "../hooks/script/useScriptAgentBridge";
+import { useAssembleScriptTimeline } from "../hooks/script/useAssembleScriptTimeline";
+import StudioShell from "./StudioShell";
+
+type DockTab = "cast" | "assistant";
+
+const StudioScriptPage = () => {
+  const { scriptId = "" } = useParams<{ scriptId: string }>();
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const ensureScript = useScriptStore((state) => state.ensureScript);
+  const title = useScriptTitle(scriptId);
+  const cast = useScriptCast(scriptId);
+  const [dockTab, setDockTab] = useState<DockTab>("assistant");
+
+  useEffect(() => {
+    ensureScript(scriptId);
+  }, [ensureScript, scriptId]);
+
+  useScriptServerSync(scriptId);
+  useScriptAgentBridge(scriptId);
+
+  const { assemble, assembling, error: assembleError } =
+    useAssembleScriptTimeline();
+
+  const dockTabs = useMemo(
+    () => [
+      { value: "cast", label: "Cast", icon: <GroupsIcon /> },
+      { value: "assistant", label: "Assistant", icon: <AutoAwesomeIcon /> }
+    ],
+    []
+  );
+
+  const createVideo = (
+    <Tooltip
+      title={
+        assembleError ??
+        "Lay the voiced lines onto a timeline and open the video editor."
+      }
+    >
+      <span>
+        <EditorButton
+          size="small"
+          variant="contained"
+          startIcon={<MovieRoundedIcon fontSize="small" />}
+          disabled={assembling}
+          onClick={() => {
+            void assemble(scriptId)
+              .then((result) =>
+                navigate(`/studio/timeline/${result.sequenceId}`)
+              )
+              .catch(() => {
+                // Surfaced via assembleError; swallow to keep the click quiet.
+              });
+          }}
+        >
+          {assembling ? "Assembling…" : "Create video"}
+        </EditorButton>
+      </span>
+    </Tooltip>
+  );
+
+  return (
+    <StudioShell title={title || "Untitled script"} actions={createVideo}>
+      <FlexRow fullHeight sx={{ flex: 1, minHeight: 0, position: "relative" }}>
+        <ScriptDocumentPane scriptId={scriptId} readOnly={false} />
+        <FlexColumn
+          fullHeight
+          sx={{
+            width: 320,
+            flexShrink: 0,
+            minHeight: 0,
+            borderLeft: `1px solid ${theme.vars.palette.divider}`
+          }}
+        >
+          <TabGroup
+            tabs={dockTabs}
+            value={dockTab}
+            onChange={(value) => setDockTab(value as DockTab)}
+            size="small"
+            fullWidth
+            sx={{
+              flexShrink: 0,
+              borderBottom: `1px solid ${theme.vars.palette.divider}`
+            }}
+          />
+          <FlexColumn
+            fullWidth
+            sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}
+          >
+            {dockTab === "cast" ? (
+              <ScriptCastPanel
+                scriptId={scriptId}
+                cast={cast}
+                readOnly={false}
+              />
+            ) : (
+              <ScriptAgentPanel scriptId={scriptId} />
+            )}
+          </FlexColumn>
+        </FlexColumn>
+      </FlexRow>
+    </StudioShell>
+  );
+};
+
+export default StudioScriptPage;

--- a/web/src/studio/StudioShell.tsx
+++ b/web/src/studio/StudioShell.tsx
@@ -1,0 +1,106 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * The Studio chrome: one thin header (back link, brand, page title, page
+ * actions, credit balance) over a full-height body. Deliberately has no tabs,
+ * panels, or node graph — the Studio is the beginner shell around the existing
+ * storyboard, script, and timeline surfaces.
+ */
+
+import { useNavigate } from "react-router-dom";
+import { useTheme } from "@mui/material/styles";
+import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
+import BoltRoundedIcon from "@mui/icons-material/BoltRounded";
+import MovieFilterRoundedIcon from "@mui/icons-material/MovieFilterRounded";
+import {
+  Chip,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  SPACING,
+  Text,
+  Tooltip
+} from "../components/ui_primitives";
+import { useStudioCredits } from "./useStudioCredits";
+
+const CreditsChip = () => {
+  const { remaining, used, grant, loading } = useStudioCredits();
+  return (
+    <Tooltip
+      title={`${used} of ${grant} credits used. 1 credit = 1¢ of generation.`}
+    >
+      <span>
+        <Chip
+          compact
+          color={remaining > 0 ? "primary" : "error"}
+          icon={<BoltRoundedIcon />}
+          label={loading ? "credits…" : `${remaining} credits`}
+        />
+      </span>
+    </Tooltip>
+  );
+};
+
+export interface StudioShellProps {
+  /** Page title shown next to the brand; omit on the home screen. */
+  title?: string;
+  /** Show the back-to-home button (every page except home). */
+  showBack?: boolean;
+  /** Page-specific header actions (e.g. "Create video"). */
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const StudioShell = ({
+  title,
+  showBack = true,
+  actions,
+  children
+}: StudioShellProps) => {
+  const theme = useTheme();
+  const navigate = useNavigate();
+  return (
+    <FlexColumn fullHeight sx={{ width: "100%", minHeight: 0 }}>
+      <FlexRow
+        align="center"
+        gap={SPACING.md}
+        sx={{
+          flexShrink: 0,
+          px: SPACING.lg,
+          py: SPACING.sm,
+          borderBottom: `1px solid ${theme.vars.palette.divider}`
+        }}
+      >
+        {showBack && (
+          <EditorButton
+            size="small"
+            startIcon={<ArrowBackRoundedIcon fontSize="small" />}
+            onClick={() => navigate("/studio")}
+          >
+            Studio
+          </EditorButton>
+        )}
+        {!showBack && (
+          <FlexRow align="center" gap={SPACING.sm}>
+            <MovieFilterRoundedIcon fontSize="small" />
+            <Text size="normal" weight={600}>
+              NodeTool Studio
+            </Text>
+          </FlexRow>
+        )}
+        {title && (
+          <Text size="normal" color="secondary" truncate>
+            {title}
+          </Text>
+        )}
+        <FlexRow sx={{ flex: 1 }} />
+        {actions}
+        <CreditsChip />
+      </FlexRow>
+      <FlexColumn sx={{ flex: 1, minHeight: 0, width: "100%" }}>
+        {children}
+      </FlexColumn>
+    </FlexColumn>
+  );
+};
+
+export default StudioShell;

--- a/web/src/studio/StudioStoryboardPage.tsx
+++ b/web/src/studio/StudioStoryboardPage.tsx
@@ -1,0 +1,123 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * Studio storyboard page: the existing storyboard editor (board + agent
+ * panel + generation queue) inside the Studio chrome, minus the workspace
+ * sidebar and tab machinery. Two Studio-specific behaviors:
+ *
+ * - New boards get the curated Studio models stamped on (director, still,
+ *   clip), so a beginner never touches a model picker.
+ * - Assembling navigates straight to `/studio/timeline/:id`, the product's
+ *   one finishing surface.
+ */
+
+import { useCallback, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useTheme } from "@mui/material/styles";
+import { FlexColumn } from "../components/ui_primitives";
+import StoryboardBoard from "../components/storyboard/StoryboardBoard";
+import StoryboardAgentPanel from "../components/storyboard/StoryboardAgentPanel";
+import StoryboardQueueOverlay from "../components/storyboard/StoryboardQueueOverlay";
+import { useStoryboardStore } from "../stores/storyboard/StoryboardStore";
+import { useStoryboardGenerationSubscriptions } from "../stores/storyboard/StoryboardGenerationStore";
+import { useStoryboardServerSync } from "../hooks/storyboard/useStoryboardServerSync";
+import { useStoryboardAgentBridge } from "../hooks/storyboard/useStoryboardAgentBridge";
+import { useDirectScreenplay } from "../hooks/storyboard/useDirectScreenplay";
+import { useAssembleTimeline } from "../hooks/storyboard/useAssembleTimeline";
+import StudioShell from "./StudioShell";
+import {
+  STUDIO_CLIP_MODEL,
+  STUDIO_DIRECTOR_MODEL,
+  STUDIO_STILL_MODEL
+} from "./curatedModels";
+
+/** Stamp the curated models onto a board that has none selected. */
+const useStudioModelPolicy = (boardId: string) => {
+  const hasAnyModel = useStoryboardStore((state) => {
+    const board = state.boards[boardId];
+    return board
+      ? Boolean(board.directorModel || board.imageModel || board.videoModel)
+      : null;
+  });
+  useEffect(() => {
+    if (hasAnyModel === false) {
+      const store = useStoryboardStore.getState();
+      store.setDirectorModel(boardId, STUDIO_DIRECTOR_MODEL);
+      store.setImageModel(boardId, STUDIO_STILL_MODEL);
+      store.setVideoModel(boardId, STUDIO_CLIP_MODEL);
+    }
+  }, [hasAnyModel, boardId]);
+};
+
+const StudioStoryboardPage = () => {
+  const { boardId = "" } = useParams<{ boardId: string }>();
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const ensureBoard = useStoryboardStore((state) => state.ensureBoard);
+  const title = useStoryboardStore(
+    (state) => state.boards[boardId]?.title ?? ""
+  );
+
+  useEffect(() => {
+    ensureBoard(boardId);
+  }, [ensureBoard, boardId]);
+
+  useStoryboardServerSync(boardId);
+  useStoryboardAgentBridge(boardId);
+  useStoryboardGenerationSubscriptions();
+  useStudioModelPolicy(boardId);
+
+  const { direct, directing, error: directError } = useDirectScreenplay();
+  const handleDirect = useCallback(
+    (shotCount: number) => direct(boardId, shotCount),
+    [direct, boardId]
+  );
+
+  const { assemble, assembling, error: assembleError } = useAssembleTimeline();
+  const handleAssemble = useCallback(() => {
+    void assemble(boardId)
+      .then((result) => navigate(`/studio/timeline/${result.sequenceId}`))
+      .catch(() => {
+        // Surfaced via assembleError; swallow to keep the click handler quiet.
+      });
+  }, [assemble, boardId, navigate]);
+
+  return (
+    <StudioShell title={title || "Untitled storyboard"}>
+      <div
+        style={{
+          display: "flex",
+          flex: 1,
+          minHeight: 0,
+          position: "relative"
+        }}
+      >
+        <StoryboardQueueOverlay boardId={boardId} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <StoryboardBoard
+            boardId={boardId}
+            readOnly={false}
+            onDirect={handleDirect}
+            directing={directing}
+            directError={directError}
+            onAssemble={handleAssemble}
+            assembling={assembling}
+            assembleError={assembleError}
+          />
+        </div>
+        <FlexColumn
+          fullHeight
+          sx={{
+            width: 320,
+            flexShrink: 0,
+            minHeight: 0,
+            borderLeft: `1px solid ${theme.vars.palette.divider}`
+          }}
+        >
+          <StoryboardAgentPanel boardId={boardId} />
+        </FlexColumn>
+      </div>
+    </StudioShell>
+  );
+};
+
+export default StudioStoryboardPage;

--- a/web/src/studio/StudioTimelinePage.tsx
+++ b/web/src/studio/StudioTimelinePage.tsx
@@ -1,0 +1,28 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * Studio timeline page: the full timeline editor — the product's finishing
+ * surface — inside the Studio chrome. The editor brings its own top bar,
+ * preview, tracks, inspector, and agent panel; Studio only adds the way home.
+ */
+
+import { Suspense, lazy } from "react";
+import { useParams } from "react-router-dom";
+import { LoadingSpinner } from "../components/ui_primitives";
+import StudioShell from "./StudioShell";
+
+const TimelineEditor = lazy(
+  () => import("../components/timeline/TimelineEditor")
+);
+
+const StudioTimelinePage = () => {
+  const { sequenceId = "" } = useParams<{ sequenceId: string }>();
+  return (
+    <StudioShell title="Edit video">
+      <Suspense fallback={<LoadingSpinner />}>
+        <TimelineEditor sequenceId={sequenceId} active />
+      </Suspense>
+    </StudioShell>
+  );
+};
+
+export default StudioTimelinePage;

--- a/web/src/studio/curatedModels.ts
+++ b/web/src/studio/curatedModels.ts
@@ -1,0 +1,49 @@
+/**
+ * The Studio model policy: one curated model per role, stamped onto every new
+ * Studio project so beginners never see a model picker. Editing these values
+ * is the whole "model management" surface of the product.
+ *
+ * Ids must exist in the corresponding provider catalog — `nodetool validate`
+ * rejects unknown provider/model pairs at run time, so a typo here fails
+ * loudly, not silently.
+ */
+
+import type {
+  ImageModelValue,
+  LanguageModelValue,
+  VideoModelValue
+} from "../stores/ApiTypes";
+
+/** Directs screenplays and drives the in-editor assistants. */
+export const STUDIO_DIRECTOR_MODEL: LanguageModelValue = {
+  type: "language_model",
+  id: "claude-sonnet-5",
+  provider: "anthropic",
+  name: "Claude Sonnet 5"
+};
+
+/** Renders storyboard keyframe stills. */
+export const STUDIO_STILL_MODEL: ImageModelValue = {
+  type: "image_model",
+  id: "fal-ai/flux-1/schnell",
+  provider: "fal_ai",
+  name: "FLUX.1 Schnell",
+  path: ""
+};
+
+/** Animates keyframes into shot clips. */
+export const STUDIO_CLIP_MODEL: VideoModelValue = {
+  type: "video_model",
+  id: "fal-ai/kling-video/o1/standard/image-to-video",
+  provider: "fal_ai",
+  name: "Kling O1 Standard"
+};
+
+/**
+ * Credits are a beginner-friendly veneer over the prediction ledger:
+ * 1 credit = one US cent of provider spend. The grant is a flat prototype
+ * allowance; the real product replaces it with purchased balances enforced
+ * server-side (see docs/agentic-video-product.md).
+ */
+export const USD_PER_CREDIT = 0.01;
+export const STUDIO_CREDIT_GRANT = 1_000;

--- a/web/src/studio/useStudioCredits.ts
+++ b/web/src/studio/useStudioCredits.ts
@@ -1,0 +1,40 @@
+/**
+ * Derives the Studio credit balance from the prediction ledger the whole
+ * platform already writes: every provider call lands in `nodetool_predictions`
+ * with its cost, `costs.dashboard` aggregates it, and this hook converts the
+ * total to credits against the prototype grant. Display-level only — nothing
+ * is blocked client-side; hard enforcement belongs to the server budget gate.
+ */
+
+import { useMemo } from "react";
+import { trpc } from "../trpc/client";
+import { STUDIO_CREDIT_GRANT, USD_PER_CREDIT } from "./curatedModels";
+
+export interface StudioCredits {
+  grant: number;
+  used: number;
+  remaining: number;
+  /** True until the first ledger response arrives. */
+  loading: boolean;
+}
+
+export function useStudioCredits(): StudioCredits {
+  const tzOffsetMinutes = new Date().getTimezoneOffset();
+  const query = trpc.costs.dashboard.useQuery(
+    { days: 90, tzOffsetMinutes, executionsLimit: 1 },
+    { staleTime: 60_000, retry: false, refetchOnWindowFocus: false }
+  );
+
+  return useMemo(() => {
+    const spentUsd =
+      query.data?.providers.reduce((sum, p) => sum + (p.total_cost ?? 0), 0) ??
+      0;
+    const used = Math.ceil(spentUsd / USD_PER_CREDIT);
+    return {
+      grant: STUDIO_CREDIT_GRANT,
+      used,
+      remaining: Math.max(0, STUDIO_CREDIT_GRANT - used),
+      loading: query.isLoading
+    };
+  }, [query.data, query.isLoading]);
+}


### PR DESCRIPTION
## What

A rapid prototype of the agentic-video niche product: `/studio`, a simple shell for absolute beginners built entirely from existing NodeTool surfaces. Two creation paths — **storyboard** and **script** — both finishing in the **timeline editor**, with a curated model list and a credits display instead of provider pricing.

## How it's put together

- **`/studio`** (StudioHome): two creation-path cards plus a merged recent-projects list across storyboards, scripts, and timelines. Header always shows the credit balance.
- **`/studio/storyboard/:id`**: the existing storyboard editor (board + agent panel + generation queue) minus workspace tabs/sidebar. New boards get the curated models stamped on (director / still / clip) so beginners never open a model picker. *Assemble* navigates to the Studio timeline page.
- **`/studio/script/:id`**: the existing script editor (document pane + cast/assistant dock). A header *Create video* button assembles voiced takes into a timeline and navigates there.
- **`/studio/timeline/:id`**: the full `TimelineEditor` inside the Studio chrome — the one finishing surface.
- **`curatedModels.ts`**: the entire model policy — one language, one still, one clip model (ids validated against the provider catalogs at run time by the existing checks).
- **`useStudioCredits`**: 1 credit = $0.01 of spend from the prediction ledger (`costs.dashboard`) against a flat prototype grant. Display-only; `docs/agentic-video-product.md` lays out the path to hard enforcement via the existing `application_budgets` reserve/settle gate.

Nothing under `web/src/components/` changed — the shell is 5 new files plus 4 routes.

## Verification

- `web` typecheck and eslint pass.
- Headless Chromium smoke against a live dev server: `/studio` renders (credits chip, both cards), "New storyboard" creates a project and lands in the editor with the three curated models pre-selected, zero page/console errors.

## Known prototype seams (documented in the plan doc)

- The reused assemble hooks also open a workspace tab (harmless in Studio).
- Model stamping re-applies if a user clears all three storyboard models.
- Studio pages are desktop-first; the workspace surfaces' mobile pane-switchers weren't carried over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GwuPTt5T1sLkmpwWUt2N2

---
_Generated by [Claude Code](https://claude.ai/code/session_011GwuPTt5T1sLkmpwWUt2N2)_