### PR TITLE
Guarantee async concurrency in the QuickJS sandbox and add parallelMap

### DIFF
--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -107,7 +107,8 @@ source for read containment and the destination for write containment;
 `stat` returns `{exists, size, isDirectory, isFile, isSymlink, modifiedMs,
 createdMs, accessedMs}` and reports a missing path as `exists: false` rather
 than throwing), the pure guest-side helpers
-`toBase64`/`fromBase64`/`toHex`/`fromHex`/`utf8Encode`/`utf8Decode`,
+`toBase64`/`fromBase64`/`toHex`/`fromHex`/`utf8Encode`/`utf8Decode`/
+`parallelMap`,
 `progress(percent, message?)`, `format.{number,date,relativeTime,list}`,
 `data.{parseCsv,toCsv,selectHtml,htmlToMarkdown,parseXlsx,parseYaml,toYaml,
 parseXml,unzip,zip,diff}`, and any caller-supplied `globals`. `fetch` sends a
@@ -148,6 +149,19 @@ a thrown `Error` carrying Intl's own message. `eval` and `Function` are deleted 
 re-enter dynamic code generation. Core JS (`JSON`, `Math`, `Date`, `Map`,
 `URL`, `TextEncoder`, etc.) is QuickJS's native implementation, not a
 host-bridged version.
+
+**Async concurrency**: a bridge call starts its host-side work when invoked,
+not when awaited, so `Promise.all`/`allSettled`/`race`/`any` over `fetch`,
+`workspace.*` or any other bridge run the host operations in parallel — five
+fetches under `Promise.all` take one round trip. `parallelMap(items, fn,
+concurrency?)` is the bounded form (order-preserving, default 5, max 32,
+rejects on first failure). The per-run fetch cap counts parallel calls the
+same as serial ones. Timer globals (`setTimeout`, `setInterval`,
+`setImmediate` and their clears) are deleted inside the user-code module —
+the engine re-installs host-backed versions on every evaluation, so the
+prelude alone can't remove them; `wrapCode` does. `sleep` stays the only
+timer. Tests pinning all of this: `tests/js-sandbox.test.ts`
+("async concurrency").
 
 **State sync-back**: object-typed globals are deep-replaced on the host after
 the guest runs, so `CodeNode`'s `state` object persists across invocations.

--- a/packages/agents/src/code-gen/prompt.ts
+++ b/packages/agents/src/code-gen/prompt.ts
@@ -49,6 +49,10 @@ by returning an object whose keys are exactly the declared outputs.
   If or Switch control nodes downstream instead.
 - Prefer pure data reshaping. Reach for fetch, workspace, or getSecret only when
   the instruction asks for outside data.
+- When the node fetches or reads for each item of a list, fan the calls out with
+  \`parallelMap\` (or \`Promise.all\` for a short fixed set) instead of awaiting
+  one per loop iteration — they run concurrently, and a sequential loop over a
+  20-row list is 20 round trips where one would do.
 - Do not use \`state\` or \`yield\` unless the instruction asks for streaming or
   for values that persist across runs. A one-shot transformation needs neither.
 - Pass media and asset reference objects through unchanged. They are handles the

--- a/packages/agents/src/code-gen/sandbox-manifest.ts
+++ b/packages/agents/src/code-gen/sandbox-manifest.ts
@@ -500,6 +500,14 @@ const GUEST_HELPER_DOCS: { [K in GuestHelperName]: SandboxMemberDoc } = {
     signature: "utf8Decode(bytes) -> string",
     description: "UTF-8 decode.",
     async: false
+  },
+  parallelMap: {
+    name: "parallelMap",
+    signature:
+      "await parallelMap(items, fn, concurrency?) -> results[] // fn receives (item, index); concurrency default 5, max 32",
+    description:
+      "Run an async function over items with at most `concurrency` in flight, preserving input order. The bounded form of Promise.all fan-out — the way to fetch many URLs in parallel. Rejects on the first failure; wrap fn in try/catch to collect errors instead.",
+    async: true
   }
 };
 
@@ -632,6 +640,7 @@ export function getSandboxManifest(): SandboxManifest {
     limits: [...overridableLimits(), ...fixedLimits()],
     notes: [
       "Code runs as an async function body: top-level await works and `return` produces the node's result.",
+      "Bridge calls start host-side work when invoked, not when awaited: Promise.all / allSettled / race / any over fetch or workspace calls run them in parallel. Use parallelMap for bounded fan-out. sleep is the only timer.",
       "Return an object whose keys are the node's outputs. Emit every declared output on every return path.",
       "Media and asset values are reference objects. Pass them through unchanged.",
       "There is no module loader and no Intl. Anything a library would do comes from the bridges below."

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -1128,7 +1128,7 @@ const BATCH_EXAMPLE = `Batching turns one workflow into a dynamic pipeline — l
 per-item parameters live in your code:
 
 \`\`\`js
-const rows = data.parseCsv(await workspace.read("products.csv"));
+const rows = await data.parseCsv(await workspace.read("products.csv"));
 const runs = await nodetool.batch(rows, (row) =>
   nodetool.workflows.run(wfId, { image_url: row.image_url, title: row.title }),
   { concurrency: 3 });

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -30,6 +30,16 @@ Rules:
   seeing an observation first (and then finish the rest in that next action).
 - Multi-round protocols (poll a job, answer run escalations, retry a flaky
   call) are ONE action: write the loop, not one action per round.
+- Independent work runs CONCURRENTLY, and a sequential \`for\` loop over
+  \`await\` is the most common way an action wastes wall-clock. A call starts
+  its work when invoked, not when awaited, so
+  \`await Promise.all(items.map(x => tools.foo(x)))\` fans out for real —
+  ten independent lookups take one round trip, not ten. Use
+  \`await parallelMap(items, async (x) => …, 5)\` when the list is long enough
+  that unbounded fan-out would blow a rate limit or the per-action tool
+  budget; it preserves input order and keeps at most N in flight.
+  \`Promise.allSettled\` when some are allowed to fail. Sequence only what
+  genuinely depends on a previous result.
 - \`state\` is a plain object that persists across your actions in this step.
   Stash fetched data and intermediates there (\`state.rows = ...\`) and reuse
   them next turn — never re-fetch what you already have.

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -9,8 +9,9 @@
  * The exposed surface is a small curated one: vanilla JavaScript plus a handful
  * of bridge functions (`fetch`, `workspace`, `getSecret`, `uuid`, `sleep`,
  * `assetToSandbox`, `sandboxToAsset`, `crypto`, `console`, `progress`,
- * `format`, `data`) and a few pure guest-side binary helpers (`toBase64`,
- * `fromBase64`, `toHex`, `fromHex`, `utf8Encode`, `utf8Decode`). `crypto`
+ * `format`, `data`) and a few pure guest-side helpers (`toBase64`,
+ * `fromBase64`, `toHex`, `fromHex`, `utf8Encode`, `utf8Decode`,
+ * `parallelMap`). `crypto`
  * covers `randomUUID`, `getRandomValues`, `digest`, and `hmac`
  * (WebCrypto-backed); `workspace` covers text and binary reads/writes plus
  * `stat`, `mkdir`, and `remove`; `progress` forwards a percentage and label to
@@ -28,6 +29,16 @@
  * on first use, and are never handed to the guest — so the snippet surface is
  * the same string-in/plain-data-out contract in dev, in packaged Electron, and
  * in the browser runner, which bundles this module too.
+ *
+ * The sandbox is fully asynchronous. Every host bridge call returns a real
+ * promise, and a bridge call starts its host-side work the moment it is
+ * invoked — not when it is awaited — so `Promise.all` (and `allSettled`,
+ * `race`, `any`) over bridge calls runs them in parallel on the host. Five
+ * fetches under `Promise.all` take one round trip, not five. `parallelMap`
+ * is the bounded form of that fan-out. `sleep` is the only timer: the
+ * timer globals (`setTimeout` and friends) are deleted inside the user-code
+ * module (see {@link wrapCode}), because timer callbacks would run outside
+ * the never-reject/abort-guard conventions every bridge follows.
  */
 
 import { addSerializer, expose, loadQuickJs } from "@sebastianwessel/quickjs";
@@ -1886,9 +1897,16 @@ export function buildSandbox(
     TextDecoder: globalThis.TextDecoder,
     URL: globalThis.URL,
     URLSearchParams: globalThis.URLSearchParams,
-    // Async primitives blocked — use sleep() instead.
+    // Timer globals blocked — use sleep() for delays and Promise.all /
+    // parallelMap for concurrency. The engine re-installs host-backed timers
+    // on every evaluation, so the real deletion happens in wrapCode; these
+    // entries keep the manifest's blocked list truthful.
     setTimeout: undefined,
+    clearTimeout: undefined,
     setInterval: undefined,
+    clearInterval: undefined,
+    setImmediate: undefined,
+    clearImmediate: undefined,
     // Bridge functions — the only non-native surface the sandbox exposes.
     fetch: sandboxedFetch,
     crypto: sandboxCrypto,
@@ -1912,12 +1930,39 @@ export function buildSandbox(
 // ---------------------------------------------------------------------------
 
 /**
+ * Timer globals the guest must not see. The documented contract has always
+ * been "`sleep` is the only timer", but `@sebastianwessel/quickjs` installs
+ * host-backed `setTimeout`/`setInterval`/`setImmediate` into the context on
+ * every `evalCode` call — *after* the init prelude runs — so a prelude-time
+ * `delete` does not stick. {@link wrapCode} deletes them inside the user-code
+ * module itself, which evaluates after the library's re-install. They are
+ * blocked deliberately: their callbacks fire through `ctx.callFunction` with
+ * errors silently discarded, outside the never-reject and abort-guard
+ * conventions every bridge follows. Concurrency does not need them —
+ * bridge calls run in parallel under `Promise.all`/`parallelMap`.
+ */
+export const BLOCKED_TIMER_GLOBALS = [
+  "setTimeout",
+  "clearTimeout",
+  "setInterval",
+  "clearInterval",
+  "setImmediate",
+  "clearImmediate"
+] as const;
+
+/**
  * Wrap user code as the default export of an ES module with a top-level-awaited
  * async IIFE body, so `return <value>` inside the snippet becomes the module's
- * default export and `await` at the top level works.
+ * default export and `await` at the top level works. The module first drops
+ * the timer globals the engine re-installs per evaluation (see
+ * {@link BLOCKED_TIMER_GLOBALS}).
  */
 export function wrapCode(code: string): string {
-  return `export default await (async () => {
+  const dropTimers = BLOCKED_TIMER_GLOBALS.map(
+    (n) => `delete globalThis.${n};`
+  ).join(" ");
+  return `${dropTimers}
+export default await (async () => {
 ${code}
 })();`;
 }
@@ -2072,7 +2117,8 @@ export const GUEST_HELPER_NAMES = [
   "toHex",
   "fromHex",
   "utf8Encode",
-  "utf8Decode"
+  "utf8Decode",
+  "parallelMap"
 ] as const;
 
 export type GuestHelperName = (typeof GUEST_HELPER_NAMES)[number];
@@ -2280,6 +2326,28 @@ globalThis.fromHex = (s) => {
   const out = new Uint8Array(t.length >> 1);
   for (let i = 0; i < out.length; i++) out[i] = parseInt(t.substr(i * 2, 2), 16);
   return out;
+};
+globalThis.parallelMap = async (items, fn, concurrency) => {
+  if (typeof fn !== "function") {
+    throw new TypeError("parallelMap: fn must be a function");
+  }
+  const list = Array.from(items);
+  const raw = Number(concurrency === undefined ? 5 : concurrency);
+  const limit = Number.isFinite(raw)
+    ? Math.min(Math.max(Math.floor(raw), 1), 32)
+    : 5;
+  const results = new Array(list.length);
+  let next = 0;
+  const worker = async () => {
+    while (next < list.length) {
+      const i = next++;
+      results[i] = await fn(list[i], i);
+    }
+  };
+  const workers = [];
+  for (let w = 0; w < Math.min(limit, list.length); w++) workers.push(worker());
+  await Promise.all(workers);
+  return results;
 };
 const __revive = (v) => (v && typeof v === "object" && typeof v[__bytesMarker] === "string")
   ? globalThis.fromBase64(v[__bytesMarker])

--- a/packages/agents/src/tools/code-tools.ts
+++ b/packages/agents/src/tools/code-tools.ts
@@ -25,7 +25,9 @@ export class RunCodeTool extends Tool {
     "stat/mkdir/remove(), getSecret(), uuid(), sleep(), progress(), crypto.randomUUID/" +
     "getRandomValues/digest/hmac, format.number/date/relativeTime/list, " +
     "data.parseCsv(text, {delimiter, header}), data.selectHtml(html, selector, {attr, limit}), " +
-    "toBase64/fromBase64/toHex/fromHex. No imports — there is no module loader.";
+    "toBase64/fromBase64/toHex/fromHex. No imports — there is no module loader. " +
+    "Independent calls run concurrently: Promise.all over several fetches costs one round trip, " +
+    "and parallelMap(items, fn, concurrency) fans out a list with a bound.";
   readonly jsonSchema: Record<string, unknown> = {
     type: "object",
     properties: {

--- a/packages/agents/src/tools/js-code-tool.ts
+++ b/packages/agents/src/tools/js-code-tool.ts
@@ -82,7 +82,21 @@ Read a secret by name (API keys, tokens, etc).
 Generate a random UUID v4.
 
 ### sleep(ms)
-Pause execution (max 5s per call).
+Pause execution (max 5s per call). The only timer — \`setTimeout\`/\`setInterval\` do not exist.
+
+### parallelMap(items, fn, concurrency?) → results[]
+Run an async function over items with at most \`concurrency\` in flight (default 5, max 32), \
+preserving input order. Rejects on the first failure; catch inside \`fn\` to collect errors instead.
+\`\`\`js
+const pages = await parallelMap(urls, async (url) => (await fetch(url)).json, 5);
+\`\`\`
+
+## Concurrency
+
+Bridge calls start their work when invoked, not when awaited, so independent calls run in \
+parallel. \`await Promise.all(urls.map(u => fetch(u)))\` costs one round trip, not one per URL; \
+\`Promise.allSettled\`, \`race\` and \`any\` work too. Awaiting inside a \`for\` loop serializes \
+everything — do that only when a call depends on the previous result.
 
 ## Guidelines
 - Use \`return\` to produce the final result (returned in the "result" field)

--- a/packages/agents/tests/codeact-executor.test.ts
+++ b/packages/agents/tests/codeact-executor.test.ts
@@ -363,6 +363,23 @@ describe("CodeAct progressive tool disclosure", () => {
     expect(prompt).toContain('searchTools("query")');
   });
 
+  it("tells the model that independent calls run concurrently", async () => {
+    const { buildCodeActSystemPrompt } = await import("../src/codeact/prompt.js");
+    // The sandbox parallelizes host calls, but a model that does not know it
+    // writes `for (const x of xs) await tools.foo(x)` and pays one round trip
+    // per item. Both variants need the guidance — chat turns fan out over
+    // `tools.*` exactly as steps do.
+    for (const variant of ["step", "chat"] as const) {
+      const prompt = buildCodeActSystemPrompt({ tools: bigBelt(), variant });
+      expect(prompt, variant).toContain("Promise.all");
+      expect(prompt, variant).toContain("parallelMap");
+      // The helper's signature rides along from the manifest.
+      expect(prompt, variant).toContain("await parallelMap(items, fn");
+      // And the timers it replaces are still declared absent.
+      expect(prompt, variant).toContain("setTimeout");
+    }
+  });
+
   it("discovers a deferred tool via searchTools and calls it", async () => {
     const { step, task } = makeStep(ANSWER_SCHEMA);
     const context = createMockContext();

--- a/packages/agents/tests/js-sandbox.test.ts
+++ b/packages/agents/tests/js-sandbox.test.ts
@@ -143,6 +143,20 @@ describe("wrapCode", () => {
     expect(wrapped).toContain("return 42");
     expect(wrapped).toContain("()");
   });
+
+  it("drops the engine-provided timer globals before user code", () => {
+    const wrapped = wrapCode("return 42");
+    for (const name of [
+      "setTimeout",
+      "clearTimeout",
+      "setInterval",
+      "clearInterval",
+      "setImmediate",
+      "clearImmediate"
+    ]) {
+      expect(wrapped).toContain(`delete globalThis.${name};`);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -628,6 +642,154 @@ describe("runInSandbox fetch bridge", () => {
     });
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/Fetch limit exceeded/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runInSandbox — async concurrency
+//
+// The contract these pin: a bridge call starts its host-side work when
+// invoked, not when awaited, so Promise combinators and parallelMap fan work
+// out in parallel. A library upgrade that silently serialized host promises
+// would fail the wall-clock and in-flight assertions here.
+// ---------------------------------------------------------------------------
+
+describe("runInSandbox async concurrency", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    (globalThis as { fetch: typeof originalFetch }).fetch = originalFetch;
+  });
+
+  /** Mock fetch that resolves after `delayMs` and records peak concurrency. */
+  const trackingFetch = (delayMs: number) => {
+    let inFlight = 0;
+    const state = { maxInFlight: 0, calls: 0 };
+    (globalThis as { fetch: unknown }).fetch = vi.fn(async (url: string) => {
+      state.calls++;
+      inFlight++;
+      state.maxInFlight = Math.max(state.maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, delayMs));
+      inFlight--;
+      return new Response(JSON.stringify({ url }), { status: 200 });
+    });
+    return state;
+  };
+
+  it("runs bridge calls under Promise.all in parallel", async () => {
+    const state = trackingFetch(150);
+    const started = Date.now();
+    const result = await runInSandbox({
+      code: `
+        const urls = Array.from({ length: 5 }, (_, i) => "https://example.com/" + i);
+        const responses = await Promise.all(urls.map((u) => fetch(u)));
+        return responses.every((r) => r.ok);
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(true);
+    expect(state.maxInFlight).toBe(5);
+    // Serialized, five 150ms fetches would take >= 750ms.
+    expect(Date.now() - started).toBeLessThan(700);
+  });
+
+  it("runs concurrent sleeps in parallel", async () => {
+    const started = Date.now();
+    const result = await runInSandbox({
+      code: `
+        await Promise.all([sleep(300), sleep(300), sleep(300)]);
+        return "done";
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("done");
+    expect(Date.now() - started).toBeLessThan(800);
+  });
+
+  it("supports Promise.allSettled and Promise.race over bridges", async () => {
+    const result = await runInSandbox({
+      code: `
+        const settled = await Promise.allSettled([
+          sleep(10),
+          fetch("nonsense://blocked")
+        ]);
+        const raced = await Promise.race([
+          sleep(200).then(() => "slow"),
+          sleep(1).then(() => "fast")
+        ]);
+        return { states: settled.map((s) => s.status), raced };
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      states: ["fulfilled", "rejected"],
+      raced: "fast"
+    });
+  });
+
+  it("parallelMap preserves input order and bounds concurrency", async () => {
+    const state = trackingFetch(100);
+    const result = await runInSandbox({
+      code: `
+        const items = [0, 1, 2, 3, 4, 5];
+        const out = await parallelMap(items, async (n, i) => {
+          const r = await fetch("https://example.com/" + n);
+          return n * 10 + i;
+        }, 2);
+        return out;
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual([0, 11, 22, 33, 44, 55]);
+    expect(state.calls).toBe(6);
+    expect(state.maxInFlight).toBeLessThanOrEqual(2);
+    expect(state.maxInFlight).toBeGreaterThan(1);
+  });
+
+  it("parallelMap handles empty input and rejects on the first failure", async () => {
+    const result = await runInSandbox({
+      code: `
+        const empty = await parallelMap([], async () => 1);
+        let failed = null;
+        try {
+          await parallelMap([1, 2, 3], async (n) => {
+            if (n === 2) throw new Error("boom at " + n);
+            return n;
+          });
+        } catch (e) {
+          failed = e.message;
+        }
+        return { empty, failed };
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ empty: [], failed: "boom at 2" });
+  });
+
+  it("enforces the fetch cap across parallel calls", async () => {
+    trackingFetch(5);
+    const result = await runInSandbox({
+      code: `
+        const urls = Array.from({ length: 30 }, (_, i) => "https://example.com/" + i);
+        await Promise.all(urls.map((u) => fetch(u)));
+        return "ok";
+      `
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Fetch limit exceeded/i);
+  });
+
+  it("does not expose timer globals to user code", async () => {
+    const result = await runInSandbox({
+      code: `
+        return [
+          typeof setTimeout, typeof clearTimeout,
+          typeof setInterval, typeof clearInterval,
+          typeof setImmediate, typeof clearImmediate
+        ];
+      `
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual(Array(6).fill("undefined"));
   });
 });
 

--- a/packages/code-nodes/src/nodes/code-node.ts
+++ b/packages/code-nodes/src/nodes/code-node.ts
@@ -107,7 +107,7 @@ export class CodeNode extends BaseNode {
     "APIs: fetch(), workspace.read/write/list/readBytes/writeBytes/stat/mkdir/remove/copy/move/root(), " +
     "getSecret(), uuid(), sleep(), progress(), crypto.digest/hmac/randomUUID/getRandomValues, " +
     "format.number/date/relativeTime/list, data.parseCsv/selectHtml, " +
-    "toBase64/fromBase64/toHex/fromHex. " +
+    "toBase64/fromBase64/toHex/fromHex, parallelMap. " +
     "Dynamic inputs become global variables; return an object to define outputs." +
     "\n    code, javascript, function, script, dynamic";
   static readonly inlineFields = ["code"];
@@ -133,6 +133,8 @@ export class CodeNode extends BaseNode {
       "data.parseCsv(text, {delimiter, header}), data.selectHtml(html, selector, {attr, limit}), " +
       "toBase64/fromBase64/toHex/fromHex. Await fetch, sleep, workspace, getSecret, format, " +
       "data and crypto.digest/hmac; the rest are synchronous. " +
+      "Concurrent calls run in parallel: use Promise.all or " +
+      "parallelMap(items, fn, concurrency) to fan out fetches. " +
       "A persistent `state` object survives across streaming invocations. " +
       "Return an object — its keys become output handles."
   })

--- a/packages/node-sdk/src/code-node-validation.ts
+++ b/packages/node-sdk/src/code-node-validation.ts
@@ -54,8 +54,10 @@ export const SANDBOX_GLOBALS: ReadonlySet<string> = new Set([
   "assetToSandbox", "sandboxToAsset", "progress", "format", "data",
   // Pure guest helpers defined by the sandbox prelude
   "toBase64", "fromBase64", "toHex", "fromHex", "utf8Encode", "utf8Decode",
+  "parallelMap",
   // Blocked in the sandbox, but still not user inputs
-  "setTimeout", "setInterval", "eval", "Function",
+  "setTimeout", "clearTimeout", "setInterval", "clearInterval",
+  "setImmediate", "clearImmediate", "eval", "Function",
   // JS literals that acorn parses as Identifier nodes
   "undefined", "true", "false", "null",
   "this", "arguments", "globalThis", "self", "window", "document", "process",

--- a/web/src/hooks/editor/useChatIntegration.ts
+++ b/web/src/hooks/editor/useChatIntegration.ts
@@ -178,6 +178,8 @@ CRYPTO AND BINARY:
 
 ASYNC APIS:
 - await fetch(url, options?) → { ok, status, statusText, headers, body, json, text, bytes, arrayBuffer } — 20 calls per run, 15s timeout each, 1MB response cap. Private and loopback addresses are refused.
+- Bridge calls run in parallel: Promise.all over several fetch calls takes one round trip, not one per call.
+- await parallelMap(items, fn, concurrency?) → results in input order — bounded fan-out, concurrency default 5. The way to fetch many URLs.
 - await sleep(ms) — the only timer, capped at 5000ms
 - await getSecret(name) → string or undefined
 - uuid() → string
@@ -194,7 +196,7 @@ STREAMING: yield an object to emit multiple results, and use the state object to
 
 RETURN FORMAT: Always return an object like { output: value } or { key1: val1, key2: val2 }. Each key becomes a named output port on the node.
 
-BLOCKED: setTimeout, setInterval, eval, Function, require, import, process
+BLOCKED: setTimeout, setInterval, setImmediate, eval, Function, require, import, process
 </sandbox_api>`
       : "";
     return (

--- a/web/src/utils/codeOutputInference.ts
+++ b/web/src/utils/codeOutputInference.ts
@@ -119,8 +119,10 @@ const SANDBOX_GLOBALS = new Set([
   "assetToSandbox", "sandboxToAsset", "progress", "format", "data",
   // Pure guest helpers defined by the sandbox prelude
   "toBase64", "fromBase64", "toHex", "fromHex", "utf8Encode", "utf8Decode",
+  "parallelMap",
   // Blocked in the sandbox, but still not user inputs
-  "setTimeout", "setInterval", "eval", "Function",
+  "setTimeout", "clearTimeout", "setInterval", "clearInterval",
+  "setImmediate", "clearImmediate", "eval", "Function",
   // JS literals that acorn parses as Identifier nodes
   "undefined", "true", "false", "null", "NaN", "Infinity",
   "this", "arguments", "globalThis", "self", "window", "document", "process",


### PR DESCRIPTION
## What

Makes asynchronous programming — above all parallel fetching — a guaranteed, documented, tested feature of the QuickJS sandbox, and tells the agents that write code for it.

## Why

The engine already ran host bridge calls concurrently: a call starts its host-side work when invoked, not when awaited, so `Promise.all` over five fetches took one round trip. But nothing documented, advertised, or tested that. Two consequences:

- Authors and model-generated Code nodes had no contract to rely on.
- No agent-facing prompt mentioned it, so a model writes `for (const x of xs) await tools.foo(x)` and pays one round trip per item. Measured: five concurrent `tools.*` calls against a 200 ms tool finish in **287 ms** with all five in flight.

Worse, the documented timer contract was silently false: `@sebastianwessel/quickjs` re-installs host-backed `setTimeout`/`setInterval`/`setImmediate` into the context on every evaluation — *after* the init prelude — so the timers the manifest listed as blocked actually existed in the guest.

## Changes

**Sandbox**

- **`parallelMap(items, fn, concurrency?)`** — new pure-guest helper for bounded, order-preserving async fan-out (default 5, max 32; rejects on first failure). The recommended way to fetch many URLs.
- **Parallelism is now contract**: the sandbox manifest, code-gen prompt, editor chat sandbox docs, and both Code node descriptions state that `Promise.all`/`allSettled`/`race`/`any` over bridge calls run the host operations in parallel, with `sleep` as the only timer.
- **Timers truly blocked**: `wrapCode` deletes the six timer globals inside the user-code module, where the deletion sticks past the library's per-evaluation re-install. The sandbox record, manifest blocked list, and the mirrored global lists in `@nodetool-ai/node-sdk` and `web/src/utils/codeOutputInference.ts` now name all six.

**Agent prompts**

- **CodeAct action contract** (every step executor and chat turn): a rule that independent work runs concurrently, naming the sequential-await loop as the common waste — `Promise.all` for a fixed set, `parallelMap` for a list long enough to threaten a rate limit or the per-action tool budget, `allSettled` when some may fail.
- **Code node authoring prompt**: fan per-item fetches out rather than awaiting one per loop iteration.
- **`js` and `run_code` tool descriptions**: a Concurrency section and the `parallelMap` signature.
- Fixed an example in the `nodetool` API prompt that passed a Promise to `nodetool.batch` by calling the async `data.parseCsv` without `await` — teaching models the opposite of the point.

## Tests

New "async concurrency" block in `packages/agents/tests/js-sandbox.test.ts` pins parallel fetches (peak in-flight = 5, wall clock under the serialized floor), parallel sleeps, `Promise.allSettled`/`race` over bridges, `parallelMap` ordering/concurrency bound/empty input/failure propagation, the per-run fetch cap under parallel calls, and `typeof setTimeout === "undefined"` in user code. A library upgrade that silently serialized host promises now fails the suite. A second test pins the concurrency guidance in both CodeAct prompt variants.

## Verification

- `packages/agents`: 150 files / 2146 tests pass (includes the manifest drift suite pinning the three mirrored global lists)
- `packages/node-sdk`: 756 tests pass; `packages/code-nodes`: 258 pass
- `web` jest for `codeOutputInference`: 21 pass; `tsc --noEmit` clean for web and the touched packages; `npm run lint` clean