### PR TITLE
CodeAct sandbox graph builder runs on the shared graph DSL core

### DIFF
--- a/docs/codeact-design.md
+++ b/docs/codeact-design.md
@@ -219,6 +219,15 @@ absent throws naming it. The namespaces are `workflows`, `graph()`, `nodes`,
 `style`, `email`, `assets`, `jobs`, `collections`, `apps`, `timelines`,
 `sketches`, `scripts`, `storyboards`, plus `batch()` for bounded fan-out.
 
+`nodetool.graph()` is not its own graph language: it is the graph DSL core
+(`src/graph-dsl-core.ts`), the same implementation the GraphPlanner's
+`submit_graph` programs run on. One wiring semantics across both surfaces —
+snake_case auto ids, `node(type, props)` argument validation, `connect()`
+refusing an id the graph does not have, and handles that throw when
+interpolated into a string instead of silently becoming `"[object Object]"`.
+The sandbox layer adds only the tool-backed methods (`validate()`, `save()`,
+`run()`).
+
 `web` is the outside world behind one surface: `search(query, {provider})`
 picks whichever search backend the belt carries (`"default"`, `"openai"`,
 `"google"`, `"dataforseo"` pin one), with `news`, `images`, `browse(url)`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -54118,9 +54118,11 @@
       "dependencies": {
         "@jitl/quickjs-ng-wasmfile-release-sync": "^0.31.0",
         "@llamaindex/liteparse": "^1.5.2",
+        "@napi-rs/canvas": "^0.1.65",
         "@nodetool-ai/app-runtime": "*",
         "@nodetool-ai/config": "*",
         "@nodetool-ai/execution": "*",
+        "@nodetool-ai/image-editor": "*",
         "@nodetool-ai/kernel": "*",
         "@nodetool-ai/models": "*",
         "@nodetool-ai/node-sdk": "*",

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -540,7 +540,10 @@ follows (CodeAct, ICML 2024): docs/codeact-design.md.
   create/open), `nodetool.graph()` (an ad-hoc graph builder with
   `ref.output()` wiring, `copyFrom()` graph-into-graph copying with id
   remapping, `validate()`, `save()`, and `run()` — save-as-`codeact-adhoc` +
-  run), `nodetool.batch(items, fn, {concurrency})` for bounded fan-out (run a
+  run; it runs on the shared graph DSL core in `src/graph-dsl-core.ts`, the
+  same implementation behind the GraphPlanner's `submit_graph`, so wiring
+  semantics and guards — snake_case auto ids, `connect()` id checks, handles
+  that throw when stringified — cannot drift between the two surfaces), `nodetool.batch(items, fn, {concurrency})` for bounded fan-out (run a
   workflow once per CSV row), `nodetool.models` (`pick(capability)` resolves
   one ranked model; `find`/`list` for the long form), `nodetool.providers`
   (roster derived from the model catalog), and `nodetool.media`

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -14,6 +14,8 @@
  * from the graph-model prelude when that is loaded.
  */
 
+import { GRAPH_DSL_CORE_PRELUDE } from "../graph-dsl-core.js";
+
 /** Namespace → the belt tools that light it up (any one is enough). */
 export const NODETOOL_API_NAMESPACE_TOOLS: Record<string, readonly string[]> = {
   workflows: [
@@ -188,20 +190,11 @@ const nodetool = (() => {
     return merged;
   };
 
-  /** Accept a GraphBuilder, a bare {nodes, edges}, or a workflow record. */
-  const __graphJson = (source) => {
-    if (source && typeof source.toJSON === "function") return source.toJSON();
-    if (source && Array.isArray(source.nodes)) {
-      return { nodes: source.nodes, edges: source.edges || [] };
-    }
-    if (source && source.graph && Array.isArray(source.graph.nodes)) {
-      return { nodes: source.graph.nodes, edges: source.graph.edges || [] };
-    }
-    throw new Error(
-      "nodetool: expected a graph builder, a {nodes, edges} graph, or a " +
-      "workflow record with a .graph"
-    );
-  };
+  /**
+   * Accept a GraphBuilder, a bare {nodes, edges}, or a workflow record —
+   * the shared graph DSL core's normalizer.
+   */
+  const __graphJson = __graphJsonOf;
 
   /**
    * A backend that is registered but unusable — no key, no configuration.
@@ -253,9 +246,6 @@ const nodetool = (() => {
     );
   };
 
-  const __nodeId = (ref) =>
-    typeof ref === "string" ? ref : ref && ref.id ? ref.id : String(ref);
-
   /**
    * Normalize a model reference to the {provider, model} pair the media
    * tools take. Accepts a find/pick result ({provider, model_id}), a bare
@@ -280,173 +270,39 @@ const nodetool = (() => {
     );
   };
 
+  /**
+   * The graph DSL core (\`__graphDslBuilder\`, shared with the GraphPlanner's
+   * submit_graph programs) plus the tool-backed methods only this sandbox
+   * has: validate, save, and the save-and-run shortcut.
+   */
   function graphBuilder(base) {
-    const nodes = [];
-    const edges = [];
-    const byId = {};
-    let seq = 0;
-
-    const uniqueId = (hint) => {
-      const stem = String(hint || "node")
-        .split(".")
-        .pop()
-        .replace(/[^A-Za-z0-9_]/g, "_")
-        .toLowerCase();
-      let id = stem + "_" + (++seq);
-      while (byId[id]) id = stem + "_" + (++seq);
-      return id;
-    };
-
-    const addEdge = (source, sourceHandle, target, targetHandle) => {
-      const edge = {
-        id: "e" + (edges.length + 1) + "_" + source + "_" + target,
-        source: source,
-        sourceHandle: sourceHandle || "output",
-        target: target,
-        targetHandle: targetHandle
-      };
-      edges.push(edge);
-      return edge;
-    };
-
-    const wireProps = (targetId, props) => {
-      const plain = {};
-      for (const key of Object.keys(props || {})) {
-        const value = props[key];
-        if (value && typeof value === "object" && value.__ntOutput === true) {
-          addEdge(value.node, value.slot, targetId, key);
-        } else {
-          plain[key] = value;
-        }
+    const g = __graphDslBuilder();
+    g.validate = () => __need("validate_workflow")({ graph: g.toJSON() });
+    g.save = (name, opts) =>
+      __need("create_workflow")(
+        __merge(opts, { name: name, graph: g.toJSON() })
+      );
+    /**
+     * Run this graph ad hoc: saves it as a workflow (tagged so it is easy
+     * to find and clean up), then runs it. Returns { workflow, result }.
+     * Pass { name } to keep it as a deliberate, named workflow instead.
+     */
+    g.run = async (params, opts) => {
+      const name =
+        (opts && opts.name) || "Ad-hoc graph " + new Date().toISOString();
+      const tags = (opts && opts.tags) || ["codeact-adhoc"];
+      const workflow = await g.save(name, { tags: tags });
+      if (!workflow || !workflow.id) {
+        throw new Error("Ad-hoc run: saving the graph returned no id");
       }
-      return plain;
+      const result = await __need("run_workflow")(
+        __merge(opts && opts.interactive ? { interactive: true } : {}, {
+          workflow_id: workflow.id,
+          params: params || {}
+        })
+      );
+      return { workflow: workflow, result: result };
     };
-
-    const makeRef = (raw) => {
-      const ref = {
-        id: raw.id,
-        type: raw.type,
-        properties: raw.properties,
-        output: (slot) => ({
-          __ntOutput: true,
-          node: raw.id,
-          slot: slot || "output"
-        }),
-        set(props) {
-          Object.assign(raw.properties, wireProps(raw.id, props));
-          return ref;
-        }
-      };
-      byId[raw.id] = ref;
-      return ref;
-    };
-
-    const g = {
-      node(type, properties, opts) {
-        const id = (opts && opts.id) || uniqueId(type);
-        if (byId[id]) throw new Error('Duplicate node id "' + id + '"');
-        const raw = { id: id, type: type, properties: {} };
-        nodes.push(raw);
-        const ref = makeRef(raw);
-        Object.assign(raw.properties, wireProps(id, properties));
-        return ref;
-      },
-      connect(source, sourceHandle, target, targetHandle) {
-        return addEdge(
-          __nodeId(source),
-          sourceHandle,
-          __nodeId(target),
-          targetHandle
-        );
-      },
-      get(id) {
-        const found = byId[id];
-        if (!found) {
-          throw new Error(
-            "Node not found: " + id + ". Known: " + Object.keys(byId).join(", ")
-          );
-        }
-        return found;
-      },
-      nodes: nodes,
-      edges: edges,
-      /**
-       * Copy another graph (builder, {nodes, edges}, or workflow record) into
-       * this one. Ids that collide are remapped with a prefix; returns
-       * { idMap, refs } where refs is keyed by the SOURCE id, so wiring into
-       * copied nodes never needs the remapped name.
-       */
-      copyFrom(source, opts) {
-        const src = __graphJson(source);
-        const prefix = (opts && opts.prefix) || "";
-        const idMap = {};
-        const refs = {};
-        for (const n of src.nodes) {
-          const props = __merge(
-            n.properties ||
-              (n.data && n.data.properties ? n.data.properties : n.data)
-          );
-          let id = prefix + n.id;
-          if (byId[id]) id = uniqueId(prefix + n.id);
-          idMap[n.id] = id;
-          const raw = { id: id, type: n.type, properties: props };
-          nodes.push(raw);
-          refs[n.id] = makeRef(raw);
-        }
-        for (const e of src.edges || []) {
-          if (idMap[e.source] === undefined || idMap[e.target] === undefined) {
-            continue;
-          }
-          addEdge(
-            idMap[e.source],
-            e.sourceHandle || e.source_output,
-            idMap[e.target],
-            e.targetHandle || e.target_input
-          );
-        }
-        return { idMap: idMap, refs: refs };
-      },
-      toJSON() {
-        return {
-          nodes: nodes.map((n) => ({
-            id: n.id,
-            type: n.type,
-            properties: __merge(n.properties)
-          })),
-          edges: edges.map((e) => __merge(e))
-        };
-      },
-      validate() {
-        return __need("validate_workflow")({ graph: g.toJSON() });
-      },
-      save(name, opts) {
-        return __need("create_workflow")(
-          __merge(opts, { name: name, graph: g.toJSON() })
-        );
-      },
-      /**
-       * Run this graph ad hoc: saves it as a workflow (tagged so it is easy
-       * to find and clean up), then runs it. Returns { workflow, result }.
-       * Pass { name } to keep it as a deliberate, named workflow instead.
-       */
-      async run(params, opts) {
-        const name =
-          (opts && opts.name) || "Ad-hoc graph " + new Date().toISOString();
-        const tags = (opts && opts.tags) || ["codeact-adhoc"];
-        const workflow = await g.save(name, { tags: tags });
-        if (!workflow || !workflow.id) {
-          throw new Error("Ad-hoc run: saving the graph returned no id");
-        }
-        const result = await __need("run_workflow")(
-          __merge(opts && opts.interactive ? { interactive: true } : {}, {
-            workflow_id: workflow.id,
-            params: params || {}
-          })
-        );
-        return { workflow: workflow, result: result };
-      }
-    };
-
     if (base) g.copyFrom(base, {});
     return g;
   }
@@ -1069,8 +925,8 @@ const NAMESPACE_TOOLS_LITERAL = `const __NT_NAMESPACE_TOOLS = ${JSON.stringify(
   NODETOOL_API_NAMESPACE_TOOLS
 )};`;
 
-/** The full prelude: the namespace map plus the API definition. */
-export const NODETOOL_API_PRELUDE_FULL = `${NAMESPACE_TOOLS_LITERAL}\n${NODETOOL_API_PRELUDE}`;
+/** The full prelude: namespace map, shared graph DSL core, API definition. */
+export const NODETOOL_API_PRELUDE_FULL = `${NAMESPACE_TOOLS_LITERAL}\n${GRAPH_DSL_CORE_PRELUDE}\n${NODETOOL_API_PRELUDE}`;
 
 interface PromptEntry {
   /** Namespace key in {@link NODETOOL_API_NAMESPACE_TOOLS}. */
@@ -1101,8 +957,10 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   needed. \`g.node(type, props)\` returns a ref; pass \`ref.output(slot?)\` as a
   property value to wire an edge (or \`g.connect(a, "output", b, "text")\`).
   \`g.copyFrom(workflowOrGraph, {prefix})\` copies another graph in (ids remapped;
-  returns \`{idMap, refs}\` keyed by source id). \`await g.validate()\` before
-  \`await g.run(params)\` (saves it tagged \`codeact-adhoc\`, then runs) or
+  returns \`{idMap, refs}\` keyed by source id). Wiring is checked as you build:
+  \`connect\` refuses an id the graph does not have, and a handle inside a
+  string throws — a handle wires an edge, it is not text. \`await g.validate()\`
+  before \`await g.run(params)\` (saves it tagged \`codeact-adhoc\`, then runs) or
   \`await g.save(name)\`.`
   },
   {

--- a/packages/agents/src/graph-dsl-core.ts
+++ b/packages/agents/src/graph-dsl-core.ts
@@ -1,0 +1,231 @@
+/**
+ * Graph DSL core — the one guest-side implementation of node/edge wiring,
+ * shared by the two surfaces that let an LLM build a workflow graph in code:
+ * the GraphPlanner's `submit_graph` program (`src/graph-dsl.ts`) and the
+ * CodeAct sandbox's `nodetool.graph()` builder (`src/codeact/nodetool-api.ts`).
+ * One implementation means one wiring semantics — the same auto ids, the same
+ * argument validation, the same handle guards — so a program that works in one
+ * surface works in the other, and a validation fix lands in both.
+ *
+ * `__graphDslBuilder()` returns an instance-based builder: `node(type, props,
+ * {id})` registers a node and returns a ref whose `.output(slot?)` produces a
+ * wiring handle ({__handle, source, sourceHandle}); a handle passed as a
+ * property value becomes an edge immediately. `connect()` refuses ids the
+ * graph does not have, and a handle interpolated into a string throws instead
+ * of silently becoming "[object Object]".
+ */
+
+export const GRAPH_DSL_CORE_PRELUDE = `function __graphJsonOf(source) {
+  if (source && typeof source.toJSON === "function") return source.toJSON();
+  if (source && Array.isArray(source.nodes)) {
+    return { nodes: source.nodes, edges: source.edges || [] };
+  }
+  if (source && source.graph && Array.isArray(source.graph.nodes)) {
+    return { nodes: source.graph.nodes, edges: source.graph.edges || [] };
+  }
+  throw new Error(
+    "expected a graph builder, a {nodes, edges} graph, or a workflow " +
+    "record with a .graph"
+  );
+}
+function __graphDslBuilder() {
+  const nodes = [];
+  const edges = [];
+  const byId = Object.create(null);
+  const counters = Object.create(null);
+
+  const autoId = (hint) => {
+    const last = String(hint).split(".").pop() || "node";
+    const stem = last
+      .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+      .replace(/[^A-Za-z0-9_]/g, "_")
+      .toLowerCase();
+    let id = stem;
+    while (byId[id]) {
+      const n = (counters[stem] = (counters[stem] || 1) + 1);
+      id = stem + "_" + n;
+    }
+    return id;
+  };
+
+  const isHandle = (value) =>
+    value !== null && typeof value === "object" && value.__handle === true;
+
+  const makeHandle = (nodeId, slot) => {
+    if (slot !== undefined && (typeof slot !== "string" || slot.length === 0)) {
+      throw new Error("output(slot): slot must be a non-empty string");
+    }
+    const handle = {
+      __handle: true,
+      source: nodeId,
+      sourceHandle: slot || "output"
+    };
+    // Interpolating a handle into a string silently yields "[object
+    // Object]": no edge is created and the node gets that literal text.
+    // Refuse the conversion so the mistake surfaces where it was made.
+    handle[Symbol.toPrimitive] = function () {
+      throw new Error(
+        "Cannot use " +
+          nodeId +
+          ".output() inside a string. A handle wires an edge; it is not text. " +
+          "Pass it as the property value itself — { prompt: " +
+          nodeId +
+          ".output() } — and put any fixed instructions in a separate " +
+          "property (an Agent node's system property)."
+      );
+    };
+    return handle;
+  };
+
+  const addEdge = (source, sourceHandle, target, targetHandle) => {
+    const edge = {
+      id: "e" + (edges.length + 1) + "_" + source + "_" + target,
+      source: source,
+      sourceHandle: sourceHandle || "output",
+      target: target,
+      targetHandle: targetHandle
+    };
+    edges.push(edge);
+    return edge;
+  };
+
+  const wireProps = (targetId, props) => {
+    const plain = {};
+    for (const key of Object.keys(props || {})) {
+      const value = props[key];
+      if (isHandle(value)) {
+        addEdge(value.source, value.sourceHandle, targetId, key);
+      } else {
+        plain[key] = value;
+      }
+    }
+    return plain;
+  };
+
+  const makeRef = (raw) => {
+    const ref = {
+      id: raw.id,
+      type: raw.type,
+      properties: raw.properties,
+      output: (slot) => makeHandle(raw.id, slot),
+      set(props) {
+        Object.assign(raw.properties, wireProps(raw.id, props));
+        return ref;
+      }
+    };
+    byId[raw.id] = ref;
+    return ref;
+  };
+
+  const notFound = (id) =>
+    new Error(
+      "Node not found: " + id + ". Known: " + Object.keys(byId).join(", ")
+    );
+
+  const refId = (ref) => {
+    const id = typeof ref === "string" ? ref : ref && ref.id;
+    if (typeof id !== "string" || id.length === 0 || !byId[id]) {
+      throw notFound(typeof id === "string" && id.length > 0 ? id : String(ref));
+    }
+    return id;
+  };
+
+  const g = {
+    nodes: nodes,
+    edges: edges,
+    node(type, properties, opts) {
+      if (typeof type !== "string" || type.length === 0) {
+        throw new Error(
+          "node(type, properties): type must be a non-empty string"
+        );
+      }
+      if (
+        properties !== undefined &&
+        (properties === null ||
+          typeof properties !== "object" ||
+          Array.isArray(properties))
+      ) {
+        throw new Error("node(type, properties): properties must be an object");
+      }
+      const explicit =
+        opts && typeof opts.id === "string" && opts.id.length > 0
+          ? opts.id
+          : undefined;
+      if (explicit && byId[explicit]) {
+        throw new Error('Duplicate node id "' + explicit + '"');
+      }
+      const id = explicit || autoId(type);
+      const raw = { id: id, type: type, properties: {} };
+      nodes.push(raw);
+      const ref = makeRef(raw);
+      Object.assign(raw.properties, wireProps(id, properties));
+      return ref;
+    },
+    connect(source, sourceHandle, target, targetHandle) {
+      const sourceId = refId(source);
+      const targetId = refId(target);
+      if (typeof targetHandle !== "string" || targetHandle.length === 0) {
+        throw new Error(
+          "connect(source, sourceHandle, target, targetHandle): " +
+            "targetHandle must be a non-empty string"
+        );
+      }
+      return addEdge(sourceId, sourceHandle, targetId, targetHandle);
+    },
+    get(id) {
+      const found = byId[id];
+      if (!found) throw notFound(id);
+      return found;
+    },
+    /**
+     * Copy another graph (builder, {nodes, edges}, or workflow record) into
+     * this one. Ids that collide are remapped; returns { idMap, refs } where
+     * refs is keyed by the SOURCE id, so wiring into copied nodes never
+     * needs the remapped name.
+     */
+    copyFrom(source, opts) {
+      const src = __graphJsonOf(source);
+      const prefix = (opts && opts.prefix) || "";
+      const idMap = {};
+      const refs = {};
+      for (const n of src.nodes) {
+        const props = Object.assign(
+          {},
+          n.properties ||
+            (n.data && n.data.properties ? n.data.properties : n.data) ||
+            {}
+        );
+        let id = prefix + n.id;
+        if (byId[id]) id = autoId(id);
+        idMap[n.id] = id;
+        const raw = { id: id, type: n.type, properties: props };
+        nodes.push(raw);
+        refs[n.id] = makeRef(raw);
+      }
+      for (const e of src.edges || []) {
+        if (idMap[e.source] === undefined || idMap[e.target] === undefined) {
+          continue;
+        }
+        addEdge(
+          idMap[e.source],
+          e.sourceHandle || e.source_output,
+          idMap[e.target],
+          e.targetHandle || e.target_input
+        );
+      }
+      return { idMap: idMap, refs: refs };
+    },
+    toJSON() {
+      return {
+        nodes: nodes.map((n) => ({
+          id: n.id,
+          type: n.type,
+          properties: Object.assign({}, n.properties)
+        })),
+        edges: edges.map((e) => Object.assign({}, e))
+      };
+    }
+  };
+  return g;
+}
+`;

--- a/packages/agents/src/graph-dsl.ts
+++ b/packages/agents/src/graph-dsl.ts
@@ -12,81 +12,33 @@
 
 import type { GraphData, NodeDescriptor, Edge } from "@nodetool-ai/protocol";
 import { runInSandbox } from "./js-sandbox.js";
+import { GRAPH_DSL_CORE_PRELUDE } from "./graph-dsl-core.js";
 
 /** Wall-clock budget for a graph program. Pure graph building is fast. */
 export const GRAPH_DSL_TIMEOUT_MS = 10_000;
 
 /**
- * Guest-side prelude defining the DSL surface. `node()` registers a node and
- * returns a ref whose `.output(slot?)` produces a wiring handle; `graph()`
- * turns handle-valued top-level properties into edges (mirroring how
- * `workflow()` in @nodetool-ai/dsl derives edges from OutputHandle inputs).
- * All created nodes are included — an orphan node is a validation finding for
- * the planner to fix, not something to silently prune.
+ * Guest-side prelude defining the DSL surface: the shared graph DSL core
+ * (`graph-dsl-core.ts` — the same wiring, validation, and handle guards the
+ * CodeAct sandbox's `nodetool.graph()` uses) plus the planner's free-function
+ * form. `node()` registers a node on one implicit builder and returns a ref
+ * whose `.output(slot?)` produces a wiring handle; `graph()` collects the
+ * result (mirroring how `workflow()` in @nodetool-ai/dsl derives edges from
+ * OutputHandle inputs). All created nodes are included — an orphan node is a
+ * validation finding for the planner to fix, not something to silently prune.
  */
-const GRAPH_DSL_PRELUDE = `const __nodes = [];
-const __ids = Object.create(null);
-function __autoId(type) {
-  const last = String(type).split(".").pop() || "node";
-  const snake = last.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
-  const n = (__ids[snake] = (__ids[snake] || 0) + 1);
-  return n === 1 ? snake : snake + "_" + n;
-}
+const GRAPH_DSL_PRELUDE = `${GRAPH_DSL_CORE_PRELUDE}
+const __g = __graphDslBuilder();
 function node(type, properties, id) {
-  if (typeof type !== "string" || type.length === 0) {
-    throw new Error("node(type, properties): type must be a non-empty string");
-  }
-  if (properties !== undefined && (properties === null || typeof properties !== "object" || Array.isArray(properties))) {
-    throw new Error("node(type, properties): properties must be an object");
-  }
-  const nodeId = typeof id === "string" && id.length > 0 ? id : __autoId(type);
-  __nodes.push({ id: nodeId, type: type, properties: properties || {} });
-  return {
-    id: nodeId,
-    output: function (slot) {
-      if (slot !== undefined && (typeof slot !== "string" || slot.length === 0)) {
-        throw new Error("output(slot): slot must be a non-empty string");
-      }
-      var handle = {
-        __handle: true,
-        source: nodeId,
-        sourceHandle: slot || "output"
-      };
-      // Interpolating a handle into a string silently yields "[object
-      // Object]": no edge is created and the node gets that literal text.
-      // Refuse the conversion so the mistake comes back as a submit_graph
-      // error instead of a broken graph that validates clean.
-      handle[Symbol.toPrimitive] = function () {
-        throw new Error(
-          "Cannot use " +
-            nodeId +
-            ".output() inside a string. A handle wires an edge; it is not text. " +
-            "Pass it as the property value itself — { prompt: " +
-            nodeId +
-            ".output() } — and put any fixed instructions in a separate " +
-            "property (an Agent node's system property)."
-        );
-      };
-      return handle;
-    }
-  };
+  return __g.node(
+    type,
+    properties,
+    typeof id === "string" && id.length > 0 ? { id: id } : undefined
+  );
 }
 function graph() {
-  const nodes = [];
-  const edges = [];
-  for (const n of __nodes) {
-    const data = {};
-    for (const key in n.properties) {
-      const v = n.properties[key];
-      if (v && typeof v === "object" && v.__handle === true) {
-        edges.push({ source: v.source, sourceHandle: v.sourceHandle, target: n.id, targetHandle: key });
-      } else {
-        data[key] = v;
-      }
-    }
-    nodes.push({ id: n.id, type: n.type, properties: data });
-  }
-  return { __graph: true, nodes: nodes, edges: edges };
+  const j = __g.toJSON();
+  return { __graph: true, nodes: j.nodes, edges: j.edges };
 }
 `;
 

--- a/packages/agents/tests/graph-dsl.test.ts
+++ b/packages/agents/tests/graph-dsl.test.ts
@@ -78,6 +78,26 @@ describe("evaluateGraphDsl", () => {
     expect(graph!.nodes).toHaveLength(3);
   });
 
+  it("refuses a handle interpolated into a string", async () => {
+    const { graph, error } = await evaluateGraphDsl(`
+      const input = node("nodetool.input.StringInput", { name: "prompt" });
+      node("nodetool.agents.Agent", { prompt: "Summarize: " + input.output() });
+      return graph();
+    `);
+    expect(graph).toBeUndefined();
+    expect(error).toContain("inside a string");
+  });
+
+  it("refuses a duplicate explicit id", async () => {
+    const { graph, error } = await evaluateGraphDsl(`
+      node("nodetool.image.TextToImage", { prompt: "a" }, "hero");
+      node("nodetool.image.TextToImage", { prompt: "b" }, "hero");
+      return graph();
+    `);
+    expect(graph).toBeUndefined();
+    expect(error).toContain('Duplicate node id "hero"');
+  });
+
   it("reports syntax errors as error text", async () => {
     const { graph, error } = await evaluateGraphDsl(`const x = ;`);
     expect(graph).toBeUndefined();

--- a/packages/agents/tests/nodetool-api.test.ts
+++ b/packages/agents/tests/nodetool-api.test.ts
@@ -321,6 +321,37 @@ describe("nodetool object model", () => {
     });
   });
 
+  it("validates wiring as the graph is built (shared DSL core)", async () => {
+    const { executeTool } = createFakeRouter();
+    const session = makeSession(WORKFLOW_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `const g = nodetool.graph();
+       const inp = g.node("nodetool.input.StringInput", { name: "prompt" });
+       const errors = {};
+       try { g.node("nodetool.agents.Agent", { prompt: "Use " + inp.output() }); }
+       catch (e) { errors.interpolated = e.message; }
+       try { g.connect(inp, "output", "no_such_node", "value"); }
+       catch (e) { errors.unknownTarget = e.message; }
+       try { g.node(42, {}); }
+       catch (e) { errors.badType = e.message; }
+       const agent = g.node("nodetool.agents.Agent", {});
+       return { errors, ids: g.nodes.map((n) => n.id), agentId: agent.id };`
+    );
+    expect(obs.ok).toBe(true);
+    const r = obs.result as {
+      errors: Record<string, string>;
+      ids: string[];
+      agentId: string;
+    };
+    expect(r.errors.interpolated).toContain("inside a string");
+    expect(r.errors.unknownTarget).toContain("Node not found: no_such_node");
+    expect(r.errors.badType).toContain("type must be a non-empty string");
+    // Auto ids follow the graph DSL's snake_case scheme.
+    expect(r.ids).toEqual(["string_input", "agent"]);
+    expect(r.agentId).toBe("agent");
+  });
+
   it("copies a saved workflow's graph into a builder with id remapping", async () => {
     const { executeTool } = createFakeRouter();
     const session = makeSession(WORKFLOW_TOOLS, executeTool);


### PR DESCRIPTION
## What

`nodetool.graph()` in the CodeAct sandbox and the GraphPlanner's `submit_graph` DSL were two hand-rolled graph-building implementations with divergent semantics: incompatible handle shapes (`__ntOutput/node/slot` vs `__handle/source/sourceHandle`), different auto-id schemes (`stringinput_1` vs `string_input`), and the sandbox builder missing the DSL's guards. This extracts one guest-side core — `packages/agents/src/graph-dsl-core.ts` (`__graphDslBuilder`) — and rebuilds both surfaces on it, so a wiring fix lands in both and the two DSLs cannot drift.

## Validation the sandbox builder gains

- **Handle-in-string guard**: interpolating `ref.output()` into a string used to silently wire nothing and leave `"[object Object]"` in a property — a broken graph that only failed downstream. It now throws at the point of the mistake (`Symbol.toPrimitive` guard, previously planner-only).
- **`connect()` id checks**: connecting to an id the graph does not have now throws naming the known ids, instead of producing a dangling edge caught only by `validate_workflow`.
- **`node(type, props)` argument validation** and a required non-empty `targetHandle` on `connect()`.
- **Snake_case auto ids** (`text_to_image`, `text_to_image_2`) — the planner DSL's readable scheme replaces the builder's `texttoimage_2`.

The planner DSL gains the duplicate-explicit-id check the builder already had. The sandbox layer keeps only what needs the toolbelt: `validate()`, `save()`, and the save-and-run `run()`.

## Succinctness

The planner's `GRAPH_DSL_PRELUDE` shrinks to a thin wrapper (`node()`/`graph()` over one core builder), and `nodetool-api.ts` drops its ~150-line duplicate builder. Sandbox refs and planner refs now share one shape (both carry `.set()`, `.properties`, interchangeable handles), and the graph-namespace prompt section documents the new build-time checks in two lines.

## Tests

- `tests/graph-dsl.test.ts`: +2 (interpolated-handle refusal, duplicate explicit id); existing id-scheme and wiring tests pass unchanged.
- `tests/nodetool-api.test.ts`: +1 (build-time wiring validation: interpolation guard, unknown `connect()` target, bad type, snake_case ids).
- Full `packages/agents` suite: 150 files, 2132 passed. `npm run lint` clean; `npm run typecheck` clean for web and electron (mobile has no dependency tree in this container — pre-existing, unrelated).

Also syncs the agents package's stale `package-lock.json` entry with its `package.json` (`@napi-rs/canvas`, `@nodetool-ai/image-editor`), which was breaking clean installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJiThBaVnDxz4ipkQuGdd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJiThBaVnDxz4ipkQuGdd7)_