### PR TITLE
fix(codeact): suspend the action clock while a permission prompt is open

### DIFF
--- a/docs/codeact-design.md
+++ b/docs/codeact-design.md
@@ -185,6 +185,14 @@ materialization all stay where they are. `state` persists across the turn's
 actions; there is no `finish()` — a plain assistant message ends the turn, and
 the prompt says so (`variant: "chat"` of `buildCodeActSystemPrompt`).
 
+A gated tool call parks the running program on the user's answer, so the turn
+carries a **sandbox clock** (`createSandboxClock`): the runner suspends it for
+the length of every tool- and plan-approval round trip, and the action resumes
+with the budget it had when it asked. Without it the action's wall clock ran
+through the prompt and killed the program mid-wait — the dialog was still on
+screen, and answering it resolved nothing. Tests:
+`packages/websocket/tests/chat-codeact-approval.test.ts`.
+
 ## Workflow graph editing: the JS object model
 
 When the belt carries the `ui_*` workflow document tools, code actions get an

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -81,6 +81,7 @@ column by `resolveSandboxLimits`:
 | Limit | Default | Configured by | Ceiling |
 |-------|---------|---------------|---------|
 | Execution time | `timeoutMs` (30 s) | `setInterruptHandler` (CPU budget) + wall-clock race | — |
+| Suspended time | `DEFAULT_SUSPEND_ALLOWANCE_MS` (30 min) | `RunSandboxOptions.suspendAllowanceMs`, only with a `clock` | — |
 | Guest heap | `GUEST_MEMORY_LIMIT` = 64 MB | `runtime.setMemoryLimit` (`limits.memoryLimitBytes`) | 512 MB |
 | Call stack | `GUEST_STACK_LIMIT` = 512 KB | `runtime.setMaxStackSize` (`limits.stackLimitBytes`) | 8 MB |
 | Fetch calls | `MAX_FETCH_CALLS` = 20 per run | counter inside bridge (`limits.maxFetchCalls`) | 100 |
@@ -151,6 +152,18 @@ host-bridged version.
 **State sync-back**: object-typed globals are deep-replaced on the host after
 the guest runs, so `CodeNode`'s `state` object persists across invocations.
 Primitive globals pass by value (no sync).
+
+**Suspending the clock** (`createSandboxClock`, `RunSandboxOptions.clock`): the
+timeout bounds *guest execution*, and a program waiting on a permission prompt
+is not executing — it is waiting on a person. Charged to the same budget, the
+wait kills the program that asked, and the answer then resolves nothing. A
+caller that owns such a wait wraps it in `clock.suspend()`; the suspended time
+is added back to `timeoutMs`, so the program resumes with the budget it had.
+Suspensions nest, and the engine's own abort moves out to
+`timeoutMs + suspendAllowanceMs` as the backstop for a prompt nobody answers.
+The interrupt handler still cuts a runaway loop at exactly `timeoutMs` of
+running time. The websocket chat runner owns one clock per turn and suspends it
+around every tool- and plan-approval round trip.
 
 **Known QuickJS limitations**:
 - `url.searchParams.set(...)` doesn't propagate back to the parent URL. Build

--- a/packages/agents/src/codeact/chat-codeact.ts
+++ b/packages/agents/src/codeact/chat-codeact.ts
@@ -18,7 +18,7 @@
  */
 
 import type { ProcessingContext } from "@nodetool-ai/runtime";
-import { runInSandbox } from "../js-sandbox.js";
+import { runInSandbox, type SandboxClock } from "../js-sandbox.js";
 import { stripImagePayload } from "../tools/image-injection.js";
 import { searchTools } from "../tools/tool-search.js";
 import { truncateToolResult } from "../constants.js";
@@ -79,6 +79,13 @@ export interface ChatCodeActSessionOptions {
   maxToolCallsPerAction?: number;
   /** Tools documented in full; defaults to {@link CODEACT_RESIDENT_TOOL_NAMES}. */
   residentToolNames?: Iterable<string>;
+  /**
+   * The action's wall clock, which the host stops while a bridged call waits on
+   * the user (a permission prompt). Without it, the time a person spends
+   * deciding is charged to the action budget and the program is killed
+   * mid-wait; the answer then resolves nothing.
+   */
+  clock?: SandboxClock;
   /** Observability hook — fires before each bridged tool executes. */
   onToolCall?: (record: { name: string; args: Record<string, unknown> }) => void;
 }
@@ -327,6 +334,7 @@ export function createChatCodeActSession(
       code: `${prelude}\n${code}`,
       timeoutMs: options.actionTimeoutMs ?? DEFAULT_CODEACT_ACTION_TIMEOUT_MS,
       signal: options.signal,
+      clock: options.clock,
       limits: { maxFetchCalls: 0 },
       globals: {
         __callTool: callTool,

--- a/packages/agents/src/codeact/codeact-executor.ts
+++ b/packages/agents/src/codeact/codeact-executor.ts
@@ -40,7 +40,7 @@ import {
 import type { Step, Task } from "../types.js";
 import { Tool } from "../tools/base-tool.js";
 import { getMemoryTools } from "../tools/memory-tools.js";
-import { runInSandbox } from "../js-sandbox.js";
+import { runInSandbox, type SandboxClock } from "../js-sandbox.js";
 import { truncateToolResult } from "../constants.js";
 import {
   formatViolations,
@@ -244,6 +244,13 @@ export interface CodeActExecutorOptions {
   /** Tool calls one action may consume. Default 50. */
   maxToolCallsPerAction?: number;
   /**
+   * The action's wall clock, which the host stops while a bridged call waits on
+   * the user (a permission prompt). Without it, the time a person spends
+   * deciding is charged to the action budget and the program is killed
+   * mid-wait; the answer then resolves nothing.
+   */
+  clock?: SandboxClock;
+  /**
    * Tools documented in full in the prompt. Defaults to
    * {@link CODEACT_RESIDENT_TOOL_NAMES}; the rest of the toolbelt is
    * deferred behind `searchTools()` once the belt exceeds
@@ -278,6 +285,7 @@ export class CodeActExecutor {
   private readonly upstreamMemoryKeys: string[];
   private readonly signal?: AbortSignal;
   private readonly actionTimeoutMs?: number;
+  private readonly clock?: SandboxClock;
   private readonly maxToolCallsPerAction?: number;
   private readonly resultSchema: Record<string, unknown> | null;
   private readonly residentTools: Tool[];
@@ -303,6 +311,7 @@ export class CodeActExecutor {
     this.upstreamMemoryKeys = opts.upstreamMemoryKeys ?? [];
     this.signal = opts.signal;
     this.actionTimeoutMs = opts.actionTimeoutMs;
+    this.clock = opts.clock;
     this.maxToolCallsPerAction = opts.maxToolCallsPerAction;
 
     // Memory tools ride in the toolbelt as functions like everything else.
@@ -534,6 +543,7 @@ export class CodeActExecutor {
         context: this.context,
         timeoutMs: this.actionTimeoutMs ?? DEFAULT_CODEACT_ACTION_TIMEOUT_MS,
         signal: this.signal,
+        clock: this.clock,
         globals: {
           ...bridge.globals,
           __finish: finishBridge,

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -311,12 +311,14 @@ export {
   buildSandbox,
   runInSandbox,
   serializeResult,
-  resolveSandboxLimits
+  resolveSandboxLimits,
+  createSandboxClock
 } from "./js-sandbox.js";
 export {
   DEFAULT_TIMEOUT_MS,
   MAX_OUTPUT_SIZE,
   MAX_LOOP_ITERATIONS,
+  DEFAULT_SUSPEND_ALLOWANCE_MS,
   EXPOSED_BRIDGE_NAMES,
   GUEST_HELPER_NAMES,
   RESERVED_SANDBOX_NAMES
@@ -324,6 +326,7 @@ export {
 export type {
   RunSandboxOptions,
   RunSandboxResult,
+  SandboxClock,
   SandboxLimits,
   ResolvedSandboxLimits,
   SandboxProgressCallback,

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -74,6 +74,13 @@ export const MAX_DATA_INPUT_CHARS = 5 * 1024 * 1024;
 /** Byte ceiling for binary `data.*` inputs (xlsx workbooks, zip archives). */
 export const MAX_DATA_INPUT_BYTES = 10 * 1024 * 1024;
 
+/**
+ * Headroom added to the engine's own wall-clock abort when a {@link SandboxClock}
+ * is in play. The clock only stops the *guest's* budget; this bounds how long a
+ * run may stay suspended in total, so a prompt nobody ever answers still ends.
+ */
+export const DEFAULT_SUSPEND_ALLOWANCE_MS = 30 * 60 * 1000;
+
 /** Total uncompressed size `data.unzip` will inflate before refusing. */
 export const MAX_UNZIP_TOTAL_BYTES = 50 * 1024 * 1024;
 /** Default number of `data.selectHtml` matches returned. */
@@ -1915,6 +1922,49 @@ ${code}
 })();`;
 }
 
+/**
+ * A run's wall clock, which the host can stop while the guest waits on
+ * something outside its own control — above all a permission prompt, which is
+ * bounded only by how long a person takes to answer it.
+ *
+ * The timeout exists to bound *guest execution*: a runaway loop, a program that
+ * never returns. Time a program spends parked on a host round-trip it cannot
+ * hurry is not that, and charging it to the same budget kills the program
+ * mid-wait — the answer then resolves nothing, because the sandbox that asked
+ * is already gone.
+ *
+ * `suspend()` returns the matching resume; calls nest, and the clock restarts
+ * only when the last one resumes.
+ */
+export interface SandboxClock {
+  /** Stop the guest's budget until the returned function is called. */
+  suspend(): () => void;
+  /** Milliseconds suspended so far, including a suspension still open. */
+  suspendedMs(): number;
+}
+
+export function createSandboxClock(): SandboxClock {
+  let depth = 0;
+  let openedAt = 0;
+  let accumulated = 0;
+  return {
+    suspend() {
+      if (depth === 0) openedAt = Date.now();
+      depth++;
+      let resumed = false;
+      return () => {
+        if (resumed) return;
+        resumed = true;
+        depth--;
+        if (depth === 0) accumulated += Date.now() - openedAt;
+      };
+    },
+    suspendedMs() {
+      return depth > 0 ? accumulated + (Date.now() - openedAt) : accumulated;
+    }
+  };
+}
+
 export interface RunSandboxOptions {
   /** The JavaScript code to execute. */
   code: string;
@@ -1946,6 +1996,19 @@ export interface RunSandboxOptions {
    * run). Without a callback the guest function is a no-op.
    */
   onProgress?: SandboxProgressCallback;
+  /**
+   * Wall clock the host can stop while the guest waits on a round-trip it
+   * cannot hurry (a permission prompt). Time suspended is added back to
+   * {@link timeoutMs}, so the guest keeps its full execution budget across the
+   * wait. Without a clock the timeout is plain wall-clock, as before.
+   */
+  clock?: SandboxClock;
+  /**
+   * Total suspension a run may accumulate before the engine aborts it anyway.
+   * Only consulted when {@link clock} is set. Defaults to
+   * {@link DEFAULT_SUSPEND_ALLOWANCE_MS}.
+   */
+  suspendAllowanceMs?: number;
 }
 
 export interface RunSandboxResult {
@@ -2039,7 +2102,9 @@ export async function runInSandbox(
     globals,
     signal,
     limits,
-    onProgress
+    onProgress,
+    clock,
+    suspendAllowanceMs = DEFAULT_SUSPEND_ALLOWANCE_MS
   } = options;
   const resolvedLimits = resolveSandboxLimits(limits);
 
@@ -2085,9 +2150,13 @@ export async function runInSandbox(
         // mechanism that can stop a spinning loop. Compose cancellation with
         // the library's own wall-clock deadline (it installed one before
         // calling us; replacing it means re-implementing the deadline here).
+        // Suspended time is added back, so a program parked on a permission
+        // prompt resumes with the budget it had when it asked.
         const deadline = Date.now() + timeoutMs;
         ctx.runtime.setInterruptHandler(
-          () => signal?.aborted === true || Date.now() > deadline
+          () =>
+            signal?.aborted === true ||
+            Date.now() > deadline + (clock?.suspendedMs() ?? 0)
         );
 
         const bridges: Record<string, unknown> = {};
@@ -2348,7 +2417,13 @@ export default true;`,
         return userResult;
       },
       {
-        executionTimeout: timeoutMs,
+        // The engine's own abort is a plain `setTimeout` armed when evaluation
+        // starts — it cannot be paused. With a clock in play it becomes the
+        // backstop for a run that stays suspended forever, while the interrupt
+        // handler above keeps the exact bound on guest execution.
+        executionTimeout: clock
+          ? timeoutMs + Math.max(0, suspendAllowanceMs)
+          : timeoutMs,
         memoryLimit: resolvedLimits.memoryLimitBytes,
         maxStackSize: resolvedLimits.stackLimitBytes
       }

--- a/packages/agents/tests/chat-codeact.test.ts
+++ b/packages/agents/tests/chat-codeact.test.ts
@@ -10,6 +10,7 @@ import {
   type ChatCodeActToolCall
 } from "../src/codeact/chat-codeact.js";
 import { hasGraphModelTools } from "../src/codeact/graph-model.js";
+import { createSandboxClock } from "../src/js-sandbox.js";
 import { createMockContext } from "./_helpers/mock-context.js";
 
 const objectSchema = (props: Record<string, unknown>) => ({
@@ -507,5 +508,86 @@ describe("hasGraphModelTools", () => {
     ).toBe(true);
     expect(hasGraphModelTools(["ui_get_graph", "ui_add_node"])).toBe(false);
     expect(hasGraphModelTools([])).toBe(false);
+  });
+});
+
+describe("permission prompts suspend the action clock", () => {
+  const SLOW_TOOL = [
+    { name: "write_file", description: "write", inputSchema: objectSchema({}) }
+  ];
+
+  it("kills the action when a slow gated call is charged to the budget", async () => {
+    const session = createChatCodeActSession({
+      tools: SLOW_TOOL,
+      actionTimeoutMs: 1000,
+      executeTool: async () => {
+        await new Promise((r) => setTimeout(r, 2500));
+        return JSON.stringify({ ok: true });
+      }
+    });
+    const obs = await runAction(session, `return await tools.write_file({});`);
+    expect(obs.ok).toBe(false);
+    expect(obs.error).toContain("ExecutionTimeout");
+  }, 20_000);
+
+  it("resumes the program when the wait runs on a suspended clock", async () => {
+    const clock = createSandboxClock();
+    const session = createChatCodeActSession({
+      tools: SLOW_TOOL,
+      actionTimeoutMs: 1000,
+      clock,
+      executeTool: async () => {
+        // Stands in for the user staring at the approval dialog.
+        const resume = clock.suspend();
+        try {
+          await new Promise((r) => setTimeout(r, 2500));
+          return JSON.stringify({ ok: true });
+        } finally {
+          resume();
+        }
+      }
+    });
+    const obs = await runAction(
+      session,
+      `await tools.write_file({});\nreturn "resumed";`
+    );
+    expect(obs.ok).toBe(true);
+    expect(obs.result).toBe("resumed");
+  }, 20_000);
+
+  it("still stops a runaway program that never waits on the user", async () => {
+    const clock = createSandboxClock();
+    const session = createChatCodeActSession({
+      tools: SLOW_TOOL,
+      actionTimeoutMs: 1000,
+      clock,
+      executeTool: async () => JSON.stringify({ ok: true })
+    });
+    const obs = await runAction(session, `while (true) {}`);
+    expect(obs.ok).toBe(false);
+  }, 20_000);
+});
+
+describe("createSandboxClock", () => {
+  it("counts only suspended time, and nests", async () => {
+    const clock = createSandboxClock();
+    expect(clock.suspendedMs()).toBe(0);
+    const outer = clock.suspend();
+    const inner = clock.suspend();
+    await new Promise((r) => setTimeout(r, 60));
+    inner();
+    expect(clock.suspendedMs()).toBeGreaterThanOrEqual(50);
+    outer();
+    const settled = clock.suspendedMs();
+    await new Promise((r) => setTimeout(r, 40));
+    expect(clock.suspendedMs()).toBe(settled);
+  });
+
+  it("ignores a resume called twice", () => {
+    const clock = createSandboxClock();
+    const resume = clock.suspend();
+    resume();
+    resume();
+    expect(clock.suspendedMs()).toBeGreaterThanOrEqual(0);
   });
 });

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -145,6 +145,8 @@ import {
 } from "@nodetool-ai/agents";
 import {
   createChatCodeActSession,
+  createSandboxClock,
+  type SandboxClock,
   CODEACT_RESIDENT_TOOL_NAMES,
   EXECUTE_CODE_TOOL_NAME,
   type ChatCodeActSession,
@@ -4885,10 +4887,19 @@ export class UnifiedWebSocketRunner {
    */
   private attachPlanApproval(
     context: RuntimeProcessingContext,
-    threadId: string | null
+    threadId: string | null,
+    clock?: SandboxClock
   ): void {
-    const request: RequestPlanApproval = (plan) =>
-      this.requestPlanApproval(threadId, plan);
+    // Same reasoning as the tool-approval gate: a plan presented from inside a
+    // code action parks the guest program, and the wait belongs to the user.
+    const request: RequestPlanApproval = async (plan) => {
+      const resume = clock?.suspend();
+      try {
+        return await this.requestPlanApproval(threadId, plan);
+      } finally {
+        resume?.();
+      }
+    };
     context.set(PLAN_APPROVAL_CONTEXT_KEY, request);
   }
 
@@ -5321,9 +5332,22 @@ export class UnifiedWebSocketRunner {
     const sessionAllow =
       this.chatSessionAllow.get(threadId) ?? new Set<string>();
     this.chatSessionAllow.set(threadId, sessionAllow);
-    const requestApproval = (
+    // A gated call inside a code action parks the guest program until the user
+    // answers. That wait is the user's, not the program's: charged to the
+    // action's wall clock it kills the very program that asked, and the answer
+    // then resolves nothing. The clock stops for the length of the prompt and
+    // the action resumes with the budget it had.
+    const codeactClock = createSandboxClock();
+    const requestApproval = async (
       request: ApprovalRequest
-    ): Promise<ApprovalDecision> => this.requestToolApproval(threadId, request);
+    ): Promise<ApprovalDecision> => {
+      const resume = codeactClock.suspend();
+      try {
+        return await this.requestToolApproval(threadId, request);
+      } finally {
+        resume();
+      }
+    };
     const baseTools = gateTools(dedupedToolbelt, {
       mode: permissionMode,
       sessionAllow,
@@ -5468,7 +5492,7 @@ export class UnifiedWebSocketRunner {
     });
     // Any agent planning inside this turn (e.g. via run_node spawning an
     // Agent node in plan mode) pauses for user plan approval.
-    this.attachPlanApproval(ctx, threadId || null);
+    this.attachPlanApproval(ctx, threadId || null, codeactClock);
     // Stamp the turn's own selection so harness-launching tools (build_app)
     // inherit this chat's provider/model when the call doesn't name one.
     ctx.set(ACTIVE_MODEL_CONTEXT_KEY, {
@@ -5508,7 +5532,8 @@ export class UnifiedWebSocketRunner {
           ...RESIDENT_TOOL_NAMES
         ],
         context: ctx,
-        signal
+        signal,
+        clock: codeactClock
       });
       providerToolSchemas.push(codeactSession.providerTool);
       // `view_image` stays a direct provider tool: it is the one channel that

--- a/packages/websocket/tests/chat-codeact-approval.test.ts
+++ b/packages/websocket/tests/chat-codeact-approval.test.ts
@@ -1,0 +1,205 @@
+/**
+ * A gated tool called from inside a CodeAct action asks the user, and the
+ * program that asked resumes with the answer.
+ *
+ * The chat turn's action space is sandboxed JavaScript, so a permission prompt
+ * is raised from inside a running program. The prompt has to reach the client
+ * while that program sits parked, and the program has to pick up where it left
+ * off once the answer comes back — otherwise the dialog resolves nothing.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { pack, unpack } from "msgpackr";
+import { initTestDb } from "@nodetool-ai/models";
+import { BaseProvider } from "@nodetool-ai/runtime";
+import {
+  UnifiedWebSocketRunner,
+  type WebSocketConnection,
+  type WebSocketReceiveFrame
+} from "../src/unified-websocket-runner.js";
+
+class MockWS implements WebSocketConnection {
+  clientState: "connected" | "disconnected" = "connected";
+  applicationState: "connected" | "disconnected" = "connected";
+  sentBytes: Uint8Array[] = [];
+  sentText: string[] = [];
+  private pending: Array<WebSocketReceiveFrame> = [];
+  private waiting: Array<(f: WebSocketReceiveFrame) => void> = [];
+  async accept() {}
+  push(frame: WebSocketReceiveFrame) {
+    const next = this.waiting.shift();
+    if (next) next(frame);
+    else this.pending.push(frame);
+  }
+  async receive(): Promise<WebSocketReceiveFrame> {
+    const queued = this.pending.shift();
+    if (queued) return queued;
+    return new Promise((resolve) => this.waiting.push(resolve));
+  }
+  async sendBytes(data: Uint8Array) {
+    this.sentBytes.push(data);
+  }
+  async sendText(data: string) {
+    this.sentText.push(data);
+  }
+  async close() {
+    this.clientState = "disconnected";
+    this.applicationState = "disconnected";
+  }
+}
+
+const noop = () => ({
+  async process() {
+    return {};
+  }
+});
+
+const sentMsgs = (ws: MockWS): Record<string, unknown>[] =>
+  ws.sentBytes.map((b) => unpack(b) as Record<string, unknown>);
+
+/** Yields one `execute_code` call on the first round, then plain text. */
+function codeActProvider(code: string) {
+  let round = 0;
+  return async () =>
+    ({
+      provider: "mock",
+      async *generateMessages() {},
+      async *generateMessagesTraced() {
+        if (round++ === 0) {
+          yield { id: "tc1", name: "execute_code", args: { title: "t", code } };
+        } else {
+          yield { type: "chunk", content: "done", done: true };
+        }
+      },
+      async generateMessageTraced() {
+        return {};
+      },
+      generateMessage: vi.fn(),
+      hasToolSupport: async () => true,
+      getAvailableLanguageModels: async () => [],
+      getAvailableImageModels: async () => [],
+      getAvailableVideoModels: async () => [],
+      getAvailableTTSModels: async () => [],
+      getAvailableASRModels: async () => [],
+      getAvailableEmbeddingModels: async () => [],
+      getContainerEnv: () => ({}),
+      generateLoop: BaseProvider.prototype.generateLoop
+    }) as never;
+}
+
+/** Poll until `find` returns something, or give up. */
+async function waitFor<T>(
+  find: () => T | undefined,
+  timeoutMs = 20_000
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const hit = find();
+    if (hit !== undefined) return hit;
+    if (Date.now() > deadline) throw new Error("timed out waiting");
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+describe("codeact permission prompts", () => {
+  it("asks the user from inside a code action and resumes the program", async () => {
+    initTestDb();
+    const ws = new MockWS();
+    const runner = new UnifiedWebSocketRunner({
+      resolveExecutor: noop,
+      resolveProvider: codeActProvider(
+        `const r = await tools.write_file({ file_path: "note.txt", content: "hi" });\n` +
+          `return { wrote: String(r) };`
+      )
+    });
+    await runner.connect(ws);
+    void runner.receiveMessages();
+    void runner.handleCommand({
+      command: "chat_message",
+      data: {
+        thread_id: "t-approval",
+        content: "write a note",
+        provider: "mock",
+        model: "m",
+        permission_mode: "default"
+      }
+    });
+
+    const request = await waitFor(() =>
+      sentMsgs(ws).find((m) => m.type === "tool_approval_request")
+    );
+    expect(request).toMatchObject({
+      thread_id: "t-approval",
+      tool_name: "write_file",
+      category: "write"
+    });
+
+    // Nothing has resumed yet: the program is parked on the answer.
+    expect(
+      sentMsgs(ws).some((m) => m.type === "message" && m.role === "tool")
+    ).toBe(false);
+
+    ws.push({
+      type: "websocket.receive",
+      bytes: pack({
+        type: "tool_approval_response",
+        approval_id: request.approval_id,
+        decision: "allow"
+      })
+    } as WebSocketReceiveFrame);
+
+    const observation = await waitFor(() =>
+      sentMsgs(ws).find((m) => m.type === "message" && m.role === "tool")
+    );
+    // The action returned its own value, so the guest picked up after the wait.
+    expect(String(observation.content)).toContain('"wrote"');
+
+    await runner.disconnect();
+  }, 60_000);
+
+  it("reports a denial to the program as a thrown tool error", async () => {
+    initTestDb();
+    const ws = new MockWS();
+    const runner = new UnifiedWebSocketRunner({
+      resolveExecutor: noop,
+      resolveProvider: codeActProvider(
+        `try {\n` +
+          `  await tools.write_file({ file_path: "note.txt", content: "hi" });\n` +
+          `  return "wrote";\n` +
+          `} catch (e) {\n` +
+          `  return { denied: e.message };\n` +
+          `}`
+      )
+    });
+    await runner.connect(ws);
+    void runner.receiveMessages();
+    void runner.handleCommand({
+      command: "chat_message",
+      data: {
+        thread_id: "t-deny",
+        content: "write a note",
+        provider: "mock",
+        model: "m",
+        permission_mode: "default"
+      }
+    });
+
+    const request = await waitFor(() =>
+      sentMsgs(ws).find((m) => m.type === "tool_approval_request")
+    );
+    ws.push({
+      type: "websocket.receive",
+      bytes: pack({
+        type: "tool_approval_response",
+        approval_id: request.approval_id,
+        decision: "deny"
+      })
+    } as WebSocketReceiveFrame);
+
+    const observation = await waitFor(() =>
+      sentMsgs(ws).find((m) => m.type === "message" && m.role === "tool")
+    );
+    expect(String(observation.content)).toContain("denied");
+
+    await runner.disconnect();
+  }, 60_000);
+});


### PR DESCRIPTION
A chat turn acts by running sandboxed JavaScript, so a gated tool call raises its permission prompt from *inside* a running program. The program parked on the answer correctly — but the action's wall clock kept running through the wait. The engine aborted the action with `ExecutionTimeout` while the dialog was still on screen, and the user's answer then resolved nothing.

Reproduced against the sandbox directly: with a 3s action budget and a 6s wait on the user, the action dies at 3.06s and never resumes.

```
OBS: {"ok":false,"toolCalls":1,"error":"ExecutionTimeout: The script execution has exceeded the maximum allowed time limit."} elapsed 3061
```

## The fix

The timeout exists to bound *guest execution* — a runaway loop, a program that never returns. Time a program spends waiting on a person is not that.

`createSandboxClock()` gives the host a clock it can stop. Suspended time is added back to `timeoutMs`, so the program resumes with the budget it had when it asked:

- suspensions nest, and the clock restarts only when the last one resumes;
- the engine's own abort (a plain `setTimeout` that cannot be paused) moves out to `timeoutMs + suspendAllowanceMs`, default 30 min — the backstop for a prompt nobody ever answers;
- the QuickJS interrupt handler still cuts a runaway loop at exactly `timeoutMs` of *running* time, so the CPU bound is unchanged.

Without a clock, `runInSandbox` behaves exactly as before.

The websocket chat runner owns one clock per turn and suspends it around every tool-approval and plan-approval round trip, so both gates behave the same way. `CodeActExecutor` takes the same option, so a host wiring a gate into the step loop gets it too.

## Changes

- `packages/agents/src/js-sandbox.ts` — `SandboxClock` / `createSandboxClock`, `RunSandboxOptions.clock` + `suspendAllowanceMs`, suspended time folded into the interrupt deadline and the engine's abort.
- `packages/agents/src/codeact/chat-codeact.ts`, `codeact-executor.ts` — forward the clock into the sandbox.
- `packages/websocket/src/unified-websocket-runner.ts` — one clock per chat turn, suspended around `requestToolApproval` and the plan-approval gate.
- Docs: `packages/agents/CLAUDE.md` (sandbox limits + a section on suspending the clock), `docs/codeact-design.md` (chat turns).

## Tests

New `packages/websocket/tests/chat-codeact-approval.test.ts` drives the real runner end to end: the prompt reaches the client from inside a code action, nothing resumes until it is answered, an allow resumes the program with its own return value, and a deny reaches the guest as a thrown tool error.

`packages/agents/tests/chat-codeact.test.ts` adds the sandbox half — the action dies when a slow gated call is charged to the budget, survives when the same wait runs on a suspended clock, and a runaway loop that never waits on the user is still stopped — plus unit coverage of the clock's nesting and double-resume.

Full `packages/agents` (2134) and `packages/websocket` (2241) suites pass, along with `npm run lint` and web/electron typecheck. (Mobile typecheck and the `packages/agents` build need deps this sandbox could not install — `mobile/node_modules` is absent and `@types/diff` was missing; both are pre-existing environment gaps, not from this diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5kWyTT5dpx3vREPwcbbe3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5kWyTT5dpx3vREPwcbbe3)_