### PR TITLE
Wait for the E2E manifest, not just for the controller

### DIFF
--- a/web/tests/e2e-runner/suite.spec.ts
+++ b/web/tests/e2e-runner/suite.spec.ts
@@ -24,11 +24,17 @@ test("workflow suite executes and records artifacts", async ({ page }) => {
   });
 
   await page.goto("/e2e-runner.html?manual=1");
-  await page.waitForFunction(() => Boolean(window.__E2E__), undefined, {
-    timeout: 90_000
-  });
+  // The app installs `window.__E2E__` BEFORE it awaits `harness.init()`, so a
+  // controller that exists says nothing about the manifest having arrived.
+  // Wait for the manifest itself — reading it the moment the controller appears
+  // races the fetch and reports an empty suite.
+  await page
+    .waitForFunction(() => (window.__E2E__?.manifest().length ?? 0) > 0, undefined, {
+      timeout: 90_000
+    })
+    .catch(() => {});
 
-  const total = await page.evaluate(() => window.__E2E__!.manifest().length);
+  const total = await page.evaluate(() => window.__E2E__?.manifest().length ?? 0);
   expect(total, "manifest should list workflows").toBeGreaterThan(0);
 
   const screenshotsDir = resolve(ARTIFACT_DIR, "screenshots");


### PR DESCRIPTION
The E2E workflow suite failed on #4801 with `manifest should list workflows … Received: 0`, while the same job was green on `main`. It is a race in the driver, not in that PR.

`E2ERunnerApp` installs `window.__E2E__` **before** it awaits `harness.init()` — deliberately, so the ad-hoc `runGraph` path stays reachable when there is no manifest. `suite.spec.ts` waited only for the controller to exist and then read `manifest().length` immediately, which races the manifest fetch: on a slow load the suite sees zero workflows and fails.

## Changes

- `web/tests/e2e-runner/suite.spec.ts` waits for a non-empty manifest instead of for the controller alone. The wait is bounded (90s, same as before) and swallows only its own timeout — a manifest that never arrives still fails on the same assertion with the same message, rather than on a Playwright timeout.

## Testing

- `npx tsc --noEmit` and `eslint` clean in `web/`.
- The suite itself is the check on this PR: the E2E Workflow Runner job runs on any `packages/**` or `web/tests/e2e-runner/**` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uj6spPxbG1etGVo3bbtU9x


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uj6spPxbG1etGVo3bbtU9x)_