### PR TITLE
feat(agents): CodeAct execution mode — code actions instead of JSON tool calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -867,6 +867,15 @@ npm run dev:nodetool -- eval task-planner -p anthropic -m claude-sonnet-5
 npm run dev:nodetool -- eval script-planner -p openai -m gpt-5.4-mini
 ```
 
+A **`codeact`** suite scores the CodeAct execution mode (steps act by writing
+sandboxed JavaScript over the toolbelt instead of JSON tool calls —
+[docs/codeact-design.md](docs/codeact-design.md)) on offline instrumented
+cases: required tools invoked, action rounds within bounds, result correct.
+
+```bash
+npm run dev:nodetool -- eval codeact -p anthropic -m claude-sonnet-5
+```
+
 Alongside `graph-planner` (one-shot DSL) there are ten **tool-loop** suites
 that drive a real provider through the frontend `ui_*` tool contract against a
 headless bridge — no browser — and score the multi-turn tool-calling flow

--- a/docs/codeact-design.md
+++ b/docs/codeact-design.md
@@ -125,8 +125,9 @@ provider transcript only carries `execute_code`.
    sentence of the description) — and only for the **resident** set. The
    high-traffic tools nearly every step reaches for (the whole search family
    — `web_search`, `search_nodes`, `run_search`, `google_news`,
-   `google_images`, `asset_search`, `grep`, `glob` — plus browser, HTTP,
-   workspace files, memory, `run_subtask` — `CODEACT_RESIDENT_TOOL_NAMES`,
+   `google_images`, `asset_search`, `grep`, `glob` — plus the Claude-agent
+   file set (`read_file`, `write_file`, `edit_file`, `list_directory`),
+   browser, HTTP, memory, `run_subtask` — `CODEACT_RESIDENT_TOOL_NAMES`,
    overridable per executor) stay fully documented; once the belt exceeds `CODEACT_DEFER_THRESHOLD` (16),
    everything else is listed by name only and discovered in-sandbox via
    `await searchTools("query")`, which reuses the ToolSearch query grammar

--- a/docs/codeact-design.md
+++ b/docs/codeact-design.md
@@ -1,0 +1,197 @@
+# CodeAct Execution Mode — Design
+
+Status: implemented behind `executionMode: "codeact"` (default stays `"tools"`).
+Code: `packages/agents/src/codeact/`.
+
+## What this is
+
+An alternative action space for the agent step loop. In the default mode the
+model acts by emitting one JSON tool call per action, the host executes it, and
+the result comes back as a tool message — one round trip per tool. In CodeAct
+mode the model acts by writing a JavaScript program; the program runs in the
+QuickJS sandbox where the same toolbelt is exposed as async functions
+(`tools.web_search(...)`), and one round trip can chain, loop over, branch on,
+and post-process any number of tool calls. The program's output — return value,
+console logs, thrown error — comes back as the observation for the next turn.
+
+The research this follows:
+
+- **CodeAct** (Wang et al., ICML 2024, arXiv:2402.01030) — executable code as
+  the action space beats JSON/text tool calling: up to +20% success, ~30% fewer
+  turns. The core loop here (code action → execution observation → repair) is
+  that paper's.
+- **CaveAgent** (arXiv:2601.01569) — a *persistent* runtime across turns
+  (stateful objects survive between actions) adds +5–13.5% success and ~28%
+  fewer tokens on data-heavy tasks. Our `state` object is this: it lives on the
+  host and syncs back after every action, so turn N+1 can read what turn N
+  computed without re-serializing it through the transcript.
+- **MCP design-choice study** (arXiv:2602.15945) and Anthropic's
+  *Code execution with MCP* (Nov 2025) — decoupling tool *results* from model
+  *context* is where the token savings come from (their headline example:
+  98.7% reduction). A CodeAct program can fetch a large payload, reduce it in
+  the sandbox, and surface only the reduction; in tool mode the whole payload
+  transits the transcript.
+- **To Run or Not to Run** (arXiv:2606.26978) — execution isn't free; there are
+  regimes where restricting it saves cost with little accuracy loss. That is
+  why this is a *mode*, not a replacement: the default stays `"tools"`, and the
+  eval suite exists to measure where codeact actually wins before any default
+  flips.
+
+## What already exists (and is reused unchanged)
+
+| Piece | Where | Role here |
+|---|---|---|
+| QuickJS WASM sandbox | `packages/agents/src/js-sandbox.ts` (`runInSandbox`) | Executes every action. All its limits (30 s timeout, 64 MB heap, fetch caps, output truncation, SSRF guard, workspace containment) apply per action. |
+| Tool base class + registry | `src/tools/base-tool.ts`, `tool-registry.ts` | The toolbelt is the same `Tool[]` the tool-mode step gets — codeact adds no capability that tool mode doesn't have. |
+| Provider loop | `BaseProvider.generateLoop` | Drives the turn loop; codeact presents exactly one provider tool. |
+| Result-schema validation | `src/utils/json-schema-validate.ts` | `finish(result)` validates host-side with the same checker `finish_step` uses. |
+| Never-reject bridge convention | `js-sandbox.ts` / `script-runner.ts` | Host bridges resolve `{ok, ...}` envelopes; a guest prelude re-throws. Required by the QuickJS handle-leak workaround. |
+| Agent memory | `context.memory` | Step/task results land under the same keys; memory tools are in the toolbelt as functions like everything else. |
+
+CodeAct is *not* script mode. `ScriptRunner` orchestrates **sub-agents**
+(`agent()` spawns a `StepExecutor`); codeact is what a single step *does
+instead of* JSON tool calls. The two compose: a script-mode run whose
+sub-steps execute in codeact mode is just both flags set.
+
+## The action protocol
+
+The model sees **one** provider tool:
+
+```
+execute_code({ code: string })
+```
+
+Code actions arrive through a tool call rather than fenced text because every
+provider adapter already delivers tool calls reliably; scraping code blocks
+out of prose is exactly the fragility tool calling was invented to avoid. The
+CodeAct paper's gains come from the *action space* being code, not from the
+transport being free text.
+
+Inside the sandbox, on top of the standard surface (`console`, `fetch`,
+`workspace`, `crypto`, `data`, `format`, …), the action gets:
+
+- **`tools.<name>(args)`** — one async function per tool in the step's
+  toolbelt. Calls bridge to `Tool.executeTool` on the host. A tool that
+  returns an `{error}` payload throws in the guest, so `try/catch` is the
+  error-handling idiom. Per-action tool-call cap (`maxToolCallsPerAction`,
+  default 50) so a runaway loop can't drain budgets silently.
+- **`state`** — a plain object that persists across actions within the step
+  (host-side, synced back after every run via the sandbox's global sync-back).
+  Fetch once, reuse every turn; never re-fetch to re-look at something.
+- **`finish(result)`** — completes the step. For schema'd steps the host
+  validates against the declared schema; an invalid result throws in the guest
+  with the violation list, so the same action can repair and retry, or the
+  failure becomes the observation for the next action. Valid `finish` ends the
+  provider loop (AbortController, same mechanism as `finish_step`).
+- **The action's return value** — becomes part of the observation. Returning a
+  small summary of big intermediate data is the context-decoupling move; the
+  prompt says so explicitly.
+
+The observation sent back as the tool result is a JSON envelope:
+
+```
+{ ok, result?, error?, stack?, logs?, finished?, toolCalls }
+```
+
+truncated by the same `truncateToolResult` cap as any tool result (20 000
+chars). `toolCalls` is the count consumed, so the model can see budget burn.
+
+### Completion semantics (identical contract to StepExecutor)
+
+- Schema'd step: only a schema-valid `finish(result)` completes. Iterations
+  exhausted → explicit failed step, never a silent guess.
+- Unschema'd step: `finish(...)` works, and a plain assistant message with no
+  tool call also finalizes (its text is the result) — the same prose-mode rule
+  the tool-mode executor has.
+- Failure reporting, memory writes (`step:<id>`, `task:<id>` with
+  `useFinishTask`), and the `ProcessingMessage` stream (`task_update`,
+  `step_result`, `tool_call_update`, `chunk`) are byte-compatible with
+  `StepExecutor`, so every consumer — CLI tree, web ExecutionTree, script
+  runner, supervisor — works unchanged.
+
+Each host-bridged tool invocation is surfaced as a `tool_call_update` (id
+`codeact_<n>`), so observability keeps per-tool granularity even though the
+provider transcript only carries `execute_code`.
+
+## Prompting
+
+`buildCodeActSystemPrompt` renders:
+
+1. The action contract (write code, observe, repair; `state` discipline; keep
+   observations small — return summaries, stash payloads in `state` or
+   memory).
+2. The tool catalog as **typed signatures**, generated from each tool's JSON
+   schema (`await tools.browse({url: string, timeout?: number})` + first
+   sentence of the description). Signatures cost a fraction of full JSON
+   schemas in the prompt — the progressive-disclosure half of the Anthropic
+   MCP result.
+3. A condensed sandbox API reference (what exists beyond `tools.*`, what is
+   blocked, the key limits) derived from the same manifest the Code-node
+   prompt uses, so it cannot advertise an API the sandbox doesn't marshal.
+4. The output-schema section for schema'd steps.
+
+Caller-supplied system prompts remain preambles, exactly as in
+`StepExecutor.buildSystemPrompt` — they cannot override the execution
+contract.
+
+## Security posture
+
+The action executes with the same privileges tool mode already grants:
+
+- Every `tools.*` function is a tool the model could have called directly; the
+  bridge adds **no** capability. Per-step `tools` allow-lists stay a privilege
+  boundary — a codeact step only sees its allowed subset.
+- The sandbox's own limits bound the new part (arbitrary computation): CPU via
+  interrupt handler, heap, fetch count/size/SSRF guard, workspace containment,
+  no `eval`/`Function`, no module loader.
+- The genuinely new risk (per the MCP design-choice study) is *composition*:
+  one action can chain tool calls without per-call visibility in the provider
+  transcript. Mitigations: per-action tool-call cap, per-invocation
+  `tool_call_update` events (nothing becomes invisible to the host), and the
+  30 s default action timeout.
+- `finish` validation is host-side; the guest cannot forge a completed step.
+
+## Integration surface
+
+- `AgentOptions.executionMode?: "tools" | "codeact"` — threaded through
+  `Agent` → `ParallelTaskExecutor` → `TaskExecutor`, which picks the executor
+  class per step (`createStepExecutor`). Script mode forwards it to its
+  sub-agents; process-mode fan-out steps use it too.
+- **The setting**: `NODETOOL_AGENT_EXECUTION_MODE` (`tools` | `codeact`),
+  registered in the settings registry so it appears in the Settings UI and
+  `nodetool settings`. Resolution precedence, everywhere a mode is resolved
+  (`resolveExecutionMode`): explicit option > the setting > `"tools"`. The
+  server mirrors the stored value into the environment at startup
+  (`applyAgentExecutionModeSetting`); a real environment variable wins over
+  the stored value, and a Settings change takes effect on the next server
+  start.
+- CLI: `nodetool agent run <yaml> --codeact`; the agent YAML also takes
+  `execution_mode: codeact`. Flag > YAML > setting.
+
+## Evaluation
+
+`eval codeact` (registered next to `subtask`): objectives with instrumented
+tools where the interesting metric is *rounds* and *tool routing*, scored
+structurally (required tools invoked, forbidden ones not, action count within
+bounds, final result correct). Run the same cases through both modes to get
+the paper's comparison on our own toolbelt:
+
+```bash
+npm run dev:nodetool -- eval codeact -p anthropic -m claude-sonnet-5
+```
+
+Harness tests (`tests/codeact-executor.test.ts`) drive the executor with a
+`ScriptedProvider` — tool chaining in one action, `state` persistence across
+actions, schema repair after an invalid `finish`, error observations, prose
+finalization — no network, no model.
+
+## Non-goals (now)
+
+- Flipping the default. `"tools"` remains until the eval says otherwise per
+  the cost-effectiveness caveat above.
+- Python actions. The sandbox is JS; the CodeAct result is about code as the
+  action space, not about Python specifically.
+- Replacing planners. GraphPlanner/ScriptPlanner/CodePlanner already use
+  code-shaped *artifacts*; this changes the step execution loop only.
+- The chat/websocket toolbelt. Chat turns keep tool mode; wiring codeact into
+  the websocket runner is a follow-up once step-level evals justify it.

--- a/docs/codeact-design.md
+++ b/docs/codeact-design.md
@@ -123,10 +123,11 @@ provider transcript only carries `execute_code`.
 2. The tool catalog as **typed signatures**, generated from each tool's JSON
    schema (`await tools.browse({url: string, timeout?: number})` + first
    sentence of the description) — and only for the **resident** set. The
-   high-traffic tools nearly every step reaches for (web search, browser,
-   HTTP, workspace files, memory, `run_subtask` —
-   `CODEACT_RESIDENT_TOOL_NAMES`, overridable per executor) stay fully
-   documented; once the belt exceeds `CODEACT_DEFER_THRESHOLD` (16),
+   high-traffic tools nearly every step reaches for (the whole search family
+   — `web_search`, `search_nodes`, `run_search`, `google_news`,
+   `google_images`, `asset_search`, `grep`, `glob` — plus browser, HTTP,
+   workspace files, memory, `run_subtask` — `CODEACT_RESIDENT_TOOL_NAMES`,
+   overridable per executor) stay fully documented; once the belt exceeds `CODEACT_DEFER_THRESHOLD` (16),
    everything else is listed by name only and discovered in-sandbox via
    `await searchTools("query")`, which reuses the ToolSearch query grammar
    (`select:`, keywords, `+substr`) and returns each match's signature and

--- a/docs/codeact-design.md
+++ b/docs/codeact-design.md
@@ -122,9 +122,17 @@ provider transcript only carries `execute_code`.
    memory).
 2. The tool catalog as **typed signatures**, generated from each tool's JSON
    schema (`await tools.browse({url: string, timeout?: number})` + first
-   sentence of the description). Signatures cost a fraction of full JSON
-   schemas in the prompt — the progressive-disclosure half of the Anthropic
-   MCP result.
+   sentence of the description) — and only for the **resident** set. The
+   high-traffic tools nearly every step reaches for (web search, browser,
+   HTTP, workspace files, memory, `run_subtask` —
+   `CODEACT_RESIDENT_TOOL_NAMES`, overridable per executor) stay fully
+   documented; once the belt exceeds `CODEACT_DEFER_THRESHOLD` (16),
+   everything else is listed by name only and discovered in-sandbox via
+   `await searchTools("query")`, which reuses the ToolSearch query grammar
+   (`select:`, keywords, `+substr`) and returns each match's signature and
+   description. Deferred tools remain callable — the split spends prompt
+   tokens, not capability. This is the progressive-disclosure half of the
+   Anthropic MCP result.
 3. A condensed sandbox API reference (what exists beyond `tools.*`, what is
    blocked, the key limits) derived from the same manifest the Code-node
    prompt uses, so it cannot advertise an API the sandbox doesn't marshal.

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -459,6 +459,30 @@ downstream may treat a failure as a satisfied dependency: `TaskExecutor` blocks
 dependents and marks them failed with the blocking step named, and a plan whose
 every task failed throws instead of compiling a deliverable out of nothing.
 
+## CodeAct Execution Mode (`src/codeact/`)
+
+An alternative action space for the step loop (`executionMode: "codeact"` on
+`AgentOptions`, or the `NODETOOL_AGENT_EXECUTION_MODE` setting; default stays
+`"tools"`). Instead of one JSON tool call per
+action, each step acts by writing JavaScript that runs in the QuickJS sandbox
+with the toolbelt exposed as `tools.<name>()` functions, a `state` object that
+persists across actions, and `finish(result)` for host-validated completion.
+Design and the research it follows (CodeAct, ICML 2024): docs/codeact-design.md.
+
+- `CodeActExecutor` mirrors `StepExecutor`'s message contract, memory writes,
+  and failure semantics — consumers work unchanged. Bridged tool calls surface
+  as `tool_call_update` events (ids `codeact_<n>`).
+- The mode threads through `TaskExecutor`, `ParallelTaskExecutor`, and
+  `ScriptRunner` sub-agents; each resolves `resolveExecutionMode(explicit)` —
+  explicit option > `NODETOOL_AGENT_EXECUTION_MODE` > `"tools"`. The setting
+  is registered in the websocket settings registry (Settings UI, group
+  Execution) and mirrored into the environment at server startup. CLI:
+  `nodetool agent run <yaml> --codeact` (YAML: `execution_mode: codeact`).
+- Eval suite `codeact` runs the same offline instrumented cases through either
+  executor for a mode comparison: `nodetool eval codeact -p <p> -m <m>`.
+- Tests: `tests/codeact-executor.test.ts`, `tests/codeact-eval.test.ts`
+  (scripted provider, real sandbox, no network).
+
 ## Script Mode (code-shaped orchestration)
 
 The third planning mode next to `TaskPlan` and the graph planner: the LLM

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -472,6 +472,11 @@ Design and the research it follows (CodeAct, ICML 2024): docs/codeact-design.md.
 - `CodeActExecutor` mirrors `StepExecutor`'s message contract, memory writes,
   and failure semantics — consumers work unchanged. Bridged tool calls surface
   as `tool_call_update` events (ids `codeact_<n>`).
+- Progressive disclosure: resident tools (`CODEACT_RESIDENT_TOOL_NAMES` —
+  web search, browser, HTTP, files, memory, `run_subtask`) are documented in
+  full; past `CODEACT_DEFER_THRESHOLD` tools, the rest is name-only in the
+  prompt and discovered in-sandbox with `await searchTools("query")`
+  (ToolSearch grammar). All tools stay callable either way.
 - The mode threads through `TaskExecutor`, `ParallelTaskExecutor`, and
   `ScriptRunner` sub-agents; each resolves `resolveExecutionMode(explicit)` —
   explicit option > `NODETOOL_AGENT_EXECUTION_MODE` > `"tools"`. The setting

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -473,8 +473,9 @@ Design and the research it follows (CodeAct, ICML 2024): docs/codeact-design.md.
   and failure semantics — consumers work unchanged. Bridged tool calls surface
   as `tool_call_update` events (ids `codeact_<n>`).
 - Progressive disclosure: resident tools (`CODEACT_RESIDENT_TOOL_NAMES` —
-  web search, browser, HTTP, files, memory, `run_subtask`) are documented in
-  full; past `CODEACT_DEFER_THRESHOLD` tools, the rest is name-only in the
+  the search family incl. `web_search`/`search_nodes`/`run_search`/
+  `asset_search`/`grep`/`glob`, plus browser, HTTP, files, memory,
+  `run_subtask`) are documented in full; past `CODEACT_DEFER_THRESHOLD` tools, the rest is name-only in the
   prompt and discovered in-sandbox with `await searchTools("query")`
   (ToolSearch grammar). All tools stay callable either way.
 - The mode threads through `TaskExecutor`, `ParallelTaskExecutor`, and

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -474,8 +474,9 @@ Design and the research it follows (CodeAct, ICML 2024): docs/codeact-design.md.
   as `tool_call_update` events (ids `codeact_<n>`).
 - Progressive disclosure: resident tools (`CODEACT_RESIDENT_TOOL_NAMES` —
   the search family incl. `web_search`/`search_nodes`/`run_search`/
-  `asset_search`/`grep`/`glob`, plus browser, HTTP, files, memory,
-  `run_subtask`) are documented in full; past `CODEACT_DEFER_THRESHOLD` tools, the rest is name-only in the
+  `asset_search`/`grep`/`glob`, the Claude-agent file set
+  (`read_file`/`write_file`/`edit_file`/`list_directory`), browser, HTTP,
+  memory, `run_subtask`) are documented in full; past `CODEACT_DEFER_THRESHOLD` tools, the rest is name-only in the
   prompt and discovered in-sandbox with `await searchTools("query")`
   (ToolSearch grammar). All tools stay callable either way.
 - The mode threads through `TaskExecutor`, `ParallelTaskExecutor`, and

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -48,12 +48,14 @@ import {
   createSecurityMonitorConsult
 } from "./security-monitor.js";
 import type {
+  AgentExecutionMode,
   PlanApprovalDecision,
   RequestPlanApproval,
   Task,
   TaskPlan
 } from "./types.js";
 import { PLAN_APPROVAL_CONTEXT_KEY } from "./types.js";
+import { resolveExecutionMode } from "./codeact/execution-mode.js";
 import type { PlanCache, CheckpointStore } from "./checkpoint-store.js";
 import { resolveAgentPolicy, type AgentPolicy } from "./agent-policy.js";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
@@ -279,6 +281,14 @@ export interface AgentOptions {
    */
   useGraphPlanner?: boolean;
   /**
+   * Step action space: `"tools"` (default) is the classic one-JSON-tool-call-
+   * per-action loop; `"codeact"` has each step act by writing JavaScript that
+   * runs in the QuickJS sandbox with the toolbelt exposed as `tools.<name>()`
+   * functions (docs/codeact-design.md). Orthogonal to the planning mode —
+   * script-mode sub-agents and process-mode fan-outs honor it too.
+   */
+  executionMode?: AgentExecutionMode;
+  /**
    * Use the script planner: the LLM authors a JavaScript orchestration
    * script (loops, conditionals, budget-scaled fan-out) instead of a
    * TaskPlan, and {@link ScriptRunner} executes it deterministically in the
@@ -401,6 +411,7 @@ export class Agent {
   private readonly autoPersistMemory: boolean;
   private readonly synthesizeRecall: boolean;
   private readonly useGraphPlanner: boolean;
+  private readonly executionMode: AgentExecutionMode;
   private readonly useScriptPlanner: boolean;
   private readonly script?: string;
   private readonly graphSource?: AgentGraphSource;
@@ -447,6 +458,7 @@ export class Agent {
     this.autoPersistMemory = opts.autoPersistMemory === true;
     this.synthesizeRecall = opts.synthesizeRecall ?? true;
     this.useGraphPlanner = opts.useGraphPlanner === true;
+    this.executionMode = resolveExecutionMode(opts.executionMode);
     this.useScriptPlanner = opts.useScriptPlanner === true;
     this.script = opts.script;
     this.graphSource = opts.graph;
@@ -862,7 +874,8 @@ export class Agent {
       checkpointStore: this.checkpointStore,
       runId: this.runId,
       planTools: this.tools.map((t) => t.name),
-      signal: this.signal
+      signal: this.signal,
+      executionMode: this.executionMode
     });
 
     for await (const item of executor.execute()) {
@@ -1186,7 +1199,8 @@ export class Agent {
       maxTokens: this.policy.maxTokens,
       maxConcurrentAgents: this.policy.maxConcurrentAgents,
       maxAgentCalls: this.policy.maxAgentCalls,
-      signal: this.signal
+      signal: this.signal,
+      executionMode: this.executionMode
     });
 
     const runGen = runner.execute(script);
@@ -1441,7 +1455,8 @@ export class Agent {
       maxTokens: this.policy.maxTokens,
       maxConcurrentAgents: this.policy.maxConcurrentAgents,
       parallelExecution: true,
-      signal: this.signal
+      signal: this.signal,
+      executionMode: this.executionMode
     });
 
     for await (const item of executor.executeTasks()) {

--- a/packages/agents/src/codeact/codeact-executor.ts
+++ b/packages/agents/src/codeact/codeact-executor.ts
@@ -1,0 +1,511 @@
+/**
+ * CodeActExecutor — executes a single step with JavaScript code as the action
+ * space instead of JSON tool calls (Wang et al., ICML 2024, arXiv:2402.01030).
+ *
+ * The provider sees exactly one tool, `execute_code`. Each call runs the
+ * model's program in the QuickJS sandbox where the step's toolbelt is exposed
+ * as `tools.<name>()` functions, a `state` object persists across actions,
+ * and `finish(result)` completes the step (host-validated against the step's
+ * output schema). The program's outcome — return value, logs, error — is the
+ * observation for the next turn.
+ *
+ * The message contract (`task_update`, `step_result`, `tool_call_update`,
+ * `chunk`), memory writes, and failure semantics are byte-compatible with
+ * {@link StepExecutor}, so every consumer works unchanged.
+ */
+
+import type {
+  BaseProvider,
+  ProcessingContext,
+  Message,
+  MessageContent,
+  ProviderStreamItem,
+  ToolCall
+} from "@nodetool-ai/runtime";
+import {
+  ACTIVE_MODEL_CONTEXT_KEY,
+  memoryKeys,
+  withAgentSpanGen,
+  type ActiveModelSelection
+} from "@nodetool-ai/runtime";
+import { createLogger } from "@nodetool-ai/config";
+import {
+  TaskUpdateEvent,
+  type Chunk,
+  type ProcessingMessage,
+  type StepResult,
+  type TaskUpdate,
+  type ToolCallUpdate
+} from "@nodetool-ai/protocol";
+import type { Step, Task } from "../types.js";
+import { Tool } from "../tools/base-tool.js";
+import { getMemoryTools } from "../tools/memory-tools.js";
+import { runInSandbox } from "../js-sandbox.js";
+import { truncateToolResult } from "../constants.js";
+import {
+  formatViolations,
+  validateAgainstSchema
+} from "../utils/json-schema-validate.js";
+import { linkAbort } from "../utils/link-abort.js";
+import {
+  buildToolBridge,
+  CODEACT_PRELUDE,
+  type ToolCallRecord
+} from "./tool-api.js";
+import { buildCodeActSystemPrompt } from "./prompt.js";
+
+const log = createLogger("nodetool.agents.codeact");
+
+/**
+ * Code actions batch several tool calls per turn, so the turn budget is
+ * deliberately lower than tool mode's 30.
+ */
+export const DEFAULT_CODEACT_MAX_ITERATIONS = 20;
+
+export const EXECUTE_CODE_TOOL_NAME = "execute_code";
+
+export interface CodeActExecutorOptions {
+  task: Task;
+  step: Step;
+  context: ProcessingContext;
+  provider: BaseProvider;
+  model: string;
+  tools?: Tool[];
+  /** Preamble layered before the CodeAct contract; cannot override it. */
+  systemPrompt?: string;
+  maxIterations?: number;
+  maxTokens?: number;
+  useFinishTask?: boolean;
+  threadId?: string;
+  upstreamMemoryKeys?: string[];
+  signal?: AbortSignal;
+  /** Wall-clock limit per code action. Defaults to the sandbox's 30 s. */
+  actionTimeoutMs?: number;
+  /** Tool calls one action may consume. Default 50. */
+  maxToolCallsPerAction?: number;
+}
+
+/** Observation envelope returned to the model after each code action. */
+interface ActionObservation {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+  stack?: string;
+  logs?: string[];
+  finished?: boolean;
+  toolCalls: number;
+}
+
+export class CodeActExecutor {
+  private readonly task: Task;
+  private readonly step: Step;
+  private readonly context: ProcessingContext;
+  private readonly provider: BaseProvider;
+  private readonly model: string;
+  private readonly tools: Tool[];
+  private readonly systemPrompt: string;
+  private readonly maxIterations: number;
+  private readonly maxTokens?: number;
+  private readonly useFinishTask: boolean;
+  private readonly threadId?: string;
+  private readonly upstreamMemoryKeys: string[];
+  private readonly signal?: AbortSignal;
+  private readonly actionTimeoutMs?: number;
+  private readonly maxToolCallsPerAction?: number;
+  private readonly resultSchema: Record<string, unknown> | null;
+  /** Persists across actions within the step (CaveAgent-style runtime state). */
+  private readonly state: Record<string, unknown> = {};
+  private result: unknown = null;
+  private actionCount = 0;
+
+  constructor(opts: CodeActExecutorOptions) {
+    this.task = opts.task;
+    this.step = opts.step;
+    this.context = opts.context;
+    this.provider = opts.provider;
+    this.model = opts.model;
+    this.tools = opts.tools ? [...opts.tools] : [];
+    this.maxIterations = opts.maxIterations ?? DEFAULT_CODEACT_MAX_ITERATIONS;
+    this.maxTokens = opts.maxTokens;
+    this.useFinishTask = opts.useFinishTask ?? false;
+    this.threadId = opts.threadId;
+    this.upstreamMemoryKeys = opts.upstreamMemoryKeys ?? [];
+    this.signal = opts.signal;
+    this.actionTimeoutMs = opts.actionTimeoutMs;
+    this.maxToolCallsPerAction = opts.maxToolCallsPerAction;
+
+    // Memory tools ride in the toolbelt as functions like everything else.
+    const existing = new Set(this.tools.map((t) => t.name));
+    for (const memoryTool of getMemoryTools()) {
+      if (!existing.has(memoryTool.name)) this.tools.push(memoryTool);
+    }
+
+    this.resultSchema = this.loadResultSchema();
+    this.systemPrompt = buildCodeActSystemPrompt({
+      tools: this.tools,
+      resultSchema: this.resultSchema,
+      preamble: opts.systemPrompt
+    });
+  }
+
+  getResult(): unknown {
+    return this.result;
+  }
+
+  async *execute(): AsyncGenerator<ProcessingMessage> {
+    yield* withAgentSpanGen(
+      "step",
+      {
+        provider: this.provider.provider,
+        model: this.model,
+        task: this.step.instructions,
+        toolsCount: this.tools.length,
+        extra: {
+          "agent.step.id": this.step.id,
+          "agent.task.id": this.task.id,
+          "agent.step.mode": "codeact"
+        }
+      },
+      () => this._executeImpl()
+    );
+  }
+
+  private async *_executeImpl(): AsyncGenerator<ProcessingMessage> {
+    log.debug("CodeAct step started", {
+      stepId: this.step.id,
+      instructions: this.step.instructions.slice(0, 60)
+    });
+
+    this.context.set(ACTIVE_MODEL_CONTEXT_KEY, {
+      provider: this.provider.provider,
+      model: this.model
+    } satisfies ActiveModelSelection);
+
+    const history: Message[] = [
+      { role: "system", content: this.systemPrompt },
+      { role: "user", content: this.buildUserMessage() }
+    ];
+
+    this.step.startTime = Date.now();
+    yield this.taskUpdate(TaskUpdateEvent.StepStarted);
+
+    const abort = new AbortController();
+    const unlinkAbort = linkAbort(abort, this.signal);
+    const uiEvents: ProcessingMessage[] = [];
+    let lastAssistant: Message | null = null;
+    let generationError: Error | null = null;
+    let finishedResult: { value: unknown } | null = null;
+    let bridgedCallSeq = 0;
+
+    const toolsByName = new Map(this.tools.map((t) => [t.name, t]));
+    const onToolCall = (record: ToolCallRecord): void => {
+      bridgedCallSeq++;
+      const tool = toolsByName.get(record.name);
+      uiEvents.push({
+        type: "tool_call_update",
+        node_id: this.step.id,
+        tool_call_id: `codeact_${bridgedCallSeq}`,
+        name: record.name,
+        args: record.args,
+        message: tool
+          ? Tool.resolveMessage(tool, record.args)
+          : `Running ${record.name}`
+      } satisfies ToolCallUpdate);
+    };
+
+    const bridge = buildToolBridge({
+      tools: this.tools,
+      context: this.context,
+      onToolCall,
+      maxToolCallsPerAction: this.maxToolCallsPerAction
+    });
+
+    const finishBridge = async (
+      resultJson: unknown
+    ): Promise<{ ok: true } | { ok: false; error: string }> => {
+      let payload: unknown = null;
+      if (typeof resultJson === "string") {
+        try {
+          payload = JSON.parse(resultJson);
+        } catch {
+          return { ok: false, error: "finish: result must be JSON-serializable" };
+        }
+      }
+      if (payload === null || payload === undefined) {
+        return { ok: false, error: "finish: missing result" };
+      }
+      if (this.resultSchema) {
+        const violations = validateAgainstSchema(payload, this.resultSchema);
+        if (violations.length > 0) {
+          return {
+            ok: false,
+            error: `Result validation failed: ${formatViolations(violations)}`
+          };
+        }
+      }
+      finishedResult = { value: payload };
+      return { ok: true };
+    };
+
+    const executeAction = async (
+      args: Record<string, unknown>
+    ): Promise<string | MessageContent[]> => {
+      const code = typeof args?.["code"] === "string" ? args["code"] : "";
+      if (!code.trim()) {
+        return JSON.stringify({
+          ok: false,
+          error: "execute_code: `code` must be a non-empty string",
+          toolCalls: 0
+        } satisfies ActionObservation);
+      }
+      this.actionCount++;
+      bridge.resetActionBudget();
+
+      const outcome = await runInSandbox({
+        code: `${CODEACT_PRELUDE}\n${code}`,
+        context: this.context,
+        timeoutMs: this.actionTimeoutMs,
+        signal: this.signal,
+        globals: {
+          ...bridge.globals,
+          __finish: finishBridge,
+          state: this.state
+        }
+      });
+
+      const observation: ActionObservation = {
+        ok: outcome.success,
+        toolCalls: bridge.callCount()
+      };
+      if (outcome.success) {
+        if (outcome.result !== undefined) observation.result = outcome.result;
+      } else {
+        observation.error = outcome.error;
+        if (outcome.stack) observation.stack = outcome.stack;
+      }
+      if (outcome.logs && outcome.logs.length > 0) {
+        observation.logs = outcome.logs;
+      }
+
+      // A validated finish() completes the step even when the action crashed
+      // after recording it — the model cannot retract a validated result.
+      if (finishedResult) {
+        observation.finished = true;
+        this.storeCompletionResult(finishedResult.value);
+        uiEvents.push(this.taskUpdate(TaskUpdateEvent.StepCompleted));
+        uiEvents.push(this.stepResult(finishedResult.value));
+        abort.abort();
+      }
+
+      return truncateToolResult(JSON.stringify(observation));
+    };
+
+    const providerTools = [
+      {
+        name: EXECUTE_CODE_TOOL_NAME,
+        description:
+          "Execute a JavaScript action in the sandbox. The observation " +
+          "(return value, logs, error) is the tool result.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            code: {
+              type: "string",
+              description: "The JavaScript program to run."
+            }
+          },
+          required: ["code"],
+          additionalProperties: false
+        },
+        execute: (args: Record<string, unknown>) => executeAction(args)
+      }
+    ];
+
+    const drainUi = function* (): Generator<ProcessingMessage> {
+      while (uiEvents.length > 0) yield uiEvents.shift() as ProcessingMessage;
+    };
+
+    try {
+      const stream = this.provider.generateLoop({
+        messages: history,
+        model: this.model,
+        tools: providerTools,
+        threadId: this.threadId,
+        maxIterations: this.maxIterations,
+        maxTokens: this.maxTokens,
+        sequentialTools: true,
+        signal: abort.signal
+      });
+
+      for await (const item of stream) {
+        if (isToolCall(item)) {
+          yield {
+            type: "tool_call_update",
+            node_id: this.step.id,
+            tool_call_id: item.id,
+            name: item.name,
+            args: item.args,
+            message: "Executing code action"
+          } satisfies ToolCallUpdate;
+          yield* drainUi();
+          continue;
+        }
+        if (isChunk(item)) {
+          if (typeof item.content === "string" && item.content.length > 0) {
+            yield {
+              type: "chunk",
+              node_id: this.step.id,
+              content: item.content,
+              done: false
+            } satisfies Chunk;
+          }
+          yield* drainUi();
+          continue;
+        }
+        if ("type" in item && (item as { type?: string }).type === "message") {
+          const m = (item as { message?: Message }).message;
+          if (m && m.role === "assistant") lastAssistant = m;
+        }
+        yield* drainUi();
+      }
+    } catch (e) {
+      generationError = e instanceof Error ? e : new Error(String(e));
+      log.error("CodeAct step generation failed", {
+        stepId: this.step.id,
+        error: generationError.message
+      });
+    } finally {
+      unlinkAbort();
+    }
+
+    yield* drainUi();
+
+    // Unschema'd steps also finalize from a no-tool-call assistant message —
+    // the same prose-mode rule StepExecutor has.
+    if (
+      !this.step.completed &&
+      this.resultSchema === null &&
+      lastAssistant &&
+      (!lastAssistant.toolCalls || lastAssistant.toolCalls.length === 0) &&
+      lastAssistant.content !== null &&
+      lastAssistant.content !== undefined
+    ) {
+      this.storeCompletionResult(lastAssistant.content);
+      yield this.taskUpdate(TaskUpdateEvent.StepCompleted);
+      yield this.stepResult(lastAssistant.content);
+    }
+
+    if (!this.step.completed) {
+      this.step.endTime = Date.now();
+      const message = generationError
+        ? `Step failed: ${generationError.message}`
+        : `Step failed: exceeded ${this.maxIterations} iterations without completion`;
+      this.step.failed = true;
+      this.step.error = message;
+      const errorResult = { error: message };
+      this.result = errorResult;
+      this.context.memory.set({
+        key: memoryKeys.step(this.step.id),
+        kind: "step_result",
+        value: errorResult,
+        source: this.step.id,
+        title: `Failed: ${this.step.instructions.slice(0, 60)}`
+      });
+      yield this.taskUpdate(TaskUpdateEvent.StepFailed);
+      yield {
+        type: "step_result",
+        step: { id: this.step.id, instructions: this.step.instructions },
+        result: errorResult,
+        error: message,
+        is_task_result: this.useFinishTask
+      } satisfies StepResult;
+    }
+  }
+
+  private loadResultSchema(): Record<string, unknown> | null {
+    if (!this.step.outputSchema) return null;
+    try {
+      const parsed = JSON.parse(this.step.outputSchema) as unknown;
+      if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+      return null;
+    } catch {
+      log.warn("Ignoring unparseable outputSchema", { stepId: this.step.id });
+      return null;
+    }
+  }
+
+  private buildUserMessage(): string {
+    const parts: string[] = [this.step.instructions];
+    const keys = [
+      ...this.step.dependsOn.map((id) => memoryKeys.step(id)),
+      ...this.upstreamMemoryKeys
+    ];
+    if (keys.length > 0) {
+      parts.push(
+        `Required upstream context — read these before acting (via ` +
+          `\`await tools.memory_read({keys: [...]})\`):\n` +
+          keys.map((k) => `- ${k}`).join("\n")
+      );
+    }
+    return parts.join("\n\n");
+  }
+
+  private storeCompletionResult(value: unknown): void {
+    this.step.completed = true;
+    this.step.endTime = Date.now();
+    this.context.memory.set({
+      key: memoryKeys.step(this.step.id),
+      kind: "step_result",
+      value,
+      source: this.step.id,
+      title: this.step.instructions.slice(0, 80)
+    });
+    if (this.useFinishTask) {
+      this.context.memory.set({
+        key: memoryKeys.task(this.task.id),
+        kind: "task_result",
+        value,
+        source: this.task.id,
+        title: this.task.title
+      });
+    }
+    this.result = value;
+  }
+
+  private taskUpdate(event: TaskUpdateEvent): TaskUpdate {
+    return {
+      type: "task_update",
+      node_id: this.step.id,
+      task: { id: this.task.id, title: this.task.title },
+      step: { id: this.step.id, instructions: this.step.instructions },
+      event
+    };
+  }
+
+  private stepResult(result: unknown): StepResult {
+    return {
+      type: "step_result",
+      step: { id: this.step.id, instructions: this.step.instructions },
+      result,
+      is_task_result: this.useFinishTask
+    };
+  }
+}
+
+function isChunk(item: ProviderStreamItem): item is Chunk {
+  return (
+    "type" in item &&
+    (item as unknown as Record<string, unknown>)["type"] === "chunk" &&
+    typeof (item as unknown as Record<string, unknown>)["content"] === "string"
+  );
+}
+
+function isToolCall(item: ProviderStreamItem): item is ToolCall {
+  return (
+    "name" in item &&
+    typeof (item as unknown as Record<string, unknown>)["name"] === "string" &&
+    "id" in item
+  );
+}

--- a/packages/agents/src/codeact/codeact-executor.ts
+++ b/packages/agents/src/codeact/codeact-executor.ts
@@ -49,9 +49,12 @@ import {
 import { linkAbort } from "../utils/link-abort.js";
 import {
   buildToolBridge,
+  toolSignature,
   CODEACT_PRELUDE,
-  type ToolCallRecord
+  type ToolCallRecord,
+  type ToolSearchHit
 } from "./tool-api.js";
+import { searchTools } from "../tools/tool-search.js";
 import { buildCodeActSystemPrompt } from "./prompt.js";
 
 const log = createLogger("nodetool.agents.codeact");
@@ -63,6 +66,37 @@ const log = createLogger("nodetool.agents.codeact");
 export const DEFAULT_CODEACT_MAX_ITERATIONS = 20;
 
 export const EXECUTE_CODE_TOOL_NAME = "execute_code";
+
+/**
+ * Tools documented in full in the prompt regardless of toolbelt size — the
+ * high-traffic set nearly every step reaches for (mirroring the chat
+ * runner's resident-toolbelt idea). Everything else is deferred: still
+ * callable, but discovered through `searchTools()` first, so a 70-tool belt
+ * does not cost 70 signatures of prompt.
+ */
+export const CODEACT_RESIDENT_TOOL_NAMES: ReadonlySet<string> = new Set([
+  // Web + retrieval.
+  "web_search",
+  "browser",
+  "http_request",
+  "download_file",
+  // Workspace files.
+  "read_file",
+  "write_file",
+  "list_directory",
+  // Shared agent memory.
+  "memory_list",
+  "memory_read",
+  "memory_write",
+  // Delegation.
+  "run_subtask"
+]);
+
+/**
+ * Toolbelts at or below this size skip the split entirely — deferring three
+ * tools saves nothing and costs a discovery round.
+ */
+export const CODEACT_DEFER_THRESHOLD = 16;
 
 export interface CodeActExecutorOptions {
   task: Task;
@@ -83,6 +117,13 @@ export interface CodeActExecutorOptions {
   actionTimeoutMs?: number;
   /** Tool calls one action may consume. Default 50. */
   maxToolCallsPerAction?: number;
+  /**
+   * Tools documented in full in the prompt. Defaults to
+   * {@link CODEACT_RESIDENT_TOOL_NAMES}; the rest of the toolbelt is
+   * deferred behind `searchTools()` once the belt exceeds
+   * {@link CODEACT_DEFER_THRESHOLD}.
+   */
+  residentToolNames?: Iterable<string>;
 }
 
 /** Observation envelope returned to the model after each code action. */
@@ -113,6 +154,8 @@ export class CodeActExecutor {
   private readonly actionTimeoutMs?: number;
   private readonly maxToolCallsPerAction?: number;
   private readonly resultSchema: Record<string, unknown> | null;
+  private readonly residentTools: Tool[];
+  private readonly deferredTools: Tool[];
   /** Persists across actions within the step (CaveAgent-style runtime state). */
   private readonly state: Record<string, unknown> = {};
   private result: unknown = null;
@@ -140,9 +183,25 @@ export class CodeActExecutor {
       if (!existing.has(memoryTool.name)) this.tools.push(memoryTool);
     }
 
+    // Progressive disclosure: resident tools are documented in full; the
+    // long tail is name-only in the prompt and discovered via searchTools().
+    // Every tool stays callable either way — the split spends prompt tokens,
+    // not capability.
+    const residentNames = new Set(
+      opts.residentToolNames ?? CODEACT_RESIDENT_TOOL_NAMES
+    );
+    if (this.tools.length <= CODEACT_DEFER_THRESHOLD) {
+      this.residentTools = [...this.tools];
+      this.deferredTools = [];
+    } else {
+      this.residentTools = this.tools.filter((t) => residentNames.has(t.name));
+      this.deferredTools = this.tools.filter((t) => !residentNames.has(t.name));
+    }
+
     this.resultSchema = this.loadResultSchema();
     this.systemPrompt = buildCodeActSystemPrompt({
-      tools: this.tools,
+      tools: this.residentTools,
+      deferredTools: this.deferredTools,
       resultSchema: this.resultSchema,
       preamble: opts.systemPrompt
     });
@@ -247,6 +306,40 @@ export class CodeActExecutor {
       return { ok: true };
     };
 
+    // Discovery over the FULL toolbelt (resident hits included, so a
+    // redundant query still answers instead of coming back empty).
+    const searchCatalog = this.tools.map((t) => ({
+      name: t.name,
+      description: t.description
+    }));
+    const searchToolsBridge = async (
+      query: unknown,
+      maxResults: unknown
+    ): Promise<
+      { ok: true; result: ToolSearchHit[] } | { ok: false; error: string }
+    > => {
+      try {
+        const limit =
+          typeof maxResults === "number" && Number.isFinite(maxResults)
+            ? Math.max(1, Math.min(25, Math.floor(maxResults)))
+            : 5;
+        const byName = new Map(this.tools.map((t) => [t.name, t]));
+        const hits = searchTools(searchCatalog, String(query ?? ""), limit).map(
+          (entry): ToolSearchHit => {
+            const tool = byName.get(entry.name) as Tool;
+            return {
+              name: entry.name,
+              signature: toolSignature(tool),
+              description: tool.description
+            };
+          }
+        );
+        return { ok: true, result: hits };
+      } catch (e) {
+        return { ok: false, error: e instanceof Error ? e.message : String(e) };
+      }
+    };
+
     const executeAction = async (
       args: Record<string, unknown>
     ): Promise<string | MessageContent[]> => {
@@ -269,6 +362,7 @@ export class CodeActExecutor {
         globals: {
           ...bridge.globals,
           __finish: finishBridge,
+          __searchTools: searchToolsBridge,
           state: this.state
         }
       });

--- a/packages/agents/src/codeact/codeact-executor.ts
+++ b/packages/agents/src/codeact/codeact-executor.ts
@@ -88,9 +88,11 @@ export const CODEACT_RESIDENT_TOOL_NAMES: ReadonlySet<string> = new Set([
   "browser",
   "http_request",
   "download_file",
-  // Workspace files.
+  // Workspace files — the Claude-agent core set (read/write/edit/glob/grep
+  // above) stays top level in full.
   "read_file",
   "write_file",
+  "edit_file",
   "list_directory",
   // Shared agent memory.
   "memory_list",

--- a/packages/agents/src/codeact/codeact-executor.ts
+++ b/packages/agents/src/codeact/codeact-executor.ts
@@ -75,8 +75,16 @@ export const EXECUTE_CODE_TOOL_NAME = "execute_code";
  * does not cost 70 signatures of prompt.
  */
 export const CODEACT_RESIDENT_TOOL_NAMES: ReadonlySet<string> = new Set([
-  // Web + retrieval.
+  // Search family — every discovery entry point stays top level.
   "web_search",
+  "search_nodes",
+  "run_search",
+  "google_news",
+  "google_images",
+  "asset_search",
+  "grep",
+  "glob",
+  // Web + retrieval.
   "browser",
   "http_request",
   "download_file",

--- a/packages/agents/src/codeact/execution-mode.ts
+++ b/packages/agents/src/codeact/execution-mode.ts
@@ -1,0 +1,17 @@
+/**
+ * Execution-mode setting resolution. Precedence: explicit option >
+ * `NODETOOL_AGENT_EXECUTION_MODE` (the registered setting; the server mirrors
+ * the stored value into the environment at startup) > `"tools"`.
+ */
+
+import type { AgentExecutionMode } from "../types.js";
+
+export const AGENT_EXECUTION_MODE_ENV = "NODETOOL_AGENT_EXECUTION_MODE";
+
+export function resolveExecutionMode(
+  explicit?: AgentExecutionMode
+): AgentExecutionMode {
+  if (explicit) return explicit;
+  const raw = process.env[AGENT_EXECUTION_MODE_ENV]?.trim().toLowerCase();
+  return raw === "codeact" ? "codeact" : "tools";
+}

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -66,7 +66,13 @@ function renderSandboxSummary(manifest: SandboxManifest): string {
 }
 
 export interface CodeActPromptOptions {
+  /** Tools documented in full (signature + description) in the prompt. */
   tools: Tool[];
+  /**
+   * Deferred long tail: callable like any other tool, but listed by name
+   * only — the model pulls a signature in with `searchTools()` first.
+   */
+  deferredTools?: Tool[];
   /** Declared output schema (JSON schema) of the step, if any. */
   resultSchema?: Record<string, unknown> | null;
   /** Caller preamble — layered before the contract, never replacing it. */
@@ -88,6 +94,18 @@ export function buildCodeActSystemPrompt(
     );
   }
   sections.push(`# Tools\n${renderToolCatalog(options.tools)}`);
+  const deferred = options.deferredTools ?? [];
+  if (deferred.length > 0) {
+    sections.push(
+      `# More tools (discover before calling)\n` +
+        `These are also callable via \`tools.<name>()\`, but only their names ` +
+        `are listed here. Call \`await searchTools("query")\` (or ` +
+        `\`searchTools("select:name1,name2")\`) first — it returns each ` +
+        `match's signature and description. Do not guess arguments for a ` +
+        `tool you have not looked up.\n\n` +
+        deferred.map((t) => t.name).join(", ")
+    );
+  }
   sections.push(renderSandboxSummary(manifest));
   return sections.join("\n\n");
 }

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -1,0 +1,93 @@
+/**
+ * CodeAct system prompt — the action contract, the tool catalog rendered as
+ * typed signatures, and a condensed sandbox API reference derived from the
+ * same manifest the Code-node prompt uses (so it cannot advertise an API the
+ * sandbox does not marshal).
+ */
+
+import {
+  getSandboxManifest,
+  type SandboxManifest
+} from "../code-gen/sandbox-manifest.js";
+import type { Tool } from "../tools/base-tool.js";
+import { renderToolCatalog } from "./tool-api.js";
+
+const ACTION_CONTRACT = `# CodeAct Execution
+
+You act by writing JavaScript. Each turn, call the \`execute_code\` tool with a
+program; it runs in a sandbox and the observation (return value, console logs,
+error) comes back as the tool result. Repair and continue based on what you
+observe.
+
+Rules:
+- Chain related work into ONE action: call several tools, loop, branch, and
+  post-process in the same program instead of one action per tool call.
+- \`state\` is a plain object that persists across your actions in this step.
+  Stash fetched data and intermediates there (\`state.rows = ...\`) and reuse
+  them next turn — never re-fetch what you already have.
+- Keep observations small. \`return\` a compact summary (counts, ids, the few
+  fields you need); large payloads belong in \`state\`, the workspace, or agent
+  memory — not in the transcript.
+- A failed tool call throws; use try/catch when partial failure is acceptable.
+- Top-level \`await\` and \`return\` work. There is no module loader: no
+  \`import\`/\`require\`, and \`eval\`/\`Function\` are disabled.
+- Do not ask the user questions. Choose a reasonable assumption and proceed.`;
+
+const FINISH_SCHEMA = `# Completing the step
+
+Call \`await finish(result)\` when the objective is met. The result is validated
+against the output schema below; an invalid result throws with the violations
+so you can correct it. The step ONLY completes through \`finish\`.`;
+
+const FINISH_FREEFORM = `# Completing the step
+
+Call \`await finish(result)\` when the objective is met, or — for a purely
+textual answer — reply with a final assistant message containing no tool call.`;
+
+/** Compact, manifest-derived sandbox reference: signatures only. */
+function renderSandboxSummary(manifest: SandboxManifest): string {
+  const lines: string[] = [];
+  for (const bridge of Object.values(manifest.bridges)) {
+    if (bridge.internal || bridge.members.length === 0) continue;
+    for (const member of bridge.members) {
+      lines.push(`- ${member.signature}`);
+    }
+  }
+  for (const helper of Object.values(manifest.guestHelpers)) {
+    lines.push(`- ${helper.signature}`);
+  }
+  return [
+    `# Sandbox API (besides \`tools.*\`, \`state\`, \`finish\`)`,
+    lines.join("\n"),
+    `Built-ins: ${manifest.nativeGlobals.join(", ")}.`,
+    `Not available: ${manifest.blockedGlobals.join(", ")}.`,
+    `Each action runs under the sandbox limits (execution timeout, memory, fetch count/size); split long work across actions and carry progress in \`state\`.`
+  ].join("\n\n");
+}
+
+export interface CodeActPromptOptions {
+  tools: Tool[];
+  /** Declared output schema (JSON schema) of the step, if any. */
+  resultSchema?: Record<string, unknown> | null;
+  /** Caller preamble — layered before the contract, never replacing it. */
+  preamble?: string;
+  manifest?: SandboxManifest;
+}
+
+export function buildCodeActSystemPrompt(
+  options: CodeActPromptOptions
+): string {
+  const manifest = options.manifest ?? getSandboxManifest();
+  const sections: string[] = [];
+  if (options.preamble?.trim()) sections.push(options.preamble.trim());
+  sections.push(ACTION_CONTRACT);
+  sections.push(options.resultSchema ? FINISH_SCHEMA : FINISH_FREEFORM);
+  if (options.resultSchema) {
+    sections.push(
+      `# Output schema\n\`\`\`json\n${JSON.stringify(options.resultSchema, null, 2)}\n\`\`\``
+    );
+  }
+  sections.push(`# Tools\n${renderToolCatalog(options.tools)}`);
+  sections.push(renderSandboxSummary(manifest));
+  return sections.join("\n\n");
+}

--- a/packages/agents/src/codeact/tool-api.ts
+++ b/packages/agents/src/codeact/tool-api.ts
@@ -170,6 +170,13 @@ async function finish(result) {
   }
   return "step finished";
 }
+async function searchTools(query, maxResults) {
+  const __r = await __searchTools(String(query), maxResults === undefined ? 5 : maxResults);
+  if (!__r || __r.ok !== true) {
+    throw new Error(__r && __r.error ? __r.error : "searchTools failed");
+  }
+  return __r.result;
+}
 `;
 
 /** Names the prelude and bridge globals claim inside the guest. */
@@ -177,9 +184,11 @@ export const CODEACT_RESERVED_NAMES = [
   "tools",
   "finish",
   "state",
+  "searchTools",
   "__callTool",
   "__finish",
-  "__toolNames"
+  "__toolNames",
+  "__searchTools"
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -225,15 +234,27 @@ function firstSentence(text: string): string {
   return period > 0 ? trimmed.slice(0, period + 1) : trimmed;
 }
 
-/** `await tools.web_search({query: string, limit?: number})` + description. */
-export function renderToolSignature(tool: Tool): string {
+/** The bare call signature: `await tools.web_search({query: string, ...})`. */
+export function toolSignature(tool: Tool): string {
   const schema = tool.inputSchema as JsonSchema;
   const params = schemaTypeLabel(schema);
   const args = params === "{}" ? "" : params;
-  return `- await tools.${tool.name}(${args})\n  ${firstSentence(tool.description)}`;
+  return `await tools.${tool.name}(${args})`;
+}
+
+/** Signature bullet + first sentence of the description. */
+export function renderToolSignature(tool: Tool): string {
+  return `- ${toolSignature(tool)}\n  ${firstSentence(tool.description)}`;
 }
 
 export function renderToolCatalog(tools: Tool[]): string {
   if (tools.length === 0) return "(no tools available)";
   return tools.map(renderToolSignature).join("\n");
+}
+
+/** What `searchTools()` returns to the guest, per matched tool. */
+export interface ToolSearchHit {
+  name: string;
+  signature: string;
+  description: string;
 }

--- a/packages/agents/src/codeact/tool-api.ts
+++ b/packages/agents/src/codeact/tool-api.ts
@@ -1,0 +1,239 @@
+/**
+ * CodeAct tool API — the bridge that exposes an agent toolbelt to sandboxed
+ * JavaScript actions, and the signature rendering that documents it in the
+ * system prompt.
+ *
+ * One host bridge (`__callTool`) serves every tool; a generated guest prelude
+ * builds the `tools.<name>()` wrappers on top of it. Host bridges follow the
+ * js-sandbox never-reject convention: they resolve `{ok, ...}` envelopes and
+ * the guest wrapper re-throws, so the QuickJS host-promise-rejection leak is
+ * never hit.
+ */
+
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type { JsonSchema } from "@nodetool-ai/runtime";
+import { Tool } from "../tools/base-tool.js";
+
+/** Tool-call ceiling per code action; a runaway guest loop stops here. */
+export const DEFAULT_MAX_TOOL_CALLS_PER_ACTION = 50;
+
+/** Never-rejecting bridge envelope; the guest prelude re-throws on `ok: false`. */
+type BridgeResult = { ok: true; result: unknown } | { ok: false; error: string };
+
+export interface ToolCallRecord {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface ToolBridgeOptions {
+  tools: Tool[];
+  context: ProcessingContext;
+  /** Observability hook — fires before each bridged tool executes. */
+  onToolCall?: (record: ToolCallRecord) => void;
+  maxToolCallsPerAction?: number;
+}
+
+export interface ToolBridge {
+  /** Globals to merge into the sandbox run (`__callTool`, `__toolNames`). */
+  globals: Record<string, unknown>;
+  /** Calls consumed so far in the current action. Reset per action. */
+  callCount: () => number;
+  resetActionBudget: () => void;
+}
+
+/** Force a value through JSON so it marshals cleanly across the WASM boundary. */
+function toTransferable(value: unknown): unknown {
+  if (value === null || value === undefined) return null;
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * An `{error}` payload from a tool is a failure the guest should see as a
+ * thrown exception, not as a value to compute on.
+ */
+function extractErrorPayload(result: unknown): string | null {
+  if (result === null || typeof result !== "object" || Array.isArray(result)) {
+    return null;
+  }
+  const record = result as Record<string, unknown>;
+  if (typeof record["error"] !== "string") return null;
+  const message = record["message"];
+  return typeof message === "string" && message.length > 0
+    ? message
+    : record["error"];
+}
+
+export function buildToolBridge(options: ToolBridgeOptions): ToolBridge {
+  const byName = new Map(options.tools.map((t) => [t.name, t]));
+  const maxCalls =
+    options.maxToolCallsPerAction ?? DEFAULT_MAX_TOOL_CALLS_PER_ACTION;
+  let calls = 0;
+
+  const callTool = async (
+    name: unknown,
+    argsJson: unknown
+  ): Promise<BridgeResult> => {
+    try {
+      if (typeof name !== "string" || !byName.has(name)) {
+        return {
+          ok: false,
+          error: `Unknown tool "${String(name)}". Available: ${[...byName.keys()].join(", ")}`
+        };
+      }
+      if (calls >= maxCalls) {
+        return {
+          ok: false,
+          error: `Tool-call budget for this action exhausted (max ${maxCalls} calls). Return an intermediate result and continue in the next action.`
+        };
+      }
+      calls++;
+
+      let args: Record<string, unknown> = {};
+      if (typeof argsJson === "string" && argsJson.length > 0) {
+        try {
+          const parsed = JSON.parse(argsJson) as unknown;
+          if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+            args = parsed as Record<string, unknown>;
+          } else if (parsed !== null) {
+            return {
+              ok: false,
+              error: `tools.${name}: arguments must be an object`
+            };
+          }
+        } catch {
+          return { ok: false, error: `tools.${name}: arguments must be JSON-serializable` };
+        }
+      }
+
+      const tool = byName.get(name) as Tool;
+      options.onToolCall?.({ name, args });
+
+      const result = await Tool.executeTool(tool, options.context, args);
+      const errorPayload = extractErrorPayload(result);
+      if (errorPayload !== null) {
+        return { ok: false, error: `tools.${name}: ${errorPayload}` };
+      }
+      return { ok: true, result: toTransferable(result) };
+    } catch (e) {
+      return {
+        ok: false,
+        error: e instanceof Error ? e.message : String(e)
+      };
+    }
+  };
+
+  return {
+    globals: {
+      __callTool: callTool,
+      __toolNames: options.tools.map((t) => t.name)
+    },
+    callCount: () => calls,
+    resetActionBudget: () => {
+      calls = 0;
+    }
+  };
+}
+
+/**
+ * Guest-side prelude prepended to every code action. Builds `tools.<name>()`
+ * wrappers over `__callTool` and `finish()` over `__finish`.
+ */
+export const CODEACT_PRELUDE = `
+const tools = {};
+for (const __toolName of __toolNames) {
+  tools[__toolName] = async (args) => {
+    const __r = await __callTool(
+      __toolName,
+      JSON.stringify(args === undefined ? {} : args)
+    );
+    if (!__r || __r.ok !== true) {
+      throw new Error(__r && __r.error ? __r.error : "tool call failed: " + __toolName);
+    }
+    return __r.result;
+  };
+}
+async function finish(result) {
+  const __r = await __finish(JSON.stringify(result === undefined ? null : result));
+  if (!__r || __r.ok !== true) {
+    throw new Error(__r && __r.error ? __r.error : "finish() rejected the result");
+  }
+  return "step finished";
+}
+`;
+
+/** Names the prelude and bridge globals claim inside the guest. */
+export const CODEACT_RESERVED_NAMES = [
+  "tools",
+  "finish",
+  "state",
+  "__callTool",
+  "__finish",
+  "__toolNames"
+] as const;
+
+// ---------------------------------------------------------------------------
+// Signature rendering (JSON schema → compact TS-ish signature)
+// ---------------------------------------------------------------------------
+
+function schemaTypeLabel(schema: unknown, depth = 0): string {
+  if (schema === null || typeof schema !== "object") return "unknown";
+  const s = schema as Record<string, unknown>;
+  if (Array.isArray(s["enum"])) {
+    return (s["enum"] as unknown[])
+      .slice(0, 6)
+      .map((v) => JSON.stringify(v))
+      .join(" | ");
+  }
+  const type = s["type"];
+  if (type === "array") {
+    return `${schemaTypeLabel(s["items"], depth + 1)}[]`;
+  }
+  if (type === "object") {
+    const props = s["properties"] as Record<string, unknown> | undefined;
+    if (!props || depth >= 2) return "object";
+    const required = new Set(
+      Array.isArray(s["required"]) ? (s["required"] as string[]) : []
+    );
+    const fields = Object.entries(props)
+      .map(
+        ([key, value]) =>
+          `${key}${required.has(key) ? "" : "?"}: ${schemaTypeLabel(value, depth + 1)}`
+      )
+      .join(", ");
+    return `{${fields}}`;
+  }
+  if (type === "integer") return "number";
+  if (typeof type === "string") return type;
+  if (Array.isArray(type)) return type.join(" | ");
+  return "unknown";
+}
+
+function firstSentence(text: string): string {
+  const trimmed = text.trim().replace(/\s+/g, " ");
+  const period = trimmed.indexOf(". ");
+  return period > 0 ? trimmed.slice(0, period + 1) : trimmed;
+}
+
+/** `await tools.web_search({query: string, limit?: number})` + description. */
+export function renderToolSignature(tool: Tool): string {
+  const schema = tool.inputSchema as JsonSchema;
+  const params = schemaTypeLabel(schema);
+  const args = params === "{}" ? "" : params;
+  return `- await tools.${tool.name}(${args})\n  ${firstSentence(tool.description)}`;
+}
+
+export function renderToolCatalog(tools: Tool[]): string {
+  if (tools.length === 0) return "(no tools available)";
+  return tools.map(renderToolSignature).join("\n");
+}

--- a/packages/agents/src/evals/codeact-cases.ts
+++ b/packages/agents/src/evals/codeact-cases.ts
@@ -1,0 +1,219 @@
+/**
+ * CodeAct eval cases — objectives with instrumented tools where the
+ * interesting metrics are action rounds and tool routing. The same cases run
+ * through tool mode for the paper's comparison (Wang et al., arXiv:2402.01030)
+ * on our own toolbelt, so every objective is solvable in either action space.
+ */
+
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { Tool } from "../tools/base-tool.js";
+
+export interface CodeActToolRecorder {
+  invocations: Array<{ name: string; args: Record<string, unknown> }>;
+}
+
+export function createCodeActRecorder(): CodeActToolRecorder {
+  return { invocations: [] };
+}
+
+class RecordingTool extends Tool {
+  constructor(
+    readonly name: string,
+    readonly description: string,
+    protected override readonly jsonSchema: Record<string, unknown>,
+    private readonly recorder: CodeActToolRecorder,
+    private readonly impl: (params: Record<string, unknown>) => unknown
+  ) {
+    super();
+  }
+
+  async process(
+    _context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    this.recorder.invocations.push({ name: this.name, args: params });
+    return this.impl(params);
+  }
+}
+
+const CITY_POPULATIONS: Record<string, number> = {
+  berlin: 3_755_251,
+  hamburg: 1_892_122,
+  munich: 1_512_491,
+  cologne: 1_084_831,
+  frankfurt: 773_068
+};
+
+/**
+ * The worker toolbelt: deterministic, offline, and instrumented. `flaky_fetch`
+ * fails on its first call and succeeds afterwards, so recovery is observable.
+ */
+export function createCodeActTools(recorder: CodeActToolRecorder): Tool[] {
+  let flakyCalls = 0;
+  return [
+    new RecordingTool(
+      "calculate",
+      "Evaluate an arithmetic expression with + - * / and parentheses.",
+      {
+        type: "object",
+        properties: { expression: { type: "string" } },
+        required: ["expression"]
+      },
+      recorder,
+      (params) => {
+        const expr = String(params["expression"] ?? "");
+        if (!/^[\d\s+\-*/().]+$/.test(expr)) {
+          return { error: "invalid_expression", message: `not arithmetic: ${expr}` };
+        }
+        // Arithmetic-only input (guarded above), evaluated for the fixture.
+        // eslint-disable-next-line no-new-func
+        return { value: Number(new Function(`return (${expr});`)()) };
+      }
+    ),
+    new RecordingTool(
+      "lookup_population",
+      "Look up the population of a German city.",
+      {
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"]
+      },
+      recorder,
+      (params) => {
+        const city = String(params["city"] ?? "").toLowerCase();
+        const population = CITY_POPULATIONS[city];
+        return population === undefined
+          ? { error: "unknown_city", message: `no data for ${city}` }
+          : { city, population }
+      }
+    ),
+    new RecordingTool(
+      "list_cities",
+      "List the city names this dataset covers.",
+      { type: "object", properties: {} },
+      recorder,
+      () => ({ cities: Object.keys(CITY_POPULATIONS) })
+    ),
+    new RecordingTool(
+      "flaky_fetch",
+      "Fetch the dataset revision. Fails transiently on the first call.",
+      { type: "object", properties: {} },
+      recorder,
+      () => {
+        flakyCalls++;
+        return flakyCalls === 1
+          ? { error: "transient", message: "temporarily unavailable, retry" }
+          : { revision: "2026-08" };
+      }
+    )
+  ];
+}
+
+export interface CodeActEvalExpectations {
+  /** Tools that must have been invoked (through the bridge or directly). */
+  requiredTools?: string[];
+  forbiddenTools?: string[];
+  /** Bounds on provider turns that carried a code action. */
+  maxActions?: number;
+  /** Bounds on bridged tool invocations. */
+  minToolCalls?: number;
+  maxToolCalls?: number;
+  /** Predicate over the step's final result. */
+  resultCheck?: (result: unknown) => boolean;
+  resultCheckLabel?: string;
+}
+
+export interface CodeActEvalCase {
+  id: string;
+  description: string;
+  objective: string;
+  outputSchema?: Record<string, unknown>;
+  expect: CodeActEvalExpectations;
+}
+
+const SUM_SCHEMA = {
+  type: "object",
+  properties: { total: { type: "number" } },
+  required: ["total"]
+};
+
+export const CODEACT_EVAL_CASES: readonly CodeActEvalCase[] = [
+  {
+    id: "chain-in-one-action",
+    description: "Chain dependent tool calls inside a single action",
+    objective:
+      "Compute (17 * 23) + (441 / 21) using the calculate tool for each " +
+      "sub-expression, then finish with {total: <the sum>}.",
+    outputSchema: SUM_SCHEMA,
+    expect: {
+      requiredTools: ["calculate"],
+      maxActions: 2,
+      minToolCalls: 2,
+      resultCheck: (r) =>
+        typeof r === "object" &&
+        r !== null &&
+        (r as { total?: unknown }).total === 412,
+      resultCheckLabel: "total=412"
+    }
+  },
+  {
+    id: "loop-over-dataset",
+    description: "Discover items, then loop over a tool per item",
+    objective:
+      "Use list_cities to get every city in the dataset, look up each " +
+      "city's population, and finish with {total: <sum of all populations>}.",
+    outputSchema: SUM_SCHEMA,
+    expect: {
+      requiredTools: ["list_cities", "lookup_population"],
+      maxActions: 3,
+      minToolCalls: 6,
+      resultCheck: (r) =>
+        typeof r === "object" &&
+        r !== null &&
+        (r as { total?: unknown }).total === 9_017_763,
+      resultCheckLabel: "total=9017763"
+    }
+  },
+  {
+    id: "recover-from-failure",
+    description: "Catch a transient tool failure and retry",
+    objective:
+      "Fetch the dataset revision with flaky_fetch (it can fail " +
+      "transiently — retry on failure) and finish with " +
+      "{revision: <the revision string>}.",
+    outputSchema: {
+      type: "object",
+      properties: { revision: { type: "string" } },
+      required: ["revision"]
+    },
+    expect: {
+      requiredTools: ["flaky_fetch"],
+      minToolCalls: 2,
+      maxActions: 3,
+      resultCheck: (r) =>
+        typeof r === "object" &&
+        r !== null &&
+        (r as { revision?: unknown }).revision === "2026-08",
+      resultCheckLabel: "revision=2026-08"
+    }
+  },
+  {
+    id: "reduce-before-returning",
+    description: "Reduce data in the sandbox instead of echoing it back",
+    objective:
+      "Find the German city with the largest population in the dataset " +
+      "(list_cities, then lookup_population) and finish with " +
+      "{total: <that city's population>}. Do the comparison in code — do " +
+      "not reason over raw dumps in your messages.",
+    outputSchema: SUM_SCHEMA,
+    expect: {
+      requiredTools: ["list_cities", "lookup_population"],
+      maxActions: 3,
+      resultCheck: (r) =>
+        typeof r === "object" &&
+        r !== null &&
+        (r as { total?: unknown }).total === 3_755_251,
+      resultCheckLabel: "total=3755251 (Berlin)"
+    }
+  }
+];

--- a/packages/agents/src/evals/codeact-eval.ts
+++ b/packages/agents/src/evals/codeact-eval.ts
@@ -1,0 +1,332 @@
+/**
+ * CodeAct evaluation harness — provider-agnostic.
+ *
+ * Drives a real {@link CodeActExecutor} over the instrumented offline
+ * toolbelt in `codeact-cases.ts` and scores each run structurally: required
+ * tools invoked through the bridge, action-round and tool-call bounds, and a
+ * predicate over the final result. `--mode tools` runs the identical cases
+ * through {@link StepExecutor}, so the two action spaces compare on the same
+ * objectives (the CodeAct paper's comparison, on our toolbelt).
+ */
+
+import { randomUUID } from "node:crypto";
+import type { BaseProvider } from "@nodetool-ai/runtime";
+import { ProcessingContext } from "@nodetool-ai/runtime";
+import type { StepResult, ToolCallUpdate } from "@nodetool-ai/protocol";
+import type { EvalCheck } from "./graph-planner-eval.js";
+import { CodeActExecutor, EXECUTE_CODE_TOOL_NAME } from "../codeact/codeact-executor.js";
+import { StepExecutor } from "../step-executor.js";
+import type { Step, Task } from "../types.js";
+import type { AgentExecutionMode } from "../types.js";
+import {
+  CODEACT_EVAL_CASES,
+  createCodeActRecorder,
+  createCodeActTools,
+  type CodeActEvalCase,
+  type CodeActEvalExpectations
+} from "./codeact-cases.js";
+
+const DEFAULT_MAX_ITERATIONS = 8;
+
+/** Everything the pure checker needs — no provider, no I/O. */
+export interface CodeActObservation {
+  toolsInvoked: Set<string>;
+  /** Provider turns that carried a code action (tool mode: total tool calls). */
+  actions: number;
+  /** Bridged tool invocations (tool mode: direct tool calls). */
+  toolCalls: number;
+  result: unknown;
+}
+
+export interface CodeActCaseResult {
+  caseId: string;
+  description: string;
+  accepted: boolean;
+  score: number;
+  checks: EvalCheck[];
+  actions: number;
+  toolCalls: number;
+  durationMs: number;
+  costUsd: number;
+  error?: string;
+}
+
+export interface CodeActEvalReport {
+  provider: string;
+  model: string;
+  mode: AgentExecutionMode;
+  startedAt: string;
+  cases: CodeActCaseResult[];
+  summary: {
+    total: number;
+    accepted: number;
+    successRate: number;
+    meanScore: number;
+    avgActions: number;
+    avgToolCalls: number;
+    totalCostUsd: number;
+  };
+}
+
+export interface RunCodeActEvalOptions {
+  provider: BaseProvider;
+  model: string;
+  cases?: readonly CodeActEvalCase[];
+  /** Action space under test. Default `"codeact"`. */
+  mode?: AgentExecutionMode;
+  maxIterations?: number;
+  signal?: AbortSignal;
+  onEvent?: (line: string) => void;
+}
+
+/** Pure scorer over one run's observation. */
+export function checkCodeActExpectations(
+  obs: CodeActObservation,
+  expect: CodeActEvalExpectations
+): EvalCheck[] {
+  const checks: EvalCheck[] = [];
+  for (const name of expect.requiredTools ?? []) {
+    const pass = obs.toolsInvoked.has(name);
+    checks.push({
+      name: `tool:${name}`,
+      pass,
+      detail: pass ? undefined : `never invoked ${name}`
+    });
+  }
+  for (const name of expect.forbiddenTools ?? []) {
+    const hit = obs.toolsInvoked.has(name);
+    checks.push({
+      name: `not-tool:${name}`,
+      pass: !hit,
+      detail: hit ? `invoked forbidden tool ${name}` : undefined
+    });
+  }
+  if (expect.maxActions !== undefined) {
+    checks.push({
+      name: `actions<=${expect.maxActions}`,
+      pass: obs.actions <= expect.maxActions,
+      detail: `took ${obs.actions}`
+    });
+  }
+  if (expect.minToolCalls !== undefined) {
+    checks.push({
+      name: `toolCalls>=${expect.minToolCalls}`,
+      pass: obs.toolCalls >= expect.minToolCalls,
+      detail: `made ${obs.toolCalls}`
+    });
+  }
+  if (expect.maxToolCalls !== undefined) {
+    checks.push({
+      name: `toolCalls<=${expect.maxToolCalls}`,
+      pass: obs.toolCalls <= expect.maxToolCalls,
+      detail: `made ${obs.toolCalls}`
+    });
+  }
+  if (expect.resultCheck) {
+    const pass = expect.resultCheck(obs.result);
+    checks.push({
+      name: `result:${expect.resultCheckLabel ?? "predicate"}`,
+      pass,
+      detail: pass ? undefined : `got ${JSON.stringify(obs.result)?.slice(0, 200)}`
+    });
+  }
+  return checks;
+}
+
+async function runCase(
+  evalCase: CodeActEvalCase,
+  opts: RunCodeActEvalOptions
+): Promise<CodeActCaseResult> {
+  const mode = opts.mode ?? "codeact";
+  const recorder = createCodeActRecorder();
+  const tools = createCodeActTools(recorder);
+  const maxIterations = opts.maxIterations ?? DEFAULT_MAX_ITERATIONS;
+
+  const context = new ProcessingContext({
+    jobId: `codeact-eval-${randomUUID()}`,
+    userId: "eval-user"
+  });
+
+  const step: Step = {
+    id: randomUUID(),
+    instructions: evalCase.objective,
+    completed: false,
+    dependsOn: [],
+    logs: [],
+    outputSchema: evalCase.outputSchema
+      ? JSON.stringify(evalCase.outputSchema)
+      : undefined
+  };
+  const task: Task = {
+    id: randomUUID(),
+    title: evalCase.description,
+    steps: [step]
+  };
+
+  const executorOpts = {
+    task,
+    step,
+    context,
+    provider: opts.provider,
+    model: opts.model,
+    tools,
+    maxIterations,
+    signal: opts.signal
+  };
+  const executor =
+    mode === "codeact"
+      ? new CodeActExecutor(executorOpts)
+      : new StepExecutor(executorOpts);
+
+  const costBefore = opts.provider.getTotalCost();
+  const startedAt = Date.now();
+  let result: unknown = null;
+  let actions = 0;
+  let error: string | undefined;
+
+  try {
+    for await (const item of executor.execute()) {
+      if (opts.signal?.aborted) break;
+      if (item.type === "tool_call_update") {
+        const tc = item as ToolCallUpdate;
+        // In codeact mode a "round" is one execute_code turn; in tool mode
+        // every provider tool call is one round.
+        if (mode !== "codeact" || tc.name === EXECUTE_CODE_TOOL_NAME) {
+          actions++;
+        }
+      }
+      if (item.type === "step_result") {
+        const sr = item as StepResult;
+        if (sr.error) error = sr.error;
+        else result = sr.result;
+      }
+    }
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  const durationMs = Date.now() - startedAt;
+  const costUsd = opts.provider.getTotalCost() - costBefore;
+  const accepted = error === undefined && step.completed === true;
+
+  const observation: CodeActObservation = {
+    toolsInvoked: new Set(recorder.invocations.map((i) => i.name)),
+    actions,
+    toolCalls: recorder.invocations.length,
+    result
+  };
+
+  const checks: EvalCheck[] = [
+    { name: "accepted", pass: accepted, detail: error }
+  ];
+  if (accepted) {
+    checks.push(...checkCodeActExpectations(observation, evalCase.expect));
+  }
+  const score = accepted
+    ? checks.filter((c) => c.pass).length / checks.length
+    : 0;
+
+  return {
+    caseId: evalCase.id,
+    description: evalCase.description,
+    accepted: accepted && checks.every((c) => c.pass),
+    score,
+    checks,
+    actions,
+    toolCalls: observation.toolCalls,
+    durationMs,
+    costUsd,
+    error
+  };
+}
+
+export async function runCodeActEval(
+  opts: RunCodeActEvalOptions
+): Promise<CodeActEvalReport> {
+  const cases = opts.cases ?? CODEACT_EVAL_CASES;
+  const mode = opts.mode ?? "codeact";
+  const results: CodeActCaseResult[] = [];
+
+  for (const evalCase of cases) {
+    if (opts.signal?.aborted) break;
+    opts.onEvent?.(`▸ ${evalCase.id} (${mode})`);
+    const result = await runCase(evalCase, opts);
+    results.push(result);
+    opts.onEvent?.(
+      `  ${result.accepted ? "pass" : "FAIL"} score=${result.score.toFixed(2)} ` +
+        `actions=${result.actions} toolCalls=${result.toolCalls}`
+    );
+  }
+
+  const accepted = results.filter((r) => r.accepted).length;
+  const meanScore =
+    results.length > 0
+      ? results.reduce((sum, r) => sum + r.score, 0) / results.length
+      : 0;
+
+  return {
+    provider: opts.provider.provider,
+    model: opts.model,
+    mode,
+    startedAt: new Date().toISOString(),
+    cases: results,
+    summary: {
+      total: results.length,
+      accepted,
+      successRate: results.length > 0 ? accepted / results.length : 0,
+      meanScore,
+      avgActions:
+        results.length > 0
+          ? results.reduce((s, r) => s + r.actions, 0) / results.length
+          : 0,
+      avgToolCalls:
+        results.length > 0
+          ? results.reduce((s, r) => s + r.toolCalls, 0) / results.length
+          : 0,
+      totalCostUsd: results.reduce((s, r) => s + r.costUsd, 0)
+    }
+  };
+}
+
+export function formatCodeActReport(report: CodeActEvalReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `CodeAct eval — provider=${report.provider} model=${report.model} mode=${report.mode}`
+  );
+  lines.push("");
+  const header = [
+    "case".padEnd(26),
+    "result".padEnd(7),
+    "score".padEnd(6),
+    "acts".padEnd(5),
+    "tools".padEnd(6),
+    "time".padEnd(7),
+    "cost"
+  ].join("");
+  lines.push(header);
+  lines.push("-".repeat(header.length));
+  for (const r of report.cases) {
+    lines.push(
+      [
+        r.caseId.padEnd(26),
+        (r.accepted ? "pass" : "FAIL").padEnd(7),
+        r.score.toFixed(2).padEnd(6),
+        String(r.actions).padEnd(5),
+        String(r.toolCalls).padEnd(6),
+        `${Math.round(r.durationMs / 1000)}s`.padEnd(7),
+        r.costUsd > 0 ? `$${r.costUsd.toFixed(4)}` : "-"
+      ].join("")
+    );
+    for (const c of r.checks.filter((c) => !c.pass)) {
+      lines.push(`  ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ""}`);
+    }
+  }
+  lines.push("");
+  const s = report.summary;
+  lines.push(
+    `success ${s.accepted}/${s.total} (${(s.successRate * 100).toFixed(0)}%)  ` +
+      `meanScore ${s.meanScore.toFixed(2)}  avgActions ${s.avgActions.toFixed(1)}  ` +
+      `avgToolCalls ${s.avgToolCalls.toFixed(1)}  cost $${s.totalCostUsd.toFixed(4)}`
+  );
+  return lines.join("\n");
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -361,7 +361,9 @@ export type { StepExecutorOptions } from "./step-executor.js";
 export {
   CodeActExecutor,
   DEFAULT_CODEACT_MAX_ITERATIONS,
-  EXECUTE_CODE_TOOL_NAME
+  EXECUTE_CODE_TOOL_NAME,
+  CODEACT_RESIDENT_TOOL_NAMES,
+  CODEACT_DEFER_THRESHOLD
 } from "./codeact/codeact-executor.js";
 export type { CodeActExecutorOptions } from "./codeact/codeact-executor.js";
 export { buildCodeActSystemPrompt } from "./codeact/prompt.js";
@@ -373,6 +375,7 @@ export {
   buildToolBridge,
   renderToolCatalog,
   renderToolSignature,
+  toolSignature,
   CODEACT_PRELUDE,
   CODEACT_RESERVED_NAMES,
   DEFAULT_MAX_TOOL_CALLS_PER_ACTION

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -8,7 +8,8 @@ export type {
   Task,
   TaskPlan,
   PlanApprovalDecision,
-  RequestPlanApproval
+  RequestPlanApproval,
+  AgentExecutionMode
 } from "./types.js";
 export { PLAN_APPROVAL_CONTEXT_KEY } from "./types.js";
 
@@ -357,6 +358,25 @@ export { wrapGeneratorsParallel } from "./utils/wrap-generators-parallel.js";
 // Core execution
 export { StepExecutor } from "./step-executor.js";
 export type { StepExecutorOptions } from "./step-executor.js";
+export {
+  CodeActExecutor,
+  DEFAULT_CODEACT_MAX_ITERATIONS,
+  EXECUTE_CODE_TOOL_NAME
+} from "./codeact/codeact-executor.js";
+export type { CodeActExecutorOptions } from "./codeact/codeact-executor.js";
+export { buildCodeActSystemPrompt } from "./codeact/prompt.js";
+export {
+  resolveExecutionMode,
+  AGENT_EXECUTION_MODE_ENV
+} from "./codeact/execution-mode.js";
+export {
+  buildToolBridge,
+  renderToolCatalog,
+  renderToolSignature,
+  CODEACT_PRELUDE,
+  CODEACT_RESERVED_NAMES,
+  DEFAULT_MAX_TOOL_CALLS_PER_ACTION
+} from "./codeact/tool-api.js";
 
 // Agents
 export { Agent, loadSkillsFromDirectory } from "./agent.js";
@@ -707,6 +727,29 @@ export type {
   ToolInvocation,
   ToolRecorder
 } from "./evals/subtask-cases.js";
+
+// CodeAct evaluation harness (code actions vs JSON tool calls)
+export {
+  runCodeActEval,
+  formatCodeActReport,
+  checkCodeActExpectations
+} from "./evals/codeact-eval.js";
+export type {
+  CodeActObservation,
+  CodeActCaseResult,
+  CodeActEvalReport,
+  RunCodeActEvalOptions
+} from "./evals/codeact-eval.js";
+export {
+  CODEACT_EVAL_CASES,
+  createCodeActTools,
+  createCodeActRecorder
+} from "./evals/codeact-cases.js";
+export type {
+  CodeActEvalCase,
+  CodeActEvalExpectations,
+  CodeActToolRecorder
+} from "./evals/codeact-cases.js";
 
 // Planning-mode evaluation harnesses (TaskPlanner DAG, ScriptPlanner script)
 export {

--- a/packages/agents/src/parallel-task-executor.ts
+++ b/packages/agents/src/parallel-task-executor.ts
@@ -28,7 +28,7 @@ import { TaskExecutor } from "./task-executor.js";
 import { mergeAsyncGenerators } from "./utils/merge-generators.js";
 import { DEFAULT_AGENT_POLICY } from "./agent-policy.js";
 import type { Tool } from "./tools/base-tool.js";
-import type { Task, TaskPlan } from "./types.js";
+import type { AgentExecutionMode, Task, TaskPlan } from "./types.js";
 import type { Checkpoint, CheckpointStore } from "./checkpoint-store.js";
 import { hashPlanCheckpointKey } from "./checkpoint-store.js";
 
@@ -74,6 +74,8 @@ export interface ParallelTaskExecutorOptions {
   planTools?: string[];
   /** External cancellation, forwarded to every task and step executor. */
   signal?: AbortSignal;
+  /** Step action space — JSON tool calls (default) or CodeAct. */
+  executionMode?: AgentExecutionMode;
 }
 
 export class ParallelTaskExecutor {
@@ -93,6 +95,7 @@ export class ParallelTaskExecutor {
   private readonly runId?: string;
   private readonly planTools?: string[];
   private readonly signal?: AbortSignal;
+  private readonly executionMode?: AgentExecutionMode;
   /**
    * IDs of tasks that ran but did not genuinely succeed (budget exhausted,
    * unsatisfiable dependency, or an error result). Tracked separately from
@@ -121,6 +124,7 @@ export class ParallelTaskExecutor {
     this.runId = opts.runId;
     this.planTools = opts.planTools;
     this.signal = opts.signal;
+    this.executionMode = opts.executionMode;
   }
 
   /**
@@ -333,7 +337,8 @@ export class ParallelTaskExecutor {
       maxConcurrentAgents: this.maxConcurrentAgents,
       parallelExecution: true, // Enable parallel step execution within each task
       upstreamMemoryKeys,
-      signal: this.signal
+      signal: this.signal,
+      executionMode: this.executionMode
     });
 
     let taskResult: unknown = null;

--- a/packages/agents/src/script-runner.ts
+++ b/packages/agents/src/script-runner.ts
@@ -40,9 +40,11 @@ import type {
   ProcessingMessage,
   StepResult
 } from "@nodetool-ai/protocol";
-import { StepExecutor } from "./step-executor.js";
+import { StepExecutor, type StepExecutorOptions } from "./step-executor.js";
+import { CodeActExecutor } from "./codeact/codeact-executor.js";
+import { resolveExecutionMode } from "./codeact/execution-mode.js";
 import type { Tool } from "./tools/base-tool.js";
-import type { Step, Task } from "./types.js";
+import type { AgentExecutionMode, Step, Task } from "./types.js";
 import { runInSandbox } from "./js-sandbox.js";
 
 const log = createLogger("nodetool.agents.script-runner");
@@ -86,6 +88,8 @@ export interface ScriptRunnerOptions {
   scriptTimeoutMs?: number;
   /** External cancellation, forwarded to every sub-agent step executor. */
   signal?: AbortSignal;
+  /** Action space for every `agent()` sub-agent. Default `"tools"`. */
+  executionMode?: AgentExecutionMode;
 }
 
 /** Simple counting semaphore; released slots go to waiters FIFO. */
@@ -246,6 +250,7 @@ export class ScriptRunner {
   private readonly signal?: AbortSignal;
   private readonly maxAgentCalls: number;
   private readonly scriptTimeoutMs: number;
+  private readonly executionMode: AgentExecutionMode;
   private readonly semaphore: Semaphore;
   private readonly channel = new MessageChannel();
   private agentCalls = 0;
@@ -262,6 +267,7 @@ export class ScriptRunner {
     this.signal = opts.signal;
     this.maxAgentCalls = opts.maxAgentCalls ?? DEFAULT_MAX_AGENT_CALLS;
     this.scriptTimeoutMs = opts.scriptTimeoutMs ?? DEFAULT_SCRIPT_TIMEOUT_MS;
+    this.executionMode = resolveExecutionMode(opts.executionMode);
     this.semaphore = new Semaphore(
       opts.maxConcurrentAgents ?? DEFAULT_MAX_CONCURRENT_AGENTS
     );
@@ -396,7 +402,7 @@ export class ScriptRunner {
       ? this.tools.filter((t) => opts.tools!.includes(t.name))
       : [...this.tools];
 
-    const executor = new StepExecutor({
+    const executorOpts: StepExecutorOptions = {
       task,
       step,
       context: this.context,
@@ -407,7 +413,11 @@ export class ScriptRunner {
       maxIterations: this.maxStepIterations,
       maxTokens: this.maxTokens,
       signal: this.signal
-    });
+    };
+    const executor =
+      this.executionMode === "codeact"
+        ? new CodeActExecutor(executorOpts)
+        : new StepExecutor(executorOpts);
 
     let result: unknown = null;
     let error: string | null = null;

--- a/packages/agents/src/task-executor.ts
+++ b/packages/agents/src/task-executor.ts
@@ -26,10 +26,12 @@ import {
 } from "@nodetool-ai/protocol";
 
 const log = createLogger("nodetool.agents.task-executor");
-import { StepExecutor } from "./step-executor.js";
+import { StepExecutor, type StepExecutorOptions } from "./step-executor.js";
+import { CodeActExecutor } from "./codeact/codeact-executor.js";
+import { resolveExecutionMode } from "./codeact/execution-mode.js";
 import { mergeAsyncGenerators } from "./utils/merge-generators.js";
 import type { Tool } from "./tools/base-tool.js";
-import type { Step, Task } from "./types.js";
+import type { AgentExecutionMode, Step, Task } from "./types.js";
 import { DEFAULT_AGENT_POLICY } from "./agent-policy.js";
 
 const DEFAULT_MAX_STEPS = 50;
@@ -65,6 +67,8 @@ export interface TaskExecutorOptions {
   upstreamMemoryKeys?: string[];
   /** External cancellation, forwarded to every step executor. */
   signal?: AbortSignal;
+  /** Step action space — JSON tool calls (default) or CodeAct. */
+  executionMode?: AgentExecutionMode;
 }
 
 export class TaskExecutor {
@@ -83,6 +87,7 @@ export class TaskExecutor {
   private maxConcurrentAgents: number;
   private upstreamMemoryKeys: string[];
   private signal?: AbortSignal;
+  private executionMode: AgentExecutionMode;
   private _finishStepId: string | undefined;
 
   constructor(opts: TaskExecutorOptions) {
@@ -103,6 +108,19 @@ export class TaskExecutor {
       opts.maxConcurrentAgents ?? DEFAULT_AGENT_POLICY.maxConcurrentAgents;
     this.upstreamMemoryKeys = opts.upstreamMemoryKeys ?? [];
     this.signal = opts.signal;
+    this.executionMode = resolveExecutionMode(opts.executionMode);
+  }
+
+  /**
+   * The two executors share the option shape and message contract; the mode
+   * picks the action space (docs/codeact-design.md).
+   */
+  private createStepExecutor(
+    opts: StepExecutorOptions
+  ): StepExecutor | CodeActExecutor {
+    return this.executionMode === "codeact"
+      ? new CodeActExecutor(opts)
+      : new StepExecutor(opts);
   }
 
   /**
@@ -165,7 +183,7 @@ export class TaskExecutor {
       }
 
       const stepGenerators = normalSteps.map((step) => {
-        const executor = new StepExecutor({
+        const executor = this.createStepExecutor({
           task: this.task,
           step,
           context: this.context,
@@ -414,7 +432,7 @@ export class TaskExecutor {
     });
 
     const generators = ephemeralSteps.map((ephStep) => {
-      const executor = new StepExecutor({
+      const executor = this.createStepExecutor({
         task: this.task,
         step: ephStep,
         context: this.context,

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -74,3 +74,11 @@ export type RequestPlanApproval = (
  * wiring at every construction site.
  */
 export const PLAN_APPROVAL_CONTEXT_KEY = "request_plan_approval";
+
+/**
+ * How a step acts on its toolbelt. `"tools"` is the classic loop — one JSON
+ * tool call per action. `"codeact"` runs JavaScript actions in the QuickJS
+ * sandbox with the toolbelt exposed as `tools.<name>()` functions
+ * (docs/codeact-design.md).
+ */
+export type AgentExecutionMode = "tools" | "codeact";

--- a/packages/agents/tests/codeact-eval.test.ts
+++ b/packages/agents/tests/codeact-eval.test.ts
@@ -1,0 +1,128 @@
+/**
+ * CodeAct eval harness tests — scripted provider, no network. Proves the
+ * cases are satisfiable and the scorer reads the right signals.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  runCodeActEval,
+  formatCodeActReport
+} from "../src/evals/codeact-eval.js";
+import { CODEACT_EVAL_CASES } from "../src/evals/codeact-cases.js";
+import type {
+  BaseProvider,
+  ProviderStreamItem,
+  ToolCall
+} from "@nodetool-ai/runtime";
+
+/** Provider that answers every case with a scripted list of code actions. */
+function createScriptedLoopProvider(
+  actionsByCall: string[][]
+): BaseProvider {
+  let call = 0;
+  return {
+    provider: "fake",
+    hasToolSupport: async () => true,
+    getTotalCost: () => 0,
+    async *generateLoop(args: {
+      tools?: Array<{
+        name: string;
+        execute?: (a: Record<string, unknown>) => Promise<string | unknown>;
+      }>;
+      signal?: AbortSignal;
+    }): AsyncGenerator<ProviderStreamItem> {
+      const actions = actionsByCall[call++] ?? [];
+      const toolMap = new Map((args.tools ?? []).map((t) => [t.name, t]));
+      let idx = 0;
+      for (const code of actions) {
+        if (args.signal?.aborted) break;
+        const tc: ToolCall = {
+          id: `tc_${call}_${idx++}`,
+          name: "execute_code",
+          args: { code }
+        };
+        yield tc;
+        const tool = toolMap.get(tc.name);
+        const content = tool?.execute ? await tool.execute(tc.args) : "";
+        yield {
+          type: "message",
+          message: {
+            role: "tool",
+            toolCallId: tc.id,
+            content:
+              typeof content === "string" ? content : JSON.stringify(content)
+          }
+        };
+      }
+      yield { type: "chunk", content: "", done: true };
+    }
+  } as unknown as BaseProvider;
+}
+
+const SOLUTIONS: Record<string, string[]> = {
+  "chain-in-one-action": [
+    `const a = await tools.calculate({expression: "17 * 23"});
+     const b = await tools.calculate({expression: "441 / 21"});
+     await finish({total: a.value + b.value});`
+  ],
+  "loop-over-dataset": [
+    `const {cities} = await tools.list_cities({});
+     let total = 0;
+     for (const city of cities) {
+       const r = await tools.lookup_population({city});
+       total += r.population;
+     }
+     await finish({total});`
+  ],
+  "recover-from-failure": [
+    `let revision = null;
+     for (let i = 0; i < 3 && !revision; i++) {
+       try {
+         revision = (await tools.flaky_fetch({})).revision;
+       } catch (e) { /* transient — retry */ }
+     }
+     await finish({revision});`
+  ],
+  "reduce-before-returning": [
+    `const {cities} = await tools.list_cities({});
+     let best = 0;
+     for (const city of cities) {
+       const r = await tools.lookup_population({city});
+       if (r.population > best) best = r.population;
+     }
+     await finish({total: best});`
+  ]
+};
+
+describe("codeact eval harness", () => {
+  it("every case is satisfiable by a scripted run and scores 1.0", async () => {
+    const provider = createScriptedLoopProvider(
+      CODEACT_EVAL_CASES.map((c) => SOLUTIONS[c.id] ?? [])
+    );
+
+    const report = await runCodeActEval({
+      provider,
+      model: "scripted"
+    });
+
+    for (const result of report.cases) {
+      expect(result.accepted, `${result.caseId}: ${JSON.stringify(result.checks)}`).toBe(true);
+      expect(result.score).toBe(1);
+    }
+    expect(report.summary.successRate).toBe(1);
+    expect(formatCodeActReport(report)).toContain("success 4/4");
+  });
+
+  it("scores a wrong result as a failed check", async () => {
+    const provider = createScriptedLoopProvider([
+      [`await finish({total: 1});`]
+    ]);
+    const report = await runCodeActEval({
+      provider,
+      model: "scripted",
+      cases: [CODEACT_EVAL_CASES[0]]
+    });
+    const result = report.cases[0];
+    expect(result.accepted).toBe(false);
+    expect(result.checks.some((c) => !c.pass)).toBe(true);
+  });
+});

--- a/packages/agents/tests/codeact-executor.test.ts
+++ b/packages/agents/tests/codeact-executor.test.ts
@@ -1,0 +1,350 @@
+/**
+ * CodeActExecutor harness tests — a scripted provider drives code actions
+ * through the real QuickJS sandbox and tool bridge. No network, no model.
+ */
+import { describe, it, expect } from "vitest";
+import { CodeActExecutor } from "../src/codeact/codeact-executor.js";
+import { Tool } from "../src/tools/base-tool.js";
+import type { Step, Task } from "../src/types.js";
+import type {
+  BaseProvider,
+  ProcessingContext,
+  ProviderStreamItem,
+  ToolCall
+} from "@nodetool-ai/runtime";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+class AddTool extends Tool {
+  readonly name = "add";
+  readonly description = "Add two numbers.";
+  protected override readonly jsonSchema = {
+    type: "object",
+    properties: { a: { type: "number" }, b: { type: "number" } },
+    required: ["a", "b"]
+  };
+  calls = 0;
+  async process(
+    _context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    this.calls++;
+    return { sum: Number(params["a"]) + Number(params["b"]) };
+  }
+}
+
+class FailingTool extends Tool {
+  readonly name = "always_fails";
+  readonly description = "Fails every time.";
+  async process(): Promise<unknown> {
+    return { error: "boom", message: "this tool always fails" };
+  }
+}
+
+/**
+ * Minimal provider that owns the loop the way BaseProvider.generateLoop does:
+ * each scripted turn is either a batch of tool calls (dispatched to the
+ * ProviderTool's own `execute`) or a final assistant text message.
+ */
+type ScriptTurn = { toolCalls: ToolCall[] } | { assistant: string };
+
+function createLoopProvider(turns: ScriptTurn[]): BaseProvider {
+  return {
+    provider: "fake",
+    hasToolSupport: async () => true,
+    async *generateLoop(args: {
+      tools?: Array<{
+        name: string;
+        execute?: (a: Record<string, unknown>) => Promise<string | unknown>;
+      }>;
+      signal?: AbortSignal;
+    }): AsyncGenerator<ProviderStreamItem> {
+      const toolMap = new Map((args.tools ?? []).map((t) => [t.name, t]));
+      for (const turn of turns) {
+        if (args.signal?.aborted) break;
+        if ("assistant" in turn) {
+          yield {
+            type: "message",
+            message: { role: "assistant", content: turn.assistant }
+          };
+          continue;
+        }
+        for (const tc of turn.toolCalls) {
+          if (args.signal?.aborted) break;
+          yield tc;
+          const tool = toolMap.get(tc.name);
+          const content = tool?.execute ? await tool.execute(tc.args) : "";
+          yield {
+            type: "message",
+            message: {
+              role: "tool",
+              toolCallId: tc.id,
+              content:
+                typeof content === "string" ? content : JSON.stringify(content)
+            }
+          };
+        }
+      }
+      yield { type: "chunk", content: "", done: true };
+    }
+  } as unknown as BaseProvider;
+}
+
+function makeStep(outputSchema?: object): { step: Step; task: Task } {
+  const step: Step = {
+    id: "step_1",
+    instructions: "Compute the answer",
+    completed: false,
+    dependsOn: [],
+    logs: [],
+    outputSchema: outputSchema ? JSON.stringify(outputSchema) : undefined
+  };
+  return { step, task: { id: "task_1", title: "T", steps: [step] } };
+}
+
+const ANSWER_SCHEMA = {
+  type: "object",
+  properties: { answer: { type: "number" } },
+  required: ["answer"]
+};
+
+function codeAction(id: string, code: string): ToolCall {
+  return { id, name: "execute_code", args: { code } };
+}
+
+describe("CodeActExecutor", () => {
+  it("chains multiple tool calls in one action and finishes", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const add = new AddTool();
+    const provider = createLoopProvider([
+      {
+        toolCalls: [
+          codeAction(
+            "tc_1",
+            `const first = await tools.add({a: 1, b: 2});
+             const second = await tools.add({a: first.sum, b: 39});
+             await finish({answer: second.sum});`
+          )
+        ]
+      }
+    ]);
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: [add]
+    });
+
+    const messages: Array<{ type: string; name?: string }> = [];
+    for await (const msg of executor.execute()) {
+      messages.push({
+        type: msg.type,
+        name: (msg as { name?: string }).name
+      });
+    }
+
+    expect(step.completed).toBe(true);
+    expect(executor.getResult()).toEqual({ answer: 42 });
+    expect(add.calls).toBe(2);
+    expect(context.memory.getValue("step:step_1")).toEqual({ answer: 42 });
+    // Inner bridged calls surface as tool_call_update alongside execute_code.
+    const toolUpdates = messages.filter((m) => m.type === "tool_call_update");
+    expect(toolUpdates.map((m) => m.name)).toEqual([
+      "execute_code",
+      "add",
+      "add"
+    ]);
+  });
+
+  it("persists state across actions", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const provider = createLoopProvider([
+      { toolCalls: [codeAction("tc_1", `state.x = 41; return "stored";`)] },
+      {
+        toolCalls: [
+          codeAction("tc_2", `await finish({answer: state.x + 1});`)
+        ]
+      }
+    ]);
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: []
+    });
+    for await (const _msg of executor.execute()) {
+      // drain
+    }
+
+    expect(step.completed).toBe(true);
+    expect(executor.getResult()).toEqual({ answer: 42 });
+  });
+
+  it("rejects a schema-invalid finish and accepts the repaired one", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const provider = createLoopProvider([
+      {
+        toolCalls: [
+          codeAction("tc_1", `await finish({answer: "not a number"});`)
+        ]
+      },
+      { toolCalls: [codeAction("tc_2", `await finish({answer: 7});`)] }
+    ]);
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: []
+    });
+    for await (const _msg of executor.execute()) {
+      // drain
+    }
+
+    expect(step.completed).toBe(true);
+    expect(executor.getResult()).toEqual({ answer: 7 });
+  });
+
+  it("surfaces a failing tool as a guest exception the action can catch", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const provider = createLoopProvider([
+      {
+        toolCalls: [
+          codeAction(
+            "tc_1",
+            `let failed = false;
+             try {
+               await tools.always_fails({});
+             } catch (e) {
+               failed = e.message.includes("always fails");
+             }
+             await finish({answer: failed ? 1 : 0});`
+          )
+        ]
+      }
+    ]);
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: [new FailingTool()]
+    });
+    for await (const _msg of executor.execute()) {
+      // drain
+    }
+
+    expect(step.completed).toBe(true);
+    expect(executor.getResult()).toEqual({ answer: 1 });
+  });
+
+  it("keeps going after a crashed action", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const provider = createLoopProvider([
+      { toolCalls: [codeAction("tc_1", `throw new Error("oops");`)] },
+      { toolCalls: [codeAction("tc_2", `await finish({answer: 3});`)] }
+    ]);
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: []
+    });
+    for await (const _msg of executor.execute()) {
+      // drain
+    }
+
+    expect(step.completed).toBe(true);
+    expect(executor.getResult()).toEqual({ answer: 3 });
+  });
+
+  it("finalizes an unschema'd step from a plain assistant message", async () => {
+    const { step, task } = makeStep();
+    const context = createMockContext();
+    const provider = createLoopProvider([
+      { assistant: "The capital of France is Paris." }
+    ]);
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: []
+    });
+    for await (const _msg of executor.execute()) {
+      // drain
+    }
+
+    expect(step.completed).toBe(true);
+    expect(executor.getResult()).toBe("The capital of France is Paris.");
+  });
+
+  it("fails the step explicitly when no completion happens", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const provider = createLoopProvider([
+      { toolCalls: [codeAction("tc_1", `return "still thinking";`)] }
+    ]);
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: []
+    });
+
+    const results: Array<{ type: string; error?: string }> = [];
+    for await (const msg of executor.execute()) {
+      results.push(msg as { type: string; error?: string });
+    }
+
+    expect(step.completed).toBe(false);
+    expect(step.failed).toBe(true);
+    const stepResult = results.find((m) => m.type === "step_result");
+    expect(stepResult?.error).toContain("Step failed");
+  });
+});
+
+describe("resolveExecutionMode", () => {
+  it("prefers the explicit option, then the setting, then tools", async () => {
+    const { resolveExecutionMode, AGENT_EXECUTION_MODE_ENV } = await import(
+      "../src/codeact/execution-mode.js"
+    );
+    const saved = process.env[AGENT_EXECUTION_MODE_ENV];
+    try {
+      delete process.env[AGENT_EXECUTION_MODE_ENV];
+      expect(resolveExecutionMode()).toBe("tools");
+      process.env[AGENT_EXECUTION_MODE_ENV] = "codeact";
+      expect(resolveExecutionMode()).toBe("codeact");
+      expect(resolveExecutionMode("tools")).toBe("tools");
+      process.env[AGENT_EXECUTION_MODE_ENV] = "CodeAct";
+      expect(resolveExecutionMode()).toBe("codeact");
+      process.env[AGENT_EXECUTION_MODE_ENV] = "nonsense";
+      expect(resolveExecutionMode()).toBe("tools");
+    } finally {
+      if (saved === undefined) delete process.env[AGENT_EXECUTION_MODE_ENV];
+      else process.env[AGENT_EXECUTION_MODE_ENV] = saved;
+    }
+  });
+});

--- a/packages/agents/tests/codeact-executor.test.ts
+++ b/packages/agents/tests/codeact-executor.test.ts
@@ -179,9 +179,7 @@ describe("CodeActExecutor", () => {
       model: "m",
       tools: []
     });
-    for await (const _msg of executor.execute()) {
-      // drain
-    }
+    for await (const msg of executor.execute()) void msg;
 
     expect(step.completed).toBe(true);
     expect(executor.getResult()).toEqual({ answer: 42 });
@@ -207,9 +205,7 @@ describe("CodeActExecutor", () => {
       model: "m",
       tools: []
     });
-    for await (const _msg of executor.execute()) {
-      // drain
-    }
+    for await (const msg of executor.execute()) void msg;
 
     expect(step.completed).toBe(true);
     expect(executor.getResult()).toEqual({ answer: 7 });
@@ -243,9 +239,7 @@ describe("CodeActExecutor", () => {
       model: "m",
       tools: [new FailingTool()]
     });
-    for await (const _msg of executor.execute()) {
-      // drain
-    }
+    for await (const msg of executor.execute()) void msg;
 
     expect(step.completed).toBe(true);
     expect(executor.getResult()).toEqual({ answer: 1 });
@@ -267,9 +261,7 @@ describe("CodeActExecutor", () => {
       model: "m",
       tools: []
     });
-    for await (const _msg of executor.execute()) {
-      // drain
-    }
+    for await (const msg of executor.execute()) void msg;
 
     expect(step.completed).toBe(true);
     expect(executor.getResult()).toEqual({ answer: 3 });
@@ -290,9 +282,7 @@ describe("CodeActExecutor", () => {
       model: "m",
       tools: []
     });
-    for await (const _msg of executor.execute()) {
-      // drain
-    }
+    for await (const msg of executor.execute()) void msg;
 
     expect(step.completed).toBe(true);
     expect(executor.getResult()).toBe("The capital of France is Paris.");
@@ -346,5 +336,84 @@ describe("resolveExecutionMode", () => {
       if (saved === undefined) delete process.env[AGENT_EXECUTION_MODE_ENV];
       else process.env[AGENT_EXECUTION_MODE_ENV] = saved;
     }
+  });
+});
+
+describe("CodeAct progressive tool disclosure", () => {
+  class NamedTool extends Tool {
+    constructor(
+      readonly name: string,
+      readonly description: string
+    ) {
+      super();
+    }
+    protected override readonly jsonSchema = {
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"]
+    };
+    async process(
+      _context: ProcessingContext,
+      params: Record<string, unknown>
+    ): Promise<unknown> {
+      return { echoed: params["value"], via: this.name };
+    }
+  }
+
+  const bigBelt = () => [
+    new NamedTool("web_search", "Search the web."),
+    new NamedTool("lookup_customer", "Look up a customer record by id."),
+    ...Array.from(
+      { length: 16 },
+      (_, i) => new NamedTool(`filler_tool_${i}`, `Filler tool number ${i}.`)
+    )
+  ];
+
+  it("keeps resident tools documented and defers the long tail in the prompt", async () => {
+    const { buildCodeActSystemPrompt } = await import("../src/codeact/prompt.js");
+    const tools = bigBelt();
+    const resident = tools.filter((t) => t.name === "web_search");
+    const deferred = tools.filter((t) => t.name !== "web_search");
+    const prompt = buildCodeActSystemPrompt({
+      tools: resident,
+      deferredTools: deferred
+    });
+
+    // Resident: full signature. Deferred: name only, discoverable.
+    expect(prompt).toContain("await tools.web_search(");
+    expect(prompt).toContain("lookup_customer");
+    expect(prompt).not.toContain("await tools.lookup_customer(");
+    expect(prompt).toContain('searchTools("query")');
+  });
+
+  it("discovers a deferred tool via searchTools and calls it", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    const provider = createLoopProvider([
+      {
+        toolCalls: [
+          codeAction(
+            "tc_1",
+            `const hits = await searchTools("+lookup customer");
+             const name = hits[0].name;
+             const r = await tools[name]({value: "c42"});
+             await finish({answer: r.echoed === "c42" && r.via === "lookup_customer" ? 1 : 0});`
+          )
+        ]
+      }
+    ]);
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: bigBelt()
+    });
+    for await (const msg of executor.execute()) void msg;
+
+    expect(step.completed).toBe(true);
+    expect(executor.getResult()).toEqual({ answer: 1 });
   });
 });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -88,6 +88,8 @@ interface AgentYaml {
   objective?: string; // optional default
   model?: ModelBlock;
   planning_agent?: { enabled?: boolean; model?: ModelBlock };
+  /** Step action space: "tools" (default) or "codeact" (docs/codeact-design.md). */
+  execution_mode?: "tools" | "codeact";
   tools?: string[];
   max_iterations?: number;
   max_steps?: number;
@@ -361,6 +363,7 @@ interface RunOptions {
   workspace?: string;
   provider?: string;
   model?: string;
+  codeact?: boolean;
 }
 
 async function runAgentCommand(file: string, opts: RunOptions): Promise<void> {
@@ -478,7 +481,10 @@ async function runAgentCommand(file: string, opts: RunOptions): Promise<void> {
     tools,
     systemPrompt: effectiveSystemPrompt,
     maxSteps: cfg.max_steps,
-    planningModel
+    planningModel,
+    // Precedence: --codeact flag > YAML execution_mode > the
+    // NODETOOL_AGENT_EXECUTION_MODE setting (resolved inside Agent) > tools.
+    executionMode: opts.codeact ? "codeact" : cfg.execution_mode
   });
 
   const ctx = new ProcessingContext({
@@ -781,6 +787,10 @@ export function registerAgentCommands(program: Command): void {
     .option("-w, --workspace <path>", "Override workspace dir")
     .option("--json", "Emit each event as a JSON line on stderr")
     .option("-v, --verbose", "Include chunk/other low-level events in trace")
+    .option(
+      "--codeact",
+      "Execute steps as sandboxed JavaScript actions instead of JSON tool calls"
+    )
     .action(async (file: string, opts: RunOptions) => {
       try {
         await runAgentCommand(file, opts);

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -306,6 +306,43 @@ const subtaskSuite: EvalSuite = {
   }
 };
 
+/** CodeAct execution suite (code actions vs JSON tool calls). */
+const codeActSuite: EvalSuite = {
+  id: "codeact",
+  description:
+    "Run the CodeAct execution eval suite (steps act by writing sandboxed JavaScript over the toolbelt — docs/codeact-design.md) against a provider/model",
+  async listCases() {
+    const { CODEACT_EVAL_CASES } = await import("@nodetool-ai/agents");
+    return CODEACT_EVAL_CASES.map((c) => ({
+      id: c.id,
+      description: c.description
+    }));
+  },
+  async run(deps) {
+    const { CODEACT_EVAL_CASES, runCodeActEval, formatCodeActReport } =
+      await import("@nodetool-ai/agents");
+
+    const cases = selectCases(CODEACT_EVAL_CASES, deps.caseIds);
+    deps.log(
+      `Running ${cases.length} codeact case(s) with ${deps.providerId}/${deps.model}`
+    );
+
+    const report = await runCodeActEval({
+      provider: deps.provider,
+      model: deps.model,
+      cases,
+      maxIterations: deps.maxIterations,
+      onEvent: deps.onEvent
+    });
+
+    return {
+      report,
+      formatted: formatCodeActReport(report),
+      successRate: report.summary.successRate
+    };
+  }
+};
+
 /** TaskPlanner multi-task (plan mode) DAG-quality suite. */
 const taskPlannerSuite: EvalSuite = {
   id: "task-planner",
@@ -557,6 +594,7 @@ export const EVAL_SUITES: readonly EvalSuite[] = [
   taskPlannerSuite,
   scriptPlannerSuite,
   subtaskSuite,
+  codeActSuite,
   appBuildSuite,
   makeToolLoopSuite(
     "tool-loop",

--- a/packages/cli/src/harness/registry.ts
+++ b/packages/cli/src/harness/registry.ts
@@ -214,7 +214,7 @@ export const HARNESSES: HarnessEntry[] = [
   {
     id: "eval",
     title:
-      "Agent evaluation suites (graph-planner, graph-e2e, code-gen, task-planner, script-planner, tool-loop×8, app-build)",
+      "Agent evaluation suites (graph-planner, graph-e2e, code-gen, task-planner, script-planner, subtask, codeact, tool-loop×8, app-build)",
     command: "nodetool eval <suite> -p <provider> -m <model> [--min-success N]",
     kind: "eval",
     capabilities: ["json", "gated"],

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -50,6 +50,7 @@ import {
   type PythonBridge
 } from "@nodetool-ai/runtime";
 import { initMasterKey } from "@nodetool-ai/security";
+import { applyAgentExecutionModeSetting } from "./settings-registry.js";
 import {
   WorkerManager,
   startReaper,
@@ -279,6 +280,11 @@ try {
   // userId)` closure when invoking provider APIs — there is no shared
   // global resolver.
   await initMasterKey();
+
+  // Agent execution mode ("tools" | "codeact"): the stored setting reaches
+  // the agents package through the environment. Applied once here; changing
+  // it in Settings takes effect on the next server start.
+  await applyAgentExecutionModeSetting();
 } catch (err) {
   log.error(
     "Database setup failed",

--- a/packages/websocket/src/settings-registry.ts
+++ b/packages/websocket/src/settings-registry.ts
@@ -39,6 +39,27 @@ export function getRegisteredSettings(): SettingDefinition[] {
   return registry;
 }
 
+export const AGENT_EXECUTION_MODE_ENV = "NODETOOL_AGENT_EXECUTION_MODE";
+
+/**
+ * Mirror the stored agent execution mode into the environment so the agents
+ * package (which resolves NODETOOL_AGENT_EXECUTION_MODE) honors what the
+ * Settings UI saved. A real environment variable wins over the stored value;
+ * an unavailable settings store leaves the env/default in place.
+ */
+export async function applyAgentExecutionModeSetting(): Promise<void> {
+  if (process.env[AGENT_EXECUTION_MODE_ENV]) return;
+  try {
+    const setting = await Setting.find("1", AGENT_EXECUTION_MODE_ENV);
+    const value = setting?.value.trim().toLowerCase();
+    if (value === "codeact" || value === "tools") {
+      process.env[AGENT_EXECUTION_MODE_ENV] = value;
+    }
+  } catch {
+    // Settings store unavailable — the env var / default applies.
+  }
+}
+
 /** Get a single setting value from DB, then env var. */
 export async function getSetting(key: string): Promise<string | null> {
   const setting = await Setting.find("1", key);
@@ -134,6 +155,12 @@ s(
   "MAX_CONCURRENT_RUNS_PER_WORKFLOW",
   "Execution",
   "Maximum number of concurrent runs of the same workflow before additional runs queue (default: 4). Only applies to runs that opt into concurrency (e.g. timeline/sketch generation); canvas runs always stay sequential per workflow. Also bounded by MAX_CONCURRENT_JOBS."
+);
+s(
+  AGENT_EXECUTION_MODE_ENV,
+  "Execution",
+  "How agent steps act on their toolbelt: 'tools' (default) makes one JSON tool call per action; 'codeact' has each step write sandboxed JavaScript that calls the same tools (docs/codeact-design.md). Applied at server startup; a real environment variable wins over the stored value.",
+  ["tools", "codeact"]
 );
 
 // Provider endpoints

--- a/web/src/components/chat/message/MessageView.tsx
+++ b/web/src/components/chat/message/MessageView.tsx
@@ -44,6 +44,7 @@ import { ToolResult } from "./toolResults";
 import { formatDuration, formatToolName } from "../../../utils/formatUtils";
 import type { MediaGenerationRequest } from "../../../stores/MediaGenerationStore";
 import { visibleToolArgs as visibleArgs } from "../../../core/chat/toolCallFields";
+import { CodeBlock } from "./markdown_elements/CodeBlock";
 
 /**
  * PrettyJson - Memoized component for displaying formatted JSON.
@@ -73,6 +74,13 @@ PrettyJson.displayName = "PrettyJson";
  * tree icon signals that this card represents a deeper sub-execution.
  */
 const RUN_SUBTASK_TOOL_NAME = "run_subtask";
+
+/**
+ * `execute_code` is the CodeAct action primitive (docs/codeact-design.md):
+ * its one argument is a JavaScript program, so the card renders it as a
+ * highlighted code block instead of a JSON-escaped string.
+ */
+const EXECUTE_CODE_TOOL_NAME = "execute_code";
 
 function formatTime(dateStr?: string | null): string | null {
   if (!dateStr) {
@@ -105,6 +113,7 @@ const ToolCallCard: React.FC<{
   );
   const runningToolMessage = useGlobalChatStore((s) => s.currentToolMessage);
   const isSubtask = tc.name === RUN_SUBTASK_TOOL_NAME;
+  const isCodeAction = tc.name === EXECUTE_CODE_TOOL_NAME;
 
   // For run_subtask we lift `description` / `prompt` (Claude-Code Task naming)
   // out of args into headline + expanded body. Tolerate the older
@@ -121,15 +130,22 @@ const ToolCallCard: React.FC<{
   const subtaskInstructions = isSubtask
     ? (pickString("prompt") ?? pickString("instructions"))
     : null;
+  const actionCode = isCodeAction ? pickString("code") : null;
   const displayArgs = useMemo(() => {
     const base = visibleArgs(rawArgs);
-    if (!isSubtask || !base) return base;
+    if (!base) return base;
+    if (isCodeAction) {
+      const stripped: Record<string, unknown> = { ...base };
+      delete stripped["code"];
+      return Object.keys(stripped).length > 0 ? stripped : null;
+    }
+    if (!isSubtask) return base;
     const stripped: Record<string, unknown> = { ...base };
     for (const k of ["description", "prompt", "title", "instructions"]) {
       delete stripped[k];
     }
     return Object.keys(stripped).length > 0 ? stripped : null;
-  }, [rawArgs, isSubtask]);
+  }, [rawArgs, isSubtask, isCodeAction]);
 
   const hasArgs = !!displayArgs && Object.keys(displayArgs).length > 0;
   const resultContent = result?.content;
@@ -138,7 +154,7 @@ const ToolCallCard: React.FC<{
     resultContent != null &&
     !(typeof resultContent === "string" && resultContent.trim().length === 0);
   const hasDetails =
-    !!hasArgs || (isSubtask && !!subtaskInstructions) || hasResult;
+    !!hasArgs || (isSubtask && !!subtaskInstructions) || !!actionCode || hasResult;
   const isRunning = runningToolCallId && tc.id && runningToolCallId === tc.id;
   const durationLabel =
     !isRunning && typeof durationMs === "number"
@@ -245,6 +261,14 @@ const ToolCallCard: React.FC<{
               <Text size="small" className="subtask-instructions">
                 {subtaskInstructions}
               </Text>
+            </FlexColumn>
+          )}
+          {actionCode && (
+            <FlexColumn gap={0.5}>
+              <Caption className="tool-section-title">Code</Caption>
+              <CodeBlock inline={false} className="language-javascript">
+                {actionCode}
+              </CodeBlock>
             </FlexColumn>
           )}
           {hasArgs && (

--- a/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
+++ b/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
@@ -144,3 +144,31 @@ describe("MessageView tool-call grouping", () => {
     expect(screen.getByText("Search")).toBeInTheDocument();
   });
 });
+
+describe("MessageView CodeAct actions", () => {
+  it("renders execute_code's program as a code block, not JSON args", async () => {
+    const user = userEvent.setup();
+    renderView({
+      id: "m5",
+      role: "assistant",
+      tool_calls: [
+        {
+          id: "a",
+          name: "execute_code",
+          args: { code: 'const x = await tools.add({a: 1, b: 2});' }
+        }
+      ]
+    } as Message);
+
+    // Expand the card, then the program shows under a "Code" section.
+    await user.click(screen.getByRole("button", { name: /execute code/i }));
+    expect(screen.getByText("Code")).toBeInTheDocument();
+    // Prism splits the program into token spans; read the block's text.
+    await waitFor(() => {
+      const block = document.querySelector(".code-block-container");
+      expect(block?.textContent).toContain("tools.add({a: 1, b: 2})");
+    });
+    // The lone `code` arg is lifted out — no leftover Arguments JSON section.
+    expect(screen.queryByText("Arguments")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/execution/ExecutionTree.tsx
+++ b/web/src/components/execution/ExecutionTree.tsx
@@ -501,7 +501,14 @@ const StepInspector: React.FC<{ step: StepState }> = memo(({ step }) => {
                 <strong>{call.name || "tool"}</strong>
                 {call.message ? `  ${call.message}` : ""}
               </span>
-              {Object.keys(call.args ?? {}).length > 0 ? (
+              {call.name === "execute_code" &&
+              typeof call.args?.["code"] === "string" ? (
+                // A CodeAct action's one argument is a JavaScript program —
+                // show the program, not its JSON-escaped string.
+                <pre className="tl-inspector-code">
+                  {call.args["code"] as string}
+                </pre>
+              ) : Object.keys(call.args ?? {}).length > 0 ? (
                 <pre className="tl-inspector-code">
                   {JSON.stringify(call.args, null, 2)}
                 </pre>


### PR DESCRIPTION
## What

Adds a **CodeAct execution mode** for the agent step loop, following the CodeAct result (Wang et al., ICML 2024, arXiv:2402.01030): instead of one JSON tool call per action, a step acts by writing JavaScript that runs in the existing QuickJS sandbox, with the toolbelt exposed as `tools.<name>()` functions, a `state` object that persists across actions (CaveAgent-style stateful runtime), and `finish(result)` for host-validated completion. One round trip can chain, loop over, branch on, and post-process any number of tool calls, and large intermediates can be reduced in the sandbox instead of transiting the transcript.

Design doc first, as requested: **[docs/codeact-design.md](https://github.com/nodetool-ai/nodetool/blob/claude/codeact-implementation-design-4yorl9/docs/codeact-design.md)** — motivation, the papers it follows, action protocol, security posture, and non-goals (the default stays `"tools"` until the eval says otherwise).

## How

- **`CodeActExecutor`** (`packages/agents/src/codeact/`) — presents exactly one provider tool (`execute_code`), runs each action through `runInSandbox` with a generated prelude over a single `__callTool` host bridge (never-reject envelopes, per-action tool-call cap, per-invocation `tool_call_update` events with ids `codeact_<n>`). Message contract, memory writes (`step:<id>` / `task:<id>`), prose-mode finalization, and failure semantics are byte-compatible with `StepExecutor`, so the CLI tree, web ExecutionTree, script runner, and supervisor work unchanged.
- **The mode is a setting**: `NODETOOL_AGENT_EXECUTION_MODE` (`tools` | `codeact`), registered in the settings registry (Settings UI, group Execution) and mirrored from the stored value into the environment at server startup (`applyAgentExecutionModeSetting`). Resolution precedence everywhere (`resolveExecutionMode`): explicit option > setting > `"tools"`.
- **Wiring**: `AgentOptions.executionMode` threads through `Agent` → `ParallelTaskExecutor` → `TaskExecutor` (including process-mode fan-outs) and `ScriptRunner` sub-agents. CLI: `nodetool agent run <yaml> --codeact` (YAML: `execution_mode: codeact`).
- **Prompting**: tool catalog rendered as compact typed signatures from each tool's JSON schema, plus a sandbox reference derived from the same manifest the Code-node prompt uses, so it can't advertise an API the sandbox doesn't marshal.
- **Chat UI**: an `execute_code` call renders its program as a Prism-highlighted "Code" section in the chat tool-call card (reusing the chat `CodeBlock`), and the agent ExecutionTree step inspector prints the program instead of its JSON-escaped string.
- **Eval suite `codeact`** (`nodetool eval codeact -p <p> -m <m>`): offline instrumented cases (chaining, dataset loop, transient-failure recovery, reduce-before-return) runnable through either executor for a mode comparison; registered in `EVAL_SUITES` and the harness registry.

## Testing

- `tests/codeact-executor.test.ts` — 8 tests through the real sandbox with a scripted provider: multi-tool chaining in one action, `state` persistence, schema-invalid `finish` repair, tool failure as catchable guest exception, crash recovery, prose finalization, explicit step failure, setting resolution.
- `tests/codeact-eval.test.ts` — every eval case proven satisfiable by a scripted run; wrong results scored as failures.
- `web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx` — new case: the `execute_code` card shows a Code section and lifts the lone `code` arg out of the Arguments JSON.
- Full `packages/agents` suite: 139 files / 2077 tests pass. Websocket settings tests and the full CLI suite (557 tests) pass. `npm run build:packages`, web + electron typecheck, and `npm run lint` clean (mobile typecheck is not runnable in this sandbox — its Expo tree isn't installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UqHbMFp8Kc3xmzuw9XhcX