### PR TITLE
Make the timeline editor usable on a phone

### DIFF
--- a/web/src/components/timeline/BottomStatusBar.tsx
+++ b/web/src/components/timeline/BottomStatusBar.tsx
@@ -59,6 +59,12 @@ export interface BottomStatusBarProps {
   zoom?: number;
   /** Callback when zoom changes */
   onZoomChange?: (zoom: number) => void;
+  /**
+   * Optional control rendered at the start of the bar. The phone layout puts
+   * the panel-sheet toggle here, where a thumb reaches it and it can't collide
+   * with the zoom controls on the right.
+   */
+  actionSlot?: React.ReactNode;
 }
 
 const noop = () => {};
@@ -70,7 +76,8 @@ export const BottomStatusBar: React.FC<BottomStatusBarProps> = memo(
     failedCount = 0,
     costEstimate,
     zoom = 1,
-    onZoomChange
+    onZoomChange,
+    actionSlot
   }) => {
     const theme = useTheme();
 
@@ -85,8 +92,10 @@ export const BottomStatusBar: React.FC<BottomStatusBarProps> = memo(
         fullWidth
         css={styles(theme)}
       >
-        {/* Left: local/cloud + counts */}
-        <FlexRow gap={2} align="center">
+        {/* Left: panel toggle + local/cloud + counts */}
+        <FlexRow gap={2} align="center" sx={{ minWidth: 0 }}>
+          {actionSlot}
+
           <FlexRow gap={1} align="center">
             <ModeIcon
               sx={{ fontSize: 14, color: theme.vars.palette.text.secondary }}

--- a/web/src/components/timeline/README.md
+++ b/web/src/components/timeline/README.md
@@ -4,6 +4,38 @@ The timeline editor (`/timeline/:sequenceId`) is a generation-aware media
 sequencing surface. Tracks hold imported or AI-generated clips; each clip
 remembers how it was made and can be re-generated, versioned, and exported.
 
+## Phone layout
+
+Below the `sm` breakpoint (`useTimelineIsMobile`, matching `MobileClassProvider`
+and the sketch editor) the shell drops to one column:
+
+- **TopBar** wraps into two rows — prompt + Generate above, the model and
+  output chips in a scrolling rail below — and Settings / Save / Save as Asset
+  / Export collapse into one overflow menu.
+- **Preview** takes the full width. Inspector, Assistant, History, and the
+  script transcript move into a bottom sheet opened from the status bar, so
+  preview and tracks — the two you need at once — stay stacked and both usable.
+- **Track headers** narrow to 132px and drop the reorder grip (HTML5 drag
+  doesn't fire from touch) and the type glyph (the V1 / A1 chip already carries
+  the type). The control row scrolls: an audio track has six toggles and the
+  header fits four.
+- **Toolbar** buttons go icon-only on a 44px row.
+
+Touch gestures, since a phone has no right-click, no hover, and no Ctrl+wheel:
+
+| Gesture | Effect |
+| --- | --- |
+| Long press a clip | Clip menu (split, duplicate, lock, replace, delete) |
+| Long press empty lane | Lane menu (add text, add generated clip) |
+| Drag a clip | Move it, across tracks included |
+| Drag a clip edge | Trim (22px hit area, 8px visible grip) |
+| Drag empty lane | Scroll the timeline — marquee select is mouse-only |
+| Two-finger pinch | Zoom, anchored between the fingers |
+| Drag the divider | Resize the tracks panel |
+
+Long press is `useLongPress`, which composes with the existing pointer handlers
+rather than replacing them, so a hold and a drag can share one element.
+
 ## Asset Drag-and-Drop
 
 ### From AssetExplorer → TrackLane (supported)

--- a/web/src/components/timeline/TimelineEditor.tsx
+++ b/web/src/components/timeline/TimelineEditor.tsx
@@ -6,9 +6,16 @@
  *   TopBar (48 px)
  *   ─── resizable split ─────────────────────────
  *   FlexRow: PreviewArea (55 %) | InspectorArea (45 %)
- *   ─── horizontal drag handle (mouse + keyboard resizable) ────
+ *   ─── horizontal drag handle (pointer + keyboard resizable) ────
  *   TracksArea (user-resizable, default 240 px)
  *   BottomStatusBar (32 px)
+ *
+ * On phones there is no room for three columns: the transcript and inspector
+ * leave the row entirely and the preview takes the full width, so preview and
+ * tracks — the two surfaces you need simultaneously to edit — stay stacked and
+ * both usable. Inspector / Assistant / History / Script move into a bottom
+ * sheet opened from the status bar, mirroring how mobile video editors slide
+ * property panels over the timeline.
  *
  * Loading: shows LoadingSpinner centred in the preview region.
  * Not-found / error: shows EmptyState in the preview only; route and editor
@@ -30,13 +37,17 @@ import {
   FlexColumn,
   FlexRow,
   LoadingSpinner,
+  MobileBottomSheet,
   ProgressBar,
   TabGroup,
   Text,
+  ToolbarIconButton,
+  BORDER_RADIUS,
   MOTION
 } from "../ui_primitives";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import HistoryOutlinedIcon from "@mui/icons-material/HistoryOutlined";
+import SubtitlesOutlinedIcon from "@mui/icons-material/SubtitlesOutlined";
 import TuneOutlinedIcon from "@mui/icons-material/TuneOutlined";
 
 import { TopBar } from "./TopBar";
@@ -70,8 +81,11 @@ import { useLoadTimelineIntoStore } from "../../hooks/timeline/useLoadTimelineIn
 import { useTimelineAutosave } from "../../hooks/timeline/useTimelineAutosave";
 import { useTimelineSave } from "../../hooks/timeline/useTimelineSave";
 import { useTimelineExport } from "../../hooks/timeline/useTimelineExport";
+import { useTimelineIsMobile } from "../../hooks/timeline/useTimelineIsMobile";
 
 const HANDLE_HEIGHT_PX = 6;
+/** Phone drag handle — 6px is under any reasonable touch target. */
+const TOUCH_HANDLE_HEIGHT_PX = 20;
 const DEFAULT_TRACKS_HEIGHT_PX = 240;
 const MIN_TRACKS_HEIGHT_PX = 80;
 const MAX_TRACKS_HEIGHT_PX = 600;
@@ -115,14 +129,36 @@ const inspectorRegionStyles = (theme: Theme) =>
     justifyContent: "flex-start"
   });
 
-const dragHandleStyles = (theme: Theme) =>
+const dragHandleStyles = (theme: Theme, tall: boolean) =>
   css({
-    height: HANDLE_HEIGHT_PX,
+    height: tall ? TOUCH_HANDLE_HEIGHT_PX : HANDLE_HEIGHT_PX,
     cursor: "ns-resize",
     flexShrink: 0,
     backgroundColor: theme.vars.palette.divider,
     transition: MOTION.background,
     outline: "none",
+    // The handle is a drag target, not a scroll surface: without this a touch
+    // drag scrolls the page instead of resizing (and the pointermove stream
+    // ends in a pointercancel).
+    touchAction: "none",
+    // Grip affordance — a bare 6px line reads as a border, not a control.
+    ...(tall
+      ? {
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: theme.vars.palette.background.paper,
+          borderTop: `1px solid ${theme.vars.palette.divider}`,
+          borderBottom: `1px solid ${theme.vars.palette.divider}`,
+          "&::after": {
+            content: '""',
+            width: 36,
+            height: 3,
+            borderRadius: BORDER_RADIUS.sm,
+            backgroundColor: theme.vars.palette.text.disabled
+          }
+        }
+      : null),
     "&:hover, &.dragging": {
       backgroundColor: theme.vars.palette.primary.main
     },
@@ -156,13 +192,16 @@ const PreviewRegion: React.FC<{
   onCreateNewSequence?: () => void;
   createSequencePending?: boolean;
   createSequenceErrorMessage?: string | null;
+  /** Phone layout: the preview owns the whole row, no inspector beside it. */
+  fullWidth?: boolean;
 }> = memo(({
   isLoading,
   sequenceUnavailable,
   onRetryFetch,
   onCreateNewSequence,
   createSequencePending,
-  createSequenceErrorMessage
+  createSequenceErrorMessage,
+  fullWidth = false
 }) => {
   const theme = useTheme();
   // Canvas size + fps come from the store — the single source of truth the
@@ -175,7 +214,11 @@ const PreviewRegion: React.FC<{
     <FlexColumn
       css={previewRegionStyles(theme)}
       fullHeight
-      sx={{ flex: "0 1 55%", minWidth: 0, minHeight: 0, width: 0 }}
+      sx={
+        fullWidth
+          ? { flex: "1 1 auto", minWidth: 0, minHeight: 0, borderRight: "none" }
+          : { flex: "0 1 55%", minWidth: 0, minHeight: 0, width: 0 }
+      }
     >
       {isLoading ? (
         <LoadingSpinner text="Loading sequence…" />
@@ -233,21 +276,26 @@ const PreviewRegion: React.FC<{
 });
 PreviewRegion.displayName = "PreviewRegion";
 
-type InspectorTab = "inspector" | "agent" | "history";
+type InspectorTab = "inspector" | "agent" | "history" | "script";
+
+const INSPECTOR_TABS = [
+  { value: "inspector", label: "Inspector", icon: <TuneOutlinedIcon /> },
+  { value: "agent", label: "Assistant", icon: <AutoAwesomeIcon /> },
+  { value: "history", label: "History", icon: <HistoryOutlinedIcon /> }
+];
+
+const SCRIPT_TAB = {
+  value: "script",
+  label: "Script",
+  icon: <SubtitlesOutlinedIcon />
+};
 
 const InspectorRegion: React.FC<{ sequenceId: string | undefined }> = memo(
   ({ sequenceId }) => {
   const theme = useTheme();
   const [tab, setTab] = useState<InspectorTab>("inspector");
 
-  const tabs = useMemo(
-    () => [
-      { value: "inspector", label: "Inspector", icon: <TuneOutlinedIcon /> },
-      { value: "agent", label: "Assistant", icon: <AutoAwesomeIcon /> },
-      { value: "history", label: "History", icon: <HistoryOutlinedIcon /> }
-    ],
-    []
-  );
+  const tabs = INSPECTOR_TABS;
 
   return (
     <FlexColumn
@@ -300,13 +348,77 @@ const TranscriptRegion: React.FC = memo(() => {
 TranscriptRegion.displayName = "TranscriptRegion";
 
 /**
+ * Phone-only bottom sheet holding the panels that don't fit beside the
+ * preview: Inspector, Assistant, History, and the Script transcript when the
+ * sequence has one. Opened from the status bar; the tabs sit in the sheet
+ * header so switching panels never costs a close/reopen.
+ *
+ * `MobileBottomSheet` unmounts its content on close (`keepMounted: false`), so
+ * the tab choice is held here — reopening lands where the user left off.
+ */
+const MobilePanelSheet: React.FC<{
+  open: boolean;
+  onClose: () => void;
+  sequenceId: string | undefined;
+  tab: InspectorTab;
+  onTabChange: (tab: InspectorTab) => void;
+}> = memo(({ open, onClose, sequenceId, tab, onTabChange }) => {
+  const hasScript = useHasScript();
+  const tabs = useMemo(
+    () => (hasScript ? [...INSPECTOR_TABS, SCRIPT_TAB] : INSPECTOR_TABS),
+    [hasScript]
+  );
+
+  // A sequence can lose its script while the Script tab is showing.
+  const activeTab = tab === "script" && !hasScript ? "inspector" : tab;
+
+  const tabRail = (
+    <TabGroup
+      tabs={tabs}
+      value={activeTab}
+      onChange={(value) => onTabChange(value as InspectorTab)}
+      size="small"
+      fullWidth
+    />
+  );
+
+  return (
+    <MobileBottomSheet
+      open={open}
+      onClose={onClose}
+      headerExtras={tabRail}
+      // Short enough that the preview stays visible above it — you adjust a
+      // clip's transform or colour by watching the frame, not the form.
+      maxHeight="62vh"
+      showDragHandle
+      showClose={false}
+      ariaLabel="Timeline panels"
+    >
+      <FlexColumn fullWidth sx={{ height: "52vh", minHeight: 0 }}>
+        {activeTab === "inspector" ? (
+          <TimelineInspector />
+        ) : activeTab === "agent" ? (
+          <TimelineAgentPanel />
+        ) : activeTab === "script" ? (
+          <TranscriptPanel />
+        ) : (
+          <TimelineVersionHistoryPanel sequenceId={sequenceId} />
+        )}
+      </FlexColumn>
+    </MobileBottomSheet>
+  );
+});
+MobilePanelSheet.displayName = "MobilePanelSheet";
+
+/**
  * Zoom + generation-count status bar, isolated from the editor shell.
  *
  * Subscribes to `msPerPx` (changes per zoom tick) and the generation counts
  * (change per WebSocket progress message) itself, so those high-frequency
  * updates re-render only this leaf instead of the whole `TimelineEditorBody`.
  */
-const TimelineStatusBar: React.FC = memo(() => {
+const TimelineStatusBar: React.FC<{ actionSlot?: React.ReactNode }> = memo(
+  ({ actionSlot }) => {
   const msPerPx = useTimelineUIStore((s) => s.msPerPx);
   const setZoom = useTimelineUIStore((s) => s.setZoom);
   // Convert msPerPx to a dimensionless ratio for ZoomControls (1 = default zoom)
@@ -326,9 +438,11 @@ const TimelineStatusBar: React.FC = memo(() => {
       onZoomChange={handleZoomChange}
       generatingCount={generatingCount}
       failedCount={failedCount}
+      actionSlot={actionSlot}
     />
   );
-});
+  }
+);
 TimelineStatusBar.displayName = "TimelineStatusBar";
 
 interface TimelineEditorProps {
@@ -355,6 +469,14 @@ const TimelineEditorBody: React.FC<
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const theme = useTheme();
+  const isMobile = useTimelineIsMobile();
+
+  // Phone panel sheet (Inspector / Assistant / History / Script).
+  const [panelSheetOpen, setPanelSheetOpen] = useState(false);
+  const [panelTab, setPanelTab] = useState<InspectorTab>("inspector");
+  const openPanelSheet = useCallback(() => setPanelSheetOpen(true), []);
+  const closePanelSheet = useCallback(() => setPanelSheetOpen(false), []);
+  const hasSelection = useTimelineUIStore((s) => s.selectedClipIds.size > 0);
 
   // Register the ui_timeline_* agent tools against this instance, addressable
   // by sequence id whether or not this editor is the focused surface.
@@ -423,22 +545,28 @@ const TimelineEditorBody: React.FC<
   const pendingHeightRef = useRef<number | null>(null);
   const resizeRafIdRef = useRef<number | null>(null);
 
-  /** Begin mouse drag — capture start position and activate drag state. */
-  const handleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    dragStartYRef.current = e.clientY;
-    dragStartHeightRef.current = tracksHeight;
-    setIsDragging(true);
-  }, [tracksHeight]);
+  /** Begin drag — capture start position and activate drag state. */
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      dragStartYRef.current = e.clientY;
+      dragStartHeightRef.current = tracksHeight;
+      setIsDragging(true);
+    },
+    [tracksHeight]
+  );
 
   /**
-   * Register / unregister window-level mouse listeners for the duration of a
+   * Register / unregister window-level pointer listeners for the duration of a
    * drag. Cleanup runs on unmount, preventing listener leaks if the user
    * navigates away mid-drag.
    *
-   * `onMouseMove` fires far more often than the display refreshes, so it only
+   * Pointer events (not mouse) so the handle drags under touch as well as a
+   * mouse; `pointercancel` ends the drag when the OS takes the gesture over.
+   *
+   * `pointermove` fires far more often than the display refreshes, so it only
    * records the latest height in a ref and schedules at most one
-   * `setTracksHeight` per animation frame — otherwise every mousemove tick
+   * `setTracksHeight` per animation frame — otherwise every move tick
    * re-rendered the whole shell.
    */
   useEffect(() => {
@@ -458,7 +586,7 @@ const TimelineEditorBody: React.FC<
       }
     };
 
-    const onMouseMove = (ev: MouseEvent) => {
+    const onPointerMove = (ev: PointerEvent) => {
       const deltaY = dragStartYRef.current - ev.clientY; // drag up → taller
       pendingHeightRef.current = Math.min(
         MAX_TRACKS_HEIGHT_PX,
@@ -469,7 +597,7 @@ const TimelineEditorBody: React.FC<
       }
     };
 
-    const onMouseUp = () => {
+    const onPointerUp = () => {
       if (resizeRafIdRef.current !== null) {
         cancelAnimationFrame(resizeRafIdRef.current);
         resizeRafIdRef.current = null;
@@ -483,16 +611,18 @@ const TimelineEditorBody: React.FC<
       setIsDragging(false);
     };
 
-    window.addEventListener("mousemove", onMouseMove);
-    window.addEventListener("mouseup", onMouseUp);
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("pointercancel", onPointerUp);
 
     return () => {
       if (resizeRafIdRef.current !== null) {
         cancelAnimationFrame(resizeRafIdRef.current);
         resizeRafIdRef.current = null;
       }
-      window.removeEventListener("mousemove", onMouseMove);
-      window.removeEventListener("mouseup", onMouseUp);
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerUp);
       document.body.style.userSelect = "";
       handleEl?.classList.remove("dragging");
     };
@@ -610,7 +740,7 @@ const TimelineEditorBody: React.FC<
         css={middleAreaStyles(theme)}
         sx={{ flex: "1 1 0", minHeight: 0, overflow: "hidden" }}
       >
-        <TranscriptRegion />
+        {!isMobile && <TranscriptRegion />}
         <PreviewRegion
           isLoading={isLoading}
           sequenceUnavailable={sequenceUnavailable}
@@ -620,11 +750,12 @@ const TimelineEditorBody: React.FC<
           }
           createSequencePending={createTimeline.isPending}
           createSequenceErrorMessage={createErrorMessage}
+          fullWidth={isMobile}
         />
-        <InspectorRegion sequenceId={sequenceId} />
+        {!isMobile && <InspectorRegion sequenceId={sequenceId} />}
       </FlexRow>
 
-      {/* ── Horizontal drag handle (mouse + keyboard resizable) ───── */}
+      {/* ── Horizontal drag handle (pointer + keyboard resizable) ─── */}
       <div
         ref={handleRef}
         role="separator"
@@ -634,8 +765,8 @@ const TimelineEditorBody: React.FC<
         aria-valuemin={MIN_TRACKS_HEIGHT_PX}
         aria-valuemax={MAX_TRACKS_HEIGHT_PX}
         tabIndex={0}
-        css={dragHandleStyles(theme)}
-        onMouseDown={handleMouseDown}
+        css={dragHandleStyles(theme, isMobile)}
+        onPointerDown={handlePointerDown}
         onKeyDown={handleKeyDown}
       />
 
@@ -643,7 +774,34 @@ const TimelineEditorBody: React.FC<
       <TracksRegion heightPx={tracksHeight} />
 
       {/* ── Bottom status bar ─────────────────────────────────────── */}
-      <TimelineStatusBar />
+      <TimelineStatusBar
+        actionSlot={
+          isMobile ? (
+            <ToolbarIconButton
+              onClick={openPanelSheet}
+              tooltip="Panels"
+              aria-label="Open panels"
+              // Tinted while a clip is selected: that's when the Inspector has
+              // something to show, and it's the only hint on a phone that
+              // tapping a clip led somewhere.
+              sx={{ color: hasSelection ? "primary.main" : undefined }}
+            >
+              <TuneOutlinedIcon fontSize="small" />
+            </ToolbarIconButton>
+          ) : undefined
+        }
+      />
+
+      {/* ── Phone panel sheet ─────────────────────────────────────── */}
+      {isMobile && (
+        <MobilePanelSheet
+          open={panelSheetOpen}
+          onClose={closePanelSheet}
+          sequenceId={sequenceId}
+          tab={panelTab}
+          onTabChange={setPanelTab}
+        />
+      )}
 
       {/* ── Project settings dialog (canvas size + fps) ───────────── */}
       <ProjectSettingsDialog

--- a/web/src/components/timeline/ToolToggle.tsx
+++ b/web/src/components/timeline/ToolToggle.tsx
@@ -32,13 +32,15 @@ const PointerIcon: React.FC = () => (
   </svg>
 );
 
-const buttonStyles = (theme: Theme, active: boolean) =>
+const buttonStyles = (theme: Theme, active: boolean, compact: boolean) =>
   css({
     display: "inline-flex",
     alignItems: "center",
+    justifyContent: "center",
     gap: 6,
-    height: 24,
-    padding: theme.spacing(0, 3, 0, 2),
+    height: compact ? 28 : 24,
+    minWidth: compact ? 28 : undefined,
+    padding: compact ? 0 : theme.spacing(0, 3, 0, 2),
     background: active ? theme.vars.palette.action.selected : "transparent",
     border: `1px solid ${active ? theme.vars.palette.divider : "transparent"}`,
     color: active
@@ -63,7 +65,7 @@ const buttonStyles = (theme: Theme, active: boolean) =>
       borderColor: theme.vars.palette.primary.main
     },
     "& svg": {
-      fontSize: 14
+      fontSize: compact ? 16 : 14
     }
   });
 
@@ -71,6 +73,7 @@ interface ToolButtonProps {
   label: string;
   shortcut: string;
   active: boolean;
+  compact: boolean;
   onClick: () => void;
   children: React.ReactNode;
 }
@@ -79,6 +82,7 @@ const ToolButton: React.FC<ToolButtonProps> = ({
   label,
   shortcut,
   active,
+  compact,
   onClick,
   children
 }) => {
@@ -87,19 +91,24 @@ const ToolButton: React.FC<ToolButtonProps> = ({
     <Tooltip title={`${label} (${shortcut})`}>
       <button
         type="button"
-        css={buttonStyles(theme, active)}
+        css={buttonStyles(theme, active, compact)}
         onClick={onClick}
         aria-label={label}
         aria-pressed={active}
       >
         {children}
-        <span>{label}</span>
+        {!compact && <span>{label}</span>}
       </button>
     </Tooltip>
   );
 };
 
-export const ToolToggle: React.FC = memo(() => {
+export interface ToolToggleProps {
+  /** Phone toolbar: icon-only buttons on a 28px touch target. */
+  compact?: boolean;
+}
+
+export const ToolToggle: React.FC<ToolToggleProps> = memo(({ compact = false }) => {
   const activeTool = useTimelineUIStore((s) => s.activeTool);
   const setActiveTool = useTimelineUIStore((s) => s.setActiveTool);
   return (
@@ -108,6 +117,7 @@ export const ToolToggle: React.FC = memo(() => {
         label="Select"
         shortcut="V"
         active={activeTool === "select"}
+        compact={compact}
         onClick={() => setActiveTool("select")}
       >
         <PointerIcon />
@@ -116,6 +126,7 @@ export const ToolToggle: React.FC = memo(() => {
         label="Cut"
         shortcut="C"
         active={activeTool === "cut"}
+        compact={compact}
         onClick={() => setActiveTool("cut")}
       >
         <ContentCutOutlinedIcon />

--- a/web/src/components/timeline/TopBar.tsx
+++ b/web/src/components/timeline/TopBar.tsx
@@ -5,26 +5,44 @@
  * A single generation prompt bar (model + output settings + Generate) that
  * grows to fill, with Save / Export and an activity slot on the right. The
  * project name lives in the workspace tab, so it isn't repeated here.
+ *
+ * On phones the four labelled actions won't fit beside the prompt, so they
+ * collapse into one overflow menu and the prompt takes the width it needs
+ * (see `TopBarPrompt`'s `compact` layout).
  */
 
-import React, { memo } from "react";
+import React, { memo, useCallback, useState } from "react";
 import { useTheme } from "@mui/material/styles";
 import { css } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
-import { FlexRow, EditorButton } from "../ui_primitives";
+import {
+  FlexRow,
+  EditorButton,
+  EditorMenu,
+  MenuItemPrimitive,
+  ToolbarIconButton,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
 import SaveIcon from "@mui/icons-material/Save";
 import TuneIcon from "@mui/icons-material/Tune";
 import VideoLibraryOutlinedIcon from "@mui/icons-material/VideoLibraryOutlined";
 
 import { TopBarPrompt } from "./TopBarPrompt";
+import { useTimelineIsMobile } from "../../hooks/timeline/useTimelineIsMobile";
 
-const styles = (theme: Theme) =>
+const styles = (theme: Theme, compact: boolean) =>
   css({
-    height: 48,
+    // Phones need two rows for the prompt + chip rail; let the bar size to it.
+    height: compact ? "auto" : 48,
+    minHeight: compact ? 48 : undefined,
     borderBottom: `1px solid ${theme.vars.palette.divider}`,
     backgroundColor: theme.vars.palette.background.paper,
-    padding: `0 ${theme.spacing(1.5)}`,
+    padding: compact
+      ? `${getSpacingPx(SPACING.sm)} ${getSpacingPx(SPACING.md)}`
+      : `0 ${theme.spacing(1.5)}`,
     flexShrink: 0
   });
 
@@ -60,9 +78,90 @@ export const TopBar: React.FC<TopBarProps> = memo(
     activitySlot
   }) => {
     const theme = useTheme();
+    const isMobile = useTimelineIsMobile();
+    const [overflowAnchor, setOverflowAnchor] = useState<HTMLElement | null>(
+      null
+    );
+    const closeOverflow = useCallback(() => setOverflowAnchor(null), []);
+
+    // "Save as Asset" anchors a folder popover to whatever element was clicked.
+    // From the overflow menu that element is the menu item, which unmounts on
+    // close — so anchor the popover to the overflow button instead.
+    const overflowButtonRef = React.useRef<HTMLButtonElement>(null);
+    const runFromMenu = useCallback(
+      (action: () => void) => () => {
+        closeOverflow();
+        action();
+      },
+      [closeOverflow]
+    );
+
+    if (isMobile) {
+      const hasActions =
+        !!onOpenSettings || !!onSave || !!onSaveToAssets || !!onExportVideo;
+      return (
+        <FlexRow align="flex-start" gap={SPACING.sm} fullWidth css={styles(theme, true)}>
+          <TopBarPrompt compact />
+          {activitySlot}
+          {hasActions && (
+            <>
+              <ToolbarIconButton
+                ref={overflowButtonRef}
+                onClick={(e) => setOverflowAnchor(e.currentTarget)}
+                tooltip="More actions"
+                aria-label="More actions"
+                sx={{ flexShrink: 0 }}
+              >
+                <MoreVertIcon fontSize="small" />
+              </ToolbarIconButton>
+              <EditorMenu
+                anchorEl={overflowAnchor}
+                open={!!overflowAnchor}
+                onClose={closeOverflow}
+              >
+                {onOpenSettings && (
+                  <MenuItemPrimitive
+                    icon={<TuneIcon fontSize="small" />}
+                    label="Project settings"
+                    onClick={runFromMenu(onOpenSettings)}
+                  />
+                )}
+                {onSave && (
+                  <MenuItemPrimitive
+                    icon={<SaveIcon fontSize="small" />}
+                    label={isSaving ? "Saving…" : "Save"}
+                    disabled={isSaving}
+                    onClick={runFromMenu(onSave)}
+                  />
+                )}
+                {onSaveToAssets && (
+                  <MenuItemPrimitive
+                    icon={<VideoLibraryOutlinedIcon fontSize="small" />}
+                    label="Save as Asset"
+                    disabled={isExporting}
+                    onClick={runFromMenu(() => {
+                      const anchor = overflowButtonRef.current;
+                      if (anchor) onSaveToAssets(anchor);
+                    })}
+                  />
+                )}
+                {onExportVideo && (
+                  <MenuItemPrimitive
+                    icon={<FileDownloadIcon fontSize="small" />}
+                    label={isExporting ? "Exporting…" : "Export video"}
+                    disabled={isExporting}
+                    onClick={runFromMenu(onExportVideo)}
+                  />
+                )}
+              </EditorMenu>
+            </>
+          )}
+        </FlexRow>
+      );
+    }
 
     return (
-      <FlexRow align="center" gap={1} fullWidth css={styles(theme)}>
+      <FlexRow align="center" gap={1} fullWidth css={styles(theme, false)}>
         {/* Quick-prompt generation bar — grows to fill */}
         <TopBarPrompt />
 

--- a/web/src/components/timeline/TopBarPrompt.tsx
+++ b/web/src/components/timeline/TopBarPrompt.tsx
@@ -11,6 +11,10 @@
  * chips, then the primary Generate action. The model / duration / resolution /
  * aspect controls are the shared `MediaControlChip` + option menus, so options
  * track the selected model's manifest.
+ *
+ * On phones (`compact`) that one row is 600px of content in 390px of viewport,
+ * so it wraps into two: prompt + Generate on top, the setting chips below in a
+ * horizontally scrollable rail.
  */
 
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -28,10 +32,12 @@ import { useTimelineDirectGenJob } from "../../hooks/timeline/useTimelineDirectG
 import { useLastDirectGenModel } from "../../hooks/timeline/useLastDirectGenModel";
 import {
   EditorButton,
+  FlexColumn,
   FlexRow,
   LoadingSpinner,
   TextInput,
-  Toast
+  Toast,
+  SPACING
 } from "../ui_primitives";
 import MediaControlChip from "../chat/composer/MediaControlChip";
 import MediaOptionMenu from "../chat/composer/MediaOptionMenu";
@@ -66,7 +72,12 @@ function pickOrCreateVideoTrack(): string | undefined {
   return video.id;
 }
 
-export const TopBarPrompt: React.FC = memo(() => {
+export interface TopBarPromptProps {
+  /** Phone layout: prompt + Generate on one row, setting chips on a second. */
+  compact?: boolean;
+}
+
+export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false }) => {
   const theme = useTheme();
   const [prompt, setPrompt] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -192,44 +203,71 @@ export const TopBarPrompt: React.FC = memo(() => {
     setVideoModelOpen(false);
   }, []);
 
-  return (
-    <>
-      <FlexRow
-        gap={1}
-        align="center"
-        data-testid="topbar-prompt"
-        sx={{ flex: 1, minWidth: 0 }}
-      >
-        <TextInput
-          value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder="Generate a video at the playhead…"
-          compact
-          fullWidth
-          disabled={busy}
-          inputProps={{
-            "aria-label": "Quick text-to-video prompt",
-            "data-testid": "topbar-prompt-input"
-          }}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <AutoAwesomeIcon
-                  fontSize="small"
-                  sx={{ mr: 0.5, color: theme.vars.palette.primary.main }}
-                />
-              )
-            }
-          }}
-          sx={{
-            flex: 1,
-            minWidth: 160,
-            "& .MuiOutlinedInput-root": { height: 34 }
-          }}
-        />
+  const promptField = (
+    <TextInput
+      value={prompt}
+      onChange={(e) => setPrompt(e.target.value)}
+      onKeyDown={handleKeyDown}
+      placeholder={
+        compact ? "Generate a video…" : "Generate a video at the playhead…"
+      }
+      compact
+      fullWidth
+      disabled={busy}
+      inputProps={{
+        "aria-label": "Quick text-to-video prompt",
+        "data-testid": "topbar-prompt-input"
+      }}
+      slotProps={{
+        input: {
+          startAdornment: (
+            <AutoAwesomeIcon
+              fontSize="small"
+              sx={{ mr: 0.5, color: theme.vars.palette.primary.main }}
+            />
+          )
+        }
+      }}
+      sx={{
+        flex: 1,
+        minWidth: compact ? 0 : 160,
+        "& .MuiOutlinedInput-root": { height: 34 }
+      }}
+    />
+  );
 
-        <MediaControlChip
+  const generateButton = (
+    <EditorButton
+      variant="contained"
+      size="small"
+      disabled={!canSubmit}
+      onClick={() => void handleSubmit()}
+      startIcon={
+        busy ? (
+          <LoadingSpinner inline size={14} color="inherit" />
+        ) : (
+          <AutoAwesomeIcon fontSize="small" />
+        )
+      }
+      data-testid="topbar-generate"
+      // Icon-only on phones: the label costs ~70px the prompt needs, and the
+      // sparkle plus the field's placeholder already say what it does.
+      aria-label="Generate video"
+      sx={{
+        flexShrink: 0,
+        height: 34,
+        ...(compact
+          ? { minWidth: 44, px: 1, "& .MuiButton-startIcon": { m: 0 } }
+          : null)
+      }}
+    >
+      {compact ? null : "Generate"}
+    </EditorButton>
+  );
+
+  const settingChips = (
+    <>
+      <MediaControlChip
           ref={videoModelAnchorRef}
           icon={<MovieIcon fontSize="small" />}
           label={selectedModel?.name || "Select Model"}
@@ -295,27 +333,57 @@ export const TopBarPrompt: React.FC = memo(() => {
           onClose={() => setAspectAnchor(null)}
           value={aspect}
           options={aspectOptions}
-          onChange={(v) => setAspect(v)}
-        />
+        onChange={(v) => setAspect(v)}
+      />
+    </>
+  );
 
-        <EditorButton
-          variant="contained"
-          size="small"
-          disabled={!canSubmit}
-          onClick={() => void handleSubmit()}
-          startIcon={
-            busy ? (
-              <LoadingSpinner inline size={14} color="inherit" />
-            ) : (
-              <AutoAwesomeIcon fontSize="small" />
-            )
-          }
-          data-testid="topbar-generate"
-          sx={{ flexShrink: 0, height: 34 }}
+  return (
+    <>
+      {compact ? (
+        <FlexColumn
+          gap={SPACING.xs}
+          data-testid="topbar-prompt"
+          sx={{ flex: 1, minWidth: 0 }}
         >
-          Generate
-        </EditorButton>
-      </FlexRow>
+          <FlexRow gap={SPACING.sm} align="center" sx={{ minWidth: 0 }}>
+            {promptField}
+            {generateButton}
+          </FlexRow>
+          {/* Chip rail — scrolls horizontally rather than wrapping, so the bar
+              keeps a predictable two-row height whatever the model name is. */}
+          <FlexRow
+            gap={SPACING.sm}
+            align="center"
+            sx={{
+              minWidth: 0,
+              overflowX: "auto",
+              overflowY: "hidden",
+              pb: SPACING.micro,
+              scrollbarWidth: "none",
+              "&::-webkit-scrollbar": { display: "none" },
+              // The chips set `flexShrink: 1` themselves when truncating; in a
+              // scrolling rail that squeezes the model name down to "Selec…"
+              // instead of letting the rail scroll. Element selector so this
+              // outranks the chip's own single-class rule.
+              "& > button": { flexShrink: 0 }
+            }}
+          >
+            {settingChips}
+          </FlexRow>
+        </FlexColumn>
+      ) : (
+        <FlexRow
+          gap={1}
+          align="center"
+          data-testid="topbar-prompt"
+          sx={{ flex: 1, minWidth: 0 }}
+        >
+          {promptField}
+          {settingChips}
+          {generateButton}
+        </FlexRow>
+      )}
       <Toast
         open={error !== null}
         message={error ?? ""}

--- a/web/src/components/timeline/Tracks/AddTrackButton.tsx
+++ b/web/src/components/timeline/Tracks/AddTrackButton.tsx
@@ -22,13 +22,15 @@ import type { TimelineTrack } from "@nodetool-ai/timeline";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { Popover, MenuItemPrimitive, MOTION, BORDER_RADIUS } from "../../ui_primitives";
 
-const buttonStyles = (theme: Theme) =>
+const buttonStyles = (theme: Theme, compact: boolean) =>
   css({
     display: "inline-flex",
     alignItems: "center",
+    justifyContent: "center",
     gap: 6,
-    height: 24,
-    padding: theme.spacing(0, 3, 0, 2),
+    height: compact ? 28 : 24,
+    minWidth: compact ? 28 : undefined,
+    padding: compact ? 0 : theme.spacing(0, 3, 0, 2),
     background: "transparent",
     border: "1px solid transparent",
     color: theme.vars.palette.text.secondary,
@@ -45,7 +47,7 @@ const buttonStyles = (theme: Theme) =>
       borderColor: theme.vars.palette.divider
     },
     "& svg": {
-      fontSize: 14
+      fontSize: compact ? 18 : 14
     }
   });
 
@@ -78,7 +80,12 @@ const TRACK_TYPES: TrackTypeOption[] = [
   }
 ];
 
-export const AddTrackButton: React.FC = memo(() => {
+export interface AddTrackButtonProps {
+  /** Phone toolbar: drop the "Track" label, keep the icon and a 28px target. */
+  compact?: boolean;
+}
+
+export const AddTrackButton: React.FC<AddTrackButtonProps> = memo(({ compact = false }) => {
   const theme = useTheme();
   const addTrack = useTimelineStore((s) => s.addTrack);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -103,14 +110,15 @@ export const AddTrackButton: React.FC = memo(() => {
     <>
       <button
         type="button"
-        css={buttonStyles(theme)}
+        css={buttonStyles(theme, compact)}
         onClick={handleOpen}
         aria-label="Add track"
+        title="Add track"
         aria-haspopup="menu"
         data-testid="add-track-button"
       >
         <AddIcon />
-        <span>Track</span>
+        {!compact && <span>Track</span>}
       </button>
       <Popover
         open={Boolean(anchorEl)}

--- a/web/src/components/timeline/Tracks/Clip.tsx
+++ b/web/src/components/timeline/Tracks/Clip.tsx
@@ -43,6 +43,8 @@ import {
   useIsClipSelected
 } from "../../../stores/timeline/TimelineUIStore";
 import { useTimelinePlaybackStore } from "../../../stores/timeline/TimelinePlaybackStore";
+import { useLongPress } from "../../../hooks/timeline/useLongPress";
+import type { LongPressPoint } from "../../../hooks/timeline/useLongPress";
 import useWorkflowRunsStore from "../../../stores/WorkflowRunsStore";
 import { useAssetStore } from "../../../stores/AssetStore";
 import { getAssetUrl } from "../../../utils/assetHelpers";
@@ -90,6 +92,8 @@ function isClipCompatibleWithTrack(
 }
 
 const TRIM_HANDLE_WIDTH_PX = 8;
+/** Hit area for the same grip under a finger; the visible width stays 8px. */
+const TOUCH_TRIM_HANDLE_WIDTH_PX = 22;
 const MIN_CLIP_WIDTH_PX = 4;
 const CLIP_RADIUS_PX = parseFloat(BORDER_RADIUS.md);
 /** Width below which we suppress secondary chrome (duration label). */
@@ -381,7 +385,21 @@ const trimHandleStyles = (edge: "start" | "end", locked: boolean) =>
     "&:hover": {
       backgroundColor: locked ? undefined : "var(--palette-c_overlay_strong)"
     },
-    zIndex: Z_INDEX.base + 2
+    zIndex: Z_INDEX.base + 2,
+    // A fingertip covers far more than 8px. Widen the hit area on touch
+    // without widening the visible grip, via a transparent inset overlay —
+    // otherwise trimming a clip on a phone means repeatedly missing the
+    // handle and dragging the clip instead.
+    "@media (pointer: coarse)": {
+      "&::after": {
+        content: '""',
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        [edge === "start" ? "left" : "right"]: 0,
+        width: TOUCH_TRIM_HANDLE_WIDTH_PX
+      }
+    }
   });
 
 const statusBadgeStyles = css({
@@ -557,6 +575,20 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
   const dragStartMsRef = useRef(0);
   const isDraggingRef = useRef(false);
 
+  const [contextMenuPos, setContextMenuPos] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+
+  // Touch equivalent of right-clicking the clip. Every clip action a phone can
+  // reach — split, duplicate, delete, replace — lives in that menu, and a hold
+  // doesn't produce a `contextmenu` event on touch.
+  const clipLongPress = useLongPress(
+    useCallback((point: LongPressPoint) => {
+      setContextMenuPos({ x: point.clientX, y: point.clientY });
+    }, [])
+  );
+
   const handleDragPointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (!clip || clip.locked) {
@@ -586,6 +618,7 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       dragStartXRef.current = e.clientX;
       dragStartMsRef.current = clip.startMs;
       isDraggingRef.current = false;
+      clipLongPress.start(e);
       history.begin();
 
       // Snapshot the snap candidates ONCE at gesture start. The set of clip
@@ -653,6 +686,7 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       };
 
       const onMove = (ev: PointerEvent) => {
+        clipLongPress.move(ev);
         if (ev.buttons !== 1) return;
         const freshClip = useTimelineStore
           .getState()
@@ -706,6 +740,7 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       };
 
       const onUpOrCancel = () => {
+        clipLongPress.cancel();
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onUpOrCancel);
         window.removeEventListener("pointercancel", onUpOrCancel);
@@ -733,6 +768,7 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
     [
       clip,
       activeTool,
+      clipLongPress,
       msPerPx,
       splitClipAtTime,
       clipId,
@@ -741,11 +777,6 @@ export const Clip: React.FC<ClipProps> = memo(({ clipId }) => {
       history
     ]
   );
-
-  const [contextMenuPos, setContextMenuPos] = useState<{
-    x: number;
-    y: number;
-  } | null>(null);
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {

--- a/web/src/components/timeline/Tracks/ScriptLane.tsx
+++ b/web/src/components/timeline/Tracks/ScriptLane.tsx
@@ -24,7 +24,7 @@ import {
   isTranscriptClip,
   type TranscriptSegment
 } from "../../../stores/timeline/transcriptOps";
-import { TRACK_HEADER_WIDTH_PX } from "./TrackHeader";
+import { trackHeaderWidthCss } from "./TrackHeader";
 
 export const SCRIPT_LANE_HEIGHT_PX = 46;
 
@@ -98,7 +98,7 @@ const PauseChip = styled("div")(({ theme }) => ({
 }));
 
 const HeaderCell = styled("div")(({ theme }) => ({
-  width: TRACK_HEADER_WIDTH_PX,
+  width: trackHeaderWidthCss,
   height: SCRIPT_LANE_HEIGHT_PX,
   flexShrink: 0,
   display: "flex",

--- a/web/src/components/timeline/Tracks/ScriptToggleButton.tsx
+++ b/web/src/components/timeline/Tracks/ScriptToggleButton.tsx
@@ -19,18 +19,21 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import AddIcon from "@mui/icons-material/Add";
 import GraphicEqIcon from "@mui/icons-material/GraphicEq";
+import SubtitlesOutlinedIcon from "@mui/icons-material/SubtitlesOutlined";
 
 import { useHasScript } from "../../../hooks/timeline/useHasScript";
 import { useTimelineStore } from "../../../stores/timeline/TimelineStore";
 import { MOTION, BORDER_RADIUS } from "../../ui_primitives";
 
-const buttonStyles = (theme: Theme) =>
+const buttonStyles = (theme: Theme, compact: boolean) =>
   css({
     display: "inline-flex",
     alignItems: "center",
+    justifyContent: "center",
     gap: 6,
-    height: 24,
-    padding: theme.spacing(0, 3, 0, 2),
+    height: compact ? 28 : 24,
+    minWidth: compact ? 28 : undefined,
+    padding: compact ? 0 : theme.spacing(0, 3, 0, 2),
     background: "transparent",
     border: "1px solid transparent",
     color: theme.vars.palette.text.secondary,
@@ -47,11 +50,16 @@ const buttonStyles = (theme: Theme) =>
       borderColor: theme.vars.palette.divider
     },
     "& svg": {
-      fontSize: 14
+      fontSize: compact ? 18 : 14
     }
   });
 
-export const ScriptToggleButton: React.FC = memo(() => {
+export interface ScriptToggleButtonProps {
+  /** Phone toolbar: icon only, with the label carried by the tooltip / a11y name. */
+  compact?: boolean;
+}
+
+export const ScriptToggleButton: React.FC<ScriptToggleButtonProps> = memo(({ compact = false }) => {
   const theme = useTheme();
   const hasScript = useHasScript();
   const setScriptEnabled = useTimelineStore((s) => s.setScriptEnabled);
@@ -65,13 +73,24 @@ export const ScriptToggleButton: React.FC = memo(() => {
   return (
     <button
       type="button"
-      css={buttonStyles(theme)}
+      css={buttonStyles(theme, compact)}
       onClick={handleClick}
       aria-label={label}
+      title={label}
       data-testid="script-toggle-button"
     >
-      {hasScript ? <GraphicEqIcon /> : <AddIcon />}
-      <span>{label}</span>
+      {/* Without its label a bare "+" reads as a second Add-track button, so
+          the icon-only variant names the feature instead of the action. */}
+      {compact ? (
+        <SubtitlesOutlinedIcon
+          sx={{ color: hasScript ? "primary.main" : undefined }}
+        />
+      ) : (
+        <>
+          {hasScript ? <GraphicEqIcon /> : <AddIcon />}
+          <span>{label}</span>
+        </>
+      )}
     </button>
   );
 });

--- a/web/src/components/timeline/Tracks/TimeRuler.tsx
+++ b/web/src/components/timeline/Tracks/TimeRuler.tsx
@@ -239,12 +239,19 @@ function computeTickIntervals(msPerPx: number): {
   return { majorMs, minorMs };
 }
 
-/** Formats ms into M:SS (e.g. 0:05, 1:30). */
-function formatTimecode(ms: number): string {
-  const totalSec = Math.floor(ms / 1000);
+/**
+ * Formats ms into M:SS (e.g. 0:05, 1:30), gaining decimals once the tick
+ * interval is sub-second — otherwise zooming past 1 s/tick prints the same
+ * label on every tick ("0:02  0:02  0:02") and the ruler stops saying where
+ * anything is.
+ */
+export function formatTimecode(ms: number, majorMs = 1000): string {
+  const totalSec = ms / 1000;
   const min = Math.floor(totalSec / 60);
-  const sec = totalSec % 60;
-  return `${min}:${String(sec).padStart(2, "0")}`;
+  const sec = totalSec - min * 60;
+  const decimals = majorMs >= 1000 ? 0 : majorMs >= 500 ? 1 : 2;
+  const secText = sec.toFixed(decimals);
+  return `${min}:${sec < 10 ? "0" : ""}${secText}`;
 }
 
 export interface TimeRulerProps {
@@ -410,7 +417,7 @@ export const TimeRuler: React.FC<TimeRulerProps> = memo(
 
         if (isMajor) {
           ctx.fillStyle = textColor;
-          ctx.fillText(formatTimecode(tMs), px + 3, 3);
+          ctx.fillText(formatTimecode(tMs, majorMs), px + 3, 3);
         }
       }
 

--- a/web/src/components/timeline/Tracks/TrackHeader.tsx
+++ b/web/src/components/timeline/Tracks/TrackHeader.tsx
@@ -46,6 +46,20 @@ import ConfirmDialog from "../../dialogs/ConfirmDialog";
 
 export const TRACK_HEADER_WIDTH_PX = 192;
 /**
+ * Phone header width. 192px is half a 390px viewport — the lanes get less room
+ * than the labels. 132px is the narrowest that still fits the full control row
+ * (five 24px buttons + padding) once the reorder grip is dropped.
+ */
+export const MOBILE_TRACK_HEADER_WIDTH_PX = 132;
+/**
+ * The header width is read by four separate style blocks across three files
+ * (this header, the script lane header, the TRACKS label, the lane offsets).
+ * TracksRegion sets this custom property on its container so all of them
+ * follow one value without threading a prop through every layer.
+ */
+export const TRACK_HEADER_WIDTH_VAR = "--timeline-track-header-width";
+export const trackHeaderWidthCss = `var(${TRACK_HEADER_WIDTH_VAR}, ${TRACK_HEADER_WIDTH_PX}px)`;
+/**
  * Private drag MIME for track-reorder drags. Distinct from the asset-drop
  * types ("asset" / "selectedAssetIds") so the lane/empty-area asset-drop
  * handlers never react to a track being reordered.
@@ -56,16 +70,18 @@ const MAX_TRACK_HEIGHT_PX = 300;
 const DEFAULT_TRACK_HEIGHT_PX = SHARED_DEFAULT_TRACK_HEIGHT_PX;
 const RESIZE_HANDLE_HEIGHT_PX = 6;
 
-const headerStyles = (theme: Theme, heightPx: number) =>
+const headerStyles = (theme: Theme, heightPx: number, compact: boolean) =>
   css({
     position: "relative",
-    width: TRACK_HEADER_WIDTH_PX,
+    width: trackHeaderWidthCss,
     height: heightPx,
     flexShrink: 0,
     display: "flex",
     flexDirection: "column",
     justifyContent: "space-between",
-    padding: `${getSpacingPx(SPACING.lg)} ${getSpacingPx(SPACING.lg)} ${getSpacingPx(SPACING.lg)}`,
+    padding: compact
+      ? `${getSpacingPx(SPACING.xs)} ${getSpacingPx(SPACING.sm)}`
+      : `${getSpacingPx(SPACING.lg)} ${getSpacingPx(SPACING.lg)} ${getSpacingPx(SPACING.lg)}`,
     backgroundColor: theme.vars.palette.background.default,
     borderBottom: `1px solid ${theme.vars.palette.divider}`,
     overflow: "hidden",
@@ -184,13 +200,27 @@ const indexChipStyles = (theme: Theme) =>
     backgroundColor: "transparent"
   });
 
-const controlsRowStyles = css({
-  display: "flex",
-  flexDirection: "row",
-  alignItems: "center",
-  gap: getSpacingPx(SPACING.micro),
-  marginLeft: `-${getSpacingPx(SPACING.xs)}` // align icon edges flush with the type glyph
-});
+const controlsRowStyles = (compact: boolean) =>
+  css({
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    gap: getSpacingPx(compact ? SPACING.none : SPACING.micro),
+    // align icon edges flush with the type glyph
+    marginLeft: compact ? 0 : `-${getSpacingPx(SPACING.xs)}`,
+    // An audio track carries six controls (visible, lock, mute, solo, fx,
+    // delete), which is more than a 132px header fits. Scroll the row rather
+    // than clip it — the header's `overflow: hidden` would otherwise drop
+    // delete and the effects chain with no way to reach them on a phone.
+    ...(compact
+      ? {
+          overflowX: "auto" as const,
+          scrollbarWidth: "none" as const,
+          "&::-webkit-scrollbar": { display: "none" },
+          "& > *": { flexShrink: 0 }
+        }
+      : null)
+  });
 
 const iconButtonStyles = (theme: Theme, active = true) =>
   css({
@@ -241,9 +271,16 @@ export interface TrackHeaderProps {
   track: TimelineTrack;
   /** Pre-computed 1-based index within the track's type group. */
   typedIndex: number;
+  /**
+   * Phone layout: tighter padding, and the type glyph and reorder grip give up
+   * their space to the name. The grip is no loss — it drives HTML5 drag-and-
+   * drop, which doesn't fire from touch — and the index chip (V1 / A1) already
+   * carries the type the glyph was showing.
+   */
+  compact?: boolean;
 }
 
-export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex }) => {
+export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex, compact = false }) => {
   const theme = useTheme();
 
   const setTrackVisible = useTimelineStore((s) => s.setTrackVisible);
@@ -446,7 +483,7 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
     <>
     <div
       ref={headerRef}
-      css={headerStyles(theme, heightPx)}
+      css={headerStyles(theme, heightPx, compact)}
       data-testid={`track-header-${track.id}`}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
@@ -460,26 +497,30 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
       )}
       {/* Top row: drag handle · type glyph · name · index chip */}
       <div css={topRowStyles}>
-        <div
-          css={dragHandleStyles(theme)}
-          draggable
-          onDragStart={handleDragStart}
-          onDragEnd={handleDragEnd}
-          aria-label={`Reorder ${track.name}`}
-          role="button"
-          tabIndex={-1}
-          title="Drag to reorder track"
-          data-testid={`track-drag-handle-${track.id}`}
-        >
-          <DragIndicatorIcon />
-        </div>
-        <div
-          css={typeGlyphStyles(theme, accent)}
-          aria-hidden
-          title={meta.label}
-        >
-          <TypeIcon />
-        </div>
+        {!compact && (
+          <>
+            <div
+              css={dragHandleStyles(theme)}
+              draggable
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+              aria-label={`Reorder ${track.name}`}
+              role="button"
+              tabIndex={-1}
+              title="Drag to reorder track"
+              data-testid={`track-drag-handle-${track.id}`}
+            >
+              <DragIndicatorIcon />
+            </div>
+            <div
+              css={typeGlyphStyles(theme, accent)}
+              aria-hidden
+              title={meta.label}
+            >
+              <TypeIcon />
+            </div>
+          </>
+        )}
         <div css={nameWrapStyles}>
           <input
             ref={inputRef}
@@ -504,7 +545,10 @@ export const TrackHeader: React.FC<TrackHeaderProps> = memo(({ track, typedIndex
       </div>
 
       {/* Controls row */}
-      <div css={controlsRowStyles}>
+      <div
+        css={controlsRowStyles(compact)}
+        className={compact ? "timeline-track-controls" : undefined}
+      >
         <Tooltip title={track.visible ? "Hide track" : "Show track"}>
           <button
             type="button"

--- a/web/src/components/timeline/Tracks/TrackLane.tsx
+++ b/web/src/components/timeline/Tracks/TrackLane.tsx
@@ -46,6 +46,8 @@ import {
   isCompatibleWithTrack
 } from "../dnd/assetToClipAdapter";
 import { useVideoAudioImport } from "../../../hooks/timeline/useVideoAudioImport";
+import { useLongPress } from "../../../hooks/timeline/useLongPress";
+import type { LongPressPoint } from "../../../hooks/timeline/useLongPress";
 
 const DEFAULT_TRACK_HEIGHT_PX = 64;
 /** Duration (ms) the mismatch warning banner remains visible. */
@@ -130,6 +132,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
 
   const heightPx = track.heightPx ?? DEFAULT_TRACK_HEIGHT_PX;
 
+  const laneRef = useRef<HTMLDivElement>(null);
   const isRubberBandingRef = useRef(false);
   const rbStartRef = useRef({ x: 0, y: 0 });
   /** Selection snapshot taken at pointerdown when Shift is held (union mode). */
@@ -307,6 +310,39 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
     ]
   );
 
+  /** Open the lane menu at a viewport point, resolving the time under it. */
+  const openLaneMenuAt = useCallback(
+    (clientX: number, clientY: number, laneEl: HTMLDivElement) => {
+      if (track.locked) {
+        return;
+      }
+      const rect = laneEl.getBoundingClientRect();
+      const dropX = clientX - rect.left;
+      const startMs = Math.max(0, Math.round(dropX * msPerPx));
+      setContextMenuPos({ x: clientX, y: clientY, startMs });
+    },
+    [track.locked, msPerPx]
+  );
+
+  // Touch equivalent of the right-click menu below: without it a phone has no
+  // way to add a clip to an empty lane.
+  const laneLongPress = useLongPress(
+    useCallback(
+      (point: LongPressPoint) => {
+        const laneEl = laneRef.current;
+        if (!laneEl || point.target !== laneEl) {
+          return;
+        }
+        // The hold became a menu, not a band — drop the gesture pointerdown
+        // started so releasing doesn't re-select.
+        isRubberBandingRef.current = false;
+        setRubberBand(null);
+        openLaneMenuAt(point.clientX, point.clientY, laneEl);
+      },
+      [openLaneMenuAt]
+    )
+  );
+
   const handleLanePointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       // Only respond to primary button on the lane itself (not clips)
@@ -314,6 +350,18 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
         return;
       }
       if (e.button !== 0) {
+        return;
+      }
+
+      // Touch: a drag across empty lane means "scroll the timeline", so the
+      // gesture is left to the scroller. Rubber-band marquee needs a second
+      // pointer to hold a modifier and has no equivalent on a phone; only the
+      // seek and the long-press menu below apply. (Capturing the pointer here
+      // would also suppress the native scroll outright.)
+      if (e.pointerType === "touch") {
+        laneLongPress.start(e);
+        const touchRect = e.currentTarget.getBoundingClientRect();
+        seek(Math.round((e.clientX - touchRect.left) * msPerPx));
         return;
       }
 
@@ -355,7 +403,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
       const timeMs = Math.round(localX * msPerPx);
       seek(timeMs);
     },
-    [clearSelection, msPerPx, seek, track.id]
+    [clearSelection, laneLongPress, msPerPx, seek, track.id]
   );
 
   // Apply the rubber-band selection for the given content-space range. Deduped
@@ -387,6 +435,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
 
   const handleLanePointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
+      laneLongPress.move(e);
       if (!isRubberBandingRef.current || e.buttons !== 1) {
         return;
       }
@@ -410,17 +459,18 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
       const rbStartMs = left * msPerPx;
       applyRubberBandSelection(rbStartMs, rbStartMs + width * msPerPx);
     },
-    [msPerPx, applyRubberBandSelection]
+    [laneLongPress, msPerPx, applyRubberBandSelection]
   );
 
   const handleLanePointerUp = useCallback(() => {
+    laneLongPress.cancel();
     isRubberBandingRef.current = false;
     rbBaseSelectionRef.current = null;
     rbLastAppliedRef.current = null;
     rbTrackClipsRef.current = [];
     rbLaneRectRef.current = null;
     setRubberBand(null);
-  }, []);
+  }, [laneLongPress]);
 
   const handleLaneContextMenu = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -432,12 +482,9 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
         return;
       }
       e.preventDefault();
-      const rect = e.currentTarget.getBoundingClientRect();
-      const dropX = e.clientX - rect.left;
-      const startMs = Math.max(0, Math.round(dropX * msPerPx));
-      setContextMenuPos({ x: e.clientX, y: e.clientY, startMs });
+      openLaneMenuAt(e.clientX, e.clientY, e.currentTarget);
     },
-    [track.locked, msPerPx]
+    [track.locked, openLaneMenuAt]
   );
 
   const handleAddClipFromMenu = useCallback(() => {
@@ -480,6 +527,7 @@ export const TrackLane: React.FC<TrackLaneProps> = memo(({ track }) => {
 
   return (
     <div
+      ref={laneRef}
       css={laneStyles(theme, heightPx, track.visible, rubberBand !== null, isDragOver, isDragReject)}
       data-testid={`track-lane-${track.id}`}
       onPointerDown={handleLanePointerDown}

--- a/web/src/components/timeline/Tracks/TracksRegion.tsx
+++ b/web/src/components/timeline/Tracks/TracksRegion.tsx
@@ -65,7 +65,12 @@ import {
   copyClipsToClipboard,
   hasClipboardClips
 } from "../../../stores/timeline/clipboardOps";
-import { TRACK_HEADER_WIDTH_PX } from "./TrackHeader";
+import {
+  MOBILE_TRACK_HEADER_WIDTH_PX,
+  TRACK_HEADER_WIDTH_PX,
+  TRACK_HEADER_WIDTH_VAR,
+  trackHeaderWidthCss
+} from "./TrackHeader";
 import { TrackHeader } from "./TrackHeader";
 import { TrackLane } from "./TrackLane";
 import { TimeRuler } from "./TimeRuler";
@@ -87,6 +92,7 @@ import { ToolToggle } from "../ToolToggle";
 import { TimelineShortcutsDialog } from "../TimelineShortcutsDialog";
 import { FlexRow, HelpButton, FONT_SIZE_MONO, FONT_WEIGHT, BORDER_RADIUS, SPACING, getSpacingPx, Z_INDEX } from "../../ui_primitives";
 import { useHasScript } from "../../../hooks/timeline/useHasScript";
+import { useTimelineIsMobile } from "../../../hooks/timeline/useTimelineIsMobile";
 import { useVideoAudioImport } from "../../../hooks/timeline/useVideoAudioImport";
 import { deserializeDragData } from "../../../lib/dragdrop";
 import type { Asset } from "../../../stores/ApiTypes";
@@ -117,24 +123,30 @@ const containerStyles = (theme: Theme) =>
     backgroundColor: theme.vars.palette.background.default
   });
 
-const toolbarStyles = (theme: Theme) =>
+const TOOLBAR_HEIGHT_PX = 36;
+/** Phone toolbar: tall enough for the app-wide 44px touch target. */
+const TOUCH_TOOLBAR_HEIGHT_PX = 44;
+
+const toolbarStyles = (theme: Theme, compact: boolean) =>
   css({
-    height: 36,
+    height: compact ? TOUCH_TOOLBAR_HEIGHT_PX : TOOLBAR_HEIGHT_PX,
     flexShrink: 0,
-    padding: `0 ${getSpacingPx(SPACING.lg)} 0 ${getSpacingPx(SPACING.md)}`,
+    padding: compact
+      ? `0 ${getSpacingPx(SPACING.sm)}`
+      : `0 ${getSpacingPx(SPACING.lg)} 0 ${getSpacingPx(SPACING.md)}`,
     borderBottom: `1px solid ${theme.vars.palette.divider}`,
     backgroundColor: theme.vars.palette.background.paper
   });
 
-const tracksSectionHeaderStyles = (theme: Theme) =>
+const tracksSectionHeaderStyles = (theme: Theme, compact: boolean) =>
   css({
-    width: TRACK_HEADER_WIDTH_PX,
+    width: trackHeaderWidthCss,
     height: 28,
     flexShrink: 0,
     display: "flex",
     alignItems: "center",
     gap: getSpacingPx(SPACING.sm),
-    padding: `0 ${getSpacingPx(SPACING.lg)}`,
+    padding: `0 ${getSpacingPx(compact ? SPACING.sm : SPACING.lg)}`,
     backgroundColor: theme.vars.palette.background.paper,
     borderBottom: `1px solid ${theme.vars.palette.divider}`,
     color: theme.vars.palette.text.secondary,
@@ -175,6 +187,11 @@ const headerColumnStyles = (theme: Theme) =>
 const scrollableAreaStyles = css({
   flex: "1 1 auto",
   overflowX: "auto",
+  // Panning stays with the browser (it scrolls this element); pinching does
+  // not, so the two-finger gesture below zooms the timeline instead of the
+  // page. Without this the browser claims the pinch and the handler never
+  // sees the second pointer.
+  touchAction: "pan-x pan-y",
   // Vertical scrolling lives here (not on the outer row) so the horizontal
   // scrollbar stays pinned to the bottom of the visible viewport instead of
   // sliding off-screen below a tall track stack. The header column's scrollTop
@@ -199,6 +216,10 @@ export interface TracksRegionProps {
 export const TracksRegion: React.FC<TracksRegionProps> = memo(
   ({ heightPx }) => {
     const theme = useTheme();
+    const isMobile = useTimelineIsMobile();
+    const headerWidthPx = isMobile
+      ? MOBILE_TRACK_HEADER_WIDTH_PX
+      : TRACK_HEADER_WIDTH_PX;
 
     const tracks = useTimelineStore((s) => s.tracks);
     // Content extent for sizing the ruler / scroll width. The stored
@@ -333,7 +354,9 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
     );
 
     // Track area height minus toolbar + ruler + bottom scrollbar
-    const TOOLBAR_HEIGHT = 36;
+    const TOOLBAR_HEIGHT = isMobile
+      ? TOUCH_TOOLBAR_HEIGHT_PX
+      : TOOLBAR_HEIGHT_PX;
     const RULER_HEIGHT = 28;
     const lanesHeight = Math.max(
       0,
@@ -461,6 +484,90 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
           cancelAnimationFrame(zoomRafIdRef.current);
           zoomRafIdRef.current = null;
         }
+      };
+    }, [uiStoreApi]);
+
+    // Pinch-to-zoom (touch). The desktop route to zoom is Ctrl+wheel, which a
+    // phone has no way to produce; without this the only zoom on a phone is the
+    // status-bar buttons, and trimming to a frame needs a scale you can reach
+    // mid-gesture. Feeds the same setZoom + `zoomAnchorRef` path the wheel
+    // handler uses, so the point between the fingers stays put as the lanes
+    // rescale.
+    useEffect(() => {
+      const el = scrollableRef.current;
+      if (!el) return;
+
+      const points = new Map<number, { x: number; y: number }>();
+      let startDistance = 0;
+      let startMsPerPx = 0;
+      let rafId: number | null = null;
+
+      const twoPoints = (): [{ x: number; y: number }, { x: number; y: number }] | null => {
+        if (points.size !== 2) return null;
+        const [a, b] = [...points.values()];
+        return [a, b];
+      };
+
+      const applyPinch = () => {
+        rafId = null;
+        const pair = twoPoints();
+        if (!pair || startDistance === 0) return;
+        const [a, b] = pair;
+        const distance = Math.hypot(a.x - b.x, a.y - b.y);
+        if (distance === 0) return;
+
+        // Fingers apart → smaller msPerPx → zoomed in.
+        const next = Math.min(
+          MAX_MS_PER_PX,
+          Math.max(MIN_MS_PER_PX, startMsPerPx * (startDistance / distance))
+        );
+        const current = uiStoreApi.getState().msPerPx;
+        if (next === current) return;
+
+        const rect = el.getBoundingClientRect();
+        const midPx = (a.x + b.x) / 2 - rect.left;
+        zoomAnchorRef.current = {
+          timeMs: (el.scrollLeft + midPx) * current,
+          cursorPx: midPx
+        };
+        uiStoreApi.getState().setZoom(next);
+      };
+
+      const onPointerDown = (e: PointerEvent) => {
+        if (e.pointerType !== "touch") return;
+        points.set(e.pointerId, { x: e.clientX, y: e.clientY });
+        if (points.size === 2) {
+          const pair = twoPoints();
+          if (!pair) return;
+          startDistance = Math.hypot(pair[0].x - pair[1].x, pair[0].y - pair[1].y);
+          startMsPerPx = uiStoreApi.getState().msPerPx;
+        }
+      };
+
+      const onPointerMove = (e: PointerEvent) => {
+        if (!points.has(e.pointerId)) return;
+        points.set(e.pointerId, { x: e.clientX, y: e.clientY });
+        if (points.size !== 2 || startDistance === 0) return;
+        // A pinch delivers well over one move per frame per finger; batch to
+        // one setZoom per frame so the lanes/clips/ruler re-render once.
+        if (rafId === null) rafId = requestAnimationFrame(applyPinch);
+      };
+
+      const onPointerUp = (e: PointerEvent) => {
+        points.delete(e.pointerId);
+        if (points.size < 2) startDistance = 0;
+      };
+
+      el.addEventListener("pointerdown", onPointerDown);
+      el.addEventListener("pointermove", onPointerMove);
+      el.addEventListener("pointerup", onPointerUp);
+      el.addEventListener("pointercancel", onPointerUp);
+      return () => {
+        el.removeEventListener("pointerdown", onPointerDown);
+        el.removeEventListener("pointermove", onPointerMove);
+        el.removeEventListener("pointerup", onPointerUp);
+        el.removeEventListener("pointercancel", onPointerUp);
+        if (rafId !== null) cancelAnimationFrame(rafId);
       };
     }, [uiStoreApi]);
 
@@ -817,7 +924,12 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
     return (
       <div
         css={containerStyles(theme)}
-        style={{ height: heightPx }}
+        style={
+          {
+            height: heightPx,
+            [TRACK_HEADER_WIDTH_VAR]: `${headerWidthPx}px`
+          } as React.CSSProperties
+        }
         data-testid="tracks-region"
         aria-label="Tracks region"
       >
@@ -825,23 +937,27 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         <FlexRow
           align="center"
           gap={0.5}
-          css={toolbarStyles(theme)}
+          css={toolbarStyles(theme, isMobile)}
           data-testid="timeline-toolbar"
         >
-          <ToolToggle />
+          <ToolToggle compact={isMobile} />
           <div style={{ flex: "1 1 auto" }} />
-          <ScriptToggleButton />
-          <AddTrackButton />
-          <HelpButton
-            onClick={() => setShortcutsOpen(true)}
-            iconVariant="helpOutline"
-            tooltip="Keyboard shortcuts (?)"
-          />
+          <ScriptToggleButton compact={isMobile} />
+          <AddTrackButton compact={isMobile} />
+          {/* The shortcut sheet documents keyboard bindings — nothing a phone
+              can act on, and the row has no width to spare. */}
+          {!isMobile && (
+            <HelpButton
+              onClick={() => setShortcutsOpen(true)}
+              iconVariant="helpOutline"
+              tooltip="Keyboard shortcuts (?)"
+            />
+          )}
         </FlexRow>
 
         {/* ── Sub-header: TRACKS label + ruler ────────────────────────── */}
         <FlexRow align="stretch" fullWidth>
-          <div css={tracksSectionHeaderStyles(theme)}>
+          <div css={tracksSectionHeaderStyles(theme, isMobile)}>
             <span>Tracks</span>
             <span
               css={trackCountChipStyles(theme)}
@@ -879,7 +995,11 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
                 {hasScript && track.id === scriptBeforeTrackId && (
                   <ScriptLaneHeader />
                 )}
-                <TrackHeader track={track} typedIndex={typedIndexMap.get(track.id) ?? 1} />
+                <TrackHeader
+                  track={track}
+                  typedIndex={typedIndexMap.get(track.id) ?? 1}
+                  compact={isMobile}
+                />
                 {expandedFxTrackId === track.id && (
                   <div
                     style={{ height: FX_PANEL_HEIGHT_PX }}
@@ -935,7 +1055,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
         <TimelineScrollbar
           contentWidthPx={totalWidthPx}
           viewportWidthPx={fxPanelWidth}
-          leftInsetPx={TRACK_HEADER_WIDTH_PX}
+          leftInsetPx={headerWidthPx}
           onScrollTo={scrollToLeft}
         />
 
@@ -949,7 +1069,7 @@ export const TracksRegion: React.FC<TracksRegionProps> = memo(
             position: "absolute",
             top: TOOLBAR_HEIGHT,
             bottom: 0,
-            left: TRACK_HEADER_WIDTH_PX,
+            left: headerWidthPx,
             right: 0,
             pointerEvents: "none",
             overflow: "hidden"

--- a/web/src/components/timeline/Tracks/__tests__/formatTimecode.test.ts
+++ b/web/src/components/timeline/Tracks/__tests__/formatTimecode.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Ruler label formatting.
+ *
+ * The tick interval drops to 500 / 200 / 100 ms as you zoom in, which
+ * pinch-to-zoom makes routine on a phone. A whole-second label repeats itself
+ * at those intervals ("0:02  0:02  0:02"), so the label carries decimals once
+ * the interval goes sub-second.
+ */
+
+import { formatTimecode } from "../TimeRuler";
+
+describe("formatTimecode", () => {
+  it("prints M:SS at second-or-coarser tick intervals", () => {
+    expect(formatTimecode(0, 1000)).toBe("0:00");
+    expect(formatTimecode(5000, 1000)).toBe("0:05");
+    expect(formatTimecode(90_000, 5000)).toBe("1:30");
+    expect(formatTimecode(605_000, 60_000)).toBe("10:05");
+  });
+
+  it("keeps whole seconds as the default", () => {
+    expect(formatTimecode(2400)).toBe("0:02");
+  });
+
+  it("adds one decimal at a 500ms interval", () => {
+    expect(formatTimecode(2000, 500)).toBe("0:02.0");
+    expect(formatTimecode(2500, 500)).toBe("0:02.5");
+  });
+
+  it("adds two decimals below 500ms, so adjacent ticks differ", () => {
+    expect(formatTimecode(2000, 100)).toBe("0:02.00");
+    expect(formatTimecode(2100, 100)).toBe("0:02.10");
+    expect(formatTimecode(2200, 100)).toBe("0:02.20");
+    expect(formatTimecode(2200, 200)).toBe("0:02.20");
+  });
+
+  it("pads seconds under ten and rolls over past a minute", () => {
+    expect(formatTimecode(9900, 100)).toBe("0:09.90");
+    expect(formatTimecode(61_500, 500)).toBe("1:01.5");
+    expect(formatTimecode(70_000, 100)).toBe("1:10.00");
+  });
+});

--- a/web/src/hooks/timeline/__tests__/useLongPress.test.ts
+++ b/web/src/hooks/timeline/__tests__/useLongPress.test.ts
@@ -1,0 +1,123 @@
+/**
+ * useLongPress — the touch stand-in for a right-click.
+ *
+ * The timeline's clip and lane menus are the only route to add / split /
+ * duplicate / delete on a phone, so these assert the hold fires, a mouse is
+ * left to its own context menu, and a hold that turns into a drag doesn't
+ * steal the gesture.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+
+import { useLongPress } from "../useLongPress";
+
+const pointer = (
+  overrides: Partial<{
+    clientX: number;
+    clientY: number;
+    pointerType: string;
+    target: EventTarget | null;
+  }> = {}
+) => ({
+  clientX: 100,
+  clientY: 100,
+  pointerType: "touch",
+  target: null,
+  ...overrides
+});
+
+describe("useLongPress", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("fires after the hold elapses and reports where the finger went down", () => {
+    const onLongPress = jest.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    const target = document.createElement("div");
+
+    act(() => {
+      result.current.start(pointer({ clientX: 42, clientY: 7, target }));
+    });
+    expect(onLongPress).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(onLongPress).toHaveBeenCalledWith({
+      clientX: 42,
+      clientY: 7,
+      target
+    });
+  });
+
+  it("ignores a mouse — it already has a context menu", () => {
+    const onLongPress = jest.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+
+    act(() => {
+      result.current.start(pointer({ pointerType: "mouse" }));
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("cancels once the finger moves past the tolerance, so a drag wins", () => {
+    const onLongPress = jest.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+
+    act(() => {
+      result.current.start(pointer({ clientX: 100, clientY: 100 }));
+      result.current.move({ clientX: 140, clientY: 100 });
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("tolerates the jitter of a finger holding still", () => {
+    const onLongPress = jest.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+
+    act(() => {
+      result.current.start(pointer({ clientX: 100, clientY: 100 }));
+      result.current.move({ clientX: 104, clientY: 103 });
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels explicitly on pointer up", () => {
+    const onLongPress = jest.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+
+    act(() => {
+      result.current.start(pointer());
+      result.current.cancel();
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("does not fire after unmount", () => {
+    const onLongPress = jest.fn();
+    const { result, unmount } = renderHook(() => useLongPress(onLongPress));
+
+    act(() => {
+      result.current.start(pointer());
+    });
+    unmount();
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/timeline/useLongPress.ts
+++ b/web/src/hooks/timeline/useLongPress.ts
@@ -1,0 +1,109 @@
+/**
+ * useLongPress
+ *
+ * Turns a touch hold into the same action a right-click gives a mouse.
+ *
+ * The timeline's clip and lane menus hang off `onContextMenu`, which a touch
+ * hold does not reliably produce — iOS Safari never fires it from a long press,
+ * and Android Chrome only does so when the browser hasn't claimed the gesture
+ * for text selection first. Without this, a phone has no route to "add clip",
+ * "split", "duplicate", or "delete" at all.
+ *
+ * Composes with existing pointer handlers rather than replacing them: call
+ * `start` / `move` / `cancel` from the handlers a component already has, so the
+ * hold can coexist with a drag or rubber-band gesture on the same element.
+ * Mouse pointers are ignored — they have a real context menu.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+
+export interface LongPressPoint {
+  clientX: number;
+  clientY: number;
+  target: EventTarget | null;
+}
+
+/**
+ * Structural shape shared by React's synthetic pointer event and the DOM's —
+ * clip drags track movement through window listeners, so both reach `move`.
+ */
+export interface LongPressSource {
+  clientX: number;
+  clientY: number;
+  pointerType: string;
+  target: EventTarget | null;
+}
+
+export interface UseLongPressOptions {
+  /** Hold duration before the press counts. */
+  delayMs?: number;
+  /** Movement past this cancels the hold and lets the drag win. */
+  moveTolerancePx?: number;
+}
+
+export interface LongPressHandlers {
+  start: (e: LongPressSource) => void;
+  move: (e: Pick<LongPressSource, "clientX" | "clientY">) => void;
+  cancel: () => void;
+}
+
+export function useLongPress(
+  onLongPress: (point: LongPressPoint) => void,
+  { delayMs = 500, moveTolerancePx = 10 }: UseLongPressOptions = {}
+): LongPressHandlers {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const originRef = useRef<{ x: number; y: number } | null>(null);
+  const callbackRef = useRef(onLongPress);
+
+  useEffect(() => {
+    callbackRef.current = onLongPress;
+  }, [onLongPress]);
+
+  const cancel = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    originRef.current = null;
+  }, []);
+
+  const start = useCallback(
+    (e: LongPressSource) => {
+      if (e.pointerType === "mouse") {
+        return;
+      }
+      cancel();
+      // Read the coordinates now: the timer fires long after this event object
+      // has been handed back.
+      const point: LongPressPoint = {
+        clientX: e.clientX,
+        clientY: e.clientY,
+        target: e.target
+      };
+      originRef.current = { x: e.clientX, y: e.clientY };
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = null;
+        originRef.current = null;
+        callbackRef.current(point);
+      }, delayMs);
+    },
+    [cancel, delayMs]
+  );
+
+  const move = useCallback(
+    (e: Pick<LongPressSource, "clientX" | "clientY">) => {
+      const origin = originRef.current;
+      if (origin === null) {
+        return;
+      }
+      if (Math.hypot(e.clientX - origin.x, e.clientY - origin.y) > moveTolerancePx) {
+        cancel();
+      }
+    },
+    [cancel, moveTolerancePx]
+  );
+
+  useEffect(() => cancel, [cancel]);
+
+  return { start, move, cancel };
+}

--- a/web/src/hooks/timeline/useTimelineIsMobile.ts
+++ b/web/src/hooks/timeline/useTimelineIsMobile.ts
@@ -1,0 +1,20 @@
+/**
+ * useTimelineIsMobile
+ *
+ * True on narrow viewports (below the `sm` breakpoint = 600px) where the
+ * timeline editor's desktop layout doesn't fit: a 55/45 preview–inspector
+ * split, a 192px track-header column, and a top bar carrying a prompt plus
+ * four setting chips plus four labelled buttons. Below `sm` those collapse to
+ * a single-column shell (see TimelineEditor).
+ *
+ * Mirrors the query used by MobileClassProvider and `useSketchIsMobile` so the
+ * timeline shares one mobile threshold with the rest of the app.
+ */
+
+import { useMediaQuery } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+
+export function useTimelineIsMobile(): boolean {
+  const theme = useTheme();
+  return useMediaQuery(theme.breakpoints.down("sm"));
+}

--- a/web/src/styles/mobile.css
+++ b/web/src/styles/mobile.css
@@ -599,6 +599,19 @@
     font-size: 18px !important;
   }
 
+  /* A timeline track header is 132px wide and 64px tall and carries up to six
+     toggles (visible, lock, mute, solo, effects, delete). At 44px each they
+     need 264px, so the blanket rule above pushed four of them out of a
+     clipped box. 30x26 keeps every control reachable inside the header and
+     still clears the 24x24 minimum. */
+  .mobile .timeline-track-controls > button {
+    width: 30px !important;
+    height: 26px !important;
+    min-width: 30px !important;
+    min-height: 26px !important;
+    padding: 0 !important;
+  }
+
   .mobile .main-container {
     height: 100dvh !important;
     max-height: 100dvh !important;


### PR DESCRIPTION
## What was wrong

Rendered at 390×844 in Chrome, the timeline editor was unusable:

- The top bar packed a prompt, four setting chips, and four labelled buttons into one 48px row, so **"Generate", "Settings", "Save", "Save as Asset", and "Export" drew on top of each other**.
- The middle row split 55/45 into a 214px preview and a 175px inspector, with the inspector's tabs running off-screen.
- The 192px track headers took half the viewport, leaving the lanes 198px.
- Nothing answered a finger. Adding, splitting, duplicating, and deleting a clip all hang off `onContextMenu`, which a touch hold does not produce (never on iOS Safari, inconsistently elsewhere) — so there was **no route to add a clip at all**. Zoom was Ctrl+wheel only.

## What changed

Below the `sm` breakpoint (`useTimelineIsMobile`, the threshold `MobileClassProvider` and the sketch editor already use):

- **Top bar** wraps into two rows — prompt + Generate, then the chips in a horizontally scrolling rail — and the four actions collapse into an overflow menu.
- **Preview** takes the full width. Inspector / Assistant / History / Script move into a bottom sheet opened from the status bar, so preview and tracks — the two surfaces you need simultaneously — stay stacked and both usable.
- **Track headers** narrow to 132px, dropping the reorder grip (HTML5 drag never fires from touch) and the type glyph (the V1 / A1 chip already carries the type). The control row scrolls, since an audio track has six toggles.
- **Toolbar** buttons go icon-only on a 44px row.

Touch gestures, none of which existed before:

| Gesture | Effect |
| --- | --- |
| Long press a clip | Clip menu (split, duplicate, lock, replace, delete) |
| Long press empty lane | Lane menu (add text, add generated clip) |
| Drag a clip edge | Trim — 22px hit area on coarse pointers, 8px visible grip |
| Drag empty lane | Scroll the timeline; marquee select stays mouse-only |
| Two-finger pinch | Zoom, anchored between the fingers |
| Drag the divider | Resize the tracks panel (was mouse-events-only) |

`useLongPress` composes with the existing pointer handlers rather than replacing them, so a hold and a drag can share one element.

## Two fixes that fell out

- The blanket `.mobile button { min-width/height: 44px }` rule in `mobile.css` turned six 24px track toggles into 264px of content inside a clipped 120px box, silently dropping delete and the effects chain. Scoped exception added, matching the other dense-cluster exceptions already in that file.
- `formatTimecode` floored every ruler label to whole seconds, so the sub-second tick intervals that pinch-to-zoom now makes routine printed `0:02  0:02  0:02`. Now `0:02.40  0:02.60  0:02.80`.

## Verification

Driven in headless Chromium over CDP with real touch events at 360×640, 390×844, 834×1112, and 1440×900. Each gesture above was executed and its effect asserted — a text clip added via long press, dragged (x 173→243), trimmed (width 300→244), pinched (zoom 100%→367%), and edited through the bottom sheet. Zero horizontal document overflow at every width. **Desktop layout is unchanged** (verified by screenshot).

`npm run typecheck` and `npm run lint` clean. Full web suite: 1079 suites, 12,620 tests passing, including 11 new ones covering `useLongPress` and the ruler formatter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuDTX29QBQBLqgWxMcwsdj)_