### PR TITLE
Minimize the QuickJS toolbelt and enable nodetool.* in Code nodes

### DIFF
--- a/docs/CODE_NODE_COVERAGE.md
+++ b/docs/CODE_NODE_COVERAGE.md
@@ -95,7 +95,7 @@ Verified against `packages/agents/src/js-sandbox.ts` by running code in it:
 | `Date`, ISO parse/format | yes |
 | `fetch()` (host-mediated, rate-limited) | yes |
 | `workspace.read/write/readBytes/writeBytes/list/stat/mkdir/remove` | yes |
-| `getSecret()`, `uuid()`, `sleep()`, `progress()` | yes |
+| `getSecret()`, `sleep()`, `progress()` | yes |
 | `crypto.digest/hmac/randomUUID/getRandomValues` | yes |
 | `data.parseCsv` (papaparse), `data.selectHtml` (cheerio) | yes |
 | `format.number/date/relativeTime/list` (host `Intl` bridge) | yes |

--- a/docs/execution-strategies.md
+++ b/docs/execution-strategies.md
@@ -144,7 +144,7 @@ workflow, and runs the same way in the browser and on the server: no Docker, no
 subprocess, no host interpreter.
 
 The guest gets standard JavaScript plus a fixed set of bridges — `fetch()`,
-workspace file access, `getSecret()`, `uuid()`, `sleep()`, `progress()`,
+workspace file access, `getSecret()`, `sleep()`, `progress()`,
 `crypto`, `format`, and CSV/HTML `data` helpers. Dynamic inputs arrive as
 globals; the keys of the returned object become the node's outputs.
 

--- a/docs/plans/code-node-ai-authoring.md
+++ b/docs/plans/code-node-ai-authoring.md
@@ -30,8 +30,8 @@ changes removed most of what the earlier draft of this plan had to build:
 - **The sandbox grew a real standard library.** `js-sandbox.ts` now bridges
   `format.*` (Intl number/date/relative-time/list), `data.parseCsv`
   (papaparse), `data.selectHtml` (cheerio), `crypto.*` (WebCrypto),
-  `progress()`, binary helpers (`toBase64`/`fromBase64`/`toHex`/`fromHex`,
-  `utf8Encode`/`utf8Decode`), extended `workspace`
+  `progress()`, binary helpers (`toBase64`/`fromBase64`/`toHex`/`fromHex`),
+  extended `workspace`
   (bytes/stat/mkdir/remove), and per-run limit overrides. The old gap —
   prompts advertising libraries the sandbox lacked — is now mostly a prompt
   bug, not a missing capability.

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -642,9 +642,11 @@ follows (CodeAct, ICML 2024): docs/codeact-design.md.
   `nodetool.apps` (`build/debug`), `nodetool.agents` (`run(prompt)` spawns a
   `run_subtask` child with a fresh context; fan out via
   `nodetool.batch(prompts, (p) => nodetool.agents.run(p))`), the single-node harness on `nodetool.nodes.run(type,
-  inputs)`, `nodetool.web` (one surface over every search/fetch tool:
-  `search(query, {provider})` picks the backend the belt carries — `"default"`,
-  `"openai"`, `"google"`, `"dataforseo"` pin one — plus `news`, `images`,
+  inputs)`, `nodetool.web` (the outside world:
+  `search(query, {provider})`, `news` and `images` call the routed search
+  tools — `web_search`/`google_news`/`google_images` pick the first configured
+  backend host-side, and `provider` pins one: `"default"`, `"openai"`,
+  `"google"`, `"dataforseo"` — plus
   `browse(url)`, `fetch(url)`, `download`, `screenshot`), `nodetool.memory`
   (`save/list/update/remove` over `thread_memory_*`), `nodetool.style`
   (`profile/record`), `nodetool.email` (`search/archive/label`), plus `assets`
@@ -670,12 +672,16 @@ follows (CodeAct, ICML 2024): docs/codeact-design.md.
   tools (`calculate`, `geometry`, `trigonometry`, `statistics`,
   `unit_conversion`) were deleted outright, MCP included; `run_code` and `js`
   remain for callers that want a code tool. `getAgentToolbelt()`
-  (`src/tools/builtin-tools.ts`) additionally drops the provider-specific media
-  duplicates `image_generation`, `openai_image_generation`,
+  (`src/tools/builtin-tools.ts`) additionally drops the provider-specific
+  duplicates: the media tools `image_generation`, `openai_image_generation`,
   `google_image_generation` and `openai_text_to_speech` — `nodetool.media`
   covers them through the provider-agnostic `generate_image` /
-  `generate_speech`. `getBuiltinTools()` still returns them, so MCP clients,
-  which have no object model, keep them.
+  `generate_speech` — and the search backends `openai_web_search`,
+  `google_grounded_search`, `dataforseo_search`, `dataforseo_news` and
+  `dataforseo_images`, which `web_search`/`google_news`/`google_images` reach
+  by routing across the configured backends host-side (`backend` pins one).
+  `getBuiltinTools()` still returns them all, so MCP clients, which have no
+  object model, keep them.
 - Eval suite `codeact` scores the executor on offline instrumented cases:
   `nodetool eval codeact -p <p> -m <m>`. Beyond the four toy-toolbelt cases
   it covers the full `nodetool.*` API surface: 19 cases over two

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -101,7 +101,7 @@ QuickJS's memory limiter counts its own heap objects; string and typed-array
 payloads are not charged against it, so `memoryLimitBytes` bites on object
 allocation, not on `new Uint8Array(n)`.
 
-Exposed guest surface: `console`, `fetch`, `uuid`, `sleep`, `getSecret`,
+Exposed guest surface: `console`, `fetch`, `sleep`, `getSecret`,
 `crypto.{randomUUID,getRandomValues,digest,hmac}` (WebCrypto-backed — `digest`
 and `hmac` take SHA-1/256/384/512 and accept string or `Uint8Array` input, both
 returning a `Uint8Array`), `workspace.{read,write,list,readBytes,writeBytes,
@@ -111,11 +111,14 @@ source for read containment and the destination for write containment;
 `stat` returns `{exists, size, isDirectory, isFile, isSymlink, modifiedMs,
 createdMs, accessedMs}` and reports a missing path as `exists: false` rather
 than throwing), the pure guest-side helpers
-`toBase64`/`fromBase64`/`toHex`/`fromHex`/`utf8Encode`/`utf8Decode`/
-`parallelMap`/`createCanvas`,
+`toBase64`/`fromBase64`/`toHex`/`fromHex`/`parallelMap`/`createCanvas`
+(UUIDs come from `crypto.randomUUID` and UTF-8 from the native
+`TextEncoder`/`TextDecoder` — the old `uuid`/`utf8Encode`/`utf8Decode`
+aliases are gone),
 `progress(percent, message?)`, `format.{number,date,relativeTime,list}`,
 `image.{info,decode,encode,resize,crop,rotate,flip,adjust,composite,convert}`,
-`canvas.{render,measureText}`,
+`canvas.measureText` (plus `canvas.render`, the undocumented plumbing behind
+`createCanvas(...).toBytes()`),
 `data.{parseCsv,toCsv,selectHtml,htmlToMarkdown,parseXlsx,parseYaml,toYaml,
 parseXml,unzip,zip,diff}`, and any caller-supplied `globals`. `fetch` sends a
 `Uint8Array` body as raw bytes instead of JSON.
@@ -629,16 +632,16 @@ follows (CodeAct, ICML 2024): docs/codeact-design.md.
   semantics and guards — snake_case auto ids, `connect()` id checks, handles
   that throw when stringified — cannot drift between the two surfaces), `nodetool.batch(items, fn, {concurrency})` for bounded fan-out (run a
   workflow once per CSV row), `nodetool.models` (`pick(capability)` resolves
-  one ranked model; `find`/`list` for the long form), `nodetool.providers`
-  (roster derived from the model catalog), and `nodetool.media`
+  one ranked model; `find`/`list` for the long form; `forProvider(provider)`
+  for one provider's own catalog), and `nodetool.media`
   (`generateImage/editImage/generateVideo/animateImage/speak/transcribe/embed`
   plus the judge loop `critique/compare/scoreAdherence`, each taking a
   pick/find result or `"provider/model_id"`), `nodetool.nodes`
   (`search/info/list` — the graph builder's discovery half),
   `nodetool.documents` (convert, PDF text/tables, markdown↔pdf),
   `nodetool.apps` (`build/debug`), `nodetool.agents` (`run(prompt)` spawns a
-  `run_subtask` child with a fresh context; `fanout(prompts, {concurrency})`
-  batches them), the single-node harness on `nodetool.nodes.run(type,
+  `run_subtask` child with a fresh context; fan out via
+  `nodetool.batch(prompts, (p) => nodetool.agents.run(p))`), the single-node harness on `nodetool.nodes.run(type,
   inputs)`, `nodetool.web` (one surface over every search/fetch tool:
   `search(query, {provider})` picks the backend the belt carries — `"default"`,
   `"openai"`, `"google"`, `"dataforseo"` pin one — plus `news`, `images`,
@@ -650,8 +653,8 @@ follows (CodeAct, ICML 2024): docs/codeact-design.md.
   `collections` (full RAG loop: `index/indexBatch/search/hybridSearch/query`),
   `timelines`, `sketches`, `scripts`, and `storyboards`. `workflows` also
   carries `resolve(sessionId, escalationId, action)` for interactive-run
-  escalations and `examples()`/`example("<package>/<name>")` feeding
-  `copyFrom`. Every method wraps a
+  escalations and `example("<package>/<name>")` feeding `copyFrom`
+  (`list({workflow_type: "example"})` enumerates the shipped examples). Every method wraps a
   belt tool, so gating and routing are untouched; a method whose backing tool
   is missing throws naming the tool, and the prompt section documents only the
   namespaces the belt can serve (`buildNodetoolApiPromptSection`). One surface

--- a/packages/agents/scripts/live-agents-harness.ts
+++ b/packages/agents/scripts/live-agents-harness.ts
@@ -106,11 +106,10 @@ const one = await nodetool.agents.run(
   "What is the capital of France? Reply with ONLY the city name."
 );
 
-const many = await nodetool.agents.fanout([
+const many = await nodetool.batch([
   "What is the capital of Japan? Reply with ONLY the city name.",
-  { prompt: "What is the capital of Italy? Reply with ONLY the city name.",
-    description: "Italy capital" }
-], { concurrency: 2 });
+  "What is the capital of Italy? Reply with ONLY the city name."
+], (p) => nodetool.agents.run(p), { concurrency: 2 });
 
 return {
   slug: { ok: slug.ok, out: slug.chunks },

--- a/packages/agents/scripts/live-nodetool-api.ts
+++ b/packages/agents/scripts/live-nodetool-api.ts
@@ -83,7 +83,7 @@ return runs.map((r) => ({
     // 3. Examples → copyFrom → inspect + revalidate.
     name: "example-copy",
     code: `
-const examples = await nodetool.workflows.examples({ limit: 50 });
+const examples = await nodetool.workflows.list({ workflow_type: "example", limit: 50 });
 const list = examples.workflows || examples;
 const pick = list.find((w) => /getting|start|hello|text/i.test(w.name)) || list[0];
 const full = await nodetool.workflows.example(
@@ -103,10 +103,17 @@ return {
 };`
   },
   {
-    // 4. Providers → pick → one cheap image (skips without a t2i provider).
+    // 4. Model catalog → pick → one cheap image (skips without a t2i provider).
     name: "media-pick",
     code: `
-const providers = await nodetool.providers.list();
+const catalog = await nodetool.models.list({ limit: 1000 });
+const byProvider = {};
+for (const m of (catalog.results || [])) {
+  byProvider[m.provider] = (byProvider[m.provider] || 0) + 1;
+}
+const providers = Object.keys(byProvider).map(
+  (p) => ({ provider: p, models: byProvider[p] })
+);
 let picked = null;
 let image = null;
 try {

--- a/packages/agents/src/code-gen/sandbox-manifest.ts
+++ b/packages/agents/src/code-gen/sandbox-manifest.ts
@@ -105,7 +105,8 @@ export interface SandboxManifest {
   readonly blockedGlobals: readonly string[];
   /**
    * Globals the Code node injects per run, on top of what the guest has:
-   * the declared inputs arrive on `inputs`, and `state` persists across runs.
+   * the declared inputs arrive on `inputs`, `state` persists across runs, and
+   * the tool bridge preludes define `tools` and the `nodetool` object model.
    * Not in the guest snapshot — nothing puts them there until a node runs.
    */
   readonly nodeGlobals: readonly string[];
@@ -935,7 +936,7 @@ export function getSandboxManifest(): SandboxManifest {
     guestHelpers: GUEST_HELPER_DOCS,
     nativeGlobals: native,
     blockedGlobals: blocked,
-    nodeGlobals: [CODE_INPUTS_GLOBAL, "state"],
+    nodeGlobals: [CODE_INPUTS_GLOBAL, "state", "nodetool", "tools"],
     limits: [...overridableLimits(), ...fixedLimits()],
     notes: [
       {
@@ -959,6 +960,10 @@ export function getSandboxManifest(): SandboxManifest {
       },
       {
         text: "There is no module loader and no Intl. Anything a library would do comes from the bridges below."
+      },
+      {
+        text: "The platform object model is available as `nodetool` (with the raw `tools` bridge under it): nodetool.capabilities() reports which namespaces are live in this environment; a method whose backing tool is missing throws naming that tool. Tool-backed calls can spend money (media generation, workflow runs) and reach the web — permission gating stays with the tools themselves.",
+        audience: "code-node"
       }
     ]
   };

--- a/packages/agents/src/code-gen/sandbox-manifest.ts
+++ b/packages/agents/src/code-gen/sandbox-manifest.ts
@@ -53,6 +53,13 @@ export interface SandboxBridgeDoc {
   readonly kind: "function" | "namespace";
   readonly description: string;
   readonly members: readonly SandboxMemberDoc[];
+  /**
+   * Members that exist and work but are plumbing behind a guest helper
+   * (e.g. `canvas.render` behind `createCanvas(...).toBytes()`). They stay in
+   * `sandboxManifestNames` — a reference to one is not a phantom — but the
+   * prompt/doc renderers never advertise them.
+   */
+  readonly internalMembers?: readonly SandboxMemberDoc[];
   /** Sandbox plumbing, not part of the authoring surface. */
   readonly internal?: boolean;
 }
@@ -188,19 +195,6 @@ const BRIDGE_DOCS: { [K in ExposedBridgeName]: SandboxBridgeDoc } = {
         signature: "await crypto.hmac(algorithm, key, data) -> Uint8Array",
         description: "HMAC over a string or Uint8Array key and payload.",
         async: true
-      }
-    ]
-  },
-  uuid: {
-    name: "uuid",
-    kind: "function",
-    description: "Shorthand for crypto.randomUUID.",
-    members: [
-      {
-        name: "uuid",
-        signature: "uuid() -> string",
-        description: "Random UUID v4.",
-        async: false
       }
     ]
   },
@@ -469,7 +463,7 @@ const BRIDGE_DOCS: { [K in ExposedBridgeName]: SandboxBridgeDoc } = {
         name: "data.unzip",
         signature: "await data.unzip(bytes) -> {path: Uint8Array}",
         description:
-          "Extract a zip archive to a map of entry path to content bytes (utf8Decode for text entries).",
+          "Extract a zip archive to a map of entry path to content bytes (new TextDecoder().decode(...) for text entries).",
         async: true
       },
       {
@@ -580,23 +574,25 @@ const BRIDGE_DOCS: { [K in ExposedBridgeName]: SandboxBridgeDoc } = {
     name: "canvas",
     kind: "namespace",
     description:
-      "Draw with a real Canvas 2D context. Use createCanvas for the familiar " +
-      "API; these are the raw calls behind it.",
+      "Canvas 2D text metrics. Drawing itself goes through createCanvas, " +
+      "whose toBytes renders the recorded calls host-side.",
     members: [
-      {
-        name: "canvas.render",
-        signature:
-          "await canvas.render(spec) -> Uint8Array // spec: { width, height, background, format, quality, gradients, ops }",
-        description:
-          "Replay a recorded draw list and encode the result. createCanvas builds the spec for you.",
-        async: true
-      },
       {
         name: "canvas.measureText",
         signature:
           "await canvas.measureText(text, font?) -> { width, actualBoundingBoxAscent, actualBoundingBoxDescent, ... }",
         description:
           "Text metrics for a CSS font string, so text can be laid out before it is drawn.",
+        async: true
+      }
+    ],
+    internalMembers: [
+      {
+        name: "canvas.render",
+        signature:
+          "await canvas.render(spec) -> Uint8Array // spec: { width, height, background, format, quality, gradients, ops }",
+        description:
+          "The machinery behind createCanvas(...).toBytes(): replay a recorded draw list and encode the result.",
         async: true
       }
     ]
@@ -635,18 +631,6 @@ const GUEST_HELPER_DOCS: { [K in GuestHelperName]: SandboxMemberDoc } = {
     description: "Decode hex to bytes.",
     async: false
   },
-  utf8Encode: {
-    name: "utf8Encode",
-    signature: "utf8Encode(text) -> Uint8Array",
-    description: "UTF-8 encode.",
-    async: false
-  },
-  utf8Decode: {
-    name: "utf8Decode",
-    signature: "utf8Decode(bytes) -> string",
-    description: "UTF-8 decode.",
-    async: false
-  },
   parallelMap: {
     name: "parallelMap",
     signature:
@@ -660,7 +644,7 @@ const GUEST_HELPER_DOCS: { [K in GuestHelperName]: SandboxMemberDoc } = {
     signature:
       "createCanvas(width, height) -> { width, height, getContext, toBytes, toSpec }",
     description:
-      "A Canvas 2D surface. getContext with \"2d\" returns a context taking the usual calls — fillRect, arc, fillText, drawImage, createLinearGradient, save, translate, rotate — synchronously; awaiting toBytes with an options object of format, quality and background renders them and returns the encoded image. drawImage takes image bytes, not an image object, and toSpec hands the recorded draw list to canvas.render instead.",
+      "A Canvas 2D surface. getContext with \"2d\" returns a context taking the usual calls — fillRect, arc, fillText, drawImage, createLinearGradient, save, translate, rotate — synchronously; awaiting toBytes with an options object of format, quality and background renders them and returns the encoded image. drawImage takes image bytes, not an image object, and toSpec returns the recorded draw list.",
     async: false
   }
 };
@@ -808,7 +792,6 @@ export const GUEST_GLOBALS_SNAPSHOT: readonly string[] = [
   "BigInt64Array",
   "BigUint64Array",
   "Boolean",
-  "Buffer",
   "DataView",
   "Date",
   "Error",
@@ -816,7 +799,6 @@ export const GUEST_GLOBALS_SNAPSHOT: readonly string[] = [
   "FinalizationRegistry",
   "Float32Array",
   "Float64Array",
-  "Headers",
   "Infinity",
   "Int16Array",
   "Int32Array",
@@ -834,8 +816,6 @@ export const GUEST_GLOBALS_SNAPSHOT: readonly string[] = [
   "ReferenceError",
   "Reflect",
   "RegExp",
-  "Request",
-  "Response",
   "Set",
   "SharedArrayBuffer",
   "String",
@@ -864,7 +844,6 @@ export const GUEST_GLOBALS_SNAPSHOT: readonly string[] = [
   "decodeURIComponent",
   "encodeURI",
   "encodeURIComponent",
-  "env",
   "escape",
   "fetch",
   "format",
@@ -878,8 +857,6 @@ export const GUEST_GLOBALS_SNAPSHOT: readonly string[] = [
   "parallelMap",
   "parseFloat",
   "parseInt",
-  "performance",
-  "process",
   "progress",
   "queueMicrotask",
   "sandboxToAsset",
@@ -888,9 +865,6 @@ export const GUEST_GLOBALS_SNAPSHOT: readonly string[] = [
   "toHex",
   "undefined",
   "unescape",
-  "utf8Decode",
-  "utf8Encode",
-  "uuid",
   "workspace"
 ];
 
@@ -908,7 +882,12 @@ const ABSENT_GLOBALS = [
   "Intl",
   "atob",
   "btoa",
-  "structuredClone"
+  "structuredClone",
+  // Removed aliases: crypto.randomUUID replaces uuid(), and the native
+  // TextEncoder/TextDecoder replace the utf8 helpers.
+  "utf8Decode",
+  "utf8Encode",
+  "uuid"
 ] as const;
 
 /**
@@ -980,9 +959,6 @@ export function getSandboxManifest(): SandboxManifest {
       },
       {
         text: "There is no module loader and no Intl. Anything a library would do comes from the bridges below."
-      },
-      {
-        text: "`process`, `env` and `Buffer` exist but are the sandbox's own stubs, not Node's: `process.env` is empty and the working directory is \"/\". Nothing reaches the host through them."
       }
     ]
   };
@@ -997,6 +973,7 @@ export function sandboxManifestNames(
   for (const bridge of Object.values(manifest.bridges)) {
     names.add(bridge.name);
     for (const member of bridge.members) names.add(member.name);
+    for (const member of bridge.internalMembers ?? []) names.add(member.name);
   }
   for (const helper of Object.values(manifest.guestHelpers)) {
     names.add(helper.name);

--- a/packages/agents/src/code-gen/sandbox-prompt.ts
+++ b/packages/agents/src/code-gen/sandbox-prompt.ts
@@ -117,7 +117,7 @@ export function renderSandboxApiReference(
 
 /**
  * Identifier-like API references in a block of instruction text: bare calls
- * (`uuid(`) and dotted access (`data.parseCsv`). Returns the root name of each,
+ * (`sleep(`) and dotted access (`data.parseCsv`). Returns the root name of each,
  * which is what has to exist in the sandbox.
  */
 export function extractApiReferences(text: string): string[] {

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -33,7 +33,6 @@ export const NODETOOL_API_NAMESPACE_TOOLS: Record<string, readonly string[]> = {
   nodes: ["search_nodes", "get_node_info", "list_nodes", "run_node"],
   agents: ["run_subtask"],
   models: ["find_model", "list_models", "list_provider_models"],
-  providers: ["list_models", "list_provider_models"],
   media: [
     "generate_image",
     "edit_image",
@@ -175,20 +174,6 @@ const nodetool = (() => {
     return fn;
   };
   const __merge = (a, b) => Object.assign({}, a || {}, b || {});
-
-  /**
-   * \`taste_profile\` is a prompt block (a string). Accept the full record
-   * \`profileDetails()\` returns too, so passing either shape works.
-   */
-  const __taste = (opts) => {
-    const merged = __merge(opts);
-    const profile = merged.taste_profile;
-    if (profile && typeof profile === "object" &&
-        typeof profile.profile === "string") {
-      merged.taste_profile = profile.profile;
-    }
-    return merged;
-  };
 
   /**
    * Accept a GraphBuilder, a bare {nodes, edges}, or a workflow record —
@@ -405,21 +390,6 @@ const nodetool = (() => {
           text.split(/\\s+/).slice(0, 6).join(" ") ||
           "Subtask";
         return __need("run_subtask")({ description: description, prompt: text });
-      },
-      /**
-       * Fan out sub-agents over prompts (strings or {prompt, description})
-       * with nodetool.batch semantics: bounded concurrency, one settled
-       * {ok, value | error} entry per prompt.
-       */
-      fanout(prompts, opts) {
-        return api.batch(
-          Array.from(prompts),
-          (p) =>
-            typeof p === "string"
-              ? api.agents.run(p, opts)
-              : api.agents.run(p.prompt, __merge(opts, { description: p.description })),
-          opts
-        );
       }
     },
 
@@ -462,9 +432,6 @@ const nodetool = (() => {
             action: action
           })
         ),
-      /** Shipped example workflows — id, name, description, tags only. */
-      examples: (opts) =>
-        __need("list_workflows")(__merge(opts, { workflow_type: "example" })),
       /**
        * One example workflow, graph included — ready for
        * nodetool.graph().copyFrom(...). Name is "<package>/<example>", or
@@ -487,7 +454,7 @@ const nodetool = (() => {
           throw new Error(
             "nodetool.workflows.example: name an example — " +
             '"<package>/<example>", or (example, {package}). ' +
-            "nodetool.workflows.examples() lists them."
+            'nodetool.workflows.list({workflow_type: "example"}) lists them.'
           );
         }
         return __need("get_example_workflow")({
@@ -529,38 +496,10 @@ const nodetool = (() => {
         }
         return results[0];
       },
-      list: (opts) => __need("list_models")(__merge(opts))
-    },
-
-    providers: {
-      /** Configured providers, derived from the model catalog: one entry per
-       * provider with its model count and the model types it serves. */
-      async list() {
-        const res = await __need("list_models")({ limit: 1000 });
-        const byProvider = {};
-        for (const m of (res && res.results) || []) {
-          const entry =
-            byProvider[m.provider] ||
-            (byProvider[m.provider] = {
-              provider: m.provider,
-              models: 0,
-              types: []
-            });
-          entry.models++;
-          if (m.type && entry.types.indexOf(m.type) < 0) {
-            entry.types.push(m.type);
-          }
-        }
-        const list = Object.keys(byProvider).map((key) => byProvider[key]);
-        if (list.length === 0 && res && res.note) {
-          return { providers: [], note: res.note };
-        }
-        return list;
-      },
-      models: (provider, opts) =>
-        __has("list_provider_models")
-          ? tools.list_provider_models(__merge(opts, { provider: provider }))
-          : __need("list_models")(__merge(opts, { provider: provider }))
+      list: (opts) => __need("list_models")(__merge(opts)),
+      /** One provider's own catalog. */
+      forProvider: (provider, opts) =>
+        __need("list_provider_models")(__merge(opts, { provider: provider }))
     },
 
     media: {
@@ -603,7 +542,7 @@ const nodetool = (() => {
       critique: (image, brief, model, opts) =>
         __need("critique_image")(
           __merge(
-            __taste(opts),
+            opts,
             __merge(__model(model), { image: image, brief: brief })
           )
         ),
@@ -611,7 +550,7 @@ const nodetool = (() => {
       compare: (images, brief, model, opts) =>
         __need("compare_images")(
           __merge(
-            __taste(opts),
+            opts,
             __merge(__model(model), { images: images, brief: brief })
           )
         ),
@@ -725,8 +664,7 @@ const nodetool = (() => {
     style: {
       /**
        * The user's accumulated taste as a prompt-ready block: a string, which
-       * is what generation prompts and \`taste_profile\` take. Use
-       * \`profileDetails()\` for the individual preference records.
+       * is what generation prompts and \`taste_profile\` take.
        */
       profile: (opts) =>
         __need("get_style_profile")(__merge(opts)).then((r) =>
@@ -734,8 +672,6 @@ const nodetool = (() => {
             ? r.profile
             : r
         ),
-      /** The same profile plus the preference items behind it. */
-      profileDetails: (opts) => __need("get_style_profile")(__merge(opts)),
       /** Record one preference learned from a choice or a correction. */
       record: (takeaway, opts) =>
         __need("record_style_preference")(
@@ -748,9 +684,7 @@ const nodetool = (() => {
       /** Image assets as lightweight handles — feed an id to view_image. */
       images: (opts) => __need("list_images")(__merge(opts)),
       search: (query, opts) =>
-        __has("asset_search")
-          ? tools.asset_search(__merge(opts, { query: query }))
-          : __need("list_assets")(__merge(opts, { query: query })),
+        __need("asset_search")(__merge(opts, { query: query })),
       get: (id) => __need("get_asset")({ asset_id: id }),
       save: (name, opts) => __need("save_asset")(__merge(opts, { name: name })),
       read: (name, opts) => __need("read_asset")(__merge(opts, { name: name }))
@@ -946,7 +880,7 @@ interface PromptEntry {
 const NAMESPACE_DOCS: PromptEntry[] = [
   {
     namespace: "workflows",
-    doc: `- \`nodetool.workflows\` — \`list()\` and \`examples()\` return \`{workflows}\`
+    doc: `- \`nodetool.workflows\` — \`list()\` returns \`{workflows}\`
   (an envelope, not a bare array), \`get(id)\`, \`run(id, params, {interactive})\`,
   \`start(id, params)\` (background job), \`debug(id, params)\`, \`validate(idOrGraph)\`,
   \`create(name, graph, {description, tags})\`, \`open(id?)\` (the editable object
@@ -955,7 +889,7 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   {outputs, reason, apply_to})\` — retry/substitute/skip/end_stream/fail — and
   get the next escalation or the final report. Write the whole
   run-and-resolve loop (\`while (report.status === "escalated") ...\`) in one
-  action. \`examples()\` lists the shipped
+  action. \`list({workflow_type: "example"})\` enumerates the shipped
   example workflows and \`example("<package>/<name>")\` loads one with its
   graph, ready for \`nodetool.graph().copyFrom(...)\`.`
   },
@@ -985,8 +919,8 @@ const NAMESPACE_DOCS: PromptEntry[] = [
     namespace: "agents",
     doc: `- \`nodetool.agents\` — delegate to sub-agents. \`await run(prompt, {description})\`
   spawns a child with this belt's tools but a FRESH context: the prompt must be
-  self-contained (ask for JSON in it when you want structure back).
-  \`fanout(prompts, {concurrency})\` runs several with batch semantics — one
+  self-contained (ask for JSON in it when you want structure back). Fan out
+  with \`nodetool.batch(prompts, (p) => nodetool.agents.run(p))\` — one
   settled \`{ok, value | error}\` entry per prompt. Delegate work that benefits
   from a fresh focused context, not one-tool errands.`
   },
@@ -996,13 +930,9 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   (e.g. \`pick("text_to_image")\` → \`{provider, model_id}\`), \`find(capability,
   {task, provider_hint, prefer_local, limit})\` for the ranked list (returns
   \`{results}\`),
-  \`list({provider, model_type})\` to browse. Never guess a model id — pick one,
+  \`list({provider, model_type})\` to browse, \`forProvider(provider)\` for one
+  provider's own catalog. Never guess a model id — pick one,
   then pass it to \`nodetool.media.*\` or into node properties.`
-  },
-  {
-    namespace: "providers",
-    doc: `- \`nodetool.providers\` — \`list()\` (configured providers with model counts and
-  types), \`models(provider)\` (one provider's catalog).`
   },
   {
     namespace: "media",
@@ -1050,9 +980,8 @@ const NAMESPACE_DOCS: PromptEntry[] = [
     namespace: "style",
     doc: `- \`nodetool.style\` — the user's accumulated taste. \`profile({query, k})\`
   returns a string block to inject into generation prompts and to pass as
-  \`taste_profile\` to \`nodetool.media.critique/compare\`
-  (\`profileDetails()\` returns that block plus the preference records behind
-  it); \`record(takeaway, {chosen, rejected, brief})\` saves one preference
+  \`taste_profile\` to \`nodetool.media.critique/compare\`;
+  \`record(takeaway, {chosen, rejected, brief})\` saves one preference
   whenever the user picks between candidates or corrects a style.`
   },
   {
@@ -1206,6 +1135,14 @@ Reach for a \`ui_*\` tool only for what a server-side edit cannot do:
 
 If you do not know the document's id, find it with \`list()\` on the namespace.`;
 
+/**
+ * Heading of the prompt section {@link buildNodetoolApiPromptSection} renders.
+ * `buildCodeActSystemPrompt` keys on it to know the `nodetool` object model is
+ * loaded — and then documents `nodetool.batch` as THE fan-out primitive
+ * instead of the bare-sandbox `parallelMap` helper.
+ */
+export const NODETOOL_API_SECTION_HEADER = "# The `nodetool` object model";
+
 export function buildNodetoolApiPromptSection(
   toolNames: Iterable<string>
 ): string {
@@ -1218,7 +1155,7 @@ export function buildNodetoolApiPromptSection(
   if (active.length === 0) return "";
 
   const sections: string[] = [
-    `# The \`nodetool\` object model`,
+    NODETOOL_API_SECTION_HEADER,
     `Platform objects — workflows, graphs, models, media, documents — are
 driven through \`nodetool.*\`, not through raw \`tools.*\` calls. The backing
 tools are deliberately absent from the tool catalog above; this object model

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -54,13 +54,8 @@ export const NODETOOL_API_NAMESPACE_TOOLS: Record<string, readonly string[]> = {
   ],
   web: [
     "web_search",
-    "openai_web_search",
-    "google_grounded_search",
-    "google_images",
     "google_news",
-    "dataforseo_search",
-    "dataforseo_news",
-    "dataforseo_images",
+    "google_images",
     "http_request",
     "download_file",
     "browser",
@@ -182,53 +177,18 @@ const nodetool = (() => {
   const __graphJson = __graphJsonOf;
 
   /**
-   * A backend that is registered but unusable — no key, no configuration.
-   * The belt carries the tool, so \`__has\` says yes and only the call finds
-   * out; that is a reason to try the next backend, not to fail the search.
+   * Build the args for a routed web-search tool. The tool routes across the
+   * configured backends host-side; \`opts.provider\` maps onto its \`backend\`
+   * pin (\`aliases\` translates the old guest names — "default", "google" —
+   * onto the tool's backend enum; other values pass through).
    */
-  const __unconfigured = (message) =>
-    /api[_ -]?key|not configured|unconfigured|no credential|credentials|missing|unauthorized|forbidden|401|403/i
-      .test(String(message || ""));
-
-  /**
-   * Route a web query to one of several interchangeable backing tools.
-   * \`choices\` is [providerName, toolName, queryField][] in preference order.
-   * \`opts.provider\` pins one — it is then the only backend tried, and its
-   * failure is the call's failure. Otherwise backends are tried in order and
-   * an unconfigured one falls through to the next; exhausting them all throws
-   * with every error.
-   */
-  const __pickWeb = async (method, opts, choices, query) => {
-    const rest = __merge(opts);
-    const wanted = rest.provider;
-    delete rest.provider;
-    const text = String(query === undefined || query === null ? "" : query);
-    const failures = [];
-    for (const choice of choices) {
-      if (wanted !== undefined && wanted !== choice[0]) continue;
-      if (!__has(choice[1])) continue;
-      const args = __merge(rest);
-      args[choice[2]] = text;
-      try {
-        return await tools[choice[1]](args);
-      } catch (e) {
-        const message = e && e.message ? e.message : String(e);
-        if (wanted !== undefined) throw e;
-        if (!__unconfigured(message)) throw e;
-        failures.push(choice[0] + " (" + choice[1] + "): " + message);
-      }
-    }
-    if (failures.length > 0) {
-      throw new Error(
-        "nodetool.web." + method + ": every available backend is " +
-        "unconfigured — " + failures.join("; ")
-      );
-    }
-    throw new Error(
-      "nodetool.web." + method + ": no backing tool on this belt" +
-      (wanted !== undefined ? ' for provider "' + wanted + '"' : "") +
-      " (tried " + choices.map((c) => c[1]).join(", ") + ")."
-    );
+  const __webArgs = (opts, aliases, field, query) => {
+    const args = __merge(opts);
+    const provider = args.provider;
+    delete args.provider;
+    if (provider !== undefined) args.backend = aliases[provider] || provider;
+    args[field] = String(query === undefined || query === null ? "" : query);
+    return args;
   };
 
   /**
@@ -587,41 +547,21 @@ const nodetool = (() => {
 
     web: {
       /**
-       * Search the web. Providers in preference order: "default"
-       * (web_search), "openai", "google", "dataforseo". Naming one that is
-       * not on the belt throws and says so.
+       * Search the web. \`web_search\` routes across the configured backends
+       * host-side; \`opts.provider\` pins one — "default", "openai", "google"
+       * (grounded/Gemini), "dataforseo".
        */
       search: (query, opts) =>
-        __pickWeb(
-          "search",
-          opts,
-          [
-            ["default", "web_search", "query"],
-            ["openai", "openai_web_search", "query"],
-            ["google", "google_grounded_search", "query"],
-            ["dataforseo", "dataforseo_search", "keyword"]
-          ],
-          query
+        __need("web_search")(
+          __webArgs(opts, { google: "gemini" }, "query", query)
         ),
       news: (query, opts) =>
-        __pickWeb(
-          "news",
-          opts,
-          [
-            ["google", "google_news", "keyword"],
-            ["dataforseo", "dataforseo_news", "keyword"]
-          ],
-          query
+        __need("google_news")(
+          __webArgs(opts, { google: "serpapi" }, "keyword", query)
         ),
       images: (query, opts) =>
-        __pickWeb(
-          "images",
-          opts,
-          [
-            ["google", "google_images", "keyword"],
-            ["dataforseo", "dataforseo_images", "keyword"]
-          ],
-          query
+        __need("google_images")(
+          __webArgs(opts, { google: "serpapi" }, "keyword", query)
         ),
       /** One HTTP request; returns the response body as text. */
       fetch: (url, opts) => __need("http_request")(__merge(opts, { url: url })),
@@ -960,10 +900,10 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   },
   {
     namespace: "web",
-    doc: `- \`nodetool.web\` — the outside world. \`await search(query, {provider})\` picks
-  the best search backend this belt carries (\`provider\` pins one:
-  \`"default"\`, \`"openai"\`, \`"google"\`, \`"dataforseo"\`), \`news(query)\` and
-  \`images(query)\` are the vertical searches. \`browse(url)\` returns a page's
+    doc: `- \`nodetool.web\` — the outside world. \`await search(query, {provider})\`,
+  \`news(query)\` and \`images(query)\` route across the configured search
+  backends host-side; \`provider\` pins one (\`"default"\`, \`"openai"\`,
+  \`"google"\`, \`"dataforseo"\`). \`browse(url)\` returns a page's
   readable text, \`fetch(url, {method, headers, body})\` is a raw HTTP request,
   \`download(url, outputFile)\` saves bytes into the workspace, and
   \`screenshot(url, outputFile)\` renders a page to PNG.`

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -10,9 +10,30 @@ import {
   type SandboxManifest
 } from "../code-gen/sandbox-manifest.js";
 import { extractApiReferences } from "../code-gen/sandbox-prompt.js";
+import { NODETOOL_API_SECTION_HEADER } from "./nodetool-api.js";
 import { renderToolCatalog, type ToolSignatureSource } from "./tool-api.js";
 
-const ACTION_CONTRACT_BASE = `# CodeAct Execution
+/**
+ * The bounded fan-out primitive the concurrency bullet advertises. One per
+ * prompt: with the `nodetool` object model loaded, `nodetool.batch` is THE
+ * fan-out primitive and the bare-sandbox `parallelMap` helper is not also
+ * documented (it stays available). Without the object model, `parallelMap`
+ * is the only one there is.
+ */
+const BOUNDED_FANOUT_PARALLEL_MAP = `Use
+  \`await parallelMap(items, async (x) => …, 5)\` when the list is long enough
+  that unbounded fan-out would blow a rate limit or the per-action tool
+  budget; it preserves input order and keeps at most N in flight.`;
+
+const BOUNDED_FANOUT_NODETOOL_BATCH = `Use
+  \`await nodetool.batch(items, async (x) => …, {concurrency: 5})\` when the
+  list is long enough that unbounded fan-out would blow a rate limit or the
+  per-action tool budget; it keeps at most N in flight and settles each entry
+  as \`{ok, value | error}\` instead of rejecting.`;
+
+const actionContractBase = (
+  boundedFanout: string
+) => `# CodeAct Execution
 
 You act by writing JavaScript. Each turn, call the \`execute_code\` tool with a
 program; it runs in a sandbox and the observation (return value, console logs,
@@ -35,10 +56,7 @@ Rules:
   \`await\` is the most common way an action wastes wall-clock. A call starts
   its work when invoked, not when awaited, so
   \`await Promise.all(items.map(x => tools.foo(x)))\` fans out for real —
-  ten independent lookups take one round trip, not ten. Use
-  \`await parallelMap(items, async (x) => …, 5)\` when the list is long enough
-  that unbounded fan-out would blow a rate limit or the per-action tool
-  budget; it preserves input order and keeps at most N in flight.
+  ten independent lookups take one round trip, not ten. ${boundedFanout}
   \`Promise.allSettled\` when some are allowed to fail. Sequence only what
   genuinely depends on a previous result.
 - \`state\` is a plain object that persists across your actions in this step.
@@ -57,14 +75,19 @@ Rules:
 - A failed tool call throws; use try/catch when partial failure is acceptable.
 - Top-level \`await\` and \`return\` work.`;
 
-const ACTION_CONTRACT_STEP = `${ACTION_CONTRACT_BASE}
+const actionContractStep = (
+  boundedFanout: string
+) => `${actionContractBase(boundedFanout)}
 - For file work use the sandbox's own \`workspace.*\` API (\`read\`, \`write\`,
   \`list\`, \`readBytes\`, \`writeBytes\`, \`stat\`, \`copy\`, \`move\`, \`mkdir\`,
   \`remove\`) — it is in-process, so a read costs nothing a tool call would.
 - Do not ask the user questions. Choose a reasonable assumption and proceed.`;
 
-function actionContractChat(unavailable: readonly string[]): string {
-  return `${ACTION_CONTRACT_BASE}
+function actionContractChat(
+  unavailable: readonly string[],
+  boundedFanout: string
+): string {
+  return `${actionContractBase(boundedFanout)}
 - Network, secrets, files, and assets are available only through \`tools.*\`,
   so permission checks and approvals cannot be bypassed. Unusable here:
   ${unavailable.map((name) => `\`${name}\``).join(", ")} — a chat action runs
@@ -155,7 +178,8 @@ function relevantNotes(
 /** Compact, manifest-derived sandbox reference: signatures only. */
 function renderSandboxSummary(
   manifest: SandboxManifest,
-  variant: "step" | "chat"
+  variant: "step" | "chat",
+  nodetoolApiLoaded: boolean
 ): string {
   const unavailableInChat = new Set(chatUnavailableBridges(manifest));
   const lines: string[] = [];
@@ -167,6 +191,12 @@ function renderSandboxSummary(
     }
   }
   for (const helper of Object.values(manifest.guestHelpers)) {
+    // One fan-out primitive per prompt: with the `nodetool` object model
+    // loaded, `nodetool.batch` is the documented one and `parallelMap` is
+    // not also advertised (it stays available in the sandbox).
+    if (nodetoolApiLoaded && helper.signature.includes("parallelMap")) {
+      continue;
+    }
     lines.push(`- ${helper.signature}`);
   }
   const besides =
@@ -221,12 +251,18 @@ export function buildCodeActSystemPrompt(
 ): string {
   const manifest = options.manifest ?? getSandboxManifest();
   const variant = options.variant ?? "step";
+  const nodetoolApiLoaded = (options.extraSections ?? []).some((section) =>
+    section.includes(NODETOOL_API_SECTION_HEADER)
+  );
+  const boundedFanout = nodetoolApiLoaded
+    ? BOUNDED_FANOUT_NODETOOL_BATCH
+    : BOUNDED_FANOUT_PARALLEL_MAP;
   const sections: string[] = [];
   if (options.preamble?.trim()) sections.push(options.preamble.trim());
   sections.push(
     variant === "chat"
-      ? actionContractChat(chatUnavailableBridges(manifest))
-      : ACTION_CONTRACT_STEP
+      ? actionContractChat(chatUnavailableBridges(manifest), boundedFanout)
+      : actionContractStep(boundedFanout)
   );
   if (variant === "chat") {
     sections.push(CHAT_COMPLETION);
@@ -266,6 +302,6 @@ export function buildCodeActSystemPrompt(
   for (const section of options.extraSections ?? []) {
     if (section.trim()) sections.push(section.trim());
   }
-  sections.push(renderSandboxSummary(manifest, variant));
+  sections.push(renderSandboxSummary(manifest, variant, nodetoolApiLoaded));
   return sections.join("\n\n");
 }

--- a/packages/agents/src/codeact/tool-api.ts
+++ b/packages/agents/src/codeact/tool-api.ts
@@ -24,6 +24,9 @@ import {
 } from "../tools/image-injection.js";
 import { GRAPH_MODEL_GLOBALS } from "./graph-model.js";
 import { NODETOOL_API_GLOBALS } from "./nodetool-api.js";
+import { TOOLS_PRELUDE } from "./tools-prelude.js";
+
+export { TOOLS_PRELUDE } from "./tools-prelude.js";
 
 /** Tool-call ceiling per code action; a runaway guest loop stops here. */
 export const DEFAULT_MAX_TOOL_CALLS_PER_ACTION = 50;
@@ -248,22 +251,11 @@ export function buildCoreProviderTools(options: {
 
 /**
  * Guest-side prelude prepended to every code action. Builds `tools.<name>()`
- * wrappers over `__callTool` and `finish()` over `__finish`.
+ * wrappers over `__callTool` (via {@link TOOLS_PRELUDE}) and `finish()` over
+ * `__finish`. Hosts without a `__finish` bridge — the Code node — prepend
+ * `TOOLS_PRELUDE` alone.
  */
-export const CODEACT_PRELUDE = `
-const tools = {};
-for (const __toolName of __toolNames) {
-  tools[__toolName] = async (args) => {
-    const __r = await __callTool(
-      __toolName,
-      JSON.stringify(args === undefined ? {} : args)
-    );
-    if (!__r || __r.ok !== true) {
-      throw new Error(__r && __r.error ? __r.error : "tool call failed: " + __toolName);
-    }
-    return __r.result;
-  };
-}
+export const CODEACT_PRELUDE = `${TOOLS_PRELUDE}
 async function finish(result) {
   const __r = await __finish(JSON.stringify(result === undefined ? null : result));
   if (!__r || __r.ok !== true) {

--- a/packages/agents/src/codeact/tools-prelude.ts
+++ b/packages/agents/src/codeact/tools-prelude.ts
@@ -1,0 +1,28 @@
+/**
+ * The `tools.<name>()` wrapper prelude — a leaf module with no imports, so a
+ * browser bundle can carry it without dragging in the toolbelt or any host
+ * bridge machinery. `CODEACT_PRELUDE` (codeact executors) layers `finish()`
+ * and `searchTools()` on top; `nodetool.code.Code` prepends this plus the
+ * `nodetool` object-model prelude directly.
+ *
+ * Guest contract: the host installs `__toolNames` (string[]) and `__callTool`
+ * (a never-rejecting bridge resolving `{ok, result|error}` envelopes) as
+ * sandbox globals. With `__toolNames = []` the loop defines nothing and the
+ * `nodetool` prelude degrades to an empty `capabilities()` with every method
+ * throwing the name of its missing tool.
+ */
+export const TOOLS_PRELUDE = `
+const tools = {};
+for (const __toolName of __toolNames) {
+  tools[__toolName] = async (args) => {
+    const __r = await __callTool(
+      __toolName,
+      JSON.stringify(args === undefined ? {} : args)
+    );
+    if (!__r || __r.ok !== true) {
+      throw new Error(__r && __r.error ? __r.error : "tool call failed: " + __toolName);
+    }
+    return __r.result;
+  };
+}
+`;

--- a/packages/agents/src/evals/codeact-api-core.ts
+++ b/packages/agents/src/evals/codeact-api-core.ts
@@ -1,6 +1,6 @@
 /**
  * CodeAct eval cases for the CORE `nodetool.*` namespaces — workflows, graph,
- * nodes, models, providers, media, jobs, assets, agents (plus `batch`).
+ * nodes, models, media, jobs, assets, agents (plus `batch`).
  *
  * The belt below is a set of fakes named exactly like the real tools, so the
  * executor lights up the object model, its prompt section, and the guest
@@ -1249,7 +1249,7 @@ export const CODEACT_API_CORE_CASES: readonly CodeActEvalCase[] = [
       required: ["provider", "model", "uris"]
     },
     createTools: createCoreApiTools,
-    namespaces: ["providers", "models", "media"],
+    namespaces: ["models", "media"],
     expect: {
       requiredTools: ["list_models", "find_model", "generate_image"],
       maxActions: 5,

--- a/packages/agents/src/evals/codeact-api-surfaces.ts
+++ b/packages/agents/src/evals/codeact-api-surfaces.ts
@@ -805,8 +805,9 @@ function resolveShots(doc: StoryboardDoc, targets: unknown): Shot[] {
 
 /**
  * Instrumented fakes for the data + creative belt tools, over a fresh world.
- * `web_search` is deliberately unconfigured, so `nodetool.web.search` has to
- * fall through to the next backend the way it does on a real half-keyed belt.
+ * `web_search` is the one search entry point — the real tool routes across
+ * its configured backends host-side, so the belt carries no per-provider
+ * search duplicates.
  */
 export function createSurfaceApiTools(recorder: CodeActToolRecorder): Tool[] {
   const world = createWorld();
@@ -991,18 +992,8 @@ export function createSurfaceApiTools(recorder: CodeActToolRecorder): Tool[] {
     // -- web --------------------------------------------------------------
     tool(
       "web_search",
-      "Default web search backend.",
-      obj({ query: S }, ["query"]),
-      () => {
-        // The half-keyed belt: registered, unusable. `nodetool.web.search`
-        // reads this as a reason to try the next backend.
-        throw new Error("search provider api key not configured");
-      }
-    ),
-    tool(
-      "openai_web_search",
-      "Web search through the OpenAI backend.",
-      obj({ query: S, max_results: N }, ["query"]),
+      "Search the web (routes across configured backends host-side).",
+      obj({ query: S, backend: S, max_results: N }, ["query"]),
       (params) => {
         const query = str(params["query"]);
         const ranked = WEB_PAGES.map((page) => ({
@@ -1013,7 +1004,7 @@ export function createSurfaceApiTools(recorder: CodeActToolRecorder): Tool[] {
         }))
           .sort((a, b) => b.score - a.score || a.url.localeCompare(b.url))
           .slice(0, num(params["max_results"], 5));
-        return { provider: "openai", query, results: ranked };
+        return { query, results: ranked };
       }
     ),
     tool(
@@ -1918,7 +1909,7 @@ export const CODEACT_API_SURFACE_CASES: readonly CodeActEvalCase[] = [
       "sandbox"
     ]),
     expect: {
-      requiredTools: ["openai_web_search"],
+      requiredTools: ["web_search"],
       maxActions: 4,
       resultCheck: (r: unknown) =>
         asString(field(r, "url")) ===

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -7,10 +7,10 @@
  * between host and guest (unlike Node's `node:vm`, which shares the V8 heap).
  *
  * The exposed surface is a small curated one: vanilla JavaScript plus a handful
- * of bridge functions (`fetch`, `workspace`, `getSecret`, `uuid`, `sleep`,
+ * of bridge functions (`fetch`, `workspace`, `getSecret`, `sleep`,
  * `assetToSandbox`, `sandboxToAsset`, `crypto`, `console`, `progress`,
  * `format`, `data`, `image`, `canvas`) and a few pure guest-side helpers
- * (`toBase64`, `fromBase64`, `toHex`, `fromHex`, `utf8Encode`, `utf8Decode`,
+ * (`toBase64`, `fromBase64`, `toHex`, `fromHex`,
  * `parallelMap`, `createCanvas`). `crypto`
  * covers `randomUUID`, `getRandomValues`, `digest`, and `hmac`
  * (WebCrypto-backed); `workspace` covers text and binary reads/writes plus
@@ -1314,8 +1314,6 @@ export function buildSandbox(
     }
   };
 
-  const uuid = () => globalThis.crypto.randomUUID();
-
   // WebCrypto exists in both Node >= 20 and browsers, so no node:crypto import
   // is needed and the sandbox stays browser-safe. `getRandomValues` is the one
   // synchronous member: it clamps instead of throwing, since a host throw does
@@ -2145,7 +2143,6 @@ export function buildSandbox(
     // Bridge functions — the only non-native surface the sandbox exposes.
     fetch: sandboxedFetch,
     crypto: sandboxCrypto,
-    uuid,
     sleep,
     getSecret,
     workspace,
@@ -2333,7 +2330,6 @@ export const EXPOSED_BRIDGE_NAMES = [
   "console",
   "fetch",
   "crypto",
-  "uuid",
   "sleep",
   "getSecret",
   "workspace",
@@ -2355,16 +2351,34 @@ export const GUEST_HELPER_NAMES = [
   "fromBase64",
   "toHex",
   "fromHex",
-  "utf8Encode",
-  "utf8Decode",
   "parallelMap",
   "createCanvas"
 ] as const;
 
 export type GuestHelperName = (typeof GUEST_HELPER_NAMES)[number];
 
-/** Globals the prelude removes so the guest cannot re-enter code generation. */
-export const DELETED_GUEST_GLOBALS = ["eval", "Function"] as const;
+/**
+ * Globals the init prelude removes. `eval` and `Function` go so the guest
+ * cannot re-enter code generation. The rest are stubs
+ * `@sebastianwessel/quickjs` installs unconditionally (its node-compatibility
+ * layer and `provideEnv` have no off switch): `Buffer`, `process`, `env`,
+ * `Headers`, `Request`, `Response`, `performance`. Nothing in the sandbox's
+ * own machinery uses them — the fetch bridge returns plain objects and the
+ * guest-to-host serializers dispatch on constructor names no guest code can
+ * reach once the classes are gone — so they are deleted to keep the guest
+ * surface minimal instead of documented as stubs.
+ */
+export const DELETED_GUEST_GLOBALS = [
+  "eval",
+  "Function",
+  "Buffer",
+  "process",
+  "env",
+  "Headers",
+  "Request",
+  "Response",
+  "performance"
+] as const;
 
 /** Names that should never be reassigned via `globals` — core sandbox APIs. */
 export const RESERVED_SANDBOX_NAMES: ReadonlySet<string> = new Set<string>([
@@ -2519,25 +2533,8 @@ export async function runInSandbox(
           `const __marker = "${SANDBOX_ERROR_MARKER}";
 const __bytesMarker = "${SANDBOX_BYTES_MARKER}";
 const __b64chars = "${BASE64_ALPHABET}";
-const __hasTE = typeof TextEncoder === "function";
-globalThis.utf8Encode = (s) => {
-  if (__hasTE) return new TextEncoder().encode(String(s));
-  const esc = encodeURIComponent(String(s));
-  const out = [];
-  for (let i = 0; i < esc.length; i++) {
-    if (esc[i] === "%") { out.push(parseInt(esc.substr(i + 1, 2), 16)); i += 2; }
-    else out.push(esc.charCodeAt(i));
-  }
-  return new Uint8Array(out);
-};
-globalThis.utf8Decode = (b) => {
-  if (__hasTE) return new TextDecoder().decode(b instanceof Uint8Array ? b : Uint8Array.from(b));
-  let esc = "";
-  for (let i = 0; i < b.length; i++) esc += "%" + (b[i] < 16 ? "0" : "") + b[i].toString(16);
-  return decodeURIComponent(esc);
-};
 globalThis.toBase64 = (input) => {
-  const b = typeof input === "string" ? globalThis.utf8Encode(input) : input;
+  const b = typeof input === "string" ? new TextEncoder().encode(input) : input;
   let out = "";
   for (let i = 0; i < b.length; i += 3) {
     const c = (b[i] << 16) | ((b[i + 1] || 0) << 8) | (b[i + 2] || 0);

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -2894,3 +2894,18 @@ export default true;`,
     };
   }
 }
+
+// ---------------------------------------------------------------------------
+// Guest preludes for tool-bridged hosts
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-exported here because `./js-sandbox` is the one browser-safe subpath
+ * export of this package: `nodetool.code.Code` (packages/code-nodes) is
+ * bundled for the in-browser runner and must reach these prelude strings
+ * without importing the package index, which drags the whole toolbelt —
+ * native canvas, IMAP, execution — into a web build. Both modules are pure
+ * strings over leaf imports.
+ */
+export { TOOLS_PRELUDE } from "./codeact/tools-prelude.js";
+export { NODETOOL_API_PRELUDE_FULL } from "./codeact/nodetool-api.js";

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -231,17 +231,25 @@ export function getBuiltinTools(): Tool[] {
 
 /**
  * Built-ins an agent's toolbelt leaves out. Every one is a provider-specific
- * duplicate of a capability the `nodetool.media.*` object model already covers
- * through the provider-agnostic `generate_image` / `generate_speech`: offering
- * both makes the model choose a provider before it has chosen a model. They
+ * duplicate of a capability a routed tool already covers: the media tools
+ * through the provider-agnostic `generate_image` / `generate_speech` (the
+ * `nodetool.media.*` object model), and the search backends through
+ * `web_search` / `google_news` / `google_images`, which route across the
+ * configured backends host-side (`backend` pins one). Offering the duplicates
+ * makes the model choose a provider before it has chosen a backend. They all
  * stay in {@link getBuiltinTools}, so MCP clients — which have no object model
- * and no `find_model` habit — keep them.
+ * and no routing habit — keep them.
  */
 export const AGENT_TOOLBELT_EXCLUDED: ReadonlySet<string> = new Set([
   "image_generation",
   "openai_image_generation",
   "google_image_generation",
-  "openai_text_to_speech"
+  "openai_text_to_speech",
+  "openai_web_search",
+  "google_grounded_search",
+  "dataforseo_search",
+  "dataforseo_news",
+  "dataforseo_images"
 ]);
 
 /**

--- a/packages/agents/src/tools/code-tools.ts
+++ b/packages/agents/src/tools/code-tools.ts
@@ -22,7 +22,7 @@ export class RunCodeTool extends Tool {
   readonly description =
     "Execute JavaScript code in a sandboxed QuickJS environment. Only javascript is supported. " +
     "Vanilla JS plus bridges: fetch(), console.*, workspace.read/write/list/readBytes/writeBytes/" +
-    "stat/mkdir/remove(), getSecret(), uuid(), sleep(), progress(), crypto.randomUUID/" +
+    "stat/mkdir/remove(), getSecret(), sleep(), progress(), crypto.randomUUID/" +
     "getRandomValues/digest/hmac, format.number/date/relativeTime/list, " +
     "data.parseCsv(text, {delimiter, header}), data.selectHtml(html, selector, {attr, limit}), " +
     "toBase64/fromBase64/toHex/fromHex. No imports — there is no module loader. " +

--- a/packages/agents/src/tools/dataseo-tools.ts
+++ b/packages/agents/src/tools/dataseo-tools.ts
@@ -32,6 +32,22 @@ async function getDataForSEOCredentials(
   return { login, password };
 }
 
+/**
+ * Whether the DataForSEO backend is usable: both credentials are present in
+ * the secret store or the environment. Configuration is decided here, before
+ * any call — never by sniffing an error message afterwards.
+ */
+export async function dataForSeoConfigured(
+  context: ProcessingContext
+): Promise<boolean> {
+  try {
+    await getDataForSEOCredentials(context);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function makeAuthHeader(login: string, password: string): string {
   const encoded = Buffer.from(`${login}:${password}`).toString("base64");
   return `Basic ${encoded}`;

--- a/packages/agents/src/tools/google-tools.ts
+++ b/packages/agents/src/tools/google-tools.ts
@@ -22,6 +22,21 @@ async function getGeminiApiKey(context?: ProcessingContext): Promise<string> {
   return key;
 }
 
+/**
+ * Whether the Gemini grounded-search backend is usable: its API key is present
+ * in the secret store or the environment. Configuration is decided here,
+ * before any call — never by sniffing an error message afterwards.
+ */
+export async function geminiSearchConfigured(
+  context: ProcessingContext
+): Promise<boolean> {
+  const fromCtx =
+    typeof context?.getSecret === "function"
+      ? await context.getSecret("GEMINI_API_KEY")
+      : null;
+  return Boolean(fromCtx ?? process.env["GEMINI_API_KEY"]);
+}
+
 export class GoogleGroundedSearchTool extends Tool {
   readonly name = "google_grounded_search";
   readonly description =

--- a/packages/agents/src/tools/js-code-tool.ts
+++ b/packages/agents/src/tools/js-code-tool.ts
@@ -63,8 +63,9 @@ Locale-aware formatting (Intl-backed; defaults to en-US).
 ### crypto.randomUUID() / .getRandomValues(n) / .digest(algo, data) / .hmac(algo, key, data)
 SHA-1/256/384/512. \`digest\` and \`hmac\` are async and return a Uint8Array.
 
-### toBase64(x) / fromBase64(s) / toHex(bytes) / fromHex(s) / utf8Encode(s) / utf8Decode(bytes)
-Binary and text conversion helpers (synchronous, guest-side).
+### toBase64(x) / fromBase64(s) / toHex(bytes) / fromHex(s)
+Binary conversion helpers (synchronous, guest-side). UTF-8 goes through the
+native \`TextEncoder\` / \`TextDecoder\`.
 
 ### progress(percent, message?)
 Report progress to the caller (0–100). Fire-and-forget.
@@ -77,9 +78,6 @@ Persist a workspace file as an asset and return an AssetRef.
 
 ### getSecret(name) → string | undefined
 Read a secret by name (API keys, tokens, etc).
-
-### uuid() → string
-Generate a random UUID v4.
 
 ### sleep(ms)
 Pause execution (max 5s per call). The only timer — \`setTimeout\`/\`setInterval\` do not exist.

--- a/packages/agents/src/tools/openai-tools.ts
+++ b/packages/agents/src/tools/openai-tools.ts
@@ -23,6 +23,21 @@ async function getOpenAIClient(context?: ProcessingContext) {
   return new OpenAI({ apiKey });
 }
 
+/**
+ * Whether the OpenAI web-search backend is usable: its API key is present in
+ * the secret store or the environment. Configuration is decided here, before
+ * any call — never by sniffing an error message afterwards.
+ */
+export async function openAiSearchConfigured(
+  context: ProcessingContext
+): Promise<boolean> {
+  const fromCtx =
+    typeof context?.getSecret === "function"
+      ? await context.getSecret("OPENAI_API_KEY")
+      : null;
+  return Boolean(fromCtx ?? process.env["OPENAI_API_KEY"]);
+}
+
 export class OpenAIWebSearchTool extends Tool {
   readonly name = "openai_web_search";
   readonly description = "Search the web using OpenAI's web search API";

--- a/packages/agents/src/tools/search-tools.ts
+++ b/packages/agents/src/tools/search-tools.ts
@@ -1,16 +1,32 @@
 /**
- * Web search tools using the SerpAPI service.
+ * The three agent-facing search tools: `web_search`, `google_news`,
+ * `google_images`.
  *
- * Port of src/nodetool/agents/tools/serp_tools.py (GoogleSearchTool,
- * GoogleNewsTool, GoogleImagesTool).
- *
- * Internally delegates to the SerpApiProvider abstraction when available.
+ * Each routes host-side across the configured search backends in preference
+ * order (`web_search`: SerpAPI → OpenAI → Gemini grounded → DataForSEO;
+ * news/images: SerpAPI → DataForSEO). "Configured" is decided from real
+ * configuration — the backend's required secrets, checked before any call —
+ * never by sniffing error messages. A real error from a configured backend
+ * fails the call; there is no fallthrough past a backend that has its keys.
+ * The optional `backend` param pins one backend; pinning an unconfigured one
+ * is an error naming the missing key.
  */
 
 import { WEB_SEARCH_TOOL_NAME, type ProcessingContext } from "@nodetool-ai/runtime";
 import { Tool } from "./base-tool.js";
 import type { SerpProvider } from "./serp-providers/index.js";
 import { SerpApiProvider } from "./serp-providers/serpapi-provider.js";
+import { OpenAIWebSearchTool, openAiSearchConfigured } from "./openai-tools.js";
+import {
+  GoogleGroundedSearchTool,
+  geminiSearchConfigured
+} from "./google-tools.js";
+import {
+  DataForSEOSearchTool,
+  DataForSEONewsTool,
+  DataForSEOImagesTool,
+  dataForSeoConfigured
+} from "./dataseo-tools.js";
 
 async function getSerpApiKey(context: ProcessingContext): Promise<string> {
   const fromCtx = await context.getSecret("SERPAPI_API_KEY");
@@ -23,6 +39,91 @@ async function getSerpApiKey(context: ProcessingContext): Promise<string> {
     "SERPAPI_API_KEY is not configured. Set it as an environment variable or via the secret resolver."
   );
 }
+
+/** Whether the SerpAPI backend is usable: its key is in the store or env. */
+export async function serpApiConfigured(
+  context: ProcessingContext
+): Promise<boolean> {
+  const fromCtx =
+    typeof context?.getSecret === "function"
+      ? await context.getSecret("SERPAPI_API_KEY")
+      : null;
+  return Boolean(fromCtx ?? process.env.SERPAPI_API_KEY);
+}
+
+/** One interchangeable backing service behind a search tool. */
+interface SearchBackend {
+  /** The value the tool's `backend` param takes to pin this backend. */
+  name: string;
+  /** The secret(s) that make it usable, for error messages. */
+  requires: string;
+  isConfigured(context: ProcessingContext): Promise<boolean>;
+  run(context: ProcessingContext): Promise<unknown>;
+}
+
+/**
+ * Run the first configured backend, or the pinned one. Unconfigured backends
+ * are skipped up front; once a backend runs, its failure is the call's
+ * failure — a real error never falls through to the next backend.
+ */
+async function runFirstConfiguredBackend(
+  toolName: string,
+  context: ProcessingContext,
+  backends: SearchBackend[],
+  pinnedRaw: unknown
+): Promise<unknown> {
+  // `default` always means the tool's own first backend.
+  const pinned =
+    pinnedRaw === undefined || pinnedRaw === null || pinnedRaw === ""
+      ? undefined
+      : String(pinnedRaw) === "default"
+        ? backends[0].name
+        : String(pinnedRaw);
+  if (pinned !== undefined) {
+    const backend = backends.find((b) => b.name === pinned);
+    if (!backend) {
+      throw new Error(
+        `${toolName}: unknown backend "${pinned}" — one of ` +
+          backends.map((b) => b.name).join(", ") +
+          "."
+      );
+    }
+    if (!(await backend.isConfigured(context))) {
+      throw new Error(
+        `${toolName}: backend "${backend.name}" is not configured — set ` +
+          `${backend.requires}.`
+      );
+    }
+    return backend.run(context);
+  }
+
+  const unconfigured: string[] = [];
+  for (const backend of backends) {
+    if (await backend.isConfigured(context)) return backend.run(context);
+    unconfigured.push(`${backend.name} needs ${backend.requires}`);
+  }
+  throw new Error(
+    `${toolName}: no search backend is configured — ` +
+      unconfigured.join("; ") +
+      "."
+  );
+}
+
+/**
+ * The delegated tools report failures as `{error}` objects; on this routed
+ * path the backend was verified configured first, so an `{error}` is a real
+ * failure and must fail the call, not fall through.
+ */
+function unwrapBackendResult(result: unknown): Record<string, unknown> {
+  if (result !== null && typeof result === "object") {
+    const record = result as Record<string, unknown>;
+    if (typeof record.error === "string") throw new Error(record.error);
+    return record;
+  }
+  throw new Error(`Unexpected search backend result: ${String(result)}`);
+}
+
+const DATAFORSEO_REQUIRES = "DATA_FOR_SEO_LOGIN and DATA_FOR_SEO_PASSWORD";
 
 interface SerpApiParams {
   engine: string;
@@ -83,10 +184,11 @@ function domainOf(link: string | null | undefined): string {
 
 /**
  * Web search, modeled on Claude Code's `WebSearch` tool: a `query` plus
- * optional `allowed_domains` / `blocked_domains` filters. Backed by SerpAPI on
- * providers without a built-in web search. Providers that DO have one
- * (`supportsNativeWebSearch`) render a tool of this name as their own
- * server-side search instead of calling this implementation.
+ * optional `allowed_domains` / `blocked_domains` filters. Routes host-side
+ * across the configured backends — SerpAPI, then OpenAI web search, then
+ * Gemini grounded search, then DataForSEO. Providers that have a built-in
+ * web search (`supportsNativeWebSearch`) render a tool of this name as their
+ * own server-side search instead of calling this implementation.
  */
 export class WebSearchTool extends Tool {
   readonly name = WEB_SEARCH_TOOL_NAME;
@@ -95,7 +197,8 @@ export class WebSearchTool extends Tool {
     "information for current events and recent data beyond the model's training " +
     "cutoff. Each result includes the title, URL, and snippet. Optionally scope " +
     "results with allowed_domains (only these domains) or blocked_domains " +
-    "(never these domains).";
+    "(never these domains). Runs on the first configured backend; `backend` " +
+    "pins one.";
   readonly jsonSchema: Record<string, unknown> = {
     type: "object",
     properties: {
@@ -113,6 +216,13 @@ export class WebSearchTool extends Tool {
         type: "array",
         items: { type: "string" },
         description: "Never include results from these domains."
+      },
+      backend: {
+        type: "string",
+        enum: ["serpapi", "openai", "gemini", "dataforseo"],
+        description:
+          "Pin one search backend instead of routing to the first " +
+          "configured one."
       }
     },
     required: ["query"]
@@ -163,39 +273,122 @@ export class WebSearchTool extends Tool {
       return true;
     };
 
-    let raw: Array<{
-      title: string | null;
-      link: string | null;
-      snippet: string | null;
-    }>;
-    if (this._provider) {
-      const results = await this._provider.search(effectiveQuery, {
-        numResults
-      });
-      raw = results.map((r) => ({
-        title: r.title ?? null,
-        link: r.url ?? null,
-        snippet: r.snippet ?? null
-      }));
-    } else {
-      const apiKey = await getSerpApiKey(context);
-      const data = (await serpApiFetch({
-        engine: "google",
-        q: effectiveQuery,
-        api_key: apiKey,
-        num: numResults
-      })) as Record<string, unknown>;
-      const organicResults = (data.organic_results ?? []) as Array<
-        Record<string, unknown>
-      >;
-      raw = organicResults.map((r) => ({
-        title: (r.title as string) ?? null,
-        link: (r.link as string) ?? null,
-        snippet: (r.snippet as string) ?? null
-      }));
-    }
+    const formatFiltered = (
+      raw: Array<{
+        title: string | null;
+        link: string | null;
+        snippet: string | null;
+      }>
+    ) => formatSearchResults(raw.filter((r) => keep(r.link)));
 
-    return formatSearchResults(raw.filter((r) => keep(r.link)));
+    const backends: SearchBackend[] = [
+      {
+        name: "serpapi",
+        requires: "SERPAPI_API_KEY",
+        isConfigured: async (ctx) =>
+          this._provider !== undefined || serpApiConfigured(ctx),
+        run: async (ctx) => {
+          let raw: Array<{
+            title: string | null;
+            link: string | null;
+            snippet: string | null;
+          }>;
+          if (this._provider) {
+            const results = await this._provider.search(effectiveQuery, {
+              numResults
+            });
+            raw = results.map((r) => ({
+              title: r.title ?? null,
+              link: r.url ?? null,
+              snippet: r.snippet ?? null
+            }));
+          } else {
+            const apiKey = await getSerpApiKey(ctx);
+            const data = (await serpApiFetch({
+              engine: "google",
+              q: effectiveQuery,
+              api_key: apiKey,
+              num: numResults
+            })) as Record<string, unknown>;
+            const organicResults = (data.organic_results ?? []) as Array<
+              Record<string, unknown>
+            >;
+            raw = organicResults.map((r) => ({
+              title: (r.title as string) ?? null,
+              link: (r.link as string) ?? null,
+              snippet: (r.snippet as string) ?? null
+            }));
+          }
+          return formatFiltered(raw);
+        }
+      },
+      {
+        name: "openai",
+        requires: "OPENAI_API_KEY",
+        isConfigured: openAiSearchConfigured,
+        run: async (ctx) => {
+          const result = unwrapBackendResult(
+            await new OpenAIWebSearchTool().process(ctx, {
+              query: effectiveQuery
+            })
+          );
+          return String(result.results ?? "");
+        }
+      },
+      {
+        name: "gemini",
+        requires: "GEMINI_API_KEY",
+        isConfigured: geminiSearchConfigured,
+        run: async (ctx) => {
+          const result = unwrapBackendResult(
+            await new GoogleGroundedSearchTool().process(ctx, {
+              query: effectiveQuery
+            })
+          );
+          const text = Array.isArray(result.results)
+            ? result.results.join("\n\n")
+            : String(result.results ?? "");
+          const sources = (
+            (result.sources ?? []) as Array<{ title: string; url: string }>
+          ).filter((s) => keep(s.url));
+          if (sources.length === 0) return text;
+          const sourceLines = sources
+            .map((s, i) => `${i + 1}. ${s.title}\n   ${s.url}`)
+            .join("\n\n");
+          return `${text}\n\nSources:\n\n${sourceLines}`;
+        }
+      },
+      {
+        name: "dataforseo",
+        requires: DATAFORSEO_REQUIRES,
+        isConfigured: dataForSeoConfigured,
+        run: async (ctx) => {
+          const result = unwrapBackendResult(
+            await new DataForSEOSearchTool().process(ctx, {
+              keyword: effectiveQuery,
+              num_results: numResults
+            })
+          );
+          const results = (result.results ?? []) as Array<
+            Record<string, unknown>
+          >;
+          return formatFiltered(
+            results.map((r) => ({
+              title: (r.title as string) ?? null,
+              link: (r.url as string) ?? null,
+              snippet: (r.snippet as string) ?? null
+            }))
+          );
+        }
+      }
+    ];
+
+    return runFirstConfiguredBackend(
+      this.name,
+      context,
+      backends,
+      params.backend
+    );
   }
 
   userMessage(params: Record<string, unknown>): string {
@@ -211,7 +404,8 @@ export class WebSearchTool extends Tool {
 export class GoogleNewsTool extends Tool {
   readonly name = "google_news";
   readonly description =
-    "Search Google News to retrieve live news articles via SerpAPI.";
+    "Search Google News to retrieve live news articles. Runs on the first " +
+    "configured backend (SerpAPI, then DataForSEO); `backend` pins one.";
   readonly jsonSchema: Record<string, unknown> = {
     type: "object",
     properties: {
@@ -223,6 +417,13 @@ export class GoogleNewsTool extends Tool {
         type: "integer",
         description: "Number of news results to retrieve.",
         default: 10
+      },
+      backend: {
+        type: "string",
+        enum: ["serpapi", "dataforseo"],
+        description:
+          "Pin one search backend instead of routing to the first " +
+          "configured one."
       }
     },
     required: ["keyword"]
@@ -242,29 +443,66 @@ export class GoogleNewsTool extends Tool {
     const keyword = params.keyword as string | undefined;
     if (!keyword) return { error: "keyword is required" };
 
-    const apiKey = await getSerpApiKey(context);
     const numResults = (params.num_results as number) ?? 10;
 
-    const data = (await serpApiFetch({
-      engine: "google_news",
-      q: keyword,
-      api_key: apiKey,
-      num: numResults
-    })) as Record<string, unknown>;
+    const backends: SearchBackend[] = [
+      {
+        name: "serpapi",
+        requires: "SERPAPI_API_KEY",
+        isConfigured: serpApiConfigured,
+        run: async (ctx) => {
+          const apiKey = await getSerpApiKey(ctx);
+          const data = (await serpApiFetch({
+            engine: "google_news",
+            q: keyword,
+            api_key: apiKey,
+            num: numResults
+          })) as Record<string, unknown>;
+          const newsResults = (data.news_results ?? []) as Array<
+            Record<string, unknown>
+          >;
+          const results = newsResults.map((r) => ({
+            title: r.title ?? null,
+            link: r.link ?? null,
+            snippet: r.snippet ?? null,
+            date: r.date ?? null,
+            source: (r.source as Record<string, unknown>)?.name ?? null
+          }));
+          return { success: true, results };
+        }
+      },
+      {
+        name: "dataforseo",
+        requires: DATAFORSEO_REQUIRES,
+        isConfigured: dataForSeoConfigured,
+        run: async (ctx) => {
+          const result = unwrapBackendResult(
+            await new DataForSEONewsTool().process(ctx, {
+              keyword,
+              num_results: numResults
+            })
+          );
+          const items = (result.results ?? []) as Array<
+            Record<string, unknown>
+          >;
+          const results = items.map((r) => ({
+            title: r.title ?? null,
+            link: r.url ?? null,
+            snippet: r.snippet ?? null,
+            date: r.published_at ?? null,
+            source: r.source ?? null
+          }));
+          return { success: true, results };
+        }
+      }
+    ];
 
-    const newsResults = (data.news_results ?? []) as Array<
-      Record<string, unknown>
-    >;
-
-    const results = newsResults.map((r) => ({
-      title: r.title ?? null,
-      link: r.link ?? null,
-      snippet: r.snippet ?? null,
-      date: r.date ?? null,
-      source: (r.source as Record<string, unknown>)?.name ?? null
-    }));
-
-    return { success: true, results };
+    return runFirstConfiguredBackend(
+      this.name,
+      context,
+      backends,
+      params.backend
+    );
   }
 
   userMessage(params: Record<string, unknown>): string {
@@ -277,7 +515,8 @@ export class GoogleNewsTool extends Tool {
 export class GoogleImagesTool extends Tool {
   readonly name = "google_images";
   readonly description =
-    "Search Google Images to retrieve image results via SerpAPI.";
+    "Search Google Images to retrieve image results. Runs on the first " +
+    "configured backend (SerpAPI, then DataForSEO); `backend` pins one.";
   readonly jsonSchema: Record<string, unknown> = {
     type: "object",
     properties: {
@@ -289,6 +528,13 @@ export class GoogleImagesTool extends Tool {
         type: "integer",
         description: "Number of image results to retrieve.",
         default: 20
+      },
+      backend: {
+        type: "string",
+        enum: ["serpapi", "dataforseo"],
+        description:
+          "Pin one search backend instead of routing to the first " +
+          "configured one."
       }
     },
     required: ["keyword"]
@@ -308,28 +554,64 @@ export class GoogleImagesTool extends Tool {
     const keyword = params.keyword as string | undefined;
     if (!keyword) return { error: "keyword is required" };
 
-    const apiKey = await getSerpApiKey(context);
     const numResults = (params.num_results as number) ?? 20;
 
-    const data = (await serpApiFetch({
-      engine: "google_images",
-      q: keyword,
-      api_key: apiKey,
-      num: numResults
-    })) as Record<string, unknown>;
+    const backends: SearchBackend[] = [
+      {
+        name: "serpapi",
+        requires: "SERPAPI_API_KEY",
+        isConfigured: serpApiConfigured,
+        run: async (ctx) => {
+          const apiKey = await getSerpApiKey(ctx);
+          const data = (await serpApiFetch({
+            engine: "google_images",
+            q: keyword,
+            api_key: apiKey,
+            num: numResults
+          })) as Record<string, unknown>;
+          const imagesResults = (data.images_results ?? []) as Array<
+            Record<string, unknown>
+          >;
+          const results = imagesResults.map((r) => ({
+            title: r.title ?? null,
+            link: r.link ?? null,
+            original: r.original ?? null,
+            thumbnail: r.thumbnail ?? null
+          }));
+          return { success: true, results };
+        }
+      },
+      {
+        name: "dataforseo",
+        requires: DATAFORSEO_REQUIRES,
+        isConfigured: dataForSeoConfigured,
+        run: async (ctx) => {
+          const result = unwrapBackendResult(
+            await new DataForSEOImagesTool().process(ctx, {
+              keyword,
+              num_results: numResults
+            })
+          );
+          const items = (result.results ?? []) as Array<
+            Record<string, unknown>
+          >;
+          const results = items.map((r) => ({
+            title: r.title ?? null,
+            link: r.source_url ?? null,
+            original: r.image_url ?? null,
+            thumbnail: null
+          }));
+          return { success: true, results };
+        }
+      }
+    ];
 
-    const imagesResults = (data.images_results ?? []) as Array<
-      Record<string, unknown>
-    >;
-
-    const results = imagesResults.map((r) => ({
-      title: r.title ?? null,
-      link: r.link ?? null,
-      original: r.original ?? null,
-      thumbnail: r.thumbnail ?? null
-    }));
-
-    return { success: true, results };
+    return runFirstConfiguredBackend(
+      this.name,
+      context,
+      backends,
+      params.backend
+    );
   }
 
   userMessage(params: Record<string, unknown>): string {

--- a/packages/agents/tests/codeact-api-core.test.ts
+++ b/packages/agents/tests/codeact-api-core.test.ts
@@ -94,7 +94,8 @@ const SOLUTIONS: Record<string, string[]> = {
      await finish({ probe: probe.output, slug: run.result.outputs.slug });`
   ],
   "api-pick-model-and-batch-images": [
-    `const providers = await nodetool.providers.list();
+    `const catalog = await nodetool.models.list({ limit: 1000 });
+     const providers = [...new Set((catalog.results || []).map((m) => m.provider))];
      const model = await nodetool.models.pick("text_to_image");
      const shots = [
        "a red fox in snow",
@@ -193,7 +194,6 @@ const CORE_NAMESPACES = [
   "graph",
   "nodes",
   "models",
-  "providers",
   "media",
   "jobs",
   "assets",

--- a/packages/agents/tests/codeact-api-surfaces.test.ts
+++ b/packages/agents/tests/codeact-api-surfaces.test.ts
@@ -279,17 +279,7 @@ describe("codeact nodetool API surface cases", () => {
     expect(second.accepted).toBe(true);
   });
 
-  it("nodetool.web.search falls through the unconfigured default backend", async () => {
-    const recorder = createCodeActRecorder();
-    const belt = createSurfaceApiTools(recorder);
-    const search = belt.find((tool) => tool.name === "web_search");
-    expect(search).toBeDefined();
-    await expect(
-      search?.process(
-        {} as unknown as Parameters<NonNullable<typeof search>["process"]>[0],
-        { query: "anything" }
-      )
-    ).rejects.toThrow(/api key not configured/i);
+  it("nodetool.web.search runs through the routed web_search tool", async () => {
     const result = await runOne("web-research-brief");
     expect(result.accepted, JSON.stringify(result.checks)).toBe(true);
   });

--- a/packages/agents/tests/codeact-executor.test.ts
+++ b/packages/agents/tests/codeact-executor.test.ts
@@ -380,6 +380,26 @@ describe("CodeAct progressive tool disclosure", () => {
     }
   });
 
+  it("documents nodetool.batch as THE fan-out primitive when the object model loads", async () => {
+    const { buildCodeActSystemPrompt } = await import("../src/codeact/prompt.js");
+    const { buildNodetoolApiPromptSection } = await import(
+      "../src/codeact/nodetool-api.js"
+    );
+    const apiSection = buildNodetoolApiPromptSection(["run_workflow"]);
+    expect(apiSection).not.toBe("");
+    for (const variant of ["step", "chat"] as const) {
+      const prompt = buildCodeActSystemPrompt({
+        tools: bigBelt(),
+        variant,
+        extraSections: [apiSection]
+      });
+      expect(prompt, variant).toContain("nodetool.batch(items");
+      expect(prompt, variant).not.toContain("parallelMap");
+      // The unbounded form stays documented.
+      expect(prompt, variant).toContain("Promise.all");
+    }
+  });
+
   it("discovers a deferred tool via searchTools and calls it", async () => {
     const { step, task } = makeStep(ANSWER_SCHEMA);
     const context = createMockContext();

--- a/packages/agents/tests/js-code-tool.test.ts
+++ b/packages/agents/tests/js-code-tool.test.ts
@@ -376,10 +376,10 @@ describe("MiniJSAgentTool", () => {
     });
   });
 
-  it("uuid() returns a UUID", async () => {
+  it("crypto.randomUUID() returns a UUID", async () => {
     const result = (await tool.process(mockContext, {
       code: `
-        const id = uuid();
+        const id = crypto.randomUUID();
         return typeof id === "string" && id.length === 36;
       `
     })) as Record<string, unknown>;

--- a/packages/agents/tests/js-sandbox-data-libs.test.ts
+++ b/packages/agents/tests/js-sandbox-data-libs.test.ts
@@ -176,7 +176,7 @@ describe("data.zip / data.unzip bridges", () => {
         const entries = await data.unzip(archive);
         return {
           names: Object.keys(entries).sort(),
-          text: utf8Decode(entries["notes/a.txt"]),
+          text: new TextDecoder().decode(entries["notes/a.txt"]),
           bin: Array.from(entries["raw.bin"]),
           isBytes: entries["raw.bin"] instanceof Uint8Array
         };`

--- a/packages/agents/tests/js-sandbox-media.test.ts
+++ b/packages/agents/tests/js-sandbox-media.test.ts
@@ -369,7 +369,7 @@ describe("image transforms", () => {
 
   it("reports a decode failure with the format it sniffed", async () => {
     const message = await run(`
-      try { await image.info(utf8Encode("not an image at all")); return "no throw"; }
+      try { await image.info(new TextEncoder().encode("not an image at all")); return "no throw"; }
       catch (e) { return e.message; }
     `);
     expect(message).toMatch(/could not decode the image \(unknown\)/);

--- a/packages/agents/tests/js-sandbox.test.ts
+++ b/packages/agents/tests/js-sandbox.test.ts
@@ -2,7 +2,7 @@
  * Tests for js-sandbox.ts — sandboxed JavaScript execution.
  *
  * The sandbox is intentionally lib-free: only vanilla JS plus a handful of
- * bridge functions (fetch, workspace, getSecret, uuid, sleep, console).
+ * bridge functions (fetch, workspace, getSecret, sleep, console).
  * These tests lock that contract down so future refactors can't accidentally
  * re-introduce lodash / dayjs / cheerio / csv-parse / validator into the
  * user-code surface.
@@ -216,7 +216,6 @@ describe("buildSandbox", () => {
   it("exposes the bridge functions", () => {
     const { sandbox } = buildSandbox();
     expect(typeof sandbox.fetch).toBe("function");
-    expect(typeof sandbox.uuid).toBe("function");
     expect(typeof sandbox.sleep).toBe("function");
     expect(typeof sandbox.getSecret).toBe("function");
     expect(typeof sandbox.workspace).toBe("object");
@@ -564,12 +563,15 @@ describe("runInSandbox", () => {
     expect(r2.success).toBe(false);
   });
 
-  it("uuid() returns a valid v4 UUID", async () => {
-    const result = await runInSandbox({ code: "return uuid();" });
+  it("crypto.randomUUID() returns a valid v4 UUID and uuid() is gone", async () => {
+    const result = await runInSandbox({ code: "return crypto.randomUUID();" });
     expect(result.success).toBe(true);
     expect(result.result).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
     );
+    const removed = await runInSandbox({ code: "return uuid();" });
+    expect(removed.success).toBe(false);
+    expect(removed.error).toMatch(/uuid/);
   });
 
   it("sleep(ms) pauses execution and is capped", async () => {
@@ -1113,7 +1115,7 @@ describe("runInSandbox crypto bridge", () => {
     const result = await runInSandbox({
       code: `
         const a = await crypto.digest("SHA-1", "abc");
-        const b = await crypto.digest("sha1", utf8Encode("abc"));
+        const b = await crypto.digest("sha1", new TextEncoder().encode("abc"));
         return { a: toHex(a), b: toHex(b) };
       `
     });
@@ -1172,7 +1174,7 @@ describe("runInSandbox crypto bridge", () => {
   it("accepts binary keys and data for hmac", async () => {
     const result = await runInSandbox({
       code: `
-        const mac = await crypto.hmac("SHA-256", utf8Encode("key"), utf8Encode("msg"));
+        const mac = await crypto.hmac("SHA-256", new TextEncoder().encode("key"), new TextEncoder().encode("msg"));
         const mac2 = await crypto.hmac("SHA-256", "key", "msg");
         return { same: toHex(mac) === toHex(mac2), len: mac.length };
       `
@@ -1220,7 +1222,7 @@ describe("runInSandbox binary helpers", () => {
       code: `
         const b64 = toBase64("hello world");
         const back = fromBase64(b64);
-        return { b64, text: utf8Decode(back), isBytes: back instanceof Uint8Array };
+        return { b64, text: new TextDecoder().decode(back), isBytes: back instanceof Uint8Array };
       `
     });
     expect(result.success).toBe(true);
@@ -1253,9 +1255,9 @@ describe("runInSandbox binary helpers", () => {
   it("round-trips hex", async () => {
     const result = await runInSandbox({
       code: `
-        const hex = toHex(utf8Encode("nodetool"));
+        const hex = toHex(new TextEncoder().encode("nodetool"));
         const back = fromHex(hex);
-        return { hex, text: utf8Decode(back) };
+        return { hex, text: new TextDecoder().decode(back) };
       `
     });
     expect(result.success).toBe(true);
@@ -1265,11 +1267,11 @@ describe("runInSandbox binary helpers", () => {
     });
   });
 
-  it("round-trips non-ASCII text through utf8Encode/utf8Decode", async () => {
+  it("round-trips non-ASCII text through TextEncoder/TextDecoder", async () => {
     const result = await runInSandbox({
       code: `
-        const bytes = utf8Encode("héllo — 世界");
-        return { len: bytes.length, text: utf8Decode(bytes) };
+        const bytes = new TextEncoder().encode("héllo — 世界");
+        return { len: bytes.length, text: new TextDecoder().decode(bytes) };
       `
     });
     expect(result.success).toBe(true);
@@ -1281,7 +1283,7 @@ describe("runInSandbox binary helpers", () => {
 
   it("accepts base64url input in fromBase64", async () => {
     const result = await runInSandbox({
-      code: `return utf8Decode(fromBase64("aGVsbG8_d29ybGQ-"));`
+      code: `return new TextDecoder().decode(fromBase64("aGVsbG8_d29ybGQ-"));`
     });
     expect(result.success).toBe(true);
     expect(result.result).toBe(

--- a/packages/agents/tests/nodetool-api-web-memory.test.ts
+++ b/packages/agents/tests/nodetool-api-web-memory.test.ts
@@ -19,13 +19,8 @@ const toolDef = (name: string) => ({
 
 const WEB_TOOLS = [
   "web_search",
-  "openai_web_search",
-  "google_grounded_search",
   "google_news",
   "google_images",
-  "dataforseo_search",
-  "dataforseo_news",
-  "dataforseo_images",
   "http_request",
   "download_file",
   "browser",
@@ -100,129 +95,49 @@ describe("nodetool.web", () => {
     });
   });
 
-  it("pins a named provider and maps onto that tool's query field", async () => {
+  it("maps provider onto the tool's backend pin (old guest names included)", async () => {
     const { executeTool, calls } = createEchoRouter();
     const session = makeSession(WEB_TOOLS, executeTool);
     const obs = await runAction(
       session,
       `await nodetool.web.search("fox", { provider: "dataforseo", num_results: 3 });
        await nodetool.web.search("fox", { provider: "google" });
+       await nodetool.web.search("fox", { provider: "openai" });
+       await nodetool.web.news("fox", { provider: "google" });
+       await nodetool.web.images("fox", { provider: "dataforseo" });
        return true;`
     );
     expect(obs.ok).toBe(true);
     expect(calls[0]).toMatchObject({
-      name: "dataforseo_search",
-      args: { keyword: "fox", num_results: 3 }
+      name: "web_search",
+      args: { query: "fox", backend: "dataforseo", num_results: 3 }
     });
-    // `provider` selects the backend; it is never forwarded as an argument.
+    // `provider` becomes the backend pin; it is never forwarded as-is.
     expect(calls[0].args).not.toHaveProperty("provider");
     expect(calls[1]).toMatchObject({
-      name: "google_grounded_search",
-      args: { query: "fox" }
+      name: "web_search",
+      args: { query: "fox", backend: "gemini" }
+    });
+    expect(calls[2]).toMatchObject({
+      name: "web_search",
+      args: { query: "fox", backend: "openai" }
+    });
+    expect(calls[3]).toMatchObject({
+      name: "google_news",
+      args: { keyword: "fox", backend: "serpapi" }
+    });
+    expect(calls[4]).toMatchObject({
+      name: "google_images",
+      args: { keyword: "fox", backend: "dataforseo" }
     });
   });
 
-  it("falls back to the next available provider when the preferred one is absent", async () => {
-    const { executeTool, calls } = createEchoRouter();
-    const session = makeSession(
-      ["dataforseo_search", "dataforseo_news"].map(toolDef),
-      executeTool
-    );
-    const obs = await runAction(
-      session,
-      `await nodetool.web.search("fox");
-       await nodetool.web.news("fox");
-       return true;`
-    );
-    expect(obs.ok).toBe(true);
-    expect(calls.map((c) => c.name)).toEqual([
-      "dataforseo_search",
-      "dataforseo_news"
-    ]);
-  });
-
-  it("throws naming the tools it tried when nothing can serve the method", async () => {
+  it("throws naming the missing tool when the belt cannot serve the method", async () => {
     const { executeTool } = createEchoRouter();
     const session = makeSession(["http_request"].map(toolDef), executeTool);
     const obs = await runAction(session, `await nodetool.web.search("fox");`);
     expect(obs.ok).toBe(false);
-    expect(obs.error).toContain("nodetool.web.search");
     expect(obs.error).toContain("web_search");
-  });
-
-  it("throws when a pinned provider is not on the belt", async () => {
-    const { executeTool } = createEchoRouter();
-    const session = makeSession(["web_search"].map(toolDef), executeTool);
-    const obs = await runAction(
-      session,
-      `await nodetool.web.search("fox", { provider: "openai" });`
-    );
-    expect(obs.ok).toBe(false);
-    expect(obs.error).toContain('provider "openai"');
-  });
-
-  it("falls through to the next backend when one is unconfigured", async () => {
-    const calls: ChatCodeActToolCall[] = [];
-    const executeTool = async (call: ChatCodeActToolCall): Promise<unknown> => {
-      calls.push(call);
-      if (call.name === "web_search") {
-        return { error: "SERPAPI_API_KEY is not configured" };
-      }
-      return JSON.stringify({ tool: call.name, args: call.args });
-    };
-    const session = makeSession(WEB_TOOLS, executeTool);
-    const obs = await runAction(
-      session,
-      `const r = await nodetool.web.search("fox");
-       return r.tool;`
-    );
-    expect(obs.ok).toBe(true);
-    expect(obs.result).toBe("openai_web_search");
-    expect(calls.map((c) => c.name)).toEqual([
-      "web_search",
-      "openai_web_search"
-    ]);
-  });
-
-  it("reports every backend's error once they are all unconfigured", async () => {
-    const executeTool = async (call: ChatCodeActToolCall): Promise<unknown> => ({
-      error: `${call.name}: missing api key`
-    });
-    const session = makeSession(WEB_TOOLS, executeTool);
-    const obs = await runAction(session, `await nodetool.web.search("fox");`);
-    expect(obs.ok).toBe(false);
-    expect(obs.error).toContain("nodetool.web.search");
-    expect(obs.error).toContain("web_search");
-    expect(obs.error).toContain("dataforseo_search");
-  });
-
-  it("does not fall through on an ordinary backend failure", async () => {
-    const calls: ChatCodeActToolCall[] = [];
-    const executeTool = async (call: ChatCodeActToolCall): Promise<unknown> => {
-      calls.push(call);
-      return { error: "upstream returned 500" };
-    };
-    const session = makeSession(WEB_TOOLS, executeTool);
-    const obs = await runAction(session, `await nodetool.web.search("fox");`);
-    expect(obs.ok).toBe(false);
-    expect(obs.error).toContain("upstream returned 500");
-    expect(calls.map((c) => c.name)).toEqual(["web_search"]);
-  });
-
-  it("never falls through when the caller pinned a provider", async () => {
-    const calls: ChatCodeActToolCall[] = [];
-    const executeTool = async (call: ChatCodeActToolCall): Promise<unknown> => {
-      calls.push(call);
-      return { error: "OPENAI_API_KEY is not configured" };
-    };
-    const session = makeSession(WEB_TOOLS, executeTool);
-    const obs = await runAction(
-      session,
-      `await nodetool.web.search("fox", { provider: "openai" });`
-    );
-    expect(obs.ok).toBe(false);
-    expect(obs.error).toContain("OPENAI_API_KEY");
-    expect(calls.map((c) => c.name)).toEqual(["openai_web_search"]);
   });
 
   it("maps images, fetch, browse, download and screenshot onto their tools", async () => {

--- a/packages/agents/tests/nodetool-api-web-memory.test.ts
+++ b/packages/agents/tests/nodetool-api-web-memory.test.ts
@@ -343,13 +343,11 @@ describe("nodetool.style", () => {
     const obs = await runAction(
       session,
       `const profile = await nodetool.style.profile();
-       const details = await nodetool.style.profileDetails();
-       return { profile: profile, itemCount: details.items.length };`
+       return { profile: profile };`
     );
     expect(obs.ok).toBe(true);
     expect(obs.result).toEqual({
-      profile: "- Prefers muted palettes.",
-      itemCount: 1
+      profile: "- Prefers muted palettes."
     });
   });
 
@@ -378,13 +376,10 @@ describe("nodetool.style", () => {
     expect(calls[1].args["taste_profile"]).toBe("- Muted palettes.");
   });
 
-  it("accepts the full profile record as taste_profile too", async () => {
+  it("passes critique opts through unwrapped", async () => {
     const calls: ChatCodeActToolCall[] = [];
     const executeTool = async (call: ChatCodeActToolCall): Promise<unknown> => {
       calls.push(call);
-      if (call.name === "get_style_profile") {
-        return JSON.stringify({ profile: "- Muted palettes.", items: [] });
-      }
       return JSON.stringify({ verdict: "ok" });
     };
     const session = makeSession(
@@ -393,14 +388,15 @@ describe("nodetool.style", () => {
     );
     const obs = await runAction(
       session,
-      `const details = await nodetool.style.profileDetails();
-       await nodetool.media.critique("asset://a1", "a poster", "openai/gpt-5.4", {
-         taste_profile: details
+      `await nodetool.media.critique("asset://a1", "a poster", "openai/gpt-5.4", {
+         taste_profile: "- Muted palettes.",
+         max_defects: 3
        });
        return true;`
     );
     expect(obs.ok).toBe(true);
-    expect(calls[1].args["taste_profile"]).toBe("- Muted palettes.");
+    expect(calls[0].args["taste_profile"]).toBe("- Muted palettes.");
+    expect(calls[0].args["max_defects"]).toBe(3);
   });
 
   it("maps profile/record onto the style tools", async () => {

--- a/packages/agents/tests/nodetool-api-workflows.test.ts
+++ b/packages/agents/tests/nodetool-api-workflows.test.ts
@@ -180,12 +180,14 @@ describe("nodetool.workflows escalations", () => {
 });
 
 describe("nodetool.workflows examples", () => {
-  it("lists examples through list_workflows", async () => {
+  it("lists examples through list({workflow_type: \"example\"})", async () => {
     const { executeTool, calls } = createFakeRouter();
     const session = makeSession(WORKFLOW_TOOLS, executeTool);
     const obs = await runAction(
       session,
-      `return await nodetool.workflows.examples({ query: "sum", limit: 5 });`
+      `return await nodetool.workflows.list({
+         workflow_type: "example", query: "sum", limit: 5
+       });`
     );
     expect(obs.ok).toBe(true);
     expect(obs.result).toMatchObject({

--- a/packages/agents/tests/nodetool-api.test.ts
+++ b/packages/agents/tests/nodetool-api.test.ts
@@ -107,6 +107,12 @@ function createFakeRouter() {
             }
           ]
         });
+      case "list_provider_models":
+        return JSON.stringify({
+          provider: args["provider"],
+          total: 1,
+          results: [{ provider: args["provider"], id: "fal-ai/flux/schnell" }]
+        });
       case "list_models":
         return JSON.stringify({
           total: 3,
@@ -171,7 +177,6 @@ describe("nodetool object model", () => {
     expect(Object.keys(caps).sort()).toEqual([
       "graph",
       "models",
-      "providers",
       "workflows"
     ]);
     expect(caps["workflows"]).toContain("run_workflow");
@@ -234,20 +239,22 @@ describe("nodetool object model", () => {
     expect(String(obs.result)).toContain("nodetool.models.pick");
   });
 
-  it("derives the provider roster from the model catalog", async () => {
-    const { executeTool } = createFakeRouter();
-    const session = makeSession(MODEL_TOOLS, executeTool);
-    const obs = await runAction(session, `return nodetool.providers.list();`);
+  it("routes forProvider through list_provider_models", async () => {
+    const { executeTool, calls } = createFakeRouter();
+    const session = makeSession(
+      [...MODEL_TOOLS, toolDef("list_provider_models")],
+      executeTool
+    );
+    const obs = await runAction(
+      session,
+      `await nodetool.models.forProvider("fal_ai", { limit: 5 });
+       return true;`
+    );
     expect(obs.ok).toBe(true);
-    const providers = obs.result as Array<{
-      provider: string;
-      models: number;
-      types: string[];
-    }>;
-    expect(providers).toHaveLength(2);
-    const openai = providers.find((p) => p.provider === "openai");
-    expect(openai?.models).toBe(2);
-    expect(openai?.types.sort()).toEqual(["image", "language"]);
+    expect(calls[0]).toMatchObject({
+      name: "list_provider_models",
+      args: { provider: "fal_ai", limit: 5 }
+    });
   });
 
   it("wraps workflow CRUD and run with clean call shapes", async () => {
@@ -506,8 +513,9 @@ describe("nodetool object model", () => {
        const one = await nodetool.agents.run(
          "Summarize the release notes and reply as JSON with {summary}."
        );
-       const many = await nodetool.agents.fanout(
-         ["First topic", { prompt: "Second topic", description: "Topic two" }],
+       const many = await nodetool.batch(
+         ["First topic", "Topic two"],
+         (p) => nodetool.agents.run(p),
          { concurrency: 2 }
        );
        return { node, one, ok: many.filter((r) => r.ok).length };`
@@ -523,11 +531,11 @@ describe("nodetool object model", () => {
       "Summarize the release notes and reply"
     );
     expect(calls[1].args["prompt"]).toContain("reply as JSON");
-    const fanoutDescriptions = calls
+    const batchDescriptions = calls
       .slice(2)
       .map((c) => c.args["description"]);
-    expect(fanoutDescriptions).toContain("First topic");
-    expect(fanoutDescriptions).toContain("Topic two");
+    expect(batchDescriptions).toContain("First topic");
+    expect(batchDescriptions).toContain("Topic two");
     expect((obs.result as { ok: number }).ok).toBe(2);
   });
 

--- a/packages/agents/tests/sandbox-manifest-drift.test.ts
+++ b/packages/agents/tests/sandbox-manifest-drift.test.ts
@@ -66,7 +66,7 @@ describe("sandbox manifest", () => {
         expect(typeof value, bridge.name).toBe("function");
         continue;
       }
-      const documented = bridge.members
+      const documented = [...bridge.members, ...(bridge.internalMembers ?? [])]
         .map((m) => m.name.split(".")[1])
         .sort();
       expect(Object.keys(value as object).sort(), bridge.name).toEqual(

--- a/packages/agents/tests/sandbox-manifest-drift.test.ts
+++ b/packages/agents/tests/sandbox-manifest-drift.test.ts
@@ -174,6 +174,9 @@ function documentedGlobals(): Set<string> {
     [...sandboxManifestNames(manifest)].filter((n) => !n.includes("."))
   );
   for (const name of manifest.blockedGlobals) documented.add(name);
+  // Per-run injections (`inputs`, `state`, the tool bridge's `tools` and
+  // `nodetool`) are part of the surface the node-sdk validator must accept.
+  for (const name of manifest.nodeGlobals) documented.add(name);
   documented.delete("__maxIter");
   return documented;
 }

--- a/packages/agents/tests/search-tools.test.ts
+++ b/packages/agents/tests/search-tools.test.ts
@@ -5,9 +5,48 @@ import {
   GoogleImagesTool
 } from "../src/tools/search-tools.js";
 
+vi.mock("openai", () => ({
+  OpenAI: class {
+    chat = {
+      completions: {
+        create: async () => ({
+          choices: [{ message: { content: "openai backend answer" } }]
+        })
+      }
+    };
+  }
+}));
+
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                           */
 /* ------------------------------------------------------------------ */
+
+/**
+ * Routing reads real configuration (secrets/env), so ambient keys in the test
+ * process would change which backend is picked. Pin them all to absent.
+ */
+const BACKEND_ENV_KEYS = [
+  "SERPAPI_API_KEY",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "DATA_FOR_SEO_LOGIN",
+  "DATA_FOR_SEO_PASSWORD"
+] as const;
+const envStash: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of BACKEND_ENV_KEYS) {
+    envStash[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of BACKEND_ENV_KEYS) {
+    if (envStash[key] === undefined) delete process.env[key];
+    else process.env[key] = envStash[key];
+  }
+});
 
 /** Build a mock ProcessingContext whose getSecret returns the given map. */
 function makeContext(secrets: Record<string, string | null> = {}) {
@@ -347,5 +386,248 @@ describe("GoogleImagesTool", () => {
     const pt = tool.toProviderTool();
     expect(pt.name).toBe("google_images");
     expect(pt.inputSchema).toBeDefined();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Host-side backend routing                                         */
+/* ------------------------------------------------------------------ */
+
+describe("search backend routing", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+    fetchSpy = undefined;
+  });
+
+  it("web_search falls to the OpenAI backend when SerpAPI is unconfigured", async () => {
+    const tool = new WebSearchTool();
+    const ctx = makeContext({ OPENAI_API_KEY: "ok" });
+    const result = await tool.process(ctx, { query: "fox" });
+    expect(result).toBe("openai backend answer");
+  });
+
+  it("web_search falls to DataForSEO when only its credentials exist", async () => {
+    const tool = new WebSearchTool();
+    const ctx = makeContext({
+      DATA_FOR_SEO_LOGIN: "user",
+      DATA_FOR_SEO_PASSWORD: "pass"
+    });
+    fetchSpy = stubFetch({
+      status_code: 20000,
+      status_message: "Ok.",
+      tasks: [
+        {
+          result: [
+            {
+              items: [
+                {
+                  type: "organic",
+                  title: "Fox facts",
+                  url: "https://foxes.example",
+                  description: "All about foxes"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+    const result = (await tool.process(ctx, { query: "fox" })) as string;
+    expect(result).toContain("1. Fox facts");
+    expect(result).toContain("https://foxes.example");
+    const calledUrl = String(fetchSpy.mock.calls[0][0]);
+    expect(calledUrl).toContain("api.dataforseo.com");
+  });
+
+  it("web_search pinned to the Gemini backend formats text plus sources", async () => {
+    const tool = new WebSearchTool();
+    const ctx = makeContext({
+      SERPAPI_API_KEY: "serp",
+      GEMINI_API_KEY: "gem"
+    });
+    fetchSpy = stubFetch({
+      candidates: [
+        {
+          content: { parts: [{ text: "Grounded answer." }] },
+          groundingMetadata: {
+            groundingChunks: [
+              { web: { title: "Source A", uri: "https://a.example" } }
+            ]
+          }
+        }
+      ]
+    });
+    const result = (await tool.process(ctx, {
+      query: "fox",
+      backend: "gemini"
+    })) as string;
+    expect(result).toContain("Grounded answer.");
+    expect(result).toContain("Sources:");
+    expect(result).toContain("https://a.example");
+    const calledUrl = String(fetchSpy.mock.calls[0][0]);
+    expect(calledUrl).toContain("generativelanguage.googleapis.com");
+  });
+
+  it("a pin overrides preference order even when earlier backends are configured", async () => {
+    const tool = new WebSearchTool();
+    const ctx = makeContext({
+      SERPAPI_API_KEY: "serp",
+      DATA_FOR_SEO_LOGIN: "user",
+      DATA_FOR_SEO_PASSWORD: "pass"
+    });
+    fetchSpy = stubFetch({
+      status_code: 20000,
+      status_message: "Ok.",
+      tasks: [{ result: [{ items: [] }] }]
+    });
+    await tool.process(ctx, { query: "fox", backend: "dataforseo" });
+    const calledUrl = String(fetchSpy.mock.calls[0][0]);
+    expect(calledUrl).toContain("api.dataforseo.com");
+  });
+
+  it("a pinned unconfigured backend is an error naming the missing key", async () => {
+    const tool = new WebSearchTool();
+    const ctx = makeContext({ SERPAPI_API_KEY: "serp" });
+    await expect(
+      tool.process(ctx, { query: "fox", backend: "openai" })
+    ).rejects.toThrow(/openai.*OPENAI_API_KEY/);
+    await expect(
+      new GoogleNewsTool().process(ctx, {
+        keyword: "fox",
+        backend: "dataforseo"
+      })
+    ).rejects.toThrow(/DATA_FOR_SEO_LOGIN and DATA_FOR_SEO_PASSWORD/);
+  });
+
+  it("an unknown backend pin is an error listing the valid ones", async () => {
+    const tool = new WebSearchTool();
+    const ctx = makeContext({ SERPAPI_API_KEY: "serp" });
+    await expect(
+      tool.process(ctx, { query: "fox", backend: "bing" })
+    ).rejects.toThrow(/unknown backend "bing".*serpapi, openai, gemini, dataforseo/);
+  });
+
+  it('backend "default" means the tool\'s own first backend', async () => {
+    const tool = new WebSearchTool();
+    const ctx = makeContext({ SERPAPI_API_KEY: "serp" });
+    fetchSpy = stubFetch({ organic_results: [] });
+    const result = await tool.process(ctx, {
+      query: "fox",
+      backend: "default"
+    });
+    expect(result).toBe("No results.");
+    expect(String(fetchSpy.mock.calls[0][0])).toContain("serpapi.com");
+  });
+
+  it("a real error from a configured backend does not fall through", async () => {
+    const tool = new WebSearchTool();
+    const ctx = makeContext({
+      SERPAPI_API_KEY: "serp",
+      DATA_FOR_SEO_LOGIN: "user",
+      DATA_FOR_SEO_PASSWORD: "pass"
+    });
+    fetchSpy = stubFetch({ error: "boom" }, 500);
+    await expect(tool.process(ctx, { query: "fox" })).rejects.toThrow(
+      "SerpAPI request failed (500)"
+    );
+    // Only the SerpAPI call happened — no DataForSEO fallthrough.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0][0])).toContain("serpapi.com");
+  });
+
+  it("google_news routes to DataForSEO and keeps its result shape", async () => {
+    const tool = new GoogleNewsTool();
+    const ctx = makeContext({
+      DATA_FOR_SEO_LOGIN: "user",
+      DATA_FOR_SEO_PASSWORD: "pass"
+    });
+    fetchSpy = stubFetch({
+      status_code: 20000,
+      status_message: "Ok.",
+      tasks: [
+        {
+          result: [
+            {
+              items: [
+                {
+                  type: "news_search",
+                  title: "Fox news item",
+                  url: "https://news.example/fox",
+                  source: "Example News",
+                  timestamp: "2026-08-01 10:00:00 +00:00",
+                  description: "A fox did something."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+    const result = (await tool.process(ctx, { keyword: "fox" })) as Record<
+      string,
+      unknown
+    >;
+    expect(result.success).toBe(true);
+    expect(result.results).toEqual([
+      {
+        title: "Fox news item",
+        link: "https://news.example/fox",
+        snippet: "A fox did something.",
+        date: "2026-08-01",
+        source: "Example News"
+      }
+    ]);
+  });
+
+  it("google_images routes to DataForSEO and keeps its result shape", async () => {
+    const tool = new GoogleImagesTool();
+    const ctx = makeContext({
+      DATA_FOR_SEO_LOGIN: "user",
+      DATA_FOR_SEO_PASSWORD: "pass"
+    });
+    fetchSpy = stubFetch({
+      status_code: 20000,
+      status_message: "Ok.",
+      tasks: [
+        {
+          result: [
+            {
+              items: [
+                {
+                  type: "images_search",
+                  title: "A fox",
+                  image_url: "https://img.example/fox.jpg",
+                  source_url: "https://page.example/fox",
+                  alt: "fox"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+    const result = (await tool.process(ctx, { keyword: "fox" })) as Record<
+      string,
+      unknown
+    >;
+    expect(result.success).toBe(true);
+    expect(result.results).toEqual([
+      {
+        title: "A fox",
+        link: "https://page.example/fox",
+        original: "https://img.example/fox.jpg",
+        thumbnail: null
+      }
+    ]);
+  });
+
+  it("no configured backend at all names every missing key", async () => {
+    const tool = new WebSearchTool();
+    const ctx = makeContext({});
+    await expect(tool.process(ctx, { query: "fox" })).rejects.toThrow(
+      /no search backend is configured.*SERPAPI_API_KEY.*OPENAI_API_KEY.*GEMINI_API_KEY.*DATA_FOR_SEO_LOGIN/
+    );
   });
 });

--- a/packages/code-nodes/src/nodes/code-node.ts
+++ b/packages/code-nodes/src/nodes/code-node.ts
@@ -4,25 +4,36 @@
  * Runs user code in an isolated QuickJS WebAssembly guest (see
  * `@nodetool-ai/agents/js-sandbox`) with standard JavaScript plus the bridge
  * APIs: fetch(), workspace (text/bytes/stat/mkdir/remove/copy/move/root),
- * getSecret(), uuid(), sleep(), progress(), crypto, format, data (CSV/HTML
- * parsing) and the base64/hex helpers. Dynamic inputs are injected as global
- * variables in the sandbox.
+ * getSecret(), sleep(), progress(), crypto (randomUUID/digest/hmac), format,
+ * data (CSV/HTML parsing) and the base64/hex helpers. Dynamic inputs arrive
+ * on the `inputs` object.
+ *
+ * On a server host the code also gets the `nodetool` object model — the
+ * platform as objects (`nodetool.workflows`, `nodetool.assets`, …), backed by
+ * the agent toolbelt through a `tools.<name>()` bridge. The belt is loaded
+ * lazily and only on Node: the in-browser runner bundles this module, so the
+ * toolbelt (native canvas, IMAP, execution) must never sit in its static
+ * import graph. Without a belt, `nodetool.capabilities()` reports `{}` and
+ * every method throws naming its missing tool instead of a ReferenceError.
  *
  * Example:
  *   // inputs: { x: 5, text: "hello" }
  *   // code:
- *   const sum = x + 10;
- *   const upper = text.toUpperCase();
+ *   const sum = inputs.x + 10;
+ *   const upper = inputs.text.toUpperCase();
  *   return { sum, upper };
  *   // outputs: { sum: 15, upper: "HELLO" }
  */
 
-import { BaseNode, prop, CODE_INPUTS_GLOBAL } from "@nodetool-ai/node-sdk";
+import { BaseNode, prop, CODE_INPUTS_GLOBAL, NodeRegistry } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import {
   runInSandbox,
+  TOOLS_PRELUDE,
+  NODETOOL_API_PRELUDE_FULL,
   type SandboxLimits
 } from "@nodetool-ai/agents/js-sandbox";
+import { importHidden } from "@nodetool-ai/config";
 import { ALL_PLATFORMS } from "@nodetool-ai/protocol";
 
 /** JS keywords that cannot be used as variable names. */
@@ -98,6 +109,100 @@ const JS_RESERVED = new Set([
 const STATEMENT_KEYWORDS =
   /^(if|else|for|while|do|switch|try|catch|finally|throw|const|let|var|class|function|with|debugger|break|continue|return)\b/;
 
+// ---------------------------------------------------------------------------
+// The `nodetool` object model — toolbelt bridge
+// ---------------------------------------------------------------------------
+
+/**
+ * The guest prelude every run gets: `tools.<name>()` wrappers over the
+ * `__callTool` bridge, then the `nodetool` object model on top of them. Both
+ * are plain strings, so prepending them costs nothing even where no belt
+ * exists — the object model degrades per namespace by design.
+ */
+const NODETOOL_PRELUDE = `${TOOLS_PRELUDE}\n${NODETOOL_API_PRELUDE_FULL}`;
+
+/** Type-only view of the agents package index; erased at compile time. */
+type AgentsModule = typeof import("@nodetool-ai/agents");
+type AgentTool = InstanceType<AgentsModule["Tool"]>;
+
+/**
+ * Bridge globals for a host with no toolbelt (browser runner, no context):
+ * the prelude builds zero wrappers, `nodetool.capabilities()` returns `{}`,
+ * and every `nodetool.*` method throws naming its missing tool.
+ */
+const NO_TOOLS_GLOBALS: Record<string, unknown> = {
+  __toolNames: [] as string[],
+  __callTool: async () => ({
+    ok: false as const,
+    error: "no tools in this environment"
+  })
+};
+
+let agentsModulePromise: Promise<AgentsModule | null> | null = null;
+
+/**
+ * The agents package index, loaded lazily and hidden from bundlers.
+ * `importHidden` answers `null` off Node, so a browser bundle never resolves
+ * the toolbelt's server-only dependencies. Hosts where the bare specifier is
+ * not resolvable at runtime (the packaged Electron backend inlines workspace
+ * packages instead of staging them in `_modules/`) degrade the same way the
+ * browser does unless they inject a belt via {@link setCodeNodeTools}.
+ */
+function loadAgentsModule(): Promise<AgentsModule | null> {
+  if (!agentsModulePromise) {
+    agentsModulePromise = importHidden<AgentsModule>(
+      "@nodetool-ai/agents"
+    ).catch(() => null);
+  }
+  return agentsModulePromise;
+}
+
+let toolOverride: AgentTool[] | null = null;
+
+/**
+ * Test/host injection point: replace the assembled toolbelt with a fixed set
+ * (`[]` simulates a beltless host). Pass `null` to restore the default
+ * assembly.
+ */
+export function setCodeNodeTools(tools: AgentTool[] | null): void {
+  toolOverride = tools;
+}
+
+/**
+ * Assemble the belt the way an agent loop would: `getAgentToolbelt()` plus
+ * the in-process core API tools. Only the node registry is constructible
+ * here (`NodeRegistry.global` — populated in any process that registered
+ * node packages); the example catalog, DSL exporter and provider set live
+ * above this package, so their tools stay dark and the `nodetool` prelude
+ * reports the difference via `capabilities()`.
+ */
+function assembleToolbelt(mod: AgentsModule): AgentTool[] {
+  const byName = new Map<string, AgentTool>();
+  const registry = NodeRegistry.global;
+  for (const tool of [
+    ...mod.getAgentToolbelt(),
+    ...mod.getAllMcpTools({ registry })
+  ]) {
+    byName.set(tool.name, tool);
+  }
+  return [...byName.values()];
+}
+
+/**
+ * Globals wiring the `tools`/`nodetool` preludes to a real tool bridge, or
+ * the inert stub when no belt is constructible. Tool execution needs a
+ * ProcessingContext; without one the stub keeps the prelude harmless.
+ */
+async function toolBridgeGlobals(
+  context: ProcessingContext | undefined
+): Promise<Record<string, unknown>> {
+  if (!context) return NO_TOOLS_GLOBALS;
+  const mod = await loadAgentsModule();
+  if (!mod) return NO_TOOLS_GLOBALS;
+  const tools = toolOverride ?? assembleToolbelt(mod);
+  return mod.buildToolBridge({ tools, context }).globals;
+}
+
 export class CodeNode extends BaseNode {
   static readonly nodeType = "nodetool.code.Code";
   static readonly platforms = ALL_PLATFORMS;
@@ -105,10 +210,14 @@ export class CodeNode extends BaseNode {
   static readonly description =
     "Execute vanilla JavaScript in a sandboxed environment. " +
     "APIs: fetch(), workspace.read/write/list/readBytes/writeBytes/stat/mkdir/remove/copy/move/root(), " +
-    "getSecret(), uuid(), sleep(), progress(), crypto.digest/hmac/randomUUID/getRandomValues, " +
+    "getSecret(), sleep(), progress(), crypto.digest/hmac/randomUUID/getRandomValues, " +
     "format.number/date/relativeTime/list, data.parseCsv/selectHtml, " +
-    "toBase64/fromBase64/toHex/fromHex, parallelMap. " +
-    "Dynamic inputs become global variables; return an object to define outputs." +
+    "toBase64/fromBase64/toHex/fromHex, parallelMap, plus the `nodetool` object model " +
+    "(workflows, assets, jobs, …) backed by platform tools on server hosts — " +
+    "nodetool.capabilities() reports what is live. Tool-backed calls can spend money " +
+    "(media generation, workflow runs) and reach the web; each tool applies its own " +
+    "permission gating. " +
+    "Dynamic inputs arrive on the `inputs` object; return an object to define outputs." +
     "\n    code, javascript, function, script, dynamic";
   static readonly inlineFields = ["code"];
   static readonly inputFields = [];
@@ -124,10 +233,10 @@ export class CodeNode extends BaseNode {
     title: "Code",
     description:
       "JavaScript code to execute. " +
-      "Dynamic inputs are available as variables. " +
+      "Dynamic inputs arrive on the `inputs` object. " +
       "APIs: fetch(url, options), workspace.read/write/list/readBytes/writeBytes/stat/mkdir/remove/copy/move/root, " +
       "workspace.stat(path) returns {exists, size, isDirectory, isFile, isSymlink, modifiedMs, createdMs, accessedMs}, " +
-      "getSecret(name), uuid(), sleep(ms), progress(percent, message), " +
+      "getSecret(name), sleep(ms), progress(percent, message), " +
       "crypto.randomUUID/getRandomValues/digest/hmac, " +
       "format.number/date/relativeTime/list, " +
       "data.parseCsv(text, {delimiter, header}), data.selectHtml(html, selector, {attr, limit}), " +
@@ -135,6 +244,9 @@ export class CodeNode extends BaseNode {
       "data and crypto.digest/hmac; the rest are synchronous. " +
       "Concurrent calls run in parallel: use Promise.all or " +
       "parallelMap(items, fn, concurrency) to fan out fetches. " +
+      "The `nodetool` object model exposes platform tools (nodetool.workflows, " +
+      "nodetool.assets, …) where the host carries them — nodetool.capabilities() " +
+      "reports live namespaces; elsewhere a method throws naming its missing tool. " +
       "A persistent `state` object survives across streaming invocations. " +
       "Return an object — its keys become output handles."
   })
@@ -247,11 +359,12 @@ export class CodeNode extends BaseNode {
     // State stays a direct reference so mutations persist across calls.
     const globals = {
       [CODE_INPUTS_GLOBAL]: deepCopyInputs(dynamicInputs),
-      state: this._state
+      state: this._state,
+      ...(await toolBridgeGlobals(context))
     };
 
     const sandboxResult = await runInSandbox({
-      code: body,
+      code: `${NODETOOL_PRELUDE}\n${body}`,
       context,
       timeoutMs: timeout > 0 ? timeout * 1000 : undefined,
       globals,
@@ -285,7 +398,8 @@ export class CodeNode extends BaseNode {
     };
     const dynamicInputs = extractDynamicInputs(allInputs);
 
-    const wrappedBody = `
+    // The prelude sits outside the yield_ rewrite: only user code streams.
+    const wrappedBody = `${NODETOOL_PRELUDE}
       const __yielded = [];
       function yield_(value) { __yielded.push(value); }
       ${code.replace(/\byield\b/g, "yield_")}
@@ -299,7 +413,8 @@ export class CodeNode extends BaseNode {
     // State stays a direct reference so mutations persist across calls.
     const globals = {
       [CODE_INPUTS_GLOBAL]: deepCopyInputs(dynamicInputs),
-      state: this._state
+      state: this._state,
+      ...(await toolBridgeGlobals(context))
     };
 
     const sandboxResult = await runInSandbox({

--- a/packages/code-nodes/tests/code-node-limits.test.ts
+++ b/packages/code-nodes/tests/code-node-limits.test.ts
@@ -6,7 +6,9 @@ const runInSandbox = vi.fn(async () => ({
 }));
 
 vi.mock("@nodetool-ai/agents/js-sandbox", () => ({
-  runInSandbox
+  runInSandbox,
+  TOOLS_PRELUDE: "",
+  NODETOOL_API_PRELUDE_FULL: ""
 }));
 
 // Import the source module so vitest processes it and the mock above applies.

--- a/packages/code-nodes/tests/code-node-nodetool.test.ts
+++ b/packages/code-nodes/tests/code-node-nodetool.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The `nodetool` object model inside `nodetool.code.Code`.
+ *
+ * The node prepends the `tools.*` wrapper prelude and the full `nodetool`
+ * prelude to every run, wired to a real tool bridge when a belt is
+ * constructible. These tests drive both ends of that contract: a fake belt
+ * carrying a platform-named tool, and the degraded hosts (empty belt, no
+ * ProcessingContext) where `nodetool.capabilities()` is `{}` and every method
+ * throws naming its missing tool.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { CodeNode, setCodeNodeTools } from "@nodetool-ai/code-nodes";
+import { Tool } from "@nodetool-ai/agents";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+
+/** Minimal context: the fake tools below never read it. */
+const fakeContext = {} as unknown as ProcessingContext;
+
+class FakeListWorkflowsTool extends Tool {
+  readonly name = "list_workflows";
+  readonly description = "Fake list_workflows for tests.";
+  calls: Record<string, unknown>[] = [];
+  async process(
+    _context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    this.calls.push(params);
+    return [{ id: "wf_1", name: "First" }, { id: "wf_2", name: "Second" }];
+  }
+}
+
+class FailingTool extends Tool {
+  readonly name = "get_workflow";
+  readonly description = "Always fails.";
+  async process(): Promise<unknown> {
+    return { error: "boom", message: "workflow store is on fire" };
+  }
+}
+
+function runNode(
+  code: string,
+  context?: ProcessingContext
+): Promise<Record<string, unknown>> {
+  const node = new CodeNode({ code });
+  return node.process(context);
+}
+
+afterEach(() => setCodeNodeTools(null));
+
+describe("CodeNode — nodetool object model", () => {
+  it("routes nodetool.* calls through the injected belt", async () => {
+    const listTool = new FakeListWorkflowsTool();
+    setCodeNodeTools([listTool]);
+    const r = await runNode(
+      `
+      const caps = nodetool.capabilities();
+      const wfs = await nodetool.workflows.list({ limit: 5 });
+      return { namespaces: Object.keys(caps), ids: wfs.map((w) => w.id) };
+      `,
+      fakeContext
+    );
+    expect(r["namespaces"]).toEqual(["workflows"]);
+    expect(r["ids"]).toEqual(["wf_1", "wf_2"]);
+    expect(listTool.calls).toEqual([{ limit: 5 }]);
+  });
+
+  it("exposes the raw tools.<name>() bridge alongside nodetool", async () => {
+    setCodeNodeTools([new FakeListWorkflowsTool()]);
+    const r = await runNode(
+      "return { count: (await tools.list_workflows()).length };",
+      fakeContext
+    );
+    expect(r).toEqual({ count: 2 });
+  });
+
+  it("rethrows a tool {error} payload as a guest exception", async () => {
+    setCodeNodeTools([new FailingTool()]);
+    const r = await runNode(
+      `
+      try {
+        await nodetool.workflows.get("wf_1");
+        return { threw: false };
+      } catch (e) {
+        return { threw: true, message: e.message };
+      }
+      `,
+      fakeContext
+    );
+    expect(r["threw"]).toBe(true);
+    expect(String(r["message"])).toContain("workflow store is on fire");
+  });
+
+  it("with an empty belt: capabilities() is {} and methods name their tool", async () => {
+    setCodeNodeTools([]);
+    const r = await runNode(
+      `
+      const caps = nodetool.capabilities();
+      let error = null;
+      try {
+        await nodetool.workflows.list();
+      } catch (e) {
+        error = e.message;
+      }
+      return { caps, error };
+      `,
+      fakeContext
+    );
+    expect(r["caps"]).toEqual({});
+    expect(String(r["error"])).toContain("list_workflows");
+  });
+
+  it("without a ProcessingContext: same degradation, no ReferenceError", async () => {
+    const r = await runNode(`
+      const caps = nodetool.capabilities();
+      let error = null;
+      try {
+        await nodetool.assets.list();
+      } catch (e) {
+        error = e.message;
+      }
+      return { caps, hasTools: typeof tools === "object", error };
+    `);
+    expect(r["caps"]).toEqual({});
+    expect(r["hasTools"]).toBe(true);
+    expect(String(r["error"])).toContain("list_assets");
+  });
+
+  it("plain code that never touches nodetool runs unchanged", async () => {
+    const r = await runNode("return { sum: 1 + 2 };");
+    expect(r).toEqual({ sum: 3 });
+  });
+
+  it("streaming (yield) bodies get the object model too", async () => {
+    setCodeNodeTools([new FakeListWorkflowsTool()]);
+    const node = new CodeNode({
+      code: `
+        const wfs = await nodetool.workflows.list();
+        for (const wf of wfs) { yield({ id: wf.id }); }
+      `
+    });
+    const out: Record<string, unknown>[] = [];
+    for await (const item of node.genProcess(fakeContext)) out.push(item);
+    expect(out).toEqual([{ id: "wf_1" }, { id: "wf_2" }]);
+  });
+});

--- a/packages/node-sdk/src/code-node-validation.ts
+++ b/packages/node-sdk/src/code-node-validation.ts
@@ -45,30 +45,34 @@ export function isJsCodeNodeType(nodeType: string): boolean {
 export const SANDBOX_GLOBALS: ReadonlySet<string> = new Set([
   // Guest globals, as observed in the running QuickJS sandbox
   "AggregateError", "Array", "ArrayBuffer", "BigInt", "BigInt64Array",
-  "BigUint64Array", "Boolean", "Buffer", "DataView", "Date", "Error",
+  "BigUint64Array", "Boolean", "DataView", "Date", "Error",
   "EvalError", "FinalizationRegistry", "Float32Array", "Float64Array",
-  "Headers", "Infinity", "Int16Array", "Int32Array", "Int8Array",
+  "Infinity", "Int16Array", "Int32Array", "Int8Array",
   "InternalError", "JSON", "Map", "Math", "NaN", "Number", "Object",
   "Promise", "Proxy", "RangeError", "ReferenceError", "Reflect", "RegExp",
-  "Request", "Response", "Set", "SharedArrayBuffer", "String", "Symbol",
+  "Set", "SharedArrayBuffer", "String", "Symbol",
   "SyntaxError", "TextDecoder", "TextEncoder", "TypeError", "URIError",
   "URL", "URLSearchParams", "Uint16Array", "Uint32Array", "Uint8Array",
   "Uint8ClampedArray", "WeakMap", "WeakRef", "WeakSet", "decodeURI",
-  "decodeURIComponent", "encodeURI", "encodeURIComponent", "env", "escape",
-  "globalThis", "isFinite", "isNaN", "parseFloat", "parseInt", "performance",
-  "process", "queueMicrotask", "undefined", "unescape",
+  "decodeURIComponent", "encodeURI", "encodeURIComponent", "escape",
+  "globalThis", "isFinite", "isNaN", "parseFloat", "parseInt",
+  "queueMicrotask", "undefined", "unescape",
   // Host bridges
-  "console", "fetch", "crypto", "uuid", "sleep", "getSecret", "workspace",
+  "console", "fetch", "crypto", "sleep", "getSecret", "workspace",
   "assetToSandbox", "sandboxToAsset", "progress", "format", "data",
   "image", "canvas",
   // Pure guest helpers defined by the sandbox prelude
-  "toBase64", "fromBase64", "toHex", "fromHex", "utf8Encode", "utf8Decode",
+  "toBase64", "fromBase64", "toHex", "fromHex",
   "parallelMap", "createCanvas",
+  // The tool bridge preludes: `tools.<name>()` wrappers and the `nodetool`
+  // object model over them
+  "tools", "nodetool",
   // Absent from this guest, but not user inputs either
   "setTimeout", "clearTimeout", "setInterval", "clearInterval",
   "setImmediate", "clearImmediate", "eval", "Function",
   "btoa", "atob", "structuredClone", "Intl", "AbortController", "Blob",
-  "FormData",
+  "FormData", "Buffer", "Headers", "Request", "Response", "env", "process",
+  "performance", "uuid", "utf8Encode", "utf8Decode",
   // JS literals that acorn parses as Identifier nodes
   "true", "false", "null",
   "this", "arguments", "self", "window", "document",
@@ -88,7 +92,10 @@ const ABSENT_GLOBALS: ReadonlySet<string> = new Set([
   "setTimeout", "clearTimeout", "setInterval", "clearInterval",
   "setImmediate", "clearImmediate", "eval", "Function",
   "btoa", "atob", "structuredClone", "Intl", "AbortController", "Blob",
-  "FormData"
+  "FormData",
+  // Removed guest names: deleted quickjs stubs and retired prelude aliases
+  "Buffer", "Headers", "Request", "Response", "env", "process",
+  "performance", "uuid", "utf8Encode", "utf8Decode"
 ]);
 
 export interface CodeNodeIssue {
@@ -191,7 +198,9 @@ export function validateCodeNodeBody(
         `The code reads ${formatNames(absentNames.sort())}, which other JavaScript runtimes ` +
         `have but this sandbox does not — ${absentNames.length > 1 ? "they throw" : "it throws"} ReferenceError. ` +
         "Use the sandbox equivalent: toBase64/fromBase64 for base64, format.* for Intl, " +
-        "sleep for timers, JSON round-trip for a deep copy."
+        "sleep for timers, JSON round-trip for a deep copy, crypto.randomUUID() for uuid, " +
+        "new TextEncoder()/new TextDecoder() for utf8Encode/utf8Decode, and plain " +
+        "fetch() objects instead of Headers/Request/Response."
     });
   }
   const undefinedNames = unbound.filter(

--- a/packages/node-sdk/tests/code-node-validation.test.ts
+++ b/packages/node-sdk/tests/code-node-validation.test.ts
@@ -69,6 +69,48 @@ describe("validateCodeNodeBody", () => {
     ).toEqual([]);
   });
 
+  it("accepts the tool bridge names `nodetool` and `tools`", () => {
+    expect(
+      codes(
+        body(
+          `const caps = nodetool.capabilities();
+           const wfs = await tools.list_workflows({});
+           return { caps, count: wfs.length };`,
+          [],
+          ["caps", "count"]
+        )
+      )
+    ).toEqual([]);
+  });
+
+  it("tells a body reading a removed guest name what replaced it", () => {
+    const issues = validateCodeNodeBody(
+      body("return { id: uuid(), bytes: utf8Encode(inputs.text) };", ["text"], [
+        "id",
+        "bytes"
+      ])
+    );
+    const absent = issues.find((i) => i.code === "code_undefined_name");
+    expect(absent?.severity).toBe("error");
+    expect(absent?.message).toContain("crypto.randomUUID()");
+    expect(absent?.message).toContain("TextEncoder");
+  });
+
+  it("flags the deleted quickjs stubs (Buffer, process, Headers)", () => {
+    const issues = validateCodeNodeBody(
+      body(
+        "return { b: Buffer.from(inputs.text), e: process.env.HOME, h: new Headers() };",
+        ["text"],
+        ["b", "e", "h"]
+      )
+    );
+    const absent = issues.find((i) => i.code === "code_undefined_name");
+    expect(absent?.severity).toBe("error");
+    expect(absent?.message).toContain('"Buffer"');
+    expect(absent?.message).toContain('"process"');
+    expect(absent?.message).toContain('"Headers"');
+  });
+
   it("does not flag a typeof guard or an implicit global", () => {
     expect(
       codes(

--- a/web/src/config/codeSnippets.ts
+++ b/web/src/config/codeSnippets.ts
@@ -868,7 +868,7 @@ return {
     title: "Generate UUID v4",
     description: "Generate a random UUID v4",
     category: "UUID",
-    code: "return { output: uuid() };",
+    code: "return { output: crypto.randomUUID() };",
     tags: ["uuid", "v4", "random", "generate", "id"],
   },
   {

--- a/web/src/hooks/editor/useChatIntegration.ts
+++ b/web/src/hooks/editor/useChatIntegration.ts
@@ -174,7 +174,7 @@ FORMATTING (there is no Intl; these are host calls, default locale en-US):
 CRYPTO AND BINARY:
 - crypto.randomUUID() → string; crypto.getRandomValues(length) → Uint8Array
 - await crypto.digest(algorithm, data) and await crypto.hmac(algorithm, key, data) → Uint8Array; SHA-1/256/384/512
-- toBase64, fromBase64, toHex, fromHex, utf8Encode, utf8Decode — synchronous conversions between strings and Uint8Array
+- toBase64, fromBase64, toHex, fromHex — synchronous conversions between strings/bytes; TextEncoder and TextDecoder are native for UTF-8
 
 ASYNC APIS:
 - await fetch(url, options?) → { ok, status, statusText, headers, body, json, text, bytes, arrayBuffer } — 20 calls per run, 15s timeout each, 1MB response cap. Private and loopback addresses are refused.
@@ -182,7 +182,6 @@ ASYNC APIS:
 - await parallelMap(items, fn, concurrency?) → results in input order — bounded fan-out, concurrency default 5. The way to fetch many URLs.
 - await sleep(ms) — the only timer, capped at 5000ms
 - await getSecret(name) → string or undefined
-- uuid() → string
 - progress(percent, message?) — drives the node progress bar; fire-and-forget
 
 IMAGES (encoded bytes in, encoded bytes out, so calls chain; png, jpeg, webp, avif):


### PR DESCRIPTION
Makes the QuickJS guest surface minimal — one name per capability — and gives `nodetool.code.Code` the full `nodetool.*` object model.

## Sandbox surface

- Remove the `uuid` bridge (alias of `crypto.randomUUID`).
- Remove the `utf8Encode` / `utf8Decode` helpers (the guest has native `TextEncoder` / `TextDecoder`).
- Delete the `@sebastianwessel/quickjs` stub globals (`Buffer`, `process`, `env`, `Headers`, `Request`, `Response`, `performance`) in the sandbox-init prelude — the library has no switch for them. The manifest's blocked-globals list now names them, so prompts say they are absent instead of documenting stubs.
- Demote `canvas.render` to an internal member: `createCanvas(...).toBytes()` stays the documented path, `canvas.measureText` stays public.
- Regenerated `GUEST_GLOBALS_SNAPSHOT` from the live probe; drift tests updated.

## `nodetool.*` prelude dedup

- Delete `agents.fanout` (compose `nodetool.batch` + `agents.run`), `workflows.examples()` (use `list({workflow_type: "example"})`), the `providers` namespace (`models.forProvider(provider)` covers the one real tool behind it), and `style.profileDetails` plus the `__taste` normalizer.
- `assets.search` no longer falls back silently to `list_assets`.
- The CodeAct prompt documents one fan-out primitive: `nodetool.batch` when the object model is loaded, `parallelMap` otherwise.

## Search consolidation (follow-up commit on this branch)

- `web_search`, `google_news`, `google_images` route across configured backends host-side (configuration-checked, not error-message-sniffed); the provider-specific search tools leave the agent belt (they stay registered for MCP). The guest-side `__pickWeb` router and its `__unconfigured` regex are deleted.

## `nodetool` in Code nodes (follow-up commit on this branch)

- `nodetool.code.Code` gets the `tools.*` bridge and the full `nodetool.*` object model, assembled from the agent toolbelt where the host can construct one; hosts without a belt degrade cleanly (`nodetool.capabilities()` → `{}`, methods throw naming the missing tool). Manifest and node-sdk validator learn the new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mmkCetZEMtpdnZE9LYt6y

---
_Generated by [Claude Code](https://claude.ai/code/session_018mmkCetZEMtpdnZE9LYt6y)_