### PR TITLE
ci: stop cancelled Ring 1 runs from failing the Fly deploy

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -104,7 +104,12 @@ F2 wires this table into the actual gates:
   workflows' conclusion on the triggering commit before `deploy` runs —
   whichever of the two finishes second is the run that actually reaches
   `deploy` (the other is superseded by `fly-deploy`'s existing
-  `cancel-in-progress` concurrency group).
+  `cancel-in-progress` concurrency group). Because that gate reads a
+  per-commit conclusion, `user-journeys.yml` does not cancel superseded runs
+  on `main` — a run cancelled by the next merge would read as "Ring 1 failed"
+  and block the release. And when the gate does see a red or cancelled
+  upstream for a commit `main` has already moved past, it skips the deploy
+  instead of failing: that commit's image is not what anyone is releasing.
 - **Ring 2**: `release.yaml` gained a per-OS "Reliability Ring 2
   packed-backend journey" step right after each OS's existing smoke-boot
   step, running linear-text-pipeline against that OS's packed backend

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -58,10 +58,12 @@ jobs:
     timeout-minutes: 65
     outputs:
       sha: ${{ github.event.workflow_run.head_sha }}
+      deploy: ${{ steps.poll.outputs.deploy }}
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Poll for both workflows' success on this commit
+        id: poll
         shell: bash
         run: |
           set -euo pipefail
@@ -74,6 +76,20 @@ jobs:
               --jq '.workflow_runs[0].conclusion // "pending"'
           }
 
+          # True once a newer commit has landed on main. That commit's own
+          # fly-deploy run releases the newer image, so anything this run could
+          # still conclude about ${sha} is moot — and a red X here would be
+          # noise, not a broken deploy.
+          superseded() {
+            [ "$(gh api "repos/${repo}/commits/main" --jq .sha)" != "${sha}" ]
+          }
+
+          skip() {
+            echo "::notice::${1} Superseded on main; skipping the deploy of ${sha}."
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
           for attempt in $(seq 1 60); do
             docker_conclusion="$(conclusion_for docker.yml)"
             journeys_conclusion="$(conclusion_for user-journeys.yml)"
@@ -81,19 +97,29 @@ jobs:
 
             if [ "${docker_conclusion}" = "success" ] && [ "${journeys_conclusion}" = "success" ]; then
               echo "Both workflows succeeded for ${sha}."
+              echo "deploy=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            if [ "${docker_conclusion}" = "failure" ] || [ "${docker_conclusion}" = "cancelled" ]; then
-              echo "::error::docker.yml concluded '${docker_conclusion}' for ${sha}; not deploying."
-              exit 1
-            fi
-            if [ "${journeys_conclusion}" = "failure" ] || [ "${journeys_conclusion}" = "cancelled" ]; then
-              echo "::error::user-journeys.yml (reliability-ring1) concluded '${journeys_conclusion}' for ${sha}; not deploying."
-              exit 1
-            fi
+            case "${docker_conclusion}" in
+              failure|cancelled|timed_out)
+                if superseded; then skip "docker.yml concluded '${docker_conclusion}' for ${sha}."; fi
+                echo "::error::docker.yml concluded '${docker_conclusion}' for ${sha}; not deploying."
+                exit 1
+                ;;
+            esac
+            case "${journeys_conclusion}" in
+              failure|cancelled|timed_out)
+                if superseded; then skip "user-journeys.yml (reliability-ring1) concluded '${journeys_conclusion}' for ${sha}."; fi
+                echo "::error::user-journeys.yml (reliability-ring1) concluded '${journeys_conclusion}' for ${sha}; not deploying."
+                exit 1
+                ;;
+            esac
             sleep 60
           done
 
+          if superseded; then
+            skip "Timed out waiting for docker.yml and user-journeys.yml on ${sha}."
+          fi
           echo "::error::Timed out waiting for docker.yml and user-journeys.yml to both complete for ${sha}."
           exit 1
 
@@ -103,11 +129,13 @@ jobs:
     runs-on: ubuntu-latest
     # Skip when the image build (or the reliability Ring 1 gate) failed/was
     # cancelled. workflow_dispatch always runs (manual re-deploy); on
-    # workflow_run, `gate` must have completed successfully.
+    # workflow_run, `gate` must have completed successfully AND still consider
+    # this commit worth releasing — it reports deploy=false for a commit main
+    # has already moved past, whose own run does the releasing.
     if: >
       always() &&
       (github.event_name == 'workflow_dispatch' ||
-       needs.gate.result == 'success')
+       (needs.gate.result == 'success' && needs.gate.outputs.deploy == 'true'))
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/user-journeys.yml
+++ b/.github/workflows/user-journeys.yml
@@ -27,9 +27,14 @@ on:
 permissions:
   contents: read
 
+# On main, every commit's reliability-ring1 run must reach a conclusion of its
+# own: fly-deploy.yml gates the deploy on this workflow's result for that exact
+# head_sha, so a run cancelled by a follow-up merge reads as "Ring 1 failed" and
+# blocks the release. Same reasoning (and same expression) as docker.yml.
+# Elsewhere — PR branches, tags — superseded runs are still cancelled.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   journeys:


### PR DESCRIPTION
## What broke

[Run 31256065058](https://github.com/nodetool-ai/nodetool/actions/runs/31256065058/job/93099468812) failed on its first poll:

```
attempt 1/60: docker.yml=success user-journeys.yml=cancelled
::error::user-journeys.yml (reliability-ring1) concluded 'cancelled' for 97f053e…; not deploying.
```

`user-journeys.yml` carried `cancel-in-progress: true` on a group keyed by ref, so two merges landing on `main` within three minutes (`97f053e` at 11:47, `8cdf606` at 11:50) cancelled the earlier commit's `reliability-ring1` run. `fly-deploy.yml`'s gate reads a per-commit conclusion and treats `cancelled` as a hard failure — so a commit that was merely superseded produced a red deploy. The same pattern shows up repeatedly in the run history (four consecutive cancellations on 2026-08-07).

## Changes

- **`user-journeys.yml`** — don't cancel superseded runs on `main`, using the same expression `docker.yml` already uses. Every main commit's Ring 1 now reaches a conclusion of its own, which is exactly what the gate polls for. PR branches and tags still cancel.
- **`fly-deploy.yml`** — when an upstream is red or cancelled for a commit `main` has already moved past, skip the deploy instead of failing it. The gate emits a `deploy` output that `deploy`'s `if` requires, so a superseded commit ends green-and-skipped rather than red, and the newer commit's own run does the releasing.
- Fold `timed_out` into the terminal conclusions the gate reacts to, instead of polling on until the 65-minute job timeout.
- **`.github/workflows/README.md`** — record why Ring 1 doesn't cancel on `main`, since that's the non-obvious coupling.

## Verification

Both workflow files parse. The gate script was extracted and exercised against a stubbed `gh` across four cases:

| docker | journeys | commit is tip of main | result |
| --- | --- | --- | --- |
| success | success | yes | exit 0, `deploy=true` |
| success | cancelled | no | exit 0, `deploy=false`, notice |
| success | cancelled | yes | exit 1, error (unchanged) |
| failure | success | yes | exit 1, error (unchanged) |

A genuinely failing Ring 1 on the tip of `main` still blocks the deploy — only the superseded case changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGkCEj3kPc4QMCxBPGo95p

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGkCEj3kPc4QMCxBPGo95p)_