### PR TITLE
Replace "~120 tools in the toolbelt" with what agents can actually do

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 NodeTool is an open-source creative AI suite that runs on your machine. A node-based canvas, a multi-track video timeline, and a layered sketch editor share one workspace, and every major AI model, cloud or local, wires into all three.
 
-It is agent-first: every editor is exposed to agents as tools — around 120 of them — so an agent can build the workflow, run it, and repair what fails on the same surfaces you use.
+It is agent-first: every action you can take in the UI is also an agent tool, so an agent can wire a graph, paint a layer, cut a clip, or place a widget on the same surfaces you use, then run the result and repair what fails.
 
 * **The Whole App Is the Toolbelt:** Agents drive the canvas, sketch pad, storyboard, timeline, script editor, 3D scene, and app builder.
 * **Pay Provider Prices:** Bring your own API keys and pay providers at cost. No markup.
@@ -61,7 +61,7 @@ Closed platforms lock you in. NodeTool is built for independence.
 
 | | |
 | :--- | :--- |
-| **Agents in every editor** | ~120 tools covering canvas, sketch, storyboard, timeline, script, 3D, and apps |
+| **Agents in every editor** | Anything you can click, an agent can do — canvas, sketch, storyboard, timeline, script, 3D, and apps |
 | **Agents that build** | Describe a pipeline; the agent authors the graph, picks models, and validates before it runs |
 | **Mini apps** | Turn a workflow into a focused interface — built and tested by an agent, or by hand |
 | **Supervised runs** | An agent on the failure path: retry, repair, skip, or stop, on a budget you set |
@@ -83,7 +83,7 @@ Closed platforms lock you in. NodeTool is built for independence.
 
 Most tools bolt a chat panel onto an editor. NodeTool went the other way: the app itself is built as tools an agent can operate, so agents do the work on the same surfaces you use.
 
-*   **The whole app is the toolbelt.** Around 120 tools cover the node canvas, the layered sketch pad, the storyboard, the video timeline, the script editor, the 3D scene, and the app builder. If you can click it, an agent can drive it.
+*   **The whole app is the toolbelt.** Every editor hands the agent the same actions you have: add a node and wire it, paint on a layer and set its blend mode, cut and retime a clip, revise a shot, voice a script line, place a widget in an app. If you can click it, an agent can drive it — the node canvas, the layered sketch pad, the storyboard, the video timeline, the script editor, the 3D scene, and the app builder.
 *   **Agents build workflows.** Describe the pipeline and the agent authors the graph — picks the nodes, wires the edges, selects the models — and validates it before anything runs. What it leaves behind is a workflow you can inspect, edit, and rerun.
 *   **Agents build apps, and test them.** Ask for a mini app and the agent plans the workflows, places the widgets, wires them together, then replays every interaction and has a second model judge whether the result does what you asked. No passing verdict, no app.
 *   **An agent on the failure path.** Supervised runs (`--supervise`) put an agent on call: when a step fails mid-run it decides — retry, repair the output, skip the item, or stop — inside a decision and cost budget you set, with every intervention logged.
@@ -234,7 +234,7 @@ nodetool/
 │   ├── kernel/        #   Workflow graph & runner
 │   ├── node-sdk/      #   BaseNode class & node registry
 │   ├── base-nodes/    #   100+ built-in node types
-│   ├── agents/        #   Planning agents, the ~120-tool belt, app build harness
+│   ├── agents/        #   Planning agents, the editor toolbelt, app build harness
 │   ├── runtime/       #   Processing context & model providers
 │   ├── websocket/     #   HTTP + WebSocket server (entry point)
 │   ├── vectorstore/   #   SQLite-vec vector database

--- a/marketing/public/agents.md
+++ b/marketing/public/agents.md
@@ -7,6 +7,6 @@ product: NodeTool
 ---
 # NodeTool Agents
 
-NodeTool is agent-first. Every editor — the node canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools, around 120 in all. An agent plans multi-step tasks, builds and runs workflows, and repairs what fails, on the same surfaces you use. The full toolbelt is also exposed over MCP for outside agents such as Claude Desktop and Claude Code.
+NodeTool is agent-first. Every editor — the node canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — hands agents the same actions you have: wire a graph, paint a layer, cut a clip, revise a shot, place a widget. An agent plans multi-step tasks, builds and runs workflows, and repairs what fails, on the same surfaces you use. The full toolbelt is also exposed over MCP for outside agents such as Claude Desktop and Claude Code.
 
 Read the [agent documentation](https://docs.nodetool.ai/agents/index.md) for installation, schema discovery, validation, execution, and job monitoring.

--- a/marketing/public/developers.md
+++ b/marketing/public/developers.md
@@ -7,6 +7,6 @@ product: NodeTool
 ---
 # NodeTool Developer Platform
 
-NodeTool provides a TypeScript SDK, CLI, HTTP and WebSocket APIs, custom-node APIs, and a deployable workflow runtime. It is agent-first: every editor is exposed as tools, around 120 in all, and the full toolbelt speaks MCP, so Claude Code or any MCP-aware agent can build, validate, run, and debug workflows.
+NodeTool provides a TypeScript SDK, CLI, HTTP and WebSocket APIs, custom-node APIs, and a deployable workflow runtime. It is agent-first: every editor action is also an agent tool, and the full toolbelt speaks MCP, so Claude Code or any MCP-aware agent can build, validate, run, and debug workflows.
 
 Use the [CLI](https://docs.nodetool.ai/cli.md) for automation, the [node catalog](https://docs.nodetool.ai/nodes/catalog.json) to discover node schemas, and the [developer guide](https://docs.nodetool.ai/developer/index.md) to extend NodeTool.

--- a/marketing/public/llms.txt
+++ b/marketing/public/llms.txt
@@ -4,7 +4,7 @@
 
 ## What NodeTool is
 
-- An agent-first workspace: every editor is exposed to agents as tools, around 120 in all, and the full toolbelt speaks MCP for outside agents such as Claude Desktop and Claude Code.
+- An agent-first workspace: every action in every editor is also an agent tool — anything you can click, an agent can do — and the full toolbelt speaks MCP for outside agents such as Claude Desktop and Claude Code.
 - A visual, node-based editor for building AI workflows: connect models and tools as nodes on a canvas instead of writing glue code.
 - Two editions of one open-source codebase: **Studio**, a free desktop app for macOS, Windows, and Linux, and **Cloud**, the same app hosted in a browser (currently in alpha).
 - Planning agents: give an agent a goal and it plans the steps, picks a model or tool, and executes multi-step tasks on the canvas.

--- a/marketing/scripts/generate-llms-txt.mjs
+++ b/marketing/scripts/generate-llms-txt.mjs
@@ -32,7 +32,7 @@ const PREAMBLE = `# NodeTool
 
 ## What NodeTool is
 
-- An agent-first workspace: every editor is exposed to agents as tools, around 120 in all, and the full toolbelt speaks MCP for outside agents such as Claude Desktop and Claude Code.
+- An agent-first workspace: every action in every editor is also an agent tool — anything you can click, an agent can do — and the full toolbelt speaks MCP for outside agents such as Claude Desktop and Claude Code.
 - A visual, node-based editor for building AI workflows: connect models and tools as nodes on a canvas instead of writing glue code.
 - Two editions of one open-source codebase: **Studio**, a free desktop app for macOS, Windows, and Linux, and **Cloud**, the same app hosted in a browser (currently in alpha).
 - Planning agents: give an agent a goal and it plans the steps, picks a model or tool, and executes multi-step tasks on the canvas.
@@ -133,7 +133,7 @@ Cloud uses bring-your-own provider keys. See [pricing](${BASE_URL}/pricing.md) a
     title: "NodeTool Developer Platform",
     description:
       "Build, run, extend, and deploy NodeTool workflows with code — or through an agent.",
-    body: `NodeTool provides a TypeScript SDK, CLI, HTTP and WebSocket APIs, custom-node APIs, and a deployable workflow runtime. It is agent-first: every editor is exposed as tools, around 120 in all, and the full toolbelt speaks MCP, so Claude Code or any MCP-aware agent can build, validate, run, and debug workflows.
+    body: `NodeTool provides a TypeScript SDK, CLI, HTTP and WebSocket APIs, custom-node APIs, and a deployable workflow runtime. It is agent-first: every editor action is also an agent tool, and the full toolbelt speaks MCP, so Claude Code or any MCP-aware agent can build, validate, run, and debug workflows.
 
 Use the [CLI](https://docs.nodetool.ai/cli.md) for automation, the [node catalog](https://docs.nodetool.ai/nodes/catalog.json) to discover node schemas, and the [developer guide](https://docs.nodetool.ai/developer/index.md) to extend NodeTool.`,
   },
@@ -141,7 +141,7 @@ Use the [CLI](https://docs.nodetool.ai/cli.md) for automation, the [node catalog
     title: "NodeTool Agents",
     description:
       "NodeTool is agent-first: every editor is exposed to agents as tools.",
-    body: `NodeTool is agent-first. Every editor — the node canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools, around 120 in all. An agent plans multi-step tasks, builds and runs workflows, and repairs what fails, on the same surfaces you use. The full toolbelt is also exposed over MCP for outside agents such as Claude Desktop and Claude Code.
+    body: `NodeTool is agent-first. Every editor — the node canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — hands agents the same actions you have: wire a graph, paint a layer, cut a clip, revise a shot, place a widget. An agent plans multi-step tasks, builds and runs workflows, and repairs what fails, on the same surfaces you use. The full toolbelt is also exposed over MCP for outside agents such as Claude Desktop and Claude Code.
 
 Read the [agent documentation](https://docs.nodetool.ai/agents/index.md) for installation, schema discovery, validation, execution, and job monitoring.`,
   },

--- a/marketing/src/components/ChatUISection.tsx
+++ b/marketing/src/components/ChatUISection.tsx
@@ -48,9 +48,9 @@ export default function ChatUISection() {
             className="text-lg text-slate-400 leading-relaxed"
           >
             The chat isn&apos;t a help panel — it&apos;s an agent with the whole
-            app as its toolbelt, around 120 tools across every editor. Ask in
-            plain English and it builds the workflow, runs it, and leaves
-            behind something you can inspect, edit, and rerun.
+            app as its toolbelt: anything you can click in any editor, it can
+            do. Ask in plain English and it builds the workflow, runs it, and
+            leaves behind something you can inspect, edit, and rerun.
           </motion.p>
         </div>
 

--- a/marketing/src/components/agents/AgentFeaturesSection.tsx
+++ b/marketing/src/components/agents/AgentFeaturesSection.tsx
@@ -25,7 +25,7 @@ export default function AgentFeaturesSection({
       icon: Brain,
       title: "The whole app is the toolbelt",
       description:
-        "Around 120 tools cover every editor: the node canvas, the layered sketch pad, the storyboard, the video timeline, the script editor, the 3D scene, and the app builder. If you can click it, an agent can drive it.",
+        "Every editor hands the agent the same actions you have: add a node and wire it, paint on a layer, cut and retime a clip, revise a shot, place a widget in an app. If you can click it, an agent can drive it — the node canvas, the layered sketch pad, the storyboard, the video timeline, the script editor, the 3D scene, and the app builder.",
       color: "teal",
     },
     {

--- a/marketing/src/components/developers/DevelopersHero.tsx
+++ b/marketing/src/components/developers/DevelopersHero.tsx
@@ -45,9 +45,9 @@ export default function DevelopersHero() {
           TypeScript-first, async Node.js under the hood, the same open-source
           codebase that ships Studio and Cloud. Write a custom node, drive the
           canvas from a CLI, generate workflows in code — or point Claude Code
-          at the MCP server and let an agent do it: every editor is exposed as
-          tools, around 120 in all, with validators and debug harnesses built
-          for the agent loop.
+          at the MCP server and let an agent do it: every editor action is
+          also a tool, with validators and debug harnesses built for the agent
+          loop.
         </motion.p>
 
         {/* Feature Pills */}


### PR DESCRIPTION
"Around 120 tools in the toolbelt" is a number without a scale. A reader has no idea whether 120 is a lot, and it says nothing about what the agent can do for them — the one thing they're trying to find out.

Every occurrence now states the capability instead, with concrete actions named:

- **README** — hero line, the "what's in the box" row, the Agents bullet, and the package tree comment.
- **marketing** — `AgentFeaturesSection`, `ChatUISection`, `DevelopersHero`.
- **llms.txt generator** — the preamble and the `agents.md` / `developers.md` page constants; `public/llms.txt`, `public/agents.md`, and `public/developers.md` regenerated (`npx tsx scripts/generate-llms-txt.mjs --check` is clean).

The claim that carries the meaning: *anything you can click in any editor, an agent can do* — wire a graph, paint a layer and set its blend mode, cut and retime a clip, revise a shot, voice a script line, place a widget in an app. Same claim as the count, but a reader can picture it.

Prose only; no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_017wPftVa8sDaeT5qa1QdekP)_