### PR TITLE
feat(chat): render sketch and timeline previews inline in chat

### DIFF
--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1285,14 +1285,16 @@ forward is a workflow.
   every sequence also keeps a snapshot history, read with
   \`list_timeline_versions\` and \`get_timeline_version\`, pinned with
   \`create_timeline_version\` and rolled back with
-  \`restore_timeline_version\` — none of which needs an open editor.
+  \`restore_timeline_version\` — none of which needs an open editor. A
+  timeline can be previewed inline in chat; see "Linking resources".
 - **sketch** — a layered image document. Family \`+sketch\`: layers, drawing
   tools, generating into a layer, rendering the result to an asset.
   \`validate_sketch\` statically checks a document — the open one or any saved
   one by id. \`list_sketches\` finds one; every sketch also keeps a snapshot
   history, read with \`list_sketch_versions\` and \`get_sketch_version\`,
   pinned with \`create_sketch_version\` and rolled back with
-  \`restore_sketch_version\` — none of which needs an open editor.
+  \`restore_sketch_version\` — none of which needs an open editor. A sketch
+  can be previewed inline in chat; see "Linking resources".
 - **model3d** — a 3D scene. Family \`+ui_3d\`: add and transform objects, set
   materials, capture a view as an image.
 - **collection** — a vector store for RAG. \`list_collections\`,
@@ -1357,6 +1359,16 @@ field; copy that string rather than composing one. At most one link per
 resource per reply, and never link a resource you only looked up. Images are
 the exception: show them inline per "Image and media" above instead of
 linking them.
+
+Sketches and timelines can be SHOWN inline, not just linked. Embed one with
+image syntax on its own line — \`![Label](sketch://<id>)\` or
+\`![Label](timeline://<id>)\` — and the chat UI renders a live preview of the
+document (the sketch's composited canvas, the timeline's preview frame) with
+an open-in-editor chip beneath it. Do this after creating or meaningfully
+changing a sketch or timeline so the user sees the result without opening the
+editor; use a plain link when you only reference one. An embed counts as that
+resource's one link for the reply — don't also link it. Other resource kinds
+have no inline renderer: link them, never embed them with image syntax.
 
 # File types
 References to documents, images, videos, or audio files have the shape:

--- a/web/src/components/chat/message/ChatMarkdown.tsx
+++ b/web/src/components/chat/message/ChatMarkdown.tsx
@@ -5,6 +5,9 @@ import ReactMarkdown, { defaultUrlTransform, type Options } from "react-markdown
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import { isResourceUri } from "@nodetool-ai/protocol";
+import InlineResourcePreview, {
+  isInlinePreviewUri
+} from "./InlineResourcePreview";
 import "../../../styles/markdown/nodetool-markdown.css";
 import { SPACING, getSpacingPx } from "../../ui_primitives";
 import { CodeBlock } from "./markdown_elements/CodeBlock";
@@ -107,6 +110,31 @@ const useChatAssetSrc = (src: string | undefined): string | undefined => {
   return src;
 };
 
+/**
+ * A paragraph that carries an inline document preview renders as a `<div>`:
+ * the preview is a block element (canvas frame + chip), which is invalid
+ * inside `<p>` and would trip React's DOM-nesting warning.
+ */
+interface HastNodeLike {
+  type?: string;
+  tagName?: string;
+  properties?: { src?: unknown };
+  children?: HastNodeLike[];
+}
+
+const containsInlinePreview = (node: unknown): boolean => {
+  const children = (node as HastNodeLike | undefined)?.children;
+  return Boolean(
+    children?.some(
+      (child) =>
+        child.type === "element" &&
+        child.tagName === "img" &&
+        typeof child.properties?.src === "string" &&
+        isInlinePreviewUri(child.properties.src)
+    )
+  );
+};
+
 const ChatMarkdownImg: React.FC<React.ComponentPropsWithoutRef<"img">> = ({
   src,
   alt,
@@ -144,9 +172,25 @@ const ChatMarkdown: React.FC<ChatMarkdownProps> = React.memo(({
     () => ({
       code: (props: React.ComponentPropsWithoutRef<"code">) => <CodeBlock {...props} onInsert={onInsertCode} />,
       pre: (props: React.ComponentPropsWithoutRef<"pre">) => <PreRenderer {...props} onInsert={onInsertCode} />,
-      img: ({ node: _node, ...props }: { node?: unknown } & React.ComponentPropsWithoutRef<"img">) => (
-        <ChatMarkdownImg {...props} />
-      ),
+      img: ({ node: _node, ...props }: { node?: unknown } & React.ComponentPropsWithoutRef<"img">) => {
+        const src = typeof props.src === "string" ? props.src : undefined;
+        if (src && isInlinePreviewUri(src)) {
+          return (
+            <InlineResourcePreview uri={src} label={props.alt || src} />
+          );
+        }
+        return <ChatMarkdownImg {...props} />;
+      },
+      p: ({
+        node,
+        children,
+        ...props
+      }: { node?: unknown } & React.ComponentPropsWithoutRef<"p">) =>
+        containsInlinePreview(node) ? (
+          <div {...props}>{children}</div>
+        ) : (
+          <p {...props}>{children}</p>
+        ),
       a: ({ node: _node, ...props }: { node?: unknown } & React.ComponentPropsWithoutRef<"a">) => {
         const { href, children } = props;
         if (href && isResourceUri(href)) {

--- a/web/src/components/chat/message/InlineResourcePreview.tsx
+++ b/web/src/components/chat/message/InlineResourcePreview.tsx
@@ -1,0 +1,149 @@
+/**
+ * InlineResourcePreview — a sketch or timeline rendered directly in chat prose.
+ *
+ * The agent embeds a document with image syntax (`![Label](sketch://sk_1)`,
+ * `![Label](timeline://tl_7)`); ChatMarkdown routes those two kinds here. The
+ * component fetches the document and renders the same read-only renderer the
+ * editors ship, with a ResourceChip beneath it to open the document in its
+ * editor. Anything that cannot be previewed — unknown kind, load failure, a
+ * document today's renderer cannot resolve — degrades to the chip alone.
+ */
+import React, { useMemo } from "react";
+import { parseResourceUri, type ResourceKind } from "@nodetool-ai/protocol";
+
+import {
+  BORDER_RADIUS,
+  Box,
+  Caption,
+  FlexColumn,
+  LoadingSpinner,
+  SPACING
+} from "../../ui_primitives";
+import { trpc } from "../../../trpc/client";
+import {
+  resolveSketchDocument,
+  resolveTimelineSequence
+} from "../../node/outputValueResolvers";
+import ResourceChip from "./ResourceChip";
+
+const LazySketchRenderer = React.lazy(
+  () => import("../../sketch/SketchRenderer")
+);
+const LazyTimelineRenderer = React.lazy(
+  () => import("../../timeline/TimelineRenderer")
+);
+
+const PREVIEW_KINDS: readonly ResourceKind[] = ["sketch", "timeline"];
+
+/** True when the URI names a resource kind chat can render inline. */
+export const isInlinePreviewUri = (uri: string): boolean => {
+  const ref = parseResourceUri(uri);
+  return ref !== null && PREVIEW_KINDS.includes(ref.kind);
+};
+
+const PREVIEW_HEIGHT = 280;
+
+const frameSx = {
+  width: "100%",
+  height: PREVIEW_HEIGHT,
+  overflow: "hidden",
+  borderRadius: BORDER_RADIUS.md
+} as const;
+
+const SketchPreview: React.FC<{ id: string }> = ({ id }) => {
+  const query = trpc.sketch.get.useQuery({ id }, { staleTime: 30_000 });
+  const document = useMemo(
+    () => resolveSketchDocument(query.data),
+    [query.data]
+  );
+
+  if (document) {
+    return (
+      <Box sx={frameSx}>
+        <React.Suspense
+          fallback={<LoadingSpinner size="small" text="Loading preview" />}
+        >
+          <LazySketchRenderer
+            document={document}
+            ariaLabel="Sketch preview"
+            showDimensions
+          />
+        </React.Suspense>
+      </Box>
+    );
+  }
+  if (query.isLoading) {
+    return <LoadingSpinner size="small" text="Loading sketch" />;
+  }
+  if (query.isError) {
+    return <Caption color="secondary">Could not load this sketch.</Caption>;
+  }
+  return null;
+};
+
+const TimelinePreview: React.FC<{ id: string }> = ({ id }) => {
+  const query = trpc.timeline.get.useQuery({ id }, { staleTime: 30_000 });
+  const sequence = useMemo(
+    () => resolveTimelineSequence(query.data),
+    [query.data]
+  );
+
+  if (sequence) {
+    return (
+      <Box sx={frameSx}>
+        <React.Suspense
+          fallback={<LoadingSpinner size="small" text="Loading preview" />}
+        >
+          <LazyTimelineRenderer
+            sequence={sequence}
+            ariaLabel="Timeline preview"
+            showMetadata
+          />
+        </React.Suspense>
+      </Box>
+    );
+  }
+  if (query.isLoading) {
+    return <LoadingSpinner size="small" text="Loading timeline" />;
+  }
+  if (query.isError) {
+    return <Caption color="secondary">Could not load this timeline.</Caption>;
+  }
+  return null;
+};
+
+interface InlineResourcePreviewProps {
+  uri: string;
+  label: string;
+}
+
+const InlineResourcePreview: React.FC<InlineResourcePreviewProps> = ({
+  uri,
+  label
+}) => {
+  const ref = useMemo(() => parseResourceUri(uri), [uri]);
+
+  if (!ref || !PREVIEW_KINDS.includes(ref.kind)) {
+    return <ResourceChip uri={uri} label={label} />;
+  }
+
+  return (
+    <FlexColumn
+      gap={SPACING.xs}
+      align="flex-start"
+      sx={{ width: "100%", minWidth: 0 }}
+      data-testid="inline-resource-preview"
+    >
+      {ref.kind === "sketch" ? (
+        <SketchPreview id={ref.id} />
+      ) : (
+        <TimelinePreview id={ref.id} />
+      )}
+      <ResourceChip uri={uri} label={label} />
+    </FlexColumn>
+  );
+};
+
+InlineResourcePreview.displayName = "InlineResourcePreview";
+
+export default InlineResourcePreview;

--- a/web/src/components/chat/message/__tests__/ChatMarkdown.inlinePreviews.test.tsx
+++ b/web/src/components/chat/message/__tests__/ChatMarkdown.inlinePreviews.test.tsx
@@ -1,0 +1,219 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../../__mocks__/themeMock";
+
+const mockSketchGet = jest.fn();
+const mockTimelineGet = jest.fn();
+const mockSignUrl = jest.fn();
+
+jest.mock("../../../../trpc/client", () => ({
+  trpc: {
+    sketch: {
+      get: { useQuery: (...args: unknown[]) => mockSketchGet(...args) }
+    },
+    timeline: {
+      get: { useQuery: (...args: unknown[]) => mockTimelineGet(...args) }
+    },
+    storage: {
+      signUrl: { useQuery: (...args: unknown[]) => mockSignUrl(...args) }
+    }
+  }
+}));
+
+jest.mock("../../../sketch/SketchRenderer", () => ({
+  __esModule: true,
+  default: () => <div data-testid="sketch-renderer" />
+}));
+
+jest.mock("../../../timeline/TimelineRenderer", () => ({
+  __esModule: true,
+  default: () => <div data-testid="timeline-renderer" />
+}));
+
+jest.mock("../../../../lib/chat/openResource", () => ({
+  __esModule: true,
+  openResource: jest.fn(),
+  canOpenResource: () => true
+}));
+
+/**
+ * react-markdown is ESM-only; this mock handles markdown images `![](src)`
+ * and links `[label](href)` and forwards them to `components.img` /
+ * `components.a`, sanitizing through `urlTransform` the way the real one does.
+ */
+jest.mock("react-markdown", () => {
+  const react = jest.requireActual<typeof import("react")>("react");
+  const SAFE_SCHEME = /^(https?|mailto|irc|ircs|xmpp):/i;
+  const defaultUrlTransform = (url: string): string => {
+    const colon = url.indexOf(":");
+    if (colon === -1 || SAFE_SCHEME.test(url)) return url;
+    const questionMark = url.indexOf("?");
+    const hash = url.indexOf("#");
+    const slash = url.indexOf("/");
+    const beforePath =
+      (slash === -1 || colon < slash) &&
+      (questionMark === -1 || colon < questionMark) &&
+      (hash === -1 || colon < hash);
+    return beforePath ? "" : url;
+  };
+  const TOKEN = /!\[([^\]]*)\]\(([^)]+)\)|\[([^\]]*)\]\(([^)]+)\)/g;
+  const MockMarkdown = ({
+    children,
+    components,
+    urlTransform
+  }: {
+    children?: string;
+    components?: {
+      img?: React.ComponentType<{ src?: string; alt?: string }>;
+      a?: React.ComponentType<React.ComponentPropsWithoutRef<"a">>;
+    };
+    urlTransform?: (url: string) => string | null | undefined;
+  }) => {
+    const content = children ?? "";
+    const transform = urlTransform ?? defaultUrlTransform;
+    const parts: React.ReactNode[] = [];
+    let cursor = 0;
+    let match: RegExpExecArray | null;
+    TOKEN.lastIndex = 0;
+    while ((match = TOKEN.exec(content)) !== null) {
+      parts.push(content.slice(cursor, match.index));
+      if (match[1] !== undefined && match[2] !== undefined) {
+        const src = transform(match[2]) ?? "";
+        if (src && components?.img) {
+          parts.push(
+            react.createElement(components.img, {
+              key: match.index,
+              src,
+              alt: match[1]
+            })
+          );
+        }
+      } else if (match[3] !== undefined && match[4] !== undefined) {
+        const href = transform(match[4]) ?? "";
+        if (href && components?.a) {
+          parts.push(
+            react.createElement(
+              components.a,
+              { href, key: match.index },
+              match[3]
+            )
+          );
+        }
+      }
+      cursor = match.index + match[0].length;
+    }
+    parts.push(content.slice(cursor));
+    return react.createElement(react.Fragment, null, ...parts);
+  };
+  return { __esModule: true, default: MockMarkdown, defaultUrlTransform };
+});
+
+// Import after mocks
+import ChatMarkdown from "../ChatMarkdown";
+
+const idleQuery = { data: undefined, isLoading: false, isError: false };
+
+const SKETCH_DOCUMENT = {
+  canvas: { width: 512, height: 512 },
+  layers: [],
+  activeLayerId: "layer-1"
+};
+
+const TIMELINE_SEQUENCE = {
+  id: "tl_1",
+  name: "Cut",
+  fps: 30,
+  width: 1920,
+  height: 1080,
+  durationMs: 4000,
+  tracks: [],
+  clips: [],
+  markers: []
+};
+
+const renderMarkdown = (content: string) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ChatMarkdown content={content} />
+    </ThemeProvider>
+  );
+
+describe("ChatMarkdown inline document previews", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSketchGet.mockReturnValue(idleQuery);
+    mockTimelineGet.mockReturnValue(idleQuery);
+    mockSignUrl.mockReturnValue({ data: undefined });
+  });
+
+  it("renders an embedded sketch as an inline preview", async () => {
+    mockSketchGet.mockReturnValue({
+      data: { id: "sk_1", document: { sketch: SKETCH_DOCUMENT } },
+      isLoading: false,
+      isError: false
+    });
+
+    renderMarkdown("![Poster draft](sketch://sk_1)");
+
+    expect(mockSketchGet).toHaveBeenCalledWith(
+      { id: "sk_1" },
+      expect.objectContaining({ staleTime: 30_000 })
+    );
+    expect(await screen.findByTestId("sketch-renderer")).toBeInTheDocument();
+    // The open-in-editor chip carries the label.
+    expect(screen.getByText("Poster draft")).toBeInTheDocument();
+  });
+
+  it("renders an embedded timeline as an inline preview", async () => {
+    mockTimelineGet.mockReturnValue({
+      data: TIMELINE_SEQUENCE,
+      isLoading: false,
+      isError: false
+    });
+
+    renderMarkdown("![First cut](timeline://tl_1)");
+
+    expect(mockTimelineGet).toHaveBeenCalledWith(
+      { id: "tl_1" },
+      expect.objectContaining({ staleTime: 30_000 })
+    );
+    expect(await screen.findByTestId("timeline-renderer")).toBeInTheDocument();
+    expect(screen.getByText("First cut")).toBeInTheDocument();
+  });
+
+  it("keeps a plain sketch link as a chip, not a preview", () => {
+    renderMarkdown("Edited [the poster](sketch://sk_1).");
+
+    expect(screen.getByText("the poster")).toBeInTheDocument();
+    expect(screen.queryByTestId("inline-resource-preview")).toBeNull();
+    expect(mockSketchGet).not.toHaveBeenCalled();
+  });
+
+  it("still renders asset:// images as plain images", () => {
+    mockSignUrl.mockReturnValue({ data: { url: "http://x/signed.png" } });
+    const { container } = renderMarkdown("![](asset://abc.png)");
+
+    expect(screen.queryByTestId("inline-resource-preview")).toBeNull();
+    expect(container.querySelector("img")).toHaveAttribute(
+      "src",
+      "http://x/signed.png"
+    );
+  });
+
+  it("degrades to the chip when the document fails to load", () => {
+    mockSketchGet.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { message: "not found" }
+    });
+
+    renderMarkdown("![Poster draft](sketch://sk_1)");
+
+    expect(screen.queryByTestId("sketch-renderer")).toBeNull();
+    expect(screen.getByText("Could not load this sketch.")).toBeInTheDocument();
+    expect(screen.getByText("Poster draft")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Lets the chat agent **show** a sketch or timeline directly in the chat UI instead of only linking it. Embedding one with image syntax — `[Poster draft](sketch://<id>)` or `[First cut](timeline://<id>)` — now renders a live inline preview of the document in the reply.

## How

- **`InlineResourcePreview`** (new, `web/src/components/chat/message/`): parses the resource URI, fetches the document over tRPC (`sketch.get` / `timeline.get`), resolves it with the existing `outputValueResolvers`, and renders the read-only `SketchRenderer` / `TimelineRenderer` the editors already ship (both lazy-loaded so chat doesn't pay for the compositors up front). The existing `ResourceChip` sits beneath the preview as the open-in-editor affordance. Load failures and unresolvable documents degrade to the chip.
- **`ChatMarkdown`**: the `img` override routes `sketch://` / `timeline://` sources to the preview; every other source (including `asset://` images) behaves as before. A paragraph carrying a preview renders as a `div` so the block preview doesn't sit inside a `<p>`. Plain markdown *links* to these kinds keep rendering as compact chips.
- **System prompt** (`unified-websocket-runner.ts`): the "Linking resources" section now documents the embed syntax, when to embed vs. link, and that other resource kinds have no inline renderer; the sketch and timeline bullets under "NodeTool resources" point at it. The `ui_sketch_*` / `ui_timeline_*` tool results already carry the ready-made `url` the agent copies into the embed.

## Tests

- New `ChatMarkdown.inlinePreviews.test.tsx`: sketch embed renders the sketch renderer, timeline embed renders the timeline renderer, plain links stay chips (no fetch), `asset://` images unchanged, load failure degrades to the chip. All chat suites pass (21 suites, 168 tests).
- `packages/websocket` tests pass (195 files, 2239 tests). Web typecheck and lint pass.

Notes: root `npm run typecheck` fails only on `mobile/` in this sandbox (its non-workspace Expo tree isn't installed here) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFYBK47BaHRPKuowHKPstC

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFYBK47BaHRPKuowHKPstC)_