### PR TITLE
Code node inputs arrive on an `inputs` object, not as globals

### DIFF
--- a/packages/agents/src/code-gen/prompt.ts
+++ b/packages/agents/src/code-gen/prompt.ts
@@ -38,8 +38,9 @@ it with the submit_code tool. The submitted arguments are the only thing that
 counts: text you write outside the tool call, including fenced code blocks, is
 discarded.
 
-Each declared input arrives as a global variable of that name. The function ends
-by returning an object whose keys are exactly the declared outputs.
+Declared inputs arrive on one \`inputs\` object — read \`inputs.<name>\`, never a
+bare \`<name>\`. The function ends by returning an object whose keys are exactly
+the declared outputs.
 
 # Rules
 

--- a/packages/agents/src/code-gen/sandbox-manifest.ts
+++ b/packages/agents/src/code-gen/sandbox-manifest.ts
@@ -25,6 +25,7 @@ import {
   type ExposedBridgeName,
   type GuestHelperName
 } from "../js-sandbox.js";
+import { CODE_INPUTS_GLOBAL } from "@nodetool-ai/node-sdk";
 import {
   MAX_CANVAS_OPS,
   MAX_DECODE_PIXELS,
@@ -95,6 +96,12 @@ export interface SandboxManifest {
   readonly nativeGlobals: readonly string[];
   /** Names that exist in other JS runtimes but not here. */
   readonly blockedGlobals: readonly string[];
+  /**
+   * Globals the Code node injects per run, on top of what the guest has:
+   * the declared inputs arrive on `inputs`, and `state` persists across runs.
+   * Not in the guest snapshot — nothing puts them there until a node runs.
+   */
+  readonly nodeGlobals: readonly string[];
   readonly limits: readonly SandboxLimitDoc[];
   readonly notes: readonly SandboxNote[];
 }
@@ -949,6 +956,7 @@ export function getSandboxManifest(): SandboxManifest {
     guestHelpers: GUEST_HELPER_DOCS,
     nativeGlobals: native,
     blockedGlobals: blocked,
+    nodeGlobals: [CODE_INPUTS_GLOBAL, "state"],
     limits: [...overridableLimits(), ...fixedLimits()],
     notes: [
       {
@@ -960,6 +968,10 @@ export function getSandboxManifest(): SandboxManifest {
       },
       {
         text: "Return an object whose keys are the node's outputs. Emit every declared output on every return path.",
+        audience: "code-node"
+      },
+      {
+        text: "Declared inputs arrive on the `inputs` object: read `inputs.name`. A bare `name` is a ReferenceError.",
         audience: "code-node"
       },
       { text: "Media and asset values are reference objects. Pass them through unchanged." },

--- a/packages/agents/src/code-gen/sandbox-prompt.ts
+++ b/packages/agents/src/code-gen/sandbox-prompt.ts
@@ -148,6 +148,7 @@ export function unknownApiReferences(
   const known = new Set<string>([
     ...manifest.nativeGlobals,
     ...manifest.blockedGlobals,
+    ...manifest.nodeGlobals,
     ...Object.keys(manifest.bridges),
     ...Object.keys(manifest.guestHelpers)
   ]);

--- a/packages/agents/tests/sandbox-manifest-drift.test.ts
+++ b/packages/agents/tests/sandbox-manifest-drift.test.ts
@@ -27,10 +27,6 @@ const CHAT_INTEGRATION = path.join(
   repoRoot,
   "web/src/hooks/editor/useChatIntegration.ts"
 );
-const OUTPUT_INFERENCE = path.join(
-  repoRoot,
-  "web/src/utils/codeOutputInference.ts"
-);
 
 /** Names the Code node or JS syntax supplies — not part of the sandbox. */
 const NODE_LEVEL_NAMES = new Set([
@@ -50,6 +46,7 @@ const NODE_LEVEL_NAMES = new Set([
   "code",
   "timeout",
   "state",
+  "inputs",
   "__maxIter"
 ]);
 
@@ -182,38 +179,20 @@ function documentedGlobals(): Set<string> {
 }
 
 /**
- * Names a consumer may deliberately omit, with the reason.
+ * The node-sdk graph validator restates the manifest because it cannot import
+ * it — the dependency runs the other way. Drift either way is a bug: a missing
+ * name turns a legitimate bridge call into a bogus "not defined" error, an
+ * extra one hides a real reference.
  *
- * The two copies answer different questions, so an identical set is not always
- * right. The validator asks "does this name resolve?" — `env` does, so reading
- * it is not an error. Input inference asks "could this usefully be an input?" —
- * dynamic inputs are exposed after the library's stubs and shadow them
- * (`js-sandbox.ts` installs user globals last), so a Code node with an input
- * named `env` works, and treating the stub as a reserved name would drop the
- * handle on re-inference and silently read `{}` instead.
- *
- * Keep this list short and reasoned. It is the escape hatch that stops the
- * pinning below from locking in a bug, which is exactly what the old
- * hand-restated sets did.
- */
-const INTENTIONAL_OMISSIONS: Record<string, ReadonlySet<string>> = {
-  "the web set": new Set(["env"]),
-  "the node-sdk set": new Set()
-};
-
-/**
- * Both copies of the sandbox global list — the web editor's input inference and
- * the node-sdk graph validator — restate the manifest because neither package
- * can import it. Drift either way is a bug: a missing name invents an input or
- * a "not defined" error, an extra one hides a real reference.
+ * The web editor used to keep a second copy for input inference. It no longer
+ * needs one: inputs arrive on the `inputs` object, so inference reads
+ * `inputs.name` instead of subtracting every sandbox global from the free
+ * identifiers.
  */
 function expectMatchesSandbox(names: ReadonlySet<string>, label: string): void {
   const documented = documentedGlobals();
-  const allowed = INTENTIONAL_OMISSIONS[label] ?? new Set<string>();
 
-  const missing = [...documented].filter(
-    (n) => !names.has(n) && !allowed.has(n)
-  );
+  const missing = [...documented].filter((n) => !names.has(n));
   expect(missing, `sandbox names ${label} omits`).toEqual([]);
 
   const phantom = [...names].filter(
@@ -221,21 +200,6 @@ function expectMatchesSandbox(names: ReadonlySet<string>, label: string): void {
   );
   expect(phantom, `${label} names the sandbox does not provide`).toEqual([]);
 }
-
-describe("web input inference globals", () => {
-  it("matches the sandbox surface", () => {
-    const source = readIfPresent(OUTPUT_INFERENCE);
-    if (!source) return;
-    const literal = source.match(
-      /const SANDBOX_GLOBALS = new Set\(\[([\s\S]*?)\]\)/
-    );
-    expect(literal, "SANDBOX_GLOBALS in codeOutputInference.ts").toBeTruthy();
-    const webNames = new Set(
-      [...literal![1].matchAll(/"([^"]+)"/g)].map((m) => m[1])
-    );
-    expectMatchesSandbox(webNames, "the web set");
-  });
-});
 
 describe("graph validator globals", () => {
   it("matches the sandbox surface", () => {

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Research Paper Summarizer.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Research Paper Summarizer.json
@@ -61,7 +61,7 @@
         "parent_id": null,
         "type": "nodetool.code.Code",
         "data": {
-          "code": "const res = await fetch(url, { headers: { ...headers } });\nreturn { output: await res.text(), status: res.status };",
+          "code": "const res = await fetch(inputs.url, { headers: { ...inputs.headers } });\nreturn { output: await res.text(), status: res.status };",
           "timeout": 30,
           "max_response_mb": 8,
           "allow_local_network": false,
@@ -291,7 +291,7 @@
         "parent_id": null,
         "type": "nodetool.code.Code",
         "data": {
-          "code": "const res = await fetch(url, { headers: { ...headers } });\nreturn { output: await res.text(), status: res.status };",
+          "code": "const res = await fetch(inputs.url, { headers: { ...inputs.headers } });\nreturn { output: await res.text(), status: res.status };",
           "timeout": 30,
           "max_response_mb": 8,
           "allow_local_network": false,

--- a/packages/cli/src/commands/migrate-code-inputs.ts
+++ b/packages/cli/src/commands/migrate-code-inputs.ts
@@ -12,10 +12,13 @@
  * Safe to re-run: a body already reading `inputs.*` has nothing to rewrite.
  */
 import { Workflow } from "@nodetool-ai/models";
+import {
+  migrateCodeBodyToInputs,
+  isJsCodeNodeType
+} from "@nodetool-ai/node-sdk";
 
 /** The CLI's local-mode user, matching `nodetool.ts`. */
 const LOCAL_USER_ID = "1";
-import { migrateCodeBodyToInputs, isJsCodeNodeType } from "@nodetool-ai/node-sdk";
 
 export interface MigrateCodeInputsOptions {
   dryRun?: boolean;

--- a/packages/cli/src/commands/migrate-code-inputs.ts
+++ b/packages/cli/src/commands/migrate-code-inputs.ts
@@ -1,0 +1,169 @@
+/**
+ * `nodetool workflows migrate-code-inputs` — rewrite stored Code node bodies
+ * for the `inputs` object.
+ *
+ * A Code node's declared inputs used to arrive as globals of their own name.
+ * They now arrive on one `inputs` object, so a body written the old way throws
+ * a ReferenceError on its first input read. This walks the saved workflows and
+ * rewrites `name` to `inputs.name` for every declared input, using the AST so a
+ * name inside a string, a comment, an object key, or a local binding is left
+ * alone.
+ *
+ * Safe to re-run: a body already reading `inputs.*` has nothing to rewrite.
+ */
+import { Workflow } from "@nodetool-ai/models";
+
+/** The CLI's local-mode user, matching `nodetool.ts`. */
+const LOCAL_USER_ID = "1";
+import { migrateCodeBodyToInputs, isJsCodeNodeType } from "@nodetool-ai/node-sdk";
+
+export interface MigrateCodeInputsOptions {
+  dryRun?: boolean;
+  /** Migrate this user's workflows instead of the local user's. */
+  userId?: string;
+  json?: boolean;
+}
+
+export interface MigrateCodeInputsReport {
+  workflowsScanned: number;
+  codeNodesScanned: number;
+  nodesRewritten: number;
+  workflowsUpdated: number;
+  failed: number;
+  entries: Array<{
+    workflowId: string;
+    workflowName: string;
+    nodeId: string;
+    rewritten: string[];
+    error?: string;
+  }>;
+}
+
+interface GraphNode {
+  id?: unknown;
+  type?: unknown;
+  data?: Record<string, unknown>;
+  dynamic_properties?: Record<string, unknown>;
+  dynamic_inputs?: Record<string, unknown>;
+}
+
+interface GraphEdge {
+  target?: unknown;
+  targetHandle?: unknown;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * Every name the node can read: its declared slots, its inline dynamic
+ * properties, and any handle an edge feeds. The same three sources the graph
+ * validator uses — a body reading a handle it is wired to is as much an input
+ * as one reading a declared slot.
+ */
+function inputNamesFor(node: GraphNode, edges: readonly GraphEdge[]): string[] {
+  const names = new Set<string>([
+    ...Object.keys(asRecord(node.dynamic_properties)),
+    ...Object.keys(asRecord(node.dynamic_inputs))
+  ]);
+  for (const edge of edges) {
+    if (edge.target === node.id && typeof edge.targetHandle === "string") {
+      names.add(edge.targetHandle);
+    }
+  }
+  return [...names].filter((name) => name.length > 0);
+}
+
+export async function migrateCodeInputs(
+  options: MigrateCodeInputsOptions = {}
+): Promise<MigrateCodeInputsReport> {
+  const report: MigrateCodeInputsReport = {
+    workflowsScanned: 0,
+    codeNodesScanned: 0,
+    nodesRewritten: 0,
+    workflowsUpdated: 0,
+    failed: 0,
+    entries: []
+  };
+
+  const [items] = await Workflow.paginate(options.userId ?? LOCAL_USER_ID, {
+    limit: 10_000
+  });
+
+  for (const workflow of items) {
+    report.workflowsScanned++;
+    const graph = asRecord(workflow.graph);
+    const nodes = Array.isArray(graph.nodes) ? (graph.nodes as GraphNode[]) : [];
+    const edges = Array.isArray(graph.edges) ? (graph.edges as GraphEdge[]) : [];
+    let touched = false;
+
+    for (const node of nodes) {
+      if (typeof node.type !== "string" || !isJsCodeNodeType(node.type)) {
+        continue;
+      }
+      report.codeNodesScanned++;
+      const data = asRecord(node.data);
+      const code = data.code;
+      if (typeof code !== "string" || code.trim() === "") continue;
+
+      try {
+        const result = migrateCodeBodyToInputs(code, inputNamesFor(node, edges));
+        if (!result.changed) continue;
+        data.code = result.code;
+        node.data = data;
+        touched = true;
+        report.nodesRewritten++;
+        report.entries.push({
+          workflowId: String(workflow.id),
+          workflowName: String(workflow.name ?? ""),
+          nodeId: String(node.id ?? ""),
+          rewritten: result.rewritten
+        });
+      } catch (error) {
+        report.failed++;
+        report.entries.push({
+          workflowId: String(workflow.id),
+          workflowName: String(workflow.name ?? ""),
+          nodeId: String(node.id ?? ""),
+          rewritten: [],
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
+
+    if (touched) {
+      report.workflowsUpdated++;
+      if (!options.dryRun) {
+        workflow.graph = graph as unknown as typeof workflow.graph;
+        await workflow.save();
+      }
+    }
+  }
+
+  return report;
+}
+
+export function formatMigrateCodeInputsReport(
+  report: MigrateCodeInputsReport,
+  dryRun: boolean
+): string {
+  const lines: string[] = [];
+  for (const entry of report.entries) {
+    const where = `${entry.workflowName || entry.workflowId} › ${entry.nodeId}`;
+    lines.push(
+      entry.error
+        ? `  fail  ${where}: ${entry.error}`
+        : `  ${dryRun ? "would" : "moved"}  ${where}: ${entry.rewritten.join(", ")}`
+    );
+  }
+  lines.push(
+    `\n${report.nodesRewritten} Code node(s) in ${report.workflowsUpdated} workflow(s) ` +
+      `${dryRun ? "would be" : "were"} rewritten ` +
+      `(${report.codeNodesScanned} scanned across ${report.workflowsScanned} workflows).`
+  );
+  if (report.failed > 0) lines.push(`${report.failed} failed.`);
+  return lines.join("\n");
+}

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -1763,6 +1763,38 @@ storage
     }
   });
 
+workflows
+  .command("migrate-code-inputs")
+  .description(
+    "Rewrite saved Code node bodies to read declared inputs off `inputs`"
+  )
+  .option("--dry-run", "Report what would change without writing anything")
+  .option("--user-id <id>", "Migrate only this user's workflows")
+  .option("--json", "Output the report as JSON")
+  .action(async (opts) => {
+    await setupDb();
+    const { migrateCodeInputs, formatMigrateCodeInputsReport } = await import(
+      "./commands/migrate-code-inputs.js"
+    );
+    try {
+      const report = await migrateCodeInputs({
+        dryRun: Boolean(opts.dryRun),
+        ...(opts.userId ? { userId: opts.userId } : {})
+      });
+      if (opts.json) {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        console.log(
+          formatMigrateCodeInputsReport(report, Boolean(opts.dryRun))
+        );
+      }
+      if (report.failed > 0) process.exit(1);
+    } catch (e) {
+      console.error(String(e));
+      process.exit(1);
+    }
+  });
+
 // ---------------------------------------------------------------------------
 // secrets
 // ---------------------------------------------------------------------------

--- a/packages/code-nodes/src/nodes/code-node.ts
+++ b/packages/code-nodes/src/nodes/code-node.ts
@@ -17,7 +17,7 @@
  *   // outputs: { sum: 15, upper: "HELLO" }
  */
 
-import { BaseNode, prop } from "@nodetool-ai/node-sdk";
+import { BaseNode, prop, CODE_INPUTS_GLOBAL } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import {
   runInSandbox,
@@ -240,8 +240,15 @@ export class CodeNode extends BaseNode {
     // Build the function body with implicit return support.
     const body = hasReturnStatement(code) ? code : wrapImplicitReturn(code);
 
-    // Inject state as a direct reference so mutations persist across calls.
-    const globals = { ...deepCopyInputs(dynamicInputs), state: this._state };
+    // Declared inputs arrive on one `inputs` object rather than as globals of
+    // their own name. Sharing the global namespace with the sandbox API let an
+    // input called `env` or `data` shadow a bridge, and made every undeclared
+    // identifier ambiguous between a typo and a missing slot.
+    // State stays a direct reference so mutations persist across calls.
+    const globals = {
+      [CODE_INPUTS_GLOBAL]: deepCopyInputs(dynamicInputs),
+      state: this._state
+    };
 
     const sandboxResult = await runInSandbox({
       code: body,
@@ -285,8 +292,15 @@ export class CodeNode extends BaseNode {
       return __yielded;
     `;
 
-    // Inject state as a direct reference so mutations persist across calls.
-    const globals = { ...deepCopyInputs(dynamicInputs), state: this._state };
+    // Declared inputs arrive on one `inputs` object rather than as globals of
+    // their own name. Sharing the global namespace with the sandbox API let an
+    // input called `env` or `data` shadow a bridge, and made every undeclared
+    // identifier ambiguous between a typo and a missing slot.
+    // State stays a direct reference so mutations persist across calls.
+    const globals = {
+      [CODE_INPUTS_GLOBAL]: deepCopyInputs(dynamicInputs),
+      state: this._state
+    };
 
     const sandboxResult = await runInSandbox({
       code: wrappedBody,

--- a/packages/code-nodes/tests/code-node.test.ts
+++ b/packages/code-nodes/tests/code-node.test.ts
@@ -11,13 +11,13 @@ function run(code: string, inputs: Record<string, unknown> = {}) {
 // ---------------------------------------------------------------------------
 
 describe("CodeNode — dynamic inputs", () => {
-  it("passes dynamic inputs as local variables", async () => {
-    const r = await run("return { sum: x + y }", { x: 3, y: 7 });
+  it("passes dynamic inputs on the inputs object", async () => {
+    const r = await run("return { sum: inputs.x + inputs.y }", { x: 3, y: 7 });
     expect(r).toEqual({ sum: 10 });
   });
 
   it("handles string inputs", async () => {
-    const r = await run("return { upper: text.toUpperCase() }", {
+    const r = await run("return { upper: inputs.text.toUpperCase() }", {
       text: "hello"
     });
     expect(r).toEqual({ upper: "HELLO" });
@@ -25,7 +25,7 @@ describe("CodeNode — dynamic inputs", () => {
 
   it("handles many input types", async () => {
     const r = await run(
-      "return { a: typeof n, b: typeof s, c: typeof b, d: Array.isArray(arr), e: typeof obj }",
+      "return { a: typeof inputs.n, b: typeof inputs.s, c: typeof inputs.b, d: Array.isArray(inputs.arr), e: typeof inputs.obj }",
       { n: 42, s: "hi", b: true, arr: [1, 2], obj: { k: 1 } }
     );
     expect(r).toEqual({
@@ -125,7 +125,7 @@ describe("CodeNode — implicit return", () => {
   });
 
   it("wraps simple identifier expression", async () => {
-    const r = await run("x * 2", { x: 21 });
+    const r = await run("inputs.x * 2", { x: 21 });
     expect(r).toEqual({ output: 42 });
   });
 
@@ -145,7 +145,7 @@ describe("CodeNode — implicit return", () => {
   });
 
   it("wraps template literal", async () => {
-    const r = await run("`hello ${name}`", { name: "world" });
+    const r = await run("`hello ${inputs.name}`", { name: "world" });
     expect(r).toEqual({ output: "hello world" });
   });
 
@@ -276,7 +276,7 @@ describe("CodeNode — real-world patterns", () => {
   it("data transformation pipeline", async () => {
     const r = await run(
       `
-      const words = text.split(" ");
+      const words = inputs.text.split(" ");
       const lengths = words.map(w => w.length);
       const total = lengths.reduce((a, b) => a + b, 0);
       return { wordCount: words.length, avgLength: total / words.length };
@@ -290,7 +290,7 @@ describe("CodeNode — real-world patterns", () => {
   it("JSON processing", async () => {
     const r = await run(
       `
-      const parsed = JSON.parse(jsonStr);
+      const parsed = JSON.parse(inputs.jsonStr);
       const names = parsed.map(p => p.name);
       return { names, count: names.length };
       `,
@@ -301,7 +301,7 @@ describe("CodeNode — real-world patterns", () => {
 
   it("math operations", async () => {
     const r = await run(
-      "return { hyp: Math.sqrt(a*a + b*b), rounded: Math.round(a/b * 100) / 100 }",
+      "return { hyp: Math.sqrt(inputs.a*inputs.a + inputs.b*inputs.b), rounded: Math.round(inputs.a/inputs.b * 100) / 100 }",
       { a: 3, b: 4 }
     );
     expect(r).toEqual({ hyp: 5, rounded: 0.75 });
@@ -309,7 +309,7 @@ describe("CodeNode — real-world patterns", () => {
 
   it("string formatting with template literals", async () => {
     const r = await run(
-      "return { greeting: `Hello, ${name}! You have ${count} items.` }",
+      "return { greeting: `Hello, ${inputs.name}! You have ${inputs.count} items.` }",
       { name: "Alice", count: 5 }
     );
     expect(r).toEqual({ greeting: "Hello, Alice! You have 5 items." });
@@ -318,7 +318,7 @@ describe("CodeNode — real-world patterns", () => {
   it("pure JS string manipulation", async () => {
     const r = await run(
       `
-      const reversed = text.split("").reverse().join("");
+      const reversed = inputs.text.split("").reverse().join("");
       return { reversed };
     `,
       { text: "hello" }
@@ -422,7 +422,7 @@ describe("CodeNode — genProcess streaming", () => {
 
   it("passes dynamic inputs to generator", async () => {
     const results = await collect(
-      "yield({ sum: x + y }); yield({ product: x * y });",
+      "yield({ sum: inputs.x + inputs.y }); yield({ product: inputs.x * inputs.y });",
       { x: 3, y: 7 }
     );
     expect(results).toEqual([{ sum: 10 }, { product: 21 }]);
@@ -562,84 +562,84 @@ describe("CodeNode — genProcess yield detection", () => {
 describe("CodeNode — input type coverage", () => {
   // Numbers
   it("handles integer input", async () => {
-    const r = await run("return { v: n }", { n: 42 });
+    const r = await run("return { v: inputs.n }", { n: 42 });
     expect(r).toEqual({ v: 42 });
   });
 
   it("handles float input", async () => {
-    const r = await run("return { v: n }", { n: 3.14 });
+    const r = await run("return { v: inputs.n }", { n: 3.14 });
     expect(r).toEqual({ v: 3.14 });
   });
 
   it("handles negative number input", async () => {
-    const r = await run("return { v: n }", { n: -7 });
+    const r = await run("return { v: inputs.n }", { n: -7 });
     expect(r).toEqual({ v: -7 });
   });
 
   it("handles zero input", async () => {
-    const r = await run("return { v: n }", { n: 0 });
+    const r = await run("return { v: inputs.n }", { n: 0 });
     expect(r).toEqual({ v: 0 });
   });
 
   it("handles Infinity input (becomes null via JSON)", async () => {
-    const r = await run("return { v: n }", { n: Infinity });
+    const r = await run("return { v: inputs.n }", { n: Infinity });
     expect(r.v).toBeNull();
   });
 
   it("handles NaN input (becomes null via JSON)", async () => {
-    const r = await run("return { v: n }", { n: NaN });
+    const r = await run("return { v: inputs.n }", { n: NaN });
     expect(r.v).toBeNull();
   });
 
   // Strings
   it("handles empty string input", async () => {
-    const r = await run("return { v: s }", { s: "" });
+    const r = await run("return { v: inputs.s }", { s: "" });
     expect(r).toEqual({ v: "" });
   });
 
   it("handles unicode string input", async () => {
-    const r = await run("return { v: s }", {
+    const r = await run("return { v: inputs.s }", {
       s: "Hello \u{1F600} \u00E9\u00E8"
     });
     expect(r).toEqual({ v: "Hello \u{1F600} \u00E9\u00E8" });
   });
 
   it("handles multiline string input", async () => {
-    const r = await run("return { v: s }", { s: "line1\nline2\nline3" });
+    const r = await run("return { v: inputs.s }", { s: "line1\nline2\nline3" });
     expect(r).toEqual({ v: "line1\nline2\nline3" });
   });
 
   // Booleans
   it("handles true input", async () => {
-    const r = await run("return { v: b }", { b: true });
+    const r = await run("return { v: inputs.b }", { b: true });
     expect(r).toEqual({ v: true });
   });
 
   it("handles false input", async () => {
-    const r = await run("return { v: b }", { b: false });
+    const r = await run("return { v: inputs.b }", { b: false });
     expect(r).toEqual({ v: false });
   });
 
   // null
   it("handles null input", async () => {
-    const r = await run("return { v: n === null }", { n: null });
+    const r = await run("return { v: inputs.n === null }", { n: null });
     expect(r).toEqual({ v: true });
   });
 
   // undefined
   it("handles undefined input", async () => {
-    const r = await run("return { v: u === undefined }", { u: undefined });
+    const r = await run("return { v: inputs.u === undefined }", { u: undefined });
     expect(r).toEqual({ v: true });
   });
 
   // Arrays
   it("handles empty array input", async () => {
-    const r = await run("return { v: arr, len: arr.length }", { arr: [] });
+    const r = await run("return { v: inputs.arr, len: inputs.arr.length }", { arr: [] });
     expect(r).toEqual({ v: [], len: 0 });
   });
 
   it("handles nested array input", async () => {
-    const r = await run("return { v: arr[1][0] }", {
+    const r = await run("return { v: inputs.arr[1][0] }", {
       arr: [
         [1, 2],
         [3, 4]
@@ -650,19 +650,19 @@ describe("CodeNode — input type coverage", () => {
 
   it("handles typed array input (Uint8Array becomes plain object via JSON)", async () => {
     const ta = new Uint8Array([10, 20, 30]);
-    const r = await run("return { v: arr, type: typeof arr }", { arr: ta });
+    const r = await run("return { v: inputs.arr, type: typeof inputs.arr }", { arr: ta });
     expect(r.v).toEqual({ "0": 10, "1": 20, "2": 30 });
     expect(r.type).toBe("object");
   });
 
   // Objects
   it("handles empty object input", async () => {
-    const r = await run("return { v: Object.keys(obj).length }", { obj: {} });
+    const r = await run("return { v: Object.keys(inputs.obj).length }", { obj: {} });
     expect(r).toEqual({ v: 0 });
   });
 
   it("handles nested object input", async () => {
-    const r = await run("return { v: obj.a.b.c }", {
+    const r = await run("return { v: inputs.obj.a.b.c }", {
       obj: { a: { b: { c: 42 } } }
     });
     expect(r).toEqual({ v: 42 });
@@ -675,16 +675,14 @@ describe("CodeNode — input type coverage", () => {
         return this.x * 2;
       }
     };
-    const r = await run("return { v: obj.x, hasDouble: typeof obj.double }", {
-      obj
-    });
+    const r = await run("return { v: inputs.obj.x, hasDouble: typeof inputs.obj.double }", { obj });
     expect(r).toEqual({ v: 10, hasDouble: "undefined" });
   });
 
   // Date
   it("handles Date input (becomes ISO string via JSON)", async () => {
     const d = new Date("2024-06-15T12:00:00Z");
-    const r = await run("return { v: d, type: typeof d }", { d });
+    const r = await run("return { v: inputs.d, type: typeof inputs.d }", { d });
     expect(r.v).toBe("2024-06-15T12:00:00.000Z");
     expect(r.type).toBe("string");
   });
@@ -692,7 +690,7 @@ describe("CodeNode — input type coverage", () => {
   // Buffer
   it("handles Buffer input (becomes object with type/data via JSON)", async () => {
     const buf = Buffer.from("hello");
-    const r = await run("return { v: buf }", { buf });
+    const r = await run("return { v: inputs.buf }", { buf });
     expect(r.v).toEqual({ type: "Buffer", data: [104, 101, 108, 108, 111] });
   });
 
@@ -702,49 +700,49 @@ describe("CodeNode — input type coverage", () => {
       ["a", 1],
       ["b", 2]
     ]);
-    const r = await run("return { v: m }", { m });
+    const r = await run("return { v: inputs.m }", { m });
     expect(r.v).toEqual({});
   });
 
   // Set
   it("handles Set input (becomes {} via JSON)", async () => {
     const s = new Set([1, 2, 3]);
-    const r = await run("return { v: s }", { s });
+    const r = await run("return { v: inputs.s }", { s });
     expect(r.v).toEqual({});
   });
 
   // RegExp
   it("handles RegExp input (becomes {} via JSON)", async () => {
     const re = /foo(\d+)/g;
-    const r = await run("return { v: re }", { re });
+    const r = await run("return { v: inputs.re }", { re });
     expect(r.v).toEqual({});
   });
 
   // Error
   it("handles Error input (becomes {} via JSON)", async () => {
     const err = new Error("test error");
-    const r = await run("return { v: err }", { err });
+    const r = await run("return { v: inputs.err }", { err });
     expect(r.v).toEqual({});
   });
 
   // BigInt
   it("handles BigInt input (becomes null — JSON.stringify throws)", async () => {
     const big = BigInt(999999999999999999n);
-    const r = await run("return { v: big }", { big });
+    const r = await run("return { v: inputs.big }", { big });
     expect(r.v).toBeNull();
   });
 
   // Function (callback)
   it("handles function input (becomes null via JSON)", async () => {
     const fn = (x: number) => x * 3;
-    const r = await run("return { v: fn }", { fn });
+    const r = await run("return { v: inputs.fn }", { fn });
     expect(r.v).toBeNull();
   });
 
   // Symbol (as a value)
   it("handles Symbol as an input value (becomes null via JSON)", async () => {
     const sym = Symbol("test");
-    const r = await run("return { v: sym }", { sym });
+    const r = await run("return { v: inputs.sym }", { sym });
     expect(r.v).toBeNull();
   });
 });
@@ -853,7 +851,7 @@ describe("CodeNode — edge cases", () => {
 
   it("returns input object (deep copy, not same reference)", async () => {
     const complex = { a: [1, 2], b: { c: "d" }, e: true };
-    const r = await run("return { x }", { x: complex });
+    const r = await run("return { x: inputs.x }", { x: complex });
     expect(r).toEqual({ x: complex });
     // Inputs are deep-copied via JSON round-trip
     expect(r.x).not.toBe(complex);
@@ -862,7 +860,7 @@ describe("CodeNode — edge cases", () => {
 
   it("modifying input array inside code does not affect original", async () => {
     const arr = [1, 2, 3];
-    const r = await run("arr.push(4); return { arr }", { arr });
+    const r = await run("inputs.arr.push(4); return { arr: inputs.arr }", { arr });
     expect(r).toEqual({ arr: [1, 2, 3, 4] });
     // Original array is NOT mutated (inputs are deep-copied)
     expect(arr).toEqual([1, 2, 3]);
@@ -870,7 +868,7 @@ describe("CodeNode — edge cases", () => {
 
   it("destructures input objects", async () => {
     const obj = { a: 1, b: 2 };
-    const r = await run("const { a, b } = obj; return { a, b }", { obj });
+    const r = await run("const { a, b } = inputs.obj; return { a, b }", { obj });
     expect(r).toEqual({ a: 1, b: 2 });
   });
 });
@@ -968,14 +966,14 @@ describe("CodeNode — binary output", () => {
 
 describe("CodeNode — fetch policy props", () => {
   it("does not leak max_response_mb into the guest as a global", async () => {
-    const r = await run("return { a: typeof max_response_mb }", {
+    const r = await run("return { a: typeof inputs.max_response_mb }", {
       max_response_mb: 5
     });
     expect(r).toEqual({ a: "undefined" });
   });
 
   it("lets user variables of other names through unchanged", async () => {
-    const r = await run("return { v: max_response }", { max_response: 7 });
+    const r = await run("return { v: inputs.max_response }", { max_response: 7 });
     expect(r).toEqual({ v: 7 });
   });
 });

--- a/packages/node-sdk/src/code-analysis.ts
+++ b/packages/node-sdk/src/code-analysis.ts
@@ -2,8 +2,8 @@
  * AST primitives for the body of a Code node (`nodetool.code.Code`).
  *
  * A Code node's `code` property is the body of one async function: declared
- * dynamic inputs arrive as globals and the returned object's keys are the
- * node's output handles. Everything a checker needs to say about such a body —
+ * dynamic inputs arrive on an `inputs` object and the returned object's keys
+ * are the node's output handles. Everything a checker needs to say about such a body —
  * does it parse, what does it return, which names does it invent — is derived
  * here, so the graph validator, the code-generation planner and the editor all
  * read the same AST rather than three approximations of it.
@@ -395,16 +395,88 @@ export function typeofGuardedNames(
   return guarded;
 }
 
+/** The global every declared input of a Code node arrives on. */
+export const CODE_INPUTS_GLOBAL = "inputs";
+
 /**
- * Identifiers the code reads without binding them. Property names, object
- * keys and labels are excluded: none of them resolve against the scope chain,
- * so none of them can throw a ReferenceError.
+ * Input names the body reads off the `inputs` global, and whether it also
+ * reaches for the object in a way this analysis cannot resolve to names.
+ *
+ * `inputs.text` and `inputs["text"]` both count. A dynamic read
+ * (`inputs[key]`), a spread, or passing `inputs` somewhere sets `opaque`:
+ * the body uses inputs the reader cannot enumerate, so a caller must not
+ * conclude an undeclared slot is unused. A body that shadows `inputs` with
+ * its own binding reports nothing — the reads are that binding's, not the
+ * node's.
  */
-export function freeIdentifiers(
+export function inputsMemberReads(statements: readonly CodeBodyStatement[]): {
+  names: string[];
+  opaque: boolean;
+} {
+  if (collectBoundNamesFrom(statements).has(CODE_INPUTS_GLOBAL)) {
+    return { names: [], opaque: false };
+  }
+  const names = new Set<string>();
+  let opaque = false;
+
+  walk(statements, (node, ancestors) => {
+    if (node.type !== "Identifier" || node.name !== CODE_INPUTS_GLOBAL) return;
+    const parent = ancestors[ancestors.length - 2];
+    // A property *named* `inputs` (`opts.inputs`, `{inputs: 1}`) is not the
+    // global. `inputs.x` is, and there `inputs` is the object, not the
+    // property.
+    if (parent?.type === "MemberExpression") {
+      if (parent.property === node && !parent.computed) return;
+      if (parent.object === node) {
+        if (!parent.computed && parent.property.type === "Identifier") {
+          names.add(parent.property.name);
+          return;
+        }
+        if (
+          parent.computed &&
+          parent.property.type === "Literal" &&
+          typeof parent.property.value === "string"
+        ) {
+          names.add(parent.property.value);
+          return;
+        }
+        // `inputs[key]` — a real read of a name only the runtime knows.
+        opaque = true;
+        return;
+      }
+    }
+    if (parent?.type === "Property" && parent.key === node && !parent.computed) {
+      return;
+    }
+    // `{...inputs}`, `f(inputs)`, `Object.keys(inputs)` — the whole bag leaves.
+    opaque = true;
+  });
+
+  return { names: [...names], opaque };
+}
+
+/** One identifier the code reads without binding it. */
+interface IdentifierRead {
+  name: string;
+  start: number;
+  end: number;
+  /** `{ text }` — a rewrite has to become `{ text: <expr> }`, not `{ <expr> }`. */
+  shorthand: boolean;
+}
+
+/**
+ * Identifier *reads* — occurrences that resolve against the scope chain.
+ * Property names, object keys and labels are excluded: none of them resolve,
+ * so none of them can throw a ReferenceError.
+ *
+ * Positions come along because the migration rewrites these occurrences in
+ * place; sharing one collector keeps "what counts as a read" from drifting
+ * between the check and the rewrite.
+ */
+function identifierReads(
   statements: readonly CodeBodyStatement[]
-): string[] {
-  const bound = collectBoundNamesFrom(statements);
-  const referenced = new Set<string>();
+): IdentifierRead[] {
+  const reads: IdentifierRead[] = [];
 
   walk(statements, (node, ancestors) => {
     if (node.type !== "Identifier") return;
@@ -416,7 +488,9 @@ export function freeIdentifiers(
         if (parent.property === node && !parent.computed) return;
         break;
       case "Property":
-        if (parent.key === node && !parent.computed) return;
+        if (parent.key === node && !parent.computed && !parent.shorthand) {
+          return;
+        }
         break;
       case "MethodDefinition":
       case "PropertyDefinition":
@@ -452,8 +526,82 @@ export function freeIdentifiers(
       default:
         break;
     }
-    referenced.add(node.name);
+    reads.push({
+      name: node.name,
+      start: node.start,
+      end: node.end,
+      shorthand: parent.type === "Property" && parent.shorthand === true
+    });
   });
 
-  return [...referenced].filter((name) => !bound.has(name));
+  // A shorthand property's `key` and `value` are the same node, so the walk
+  // reaches the occurrence twice. One position is one read.
+  const seen = new Set<number>();
+  return reads.filter((read) => {
+    if (seen.has(read.start)) return false;
+    seen.add(read.start);
+    return true;
+  });
+}
+
+/**
+ * Identifiers the code reads without binding them. Property names, object
+ * keys and labels are excluded: none of them resolve against the scope chain,
+ * so none of them can throw a ReferenceError.
+ */
+export function freeIdentifiers(
+  statements: readonly CodeBodyStatement[]
+): string[] {
+  const bound = collectBoundNamesFrom(statements);
+  const names = new Set(identifierReads(statements).map((read) => read.name));
+  return [...names].filter((name) => !bound.has(name));
+}
+
+/**
+ * Rewrite a pre-`inputs` Code node body: every free read of a declared input
+ * becomes `inputs.<name>`.
+ *
+ * Inputs used to arrive as globals of their own name. Bodies written that way
+ * throw a ReferenceError now, so this is the mechanical half of that move —
+ * offsets come from the AST, so a name inside a string or a comment, an object
+ * key, or a locally shadowed binding is left alone.
+ *
+ * Returns the rewritten source and the names it touched. `changed` is false
+ * when there was nothing to do, when the body does not parse, or when it binds
+ * `inputs` itself — rewriting into a shadowed name would silently change which
+ * object is read.
+ */
+export function migrateCodeBodyToInputs(
+  code: string,
+  inputNames: readonly string[]
+): { code: string; changed: boolean; rewritten: string[] } {
+  const unchanged = { code, changed: false, rewritten: [] as string[] };
+  const targets = new Set(inputNames);
+  if (targets.size === 0) return unchanged;
+
+  const parsed = parseCodeBody(code);
+  if ("error" in parsed) return unchanged;
+
+  const bound = collectBoundNamesFrom(parsed.statements);
+  if (bound.has(CODE_INPUTS_GLOBAL)) return unchanged;
+
+  const edits = identifierReads(parsed.statements).filter(
+    (read) => targets.has(read.name) && !bound.has(read.name)
+  );
+  if (edits.length === 0) return unchanged;
+
+  // Apply back to front so earlier offsets stay valid.
+  let out = code;
+  for (const edit of [...edits].sort((a, b) => b.start - a.start)) {
+    const replacement = edit.shorthand
+      ? `${edit.name}: ${CODE_INPUTS_GLOBAL}.${edit.name}`
+      : `${CODE_INPUTS_GLOBAL}.${edit.name}`;
+    out = out.slice(0, edit.start) + replacement + out.slice(edit.end);
+  }
+
+  return {
+    code: out,
+    changed: true,
+    rewritten: [...new Set(edits.map((e) => e.name))].sort()
+  };
 }

--- a/packages/node-sdk/src/code-node-validation.ts
+++ b/packages/node-sdk/src/code-node-validation.ts
@@ -1,9 +1,9 @@
 /**
  * Static checks for a Code node (`nodetool.code.Code`) inside a workflow graph.
  *
- * The node's `code` property is the body of one async function whose globals
- * are the node's dynamic inputs and whose returned object's keys are its output
- * handles. Nothing about that contract is enforced until the node runs, so a
+ * The node's `code` property is the body of one async function that reads the
+ * node's dynamic inputs off an `inputs` object and whose returned object's keys
+ * are its output handles. Nothing about that contract is enforced until the node runs, so a
  * body that does not parse, reads an input the node does not have, or forgets
  * an output handle that downstream nodes are wired to costs a whole run to
  * discover. Everything here is decidable from the graph alone.
@@ -13,7 +13,9 @@
  */
 import {
   analyzeCodeBody,
+  CODE_INPUTS_GLOBAL,
   freeIdentifiers,
+  inputsMemberReads,
   moduleDeclarationKinds,
   parseCodeBody,
   returnShapes,
@@ -70,8 +72,8 @@ export const SANDBOX_GLOBALS: ReadonlySet<string> = new Set([
   // JS literals that acorn parses as Identifier nodes
   "true", "false", "null",
   "this", "arguments", "self", "window", "document",
-  // Code node reserved props
-  "code", "timeout", "state",
+  // Code node reserved props and the object its declared inputs arrive on
+  "code", "timeout", "state", "inputs",
   // Sandbox internals
   "__maxIter"
 ]);
@@ -94,7 +96,7 @@ export interface CodeNodeIssue {
   /**
    * Stable category: "code_syntax" | "code_module" | "code_no_return" |
    * "code_return_shape" | "code_missing_output" | "code_undeclared_output" |
-   * "code_undefined_name" | "code_unused_input".
+   * "code_undefined_name" | "code_undefined_input" | "code_unused_input".
    */
   code: string;
   message: string;
@@ -171,12 +173,13 @@ export function validateCodeNodeBody(
   }
 
   // ── Names the body reads but nothing puts in scope ───────────────────────
+  // Declared inputs are deliberately NOT bare-name scope: they arrive on the
+  // `inputs` object, so reading one as a bare name is the ReferenceError the
+  // split below reports with the rewrite.
   const inScope = new Set(input.availableInputs);
   const free = freeIdentifiers(parsed.statements);
   const guarded = typeofGuardedNames(parsed.statements);
-  const unbound = free.filter(
-    (name) => !inScope.has(name) && !guarded.has(name)
-  );
+  const unbound = free.filter((name) => !guarded.has(name));
   const absentNames = [
     ...new Set(unbound.filter((name) => ABSENT_GLOBALS.has(name)))
   ];
@@ -194,21 +197,61 @@ export function validateCodeNodeBody(
   const undefinedNames = unbound.filter(
     (name) => !SANDBOX_GLOBALS.has(name) && !ABSENT_GLOBALS.has(name)
   );
+  // A declared input read as a bare name: the pre-`inputs` form. It is a
+  // reference to that input, so the unused check below must not also complain.
+  const bareInputReads = undefinedNames.filter((name) => inScope.has(name));
   if (undefinedNames.length > 0) {
+    const asInputs = [...new Set(bareInputReads)].sort();
+    // An input name reads as a bare identifier only in the pre-`inputs` form,
+    // which is now a ReferenceError. Naming the rewrite beats "fix the name"
+    // for the one mistake every migrated body makes.
+    const rest = undefinedNames.filter((name) => !inScope.has(name)).sort();
+    if (asInputs.length > 0) {
+      issues.push({
+        severity: "error",
+        code: "code_undefined_name",
+        message:
+          `The code reads ${formatNames(asInputs)} as ${asInputs.length > 1 ? "bare names" : "a bare name"}, but ` +
+          `${asInputs.length > 1 ? "they are inputs" : "it is an input"} of this node — inputs arrive on the \`${CODE_INPUTS_GLOBAL}\` ` +
+          `object. Use ${asInputs.map((n) => `\`${CODE_INPUTS_GLOBAL}.${n}\``).join(", ")}.`
+      });
+    }
+    if (rest.length > 0) {
+      issues.push({
+        severity: "error",
+        code: "code_undefined_name",
+        message:
+          `The code reads ${formatNames(rest)}, which ${rest.length > 1 ? "are" : "is"} neither a sandbox API ` +
+          `nor an input of this node — the sandbox throws ReferenceError. Declare ` +
+          `${rest.length > 1 ? "them" : "it"} as ${rest.length > 1 ? "dynamic inputs and read them" : "a dynamic input and read it"} off ` +
+          `\`${CODE_INPUTS_GLOBAL}\`, or fix the name.`
+      });
+    }
+  }
+
+  const { names: inputsRead, opaque: inputsOpaque } = inputsMemberReads(
+    parsed.statements
+  );
+  const unknownInputs = [
+    ...new Set(inputsRead.filter((name) => !inScope.has(name)))
+  ].sort();
+  if (unknownInputs.length > 0) {
     issues.push({
       severity: "error",
-      code: "code_undefined_name",
+      code: "code_undefined_input",
       message:
-        `The code reads ${formatNames(undefinedNames.sort())}, which ${undefinedNames.length > 1 ? "are" : "is"} neither a sandbox API ` +
-        `nor an input of this node — the sandbox throws ReferenceError. Add ${undefinedNames.length > 1 ? "them" : "it"} as ` +
-        "dynamic input(s), or fix the name."
+        `The code reads ${unknownInputs.map((n) => `\`${CODE_INPUTS_GLOBAL}.${n}\``).join(", ")}, which ` +
+        `${unknownInputs.length > 1 ? "are not inputs" : "is not an input"} of this node — the value is undefined at run time. ` +
+        `Declare ${unknownInputs.length > 1 ? "them" : "it"} as ${unknownInputs.length > 1 ? "dynamic inputs" : "a dynamic input"}, or fix the name.`
     });
   }
 
-  const read = new Set(free);
-  const declaredInputsUnused = [
-    ...new Set(input.availableInputs.filter((name) => !read.has(name)))
-  ];
+  // An unresolvable read (`inputs[key]`, a spread) could touch any slot, so
+  // nothing is provably unused.
+  const read = new Set([...inputsRead, ...bareInputReads]);
+  const declaredInputsUnused = inputsOpaque
+    ? []
+    : [...new Set(input.availableInputs.filter((name) => !read.has(name)))];
 
   // ── Outputs, against every return path the parser can see ────────────────
   const { returns, fallsThrough } = analyzeCodeBody(parsed.statements);

--- a/packages/node-sdk/tests/code-inputs-migration.test.ts
+++ b/packages/node-sdk/tests/code-inputs-migration.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { migrateCodeBodyToInputs } from "../src/code-analysis.js";
+import { validateCodeNodeBody } from "../src/code-node-validation.js";
+
+/**
+ * Inputs used to arrive as globals of their own name. These pin the mechanical
+ * half of the move to the `inputs` object: what the rewriter touches, and — the
+ * part that matters — what it must not.
+ */
+describe("migrateCodeBodyToInputs", () => {
+  it("rewrites a free read of a declared input", () => {
+    const out = migrateCodeBodyToInputs(
+      "return { upper: text.toUpperCase() };",
+      ["text"]
+    );
+    expect(out.code).toBe("return { upper: inputs.text.toUpperCase() };");
+    expect(out.rewritten).toEqual(["text"]);
+  });
+
+  it("expands a shorthand property instead of producing invalid syntax", () => {
+    const out = migrateCodeBodyToInputs("return { text };", ["text"]);
+    expect(out.code).toBe("return { text: inputs.text };");
+  });
+
+  it("leaves a name inside a string or comment alone", () => {
+    const code = `// text is the input\nconst s = "text";\nreturn { out: text + s };`;
+    const out = migrateCodeBodyToInputs(code, ["text"]);
+    expect(out.code).toBe(
+      `// text is the input\nconst s = "text";\nreturn { out: inputs.text + s };`
+    );
+  });
+
+  it("leaves an object key that happens to share the name", () => {
+    const out = migrateCodeBodyToInputs("return { text: text };", ["text"]);
+    expect(out.code).toBe("return { text: inputs.text };");
+  });
+
+  it("leaves a property access that happens to share the name", () => {
+    const out = migrateCodeBodyToInputs("return { out: row.text };", ["text"]);
+    expect(out.changed).toBe(false);
+  });
+
+  it("leaves a locally bound name alone", () => {
+    const code = "const text = 'local';\nreturn { out: text };";
+    expect(migrateCodeBodyToInputs(code, ["text"]).changed).toBe(false);
+  });
+
+  it("refuses a body that binds `inputs` itself", () => {
+    // Rewriting into a shadowed name would change which object is read.
+    const code = "const inputs = {};\nreturn { out: text };";
+    expect(migrateCodeBodyToInputs(code, ["text"]).changed).toBe(false);
+  });
+
+  it("leaves already-migrated code untouched", () => {
+    const code = "return { out: inputs.text };";
+    expect(migrateCodeBodyToInputs(code, ["text"]).changed).toBe(false);
+  });
+
+  it("does not touch a body that does not parse", () => {
+    const code = "return { out: text";
+    expect(migrateCodeBodyToInputs(code, ["text"]).changed).toBe(false);
+  });
+
+  it("produces a body the validator accepts", () => {
+    const before = "return { out: a + b };";
+    const after = migrateCodeBodyToInputs(before, ["a", "b"]).code;
+    expect(
+      validateCodeNodeBody({
+        code: after,
+        availableInputs: ["a", "b"],
+        declaredOutputs: ["out"]
+      })
+    ).toEqual([]);
+  });
+});
+
+describe("validateCodeNodeBody, inputs contract", () => {
+  it("names the rewrite when an input is read as a bare name", () => {
+    const issues = validateCodeNodeBody({
+      code: "return { out: text };",
+      availableInputs: ["text"],
+      declaredOutputs: ["out"]
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("code_undefined_name");
+    expect(issues[0].message).toContain("`inputs.text`");
+  });
+
+  it("flags a read of an input the node does not have", () => {
+    const issues = validateCodeNodeBody({
+      code: "return { out: inputs.missing };",
+      availableInputs: ["text"],
+      declaredOutputs: ["out"]
+    });
+    expect(issues.map((i) => i.code)).toContain("code_undefined_input");
+  });
+
+  it("reports an unused input from the inputs object, not free names", () => {
+    const issues = validateCodeNodeBody({
+      code: "return { out: inputs.a };",
+      availableInputs: ["a", "b"],
+      declaredOutputs: ["out"]
+    });
+    expect(issues.map((i) => i.code)).toContain("code_unused_input");
+  });
+
+  it("calls nothing unused when the body reads inputs dynamically", () => {
+    // `inputs[key]` could touch any slot, so nothing is provably unused.
+    const issues = validateCodeNodeBody({
+      code: "const key = 'a';\nreturn { out: inputs[key] };",
+      availableInputs: ["a", "b"],
+      declaredOutputs: ["out"]
+    });
+    expect(issues.map((i) => i.code)).not.toContain("code_unused_input");
+  });
+});

--- a/packages/node-sdk/tests/code-node-validation.test.ts
+++ b/packages/node-sdk/tests/code-node-validation.test.ts
@@ -20,7 +20,11 @@ describe("validateCodeNodeBody", () => {
   it("accepts a body that reads its inputs and returns its outputs", () => {
     expect(
       validateCodeNodeBody(
-        body("const total = a + b;\nreturn { total };", ["a", "b"], ["total"])
+        body(
+          "const total = inputs.a + inputs.b;\nreturn { total };",
+          ["a", "b"],
+          ["total"]
+        )
       )
     ).toEqual([]);
   });
@@ -43,7 +47,7 @@ describe("validateCodeNodeBody", () => {
 
   it("flags a name that is neither a sandbox API nor an input", () => {
     const issues = validateCodeNodeBody(
-      body("return { out: lodash.sum(values) };", ["values"], ["out"])
+      body("return { out: lodash.sum(inputs.values) };", ["values"], ["out"])
     );
     const undefinedName = issues.find((i) => i.code === "code_undefined_name");
     expect(undefinedName?.severity).toBe("error");
@@ -54,7 +58,7 @@ describe("validateCodeNodeBody", () => {
     expect(
       codes(
         body(
-          `const res = await fetch(url);
+          `const res = await fetch(inputs.url);
            state.seen = (state.seen ?? 0) + 1;
            console.log(format.number(state.seen));
            return { body: res.json, seen: state.seen };`,

--- a/packages/node-sdk/tests/graph-validation.test.ts
+++ b/packages/node-sdk/tests/graph-validation.test.ts
@@ -869,7 +869,7 @@ describe("Code nodes", () => {
   it("passes a well-formed Code node", () => {
     const report = validateGraph(
       graph({
-        properties: { code: "return { out: String(text) };" },
+        properties: { code: "return { out: String(inputs.text) };" },
         dynamic_inputs: { text: { type: { type: "str" } } },
         dynamic_outputs: { out: { type: "str" } }
       }),
@@ -913,7 +913,7 @@ describe("Code nodes", () => {
           {
             id: "c",
             type: CODE,
-            properties: { code: "return { out: text };" },
+            properties: { code: "return { out: inputs.text };" },
             dynamic_outputs: { out: { type: "str" } }
           }
         ],

--- a/web/src/components/node_types/__tests__/CodeBody.test.tsx
+++ b/web/src/components/node_types/__tests__/CodeBody.test.tsx
@@ -255,7 +255,7 @@ describe("CodeBody", () => {
     );
     const editor = screen.getByTestId("monaco");
     fireEvent.change(editor, {
-      target: { value: "return { sum: a + b };" }
+      target: { value: "return { sum: inputs.a + inputs.b };" }
     });
 
     expect(mockUpdateNodeData).toHaveBeenCalledWith("node-1", {

--- a/web/src/config/codeSnippets.ts
+++ b/web/src/config/codeSnippets.ts
@@ -88,7 +88,7 @@ export const CODE_SNIPPETS: CodeSnippet[] = [
     title: "Conditional Switch",
     description: "Return one of two values based on a condition",
     category: "Boolean & Logic",
-    code: "return { output: condition ? if_true : if_false };",
+    code: "return { output: inputs.condition ? inputs.if_true : inputs.if_false };",
     tags: ["conditional", "switch", "ternary", "if", "else"],
   },
   {
@@ -96,7 +96,7 @@ export const CODE_SNIPPETS: CodeSnippet[] = [
     title: "Logical AND",
     description: "Logical AND of two booleans",
     category: "Boolean & Logic",
-    code: "return { output: a && b };",
+    code: "return { output: inputs.a && inputs.b };",
     tags: ["and", "logical", "&&"],
   },
   {
@@ -104,7 +104,7 @@ export const CODE_SNIPPETS: CodeSnippet[] = [
     title: "Logical OR",
     description: "Logical OR of two booleans",
     category: "Boolean & Logic",
-    code: "return { output: a || b };",
+    code: "return { output: inputs.a || inputs.b };",
     tags: ["or", "logical", "||"],
   },
   {
@@ -112,7 +112,7 @@ export const CODE_SNIPPETS: CodeSnippet[] = [
     title: "Not",
     description: "Negate a boolean value",
     category: "Boolean & Logic",
-    code: "return { output: !value };",
+    code: "return { output: !inputs.value };",
     tags: ["not", "negate", "invert", "!"],
   },
   {
@@ -121,7 +121,7 @@ export const CODE_SNIPPETS: CodeSnippet[] = [
     description: "Compare two values (==, !=, >, <, >=, <=)",
     category: "Boolean & Logic",
     code: `// Change the operator as needed: ==, !=, >, <, >=, <=
-return { output: a > b };`,
+return { output: inputs.a > inputs.b };`,
     tags: ["compare", "equal", "greater", "less", "operator"],
   },
   {
@@ -129,7 +129,7 @@ return { output: a > b };`,
     title: "Is None",
     description: "Check if a value is null or undefined",
     category: "Boolean & Logic",
-    code: "return { output: value === null || value === undefined };",
+    code: "return { output: inputs.value === null || inputs.value === undefined };",
     tags: ["none", "null", "undefined", "empty", "check"],
   },
   {
@@ -137,7 +137,7 @@ return { output: a > b };`,
     title: "Is In",
     description: "Check if a value is in a list",
     category: "Boolean & Logic",
-    code: "return { output: list.includes(value) };",
+    code: "return { output: inputs.list.includes(inputs.value) };",
     tags: ["in", "includes", "contains", "member"],
   },
   {
@@ -145,7 +145,7 @@ return { output: a > b };`,
     title: "All",
     description: "Check if all values are truthy",
     category: "Boolean & Logic",
-    code: "return { output: values.every(Boolean) };",
+    code: "return { output: inputs.values.every(Boolean) };",
     tags: ["all", "every", "truthy"],
   },
   {
@@ -153,7 +153,7 @@ return { output: a > b };`,
     title: "Some",
     description: "Check if any value is truthy",
     category: "Boolean & Logic",
-    code: "return { output: values.some(Boolean) };",
+    code: "return { output: inputs.values.some(Boolean) };",
     tags: ["some", "any", "truthy"],
   },
 
@@ -165,7 +165,7 @@ return { output: a > b };`,
     title: "Add",
     description: "Add two numbers",
     category: "Math",
-    code: "return { output: a + b };",
+    code: "return { output: inputs.a + inputs.b };",
     tags: ["add", "plus", "sum", "+"],
   },
   {
@@ -173,7 +173,7 @@ return { output: a > b };`,
     title: "Subtract",
     description: "Subtract b from a",
     category: "Math",
-    code: "return { output: a - b };",
+    code: "return { output: inputs.a - inputs.b };",
     tags: ["subtract", "minus", "difference", "-"],
   },
   {
@@ -181,7 +181,7 @@ return { output: a > b };`,
     title: "Multiply",
     description: "Multiply two numbers",
     category: "Math",
-    code: "return { output: a * b };",
+    code: "return { output: inputs.a * inputs.b };",
     tags: ["multiply", "product", "times", "*"],
   },
   {
@@ -189,7 +189,7 @@ return { output: a > b };`,
     title: "Divide",
     description: "Divide a by b",
     category: "Math",
-    code: "return { output: a / b };",
+    code: "return { output: inputs.a / inputs.b };",
     tags: ["divide", "quotient", "/"],
   },
   {
@@ -197,7 +197,7 @@ return { output: a > b };`,
     title: "Modulus",
     description: "Remainder of a divided by b",
     category: "Math",
-    code: "return { output: a % b };",
+    code: "return { output: inputs.a % inputs.b };",
     tags: ["modulus", "remainder", "mod", "%"],
   },
   {
@@ -205,7 +205,7 @@ return { output: a > b };`,
     title: "Power",
     description: "Raise base to the power of exponent",
     category: "Math",
-    code: "return { output: Math.pow(base, exponent) };",
+    code: "return { output: Math.pow(inputs.base, inputs.exponent) };",
     tags: ["power", "exponent", "pow", "**"],
   },
   {
@@ -213,7 +213,7 @@ return { output: a > b };`,
     title: "Square Root",
     description: "Calculate the square root",
     category: "Math",
-    code: "return { output: Math.sqrt(value) };",
+    code: "return { output: Math.sqrt(inputs.value) };",
     tags: ["sqrt", "square root", "root"],
   },
   {
@@ -221,7 +221,7 @@ return { output: a > b };`,
     title: "Absolute Value",
     description: "Get the absolute value",
     category: "Math",
-    code: "return { output: Math.abs(value) };",
+    code: "return { output: Math.abs(inputs.value) };",
     tags: ["abs", "absolute"],
   },
   {
@@ -231,7 +231,7 @@ return { output: a > b };`,
     category: "Math",
     code: `// Round to N decimal places (0 for integer)
 const places = 0;
-return { output: Math.round(value * 10**places) / 10**places };`,
+return { output: Math.round(inputs.value * 10**places) / 10**places };`,
     tags: ["round", "ceil", "floor", "decimal"],
   },
   {
@@ -240,8 +240,8 @@ return { output: Math.round(value * 10**places) / 10**places };`,
     description: "Find the minimum or maximum of values",
     category: "Math",
     code: `return {
-  min: Math.min(a, b),
-  max: Math.max(a, b)
+  min: Math.min(inputs.a, inputs.b),
+  max: Math.max(inputs.a, inputs.b)
 };`,
     tags: ["min", "max", "minimum", "maximum", "clamp"],
   },
@@ -250,7 +250,7 @@ return { output: Math.round(value * 10**places) / 10**places };`,
     title: "Clamp",
     description: "Clamp a value between min and max",
     category: "Math",
-    code: "return { output: Math.min(Math.max(value, min), max) };",
+    code: "return { output: Math.min(Math.max(inputs.value, inputs.min), inputs.max) };",
     tags: ["clamp", "constrain", "limit", "bound"],
   },
   {
@@ -259,9 +259,9 @@ return { output: Math.round(value * 10**places) / 10**places };`,
     description: "sin, cos, tan and their inverses",
     category: "Math",
     code: `return {
-  sin: Math.sin(angle),
-  cos: Math.cos(angle),
-  tan: Math.tan(angle)
+  sin: Math.sin(inputs.angle),
+  cos: Math.cos(inputs.angle),
+  tan: Math.tan(inputs.angle)
 };`,
     tags: ["sin", "cos", "tan", "trig", "angle", "radians"],
   },
@@ -283,7 +283,7 @@ return { output: Math.random() * (max - min) + min };`,
     title: "Join Array",
     description: "Join array of strings with a separator",
     category: "Text",
-    code: `return { output: items.join(", ") };`,
+    code: `return { output: inputs.items.join(", ") };`,
     tags: ["join", "implode", "separator", "array"],
   },
   {
@@ -291,7 +291,7 @@ return { output: Math.random() * (max - min) + min };`,
     title: "Replace",
     description: "Replace all occurrences of a substring",
     category: "Text",
-    code: `return { output: text.replaceAll(search, replacement) };`,
+    code: `return { output: inputs.text.replaceAll(inputs.search, inputs.replacement) };`,
     tags: ["replace", "substitute", "swap"],
   },
   {
@@ -299,7 +299,7 @@ return { output: Math.random() * (max - min) + min };`,
     title: "Split",
     description: "Split a string into an array",
     category: "Text",
-    code: `return { output: text.split(", ") };`,
+    code: `return { output: inputs.text.split(", ") };`,
     tags: ["split", "explode", "tokenize", "array"],
   },
   {
@@ -308,8 +308,8 @@ return { output: Math.random() * (max - min) + min };`,
     description: "Convert text to upper or lower case",
     category: "Text",
     code: `return {
-  upper: text.toUpperCase(),
-  lower: text.toLowerCase()
+  upper: inputs.text.toUpperCase(),
+  lower: inputs.text.toLowerCase()
 };`,
     tags: ["upper", "lower", "case", "capitalize"],
   },
@@ -318,7 +318,7 @@ return { output: Math.random() * (max - min) + min };`,
     title: "Trim",
     description: "Remove whitespace from start and end",
     category: "Text",
-    code: "return { output: text.trim() };",
+    code: "return { output: inputs.text.trim() };",
     tags: ["trim", "strip", "whitespace"],
   },
   {
@@ -326,7 +326,7 @@ return { output: Math.random() * (max - min) + min };`,
     title: "Template String",
     description: "Format a string with variables",
     category: "Text",
-    code: "return { output: `Hello ${name}, you have ${count} items.` };",
+    code: "return { output: `Hello ${inputs.name}, you have ${inputs.count} items.` };",
     tags: ["template", "format", "interpolate", "string"],
   },
   {
@@ -334,7 +334,7 @@ return { output: Math.random() * (max - min) + min };`,
     title: "Regex Match",
     description: "Match text against a regular expression",
     category: "Text",
-    code: `const matches = text.match(/pattern/g) || [];
+    code: `const matches = inputs.text.match(/pattern/g) || [];
 return { output: matches, found: matches.length > 0 };`,
     tags: ["regex", "match", "pattern", "regular expression"],
   },
@@ -343,7 +343,7 @@ return { output: matches, found: matches.length > 0 };`,
     title: "To String",
     description: "Convert any value to a string representation",
     category: "Text",
-    code: "return { output: JSON.stringify(value, null, 2) };",
+    code: "return { output: JSON.stringify(inputs.value, null, 2) };",
     tags: ["toString", "stringify", "convert", "repr"],
   },
   {
@@ -352,8 +352,8 @@ return { output: matches, found: matches.length > 0 };`,
     description: "Pad a string to a fixed length",
     category: "Text",
     code: `return {
-  padStart: String(value).padStart(length, "0"),
-  padEnd: String(value).padEnd(length, " ")
+  padStart: String(inputs.value).padStart(inputs.length, "0"),
+  padEnd: String(inputs.value).padEnd(inputs.length, " ")
 };`,
     tags: ["pad", "padding", "fixed", "width"],
   },
@@ -366,7 +366,7 @@ return { output: matches, found: matches.length > 0 };`,
     title: "List Length",
     description: "Get the number of items in a list",
     category: "List",
-    code: "return { output: list.length };",
+    code: "return { output: inputs.list.length };",
     tags: ["length", "count", "size"],
   },
   {
@@ -374,8 +374,8 @@ return { output: matches, found: matches.length > 0 };`,
     title: "Get Element",
     description: "Get an element by index (supports negative indexing)",
     category: "List",
-    code: `const i = index < 0 ? list.length + index : index;
-return { output: list[i] };`,
+    code: `const i = inputs.index < 0 ? inputs.list.length + inputs.index : inputs.index;
+return { output: inputs.list[i] };`,
     tags: ["get", "index", "element", "access", "at"],
   },
   {
@@ -383,7 +383,7 @@ return { output: list[i] };`,
     title: "Append",
     description: "Add an item to the end of a list",
     category: "List",
-    code: "return { output: [...list, item] };",
+    code: "return { output: [...inputs.list, inputs.item] };",
     tags: ["append", "push", "add"],
   },
   {
@@ -391,7 +391,7 @@ return { output: list[i] };`,
     title: "Extend / Merge",
     description: "Combine two lists",
     category: "List",
-    code: "return { output: [...a, ...b] };",
+    code: "return { output: [...inputs.a, ...inputs.b] };",
     tags: ["extend", "merge", "combine", "concat"],
   },
   {
@@ -399,7 +399,7 @@ return { output: list[i] };`,
     title: "Slice",
     description: "Extract a portion of a list",
     category: "List",
-    code: "return { output: list.slice(start, end) };",
+    code: "return { output: inputs.list.slice(inputs.start, inputs.end) };",
     tags: ["slice", "substring", "subarray", "range"],
   },
   {
@@ -407,7 +407,7 @@ return { output: list[i] };`,
     title: "Filter",
     description: "Filter items matching a condition",
     category: "List",
-    code: "return { output: items.filter(x => x > threshold) };",
+    code: "return { output: inputs.items.filter(x => x > inputs.threshold) };",
     tags: ["filter", "select", "where", "condition"],
   },
   {
@@ -415,7 +415,7 @@ return { output: list[i] };`,
     title: "Map / Transform",
     description: "Transform each item in a list",
     category: "List",
-    code: "return { output: items.map(x => x * 2) };",
+    code: "return { output: inputs.items.map(x => x * 2) };",
     tags: ["map", "transform", "each", "apply"],
   },
   {
@@ -424,7 +424,7 @@ return { output: list[i] };`,
     description: "Sort a list (ascending or custom)",
     category: "List",
     code: `// Ascending number sort; for strings use: [...list].sort()
-return { output: [...list].sort((a, b) => a - b) };`,
+return { output: [...inputs.list].sort((a, b) => a - b) };`,
     tags: ["sort", "order", "ascending", "descending"],
   },
   {
@@ -432,7 +432,7 @@ return { output: [...list].sort((a, b) => a - b) };`,
     title: "Reverse",
     description: "Reverse the order of a list",
     category: "List",
-    code: "return { output: [...list].reverse() };",
+    code: "return { output: [...inputs.list].reverse() };",
     tags: ["reverse", "flip"],
   },
   {
@@ -440,7 +440,7 @@ return { output: [...list].sort((a, b) => a - b) };`,
     title: "Unique / Dedupe",
     description: "Remove duplicate values",
     category: "List",
-    code: "return { output: [...new Set(list)] };",
+    code: "return { output: [...new Set(inputs.list)] };",
     tags: ["unique", "dedupe", "distinct", "set"],
   },
   {
@@ -449,7 +449,7 @@ return { output: [...list].sort((a, b) => a - b) };`,
     description: "Flatten nested arrays",
     category: "List",
     code: `// depth: Infinity for full flatten, or a number
-return { output: list.flat(Infinity) };`,
+return { output: inputs.list.flat(Infinity) };`,
     tags: ["flatten", "flat", "nested", "depth"],
   },
   {
@@ -458,8 +458,8 @@ return { output: list.flat(Infinity) };`,
     description: "Split a list into chunks of a given size",
     category: "List",
     code: `const chunks = [];
-for (let i = 0; i < list.length; i += size) {
-  chunks.push(list.slice(i, i + size));
+for (let i = 0; i < inputs.list.length; i += inputs.size) {
+  chunks.push(inputs.list.slice(i, i + inputs.size));
 }
 return { output: chunks };`,
     tags: ["chunk", "batch", "partition", "group"],
@@ -469,7 +469,7 @@ return { output: chunks };`,
     title: "Sum",
     description: "Sum all numbers in a list",
     category: "List",
-    code: "return { output: list.reduce((a, b) => a + b, 0) };",
+    code: "return { output: inputs.list.reduce((a, b) => a + b, 0) };",
     tags: ["sum", "total", "add"],
   },
   {
@@ -477,7 +477,7 @@ return { output: chunks };`,
     title: "Average",
     description: "Calculate the average of a list",
     category: "List",
-    code: `return { output: list.reduce((a, b) => a + b, 0) / list.length };`,
+    code: `return { output: inputs.list.reduce((a, b) => a + b, 0) / inputs.list.length };`,
     tags: ["average", "mean", "avg"],
   },
   {
@@ -486,8 +486,8 @@ return { output: chunks };`,
     description: "Find the minimum and maximum values in a list",
     category: "List",
     code: `return {
-  min: Math.min(...list),
-  max: Math.max(...list)
+  min: Math.min(...inputs.list),
+  max: Math.max(...inputs.list)
 };`,
     tags: ["min", "max", "minimum", "maximum"],
   },
@@ -507,7 +507,7 @@ return { output: result };`,
     title: "Shuffle",
     description: "Randomly shuffle a list (Fisher-Yates)",
     category: "List",
-    code: `const arr = [...list];
+    code: `const arr = [...inputs.list];
 for (let i = arr.length - 1; i > 0; i--) {
   const j = Math.floor(Math.random() * (i + 1));
   [arr[i], arr[j]] = [arr[j], arr[i]];
@@ -520,8 +520,8 @@ return { output: arr };`,
     title: "Intersection",
     description: "Find common elements between two lists",
     category: "List",
-    code: `const setB = new Set(b);
-return { output: a.filter(x => setB.has(x)) };`,
+    code: `const setB = new Set(inputs.b);
+return { output: inputs.a.filter(x => setB.has(x)) };`,
     tags: ["intersection", "common", "shared", "overlap"],
   },
   {
@@ -529,7 +529,7 @@ return { output: a.filter(x => setB.has(x)) };`,
     title: "Union",
     description: "Combine two lists, removing duplicates",
     category: "List",
-    code: "return { output: [...new Set([...a, ...b])] };",
+    code: "return { output: [...new Set([...inputs.a, ...inputs.b])] };",
     tags: ["union", "merge", "combine", "unique"],
   },
   {
@@ -537,8 +537,8 @@ return { output: a.filter(x => setB.has(x)) };`,
     title: "Difference",
     description: "Find elements in a that are not in b",
     category: "List",
-    code: `const setB = new Set(b);
-return { output: a.filter(x => !setB.has(x)) };`,
+    code: `const setB = new Set(inputs.b);
+return { output: inputs.a.filter(x => !setB.has(x)) };`,
     tags: ["difference", "subtract", "exclude", "except"],
   },
   {
@@ -547,8 +547,8 @@ return { output: a.filter(x => !setB.has(x)) };`,
     description: "Group items by a key",
     category: "List",
     code: `const groups = {};
-for (const item of items) {
-  const k = item[key];
+for (const item of inputs.items) {
+  const k = item[inputs.key];
   (groups[k] ||= []).push(item);
 }
 return { output: groups };`,
@@ -559,7 +559,7 @@ return { output: groups };`,
     title: "Reduce",
     description: "Reduce a list to a single value",
     category: "List",
-    code: `return { output: list.reduce((acc, item) => acc + item, 0) };`,
+    code: `return { output: inputs.list.reduce((acc, item) => acc + item, 0) };`,
     tags: ["reduce", "fold", "accumulate", "aggregate"],
   },
   {
@@ -568,7 +568,7 @@ return { output: groups };`,
     description: "Repeat each list item consecutively N times: [A,B] x 2 → [A,A,B,B]",
     category: "List",
     code: `const times = 2;
-return { output: list.flatMap(item => Array(times).fill(item)) };`,
+return { output: inputs.list.flatMap(item => Array(times).fill(item)) };`,
     tags: ["repeat", "each", "duplicate", "interleave", "expand", "multiply"],
   },
   {
@@ -577,7 +577,7 @@ return { output: list.flatMap(item => Array(times).fill(item)) };`,
     description: "Duplicate a single value into a list N times",
     category: "List",
     code: `const times = 3;
-return { output: Array(times).fill(value) };`,
+return { output: Array(times).fill(inputs.value) };`,
     tags: ["repeat", "duplicate", "fill", "scalar", "constant", "expand"],
   },
   {
@@ -587,7 +587,7 @@ return { output: Array(times).fill(value) };`,
     category: "List",
     code: `const times = 3;
 const output = [];
-for (let t = 0; t < times; t++) output.push(...list);
+for (let t = 0; t < times; t++) output.push(...inputs.list);
 return { output };`,
     tags: ["tile", "repeat", "cycle", "loop", "concatenate", "duplicate"],
   },
@@ -600,9 +600,9 @@ return { output };`,
     title: "Get Value",
     description: "Get a value from a dictionary by key (supports dot paths like 'a.b.c')",
     category: "Dictionary",
-    code: `const value = String(key).split(".").reduce(
+    code: `const value = String(inputs.key).split(".").reduce(
   (acc, k) => (acc == null ? acc : acc[k]),
-  dict
+  inputs.dict
 );
 return { output: value };`,
     tags: ["get", "access", "key", "value", "path"],
@@ -612,7 +612,7 @@ return { output: value };`,
     title: "Set / Update",
     description: "Set or update a key in a dictionary",
     category: "Dictionary",
-    code: "return { output: { ...dict, [key]: value } };",
+    code: "return { output: { ...inputs.dict, [inputs.key]: inputs.value } };",
     tags: ["set", "update", "put", "assign"],
   },
   {
@@ -620,7 +620,7 @@ return { output: value };`,
     title: "Remove Key",
     description: "Remove a key from a dictionary",
     category: "Dictionary",
-    code: `const { [key]: _, ...rest } = dict;
+    code: `const { [inputs.key]: _, ...rest } = inputs.dict;
 return { output: rest };`,
     tags: ["remove", "delete", "omit", "key"],
   },
@@ -630,8 +630,8 @@ return { output: rest };`,
     description: "Get all keys or values from a dictionary",
     category: "Dictionary",
     code: `return {
-  keys: Object.keys(dict),
-  values: Object.values(dict)
+  keys: Object.keys(inputs.dict),
+  values: Object.values(inputs.dict)
 };`,
     tags: ["keys", "values", "entries"],
   },
@@ -640,7 +640,7 @@ return { output: rest };`,
     title: "Merge Dictionaries",
     description: "Merge two or more dictionaries",
     category: "Dictionary",
-    code: "return { output: { ...a, ...b } };",
+    code: "return { output: { ...inputs.a, ...inputs.b } };",
     tags: ["merge", "combine", "spread", "assign"],
   },
   {
@@ -649,7 +649,7 @@ return { output: rest };`,
     description: "Filter entries by a condition",
     category: "Dictionary",
     code: `return { output: Object.fromEntries(
-  Object.entries(dict).filter(([k, v]) => v !== null)
+  Object.entries(inputs.dict).filter(([k, v]) => v !== null)
 ) };`,
     tags: ["filter", "select", "where"],
   },
@@ -659,7 +659,7 @@ return { output: rest };`,
     description: "Create a dictionary from parallel key and value arrays",
     category: "Dictionary",
     code: `return { output: Object.fromEntries(
-  keys.map((k, i) => [k, values[i]])
+  inputs.keys.map((k, i) => [k, inputs.values[i]])
 ) };`,
     tags: ["zip", "fromEntries", "create", "build"],
   },
@@ -670,7 +670,7 @@ return { output: rest };`,
     category: "Dictionary",
     code: `const picked = ['key1', 'key2'];
 return { output: Object.fromEntries(
-  Object.entries(dict).filter(([k]) => picked.includes(k))
+  Object.entries(inputs.dict).filter(([k]) => picked.includes(k))
 ) };`,
     tags: ["pick", "select", "subset", "pluck"],
   },
@@ -681,7 +681,7 @@ return { output: Object.fromEntries(
     category: "Dictionary",
     code: `const omitted = ['key1', 'key2'];
 return { output: Object.fromEntries(
-  Object.entries(dict).filter(([k]) => !omitted.includes(k))
+  Object.entries(inputs.dict).filter(([k]) => !omitted.includes(k))
 ) };`,
     tags: ["omit", "exclude", "remove", "without"],
   },
@@ -690,7 +690,7 @@ return { output: Object.fromEntries(
     title: "To JSON",
     description: "Serialize a dictionary to JSON string",
     category: "Dictionary",
-    code: "return { output: JSON.stringify(dict, null, 2) };",
+    code: "return { output: JSON.stringify(inputs.dict, null, 2) };",
     tags: ["json", "stringify", "serialize"],
   },
   {
@@ -698,7 +698,7 @@ return { output: Object.fromEntries(
     title: "Arg Max",
     description: "Find the key with the highest value",
     category: "Dictionary",
-    code: `const entries = Object.entries(dict);
+    code: `const entries = Object.entries(inputs.dict);
 const [maxKey] = entries.reduce((a, b) => a[1] > b[1] ? a : b);
 return { output: maxKey };`,
     tags: ["argmax", "max", "key", "highest"],
@@ -709,7 +709,7 @@ return { output: maxKey };`,
     description: "Transform all values in a dictionary",
     category: "Dictionary",
     code: `return { output: Object.fromEntries(
-  Object.entries(dict).map(([k, v]) => [k, v * 2])
+  Object.entries(inputs.dict).map(([k, v]) => [k, v * 2])
 ) };`,
     tags: ["map", "transform", "values"],
   },
@@ -735,7 +735,7 @@ return {
     title: "Parse Date",
     description: "Parse a date string",
     category: "Date & Time",
-    code: `const d = new Date(dateString);
+    code: `const d = new Date(inputs.dateString);
 return { output: d.toISOString() };`,
     tags: ["parse", "convert", "string", "date"],
   },
@@ -744,7 +744,7 @@ return { output: d.toISOString() };`,
     title: "Format Date",
     description: "Format a date into a readable string",
     category: "Date & Time",
-    code: `const d = new Date(dateString);
+    code: `const d = new Date(inputs.dateString);
 return {
   iso: d.toISOString(),
   local: d.toLocaleDateString(),
@@ -758,8 +758,8 @@ return {
     title: "Add Time",
     description: "Add days, hours, or minutes to a date",
     category: "Date & Time",
-    code: `const d = new Date(dateString);
-d.setDate(d.getDate() + days);
+    code: `const d = new Date(inputs.dateString);
+d.setDate(d.getDate() + inputs.days);
 // d.setHours(d.getHours() + hours);
 // d.setMinutes(d.getMinutes() + minutes);
 return { output: d.toISOString() };`,
@@ -770,7 +770,7 @@ return { output: d.toISOString() };`,
     title: "Date Difference",
     description: "Calculate the difference between two dates",
     category: "Date & Time",
-    code: `const a = new Date(dateA), b = new Date(dateB);
+    code: `const a = new Date(inputs.dateA), b = new Date(inputs.dateB);
 const ms = Math.abs(a - b);
 return {
   days: Math.floor(ms / 86400000),
@@ -785,7 +785,7 @@ return {
     description: "Get the day of the week",
     category: "Date & Time",
     code: `const days = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"];
-const d = new Date(dateString);
+const d = new Date(inputs.dateString);
 return { output: days[d.getDay()], index: d.getDay() };`,
     tags: ["weekday", "day", "week", "name"],
   },
@@ -795,8 +795,8 @@ return { output: days[d.getDay()], index: d.getDay() };`,
     description: "Generate a list of dates between start and end",
     category: "Date & Time",
     code: `const dates = [];
-const d = new Date(start);
-const e = new Date(end);
+const d = new Date(inputs.start);
+const e = new Date(inputs.end);
 while (d <= e) {
   dates.push(d.toISOString().split("T")[0]);
   d.setDate(d.getDate() + 1);
@@ -811,7 +811,7 @@ return { output: dates };`,
     category: "Date & Time",
     code: `// unit: "day" | "week" | "month" | "year" — the week starts on Sunday
 const unit = "week";
-const start = new Date(date);
+const start = new Date(inputs.date);
 if (unit === "year") start.setMonth(0, 1);
 if (unit === "month") start.setDate(1);
 if (unit === "week") start.setDate(start.getDate() - start.getDay());
@@ -835,7 +835,7 @@ return {
     description: "Build a date object from year, month, and day numbers",
     category: "Date & Time",
     code: `// month is 1-12, day is 1-31
-return { output: { year, month, day } };`,
+return { output: { year: inputs.year, month: inputs.month, day: inputs.day } };`,
     tags: ["date", "make", "create", "constant", "year", "month", "day"],
   },
   {
@@ -846,12 +846,12 @@ return { output: { year, month, day } };`,
     code: `// utc_offset is in seconds and describes the wall-clock fields above
 return {
   output: {
-    year,
-    month,
-    day,
-    hour,
-    minute,
-    second,
+    year: inputs.year,
+    month: inputs.month,
+    day: inputs.day,
+    hour: inputs.hour,
+    minute: inputs.minute,
+    second: inputs.second,
     microsecond: 0,
     tzinfo: "UTC",
     utc_offset: 0
@@ -877,7 +877,7 @@ return {
     description: "Check if a string is a valid UUID",
     category: "UUID",
     code: `const re = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-return { output: re.test(value) };`,
+return { output: re.test(inputs.value) };`,
     tags: ["uuid", "validate", "check", "valid"],
   },
 
@@ -894,7 +894,7 @@ return { output: re.test(value) };`,
     title: "Parse JSON",
     description: "Parse a JSON string into an object",
     category: "JSON",
-    code: "return { output: JSON.parse(text) };",
+    code: "return { output: JSON.parse(inputs.text) };",
     tags: ["json", "parse", "decode", "string"],
   },
   {
@@ -910,7 +910,7 @@ return { output: re.test(value) };`,
     title: "Get JSON Path",
     description: "Extract a value using dot-path notation (e.g. 'user.address.city')",
     category: "JSON",
-    code: `const value = String(path).split(".").reduce(
+    code: `const value = String(inputs.path).split(".").reduce(
   (acc, k) => (acc == null ? acc : acc[k]),
   data
 );
@@ -922,7 +922,7 @@ return { output: value };`,
     title: "Filter JSON Array",
     description: "Filter an array of objects by a key-value match",
     category: "JSON",
-    code: `return { output: data.filter(item => item[key] === value) };`,
+    code: `return { output: data.filter(item => item[inputs.key] === inputs.value) };`,
     tags: ["json", "filter", "array", "query", "search"],
   },
   {
@@ -930,7 +930,7 @@ return { output: value };`,
     title: "Parse CSV",
     description: "Parse CSV text into an array of objects",
     category: "JSON",
-    code: `const lines = text.trim().split("\\n");
+    code: `const lines = inputs.text.trim().split("\\n");
 const headers = lines[0].split(",").map(h => h.trim());
 const rows = lines.slice(1).map(line => {
   const values = line.split(",");
@@ -958,7 +958,7 @@ return { output: rows };`,
     title: "Collect Items",
     description: "Accumulate streaming items into a list",
     category: "Streaming",
-    code: `state.items = [...(state.items || []), input];
+    code: `state.items = [...(state.items || []), inputs.input];
 return { output: [...state.items] };`,
     tags: ["collect", "accumulate", "gather", "aggregate", "stream"],
   },
@@ -968,7 +968,7 @@ return { output: [...state.items] };`,
     description: "Filter a stream — return {} to drop an item",
     category: "Streaming",
     code: `// Return {} to drop the item, or { output: value } to pass it through
-return value > threshold ? { output: value } : {};`,
+return inputs.value > inputs.threshold ? { output: inputs.value } : {};`,
     tags: ["stream", "filter", "drop", "pass", "gate"],
   },
   {
@@ -977,7 +977,7 @@ return value > threshold ? { output: value } : {};`,
     description: "Count items passing through a stream",
     category: "Streaming",
     code: `state.count = (state.count || 0) + 1;
-return { output: input, count: state.count };`,
+return { output: inputs.input, count: state.count };`,
     tags: ["count", "counter", "stream", "tally", "increment"],
   },
   {
@@ -986,7 +986,7 @@ return { output: input, count: state.count };`,
     description: "Collect N items then emit as a batch",
     category: "Streaming",
     code: `const batchSize = 5;
-state.items = [...(state.items || []), input];
+state.items = [...(state.items || []), inputs.input];
 if (state.items.length >= batchSize) {
   const batch = [...state.items];
   state.items = [];
@@ -1004,7 +1004,7 @@ return {};`,
     title: "Read File",
     description: "Read a text file from the workspace",
     category: "Files",
-    code: `const content = await workspace.read(path);
+    code: `const content = await workspace.read(inputs.path);
 return { output: content };`,
     tags: ["file", "read", "workspace", "load", "text"],
     inputs: { path: { type: "str", description: "Path relative to the workspace" } },
@@ -1015,8 +1015,8 @@ return { output: content };`,
     title: "Write File",
     description: "Write text content to a workspace file, creating parent directories",
     category: "Files",
-    code: `await workspace.write(path, content);
-return { output: path };`,
+    code: `await workspace.write(inputs.path, inputs.content);
+return { output: inputs.path };`,
     tags: ["file", "write", "save", "workspace", "export"],
     inputs: {
       path: { type: "str", description: "Path relative to the workspace" },
@@ -1029,10 +1029,10 @@ return { output: path };`,
     title: "Append To File",
     description: "Append text to a workspace file, creating it when missing",
     category: "Files",
-    code: `const info = await workspace.stat(path);
-const existing = info.exists ? await workspace.read(path) : "";
-await workspace.write(path, existing + content);
-return { output: path };`,
+    code: `const info = await workspace.stat(inputs.path);
+const existing = info.exists ? await workspace.read(inputs.path) : "";
+await workspace.write(inputs.path, existing + inputs.content);
+return { output: inputs.path };`,
     tags: ["file", "append", "write", "log", "workspace"],
     inputs: {
       path: { type: "str", description: "Path relative to the workspace" },
@@ -1045,7 +1045,7 @@ return { output: path };`,
     title: "List Files",
     description: "List the entry names of a workspace directory",
     category: "Files",
-    code: `const files = await workspace.list(path);
+    code: `const files = await workspace.list(inputs.path);
 return { output: files };`,
     tags: ["file", "list", "directory", "ls", "workspace"],
     inputs: { path: { type: "str", default: "." } },
@@ -1080,7 +1080,7 @@ const scan = async (dir) => {
     }
   }
 };
-await scan(folder);
+await scan(inputs.folder);
 return { output: found, file: found[0] ?? "" };`,
     tags: ["file", "find", "glob", "pattern", "recursive", "walk", "directory"],
     inputs: {
@@ -1093,7 +1093,7 @@ return { output: found, file: found[0] ?? "" };`,
     title: "Read Binary File",
     description: "Read a workspace file as a base64 string",
     category: "Files",
-    code: `const bytes = await workspace.readBytes(path);
+    code: `const bytes = await workspace.readBytes(inputs.path);
 return { output: toBase64(bytes) };`,
     tags: ["file", "binary", "read", "base64", "bytes"],
     inputs: { path: { type: "str", description: "Path relative to the workspace" } },
@@ -1104,8 +1104,8 @@ return { output: toBase64(bytes) };`,
     title: "Write Binary File",
     description: "Write base64 content to a workspace file as raw bytes",
     category: "Files",
-    code: `await workspace.writeBytes(path, fromBase64(content));
-return { output: path };`,
+    code: `await workspace.writeBytes(inputs.path, fromBase64(inputs.content));
+return { output: inputs.path };`,
     tags: ["file", "binary", "write", "base64", "bytes", "save"],
     inputs: {
       path: { type: "str", description: "Path relative to the workspace" },
@@ -1119,7 +1119,7 @@ return { output: path };`,
     description:
       "Check whether a path exists; paths outside the workspace need Allow Host Filesystem",
     category: "Files",
-    code: `return { output: (await workspace.stat(path)).exists };`,
+    code: `return { output: (await workspace.stat(inputs.path)).exists };`,
     tags: ["file", "exists", "check", "missing", "branch"],
     inputs: { path: { type: "str" } },
     outputs: { output: "bool" },
@@ -1130,7 +1130,7 @@ return { output: path };`,
     description:
       "Size, kind and timestamps of a path in one call; paths outside the workspace need Allow Host Filesystem",
     category: "Files",
-    code: `const info = await workspace.stat(path);
+    code: `const info = await workspace.stat(inputs.path);
 return {
   exists: info.exists,
   size: info.size,
@@ -1169,8 +1169,8 @@ return {
     description:
       "Create a directory and its parents; paths outside the workspace need Allow Host Filesystem",
     category: "Files",
-    code: `await workspace.mkdir(path);
-return { output: path };`,
+    code: `await workspace.mkdir(inputs.path);
+return { output: inputs.path };`,
     tags: ["directory", "folder", "create", "mkdir"],
     inputs: { path: { type: "str" } },
     outputs: { output: "str" },
@@ -1181,8 +1181,8 @@ return { output: path };`,
     description:
       "Copy a file, creating the destination directory; paths outside the workspace need Allow Host Filesystem",
     category: "Files",
-    code: `await workspace.copy(source, destination);
-return { output: destination };`,
+    code: `await workspace.copy(inputs.source, inputs.destination);
+return { output: inputs.destination };`,
     tags: ["file", "copy", "duplicate", "backup"],
     inputs: {
       source: { type: "str" },
@@ -1196,8 +1196,8 @@ return { output: destination };`,
     description:
       "Move or rename a file, creating the destination directory; paths outside the workspace need Allow Host Filesystem",
     category: "Files",
-    code: `await workspace.move(source, destination);
-return { output: destination };`,
+    code: `await workspace.move(inputs.source, inputs.destination);
+return { output: inputs.destination };`,
     tags: ["file", "move", "rename", "archive", "organize"],
     inputs: {
       source: { type: "str" },
@@ -1223,7 +1223,7 @@ return { output: destination };`,
     title: "Extract Substring",
     description: "Extract a portion of text by start/end index",
     category: "Text",
-    code: `return { output: text.slice(start, end) };`,
+    code: `return { output: inputs.text.slice(inputs.start, inputs.end) };`,
     tags: ["extract", "substring", "slice", "range"],
   },
   {
@@ -1232,7 +1232,7 @@ return { output: destination };`,
     description: "Split text into word-based chunks with optional overlap",
     category: "Text",
     code: `const chunkSize = 100, overlap = 0;
-const words = text.split(" ");
+const words = inputs.text.split(" ");
 const step = chunkSize - overlap;
 const chunks = [];
 for (let i = 0; i < words.length; i += step) {
@@ -1246,7 +1246,7 @@ return { output: chunks };`,
     title: "Title Case",
     description: "Convert text to title case (capitalize each word)",
     category: "Text",
-    code: `return { output: text.replace(/\\w\\S*/g, w =>
+    code: `return { output: inputs.text.replace(/\\w\\S*/g, w =>
   w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()
 ) };`,
     tags: ["title", "case", "capitalize", "words"],
@@ -1256,7 +1256,7 @@ return { output: chunks };`,
     title: "Capitalize",
     description: "Capitalize only the first character",
     category: "Text",
-    code: `return { output: text.charAt(0).toUpperCase() + text.slice(1).toLowerCase() };`,
+    code: `return { output: inputs.text.charAt(0).toUpperCase() + inputs.text.slice(1).toLowerCase() };`,
     tags: ["capitalize", "first", "letter", "sentence"],
   },
   {
@@ -1264,7 +1264,7 @@ return { output: chunks };`,
     title: "Starts With",
     description: "Check if text starts with a prefix",
     category: "Text",
-    code: `return { output: text.startsWith(prefix) };`,
+    code: `return { output: inputs.text.startsWith(inputs.prefix) };`,
     tags: ["starts", "prefix", "check", "begins"],
   },
   {
@@ -1272,7 +1272,7 @@ return { output: chunks };`,
     title: "Ends With",
     description: "Check if text ends with a suffix",
     category: "Text",
-    code: `return { output: text.endsWith(suffix) };`,
+    code: `return { output: inputs.text.endsWith(inputs.suffix) };`,
     tags: ["ends", "suffix", "check", "extension"],
   },
   {
@@ -1281,7 +1281,7 @@ return { output: chunks };`,
     description: "Check if text contains a substring (case-insensitive option)",
     category: "Text",
     code: `// case insensitive: text.toLowerCase().includes(sub.toLowerCase())
-return { output: text.includes(substring) };`,
+return { output: inputs.text.includes(inputs.substring) };`,
     tags: ["contains", "includes", "search", "find"],
   },
   {
@@ -1289,7 +1289,7 @@ return { output: text.includes(substring) };`,
     title: "Is Empty",
     description: "Check if text is empty or only whitespace",
     category: "Text",
-    code: `return { output: text.trim().length === 0 };`,
+    code: `return { output: inputs.text.trim().length === 0 };`,
     tags: ["empty", "blank", "whitespace", "check"],
   },
   {
@@ -1297,7 +1297,7 @@ return { output: text.includes(substring) };`,
     title: "Collapse Whitespace",
     description: "Replace runs of whitespace with a single space",
     category: "Text",
-    code: `return { output: text.trim().replace(/\\s+/g, " ") };`,
+    code: `return { output: inputs.text.trim().replace(/\\s+/g, " ") };`,
     tags: ["whitespace", "collapse", "normalize", "clean"],
   },
   {
@@ -1305,7 +1305,7 @@ return { output: text.includes(substring) };`,
     title: "Remove Punctuation",
     description: "Remove punctuation characters from text",
     category: "Text",
-    code: `return { output: text.replace(/[!"#$%&'()*+,\\-./:;<=>?@[\\\\\\]^_\`{|}~]/g, "") };`,
+    code: `return { output: inputs.text.replace(/[!"#$%&'()*+,\\-./:;<=>?@[\\\\\\]^_\`{|}~]/g, "") };`,
     tags: ["punctuation", "remove", "clean", "strip"],
   },
   {
@@ -1313,7 +1313,7 @@ return { output: text.includes(substring) };`,
     title: "Strip Accents",
     description: "Remove accent marks, keeping base characters",
     category: "Text",
-    code: `return { output: text.normalize("NFKD").replace(/[\\u0300-\\u036f]/g, "") };`,
+    code: `return { output: inputs.text.normalize("NFKD").replace(/[\\u0300-\\u036f]/g, "") };`,
     tags: ["accents", "diacritics", "normalize", "unicode"],
   },
   {
@@ -1321,7 +1321,7 @@ return { output: text.includes(substring) };`,
     title: "Slugify",
     description: "Convert text to a URL-safe slug",
     category: "Text",
-    code: `return { output: text
+    code: `return { output: inputs.text
   .normalize("NFKD").replace(/[\\u0300-\\u036f]/g, "")
   .replace(/[^\\w\\s-]/g, "")
   .replace(/[\\s_-]+/g, "-")
@@ -1336,9 +1336,9 @@ return { output: text.includes(substring) };`,
     description: "Count characters, words, or lines in text",
     category: "Text",
     code: `return {
-  chars: text.length,
-  words: text.split(/\\s+/).filter(Boolean).length,
-  lines: text.split(/\\r?\\n/).length
+  chars: inputs.text.length,
+  words: inputs.text.split(/\\s+/).filter(Boolean).length,
+  lines: inputs.text.split(/\\r?\\n/).length
 };`,
     tags: ["length", "count", "words", "lines", "characters"],
   },
@@ -1347,7 +1347,7 @@ return { output: text.includes(substring) };`,
     title: "Index Of",
     description: "Find the position of a substring",
     category: "Text",
-    code: `return { output: text.indexOf(substring) };`,
+    code: `return { output: inputs.text.indexOf(inputs.substring) };`,
     tags: ["index", "find", "position", "search", "indexOf"],
   },
   {
@@ -1355,7 +1355,7 @@ return { output: text.includes(substring) };`,
     title: "Surround / Wrap",
     description: "Wrap text with a prefix and suffix",
     category: "Text",
-    code: `return { output: prefix + text + suffix };`,
+    code: `return { output: inputs.prefix + inputs.text + inputs.suffix };`,
     tags: ["surround", "wrap", "prefix", "suffix", "bracket"],
   },
   {
@@ -1364,8 +1364,8 @@ return { output: text.includes(substring) };`,
     description: "Truncate text to a max length with optional ellipsis",
     category: "Text",
     code: `const maxLen = 100, ellipsis = "...";
-if (text.length <= maxLen) return { output: text };
-return { output: text.slice(0, maxLen - ellipsis.length) + ellipsis };`,
+if (inputs.text.length <= maxLen) return { output: inputs.text };
+return { output: inputs.text.slice(0, maxLen - ellipsis.length) + ellipsis };`,
     tags: ["truncate", "clip", "shorten", "ellipsis"],
   },
   {
@@ -1373,8 +1373,8 @@ return { output: text.slice(0, maxLen - ellipsis.length) + ellipsis };`,
     title: "Compare Text",
     description: "Compare two strings (equal, less, greater)",
     category: "Text",
-    code: `const result = a < b ? "less" : a > b ? "greater" : "equal";
-return { output: result, equal: a === b };`,
+    code: `const result = inputs.a < inputs.b ? "less" : inputs.a > inputs.b ? "greater" : "equal";
+return { output: result, equal: inputs.a === inputs.b };`,
     tags: ["compare", "sort", "order", "equal", "lexical"],
   },
   {
@@ -1384,7 +1384,7 @@ return { output: result, equal: a === b };`,
     category: "Text",
     code: `// 0 means unset; an exact length wins over min/max
 const minLength = 3, maxLength = 10, exactLength = 0;
-const len = text.length;
+const len = inputs.text.length;
 if (exactLength > 0) return { output: len === exactLength };
 if (minLength > 0 && len < minLength) return { output: false };
 if (maxLength > 0 && len > maxLength) return { output: false };
@@ -1400,7 +1400,7 @@ return { output: true };`,
     title: "Extract Regex Groups",
     description: "Extract capture groups from the first match",
     category: "Regex",
-    code: `const match = new RegExp(pattern).exec(text);
+    code: `const match = new RegExp(inputs.pattern).exec(inputs.text);
 return { output: match ? match.slice(1) : [] };`,
     tags: ["regex", "extract", "groups", "capture"],
   },
@@ -1409,7 +1409,7 @@ return { output: match ? match.slice(1) : [] };`,
     title: "Find All Matches",
     description: "Find all occurrences of a pattern",
     category: "Regex",
-    code: `const matches = [...text.matchAll(new RegExp(pattern, "g"))].map(m => m[0]);
+    code: `const matches = [...inputs.text.matchAll(new RegExp(inputs.pattern, "g"))].map(m => m[0]);
 return { output: matches };`,
     tags: ["regex", "find", "all", "matchAll", "global"],
   },
@@ -1418,7 +1418,7 @@ return { output: matches };`,
     title: "Regex Replace",
     description: "Replace text matching a regex pattern",
     category: "Regex",
-    code: `return { output: text.replace(new RegExp(pattern, "g"), replacement) };`,
+    code: `return { output: inputs.text.replace(new RegExp(inputs.pattern, "g"), inputs.replacement) };`,
     tags: ["regex", "replace", "substitute", "gsub"],
   },
   {
@@ -1426,7 +1426,7 @@ return { output: matches };`,
     title: "Regex Split",
     description: "Split text using a regex delimiter",
     category: "Regex",
-    code: `return { output: text.split(new RegExp(pattern)) };`,
+    code: `return { output: inputs.text.split(new RegExp(inputs.pattern)) };`,
     tags: ["regex", "split", "tokenize", "delimiter"],
   },
   {
@@ -1434,7 +1434,7 @@ return { output: matches };`,
     title: "Regex Validate",
     description: "Check if text matches a regex pattern",
     category: "Regex",
-    code: `return { output: new RegExp(pattern).test(text) };`,
+    code: `return { output: new RegExp(inputs.pattern).test(inputs.text) };`,
     tags: ["regex", "validate", "test", "check", "match"],
   },
   {
@@ -1443,7 +1443,7 @@ return { output: matches };`,
     description: "Find all matches and extract a specific capture group",
     category: "Regex",
     code: `const group = 1; // 0 = full match, 1+ = capture group
-const matches = [...text.matchAll(new RegExp(pattern, "g"))]
+const matches = [...inputs.text.matchAll(new RegExp(inputs.pattern, "g"))]
   .map(m => m[group])
   .filter(v => v !== undefined);
 return { output: matches };`,
@@ -1456,10 +1456,10 @@ return { output: matches };`,
     category: "Regex",
     code: `let count = 0;
 const maxReplacements = 2;
-const result = text.replace(new RegExp(pattern, "g"), (match) => {
+const result = inputs.text.replace(new RegExp(inputs.pattern, "g"), (match) => {
   if (count >= maxReplacements) return match;
   count++;
-  return replacement;
+  return inputs.replacement;
 });
 return { output: result };`,
     tags: ["regex", "replace", "count", "limit", "first"],
@@ -1474,7 +1474,7 @@ return { output: result };`,
     description: "Extract values using dot-path with wildcard support",
     category: "JSON",
     code: `// Supports: $.store.book[0].title, $.store.*, $.items[*].name
-const tokens = path.replace(/^\\$\\.?/, "").replace(/\\[(\\d+)\\]/g, ".$1").split(".").filter(Boolean);
+const tokens = inputs.path.replace(/^\\$\\.?/, "").replace(/\\[(\\d+)\\]/g, ".$1").split(".").filter(Boolean);
 let current = [data];
 for (const t of tokens) {
   const next = [];
@@ -1499,7 +1499,7 @@ return { output: current.length === 1 ? current[0] : current };`,
     title: "Basename / File Name",
     description: "Get the file name from a path, with and without extension",
     category: "Path",
-    code: `const p = String(path).replace(/\\/+$/, "");
+    code: `const p = String(inputs.path).replace(/\\/+$/, "");
 const base = p.slice(p.lastIndexOf("/") + 1);
 const dot = base.lastIndexOf(".");
 const ext = dot > 0 && base !== ".." ? base.slice(dot) : "";
@@ -1519,7 +1519,7 @@ return { output: base, stem: ext ? base.slice(0, -ext.length) : base };`,
     title: "Dirname / Get Directory",
     description: "Get the directory containing a path",
     category: "Path",
-    code: `const p = String(path).replace(/(?!^)\\/+$/, "");
+    code: `const p = String(inputs.path).replace(/(?!^)\\/+$/, "");
 const i = p.lastIndexOf("/");
 return { output: i < 0 ? "." : i === 0 ? "/" : p.slice(0, i) };`,
     tags: [
@@ -1536,7 +1536,7 @@ return { output: i < 0 ? "." : i === 0 ? "/" : p.slice(0, i) };`,
     title: "Split Path",
     description: "Split a path into directory and file name",
     category: "Path",
-    code: `const p = String(path).replace(/(?!^)\\/+$/, "");
+    code: `const p = String(inputs.path).replace(/(?!^)\\/+$/, "");
 const i = p.lastIndexOf("/");
 return {
   dirname: i < 0 ? "." : i === 0 ? "/" : p.slice(0, i),
@@ -1550,7 +1550,7 @@ return {
     description:
       "Split a path into root and extension (dotfiles have no extension)",
     category: "Path",
-    code: `const p = String(path).replace(/(?!^)\\/+$/, "");
+    code: `const p = String(inputs.path).replace(/(?!^)\\/+$/, "");
 const base = p.slice(p.lastIndexOf("/") + 1);
 const dot = base.lastIndexOf(".");
 const extension = dot > 0 && base !== ".." ? base.slice(dot) : "";
@@ -1570,7 +1570,7 @@ return { root: extension ? p.slice(0, -extension.length) : p, extension };`,
     title: "Join Paths",
     description: "Join path components into one normalized path",
     category: "Path",
-    code: `const joined = paths.map(String).filter(Boolean).join("/");
+    code: `const joined = inputs.paths.map(String).filter(Boolean).join("/");
 const abs = joined.startsWith("/");
 const trail = joined.length > 1 && joined.endsWith("/");
 const out = [];
@@ -1589,7 +1589,7 @@ return { output: trail && !result.endsWith("/") ? result + "/" : result };`,
     title: "Normalize Path",
     description: "Collapse redundant separators, '.' and '..' segments",
     category: "Path",
-    code: `const p = String(path);
+    code: `const p = String(inputs.path);
 const abs = p.startsWith("/");
 const trail = p.length > 1 && p.endsWith("/");
 const out = [];
@@ -1609,7 +1609,7 @@ return { output: trail && !result.endsWith("/") ? result + "/" : result };`,
     description: "Resolve a path against a base directory",
     category: "Path",
     code: `const base = "/workspace"; // directory relative paths resolve against
-const p = String(path);
+const p = String(inputs.path);
 const joined = p.startsWith("/") ? p : base.replace(/\\/+$/, "") + "/" + p;
 const out = [];
 for (const seg of joined.split("/")) {
@@ -1635,8 +1635,8 @@ return { output: "/" + out.join("/") };`,
   }
   return out;
 };
-const from = segs(start_path);
-const to = segs(target_path);
+const from = segs(inputs.start_path);
+const to = segs(inputs.target_path);
 let i = 0;
 while (i < from.length && i < to.length && from[i] === to[i]) i++;
 const up = new Array(from.length - i).fill("..");
@@ -1649,7 +1649,7 @@ return { output: [...up, ...to.slice(i)].join("/") };`,
     description: "All components of a path in one dictionary",
     category: "Path",
     code: `const base_dir = "/workspace"; // directory relative paths resolve against
-const p = String(path);
+const p = String(inputs.path);
 const trimmed = p.replace(/(?!^)\\/+$/, "");
 const i = trimmed.lastIndexOf("/");
 const basename = trimmed.slice(i + 1);
@@ -1690,7 +1690,7 @@ return {
     description: "Get the raw string from a file path value",
     category: "Path",
     code: `return {
-  output: typeof file_path === "string" ? file_path : String(file_path?.path ?? "")
+  output: typeof inputs.file_path === "string" ? inputs.file_path : String(inputs.file_path?.path ?? "")
 };`,
     tags: ["path to string", "string", "convert", "file path", "path", "raw"],
   },
@@ -1703,14 +1703,14 @@ return {
 // Wildcards: * matches any run of characters, ? matches one
 const rx = new RegExp(
   "^" +
-    String(pattern)
+    String(inputs.pattern)
       .replace(/[.+^\${}()|[\\]\\\\]/g, "\\\\$&")
       .replace(/\\*/g, ".*")
       .replace(/\\?/g, ".") +
     "$",
   case_sensitive ? "" : "i"
 );
-return { output: rx.test(String(filename)) };`,
+return { output: rx.test(String(inputs.filename)) };`,
     tags: [
       "match",
       "file name match",
@@ -1730,14 +1730,14 @@ return { output: rx.test(String(filename)) };`,
 // Wildcards: * matches any run of characters, ? matches one
 const rx = new RegExp(
   "^" +
-    String(pattern)
+    String(inputs.pattern)
       .replace(/[.+^\${}()|[\\]\\\\]/g, "\\\\$&")
       .replace(/\\*/g, ".*")
       .replace(/\\?/g, ".") +
     "$",
   case_sensitive ? "" : "i"
 );
-return { output: filenames.map(String).filter((name) => rx.test(name)) };`,
+return { output: inputs.filenames.map(String).filter((name) => rx.test(name)) };`,
     tags: [
       "filter",
       "filter file names",
@@ -1765,10 +1765,10 @@ return { output: filenames.map(String).filter((name) => rx.test(name)) };`,
   output: {
     name: "rect",
     attributes: {
-      x, y, width, height,
-      fill,
-      stroke,
-      "stroke-width": stroke_width
+      x: inputs.x, y: inputs.y, width: inputs.width, height: inputs.height,
+      fill: inputs.fill,
+      stroke: inputs.stroke,
+      "stroke-width": inputs.stroke_width
     }
   }
 };`,
@@ -1793,11 +1793,11 @@ return { output: filenames.map(String).filter((name) => rx.test(name)) };`,
   output: {
     name: "circle",
     attributes: {
-      cx, cy,
-      r: radius,
-      fill,
-      stroke,
-      "stroke-width": stroke_width
+      cx: inputs.cx, cy: inputs.cy,
+      r: inputs.radius,
+      fill: inputs.fill,
+      stroke: inputs.stroke,
+      "stroke-width": inputs.stroke_width
     }
   }
 };`,
@@ -1821,10 +1821,10 @@ return { output: filenames.map(String).filter((name) => rx.test(name)) };`,
   output: {
     name: "ellipse",
     attributes: {
-      cx, cy, rx, ry,
-      fill,
-      stroke,
-      "stroke-width": stroke_width
+      cx: inputs.cx, cy: inputs.cy, rx: inputs.rx, ry: inputs.ry,
+      fill: inputs.fill,
+      stroke: inputs.stroke,
+      "stroke-width": inputs.stroke_width
     }
   }
 };`,
@@ -1849,9 +1849,9 @@ return { output: filenames.map(String).filter((name) => rx.test(name)) };`,
   output: {
     name: "line",
     attributes: {
-      x1, y1, x2, y2,
-      stroke,
-      "stroke-width": stroke_width
+      x1: inputs.x1, y1: inputs.y1, x2: inputs.x2, y2: inputs.y2,
+      stroke: inputs.stroke,
+      "stroke-width": inputs.stroke_width
     }
   }
 };`,
@@ -1876,10 +1876,10 @@ return {
   output: {
     name: "polygon",
     attributes: {
-      points,
-      fill,
-      stroke,
-      "stroke-width": stroke_width
+      points: inputs.points,
+      fill: inputs.fill,
+      stroke: inputs.stroke,
+      "stroke-width": inputs.stroke_width
     }
   }
 };`,
@@ -1914,10 +1914,10 @@ return {
   output: {
     name: "path",
     attributes: {
-      d: path_data,
-      fill,
-      stroke,
-      "stroke-width": stroke_width
+      d: inputs.path_data,
+      fill: inputs.fill,
+      stroke: inputs.stroke,
+      "stroke-width": inputs.stroke_width
     }
   }
 };`,
@@ -1945,13 +1945,13 @@ return {
   output: {
     name: "text",
     attributes: {
-      x, y,
-      "font-family": font_family,
-      "font-size": font_size,
-      fill,
-      "text-anchor": text_anchor
+      x: inputs.x, y: inputs.y,
+      "font-family": inputs.font_family,
+      "font-size": inputs.font_size,
+      fill: inputs.fill,
+      "text-anchor": inputs.text_anchor
     },
-    content: text
+    content: inputs.text
   }
 };`,
     tags: ["text", "label", "typography", "font", "caption", "vector", "svg"],
@@ -1981,7 +1981,7 @@ return {
     name: "filter",
     attributes: { id },
     children: [
-      { name: "feGaussianBlur", attributes: { stdDeviation: std_deviation } }
+      { name: "feGaussianBlur", attributes: { stdDeviation: inputs.std_deviation } }
     ]
   }
 };`,
@@ -2004,10 +2004,10 @@ return {
     children: [
       {
         name: "feGaussianBlur",
-        attributes: { in: "SourceAlpha", stdDeviation: std_deviation }
+        attributes: { in: "SourceAlpha", stdDeviation: inputs.std_deviation }
       },
-      { name: "feOffset", attributes: { dx, dy } },
-      { name: "feFlood", attributes: { "flood-color": color } },
+      { name: "feOffset", attributes: { dx: inputs.dx, dy: inputs.dy } },
+      { name: "feFlood", attributes: { "flood-color": inputs.color } },
       { name: "feComposite", attributes: { operator: "in", in2: "SourceAlpha" } },
       {
         name: "feMerge",
@@ -2048,21 +2048,21 @@ return {
   output: {
     name: radial ? "radialGradient" : "linearGradient",
     attributes: radial
-      ? { id, cx: x1 + "%", cy: y1 + "%", r: x2 + "%" }
-      : { id, x1: x1 + "%", y1: y1 + "%", x2: x2 + "%", y2: y2 + "%" },
+      ? { id, cx: inputs.x1 + "%", cy: inputs.y1 + "%", r: inputs.x2 + "%" }
+      : { id, x1: inputs.x1 + "%", y1: inputs.y1 + "%", x2: inputs.x2 + "%", y2: inputs.y2 + "%" },
     children: [
       {
         name: "stop",
         attributes: {
           offset: "0%",
-          style: "stop-color:" + color1 + ";stop-opacity:1"
+          style: "stop-color:" + inputs.color1 + ";stop-opacity:1"
         }
       },
       {
         name: "stop",
         attributes: {
           offset: "100%",
-          style: "stop-color:" + color2 + ";stop-opacity:1"
+          style: "stop-color:" + inputs.color2 + ";stop-opacity:1"
         }
       }
     ]
@@ -2094,16 +2094,16 @@ return {
     description: "Translate, rotate, and scale an SVG element",
     category: "SVG",
     code: `const parts = [];
-if (translate_x || translate_y) {
-  parts.push("translate(" + translate_x + "," + translate_y + ")");
+if (inputs.translate_x || inputs.translate_y) {
+  parts.push("translate(" + inputs.translate_x + "," + inputs.translate_y + ")");
 }
-if (rotate) parts.push("rotate(" + rotate + ")");
-if (scale_x !== 1 || scale_y !== 1) {
-  parts.push("scale(" + scale_x + "," + scale_y + ")");
+if (inputs.rotate) parts.push("rotate(" + inputs.rotate + ")");
+if (inputs.scale_x !== 1 || inputs.scale_y !== 1) {
+  parts.push("scale(" + inputs.scale_x + "," + inputs.scale_y + ")");
 }
-const attributes = { ...content.attributes };
+const attributes = { ...inputs.content.attributes };
 if (parts.length) attributes.transform = parts.join(" ");
-return { output: { ...content, attributes } };`,
+return { output: { ...inputs.content, attributes } };`,
     tags: [
       "transform",
       "translate",
@@ -2133,10 +2133,10 @@ return {
   output: {
     name: "g",
     children: [
-      { name: "clipPath", attributes: { id }, children: [clip_content] },
+      { name: "clipPath", attributes: { id }, children: [inputs.clip_content] },
       {
-        ...content,
-        attributes: { ...content.attributes, "clip-path": "url(#" + id + ")" }
+        ...inputs.content,
+        attributes: { ...inputs.content.attributes, "clip-path": "url(#" + id + ")" }
       }
     ]
   }
@@ -2160,7 +2160,7 @@ return {
     title: "GET Text",
     description: "Fetch text content from a URL",
     category: "HTTP",
-    code: `const res = await fetch(url, { headers: { ...headers } });
+    code: `const res = await fetch(inputs.url, { headers: { ...inputs.headers } });
 return { output: await res.text(), status: res.status };`,
     tags: ["http", "get", "text", "fetch", "request", "api", "url", "download"],
   },
@@ -2169,7 +2169,7 @@ return { output: await res.text(), status: res.status };`,
     title: "GET JSON",
     description: "Fetch and parse JSON from a URL",
     category: "HTTP",
-    code: `const res = await fetch(url, { headers: { Accept: "application/json", ...headers } });
+    code: `const res = await fetch(inputs.url, { headers: { Accept: "application/json", ...inputs.headers } });
 if (res.json === undefined) throw new Error("Response is not JSON (status " + res.status + ")");
 return { output: res.json, status: res.status };`,
     tags: ["http", "get", "json", "fetch", "request", "api", "rest", "parse"],
@@ -2179,7 +2179,7 @@ return { output: res.json, status: res.status };`,
     title: "GET Bytes",
     description: "Download binary data from a URL as a Uint8Array",
     category: "HTTP",
-    code: `const res = await fetch(url, { headers: { ...headers } });
+    code: `const res = await fetch(inputs.url, { headers: { ...inputs.headers } });
 return { output: await res.bytes(), status: res.status };`,
     tags: ["http", "get", "bytes", "binary", "download", "fetch", "request", "api"],
   },
@@ -2188,10 +2188,10 @@ return { output: await res.bytes(), status: res.status };`,
     title: "POST JSON",
     description: "Send a POST request with a JSON body",
     category: "HTTP",
-    code: `const res = await fetch(url, {
+    code: `const res = await fetch(inputs.url, {
   method: "POST",
-  headers: { "Content-Type": "application/json", ...headers },
-  body: JSON.stringify(body)
+  headers: { "Content-Type": "application/json", ...inputs.headers },
+  body: JSON.stringify(inputs.body)
 });
 return { output: res.json === undefined ? res.body : res.json, status: res.status };`,
     tags: ["http", "post", "json", "send", "request", "api", "rest", "submit"],
@@ -2201,10 +2201,10 @@ return { output: res.json === undefined ? res.body : res.json, status: res.statu
     title: "PUT JSON",
     description: "Send a PUT request with a JSON body",
     category: "HTTP",
-    code: `const res = await fetch(url, {
+    code: `const res = await fetch(inputs.url, {
   method: "PUT",
-  headers: { "Content-Type": "application/json", ...headers },
-  body: JSON.stringify(body)
+  headers: { "Content-Type": "application/json", ...inputs.headers },
+  body: JSON.stringify(inputs.body)
 });
 return { output: res.json === undefined ? res.body : res.json, status: res.status };`,
     tags: ["http", "put", "update", "replace", "request", "api", "rest", "json"],
@@ -2214,10 +2214,10 @@ return { output: res.json === undefined ? res.body : res.json, status: res.statu
     title: "PATCH JSON",
     description: "Send a PATCH request with a JSON body",
     category: "HTTP",
-    code: `const res = await fetch(url, {
+    code: `const res = await fetch(inputs.url, {
   method: "PATCH",
-  headers: { "Content-Type": "application/json", ...headers },
-  body: JSON.stringify(body)
+  headers: { "Content-Type": "application/json", ...inputs.headers },
+  body: JSON.stringify(inputs.body)
 });
 return { output: res.json === undefined ? res.body : res.json, status: res.status };`,
     tags: ["http", "patch", "update", "modify", "request", "api", "rest", "json"],
@@ -2227,7 +2227,7 @@ return { output: res.json === undefined ? res.body : res.json, status: res.statu
     title: "DELETE",
     description: "Send a DELETE request and report whether it succeeded",
     category: "HTTP",
-    code: `const res = await fetch(url, { method: "DELETE", headers: { ...headers } });
+    code: `const res = await fetch(inputs.url, { method: "DELETE", headers: { ...inputs.headers } });
 return { output: res.ok, status: res.status };`,
     tags: ["http", "delete", "remove", "destroy", "request", "api", "rest"],
   },
@@ -2238,7 +2238,7 @@ return { output: res.ok, status: res.status };`,
     category: "HTTP",
     code: `// Rename the secret to whatever you stored under Settings -> Secrets
 const token = await getSecret("API_TOKEN");
-const res = await fetch(url, {
+const res = await fetch(inputs.url, {
   headers: { Accept: "application/json", Authorization: "Bearer " + token }
 });
 return { output: res.json === undefined ? res.body : res.json, status: res.status };`,
@@ -2250,10 +2250,10 @@ return { output: res.json === undefined ? res.body : res.json, status: res.statu
     description: "Run a GraphQL query or mutation against any endpoint",
     category: "HTTP",
     code: `// Add operationName here for multi-operation documents
-const res = await fetch(url, {
+const res = await fetch(inputs.url, {
   method: "POST",
   headers: { "Content-Type": "application/json", Accept: "application/json" },
-  body: JSON.stringify({ query, variables })
+  body: JSON.stringify({ query: inputs.query, variables: inputs.variables })
 });
 const json = res.json ?? {};
 return { data: json.data ?? null, errors: json.errors ?? [], status: res.status };`,
@@ -2267,10 +2267,10 @@ return { data: json.data ?? null, errors: json.errors ?? [], status: res.status 
     code: `const reqHeaders = { "Content-Type": "application/json", Accept: "application/json" };
 const token = await getSecret("GRAPHQL_AUTH_TOKEN");
 if (token) reqHeaders.Authorization = "Bearer " + token;
-const res = await fetch(url, {
+const res = await fetch(inputs.url, {
   method: "POST",
   headers: reqHeaders,
-  body: JSON.stringify({ query, variables })
+  body: JSON.stringify({ query: inputs.query, variables: inputs.variables })
 });
 const json = res.json ?? {};
 return { data: json.data ?? null, errors: json.errors ?? [], status: res.status };`,
@@ -2282,10 +2282,10 @@ return { data: json.data ?? null, errors: json.errors ?? [], status: res.status 
     description: "Send several GraphQL operations in one batched request",
     category: "HTTP",
     code: `// queries: [{ query, variables?, operationName? }, ...]
-const res = await fetch(url, {
+const res = await fetch(inputs.url, {
   method: "POST",
   headers: { "Content-Type": "application/json", Accept: "application/json" },
-  body: JSON.stringify(queries)
+  body: JSON.stringify(inputs.queries)
 });
 const json = res.json ?? [];
 return { output: Array.isArray(json) ? json : [json], status: res.status };`,
@@ -2298,7 +2298,7 @@ return { output: Array.isArray(json) ? json : [json], status: res.status };`,
     category: "HTTP",
     code: `const query = "{ __schema { queryType { name } mutationType { name } subscriptionType { name } " +
   "types { name kind fields { name type { name kind ofType { name kind } } } } } }";
-const res = await fetch(url, {
+const res = await fetch(inputs.url, {
   method: "POST",
   headers: { "Content-Type": "application/json", Accept: "application/json" },
   body: JSON.stringify({ query })
@@ -2318,7 +2318,7 @@ return { output: res.json ?? {}, types: schema ? schema.types.map(t => t.name) :
     category: "Markdown",
     code: `const maxLevel = 6; // deepest header level to keep (1-6)
 const headers = [];
-for (const line of String(markdown).split("\\n")) {
+for (const line of String(inputs.markdown).split("\\n")) {
   const m = line.match(/^(#{1,6})\\s+(.+)$/);
   if (m && m[1].length <= maxLevel) {
     headers.push({ level: m[1].length, text: m[2].trim(), index: headers.length });
@@ -2345,7 +2345,7 @@ return { output: headers };`,
 const links = [];
 // Autolinks need a scheme so inline HTML like <div> is not read as a link.
 const pattern = /\\[([^\\]]+)\\]\\(([^)]+)\\)|<([a-zA-Z][a-zA-Z0-9+.-]*:[^>\\s]+)>/g;
-for (const m of String(markdown).matchAll(pattern)) {
+for (const m of String(inputs.markdown).matchAll(pattern)) {
   if (m[1] && m[2]) links.push({ url: m[2], title: includeTitles ? m[1] : "" });
   else if (m[3]) links.push({ url: m[3], title: "" });
 }
@@ -2365,7 +2365,7 @@ return { output: links };`,
     description: "Extract fenced code blocks and their languages from markdown",
     category: "Markdown",
     code: `const blocks = [];
-for (const m of String(markdown).matchAll(/\`\`\`(\\w*)\\n([\\s\\S]*?)\\n\`\`\`/g)) {
+for (const m of String(inputs.markdown).matchAll(/\`\`\`(\\w*)\\n([\\s\\S]*?)\\n\`\`\`/g)) {
   blocks.push({ language: m[1] || "text", code: m[2].trim() });
 }
 return { output: blocks };`,
@@ -2386,7 +2386,7 @@ return { output: blocks };`,
     category: "Markdown",
     code: `const lists = [];
 let current = [];
-for (const line of String(markdown).split("\\n")) {
+for (const line of String(inputs.markdown).split("\\n")) {
   const m = line.match(/^\\s*[-*+]\\s+(.+)$/);
   if (m) current.push({ text: m[1].trim() });
   else if (current.length) { lists.push(current); current = []; }
@@ -2410,7 +2410,7 @@ return { output: lists };`,
     category: "Markdown",
     code: `const lists = [];
 let current = [];
-for (const line of String(markdown).split("\\n")) {
+for (const line of String(inputs.markdown).split("\\n")) {
   const m = line.match(/^\\s*\\d+\\.\\s+(.+)$/);
   if (m) current.push(m[1].trim());
   else if (current.length) { lists.push(current); current = []; }
@@ -2433,7 +2433,7 @@ return { output: lists };`,
     description: "Convert the first markdown table into dataframe rows",
     category: "Markdown",
     code: `const table = [];
-for (const line of String(markdown).split("\\n")) {
+for (const line of String(inputs.markdown).split("\\n")) {
   if (line.includes("|")) {
     table.push(line.split("|").slice(1, -1).map(c => c.trim()));
   } else if (table.length) break;
@@ -2466,7 +2466,7 @@ return { output: { rows } };`,
     title: "Base URL",
     description: "Extract scheme + host (the site root) from a full URL",
     category: "HTML",
-    code: `const parsed = new URL(url);
+    code: `const parsed = new URL(inputs.url);
 return { output: parsed.protocol + "//" + parsed.host };`,
     tags: [
       "base url",
@@ -2486,8 +2486,8 @@ return { output: parsed.protocol + "//" + parsed.host };`,
       "Extract every <a href> with its text, classified internal or external",
     category: "HTML",
     code: `const baseUrl = ""; // page URL — decides internal vs external
-const hrefs = await data.selectHtml(html, "a[href]", { attr: "href", limit: 1000 });
-const texts = await data.selectHtml(html, "a[href]", { limit: 1000 });
+const hrefs = await data.selectHtml(inputs.html, "a[href]", { attr: "href", limit: 1000 });
+const texts = await data.selectHtml(inputs.html, "a[href]", { limit: 1000 });
 const isInternal = (href) => {
   if (!href || href.startsWith("#")) return true;
   if (/^(mailto|tel|javascript):/i.test(href)) return false;
@@ -2524,7 +2524,7 @@ return { links, href: links[0]?.href ?? "", text: links[0]?.text ?? "" };`,
     description: "Collect every <img src> from HTML, resolved against a base URL",
     category: "HTML",
     code: `const baseUrl = ""; // page URL — resolves relative src values
-const srcs = await data.selectHtml(html, "img[src]", { attr: "src", limit: 1000 });
+const srcs = await data.selectHtml(inputs.html, "img[src]", { attr: "src", limit: 1000 });
 const resolve = (s) => {
   try { return new URL(s, baseUrl || undefined).href; } catch { return s; }
 };
@@ -2547,7 +2547,7 @@ return { images, image: images[0] ?? { uri: "", type: "image" } };`,
     description: "Collect <audio> and <audio><source> sources from HTML",
     category: "HTML",
     code: `const baseUrl = ""; // page URL — resolves relative src values
-const srcs = await data.selectHtml(html, "audio[src], audio source[src]", {
+const srcs = await data.selectHtml(inputs.html, "audio[src], audio source[src]", {
   attr: "src",
   limit: 1000
 });
@@ -2574,7 +2574,7 @@ return { audios, audio: audios[0] ?? { uri: "", type: "audio" } };`,
     category: "HTML",
     code: `const baseUrl = ""; // page URL — resolves relative src values
 const srcs = await data.selectHtml(
-  html,
+  inputs.html,
   "video[src], video source[src], iframe[src]",
   { attr: "src", limit: 1000 }
 );
@@ -2601,7 +2601,7 @@ return { videos, video: videos[0] ?? { uri: "", type: "video" } };`,
     description: "Read the page title and the description / keywords meta tags",
     category: "HTML",
     code: `const first = async (selector, attr) =>
-  (await data.selectHtml(html, selector, attr ? { attr, limit: 1 } : { limit: 1 }))[0] ?? null;
+  (await data.selectHtml(inputs.html, selector, attr ? { attr, limit: 1 } : { limit: 1 }))[0] ?? null;
 return {
   title: (await first("title")) || null,
   description: await first('meta[name="description"]', "content"),
@@ -2628,7 +2628,7 @@ return {
     title: "Validate Email",
     description: "Check whether a value is a syntactically valid email address",
     category: "Validation",
-    code: `return { output: /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z][A-Za-z0-9-]*$/.test(String(value).trim()) };`,
+    code: `return { output: /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z][A-Za-z0-9-]*$/.test(String(inputs.value).trim()) };`,
     tags: ["validate", "email", "check", "address", "valid"],
   },
   {
@@ -2638,8 +2638,8 @@ return {
     category: "Validation",
     code: `let ok = false;
 try {
-  const u = new URL(value);
-  ok = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(value) && u.host.length > 0;
+  const u = new URL(inputs.value);
+  ok = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(inputs.value) && u.host.length > 0;
 } catch (e) {
   ok = false;
 }
@@ -2651,7 +2651,7 @@ return { output: ok };`,
     title: "Validate IP Address",
     description: "Check whether a value is a valid IPv4 or IPv6 address",
     category: "Validation",
-    code: `const v = String(value);
+    code: `const v = String(inputs.value);
 const SEG = /^(25[0-5]|2[0-4]\\d|1\\d\\d|\\d{1,2})$/;
 const isIPv4 = (s) => {
   const parts = s.split(".");
@@ -2685,7 +2685,7 @@ return { is_ip: v4 || v6, is_ipv4: v4, is_ipv6: v6 };`,
     title: "Validate String",
     description: "Run common string checks at once and return one bool per check",
     category: "Validation",
-    code: `const v = String(value);
+    code: `const v = String(inputs.value);
 let isUrl = false;
 try {
   isUrl = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(v) && new URL(v).host.length > 0;
@@ -2714,7 +2714,7 @@ return {
     title: "Sanitize String",
     description: "HTML-escape and trim a string, plus the normalized email when applicable",
     category: "Validation",
-    code: `const v = String(value);
+    code: `const v = String(inputs.value);
 const trimmed = v.trim();
 const lowered = trimmed.toLowerCase();
 const isEmail = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z][A-Za-z0-9-]*$/.test(lowered);

--- a/web/src/lib/tools/__tests__/getGraphTool.test.ts
+++ b/web/src/lib/tools/__tests__/getGraphTool.test.ts
@@ -275,17 +275,18 @@ describe("ui_get_graph tool", () => {
       expect(errors.join("\n")).toContain("does not parse");
     });
 
-    it("reports a name that is neither a sandbox API nor an input", async () => {
+    it("reports an inputs read the node has no slot for", async () => {
       const errors = await codeGraph({
-        properties: { code: "return { out: lodash.sum(rows) };" },
+        properties: { code: "return { out: inputs.rows.concat(inputs.extra) };" },
         dynamic_properties: { rows: [] },
       });
-      expect(errors.join("\n")).toContain('"lodash"');
+      expect(errors.join("\n")).toContain('"inputs.extra"');
+      expect(errors.join("\n")).not.toContain('"inputs.rows"');
     });
 
     it("accepts inputs that arrive over an edge", async () => {
       const errors = await codeGraph(
-        { properties: { code: "return { out: text.length };" } },
+        { properties: { code: "return { out: inputs.text.length };" } },
         [{ id: "e1", source: "s1", target: "c1", sourceHandle: "output", targetHandle: "text" }],
         [{ id: "s1", type: "nodetool.constant.String", position: { x: -200, y: 0 }, data: {} }]
       );

--- a/web/src/lib/tools/builtin/getGraph.ts
+++ b/web/src/lib/tools/builtin/getGraph.ts
@@ -80,6 +80,10 @@ function validateCodeNode(
     ...Object.keys(asRecord(node.data?.dynamic_properties)),
     ...Object.keys(asRecord(node.data?.dynamic_inputs))
   ]);
+  // Reads off the `inputs` object that no slot or edge feeds. A bare undefined
+  // name (`lodash`) is not decidable here — that needs the sandbox global list,
+  // which lives in node-sdk's validator; `validate_workflow` and the run-time
+  // graph check report those.
   const undefinedNames = (inferInputKeysFromCode(code) ?? []).filter(
     (name) =>
       !available.has(name) && !connectedInputs.has(`${node.id}::${name}`)
@@ -87,8 +91,8 @@ function validateCodeNode(
   if (undefinedNames.length > 0) {
     errors.push(
       `Node ${nodeLabel}: the code reads ${undefinedNames
-        .map((name) => `"${name}"`)
-        .join(", ")}, which ${undefinedNames.length > 1 ? "are" : "is"} neither a sandbox API nor an input of this node.`
+        .map((name) => `"inputs.${name}"`)
+        .join(", ")}, which ${undefinedNames.length > 1 ? "are" : "is"} not an input of this node.`
     );
   }
 }

--- a/web/src/utils/__tests__/codeOutputInference.test.ts
+++ b/web/src/utils/__tests__/codeOutputInference.test.ts
@@ -66,117 +66,47 @@ describe("inferInputKeysFromCode", () => {
     expect(inferInputKeysFromCode("")).toBeNull();
   });
 
-  it("returns null when all variables are declared", () => {
-    expect(inferInputKeysFromCode("const x = 1;\nreturn { output: x };")).toBeNull();
+  it("returns null when the code reads no inputs", () => {
+    expect(inferInputKeysFromCode("return { out: 1 + 2 };")).toBeNull();
   });
 
-  it("detects undeclared variables as inputs", () => {
-    const result = inferInputKeysFromCode("return { output: a + b };");
-    expect(result).toContain("a");
-    expect(result).toContain("b");
+  it("reads names off the inputs object", () => {
+    const result = inferInputKeysFromCode(
+      "return { out: inputs.a + inputs.b };"
+    );
+    expect(result).toEqual(expect.arrayContaining(["a", "b"]));
+    expect(result).toHaveLength(2);
   });
 
-  it("ignores sandbox globals", () => {
-    const code = `const result = Math.sqrt(x);
-const data = JSON.parse(text);
-return { result, data };`;
-    const result = inferInputKeysFromCode(code);
-    expect(result).toContain("x");
-    expect(result).toContain("text");
-    expect(result).not.toContain("Math");
-    expect(result).not.toContain("JSON");
+  it("reads a bracketed string key", () => {
+    expect(inferInputKeysFromCode('return { out: inputs["a-b"] };')).toEqual([
+      "a-b"
+    ]);
   });
 
-  it("still offers `env` as an input, since a dynamic input shadows the stub", () => {
-    // The guest has an `env` stub, but user globals are exposed after it, so a
-    // Code node with an input named `env` reads the input. Treating the stub as
-    // reserved would drop the handle here and leave the code reading `{}`.
-    const result = inferInputKeysFromCode("return { output: env.API_HOST };");
-    expect(result).toContain("env");
+  it("ignores a bare identifier — inputs are not globals", () => {
+    // The old inference guessed that every undeclared name was an input, which
+    // is what let a stale sandbox-global list invent phantom slots.
+    expect(inferInputKeysFromCode("return { out: text + lodash };")).toBeNull();
   });
 
-  it("ignores the sandbox stubs a dynamic input cannot usefully replace", () => {
-    const code = `return { output: process.cwd() + Buffer.from(x).length };`;
-    const result = inferInputKeysFromCode(code);
-    expect(result).toContain("x");
-    expect(result).not.toContain("process");
-    expect(result).not.toContain("Buffer");
+  it("ignores a property named inputs on something else", () => {
+    expect(inferInputKeysFromCode("return { out: opts.inputs.a };")).toBeNull();
   });
 
-  it("ignores declared variables", () => {
-    const code = `const x = 10;
-let y = 20;
-return { output: x + y + z };`;
-    const result = inferInputKeysFromCode(code);
-    expect(result).toContain("z");
-    expect(result).not.toContain("x");
-    expect(result).not.toContain("y");
+  it("yields nothing when the body binds its own inputs", () => {
+    const code = "const inputs = { a: 1 };\nreturn { out: inputs.a };";
+    expect(inferInputKeysFromCode(code)).toBeNull();
   });
 
-  it("ignores sandbox bridges and guest helpers", () => {
-    const code = `const rows = await data.parseCsv(text);
-const when = await format.date(Date.now());
-const hash = toHex(await crypto.digest("SHA-256", text));
-progress(50);
-return { rows, when, hash };`;
-    const result = inferInputKeysFromCode(code);
-    expect(result).toContain("text");
-    for (const bridge of [
-      "data",
-      "format",
-      "crypto",
-      "progress",
-      "toHex",
-      "Date"
-    ]) {
-      expect(result).not.toContain(bridge);
-    }
+  it("yields nothing for a dynamic read it cannot enumerate", () => {
+    const code = "const k = 'a';\nreturn { out: inputs[k] };";
+    expect(inferInputKeysFromCode(code)).toBeNull();
   });
 
-  it("treats names the sandbox does not provide as inputs", () => {
-    // `_` and `dayjs` were never bridged into the guest; they are ordinary
-    // undefined variables and must surface as input handles.
-    const code = `const upper = _.toUpper(text);
-const now = dayjs();
-return { upper, now };`;
-    const result = inferInputKeysFromCode(code);
-    expect(result).toEqual(expect.arrayContaining(["_", "dayjs", "text"]));
-  });
-
-  it("ignores identifiers in comments and strings", () => {
-    const code = `// use myVar here
-const x = "hello world";
-return { output: input };`;
-    const result = inferInputKeysFromCode(code);
-    expect(result).toContain("input");
-    expect(result).not.toContain("myVar");
-    expect(result).not.toContain("hello");
-  });
-
-  it("handles function parameters as declared", () => {
-    const code = `const fn = (a, b) => a + b;
-return { output: fn(x, y) };`;
-    const result = inferInputKeysFromCode(code);
-    expect(result).toContain("x");
-    expect(result).toContain("y");
-    expect(result).not.toContain("a");
-    expect(result).not.toContain("b");
-  });
-
-  it("handles destructuring declarations", () => {
-    const code = `const { name, age } = person;
-return { output: name };`;
-    const result = inferInputKeysFromCode(code);
-    expect(result).toContain("person");
-    expect(result).not.toContain("name");
-    expect(result).not.toContain("age");
-  });
-
-  it("ignores workspace and state", () => {
-    const code = `const data = await workspace.read("file.txt");
-state.count = (state.count || 0) + 1;
-return { data };`;
-    const result = inferInputKeysFromCode(code);
-    expect(result).toBeNull();
+  it("ignores names in comments and strings", () => {
+    const code =
+      '// inputs.ghost is not read\nconst s = "inputs.other";\nreturn { out: inputs.real + s };';
+    expect(inferInputKeysFromCode(code)).toEqual(["real"]);
   });
 });

--- a/web/src/utils/codeOutputInference.test.ts
+++ b/web/src/utils/codeOutputInference.test.ts
@@ -74,143 +74,51 @@ describe("inferOutputKeysFromCode", () => {
 });
 
 describe("inferInputKeysFromCode", () => {
-  it("returns null for empty string", () => {
+  it("returns null for empty code", () => {
     expect(inferInputKeysFromCode("")).toBeNull();
   });
 
-  it("returns null for non-string input", () => {
-    expect(inferInputKeysFromCode(null as unknown as string)).toBeNull();
+  it("returns null when the code reads no inputs", () => {
+    expect(inferInputKeysFromCode("return { out: 1 + 2 };")).toBeNull();
   });
 
-  it("detects undeclared identifiers as inputs", () => {
-    const code = `return { result: inputData + 1 }`;
-    expect(inferInputKeysFromCode(code)).toEqual(["inputData"]);
+  it("reads names off the inputs object", () => {
+    const result = inferInputKeysFromCode(
+      "return { out: inputs.a + inputs.b };"
+    );
+    expect(result).toEqual(expect.arrayContaining(["a", "b"]));
+    expect(result).toHaveLength(2);
   });
 
-  it("excludes declared variables", () => {
-    const code = `
-      const x = 10;
-      let y = 20;
-      return { result: x + y }
-    `;
+  it("reads a bracketed string key", () => {
+    expect(inferInputKeysFromCode('return { out: inputs["a-b"] };')).toEqual([
+      "a-b"
+    ]);
+  });
+
+  it("ignores a bare identifier — inputs are not globals", () => {
+    // The old inference guessed that every undeclared name was an input, which
+    // is what let a stale sandbox-global list invent phantom slots.
+    expect(inferInputKeysFromCode("return { out: text + lodash };")).toBeNull();
+  });
+
+  it("ignores a property named inputs on something else", () => {
+    expect(inferInputKeysFromCode("return { out: opts.inputs.a };")).toBeNull();
+  });
+
+  it("yields nothing when the body binds its own inputs", () => {
+    const code = "const inputs = { a: 1 };\nreturn { out: inputs.a };";
     expect(inferInputKeysFromCode(code)).toBeNull();
   });
 
-  it("excludes sandbox globals", () => {
-    const code = `
-      const result = JSON.parse(Math.random().toString());
-      console.log(result);
-      return { result }
-    `;
+  it("yields nothing for a dynamic read it cannot enumerate", () => {
+    const code = "const k = 'a';\nreturn { out: inputs[k] };";
     expect(inferInputKeysFromCode(code)).toBeNull();
   });
 
-  it("excludes function declarations", () => {
-    const code = `
-      function helper(a, b) { return a + b; }
-      return { sum: helper(1, 2) }
-    `;
-    expect(inferInputKeysFromCode(code)).toBeNull();
-  });
-
-  it("excludes function expression names and params", () => {
-    const code = `
-      const fn = function process(item) { return item; };
-      return { out: fn(1) }
-    `;
-    expect(inferInputKeysFromCode(code)).toBeNull();
-  });
-
-  it("excludes arrow function params", () => {
-    const code = `
-      const fn = (item) => item * 2;
-      return { out: fn(1) }
-    `;
-    expect(inferInputKeysFromCode(code)).toBeNull();
-  });
-
-  it("does not count property accesses as inputs", () => {
-    const code = `return { result: myObj.someProp }`;
-    const inputs = inferInputKeysFromCode(code);
-    expect(inputs).toContain("myObj");
-    expect(inputs).not.toContain("someProp");
-  });
-
-  it("does not count object keys as inputs", () => {
-    const code = `return { foo: 123 }`;
-    expect(inferInputKeysFromCode(code)).toBeNull();
-  });
-
-  it("handles destructuring declarations", () => {
-    const code = `
-      const { a, b } = someInput;
-      return { sum: a + b }
-    `;
-    const inputs = inferInputKeysFromCode(code);
-    expect(inputs).toContain("someInput");
-    expect(inputs).not.toContain("a");
-    expect(inputs).not.toContain("b");
-  });
-
-  it("handles array destructuring", () => {
-    const code = `
-      const [first, ...rest] = items;
-      return { first, count: rest.length }
-    `;
-    const inputs = inferInputKeysFromCode(code);
-    expect(inputs).toContain("items");
-    expect(inputs).not.toContain("first");
-    expect(inputs).not.toContain("rest");
-  });
-
-  it("excludes class declarations", () => {
-    const code = `
-      class MyClass {}
-      return { instance: new MyClass() }
-    `;
-    expect(inferInputKeysFromCode(code)).toBeNull();
-  });
-
-  it("excludes catch clause params", () => {
-    const code = `
-      try { throw inputVal } catch (err) { return { error: err.message } }
-    `;
-    const inputs = inferInputKeysFromCode(code);
-    expect(inputs).toContain("inputVal");
-    expect(inputs).not.toContain("err");
-  });
-
-  it("returns null for invalid code", () => {
-    expect(inferInputKeysFromCode("{{{{ not valid")).toBeNull();
-  });
-
-  it("excludes import declarations", () => {
-    const code = `
-      import { foo } from "bar";
-      return { result: foo() }
-    `;
-    expect(inferInputKeysFromCode(code)).toBeNull();
-  });
-
-  it("detects multiple undeclared inputs", () => {
-    const code = `return { sum: a + b + c }`;
-    const inputs = inferInputKeysFromCode(code);
-    expect(inputs).toEqual(expect.arrayContaining(["a", "b", "c"]));
-    expect(inputs).toHaveLength(3);
-  });
-
-  it("excludes the data bridge but not names the sandbox lacks", () => {
-    // `_` and `dayjs` are not bridged into the guest, so a reference to one is
-    // an ordinary undefined variable and becomes an input. `data` is a real
-    // bridge (data.parseCsv / data.selectHtml) and is not.
-    const code = `
-      const rows = await data.parseCsv(text);
-      const result = _.map(rows, (x) => x * 2);
-      const d = dayjs();
-      return { result, d }
-    `;
-    const inputs = inferInputKeysFromCode(code);
-    expect(inputs).not.toContain("data");
-    expect(inputs).toEqual(expect.arrayContaining(["_", "dayjs", "text"]));
+  it("ignores names in comments and strings", () => {
+    const code =
+      '// inputs.ghost is not read\nconst s = "inputs.other";\nreturn { out: inputs.real + s };';
+    expect(inferInputKeysFromCode(code)).toEqual(["real"]);
   });
 });

--- a/web/src/utils/codeOutputInference.ts
+++ b/web/src/utils/codeOutputInference.ts
@@ -3,8 +3,7 @@
  *
  * Uses acorn to parse the code into an AST, then walks it to find:
  * - Outputs: keys of the object literal in the last `return { ... }` statement
- * - Inputs: identifiers that are referenced but never declared in the code
- *           and are not sandbox-provided globals
+ * - Inputs: names read off the `inputs` object
  */
 import * as acorn from "acorn";
 
@@ -96,63 +95,16 @@ function extractObjectKeys(objExpr: acorn.ObjectExpression): string[] {
 // ---------------------------------------------------------------------------
 
 /**
- * Identifiers provided by the sandbox or the Code node itself.
+ * Infer input names from JavaScript code.
  *
- * Mirrors the sandbox manifest in `@nodetool-ai/agents`
- * (`src/code-gen/sandbox-manifest.ts`), which web cannot import — the package
- * is not a web dependency and pulls in the QuickJS WASM runtime. A name that
- * does not exist in the sandbox keeps a real undefined variable from becoming
- * an input handle; a missing bridge name grows a bogus one. The pinning test
- * lives in `packages/agents/tests/sandbox-manifest-drift.test.ts`.
- */
-const SANDBOX_GLOBALS = new Set([
-  // Guest globals, as observed in the running QuickJS sandbox
-  "AggregateError", "Array", "ArrayBuffer", "BigInt", "BigInt64Array",
-  "BigUint64Array", "Boolean", "Buffer", "DataView", "Date", "Error",
-  "EvalError", "FinalizationRegistry", "Float32Array", "Float64Array",
-  "Headers", "Infinity", "Int16Array", "Int32Array", "Int8Array",
-  "InternalError", "JSON", "Map", "Math", "NaN", "Number", "Object",
-  "Promise", "Proxy", "RangeError", "ReferenceError", "Reflect", "RegExp",
-  "Request", "Response", "Set", "SharedArrayBuffer", "String", "Symbol",
-  "SyntaxError", "TextDecoder", "TextEncoder", "TypeError", "URIError",
-  "URL", "URLSearchParams", "Uint16Array", "Uint32Array", "Uint8Array",
-  "Uint8ClampedArray", "WeakMap", "WeakRef", "WeakSet", "decodeURI",
-  "decodeURIComponent", "encodeURI", "encodeURIComponent", "escape",
-  "globalThis", "isFinite", "isNaN", "parseFloat", "parseInt", "performance",
-  "process", "queueMicrotask", "undefined", "unescape",
-  // `env` is deliberately absent, though the guest has it. Dynamic inputs are
-  // exposed after the sandbox's stubs and shadow them, so a Code node with an
-  // input named `env` works — listing it here would drop that handle on
-  // re-inference and leave the code silently reading the empty stub. The
-  // node-sdk validator still accepts `env` as a resolvable name; the two lists
-  // answer different questions. Pinned by INTENTIONAL_OMISSIONS in
-  // packages/agents/tests/sandbox-manifest-drift.test.ts.
-  // Host bridges
-  "console", "fetch", "crypto", "uuid", "sleep", "getSecret", "workspace",
-  "assetToSandbox", "sandboxToAsset", "progress", "format", "data",
-  "image", "canvas",
-  // Pure guest helpers defined by the sandbox prelude
-  "toBase64", "fromBase64", "toHex", "fromHex", "utf8Encode", "utf8Decode",
-  "parallelMap", "createCanvas",
-  // Absent from this guest, but not user inputs either
-  "setTimeout", "clearTimeout", "setInterval", "clearInterval",
-  "setImmediate", "clearImmediate", "eval", "Function",
-  "btoa", "atob", "structuredClone", "Intl", "AbortController", "Blob",
-  "FormData",
-  // JS literals that acorn parses as Identifier nodes
-  "true", "false", "null",
-  "this", "arguments", "self", "window", "document",
-  // Code node reserved props
-  "code", "timeout", "state",
-  // Sandbox internals
-  "__maxIter",
-]);
-
-/**
- * Infer input variable names from JavaScript code.
+ * Declared inputs arrive on the `inputs` object, so inference is a scan for
+ * `inputs.name` / `inputs["name"]` rather than a guess at which undeclared
+ * identifier is a slot. That guess needed the full list of sandbox globals to
+ * subtract, and every name missing from it invented a phantom input.
  *
- * Finds identifiers that are referenced but not declared in the code
- * and not part of the sandbox globals.
+ * A body that shadows `inputs` with its own binding, or reaches for it
+ * dynamically (`inputs[key]`, `{...inputs}`), yields no names — there is
+ * nothing to enumerate.
  *
  * Returns an array of input names, or null if none found.
  */
@@ -160,109 +112,40 @@ export function inferInputKeysFromCode(code: string): string[] | null {
   const ast = tryParse(code);
   if (!ast) return null;
 
-  const declared = new Set<string>();
-  const referenced = new Set<string>();
-
-  // Collect all declarations
+  const shadowed = new Set<string>();
   walkAst(ast, (node) => {
     switch (node.type) {
       case "VariableDeclarator":
-        collectBindingNames(node.id, declared);
+        collectBindingNames(node.id, shadowed);
         break;
       case "FunctionDeclaration":
       case "FunctionExpression":
-        if (node.id?.name) declared.add(node.id.name);
-        for (const param of node.params) {
-          collectBindingNames(param, declared);
-        }
-        break;
       case "ArrowFunctionExpression":
-        for (const param of node.params) {
-          collectBindingNames(param, declared);
-        }
-        break;
-      case "ClassDeclaration":
-        if (node.id?.name) declared.add(node.id.name);
-        break;
-      case "CatchClause":
-        if (node.param) collectBindingNames(node.param, declared);
-        break;
-      case "ImportDeclaration":
-        for (const spec of node.specifiers) {
-          if (spec.local.name) declared.add(spec.local.name);
-        }
+        for (const param of node.params) collectBindingNames(param, shadowed);
         break;
     }
   });
+  if (shadowed.has("inputs")) return null;
 
-  // Collect all referenced identifiers (excluding property access and object keys)
+  const names = new Set<string>();
   walkAst(ast, (node, ancestors) => {
-    if (node.type !== "Identifier") return;
+    if (node.type !== "Identifier" || node.name !== "inputs") return;
     const parent = ancestors[ancestors.length - 2];
-    if (!parent) return;
-
-    // Skip if this is a property access (obj.prop — skip prop)
-    if (parent.type === "MemberExpression" && parent.property === node && !parent.computed) {
-      return;
-    }
-    // Skip if this is an object key in an object literal
-    if (parent.type === "Property" && parent.key === node && !parent.computed) {
-      return;
-    }
-    // Skip if this is a class member key (class A { foo() {} })
-    if (
-      (parent.type === "MethodDefinition" || parent.type === "PropertyDefinition") &&
-      parent.key === node &&
-      !parent.computed
-    ) {
-      return;
-    }
-    // Skip labels (declaration and break/continue references)
-    if (parent.type === "LabeledStatement" && parent.label === node) {
+    if (parent?.type !== "MemberExpression" || parent.object !== node) return;
+    if (!parent.computed && parent.property.type === "Identifier") {
+      names.add(parent.property.name);
       return;
     }
     if (
-      (parent.type === "BreakStatement" || parent.type === "ContinueStatement") &&
-      parent.label === node
+      parent.computed &&
+      parent.property.type === "Literal" &&
+      typeof parent.property.value === "string"
     ) {
-      return;
+      names.add(parent.property.value);
     }
-    // Skip meta properties (import.meta, new.target)
-    if (parent.type === "MetaProperty") {
-      return;
-    }
-    // Skip import/export specifier names (locals are collected as declared)
-    if (
-      parent.type === "ImportSpecifier" ||
-      parent.type === "ImportDefaultSpecifier" ||
-      parent.type === "ImportNamespaceSpecifier" ||
-      parent.type === "ExportSpecifier"
-    ) {
-      return;
-    }
-    // Skip declaration sites (already collected)
-    if (parent.type === "VariableDeclarator" && parent.id === node) {
-      return;
-    }
-    if (
-      (parent.type === "FunctionDeclaration" || parent.type === "FunctionExpression" ||
-       parent.type === "ClassDeclaration" || parent.type === "ClassExpression") &&
-      parent.id === node
-    ) {
-      return;
-    }
-
-    referenced.add(node.name);
   });
 
-  const inputs: string[] = [];
-  for (const ref of referenced) {
-    if (declared.has(ref)) continue;
-    if (SANDBOX_GLOBALS.has(ref)) continue;
-    inputs.push(ref);
-  }
-
-  return inputs.length > 0 ? inputs : null;
+  return names.size > 0 ? [...names] : null;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #4798 (merged). Rebased onto `main`, one commit.

## Why

A Code node's declared inputs shared the global namespace with the sandbox API. Two consequences, and the second is the expensive one:

1. An input named `env`, `data`, `format` or `performance` shadowed a bridge.
2. The shared namespace made every undeclared identifier ambiguous. Input inference had to *guess* that any free name which wasn't a sandbox global was a slot — so it needed the exact list of sandbox globals to subtract, and every name missing from that list invented a phantom input.

#4798 fixed one instance of (2). This removes the design that keeps producing them.

## What changes

`inputs.name` is read where `name` used to be.

- **Inference is a scan, not a guess.** The web editor's 99-line free-identifier walk and its hand-restated copy of the sandbox globals are both deleted. The drift test now pins one mirror instead of two, and the `INTENTIONAL_OMISSIONS` escape hatch #4798 added for `env` is gone along with the conflict that required it.
- **The validator's hedge splits in two.** "Neither a sandbox API nor an input" becomes either a bare read of a declared input, which names the rewrite (``Use `inputs.url` ``), or `inputs.missing`, which is its own `code_undefined_input`.
- **An input can be called anything.** Nothing it shares a name with matters any more.

## The migration

Breaking, so it ships with the rewrite rather than a note telling users to do it.

`migrateCodeBodyToInputs` (node-sdk) rewrites a body from the AST, so:
- a name inside a string, a comment, or an object key is left alone
- a shorthand property expands to `{ text: inputs.text }` instead of producing `{ text: inputs.text: inputs.text }` (a real bug the tests caught — acorn gives a shorthand property the same node for `key` and `value`, so the occurrence was recorded twice)
- a locally bound name is left alone
- a body that binds `inputs` itself is refused rather than silently repointed

`nodetool workflows migrate-code-inputs [--dry-run] [--user-id]` drives it over saved workflows, taking input names from declared slots, inline dynamic properties **and** edge-fed handles alike.

Everything shipped is migrated with that same function rather than by hand:
- **175 palette snippets** in `codeSnippets.ts`. Their inputs are inferred from their bodies, so without this they'd have silently lost every slot.
- The one shipped example (`Research Paper Summarizer`).
- 41 test bodies across `code-nodes`, `node-sdk` and `web`.

## Two things this surfaced

**`getGraph.ts` had a third copy of Code-node validation** that used `inferInputKeysFromCode` as a proxy for "undefined names". That only ever worked because the old inference returned every undeclared identifier. It now reports unknown `inputs.*` reads; bare undefined names need the sandbox global list, which lives in node-sdk's validator, so `validate_workflow` and the graph check own that case. Noted in a comment at the call site.

**The manifest grew `nodeGlobals`.** `inputs` and `state` are injected per run and appear in no guest snapshot, so `unknownApiReferences` had no way to account for prompts that name them — the drift guard from #4798 correctly flagged `inputs` the moment the prompt started using it.

## Verification

Re-run after the rebase onto `main`:

- `packages/node-sdk` — 770 passed (new `code-inputs-migration.test.ts`, 14 cases)
- `packages/code-nodes` — 258 passed
- `packages/agents` — 2185 passed
- `packages/cli` — 564 passed
- `web` — full Jest suite, 12646 passed
- `npm run validate:examples` — **249/249 graphs validate cleanly**, exit 0
- `npm run lint`, web `tsc --noEmit`, `packages/cli tsc --noEmit` — clean

## Known limitation

`parseCodeBody` wraps a body in a non-generator async function, so a body using `yield` (a streaming Code node) does not parse and is therefore skipped by the migration and by static analysis. Those bodies migrate by hand; the validator already reports nothing for them today, so this is a pre-existing blind spot rather than a new one. Worth closing separately by parsing as a generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQwBvmV7Wjxn5RFR8E1Mst