### PR TITLE
feat(credits): credit ledger, subscription plans, and a metered nodetool provider

### DIFF
--- a/docs/agentic-video-product.md
+++ b/docs/agentic-video-product.md
@@ -75,14 +75,24 @@ Server-owned, in `packages/models/src/credits.ts` (`@nodetool-ai/models`):
 - **API**: `trpc.credits.status | setPlan | topup`
   (`packages/websocket/src/trpc/routers/credits.ts`, schemas in
   `packages/protocol/src/api-schemas/credits.ts`).
-- **Enforcement** (`packages/websocket/src/credit-gate.ts`): off by default —
-  the open platform meters cost but never blocks. A Studio deployment sets
-  `NODETOOL_CREDITS_ENFORCED=1`, and then every spend path refuses on an
-  empty balance with `BUDGET_EXCEEDED`: workflow runs (`admitCreditRun` in
-  `unified-websocket-runner.ts`, next to the application-budget gate, using
-  the same cost estimate as a floor) and the direct `generate_media` /
-  `transcribe_audio` RPCs the script editor voices through. Like the app
-  gate, it fails open on gate errors.
+- **The `nodetool` provider is what gets metered.** NodeTool's own managed
+  models are a real provider (`packages/runtime/src/providers/nodetool-provider.ts`,
+  id `nodetool`): each curated model (`NODETOOL_MODELS` in
+  `@nodetool-ai/protocol`) names a delegate provider+model, and the provider
+  runs the delegate on *platform-owned* keys (`NODETOOL_PLATFORM_FAL_KEY`,
+  `NODETOOL_PLATFORM_ANTHROPIC_KEY`) rather than the user's. Cost is absorbed
+  from the delegate at the delegate's price, and
+  `@nodetool-ai/model-pricing` translates `nodetool/...` ids to the delegate
+  before lookup so estimates are real numbers. Models appear in the pickers
+  only when their platform key is set.
+- **Enforcement follows the provider, not the deployment**
+  (`packages/websocket/src/credit-gate.ts`): a workflow run is gated only on
+  the slice of its estimate whose provider is `nodetool`
+  (`estimateNodetoolSpend` → `admitCreditRun`, next to the
+  application-budget gate); the direct `generate_media`/`transcribe_audio`
+  RPCs are gated only when called with `provider: "nodetool"`. BYOK
+  providers are never gated — credits and bring-your-own-key coexist on one
+  server, per user, per call. The gate fails open on its own errors.
 - **UI**: the header chip reads `credits.status` and links to
   `/studio/account` — balance, usage, plan cards, and the (clearly labeled)
   test top-up.

--- a/docs/agentic-video-product.md
+++ b/docs/agentic-video-product.md
@@ -57,31 +57,46 @@ Changing the lineup is editing that file. If the product later needs per-plan
 lineups (e.g. faster models on the free tier), the same shape can move to a
 server-delivered config.
 
-## Credits
+## Credits and plans
 
-Prototype semantics, in `web/src/studio/useStudioCredits.ts`:
+Server-owned, in `packages/models/src/credits.ts` (`@nodetool-ai/models`):
 
-- 1 credit = $0.01 of provider spend.
-- Balance = flat grant (1,000 credits) minus everything in the prediction
-  ledger for the last 90 days, read from `costs.dashboard`.
-- Display-only: the chip in the Studio header. Nothing is blocked
-  client-side.
+- **1 credit = $0.01 of provider spend.** Spend is never double-booked: the
+  balance is `sum(grant ledger) - ceil(prediction spend / 1¢)`, read straight
+  from the `nodetool_predictions` rows every provider call already writes.
+- **Ledger** (`nodetool_credit_ledger`) holds grants only: monthly plan
+  accruals, top-ups, adjustments. Plan grants use the row id
+  `plan:<userId>:<planId>:<YYYY-MM>`, so the lazy accrual (run on every
+  status read) is idempotent by primary key — no cron.
+- **Plans** (`nodetool_user_subscriptions`, catalog `CREDIT_PLANS`): Free
+  300/mo, Creator 3,000/mo ($12), Pro 10,000/mo ($40). Switching is instant
+  and unbilled; a payment provider integration replaces the `topup` mutation
+  with a checkout session and writes ledger rows from its webhook.
+- **API**: `trpc.credits.status | setPlan | topup`
+  (`packages/websocket/src/trpc/routers/credits.ts`, schemas in
+  `packages/protocol/src/api-schemas/credits.ts`).
+- **Enforcement** (`packages/websocket/src/credit-gate.ts`): off by default —
+  the open platform meters cost but never blocks. A Studio deployment sets
+  `NODETOOL_CREDITS_ENFORCED=1`, and then every spend path refuses on an
+  empty balance with `BUDGET_EXCEEDED`: workflow runs (`admitCreditRun` in
+  `unified-websocket-runner.ts`, next to the application-budget gate, using
+  the same cost estimate as a floor) and the direct `generate_media` /
+  `transcribe_audio` RPCs the script editor voices through. Like the app
+  gate, it fails open on gate errors.
+- **UI**: the header chip reads `credits.status` and links to
+  `/studio/account` — balance, usage, plan cards, and the (clearly labeled)
+  test top-up.
 
-The path to real enforcement already exists in the platform and is the next
-step after the prototype validates:
+Still open, in order of value:
 
-1. **Server gate.** The `application_budgets` machinery
-   (`packages/models/src/application-budget.ts`, enforced in
-   `unified-websocket-runner.ts` with `BUDGET_EXCEEDED`) already does
-   estimate → reserve → settle per invocation. Generalize the key from
-   `application_id` to a user-scoped budget row and every generation path —
-   storyboard stills/clips, voicing, timeline generate — is gated by the same
-   code.
-2. **Purchases.** A `credits` tRPC router (alongside `costsRouter`) exposing
-   balance + top-ups; grants become ledger rows instead of a client constant.
-3. **Estimates before spend.** `@nodetool-ai/model-pricing`
+1. **Per-action estimates.** `@nodetool-ai/model-pricing`
    (`getModelUnitPrice`) prices the curated models per unit, so shot cards
    and the voice-all button can show "≈ 3 credits" before the click.
+2. **Payments.** Stripe (or similar) in front of `setPlan`/`topup`; the
+   ledger and gate don't change.
+3. **Direct-RPC metering.** `generate_media`/`transcribe_audio` are gated but
+   still write no prediction rows, so their spend doesn't decrement the
+   balance. Recording a row at the provider's reported cost closes that.
 
 ## From prototype to product
 

--- a/packages/model-pricing/package.json
+++ b/packages/model-pricing/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@nodetool-ai/fal-nodes": "*",
     "@nodetool-ai/kie-nodes": "*",
-    "@nodetool-ai/node-sdk": "*"
+    "@nodetool-ai/node-sdk": "*",
+    "@nodetool-ai/protocol": "*"
   },
   "devDependencies": {
     "typescript": "^5.7.2",

--- a/packages/model-pricing/src/index.ts
+++ b/packages/model-pricing/src/index.ts
@@ -27,6 +27,7 @@ import type {
 import falUnitPricingCatalog from "@nodetool-ai/fal-nodes/unit-pricing-catalog";
 import kieUnitPricingCatalog from "@nodetool-ai/kie-nodes/unit-pricing-catalog";
 import { getGenspendPrice, GENSPEND_CURRENCY } from "./genspend-catalog.js";
+import { resolveNodetoolDelegate } from "@nodetool-ai/protocol";
 
 interface CatalogPrice {
   unit_price?: unknown;
@@ -86,6 +87,17 @@ function genspendPrice(model: SelectedModel): ModelUnitPricingLike | null {
 export function getModelUnitPrice(
   model: SelectedModel
 ): ModelUnitPricingLike | null {
+  // NodeTool's managed models price at their delegate's rate: translate the
+  // curated id to the underlying provider+model before the catalog lookups,
+  // so credit estimates for the metered provider are real numbers.
+  if (model.provider === "nodetool") {
+    const delegate = resolveNodetoolDelegate(model.id);
+    if (!delegate) return null;
+    return getModelUnitPrice({
+      id: delegate.model,
+      provider: delegate.provider
+    });
+  }
   return falPrice(model.id) ?? kiePrice(model.id) ?? genspendPrice(model);
 }
 

--- a/packages/model-pricing/tests/model-pricing.test.ts
+++ b/packages/model-pricing/tests/model-pricing.test.ts
@@ -63,4 +63,21 @@ describe("getModelUnitPrice", () => {
   it("returns null for a model in no catalog", () => {
     expect(getModelUnitPrice({ id: "no-such/model", provider: null })).toBeNull();
   });
+
+  it("prices a nodetool model at its delegate's rate", () => {
+    const direct = getModelUnitPrice({
+      id: "fal-ai/flux-1/schnell",
+      provider: "fal_ai"
+    });
+    expect(direct).not.toBeNull();
+    expect(
+      getModelUnitPrice({ id: "nodetool/flux-schnell", provider: "nodetool" })
+    ).toEqual(direct);
+  });
+
+  it("returns null for an unknown nodetool model id", () => {
+    expect(
+      getModelUnitPrice({ id: "nodetool/nope", provider: "nodetool" })
+    ).toBeNull();
+  });
 });

--- a/packages/models/src/credits.ts
+++ b/packages/models/src/credits.ts
@@ -12,7 +12,8 @@
  * would write `topup` rows and flip `plan_id`; until then plan switches are
  * instant and top-ups are stubbed.
  */
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
+import { NODETOOL_PROVIDER_ID } from "@nodetool-ai/protocol";
 
 import { getDb } from "./db.js";
 import { creditLedger, userSubscriptions } from "./schema/credits.js";
@@ -222,10 +223,18 @@ export async function creditStatus(userId: string): Promise<CreditStatus> {
     .where(eq(creditLedger.user_id, userId));
   const grantedCredits = Number(grantRows[0]?.total ?? 0);
 
+  // Only the managed provider's spend counts against credits — BYOK
+  // predictions (fal_ai, anthropic, …) ride the user's own keys and must
+  // never drain the balance.
   const spendRows = await db
     .select({ total: sql<number>`COALESCE(SUM(${predictions.cost}), 0)` })
     .from(predictions)
-    .where(eq(predictions.user_id, userId));
+    .where(
+      and(
+        eq(predictions.user_id, userId),
+        eq(predictions.provider, NODETOOL_PROVIDER_ID)
+      )
+    );
   const spentUsd = Number(spendRows[0]?.total ?? 0);
   const spentCredits = Math.ceil(spentUsd / USD_PER_CREDIT);
 

--- a/packages/models/src/credits.ts
+++ b/packages/models/src/credits.ts
@@ -1,0 +1,272 @@
+/**
+ * User credits and subscription plans — the Studio product's billing layer.
+ *
+ * The ledger stores grants only. Spend is never written here: every provider
+ * call already lands in `nodetool_predictions` with its USD cost, so
+ *
+ *   balance = sum(ledger.delta) - ceil(prediction spend / USD_PER_CREDIT)
+ *
+ * Plans accrue lazily: the first balance read in a month inserts that month's
+ * grant, keyed `plan:<userId>:<periodKey>` so the primary key makes double
+ * accrual impossible. No cron, no payment state — a payment provider webhook
+ * would write `topup` rows and flip `plan_id`; until then plan switches are
+ * instant and top-ups are stubbed.
+ */
+import { eq, sql } from "drizzle-orm";
+
+import { getDb } from "./db.js";
+import { creditLedger, userSubscriptions } from "./schema/credits.js";
+import { predictions } from "./schema/predictions.js";
+import { createTimeOrderedUuid } from "./base-model.js";
+
+/** One credit is one US cent of provider spend. */
+export const USD_PER_CREDIT = 0.01;
+
+export interface CreditPlan {
+  id: string;
+  name: string;
+  /** Credits granted at the start of each calendar month (UTC). */
+  monthlyCredits: number;
+  /** Display price; billing itself is not implemented. */
+  priceUsdPerMonth: number;
+  blurb: string;
+}
+
+export const CREDIT_PLANS: readonly CreditPlan[] = [
+  {
+    id: "free",
+    name: "Free",
+    monthlyCredits: 300,
+    priceUsdPerMonth: 0,
+    blurb: "Try both creation paths with a monthly starter allowance."
+  },
+  {
+    id: "creator",
+    name: "Creator",
+    monthlyCredits: 3_000,
+    priceUsdPerMonth: 12,
+    blurb: "Enough for regular short-form work: stills, clips, and voice."
+  },
+  {
+    id: "pro",
+    name: "Pro",
+    monthlyCredits: 10_000,
+    priceUsdPerMonth: 40,
+    blurb: "Headroom for daily production and longer cuts."
+  }
+] as const;
+
+export const DEFAULT_PLAN_ID = "free";
+
+export const planById = (planId: string): CreditPlan | null =>
+  CREDIT_PLANS.find((p) => p.id === planId) ?? null;
+
+/** Calendar-month key, UTC — "2026-08". */
+export const periodKeyFor = (now: Date): string =>
+  `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+
+export interface UserSubscription {
+  userId: string;
+  planId: string;
+  status: string;
+  updatedAt: string;
+}
+
+export interface CreditStatus {
+  userId: string;
+  plan: CreditPlan;
+  periodKey: string;
+  /** All grants ever recorded, in credits. */
+  grantedCredits: number;
+  /** All prediction spend ever recorded, rounded up, in credits. */
+  spentCredits: number;
+  /** grantedCredits - spentCredits, floored at 0 for display. */
+  balanceCredits: number;
+  spentUsd: number;
+}
+
+export type CreditDecision =
+  | { allowed: true; status: CreditStatus }
+  | { allowed: false; reason: string; status: CreditStatus };
+
+const toSubscription = (row: Record<string, unknown>): UserSubscription => ({
+  userId: String(row.user_id),
+  planId: String(row.plan_id ?? DEFAULT_PLAN_ID),
+  status: String(row.status ?? "active"),
+  updatedAt: String(row.updated_at ?? "")
+});
+
+/** The user's subscription, creating the default (free) row on first read. */
+export async function getSubscription(
+  userId: string
+): Promise<UserSubscription> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(userSubscriptions)
+    .where(eq(userSubscriptions.user_id, userId))
+    .limit(1);
+  if (rows[0]) return toSubscription(rows[0] as Record<string, unknown>);
+
+  const now = new Date().toISOString();
+  try {
+    await db.insert(userSubscriptions).values({
+      user_id: userId,
+      plan_id: DEFAULT_PLAN_ID,
+      status: "active",
+      created_at: now,
+      updated_at: now
+    });
+  } catch {
+    // Concurrent first read created it; fall through to the re-read.
+  }
+  const created = await db
+    .select()
+    .from(userSubscriptions)
+    .where(eq(userSubscriptions.user_id, userId))
+    .limit(1);
+  return toSubscription(created[0] as Record<string, unknown>);
+}
+
+export async function setSubscriptionPlan(
+  userId: string,
+  planId: string
+): Promise<UserSubscription> {
+  const plan = planById(planId);
+  if (!plan) throw new Error(`Unknown plan "${planId}".`);
+  await getSubscription(userId);
+  const db = getDb();
+  await db
+    .update(userSubscriptions)
+    .set({ plan_id: plan.id, updated_at: new Date().toISOString() })
+    .where(eq(userSubscriptions.user_id, userId));
+  // Accrue the new plan's grant for the current month right away, so an
+  // upgrade is usable the moment it happens (the id keys on plan too, so an
+  // upgraded month carries both grants — acceptable, and simpler than
+  // proration).
+  await ensureMonthlyGrant(userId, new Date());
+  return getSubscription(userId);
+}
+
+/**
+ * Insert this month's plan grant if it isn't there yet. Idempotent via the
+ * primary key `plan:<userId>:<planId>:<periodKey>`.
+ */
+export async function ensureMonthlyGrant(
+  userId: string,
+  now: Date
+): Promise<void> {
+  const subscription = await getSubscription(userId);
+  const plan = planById(subscription.planId) ?? planById(DEFAULT_PLAN_ID)!;
+  if (subscription.status !== "active" || plan.monthlyCredits <= 0) return;
+
+  const periodKey = periodKeyFor(now);
+  const id = `plan:${userId}:${plan.id}:${periodKey}`;
+  const db = getDb();
+  const existing = await db
+    .select({ id: creditLedger.id })
+    .from(creditLedger)
+    .where(eq(creditLedger.id, id))
+    .limit(1);
+  if (existing[0]) return;
+  try {
+    await db.insert(creditLedger).values({
+      id,
+      user_id: userId,
+      delta: plan.monthlyCredits,
+      kind: "plan_grant",
+      description: `${plan.name} plan — ${periodKey}`,
+      period_key: periodKey,
+      created_at: now.toISOString()
+    });
+  } catch {
+    // Lost a race with a concurrent accrual of the same id — already granted.
+  }
+}
+
+/** Record a top-up or manual adjustment. */
+export async function grantCredits(
+  userId: string,
+  delta: number,
+  kind: "topup" | "adjustment",
+  description?: string
+): Promise<void> {
+  if (!Number.isFinite(delta) || delta === 0) {
+    throw new Error("Credit delta must be a non-zero number.");
+  }
+  const db = getDb();
+  await db.insert(creditLedger).values({
+    id: createTimeOrderedUuid(),
+    user_id: userId,
+    delta: Math.trunc(delta),
+    kind,
+    description: description ?? null,
+    period_key: null,
+    created_at: new Date().toISOString()
+  });
+}
+
+/** Balance, plan, and totals — accrues the current month's grant first. */
+export async function creditStatus(userId: string): Promise<CreditStatus> {
+  const now = new Date();
+  await ensureMonthlyGrant(userId, now);
+  const subscription = await getSubscription(userId);
+  const plan = planById(subscription.planId) ?? planById(DEFAULT_PLAN_ID)!;
+
+  const db = getDb();
+  const grantRows = await db
+    .select({
+      total: sql<number>`COALESCE(SUM(${creditLedger.delta}), 0)`
+    })
+    .from(creditLedger)
+    .where(eq(creditLedger.user_id, userId));
+  const grantedCredits = Number(grantRows[0]?.total ?? 0);
+
+  const spendRows = await db
+    .select({ total: sql<number>`COALESCE(SUM(${predictions.cost}), 0)` })
+    .from(predictions)
+    .where(eq(predictions.user_id, userId));
+  const spentUsd = Number(spendRows[0]?.total ?? 0);
+  const spentCredits = Math.ceil(spentUsd / USD_PER_CREDIT);
+
+  return {
+    userId,
+    plan,
+    periodKey: periodKeyFor(now),
+    grantedCredits,
+    spentCredits,
+    balanceCredits: Math.max(0, grantedCredits - spentCredits),
+    spentUsd
+  };
+}
+
+/**
+ * The pre-spend gate. `estimatedUsd` is a floor (unpriceable nodes estimate
+ * 0), so the check is: the balance must cover the estimate, and must be
+ * positive at all. Callers decide whether the gate is on at all
+ * (NODETOOL_CREDITS_ENFORCED).
+ */
+export async function checkCredits(
+  userId: string,
+  estimatedUsd: number
+): Promise<CreditDecision> {
+  const status = await creditStatus(userId);
+  const estimatedCredits = Math.ceil(
+    Math.max(0, estimatedUsd) / USD_PER_CREDIT
+  );
+  if (status.balanceCredits <= 0) {
+    return {
+      allowed: false,
+      reason: `Out of credits on the ${status.plan.name} plan. Upgrade or top up to continue.`,
+      status
+    };
+  }
+  if (estimatedCredits > status.balanceCredits) {
+    return {
+      allowed: false,
+      reason: `This run needs about ${estimatedCredits} credits but ${status.balanceCredits} remain.`,
+      status
+    };
+  }
+  return { allowed: true, status };
+}

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -1161,6 +1161,25 @@ function getCreateSchemaSql(): string {
     CREATE INDEX IF NOT EXISTS "idx_application_invocation_created" ON "application_invocations" ("created_at");
     CREATE INDEX IF NOT EXISTS "idx_application_invocation_invocation" ON "application_invocations" ("invocation_id");
 
+    CREATE TABLE IF NOT EXISTS "nodetool_credit_ledger" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL,
+      "delta" integer NOT NULL,
+      "kind" text NOT NULL,
+      "description" text,
+      "period_key" text,
+      "created_at" text NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS "idx_credit_ledger_user" ON "nodetool_credit_ledger" ("user_id");
+
+    CREATE TABLE IF NOT EXISTS "nodetool_user_subscriptions" (
+      "user_id" text PRIMARY KEY NOT NULL,
+      "plan_id" text NOT NULL DEFAULT 'free',
+      "status" text NOT NULL DEFAULT 'active',
+      "created_at" text NOT NULL,
+      "updated_at" text NOT NULL
+    );
+
     CREATE TABLE IF NOT EXISTS "scripts" (
       "id" text PRIMARY KEY NOT NULL,
       "user_id" text NOT NULL,

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -333,3 +333,22 @@ export function getGlobalAdapterResolver():
 // Legacy types kept for API compat
 export type { IndexSpec } from "./legacy-compat.js";
 export type { ModelClass, AdapterResolver } from "./legacy-compat.js";
+export {
+  CREDIT_PLANS,
+  DEFAULT_PLAN_ID,
+  USD_PER_CREDIT,
+  checkCredits,
+  creditStatus,
+  ensureMonthlyGrant,
+  getSubscription,
+  grantCredits,
+  periodKeyFor,
+  planById,
+  setSubscriptionPlan
+} from "./credits.js";
+export type {
+  CreditDecision,
+  CreditPlan,
+  CreditStatus,
+  UserSubscription
+} from "./credits.js";

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -2571,6 +2571,50 @@ export const migrations: MigrationDef[] = [
       await db.execute("DROP INDEX IF EXISTS idx_idv_document");
       await db.execute("DROP TABLE IF EXISTS image_document_versions");
     }
+  },
+
+  // ── User credits and subscription plans ────────────────────────────
+  // The Studio product's billing veneer. The ledger holds grants only
+  // (plan accruals, top-ups, adjustments); spend already lives in
+  // nodetool_predictions, so balance = sum(delta) - spend-in-credits.
+  // Plan grants use the id `plan:<userId>:<periodKey>` so the lazy monthly
+  // accrual is idempotent by primary key. One subscription row per user;
+  // payment state stays out until a payment provider is wired in.
+  {
+    version: "20260806_000000",
+    name: "create_credit_ledger_and_subscriptions",
+    createsTables: ["nodetool_credit_ledger", "nodetool_user_subscriptions"],
+    modifiesTables: [],
+    async up(db) {
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS nodetool_credit_ledger (
+          id TEXT PRIMARY KEY NOT NULL,
+          user_id TEXT NOT NULL,
+          delta INTEGER NOT NULL,
+          kind TEXT NOT NULL,
+          description TEXT,
+          period_key TEXT,
+          created_at TEXT NOT NULL
+        )
+      `);
+      await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_credit_ledger_user ON nodetool_credit_ledger (user_id)"
+      );
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS nodetool_user_subscriptions (
+          user_id TEXT PRIMARY KEY NOT NULL,
+          plan_id TEXT NOT NULL DEFAULT 'free',
+          status TEXT NOT NULL DEFAULT 'active',
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        )
+      `);
+    },
+    async down(db) {
+      await db.execute("DROP TABLE IF EXISTS nodetool_user_subscriptions");
+      await db.execute("DROP INDEX IF EXISTS idx_credit_ledger_user");
+      await db.execute("DROP TABLE IF EXISTS nodetool_credit_ledger");
+    }
   }
 ];
 

--- a/packages/models/src/schema-pg/credits.ts
+++ b/packages/models/src/schema-pg/credits.ts
@@ -1,0 +1,25 @@
+import { pgTable, text, integer, index } from "drizzle-orm/pg-core";
+
+// See the SQLite schema (../schema/credits.ts) for field documentation.
+
+export const creditLedger = pgTable(
+  "nodetool_credit_ledger",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    delta: integer("delta").notNull(),
+    kind: text("kind").notNull(),
+    description: text("description"),
+    period_key: text("period_key"),
+    created_at: text("created_at").notNull()
+  },
+  (table) => [index("idx_credit_ledger_user").on(table.user_id)]
+);
+
+export const userSubscriptions = pgTable("nodetool_user_subscriptions", {
+  user_id: text("user_id").primaryKey(),
+  plan_id: text("plan_id").notNull().default("free"),
+  status: text("status").notNull().default("active"),
+  created_at: text("created_at").notNull(),
+  updated_at: text("updated_at").notNull()
+});

--- a/packages/models/src/schema-pg/index.ts
+++ b/packages/models/src/schema-pg/index.ts
@@ -29,3 +29,4 @@ export { scripts } from "./scripts.js";
 export { triggerInputs } from "./trigger-inputs.js";
 export { runInboxMessages } from "./run-inbox-messages.js";
 export { triggerRegistrations } from "./trigger-registrations.js";
+export { creditLedger, userSubscriptions } from "./credits.js";

--- a/packages/models/src/schema/credits.ts
+++ b/packages/models/src/schema/credits.ts
@@ -1,0 +1,39 @@
+import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+
+/**
+ * Credit grants per user. Spend is not written here — it already lives in
+ * `nodetool_predictions` — so the balance is one subtraction:
+ * sum(grants) - ceil(prediction spend / credit price).
+ *
+ * Plan grants are idempotent by construction: their row id is
+ * `plan:<userId>:<periodKey>`, so re-running the lazy monthly accrual can
+ * never double-grant.
+ */
+export const creditLedger = sqliteTable(
+  "nodetool_credit_ledger",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    /** Credits granted (positive) or revoked (negative). */
+    delta: integer("delta").notNull(),
+    /** "plan_grant" | "topup" | "adjustment" */
+    kind: text("kind").notNull(),
+    description: text("description"),
+    /** Month key ("2026-08") for plan grants; null otherwise. */
+    period_key: text("period_key"),
+    created_at: text("created_at").notNull()
+  },
+  (table) => [index("idx_credit_ledger_user").on(table.user_id)]
+);
+
+/**
+ * One subscription per user. No payment state — a payment provider webhook
+ * would flip `plan_id`/`status` here; until then plan switches are instant.
+ */
+export const userSubscriptions = sqliteTable("nodetool_user_subscriptions", {
+  user_id: text("user_id").primaryKey(),
+  plan_id: text("plan_id").notNull().default("free"),
+  status: text("status").notNull().default("active"),
+  created_at: text("created_at").notNull(),
+  updated_at: text("updated_at").notNull()
+});

--- a/packages/models/src/schema/index.ts
+++ b/packages/models/src/schema/index.ts
@@ -30,3 +30,4 @@ export { workerProfiles, workerInstances } from "./workers.js";
 export { triggerInputs } from "./trigger-inputs.js";
 export { runInboxMessages } from "./run-inbox-messages.js";
 export { triggerRegistrations } from "./trigger-registrations.js";
+export { creditLedger, userSubscriptions } from "./credits.js";

--- a/packages/models/tests/credits.test.ts
+++ b/packages/models/tests/credits.test.ts
@@ -18,12 +18,12 @@ const USER = "u1";
 const FREE = CREDIT_PLANS.find((p) => p.id === "free")!;
 const CREATOR = CREDIT_PLANS.find((p) => p.id === "creator")!;
 
-const spend = (cost: number) =>
+const spend = (cost: number, provider = "nodetool") =>
   Prediction.create<Prediction>({
     user_id: USER,
     node_id: "n",
     node_type: "test",
-    provider: "test",
+    provider,
     model: "test",
     cost
   });
@@ -97,6 +97,19 @@ describe("credits", () => {
     if (!big.allowed) {
       expect(big.reason).toContain("credits");
     }
+  });
+
+  it("only managed-provider spend counts — BYOK predictions never drain credits", async () => {
+    await creditStatus(USER);
+    await spend(0.5, "fal_ai");
+    await spend(1.25, "anthropic");
+    const untouched = await creditStatus(USER);
+    expect(untouched.spentCredits).toBe(0);
+    expect(untouched.balanceCredits).toBe(FREE.monthlyCredits);
+
+    await spend(0.02, "nodetool");
+    const managed = await creditStatus(USER);
+    expect(managed.spentCredits).toBe(2);
   });
 
   it("credits are per user", async () => {

--- a/packages/models/tests/credits.test.ts
+++ b/packages/models/tests/credits.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { initTestDb } from "../src/db.js";
+import { Prediction } from "../src/prediction.js";
+import {
+  CREDIT_PLANS,
+  USD_PER_CREDIT,
+  checkCredits,
+  creditStatus,
+  ensureMonthlyGrant,
+  getSubscription,
+  grantCredits,
+  periodKeyFor,
+  setSubscriptionPlan
+} from "../src/credits.js";
+
+const USER = "u1";
+const FREE = CREDIT_PLANS.find((p) => p.id === "free")!;
+const CREATOR = CREDIT_PLANS.find((p) => p.id === "creator")!;
+
+const spend = (cost: number) =>
+  Prediction.create<Prediction>({
+    user_id: USER,
+    node_id: "n",
+    node_type: "test",
+    provider: "test",
+    model: "test",
+    cost
+  });
+
+describe("credits", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("defaults a new user to the free plan and accrues its monthly grant once", async () => {
+    const sub = await getSubscription(USER);
+    expect(sub.planId).toBe("free");
+
+    const first = await creditStatus(USER);
+    expect(first.grantedCredits).toBe(FREE.monthlyCredits);
+    expect(first.balanceCredits).toBe(FREE.monthlyCredits);
+    expect(first.periodKey).toBe(periodKeyFor(new Date()));
+
+    // A second read in the same month must not double-grant.
+    const second = await creditStatus(USER);
+    expect(second.grantedCredits).toBe(FREE.monthlyCredits);
+  });
+
+  it("accrues again in a new month", async () => {
+    await creditStatus(USER);
+    const nextMonth = new Date();
+    nextMonth.setUTCMonth(nextMonth.getUTCMonth() + 1);
+    await ensureMonthlyGrant(USER, nextMonth);
+    const status = await creditStatus(USER);
+    expect(status.grantedCredits).toBe(FREE.monthlyCredits * 2);
+  });
+
+  it("subtracts prediction spend, rounded up to whole credits", async () => {
+    await creditStatus(USER);
+    await spend(0.015); // 1.5 credits → counts as 2
+    const status = await creditStatus(USER);
+    expect(status.spentCredits).toBe(2);
+    expect(status.balanceCredits).toBe(FREE.monthlyCredits - 2);
+  });
+
+  it("switching plans grants the new plan's month immediately", async () => {
+    await creditStatus(USER);
+    const sub = await setSubscriptionPlan(USER, "creator");
+    expect(sub.planId).toBe("creator");
+    const status = await creditStatus(USER);
+    expect(status.plan.id).toBe("creator");
+    expect(status.grantedCredits).toBe(
+      FREE.monthlyCredits + CREATOR.monthlyCredits
+    );
+  });
+
+  it("top-ups add to the balance", async () => {
+    await creditStatus(USER);
+    await grantCredits(USER, 500, "topup");
+    const status = await creditStatus(USER);
+    expect(status.balanceCredits).toBe(FREE.monthlyCredits + 500);
+  });
+
+  it("refuses an empty balance and an estimate beyond the balance", async () => {
+    await creditStatus(USER);
+    await spend(FREE.monthlyCredits * USD_PER_CREDIT); // drain exactly
+
+    const drained = await checkCredits(USER, 0);
+    expect(drained.allowed).toBe(false);
+
+    await grantCredits(USER, 10, "topup");
+    const small = await checkCredits(USER, 5 * USD_PER_CREDIT);
+    expect(small.allowed).toBe(true);
+    const big = await checkCredits(USER, 50 * USD_PER_CREDIT);
+    expect(big.allowed).toBe(false);
+    if (!big.allowed) {
+      expect(big.reason).toContain("credits");
+    }
+  });
+
+  it("credits are per user", async () => {
+    await creditStatus(USER);
+    await creditStatus("u2");
+    await spend(0.5);
+    const other = await creditStatus("u2");
+    expect(other.spentCredits).toBe(0);
+    expect(other.balanceCredits).toBe(FREE.monthlyCredits);
+  });
+});

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 59;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 60;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);

--- a/packages/protocol/src/api-schemas/credits.ts
+++ b/packages/protocol/src/api-schemas/credits.ts
@@ -25,6 +25,8 @@ export const creditStatusOutput = z.object({
    * are never gated — both models coexist on one server.
    */
   meteredProvider: z.string(),
+  /** True only on dev servers that opt into the no-payment test top-up. */
+  testTopupEnabled: z.boolean(),
   plans: z.array(creditPlan)
 });
 export type CreditStatusOutput = z.infer<typeof creditStatusOutput>;

--- a/packages/protocol/src/api-schemas/credits.ts
+++ b/packages/protocol/src/api-schemas/credits.ts
@@ -20,8 +20,11 @@ export const creditStatusOutput = z.object({
   spentCredits: z.number().int(),
   balanceCredits: z.number().int(),
   spentUsd: z.number(),
-  /** Whether the server refuses runs when the balance is empty. */
-  enforced: z.boolean(),
+  /**
+   * The provider whose spend the balance meters ("nodetool"). BYOK providers
+   * are never gated — both models coexist on one server.
+   */
+  meteredProvider: z.string(),
   plans: z.array(creditPlan)
 });
 export type CreditStatusOutput = z.infer<typeof creditStatusOutput>;

--- a/packages/protocol/src/api-schemas/credits.ts
+++ b/packages/protocol/src/api-schemas/credits.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+// ── Shared shapes ──────────────────────────────────────────────────
+
+export const creditPlan = z.object({
+  id: z.string(),
+  name: z.string(),
+  monthlyCredits: z.number().int(),
+  priceUsdPerMonth: z.number(),
+  blurb: z.string()
+});
+export type CreditPlanSchema = z.infer<typeof creditPlan>;
+
+export const creditStatusOutput = z.object({
+  userId: z.string(),
+  plan: creditPlan,
+  /** Calendar-month key, UTC — "2026-08". */
+  periodKey: z.string(),
+  grantedCredits: z.number().int(),
+  spentCredits: z.number().int(),
+  balanceCredits: z.number().int(),
+  spentUsd: z.number(),
+  /** Whether the server refuses runs when the balance is empty. */
+  enforced: z.boolean(),
+  plans: z.array(creditPlan)
+});
+export type CreditStatusOutput = z.infer<typeof creditStatusOutput>;
+
+// ── Inputs ─────────────────────────────────────────────────────────
+
+export const setPlanInput = z.object({
+  planId: z.string().min(1)
+});
+
+export const topupInput = z.object({
+  /** Credits to add. Bounded until a payment provider fronts this. */
+  credits: z.number().int().min(1).max(50_000)
+});

--- a/packages/protocol/src/api-schemas/index.ts
+++ b/packages/protocol/src/api-schemas/index.ts
@@ -4,6 +4,7 @@ export * as assets from "./assets.js";
 export * as codeGen from "./code-gen.js";
 export * as collections from "./collections.js";
 export * as costs from "./costs.js";
+export * as credits from "./credits.js";
 export * as files from "./files.js";
 export * as fonts from "./fonts.js";
 export * as jobs from "./jobs.js";

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -1042,6 +1042,9 @@ export const PROVIDER_IDS = {
   CEREBRAS: "cerebras",
   EVOLINK: "evolink",
   GMI: "gmi",
+  // NodeTool's own managed models: curated delegates run on platform keys and
+  // metered against the user's credit balance (BYOK providers stay unmetered).
+  NODETOOL: "nodetool",
   // Media / 3D / utility APIs
   REPLICATE: "replicate",
   FAL_AI: "fal_ai",

--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -213,7 +213,8 @@ export const CLOUD_PROVIDER_IDS: readonly string[] = [
   "mistral",
   "xai",
   "fal_ai",
-  "kie"
+  "kie",
+  "nodetool"
 ];
 
 /**

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -35,3 +35,4 @@ export {
   normalizePlatforms,
   supportsPlatform
 } from "./platform.js";
+export * from "./nodetool-models.js";

--- a/packages/protocol/src/nodetool-models.ts
+++ b/packages/protocol/src/nodetool-models.ts
@@ -1,0 +1,59 @@
+/**
+ * The curated catalog behind the `nodetool` provider — NodeTool's own managed
+ * models. Each entry names the delegate that actually serves it; the provider
+ * runs the delegate on platform-owned keys and the spend is metered against
+ * the user's credit balance. BYOK providers are untouched by any of this.
+ *
+ * Pure data on purpose: the runtime provider routes with it, model-pricing
+ * translates ids through it, and the web curated-model config points at it.
+ */
+
+export interface NodetoolModelDef {
+  /** Public model id under the `nodetool` provider, e.g. "nodetool/flux-schnell". */
+  id: string;
+  name: string;
+  kind: "language" | "image" | "video";
+  /** Image/video task hints for the pickers. */
+  tasks?: string[];
+  delegate: {
+    provider: string;
+    model: string;
+  };
+}
+
+export const NODETOOL_PROVIDER_ID = "nodetool";
+
+export const NODETOOL_MODELS: readonly NodetoolModelDef[] = [
+  {
+    id: "nodetool/director",
+    name: "NodeTool Director",
+    kind: "language",
+    delegate: { provider: "anthropic", model: "claude-sonnet-5" }
+  },
+  {
+    id: "nodetool/flux-schnell",
+    name: "NodeTool Still (FLUX Schnell)",
+    kind: "image",
+    tasks: ["text_to_image", "image_to_image"],
+    delegate: { provider: "fal_ai", model: "fal-ai/flux-1/schnell" }
+  },
+  {
+    id: "nodetool/kling-standard",
+    name: "NodeTool Clip (Kling Standard)",
+    kind: "video",
+    tasks: ["image_to_video"],
+    delegate: {
+      provider: "fal_ai",
+      model: "fal-ai/kling-video/o1/standard/image-to-video"
+    }
+  }
+] as const;
+
+export const nodetoolModelById = (id: string): NodetoolModelDef | null =>
+  NODETOOL_MODELS.find((m) => m.id === id) ?? null;
+
+/** The delegate behind a nodetool model id, or null for an unknown id. */
+export const resolveNodetoolDelegate = (
+  id: string
+): { provider: string; model: string } | null =>
+  nodetoolModelById(id)?.delegate ?? null;

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -36,6 +36,7 @@ import { HuggingFaceProvider } from "./huggingface-provider.js";
 import { PythonProvider } from "./python-provider.js";
 import { ReplicateProvider } from "./replicate-provider.js";
 import { FalProvider } from "./fal-provider.js";
+import { NodetoolProvider } from "./nodetool-provider.js";
 import { KieProvider } from "./kie-provider.js";
 import { ElevenLabsProvider } from "./elevenlabs-provider.js";
 import { TopazProvider } from "./topaz-provider.js";
@@ -81,6 +82,7 @@ export { HuggingFaceProvider };
 export { PythonProvider };
 export { ReplicateProvider };
 export { FalProvider };
+export { NodetoolProvider };
 export { KieProvider };
 export {
   registerWebhookWait,
@@ -276,6 +278,19 @@ registerBuiltinProvider(PROVIDER_IDS.MOONSHOT, MoonshotProvider, { KIMI_API_KEY:
 registerBuiltinProvider(PROVIDER_IDS.MINIMAX, MinimaxProvider, { MINIMAX_API_KEY: "" });
 registerBuiltinProvider(PROVIDER_IDS.REPLICATE, ReplicateProvider, { REPLICATE_API_TOKEN: "" });
 registerBuiltinProvider(PROVIDER_IDS.FAL_AI, FalProvider, { FAL_API_KEY: "" });
+// NodeTool's own managed models: curated delegates on platform-owned keys,
+// metered against the user's credit balance. Registered with no required
+// kwargs — availability is per model, decided by which platform keys are set
+// (the model listers return only funded entries).
+registerBuiltinProvider(
+  PROVIDER_IDS.NODETOOL,
+  NodetoolProvider,
+  {},
+  {
+    NODETOOL_PLATFORM_FAL_KEY: "",
+    NODETOOL_PLATFORM_ANTHROPIC_KEY: ""
+  }
+);
 registerBuiltinProvider(PROVIDER_IDS.KIE, KieProvider, { KIE_API_KEY: "" });
 registerBuiltinProvider(PROVIDER_IDS.ELEVENLABS, ElevenLabsProvider, { ELEVENLABS_API_KEY: "" });
 registerBuiltinProvider(PROVIDER_IDS.TOPAZ, TopazProvider, { TOPAZ_API_KEY: "" });

--- a/packages/runtime/src/providers/nodetool-provider.ts
+++ b/packages/runtime/src/providers/nodetool-provider.ts
@@ -39,7 +39,6 @@ const PLATFORM_KEYS: Record<string, string> = {
 
 export class NodetoolProvider extends BaseProvider {
   private secrets: Record<string, unknown>;
-  private inner = new Map<string, BaseProvider>();
   private _absorbedCost = 0;
 
   static override requiredSecrets(): string[] {
@@ -61,7 +60,14 @@ export class NodetoolProvider extends BaseProvider {
     return this.platformKey(delegateProvider) != null;
   }
 
-  /** The delegate serving a nodetool model id, constructed on platform keys. */
+  /**
+   * The delegate serving a nodetool model id, constructed on platform keys.
+   * A fresh instance per call on purpose: cost is read off the delegate's
+   * cumulative counter after the call, and a shared delegate serving
+   * overlapping calls would double-count one call's cost into another's
+   * absorption window. Construction is cheap — both delegates build their
+   * network clients lazily.
+   */
   private delegateFor(modelId: string): {
     provider: BaseProvider;
     model: string;
@@ -77,15 +83,11 @@ export class NodetoolProvider extends BaseProvider {
           `(missing ${PLATFORM_KEYS[def.delegate.provider]}).`
       );
     }
-    let instance = this.inner.get(def.delegate.provider);
-    if (!instance) {
-      instance =
-        def.delegate.provider === "fal_ai"
-          ? new FalProvider({ FAL_API_KEY: key })
-          : new AnthropicProvider({ ANTHROPIC_API_KEY: key });
-      this.inner.set(def.delegate.provider, instance);
-    }
-    return { provider: instance, model: def.delegate.model };
+    const provider =
+      def.delegate.provider === "fal_ai"
+        ? new FalProvider({ FAL_API_KEY: key })
+        : new AnthropicProvider({ ANTHROPIC_API_KEY: key });
+    return { provider, model: def.delegate.model };
   }
 
   /** Run a delegated call and absorb the delegate's cost delta as our own. */
@@ -111,7 +113,6 @@ export class NodetoolProvider extends BaseProvider {
 
   override resetCost(): void {
     this._absorbedCost = 0;
-    for (const inner of this.inner.values()) inner.resetCost();
   }
 
   protected override declaredCapabilities(): ProviderCapability[] {

--- a/packages/runtime/src/providers/nodetool-provider.ts
+++ b/packages/runtime/src/providers/nodetool-provider.ts
@@ -1,0 +1,232 @@
+/**
+ * NodeTool's own managed models — the provider behind the credits product.
+ *
+ * Every model in the curated catalog (`NODETOOL_MODELS` in
+ * `@nodetool-ai/protocol`) names a delegate provider + model; this provider
+ * runs the delegate on *platform-owned* keys (`NODETOOL_PLATFORM_FAL_KEY`,
+ * `NODETOOL_PLATFORM_ANTHROPIC_KEY`) rather than the user's. That split is
+ * the whole billing model: calls through `nodetool` are metered against the
+ * user's credit balance server-side, while BYOK providers keep running on the
+ * user's own keys, unmetered.
+ *
+ * Cost is accounted at the delegate's price: each call absorbs the inner
+ * provider's cost delta into this instance, so the host's prediction logging
+ * records real USD under provider "nodetool".
+ */
+import {
+  NODETOOL_MODELS,
+  nodetoolModelById
+} from "@nodetool-ai/protocol";
+import { BaseProvider, type ProviderCapability } from "./base-provider.js";
+import type {
+  ImageModel,
+  ImageToImageParams,
+  ImageToVideoParams,
+  LanguageModel,
+  Message,
+  ProviderStreamItem,
+  TextToImageParams,
+  TextToVideoParams,
+  VideoModel
+} from "./types.js";
+import { FalProvider } from "./fal-provider.js";
+import { AnthropicProvider } from "./anthropic-provider.js";
+
+const PLATFORM_KEYS: Record<string, string> = {
+  fal_ai: "NODETOOL_PLATFORM_FAL_KEY",
+  anthropic: "NODETOOL_PLATFORM_ANTHROPIC_KEY"
+};
+
+export class NodetoolProvider extends BaseProvider {
+  private secrets: Record<string, unknown>;
+  private inner = new Map<string, BaseProvider>();
+  private _absorbedCost = 0;
+
+  static override requiredSecrets(): string[] {
+    return [];
+  }
+
+  constructor(secrets: Record<string, unknown> = {}) {
+    super("nodetool");
+    this.secrets = secrets;
+  }
+
+  private platformKey(delegateProvider: string): string | null {
+    const keyName = PLATFORM_KEYS[delegateProvider];
+    const value = keyName ? this.secrets[keyName] : null;
+    return typeof value === "string" && value.length > 0 ? value : null;
+  }
+
+  private isFunded(delegateProvider: string): boolean {
+    return this.platformKey(delegateProvider) != null;
+  }
+
+  /** The delegate serving a nodetool model id, constructed on platform keys. */
+  private delegateFor(modelId: string): {
+    provider: BaseProvider;
+    model: string;
+  } {
+    const def = nodetoolModelById(modelId);
+    if (!def) {
+      throw new Error(`Unknown NodeTool model "${modelId}".`);
+    }
+    const key = this.platformKey(def.delegate.provider);
+    if (!key) {
+      throw new Error(
+        `NodeTool model "${modelId}" is not available on this server ` +
+          `(missing ${PLATFORM_KEYS[def.delegate.provider]}).`
+      );
+    }
+    let instance = this.inner.get(def.delegate.provider);
+    if (!instance) {
+      instance =
+        def.delegate.provider === "fal_ai"
+          ? new FalProvider({ FAL_API_KEY: key })
+          : new AnthropicProvider({ ANTHROPIC_API_KEY: key });
+      this.inner.set(def.delegate.provider, instance);
+    }
+    return { provider: instance, model: def.delegate.model };
+  }
+
+  /** Run a delegated call and absorb the delegate's cost delta as our own. */
+  private async absorbing<T>(
+    inner: BaseProvider,
+    call: () => Promise<T>
+  ): Promise<T> {
+    const before = inner.getTotalCost();
+    try {
+      return await call();
+    } finally {
+      this._absorbedCost += inner.getTotalCost() - before;
+    }
+  }
+
+  override get cost(): number {
+    return this._absorbedCost;
+  }
+
+  override getTotalCost(): number {
+    return this._absorbedCost;
+  }
+
+  override resetCost(): void {
+    this._absorbedCost = 0;
+    for (const inner of this.inner.values()) inner.resetCost();
+  }
+
+  protected override declaredCapabilities(): ProviderCapability[] {
+    const capabilities: ProviderCapability[] = [];
+    for (const def of NODETOOL_MODELS) {
+      if (!this.isFunded(def.delegate.provider)) continue;
+      if (def.kind === "language") capabilities.push("generate_message");
+      if (def.kind === "image")
+        capabilities.push("text_to_image", "image_to_image");
+      if (def.kind === "video") capabilities.push("image_to_video");
+    }
+    return [...new Set(capabilities)];
+  }
+
+  private fundedModels(kind: "language" | "image" | "video") {
+    return NODETOOL_MODELS.filter(
+      (def) => def.kind === kind && this.isFunded(def.delegate.provider)
+    );
+  }
+
+  override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
+    return this.fundedModels("language").map((def) => ({
+      type: "language_model",
+      id: def.id,
+      name: def.name,
+      provider: "nodetool"
+    }));
+  }
+
+  override async getAvailableImageModels(): Promise<ImageModel[]> {
+    return this.fundedModels("image").map((def) => ({
+      type: "image_model",
+      id: def.id,
+      name: def.name,
+      provider: "nodetool",
+      supported_tasks: def.tasks ?? []
+    }));
+  }
+
+  override async getAvailableVideoModels(): Promise<VideoModel[]> {
+    return this.fundedModels("video").map((def) => ({
+      type: "video_model",
+      id: def.id,
+      name: def.name,
+      provider: "nodetool",
+      supported_tasks: def.tasks ?? []
+    }));
+  }
+
+  override async textToImage(params: TextToImageParams): Promise<Uint8Array> {
+    const { provider, model } = this.delegateFor(params.model.id);
+    return this.absorbing(provider, () =>
+      provider.textToImage({
+        ...params,
+        model: { ...params.model, id: model, provider: provider.provider }
+      })
+    );
+  }
+
+  override async imageToImage(
+    images: Uint8Array[],
+    params: ImageToImageParams
+  ): Promise<Uint8Array> {
+    const { provider, model } = this.delegateFor(params.model.id);
+    return this.absorbing(provider, () =>
+      provider.imageToImage(images, {
+        ...params,
+        model: { ...params.model, id: model, provider: provider.provider }
+      })
+    );
+  }
+
+  override async textToVideo(params: TextToVideoParams): Promise<Uint8Array> {
+    const { provider, model } = this.delegateFor(params.model.id);
+    return this.absorbing(provider, () =>
+      provider.textToVideo({
+        ...params,
+        model: { ...params.model, id: model, provider: provider.provider }
+      })
+    );
+  }
+
+  override async imageToVideo(
+    images: Uint8Array[],
+    params: ImageToVideoParams
+  ): Promise<Uint8Array> {
+    const { provider, model } = this.delegateFor(params.model.id);
+    return this.absorbing(provider, () =>
+      provider.imageToVideo(images, {
+        ...params,
+        model: { ...params.model, id: model, provider: provider.provider }
+      })
+    );
+  }
+
+  override async generateMessage(
+    args: Parameters<BaseProvider["generateMessage"]>[0]
+  ): Promise<Message> {
+    const { provider, model } = this.delegateFor(args.model);
+    return this.absorbing(provider, () =>
+      provider.generateMessage({ ...args, model })
+    );
+  }
+
+  override async *generateMessages(
+    args: Parameters<BaseProvider["generateMessages"]>[0]
+  ): AsyncGenerator<ProviderStreamItem> {
+    const { provider, model } = this.delegateFor(args.model);
+    const before = provider.getTotalCost();
+    try {
+      yield* provider.generateMessages({ ...args, model });
+    } finally {
+      this._absorbedCost += provider.getTotalCost() - before;
+    }
+  }
+}
+
+export default NodetoolProvider;

--- a/packages/runtime/tests/nodetool-provider.test.ts
+++ b/packages/runtime/tests/nodetool-provider.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+
+import { NodetoolProvider } from "../src/providers/nodetool-provider.js";
+
+describe("NodetoolProvider", () => {
+  it("lists no models when no platform key is set", async () => {
+    const provider = new NodetoolProvider({});
+    expect(await provider.getAvailableImageModels()).toEqual([]);
+    expect(await provider.getAvailableVideoModels()).toEqual([]);
+    expect(await provider.getAvailableLanguageModels()).toEqual([]);
+    // The base class always advertises chat; media capabilities appear only
+    // once a platform key funds them.
+    expect(provider.getCapabilities().sort()).toEqual([
+      "generate_message",
+      "generate_messages"
+    ]);
+  });
+
+  it("lists only the models whose delegate is funded, stamped nodetool", async () => {
+    const provider = new NodetoolProvider({
+      NODETOOL_PLATFORM_FAL_KEY: "platform-key"
+    });
+    const images = await provider.getAvailableImageModels();
+    const videos = await provider.getAvailableVideoModels();
+    expect(images.map((m) => m.id)).toContain("nodetool/flux-schnell");
+    expect(videos.map((m) => m.id)).toContain("nodetool/kling-standard");
+    for (const model of [...images, ...videos]) {
+      expect(model.provider).toBe("nodetool");
+    }
+    // The language model delegates to anthropic, which is not funded here.
+    expect(await provider.getAvailableLanguageModels()).toEqual([]);
+    expect(provider.getCapabilities()).toContain("text_to_image");
+    expect(provider.getCapabilities()).toContain("image_to_video");
+  });
+
+  it("refuses a call for an unfunded model with the platform key named", async () => {
+    const provider = new NodetoolProvider({});
+    await expect(
+      provider.textToImage({
+        model: {
+          type: "image_model",
+          id: "nodetool/flux-schnell",
+          name: "x",
+          provider: "nodetool"
+        },
+        prompt: "a fox"
+      })
+    ).rejects.toThrow(/NODETOOL_PLATFORM_FAL_KEY/);
+  });
+
+  it("rejects an unknown model id", async () => {
+    const provider = new NodetoolProvider({
+      NODETOOL_PLATFORM_FAL_KEY: "platform-key"
+    });
+    await expect(
+      provider.textToImage({
+        model: {
+          type: "image_model",
+          id: "nodetool/not-a-model",
+          name: "x",
+          provider: "nodetool"
+        },
+        prompt: "a fox"
+      })
+    ).rejects.toThrow(/Unknown NodeTool model/);
+  });
+});

--- a/packages/runtime/tests/providers/provider-contract.fixtures.ts
+++ b/packages/runtime/tests/providers/provider-contract.fixtures.ts
@@ -31,6 +31,11 @@ export const CONTRACT_MODEL_AUTH_ERROR = "contract-test-model-error-401";
  * packages/runtime/src/providers/*.ts (grep for "does not support chat").
  */
 export const MEDIA_ONLY_EXEMPTIONS: Record<string, string> = {
+  nodetool:
+    "Delegating provider (NodeTool's managed models): it makes no wire calls " +
+    "of its own — chat routes to the delegate named in NODETOOL_MODELS, whose " +
+    "own cassette covers the contract. An id outside the curated catalog " +
+    "(like the contract model) rejects cleanly.",
   fal_ai: "Image/video generation provider; generateMessage(s) always throws.",
   elevenlabs: "Text-to-speech provider; generateMessage(s) always throws.",
   topaz: "Image upscaling provider; generateMessage(s) always throws.",

--- a/packages/websocket/src/credit-gate.ts
+++ b/packages/websocket/src/credit-gate.ts
@@ -1,0 +1,38 @@
+/**
+ * The user-credit spend gate. Off by default: the open platform meters cost
+ * but never blocks on it. A product deployment that sells credits (the
+ * Studio) sets NODETOOL_CREDITS_ENFORCED=1 and every spend path asks this
+ * gate before calling a provider.
+ *
+ * Like the application-budget gate, it fails open: metering must never take
+ * the runner down.
+ */
+import { checkCredits } from "@nodetool-ai/models";
+
+export const creditsEnforced = (): boolean => {
+  const value = process.env.NODETOOL_CREDITS_ENFORCED?.toLowerCase();
+  return value === "1" || value === "true";
+};
+
+export type CreditGateResult = { allowed: true } | { allowed: false; reason: string };
+
+/**
+ * Decide whether `userId` may spend an estimated `estimatedUsd`. Estimates
+ * are floors (unpriceable work estimates 0), so an empty balance blocks even
+ * a 0-estimate call.
+ */
+export async function admitSpend(
+  userId: string | null | undefined,
+  estimatedUsd: number
+): Promise<CreditGateResult> {
+  if (!creditsEnforced()) return { allowed: true };
+  try {
+    const decision = await checkCredits(userId ?? "1", estimatedUsd);
+    return decision.allowed
+      ? { allowed: true }
+      : { allowed: false, reason: decision.reason };
+  } catch (error) {
+    console.error("Credit gate check failed (failing open):", error);
+    return { allowed: true };
+  }
+}

--- a/packages/websocket/src/credit-gate.ts
+++ b/packages/websocket/src/credit-gate.ts
@@ -1,31 +1,29 @@
 /**
- * The user-credit spend gate. Off by default: the open platform meters cost
- * but never blocks on it. A product deployment that sells credits (the
- * Studio) sets NODETOOL_CREDITS_ENFORCED=1 and every spend path asks this
- * gate before calling a provider.
+ * The credit spend gate for NodeTool's managed provider.
+ *
+ * Only spend routed through provider "nodetool" — curated models running on
+ * platform-owned keys — is metered; the callers hold that condition. BYOK
+ * providers are never gated: their spend rides the user's own keys, and both
+ * models coexist on one server.
  *
  * Like the application-budget gate, it fails open: metering must never take
  * the runner down.
  */
 import { checkCredits } from "@nodetool-ai/models";
 
-export const creditsEnforced = (): boolean => {
-  const value = process.env.NODETOOL_CREDITS_ENFORCED?.toLowerCase();
-  return value === "1" || value === "true";
-};
-
-export type CreditGateResult = { allowed: true } | { allowed: false; reason: string };
+export type CreditGateResult =
+  | { allowed: true }
+  | { allowed: false; reason: string };
 
 /**
- * Decide whether `userId` may spend an estimated `estimatedUsd`. Estimates
- * are floors (unpriceable work estimates 0), so an empty balance blocks even
- * a 0-estimate call.
+ * Decide whether `userId` may spend an estimated `estimatedUsd` through the
+ * managed provider. Estimates are floors (unpriceable work estimates 0), so
+ * an empty balance blocks even a 0-estimate call.
  */
 export async function admitSpend(
   userId: string | null | undefined,
   estimatedUsd: number
 ): Promise<CreditGateResult> {
-  if (!creditsEnforced()) return { allowed: true };
   try {
     const decision = await checkCredits(userId ?? "1", estimatedUsd);
     return decision.allowed

--- a/packages/websocket/src/credit-gate.ts
+++ b/packages/websocket/src/credit-gate.ts
@@ -16,16 +16,74 @@ export type CreditGateResult =
   | { allowed: false; reason: string };
 
 /**
+ * In-flight reservations: spend admitted but not yet in the prediction
+ * ledger. Without them, N concurrent submissions all pass against the same
+ * balance and a small balance authorizes N× its worth of platform spend.
+ * A reservation is taken when a run is admitted and released at its terminal
+ * state (or cancel-while-queued); the TTL bounds leaks from paths that never
+ * reach either (process-local state — a multi-instance deployment needs the
+ * reservation moved into the database, as application-budgets does).
+ */
+interface SpendReservation {
+  usd: number;
+  at: number;
+}
+
+const RESERVATION_TTL_MS = 2 * 60 * 60 * 1000;
+const reservations = new Map<string, Map<string, SpendReservation>>();
+
+export function reserveSpend(
+  userId: string,
+  key: string,
+  estimatedUsd: number
+): void {
+  let byKey = reservations.get(userId);
+  if (!byKey) {
+    byKey = new Map();
+    reservations.set(userId, byKey);
+  }
+  byKey.set(key, { usd: Math.max(0, estimatedUsd), at: Date.now() });
+}
+
+/** Releasing an unknown key is a no-op, so terminal paths can call it blindly. */
+export function releaseSpend(userId: string, key: string): void {
+  const byKey = reservations.get(userId);
+  if (!byKey) return;
+  byKey.delete(key);
+  if (byKey.size === 0) reservations.delete(userId);
+}
+
+export function reservedSpendUsd(userId: string): number {
+  const byKey = reservations.get(userId);
+  if (!byKey) return 0;
+  const cutoff = Date.now() - RESERVATION_TTL_MS;
+  let total = 0;
+  for (const [key, reservation] of byKey) {
+    if (reservation.at < cutoff) {
+      byKey.delete(key);
+      continue;
+    }
+    total += reservation.usd;
+  }
+  if (byKey.size === 0) reservations.delete(userId);
+  return total;
+}
+
+/**
  * Decide whether `userId` may spend an estimated `estimatedUsd` through the
- * managed provider. Estimates are floors (unpriceable work estimates 0), so
- * an empty balance blocks even a 0-estimate call.
+ * managed provider, counting spend already admitted but not yet settled.
+ * Estimates are floors (unpriceable work estimates 0), so an empty balance
+ * blocks even a 0-estimate call.
  */
 export async function admitSpend(
   userId: string | null | undefined,
   estimatedUsd: number
 ): Promise<CreditGateResult> {
   try {
-    const decision = await checkCredits(userId ?? "1", estimatedUsd);
+    const decision = await checkCredits(
+      userId ?? "1",
+      estimatedUsd + reservedSpendUsd(userId ?? "1")
+    );
     return decision.allowed
       ? { allowed: true }
       : { allowed: false, reason: decision.reason };

--- a/packages/websocket/src/trpc/router.ts
+++ b/packages/websocket/src/trpc/router.ts
@@ -4,6 +4,7 @@ import { assetsRouter } from "./routers/assets.js";
 import { codeGenRouter } from "./routers/code-gen.js";
 import { collectionsRouter } from "./routers/collections.js";
 import { costsRouter } from "./routers/costs.js";
+import { creditsRouter } from "./routers/credits.js";
 import { extensionRouter } from "./routers/extension.js";
 import { filesRouter } from "./routers/files.js";
 import { jobsRouter } from "./routers/jobs.js";
@@ -38,6 +39,7 @@ export const appRouter = router({
   codeGen: codeGenRouter,
   collections: collectionsRouter,
   costs: costsRouter,
+  credits: creditsRouter,
   extension: extensionRouter,
   files: filesRouter,
   fonts: fontsRouter,

--- a/packages/websocket/src/trpc/routers/credits.ts
+++ b/packages/websocket/src/trpc/routers/credits.ts
@@ -1,0 +1,68 @@
+import { TRPCError } from "@trpc/server";
+import {
+  CREDIT_PLANS,
+  creditStatus,
+  grantCredits,
+  planById,
+  setSubscriptionPlan
+} from "@nodetool-ai/models";
+import { router } from "../index.js";
+import { protectedProcedure } from "../middleware.js";
+import {
+  creditStatusOutput,
+  setPlanInput,
+  topupInput
+} from "@nodetool-ai/protocol/api-schemas/credits.js";
+import { creditsEnforced } from "../../credit-gate.js";
+
+const statusFor = async (userId: string) => {
+  const status = await creditStatus(userId);
+  return {
+    ...status,
+    enforced: creditsEnforced(),
+    plans: [...CREDIT_PLANS]
+  };
+};
+
+/**
+ * User credits and subscription plans (the Studio billing layer). Balance and
+ * plan catalog come from `@nodetool-ai/models`; the monthly plan grant
+ * accrues lazily on the first status read of the month.
+ */
+export const creditsRouter = router({
+  status: protectedProcedure
+    .output(creditStatusOutput)
+    .query(({ ctx }) => statusFor(ctx.userId)),
+
+  setPlan: protectedProcedure
+    .input(setPlanInput)
+    .output(creditStatusOutput)
+    .mutation(async ({ ctx, input }) => {
+      if (!planById(input.planId)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Unknown plan "${input.planId}".`
+        });
+      }
+      await setSubscriptionPlan(ctx.userId, input.planId);
+      return statusFor(ctx.userId);
+    }),
+
+  /**
+   * Prototype top-up: adds credits with no payment behind it. A payment
+   * provider integration replaces this mutation with a checkout session and
+   * writes the ledger row from the webhook instead.
+   */
+  topup: protectedProcedure
+    .input(topupInput)
+    .output(creditStatusOutput)
+    .mutation(async ({ ctx, input }) => {
+      await grantCredits(
+        ctx.userId,
+        input.credits,
+        "topup",
+        "Manual top-up (no payment provider configured)"
+      );
+      return statusFor(ctx.userId);
+    })
+});

--- a/packages/websocket/src/trpc/routers/credits.ts
+++ b/packages/websocket/src/trpc/routers/credits.ts
@@ -15,11 +15,22 @@ import {
 } from "@nodetool-ai/protocol/api-schemas/credits.js";
 import { NODETOOL_PROVIDER_ID } from "@nodetool-ai/protocol";
 
+/**
+ * Whether the unauthenticated-by-payment test top-up is allowed. Off unless
+ * the operator explicitly opts a development server in: minted credits unlock
+ * spend on platform-owned keys, so an open mint endpoint is an open wallet.
+ */
+const testTopupEnabled = (): boolean => {
+  const value = process.env.NODETOOL_ENABLE_TEST_TOPUP?.toLowerCase();
+  return value === "1" || value === "true";
+};
+
 const statusFor = async (userId: string) => {
   const status = await creditStatus(userId);
   return {
     ...status,
     meteredProvider: NODETOOL_PROVIDER_ID,
+    testTopupEnabled: testTopupEnabled(),
     plans: [...CREDIT_PLANS]
   };
 };
@@ -49,7 +60,8 @@ export const creditsRouter = router({
     }),
 
   /**
-   * Prototype top-up: adds credits with no payment behind it. A payment
+   * Development-only top-up: adds credits with no payment behind it, and is
+   * refused unless the operator sets NODETOOL_ENABLE_TEST_TOPUP. A payment
    * provider integration replaces this mutation with a checkout session and
    * writes the ledger row from the webhook instead.
    */
@@ -57,6 +69,14 @@ export const creditsRouter = router({
     .input(topupInput)
     .output(creditStatusOutput)
     .mutation(async ({ ctx, input }) => {
+      if (!testTopupEnabled()) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Top-ups are disabled on this server: no payment provider is " +
+            "configured and NODETOOL_ENABLE_TEST_TOPUP is not set."
+        });
+      }
       await grantCredits(
         ctx.userId,
         input.credits,

--- a/packages/websocket/src/trpc/routers/credits.ts
+++ b/packages/websocket/src/trpc/routers/credits.ts
@@ -13,13 +13,13 @@ import {
   setPlanInput,
   topupInput
 } from "@nodetool-ai/protocol/api-schemas/credits.js";
-import { creditsEnforced } from "../../credit-gate.js";
+import { NODETOOL_PROVIDER_ID } from "@nodetool-ai/protocol";
 
 const statusFor = async (userId: string) => {
   const status = await creditStatus(userId);
   return {
     ...status,
-    enforced: creditsEnforced(),
+    meteredProvider: NODETOOL_PROVIDER_ID,
     plans: [...CREDIT_PLANS]
   };
 };

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -4,7 +4,7 @@ import { pathToFileURL } from "node:url";
 import { getSecret } from "@nodetool-ai/models";
 import { getSetting } from "./settings-registry.js";
 import { ApiErrorCode } from "./error-codes.js";
-import { admitSpend } from "./credit-gate.js";
+import { admitSpend, releaseSpend, reserveSpend } from "./credit-gate.js";
 import { JobConcurrencyQueue } from "./job-queue.js";
 import { packWebSocketMessage, unpackWebSocketMessage } from "./messagepack.js";
 import {
@@ -1699,6 +1699,25 @@ export function resolveRunJobUserId(
   return requestUserId?.trim() || connectionUserId?.trim() || "1";
 }
 
+interface DirectMediaGenerationRequest {
+  mode: "image" | "image_edit" | "inpaint" | "video" | "audio";
+  provider: string;
+  model: string;
+  prompt: string;
+  sourceAssetId?: string;
+  maskAssetId?: string;
+  width?: number;
+  height?: number;
+  aspectRatio?: string;
+  resolution?: string;
+  strength?: number;
+  numInferenceSteps?: number;
+  variations?: number;
+  voice?: string;
+  speed?: number;
+  audioFormat?: string;
+}
+
 interface ActiveJob {
   jobId: string;
   workflowId: string | null;
@@ -3110,14 +3129,20 @@ export class UnifiedWebSocketRunner {
   private async admitCreditRun(req: RunJobRequest): Promise<boolean> {
     const { usesNodetool, estimatedUsd } = this.estimateNodetoolSpend(req);
     if (!usesNodetool) return true;
+    // Pin the job id now so the reservation taken here can be released at the
+    // run's terminal state (and on cancel-while-queued) under the same key.
+    req.job_id ??= randomUUID();
     const decision = await admitSpend(this.userId, estimatedUsd);
-    if (decision.allowed) return true;
-    return this.refuseRun(
-      req,
-      req.job_id ?? randomUUID(),
-      ApiErrorCode.BUDGET_EXCEEDED,
-      decision.reason
-    );
+    if (!decision.allowed) {
+      return this.refuseRun(
+        req,
+        req.job_id,
+        ApiErrorCode.BUDGET_EXCEEDED,
+        decision.reason
+      );
+    }
+    reserveSpend(this.userId ?? "1", req.job_id, estimatedUsd);
+    return true;
   }
 
   async runJob(req: RunJobRequest): Promise<void> {
@@ -3622,6 +3647,7 @@ export class UnifiedWebSocketRunner {
       }
       await this.persistTerminalJobStatus(active);
       await this.settleApplicationInvocation(active);
+      releaseSpend(this.userId ?? "1", active.jobId);
     } finally {
       // Terminal: the session stops buffering and starts its retention
       // window, so a client reconnecting shortly after still gets the tail
@@ -4099,6 +4125,7 @@ export class UnifiedWebSocketRunner {
 
     await this.persistTerminalJobStatus(active);
     await this.settleApplicationInvocation(active);
+    releaseSpend(this.userId ?? "1", active.jobId);
     // Slot release + queue drain happen in the streamJobMessages wrapper's
     // finally, so they run even if the drain loop above throws.
   }
@@ -4252,6 +4279,7 @@ export class UnifiedWebSocketRunner {
     // and tell the client it's cancelled before it ever starts.
     const queued = this.jobQueue.remove(jobId);
     if (queued) {
+      releaseSpend(this.userId ?? "1", jobId);
       const cancelledWorkflowId = queued.workflow_id ?? workflowId ?? null;
       // Mark the persisted queued row cancelled so it leaves the queue in
       // jobs.list too (not just the in-memory queue).
@@ -7609,24 +7637,9 @@ export class UnifiedWebSocketRunner {
    * image layers and the timeline's direct-gen video / audio clips; the
    * chat-path equivalents stay in `handleMediaGenerationMessage` for now.
    */
-  private async runDirectMediaGeneration(req: {
-    mode: "image" | "image_edit" | "inpaint" | "video" | "audio";
-    provider: string;
-    model: string;
-    prompt: string;
-    sourceAssetId?: string;
-    maskAssetId?: string;
-    width?: number;
-    height?: number;
-    aspectRatio?: string;
-    resolution?: string;
-    strength?: number;
-    numInferenceSteps?: number;
-    variations?: number;
-    voice?: string;
-    speed?: number;
-    audioFormat?: string;
-  }): Promise<{ asset_ids: string[] }> {
+  private async runDirectMediaGeneration(
+    req: DirectMediaGenerationRequest
+  ): Promise<{ asset_ids: string[] }> {
     if (!this.resolveProvider) {
       throw new Error("No provider resolver configured");
     }
@@ -7636,18 +7649,61 @@ export class UnifiedWebSocketRunner {
     if (!req.prompt || !req.prompt.trim()) {
       throw new Error("prompt is required");
     }
-
     const userId = this.userId ?? "1";
-    // Only NodeTool's managed provider is metered; BYOK providers run on the
-    // user's own keys. Direct generation has no per-node estimate, so the
-    // gate refuses on an empty balance.
-    if (req.provider === "nodetool") {
-      const creditDecision = await admitSpend(userId, 0);
-      if (!creditDecision.allowed) {
-        throw new Error(creditDecision.reason);
-      }
-    }
     const provider = await this.resolveProvider(req.provider, userId);
+    if (req.provider !== "nodetool") {
+      // BYOK: the user's own keys, never metered.
+      return this.runDirectMediaGenerationInner(req, provider);
+    }
+
+    // NodeTool's managed provider: admit against the balance (including
+    // in-flight reservations), reserve the unit-price estimate for the
+    // duration of the call, and record the spend as a prediction row so the
+    // balance actually decrements. Cost is the larger of the delegate's own
+    // tracked cost and the unit-price estimate — fal-style delegates bill
+    // per unit and track nothing themselves.
+    const variations = Math.max(1, Math.min(Number(req.variations ?? 1), 8));
+    const unit = getModelUnitPrice({ id: req.model, provider: "nodetool" });
+    const estimatedUsd = (unit?.unit_price ?? 0) * variations;
+    const decision = await admitSpend(userId, estimatedUsd);
+    if (!decision.allowed) {
+      throw new Error(decision.reason);
+    }
+    const reservationKey = `media:${randomUUID()}`;
+    reserveSpend(userId, reservationKey, estimatedUsd);
+    try {
+      const result = await this.runDirectMediaGenerationInner(req, provider);
+      const cost = Math.max(provider.getTotalCost(), estimatedUsd);
+      if (cost > 0) {
+        try {
+          await Prediction.create<Prediction>({
+            user_id: userId,
+            provider: "nodetool",
+            model: req.model,
+            node_type: `direct.${req.mode}`,
+            cost,
+            currency: "USD",
+            billing_unit: unit?.billing_unit ?? null,
+            quantity: variations,
+            workflow_id: null,
+            node_id: "",
+            status: "completed"
+          });
+        } catch (err) {
+          this.logError("direct media cost persistence failed", err);
+        }
+      }
+      return result;
+    } finally {
+      releaseSpend(userId, reservationKey);
+    }
+  }
+
+  private async runDirectMediaGenerationInner(
+    req: DirectMediaGenerationRequest,
+    provider: BaseProvider
+  ): Promise<{ asset_ids: string[] }> {
+    const userId = this.userId ?? "1";
     const variations = Math.max(1, Math.min(Number(req.variations ?? 1), 8));
 
     const storeAsset = async (
@@ -7950,6 +8006,26 @@ export class UnifiedWebSocketRunner {
       language: req.language,
       word_timestamps: true
     });
+
+    // Metered provider: record what the delegate tracked so the spend lands
+    // in the ledger the balance is computed from. Best-effort, never throws.
+    if (req.provider === "nodetool" && provider.getTotalCost() > 0) {
+      try {
+        await Prediction.create<Prediction>({
+          user_id: userId,
+          provider: "nodetool",
+          model: req.model,
+          node_type: "direct.transcription",
+          cost: provider.getTotalCost(),
+          currency: "USD",
+          workflow_id: null,
+          node_id: "",
+          status: "completed"
+        });
+      } catch (err) {
+        this.logError("direct transcription cost persistence failed", err);
+      }
+    }
 
     const words = (result.chunks ?? [])
       .map((chunk) => ({

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -4,7 +4,7 @@ import { pathToFileURL } from "node:url";
 import { getSecret } from "@nodetool-ai/models";
 import { getSetting } from "./settings-registry.js";
 import { ApiErrorCode } from "./error-codes.js";
-import { admitSpend, creditsEnforced } from "./credit-gate.js";
+import { admitSpend } from "./credit-gate.js";
 import { JobConcurrencyQueue } from "./job-queue.js";
 import { packWebSocketMessage, unpackWebSocketMessage } from "./messagepack.js";
 import {
@@ -2876,6 +2876,44 @@ export class UnifiedWebSocketRunner {
     }
   }
 
+  /**
+   * The slice of a run that spends through NodeTool's managed provider —
+   * the only spend the credit balance meters. BYOK nodes are excluded on
+   * purpose: their cost rides the user's own keys.
+   */
+  private estimateNodetoolSpend(req: RunJobRequest): {
+    usesNodetool: boolean;
+    estimatedUsd: number;
+  } {
+    const nodes = req.graph?.nodes;
+    if (!nodes || !this.getNodeMetadata) {
+      return { usesNodetool: false, estimatedUsd: 0 };
+    }
+    try {
+      const estimate = estimateWorkflowCost({
+        nodes: nodes.map((node) => ({
+          id: String(node.id),
+          type: String(node.type),
+          data: (node.data ?? {}) as Record<string, unknown>
+        })),
+        getMetadata: (nodeType: string) => this.getNodeMetadata?.(nodeType),
+        getModelPrice: getModelUnitPrice
+      });
+      const items = estimate.items.filter(
+        (item) => item.provider === "nodetool"
+      );
+      const total = items.reduce(
+        (sum, item) =>
+          sum + (Number.isFinite(item.estimated_cost) ? item.estimated_cost : 0),
+        0
+      );
+      return { usesNodetool: items.length > 0, estimatedUsd: total };
+    } catch (err) {
+      this.logError("nodetool spend estimate failed", err);
+      return { usesNodetool: false, estimatedUsd: 0 };
+    }
+  }
+
   /** Tell the client a run was refused, in the shape a failed job takes. */
   private refuseRun(
     req: RunJobRequest,
@@ -3061,14 +3099,17 @@ export class UnifiedWebSocketRunner {
   }
 
   /**
-   * Gate every run on the user's credit balance when the deployment enforces
-   * credits (NODETOOL_CREDITS_ENFORCED — the Studio product). Estimates are
-   * floors, so an empty balance refuses even a 0-estimate run. Fails open on
-   * gate errors, like the application-budget gate above.
+   * Gate a run on the user's credit balance — but only the part of the run
+   * that spends through NodeTool's managed provider. A graph with no
+   * `nodetool` models passes untouched (BYOK stays unmetered); one with them
+   * is refused when the balance is empty or can't cover the estimate.
+   * Estimates are floors, so an empty balance refuses even a 0-estimate
+   * nodetool call. Fails open on gate errors, like the application-budget
+   * gate above.
    */
   private async admitCreditRun(req: RunJobRequest): Promise<boolean> {
-    if (!creditsEnforced()) return true;
-    const estimatedUsd = await this.estimateRunCost(req);
+    const { usesNodetool, estimatedUsd } = this.estimateNodetoolSpend(req);
+    if (!usesNodetool) return true;
     const decision = await admitSpend(this.userId, estimatedUsd);
     if (decision.allowed) return true;
     return this.refuseRun(
@@ -7597,11 +7638,14 @@ export class UnifiedWebSocketRunner {
     }
 
     const userId = this.userId ?? "1";
-    // Direct generation has no per-node estimate; the gate still refuses an
-    // empty balance when the deployment enforces credits.
-    const creditDecision = await admitSpend(userId, 0);
-    if (!creditDecision.allowed) {
-      throw new Error(creditDecision.reason);
+    // Only NodeTool's managed provider is metered; BYOK providers run on the
+    // user's own keys. Direct generation has no per-node estimate, so the
+    // gate refuses on an empty balance.
+    if (req.provider === "nodetool") {
+      const creditDecision = await admitSpend(userId, 0);
+      if (!creditDecision.allowed) {
+        throw new Error(creditDecision.reason);
+      }
     }
     const provider = await this.resolveProvider(req.provider, userId);
     const variations = Math.max(1, Math.min(Number(req.variations ?? 1), 8));
@@ -7879,9 +7923,11 @@ export class UnifiedWebSocketRunner {
     }
 
     const userId = this.userId ?? "1";
-    const creditDecision = await admitSpend(userId, 0);
-    if (!creditDecision.allowed) {
-      throw new Error(creditDecision.reason);
+    if (req.provider === "nodetool") {
+      const creditDecision = await admitSpend(userId, 0);
+      if (!creditDecision.allowed) {
+        throw new Error(creditDecision.reason);
+      }
     }
     const asset = await Asset.find(userId, req.assetId);
     if (!asset) {

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url";
 import { getSecret } from "@nodetool-ai/models";
 import { getSetting } from "./settings-registry.js";
 import { ApiErrorCode } from "./error-codes.js";
+import { admitSpend, creditsEnforced } from "./credit-gate.js";
 import { JobConcurrencyQueue } from "./job-queue.js";
 import { packWebSocketMessage, unpackWebSocketMessage } from "./messagepack.js";
 import {
@@ -3059,9 +3060,29 @@ export class UnifiedWebSocketRunner {
     return true;
   }
 
+  /**
+   * Gate every run on the user's credit balance when the deployment enforces
+   * credits (NODETOOL_CREDITS_ENFORCED — the Studio product). Estimates are
+   * floors, so an empty balance refuses even a 0-estimate run. Fails open on
+   * gate errors, like the application-budget gate above.
+   */
+  private async admitCreditRun(req: RunJobRequest): Promise<boolean> {
+    if (!creditsEnforced()) return true;
+    const estimatedUsd = await this.estimateRunCost(req);
+    const decision = await admitSpend(this.userId, estimatedUsd);
+    if (decision.allowed) return true;
+    return this.refuseRun(
+      req,
+      req.job_id ?? randomUUID(),
+      ApiErrorCode.BUDGET_EXCEEDED,
+      decision.reason
+    );
+  }
+
   async runJob(req: RunJobRequest): Promise<void> {
     req._accepted_at_ms ??= performance.now();
     if (!(await this.admitApplicationRun(req))) return;
+    if (!(await this.admitCreditRun(req))) return;
     const max = await this.getMaxConcurrentJobs();
     const perWorkflowMax = await this.perWorkflowLimitFor(req);
     // Queue the run when over the global cap, or when this workflow already has
@@ -7576,6 +7597,12 @@ export class UnifiedWebSocketRunner {
     }
 
     const userId = this.userId ?? "1";
+    // Direct generation has no per-node estimate; the gate still refuses an
+    // empty balance when the deployment enforces credits.
+    const creditDecision = await admitSpend(userId, 0);
+    if (!creditDecision.allowed) {
+      throw new Error(creditDecision.reason);
+    }
     const provider = await this.resolveProvider(req.provider, userId);
     const variations = Math.max(1, Math.min(Number(req.variations ?? 1), 8));
 
@@ -7852,6 +7879,10 @@ export class UnifiedWebSocketRunner {
     }
 
     const userId = this.userId ?? "1";
+    const creditDecision = await admitSpend(userId, 0);
+    if (!creditDecision.allowed) {
+      throw new Error(creditDecision.reason);
+    }
     const asset = await Asset.find(userId, req.assetId);
     if (!asset) {
       throw new Error(`Audio asset not found: ${req.assetId}`);

--- a/packages/websocket/tests/credit-gate.test.ts
+++ b/packages/websocket/tests/credit-gate.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { initTestDb, grantCredits, Prediction } from "@nodetool-ai/models";
+import { admitSpend, creditsEnforced } from "../src/credit-gate.js";
+
+const USER = "u1";
+
+describe("credit gate", () => {
+  beforeEach(() => {
+    initTestDb();
+    delete process.env.NODETOOL_CREDITS_ENFORCED;
+  });
+
+  afterEach(() => {
+    delete process.env.NODETOOL_CREDITS_ENFORCED;
+  });
+
+  it("is off by default — the open platform never blocks on credits", async () => {
+    expect(creditsEnforced()).toBe(false);
+    const decision = await admitSpend(USER, 10_000);
+    expect(decision.allowed).toBe(true);
+  });
+
+  it("when enforced, admits a funded user and refuses a drained one", async () => {
+    process.env.NODETOOL_CREDITS_ENFORCED = "1";
+
+    // First read accrues the free plan's monthly grant.
+    const funded = await admitSpend(USER, 0.05);
+    expect(funded.allowed).toBe(true);
+
+    // Drain past the grant with recorded spend, then refuse.
+    await grantCredits(USER, 10, "adjustment", "test");
+    await Prediction.create<Prediction>({
+      user_id: USER,
+      node_id: "n",
+      node_type: "test",
+      provider: "test",
+      model: "test",
+      cost: 1_000
+    });
+    const drained = await admitSpend(USER, 0);
+    expect(drained.allowed).toBe(false);
+    if (!drained.allowed) {
+      expect(drained.reason).toContain("credits");
+    }
+  });
+
+  it("refuses an estimate beyond the balance", async () => {
+    process.env.NODETOOL_CREDITS_ENFORCED = "true";
+    const decision = await admitSpend(USER, 100); // $100 ≫ free grant
+    expect(decision.allowed).toBe(false);
+  });
+});

--- a/packages/websocket/tests/credit-gate.test.ts
+++ b/packages/websocket/tests/credit-gate.test.ts
@@ -1,41 +1,29 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 
 import { initTestDb, grantCredits, Prediction } from "@nodetool-ai/models";
-import { admitSpend, creditsEnforced } from "../src/credit-gate.js";
+import { admitSpend } from "../src/credit-gate.js";
 
 const USER = "u1";
 
 describe("credit gate", () => {
   beforeEach(() => {
     initTestDb();
-    delete process.env.NODETOOL_CREDITS_ENFORCED;
   });
 
-  afterEach(() => {
-    delete process.env.NODETOOL_CREDITS_ENFORCED;
-  });
-
-  it("is off by default — the open platform never blocks on credits", async () => {
-    expect(creditsEnforced()).toBe(false);
-    const decision = await admitSpend(USER, 10_000);
-    expect(decision.allowed).toBe(true);
-  });
-
-  it("when enforced, admits a funded user and refuses a drained one", async () => {
-    process.env.NODETOOL_CREDITS_ENFORCED = "1";
-
-    // First read accrues the free plan's monthly grant.
+  it("admits a funded user", async () => {
+    // First check accrues the free plan's monthly grant.
     const funded = await admitSpend(USER, 0.05);
     expect(funded.allowed).toBe(true);
+  });
 
-    // Drain past the grant with recorded spend, then refuse.
+  it("refuses a drained balance", async () => {
     await grantCredits(USER, 10, "adjustment", "test");
     await Prediction.create<Prediction>({
       user_id: USER,
       node_id: "n",
       node_type: "test",
-      provider: "test",
-      model: "test",
+      provider: "nodetool",
+      model: "nodetool/flux-schnell",
       cost: 1_000
     });
     const drained = await admitSpend(USER, 0);
@@ -46,7 +34,6 @@ describe("credit gate", () => {
   });
 
   it("refuses an estimate beyond the balance", async () => {
-    process.env.NODETOOL_CREDITS_ENFORCED = "true";
     const decision = await admitSpend(USER, 100); // $100 ≫ free grant
     expect(decision.allowed).toBe(false);
   });

--- a/packages/websocket/tests/credit-gate.test.ts
+++ b/packages/websocket/tests/credit-gate.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach } from "vitest";
 
 import { initTestDb, grantCredits, Prediction } from "@nodetool-ai/models";
-import { admitSpend } from "../src/credit-gate.js";
+import {
+  admitSpend,
+  releaseSpend,
+  reserveSpend,
+  reservedSpendUsd
+} from "../src/credit-gate.js";
 
 const USER = "u1";
 
@@ -36,5 +41,26 @@ describe("credit gate", () => {
   it("refuses an estimate beyond the balance", async () => {
     const decision = await admitSpend(USER, 100); // $100 ≫ free grant
     expect(decision.allowed).toBe(false);
+  });
+
+  it("in-flight reservations count against the balance until released", async () => {
+    // Free grant = 300 credits = $3. Two concurrent $2 runs must not both
+    // pass: the first reserves, the second sees the reservation and refuses.
+    const first = await admitSpend(USER, 2);
+    expect(first.allowed).toBe(true);
+    reserveSpend(USER, "job-1", 2);
+
+    const second = await admitSpend(USER, 2);
+    expect(second.allowed).toBe(false);
+
+    releaseSpend(USER, "job-1");
+    expect(reservedSpendUsd(USER)).toBe(0);
+    const afterRelease = await admitSpend(USER, 2);
+    expect(afterRelease.allowed).toBe(true);
+  });
+
+  it("releasing an unknown reservation is a no-op", () => {
+    releaseSpend(USER, "never-reserved");
+    expect(reservedSpendUsd(USER)).toBe(0);
   });
 });

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -145,6 +145,9 @@ const StudioScriptPage = React.lazy(() => import("./studio/StudioScriptPage"));
 const StudioTimelinePage = React.lazy(
   () => import("./studio/StudioTimelinePage")
 );
+const StudioAccountPage = React.lazy(
+  () => import("./studio/StudioAccountPage")
+);
 import {
   ChatThreadRedirect,
   WorkflowEditorRedirect
@@ -441,7 +444,8 @@ function getRoutes() {
         { path: "/studio", el: <StudioHome /> },
         { path: "/studio/storyboard/:boardId", el: <StudioStoryboardPage /> },
         { path: "/studio/script/:scriptId", el: <StudioScriptPage /> },
-        { path: "/studio/timeline/:sequenceId", el: <StudioTimelinePage /> }
+        { path: "/studio/timeline/:sequenceId", el: <StudioTimelinePage /> },
+        { path: "/studio/account", el: <StudioAccountPage /> }
       ] as const
     ).map(({ path, el }) => ({
       path,

--- a/web/src/studio/StudioAccountPage.tsx
+++ b/web/src/studio/StudioAccountPage.tsx
@@ -1,0 +1,162 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * Plan & credits: the Studio account page. Balance and usage from
+ * `trpc.credits.status`, plan switching via `credits.setPlan`, and a
+ * prototype top-up (`credits.topup` — no payment provider behind it yet, and
+ * the button says so).
+ */
+
+import { useState } from "react";
+import { useTheme } from "@mui/material/styles";
+import BoltRoundedIcon from "@mui/icons-material/BoltRounded";
+import {
+  AlertBanner,
+  Card,
+  Chip,
+  EditorButton,
+  FlexColumn,
+  FlexRow,
+  LoadingSpinner,
+  SPACING,
+  Text
+} from "../components/ui_primitives";
+import { trpc } from "../trpc/client";
+import { useStudioCredits } from "./useStudioCredits";
+import StudioShell from "./StudioShell";
+
+const TOPUP_CREDITS = 1_000;
+
+const StudioAccountPage = () => {
+  const theme = useTheme();
+  const { status, loading } = useStudioCredits();
+  const utils = trpc.useUtils();
+  const [error, setError] = useState<string | null>(null);
+
+  const onSettled = {
+    onSuccess: () => {
+      setError(null);
+      void utils.credits.status.invalidate();
+    },
+    onError: (e: { message: string }) => setError(e.message)
+  };
+  const setPlan = trpc.credits.setPlan.useMutation(onSettled);
+  const topup = trpc.credits.topup.useMutation(onSettled);
+
+  return (
+    <StudioShell title="Plan & credits">
+      <FlexColumn
+        align="center"
+        gap={SPACING.xl}
+        sx={{ flex: 1, minHeight: 0, overflowY: "auto", p: SPACING.xl }}
+      >
+        {loading && <LoadingSpinner />}
+        {error && (
+          <AlertBanner severity="error" onClose={() => setError(null)}>
+            {error}
+          </AlertBanner>
+        )}
+        {status && (
+          <>
+            <Card
+              variant="outlined"
+              padding="comfortable"
+              sx={{ width: "100%", maxWidth: 880 }}
+            >
+              <FlexRow align="center" gap={SPACING.lg} wrap>
+                <BoltRoundedIcon />
+                <FlexColumn sx={{ flex: 1, minWidth: 200 }}>
+                  <Text size="giant" weight={600}>
+                    {status.balanceCredits} credits
+                  </Text>
+                  <Text size="small" color="secondary">
+                    {status.plan.name} plan · {status.spentCredits} used of{" "}
+                    {status.grantedCredits} granted · resets monthly (
+                    {status.periodKey})
+                  </Text>
+                </FlexColumn>
+                <EditorButton
+                  variant="outlined"
+                  disabled={topup.isPending}
+                  onClick={() => topup.mutate({ credits: TOPUP_CREDITS })}
+                >
+                  {topup.isPending
+                    ? "Adding…"
+                    : `Add ${TOPUP_CREDITS} credits (test)`}
+                </EditorButton>
+              </FlexRow>
+              {!status.enforced && (
+                <Text size="smaller" color="secondary" sx={{ mt: SPACING.md }}>
+                  This server tracks credits but does not block generation
+                  (NODETOOL_CREDITS_ENFORCED is off).
+                </Text>
+              )}
+            </Card>
+
+            <FlexColumn gap={SPACING.sm} sx={{ width: "100%", maxWidth: 880 }}>
+              <Text size="small" weight={600} color="secondary">
+                Plans
+              </Text>
+              <FlexRow gap={SPACING.lg} wrap>
+                {status.plans.map((plan) => {
+                  const current = plan.id === status.plan.id;
+                  return (
+                    <Card
+                      key={plan.id}
+                      variant="outlined"
+                      padding="comfortable"
+                      sx={{
+                        flex: 1,
+                        minWidth: 220,
+                        borderColor: current
+                          ? theme.vars.palette.primary.main
+                          : undefined
+                      }}
+                    >
+                      <FlexColumn gap={SPACING.md} align="flex-start">
+                        <FlexRow
+                          align="center"
+                          gap={SPACING.sm}
+                          justify="space-between"
+                          fullWidth
+                        >
+                          <Text size="big" weight={600}>
+                            {plan.name}
+                          </Text>
+                          {current && <Chip compact label="Current" />}
+                        </FlexRow>
+                        <Text size="normal">
+                          {plan.monthlyCredits.toLocaleString()} credits / month
+                        </Text>
+                        <Text size="small" color="secondary">
+                          {plan.priceUsdPerMonth === 0
+                            ? "Free"
+                            : `$${plan.priceUsdPerMonth}/month`}
+                        </Text>
+                        <Text size="small" color="secondary">
+                          {plan.blurb}
+                        </Text>
+                        <EditorButton
+                          variant={current ? "outlined" : "contained"}
+                          disabled={current || setPlan.isPending}
+                          onClick={() => setPlan.mutate({ planId: plan.id })}
+                        >
+                          {current ? "Selected" : "Switch to " + plan.name}
+                        </EditorButton>
+                      </FlexColumn>
+                    </Card>
+                  );
+                })}
+              </FlexRow>
+              <Text size="smaller" color="secondary">
+                Plan changes are instant and unbilled in this prototype — a
+                payment provider hooks in behind the same ledger.
+              </Text>
+            </FlexColumn>
+          </>
+        )}
+      </FlexColumn>
+    </StudioShell>
+  );
+};
+
+export default StudioAccountPage;

--- a/web/src/studio/StudioAccountPage.tsx
+++ b/web/src/studio/StudioAccountPage.tsx
@@ -84,12 +84,10 @@ const StudioAccountPage = () => {
                     : `Add ${TOPUP_CREDITS} credits (test)`}
                 </EditorButton>
               </FlexRow>
-              {!status.enforced && (
-                <Text size="smaller" color="secondary" sx={{ mt: SPACING.md }}>
-                  This server tracks credits but does not block generation
-                  (NODETOOL_CREDITS_ENFORCED is off).
-                </Text>
-              )}
+              <Text size="smaller" color="secondary" sx={{ mt: SPACING.md }}>
+                Credits meter NodeTool's managed models only — bring your own
+                provider keys and those calls stay unmetered.
+              </Text>
             </Card>
 
             <FlexColumn gap={SPACING.sm} sx={{ width: "100%", maxWidth: 880 }}>

--- a/web/src/studio/StudioAccountPage.tsx
+++ b/web/src/studio/StudioAccountPage.tsx
@@ -74,15 +74,17 @@ const StudioAccountPage = () => {
                     {status.periodKey})
                   </Text>
                 </FlexColumn>
-                <EditorButton
-                  variant="outlined"
-                  disabled={topup.isPending}
-                  onClick={() => topup.mutate({ credits: TOPUP_CREDITS })}
-                >
-                  {topup.isPending
-                    ? "Adding…"
-                    : `Add ${TOPUP_CREDITS} credits (test)`}
-                </EditorButton>
+                {status.testTopupEnabled && (
+                  <EditorButton
+                    variant="outlined"
+                    disabled={topup.isPending}
+                    onClick={() => topup.mutate({ credits: TOPUP_CREDITS })}
+                  >
+                    {topup.isPending
+                      ? "Adding…"
+                      : `Add ${TOPUP_CREDITS} credits (test)`}
+                  </EditorButton>
+                )}
               </FlexRow>
               <Text size="smaller" color="secondary" sx={{ mt: SPACING.md }}>
                 Credits meter NodeTool's managed models only — bring your own

--- a/web/src/studio/StudioShell.tsx
+++ b/web/src/studio/StudioShell.tsx
@@ -23,14 +23,18 @@ import {
 import { useStudioCredits } from "./useStudioCredits";
 
 const CreditsChip = () => {
-  const { remaining, used, grant, loading } = useStudioCredits();
+  const navigate = useNavigate();
+  const { status, remaining, loading } = useStudioCredits();
+  const title = status
+    ? `${status.plan.name} plan — ${status.spentCredits} of ${status.grantedCredits} credits used. 1 credit = 1¢ of generation. Click to manage.`
+    : "Plan & credits";
   return (
-    <Tooltip
-      title={`${used} of ${grant} credits used. 1 credit = 1¢ of generation.`}
-    >
+    <Tooltip title={title}>
       <span>
         <Chip
           compact
+          clickable
+          onClick={() => navigate("/studio/account")}
           color={remaining > 0 ? "primary" : "error"}
           icon={<BoltRoundedIcon />}
           label={loading ? "credits…" : `${remaining} credits`}

--- a/web/src/studio/curatedModels.ts
+++ b/web/src/studio/curatedModels.ts
@@ -39,11 +39,6 @@ export const STUDIO_CLIP_MODEL: VideoModelValue = {
   name: "Kling O1 Standard"
 };
 
-/**
- * Credits are a beginner-friendly veneer over the prediction ledger:
- * 1 credit = one US cent of provider spend. The grant is a flat prototype
- * allowance; the real product replaces it with purchased balances enforced
- * server-side (see docs/agentic-video-product.md).
- */
-export const USD_PER_CREDIT = 0.01;
-export const STUDIO_CREDIT_GRANT = 1_000;
+// Credits and plans are server-owned: balance, plan catalog, and enforcement
+// live in @nodetool-ai/models (`credits.ts`) behind `trpc.credits.*`.
+// See docs/agentic-video-product.md.

--- a/web/src/studio/curatedModels.ts
+++ b/web/src/studio/curatedModels.ts
@@ -1,11 +1,13 @@
 /**
- * The Studio model policy: one curated model per role, stamped onto every new
- * Studio project so beginners never see a model picker. Editing these values
- * is the whole "model management" surface of the product.
+ * The Studio model policy: every new Studio project is stamped with NodeTool's
+ * own managed models — the `nodetool` provider — so beginners never see a
+ * model picker and never need an API key. Those calls run on platform keys
+ * and are metered against the credit balance; users who dig into the reused
+ * editors can still pick any BYOK provider, unmetered.
  *
- * Ids must exist in the corresponding provider catalog — `nodetool validate`
- * rejects unknown provider/model pairs at run time, so a typo here fails
- * loudly, not silently.
+ * The curated catalog itself (ids, names, delegates) is
+ * `NODETOOL_MODELS` in `@nodetool-ai/protocol` — this file just selects which
+ * entry fills each Studio role.
  */
 
 import type {
@@ -17,28 +19,24 @@ import type {
 /** Directs screenplays and drives the in-editor assistants. */
 export const STUDIO_DIRECTOR_MODEL: LanguageModelValue = {
   type: "language_model",
-  id: "claude-sonnet-5",
-  provider: "anthropic",
-  name: "Claude Sonnet 5"
+  id: "nodetool/director",
+  provider: "nodetool",
+  name: "NodeTool Director"
 };
 
 /** Renders storyboard keyframe stills. */
 export const STUDIO_STILL_MODEL: ImageModelValue = {
   type: "image_model",
-  id: "fal-ai/flux-1/schnell",
-  provider: "fal_ai",
-  name: "FLUX.1 Schnell",
+  id: "nodetool/flux-schnell",
+  provider: "nodetool",
+  name: "NodeTool Still (FLUX Schnell)",
   path: ""
 };
 
 /** Animates keyframes into shot clips. */
 export const STUDIO_CLIP_MODEL: VideoModelValue = {
   type: "video_model",
-  id: "fal-ai/kling-video/o1/standard/image-to-video",
-  provider: "fal_ai",
-  name: "Kling O1 Standard"
+  id: "nodetool/kling-standard",
+  provider: "nodetool",
+  name: "NodeTool Clip (Kling Standard)"
 };
-
-// Credits and plans are server-owned: balance, plan catalog, and enforcement
-// live in @nodetool-ai/models (`credits.ts`) behind `trpc.credits.*`.
-// See docs/agentic-video-product.md.

--- a/web/src/studio/useStudioCredits.ts
+++ b/web/src/studio/useStudioCredits.ts
@@ -1,40 +1,32 @@
 /**
- * Derives the Studio credit balance from the prediction ledger the whole
- * platform already writes: every provider call lands in `nodetool_predictions`
- * with its cost, `costs.dashboard` aggregates it, and this hook converts the
- * total to credits against the prototype grant. Display-level only — nothing
- * is blocked client-side; hard enforcement belongs to the server budget gate.
+ * Server-backed Studio credits: balance, plan, and the plan catalog come from
+ * `trpc.credits.status`, which accrues the month's plan grant on read. The
+ * server enforces spend only when the deployment sets
+ * NODETOOL_CREDITS_ENFORCED (`enforced` in the payload says so).
  */
 
-import { useMemo } from "react";
 import { trpc } from "../trpc/client";
-import { STUDIO_CREDIT_GRANT, USD_PER_CREDIT } from "./curatedModels";
+import type { RouterOutputs } from "../trpc/client";
+
+export type CreditStatusOutput = RouterOutputs["credits"]["status"];
 
 export interface StudioCredits {
-  grant: number;
-  used: number;
+  status: CreditStatusOutput | null;
   remaining: number;
-  /** True until the first ledger response arrives. */
   loading: boolean;
+  refetch: () => void;
 }
 
 export function useStudioCredits(): StudioCredits {
-  const tzOffsetMinutes = new Date().getTimezoneOffset();
-  const query = trpc.costs.dashboard.useQuery(
-    { days: 90, tzOffsetMinutes, executionsLimit: 1 },
-    { staleTime: 60_000, retry: false, refetchOnWindowFocus: false }
-  );
-
-  return useMemo(() => {
-    const spentUsd =
-      query.data?.providers.reduce((sum, p) => sum + (p.total_cost ?? 0), 0) ??
-      0;
-    const used = Math.ceil(spentUsd / USD_PER_CREDIT);
-    return {
-      grant: STUDIO_CREDIT_GRANT,
-      used,
-      remaining: Math.max(0, STUDIO_CREDIT_GRANT - used),
-      loading: query.isLoading
-    };
-  }, [query.data, query.isLoading]);
+  const query = trpc.credits.status.useQuery(undefined, {
+    staleTime: 30_000,
+    retry: false,
+    refetchOnWindowFocus: false
+  });
+  return {
+    status: query.data ?? null,
+    remaining: query.data?.balanceCredits ?? 0,
+    loading: query.isLoading,
+    refetch: () => void query.refetch()
+  };
 }

--- a/web/src/studio/useStudioCredits.ts
+++ b/web/src/studio/useStudioCredits.ts
@@ -1,8 +1,8 @@
 /**
  * Server-backed Studio credits: balance, plan, and the plan catalog come from
- * `trpc.credits.status`, which accrues the month's plan grant on read. The
- * server enforces spend only when the deployment sets
- * NODETOOL_CREDITS_ENFORCED (`enforced` in the payload says so).
+ * `trpc.credits.status`, which accrues the month's plan grant on read.
+ * Credits meter only the `nodetool` provider (`meteredProvider` in the
+ * payload) — BYOK providers stay unmetered.
  */
 
 import { trpc } from "../trpc/client";

--- a/web/src/utils/providerDisplay.ts
+++ b/web/src/utils/providerDisplay.ts
@@ -108,6 +108,7 @@ export const formatGenericProviderName = (provider?: string): string => {
     "point-e": "Point-E",
     meshy: "Meshy AI",
     "meshy-ai": "Meshy AI",
+    nodetool: "NodeTool",
     rodin: "Rodin AI",
     "rodin-ai": "Rodin AI",
     mlx: "MLX"


### PR DESCRIPTION
## What

Credit management and subscription plans for the Studio product (follow-up to #4758), with metering modeled as a **provider**, not a deployment switch: NodeTool's own managed models are a real provider (`nodetool`) whose spend is metered against the user's credit balance, while BYOK providers coexist unmetered on the same server.

## Design

- **Balance = grants − spend.** `nodetool_credit_ledger` stores grants only (plan accruals, top-ups, adjustments). Spend is read from the `nodetool_predictions` rows every provider call already writes, at 1 credit = $0.01 — no double bookkeeping.
- **Plans without a cron.** `nodetool_user_subscriptions` holds one row per user (Free 300/mo, Creator 3,000/mo $12, Pro 10,000/mo $40). Monthly grants accrue lazily on the first status read of the month, keyed `plan:<user>:<plan>:<YYYY-MM>` so the primary key makes double accrual impossible.
- **The `nodetool` provider is what gets metered.** Each curated model (`NODETOOL_MODELS` in protocol) names a delegate provider+model; `NodetoolProvider` runs the delegate on *platform-owned* keys (`NODETOOL_PLATFORM_FAL_KEY`, `NODETOOL_PLATFORM_ANTHROPIC_KEY`), absorbs the delegate's cost at the delegate's price, and lists only funded models — the provider appears in pickers exactly when the server can serve it. `model-pricing` translates `nodetool/...` ids to the delegate before catalog lookup, so estimates are real numbers.
- **Enforcement follows the provider.** Workflow runs are gated only on the `nodetool` slice of their cost estimate (`estimateNodetoolSpend` → `admitCreditRun`, beside the existing application-budget gate); the direct `generate_media`/`transcribe_audio` RPCs are gated only when called with `provider: "nodetool"`. BYOK is never gated. The gate fails open on its own errors, like the app-budget gate.
- **Payments are a stub on purpose.** `credits.topup` adds credits with no payment behind it and the UI says so; a payment provider integration replaces that mutation with a checkout session writing the same ledger rows from its webhook.

## Changes

- `packages/protocol`: `PROVIDER_IDS.NODETOOL`, curated catalog `nodetool-models.ts`, `api-schemas/credits.ts` (status reports `meteredProvider`), cloud-profile inclusion.
- `packages/runtime`: `providers/nodetool-provider.ts` (delegating provider, cost absorption, funded-model listing) + registration.
- `packages/model-pricing`: nodetool→delegate id translation in `getModelUnitPrice`.
- `packages/models`: `credits.ts` (catalog, subscription, accrual, balance, `checkCredits`), schema + pg mirror, migration `20260806_000000`, test-DB DDL.
- `packages/websocket`: `credit-gate.ts`, `trpc/routers/credits.ts`, provider-scoped gating in `unified-websocket-runner.ts`.
- `web/src/studio`: curated models point at the `nodetool` provider; server-backed credits chip; `/studio/account` page (balance, usage, plan cards, test top-up); provider display name.
- `docs/agentic-video-product.md` rewritten to match.

## Verification

- Tests: credits model (7), credit gate (3), NodetoolProvider (4 — funded filtering, provider stamping, missing-key and unknown-id errors), pricing translation (2), migration-count bump. Full `models` suite green (814); websocket suite green (2,211); web typecheck + eslint green.
- Live server smoke: with `NODETOOL_PLATFORM_FAL_KEY` set, `models.imageByProvider`/`videoByProvider` for `nodetool` return exactly the funded curated models stamped `provider: "nodetool"`; the anthropic-delegated director is absent without its key. `/studio/account` renders; Free→Creator switch moves the balance 300 → 3,300 instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GwuPTt5T1sLkmpwWUt2N2