### PR TITLE
Ship Wave-1 SEO content: privacy-first, self-hosted, text-to-video, RAG, GPU FAQ

### DIFF
--- a/marketing/public/llms.txt
+++ b/marketing/public/llms.txt
@@ -52,6 +52,7 @@
 - [Studio or Cloud — which should I use?](https://nodetool.ai/faq/studio-or-cloud)
 - [Which models are supported?](https://nodetool.ai/faq/which-models-are-supported)
 - [Can I run models locally?](https://nodetool.ai/faq/can-i-run-models-locally)
+- [Do I need a GPU to run NodeTool?](https://nodetool.ai/faq/do-i-need-a-gpu)
 - [How is NodeTool different from ComfyUI?](https://nodetool.ai/faq/how-is-nodetool-different-from-comfyui)
 - [How is NodeTool different from Weavy (now Figma Weave) and other closed canvases?](https://nodetool.ai/faq/how-is-nodetool-different-from-closed-canvases)
 - [How is NodeTool different from n8n or Flowise?](https://nodetool.ai/faq/how-is-nodetool-different-from-n8n-and-flowise)

--- a/marketing/seo/CONTENT_KEYWORD_STRATEGY.md
+++ b/marketing/seo/CONTENT_KEYWORD_STRATEGY.md
@@ -208,14 +208,14 @@ Impact is judged on differentiation × reachable demand, not raw volume.
 
 | # | Title | Slug | Effort | Impact | Notes |
 |---|---|---|---|---|---|
-| 21 | Privacy-First AI Workflow Builder | `/solutions/privacy-first` | S | High | Seed keyword. Distinct from the legal `/privacy` page |
+| 21 | ~~Privacy-First AI Workflow Builder~~ | `/solutions/privacy-first` | S | High | ~~Seed keyword. Distinct from the legal `/privacy` page~~ **Shipped 2026-08-07.** |
 | 22 | Offline AI Generation | `/solutions/offline` | S | Mid | Splits "offline" intent off the local-first landing |
-| 23 | Self-Hosted AI Workflows | `/solutions/self-hosted` | S | High | Owns the deploy/ownership query set |
+| 23 | ~~Self-Hosted AI Workflows~~ | `/solutions/self-hosted` | S | High | ~~Owns the deploy/ownership query set~~ **Shipped 2026-08-07.** |
 | 24 | AI Workflows for Agencies | `/solutions/agencies` | S | Mid | Client-work framing; per-client key isolation |
 | 25 | AI Workflows for Game Art | `/solutions/game-art` | S | Mid | Asset batches, style consistency |
 | 26 | AI Workflows for E-commerce Product Shots | `/solutions/product-shots` | S | High | Existing showcase prompts already cover this |
-| 27 | Text to Video | `/tasks/text-to-video` | S | High | Missing from a 6-task hub set; high demand |
-| 28 | Local RAG | `/tasks/rag` | S | High | Seed keyword; the hub the RAG guides point at |
+| 27 | ~~Text to Video~~ | `/tasks/text-to-video` | S | High | ~~Missing from a 6-task hub set; high demand~~ **Shipped 2026-08-07.** |
+| 28 | ~~Local RAG~~ | `/tasks/rag` | S | High | ~~Seed keyword; the hub the RAG guides point at~~ **Shipped 2026-08-07.** |
 | 29 | Batch Generation | `/tasks/batch-generation` | S | Mid | Cross-links templates, apps, showcase |
 | 30 | Speech to Text | `/tasks/speech-to-text` | S | Mid | Completes the audio task set with text-to-speech |
 | 31 | Image Editing & Inpainting | `/tasks/image-editing` | S | Mid | Big shipped node coverage, no hub |
@@ -240,7 +240,7 @@ on docs.nodetool.ai and must not be duplicated here.
 | 36 | What does local-first mean for AI tools? | `/faq/what-is-local-first-ai` | S | Mid |
 | 37 | What is a workflow template? | `/faq/what-is-a-workflow-template` | S | Low |
 | 38 | What is a mini app? | `/faq/what-is-a-mini-app` | S | Mid |
-| 39 | Do I need a GPU to run NodeTool? | `/faq/do-i-need-a-gpu` | S | High |
+| 39 | ~~Do I need a GPU to run NodeTool?~~ | `/faq/do-i-need-a-gpu` | S | High — **Shipped 2026-08-07.** |
 | 40 | Can I use NodeTool commercially? | `/faq/commercial-use` | S | Mid |
 
 ### Build order
@@ -250,7 +250,7 @@ traffic the S-effort rows already prove out.
 
 | Wave | Items | Why |
 |---|---|---|
-| 1 | 2, 3, 4, 21, 23, 27, 28, 39 | All S-effort rows in existing modules. No new routes |
+| 1 | 2, 3, 4, 21, 23, 27, 28, 39 | All S-effort rows in existing modules. No new routes. **21, 23, 27, 28, 39 shipped 2026-08-07**; 2–4 (qualified alternatives) remain — they need route changes beyond a data row |
 | 2 | 1, 32, 33, 34 | Four hub/pillar pages; each needs a route folder but no new engine |
 | 3 | 11–20 | The `/guides` engine: one `guideEntries.ts` module plus `app/guides/[slug]`, registered in `registry.ts` like every other engine |
 

--- a/marketing/src/data/faqEntries.ts
+++ b/marketing/src/data/faqEntries.ts
@@ -245,6 +245,15 @@ const seeds: FaqSeed[] = [
     relatedRoute: "/agents",
     surfaces: ["agents"],
   },
+  {
+    slug: "do-i-need-a-gpu",
+    question: "Do I need a GPU to run NodeTool?",
+    answerMd:
+      "No. NodeTool works entirely with cloud providers — bring your own API key, and the model runs on the provider's hardware with nothing to install locally. A GPU only matters if you choose to run open-weight models yourself through Ollama, MLX, or llama.cpp: it speeds those up, but many smaller local models run fine on CPU too, just slower.",
+    category: "models",
+    relatedRoute: "/solutions/local-first",
+    surfaces: ["landing", "models"],
+  },
 ];
 
 const FAQ_BASE = "/faq";

--- a/marketing/src/data/landingEntries.ts
+++ b/marketing/src/data/landingEntries.ts
@@ -270,6 +270,80 @@ export const landingEntries: LandingEntry[] = [
     ],
     accent: "blue",
   },
+  {
+    route: "/solutions/privacy-first",
+    title: title("Privacy-First AI Workflow Builder"),
+    description:
+      "Keep your data on your own machine. NodeTool Studio runs image, video, audio, and text workflows on local models with no account and nothing sent to a third-party server unless you choose to.",
+    priority: 0.7,
+    changeFrequency: "monthly",
+    indexable: true,
+    slug: "privacy-first",
+    kind: "persona",
+    eyebrow: "For privacy-first teams",
+    headline: "Privacy-First AI Workflow Builder",
+    subhead:
+      "Cloud AI tools send your prompts, files, and outputs through someone else's server by default. NodeTool Studio runs entirely on your own hardware with open-weight models — nothing leaves your machine unless you explicitly wire in a cloud provider.",
+    featuredTemplate: "image-enhance",
+    highlights: [
+      "Local models by default — no data ever leaves your machine",
+      "No account, no telemetry, no server NodeTool controls",
+      "Cloud providers are opt-in per node, on your own keys",
+    ],
+    sections: ["features", "use-cases"],
+    faqs: [
+      {
+        q: "Does any of my data leave my machine?",
+        a: "Not with local models. NodeTool Studio runs open-weight models on your own hardware, and assets, workflows, and keys stay on disk. Data only leaves when you deliberately wire a node to a cloud provider.",
+      },
+      {
+        q: "How is this different from cloud-only AI tools?",
+        a: "Most AI canvases route every prompt and file through their own servers before you see a result. NodeTool has no server in that path by default — the graph executes locally, and a cloud call happens only where you add one.",
+      },
+      {
+        q: "Can I mix local and cloud models in one workflow?",
+        a: "Yes. Run the sensitive steps on local models and send only the parts you choose to a cloud provider, node by node, in the same graph.",
+      },
+    ],
+    accent: "emerald",
+  },
+  {
+    route: "/solutions/self-hosted",
+    title: title("Self-Hosted AI Workflows"),
+    description:
+      "Run NodeTool on your own server with Docker. Full control over data, uptime, and cost — no vendor lock-in and no per-seat SaaS bill.",
+    priority: 0.7,
+    changeFrequency: "monthly",
+    indexable: true,
+    slug: "self-hosted",
+    kind: "persona",
+    eyebrow: "For self-hosters",
+    headline: "Self-Hosted AI Workflows",
+    subhead:
+      "Deploy NodeTool on infrastructure you own. The same open-source app that runs on your laptop starts from one `docker-compose.yml`, so a team can run workflows, models, and data behind its own firewall instead of a SaaS vendor's.",
+    featuredTemplate: "chat-with-your-documents",
+    highlights: [
+      "One Docker Compose file to stand up your own server",
+      "Your database, your storage, your uptime — no vendor lock-in",
+      "AGPL-3.0 open source, so nothing is held back for a paid tier",
+    ],
+    sections: ["features", "use-cases"],
+    faqs: [
+      {
+        q: "How do I self-host NodeTool?",
+        a: "Run it with the reference `docker-compose.yml` in the repository, or the `packages/deploy` tooling for more control. It's the same open-source app you'd run on the desktop, pointed at your own storage and database.",
+      },
+      {
+        q: "Do I still bring my own model keys when self-hosting?",
+        a: "Yes. Self-hosting NodeTool controls where the app and your data live; you still connect your own provider keys, or run local/open-weight models on the host's own hardware.",
+      },
+      {
+        q: "Why self-host instead of using a SaaS workflow tool?",
+        a: "You own the data, the uptime, and the deployment. There is no per-seat bill, no vendor deciding what changes next, and the same AGPL-3.0 source runs whether it's on your laptop or your server.",
+      },
+    ],
+    accent: "blue",
+  },
 ];
 
 /** Hub entry for the `/solutions` index — kept in the registry too. */

--- a/marketing/src/data/taskEntries.ts
+++ b/marketing/src/data/taskEntries.ts
@@ -279,6 +279,81 @@ export const taskEntries: TaskEntry[] = [
     ],
     accent: "emerald",
   },
+  {
+    route: "/tasks/text-to-video",
+    title: title("Text to Video"),
+    description:
+      "Generate video from a text prompt with AI. Compare text-to-video models, run ready-made NodeTool workflows, and build them into a bigger pipeline.",
+    priority: 0.6,
+    changeFrequency: "weekly",
+    indexable: true,
+    slug: "text-to-video",
+    task: "Text to Video",
+    modality: "video",
+    headline: "Text-to-Video AI Models & Workflows",
+    subhead:
+      "Describe a shot and get motion. Choose a text-to-video model, drop it into a NodeTool workflow, and generate clips from a prompt alone — on one canvas with your own keys.",
+    nodeTypeMatch: ["video.TextToVideo"],
+    tagMatch: ["video"],
+    models: [
+      { name: "Veo 3.1", provider: "Google", modality: "video", blurb: "Cinematic text-to-video with native synchronized audio." },
+      { name: "Sora 2", provider: "OpenAI", modality: "video", blurb: "Prompt-to-video with strong physical realism and sound." },
+      { name: "Kling 2.6", provider: "Kling", modality: "video", blurb: "High-motion generation with strong subject consistency." },
+      { name: "Wan 2.6", provider: "Alibaba", modality: "video", blurb: "Open-weight text-to-video with fine motion control." },
+    ],
+    faqs: [
+      {
+        q: "What is text-to-video generation?",
+        a: "A model turns a written prompt into a short video clip, inferring subject, motion, and camera work from the text alone — no starting image required.",
+      },
+      {
+        q: "Which text-to-video model is best?",
+        a: "It depends on the look you want: Veo and Sora lead on cinematic realism and native audio, while open-weight models like Wan let you run locally and tune control.",
+      },
+      {
+        q: "How do I run it in NodeTool?",
+        a: "Open one of the text-to-video templates below in Studio, connect the provider key, write a prompt, and run the graph.",
+      },
+    ],
+    accent: "violet",
+  },
+  {
+    route: "/tasks/rag",
+    title: title("RAG"),
+    description:
+      "Build retrieval-augmented generation with AI. Index your own documents into a vector collection, run ready-made NodeTool workflows, and get answers that cite their sources.",
+    priority: 0.6,
+    changeFrequency: "weekly",
+    indexable: true,
+    slug: "rag",
+    task: "RAG",
+    modality: "text",
+    headline: "Local RAG: Models & Workflows",
+    subhead:
+      "Chat with your own documents. Index files into a vector collection, retrieve the passages that match a question, and have an agent answer from them — on one canvas, on your own keys or fully local.",
+    nodeTypeMatch: ["vector.IndexTextChunk", "vector.Collection", "vector.QueryText"],
+    tagMatch: ["rag", "vectorstore", "retrieval"],
+    models: [
+      { name: "nomic-embed-text", provider: "Ollama (local)", modality: "text", blurb: "Open-weight embedding model for local vector indexing." },
+      { name: "gpt-5-mini", provider: "OpenAI", modality: "text", blurb: "Fast, low-cost answer generation over retrieved passages." },
+      { name: "Claude Sonnet", provider: "Anthropic", modality: "text", blurb: "Strong grounded answers with citations from long context." },
+    ],
+    faqs: [
+      {
+        q: "What is RAG?",
+        a: "Retrieval-augmented generation searches your own documents for the passages relevant to a question, then passes those passages to a model so it answers from your material instead of guessing from training data.",
+      },
+      {
+        q: "Where does my document index live?",
+        a: "In NodeTool's own vector store (sqlite-vec), on your machine by default. Nothing has to leave your computer — embeddings and retrieval can run entirely on local models.",
+      },
+      {
+        q: "How do I run RAG in NodeTool?",
+        a: "Open the Chat With Your Documents template below, index a folder of files into a collection, and connect the query and agent nodes — no separate vector database to stand up.",
+      },
+    ],
+    accent: "cyan",
+  },
 ];
 
 /** Hub entry for the `/tasks` index — kept in the registry too. */


### PR DESCRIPTION
## Summary

- Continues the SEO strategy work in `marketing/seo/CONTENT_KEYWORD_STRATEGY.md`, which already had an accurate "what already exists" audit and a prioritized Wave 1 backlog of S-effort items (new rows in existing data modules, no new routes needed).
- Ships 5 of those Wave-1 items:
  - `/solutions/privacy-first` (`landingEntries.ts`) — local-first/no-data-leaves-your-machine positioning
  - `/solutions/self-hosted` (`landingEntries.ts`) — Docker/`docker-compose.yml` self-host story, sourced from documented deploy facts
  - `/tasks/text-to-video` (`taskEntries.ts`) — models verified against `modelEntries.ts` (Veo 3.1, Sora 2, Kling 2.6, Wan 2.6)
  - `/tasks/rag` (`taskEntries.ts`) — retrieval-augmented generation hub, matched to the real `chat-with-your-documents` template
  - `do-i-need-a-gpu` FAQ row (`faqEntries.ts`)
- Marked these 5 backlog rows as shipped in `marketing/seo/CONTENT_KEYWORD_STRATEGY.md`.
- Skipped backlog items #2–4 (qualified `/alternatives/comfyui-for-*` pages) — those need `/alternatives/[slug]` route changes beyond a data row, out of scope for this pass.

Note: `docs/SEO_STRATEGY.md` is stale relative to the current site (it still describes ~13 indexed pages; the site now ships ~100+ across models/providers/tasks/solutions/templates/apps/showcase/blog/faq engines). `marketing/seo/CONTENT_KEYWORD_STRATEGY.md` is the accurate, current source of truth and is what this PR builds from — a full rewrite of `docs/SEO_STRATEGY.md` is a good follow-up but out of scope here.

## Test plan

- [x] `npx tsc --noEmit` in `marketing/` — clean
- [x] `npm run lint` in `marketing/` — clean (only pre-existing, unrelated warnings)
- [x] Verified `image-enhance` and `chat-with-your-documents` template slugs exist in `templateEntries.generated.ts`
- [ ] `next build` full static generation (not run — large build, typecheck+lint sufficient per repo convention for data-only changes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBVKkDbrQ7PfFkToiAfViR)_