### PR TITLE
fix(gemini): strip JSON-Schema keywords the tool API rejects

### DIFF
--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -138,23 +138,57 @@ interface GeminiVideoOperation {
 }
 
 // Gemini's function-declaration schema is a strict subset of OpenAPI 3.0.
-// It rejects JSON-Schema-only fields like `additionalProperties`, `$schema`,
-// `$id`, `$ref`, `definitions`, `patternProperties`, etc. Any one of these
+// It rejects JSON-Schema-only fields like `const`, `additionalProperties`,
+// `$schema`, `$ref`, `definitions`, `patternProperties`, etc. Any one of these
 // anywhere in the tree causes a 400 that aborts the entire tool batch, so we
-// recursively strip them before sending.
+// recursively strip them before sending. Zod 4's `z.toJSONSchema` (draft
+// 2020-12) emits several of them — `const` for every `z.literal()`, `$ref` +
+// `$defs` for every reused schema — so tools defined in Zod hit this.
 const GEMINI_UNSUPPORTED_SCHEMA_KEYS = new Set([
   "additionalProperties",
   "$schema",
   "$id",
   "$ref",
+  "$defs",
+  "$comment",
   "definitions",
   "patternProperties",
   "propertyNames",
   "unevaluatedProperties",
+  "unevaluatedItems",
   "dependentSchemas",
   "dependentRequired",
   "exclusiveMinimum",
-  "exclusiveMaximum"
+  "exclusiveMaximum",
+  "const",
+  "allOf",
+  "oneOf",
+  "not",
+  "if",
+  "then",
+  "else",
+  "prefixItems",
+  "additionalItems",
+  "contains",
+  "minContains",
+  "maxContains",
+  "uniqueItems",
+  "multipleOf",
+  "examples",
+  "readOnly",
+  "writeOnly",
+  "deprecated",
+  "contentEncoding",
+  "contentMediaType"
+]);
+
+/** Keywords whose value is data, not a schema — never recurse into them. */
+const GEMINI_DATA_KEYS = new Set([
+  "enum",
+  "const",
+  "default",
+  "example",
+  "examples"
 ]);
 
 function isArraySchemaType(type: unknown): boolean {
@@ -167,24 +201,185 @@ function isArraySchemaType(type: unknown): boolean {
   return false;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/** The JSON Schema type name for a primitive literal, if it has one. */
+function primitiveSchemaType(value: unknown): string | undefined {
+  if (typeof value === "string") return "string";
+  if (typeof value === "boolean") return "boolean";
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Number.isInteger(value) ? "integer" : "number";
+  }
+  return undefined;
+}
+
+function resolveJsonPointer(
+  root: unknown,
+  pointer: string
+): { found: boolean; value: unknown } {
+  if (pointer === "#" || pointer === "") return { found: true, value: root };
+  if (!pointer.startsWith("#/")) return { found: false, value: undefined };
+  let cursor: unknown = root;
+  for (const rawSegment of pointer.slice(2).split("/")) {
+    const segment = decodeURIComponent(rawSegment)
+      .replace(/~1/g, "/")
+      .replace(/~0/g, "~");
+    if (Array.isArray(cursor)) {
+      const index = Number(segment);
+      if (!Number.isInteger(index) || index < 0 || index >= cursor.length) {
+        return { found: false, value: undefined };
+      }
+      cursor = cursor[index];
+      continue;
+    }
+    if (!isPlainObject(cursor) || !(segment in cursor)) {
+      return { found: false, value: undefined };
+    }
+    cursor = cursor[segment];
+  }
+  return { found: true, value: cursor };
+}
+
+/**
+ * Inline local `$ref`s so dropping `$defs` doesn't leave empty schemas behind.
+ * A ref that is cyclic or unresolvable degrades to a permissive object.
+ */
+function inlineGeminiRefs(
+  node: unknown,
+  root: unknown,
+  seen: ReadonlySet<string>
+): unknown {
+  if (Array.isArray(node)) {
+    return node.map((item) => inlineGeminiRefs(item, root, seen));
+  }
+  if (!isPlainObject(node)) return node;
+
+  if (typeof node.$ref === "string") {
+    const { $ref, ...rest } = node;
+    if (seen.has($ref)) return { type: "object", ...rest };
+    const { found, value } = resolveJsonPointer(root, $ref);
+    if (!found || !isPlainObject(value)) return { type: "object", ...rest };
+    const resolved = inlineGeminiRefs(
+      value,
+      root,
+      new Set([...seen, $ref])
+    ) as Record<string, unknown>;
+    const overrides = inlineGeminiRefs(rest, root, seen) as Record<
+      string,
+      unknown
+    >;
+    return { ...resolved, ...overrides };
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node)) {
+    out[key] = GEMINI_DATA_KEYS.has(key)
+      ? value
+      : inlineGeminiRefs(value, root, seen);
+  }
+  return out;
+}
+
+/** Fold `allOf` members into the parent schema; parent keys win. */
+function mergeAllOf(
+  out: Record<string, unknown>,
+  members: unknown[]
+): Record<string, unknown> {
+  for (const member of members) {
+    const sanitized = sanitizeSchemaNode(member);
+    if (!isPlainObject(sanitized)) continue;
+    for (const [key, value] of Object.entries(sanitized)) {
+      if (key === "properties" && isPlainObject(value)) {
+        out.properties = { ...value, ...((out.properties as object) ?? {}) };
+        continue;
+      }
+      if (key === "required" && Array.isArray(value)) {
+        const existing = Array.isArray(out.required) ? out.required : [];
+        out.required = [...new Set([...existing, ...value])];
+        continue;
+      }
+      if (out[key] === undefined) out[key] = value;
+    }
+  }
+  return out;
+}
+
+function sanitizeSchemaNode(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sanitizeSchemaNode);
+  if (!isPlainObject(value)) return value;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    if (GEMINI_UNSUPPORTED_SCHEMA_KEYS.has(key)) continue;
+    if (key === "properties" && isPlainObject(nested)) {
+      const properties: Record<string, unknown> = {};
+      // Property *names* are data — a property called "const" must survive.
+      for (const [name, sub] of Object.entries(nested)) {
+        properties[name] = sanitizeSchemaNode(sub);
+      }
+      out.properties = properties;
+      continue;
+    }
+    if (key === "items") {
+      out.items = sanitizeSchemaNode(
+        Array.isArray(nested) ? (nested[0] ?? { type: "string" }) : nested
+      );
+      continue;
+    }
+    if (key === "anyOf" && Array.isArray(nested)) {
+      out.anyOf = nested.map(sanitizeSchemaNode);
+      continue;
+    }
+    out[key] = GEMINI_DATA_KEYS.has(key) ? nested : sanitizeSchemaNode(nested);
+  }
+
+  // `oneOf` means the same thing to a model as `anyOf`, which Gemini accepts.
+  if (out.anyOf === undefined && Array.isArray(value.oneOf)) {
+    out.anyOf = value.oneOf.map(sanitizeSchemaNode);
+  }
+  if (Array.isArray(value.allOf)) mergeAllOf(out, value.allOf);
+
+  // `const` is what Zod emits for a literal. A single-value `enum` says the
+  // same thing in Gemini's dialect, but only for strings — its `enum` is a
+  // list of strings — so other literals keep the constraint in the description.
+  if (value.const !== undefined && out.enum === undefined) {
+    const literalType = primitiveSchemaType(value.const);
+    if (literalType === "string") {
+      out.enum = [value.const];
+      out.type ??= "string";
+    } else if (literalType) {
+      out.type ??= literalType;
+      const hint = `Must be ${JSON.stringify(value.const)}.`;
+      out.description =
+        typeof out.description === "string" && out.description
+          ? `${out.description} ${hint}`
+          : hint;
+    }
+  }
+
+  // Gemini's `type` is one string; JSON Schema allows a union. `["x","null"]`
+  // is Zod's optional/nullable shape and maps onto `nullable`.
+  if (Array.isArray(out.type)) {
+    const named = out.type.filter(
+      (t): t is string => typeof t === "string" && t.toLowerCase() !== "null"
+    );
+    if (named.length < out.type.length) out.nullable = true;
+    if (named.length > 0) out.type = named[0];
+    else delete out.type;
+  }
+
+  // Gemini rejects an array schema that omits `items` ("items: missing
+  // field"). JSON Schema allows it, so backfill a permissive default.
+  if (isArraySchemaType(out.type) && out.items === undefined) {
+    out.items = { type: "string" };
+  }
+  return out;
+}
+
 function sanitizeGeminiSchema(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(sanitizeGeminiSchema);
-  }
-  if (value && typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value)) {
-      if (GEMINI_UNSUPPORTED_SCHEMA_KEYS.has(k)) continue;
-      out[k] = sanitizeGeminiSchema(v);
-    }
-    // Gemini rejects an array schema that omits `items` ("items: missing
-    // field"). JSON Schema allows it, so backfill a permissive default.
-    if (isArraySchemaType(out.type) && out.items === undefined) {
-      out.items = { type: "string" };
-    }
-    return out;
-  }
-  return value;
+  return sanitizeSchemaNode(inlineGeminiRefs(value, value, new Set()));
 }
 
 function sanitizeToolName(name: string): string {
@@ -713,7 +908,9 @@ export class GeminiProvider extends BaseProvider {
   private applyTools(
     body: GeminiRequest,
     tools: ProviderTool[],
-    geminiTools: Array<{ functionDeclarations: Array<Record<string, unknown>> }>,
+    geminiTools: Array<{
+      functionDeclarations: Array<Record<string, unknown>>;
+    }>,
     nameMap: Map<string, string>,
     toolChoice?: string | "any"
   ): void {

--- a/packages/runtime/tests/providers/gemini-provider.test.ts
+++ b/packages/runtime/tests/providers/gemini-provider.test.ts
@@ -278,6 +278,167 @@ describe("GeminiProvider", () => {
     expect(params.properties.ids.items).toEqual({ type: "number" });
   });
 
+  it("rewrites `const` (Zod literals) into a form Gemini accepts", () => {
+    const provider = new GeminiProvider({ GEMINI_API_KEY: "k" });
+
+    const { geminiTools } = provider.formatTools([
+      {
+        name: "animate",
+        description: "",
+        inputSchema: {
+          type: "object",
+          properties: {
+            animations: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  role: { const: "in" },
+                  weight: { const: 1 },
+                  enabled: { const: true, description: "Flag." }
+                }
+              }
+            }
+          }
+        }
+      }
+    ]);
+
+    const params = geminiTools[0].functionDeclarations[0].parameters as any;
+    const item = params.properties.animations.items.properties;
+    expect(JSON.stringify(params)).not.toContain('"const"');
+    expect(item.role).toEqual({ type: "string", enum: ["in"] });
+    expect(item.weight).toEqual({
+      type: "integer",
+      description: "Must be 1."
+    });
+    expect(item.enabled).toEqual({
+      type: "boolean",
+      description: "Flag. Must be true."
+    });
+  });
+
+  it("keeps a property literally named `const`", () => {
+    const provider = new GeminiProvider({ GEMINI_API_KEY: "k" });
+
+    const { geminiTools } = provider.formatTools([
+      {
+        name: "tool",
+        description: "",
+        inputSchema: {
+          type: "object",
+          properties: { const: { type: "string" } }
+        }
+      }
+    ]);
+
+    const params = geminiTools[0].functionDeclarations[0].parameters as any;
+    expect(params.properties.const).toEqual({ type: "string" });
+  });
+
+  it("inlines local $refs and drops $defs", () => {
+    const provider = new GeminiProvider({ GEMINI_API_KEY: "k" });
+
+    const { geminiTools } = provider.formatTools([
+      {
+        name: "tool",
+        description: "",
+        inputSchema: {
+          type: "object",
+          $defs: {
+            Point: { type: "object", properties: { x: { type: "number" } } }
+          },
+          properties: {
+            start: { $ref: "#/$defs/Point" },
+            end: { $ref: "#/$defs/Point", description: "End." }
+          }
+        }
+      }
+    ]);
+
+    const params = geminiTools[0].functionDeclarations[0].parameters as any;
+    expect(params.$defs).toBeUndefined();
+    expect(params.properties.start).toEqual({
+      type: "object",
+      properties: { x: { type: "number" } }
+    });
+    expect(params.properties.end.description).toBe("End.");
+    expect(params.properties.end.properties.x).toEqual({ type: "number" });
+  });
+
+  it("degrades a recursive $ref to a permissive object", () => {
+    const provider = new GeminiProvider({ GEMINI_API_KEY: "k" });
+
+    const { geminiTools } = provider.formatTools([
+      {
+        name: "tool",
+        description: "",
+        inputSchema: {
+          type: "object",
+          $defs: {
+            Node: {
+              type: "object",
+              properties: { child: { $ref: "#/$defs/Node" } }
+            }
+          },
+          properties: { root: { $ref: "#/$defs/Node" } }
+        }
+      }
+    ]);
+
+    const params = geminiTools[0].functionDeclarations[0].parameters as any;
+    expect(params.properties.root.properties.child).toEqual({
+      type: "object"
+    });
+  });
+
+  it("maps oneOf/allOf and nullable unions onto Gemini's dialect", () => {
+    const provider = new GeminiProvider({ GEMINI_API_KEY: "k" });
+
+    const { geminiTools } = provider.formatTools([
+      {
+        name: "tool",
+        description: "",
+        inputSchema: {
+          type: "object",
+          properties: {
+            choice: {
+              oneOf: [{ type: "string" }, { type: "number" }]
+            },
+            merged: {
+              allOf: [
+                {
+                  type: "object",
+                  properties: { a: { type: "string" } },
+                  required: ["a"]
+                },
+                { properties: { b: { type: "string" } }, required: ["b"] }
+              ]
+            },
+            note: { type: ["string", "null"] }
+          }
+        }
+      }
+    ]);
+
+    const params = geminiTools[0].functionDeclarations[0].parameters as any;
+    expect(params.properties.choice.anyOf).toEqual([
+      { type: "string" },
+      { type: "number" }
+    ]);
+    expect(params.properties.choice.oneOf).toBeUndefined();
+    expect(params.properties.merged.type).toBe("object");
+    expect(Object.keys(params.properties.merged.properties).sort()).toEqual([
+      "a",
+      "b"
+    ]);
+    expect(params.properties.merged.required.sort()).toEqual(["a", "b"]);
+    expect(params.properties.note).toEqual({
+      type: "string",
+      nullable: true
+    });
+  });
+
   it("fetches available language models", async () => {
     const fetchFn = vi.fn().mockResolvedValue(
       makeFetchResponse({
@@ -700,7 +861,9 @@ describe("GeminiProvider", () => {
       messages: [{ role: "user", content: "go" }],
       tools: [{ name: "ui_storyboard_add_shot" }]
     });
-    expect(JSON.parse(fetchFn.mock.calls[0][1].body).toolConfig).toBeUndefined();
+    expect(
+      JSON.parse(fetchFn.mock.calls[0][1].body).toolConfig
+    ).toBeUndefined();
 
     // A built-in with no function declarations needs no flag either.
     fetchFn.mockClear();
@@ -709,7 +872,9 @@ describe("GeminiProvider", () => {
       messages: [{ role: "user", content: "go" }],
       tools: [{ name: "web_search" }]
     });
-    expect(JSON.parse(fetchFn.mock.calls[0][1].body).toolConfig).toBeUndefined();
+    expect(
+      JSON.parse(fetchFn.mock.calls[0][1].body).toolConfig
+    ).toBeUndefined();
   });
 
   it("maps code-interpreter tools to Gemini code execution", async () => {


### PR DESCRIPTION
## Problem

Gemini 400s the whole tool batch on a JSON-Schema keyword it has no field for:

```
Invalid JSON payload received. Unknown name "const" at
'tools[0].function_declarations[21].parameters.properties[3].value.items
 .properties[6].value.properties[0].value': Cannot find field.
```

Gemini's function-declaration schema is an OpenAPI 3.0 subset. Zod 4's `z.toJSONSchema` (draft 2020-12, used by `zodToJsonSchema` in `packages/runtime/src/zod-schema.ts`) emits `const` for every `z.literal()` and `$ref` + `$defs` for every reused schema — so any tool defined in Zod hit this. One bad keyword anywhere in the tree aborts every tool in the request, not just the offending one.

`sanitizeGeminiSchema` already stripped a handful of keywords (`additionalProperties`, `$ref`, `patternProperties`, …) but not `const`, and stripping `$ref` while dropping `$defs` left an empty schema behind.

## Changes

`packages/runtime/src/providers/gemini-provider.ts`:

- **`const` → an accepted form.** A string literal becomes a single-value `enum`; a number or boolean literal becomes its `type` plus a `Must be X.` description hint, since Gemini's `enum` takes strings only.
- **`$ref` inlined** against the root document before `$defs` is dropped. A cyclic or unresolvable ref degrades to `{ type: "object" }` rather than `{}`.
- **`oneOf` → `anyOf`** (same meaning to the model, and `anyOf` is in Gemini's dialect); **`allOf` folded** into the parent, merging `properties` and unioning `required`, with parent keys winning.
- **`["string","null"]` → `type: "string"` + `nullable: true`** — Gemini's `type` is one string, and the union is Zod's nullable shape.
- **Remaining draft-2020-12 keywords dropped**: `not`, `if`/`then`/`else`, `prefixItems`, `contains`, `uniqueItems`, `multipleOf`, `examples`, `readOnly`/`writeOnly`, `deprecated`, `contentEncoding`/`contentMediaType`, `$comment`, `$defs`.
- **Recursion is now schema-aware.** Keyword filtering no longer applies to property *names*, so a property called `const` (or `additionalProperties`) survives, and data under `enum`/`default`/`example` is copied verbatim instead of being walked as a schema.

Existing behavior kept: tool-name sanitization, and the `items` backfill for array schemas.

## Tests

Five cases added to `packages/runtime/tests/providers/gemini-provider.test.ts`: `const` rewriting for string/number/boolean literals, a property literally named `const`, `$ref` inlining with `$defs` removal, a recursive `$ref`, and the `oneOf`/`allOf`/nullable-union mapping. `npx vitest run tests/providers/gemini-provider*.test.ts` — 107 passed. `npm run lint --workspace=packages/runtime` (tsc) clean.

Unrelated pre-existing failures in `tests/providers` (fal, kie, atlascloud, manifest-models, replicate, together, topaz) are present on `main` in this environment and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174zpe4326XDbrzA4UANeQR

---
_Generated by [Claude Code](https://claude.ai/code/session_0174zpe4326XDbrzA4UANeQR)_