### PR TITLE
feat(chat): run chat turns in CodeAct mode with a JS graph object model

### DIFF
--- a/docs/codeact-design.md
+++ b/docs/codeact-design.md
@@ -178,6 +178,46 @@ The action executes with the same privileges tool mode already grants:
 - CLI: `nodetool agent run <yaml> --codeact`; the agent YAML also takes
   `execution_mode: codeact`. Flag > YAML > setting.
 
+## Chat turns (websocket runner)
+
+The chat websocket runner honors the same setting: when `resolveExecutionMode()`
+says `codeact`, a plain chat turn presents `execute_code` (plus `view_image`,
+the one channel that puts pixels into context and so cannot ride the JSON
+observation envelope) instead of the toolbelt, and the ToolSearch deferral
+machinery is replaced by the in-sandbox `searchTools()`. The adapter is
+`createChatCodeActSession` (`packages/agents/src/codeact/chat-codeact.ts`): a
+chat toolbelt mixes server tools with client (`ui_*`) tools that exist
+server-side only as schemas, so instead of `buildToolBridge` the session
+bridges `tools.<name>()` to the chat runner's own `executeTool` router —
+permission gating, client round-trips over the ToolBridge, and asset
+materialization all stay where they are. `state` persists across the turn's
+actions; there is no `finish()` — a plain assistant message ends the turn, and
+the prompt says so (`variant: "chat"` of `buildCodeActSystemPrompt`).
+
+## Workflow graph editing: the JS object model
+
+When the belt carries the `ui_*` workflow document tools, code actions get an
+object model instead of one bridged call per mutation
+(`packages/agents/src/codeact/graph-model.ts`):
+
+```js
+const wf = await openWorkflow(workflowId);
+const input = wf.addNode("in1", "nodetool.input.StringInput", { name: "prompt" });
+wf.addNode("llm1", "nodetool.agents.Agent", {}, { x: 400, y: 120 });
+wf.connect("in1", "output", "llm1", "prompt");
+wf.node("llm1").setTitle("Draft").set({ system: "be brief" });
+await wf.commit();
+```
+
+Mutators are synchronous: they update a local mirror (`wf.nodes`, `wf.edges`,
+`wf.node(id)`) and queue the equivalent `ui_*` operation. `commit()` replays
+the queue through the bridged tools — the same contract the renderer and the
+headless document tools implement, so routing, validation, and live-editor
+sync are untouched. A failed commit names the failing operation and keeps it
+(and everything after it) queued for a retry; removing a never-committed node
+cancels its queued ops instead of issuing a delete. Tests:
+`packages/agents/tests/chat-codeact.test.ts`.
+
 ## Evaluation
 
 `eval codeact` (registered next to `subtask`): objectives with instrumented
@@ -203,5 +243,3 @@ finalization — no network, no model.
   action space, not about Python specifically.
 - Replacing planners. GraphPlanner/ScriptPlanner/CodePlanner already use
   code-shaped *artifacts*; this changes the step execution loop only.
-- The chat/websocket toolbelt. Chat turns keep tool mode; wiring codeact into
-  the websocket runner is a follow-up once step-level evals justify it.

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -489,10 +489,19 @@ Design and the research it follows (CodeAct, ICML 2024): docs/codeact-design.md.
   `NODETOOL_AGENT_EXECUTION_MODE` environment variable pins the mode and wins
   over both. CLI:
   `nodetool agent run <yaml> --codeact` (YAML: `execution_mode: codeact`).
+- Chat turns honor the same setting: the websocket runner swaps the toolbelt
+  for `execute_code` (+ `view_image`) via `createChatCodeActSession`
+  (`src/codeact/chat-codeact.ts`), which bridges `tools.<name>()` to the chat
+  runner's own tool router instead of `buildToolBridge` — permission gating
+  and client (`ui_*`) round-trips stay where they are. When the belt carries
+  the `ui_*` workflow document tools, actions also get the graph object model
+  (`src/codeact/graph-model.ts`): `openWorkflow()` returns a model whose
+  synchronous mutators queue ops against a local mirror and `commit()` replays
+  them through the same `ui_*` contract.
 - Eval suite `codeact` runs the same offline instrumented cases through either
   executor for a mode comparison: `nodetool eval codeact -p <p> -m <m>`.
-- Tests: `tests/codeact-executor.test.ts`, `tests/codeact-eval.test.ts`
-  (scripted provider, real sandbox, no network).
+- Tests: `tests/codeact-executor.test.ts`, `tests/codeact-eval.test.ts`,
+  `tests/chat-codeact.test.ts` (scripted provider, real sandbox, no network).
 
 ## Script Mode (code-shaped orchestration)
 

--- a/packages/agents/src/codeact/chat-codeact.ts
+++ b/packages/agents/src/codeact/chat-codeact.ts
@@ -1,0 +1,337 @@
+/**
+ * CodeAct for chat turns — the adapter the websocket chat runner uses when the
+ * execution-mode setting is `"codeact"`.
+ *
+ * A chat toolbelt is not a `Tool[]`: it mixes server tools with client (`ui_*`)
+ * tools that exist here only as schemas, and every call must go through the
+ * chat runner's own router (permission gate, client round-trips over the
+ * ToolBridge, asset materialization). So instead of `buildToolBridge`, this
+ * session bridges `tools.<name>()` to a caller-supplied `executeTool` and
+ * leaves the routing where it is. Everything else matches the step executor:
+ * one `execute_code` provider tool, a `state` object that persists across the
+ * turn's actions, `searchTools()` for the deferred long tail, and an
+ * observation envelope as the tool result.
+ *
+ * When the belt carries the `ui_*` workflow document tools, actions also get
+ * the graph object model (`openWorkflow()` — see graph-model.ts), so graph and
+ * node editing happens on a JS object model committed through the same tools.
+ */
+
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { runInSandbox } from "../js-sandbox.js";
+import { searchTools } from "../tools/tool-search.js";
+import { truncateToolResult } from "../constants.js";
+import { buildCodeActSystemPrompt } from "./prompt.js";
+import {
+  CODEACT_PRELUDE,
+  DEFAULT_MAX_TOOL_CALLS_PER_ACTION,
+  extractErrorPayload,
+  toTransferable,
+  toolSignature,
+  type ToolSearchHit,
+  type ToolSignatureSource
+} from "./tool-api.js";
+import {
+  CODEACT_DEFER_THRESHOLD,
+  CODEACT_RESIDENT_TOOL_NAMES,
+  EXECUTE_CODE_TOOL_NAME
+} from "./codeact-executor.js";
+import {
+  GRAPH_MODEL_PRELUDE,
+  GRAPH_MODEL_PROMPT_SECTION,
+  hasGraphModelTools
+} from "./graph-model.js";
+
+export interface ChatCodeActToolCall {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface ChatCodeActSessionOptions {
+  /** The full chat toolbelt as schemas (server + client tools alike). */
+  tools: ToolSignatureSource[];
+  /**
+   * The chat runner's tool router. Receives a synthetic call id
+   * (`codeact_<n>`); returns whatever the router returns — a JSON string, a
+   * plain value, or `MessageContent[]` blocks (flattened to their text here).
+   */
+  executeTool: (call: ChatCodeActToolCall) => Promise<unknown>;
+  /** Context for the sandbox's workspace/secret APIs. */
+  context?: ProcessingContext;
+  signal?: AbortSignal;
+  /** Wall-clock limit per code action. Defaults to the sandbox's 30 s. */
+  actionTimeoutMs?: number;
+  /** Tool calls one action may consume. Default 50. */
+  maxToolCallsPerAction?: number;
+  /** Tools documented in full; defaults to {@link CODEACT_RESIDENT_TOOL_NAMES}. */
+  residentToolNames?: Iterable<string>;
+  /** Observability hook — fires before each bridged tool executes. */
+  onToolCall?: (record: { name: string; args: Record<string, unknown> }) => void;
+}
+
+export interface ChatCodeActSession {
+  /** The one provider tool the chat turn exposes in codeact mode. */
+  providerTool: {
+    name: string;
+    description: string;
+    inputSchema: Record<string, unknown>;
+  };
+  /** Appended to the chat system prompt: contract, catalog, sandbox summary. */
+  systemPromptSection: string;
+  /** Run one code action; returns the observation envelope as JSON text. */
+  executeAction(args: Record<string, unknown>): Promise<string>;
+  /** Bridged tool calls consumed so far this turn (across actions). */
+  toolCallCount(): number;
+}
+
+interface ActionObservation {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+  stack?: string;
+  logs?: string[];
+  toolCalls: number;
+}
+
+/**
+ * What the router returns is transcript-shaped (JSON strings, content
+ * blocks); the guest wants values. Parse JSON strings and flatten
+ * `MessageContent[]` to their text.
+ */
+function normalizeToolResult(raw: unknown): unknown {
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+      try {
+        return JSON.parse(trimmed) as unknown;
+      } catch {
+        return raw;
+      }
+    }
+    return raw;
+  }
+  if (
+    Array.isArray(raw) &&
+    raw.length > 0 &&
+    raw.every(
+      (block) =>
+        block !== null &&
+        typeof block === "object" &&
+        typeof (block as { type?: unknown }).type === "string"
+    )
+  ) {
+    const texts = raw
+      .map((block) => (block as { text?: unknown }).text)
+      .filter((text): text is string => typeof text === "string");
+    if (texts.length > 0) return texts.join("\n");
+  }
+  return raw;
+}
+
+export function createChatCodeActSession(
+  options: ChatCodeActSessionOptions
+): ChatCodeActSession {
+  const toolNames = options.tools.map((t) => t.name);
+  const byName = new Map(options.tools.map((t) => [t.name, t]));
+  const maxCallsPerAction =
+    options.maxToolCallsPerAction ?? DEFAULT_MAX_TOOL_CALLS_PER_ACTION;
+  const withGraphModel = hasGraphModelTools(toolNames);
+
+  // Persists across the turn's actions (CaveAgent-style runtime state).
+  const state: Record<string, unknown> = {};
+  let totalCalls = 0;
+  let actionCalls = 0;
+
+  const callTool = async (
+    name: unknown,
+    argsJson: unknown
+  ): Promise<{ ok: true; result: unknown } | { ok: false; error: string }> => {
+    try {
+      if (typeof name !== "string" || !byName.has(name)) {
+        return {
+          ok: false,
+          error: `Unknown tool "${String(name)}". Use searchTools() to discover tools.`
+        };
+      }
+      if (actionCalls >= maxCallsPerAction) {
+        return {
+          ok: false,
+          error:
+            `Tool-call budget for this action exhausted (max ${maxCallsPerAction} ` +
+            `calls). Return an intermediate result and continue in the next action.`
+        };
+      }
+      actionCalls++;
+      totalCalls++;
+
+      let args: Record<string, unknown> = {};
+      if (typeof argsJson === "string" && argsJson.length > 0) {
+        try {
+          const parsed = JSON.parse(argsJson) as unknown;
+          if (
+            parsed !== null &&
+            typeof parsed === "object" &&
+            !Array.isArray(parsed)
+          ) {
+            args = parsed as Record<string, unknown>;
+          } else if (parsed !== null) {
+            return {
+              ok: false,
+              error: `tools.${name}: arguments must be an object`
+            };
+          }
+        } catch {
+          return {
+            ok: false,
+            error: `tools.${name}: arguments must be JSON-serializable`
+          };
+        }
+      }
+
+      options.onToolCall?.({ name, args });
+      const raw = await options.executeTool({
+        id: `codeact_${totalCalls}`,
+        name,
+        args
+      });
+      const value = normalizeToolResult(raw);
+      const errorPayload = extractErrorPayload(value);
+      if (errorPayload !== null) {
+        return { ok: false, error: `tools.${name}: ${errorPayload}` };
+      }
+      return { ok: true, result: toTransferable(value) };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  };
+
+  const finishBridge = async (): Promise<{ ok: false; error: string }> => ({
+    ok: false,
+    error:
+      "finish() does not exist in chat. Reply to the user with a normal " +
+      "assistant message (no tool call) when the work is done."
+  });
+
+  const searchCatalog = options.tools.map((t) => ({
+    name: t.name,
+    description: t.description ?? ""
+  }));
+  const searchToolsBridge = async (
+    query: unknown,
+    maxResults: unknown
+  ): Promise<
+    { ok: true; result: ToolSearchHit[] } | { ok: false; error: string }
+  > => {
+    try {
+      const limit =
+        typeof maxResults === "number" && Number.isFinite(maxResults)
+          ? Math.max(1, Math.min(25, Math.floor(maxResults)))
+          : 5;
+      const hits = searchTools(searchCatalog, String(query ?? ""), limit).map(
+        (entry): ToolSearchHit => {
+          const tool = byName.get(entry.name) as ToolSignatureSource;
+          return {
+            name: entry.name,
+            signature: toolSignature(tool),
+            description: tool.description ?? ""
+          };
+        }
+      );
+      return { ok: true, result: hits };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  };
+
+  // Progressive disclosure, mirroring the step executor's split.
+  const residentNames = new Set(
+    options.residentToolNames ?? CODEACT_RESIDENT_TOOL_NAMES
+  );
+  let resident: ToolSignatureSource[];
+  let deferred: ToolSignatureSource[];
+  if (options.tools.length <= CODEACT_DEFER_THRESHOLD) {
+    resident = [...options.tools];
+    deferred = [];
+  } else {
+    resident = options.tools.filter((t) => residentNames.has(t.name));
+    deferred = options.tools.filter((t) => !residentNames.has(t.name));
+  }
+
+  const systemPromptSection = buildCodeActSystemPrompt({
+    tools: resident,
+    deferredTools: deferred,
+    variant: "chat",
+    extraSections: withGraphModel ? [GRAPH_MODEL_PROMPT_SECTION] : []
+  });
+
+  const prelude = withGraphModel
+    ? `${CODEACT_PRELUDE}\n${GRAPH_MODEL_PRELUDE}`
+    : CODEACT_PRELUDE;
+
+  const executeAction = async (
+    args: Record<string, unknown>
+  ): Promise<string> => {
+    const code = typeof args?.["code"] === "string" ? args["code"] : "";
+    if (!code.trim()) {
+      return JSON.stringify({
+        ok: false,
+        error: "execute_code: `code` must be a non-empty string",
+        toolCalls: 0
+      } satisfies ActionObservation);
+    }
+    actionCalls = 0;
+
+    const outcome = await runInSandbox({
+      code: `${prelude}\n${code}`,
+      context: options.context,
+      timeoutMs: options.actionTimeoutMs,
+      signal: options.signal,
+      globals: {
+        __callTool: callTool,
+        __toolNames: toolNames,
+        __finish: finishBridge,
+        __searchTools: searchToolsBridge,
+        state
+      }
+    });
+
+    const observation: ActionObservation = {
+      ok: outcome.success,
+      toolCalls: actionCalls
+    };
+    if (outcome.success) {
+      if (outcome.result !== undefined) observation.result = outcome.result;
+    } else {
+      observation.error = outcome.error;
+      if (outcome.stack) observation.stack = outcome.stack;
+    }
+    if (outcome.logs && outcome.logs.length > 0) {
+      observation.logs = outcome.logs;
+    }
+    return truncateToolResult(JSON.stringify(observation));
+  };
+
+  return {
+    providerTool: {
+      name: EXECUTE_CODE_TOOL_NAME,
+      description:
+        "Execute a JavaScript action in the sandbox. The observation " +
+        "(return value, logs, error) is the tool result.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          code: {
+            type: "string",
+            description: "The JavaScript program to run."
+          }
+        },
+        required: ["code"],
+        additionalProperties: false
+      }
+    },
+    systemPromptSection,
+    executeAction,
+    toolCallCount: () => totalCalls
+  };
+}

--- a/packages/agents/src/codeact/graph-model.ts
+++ b/packages/agents/src/codeact/graph-model.ts
@@ -1,0 +1,261 @@
+/**
+ * CodeAct graph object model — workflow graph and node editing as a JS object
+ * model instead of one bridged `ui_*` tool call per mutation.
+ *
+ * The guest prelude defines `openWorkflow(workflowId?)`, which loads the graph
+ * once through `tools.ui_get_graph` and returns a model whose mutators are
+ * synchronous: they update a local mirror and queue the equivalent `ui_*`
+ * operation. `commit()` replays the queue through the bridged tools — the same
+ * contract the renderer and the headless document tools already implement, so
+ * client/server routing, validation, and live-editor sync are untouched. One
+ * code action can therefore build a whole graph and pay one round trip per
+ * mutation only at commit time, with local reads in between.
+ *
+ * The prelude assumes `CODEACT_PRELUDE` ran first (it uses `tools.*`).
+ */
+
+/** The `ui_*` document tools the object model drives. */
+export const GRAPH_MODEL_TOOL_NAMES = [
+  "ui_get_graph",
+  "ui_add_node",
+  "ui_connect_nodes",
+  "ui_update_node_data",
+  "ui_delete_node",
+  "ui_delete_edge",
+  "ui_move_node",
+  "ui_set_node_title"
+] as const;
+
+/**
+ * The model needs the read plus the two constructive mutations; the rest
+ * degrade gracefully (an op whose tool is missing fails at commit with the
+ * tool named).
+ */
+const REQUIRED_TOOL_NAMES = ["ui_get_graph", "ui_add_node", "ui_connect_nodes"];
+
+/** Whether a toolbelt carries enough of the `ui_*` contract for the model. */
+export function hasGraphModelTools(toolNames: Iterable<string>): boolean {
+  const names = new Set(toolNames);
+  return REQUIRED_TOOL_NAMES.every((name) => names.has(name));
+}
+
+/**
+ * Guest-side prelude defining `openWorkflow()`. Plain QuickJS-safe JS — no
+ * host bridges of its own; every effect goes through `tools.ui_*`.
+ */
+export const GRAPH_MODEL_PRELUDE = `
+async function openWorkflow(workflowId) {
+  const __wfArgs = (extra) => {
+    const args = extra ? Object.assign({}, extra) : {};
+    if (workflowId !== undefined && workflowId !== null) {
+      args.workflow_id = workflowId;
+    }
+    return args;
+  };
+  const __snapNodes = (snap) => (snap && Array.isArray(snap.nodes) ? snap.nodes : []);
+  const __snapEdges = (snap) => (snap && Array.isArray(snap.edges) ? snap.edges : []);
+
+  const snap = await tools.ui_get_graph(__wfArgs());
+  const ops = [];
+  let edgeSeq = 0;
+
+  const model = {
+    workflowId: (snap && snap.workflow_id) || workflowId || null,
+    nodes: [],
+    edges: [],
+    node(id) {
+      const found = model.nodes.find((n) => n.id === id);
+      if (!found) {
+        throw new Error(
+          "Node not found: " + id + ". Known: " + model.nodes.map((n) => n.id).join(", ")
+        );
+      }
+      return found;
+    },
+    addNode(id, type, properties, position) {
+      if (model.nodes.some((n) => n.id === id)) {
+        throw new Error('A node with id "' + id + '" already exists.');
+      }
+      const pos = position || {
+        x: 120 + (model.nodes.length % 6) * 240,
+        y: 120 + Math.floor(model.nodes.length / 6) * 160
+      };
+      ops.push({
+        tool: "ui_add_node",
+        args: __wfArgs({ id, type, properties: properties || {}, position: pos })
+      });
+      return __wrapNode({
+        id,
+        type,
+        position: pos,
+        data: { properties: properties || {} }
+      });
+    },
+    connect(sourceId, sourceHandle, targetId, targetHandle) {
+      ops.push({
+        tool: "ui_connect_nodes",
+        args: __wfArgs({
+          source_node_id: sourceId,
+          source_handle: sourceHandle,
+          target_node_id: targetId,
+          target_handle: targetHandle
+        })
+      });
+      edgeSeq++;
+      const edge = {
+        id: "pending_edge_" + edgeSeq,
+        source: sourceId,
+        sourceHandle: sourceHandle,
+        target: targetId,
+        targetHandle: targetHandle,
+        pending: true
+      };
+      model.edges.push(edge);
+      return edge;
+    },
+    removeNode(id) {
+      model.node(id);
+      const addIndex = ops.findIndex(
+        (op) => op.tool === "ui_add_node" && op.args.id === id
+      );
+      if (addIndex >= 0) {
+        // Never committed: cancel the add and every queued op touching it.
+        for (let i = ops.length - 1; i >= 0; i--) {
+          const a = ops[i].args;
+          if (
+            a.id === id ||
+            a.node_id === id ||
+            a.source_node_id === id ||
+            a.target_node_id === id
+          ) {
+            ops.splice(i, 1);
+          }
+        }
+      } else {
+        ops.push({ tool: "ui_delete_node", args: __wfArgs({ node_id: id }) });
+      }
+      model.nodes = model.nodes.filter((n) => n.id !== id);
+      model.edges = model.edges.filter((e) => e.source !== id && e.target !== id);
+    },
+    removeEdge(edgeId) {
+      const edge = model.edges.find((e) => e.id === edgeId);
+      if (!edge) throw new Error("Edge not found: " + edgeId);
+      if (edge.pending) {
+        const opIndex = ops.findIndex(
+          (op) =>
+            op.tool === "ui_connect_nodes" &&
+            op.args.source_node_id === edge.source &&
+            op.args.source_handle === edge.sourceHandle &&
+            op.args.target_node_id === edge.target &&
+            op.args.target_handle === edge.targetHandle
+        );
+        if (opIndex >= 0) ops.splice(opIndex, 1);
+      } else {
+        ops.push({ tool: "ui_delete_edge", args: __wfArgs({ edge_id: edgeId }) });
+      }
+      model.edges = model.edges.filter((e) => e.id !== edgeId);
+    },
+    pending() {
+      return ops.length;
+    },
+    async commit() {
+      let applied = 0;
+      while (ops.length > 0) {
+        const op = ops[0];
+        try {
+          await tools[op.tool](op.args);
+        } catch (e) {
+          throw new Error(
+            "commit() failed on " + op.tool + " " + JSON.stringify(op.args).slice(0, 300) +
+            ": " + (e && e.message ? e.message : String(e)) +
+            ". " + applied + " ops were applied; the failed op and " + (ops.length - 1) +
+            " later ops are still queued — fix the problem and call commit() again."
+          );
+        }
+        ops.shift();
+        applied++;
+      }
+      const fresh = await tools.ui_get_graph(__wfArgs());
+      __load(fresh);
+      return { ok: true, applied, nodes: model.nodes.length, edges: model.edges.length };
+    }
+  };
+
+  function __wrapNode(raw) {
+    const data = raw && raw.data && typeof raw.data === "object" ? raw.data : {};
+    const view = {
+      id: raw.id,
+      type: raw.type,
+      position: raw.position || { x: 0, y: 0 },
+      title: typeof data.title === "string" ? data.title : null,
+      properties:
+        data.properties && typeof data.properties === "object" ? data.properties : {},
+      set(props) {
+        ops.push({
+          tool: "ui_update_node_data",
+          args: __wfArgs({ node_id: view.id, data: { properties: props } })
+        });
+        Object.assign(view.properties, props);
+        return view;
+      },
+      setTitle(title) {
+        ops.push({
+          tool: "ui_set_node_title",
+          args: __wfArgs({ node_id: view.id, title })
+        });
+        view.title = title;
+        return view;
+      },
+      moveTo(x, y) {
+        ops.push({
+          tool: "ui_move_node",
+          args: __wfArgs({ node_id: view.id, position: { x, y } })
+        });
+        view.position = { x, y };
+        return view;
+      },
+      remove() {
+        model.removeNode(view.id);
+      }
+    };
+    model.nodes.push(view);
+    return view;
+  }
+
+  function __load(fromSnap) {
+    model.nodes = [];
+    model.edges = __snapEdges(fromSnap).map((e) => Object.assign({}, e));
+    const rawNodes = __snapNodes(fromSnap);
+    for (const raw of rawNodes) __wrapNode(raw);
+  }
+
+  __load(snap);
+  return model;
+}
+`;
+
+/** Prompt section documenting the object model, for codeact system prompts. */
+export const GRAPH_MODEL_PROMPT_SECTION = `# Workflow graph editing (object model)
+
+Edit workflow graphs through the object model, not by calling \`tools.ui_*\`
+one mutation at a time:
+
+\`\`\`js
+const wf = await openWorkflow(workflowId);   // id from the UI context; omit for the focused workflow
+const input = wf.addNode("prompt_1", "nodetool.input.StringInput", { name: "prompt" });
+const llm = wf.addNode("llm_1", "nodetool.agents.Agent", {}, { x: 400, y: 120 });
+wf.connect("prompt_1", "output", "llm_1", "prompt");
+llm.setTitle("Draft the note").set({ system: "You draft short notes." });
+await wf.commit();                            // applies the queued ops, then reloads
+\`\`\`
+
+- \`wf.nodes\` / \`wf.edges\` are local mirrors; \`wf.node(id)\` returns a node
+  with \`.set(props)\`, \`.setTitle(t)\`, \`.moveTo(x, y)\`, \`.remove()\`.
+- \`wf.removeNode(id)\` / \`wf.removeEdge(id)\` delete; removing a not-yet-
+  committed edge just cancels its queued op.
+- Mutators are synchronous and only queue work; nothing changes in the editor
+  until \`await wf.commit()\`. A failed commit names the failing operation,
+  keeps it and later ops queued, and can be retried after a fix.
+- Use \`tools.ui_search_nodes(...)\` / \`tools.search_nodes(...)\` first when
+  unsure of a node type, and \`await wf.commit()\` before telling the user the
+  graph is ready.`;

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -9,10 +9,9 @@ import {
   getSandboxManifest,
   type SandboxManifest
 } from "../code-gen/sandbox-manifest.js";
-import type { Tool } from "../tools/base-tool.js";
-import { renderToolCatalog } from "./tool-api.js";
+import { renderToolCatalog, type ToolSignatureSource } from "./tool-api.js";
 
-const ACTION_CONTRACT = `# CodeAct Execution
+const ACTION_CONTRACT_BASE = `# CodeAct Execution
 
 You act by writing JavaScript. Each turn, call the \`execute_code\` tool with a
 program; it runs in a sandbox and the observation (return value, console logs,
@@ -30,8 +29,20 @@ Rules:
   memory — not in the transcript.
 - A failed tool call throws; use try/catch when partial failure is acceptable.
 - Top-level \`await\` and \`return\` work. There is no module loader: no
-  \`import\`/\`require\`, and \`eval\`/\`Function\` are disabled.
+  \`import\`/\`require\`, and \`eval\`/\`Function\` are disabled.`;
+
+const ACTION_CONTRACT_STEP = `${ACTION_CONTRACT_BASE}
 - Do not ask the user questions. Choose a reasonable assumption and proceed.`;
+
+const ACTION_CONTRACT_CHAT = `${ACTION_CONTRACT_BASE}
+- When you need the user's decision, stop writing code and ask in a plain
+  assistant message.`;
+
+const CHAT_COMPLETION = `# Answering the user
+
+This is a chat turn, not a step: there is no \`finish()\`. When the work is
+done, reply to the user with a normal assistant message containing no tool
+call — that message ends the turn.`;
 
 const FINISH_SCHEMA = `# Completing the step
 
@@ -45,7 +56,10 @@ Call \`await finish(result)\` when the objective is met, or — for a purely
 textual answer — reply with a final assistant message containing no tool call.`;
 
 /** Compact, manifest-derived sandbox reference: signatures only. */
-function renderSandboxSummary(manifest: SandboxManifest): string {
+function renderSandboxSummary(
+  manifest: SandboxManifest,
+  variant: "step" | "chat"
+): string {
   const lines: string[] = [];
   for (const bridge of Object.values(manifest.bridges)) {
     if (bridge.internal || bridge.members.length === 0) continue;
@@ -56,8 +70,10 @@ function renderSandboxSummary(manifest: SandboxManifest): string {
   for (const helper of Object.values(manifest.guestHelpers)) {
     lines.push(`- ${helper.signature}`);
   }
+  const besides =
+    variant === "chat" ? "`tools.*`, `state`" : "`tools.*`, `state`, `finish`";
   return [
-    `# Sandbox API (besides \`tools.*\`, \`state\`, \`finish\`)`,
+    `# Sandbox API (besides ${besides})`,
     lines.join("\n"),
     `Built-ins: ${manifest.nativeGlobals.join(", ")}.`,
     `Not available: ${manifest.blockedGlobals.join(", ")}.`,
@@ -67,31 +83,47 @@ function renderSandboxSummary(manifest: SandboxManifest): string {
 
 export interface CodeActPromptOptions {
   /** Tools documented in full (signature + description) in the prompt. */
-  tools: Tool[];
+  tools: ToolSignatureSource[];
   /**
    * Deferred long tail: callable like any other tool, but listed by name
    * only — the model pulls a signature in with `searchTools()` first.
    */
-  deferredTools?: Tool[];
+  deferredTools?: ToolSignatureSource[];
   /** Declared output schema (JSON schema) of the step, if any. */
   resultSchema?: Record<string, unknown> | null;
   /** Caller preamble — layered before the contract, never replacing it. */
   preamble?: string;
   manifest?: SandboxManifest;
+  /**
+   * `"step"` (default) is the agent-step contract: `finish()` completes the
+   * step and user questions are forbidden. `"chat"` is the chat-turn
+   * contract: no `finish()`, a plain assistant message answers the user, and
+   * asking the user is allowed. Chat callers ignore `resultSchema`.
+   */
+  variant?: "step" | "chat";
+  /** Extra sections appended after the tool catalog (e.g. the graph model). */
+  extraSections?: string[];
 }
 
 export function buildCodeActSystemPrompt(
   options: CodeActPromptOptions
 ): string {
   const manifest = options.manifest ?? getSandboxManifest();
+  const variant = options.variant ?? "step";
   const sections: string[] = [];
   if (options.preamble?.trim()) sections.push(options.preamble.trim());
-  sections.push(ACTION_CONTRACT);
-  sections.push(options.resultSchema ? FINISH_SCHEMA : FINISH_FREEFORM);
-  if (options.resultSchema) {
-    sections.push(
-      `# Output schema\n\`\`\`json\n${JSON.stringify(options.resultSchema, null, 2)}\n\`\`\``
-    );
+  sections.push(
+    variant === "chat" ? ACTION_CONTRACT_CHAT : ACTION_CONTRACT_STEP
+  );
+  if (variant === "chat") {
+    sections.push(CHAT_COMPLETION);
+  } else {
+    sections.push(options.resultSchema ? FINISH_SCHEMA : FINISH_FREEFORM);
+    if (options.resultSchema) {
+      sections.push(
+        `# Output schema\n\`\`\`json\n${JSON.stringify(options.resultSchema, null, 2)}\n\`\`\``
+      );
+    }
   }
   sections.push(`# Tools\n${renderToolCatalog(options.tools)}`);
   const deferred = options.deferredTools ?? [];
@@ -106,6 +138,9 @@ export function buildCodeActSystemPrompt(
         deferred.map((t) => t.name).join(", ")
     );
   }
-  sections.push(renderSandboxSummary(manifest));
+  for (const section of options.extraSections ?? []) {
+    if (section.trim()) sections.push(section.trim());
+  }
+  sections.push(renderSandboxSummary(manifest, variant));
   return sections.join("\n\n");
 }

--- a/packages/agents/src/codeact/tool-api.ts
+++ b/packages/agents/src/codeact/tool-api.ts
@@ -42,7 +42,7 @@ export interface ToolBridge {
 }
 
 /** Force a value through JSON so it marshals cleanly across the WASM boundary. */
-function toTransferable(value: unknown): unknown {
+export function toTransferable(value: unknown): unknown {
   if (value === null || value === undefined) return null;
   if (
     typeof value === "string" ||
@@ -62,7 +62,7 @@ function toTransferable(value: unknown): unknown {
  * An `{error}` payload from a tool is a failure the guest should see as a
  * thrown exception, not as a value to compute on.
  */
-function extractErrorPayload(result: unknown): string | null {
+export function extractErrorPayload(result: unknown): string | null {
   if (result === null || typeof result !== "object" || Array.isArray(result)) {
     return null;
   }
@@ -195,6 +195,17 @@ export const CODEACT_RESERVED_NAMES = [
 // Signature rendering (JSON schema → compact TS-ish signature)
 // ---------------------------------------------------------------------------
 
+/**
+ * The structural slice of a tool the signature renderer needs. `Tool`
+ * instances satisfy it, and so do bare provider-tool schemas — the chat
+ * runner documents client (`ui_*`) tools that exist only as JSON schemas.
+ */
+export interface ToolSignatureSource {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+}
+
 function schemaTypeLabel(schema: unknown, depth = 0): string {
   if (schema === null || typeof schema !== "object") return "unknown";
   const s = schema as Record<string, unknown>;
@@ -235,7 +246,7 @@ function firstSentence(text: string): string {
 }
 
 /** The bare call signature: `await tools.web_search({query: string, ...})`. */
-export function toolSignature(tool: Tool): string {
+export function toolSignature(tool: ToolSignatureSource): string {
   const schema = tool.inputSchema as JsonSchema;
   const params = schemaTypeLabel(schema);
   const args = params === "{}" ? "" : params;
@@ -243,11 +254,14 @@ export function toolSignature(tool: Tool): string {
 }
 
 /** Signature bullet + first sentence of the description. */
-export function renderToolSignature(tool: Tool): string {
-  return `- ${toolSignature(tool)}\n  ${firstSentence(tool.description)}`;
+export function renderToolSignature(tool: ToolSignatureSource): string {
+  const description = firstSentence(tool.description ?? "");
+  return description
+    ? `- ${toolSignature(tool)}\n  ${description}`
+    : `- ${toolSignature(tool)}`;
 }
 
-export function renderToolCatalog(tools: Tool[]): string {
+export function renderToolCatalog(tools: ToolSignatureSource[]): string {
   if (tools.length === 0) return "(no tools available)";
   return tools.map(renderToolSignature).join("\n");
 }

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -380,6 +380,19 @@ export {
   CODEACT_RESERVED_NAMES,
   DEFAULT_MAX_TOOL_CALLS_PER_ACTION
 } from "./codeact/tool-api.js";
+export type { ToolSignatureSource } from "./codeact/tool-api.js";
+export { createChatCodeActSession } from "./codeact/chat-codeact.js";
+export type {
+  ChatCodeActSession,
+  ChatCodeActSessionOptions,
+  ChatCodeActToolCall
+} from "./codeact/chat-codeact.js";
+export {
+  GRAPH_MODEL_PRELUDE,
+  GRAPH_MODEL_PROMPT_SECTION,
+  GRAPH_MODEL_TOOL_NAMES,
+  hasGraphModelTools
+} from "./codeact/graph-model.js";
 
 // Agents
 export { Agent, loadSkillsFromDirectory } from "./agent.js";

--- a/packages/agents/tests/chat-codeact.test.ts
+++ b/packages/agents/tests/chat-codeact.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Chat CodeAct session tests — code actions run in the real QuickJS sandbox
+ * against a fake chat tool router, including the workflow graph object model.
+ * No network, no model.
+ */
+import { describe, it, expect } from "vitest";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  createChatCodeActSession,
+  type ChatCodeActToolCall
+} from "../src/codeact/chat-codeact.js";
+import { hasGraphModelTools } from "../src/codeact/graph-model.js";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+const objectSchema = (props: Record<string, unknown>) => ({
+  type: "object",
+  properties: props
+});
+
+const GENERIC_TOOLS = [
+  {
+    name: "add",
+    description: "Add two numbers.",
+    inputSchema: objectSchema({ a: { type: "number" }, b: { type: "number" } })
+  },
+  {
+    name: "always_fails",
+    description: "Fails every time.",
+    inputSchema: objectSchema({})
+  }
+];
+
+const GRAPH_TOOLS = [
+  "ui_get_graph",
+  "ui_add_node",
+  "ui_connect_nodes",
+  "ui_update_node_data",
+  "ui_delete_node",
+  "ui_delete_edge",
+  "ui_move_node",
+  "ui_set_node_title"
+].map((name) => ({
+  name,
+  description: `Graph document tool ${name}.`,
+  inputSchema: objectSchema({ workflow_id: { type: "string" } })
+}));
+
+interface FakeGraph {
+  nodes: Array<Record<string, unknown>>;
+  edges: Array<Record<string, unknown>>;
+}
+
+/**
+ * A fake chat tool router over an in-memory graph document. Returns JSON
+ * strings the way the chat runner's `executeTool` does.
+ */
+function createFakeRouter(graph: FakeGraph) {
+  const calls: ChatCodeActToolCall[] = [];
+  let edgeSeq = 0;
+  const executeTool = async (call: ChatCodeActToolCall): Promise<unknown> => {
+    calls.push(call);
+    const args = call.args;
+    switch (call.name) {
+      case "add":
+        return JSON.stringify({
+          sum: Number(args["a"]) + Number(args["b"])
+        });
+      case "always_fails":
+        return JSON.stringify({ error: "boom", message: "always fails" });
+      case "ui_get_graph":
+        return JSON.stringify({
+          ok: true,
+          workflow_id: args["workflow_id"] ?? "wf1",
+          nodes: graph.nodes,
+          edges: graph.edges
+        });
+      case "ui_add_node":
+        graph.nodes.push({
+          id: args["id"],
+          type: args["type"],
+          position: args["position"],
+          data: { properties: args["properties"] ?? {} }
+        });
+        return JSON.stringify({ ok: true, node_id: args["id"] });
+      case "ui_connect_nodes": {
+        if (args["target_handle"] === "bad") {
+          return JSON.stringify({
+            error: `Target handle 'bad' not found`
+          });
+        }
+        edgeSeq++;
+        graph.edges.push({
+          id: `e${edgeSeq}`,
+          source: args["source_node_id"],
+          sourceHandle: args["source_handle"],
+          target: args["target_node_id"],
+          targetHandle: args["target_handle"]
+        });
+        return JSON.stringify({ ok: true, edge_id: `e${edgeSeq}` });
+      }
+      case "ui_update_node_data":
+      case "ui_set_node_title":
+      case "ui_move_node":
+      case "ui_delete_node":
+      case "ui_delete_edge":
+        return JSON.stringify({ ok: true });
+      default:
+        return JSON.stringify({ error: `Unknown tool ${call.name}` });
+    }
+  };
+  return { executeTool, calls };
+}
+
+function makeSession(
+  tools: Array<{ name: string; description: string; inputSchema: unknown }>,
+  executeTool: (call: ChatCodeActToolCall) => Promise<unknown>
+) {
+  return createChatCodeActSession({
+    tools,
+    executeTool,
+    context: createMockContext() as unknown as ProcessingContext
+  });
+}
+
+async function runAction(
+  session: ReturnType<typeof createChatCodeActSession>,
+  code: string
+) {
+  const observation = await session.executeAction({ code });
+  return JSON.parse(observation) as {
+    ok: boolean;
+    result?: unknown;
+    error?: string;
+    logs?: string[];
+    toolCalls: number;
+  };
+}
+
+describe("createChatCodeActSession", () => {
+  it("bridges tool calls through the router and reports the call count", async () => {
+    const { executeTool, calls } = createFakeRouter({ nodes: [], edges: [] });
+    const session = makeSession(GENERIC_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `const r = await tools.add({ a: 2, b: 3 });\nreturn r.sum;`
+    );
+    expect(obs.ok).toBe(true);
+    expect(obs.result).toBe(5);
+    expect(obs.toolCalls).toBe(1);
+    expect(calls[0]).toMatchObject({ name: "add", id: "codeact_1" });
+  });
+
+  it("surfaces {error} tool payloads as thrown guest errors", async () => {
+    const { executeTool } = createFakeRouter({ nodes: [], edges: [] });
+    const session = makeSession(GENERIC_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `try {\n  await tools.always_fails({});\n  return "no throw";\n} catch (e) {\n  return "caught: " + e.message;\n}`
+    );
+    expect(obs.ok).toBe(true);
+    expect(obs.result).toContain("caught:");
+    expect(obs.result).toContain("always fails");
+  });
+
+  it("persists state across actions within the session", async () => {
+    const { executeTool } = createFakeRouter({ nodes: [], edges: [] });
+    const session = makeSession(GENERIC_TOOLS, executeTool);
+    const first = await runAction(session, `state.count = 41;\nreturn "set";`);
+    expect(first.ok).toBe(true);
+    const second = await runAction(session, `return state.count + 1;`);
+    expect(second.ok).toBe(true);
+    expect(second.result).toBe(42);
+  });
+
+  it("rejects finish() with chat guidance", async () => {
+    const { executeTool } = createFakeRouter({ nodes: [], edges: [] });
+    const session = makeSession(GENERIC_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `try {\n  await finish({ done: true });\n  return "finished";\n} catch (e) {\n  return e.message;\n}`
+    );
+    expect(obs.ok).toBe(true);
+    expect(String(obs.result)).toContain("does not exist in chat");
+  });
+
+  it("answers searchTools() with signatures over the schema catalog", async () => {
+    const { executeTool } = createFakeRouter({ nodes: [], edges: [] });
+    const session = makeSession(GENERIC_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `const hits = await searchTools("select:add");\nreturn hits[0];`
+    );
+    expect(obs.ok).toBe(true);
+    expect(obs.result).toMatchObject({ name: "add" });
+    expect((obs.result as { signature: string }).signature).toContain(
+      "await tools.add("
+    );
+  });
+
+  it("documents the chat contract and graph model in the prompt section", () => {
+    const { executeTool } = createFakeRouter({ nodes: [], edges: [] });
+    const withGraph = makeSession(
+      [...GENERIC_TOOLS, ...GRAPH_TOOLS],
+      executeTool
+    );
+    expect(withGraph.systemPromptSection).toContain("openWorkflow(");
+    expect(withGraph.systemPromptSection).toContain("normal assistant message");
+    expect(withGraph.systemPromptSection).not.toContain("# Output schema");
+
+    const withoutGraph = makeSession(GENERIC_TOOLS, executeTool);
+    expect(withoutGraph.systemPromptSection).not.toContain("openWorkflow(");
+  });
+});
+
+describe("graph object model (openWorkflow)", () => {
+  it("queues mutations locally and replays them through ui_* on commit", async () => {
+    const graph: FakeGraph = { nodes: [], edges: [] };
+    const { executeTool, calls } = createFakeRouter(graph);
+    const session = makeSession(
+      [...GENERIC_TOOLS, ...GRAPH_TOOLS],
+      executeTool
+    );
+    const obs = await runAction(
+      session,
+      `
+const wf = await openWorkflow("wf1");
+const input = wf.addNode("in1", "nodetool.input.StringInput", { name: "prompt" });
+const agent = wf.addNode("llm1", "nodetool.agents.Agent", {}, { x: 400, y: 100 });
+wf.connect("in1", "output", "llm1", "prompt");
+agent.setTitle("Draft").set({ system: "be brief" }).moveTo(420, 120);
+const pendingBefore = wf.pending();
+const summary = await wf.commit();
+return { pendingBefore, pendingAfter: wf.pending(), summary, nodeIds: wf.nodes.map((n) => n.id) };
+`
+    );
+    expect(obs.ok).toBe(true);
+    const result = obs.result as {
+      pendingBefore: number;
+      pendingAfter: number;
+      summary: { applied: number; nodes: number; edges: number };
+      nodeIds: string[];
+    };
+    expect(result.pendingBefore).toBe(6);
+    expect(result.pendingAfter).toBe(0);
+    expect(result.summary.applied).toBe(6);
+    expect(result.summary.nodes).toBe(2);
+    expect(result.summary.edges).toBe(1);
+    expect(result.nodeIds).toEqual(["in1", "llm1"]);
+
+    const opCalls = calls.filter((c) => c.name !== "ui_get_graph");
+    expect(opCalls.map((c) => c.name)).toEqual([
+      "ui_add_node",
+      "ui_add_node",
+      "ui_connect_nodes",
+      "ui_set_node_title",
+      "ui_update_node_data",
+      "ui_move_node"
+    ]);
+    expect(opCalls[0].args).toMatchObject({
+      workflow_id: "wf1",
+      id: "in1",
+      type: "nodetool.input.StringInput",
+      properties: { name: "prompt" }
+    });
+    expect(opCalls[2].args).toMatchObject({
+      workflow_id: "wf1",
+      source_node_id: "in1",
+      source_handle: "output",
+      target_node_id: "llm1",
+      target_handle: "prompt"
+    });
+    expect(opCalls[4].args).toMatchObject({
+      node_id: "llm1",
+      data: { properties: { system: "be brief" } }
+    });
+  });
+
+  it("keeps the failed op and the rest of the queue when commit fails", async () => {
+    const graph: FakeGraph = { nodes: [], edges: [] };
+    const { executeTool, calls } = createFakeRouter(graph);
+    const session = makeSession(
+      [...GENERIC_TOOLS, ...GRAPH_TOOLS],
+      executeTool
+    );
+    const obs = await runAction(
+      session,
+      `
+const wf = await openWorkflow("wf1");
+wf.addNode("a", "t.A", {});
+wf.connect("a", "output", "missing", "bad");
+wf.addNode("b", "t.B", {});
+let failure = null;
+try {
+  await wf.commit();
+} catch (e) {
+  failure = e.message;
+}
+return { failure, pending: wf.pending() };
+`
+    );
+    expect(obs.ok).toBe(true);
+    const result = obs.result as { failure: string; pending: number };
+    expect(result.failure).toContain("ui_connect_nodes");
+    expect(result.failure).toContain("1 ops were applied");
+    // Failed connect + the later add stay queued for a retry.
+    expect(result.pending).toBe(2);
+    expect(calls.filter((c) => c.name === "ui_add_node")).toHaveLength(1);
+  });
+
+  it("cancels queued ops when an uncommitted node is removed", async () => {
+    const graph: FakeGraph = { nodes: [], edges: [] };
+    const { executeTool, calls } = createFakeRouter(graph);
+    const session = makeSession(
+      [...GENERIC_TOOLS, ...GRAPH_TOOLS],
+      executeTool
+    );
+    const obs = await runAction(
+      session,
+      `
+const wf = await openWorkflow("wf1");
+const keep = wf.addNode("keep", "t.A", {});
+const drop = wf.addNode("drop", "t.B", {});
+wf.connect("keep", "output", "drop", "input");
+drop.setTitle("doomed");
+wf.removeNode("drop");
+const summary = await wf.commit();
+return { summary, edges: wf.edges.length };
+`
+    );
+    expect(obs.ok).toBe(true);
+    const result = obs.result as {
+      summary: { applied: number };
+      edges: number;
+    };
+    // Only the surviving node's add remains.
+    expect(result.summary.applied).toBe(1);
+    expect(result.edges).toBe(0);
+    expect(calls.filter((c) => c.name === "ui_delete_node")).toHaveLength(0);
+    expect(
+      calls.filter((c) => c.name === "ui_add_node").map((c) => c.args["id"])
+    ).toEqual(["keep"]);
+  });
+
+  it("reads an existing graph into the mirror and edits it", async () => {
+    const graph: FakeGraph = {
+      nodes: [
+        {
+          id: "n1",
+          type: "t.Old",
+          position: { x: 10, y: 20 },
+          data: { properties: { value: 1 }, title: "Old node" }
+        }
+      ],
+      edges: [
+        {
+          id: "e_existing",
+          source: "n1",
+          sourceHandle: "output",
+          target: "n1",
+          targetHandle: "self"
+        }
+      ]
+    };
+    const { executeTool, calls } = createFakeRouter(graph);
+    const session = makeSession(
+      [...GENERIC_TOOLS, ...GRAPH_TOOLS],
+      executeTool
+    );
+    const obs = await runAction(
+      session,
+      `
+const wf = await openWorkflow("wf1");
+const n = wf.node("n1");
+const before = { title: n.title, value: n.properties.value };
+n.set({ value: 2 });
+wf.removeEdge("e_existing");
+await wf.commit();
+return { before, edges: wf.edges.length };
+`
+    );
+    expect(obs.ok).toBe(true);
+    const result = obs.result as {
+      before: { title: string; value: number };
+      edges: number;
+    };
+    expect(result.before).toEqual({ title: "Old node", value: 1 });
+    expect(calls.some((c) => c.name === "ui_delete_edge")).toBe(true);
+  });
+});
+
+describe("hasGraphModelTools", () => {
+  it("requires the read and constructive mutations", () => {
+    expect(
+      hasGraphModelTools(["ui_get_graph", "ui_add_node", "ui_connect_nodes"])
+    ).toBe(true);
+    expect(hasGraphModelTools(["ui_get_graph", "ui_add_node"])).toBe(false);
+    expect(hasGraphModelTools([])).toBe(false);
+  });
+});

--- a/packages/websocket/src/settings-registry.ts
+++ b/packages/websocket/src/settings-registry.ts
@@ -181,7 +181,7 @@ s(
 s(
   AGENT_EXECUTION_MODE_ENV,
   "Execution",
-  "How agent steps act on their toolbelt: 'tools' (default) makes one JSON tool call per action; 'codeact' has each step write sandboxed JavaScript that calls the same tools (docs/codeact-design.md). Applied at server startup; a real environment variable wins over the stored value.",
+  "How agent steps and chat turns act on their toolbelt: 'tools' (default) makes one JSON tool call per action; 'codeact' has each action write sandboxed JavaScript that calls the same tools — chat turns then also edit workflow graphs through the openWorkflow() object model (docs/codeact-design.md). Applied at server startup; a real environment variable wins over the stored value.",
   ["tools", "codeact"]
 );
 

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -149,6 +149,13 @@ import {
   type ToolSearchEntry
 } from "@nodetool-ai/agents";
 import {
+  createChatCodeActSession,
+  resolveExecutionMode,
+  EXECUTE_CODE_TOOL_NAME,
+  type ChatCodeActSession,
+  type ChatCodeActToolCall
+} from "@nodetool-ai/agents";
+import {
   getBuiltinTools,
   getAllMcpTools,
   registerBuiltinTools,
@@ -5195,13 +5202,19 @@ export class UnifiedWebSocketRunner {
     // deferred tools. Assigned during tool resolution below; read lazily here
     // because the resume `loadFullHistory` thunk and the prepend both run after.
     let toolSearchReminder = "";
+    // In codeact mode: the action contract + tool catalog section, assigned
+    // once the session exists (before the system message is materialized).
+    let codeactPromptSection = "";
     const buildSystemContent = (): string => {
       const base = buildChatAgentSystemPrompt(
         permissionMode,
         extraSystemPrompt,
         uiContext
       );
-      return toolSearchReminder ? `${base}\n\n${toolSearchReminder}` : base;
+      const suffix = [toolSearchReminder, codeactPromptSection]
+        .filter((s) => s.length > 0)
+        .join("\n\n");
+      return suffix ? `${base}\n\n${suffix}` : base;
     };
     const systemChatMessage = (): ProviderMessage => ({
       role: "system",
@@ -5476,13 +5489,25 @@ export class UnifiedWebSocketRunner {
     }
     const allSchemas: ProviderTool[] = [...serverSchemas, ...clientSchemas];
 
+    // Execution mode for this turn. When the stored setting (or
+    // NODETOOL_AGENT_EXECUTION_MODE) says "codeact", the chat turn presents a
+    // single `execute_code` tool and the model acts by writing sandboxed
+    // JavaScript over the same toolbelt (docs/codeact-design.md). The session
+    // is created below, once the tool router and processing context exist.
+    const useCodeAct =
+      resolveExecutionMode() === "codeact" && allSchemas.length > 0;
+
     // The live tool list handed to the provider. On the generic path it starts
     // with the minimal resident set + ToolSearch and GROWS in place as
     // ToolSearch reveals deferred tools — base-provider's loop re-reads this
     // array each iteration, so pushes become callable on the next turn.
     const providerToolSchemas: ProviderTool[] = [];
     let deferredToolCount = 0;
-    if (provider.usesNativeToolSearch) {
+    if (useCodeAct) {
+      // Codeact replaces the ToolSearch deferral machinery: the session's
+      // in-sandbox `searchTools()` covers discovery, and the only provider
+      // tools are `execute_code` (+ `view_image`, pushed below).
+    } else if (provider.usesNativeToolSearch) {
       // Native tool search (Claude Agent SDK): pass everything; the SDK defers.
       providerToolSchemas.push(...allSchemas);
     } else {
@@ -5549,6 +5574,49 @@ export class UnifiedWebSocketRunner {
       provider: providerId,
       model
     } satisfies ActiveModelSelection);
+
+    // CodeAct session for this turn. Created here so its prompt section is in
+    // place before the system message is materialized below. The tool router
+    // (`executeTool`, defined further down) is late-bound through a ref; it is
+    // assigned before the provider loop can run any action.
+    let codeactExecuteToolRef:
+      | ((toolCall: ProviderToolCall) => Promise<string | MessageContent[]>)
+      | null = null;
+    let codeactSession: ChatCodeActSession | null = null;
+    if (useCodeAct) {
+      codeactSession = createChatCodeActSession({
+        tools: allSchemas
+          .filter((s) => s.name !== "view_image")
+          .map((s) => ({
+            name: s.name,
+            description: s.description,
+            inputSchema: s.inputSchema
+          })),
+        executeTool: async (call: ChatCodeActToolCall) => {
+          if (!codeactExecuteToolRef) {
+            throw new Error("Tool router not ready");
+          }
+          return codeactExecuteToolRef({
+            id: call.id,
+            name: call.name,
+            args: call.args
+          });
+        },
+        context: ctx,
+        signal
+      });
+      providerToolSchemas.push(codeactSession.providerTool);
+      // `view_image` stays a direct provider tool: it is the one channel that
+      // puts pixels into the model's context, and pixels cannot ride the
+      // sandbox's JSON observation envelope.
+      const viewImage = allSchemas.find((s) => s.name === "view_image");
+      if (viewImage) providerToolSchemas.push(viewImage);
+      codeactPromptSection = codeactSession.systemPromptSection;
+      log.info("Chat turn running in codeact mode", {
+        threadId,
+        toolCount: allSchemas.length
+      });
+    }
 
     // Prepend system prompt if first message isn't system role — matches Python
     if (chatHistory.length === 0 || chatHistory[0].role !== "system") {
@@ -5746,6 +5814,20 @@ export class UnifiedWebSocketRunner {
         : JSON.stringify(processed);
     };
 
+    // Late-bind the codeact bridge to the router above, and route
+    // `execute_code` calls into the sandbox session; everything else (only
+    // `view_image` is offered in codeact mode) keeps the normal path.
+    codeactExecuteToolRef = executeTool;
+    const session = codeactSession;
+    const effectiveExecuteTool = session
+      ? async (
+          toolCall: ProviderToolCall
+        ): Promise<string | MessageContent[]> =>
+          toolCall.name === EXECUTE_CODE_TOOL_NAME
+            ? session.executeAction(toolCall.args)
+            : executeTool(toolCall)
+      : executeTool;
+
     // Tool name by call id, so persisted tool messages keep their name (the
     // provider Message carries only the id).
     const toolNames = new Map<string, string>();
@@ -5758,8 +5840,9 @@ export class UnifiedWebSocketRunner {
         threadId,
         providerSession: capturedSession,
         loadFullHistory: loadFullHistory ?? undefined,
-        executeTool: useTools ? executeTool : undefined,
+        executeTool: useTools ? effectiveExecuteTool : undefined,
         maxIterations: MAX_TOOL_ROUNDS,
+        sequentialTools: session ? true : undefined,
         signal
       })) {
         if (requestSeq !== undefined && requestSeq !== this.chatRequestSeq)


### PR DESCRIPTION
## What

Two connected changes, closing the "chat/websocket toolbelt" follow-up from `docs/codeact-design.md`:

1. **The chat websocket honors the CodeAct setting.** When `NODETOOL_AGENT_EXECUTION_MODE` (the existing Settings entry) resolves to `codeact`, a plain chat turn presents a single `execute_code` provider tool instead of the toolbelt. The model acts by writing sandboxed JavaScript over the same tools (`tools.<name>()`), with a `state` object persisting across the turn's actions and in-sandbox `searchTools()` replacing the ToolSearch deferral machinery. `view_image` stays a direct provider tool — it is the one channel that puts pixels into model context, which cannot ride the JSON observation envelope. Default mode is unchanged (`tools`).

2. **Workflow graph and node editing happens on a JS object model.** When the belt carries the `ui_*` workflow document tools, code actions get `openWorkflow(workflowId)`: synchronous mutators (`addNode`, `connect`, `node(id).set/.setTitle/.moveTo/.remove`, `removeNode`, `removeEdge`) edit a local mirror and queue ops, and `await wf.commit()` replays the queue through the same bridged `ui_*` tools — so client/server routing, validation, and live-editor sync are untouched, and one code action builds a whole graph. A failed commit names the failing op and keeps it (plus later ops) queued for retry; removing a never-committed node cancels its queued ops instead of issuing a delete.

## How

- `packages/agents/src/codeact/chat-codeact.ts` — `createChatCodeActSession`: a chat toolbelt mixes server tools with client (`ui_*`) tools that exist server-side only as schemas, so instead of `buildToolBridge` the session bridges every `tools.<name>()` call to the chat runner's own `executeTool` router — permission gating, ToolBridge client round-trips, and asset materialization stay where they are.
- `packages/agents/src/codeact/graph-model.ts` — the `openWorkflow()` guest prelude and its prompt section.
- `packages/agents/src/codeact/{tool-api,prompt}.ts` — signature rendering and `buildCodeActSystemPrompt` generalized to schema-shaped tools (`ToolSignatureSource`), plus a `"chat"` prompt variant (no `finish()`; asking the user is allowed; a plain assistant message ends the turn).
- `packages/websocket/src/unified-websocket-runner.ts` — mode resolution at toolbelt assembly, session creation once the processing context exists (prompt section lands before the system message is materialized; the tool router is late-bound), `execute_code` routed into the session, `sequentialTools` for codeact turns.
- Settings description, `docs/codeact-design.md`, and `packages/agents/CLAUDE.md` updated.

## Testing

- New `packages/agents/tests/chat-codeact.test.ts` (11 tests, real QuickJS sandbox, fake router, no network): tool bridging + call ids, `{error}` payloads thrown in-guest, `state` persistence, `finish()` chat guidance, `searchTools()` hits, prompt-section content, and the graph model — queued-op replay order/args, commit-failure retry semantics, uncommitted-node cancellation, existing-graph mirror reads.
- `packages/agents` suite: 140 files / 2090 tests pass. `packages/websocket` suite: 191 files / 2216 tests pass. `npm run build:packages`: all 59 packages build. Web + electron typecheck clean (mobile typecheck fails only on uninstalled Expo deps in this sandbox, pre-existing). Lint findings on touched packages are all pre-existing lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw9JB24wa34eZJ4qsCT1SZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cw9JB24wa34eZJ4qsCT1SZ)_