### PR TITLE
Show the provider strip in the model menu on narrow screens

### DIFF
--- a/web/src/styles/mobile.css
+++ b/web/src/styles/mobile.css
@@ -178,45 +178,9 @@
     max-width: 100% !important;
   }
 
-  /* Model Menu fullscreen on mobile — match Settings dialog pattern. */
-  .mobile .model-menu__dialog .MuiDialog-paper {
-    margin: 0 !important;
-    width: 100vw !important;
-    max-width: 100vw !important;
-    height: 100dvh !important;
-    max-height: 100dvh !important;
-    border-radius: 0 !important;
-  }
-
-  /* Collapse complex 3-column grid → single column */
-  .mobile .model-menu__grid {
-    display: grid !important;
-    grid-template-columns: 1fr !important;
-    grid-template-rows: auto 1fr !important;
-    gap: var(--spacing-xs) !important;
-  }
-
-  /* Hide provider list and sidebar (favorites/recent) */
-  .mobile .model-menu__providers-list,
-  .mobile .model-menu__sidebar {
-    display: none !important;
-  }
-
-  /* Hide advanced filters bar (keep just search) */
-  .mobile .model-menu__filters-bar {
-    display: none !important;
-  }
-
-  /* Expand model list to full width */
-  .mobile .model-menu__model-list-container {
-    max-width: none !important;
-    width: 100% !important;
-  }
-
-  /* Hide footer counts and other non-essential info */
-  .mobile .model-menu__footer {
-    display: none !important;
-  }
+  /* The model menu handles its own narrow-screen layout in
+     ModelMenuDialogBase (full-screen paper, horizontal provider strip), so it
+     needs no overrides here. */
 
   /* Chat Composer Mobile Styles
      Keep compose-message in its default column layout on mobile so the

--- a/web/tests/visual/chat.spec.ts
+++ b/web/tests/visual/chat.spec.ts
@@ -126,6 +126,26 @@ test.describe("Chat Interface", () => {
     );
   });
 
+  test("composer model selector keeps its provider strip @responsive", async ({
+    page
+  }) => {
+    // On narrow screens the provider rail becomes a horizontal strip. A stale
+    // `.mobile` stylesheet once hid it outright, leaving the menu with no way
+    // to filter by provider.
+    await gotoPage(page, "/chat/thread-story");
+    await waitForComposer(page);
+    expect(await openComposerChip(page, "model")).toBe(true);
+
+    const strip = page.locator(".model-menu__providers-list").first();
+    await expect(strip).toBeVisible();
+    const box = await strip.boundingBox();
+    expect(box?.width ?? 0).toBeGreaterThan(0);
+    expect(box?.height ?? 0).toBeGreaterThan(0);
+    await expect(
+      page.locator(".model-menu__provider-item").first()
+    ).toBeVisible();
+  });
+
   test("dashboard / portal @responsive @smoke", async ({ page }) => {
     // The portal (/dashboard) is the chat-led home surface: header + composer
     // + recent threads. Grouped with chat since it shares the composer shell.


### PR DESCRIPTION
## What

On mobile web the model select showed no provider buttons.

`ModelMenuDialogBase` already has its own narrow-screen layout — full-screen paper, provider rail turned into a horizontal scrolling strip above the model list. But `web/src/styles/mobile.css` still carried a block from the menu's previous layout that hid `.model-menu__providers-list` (and `.model-menu__sidebar`) with `display: none !important` below 600px, so the strip was rendered and then removed from layout. Same block also hid `.model-menu__filters-bar` (type/size filters), and its other four selectors — `__dialog`, `__grid`, `__model-list-container`, `__footer` — match nothing in the app anymore.

Removed the block. Nothing else in the app uses those classes; the component handles its own responsive layout.

## Verification

Reproduced in a real browser at 375×812 via the visual-test harness: before the change the provider list computed `display: none` with a 0×0 box; after it lays out as a 216px scrolling strip with the provider buttons visible.

Added `composer model selector keeps its provider strip @responsive` to `web/tests/visual/chat.spec.ts` — asserts the strip is visible with a non-zero box and at least one provider item. Passes on desktop, mobile, and tablet projects.

`npm run typecheck` and `npm run lint` pass; `model_menu` Jest suites pass (9 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_017Xy6kvnjDG6umoNtBQbGSm)_