### PR TITLE
Offer every hosted provider in the cloud, drop only local ones

### DIFF
--- a/docs/CLOUD_NODE_CURATION.md
+++ b/docs/CLOUD_NODE_CURATION.md
@@ -52,7 +52,8 @@ types dropped from a kept namespace), `CLOUD_PROVIDER_IDS`, and
 
 ## Providers
 
-Limited to the big foundation-model labs plus Fal + Kie for media.
+Limited to the big foundation-model labs plus OpenRouter for breadth and
+Fal + Kie for media.
 
 | Provider  | Id        | Role                          |
 | --------- | --------- | ----------------------------- |
@@ -62,14 +63,16 @@ Limited to the big foundation-model labs plus Fal + Kie for media.
 | Mistral   | `mistral` | LLM, vision                   |
 | xAI       | `xai`     | LLM, image, vision            |
 | Groq      | `groq`    | Fast LLM (via Agent/Chat nodes) |
+| OpenRouter | `openrouter` | Aggregator: one key, hundreds of LLMs (via Agent/Chat nodes) |
 | Fal       | `fal_ai`  | Hosted image/video/audio models |
 | Kie       | `kie`     | Hosted image/video/audio models |
 
-Anthropic and Groq have **no dedicated node namespace** — they reach users
-through the Agent / Chat / generator nodes via the provider registry.
+Anthropic, Groq and OpenRouter have **no dedicated node namespace** — they
+reach users through the Agent / Chat / generator nodes via the provider
+registry.
 
 **Dropped providers:** Replicate, Together, MiniMax, Topaz, Reve, AtlasCloud,
-ElevenLabs, Cohere, Voyage, Jina, Moonshot, DeepSeek, OpenRouter, Cerebras,
+ElevenLabs, Cohere, Voyage, Jina, Moonshot, DeepSeek, Cerebras,
 Evolink, Aki, Meshy, Rodin, and all local runtimes (Ollama, LM Studio,
 llama.cpp, vLLM, Hugging Face local, Transformers.js).
 

--- a/docs/CLOUD_NODE_CURATION.md
+++ b/docs/CLOUD_NODE_CURATION.md
@@ -39,42 +39,47 @@ loads unchanged. When active, three things happen at server bootstrap:
    registered).
 2. **Node registry** — every node type outside the curated allowlist is pruned
    (`applyCloudNodePolicy`).
-3. **Provider registry** — every provider outside the allowlist is pruned, so
-   only the curated providers appear in model selectors.
+3. **Provider registry** — the local engines and the local-CLI subscription
+   are pruned; every hosted API stays, so any key the settings page accepts
+   reaches a working model selector.
 
 The single source of truth is
 [`packages/protocol/src/cloud-profile.ts`](../packages/protocol/src/cloud-profile.ts):
 `CLOUD_NODE_NAMESPACES` (whole namespaces kept), `CLOUD_NODE_ALLOWLIST`
 (individual node types kept from an otherwise-trimmed namespace — the sandboxed
 Code node and the curated text nodes), `CLOUD_NODE_DENYLIST` (individual node
-types dropped from a kept namespace), `CLOUD_PROVIDER_IDS`, and
+types dropped from a kept namespace), `NON_CLOUD_PROVIDER_IDS`, and
 `CLOUD_BUILTIN_PACK_IDS`. Maintaining the cloud offering = editing those lists.
 
 ## Providers
 
-Limited to the big foundation-model labs plus OpenRouter for breadth and
-Fal + Kie for media.
+Every provider NodeTool registers is offered, except the ones a cloud server
+cannot reach on the user's behalf. The node catalog is curated; the provider
+list is not.
 
-| Provider  | Id        | Role                          |
-| --------- | --------- | ----------------------------- |
-| OpenAI    | `openai`  | LLM, image, audio, realtime   |
-| Anthropic | `anthropic` | LLM (via Agent/Chat nodes)  |
-| Google    | `gemini`  | LLM, image, audio, video      |
-| Mistral   | `mistral` | LLM, vision                   |
-| xAI       | `xai`     | LLM, image, vision            |
-| Groq      | `groq`    | Fast LLM (via Agent/Chat nodes) |
-| OpenRouter | `openrouter` | Aggregator: one key, hundreds of LLMs (via Agent/Chat nodes) |
-| Fal       | `fal_ai`  | Hosted image/video/audio models |
-| Kie       | `kie`     | Hosted image/video/audio models |
+Providers are bring-your-own-key: a key pasted into settings works the same
+from a Fly machine as from a laptop, and the settings page offers an API-key
+card for every one of them. A curated allowlist sat here before, and each
+provider it omitted still had that card — so a cloud user could save an
+OpenRouter key and find an empty model picker with nothing saying why.
 
-Anthropic, Groq and OpenRouter have **no dedicated node namespace** — they
-reach users through the Agent / Chat / generator nodes via the provider
-registry.
+**Kept:** every hosted API — OpenAI, Anthropic, Gemini, Mistral, xAI, Groq,
+OpenRouter, DeepSeek, Moonshot, MiniMax, Cerebras, Together, Alibaba, Evolink,
+GMI, AtlasCloud, Aki, Cohere, Voyage, Jina, Hugging Face, Replicate, Fal, Kie,
+ElevenLabs, Topaz, Reve, Meshy, Rodin, Codex, and NodeTool's own managed
+models.
 
-**Dropped providers:** Replicate, Together, MiniMax, Topaz, Reve, AtlasCloud,
-ElevenLabs, Cohere, Voyage, Jina, Moonshot, DeepSeek, Cerebras,
-Evolink, Aki, Meshy, Rodin, and all local runtimes (Ollama, LM Studio,
-llama.cpp, vLLM, Hugging Face local, Transformers.js).
+**Dropped** (`NON_CLOUD_PROVIDER_IDS`): the engines that run on the user's own
+machine — Ollama, LM Studio, llama.cpp, node-llama-cpp, vLLM, MLX,
+Transformers.js — plus the Claude Agent SDK, which reaches a personal
+subscription by spawning the local `claude` CLI, and the dev-only `fake`
+provider. The local engines are also never registered under the cloud profile
+in the first place.
+
+A provider needs no dedicated node namespace to be useful: Anthropic, Groq and
+OpenRouter reach users through the Agent / Chat / generator nodes, and
+ElevenLabs through the generic `nodetool.audio.TextToSpeech` node, via the
+provider registry alone.
 
 ## Namespaces kept
 
@@ -177,5 +182,7 @@ cloud profile drops:
 - Hide a single node from a kept namespace (e.g. a file-I/O node in
   `nodetool.text`, or a developer agent in `nodetool.agents`) → add its node
   type to `CLOUD_NODE_DENYLIST`.
-- Add/remove a provider → edit `CLOUD_PROVIDER_IDS` (and, for whole provider
-  packs, `CLOUD_BUILTIN_PACK_IDS`).
+- Hide a provider that cannot work in the cloud → add its id to
+  `NON_CLOUD_PROVIDER_IDS`. A newly registered provider is offered by default;
+  nothing needs editing to ship one. For whole provider packs, edit
+  `CLOUD_BUILTIN_PACK_IDS`.

--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -204,6 +204,11 @@ export const CLOUD_NODE_DENYLIST: readonly string[] = [
  * plus Fal and Kie for media. Anthropic and Groq have no dedicated node
  * namespace — they reach users through the Agent / Chat / generator nodes via
  * the provider registry, so they live here only.
+ *
+ * OpenRouter is here for the same reason the labs are: it is a bring-your-own-key
+ * aggregator reached through the same nodes, and one key covers hundreds of
+ * models. Pruning it while the settings UI still offers an OpenRouter key card
+ * let a cloud user save a key and find an empty model picker.
  */
 export const CLOUD_PROVIDER_IDS: readonly string[] = [
   "openai",
@@ -212,6 +217,7 @@ export const CLOUD_PROVIDER_IDS: readonly string[] = [
   "groq",
   "mistral",
   "xai",
+  "openrouter",
   "fal_ai",
   "kie",
   "nodetool"

--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -200,27 +200,40 @@ export const CLOUD_NODE_DENYLIST: readonly string[] = [
 ];
 
 /**
- * Provider ids exposed in the cloud product: the big foundation-model labs
- * plus Fal and Kie for media. Anthropic and Groq have no dedicated node
- * namespace — they reach users through the Agent / Chat / generator nodes via
- * the provider registry, so they live here only.
+ * Providers kept *out* of the cloud product. Every other registered provider
+ * is offered — the node catalog is curated, the provider list is not.
  *
- * OpenRouter is here for the same reason the labs are: it is a bring-your-own-key
- * aggregator reached through the same nodes, and one key covers hundreds of
- * models. Pruning it while the settings UI still offers an OpenRouter key card
- * let a cloud user save a key and find an empty model picker.
+ * The rule is reachability, not curation: a provider stays out when the cloud
+ * server cannot reach it on the user's behalf. That is either an engine that
+ * runs on the user's own machine (Ollama, LM Studio, llama.cpp, vLLM,
+ * Transformers.js in-process) or a personal subscription reached by spawning a
+ * local CLI (the Claude Agent SDK shells out to `claude`). Everything else is
+ * an HTTP API behind a key the user pastes into settings, which works the same
+ * from a Fly machine as from a laptop.
+ *
+ * A curated allowlist sat here before, and every provider it omitted still had
+ * an API-key card in settings: a cloud user could save an OpenRouter key and
+ * find an empty model picker, with nothing saying why. Listing only what
+ * genuinely cannot work keeps the settings UI and the registry from drifting.
+ *
+ * The local engines are additionally never registered under the cloud profile
+ * (see the provider index); naming them here keeps the predicate honest for
+ * anything registered after that gate, and for callers asking about a
+ * provider id on its own.
  */
-export const CLOUD_PROVIDER_IDS: readonly string[] = [
-  "openai",
-  "anthropic",
-  "gemini",
-  "groq",
-  "mistral",
-  "xai",
-  "openrouter",
-  "fal_ai",
-  "kie",
-  "nodetool"
+export const NON_CLOUD_PROVIDER_IDS: readonly string[] = [
+  // Engines that run on the user's own machine.
+  "ollama",
+  "lmstudio",
+  "llama_cpp",
+  "node_llama_cpp",
+  "vllm",
+  "mlx",
+  "transformers_js",
+  // A personal subscription reached by spawning the local `claude` CLI.
+  "claude_agent_sdk",
+  // Test double, dev-gated at registration.
+  "fake"
 ];
 
 /**
@@ -246,7 +259,13 @@ export function isCloudNodeType(nodeType: string): boolean {
   );
 }
 
-/** Whether `providerId` is exposed in the cloud product. */
+/**
+ * Whether `providerId` is exposed in the cloud product — true for everything
+ * except the local engines and local-CLI subscriptions in
+ * {@link NON_CLOUD_PROVIDER_IDS}. An unknown id is treated as cloud-eligible:
+ * a provider added to the registry reaches cloud users without a second edit
+ * here, and one that cannot work there has to be named.
+ */
 export function isCloudProvider(providerId: string): boolean {
-  return CLOUD_PROVIDER_IDS.includes(providerId);
+  return !NON_CLOUD_PROVIDER_IDS.includes(providerId);
 }

--- a/packages/protocol/tests/cloud-profile.test.ts
+++ b/packages/protocol/tests/cloud-profile.test.ts
@@ -170,8 +170,18 @@ describe("code is node-level trimmed; text is whole-listed minus file I/O", () =
 });
 
 describe("cloud provider + pack allowlists", () => {
-  it("keeps the big labs plus Fal and Kie, drops the rest", () => {
-    for (const id of ["openai", "anthropic", "gemini", "mistral", "xai", "groq", "fal_ai", "kie"]) {
+  it("keeps the big labs plus OpenRouter, Fal and Kie, drops the rest", () => {
+    for (const id of [
+      "openai",
+      "anthropic",
+      "gemini",
+      "mistral",
+      "xai",
+      "groq",
+      "openrouter",
+      "fal_ai",
+      "kie"
+    ]) {
       expect(isCloudProvider(id)).toBe(true);
     }
     for (const id of ["replicate", "together", "minimax", "topaz", "cohere", "ollama"]) {

--- a/packages/protocol/tests/cloud-profile.test.ts
+++ b/packages/protocol/tests/cloud-profile.test.ts
@@ -4,7 +4,7 @@ import {
   CLOUD_NODE_ALLOWLIST,
   CLOUD_NODE_DENYLIST,
   CLOUD_HOST_FILE_NODES,
-  CLOUD_PROVIDER_IDS,
+  NON_CLOUD_PROVIDER_IDS,
   CLOUD_BUILTIN_PACK_IDS,
   isCloudNodeType,
   isCloudProvider,
@@ -170,7 +170,7 @@ describe("code is node-level trimmed; text is whole-listed minus file I/O", () =
 });
 
 describe("cloud provider + pack allowlists", () => {
-  it("keeps the big labs plus OpenRouter, Fal and Kie, drops the rest", () => {
+  it("keeps every hosted API — the labs, the aggregators, and the media APIs", () => {
     for (const id of [
       "openai",
       "anthropic",
@@ -180,13 +180,39 @@ describe("cloud provider + pack allowlists", () => {
       "groq",
       "openrouter",
       "fal_ai",
-      "kie"
+      "kie",
+      "replicate",
+      "together",
+      "minimax",
+      "elevenlabs",
+      "meshy",
+      "rodin",
+      "topaz",
+      "cohere",
+      "voyage",
+      "deepseek",
+      "huggingface"
     ]) {
       expect(isCloudProvider(id)).toBe(true);
     }
-    for (const id of ["replicate", "together", "minimax", "topaz", "cohere", "ollama"]) {
+  });
+
+  it("drops local engines and the local-CLI subscription", () => {
+    for (const id of [
+      "ollama",
+      "lmstudio",
+      "llama_cpp",
+      "node_llama_cpp",
+      "vllm",
+      "transformers_js",
+      "claude_agent_sdk"
+    ]) {
       expect(isCloudProvider(id)).toBe(false);
     }
+  });
+
+  it("treats an unknown provider id as cloud-eligible", () => {
+    expect(isCloudProvider("some-future-hosted-api")).toBe(true);
   });
 
   it("denylisted node types target an allowed namespace and stay out", () => {
@@ -206,8 +232,10 @@ describe("cloud provider + pack allowlists", () => {
     }
   });
 
-  it("provider allowlist is non-empty and unique", () => {
-    expect(CLOUD_PROVIDER_IDS.length).toBeGreaterThan(0);
-    expect(new Set(CLOUD_PROVIDER_IDS).size).toBe(CLOUD_PROVIDER_IDS.length);
+  it("non-cloud provider list is non-empty and unique", () => {
+    expect(NON_CLOUD_PROVIDER_IDS.length).toBeGreaterThan(0);
+    expect(new Set(NON_CLOUD_PROVIDER_IDS).size).toBe(
+      NON_CLOUD_PROVIDER_IDS.length
+    );
   });
 });

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -270,7 +270,7 @@ registerBuiltinProvider(PROVIDER_IDS.ANTHROPIC, AnthropicProvider, { ANTHROPIC_A
 // store, so the provider is always "configured"; a missing CLI or a missing
 // optional `@anthropic-ai/claude-agent-sdk` package (a soft dependency the user
 // installs themselves) surfaces at call time. Pruned from the cloud profile
-// (not in CLOUD_PROVIDER_IDS) since it needs a local executable and subscription.
+// (in NON_CLOUD_PROVIDER_IDS) since it needs a local executable and subscription.
 registerBuiltinProvider(PROVIDER_IDS.CLAUDE_AGENT_SDK, ClaudeAgentProvider, {});
 registerBuiltinProvider(PROVIDER_IDS.GEMINI, GeminiProvider, { GEMINI_API_KEY: "" });
 registerBuiltinProvider(PROVIDER_IDS.GROQ, GroqProvider, { GROQ_API_KEY: "" });
@@ -388,11 +388,12 @@ if (
 }
 
 // Cloud profile (production default, or NODETOOL_NODE_PROFILE=cloud; disabled
-// by NODETOOL_NODE_PROFILE=full): keep only the
-// curated provider allowlist (the big LLM labs plus Fal + Kie). Pruning after
-// registration — rather than gating each register call — keeps the
-// registration block above untouched and works regardless of which providers
-// a future edit adds.
+// by NODETOOL_NODE_PROFILE=full): drop the providers a cloud server cannot
+// reach on the user's behalf — local engines and the local-CLI subscription.
+// Every hosted API stays, since it works the same from a Fly machine as from a
+// laptop. Pruning after registration — rather than gating each register call —
+// keeps the registration block above untouched and works regardless of which
+// providers a future edit adds.
 if (_cloudProfile) {
   for (const id of listBuiltinProviderIds()) {
     if (!isCloudProvider(id)) unregisterBuiltinProvider(id);

--- a/packages/runtime/tests/providers/cloud-profile-providers.test.ts
+++ b/packages/runtime/tests/providers/cloud-profile-providers.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 
+// Every hosted API survives the cloud profile: settings offers an API-key card
+// for each, and a key with no provider behind it is an empty model picker.
 const CLOUD = [
   "openai",
   "anthropic",
@@ -7,13 +9,9 @@ const CLOUD = [
   "groq",
   "mistral",
   "xai",
-  // A cloud user can save an OpenRouter key in settings; pruning the provider
-  // left that key with an empty language-model picker.
   "openrouter",
   "fal_ai",
-  "kie"
-];
-const OUT_OF_SCOPE = [
+  "kie",
   "replicate",
   "together",
   "minimax",
@@ -26,7 +24,18 @@ const OUT_OF_SCOPE = [
   "huggingface",
   "deepseek",
   "moonshot",
-  "ollama"
+  "elevenlabs",
+  "meshy",
+  "rodin"
+];
+// Local engines are never registered under the cloud profile in the first
+// place; the CLI-backed subscription is registered and then pruned.
+const OUT_OF_SCOPE = [
+  "ollama",
+  "lmstudio",
+  "llama_cpp",
+  "node_llama_cpp",
+  "claude_agent_sdk"
 ];
 
 // The provider registry registers (and, under the cloud profile, prunes) at

--- a/packages/runtime/tests/providers/cloud-profile-providers.test.ts
+++ b/packages/runtime/tests/providers/cloud-profile-providers.test.ts
@@ -7,6 +7,9 @@ const CLOUD = [
   "groq",
   "mistral",
   "xai",
+  // A cloud user can save an OpenRouter key in settings; pruning the provider
+  // left that key with an empty language-model picker.
+  "openrouter",
   "fal_ai",
   "kie"
 ];
@@ -21,7 +24,6 @@ const OUT_OF_SCOPE = [
   "voyage",
   "jina",
   "huggingface",
-  "openrouter",
   "deepseek",
   "moonshot",
   "ollama"


### PR DESCRIPTION
OpenRouter models never appeared in the language model select on the deployed app. The cause generalizes, so this PR fixes the rule rather than the one provider.

## Cause

`fly.toml` sets `NODETOOL_ENV=production`, which activates the cloud profile, which prunes the provider registry against `CLOUD_PROVIDER_IDS` — nine ids. The settings page offers an API-key card for all thirty-odd providers, unconditionally. Every provider in that gap behaved the same way: save a key, get an empty model picker, with nothing saying why.

Two surfaces were curated past the point of working:

- `nodetool.model3d` is in `CLOUD_NODE_NAMESPACES`, but the only 3D providers (Meshy, Rodin) were pruned — `TextTo3D` / `ImageTo3D` shipped with nothing selectable.
- Voice had no provider but OpenAI, while the cloud keeps `nodetool.audio`, `nodetool.timeline`, and the script-voicing tools.

Locally (profile off) the whole chain already worked; I verified that end to end against a clean DB and in a real browser before changing anything, which is what pointed at the profile as the only place it could break.

## Change

Invert the rule. Providers are bring-your-own-key, so a hosted API works the same from a Fly machine as from a laptop. What genuinely cannot work is an engine on the user's own machine, or a subscription reached by spawning a local CLI.

`NON_CLOUD_PROVIDER_IDS` names those — Ollama, LM Studio, llama.cpp, node-llama-cpp, vLLM, MLX, Transformers.js, the Claude Agent SDK (shells out to `claude`), and the dev-only `fake`. `isCloudProvider` negates that list, so an unknown id is cloud-eligible and a newly registered provider reaches cloud users without a second edit here.

**The node catalog stays curated.** `CLOUD_NODE_NAMESPACES`, the node allow/denylists and `CLOUD_BUILTIN_PACK_IDS` are untouched. A provider needs no node pack to be useful: Anthropic and Groq already reach users through the Agent / Chat nodes, ElevenLabs through the generic `nodetool.audio.TextToSpeech`.

This also closes a related mismatch without extra code: `curatedForKind` merges `RECOMMENDED_MODELS` into cloud pickers without profile filtering, which used to offer MiniMax music and Voyage/Jina/Cohere embedding models with no provider behind them. Every provider in that list is now registered.

- `packages/protocol/src/cloud-profile.ts` — `NON_CLOUD_PROVIDER_IDS` replaces `CLOUD_PROVIDER_IDS`; `isCloudProvider` inverts
- `packages/runtime/src/providers/index.ts` — comments only; the pruning loop is unchanged
- `packages/protocol/tests/cloud-profile.test.ts`, `packages/runtime/tests/providers/cloud-profile-providers.test.ts` — assert every hosted API survives, local engines and the CLI subscription don't, unknown ids are eligible
- `docs/CLOUD_NODE_CURATION.md` — providers section and maintenance notes

## Verification

Server run with `NODETOOL_NODE_PROFILE=cloud NODETOOL_ENV=production`:

```
31 providers registered, no local engine among them:
aki, alibaba, anthropic, atlascloud, cerebras, codex, cohere, deepseek,
elevenlabs, evolink, fal_ai, gemini, gmi, groq, huggingface, jina, kie,
meshy, minimax, mistral, moonshot, nodetool, openai, openrouter,
replicate, reve, rodin, together, topaz, voyage, xai
```

Saving keys through the same tRPC call the settings UI uses, then re-querying `models.providers`:

```
before: ['nodetool']
after:  ['elevenlabs', 'meshy', 'nodetool', 'openrouter', 'replicate']
```

`npm run lint` and `npm run typecheck` pass (mobile typecheck fails on missing Expo deps in this sandbox, pre-existing and unrelated). Full protocol suite (796 tests) and the runtime cloud-profile and OpenRouter suites pass.

## Worth a look during review

`codex` is kept — it is an OAuth token against the ChatGPT backend over HTTP, not a local CLI, so it passes the "can a cloud server reach it" test. If shipping a personal-subscription provider in a hosted product is a policy call rather than a technical one, add it to `NON_CLOUD_PROVIDER_IDS` and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UXh57qqTdamxsnqXxiovP