### PR TITLE
Expose fal language models in the model select

### DIFF
--- a/packages/runtime/src/providers/fal-provider.ts
+++ b/packages/runtime/src/providers/fal-provider.ts
@@ -2,13 +2,16 @@
  * FAL AI Provider — wraps the @fal-ai/client SDK to provide image generation
  * through the standard BaseProvider interface.
  *
- * Supports: textToImage, imageToImage, getAvailableImageModels
+ * Supports: textToImage, imageToImage, getAvailableImageModels, and chat
+ * against fal's OpenAI-compatible LLM route.
  */
 
 import { BaseProvider } from "./base-provider.js";
 import { createLogger } from "@nodetool-ai/config";
+import { OpenAICompatProvider } from "./openai-compat-provider.js";
 import type {
   ImageModel,
+  LanguageModel,
   VideoModel,
   TTSModel,
   MusicModel,
@@ -45,6 +48,18 @@ const log = createLogger("nodetool.runtime.providers.fal");
 
 const FAL_MANIFEST_PKG = "@nodetool-ai/fal-nodes";
 const FAL_MANIFEST_PATH = "fal-manifest.json";
+
+/** fal's OpenAI-compatible chat route (`openrouter/router`). */
+const FAL_LLM_BASE_URL = "https://fal.run/openrouter/router/openai/v1";
+
+/** Public, keyless catalog of the ids that route accepts. */
+const OPENROUTER_CATALOG_URL = "https://openrouter.ai/api/v1/models";
+
+interface OpenRouterCatalogRow {
+  id?: string;
+  name?: string;
+  supported_parameters?: string[];
+}
 
 type FalQueueUpdate = {
   status: string;
@@ -404,14 +419,22 @@ function sizeEnumRank(value: string): number {
 export class FalProvider extends BaseProvider {
   private apiKey: string;
   private _client: FalClient | null = null;
+  private _chat: OpenAICompatProvider | null = null;
+  private readonly _fetch: typeof fetch;
+  /** Model ids the catalog says accept `tools`. Filled by the model listing. */
+  private _toolCapableModels: Set<string> | null = null;
 
   static override requiredSecrets(): string[] {
     return ["FAL_API_KEY"];
   }
 
-  constructor(secrets: Record<string, unknown> = {}) {
+  constructor(
+    secrets: Record<string, unknown> = {},
+    options: { fetchFn?: typeof fetch } = {}
+  ) {
     super("fal_ai");
     this.apiKey = (secrets["FAL_API_KEY"] as string) ?? "";
+    this._fetch = options.fetchFn ?? globalThis.fetch.bind(globalThis);
   }
 
   /** Build an onQueueUpdate callback that forwards progress via emitMessage. */
@@ -570,17 +593,95 @@ export class FalProvider extends BaseProvider {
     return b.args;
   }
 
-  async generateMessage(
-    _args: Parameters<BaseProvider["generateMessage"]>[0]
-  ): Promise<Message> {
-    throw new Error("fal_ai does not support chat generation");
+  /**
+   * fal's chat surface is an OpenAI-compatible route
+   * ({@link FAL_LLM_BASE_URL}) backed by OpenRouter, so it speaks the same
+   * dialect every other gateway provider here does — with one difference: fal
+   * authenticates with `Key <FAL_KEY>`, not `Bearer`, and answers 401 to the
+   * Bearer form. The compat client spreads `defaultHeaders` after its own
+   * Authorization, so this overrides it.
+   */
+  private chatProvider(): OpenAICompatProvider {
+    if (this._chat) return this._chat;
+    if (!this.apiKey) {
+      throw new Error("FAL_API_KEY is required for chat generation");
+    }
+    const chat = new OpenAICompatProvider(
+      {
+        providerId: "fal_ai",
+        apiKey: this.apiKey,
+        baseURL: FAL_LLM_BASE_URL,
+        defaultHeaders: { Authorization: `Key ${this.apiKey}` }
+      },
+      { fetchFn: this._fetch }
+    );
+    chat.setMessageEmitter((msg) => this.emitMessage(msg));
+    this._chat = chat;
+    return chat;
   }
 
-  // eslint-disable-next-line require-yield
+  /**
+   * Language models reachable through fal's OpenAI-compatible route. The route
+   * is OpenRouter's router, so the ids it accepts are OpenRouter's ids and its
+   * public catalog is the model list — fal itself publishes no `/models` for
+   * this endpoint. Unreachable catalog means no language models rather than a
+   * failed provider, matching how the other enumerating providers fail.
+   */
+  override async getAvailableLanguageModels(): Promise<LanguageModel[]> {
+    let rows: OpenRouterCatalogRow[];
+    try {
+      const response = await this._fetch(OPENROUTER_CATALOG_URL);
+      if (!response.ok) return [];
+      const payload = (await response.json()) as {
+        data?: OpenRouterCatalogRow[];
+      };
+      rows = payload.data ?? [];
+    } catch (err) {
+      log.warn(`Could not load the fal language-model catalog: ${err}`);
+      return [];
+    }
+
+    const toolCapable = new Set<string>();
+    const models: LanguageModel[] = [];
+    for (const row of rows) {
+      if (typeof row.id !== "string" || row.id.length === 0) continue;
+      if (row.supported_parameters?.includes("tools")) toolCapable.add(row.id);
+      models.push({ id: row.id, name: row.name ?? row.id, provider: "fal_ai" });
+    }
+    this._toolCapableModels = toolCapable;
+    return models;
+  }
+
+  /**
+   * Tool support varies model by model across a 300-model catalog, so answer
+   * from what the catalog declared. Before any listing there is nothing to
+   * answer from — say yes, as the base class does, rather than hiding tools
+   * from a model that has them.
+   */
+  override async hasToolSupport(model: string): Promise<boolean> {
+    return this._toolCapableModels?.has(model) ?? true;
+  }
+
+  async generateMessage(
+    args: Parameters<BaseProvider["generateMessage"]>[0]
+  ): Promise<Message> {
+    return this.chatProvider().generateMessage(args);
+  }
+
   async *generateMessages(
-    _args: Parameters<BaseProvider["generateMessages"]>[0]
+    args: Parameters<BaseProvider["generateMessages"]>[0]
   ): AsyncGenerator<ProviderStreamItem> {
-    throw new Error("fal_ai does not support chat generation");
+    yield* this.chatProvider().generateMessages(args);
+  }
+
+  /** Chat spend accrues on the delegate; report it as this provider's own. */
+  override get cost(): number {
+    return super.cost + (this._chat?.cost ?? 0);
+  }
+
+  override resetCost(): void {
+    super.resetCost();
+    this._chat?.resetCost();
   }
 
   private buildTextToImageArgs(

--- a/packages/runtime/tests/providers/fal-provider.test.ts
+++ b/packages/runtime/tests/providers/fal-provider.test.ts
@@ -45,21 +45,94 @@ describe("FalProvider", () => {
     expect(ids).toContain("fal-ai/fast-sdxl");
   });
 
-  // --- Chat generation throws ---
+  // --- Language models ---
 
-  it("generateMessage throws (not supported)", async () => {
-    const p = createProvider();
-    await expect(
-      p.generateMessage({ messages: [], model: "test" } as any)
-    ).rejects.toThrow("fal_ai does not support chat generation");
+  function catalogFetch(rows: unknown[]): typeof fetch {
+    return vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: rows })
+    }) as unknown as typeof fetch;
+  }
+
+  it("lists language models from the catalog behind fal's LLM route", async () => {
+    const fetchFn = catalogFetch([
+      { id: "anthropic/claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
+      { id: "openai/gpt-5", name: "GPT-5" }
+    ]);
+    const p = new FalProvider({ FAL_API_KEY: "test-key" }, { fetchFn });
+
+    const models = await p.getAvailableLanguageModels();
+
+    expect(fetchFn).toHaveBeenCalledWith("https://openrouter.ai/api/v1/models");
+    expect(models).toEqual([
+      {
+        id: "anthropic/claude-sonnet-4.5",
+        name: "Claude Sonnet 4.5",
+        provider: "fal_ai"
+      },
+      { id: "openai/gpt-5", name: "GPT-5", provider: "fal_ai" }
+    ]);
   });
 
-  it("generateMessages throws (not supported)", async () => {
-    const p = createProvider();
-    const gen = p.generateMessages({ messages: [], model: "test" } as any);
-    await expect(gen.next()).rejects.toThrow(
-      "fal_ai does not support chat generation"
+  it("returns no language models when the catalog is unreachable", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValue(new Error("offline")) as unknown as typeof fetch;
+    const p = new FalProvider({ FAL_API_KEY: "test-key" }, { fetchFn });
+
+    expect(await p.getAvailableLanguageModels()).toEqual([]);
+  });
+
+  it("reports tool support from what the catalog declared", async () => {
+    const fetchFn = catalogFetch([
+      { id: "with-tools", supported_parameters: ["tools", "temperature"] },
+      { id: "without-tools", supported_parameters: ["temperature"] }
+    ]);
+    const p = new FalProvider({ FAL_API_KEY: "test-key" }, { fetchFn });
+
+    // Before any listing there is nothing to answer from.
+    expect(await p.hasToolSupport("without-tools")).toBe(true);
+
+    await p.getAvailableLanguageModels();
+
+    expect(await p.hasToolSupport("with-tools")).toBe(true);
+    expect(await p.hasToolSupport("without-tools")).toBe(false);
+  });
+
+  // --- Chat generation ---
+
+  it("chats over fal's OpenAI-compatible route with Key auth", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({
+        choices: [{ message: { role: "assistant", content: "hi" } }]
+      })
+    }) as unknown as typeof fetch;
+    const p = new FalProvider({ FAL_API_KEY: "test-key" }, { fetchFn });
+
+    const message = await p.generateMessage({
+      messages: [{ role: "user", content: "hello" }],
+      model: "openai/gpt-5"
+    } as any);
+
+    expect(message.content).toBe("hi");
+    const [url, init] = (fetchFn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(url).toBe(
+      "https://fal.run/openrouter/router/openai/v1/chat/completions"
     );
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Key test-key"
+    );
+  });
+
+  it("refuses chat generation without an API key", async () => {
+    const p = new FalProvider({});
+    await expect(
+      p.generateMessage({ messages: [], model: "openai/gpt-5" } as any)
+    ).rejects.toThrow("FAL_API_KEY is required");
   });
 
   // --- textToImage ---


### PR DESCRIPTION
## Why

fal LLMs never appeared in the model select. The picker is built from each available provider's `getAvailableLanguageModels()`, and `FalProvider` only enumerated image, video, TTS and music models — it inherited the base class's empty language-model list and threw `"fal_ai does not support chat generation"` from both chat entry points. fal's image models showed up; its LLMs could not.

## What changed

`FalProvider` now speaks chat and enumerates language models.

- **Chat** delegates to an `OpenAICompatProvider` pointed at `https://fal.run/openrouter/router/openai/v1`, fal's OpenAI-compatible route. fal authenticates it with `Key <FAL_KEY>` and answers 401 to the Bearer form, so the delegate overrides the compat client's `Authorization` header via `defaultHeaders`. The delegate is created lazily and forwards progress messages through the provider's own emitter.
- **Model listing** comes from OpenRouter's public, keyless catalog — the route is OpenRouter's router, so the ids it accepts are OpenRouter's ids, and fal publishes no `/models` for it. A catalog that will not load yields no language models rather than a failed provider, matching how the other enumerating providers fail.
- **Tool support** is read per model from the catalog's `supported_parameters` instead of the base class's blanket yes. Before any listing there is nothing to answer from, so it still answers yes rather than hiding tools from a model that has them.
- **Cost** accrues on the delegate, so `cost` and `resetCost` fold it in.

The constructor takes an optional `fetchFn` so the catalog and chat paths are testable without network.

Nothing else needed changing: `getAllModels` and `availableForKind` already aggregate every available provider's language models, and no frontend code filters fal out.

## Testing

- `packages/runtime` provider suite: 98 files, 1759 tests, all passing.
- New tests cover the catalog mapping, the unreachable-catalog case, per-model tool support, the chat request's URL and `Key` auth header, and the missing-key refusal. The two tests asserting the old "not supported" throws are replaced.
- `npm run typecheck` clean for web, electron and all backend packages (mobile fails on missing Expo deps, pre-existing in this environment). `npm run lint` clean.

## Note

Cost calculation has no fal entries for these model ids, so LLM spend through fal records as zero in the prediction ledger. The OpenRouter catalog rows carry per-token pricing, so wiring that in is a follow-up if it matters.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2WSTaGZZySxQXUNhvdj5m)_