### PR TITLE
Expose image and canvas APIs in the QuickJS sandbox

### DIFF
--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -92,6 +92,10 @@ column by `resolveSandboxLimits`:
 | Progress reports | `MAX_PROGRESS_CALLS` = 1000 per run, one per `PROGRESS_MIN_INTERVAL_MS` = 100 ms | counter + timestamp inside the bridge | — |
 | `data.*` input | `MAX_DATA_INPUT_CHARS` = 5 MB of text | length check inside each bridge | — |
 | `data.selectHtml` matches | `DEFAULT_SELECT_HTML_LIMIT` = 100 | `options.limit` | `MAX_SELECT_HTML_LIMIT` = 1000 |
+| `image.*` input | `MAX_IMAGE_INPUT_BYTES` = 25 MB | length check inside each bridge | — |
+| Image / canvas pixels | `MAX_IMAGE_PIXELS` = 32 M, longest edge `MAX_IMAGE_DIMENSION` = 16384 | `assertSurfaceSize` | — |
+| `image.decode` pixels | `MAX_DECODE_PIXELS` = 8 M | check inside the bridge | — |
+| Canvas draw ops | `MAX_CANVAS_OPS` = 10 000 per render | count inside `renderCanvas` | — |
 
 QuickJS's memory limiter counts its own heap objects; string and typed-array
 payloads are not charged against it, so `memoryLimitBytes` bites on object
@@ -108,8 +112,10 @@ source for read containment and the destination for write containment;
 createdMs, accessedMs}` and reports a missing path as `exists: false` rather
 than throwing), the pure guest-side helpers
 `toBase64`/`fromBase64`/`toHex`/`fromHex`/`utf8Encode`/`utf8Decode`/
-`parallelMap`,
+`parallelMap`/`createCanvas`,
 `progress(percent, message?)`, `format.{number,date,relativeTime,list}`,
+`image.{info,decode,encode,resize,crop,rotate,flip,adjust,composite,convert}`,
+`canvas.{render,measureText}`,
 `data.{parseCsv,toCsv,selectHtml,htmlToMarkdown,parseXlsx,parseYaml,toYaml,
 parseXml,unzip,zip,diff}`, and any caller-supplied `globals`. `fetch` sends a
 `Uint8Array` body as raw bytes instead of JSON.
@@ -120,6 +126,36 @@ parseXml,unzip,zip,diff}`, and any caller-supplied `globals`. `fetch` sends a
 wires it to `context.postMessage({ type: "node_progress", … })`, the same
 channel the Python worker uses, so a long-running snippet drives the node's
 progress bar.
+
+`image` and `canvas` are the media namespaces, both host bridges over a real
+2D canvas (`src/sandbox-media.ts`). The backend is picked at first use:
+`@napi-rs/canvas` (Skia) on Node, loaded through `importHidden` so no bundler
+pulls the native addon into a browser graph — it is already staged as an
+external by `scripts/bundle-backend.mjs` — and `OffscreenCanvas` +
+`createImageBitmap` in the browser runner. `image` takes and returns *encoded*
+bytes (`png`/`jpeg`/`webp`/`avif`), so `resize` → `adjust` → `convert` chains
+without the guest ever holding a surface: `info`, `decode`, `encode`, `resize`
+(`fit`: cover/contain/fill), `crop`, `rotate` (grows to the rotated bounding
+box), `flip`, `adjust` (the CSS filter set), `composite` (layers with position,
+size, opacity and `globalCompositeOperation` blend mode) and `convert`.
+Encoding to `jpeg` fills transparency with `background`, white by default.
+
+A canvas *context* is a host object with methods, which the plain-data bridge
+contract cannot carry, so drawing is recorded rather than proxied: the guest
+helper `createCanvas(width, height)` returns a surface whose `getContext("2d")`
+takes the ordinary Canvas 2D calls **synchronously**, appending each to a draw
+list, and `await surface.toBytes({format, quality, background})` ships the whole
+list through `canvas.render` to be replayed against a real context and encoded.
+`drawImage` takes image bytes, not an image object. Gradients work the same way
+— `createLinearGradient` returns a tagged handle that the renderer swaps for the
+real gradient when it is assigned to `fillStyle`. The method and property
+allowlists live in `src/sandbox-canvas-api.ts`, read by both the guest recorder
+and the host replay, and an op naming anything outside them is refused. The
+recorded ops are marshaled out of the guest one object at a time (~1 ms each),
+which is what `MAX_CANVAS_OPS` really bounds — for heavy composition reach for
+`image.composite` instead of tens of thousands of primitives.
+`canvas.measureText(text, font?)` returns text metrics so text can be laid out
+before it is drawn.
 
 `data` is the structured-data namespace, all host bridges over libraries that
 stay host-side: `parseCsv`/`toCsv` (papaparse — values stay strings, no

--- a/packages/agents/src/code-gen/sandbox-manifest.ts
+++ b/packages/agents/src/code-gen/sandbox-manifest.ts
@@ -23,6 +23,12 @@ import {
   type ExposedBridgeName,
   type GuestHelperName
 } from "../js-sandbox.js";
+import {
+  MAX_CANVAS_OPS,
+  MAX_DECODE_PIXELS,
+  MAX_IMAGE_INPUT_BYTES,
+  MAX_IMAGE_PIXELS
+} from "../sandbox-media.js";
 
 /** The node this manifest describes. */
 export const SANDBOX_MANIFEST_NODE_TYPE = "nodetool.code.Code";
@@ -455,6 +461,118 @@ const BRIDGE_DOCS: { [K in ExposedBridgeName]: SandboxBridgeDoc } = {
       }
     ]
   },
+  image: {
+    name: "image",
+    kind: "namespace",
+    description:
+      "Raster image editing. Every member takes and returns encoded image " +
+      "bytes, so calls chain. Formats: png, jpeg, webp, avif.",
+    members: [
+      {
+        name: "image.info",
+        signature:
+          "await image.info(bytes) -> { width, height, format, byteLength }",
+        description:
+          "Dimensions and encoding of an image, without decoding it into the guest.",
+        async: true
+      },
+      {
+        name: "image.decode",
+        signature:
+          "await image.decode(bytes) -> { width, height, pixels } // pixels: RGBA Uint8Array",
+        description:
+          "Raw pixels for per-pixel work. Four bytes per pixel — resize first, and prefer the other members when they do the job.",
+        async: true
+      },
+      {
+        name: "image.encode",
+        signature:
+          "await image.encode({ width, height, pixels }, options?) -> Uint8Array // options: format, quality, background",
+        description: "Encode raw RGBA pixels — the inverse of decode.",
+        async: true
+      },
+      {
+        name: "image.resize",
+        signature:
+          "await image.resize(bytes, options) -> Uint8Array // options: width, height, fit (cover | contain | fill), background, format, quality",
+        description:
+          "Scale an image. One of width or height keeps the aspect ratio; both apply the fit mode, which defaults to contain.",
+        async: true
+      },
+      {
+        name: "image.crop",
+        signature:
+          "await image.crop(bytes, options) -> Uint8Array // options: x, y, width, height, format, quality",
+        description:
+          "Cut a rectangle out. A rectangle outside the image is an error, not a clamp.",
+        async: true
+      },
+      {
+        name: "image.rotate",
+        signature:
+          "await image.rotate(bytes, degrees, options?) -> Uint8Array // options: background, format, quality",
+        description:
+          "Rotate clockwise, growing the canvas to the rotated bounding box so nothing is clipped.",
+        async: true
+      },
+      {
+        name: "image.flip",
+        signature:
+          "await image.flip(bytes, options?) -> Uint8Array // options: horizontal (default true), vertical, format, quality",
+        description: "Mirror an image.",
+        async: true
+      },
+      {
+        name: "image.adjust",
+        signature:
+          "await image.adjust(bytes, options) -> Uint8Array // options: brightness, contrast, saturate, grayscale, sepia, invert, blur, hueRotate, opacity, format, quality",
+        description:
+          "Filter an image. 1 is unchanged for the multiplying filters, 0 for grayscale, sepia, invert and blur.",
+        async: true
+      },
+      {
+        name: "image.composite",
+        signature:
+          "await image.composite(bytes, layers, options?) -> Uint8Array // layer: { image, x, y, width, height, opacity, blendMode }",
+        description:
+          "Draw layers over a base image — watermarks, badges, stacked renders. blendMode takes the Canvas globalCompositeOperation names.",
+        async: true
+      },
+      {
+        name: "image.convert",
+        signature:
+          "await image.convert(bytes, options) -> Uint8Array // options: format, quality, background",
+        description:
+          "Re-encode without resampling. Converting to jpeg fills transparency with background, white by default.",
+        async: true
+      }
+    ]
+  },
+  canvas: {
+    name: "canvas",
+    kind: "namespace",
+    description:
+      "Draw with a real Canvas 2D context. Use createCanvas for the familiar " +
+      "API; these are the raw calls behind it.",
+    members: [
+      {
+        name: "canvas.render",
+        signature:
+          "await canvas.render(spec) -> Uint8Array // spec: { width, height, background, format, quality, gradients, ops }",
+        description:
+          "Replay a recorded draw list and encode the result. createCanvas builds the spec for you.",
+        async: true
+      },
+      {
+        name: "canvas.measureText",
+        signature:
+          "await canvas.measureText(text, font?) -> { width, actualBoundingBoxAscent, actualBoundingBoxDescent, ... }",
+        description:
+          "Text metrics for a CSS font string, so text can be laid out before it is drawn.",
+        async: true
+      }
+    ]
+  },
   __maxIter: {
     name: "__maxIter",
     kind: "function",
@@ -508,6 +626,14 @@ const GUEST_HELPER_DOCS: { [K in GuestHelperName]: SandboxMemberDoc } = {
     description:
       "Run an async function over items with at most `concurrency` in flight, preserving input order. The bounded form of Promise.all fan-out — the way to fetch many URLs in parallel. Rejects on the first failure; wrap fn in try/catch to collect errors instead.",
     async: true
+  },
+  createCanvas: {
+    name: "createCanvas",
+    signature:
+      "createCanvas(width, height) -> { width, height, getContext, toBytes, toSpec }",
+    description:
+      "A Canvas 2D surface. getContext with \"2d\" returns a context taking the usual calls — fillRect, arc, fillText, drawImage, createLinearGradient, save, translate, rotate — synchronously; awaiting toBytes with an options object of format, quality and background renders them and returns the encoded image. drawImage takes image bytes, not an image object, and toSpec hands the recorded draw list to canvas.render instead.",
+    async: false
   }
 };
 
@@ -603,6 +729,30 @@ function fixedLimits(): SandboxLimitDoc[] {
       unit: "count",
       value: DEFAULT_SELECT_HTML_LIMIT,
       ceiling: MAX_SELECT_HTML_LIMIT
+    },
+    {
+      key: "maxImageInputBytes",
+      description: "encoded image accepted by an image.* call",
+      unit: "bytes",
+      value: MAX_IMAGE_INPUT_BYTES
+    },
+    {
+      key: "maxImagePixels",
+      description: "pixels in a decoded image or rendered canvas",
+      unit: "count",
+      value: MAX_IMAGE_PIXELS
+    },
+    {
+      key: "maxDecodePixels",
+      description: "pixels returned by image.decode",
+      unit: "count",
+      value: MAX_DECODE_PIXELS
+    },
+    {
+      key: "maxCanvasOps",
+      description: "draw operations per canvas render",
+      unit: "count",
+      value: MAX_CANVAS_OPS
     }
   ];
 }
@@ -643,6 +793,7 @@ export function getSandboxManifest(): SandboxManifest {
       "Bridge calls start host-side work when invoked, not when awaited: Promise.all / allSettled / race / any over fetch or workspace calls run them in parallel. Use parallelMap for bounded fan-out. sleep is the only timer.",
       "Return an object whose keys are the node's outputs. Emit every declared output on every return path.",
       "Media and asset values are reference objects. Pass them through unchanged.",
+      "Images are edited as encoded bytes: assetToSandbox then workspace.readBytes to get them, image.* or createCanvas to change them, workspace.writeBytes then sandboxToAsset to hand one back.",
       "There is no module loader and no Intl. Anything a library would do comes from the bridges below."
     ]
   };

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -9,9 +9,9 @@
  * The exposed surface is a small curated one: vanilla JavaScript plus a handful
  * of bridge functions (`fetch`, `workspace`, `getSecret`, `uuid`, `sleep`,
  * `assetToSandbox`, `sandboxToAsset`, `crypto`, `console`, `progress`,
- * `format`, `data`) and a few pure guest-side helpers (`toBase64`,
- * `fromBase64`, `toHex`, `fromHex`, `utf8Encode`, `utf8Decode`,
- * `parallelMap`). `crypto`
+ * `format`, `data`, `image`, `canvas`) and a few pure guest-side helpers
+ * (`toBase64`, `fromBase64`, `toHex`, `fromHex`, `utf8Encode`, `utf8Decode`,
+ * `parallelMap`, `createCanvas`). `crypto`
  * covers `randomUUID`, `getRandomValues`, `digest`, and `hmac`
  * (WebCrypto-backed); `workspace` covers text and binary reads/writes plus
  * `stat`, `mkdir`, and `remove`; `progress` forwards a percentage and label to
@@ -24,8 +24,10 @@
  * The guest itself stays module-free — there is no loader, so user code cannot
  * `import`/`require` anything. Library-backed capabilities reach it only
  * through narrow host bridges that take and return plain data:
- * `data.parseCsv` (papaparse), `data.selectHtml` (cheerio), `format.*` (Intl)
- * and `crypto.*` (WebCrypto). The libraries run host-side, are imported lazily
+ * `data.parseCsv` (papaparse), `data.selectHtml` (cheerio), `format.*` (Intl),
+ * `crypto.*` (WebCrypto), and `image.*`/`canvas.*` (a real 2D canvas —
+ * `@napi-rs/canvas` on Node, `OffscreenCanvas` in the browser runner; see
+ * `sandbox-media.ts`). The libraries run host-side, are imported lazily
  * on first use, and are never handed to the guest — so the snippet surface is
  * the same string-in/plain-data-out contract in dev, in packaged Electron, and
  * in the browser runner, which bundles this module too.
@@ -52,6 +54,12 @@ const quickJsVariant = (
 ).default;
 import { Scope } from "quickjs-emscripten-core";
 import { importNodeBuiltin } from "@nodetool-ai/config";
+import {
+  CANVAS_GRADIENT_FACTORIES,
+  CANVAS_GRADIENT_MARKER,
+  CANVAS_METHODS,
+  CANVAS_PROPERTIES
+} from "./sandbox-canvas-api.js";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 
 // ---------------------------------------------------------------------------
@@ -298,6 +306,27 @@ function encodeBase64(bytes: Uint8Array): string {
 /** Tag bytes for the guest prelude to turn back into a real `Uint8Array`. */
 function toGuestBytes(bytes: Uint8Array): Record<string, string> {
   return { [SANDBOX_BYTES_MARKER]: encodeBase64(bytes) };
+}
+
+/**
+ * Same tagging, applied at any depth. A bridge that returns bytes inside a
+ * record (`image.decode`'s `{width, height, pixels}`) hands its result through
+ * this; the guest side pairs it with `__wrapDeep`, which revives every marker.
+ */
+function toGuestBytesDeep(value: unknown, depth = 0): unknown {
+  if (value instanceof Uint8Array) return toGuestBytes(value);
+  if (depth >= SERIALIZE_MAX_DEPTH) return value;
+  if (Array.isArray(value)) {
+    return value.map((v) => toGuestBytesDeep(v, depth + 1));
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = toGuestBytesDeep(v, depth + 1);
+    }
+    return out;
+  }
+  return value;
 }
 
 function neverReject<Args extends unknown[], R>(
@@ -633,6 +662,18 @@ async function loadDiff(): Promise<DiffLike> {
     (v) =>
       typeof (v as DiffLike | undefined)?.createTwoFilesPatch === "function"
   );
+}
+
+export type SandboxMediaModule = typeof import("./sandbox-media.js");
+
+/**
+ * The media engine behind the `image` and `canvas` bridges. Loaded on first
+ * use like the data libraries, and for the same reasons — the canvas backend
+ * (Skia on Node) is heavy, and nothing that never draws should pay for it.
+ * Unlike those, the import is intra-package, so every bundler resolves it.
+ */
+async function loadSandboxMedia(): Promise<SandboxMediaModule> {
+  return import("./sandbox-media.js");
 }
 
 /** True if a literal IPv4/IPv6 host is loopback, link-local, or private. */
@@ -1857,6 +1898,40 @@ export function buildSandbox(
     }
   };
 
+  // Media bridges. The engine (`sandbox-media.ts`) is imported on first use
+  // like every other library-backed bridge, and picks its canvas backend from
+  // the runtime — `@napi-rs/canvas` on Node, `OffscreenCanvas` in the browser
+  // runner. Bytes come back tagged for the guest prelude to revive, so the
+  // guest-visible API is `Uint8Array` in and `Uint8Array` out.
+  const withGuestBytes = <A extends unknown[]>(
+    fn: (...args: A) => Promise<unknown>
+  ): ((...args: A) => Promise<unknown>) => {
+    return async (...args: A) => toGuestBytesDeep(await fn(...args));
+  };
+
+  const mediaMember = <A extends unknown[]>(
+    pick: (media: SandboxMediaModule) => (...args: A) => Promise<unknown>
+  ): ((...args: A) => Promise<unknown>) =>
+    withGuestBytes(async (...args: A) => pick(await loadSandboxMedia())(...args));
+
+  const image = {
+    info: mediaMember((m) => m.imageOps.info),
+    decode: mediaMember((m) => m.imageOps.decode),
+    encode: mediaMember((m) => m.imageOps.encode),
+    resize: mediaMember((m) => m.imageOps.resize),
+    crop: mediaMember((m) => m.imageOps.crop),
+    rotate: mediaMember((m) => m.imageOps.rotate),
+    flip: mediaMember((m) => m.imageOps.flip),
+    adjust: mediaMember((m) => m.imageOps.adjust),
+    composite: mediaMember((m) => m.imageOps.composite),
+    convert: mediaMember((m) => m.imageOps.convert)
+  };
+
+  const canvas = {
+    render: mediaMember((m) => m.renderCanvas),
+    measureText: mediaMember((m) => m.measureCanvasText)
+  };
+
   const sandbox: Record<string, unknown> = {
     // Core JS globals are native in QuickJS; we still reflect them in the
     // descriptor so callers that inspect `sandbox.JSON` / `sandbox.Math`
@@ -1919,6 +1994,8 @@ export function buildSandbox(
     progress,
     format,
     data,
+    image,
+    canvas,
     __maxIter: MAX_LOOP_ITERATIONS
   };
 
@@ -2105,6 +2182,8 @@ export const EXPOSED_BRIDGE_NAMES = [
   "progress",
   "format",
   "data",
+  "image",
+  "canvas",
   "__maxIter"
 ] as const;
 
@@ -2118,7 +2197,8 @@ export const GUEST_HELPER_NAMES = [
   "fromHex",
   "utf8Encode",
   "utf8Decode",
-  "parallelMap"
+  "parallelMap",
+  "createCanvas"
 ] as const;
 
 export type GuestHelperName = (typeof GUEST_HELPER_NAMES)[number];
@@ -2236,6 +2316,8 @@ export async function runInSandbox(
         bridges.workspace = wrapAllMembers(bridges.workspace);
         bridges.format = wrapAllMembers(bridges.format);
         bridges.data = wrapAllMembers(bridges.data);
+        bridges.image = wrapAllMembers(bridges.image);
+        bridges.canvas = wrapAllMembers(bridges.canvas);
         const hostCrypto = bridges.crypto as {
           randomUUID: () => string;
           getRandomValues: (n: number) => Record<string, string>;
@@ -2426,6 +2508,96 @@ globalThis.data = {
   unzip: __wrapDeep(__data.unzip),
   zip: __wrap(__data.zip),
   diff: __wrap(__data.diff)
+};
+const __image = globalThis.image;
+globalThis.image = {
+  info: __wrapDeep(__image.info),
+  decode: __wrapDeep(__image.decode),
+  encode: __wrapDeep(__image.encode),
+  resize: __wrapDeep(__image.resize),
+  crop: __wrapDeep(__image.crop),
+  rotate: __wrapDeep(__image.rotate),
+  flip: __wrapDeep(__image.flip),
+  adjust: __wrapDeep(__image.adjust),
+  composite: __wrapDeep(__image.composite),
+  convert: __wrapDeep(__image.convert)
+};
+const __canvasBridge = globalThis.canvas;
+globalThis.canvas = {
+  render: __wrapDeep(__canvasBridge.render),
+  measureText: __wrapDeep(__canvasBridge.measureText)
+};
+const __canvasProps = ${JSON.stringify(CANVAS_PROPERTIES)};
+const __canvasMethods = ${JSON.stringify(CANVAS_METHODS)};
+const __canvasGradients = ${JSON.stringify(CANVAS_GRADIENT_FACTORIES)};
+const __gradMarker = "${CANVAS_GRADIENT_MARKER}";
+// A canvas context is a host object with methods, which the bridge contract
+// cannot carry. So this records the ordinary Canvas 2D calls synchronously and
+// ships the whole draw list in one canvas.render() when toBytes() is awaited.
+globalThis.createCanvas = (width, height) => {
+  const ops = [];
+  const gradients = {};
+  let gradientSeq = 0;
+  const asStyle = (value) =>
+    value && typeof value === "object" && typeof value[__gradMarker] === "string"
+      ? { [__gradMarker]: value[__gradMarker] }
+      : value;
+  const ctx = {};
+  for (const name of __canvasMethods) {
+    ctx[name] = (...args) => {
+      ops.push({ op: name, args });
+      return ctx;
+    };
+  }
+  ctx.drawImage = (source, ...rest) => {
+    ops.push({ op: "drawImage", args: [source, ...rest] });
+    return ctx;
+  };
+  const values = {};
+  for (const prop of __canvasProps) {
+    Object.defineProperty(ctx, prop, {
+      enumerable: true,
+      get: () => values[prop],
+      set: (value) => {
+        values[prop] = value;
+        ops.push({ op: "set", args: [prop, asStyle(value)] });
+      }
+    });
+  }
+  for (const factory of Object.keys(__canvasGradients)) {
+    ctx[factory] = (...coords) => {
+      const id = "g" + gradientSeq++;
+      const spec = { type: __canvasGradients[factory], coords, stops: [] };
+      gradients[id] = spec;
+      const handle = {
+        [__gradMarker]: id,
+        addColorStop: (offset, color) => {
+          spec.stops.push([offset, color]);
+          return handle;
+        }
+      };
+      return handle;
+    };
+  }
+  const surface = {
+    width,
+    height,
+    getContext: (kind) => {
+      if (kind !== undefined && kind !== "2d") {
+        throw new Error('createCanvas: only the "2d" context exists');
+      }
+      return ctx;
+    },
+    toSpec: (options) => ({
+      width,
+      height,
+      gradients,
+      ops,
+      ...(options || {})
+    }),
+    toBytes: (options) => globalThis.canvas.render(surface.toSpec(options))
+  };
+  return surface;
 };
 const __crypto = globalThis.crypto;
 globalThis.crypto = {

--- a/packages/agents/src/sandbox-canvas-api.ts
+++ b/packages/agents/src/sandbox-canvas-api.ts
@@ -1,0 +1,84 @@
+/**
+ * The Canvas 2D surface the sandbox exposes, named in one place.
+ *
+ * Two sides read these lists and must agree: the guest-side recorder in the
+ * sandbox prelude, which builds a context object with exactly these members,
+ * and the host-side replay in `sandbox-media.ts`, which refuses any op naming
+ * something outside them. Splitting them out of the media engine keeps that
+ * engine — and the native canvas behind it — lazily loaded, since the prelude
+ * needs the names long before anything draws.
+ */
+
+/** Context properties a recorded draw list may set. */
+export const CANVAS_PROPERTIES = [
+  "fillStyle",
+  "strokeStyle",
+  "lineWidth",
+  "lineCap",
+  "lineJoin",
+  "miterLimit",
+  "lineDashOffset",
+  "globalAlpha",
+  "globalCompositeOperation",
+  "filter",
+  "font",
+  "textAlign",
+  "textBaseline",
+  "direction",
+  "letterSpacing",
+  "imageSmoothingEnabled",
+  "imageSmoothingQuality",
+  "shadowColor",
+  "shadowBlur",
+  "shadowOffsetX",
+  "shadowOffsetY"
+] as const;
+
+/**
+ * Context methods a recorded draw list may call. `drawImage` is deliberately
+ * absent: it is the one call carrying binary, and both sides special-case it.
+ */
+export const CANVAS_METHODS = [
+  "save",
+  "restore",
+  "translate",
+  "rotate",
+  "scale",
+  "transform",
+  "setTransform",
+  "resetTransform",
+  "beginPath",
+  "closePath",
+  "moveTo",
+  "lineTo",
+  "bezierCurveTo",
+  "quadraticCurveTo",
+  "arc",
+  "arcTo",
+  "ellipse",
+  "rect",
+  "roundRect",
+  "fill",
+  "stroke",
+  "clip",
+  "fillRect",
+  "strokeRect",
+  "clearRect",
+  "fillText",
+  "strokeText",
+  "setLineDash"
+] as const;
+
+/** Gradient factories the recorder offers; each returns a gradient handle. */
+export const CANVAS_GRADIENT_FACTORIES = {
+  createLinearGradient: "linear",
+  createRadialGradient: "radial",
+  createConicGradient: "conic"
+} as const;
+
+/**
+ * Marker key on a gradient handle. A gradient is a host object, so the guest
+ * holds a tag instead and the renderer swaps in the real one when the tag is
+ * assigned to `fillStyle` or `strokeStyle`.
+ */
+export const CANVAS_GRADIENT_MARKER = "__nodetool_canvas_gradient__";

--- a/packages/agents/src/sandbox-media.ts
+++ b/packages/agents/src/sandbox-media.ts
@@ -1,0 +1,1034 @@
+/**
+ * Host-side media engine behind the sandbox's `image` and `canvas` bridges.
+ *
+ * The guest never sees a canvas, a context, or an image object — those are host
+ * resources with methods, and the bridge contract is plain data in, plain data
+ * out. So the boundary carries encoded image bytes (`Uint8Array`) and, for
+ * drawing, a *draw list*: the guest records ordinary Canvas 2D calls
+ * synchronously and ships them in one {@link CanvasRenderSpec}, which this
+ * module replays against a real 2D context and encodes.
+ *
+ * Two backends implement the same surface, picked at first use:
+ *
+ * - **Node** — `@napi-rs/canvas` (Skia). Imported through `importHidden`, so no
+ *   bundler tries to resolve the native addon into a browser graph. It is
+ *   already staged as an external in `scripts/bundle-backend.mjs`, so the
+ *   packaged Electron backend resolves it at runtime.
+ * - **Browser / worker** — `OffscreenCanvas` + `createImageBitmap` +
+ *   `convertToBlob`, so the in-browser runner draws with the platform's own
+ *   canvas instead of shipping a second copy of Skia.
+ *
+ * Neither backend is ever handed to the guest.
+ */
+
+import { importHidden } from "@nodetool-ai/config";
+import {
+  CANVAS_GRADIENT_MARKER,
+  CANVAS_METHODS,
+  CANVAS_PROPERTIES
+} from "./sandbox-canvas-api.js";
+
+// ---------------------------------------------------------------------------
+// Limits
+// ---------------------------------------------------------------------------
+
+/** Largest encoded image the `image.*` bridges accept. */
+export const MAX_IMAGE_INPUT_BYTES = 25 * 1024 * 1024;
+/** Pixel ceiling for a decoded image or a rendered canvas. */
+export const MAX_IMAGE_PIXELS = 32 * 1024 * 1024;
+/** Longest edge any single surface may have. */
+export const MAX_IMAGE_DIMENSION = 16_384;
+/**
+ * Pixel ceiling for `image.decode`. Lower than {@link MAX_IMAGE_PIXELS}: raw
+ * RGBA is four bytes a pixel and crosses the boundary base64-encoded, so the
+ * guest pays roughly 5.4x the pixel count in transferred characters.
+ */
+export const MAX_DECODE_PIXELS = 8 * 1024 * 1024;
+/**
+ * Draw operations replayed per `canvas` render. The ceiling is generous
+ * against what the boundary can carry, not against Skia: each recorded op is
+ * a small object marshaled out of the guest, which costs around a millisecond,
+ * so a draw list this long already spends most of a default run's budget
+ * getting to the host. Composing several images with `image.composite` beats
+ * drawing tens of thousands of primitives.
+ */
+export const MAX_CANVAS_OPS = 10_000;
+/** Composite layers accepted by one `image.composite` call. */
+export const MAX_COMPOSITE_LAYERS = 64;
+/** Default JPEG/WebP/AVIF quality when the caller names none. */
+export const DEFAULT_IMAGE_QUALITY = 0.92;
+
+export const IMAGE_FORMATS = ["png", "jpeg", "webp", "avif"] as const;
+export type ImageFormat = (typeof IMAGE_FORMATS)[number];
+
+// ---------------------------------------------------------------------------
+// Backend
+// ---------------------------------------------------------------------------
+
+/** The subset of `CanvasRenderingContext2D` both backends satisfy. */
+export interface MediaContext2D {
+  [key: string]: unknown;
+  drawImage: (...args: unknown[]) => void;
+  measureText: (text: string) => { width: number } & Record<string, unknown>;
+  createLinearGradient: (...args: number[]) => MediaGradient;
+  createRadialGradient: (...args: number[]) => MediaGradient;
+  createConicGradient?: (...args: number[]) => MediaGradient;
+  getImageData: (
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) => { data: ArrayLike<number> };
+  putImageData: (data: unknown, x: number, y: number) => void;
+}
+
+export interface MediaGradient {
+  addColorStop: (offset: number, color: string) => void;
+}
+
+export interface MediaSurface {
+  readonly width: number;
+  readonly height: number;
+  readonly ctx: MediaContext2D;
+}
+
+/** A decoded image the backend's `drawImage` accepts. */
+export interface MediaImage {
+  readonly width: number;
+  readonly height: number;
+  readonly handle: unknown;
+}
+
+export interface MediaBackend {
+  createSurface(width: number, height: number): MediaSurface;
+  decode(bytes: Uint8Array): Promise<MediaImage>;
+  /** Wrap raw RGBA pixels as a drawable of the given size. */
+  fromPixels(
+    pixels: Uint8Array,
+    width: number,
+    height: number
+  ): Promise<MediaImage>;
+  encode(
+    surface: MediaSurface,
+    format: ImageFormat,
+    quality: number
+  ): Promise<Uint8Array>;
+}
+
+interface NapiCanvasModule {
+  createCanvas: (
+    w: number,
+    h: number
+  ) => {
+    width: number;
+    height: number;
+    getContext: (kind: "2d") => MediaContext2D;
+    encode: (format: string, quality?: number) => Promise<Uint8Array>;
+  };
+  loadImage: (
+    input: Uint8Array
+  ) => Promise<{ width: number; height: number } & object>;
+  ImageData: new (
+    data: Uint8ClampedArray,
+    width: number,
+    height: number
+  ) => unknown;
+}
+
+function napiQuality(format: ImageFormat, quality: number): number | undefined {
+  // Skia takes 0-100 for the lossy encoders and ignores it for PNG.
+  if (format === "png") return undefined;
+  return Math.round(Math.min(Math.max(quality, 0), 1) * 100);
+}
+
+function createNodeBackend(mod: NapiCanvasModule): MediaBackend {
+  return {
+    createSurface(width, height) {
+      const canvas = mod.createCanvas(width, height);
+      const ctx = canvas.getContext("2d");
+      return {
+        width,
+        height,
+        ctx,
+        // Kept off the public interface — `encode` reaches it through the
+        // closure below rather than widening MediaSurface with a backend type.
+        ...({ __canvas: canvas } as Record<string, unknown>)
+      } as MediaSurface;
+    },
+    async decode(bytes) {
+      const img = await mod.loadImage(bytes);
+      return { width: img.width, height: img.height, handle: img };
+    },
+    async fromPixels(pixels, width, height) {
+      const canvas = mod.createCanvas(width, height);
+      const ctx = canvas.getContext("2d");
+      const clamped = new Uint8ClampedArray(
+        pixels.buffer.slice(
+          pixels.byteOffset,
+          pixels.byteOffset + pixels.byteLength
+        ) as ArrayBuffer
+      );
+      ctx.putImageData(new mod.ImageData(clamped, width, height), 0, 0);
+      return { width, height, handle: canvas };
+    },
+    async encode(surface, format, quality) {
+      const canvas = (surface as unknown as { __canvas: NapiSurfaceCanvas })
+        .__canvas;
+      const q = napiQuality(format, quality);
+      const out =
+        q === undefined
+          ? await canvas.encode(format)
+          : await canvas.encode(format, q);
+      return out instanceof Uint8Array ? out : new Uint8Array(out);
+    }
+  };
+}
+
+type NapiSurfaceCanvas = ReturnType<NapiCanvasModule["createCanvas"]>;
+
+interface OffscreenCanvasLike {
+  width: number;
+  height: number;
+  getContext: (kind: "2d") => MediaContext2D | null;
+  convertToBlob: (opts?: {
+    type?: string;
+    quality?: number;
+  }) => Promise<{ arrayBuffer: () => Promise<ArrayBuffer> }>;
+}
+
+function createBrowserBackend(): MediaBackend {
+  const make = (w: number, h: number): OffscreenCanvasLike =>
+    new (globalThis as unknown as {
+      OffscreenCanvas: new (w: number, h: number) => OffscreenCanvasLike;
+    }).OffscreenCanvas(w, h);
+  const createBitmap = (
+    globalThis as unknown as {
+      createImageBitmap: (source: unknown) => Promise<{
+        width: number;
+        height: number;
+      }>;
+    }
+  ).createImageBitmap;
+
+  return {
+    createSurface(width, height) {
+      const canvas = make(width, height);
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("2d canvas context unavailable");
+      return {
+        width,
+        height,
+        ctx,
+        ...({ __canvas: canvas } as Record<string, unknown>)
+      } as MediaSurface;
+    },
+    async decode(bytes) {
+      const blob = new Blob([bytes as BlobPart]);
+      const bitmap = await createBitmap(blob);
+      return { width: bitmap.width, height: bitmap.height, handle: bitmap };
+    },
+    async fromPixels(pixels, width, height) {
+      const clamped = new Uint8ClampedArray(
+        pixels.buffer.slice(
+          pixels.byteOffset,
+          pixels.byteOffset + pixels.byteLength
+        ) as ArrayBuffer
+      );
+      const data = new ImageData(clamped, width, height);
+      const bitmap = await createBitmap(data);
+      return { width, height, handle: bitmap };
+    },
+    async encode(surface, format, quality) {
+      const canvas = (surface as unknown as { __canvas: OffscreenCanvasLike })
+        .__canvas;
+      const blob = await canvas.convertToBlob({
+        type: `image/${format}`,
+        quality
+      });
+      return new Uint8Array(await blob.arrayBuffer());
+    }
+  };
+}
+
+let backendPromise: Promise<MediaBackend> | null = null;
+
+/** Resolve the platform's canvas backend. Cached — the choice cannot change. */
+export async function getMediaBackend(): Promise<MediaBackend> {
+  if (!backendPromise) {
+    backendPromise = (async () => {
+      const mod = await importHidden<NapiCanvasModule>("@napi-rs/canvas").catch(
+        () => null
+      );
+      if (mod && typeof mod.createCanvas === "function") {
+        return createNodeBackend(mod);
+      }
+      if (
+        typeof (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas ===
+        "function"
+      ) {
+        return createBrowserBackend();
+      }
+      throw new Error(
+        "image and canvas need a 2D canvas: install @napi-rs/canvas on Node, " +
+          "or run somewhere with OffscreenCanvas"
+      );
+    })();
+    // A failed probe must not be cached as a rejected promise forever.
+    backendPromise.catch(() => {
+      backendPromise = null;
+    });
+  }
+  return backendPromise;
+}
+
+/** Test seam: force a backend (or clear it with `null`). */
+export function setMediaBackend(backend: MediaBackend | null): void {
+  backendPromise = backend ? Promise.resolve(backend) : null;
+}
+
+// ---------------------------------------------------------------------------
+// Shared validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Accept the two shapes bytes arrive in. Guest `Uint8Array`s are marshaled
+ * natively by the typed-array serializers, but a value that travelled through
+ * a plain-object round trip arrives numeric-keyed — coerce rather than refuse,
+ * so `image.resize(JSON.parse(...).bytes)` behaves.
+ */
+export function asImageBytes(value: unknown, label: string): Uint8Array {
+  if (value instanceof Uint8Array) return value;
+  if (ArrayBuffer.isView(value)) {
+    const view = value as ArrayBufferView;
+    return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+  }
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const length = Number(record.length ?? -1);
+    if (Number.isInteger(length) && length >= 0) {
+      const out = new Uint8Array(length);
+      for (let i = 0; i < length; i++) out[i] = Number(record[i]) & 255;
+      return out;
+    }
+  }
+  throw new Error(`${label} must be a Uint8Array of encoded image bytes`);
+}
+
+/**
+ * Call a context method by name, keeping the receiver. The backends' contexts
+ * are native objects — pulling a method off one and calling it bare throws
+ * "Illegal invocation" — and the index signature that makes the allowlist
+ * replay possible hides that from the type checker.
+ */
+function invoke(ctx: MediaContext2D, name: string, ...args: unknown[]): void {
+  const fn = ctx[name];
+  if (typeof fn !== "function") {
+    throw new Error(`canvas: "${name}" is not available in this runtime`);
+  }
+  (fn as (...a: unknown[]) => void).apply(ctx, args);
+}
+
+function assertInputSize(bytes: Uint8Array, label: string): void {
+  if (bytes.length === 0) throw new Error(`${label}: image bytes are empty`);
+  if (bytes.length > MAX_IMAGE_INPUT_BYTES) {
+    throw new Error(
+      `${label}: image exceeds the ${MAX_IMAGE_INPUT_BYTES} byte limit`
+    );
+  }
+}
+
+export function assertSurfaceSize(
+  width: number,
+  height: number,
+  label: string
+): void {
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width < 1 ||
+    height < 1
+  ) {
+    throw new Error(`${label}: width and height must be positive numbers`);
+  }
+  if (width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION) {
+    throw new Error(
+      `${label}: no edge may exceed ${MAX_IMAGE_DIMENSION} pixels`
+    );
+  }
+  if (width * height > MAX_IMAGE_PIXELS) {
+    throw new Error(`${label}: exceeds the ${MAX_IMAGE_PIXELS} pixel limit`);
+  }
+}
+
+function resolveFormat(value: unknown, label: string): ImageFormat {
+  if (value === undefined || value === null) return "png";
+  const name = String(value).toLowerCase();
+  const normalized = name === "jpg" ? "jpeg" : name;
+  if (!(IMAGE_FORMATS as readonly string[]).includes(normalized)) {
+    throw new Error(
+      `${label}: format must be one of ${IMAGE_FORMATS.join(", ")}`
+    );
+  }
+  return normalized as ImageFormat;
+}
+
+function resolveQuality(value: unknown): number {
+  const q = Number(value ?? DEFAULT_IMAGE_QUALITY);
+  if (!Number.isFinite(q)) return DEFAULT_IMAGE_QUALITY;
+  return Math.min(Math.max(q, 0), 1);
+}
+
+interface EncodeOptions {
+  format: ImageFormat;
+  quality: number;
+}
+
+function encodeOptions(
+  options: Record<string, unknown> | undefined,
+  label: string,
+  fallbackFormat: ImageFormat = "png"
+): EncodeOptions {
+  const opts = options ?? {};
+  return {
+    format:
+      opts.format === undefined
+        ? fallbackFormat
+        : resolveFormat(opts.format, label),
+    quality: resolveQuality(opts.quality)
+  };
+}
+
+/** Magic-number sniff — the encoder that produced the bytes, before decoding. */
+export function sniffImageFormat(bytes: Uint8Array): string {
+  const at = (i: number): number => bytes[i] ?? -1;
+  if (at(0) === 0x89 && at(1) === 0x50 && at(2) === 0x4e && at(3) === 0x47) {
+    return "png";
+  }
+  if (at(0) === 0xff && at(1) === 0xd8 && at(2) === 0xff) return "jpeg";
+  if (at(0) === 0x47 && at(1) === 0x49 && at(2) === 0x46) return "gif";
+  if (at(0) === 0x42 && at(1) === 0x4d) return "bmp";
+  const tag = (offset: number, text: string): boolean =>
+    [...text].every((ch, i) => at(offset + i) === ch.charCodeAt(0));
+  if (tag(0, "RIFF") && tag(8, "WEBP")) return "webp";
+  if (tag(4, "ftyp")) {
+    if (tag(8, "avif") || tag(8, "avis")) return "avif";
+    if (tag(8, "heic") || tag(8, "heix") || tag(8, "mif1")) return "heic";
+  }
+  if (tag(0, "<svg") || tag(0, "<?xml")) return "svg";
+  return "unknown";
+}
+
+async function decodeImage(
+  bytes: Uint8Array,
+  label: string
+): Promise<{ backend: MediaBackend; image: MediaImage }> {
+  assertInputSize(bytes, label);
+  const backend = await getMediaBackend();
+  let image: MediaImage;
+  try {
+    image = await backend.decode(bytes);
+  } catch (e) {
+    throw new Error(
+      `${label}: could not decode the image (${sniffImageFormat(bytes)}) — ${
+        e instanceof Error ? e.message : String(e)
+      }`
+    );
+  }
+  assertSurfaceSize(image.width, image.height, label);
+  return { backend, image };
+}
+
+/** Render `draw` onto a fresh surface and encode it. */
+async function renderTo(
+  backend: MediaBackend,
+  width: number,
+  height: number,
+  encode: EncodeOptions,
+  background: string | undefined,
+  draw: (ctx: MediaContext2D) => void
+): Promise<Uint8Array> {
+  const surface = backend.createSurface(Math.round(width), Math.round(height));
+  const ctx = surface.ctx;
+  // JPEG has no alpha: without a ground, transparent pixels encode as black.
+  const ground =
+    background ?? (encode.format === "jpeg" ? "#ffffff" : undefined);
+  if (ground) {
+    ctx.fillStyle = ground;
+    invoke(ctx, "fillRect", 0, 0, surface.width, surface.height);
+  }
+  draw(ctx);
+  return backend.encode(surface, encode.format, encode.quality);
+}
+
+// ---------------------------------------------------------------------------
+// image.* bridge
+// ---------------------------------------------------------------------------
+
+type Fit = "cover" | "contain" | "fill";
+
+function resolveFit(value: unknown, label: string): Fit {
+  if (value === undefined || value === null) return "contain";
+  const fit = String(value);
+  if (fit !== "cover" && fit !== "contain" && fit !== "fill") {
+    throw new Error(`${label}: fit must be cover, contain or fill`);
+  }
+  return fit;
+}
+
+/**
+ * Source rectangle and destination rectangle for a fit-constrained draw.
+ * `cover` crops the source, `contain` letterboxes into the destination,
+ * `fill` stretches.
+ */
+function fitRects(
+  sw: number,
+  sh: number,
+  dw: number,
+  dh: number,
+  fit: Fit
+): [number, number, number, number, number, number, number, number] {
+  if (fit === "fill") return [0, 0, sw, sh, 0, 0, dw, dh];
+  if (fit === "cover") {
+    const scale = Math.max(dw / sw, dh / sh);
+    const cw = Math.min(sw, dw / scale);
+    const ch = Math.min(sh, dh / scale);
+    return [(sw - cw) / 2, (sh - ch) / 2, cw, ch, 0, 0, dw, dh];
+  }
+  const scale = Math.min(dw / sw, dh / sh);
+  const w = sw * scale;
+  const h = sh * scale;
+  return [0, 0, sw, sh, (dw - w) / 2, (dh - h) / 2, w, h];
+}
+
+const FILTER_BUILDERS: Record<string, (value: number) => string> = {
+  brightness: (v) => `brightness(${v})`,
+  contrast: (v) => `contrast(${v})`,
+  saturate: (v) => `saturate(${v})`,
+  grayscale: (v) => `grayscale(${v})`,
+  sepia: (v) => `sepia(${v})`,
+  invert: (v) => `invert(${v})`,
+  blur: (v) => `blur(${v}px)`,
+  hueRotate: (v) => `hue-rotate(${v}deg)`,
+  opacity: (v) => `opacity(${v})`
+};
+
+function buildFilter(options: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const [key, build] of Object.entries(FILTER_BUILDERS)) {
+    const raw = options[key];
+    if (raw === undefined || raw === null) continue;
+    const value = Number(raw);
+    if (!Number.isFinite(value)) {
+      throw new Error(`image.adjust: ${key} must be a number`);
+    }
+    parts.push(build(value));
+  }
+  return parts.join(" ");
+}
+
+export interface ImageBridge {
+  info(bytes: unknown): Promise<Record<string, unknown>>;
+  decode(bytes: unknown): Promise<Record<string, unknown>>;
+  encode(
+    pixels: unknown,
+    options?: Record<string, unknown>
+  ): Promise<Uint8Array>;
+  resize(bytes: unknown, options?: Record<string, unknown>): Promise<Uint8Array>;
+  crop(bytes: unknown, options?: Record<string, unknown>): Promise<Uint8Array>;
+  rotate(
+    bytes: unknown,
+    degrees: unknown,
+    options?: Record<string, unknown>
+  ): Promise<Uint8Array>;
+  flip(bytes: unknown, options?: Record<string, unknown>): Promise<Uint8Array>;
+  adjust(bytes: unknown, options?: Record<string, unknown>): Promise<Uint8Array>;
+  composite(
+    bytes: unknown,
+    layers: unknown,
+    options?: Record<string, unknown>
+  ): Promise<Uint8Array>;
+  convert(
+    bytes: unknown,
+    options?: Record<string, unknown>
+  ): Promise<Uint8Array>;
+}
+
+/**
+ * The `image` namespace. Every member takes and returns encoded image bytes,
+ * so results chain (`resize` → `adjust` → `convert`) without the guest ever
+ * holding a decoded surface.
+ */
+export function createImageBridge(): ImageBridge {
+  return {
+    async info(bytes) {
+      const input = asImageBytes(bytes, "image.info: bytes");
+      const { image } = await decodeImage(input, "image.info");
+      return {
+        width: image.width,
+        height: image.height,
+        format: sniffImageFormat(input),
+        byteLength: input.length
+      };
+    },
+
+    async decode(bytes) {
+      const input = asImageBytes(bytes, "image.decode: bytes");
+      const { backend, image } = await decodeImage(input, "image.decode");
+      if (image.width * image.height > MAX_DECODE_PIXELS) {
+        throw new Error(
+          `image.decode: ${image.width}x${image.height} exceeds the ` +
+            `${MAX_DECODE_PIXELS} pixel limit — resize first, or work on ` +
+            "encoded bytes"
+        );
+      }
+      const surface = backend.createSurface(image.width, image.height);
+      surface.ctx.drawImage(image.handle, 0, 0);
+      const data = surface.ctx.getImageData(0, 0, image.width, image.height);
+      return {
+        width: image.width,
+        height: image.height,
+        pixels: Uint8Array.from(data.data as ArrayLike<number>)
+      };
+    },
+
+    async encode(pixels, options) {
+      const source = (pixels ?? {}) as Record<string, unknown>;
+      const width = Math.round(Number(source.width));
+      const height = Math.round(Number(source.height));
+      assertSurfaceSize(width, height, "image.encode");
+      const raw = asImageBytes(source.pixels, "image.encode: pixels");
+      if (raw.length !== width * height * 4) {
+        throw new Error(
+          `image.encode: pixels must hold width*height*4 RGBA bytes ` +
+            `(expected ${width * height * 4}, got ${raw.length})`
+        );
+      }
+      const encode = encodeOptions(options, "image.encode");
+      const backend = await getMediaBackend();
+      const image = await backend.fromPixels(raw, width, height);
+      return renderTo(
+        backend,
+        width,
+        height,
+        encode,
+        options?.background as string | undefined,
+        (ctx) => ctx.drawImage(image.handle, 0, 0)
+      );
+    },
+
+    async resize(bytes, options) {
+      const opts = options ?? {};
+      const input = asImageBytes(bytes, "image.resize: bytes");
+      const { backend, image } = await decodeImage(input, "image.resize");
+      const fit = resolveFit(opts.fit, "image.resize");
+      let width = opts.width === undefined ? NaN : Number(opts.width);
+      let height = opts.height === undefined ? NaN : Number(opts.height);
+      if (!Number.isFinite(width) && !Number.isFinite(height)) {
+        throw new Error("image.resize: pass width, height, or both");
+      }
+      // One dimension given keeps the aspect ratio; the fit modes only matter
+      // once the caller has pinned a box.
+      if (!Number.isFinite(width)) {
+        width = (image.width * height) / image.height;
+      }
+      if (!Number.isFinite(height)) {
+        height = (image.height * width) / image.width;
+      }
+      width = Math.max(1, Math.round(width));
+      height = Math.max(1, Math.round(height));
+      assertSurfaceSize(width, height, "image.resize");
+      const rect = fitRects(image.width, image.height, width, height, fit);
+      const encode = encodeOptions(options, "image.resize");
+      return renderTo(
+        backend,
+        width,
+        height,
+        encode,
+        opts.background as string | undefined,
+        (ctx) => ctx.drawImage(image.handle, ...rect)
+      );
+    },
+
+    async crop(bytes, options) {
+      const opts = options ?? {};
+      const input = asImageBytes(bytes, "image.crop: bytes");
+      const { backend, image } = await decodeImage(input, "image.crop");
+      const x = Math.round(Number(opts.x ?? 0));
+      const y = Math.round(Number(opts.y ?? 0));
+      const width = Math.round(Number(opts.width ?? image.width - x));
+      const height = Math.round(Number(opts.height ?? image.height - y));
+      if (![x, y, width, height].every(Number.isFinite)) {
+        throw new Error("image.crop: x, y, width and height must be numbers");
+      }
+      if (
+        x < 0 ||
+        y < 0 ||
+        width < 1 ||
+        height < 1 ||
+        x + width > image.width ||
+        y + height > image.height
+      ) {
+        throw new Error(
+          `image.crop: rectangle ${width}x${height}+${x}+${y} falls outside ` +
+            `the ${image.width}x${image.height} image`
+        );
+      }
+      const encode = encodeOptions(options, "image.crop");
+      return renderTo(
+        backend,
+        width,
+        height,
+        encode,
+        opts.background as string | undefined,
+        (ctx) =>
+          ctx.drawImage(image.handle, x, y, width, height, 0, 0, width, height)
+      );
+    },
+
+    async rotate(bytes, degrees, options) {
+      const opts = options ?? {};
+      const input = asImageBytes(bytes, "image.rotate: bytes");
+      const angle = Number(degrees);
+      if (!Number.isFinite(angle)) {
+        throw new Error("image.rotate: degrees must be a number");
+      }
+      const { backend, image } = await decodeImage(input, "image.rotate");
+      const radians = (angle * Math.PI) / 180;
+      const cos = Math.abs(Math.cos(radians));
+      const sin = Math.abs(Math.sin(radians));
+      // The bounding box of the rotated rectangle, so nothing is clipped.
+      const width = Math.max(1, Math.round(image.width * cos + image.height * sin));
+      const height = Math.max(1, Math.round(image.width * sin + image.height * cos));
+      assertSurfaceSize(width, height, "image.rotate");
+      const encode = encodeOptions(options, "image.rotate");
+      return renderTo(
+        backend,
+        width,
+        height,
+        encode,
+        opts.background as string | undefined,
+        (ctx) => {
+          invoke(ctx, "translate", width / 2, height / 2);
+          invoke(ctx, "rotate", radians);
+          ctx.drawImage(image.handle, -image.width / 2, -image.height / 2);
+        }
+      );
+    },
+
+    async flip(bytes, options) {
+      const opts = options ?? {};
+      const input = asImageBytes(bytes, "image.flip: bytes");
+      const horizontal = opts.horizontal === undefined ? true : Boolean(opts.horizontal);
+      const vertical = Boolean(opts.vertical);
+      const { backend, image } = await decodeImage(input, "image.flip");
+      const encode = encodeOptions(options, "image.flip");
+      return renderTo(
+        backend,
+        image.width,
+        image.height,
+        encode,
+        opts.background as string | undefined,
+        (ctx) => {
+          invoke(
+            ctx,
+            "translate",
+            horizontal ? image.width : 0,
+            vertical ? image.height : 0
+          );
+          invoke(ctx, "scale", horizontal ? -1 : 1, vertical ? -1 : 1);
+          ctx.drawImage(image.handle, 0, 0);
+        }
+      );
+    },
+
+    async adjust(bytes, options) {
+      const opts = options ?? {};
+      const input = asImageBytes(bytes, "image.adjust: bytes");
+      const filter = buildFilter(opts);
+      if (!filter) {
+        throw new Error(
+          `image.adjust: name at least one of ${Object.keys(
+            FILTER_BUILDERS
+          ).join(", ")}`
+        );
+      }
+      const { backend, image } = await decodeImage(input, "image.adjust");
+      const encode = encodeOptions(options, "image.adjust");
+      return renderTo(
+        backend,
+        image.width,
+        image.height,
+        encode,
+        opts.background as string | undefined,
+        (ctx) => {
+          ctx.filter = filter;
+          ctx.drawImage(image.handle, 0, 0);
+        }
+      );
+    },
+
+    async composite(bytes, layers, options) {
+      const opts = options ?? {};
+      const input = asImageBytes(bytes, "image.composite: bytes");
+      if (!Array.isArray(layers)) {
+        throw new Error("image.composite: layers must be an array");
+      }
+      if (layers.length > MAX_COMPOSITE_LAYERS) {
+        throw new Error(
+          `image.composite: at most ${MAX_COMPOSITE_LAYERS} layers per call`
+        );
+      }
+      const { backend, image } = await decodeImage(input, "image.composite");
+      const drawn: {
+        image: MediaImage;
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+        opacity: number;
+        blendMode: string;
+      }[] = [];
+      for (const [index, entry] of layers.entries()) {
+        const layer = (entry ?? {}) as Record<string, unknown>;
+        const label = `image.composite: layer ${index}`;
+        const layerBytes = asImageBytes(layer.image, `${label} image`);
+        const decoded = await decodeImage(layerBytes, label);
+        drawn.push({
+          image: decoded.image,
+          x: Number(layer.x ?? 0),
+          y: Number(layer.y ?? 0),
+          width: Number(layer.width ?? decoded.image.width),
+          height: Number(layer.height ?? decoded.image.height),
+          opacity:
+            layer.opacity === undefined
+              ? 1
+              : Math.min(Math.max(Number(layer.opacity), 0), 1),
+          blendMode: String(layer.blendMode ?? "source-over")
+        });
+      }
+      const encode = encodeOptions(options, "image.composite");
+      return renderTo(
+        backend,
+        image.width,
+        image.height,
+        encode,
+        opts.background as string | undefined,
+        (ctx) => {
+          ctx.drawImage(image.handle, 0, 0);
+          for (const layer of drawn) {
+            ctx.globalAlpha = layer.opacity;
+            ctx.globalCompositeOperation = layer.blendMode;
+            ctx.drawImage(
+              layer.image.handle,
+              layer.x,
+              layer.y,
+              layer.width,
+              layer.height
+            );
+          }
+          ctx.globalAlpha = 1;
+          ctx.globalCompositeOperation = "source-over";
+        }
+      );
+    },
+
+    async convert(bytes, options) {
+      const opts = options ?? {};
+      const input = asImageBytes(bytes, "image.convert: bytes");
+      const { backend, image } = await decodeImage(input, "image.convert");
+      const encode = encodeOptions(options, "image.convert");
+      return renderTo(
+        backend,
+        image.width,
+        image.height,
+        encode,
+        opts.background as string | undefined,
+        (ctx) => ctx.drawImage(image.handle, 0, 0)
+      );
+    }
+  };
+}
+
+/** The `image` namespace, built once — the members are pure closures. */
+export const imageOps: ImageBridge = createImageBridge();
+
+// ---------------------------------------------------------------------------
+// canvas.* bridge
+// ---------------------------------------------------------------------------
+
+const PROPERTY_SET = new Set<string>(CANVAS_PROPERTIES);
+const METHOD_SET = new Set<string>(CANVAS_METHODS);
+
+export interface CanvasGradientSpec {
+  readonly type: "linear" | "radial" | "conic";
+  readonly coords: readonly number[];
+  readonly stops: readonly (readonly [number, string])[];
+}
+
+export interface CanvasOp {
+  readonly op: string;
+  readonly args?: readonly unknown[];
+}
+
+export interface CanvasRenderSpec {
+  readonly width: number;
+  readonly height: number;
+  readonly background?: string;
+  readonly format?: string;
+  readonly quality?: number;
+  readonly gradients?: Record<string, CanvasGradientSpec>;
+  readonly ops?: readonly CanvasOp[];
+}
+
+function buildGradients(
+  ctx: MediaContext2D,
+  specs: Record<string, CanvasGradientSpec> | undefined
+): Map<string, MediaGradient> {
+  const out = new Map<string, MediaGradient>();
+  for (const [id, spec] of Object.entries(specs ?? {})) {
+    const coords = (spec.coords ?? []).map(Number);
+    let gradient: MediaGradient;
+    if (spec.type === "linear") {
+      gradient = ctx.createLinearGradient(...coords);
+    } else if (spec.type === "radial") {
+      gradient = ctx.createRadialGradient(...coords);
+    } else if (spec.type === "conic" && ctx.createConicGradient) {
+      gradient = ctx.createConicGradient(...coords);
+    } else {
+      throw new Error(`canvas: gradient type "${spec.type}" is not available`);
+    }
+    for (const [offset, color] of spec.stops ?? []) {
+      gradient.addColorStop(Number(offset), String(color));
+    }
+    out.set(id, gradient);
+  }
+  return out;
+}
+
+/**
+ * Replay a recorded draw list and return the encoded image.
+ *
+ * Ops are validated against the allowlists above, and `drawImage`'s first
+ * argument is decoded here rather than in the guest — so the guest passes plain
+ * image bytes and never holds a drawable.
+ */
+export async function renderCanvas(
+  spec: CanvasRenderSpec
+): Promise<Uint8Array> {
+  if (!spec || typeof spec !== "object") {
+    throw new Error("canvas.render: spec must be an object");
+  }
+  const width = Math.round(Number(spec.width));
+  const height = Math.round(Number(spec.height));
+  assertSurfaceSize(width, height, "canvas.render");
+  const ops = spec.ops ?? [];
+  if (!Array.isArray(ops)) {
+    throw new Error("canvas.render: ops must be an array");
+  }
+  if (ops.length > MAX_CANVAS_OPS) {
+    throw new Error(
+      `canvas.render: ${ops.length} operations exceeds the ${MAX_CANVAS_OPS} limit`
+    );
+  }
+
+  const backend = await getMediaBackend();
+  const encode = encodeOptions(
+    { format: spec.format, quality: spec.quality },
+    "canvas.render"
+  );
+
+  // Decode every drawImage source up front: the replay itself is synchronous,
+  // so an await inside it would interleave with nothing and only complicate
+  // the transform stack's lifetime.
+  const decoded = new Map<number, MediaImage>();
+  for (const [index, entry] of ops.entries()) {
+    if (entry?.op !== "drawImage") continue;
+    const args = entry.args ?? [];
+    const bytes = asImageBytes(args[0], `canvas.render: op ${index} image`);
+    const { image } = await decodeImage(bytes, `canvas.render: op ${index}`);
+    decoded.set(index, image);
+  }
+
+  const surface = backend.createSurface(width, height);
+  const ctx = surface.ctx;
+  const gradients = buildGradients(ctx, spec.gradients);
+  const resolveStyle = (value: unknown): unknown => {
+    if (value && typeof value === "object") {
+      const id = (value as Record<string, unknown>)[CANVAS_GRADIENT_MARKER];
+      if (typeof id === "string") {
+        const gradient = gradients.get(id);
+        if (!gradient) {
+          throw new Error("canvas.render: unknown gradient reference");
+        }
+        return gradient;
+      }
+    }
+    return value;
+  };
+
+  if (spec.background) {
+    ctx.fillStyle = String(spec.background);
+    invoke(ctx, "fillRect", 0, 0, width, height);
+  } else if (encode.format === "jpeg") {
+    ctx.fillStyle = "#ffffff";
+    invoke(ctx, "fillRect", 0, 0, width, height);
+  }
+
+  for (const [index, entry] of ops.entries()) {
+    const name = entry?.op;
+    const args = (entry?.args ?? []) as unknown[];
+    if (name === "set") {
+      const [property, value] = args;
+      const key = String(property);
+      if (!PROPERTY_SET.has(key)) {
+        throw new Error(`canvas.render: op ${index} sets unknown property "${key}"`);
+      }
+      ctx[key] = resolveStyle(value);
+      continue;
+    }
+    if (name === "drawImage") {
+      const image = decoded.get(index);
+      if (!image) {
+        throw new Error(`canvas.render: op ${index} has no image`);
+      }
+      ctx.drawImage(image.handle, ...args.slice(1));
+      continue;
+    }
+    if (!METHOD_SET.has(String(name))) {
+      throw new Error(`canvas.render: op ${index} calls unknown method "${name}"`);
+    }
+    invoke(ctx, String(name), ...args);
+  }
+
+  return backend.encode(surface, encode.format, encode.quality);
+}
+
+/** Text metrics for a font, so the guest can lay text out before drawing it. */
+export async function measureCanvasText(
+  text: unknown,
+  font: unknown
+): Promise<Record<string, number>> {
+  if (typeof text !== "string") {
+    throw new Error("canvas.measureText: text must be a string");
+  }
+  const backend = await getMediaBackend();
+  const surface = backend.createSurface(1, 1);
+  if (font !== undefined && font !== null) {
+    surface.ctx.font = String(font);
+  }
+  const metrics = surface.ctx.measureText(text);
+  const pick = (key: string): number => {
+    const value = (metrics as Record<string, unknown>)[key];
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+  };
+  return {
+    width: pick("width"),
+    actualBoundingBoxLeft: pick("actualBoundingBoxLeft"),
+    actualBoundingBoxRight: pick("actualBoundingBoxRight"),
+    actualBoundingBoxAscent: pick("actualBoundingBoxAscent"),
+    actualBoundingBoxDescent: pick("actualBoundingBoxDescent"),
+    fontBoundingBoxAscent: pick("fontBoundingBoxAscent"),
+    fontBoundingBoxDescent: pick("fontBoundingBoxDescent")
+  };
+}

--- a/packages/agents/tests/js-sandbox-media.test.ts
+++ b/packages/agents/tests/js-sandbox-media.test.ts
@@ -1,0 +1,402 @@
+/**
+ * The `image` and `canvas` bridges — real sandbox runs against the real canvas
+ * backend, no network. Pixels are read back through `image.decode`, so these
+ * assert what was drawn rather than that a call returned something.
+ */
+import { describe, it, expect } from "vitest";
+import { runInSandbox } from "../src/js-sandbox.js";
+import {
+  CANVAS_METHODS,
+  CANVAS_PROPERTIES
+} from "../src/sandbox-canvas-api.js";
+import {
+  MAX_CANVAS_OPS,
+  asImageBytes,
+  renderCanvas,
+  sniffImageFormat
+} from "../src/sandbox-media.js";
+
+/** Run a snippet and fail loudly with the sandbox's own error. */
+async function run(code: string): Promise<unknown> {
+  const result = await runInSandbox({ code, timeoutMs: 60_000 });
+  if (!result.success) throw new Error(result.error ?? "sandbox run failed");
+  return result.result;
+}
+
+/** A solid PNG the guest can build for itself, as a reusable prelude. */
+const SOLID = (
+  width: number,
+  height: number,
+  color: string
+): string => `
+  const __c = createCanvas(${width}, ${height});
+  const __g = __c.getContext("2d");
+  __g.fillStyle = ${JSON.stringify(color)};
+  __g.fillRect(0, 0, ${width}, ${height});
+  const solid = await __c.toBytes();
+`;
+
+/** RGBA at (x, y) of a decoded image, as a plain array. */
+const PIXEL = `
+  const pixelAt = (decoded, x, y) => {
+    const i = (y * decoded.width + x) * 4;
+    return Array.from(decoded.pixels.slice(i, i + 4));
+  };
+`;
+
+describe("createCanvas", () => {
+  it("draws, encodes, and reports the pixels it drew", async () => {
+    const result = (await run(`
+      ${PIXEL}
+      const c = createCanvas(10, 10);
+      const g = c.getContext("2d");
+      g.fillStyle = "#ff0000";
+      g.fillRect(0, 0, 10, 10);
+      g.fillStyle = "#00ff00";
+      g.fillRect(0, 0, 5, 5);
+      const png = await c.toBytes();
+      const decoded = await image.decode(png);
+      return {
+        isBytes: png instanceof Uint8Array,
+        info: await image.info(png),
+        topLeft: pixelAt(decoded, 1, 1),
+        bottomRight: pixelAt(decoded, 8, 8)
+      };
+    `)) as Record<string, unknown>;
+
+    expect(result.isBytes).toBe(true);
+    expect(result.info).toMatchObject({ width: 10, height: 10, format: "png" });
+    expect(result.topLeft).toEqual([0, 255, 0, 255]);
+    expect(result.bottomRight).toEqual([255, 0, 0, 255]);
+  });
+
+  it("applies a gradient assigned as a fill style", async () => {
+    const result = (await run(`
+      ${PIXEL}
+      const c = createCanvas(64, 4);
+      const g = c.getContext("2d");
+      const grad = g.createLinearGradient(0, 0, 64, 0);
+      grad.addColorStop(0, "#ff0000");
+      grad.addColorStop(1, "#0000ff");
+      g.fillStyle = grad;
+      g.fillRect(0, 0, 64, 4);
+      const decoded = await image.decode(await c.toBytes());
+      return { left: pixelAt(decoded, 0, 2), right: pixelAt(decoded, 63, 2) };
+    `)) as { left: number[]; right: number[] };
+
+    // Endpoints land on the stops; the midpoint is the interpolation.
+    expect(result.left[0]).toBeGreaterThan(200);
+    expect(result.left[2]).toBeLessThan(60);
+    expect(result.right[2]).toBeGreaterThan(200);
+    expect(result.right[0]).toBeLessThan(60);
+  });
+
+  it("honours the transform stack across save and restore", async () => {
+    const result = (await run(`
+      ${PIXEL}
+      const c = createCanvas(20, 20);
+      const g = c.getContext("2d");
+      g.save();
+      g.translate(10, 10);
+      g.fillStyle = "#ffffff";
+      g.fillRect(0, 0, 10, 10);
+      g.restore();
+      g.fillStyle = "#ff00ff";
+      g.fillRect(0, 0, 4, 4);
+      const decoded = await image.decode(await c.toBytes());
+      return { shifted: pixelAt(decoded, 15, 15), origin: pixelAt(decoded, 1, 1) };
+    `)) as { shifted: number[]; origin: number[] };
+
+    expect(result.shifted).toEqual([255, 255, 255, 255]);
+    expect(result.origin).toEqual([255, 0, 255, 255]);
+  });
+
+  it("draws image bytes onto the canvas", async () => {
+    const result = (await run(`
+      ${SOLID(8, 8, "#0000ff")}
+      ${PIXEL}
+      const c = createCanvas(16, 16);
+      const g = c.getContext("2d");
+      g.drawImage(solid, 8, 8);
+      const decoded = await image.decode(await c.toBytes());
+      return { drawn: pixelAt(decoded, 12, 12), empty: pixelAt(decoded, 2, 2) };
+    `)) as { drawn: number[]; empty: number[] };
+
+    expect(result.drawn).toEqual([0, 0, 255, 255]);
+    expect(result.empty[3]).toBe(0);
+  });
+
+  it("fills a jpeg's transparency with white rather than black", async () => {
+    const result = (await run(`
+      ${PIXEL}
+      const c = createCanvas(8, 8);
+      const jpeg = await c.toBytes({ format: "jpeg" });
+      const decoded = await image.decode(jpeg);
+      return { head: Array.from(jpeg.slice(0, 3)), corner: pixelAt(decoded, 0, 0) };
+    `)) as { head: number[]; corner: number[] };
+
+    expect(result.head).toEqual([0xff, 0xd8, 0xff]);
+    expect(result.corner[0]).toBeGreaterThan(240);
+    expect(result.corner[3]).toBe(255);
+  });
+
+  it("refuses a context other than 2d", async () => {
+    const message = await run(`
+      try { createCanvas(4, 4).getContext("webgl"); return "no throw"; }
+      catch (e) { return e.message; }
+    `);
+    expect(message).toMatch(/only the "2d" context/);
+  });
+
+  it("offers every allowlisted method and property", async () => {
+    const surface = (await run(`
+      const g = createCanvas(4, 4).getContext("2d");
+      return {
+        methods: ${JSON.stringify(CANVAS_METHODS)}.filter((n) => typeof g[n] !== "function"),
+        properties: ${JSON.stringify(CANVAS_PROPERTIES)}.filter((n) => !(n in g))
+      };
+    `)) as { methods: string[]; properties: string[] };
+
+    expect(surface.methods).toEqual([]);
+    expect(surface.properties).toEqual([]);
+  });
+});
+
+describe("canvas.render", () => {
+  it("renders a hand-built draw list", async () => {
+    const result = (await run(`
+      ${PIXEL}
+      const png = await canvas.render({
+        width: 8,
+        height: 8,
+        background: "#000000",
+        ops: [
+          { op: "set", args: ["fillStyle", "#ffffff"] },
+          { op: "fillRect", args: [0, 0, 4, 4] }
+        ]
+      });
+      const decoded = await image.decode(png);
+      return { lit: pixelAt(decoded, 1, 1), dark: pixelAt(decoded, 6, 6) };
+    `)) as { lit: number[]; dark: number[] };
+
+    expect(result.lit).toEqual([255, 255, 255, 255]);
+    expect(result.dark).toEqual([0, 0, 0, 255]);
+  });
+
+  it("refuses an op outside the allowlist", async () => {
+    const message = await run(`
+      try {
+        await canvas.render({
+          width: 4, height: 4,
+          ops: [{ op: "getImageData", args: [0, 0, 1, 1] }]
+        });
+        return "no throw";
+      } catch (e) { return e.message; }
+    `);
+    expect(message).toMatch(/unknown method "getImageData"/);
+  });
+
+  it("refuses a property outside the allowlist", async () => {
+    const message = await run(`
+      try {
+        await canvas.render({
+          width: 4, height: 4,
+          ops: [{ op: "set", args: ["canvas", null] }]
+        });
+        return "no throw";
+      } catch (e) { return e.message; }
+    `);
+    expect(message).toMatch(/unknown property "canvas"/);
+  });
+
+  // Driven host-side: marshaling an over-limit draw list out of the guest costs
+  // more than the run's whole budget, which is the point of the cap.
+  it("caps the draw list", async () => {
+    const ops = Array.from({ length: MAX_CANVAS_OPS + 1 }, () => ({
+      op: "beginPath" as const,
+      args: []
+    }));
+    await expect(renderCanvas({ width: 4, height: 4, ops })).rejects.toThrow(
+      /exceeds the \d+ limit/
+    );
+  });
+
+  it("measures text for a font", async () => {
+    const metrics = (await run(`
+      return await canvas.measureText("iiii", "40px sans-serif");
+    `)) as Record<string, number>;
+    expect(metrics.width).toBeGreaterThan(0);
+    expect(typeof metrics.actualBoundingBoxAscent).toBe("number");
+  });
+});
+
+describe("image transforms", () => {
+  it("resizes to a box, keeping the aspect ratio from one dimension", async () => {
+    const result = (await run(`
+      ${SOLID(40, 20, "#123456")}
+      const auto = await image.info(await image.resize(solid, { width: 20 }));
+      const boxed = await image.info(
+        await image.resize(solid, { width: 10, height: 10, fit: "cover" })
+      );
+      return { auto, boxed };
+    `)) as Record<string, { width: number; height: number }>;
+
+    expect(result.auto).toMatchObject({ width: 20, height: 10 });
+    expect(result.boxed).toMatchObject({ width: 10, height: 10 });
+  });
+
+  it("needs at least one dimension", async () => {
+    const message = await run(`
+      ${SOLID(4, 4, "#ffffff")}
+      try { await image.resize(solid, {}); return "no throw"; }
+      catch (e) { return e.message; }
+    `);
+    expect(message).toMatch(/pass width, height, or both/);
+  });
+
+  it("crops the requested rectangle and refuses one outside the image", async () => {
+    const result = (await run(`
+      ${PIXEL}
+      const c = createCanvas(10, 10);
+      const g = c.getContext("2d");
+      g.fillStyle = "#000000";
+      g.fillRect(0, 0, 10, 10);
+      g.fillStyle = "#ffff00";
+      g.fillRect(5, 5, 5, 5);
+      const src = await c.toBytes();
+      const cropped = await image.crop(src, { x: 5, y: 5, width: 5, height: 5 });
+      const decoded = await image.decode(cropped);
+      let error = null;
+      try { await image.crop(src, { x: 8, y: 0, width: 5, height: 5 }); }
+      catch (e) { error = e.message; }
+      return { size: [decoded.width, decoded.height], corner: pixelAt(decoded, 0, 0), error };
+    `)) as { size: number[]; corner: number[]; error: string };
+
+    expect(result.size).toEqual([5, 5]);
+    expect(result.corner).toEqual([255, 255, 0, 255]);
+    expect(result.error).toMatch(/falls outside/);
+  });
+
+  it("grows the canvas to the rotated bounding box", async () => {
+    const info = (await run(`
+      ${SOLID(40, 20, "#ffffff")}
+      return await image.info(await image.rotate(solid, 90));
+    `)) as { width: number; height: number };
+    expect(info).toMatchObject({ width: 20, height: 40 });
+  });
+
+  it("mirrors horizontally by default", async () => {
+    const result = (await run(`
+      ${PIXEL}
+      const c = createCanvas(4, 1);
+      const g = c.getContext("2d");
+      g.fillStyle = "#ff0000";
+      g.fillRect(0, 0, 1, 1);
+      g.fillStyle = "#0000ff";
+      g.fillRect(1, 0, 3, 1);
+      const decoded = await image.decode(await image.flip(await c.toBytes()));
+      return { last: pixelAt(decoded, 3, 0) };
+    `)) as { last: number[] };
+    expect(result.last).toEqual([255, 0, 0, 255]);
+  });
+
+  it("desaturates through adjust and names the options when given none", async () => {
+    const result = (await run(`
+      ${SOLID(4, 4, "#ff0000")}
+      ${PIXEL}
+      const gray = await image.decode(await image.adjust(solid, { grayscale: 1 }));
+      let error = null;
+      try { await image.adjust(solid, {}); } catch (e) { error = e.message; }
+      return { pixel: pixelAt(gray, 1, 1), error };
+    `)) as { pixel: number[]; error: string };
+
+    expect(result.pixel[0]).toBe(result.pixel[1]);
+    expect(result.pixel[1]).toBe(result.pixel[2]);
+    expect(result.error).toMatch(/name at least one of/);
+  });
+
+  it("composites a layer at a position and opacity", async () => {
+    const result = (await run(`
+      ${PIXEL}
+      const base = createCanvas(10, 10);
+      const bg = base.getContext("2d");
+      bg.fillStyle = "#000000";
+      bg.fillRect(0, 0, 10, 10);
+      const layer = createCanvas(4, 4);
+      const lg = layer.getContext("2d");
+      lg.fillStyle = "#ffffff";
+      lg.fillRect(0, 0, 4, 4);
+      const out = await image.composite(await base.toBytes(), [
+        { image: await layer.toBytes(), x: 0, y: 0, opacity: 0.5 }
+      ]);
+      const decoded = await image.decode(out);
+      return { blended: pixelAt(decoded, 1, 1), untouched: pixelAt(decoded, 9, 9) };
+    `)) as { blended: number[]; untouched: number[] };
+
+    expect(result.blended[0]).toBeGreaterThan(100);
+    expect(result.blended[0]).toBeLessThan(160);
+    expect(result.untouched).toEqual([0, 0, 0, 255]);
+  });
+
+  it("converts between formats and refuses one it cannot encode", async () => {
+    const result = (await run(`
+      ${SOLID(8, 8, "#ff8800")}
+      const webp = await image.convert(solid, { format: "webp" });
+      let error = null;
+      try { await image.convert(solid, { format: "tiff" }); }
+      catch (e) { error = e.message; }
+      return { webp: Array.from(webp.slice(0, 4)), error };
+    `)) as { webp: number[]; error: string };
+
+    expect(String.fromCharCode(...result.webp)).toBe("RIFF");
+    expect(result.error).toMatch(/format must be one of/);
+  });
+
+  it("round-trips raw pixels through decode and encode", async () => {
+    const result = (await run(`
+      ${PIXEL}
+      const decoded = await image.decode(await (async () => {
+        ${SOLID(6, 6, "#00ff00")}
+        return solid;
+      })());
+      const again = await image.decode(await image.encode(decoded));
+      return { size: [again.width, again.height], pixel: pixelAt(again, 3, 3) };
+    `)) as { size: number[]; pixel: number[] };
+
+    expect(result.size).toEqual([6, 6]);
+    expect(result.pixel).toEqual([0, 255, 0, 255]);
+  });
+
+  it("reports a decode failure with the format it sniffed", async () => {
+    const message = await run(`
+      try { await image.info(utf8Encode("not an image at all")); return "no throw"; }
+      catch (e) { return e.message; }
+    `);
+    expect(message).toMatch(/could not decode the image \(unknown\)/);
+  });
+});
+
+describe("byte coercion and format sniffing", () => {
+  it("accepts a numeric-keyed object as bytes", () => {
+    expect(asImageBytes({ 0: 1, 1: 2, length: 2 }, "x")).toEqual(
+      new Uint8Array([1, 2])
+    );
+  });
+
+  it("refuses a value that is not byte-shaped", () => {
+    expect(() => asImageBytes("png", "image.info: bytes")).toThrow(
+      /must be a Uint8Array/
+    );
+  });
+
+  it("names the container formats by magic number", () => {
+    expect(sniffImageFormat(new Uint8Array([0x89, 0x50, 0x4e, 0x47]))).toBe(
+      "png"
+    );
+    expect(sniffImageFormat(new Uint8Array([0xff, 0xd8, 0xff]))).toBe("jpeg");
+    expect(
+      sniffImageFormat(new TextEncoder().encode("RIFF????WEBPVP8 "))
+    ).toBe("webp");
+    expect(sniffImageFormat(new Uint8Array([1, 2, 3, 4]))).toBe("unknown");
+  });
+});

--- a/packages/node-sdk/src/code-node-validation.ts
+++ b/packages/node-sdk/src/code-node-validation.ts
@@ -52,9 +52,10 @@ export const SANDBOX_GLOBALS: ReadonlySet<string> = new Set([
   // Host bridges
   "fetch", "crypto", "uuid", "sleep", "getSecret", "workspace",
   "assetToSandbox", "sandboxToAsset", "progress", "format", "data",
+  "image", "canvas",
   // Pure guest helpers defined by the sandbox prelude
   "toBase64", "fromBase64", "toHex", "fromHex", "utf8Encode", "utf8Decode",
-  "parallelMap",
+  "parallelMap", "createCanvas",
   // Blocked in the sandbox, but still not user inputs
   "setTimeout", "clearTimeout", "setInterval", "clearInterval",
   "setImmediate", "clearImmediate", "eval", "Function",

--- a/web/src/hooks/editor/useChatIntegration.ts
+++ b/web/src/hooks/editor/useChatIntegration.ts
@@ -185,6 +185,23 @@ ASYNC APIS:
 - uuid() → string
 - progress(percent, message?) — drives the node progress bar; fire-and-forget
 
+IMAGES (encoded bytes in, encoded bytes out, so calls chain; png, jpeg, webp, avif):
+- await image.info(bytes) → { width, height, format, byteLength }
+- await image.resize(bytes, options) — width, height, fit (cover, contain, fill); one dimension keeps the aspect ratio
+- await image.crop(bytes, options) — x, y, width, height
+- await image.rotate(bytes, degrees, options?) — grows the canvas to the rotated bounding box
+- await image.flip(bytes, options?) — horizontal (default true), vertical
+- await image.adjust(bytes, options) — brightness, contrast, saturate, grayscale, sepia, invert, blur, hueRotate, opacity
+- await image.composite(bytes, layers, options?) — layer: image, x, y, width, height, opacity, blendMode
+- await image.convert(bytes, options) — format, quality; await image.decode(bytes) and await image.encode(pixels, options?) for raw RGBA
+
+CANVAS (drawing):
+- createCanvas(width, height) → a surface; getContext with "2d" gives a Canvas 2D context
+- The context takes the usual calls synchronously: fillRect, strokeRect, arc, ellipse, roundRect, fillText, drawImage, createLinearGradient, save, translate, rotate, and the usual properties
+- drawImage takes image bytes, not an image object
+- awaiting toBytes on the surface renders and returns the encoded image — options: format, quality, background
+- await canvas.measureText(text, font?) → text metrics, for laying text out before drawing it
+
 WORKSPACE (file I/O, needs a workspace context):
 - await workspace.read(path) → string; await workspace.write(path, content)
 - await workspace.readBytes(path) → Uint8Array; await workspace.writeBytes(path, bytes)

--- a/web/src/utils/codeOutputInference.ts
+++ b/web/src/utils/codeOutputInference.ts
@@ -117,9 +117,10 @@ const SANDBOX_GLOBALS = new Set([
   // Host bridges
   "fetch", "crypto", "uuid", "sleep", "getSecret", "workspace",
   "assetToSandbox", "sandboxToAsset", "progress", "format", "data",
+  "image", "canvas",
   // Pure guest helpers defined by the sandbox prelude
   "toBase64", "fromBase64", "toHex", "fromHex", "utf8Encode", "utf8Decode",
-  "parallelMap",
+  "parallelMap", "createCanvas",
   // Blocked in the sandbox, but still not user inputs
   "setTimeout", "clearTimeout", "setInterval", "clearInterval",
   "setImmediate", "clearImmediate", "eval", "Function",


### PR DESCRIPTION
Sandboxed JavaScript could parse a spreadsheet, select HTML and diff two texts, but could not touch a pixel. Two new bridges close that: `image` for raster editing and `canvas` for drawing.

## The engine

`packages/agents/src/sandbox-media.ts` picks a backend at first use, like every other library-backed bridge:

- **Node** — `@napi-rs/canvas` (Skia), loaded through `importHidden` so no bundler pulls the native addon into a browser graph. It is already staged as an external by `scripts/bundle-backend.mjs`, so the packaged Electron backend resolves it at runtime.
- **Browser / worker** — `OffscreenCanvas` + `createImageBitmap` + `convertToBlob`, so the in-browser runner draws with the platform's own canvas instead of shipping a second copy of Skia.

Neither backend is ever handed to the guest.

## `image`

Every member takes and returns *encoded* bytes (png/jpeg/webp/avif), so calls chain without the guest ever holding a surface:

```js
const thumb = await image.resize(photo, { width: 512, height: 512, fit: "cover" });
const faded = await image.adjust(thumb, { grayscale: 1, brightness: 1.1 });
return { out: await image.convert(faded, { format: "jpeg", quality: 0.8 }) };
```

`info`, `decode`, `encode`, `resize` (`fit`: cover/contain/fill), `crop`, `rotate` (grows to the rotated bounding box), `flip`, `adjust` (the CSS filter set), `composite` (layers with position, size, opacity and blend mode), `convert`. Encoding to jpeg fills transparency with `background`, white by default.

## `canvas`

A canvas context is a host object with methods, which the plain-data bridge contract cannot carry — so drawing is *recorded* rather than proxied. `createCanvas` returns a surface whose 2D context takes the ordinary calls synchronously and appends each to a draw list; awaiting `toBytes` ships the list through `canvas.render`, which replays it against a real context and encodes.

```js
const c = createCanvas(800, 400);
const g = c.getContext("2d");
const grad = g.createLinearGradient(0, 0, 800, 0);
grad.addColorStop(0, "#ff0055");
grad.addColorStop(1, "#0055ff");
g.fillStyle = grad;
g.fillRect(0, 0, 800, 400);
g.drawImage(logoBytes, 20, 20, 120, 120);   // image bytes, not an image object
g.fillStyle = "#fff";
g.font = "32px sans-serif";
g.fillText("hello", 40, 300);
return { card: await c.toBytes({ format: "png" }) };
```

Gradients cross as tagged handles the renderer swaps back in when one is assigned to `fillStyle`. The method and property allowlists live in `sandbox-canvas-api.ts` and are read by both the guest recorder and the host replay, so an op naming anything outside them is refused rather than reaching a backend-specific escape hatch. `canvas.measureText` returns metrics for laying text out first.

## Limits

| Limit | Value |
|---|---|
| `MAX_IMAGE_INPUT_BYTES` | 25 MB per `image.*` call |
| `MAX_IMAGE_PIXELS` / `MAX_IMAGE_DIMENSION` | 32 M pixels, 16384 px longest edge |
| `MAX_DECODE_PIXELS` | 8 M — raw RGBA crosses the boundary base64-encoded |
| `MAX_CANVAS_OPS` | 10 000 per render |

`MAX_CANVAS_OPS` is bounded by the boundary, not by Skia: each recorded op is a small object marshaled out of the guest at roughly a millisecond, measured at ~6.6 s for 10 000 ops. Heavy composition belongs in `image.composite`, and the constant's comment says so.

## Naming

`image` and `canvas` join the sandbox globals, so a Code node input named `image` no longer gets inferred as an input (the same trade-off `data` and `format` already carry). Discoverability won: these are the names a model reaches for.

## Kept in sync

The sandbox manifest documents both namespaces and the `createCanvas` helper; the node-sdk and web global sets and the editor chat's `<sandbox_api>` block learn the new names. `sandbox-manifest-drift.test.ts` pins all four against the real surface.

## Testing

- New `packages/agents/tests/js-sandbox-media.test.ts` — 25 cases, real sandbox runs against the real backend, no network. Assertions read pixels back through `image.decode` rather than checking that a call returned something: gradient endpoints, transform save/restore, drawn image placement, crop contents, composite opacity, jpeg's white ground. The refusal paths are covered too (non-2d context, op outside the allowlist, crop outside the image, unencodable format, undecodable bytes).
- `npm run typecheck`, `npm run lint`, full `packages/agents` suite (2173 passed), `packages/node-sdk` (756), `web` (1708) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pCFfSwuMYS9rLsyiVF3RD

---
_Generated by [Claude Code](https://claude.ai/code/session_017pCFfSwuMYS9rLsyiVF3RD)_