### PR TITLE
Derive the sandbox manifest's globals from the real QuickJS guest

### DIFF
--- a/packages/agents/scripts/probe-guest-globals.ts
+++ b/packages/agents/scripts/probe-guest-globals.ts
@@ -1,0 +1,19 @@
+/**
+ * Print the QuickJS guest's own globals as the snapshot literal
+ * `GUEST_GLOBALS_SNAPSHOT` in `src/code-gen/sandbox-manifest.ts` expects.
+ * Run after upgrading `@sebastianwessel/quickjs` or changing the prelude:
+ *
+ *     npx tsx packages/agents/scripts/probe-guest-globals.ts
+ */
+import { runInSandbox } from "../src/js-sandbox.js";
+
+const run = await runInSandbox({
+  code: "return Object.getOwnPropertyNames(globalThis)"
+});
+if (run.error) throw new Error(run.error);
+
+const names = (run.result as string[])
+  .filter((name) => !name.startsWith("__"))
+  .sort();
+
+console.log(names.map((name) => `  ${JSON.stringify(name)}`).join(",\n"));

--- a/packages/agents/src/code-gen/sandbox-manifest.ts
+++ b/packages/agents/src/code-gen/sandbox-manifest.ts
@@ -1,16 +1,18 @@
 /**
  * Serializable description of the guest surface `nodetool.code.Code` runs on.
  *
- * Every name and number here is read out of `js-sandbox.ts` rather than
- * restated, so a prompt or help text derived from the manifest cannot advertise
- * an API the sandbox does not marshal. Only the human prose (signatures,
- * descriptions) is written here.
+ * Every bridge, helper and limit here is read out of `js-sandbox.ts` rather
+ * than restated, so a prompt or help text derived from the manifest cannot
+ * advertise an API the sandbox does not marshal. Only the human prose
+ * (signatures, descriptions) and `GUEST_GLOBALS_SNAPSHOT` — which no
+ * synchronous host call can answer — are written here.
  */
 import {
   buildSandbox,
   resolveSandboxLimits,
   DELETED_GUEST_GLOBALS,
   EXPOSED_BRIDGE_NAMES,
+  GUEST_HELPER_NAMES,
   DEFAULT_TIMEOUT_MS,
   DEFAULT_FORMAT_LOCALE,
   DEFAULT_SELECT_HTML_LIMIT,
@@ -757,21 +759,162 @@ function fixedLimits(): SandboxLimitDoc[] {
   ];
 }
 
-/** Split the `buildSandbox` record into what QuickJS provides natively and what
- * it deliberately leaves undefined. */
+/**
+ * Every own global the QuickJS guest really has, machine-observed rather than
+ * inferred from the host-side `buildSandbox` record — that record states what
+ * the host means to install, which is neither what `@sebastianwessel/quickjs`
+ * marshals nor what the engine itself ships. Names beginning `__` (runtime
+ * internals) are filtered out.
+ *
+ * Booting the guest is async and `getSandboxManifest` is synchronous, so the
+ * list is checked in. Regenerate it with:
+ *
+ *     npx tsx packages/agents/scripts/probe-guest-globals.ts
+ *
+ * The live-probe case in `tests/sandbox-manifest-drift.test.ts` boots the real
+ * sandbox and fails when this drifts from it.
+ */
+export const GUEST_GLOBALS_SNAPSHOT: readonly string[] = [
+  "AggregateError",
+  "Array",
+  "ArrayBuffer",
+  "BigInt",
+  "BigInt64Array",
+  "BigUint64Array",
+  "Boolean",
+  "Buffer",
+  "DataView",
+  "Date",
+  "Error",
+  "EvalError",
+  "FinalizationRegistry",
+  "Float32Array",
+  "Float64Array",
+  "Headers",
+  "Infinity",
+  "Int16Array",
+  "Int32Array",
+  "Int8Array",
+  "InternalError",
+  "JSON",
+  "Map",
+  "Math",
+  "NaN",
+  "Number",
+  "Object",
+  "Promise",
+  "Proxy",
+  "RangeError",
+  "ReferenceError",
+  "Reflect",
+  "RegExp",
+  "Request",
+  "Response",
+  "Set",
+  "SharedArrayBuffer",
+  "String",
+  "Symbol",
+  "SyntaxError",
+  "TextDecoder",
+  "TextEncoder",
+  "TypeError",
+  "URIError",
+  "URL",
+  "URLSearchParams",
+  "Uint16Array",
+  "Uint32Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "WeakMap",
+  "WeakRef",
+  "WeakSet",
+  "assetToSandbox",
+  "canvas",
+  "console",
+  "createCanvas",
+  "crypto",
+  "data",
+  "decodeURI",
+  "decodeURIComponent",
+  "encodeURI",
+  "encodeURIComponent",
+  "env",
+  "escape",
+  "fetch",
+  "format",
+  "fromBase64",
+  "fromHex",
+  "getSecret",
+  "globalThis",
+  "image",
+  "isFinite",
+  "isNaN",
+  "parallelMap",
+  "parseFloat",
+  "parseInt",
+  "performance",
+  "process",
+  "progress",
+  "queueMicrotask",
+  "sandboxToAsset",
+  "sleep",
+  "toBase64",
+  "toHex",
+  "undefined",
+  "unescape",
+  "utf8Decode",
+  "utf8Encode",
+  "uuid",
+  "workspace"
+];
+
+/**
+ * Names a model reaches for out of habit that this guest does not have. They
+ * are absent from `GUEST_GLOBALS_SNAPSHOT` — this list is what makes the
+ * absence something the manifest can say out loud. `btoa`, `atob` and
+ * `structuredClone` sit in the host-side `buildSandbox` record but are never
+ * marshaled; `Intl` is why the `format.*` bridge exists.
+ */
+const ABSENT_GLOBALS = [
+  "AbortController",
+  "Blob",
+  "FormData",
+  "Intl",
+  "atob",
+  "btoa",
+  "structuredClone"
+] as const;
+
+/**
+ * Split the observed guest globals into what a model may use directly and what
+ * it must be told is missing. Bridges and prelude helpers are documented
+ * elsewhere in the manifest, so they drop out of both lists.
+ */
 function partitionNativeGlobals(): {
   native: string[];
   blocked: string[];
 } {
-  const bridgeNames = new Set<string>(EXPOSED_BRIDGE_NAMES);
+  const documentedElsewhere = new Set<string>([
+    ...EXPOSED_BRIDGE_NAMES,
+    ...GUEST_HELPER_NAMES
+  ]);
+  const native = GUEST_GLOBALS_SNAPSHOT.filter(
+    (name) => !documentedElsewhere.has(name)
+  );
+  // The names the host record leaves undefined are the timer globals the
+  // prelude removes.
   const { sandbox } = buildSandbox();
-  const native: string[] = [];
-  const blocked: string[] = [];
-  for (const [name, value] of Object.entries(sandbox)) {
-    if (bridgeNames.has(name)) continue;
-    (value === undefined ? blocked : native).push(name);
-  }
-  return { native, blocked: [...blocked, ...DELETED_GUEST_GLOBALS] };
+  const hostBlocked = Object.entries(sandbox)
+    .filter(([, value]) => value === undefined)
+    .map(([name]) => name);
+  return {
+    native,
+    blocked: [
+      ...hostBlocked,
+      ...DELETED_GUEST_GLOBALS,
+      ...ABSENT_GLOBALS
+    ].sort()
+  };
 }
 
 let cached: SandboxManifest | null = null;
@@ -794,7 +937,8 @@ export function getSandboxManifest(): SandboxManifest {
       "Return an object whose keys are the node's outputs. Emit every declared output on every return path.",
       "Media and asset values are reference objects. Pass them through unchanged.",
       "Images are edited as encoded bytes: assetToSandbox then workspace.readBytes to get them, image.* or createCanvas to change them, workspace.writeBytes then sandboxToAsset to hand one back.",
-      "There is no module loader and no Intl. Anything a library would do comes from the bridges below."
+      "There is no module loader and no Intl. Anything a library would do comes from the bridges below.",
+      "`process`, `env` and `Buffer` exist but are the sandbox's own stubs, not Node's: `process` carries an empty `env` and a working directory of \"/\". Nothing reaches the host through them."
     ]
   };
   return cached;

--- a/packages/agents/src/code-gen/sandbox-manifest.ts
+++ b/packages/agents/src/code-gen/sandbox-manifest.ts
@@ -65,6 +65,25 @@ export interface SandboxLimitDoc {
   readonly ceiling?: number;
 }
 
+/**
+ * A rule that holds for the guest, tagged with who it applies to.
+ *
+ * The audience is data rather than something a consumer infers from the prose:
+ * a note about the node's declared outputs is nonsense to a CodeAct action,
+ * which completes through `finish()`. Matching the wording to decide that
+ * couples one file's prompt to another file's sentences, and rewording a note
+ * would silently leak it into the wrong prompt.
+ */
+export interface SandboxNote {
+  readonly text: string;
+  /**
+   * `"all"` (default) holds anywhere the sandbox runs. `"code-node"` holds only
+   * for `nodetool.code.Code`, whose result contract is a returned object of
+   * declared outputs.
+   */
+  readonly audience?: "all" | "code-node";
+}
+
 export interface SandboxManifest {
   readonly nodeType: typeof SANDBOX_MANIFEST_NODE_TYPE;
   readonly runtime: "quickjs";
@@ -77,7 +96,7 @@ export interface SandboxManifest {
   /** Names that exist in other JS runtimes but not here. */
   readonly blockedGlobals: readonly string[];
   readonly limits: readonly SandboxLimitDoc[];
-  readonly notes: readonly string[];
+  readonly notes: readonly SandboxNote[];
 }
 
 /**
@@ -932,13 +951,27 @@ export function getSandboxManifest(): SandboxManifest {
     blockedGlobals: blocked,
     limits: [...overridableLimits(), ...fixedLimits()],
     notes: [
-      "Code runs as an async function body: top-level await works and `return` produces the node's result.",
-      "Bridge calls start host-side work when invoked, not when awaited: Promise.all / allSettled / race / any over fetch or workspace calls run them in parallel. Use parallelMap for bounded fan-out. sleep is the only timer.",
-      "Return an object whose keys are the node's outputs. Emit every declared output on every return path.",
-      "Media and asset values are reference objects. Pass them through unchanged.",
-      "Images are edited as encoded bytes: assetToSandbox then workspace.readBytes to get them, image.* or createCanvas to change them, workspace.writeBytes then sandboxToAsset to hand one back.",
-      "There is no module loader and no Intl. Anything a library would do comes from the bridges below.",
-      "`process`, `env` and `Buffer` exist but are the sandbox's own stubs, not Node's: `process` carries an empty `env` and a working directory of \"/\". Nothing reaches the host through them."
+      {
+        text: "Code runs as an async function body: top-level await works and `return` produces the node's result.",
+        audience: "code-node"
+      },
+      {
+        text: "Bridge calls start host-side work when invoked, not when awaited: Promise.all / allSettled / race / any over fetch or workspace calls run them in parallel. Use parallelMap for bounded fan-out. sleep is the only timer."
+      },
+      {
+        text: "Return an object whose keys are the node's outputs. Emit every declared output on every return path.",
+        audience: "code-node"
+      },
+      { text: "Media and asset values are reference objects. Pass them through unchanged." },
+      {
+        text: "Images are edited as encoded bytes: assetToSandbox then workspace.readBytes to get them, image.* or createCanvas to change them, workspace.writeBytes then sandboxToAsset to hand one back."
+      },
+      {
+        text: "There is no module loader and no Intl. Anything a library would do comes from the bridges below."
+      },
+      {
+        text: "`process`, `env` and `Buffer` exist but are the sandbox's own stubs, not Node's: `process.env` is empty and the working directory is \"/\". Nothing reaches the host through them."
+      }
     ]
   };
   return cached;

--- a/packages/agents/src/code-gen/sandbox-prompt.ts
+++ b/packages/agents/src/code-gen/sandbox-prompt.ts
@@ -73,7 +73,9 @@ export function renderSandboxApiReference(
     `# Sandbox API — Code node\n\nCode runs in a ${manifest.runtime} sandbox. Only the names below exist.`
   );
 
-  sections.push(`## Rules\n${manifest.notes.map((n) => `- ${n}`).join("\n")}`);
+  sections.push(
+    `## Rules\n${manifest.notes.map((n) => `- ${n.text}`).join("\n")}`
+  );
 
   const bridgeBlocks: string[] = [];
   for (const bridge of Object.values(manifest.bridges)) {

--- a/packages/agents/src/codeact/graph-model.ts
+++ b/packages/agents/src/codeact/graph-model.ts
@@ -39,6 +39,9 @@ export function hasGraphModelTools(toolNames: Iterable<string>): boolean {
   return REQUIRED_TOOL_NAMES.every((name) => names.has(name));
 }
 
+/** Guest names {@link GRAPH_MODEL_PRELUDE} defines. */
+export const GRAPH_MODEL_GLOBALS = ["openWorkflow"] as const;
+
 /**
  * Guest-side prelude defining `openWorkflow()`. Plain QuickJS-safe JS — no
  * host bridges of its own; every effect goes through `tools.ui_*`.

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -928,6 +928,14 @@ const NAMESPACE_TOOLS_LITERAL = `const __NT_NAMESPACE_TOOLS = ${JSON.stringify(
 /** The full prelude: namespace map, shared graph DSL core, API definition. */
 export const NODETOOL_API_PRELUDE_FULL = `${NAMESPACE_TOOLS_LITERAL}\n${GRAPH_DSL_CORE_PRELUDE}\n${NODETOOL_API_PRELUDE}`;
 
+/** Guest names {@link NODETOOL_API_PRELUDE_FULL} defines. */
+export const NODETOOL_API_GLOBALS = [
+  "nodetool",
+  "__NT_NAMESPACE_TOOLS",
+  "__graphJsonOf",
+  "__graphDslBuilder"
+] as const;
+
 interface PromptEntry {
   /** Namespace key in {@link NODETOOL_API_NAMESPACE_TOOLS}. */
   namespace: string;

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -126,15 +126,13 @@ export function chatUnavailableBridges(
 }
 
 /**
- * Manifest notes about the Code node's own result contract. A code action
- * returns an observation, not a node's outputs.
- */
-const NODE_ONLY_NOTE_PHRASES = ["the node's result", "the node's outputs"];
-
-/**
  * Manifest notes the action contract states in its own words, at more length
  * and with the action-loop specifics. Removing one from the contract must
  * remove it here too.
+ *
+ * Unlike the audience tag, this one is a phrase match: it exists because two
+ * files say the same thing, so there is no shared field to key on. Keep it to
+ * rules the contract genuinely restates.
  */
 const CONTRACT_NOTE_PHRASES = ["start host-side work when invoked"];
 
@@ -143,15 +141,15 @@ function relevantNotes(
   manifest: SandboxManifest,
   hidden: Set<string>
 ): string[] {
-  return manifest.notes.filter((note) => {
-    if (NODE_ONLY_NOTE_PHRASES.some((phrase) => note.includes(phrase))) {
-      return false;
-    }
-    if (CONTRACT_NOTE_PHRASES.some((phrase) => note.includes(phrase))) {
-      return false;
-    }
-    return !extractApiReferences(note).some((name) => hidden.has(name));
-  });
+  return manifest.notes
+    .filter((note) => (note.audience ?? "all") === "all")
+    .map((note) => note.text)
+    .filter((text) => {
+      if (CONTRACT_NOTE_PHRASES.some((phrase) => text.includes(phrase))) {
+        return false;
+      }
+      return !extractApiReferences(text).some((name) => hidden.has(name));
+    });
 }
 
 /** Compact, manifest-derived sandbox reference: signatures only. */

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -9,6 +9,7 @@ import {
   getSandboxManifest,
   type SandboxManifest
 } from "../code-gen/sandbox-manifest.js";
+import { extractApiReferences } from "../code-gen/sandbox-prompt.js";
 import { renderToolCatalog, type ToolSignatureSource } from "./tool-api.js";
 
 const ACTION_CONTRACT_BASE = `# CodeAct Execution
@@ -54,8 +55,7 @@ Rules:
   along in the same observation, costs nothing, and turns a wrong guess into
   something you can fix inside the same program instead of a probe action.
 - A failed tool call throws; use try/catch when partial failure is acceptable.
-- Top-level \`await\` and \`return\` work. There is no module loader: no
-  \`import\`/\`require\`, and \`eval\`/\`Function\` are disabled.`;
+- Top-level \`await\` and \`return\` work.`;
 
 const ACTION_CONTRACT_STEP = `${ACTION_CONTRACT_BASE}
 - For file work use the sandbox's own \`workspace.*\` API (\`read\`, \`write\`,
@@ -63,13 +63,15 @@ const ACTION_CONTRACT_STEP = `${ACTION_CONTRACT_BASE}
   \`remove\`) — it is in-process, so a read costs nothing a tool call would.
 - Do not ask the user questions. Choose a reasonable assumption and proceed.`;
 
-const ACTION_CONTRACT_CHAT = `${ACTION_CONTRACT_BASE}
-- Network, secrets, files, and assets are available only through \`tools.*\`.
-  Direct \`fetch\`, \`getSecret\`, \`workspace\`, \`assetToSandbox\`, and
-  \`sandboxToAsset\` access is disabled so permission checks and approvals
-  cannot be bypassed.
+function actionContractChat(unavailable: readonly string[]): string {
+  return `${ACTION_CONTRACT_BASE}
+- Network, secrets, files, and assets are available only through \`tools.*\`,
+  so permission checks and approvals cannot be bypassed. Unusable here:
+  ${unavailable.map((name) => `\`${name}\``).join(", ")} — a chat action runs
+  with no context and a zero-request fetch limit.
 - When you need the user's decision, stop writing code and ask in a plain
   assistant message.`;
+}
 
 const CHAT_COMPLETION = `# Answering the user
 
@@ -98,18 +100,66 @@ const FINISH_FREEFORM = `# Completing the step
 Call \`await finish(result)\` when the objective is met, or — for a purely
 textual answer — reply with a final assistant message containing no tool call.`;
 
+/**
+ * Bridges a chat action cannot use for a reason the manifest does not record.
+ * `fetch` exists but is cut by `maxFetchCalls: 0`, and `getSecret` answers
+ * `undefined` rather than throwing without a context. Both are enforced in
+ * `createChatCodeActSession`; everything else follows from `requiresContext`.
+ */
+const CHAT_UNAVAILABLE_BRIDGES = ["fetch", "getSecret"] as const;
+
+/**
+ * The bridges the chat variant hides: the two above plus every bridge whose
+ * members all need a `ProcessingContext`, which a chat action runs without.
+ */
+export function chatUnavailableBridges(
+  manifest: SandboxManifest = getSandboxManifest()
+): string[] {
+  const derived = Object.values(manifest.bridges)
+    .filter(
+      (bridge) =>
+        bridge.members.length > 0 &&
+        bridge.members.every((member) => member.requiresContext)
+    )
+    .map((bridge) => bridge.name as string);
+  return [...new Set([...CHAT_UNAVAILABLE_BRIDGES, ...derived])].sort();
+}
+
+/**
+ * Manifest notes about the Code node's own result contract. A code action
+ * returns an observation, not a node's outputs.
+ */
+const NODE_ONLY_NOTE_PHRASES = ["the node's result", "the node's outputs"];
+
+/**
+ * Manifest notes the action contract states in its own words, at more length
+ * and with the action-loop specifics. Removing one from the contract must
+ * remove it here too.
+ */
+const CONTRACT_NOTE_PHRASES = ["start host-side work when invoked"];
+
+/** Manifest notes that hold for a code action of this variant. */
+function relevantNotes(
+  manifest: SandboxManifest,
+  hidden: Set<string>
+): string[] {
+  return manifest.notes.filter((note) => {
+    if (NODE_ONLY_NOTE_PHRASES.some((phrase) => note.includes(phrase))) {
+      return false;
+    }
+    if (CONTRACT_NOTE_PHRASES.some((phrase) => note.includes(phrase))) {
+      return false;
+    }
+    return !extractApiReferences(note).some((name) => hidden.has(name));
+  });
+}
+
 /** Compact, manifest-derived sandbox reference: signatures only. */
 function renderSandboxSummary(
   manifest: SandboxManifest,
   variant: "step" | "chat"
 ): string {
-  const unavailableInChat = new Set([
-    "fetch",
-    "getSecret",
-    "workspace",
-    "assetToSandbox",
-    "sandboxToAsset"
-  ]);
+  const unavailableInChat = new Set(chatUnavailableBridges(manifest));
   const lines: string[] = [];
   for (const bridge of Object.values(manifest.bridges)) {
     if (bridge.internal || bridge.members.length === 0) continue;
@@ -123,8 +173,14 @@ function renderSandboxSummary(
   }
   const besides =
     variant === "chat" ? "`tools.*`, `state`" : "`tools.*`, `state`, `finish`";
+  const notes = relevantNotes(
+    manifest,
+    variant === "chat" ? unavailableInChat : new Set<string>()
+  );
   return [
     `# Sandbox API (besides ${besides})`,
+    // Before the signatures: the notes point at "the bridges below".
+    notes.map((note) => `- ${note}`).join("\n"),
     lines.join("\n"),
     `Built-ins: ${manifest.nativeGlobals.join(", ")}.`,
     `Not available: ${manifest.blockedGlobals.join(", ")}.`,
@@ -170,7 +226,9 @@ export function buildCodeActSystemPrompt(
   const sections: string[] = [];
   if (options.preamble?.trim()) sections.push(options.preamble.trim());
   sections.push(
-    variant === "chat" ? ACTION_CONTRACT_CHAT : ACTION_CONTRACT_STEP
+    variant === "chat"
+      ? actionContractChat(chatUnavailableBridges(manifest))
+      : ACTION_CONTRACT_STEP
   );
   if (variant === "chat") {
     sections.push(CHAT_COMPLETION);

--- a/packages/agents/src/codeact/tool-api.ts
+++ b/packages/agents/src/codeact/tool-api.ts
@@ -22,6 +22,8 @@ import {
   extractInjectableImages,
   stripImagePayload
 } from "../tools/image-injection.js";
+import { GRAPH_MODEL_GLOBALS } from "./graph-model.js";
+import { NODETOOL_API_GLOBALS } from "./nodetool-api.js";
 
 /** Tool-call ceiling per code action; a runaway guest loop stops here. */
 export const DEFAULT_MAX_TOOL_CALLS_PER_ACTION = 50;
@@ -278,8 +280,15 @@ async function searchTools(query, maxResults) {
 }
 `;
 
-/** Names the prelude and bridge globals claim inside the guest. */
-export const CODEACT_RESERVED_NAMES = [
+/**
+ * Every name the guest already has beyond the sandbox manifest's own surface:
+ * the host bridges the executors install as `globals`, the wrappers
+ * {@link CODEACT_PRELUDE} builds over them, and the two optional object-model
+ * preludes. User code cannot rebind these, and prompt text may name them
+ * without the sandbox-manifest drift check calling them undefined.
+ */
+export const CODEACT_INJECTED_GLOBALS = [
+  // Host bridges (`runInSandbox` globals) plus the prelude's wrappers.
   "tools",
   "finish",
   "state",
@@ -287,7 +296,9 @@ export const CODEACT_RESERVED_NAMES = [
   "__callTool",
   "__finish",
   "__toolNames",
-  "__searchTools"
+  "__searchTools",
+  ...GRAPH_MODEL_GLOBALS,
+  ...NODETOOL_API_GLOBALS
 ] as const;
 
 // ---------------------------------------------------------------------------

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -388,7 +388,7 @@ export {
   renderToolSignature,
   toolSignature,
   CODEACT_PRELUDE,
-  CODEACT_RESERVED_NAMES,
+  CODEACT_INJECTED_GLOBALS,
   DEFAULT_MAX_TOOL_CALLS_PER_ACTION
 } from "./codeact/tool-api.js";
 export type { ToolSignatureSource } from "./codeact/tool-api.js";

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -2665,7 +2665,12 @@ export default true;`,
           ? timeoutMs + Math.max(0, suspendAllowanceMs)
           : timeoutMs,
         memoryLimit: resolvedLimits.memoryLimitBytes,
-        maxStackSize: resolvedLimits.stackLimitBytes
+        maxStackSize: resolvedLimits.stackLimitBytes,
+        // The library defaults this to `{NODE_DEBUG: "true"}`, which reaches
+        // the guest as `process.env` and can flip debug paths in its `node:util`
+        // polyfill. Guest code has no business reading host-shaped environment
+        // variables, so the stub carries nothing.
+        env: {}
       }
     );
 

--- a/packages/agents/tests/codeact-prompt-drift.test.ts
+++ b/packages/agents/tests/codeact-prompt-drift.test.ts
@@ -46,15 +46,33 @@ describe("CodeAct prompt / sandbox drift", () => {
 
   it("carries the manifest's notes into the summary", () => {
     const manifest = getSandboxManifest();
-    const intl = manifest.notes.find((note) => note.includes("Intl"));
+    const intl = manifest.notes.find((note) => note.text.includes("Intl"));
     const prompt = buildCodeActSystemPrompt({ tools: [], variant: "step" });
     // The note may disappear once `Intl` is listed as a blocked global; what
     // must not happen is the prompt staying silent about it either way.
     if (intl) {
-      expect(prompt).toContain(intl);
+      expect(prompt).toContain(intl.text);
     } else {
       expect(manifest.blockedGlobals).toContain("Intl");
       expect(prompt).toContain("Intl");
+    }
+  });
+
+  it("keeps Code-node-only notes out of both variants", () => {
+    // A code action completes through finish(), so a rule about the node's
+    // declared outputs contradicts the contract. The audience tag decides this,
+    // not the wording — rewording a note must not leak it in here.
+    const nodeOnly = getSandboxManifest().notes.filter(
+      (note) => note.audience === "code-node"
+    );
+    expect(nodeOnly.length).toBeGreaterThan(0);
+    for (const variant of ["step", "chat"] as const) {
+      const prompt = buildCodeActSystemPrompt({ tools: [], variant });
+      for (const note of nodeOnly) {
+        expect(prompt, `${variant} prompt leaks a code-node note`).not.toContain(
+          note.text
+        );
+      }
     }
   });
 

--- a/packages/agents/tests/codeact-prompt-drift.test.ts
+++ b/packages/agents/tests/codeact-prompt-drift.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import {
+  buildCodeActSystemPrompt,
+  chatUnavailableBridges
+} from "../src/codeact/prompt.js";
+import { CODEACT_INJECTED_GLOBALS } from "../src/codeact/tool-api.js";
+import { getSandboxManifest } from "../src/code-gen/sandbox-manifest.js";
+import { unknownApiReferences } from "../src/code-gen/sandbox-prompt.js";
+
+/**
+ * Prose words the reference extractor reads as API names. Each is ordinary
+ * English in an example, not something the guest has to provide.
+ */
+const PROSE_ALLOWLIST = new Set([
+  // `parallelMap(items, …)` in the concurrency bullet names its own argument.
+  "items"
+]);
+
+const KNOWN = new Set<string>([...CODEACT_INJECTED_GLOBALS, ...PROSE_ALLOWLIST]);
+
+function undocumented(prompt: string): string[] {
+  return unknownApiReferences(prompt).filter((name) => !KNOWN.has(name));
+}
+
+const VARIANTS = ["step", "chat"] as const;
+
+describe("CodeAct prompt / sandbox drift", () => {
+  for (const variant of VARIANTS) {
+    it(`names no API the sandbox lacks (${variant})`, () => {
+      const prompt = buildCodeActSystemPrompt({ tools: [], variant });
+      expect(undocumented(prompt)).toEqual([]);
+    });
+  }
+
+  it("flags an API the sandbox does not have", () => {
+    const bogus = buildCodeActSystemPrompt({
+      tools: [],
+      variant: "step",
+      preamble: "Group the rows with lodash.groupBy(rows, 'id')."
+    });
+    expect(undocumented(bogus)).toContain("lodash");
+  });
+
+  it("carries the manifest's notes into the summary", () => {
+    const manifest = getSandboxManifest();
+    const intl = manifest.notes.find((note) => note.includes("Intl"));
+    const prompt = buildCodeActSystemPrompt({ tools: [], variant: "step" });
+    // The note may disappear once `Intl` is listed as a blocked global; what
+    // must not happen is the prompt staying silent about it either way.
+    if (intl) {
+      expect(prompt).toContain(intl);
+    } else {
+      expect(manifest.blockedGlobals).toContain("Intl");
+      expect(prompt).toContain("Intl");
+    }
+  });
+
+  it("states the module-loader rule once, from the manifest", () => {
+    const prompt = buildCodeActSystemPrompt({ tools: [], variant: "step" });
+    const occurrences = prompt.split("no module loader").length - 1;
+    expect(occurrences).toBe(1);
+  });
+});
+
+describe("chat variant exclusions", () => {
+  const chatSource = readFileSync(
+    path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../src/codeact/chat-codeact.ts"
+    ),
+    "utf-8"
+  );
+
+  it("matches what a chat action actually disables", () => {
+    expect(chatUnavailableBridges()).toEqual([
+      "assetToSandbox",
+      "fetch",
+      "getSecret",
+      "sandboxToAsset",
+      "workspace"
+    ]);
+  });
+
+  it("is what createChatCodeActSession enforces", () => {
+    // No `context` reaches the sandbox, so every context-only bridge throws.
+    const call = chatSource.slice(chatSource.indexOf("await runInSandbox({"));
+    const args = call.slice(0, call.indexOf("\n    });"));
+    expect(args).not.toMatch(/^\s*context:/m);
+    expect(args).toContain("maxFetchCalls: 0");
+  });
+
+  it("hides every excluded bridge from the chat prompt", () => {
+    const manifest = getSandboxManifest();
+    const chat = buildCodeActSystemPrompt({ tools: [], variant: "chat" });
+    const step = buildCodeActSystemPrompt({ tools: [], variant: "step" });
+    for (const name of chatUnavailableBridges()) {
+      const bridge = manifest.bridges[name as keyof typeof manifest.bridges];
+      for (const member of bridge.members) {
+        expect(step).toContain(member.signature);
+        expect(chat).not.toContain(member.signature);
+      }
+    }
+  });
+});

--- a/packages/agents/tests/sandbox-manifest-drift.test.ts
+++ b/packages/agents/tests/sandbox-manifest-drift.test.ts
@@ -182,6 +182,26 @@ function documentedGlobals(): Set<string> {
 }
 
 /**
+ * Names a consumer may deliberately omit, with the reason.
+ *
+ * The two copies answer different questions, so an identical set is not always
+ * right. The validator asks "does this name resolve?" — `env` does, so reading
+ * it is not an error. Input inference asks "could this usefully be an input?" —
+ * dynamic inputs are exposed after the library's stubs and shadow them
+ * (`js-sandbox.ts` installs user globals last), so a Code node with an input
+ * named `env` works, and treating the stub as a reserved name would drop the
+ * handle on re-inference and silently read `{}` instead.
+ *
+ * Keep this list short and reasoned. It is the escape hatch that stops the
+ * pinning below from locking in a bug, which is exactly what the old
+ * hand-restated sets did.
+ */
+const INTENTIONAL_OMISSIONS: Record<string, ReadonlySet<string>> = {
+  "the web set": new Set(["env"]),
+  "the node-sdk set": new Set()
+};
+
+/**
  * Both copies of the sandbox global list — the web editor's input inference and
  * the node-sdk graph validator — restate the manifest because neither package
  * can import it. Drift either way is a bug: a missing name invents an input or
@@ -189,8 +209,11 @@ function documentedGlobals(): Set<string> {
  */
 function expectMatchesSandbox(names: ReadonlySet<string>, label: string): void {
   const documented = documentedGlobals();
+  const allowed = INTENTIONAL_OMISSIONS[label] ?? new Set<string>();
 
-  const missing = [...documented].filter((n) => !names.has(n));
+  const missing = [...documented].filter(
+    (n) => !names.has(n) && !allowed.has(n)
+  );
   expect(missing, `sandbox names ${label} omits`).toEqual([]);
 
   const phantom = [...names].filter(

--- a/packages/agents/tests/sandbox-manifest-drift.test.ts
+++ b/packages/agents/tests/sandbox-manifest-drift.test.ts
@@ -2,10 +2,11 @@ import { describe, it, expect } from "vitest";
 import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
-import { buildSandbox } from "../src/js-sandbox.js";
+import { buildSandbox, runInSandbox } from "../src/js-sandbox.js";
 import {
   getSandboxManifest,
-  sandboxManifestNames
+  sandboxManifestNames,
+  GUEST_GLOBALS_SNAPSHOT
 } from "../src/code-gen/sandbox-manifest.js";
 import {
   renderSandboxApiReference,
@@ -91,6 +92,42 @@ describe("sandbox manifest", () => {
     expect(manifest.blockedGlobals).toContain("eval");
     expect(manifest.nativeGlobals).toContain("JSON");
     expect(manifest.nativeGlobals).not.toContain("setTimeout");
+  });
+
+  it("documents the byte and number types the bridges return", () => {
+    for (const name of ["Uint8Array", "ArrayBuffer", "DataView", "BigInt"]) {
+      expect(manifest.nativeGlobals, name).toContain(name);
+    }
+  });
+
+  it("names what other runtimes have and this guest does not", () => {
+    for (const name of ["btoa", "atob", "structuredClone", "Intl"]) {
+      expect(manifest.blockedGlobals, name).toContain(name);
+      expect(manifest.nativeGlobals, name).not.toContain(name);
+    }
+  });
+});
+
+describe("guest globals snapshot", () => {
+  // The manifest is built synchronously from a checked-in list because booting
+  // QuickJS is async. This is what holds that list to the running guest.
+  it("equals what the running sandbox reports", async () => {
+    const run = await runInSandbox({
+      code: "return Object.getOwnPropertyNames(globalThis)"
+    });
+    expect(run.error).toBeFalsy();
+    const observed = (run.result as string[])
+      .filter((name) => !name.startsWith("__"))
+      .sort();
+    expect(observed).toEqual([...GUEST_GLOBALS_SNAPSHOT]);
+  }, 60_000);
+
+  it("has no name the manifest calls blocked", () => {
+    const blocked = getSandboxManifest().blockedGlobals;
+    const present = blocked.filter((name) =>
+      GUEST_GLOBALS_SNAPSHOT.includes(name)
+    );
+    expect(present, "blocked names the guest actually has").toEqual([]);
   });
 });
 

--- a/packages/node-sdk/src/code-node-validation.ts
+++ b/packages/node-sdk/src/code-node-validation.ts
@@ -41,31 +41,52 @@ export function isJsCodeNodeType(nodeType: string): boolean {
  * `packages/agents/tests/sandbox-manifest-drift.test.ts`.
  */
 export const SANDBOX_GLOBALS: ReadonlySet<string> = new Set([
-  // QuickJS built-ins
-  "console", "JSON", "Math", "Date", "RegExp", "Array", "Object", "String",
-  "Number", "Boolean", "Map", "Set", "WeakMap", "WeakSet", "Symbol", "Promise",
-  "Error", "TypeError", "RangeError", "URIError", "SyntaxError",
-  "parseInt", "parseFloat", "isNaN", "isFinite",
-  "encodeURIComponent", "decodeURIComponent", "encodeURI", "decodeURI",
-  "btoa", "atob", "structuredClone", "TextEncoder", "TextDecoder",
-  "URL", "URLSearchParams", "Infinity", "NaN",
+  // Guest globals, as observed in the running QuickJS sandbox
+  "AggregateError", "Array", "ArrayBuffer", "BigInt", "BigInt64Array",
+  "BigUint64Array", "Boolean", "Buffer", "DataView", "Date", "Error",
+  "EvalError", "FinalizationRegistry", "Float32Array", "Float64Array",
+  "Headers", "Infinity", "Int16Array", "Int32Array", "Int8Array",
+  "InternalError", "JSON", "Map", "Math", "NaN", "Number", "Object",
+  "Promise", "Proxy", "RangeError", "ReferenceError", "Reflect", "RegExp",
+  "Request", "Response", "Set", "SharedArrayBuffer", "String", "Symbol",
+  "SyntaxError", "TextDecoder", "TextEncoder", "TypeError", "URIError",
+  "URL", "URLSearchParams", "Uint16Array", "Uint32Array", "Uint8Array",
+  "Uint8ClampedArray", "WeakMap", "WeakRef", "WeakSet", "decodeURI",
+  "decodeURIComponent", "encodeURI", "encodeURIComponent", "env", "escape",
+  "globalThis", "isFinite", "isNaN", "parseFloat", "parseInt", "performance",
+  "process", "queueMicrotask", "undefined", "unescape",
   // Host bridges
-  "fetch", "crypto", "uuid", "sleep", "getSecret", "workspace",
+  "console", "fetch", "crypto", "uuid", "sleep", "getSecret", "workspace",
   "assetToSandbox", "sandboxToAsset", "progress", "format", "data",
   "image", "canvas",
   // Pure guest helpers defined by the sandbox prelude
   "toBase64", "fromBase64", "toHex", "fromHex", "utf8Encode", "utf8Decode",
   "parallelMap", "createCanvas",
-  // Blocked in the sandbox, but still not user inputs
+  // Absent from this guest, but not user inputs either
   "setTimeout", "clearTimeout", "setInterval", "clearInterval",
   "setImmediate", "clearImmediate", "eval", "Function",
+  "btoa", "atob", "structuredClone", "Intl", "AbortController", "Blob",
+  "FormData",
   // JS literals that acorn parses as Identifier nodes
-  "undefined", "true", "false", "null",
-  "this", "arguments", "globalThis", "self", "window", "document", "process",
+  "true", "false", "null",
+  "this", "arguments", "self", "window", "document",
   // Code node reserved props
   "code", "timeout", "state",
   // Sandbox internals
   "__maxIter"
+]);
+
+/**
+ * The subset of `SANDBOX_GLOBALS` the guest does not actually have. They stay
+ * in that set so neither the graph validator nor the editor's input inference
+ * turns one into a dynamic input handle, but a body that reads one gets told
+ * what to use instead.
+ */
+const ABSENT_GLOBALS: ReadonlySet<string> = new Set([
+  "setTimeout", "clearTimeout", "setInterval", "clearInterval",
+  "setImmediate", "clearImmediate", "eval", "Function",
+  "btoa", "atob", "structuredClone", "Intl", "AbortController", "Blob",
+  "FormData"
 ]);
 
 export interface CodeNodeIssue {
@@ -153,9 +174,25 @@ export function validateCodeNodeBody(
   const inScope = new Set(input.availableInputs);
   const free = freeIdentifiers(parsed.statements);
   const guarded = typeofGuardedNames(parsed.statements);
-  const undefinedNames = free.filter(
-    (name) =>
-      !inScope.has(name) && !SANDBOX_GLOBALS.has(name) && !guarded.has(name)
+  const unbound = free.filter(
+    (name) => !inScope.has(name) && !guarded.has(name)
+  );
+  const absentNames = [
+    ...new Set(unbound.filter((name) => ABSENT_GLOBALS.has(name)))
+  ];
+  if (absentNames.length > 0) {
+    issues.push({
+      severity: "error",
+      code: "code_undefined_name",
+      message:
+        `The code reads ${formatNames(absentNames.sort())}, which other JavaScript runtimes ` +
+        `have but this sandbox does not — ${absentNames.length > 1 ? "they throw" : "it throws"} ReferenceError. ` +
+        "Use the sandbox equivalent: toBase64/fromBase64 for base64, format.* for Intl, " +
+        "sleep for timers, JSON round-trip for a deep copy."
+    });
+  }
+  const undefinedNames = unbound.filter(
+    (name) => !SANDBOX_GLOBALS.has(name) && !ABSENT_GLOBALS.has(name)
   );
   if (undefinedNames.length > 0) {
     issues.push({

--- a/web/src/utils/__tests__/codeOutputInference.test.ts
+++ b/web/src/utils/__tests__/codeOutputInference.test.ts
@@ -87,6 +87,22 @@ return { result, data };`;
     expect(result).not.toContain("JSON");
   });
 
+  it("still offers `env` as an input, since a dynamic input shadows the stub", () => {
+    // The guest has an `env` stub, but user globals are exposed after it, so a
+    // Code node with an input named `env` reads the input. Treating the stub as
+    // reserved would drop the handle here and leave the code reading `{}`.
+    const result = inferInputKeysFromCode("return { output: env.API_HOST };");
+    expect(result).toContain("env");
+  });
+
+  it("ignores the sandbox stubs a dynamic input cannot usefully replace", () => {
+    const code = `return { output: process.cwd() + Buffer.from(x).length };`;
+    const result = inferInputKeysFromCode(code);
+    expect(result).toContain("x");
+    expect(result).not.toContain("process");
+    expect(result).not.toContain("Buffer");
+  });
+
   it("ignores declared variables", () => {
     const code = `const x = 10;
 let y = 20;

--- a/web/src/utils/codeOutputInference.ts
+++ b/web/src/utils/codeOutputInference.ts
@@ -117,9 +117,16 @@ const SANDBOX_GLOBALS = new Set([
   "SyntaxError", "TextDecoder", "TextEncoder", "TypeError", "URIError",
   "URL", "URLSearchParams", "Uint16Array", "Uint32Array", "Uint8Array",
   "Uint8ClampedArray", "WeakMap", "WeakRef", "WeakSet", "decodeURI",
-  "decodeURIComponent", "encodeURI", "encodeURIComponent", "env", "escape",
+  "decodeURIComponent", "encodeURI", "encodeURIComponent", "escape",
   "globalThis", "isFinite", "isNaN", "parseFloat", "parseInt", "performance",
   "process", "queueMicrotask", "undefined", "unescape",
+  // `env` is deliberately absent, though the guest has it. Dynamic inputs are
+  // exposed after the sandbox's stubs and shadow them, so a Code node with an
+  // input named `env` works — listing it here would drop that handle on
+  // re-inference and leave the code silently reading the empty stub. The
+  // node-sdk validator still accepts `env` as a resolvable name; the two lists
+  // answer different questions. Pinned by INTENTIONAL_OMISSIONS in
+  // packages/agents/tests/sandbox-manifest-drift.test.ts.
   // Host bridges
   "console", "fetch", "crypto", "uuid", "sleep", "getSecret", "workspace",
   "assetToSandbox", "sandboxToAsset", "progress", "format", "data",

--- a/web/src/utils/codeOutputInference.ts
+++ b/web/src/utils/codeOutputInference.ts
@@ -106,27 +106,35 @@ function extractObjectKeys(objExpr: acorn.ObjectExpression): string[] {
  * lives in `packages/agents/tests/sandbox-manifest-drift.test.ts`.
  */
 const SANDBOX_GLOBALS = new Set([
-  // QuickJS built-ins
-  "console", "JSON", "Math", "Date", "RegExp", "Array", "Object", "String",
-  "Number", "Boolean", "Map", "Set", "WeakMap", "WeakSet", "Symbol", "Promise",
-  "Error", "TypeError", "RangeError", "URIError", "SyntaxError",
-  "parseInt", "parseFloat", "isNaN", "isFinite",
-  "encodeURIComponent", "decodeURIComponent", "encodeURI", "decodeURI",
-  "btoa", "atob", "structuredClone", "TextEncoder", "TextDecoder",
-  "URL", "URLSearchParams", "Infinity", "NaN",
+  // Guest globals, as observed in the running QuickJS sandbox
+  "AggregateError", "Array", "ArrayBuffer", "BigInt", "BigInt64Array",
+  "BigUint64Array", "Boolean", "Buffer", "DataView", "Date", "Error",
+  "EvalError", "FinalizationRegistry", "Float32Array", "Float64Array",
+  "Headers", "Infinity", "Int16Array", "Int32Array", "Int8Array",
+  "InternalError", "JSON", "Map", "Math", "NaN", "Number", "Object",
+  "Promise", "Proxy", "RangeError", "ReferenceError", "Reflect", "RegExp",
+  "Request", "Response", "Set", "SharedArrayBuffer", "String", "Symbol",
+  "SyntaxError", "TextDecoder", "TextEncoder", "TypeError", "URIError",
+  "URL", "URLSearchParams", "Uint16Array", "Uint32Array", "Uint8Array",
+  "Uint8ClampedArray", "WeakMap", "WeakRef", "WeakSet", "decodeURI",
+  "decodeURIComponent", "encodeURI", "encodeURIComponent", "env", "escape",
+  "globalThis", "isFinite", "isNaN", "parseFloat", "parseInt", "performance",
+  "process", "queueMicrotask", "undefined", "unescape",
   // Host bridges
-  "fetch", "crypto", "uuid", "sleep", "getSecret", "workspace",
+  "console", "fetch", "crypto", "uuid", "sleep", "getSecret", "workspace",
   "assetToSandbox", "sandboxToAsset", "progress", "format", "data",
   "image", "canvas",
   // Pure guest helpers defined by the sandbox prelude
   "toBase64", "fromBase64", "toHex", "fromHex", "utf8Encode", "utf8Decode",
   "parallelMap", "createCanvas",
-  // Blocked in the sandbox, but still not user inputs
+  // Absent from this guest, but not user inputs either
   "setTimeout", "clearTimeout", "setInterval", "clearInterval",
   "setImmediate", "clearImmediate", "eval", "Function",
+  "btoa", "atob", "structuredClone", "Intl", "AbortController", "Blob",
+  "FormData",
   // JS literals that acorn parses as Identifier nodes
-  "undefined", "true", "false", "null", "NaN", "Infinity",
-  "this", "arguments", "globalThis", "self", "window", "document", "process",
+  "true", "false", "null",
+  "this", "arguments", "self", "window", "document",
   // Code node reserved props
   "code", "timeout", "state",
   // Sandbox internals


### PR DESCRIPTION
## The bug

`partitionNativeGlobals()` in `sandbox-manifest.ts` derived `nativeGlobals` / `blockedGlobals` from `Object.entries(buildSandbox().sandbox)` — the **host-side intent record**. That is neither what `@sebastianwessel/quickjs` actually installs in the guest, nor does it include QuickJS's own built-ins. Probing the live guest with `runInSandbox({code: 'return Object.getOwnPropertyNames(globalThis)'})` showed drift in both directions.

**3 phantom names** — documented in every prompt and both mirror sets, but `typeof === "undefined"` in the guest:

```
btoa: "undefined"   atob: "undefined"   structuredClone: "undefined"
```

A model reaching for `btoa(x)` got a ReferenceError and nothing flagged it — precisely the failure the manifest exists to prevent.

**37 real guest globals were undocumented**, including every typed array: `Uint8Array`, `ArrayBuffer`, `DataView`, `Int8Array`…`Float64Array`, `BigInt`, `Proxy`, `Reflect`, `ReferenceError`, `WeakRef`, `performance`, `queueMicrotask`, `Headers`/`Request`/`Response`, `Buffer`, `process`, `env`.

`Uint8Array` is the documented return type of `fromBase64`, `crypto.digest`, `crypto.getRandomValues`, `workspace.readBytes`, `data.unzip` and all ten `image.*` members. Before this change:

```
validateCodeNodeBody({ code: 'const a = new Uint8Array(4); const v = new DataView(a.buffer); …' })
→ [{ severity: "error", code: "code_undefined_name",
     message: 'The code reads "BigInt", "DataView", "Uint8Array", "performance",
               which are neither a sandbox API nor an input of this node…' }]
```

Downstream of the same set, web's `inferInputs` would invent a dynamic input slot named `Uint8Array`, and the `code-gen` eval scored a model down via `unknownApiReferences` for writing correct code.

The drift test **locked the bug in**: it pins both mirror sets to `documentedGlobals()` bidirectionally, so adding `Uint8Array` to `SANDBOX_GLOBALS` failed the test, and so did removing `btoa`.

## The fix

The guest global list is now a checked-in snapshot (`GUEST_GLOBALS_SNAPSHOT`, 89 names) regenerated by `packages/agents/scripts/probe-guest-globals.ts`, with a new drift test that boots the real sandbox and asserts the snapshot still equals the guest's `globalThis`.

`getSandboxManifest()` stays **synchronous**. Booting QuickJS is async, but the function is called synchronously from every prompt builder, the graph validator path and the evals — making it async was not worth the blast radius, so the snapshot plus a live-probe test carries the guarantee instead.

Names other runtimes have and this guest lacks (`Intl`, `AbortController`, `Blob`, `FormData`, plus the three phantoms) move into `blockedGlobals`, whose documented meaning is exactly that. A body reading one now gets an error naming the sandbox equivalent rather than silence:

> `btoa("x")` → *"which other JavaScript runtimes have but this sandbox does not — it throws ReferenceError. Use the sandbox equivalent: toBase64/fromBase64 for base64…"*

Both mirrors (`packages/node-sdk`, `web/`) are updated so the bidirectional assertions now lock in the correct set. Final counts: 69 native, 15 blocked, 106 documented names.

## Also: three gaps around the CodeAct prompt

`buildCodeActSystemPrompt` is built for **every agent step and every chat turn** and had no drift guard at all.

- **`CODEACT_INJECTED_GLOBALS`** declares the guest names the executors install (`tools`, `state`, `finish`, `searchTools`, and the object-model preludes' `nodetool` / `openWorkflow`) next to the code installing them, so the manifest check can reach the injected half of the surface. The new `codeact-prompt-drift.test.ts` fails when the contract names an API the sandbox lacks — verified by appending "`lodash.groupBy(rows)`" to the action contract and watching both variants fail with `expected ['lodash'] to deeply equal []`.
- **`manifest.notes` now render into the CodeAct summary.** The prompt never said `Intl` is absent, which is the entire reason the `format.*` bridge exists. The hand-copied "no module loader" sentence is deleted rather than kept alongside the note — a hand-copy is the drift this design exists to prevent.
- **The chat variant's hidden bridges are derived** from the `requiresContext` flag the manifest already carries, leaving `fetch` and `getSecret` as a commented exception with the reason. A test pins the derived set against what `createChatCodeActSession` actually enforces (no `context`, `maxFetchCalls: 0`), linking assertion to enforcement for the first time. The chat contract also claimed `fetch` was "disabled" when `maxFetchCalls: 0` means it exists and throws.

## Verification

Manifest and guest now agree in all three directions:

```
PRESENT but undocumented:        (none)
DOCUMENTED as native but absent: (none)
BLOCKED but actually present:    (none)

repro Uint8Array/DataView/BigInt/performance -> []          (was 1 error naming all four)
btoa now flagged                              -> code_undefined_name
guest runs the repro                          -> ok
guest btoa                                    -> ReferenceError: 'btoa' is not defined
```

- `npm run test --workspace=packages/agents` — 152 files, 2185 passed, 1 skipped
- `npm run test --workspace=packages/node-sdk` — 51 files, 756 passed, 2 skipped
- `cd web && npx jest src/utils` — 150 suites, 2202 passed
- `npm run lint` — clean
- `npm run typecheck` — web, electron and packages clean. The mobile leg fails only on missing `react-native`/`expo` modules: `mobile/node_modules` is empty in this environment and no file in this diff is under `mobile/`.

## Known gap left open

The `extraSections` (the graph-model and `nodetool.*` prompt sections) are still outside the drift check. Their examples bind local names (`wf`, `g`, `rows`) that would need a broad allowlist, which would weaken the check for the parts it does cover. Worth a follow-up that teaches the extractor about locally-bound names rather than allowlisting around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQwBvmV7Wjxn5RFR8E1Mst

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQwBvmV7Wjxn5RFR8E1Mst)_