### PR TITLE
feat(studio): curated model dropdowns, no model picker for the assistants

### DIFF
--- a/packages/protocol/src/nodetool-models.ts
+++ b/packages/protocol/src/nodetool-models.ts
@@ -4,22 +4,59 @@
  * runs the delegate on platform-owned keys and the spend is metered against
  * the user's credit balance. BYOK providers are untouched by any of this.
  *
+ * The catalog is also the Studio beginner shell's model menu: the shell shows
+ * a plain dropdown of the entries of one kind instead of the full provider
+ * browser, so `name` and `blurb` are user-facing copy and the order here is
+ * the order a beginner sees (cheapest/fastest first, default first).
+ *
  * Pure data on purpose: the runtime provider routes with it, model-pricing
  * translates ids through it, and the web curated-model config points at it.
  */
+
+export interface NodetoolVoiceDef {
+  /** Voice id the delegate endpoint accepts. */
+  id: string;
+  /** User-facing voice name. */
+  name: string;
+}
 
 export interface NodetoolModelDef {
   /** Public model id under the `nodetool` provider, e.g. "nodetool/flux-schnell". */
   id: string;
   name: string;
-  kind: "language" | "image" | "video";
+  kind: NodetoolModelKind;
+  /** One line of user-facing copy for the Studio dropdown. */
+  blurb?: string;
   /** Image/video task hints for the pickers. */
   tasks?: string[];
   delegate: {
     provider: string;
     model: string;
   };
+  /**
+   * Delegate serving image-to-image, when the endpoint behind {@link delegate}
+   * only takes text. FAL splits most image families into a generate and an
+   * edit endpoint; a curated still model claims `image_to_image` only when
+   * this is set.
+   */
+  editDelegate?: {
+    provider: string;
+    model: string;
+  };
+  /**
+   * Delegate serving text-to-video, when the endpoint behind {@link delegate}
+   * animates an existing frame. Same split as {@link editDelegate}: a curated
+   * clip model claims `text_to_video` only when this is set.
+   */
+  textDelegate?: {
+    provider: string;
+    model: string;
+  };
+  /** Selectable voices, for `tts` entries. */
+  voices?: readonly NodetoolVoiceDef[];
 }
+
+export type NodetoolModelKind = "language" | "image" | "video" | "tts";
 
 export const NODETOOL_PROVIDER_ID = "nodetool";
 
@@ -28,32 +65,126 @@ export const NODETOOL_MODELS: readonly NodetoolModelDef[] = [
     id: "nodetool/director",
     name: "NodeTool Director",
     kind: "language",
+    blurb: "Writes and directs. Not user-selectable.",
     delegate: { provider: "anthropic", model: "claude-sonnet-5" }
   },
   {
     id: "nodetool/flux-schnell",
-    name: "NodeTool Still (FLUX Schnell)",
+    name: "Fast",
     kind: "image",
-    tasks: ["text_to_image", "image_to_image"],
+    blurb: "Cheapest stills, seconds per shot. Text prompts only.",
+    tasks: ["text_to_image"],
     delegate: { provider: "fal_ai", model: "fal-ai/flux-1/schnell" }
   },
   {
-    id: "nodetool/kling-standard",
-    name: "NodeTool Clip (Kling Standard)",
+    id: "nodetool/nano-banana",
+    name: "Balanced",
+    kind: "image",
+    blurb: "Sharper stills, and it can work from your reference images.",
+    tasks: ["text_to_image", "image_to_image"],
+    delegate: { provider: "fal_ai", model: "fal-ai/nano-banana" },
+    editDelegate: { provider: "fal_ai", model: "fal-ai/nano-banana/edit" }
+  },
+  {
+    id: "nodetool/seedream",
+    name: "Detailed",
+    kind: "image",
+    blurb: "Most detail per still, and the slowest of the three.",
+    tasks: ["text_to_image", "image_to_image"],
+    delegate: {
+      provider: "fal_ai",
+      model: "fal-ai/bytedance/seedream/v4/text-to-image"
+    },
+    editDelegate: {
+      provider: "fal_ai",
+      model: "fal-ai/bytedance/seedream/v4/edit"
+    }
+  },
+  {
+    id: "nodetool/hailuo-fast",
+    name: "Fast",
     kind: "video",
-    tasks: ["image_to_video"],
+    blurb: "Cheapest clips, good for blocking out a cut.",
+    tasks: ["image_to_video", "text_to_video"],
+    delegate: {
+      provider: "fal_ai",
+      model: "fal-ai/minimax/hailuo-02-fast/image-to-video"
+    },
+    textDelegate: {
+      provider: "fal_ai",
+      model: "fal-ai/minimax/hailuo-02/pro/text-to-video"
+    }
+  },
+  {
+    id: "nodetool/kling-turbo",
+    name: "Balanced",
+    kind: "video",
+    blurb: "Steadier motion at half the price of the best tier.",
+    tasks: ["image_to_video", "text_to_video"],
+    delegate: {
+      provider: "fal_ai",
+      model: "fal-ai/kling-video/v2.5-turbo/standard/image-to-video"
+    },
+    textDelegate: {
+      provider: "fal_ai",
+      model: "fal-ai/kling-video/v3/turbo/standard/text-to-video"
+    }
+  },
+  {
+    id: "nodetool/kling-standard",
+    name: "Best",
+    kind: "video",
+    blurb: "Most faithful motion, for the shots that carry the film.",
+    tasks: ["image_to_video", "text_to_video"],
     delegate: {
       provider: "fal_ai",
       model: "fal-ai/kling-video/o1/standard/image-to-video"
+    },
+    textDelegate: {
+      provider: "fal_ai",
+      model: "fal-ai/kling-video/o3/standard/text-to-video"
     }
+  },
+  {
+    id: "nodetool/kokoro",
+    name: "NodeTool Voice",
+    kind: "tts",
+    blurb: "Eight voices for reading a script aloud.",
+    tasks: ["text_to_speech"],
+    delegate: { provider: "fal_ai", model: "fal-ai/kokoro" },
+    voices: [
+      { id: "af_heart", name: "Ada — warm, female" },
+      { id: "af_nova", name: "Nova — bright, female" },
+      { id: "af_sky", name: "Sky — soft, female" },
+      { id: "am_michael", name: "Michael — warm, male" },
+      { id: "am_echo", name: "Echo — even, male" },
+      { id: "am_fenrir", name: "Fenrir — deep, male" },
+      { id: "af_bella", name: "Bella — rich, female" },
+      { id: "am_puck", name: "Puck — playful, male" }
+    ]
   }
 ] as const;
 
 export const nodetoolModelById = (id: string): NodetoolModelDef | null =>
   NODETOOL_MODELS.find((m) => m.id === id) ?? null;
 
-/** The delegate behind a nodetool model id, or null for an unknown id. */
+/** The curated entries of one kind, in menu order. */
+export const nodetoolModelsOfKind = (
+  kind: NodetoolModelKind
+): NodetoolModelDef[] => NODETOOL_MODELS.filter((m) => m.kind === kind);
+
+/**
+ * The delegate behind a nodetool model id, or null for an unknown id. Pass
+ * `"image_to_image"` or `"text_to_video"` to get the endpoint the entry names
+ * for that task, when it names one.
+ */
 export const resolveNodetoolDelegate = (
-  id: string
-): { provider: string; model: string } | null =>
-  nodetoolModelById(id)?.delegate ?? null;
+  id: string,
+  task?: string
+): { provider: string; model: string } | null => {
+  const def = nodetoolModelById(id);
+  if (!def) return null;
+  if (task === "image_to_image" && def.editDelegate) return def.editDelegate;
+  if (task === "text_to_video" && def.textDelegate) return def.textDelegate;
+  return def.delegate;
+};

--- a/packages/runtime/src/providers/nodetool-provider.ts
+++ b/packages/runtime/src/providers/nodetool-provider.ts
@@ -15,10 +15,12 @@
  */
 import {
   NODETOOL_MODELS,
-  nodetoolModelById
+  nodetoolModelById,
+  type NodetoolModelKind
 } from "@nodetool-ai/protocol";
 import { BaseProvider, type ProviderCapability } from "./base-provider.js";
 import type {
+  EncodedAudioResult,
   ImageModel,
   ImageToImageParams,
   ImageToVideoParams,
@@ -27,6 +29,7 @@ import type {
   ProviderStreamItem,
   TextToImageParams,
   TextToVideoParams,
+  TTSModel,
   VideoModel
 } from "./types.js";
 import { FalProvider } from "./fal-provider.js";
@@ -68,7 +71,10 @@ export class NodetoolProvider extends BaseProvider {
    * absorption window. Construction is cheap — both delegates build their
    * network clients lazily.
    */
-  private delegateFor(modelId: string): {
+  private delegateFor(
+    modelId: string,
+    task?: string
+  ): {
     provider: BaseProvider;
     model: string;
   } {
@@ -76,18 +82,22 @@ export class NodetoolProvider extends BaseProvider {
     if (!def) {
       throw new Error(`Unknown NodeTool model "${modelId}".`);
     }
-    const key = this.platformKey(def.delegate.provider);
+    const delegate =
+      (task === "image_to_image" ? def.editDelegate : undefined) ??
+      (task === "text_to_video" ? def.textDelegate : undefined) ??
+      def.delegate;
+    const key = this.platformKey(delegate.provider);
     if (!key) {
       throw new Error(
         `NodeTool model "${modelId}" is not available on this server ` +
-          `(missing ${PLATFORM_KEYS[def.delegate.provider]}).`
+          `(missing ${PLATFORM_KEYS[delegate.provider]}).`
       );
     }
     const provider =
-      def.delegate.provider === "fal_ai"
+      delegate.provider === "fal_ai"
         ? new FalProvider({ FAL_API_KEY: key })
         : new AnthropicProvider({ ANTHROPIC_API_KEY: key });
-    return { provider, model: def.delegate.model };
+    return { provider, model: delegate.model };
   }
 
   /** Run a delegated call and absorb the delegate's cost delta as our own. */
@@ -120,14 +130,20 @@ export class NodetoolProvider extends BaseProvider {
     for (const def of NODETOOL_MODELS) {
       if (!this.isFunded(def.delegate.provider)) continue;
       if (def.kind === "language") capabilities.push("generate_message");
-      if (def.kind === "image")
-        capabilities.push("text_to_image", "image_to_image");
-      if (def.kind === "video") capabilities.push("image_to_video");
+      if (def.kind === "image") {
+        capabilities.push("text_to_image");
+        if (def.editDelegate) capabilities.push("image_to_image");
+      }
+      if (def.kind === "video") {
+        capabilities.push("image_to_video");
+        if (def.textDelegate) capabilities.push("text_to_video");
+      }
+      if (def.kind === "tts") capabilities.push("text_to_speech");
     }
     return [...new Set(capabilities)];
   }
 
-  private fundedModels(kind: "language" | "image" | "video") {
+  private fundedModels(kind: NodetoolModelKind) {
     return NODETOOL_MODELS.filter(
       (def) => def.kind === kind && this.isFunded(def.delegate.provider)
     );
@@ -162,6 +178,15 @@ export class NodetoolProvider extends BaseProvider {
     }));
   }
 
+  override async getAvailableTTSModels(): Promise<TTSModel[]> {
+    return this.fundedModels("tts").map((def) => ({
+      id: def.id,
+      name: def.name,
+      provider: "nodetool",
+      voices: (def.voices ?? []).map((voice) => voice.id)
+    }));
+  }
+
   override async textToImage(params: TextToImageParams): Promise<Uint8Array> {
     const { provider, model } = this.delegateFor(params.model.id);
     return this.absorbing(provider, () =>
@@ -176,7 +201,10 @@ export class NodetoolProvider extends BaseProvider {
     images: Uint8Array[],
     params: ImageToImageParams
   ): Promise<Uint8Array> {
-    const { provider, model } = this.delegateFor(params.model.id);
+    const { provider, model } = this.delegateFor(
+      params.model.id,
+      "image_to_image"
+    );
     return this.absorbing(provider, () =>
       provider.imageToImage(images, {
         ...params,
@@ -186,7 +214,10 @@ export class NodetoolProvider extends BaseProvider {
   }
 
   override async textToVideo(params: TextToVideoParams): Promise<Uint8Array> {
-    const { provider, model } = this.delegateFor(params.model.id);
+    const { provider, model } = this.delegateFor(
+      params.model.id,
+      "text_to_video"
+    );
     return this.absorbing(provider, () =>
       provider.textToVideo({
         ...params,
@@ -205,6 +236,19 @@ export class NodetoolProvider extends BaseProvider {
         ...params,
         model: { ...params.model, id: model, provider: provider.provider }
       })
+    );
+  }
+
+  override async textToSpeechEncoded(args: {
+    text: string;
+    model: string;
+    voice?: string;
+    speed?: number;
+    audioFormat?: string;
+  }): Promise<EncodedAudioResult | null> {
+    const { provider, model } = this.delegateFor(args.model);
+    return this.absorbing(provider, () =>
+      provider.textToSpeechEncoded({ ...args, model })
     );
   }
 

--- a/packages/runtime/tests/nodetool-provider.test.ts
+++ b/packages/runtime/tests/nodetool-provider.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 
+import { NODETOOL_MODELS, resolveNodetoolDelegate } from "@nodetool-ai/protocol";
+
 import { NodetoolProvider } from "../src/providers/nodetool-provider.js";
 
 describe("NodetoolProvider", () => {
@@ -33,6 +35,33 @@ describe("NodetoolProvider", () => {
     expect(provider.getCapabilities()).toContain("image_to_video");
   });
 
+  it("lists the curated voices of a funded TTS model", async () => {
+    const provider = new NodetoolProvider({
+      NODETOOL_PLATFORM_FAL_KEY: "platform-key"
+    });
+    const [voiceModel] = await provider.getAvailableTTSModels();
+    expect(voiceModel.provider).toBe("nodetool");
+    expect(voiceModel.voices?.length).toBeGreaterThan(1);
+    expect(provider.getCapabilities()).toContain("text_to_speech");
+  });
+
+  it("only claims image_to_image for models with an edit delegate", async () => {
+    const provider = new NodetoolProvider({
+      NODETOOL_PLATFORM_FAL_KEY: "platform-key"
+    });
+    const editable = NODETOOL_MODELS.filter(
+      (def) => def.kind === "image" && def.editDelegate
+    );
+    expect(editable.length).toBeGreaterThan(0);
+    const images = await provider.getAvailableImageModels();
+    for (const model of images) {
+      const def = NODETOOL_MODELS.find((d) => d.id === model.id);
+      expect(model.supported_tasks?.includes("image_to_image")).toBe(
+        Boolean(def?.editDelegate)
+      );
+    }
+  });
+
   it("refuses a call for an unfunded model with the platform key named", async () => {
     const provider = new NodetoolProvider({});
     await expect(
@@ -46,6 +75,19 @@ describe("NodetoolProvider", () => {
         prompt: "a fox"
       })
     ).rejects.toThrow(/NODETOOL_PLATFORM_FAL_KEY/);
+  });
+
+  it("routes image_to_image to the edit endpoint", () => {
+    expect(resolveNodetoolDelegate("nodetool/nano-banana")?.model).toBe(
+      "fal-ai/nano-banana"
+    );
+    expect(
+      resolveNodetoolDelegate("nodetool/nano-banana", "image_to_image")?.model
+    ).toBe("fal-ai/nano-banana/edit");
+    // A model with no edit endpoint stays on its one delegate.
+    expect(
+      resolveNodetoolDelegate("nodetool/flux-schnell", "image_to_image")?.model
+    ).toBe("fal-ai/flux-1/schnell");
   });
 
   it("rejects an unknown model id", async () => {

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -136,6 +136,11 @@ export interface MediaChatComposerProps {
   /** Pure chat panel: hide the mode picker and force "chat" mode. Used by the
    *  app builder / video / 3d editor agent panels which are hardcoded to chat. */
   hideModePicker?: boolean;
+  /**
+   * Hide the language-model chip. The Studio beginner shell pins the assistant
+   * to a curated model, so there is nothing to pick.
+   */
+  hideModelPicker?: boolean;
   /** Thread this composer writes to. A surface that opened the thread with a
    *  prompt in mind (the dashboard quick starters) seeds it through
    *  ChatDraftStore; the seed lands in the textarea once, unsent. */
@@ -176,6 +181,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
   leadingActions,
   placeholder: placeholderOverride,
   hideModePicker = false,
+  hideModelPicker = false,
   threadId
 }) => {
   const theme = useTheme();
@@ -1098,7 +1104,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
           {isPi && <PiComposerControls disabled={isBusy} />}
 
           {/* Model chip — changes based on mode */}
-          {!isPi && mode === "chat" && (
+          {!isPi && mode === "chat" && !hideModelPicker && (
             <>
               <MediaControlChip
                 ref={languageModelAnchorRef}

--- a/web/src/components/chat/containers/ChatInputSection.tsx
+++ b/web/src/components/chat/containers/ChatInputSection.tsx
@@ -70,6 +70,7 @@ type ChatInputSectionProps = {
   placeholder?: string;
   /** Pure chat panel: hide the media mode picker, force chat mode. */
   hideModePicker?: boolean;
+  hideModelPicker?: boolean;
   /** Thread this composer writes to; used to pick up a seeded prompt. */
   threadId?: string | null;
 };
@@ -89,6 +90,7 @@ const ChatInputSection = ({
   composerToolbar,
   placeholder,
   hideModePicker,
+  hideModelPicker,
   threadId
 }: ChatInputSectionProps) => {
   const isLoading = status === "loading";
@@ -122,6 +124,7 @@ const ChatInputSection = ({
             requireToolSupport={requireToolSupport}
             placeholder={placeholder}
             hideModePicker={hideModePicker}
+            hideModelPicker={hideModelPicker}
             threadId={threadId}
           />
         )}

--- a/web/src/components/chat/containers/ChatView.tsx
+++ b/web/src/components/chat/containers/ChatView.tsx
@@ -168,6 +168,8 @@ type ChatViewProps = {
   composerPlaceholder?: string;
   /** Pure chat panel: hide the media mode picker and force chat mode. */
   hideModePicker?: boolean;
+  /** Hide the language-model chip (the Studio shell pins the model). */
+  hideModelPicker?: boolean;
   /**
    * Show a "New chat" button above the thread. For surfaces with no chrome of
    * their own (the workspace chat tab); panels that already carry a header
@@ -218,6 +220,7 @@ const ChatView = ({
   composerToolbar,
   composerPlaceholder,
   hideModePicker,
+  hideModelPicker,
   showNewChatButton = false,
   threadId
 }: ChatViewProps) => {
@@ -323,6 +326,7 @@ const ChatView = ({
           composerToolbar={composerToolbar}
           placeholder={composerPlaceholder}
           hideModePicker={hideModePicker}
+          hideModelPicker={hideModelPicker}
           threadId={effectiveThreadId}
         />
       </div>

--- a/web/src/components/properties/ImageModelSelect.tsx
+++ b/web/src/components/properties/ImageModelSelect.tsx
@@ -13,6 +13,9 @@ import {
   type ImageModelTask
 } from "../../hooks/useModelsByProvider";
 import ModelSelectButton from "./shared/ModelSelectButton";
+import CuratedModelSelect from "./curated/CuratedModelSelect";
+import { useInStudio } from "../../studio/StudioContext";
+import { forTasks, STUDIO_STILL_MODELS } from "../../studio/curatedModels";
 
 interface ImageModelSelectProps {
   onChange: (value: ImageModelValue) => void;
@@ -32,6 +35,7 @@ const ImageModelSelect: React.FC<ImageModelSelectProps> = ({
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const addRecent = useModelPreferencesStore((s) => s.addRecent);
+  const inStudio = useInStudio();
 
   const { models: fetchedModels } = useImageModelsByProvider();
 
@@ -121,6 +125,17 @@ const ImageModelSelect: React.FC<ImageModelSelectProps> = ({
     },
     [onChange, addRecent]
   );
+
+  if (inStudio) {
+    return (
+      <CuratedModelSelect
+        label="Image model"
+        options={forTasks(STUDIO_STILL_MODELS, task)}
+        value={value}
+        onChange={onChange}
+      />
+    );
+  }
 
   return (
     <>

--- a/web/src/components/properties/TTSModelSelect.tsx
+++ b/web/src/components/properties/TTSModelSelect.tsx
@@ -12,6 +12,9 @@ import { trpc } from "../../lib/trpc";
 import Select from "../inputs/Select";
 import { useQuery } from "@tanstack/react-query";
 import ModelSelectButton from "./shared/ModelSelectButton";
+import CuratedModelSelect from "./curated/CuratedModelSelect";
+import { useInStudio } from "../../studio/StudioContext";
+import { STUDIO_VOICES } from "../../studio/curatedModels";
 import { SPACING, getSpacingPx } from "../ui_primitives";
 
 interface TTSModelSelectProps {
@@ -30,6 +33,7 @@ const TTSModelSelect: React.FC<TTSModelSelectProps> = ({
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const addRecent = useModelPreferencesStore((s) => s.addRecent);
+  const inStudio = useInStudio();
   const { data: models } = useQuery({
     queryKey: ["tts-models"],
     queryFn: () => trpc.models.tts.query() as Promise<TTSModel[]>
@@ -147,6 +151,19 @@ const TTSModelSelect: React.FC<TTSModelSelectProps> = ({
     flexDirection: "column" as const,
     gap: getSpacingPx(SPACING.xs)
   }), []);
+
+  // A curated voice is one model plus one voice, so Studio picks a voice
+  // directly instead of a model picker followed by a voice picker.
+  if (inStudio) {
+    return (
+      <CuratedModelSelect
+        label="Voice"
+        options={STUDIO_VOICES}
+        value={selectedVoice}
+        onChange={onChange}
+      />
+    );
+  }
 
   return (
     <div style={containerStyle}>

--- a/web/src/components/properties/VideoModelSelect.tsx
+++ b/web/src/components/properties/VideoModelSelect.tsx
@@ -12,6 +12,9 @@ import { trpc } from "../../lib/trpc";
 import { useQuery } from "@tanstack/react-query";
 import type { VideoModelTask } from "../../hooks/useModelsByProvider";
 import ModelSelectButton from "./shared/ModelSelectButton";
+import CuratedModelSelect from "./curated/CuratedModelSelect";
+import { useInStudio } from "../../studio/StudioContext";
+import { forTasks, STUDIO_CLIP_MODELS } from "../../studio/curatedModels";
 
 interface VideoModelSelectProps {
   onChange: (value: VideoModelValue) => void;
@@ -31,6 +34,7 @@ const VideoModelSelect: React.FC<VideoModelSelectProps> = ({
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const addRecent = useModelPreferencesStore((s) => s.addRecent);
+  const inStudio = useInStudio();
 
   const { data: models } = useQuery({
     queryKey: ["video-models"],
@@ -70,6 +74,17 @@ const VideoModelSelect: React.FC<VideoModelSelectProps> = ({
     },
     [onChange, addRecent]
   );
+
+  if (inStudio) {
+    return (
+      <CuratedModelSelect
+        label="Video model"
+        options={forTasks(STUDIO_CLIP_MODELS, task)}
+        value={value}
+        onChange={onChange}
+      />
+    );
+  }
 
   return (
     <>

--- a/web/src/components/properties/curated/CuratedModelSelect.tsx
+++ b/web/src/components/properties/curated/CuratedModelSelect.tsx
@@ -1,0 +1,61 @@
+/**
+ * The Studio beginner shell's model control: a plain dropdown over the few
+ * curated options for one role, with the selected option's blurb underneath.
+ * No provider browser, no search, no API keys — the shared model selects swap
+ * themselves for this inside the Studio shell.
+ */
+
+import React, { useCallback, useMemo } from "react";
+import { SelectField } from "../../ui_primitives";
+import type { CuratedOption } from "../../../studio/curatedModels";
+
+interface CuratedModelSelectProps<T> {
+  label: string;
+  options: CuratedOption<T>[];
+  /** Current selection's option id; anything unknown reads as nothing selected. */
+  value: string;
+  onChange: (value: T) => void;
+  disabled?: boolean;
+}
+
+function CuratedModelSelectInner<T>({
+  label,
+  options,
+  value,
+  onChange,
+  disabled
+}: CuratedModelSelectProps<T>) {
+  const selectOptions = useMemo(
+    () => options.map((option) => ({ value: option.id, label: option.label })),
+    [options]
+  );
+  const selected = useMemo(
+    () => options.find((option) => option.id === value),
+    [options, value]
+  );
+  const handleChange = useCallback(
+    (id: string) => {
+      const picked = options.find((option) => option.id === id);
+      if (picked) onChange(picked.value);
+    },
+    [options, onChange]
+  );
+
+  return (
+    <SelectField
+      label={label}
+      value={selected ? value : ""}
+      onChange={handleChange}
+      options={selectOptions}
+      description={selected?.blurb || undefined}
+      disabled={disabled}
+      size="small"
+    />
+  );
+}
+
+export const CuratedModelSelect = React.memo(
+  CuratedModelSelectInner
+) as typeof CuratedModelSelectInner;
+
+export default CuratedModelSelect;

--- a/web/src/components/script/ScriptAgentPanel.tsx
+++ b/web/src/components/script/ScriptAgentPanel.tsx
@@ -11,6 +11,7 @@ import { FlexColumn, Text, SPACING, getSpacingPx } from "../ui_primitives";
 import ChatView from "../chat/containers/ChatView";
 import ChatPanelHeader from "../chat/containers/ChatPanelHeader";
 import useGlobalChatStore from "../../stores/GlobalChatStore";
+import { useInStudio } from "../../studio/StudioContext";
 
 const styles = (_theme: Theme) =>
   css({
@@ -50,6 +51,7 @@ interface ScriptAgentPanelProps {
 const ScriptAgentPanel = ({ scriptId }: ScriptAgentPanelProps) => {
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
+  const inStudio = useInStudio();
 
   // Bind the open script id as the chat's `workflow_id`. The server only
   // forwards client `ui_*` tools to the model when a turn carries a
@@ -164,6 +166,7 @@ const ScriptAgentPanel = ({ scriptId }: ScriptAgentPanelProps) => {
           progressMessage={statusMessage}
           model={selectedModel}
           onModelChange={setSelectedModel}
+          hideModelPicker={inStudio}
           onStop={stopGeneration}
           onNewChat={handleNewChat}
           requireToolSupport

--- a/web/src/components/script/ScriptCastPanel.tsx
+++ b/web/src/components/script/ScriptCastPanel.tsx
@@ -18,6 +18,8 @@ import {
 } from "../ui_primitives";
 import TTSModelSelect from "../properties/TTSModelSelect";
 import type { TTSModelValue } from "../../stores/ApiTypes";
+import { useInStudio } from "../../studio/StudioContext";
+import { STUDIO_VOICE } from "../../studio/curatedModels";
 import {
   useScriptStore,
   type ScriptSpeaker,
@@ -124,6 +126,9 @@ const ScriptCastPanel = ({
 }: ScriptCastPanelProps) => {
   const theme = useTheme();
   const addSpeaker = useScriptStore((s) => s.addSpeaker);
+  // Studio hands a new speaker a curated voice, so the beginner shell never
+  // starts a cast on an unset picker.
+  const inStudio = useInStudio();
 
   const onAdd = useCallback(() => {
     addSpeaker(scriptId, {
@@ -137,9 +142,12 @@ const ScriptCastPanel = ({
         theme.vars.palette.info.main,
         theme.vars.palette.error.main
       ][cast.length % 6],
-      voice: null
+      voice:
+        inStudio && STUDIO_VOICE
+          ? modelValueToVoice(STUDIO_VOICE)
+          : null
     });
-  }, [addSpeaker, scriptId, cast.length, theme]);
+  }, [addSpeaker, scriptId, cast.length, theme, inStudio]);
 
   return (
     <FlexColumn

--- a/web/src/components/storyboard/StoryboardAgentPanel.tsx
+++ b/web/src/components/storyboard/StoryboardAgentPanel.tsx
@@ -11,6 +11,7 @@ import { FlexColumn, Text, SPACING, getSpacingPx } from "../ui_primitives";
 import ChatView from "../chat/containers/ChatView";
 import ChatPanelHeader from "../chat/containers/ChatPanelHeader";
 import useGlobalChatStore from "../../stores/GlobalChatStore";
+import { useInStudio } from "../../studio/StudioContext";
 
 const styles = (_theme: Theme) =>
   css({
@@ -52,6 +53,7 @@ interface StoryboardAgentPanelProps {
 const StoryboardAgentPanel = ({ boardId }: StoryboardAgentPanelProps) => {
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
+  const inStudio = useInStudio();
 
   // Bind the open board id as the chat's `workflow_id`. The server only
   // forwards client `ui_*` tools to the model when a turn carries a
@@ -167,6 +169,7 @@ const StoryboardAgentPanel = ({ boardId }: StoryboardAgentPanelProps) => {
           progressMessage={statusMessage}
           model={selectedModel}
           onModelChange={setSelectedModel}
+          hideModelPicker={inStudio}
           onStop={stopGeneration}
           onNewChat={handleNewChat}
           requireToolSupport

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -47,6 +47,7 @@ import {
   type ImageModelTask
 } from "../../hooks/useModelsByProvider";
 import LanguageModelSelect from "../properties/LanguageModelSelect";
+import { useInStudio } from "../../studio/StudioContext";
 import ImageModelSelect from "../properties/ImageModelSelect";
 import VideoModelSelect from "../properties/VideoModelSelect";
 import ShotCard from "./ShotCard";
@@ -222,6 +223,7 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
     shots
   } = useBoard(boardId);
 
+  const inStudio = useInStudio();
   const setTitle = useStoryboardStore((state) => state.setTitle);
   const setBrief = useStoryboardStore((state) => state.setBrief);
   const setStyle = useStoryboardStore((state) => state.setStyle);
@@ -346,12 +348,16 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
               </FormSection>
 
               <FormSection label="Direction" className="settings">
-                <FormField label="Screenplay model" sx={modelFieldSx}>
-                  <LanguageModelSelect
-                    value={directorModel?.id ?? ""}
-                    onChange={(value) => setDirectorModel(boardId, value)}
-                  />
-                </FormField>
+                {/* The Studio shell pins the director model — a beginner
+                    picks what the film looks like, not which LLM writes it. */}
+                {!inStudio && (
+                  <FormField label="Screenplay model" sx={modelFieldSx}>
+                    <LanguageModelSelect
+                      value={directorModel?.id ?? ""}
+                      onChange={(value) => setDirectorModel(boardId, value)}
+                    />
+                  </FormField>
+                )}
                 <FormField label="Still model" sx={modelFieldSx}>
                   <ImageModelSelect
                     value={imageModel?.id ?? ""}

--- a/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
@@ -56,6 +56,7 @@ jest.mock("../ShotCard", () => stub("shot-card"));
 jest.mock("../StoryboardEntitiesField", () => stub("entities"));
 
 import StoryboardBoard from "../StoryboardBoard";
+import { StudioProvider } from "../../../studio/StudioContext";
 
 const makeShot = (id: string): Shot => ({
   type: "shot",
@@ -70,6 +71,15 @@ const renderBoard = (onDirect: (n: number) => void) =>
   render(
     <ThemeProvider theme={mockTheme}>
       <StoryboardBoard boardId="board-1" onDirect={onDirect} />
+    </ThemeProvider>
+  );
+
+const renderBoardInStudio = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <StudioProvider>
+        <StoryboardBoard boardId="board-1" onDirect={jest.fn()} />
+      </StudioProvider>
     </ThemeProvider>
   );
 
@@ -104,5 +114,23 @@ describe("StoryboardBoard direct guard", () => {
     await user.click(within(dialog).getByRole("button", { name: "Re-direct" }));
 
     expect(onDirect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("StoryboardBoard model fields", () => {
+  it("offers still and clip models but no screenplay model in Studio", () => {
+    mockShots = [];
+    renderBoardInStudio();
+
+    expect(screen.getByTestId("image-model")).toBeInTheDocument();
+    expect(screen.getByTestId("video-model")).toBeInTheDocument();
+    expect(screen.queryByTestId("lang-model")).not.toBeInTheDocument();
+  });
+
+  it("keeps the screenplay model in the workspace editor", () => {
+    mockShots = [];
+    renderBoard(jest.fn());
+
+    expect(screen.getByTestId("lang-model")).toBeInTheDocument();
   });
 });

--- a/web/src/components/timeline/TimelineAgentPanel.tsx
+++ b/web/src/components/timeline/TimelineAgentPanel.tsx
@@ -11,6 +11,7 @@ import { FlexColumn, Text, SPACING, getSpacingPx } from "../ui_primitives";
 import ChatView from "../chat/containers/ChatView";
 import ChatPanelHeader from "../chat/containers/ChatPanelHeader";
 import useGlobalChatStore from "../../stores/GlobalChatStore";
+import { useInStudio } from "../../studio/StudioContext";
 import { useTimelineStore } from "../../stores/timeline/TimelineStore";
 
 const styles = (_theme: Theme) =>
@@ -47,6 +48,7 @@ const styles = (_theme: Theme) =>
 const TimelineAgentPanel = () => {
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
+  const inStudio = useInStudio();
 
   // Bind the open sequence as the chat's `workflow_id`. The server only
   // forwards client `ui_*` tools to the model when a turn carries a
@@ -160,6 +162,7 @@ const TimelineAgentPanel = () => {
           progressMessage={statusMessage}
           model={selectedModel}
           onModelChange={setSelectedModel}
+          hideModelPicker={inStudio}
           onStop={stopGeneration}
           onNewChat={handleNewChat}
           requireToolSupport

--- a/web/src/components/timeline/TopBarPrompt.tsx
+++ b/web/src/components/timeline/TopBarPrompt.tsx
@@ -53,6 +53,8 @@ import type {
   VideoResolution
 } from "../../stores/MediaGenerationStore";
 import type { VideoModel } from "../../stores/ApiTypes";
+import { useInStudio } from "../../studio/StudioContext";
+import { forTasks, STUDIO_CLIP_MODELS } from "../../studio/curatedModels";
 
 /**
  * Resolve the video track to drop the clip onto: the first unlocked video
@@ -79,6 +81,7 @@ export interface TopBarPromptProps {
 
 export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false }) => {
   const theme = useTheme();
+  const inStudio = useInStudio();
   const [prompt, setPrompt] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -192,6 +195,18 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
     [handleSubmit]
   );
 
+  // Inside the Studio shell the chip opens the curated list instead of the
+  // provider browser — same chip, three options, no API keys.
+  const curatedClipOptions = useMemo(
+    () =>
+      forTasks(STUDIO_CLIP_MODELS, "text_to_video").map((option) => ({
+        id: option.id,
+        label: option.label,
+        description: option.blurb
+      })),
+    []
+  );
+
   const handlePickVideoModel = useCallback((model: VideoModel) => {
     const normalized = normalizeVideoModel(model);
     setUserPicked(true);
@@ -276,15 +291,30 @@ export const TopBarPrompt: React.FC<TopBarPromptProps> = memo(({ compact = false
           truncate
           showChevron={false}
         />
-        {videoModelOpen && (
-          <VideoModelMenuDialog
-            open
-            anchorEl={videoModelAnchorRef.current}
-            onClose={() => setVideoModelOpen(false)}
-            onModelChange={handlePickVideoModel}
-            task="text_to_video"
-          />
-        )}
+        {videoModelOpen &&
+          (inStudio ? (
+            <MediaOptionMenu
+              anchorEl={videoModelAnchorRef.current}
+              open
+              onClose={() => setVideoModelOpen(false)}
+              header="Video model"
+              value={selectedModel?.id ?? ""}
+              options={curatedClipOptions}
+              onChange={(id) => {
+                const picked = STUDIO_CLIP_MODELS.find((o) => o.id === id);
+                if (picked) handlePickVideoModel(picked.value);
+                setVideoModelOpen(false);
+              }}
+            />
+          ) : (
+            <VideoModelMenuDialog
+              open
+              anchorEl={videoModelAnchorRef.current}
+              onClose={() => setVideoModelOpen(false)}
+              onModelChange={handlePickVideoModel}
+              task="text_to_video"
+            />
+          ))}
 
         <MediaControlChip
           icon={<AccessTimeIcon fontSize="small" />}

--- a/web/src/studio/StudioContext.tsx
+++ b/web/src/studio/StudioContext.tsx
@@ -1,0 +1,20 @@
+/**
+ * Marks the subtree rendered inside the Studio beginner shell. The Studio
+ * reuses the workspace editors wholesale, and the one thing it changes about
+ * them is model choice: the shared model selects collapse to a plain dropdown
+ * over the curated catalog, and the LLM pickers disappear entirely. Reading
+ * that from context keeps the change out of every editor's prop chain.
+ */
+
+import { createContext, useContext } from "react";
+
+const StudioContext = createContext(false);
+
+export const StudioProvider = ({ children }: { children: React.ReactNode }) => (
+  <StudioContext.Provider value={true}>{children}</StudioContext.Provider>
+);
+
+/** True inside the Studio shell, false in the workspace editors. */
+export const useInStudio = (): boolean => useContext(StudioContext);
+
+export default StudioProvider;

--- a/web/src/studio/StudioShell.tsx
+++ b/web/src/studio/StudioShell.tsx
@@ -22,6 +22,7 @@ import {
 } from "../components/ui_primitives";
 import { useStudioCredits } from "./useStudioCredits";
 import { useStudioAssistantModel } from "./useStudioAssistantModel";
+import { StudioProvider } from "./StudioContext";
 
 const CreditsChip = () => {
   const navigate = useNavigate();
@@ -74,47 +75,49 @@ const StudioShell = ({
   const navigate = useNavigate();
   useStudioAssistantModel();
   return (
-    <FlexColumn fullHeight sx={{ width: "100%", minHeight: 0 }}>
-      <FlexRow
-        align="center"
-        gap={SPACING.md}
-        sx={{
-          flexShrink: 0,
-          px: SPACING.lg,
-          py: SPACING.sm,
-          borderBottom: `1px solid ${theme.vars.palette.divider}`
-        }}
-      >
-        {showBack && (
-          <EditorButton
-            size="small"
-            startIcon={<ArrowBackRoundedIcon fontSize="small" />}
-            onClick={() => navigate("/studio")}
-          >
-            Studio
-          </EditorButton>
-        )}
-        {!showBack && (
-          <FlexRow align="center" gap={SPACING.sm}>
-            <MovieFilterRoundedIcon fontSize="small" />
-            <Text size="normal" weight={600}>
-              NodeTool Studio
+    <StudioProvider>
+      <FlexColumn fullHeight sx={{ width: "100%", minHeight: 0 }}>
+        <FlexRow
+          align="center"
+          gap={SPACING.md}
+          sx={{
+            flexShrink: 0,
+            px: SPACING.lg,
+            py: SPACING.sm,
+            borderBottom: `1px solid ${theme.vars.palette.divider}`
+          }}
+        >
+          {showBack && (
+            <EditorButton
+              size="small"
+              startIcon={<ArrowBackRoundedIcon fontSize="small" />}
+              onClick={() => navigate("/studio")}
+            >
+              Studio
+            </EditorButton>
+          )}
+          {!showBack && (
+            <FlexRow align="center" gap={SPACING.sm}>
+              <MovieFilterRoundedIcon fontSize="small" />
+              <Text size="normal" weight={600}>
+                NodeTool Studio
+              </Text>
+            </FlexRow>
+          )}
+          {title && (
+            <Text size="normal" color="secondary" truncate>
+              {title}
             </Text>
-          </FlexRow>
-        )}
-        {title && (
-          <Text size="normal" color="secondary" truncate>
-            {title}
-          </Text>
-        )}
-        <FlexRow sx={{ flex: 1 }} />
-        {actions}
-        <CreditsChip />
-      </FlexRow>
-      <FlexColumn sx={{ flex: 1, minHeight: 0, width: "100%" }}>
-        {children}
+          )}
+          <FlexRow sx={{ flex: 1 }} />
+          {actions}
+          <CreditsChip />
+        </FlexRow>
+        <FlexColumn sx={{ flex: 1, minHeight: 0, width: "100%" }}>
+          {children}
+        </FlexColumn>
       </FlexColumn>
-    </FlexColumn>
+    </StudioProvider>
   );
 };
 

--- a/web/src/studio/StudioStoryboardPage.tsx
+++ b/web/src/studio/StudioStoryboardPage.tsx
@@ -5,7 +5,9 @@
  * sidebar and tab machinery. Two Studio-specific behaviors:
  *
  * - New boards get the curated Studio models stamped on (director, still,
- *   clip), so a beginner never touches a model picker.
+ *   clip), so a board generates before anyone opens a dropdown. The still and
+ *   clip pickers stay, curated down to three options each; the director is
+ *   pinned and its picker is hidden.
  * - Assembling navigates straight to `/studio/timeline/:id`, the product's
  *   one finishing surface.
  */

--- a/web/src/studio/__tests__/curatedModelPickers.test.tsx
+++ b/web/src/studio/__tests__/curatedModelPickers.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../__mocks__/themeMock";
+import ImageModelSelect from "../../components/properties/ImageModelSelect";
+import VideoModelSelect from "../../components/properties/VideoModelSelect";
+import { StudioProvider } from "../StudioContext";
+import { STUDIO_STILL_MODELS, STUDIO_CLIP_MODELS } from "../curatedModels";
+
+jest.mock("../../components/model_menu/ImageModelMenuDialog", () => ({
+  __esModule: true,
+  default: () => <div data-testid="image-model-dialog" />
+}));
+
+jest.mock("../../components/model_menu/VideoModelMenuDialog", () => ({
+  __esModule: true,
+  default: () => <div data-testid="video-model-dialog" />
+}));
+
+jest.mock("../../hooks/useModelsByProvider", () => ({
+  __esModule: true,
+  useImageModelsByProvider: () => ({ models: [], isLoading: false })
+}));
+
+jest.mock("@tanstack/react-query", () => ({
+  __esModule: true,
+  useQuery: () => ({ data: [] })
+}));
+
+const inStudio = (ui: React.ReactElement) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <StudioProvider>{ui}</StudioProvider>
+    </ThemeProvider>
+  );
+
+const inWorkspace = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
+
+describe("Studio curated model pickers", () => {
+  it("offers only the curated stills, and the full browser outside Studio", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    inStudio(
+      <ImageModelSelect value={STUDIO_STILL_MODELS[0].id} onChange={onChange} />
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(STUDIO_STILL_MODELS.length);
+
+    await user.click(options[options.length - 1]);
+    expect(onChange).toHaveBeenCalledWith(
+      STUDIO_STILL_MODELS[STUDIO_STILL_MODELS.length - 1].value
+    );
+  });
+
+  it("filters the curated stills by the requested task", async () => {
+    const user = userEvent.setup();
+    inStudio(
+      <ImageModelSelect value="" onChange={jest.fn()} task="image_to_image" />
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    const editable = STUDIO_STILL_MODELS.filter((option) =>
+      option.tasks.includes("image_to_image")
+    );
+    expect(editable.length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("option")).toHaveLength(editable.length);
+  });
+
+  it("offers only the curated clips", async () => {
+    const user = userEvent.setup();
+    inStudio(
+      <VideoModelSelect value={STUDIO_CLIP_MODELS[0].id} onChange={jest.fn()} />
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getAllByRole("option")).toHaveLength(
+      STUDIO_CLIP_MODELS.length
+    );
+  });
+
+  it("keeps the full model browser outside the Studio shell", () => {
+    inWorkspace(<ImageModelSelect value="" onChange={jest.fn()} />);
+
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.getByTestId("image-model-dialog")).toBeInTheDocument();
+  });
+});

--- a/web/src/studio/curatedModels.ts
+++ b/web/src/studio/curatedModels.ts
@@ -1,42 +1,142 @@
 /**
- * The Studio model policy: every new Studio project is stamped with NodeTool's
- * own managed models — the `nodetool` provider — so beginners never see a
- * model picker and never need an API key. Those calls run on platform keys
- * and are metered against the credit balance; users who dig into the reused
- * editors can still pick any BYOK provider, unmetered.
+ * The Studio model policy: Studio runs on NodeTool's own managed models — the
+ * `nodetool` provider — so a beginner never needs an API key. Those calls run
+ * on platform keys and are metered against the credit balance; users who dig
+ * into the reused editors from the workspace can still pick any BYOK provider,
+ * unmetered.
  *
- * The curated catalog itself (ids, names, delegates) is
- * `NODETOOL_MODELS` in `@nodetool-ai/protocol` — this file just selects which
- * entry fills each Studio role.
+ * Studio shows a plain dropdown over the few curated options per role rather
+ * than the full provider browser, and shows nothing at all for the language
+ * model: the director is pinned, because picking the brain behind the
+ * assistants is not a beginner's decision.
+ *
+ * The catalog itself (ids, names, blurbs, delegates) is `NODETOOL_MODELS` in
+ * `@nodetool-ai/protocol` — this file adapts it to the value shapes the web
+ * model properties use.
  */
 
+import {
+  NODETOOL_PROVIDER_ID,
+  nodetoolModelsOfKind,
+  type NodetoolModelDef
+} from "@nodetool-ai/protocol";
 import type {
   ImageModelValue,
   LanguageModelValue,
+  TTSModelValue,
   VideoModelValue
 } from "../stores/ApiTypes";
 
-/** Directs screenplays and drives the in-editor assistants. */
+const provider = NODETOOL_PROVIDER_ID;
+
+const toImageModel = (def: NodetoolModelDef): ImageModelValue => ({
+  type: "image_model",
+  id: def.id,
+  provider,
+  name: def.name,
+  path: ""
+});
+
+const toVideoModel = (def: NodetoolModelDef): VideoModelValue => ({
+  type: "video_model",
+  id: def.id,
+  provider,
+  name: def.name
+});
+
+const toTTSModel = (def: NodetoolModelDef, voice?: string): TTSModelValue => ({
+  type: "tts_model",
+  id: def.id,
+  provider,
+  name: def.name,
+  voices: (def.voices ?? []).map((v) => v.id),
+  selected_voice: voice ?? def.voices?.[0]?.id ?? ""
+});
+
+/** Directs screenplays and drives the in-editor assistants. Not selectable. */
 export const STUDIO_DIRECTOR_MODEL: LanguageModelValue = {
   type: "language_model",
-  id: "nodetool/director",
-  provider: "nodetool",
-  name: "NodeTool Director"
+  id: nodetoolModelsOfKind("language")[0].id,
+  provider,
+  name: nodetoolModelsOfKind("language")[0].name
 };
 
-/** Renders storyboard keyframe stills. */
-export const STUDIO_STILL_MODEL: ImageModelValue = {
-  type: "image_model",
-  id: "nodetool/flux-schnell",
-  provider: "nodetool",
-  name: "NodeTool Still (FLUX Schnell)",
-  path: ""
+export interface CuratedOption<T> {
+  /** What the dropdown selects on. The model id, or the voice id for voices. */
+  id: string;
+  value: T;
+  /** User-facing name, e.g. "Balanced". */
+  label: string;
+  /** One line on what the choice costs you and buys you. */
+  blurb: string;
+  /** Capabilities, e.g. `["text_to_image", "image_to_image"]`. */
+  tasks: string[];
+}
+
+const options = <T>(
+  kind: "image" | "video",
+  map: (def: NodetoolModelDef) => T
+): CuratedOption<T>[] =>
+  nodetoolModelsOfKind(kind).map((def) => ({
+    id: def.id,
+    value: map(def),
+    label: def.name,
+    blurb: def.blurb ?? "",
+    tasks: def.tasks ?? []
+  }));
+
+/** The curated options that can do at least one of the requested tasks. */
+export const forTasks = <T>(
+  list: CuratedOption<T>[],
+  task?: string | string[]
+): CuratedOption<T>[] => {
+  const wanted = task ? (Array.isArray(task) ? task : [task]) : [];
+  if (wanted.length === 0) return list;
+  return list.filter((option) => wanted.some((t) => option.tasks.includes(t)));
 };
 
-/** Animates keyframes into shot clips. */
-export const STUDIO_CLIP_MODEL: VideoModelValue = {
-  type: "video_model",
-  id: "nodetool/kling-standard",
-  provider: "nodetool",
-  name: "NodeTool Clip (Kling Standard)"
-};
+/** Renders storyboard keyframe stills, cheapest first. */
+export const STUDIO_STILL_MODELS: CuratedOption<ImageModelValue>[] = options(
+  "image",
+  toImageModel
+);
+
+/** Animates keyframes into shot clips, cheapest first. */
+export const STUDIO_CLIP_MODELS: CuratedOption<VideoModelValue>[] = options(
+  "video",
+  toVideoModel
+);
+
+/**
+ * Reads a script aloud. A curated voice is one model + one voice, so the
+ * dropdown is a flat list of voices rather than a model picker plus a voice
+ * picker.
+ */
+export const STUDIO_VOICES: CuratedOption<TTSModelValue>[] =
+  nodetoolModelsOfKind("tts").flatMap((def) =>
+    (def.voices ?? []).map((voice) => ({
+      id: voice.id,
+      value: toTTSModel(def, voice.id),
+      label: voice.name,
+      blurb: "",
+      tasks: def.tasks ?? []
+    }))
+  );
+
+/**
+ * What a new Studio project starts on. The still default is the middle tier
+ * rather than the cheapest: it is the cheapest one that can work from an
+ * entity's reference images, and a beginner who adds a character expects it
+ * to look like that character.
+ */
+export const STUDIO_STILL_MODEL: ImageModelValue =
+  optionById(STUDIO_STILL_MODELS, "nodetool/nano-banana") ??
+  STUDIO_STILL_MODELS[0].value;
+export const STUDIO_CLIP_MODEL: VideoModelValue =
+  optionById(STUDIO_CLIP_MODELS, "nodetool/kling-turbo") ??
+  STUDIO_CLIP_MODELS[0].value;
+export const STUDIO_VOICE: TTSModelValue | undefined = STUDIO_VOICES[0]?.value;
+
+function optionById<T>(list: CuratedOption<T>[], id: string): T | undefined {
+  return list.find((option) => option.id === id)?.value;
+}

--- a/web/src/studio/useStudioAssistantModel.ts
+++ b/web/src/studio/useStudioAssistantModel.ts
@@ -1,10 +1,11 @@
 /**
  * Pin the Studio assistants to the curated director model. Every editor's
  * agent panel reads `GlobalChatStore.selectedModel`, so inside the Studio
- * shell that selection is forced to the curated model (the model picker the
- * panels render then shows it, and turns run on it — metered like all
- * `nodetool`-provider calls). The user's own selection is restored when the
- * shell unmounts, so workspace chat is untouched.
+ * shell that selection is forced to the curated model and the panels hide
+ * their model chip — picking the brain behind the assistants is not a
+ * beginner's decision. Turns run on it, metered like all `nodetool`-provider
+ * calls. The user's own selection is restored when the shell unmounts, so
+ * workspace chat is untouched.
  */
 
 import { useEffect } from "react";


### PR DESCRIPTION
The Studio beginner shell reuses the workspace editors, and those editors open the full provider browser for every model choice — a dialog full of providers and API keys a beginner has neither.

## What changed

**Simple dropdowns for the media roles.** Inside the Studio shell, `ImageModelSelect`, `VideoModelSelect`, and `TTSModelSelect` render a plain `SelectField` over the curated `nodetool` catalog instead of opening the model browser: three stills (Fast / Balanced / Detailed), three clips (Fast / Balanced / Best), and eight voices, each with one line on what it costs and buys. The timeline top bar's generate chip opens the same curated list.

**No model picker for the LLMs.** The director is pinned, so the storyboard's "Screenplay model" field is hidden and the storyboard / script / timeline agent panels hide their model chip (new `hideModelPicker` prop through `ChatView` → `ChatInputSection` → `MediaChatComposer`).

**One context, no prop plumbing.** A new `StudioContext` marks the subtree the shell renders; the shared selects read it. Nothing changes in the workspace editors — verified by test.

**Catalog and provider.** `NODETOOL_MODELS` grew to make the dropdowns worth opening, and gained two delegate splits so a curated entry claims only what it can do: `editDelegate` (image-to-image runs on FAL's edit endpoint — the old catalog claimed `image_to_image` for an endpoint that takes no image) and `textDelegate` (text-to-video runs on the family's t2v endpoint). `NodetoolProvider` now also serves TTS, and picks the delegate per task. Every new delegate id exists in the FAL manifest and has a unit price, so credit estimates stay real.

Studio defaults moved with it: a new board starts on the balanced still (the cheapest curated one that can use an entity's reference images) and the balanced clip, and a new Studio speaker gets a curated voice instead of an empty picker.

## Verification

- `packages/runtime` — 98 provider suites, 1759 tests; `nodetool-provider.test.ts` extended with the voice listing, the task-scoped delegate routing, and the `image_to_image`-only-with-an-edit-delegate rule
- `packages/protocol` (794), `packages/model-pricing` (52), `packages/websocket` credit gate — pass
- `web` — full Jest run, 1086 suites / 12659 tests, including new `studio/__tests__/curatedModelPickers.test.tsx` and two `StoryboardBoard` cases
- `web` typecheck and eslint clean on the touched files

Two failures in this environment are pre-existing and unrelated: `packages/agents` won't build (`@types/diff` missing), which leaves `base-nodes`/`dsl` dist absent and fails the `websocket` suites that import them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3VCZXKoqNUkDgBkdaRQ4i

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3VCZXKoqNUkDgBkdaRQ4i)_