### PR TITLE
Sandbox packages: fix delivery caching, browser revalidation, and WASM budget concurrency

### DIFF
--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -204,6 +204,14 @@ guest JS and passes scalars in.
 | Aggregate WASM wall clock per invocation | 30 s |
 | Per-call timeout | 5 s, then the worker is terminated **and replaced** |
 
+The aggregate wall clock is a **reservation**, not a meter read on completion.
+A call is admitted only after taking `min(perCallTimeout, remaining)` out of
+the budget, so concurrent calls divide one cap instead of each seeing the whole
+remainder, and the reservation is what bounds that call's timeout. On
+completion the reservation is replaced by the real duration — a fast call
+refunds, one cut at its timeout keeps the charge — so the budget stays the sum
+of call durations it documents.
+
 The dispatcher is the boundary, not the hiding: it serves only the run's
 declared WASM modules and validates module identity, export allowlist, argument
 count, and argument type before any worker runs — `i32` rejects out of range

--- a/packages/agents/src/wasm-sandbox/host.ts
+++ b/packages/agents/src/wasm-sandbox/host.ts
@@ -354,26 +354,38 @@ export function createSandboxWasmDispatcher(
           `${runModule.specifier}: this node exhausted its budget of ${budgets.callsPerInvocation} WASM calls per invocation`
         );
       }
-      const remainingWallClock = budgets.wallClockMs - wallClockUsed;
-      if (remainingWallClock <= 0) {
-        throw new SandboxWasmError(
-          `${runModule.specifier}: this node exhausted its budget of ${budgets.wallClockMs} ms of WASM wall clock per invocation`
-        );
-      }
       callsUsed += 1;
 
       const compiled = await compileSandboxWasm(runModule.contentDigest, runModule.bytes);
       await enter();
+
+      // The wall clock is *reserved* here, not merely read: charging only on
+      // completion let every concurrently admitted call see the whole
+      // remainder, so two calls under the default concurrency of 2 could each
+      // be handed a 30 s budget and spend 60 s of worker time between them.
+      // Read and reserve sit in one synchronous run of this function — no
+      // await between them — so a second call admitted meanwhile can only ever
+      // see what is left after this one took its share.
+      const remainingWallClock = budgets.wallClockMs - wallClockUsed;
+      if (remainingWallClock <= 0) {
+        leave();
+        throw new SandboxWasmError(
+          `${runModule.specifier}: this node exhausted its budget of ${budgets.wallClockMs} ms of WASM wall clock per invocation`
+        );
+      }
+      const reserved = Math.min(runModule.callTimeoutMs, remainingWallClock);
+      wallClockUsed += reserved;
+
       const startedAt = Date.now();
       try {
-        return await pool.run(
-          compiled,
-          exported.wasmName,
-          converted,
-          Math.min(runModule.callTimeoutMs, remainingWallClock)
-        );
+        // The effective timeout is the reservation, so the call cannot outrun
+        // what it was actually admitted for.
+        return await pool.run(compiled, exported.wasmName, converted, reserved);
       } finally {
-        wallClockUsed += Date.now() - startedAt;
+        // Replace the reservation with what the call really cost: a fast call
+        // refunds the difference, one that ran to its timeout charges what it
+        // took. The budget stays the documented sum of call durations.
+        wallClockUsed += Date.now() - startedAt - reserved;
         leave();
       }
     }

--- a/packages/agents/tests/wasm-sandbox-host.test.ts
+++ b/packages/agents/tests/wasm-sandbox-host.test.ts
@@ -163,6 +163,62 @@ describe("WASM budgets", () => {
     );
   });
 
+  it("never admits more wall clock than the cap, however many calls run at once", async () => {
+    // Two calls run concurrently under the default concurrency of 2. Each is
+    // admitted against what is left *after* the other reserved, so the budget
+    // the two are handed sums to the cap rather than to twice it. The worker
+    // never answers, so each call spends exactly the timeout it was admitted
+    // with, and the error names that number.
+    const { dispatcher, pool } = dispatcherFor(
+      { limits: { wallClockMs: 60, callTimeoutMs: 50 } },
+      hangingFactory
+    );
+
+    const settled = await Promise.allSettled([
+      dispatcher.call(REFERENCE_SPECIFIER, "spin", []),
+      dispatcher.call(REFERENCE_SPECIFIER, "spin", [])
+    ]);
+
+    const admitted = settled.map((outcome) => {
+      expect(outcome.status).toBe("rejected");
+      const message = String(
+        (outcome as PromiseRejectedResult).reason?.message ?? ""
+      );
+      const timeout = /exceeded its (\d+) ms per-call timeout/.exec(message);
+      // A call refused outright admits nothing — that is the other legal
+      // answer for the second call.
+      if (timeout === null) {
+        expect(message).toMatch(/budget of 60 ms of WASM wall clock/);
+        return 0;
+      }
+      return Number(timeout[1]);
+    });
+
+    expect(admitted[0]).toBe(50);
+    expect(admitted.reduce((sum, ms) => sum + ms, 0)).toBeLessThanOrEqual(60);
+    // And the cap is spent: nothing further is admitted.
+    await expect(dispatcher.call(REFERENCE_SPECIFIER, "spin", [])).rejects.toThrow(
+      /budget of 60 ms of WASM wall clock/
+    );
+    pool.dispose();
+  });
+
+  it("refunds a reservation a fast call did not spend", async () => {
+    // Each call reserves its whole per-call timeout up front. Without the
+    // refund on completion, three 80 ms reservations would exhaust a 200 ms
+    // budget even though the calls take no time at all.
+    const { dispatcher } = dispatcherFor(
+      { limits: { wallClockMs: 200, callTimeoutMs: 80 } },
+      new FakeFactory()
+    );
+
+    for (let call = 0; call < 5; call += 1) {
+      await expect(
+        dispatcher.call(REFERENCE_SPECIFIER, "add", [7, 0])
+      ).resolves.toBe(7);
+    }
+  });
+
   it("holds the per-invocation call concurrency at two", async () => {
     const factory = new FakeFactory(15);
     const { dispatcher } = dispatcherFor({}, factory);

--- a/packages/websocket/src/routes/sandbox-modules.ts
+++ b/packages/websocket/src/routes/sandbox-modules.ts
@@ -15,8 +15,18 @@ import type { FastifyPluginAsync } from "fastify";
 import { getSandboxCatalog } from "../sandbox-catalog.js";
 import { getHttpRateLimitConfig } from "../lib/http-rate-limit.js";
 
-/** A year, in seconds: responses are immutable because the ETag is a digest. */
-const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+/**
+ * The URL is the *stable* module id, not the digest, so the body behind it
+ * changes whenever the pack is upgraded. `immutable` would let a browser or a
+ * proxy keep serving the old source without ever revalidating — the ETag below
+ * would never be consulted. `no-cache` still lets the client store the
+ * response; it just has to ask before reusing it, and the strong ETag turns
+ * that question into a 304 whenever nothing moved.
+ *
+ * `private` because delivery is authorized per client: a shared cache must not
+ * hold a private pack's source and hand it to the next requester.
+ */
+const REVALIDATE_CACHE_CONTROL = "private, no-cache";
 
 const sandboxModulesRoutes: FastifyPluginAsync = async (app) => {
   // The server registers @fastify/rate-limit globally, which already covers
@@ -69,7 +79,7 @@ const sandboxModulesRoutes: FastifyPluginAsync = async (app) => {
       .header("X-Sandbox-File-Id", delivery.fileId)
       .header("X-Sandbox-Internal", delivery.internal ? "1" : "0")
       .header("ETag", etag)
-      .header("Cache-Control", IMMUTABLE_CACHE_CONTROL);
+      .header("Cache-Control", REVALIDATE_CACHE_CONTROL);
     if (delivery.packVersion !== undefined) {
       reply.header("X-Sandbox-Pack-Version", delivery.packVersion);
     }

--- a/packages/websocket/tests/sandbox-modules-route.test.ts
+++ b/packages/websocket/tests/sandbox-modules-route.test.ts
@@ -78,7 +78,7 @@ afterEach(async () => {
 });
 
 describe("GET /api/sandbox-modules/*", () => {
-  it("serves the module source with digest and immutable caching headers", async () => {
+  it("serves the module source with digest and revalidating caching headers", async () => {
     const response = await app.inject({
       method: "GET",
       url: "/api/sandbox-modules/@acme/geo"
@@ -94,9 +94,11 @@ describe("GET /api/sandbox-modules/*", () => {
     expect(response.headers["x-sandbox-file-id"]).toBe("sandbox/geo.js");
     expect(response.headers["x-sandbox-internal"]).toBe("0");
     expect(response.headers["etag"]).toBe(`"${DIGEST}"`);
-    expect(response.headers["cache-control"]).toBe(
-      "public, max-age=31536000, immutable"
-    );
+    // The URL is the stable module id, so `immutable` would be unsound: a pack
+    // upgrade changes the body behind the same URL, and an immutable response
+    // is never revalidated — a browser could run last year's source. `private`
+    // keeps an authorized pack's source out of shared caches.
+    expect(response.headers["cache-control"]).toBe("private, no-cache");
     expect(response.headers["x-sandbox-module-dependencies"]).toBe(
       JSON.stringify(["@acme/geo::sandbox/helper.js"])
     );
@@ -104,6 +106,8 @@ describe("GET /api/sandbox-modules/*", () => {
   });
 
   it("answers 304 when the client already holds this digest", async () => {
+    // `no-cache` makes every reuse a conditional request, so this is the hot
+    // path, not an edge case: one cheap round trip instead of a re-download.
     const response = await app.inject({
       method: "GET",
       url: "/api/sandbox-modules/@acme/geo",
@@ -112,6 +116,22 @@ describe("GET /api/sandbox-modules/*", () => {
 
     expect(response.statusCode).toBe(304);
     expect(response.body).toBe("");
+    expect(response.headers["cache-control"]).toBe("private, no-cache");
+    expect(response.headers["etag"]).toBe(`"${DIGEST}"`);
+  });
+
+  it("answers 200 with the new body when the client holds a superseded digest", async () => {
+    // The URL did not change — the pack did. This is exactly what `immutable`
+    // would have hidden from the client for up to a year.
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/sandbox-modules/@acme/geo",
+      headers: { "if-none-match": `"${"9".repeat(64)}"` }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe(SOURCE);
+    expect(response.headers["etag"]).toBe(`"${DIGEST}"`);
   });
 
   it("accepts a percent-encoded scoped id and an internal graph-file id", async () => {

--- a/web/src/lib/workflow/__tests__/sandboxModuleCatalog.test.ts
+++ b/web/src/lib/workflow/__tests__/sandboxModuleCatalog.test.ts
@@ -66,26 +66,41 @@ async function jsResponse(
   });
 }
 
-type FetchStub = jest.Mock<Promise<Response>, [unknown]>;
+type FetchStub = jest.Mock<Promise<Response>, [unknown, RequestInit?]>;
 
 /** jsdom has no `fetch`, so install one rather than spy on a missing global. */
-function installFetch(impl: (input: unknown) => Promise<Response>): FetchStub {
+function installFetch(
+  impl: (input: unknown, init?: RequestInit) => Promise<Response>
+): FetchStub {
   const mock = jest.fn(impl) as FetchStub;
   (globalThis as { fetch?: unknown }).fetch = mock;
   return mock;
 }
 
-/** The two-file graph the server serves for `@acme/geo`. */
-function serveGeoGraph(): FetchStub {
-  return installFetch(async (input) => {
+/** The `If-None-Match` validator a conditional request carries, if any. */
+function validatorOf(init?: RequestInit): string | null {
+  return new Headers(init?.headers).get("If-None-Match");
+}
+
+/**
+ * The two-file graph the server serves for `@acme/geo`, honoring
+ * `If-None-Match` the way the delivery route does — the route answers
+ * `Cache-Control: private, no-cache`, so a conditional request is what the
+ * client sends for anything it already holds.
+ */
+function serveGeoGraph(digest: string = DIGEST): FetchStub {
+  return installFetch(async (input, init) => {
+    if (validatorOf(init) === `"${digest}"`) return fakeResponse(304, "");
     const url = String(input);
     if (url.includes(encodeURIComponent(HELPER_ID))) {
       return jsResponse(HELPER_SOURCE, {
+        "X-Content-Digest": digest,
         "X-Sandbox-File-Id": "sandbox/internal/round.js",
         "X-Sandbox-Internal": "1"
       });
     }
     return jsResponse(ENTRY_SOURCE, {
+      "X-Content-Digest": digest,
       "X-Sandbox-Module-Dependencies": JSON.stringify([HELPER_ID])
     });
   });
@@ -170,13 +185,65 @@ describe("fetchSandboxModuleClosure", () => {
     expect(records.find((r) => r.moduleId === HELPER_ID)?.internal).toBe(true);
   });
 
-  it("serves a second run from the cache", async () => {
+  it("revalidates the root on a second run and keeps the cache on a 304", async () => {
+    // Nothing tells the browser a pack was upgraded, so a cached root is never
+    // simply accepted: the second run asks, conditionally, and the 304 is what
+    // makes reusing the closure safe rather than hopeful.
     const fetchMock = serveGeoGraph();
 
-    await fetchSandboxModuleClosure(["@acme/geo"]);
-    await fetchSandboxModuleClosure(["@acme/geo"]);
+    const first = await fetchSandboxModuleClosure(["@acme/geo"]);
+    const second = await fetchSandboxModuleClosure(["@acme/geo"]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const [, revalidation] = fetchMock.mock.calls[2] ?? [];
+    expect(validatorOf(revalidation)).toBe(`"${DIGEST}"`);
+    // The 304 costs a round trip, not a re-download: the records are the ones
+    // already verified, dependencies included.
+    expect(second).toEqual(first);
+  });
+
+  it("replaces the whole closure when the revalidated root moved", async () => {
+    serveGeoGraph();
+    const warm = await fetchSandboxModuleClosure(["@acme/geo"]);
+    expect(warm.every((record) => record.contentDigest === DIGEST)).toBe(true);
+
+    // v2: same ids, new digest, new source. The conditional request no longer
+    // matches, so the root comes back 200 and the cached helper — whose digest
+    // is now stale against it — is fetched again.
+    const V2_ENTRY = `${ENTRY_SOURCE}export const version = 2;\n`;
+    const V2_HELPER = "export const round = (n) => Math.round(n);\n";
+    const fetchMock = installFetch(async (input, init) => {
+      if (validatorOf(init) === `"${OTHER_DIGEST}"`) return fakeResponse(304, "");
+      const url = String(input);
+      if (url.includes(encodeURIComponent(HELPER_ID))) {
+        return jsResponse(V2_HELPER, {
+          "X-Content-Digest": OTHER_DIGEST,
+          "X-Sandbox-File-Id": "sandbox/internal/round.js",
+          "X-Sandbox-Internal": "1"
+        });
+      }
+      return jsResponse(V2_ENTRY, {
+        "X-Content-Digest": OTHER_DIGEST,
+        "X-Sandbox-Module-Dependencies": JSON.stringify([HELPER_ID])
+      });
+    });
+
+    const upgraded = await fetchSandboxModuleClosure(["@acme/geo"]);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(upgraded.every((record) => record.contentDigest === OTHER_DIGEST)).toBe(
+      true
+    );
+    const entry = upgraded.find((record) => record.moduleId === "@acme/geo");
+    const helper = upgraded.find((record) => record.moduleId === HELPER_ID);
+    expect(entry).toMatchObject({ kind: "js", source: V2_ENTRY });
+    expect(helper).toMatchObject({ kind: "js", source: V2_HELPER });
+
+    // And v2 is what the cache now holds: the next run revalidates against the
+    // new digest and is answered 304.
+    const again = await fetchSandboxModuleClosure(["@acme/geo"]);
+    expect(again).toEqual(upgraded);
+    expect(validatorOf(fetchMock.mock.calls[2]?.[1])).toBe(`"${OTHER_DIGEST}"`);
   });
 
   it("re-fetches a dependency left over from another pack version", async () => {
@@ -199,9 +266,11 @@ describe("fetchSandboxModuleClosure", () => {
     const fetchMock = serveGeoGraph();
     await fetchSandboxModuleClosure(["@acme/geo"]);
 
-    // The entry is cached; the stale-digest helper is fetched again.
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+    // The root is revalidated and answers 304; the stale-digest helper is
+    // fetched again.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(validatorOf(fetchMock.mock.calls[0]?.[1])).toBe(`"${DIGEST}"`);
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain(
       encodeURIComponent(HELPER_ID)
     );
   });

--- a/web/src/lib/workflow/sandboxModuleCatalog.ts
+++ b/web/src/lib/workflow/sandboxModuleCatalog.ts
@@ -18,10 +18,14 @@
  * The records are plain, structured-cloneable data, so the prefetch happens once
  * on the main thread and the same records seed a catalog inside the Web Worker.
  *
- * The cache is keyed by module id with the module-graph digest as its version:
- * a pack upgrade moves the digest, so the stale entry misses naturally. The
- * digest is *not* a hash of any one response — every file of a graph shares it —
- * which is why verification uses the per-file `contentSha256` instead.
+ * The cache is keyed by module id with the module-graph digest as its version.
+ * Nothing in the browser announces a pack upgrade, so the digest has to be
+ * asked for: each prefetch revalidates the declared roots conditionally
+ * (`If-None-Match` against the cached digest, 304 when nothing moved), and a
+ * root that comes back changed invalidates every cached file whose digest no
+ * longer matches it. The digest is *not* a hash of any one response — every
+ * file of a graph shares it — which is why verification uses the per-file
+ * `contentSha256` instead.
  */
 
 // Type-only: the contract lives in runtime, but nothing of runtime's
@@ -198,17 +202,31 @@ function parseWasmContract(
   return contract.data;
 }
 
+/** What a conditional fetch answers when the server's copy has not moved. */
+const NOT_MODIFIED = Symbol("not-modified");
+
 /**
  * Fetch one module by opaque id and verify its body before returning it.
  *
  * A body that does not hash to the header's `contentSha256` is not cached and
  * not returned: the point of the check is that nothing unverified reaches the
  * guest, and a poisoned cache would defeat it on the next run.
+ *
+ * `cachedDigest` makes the request conditional: the route's ETag is the
+ * module-graph digest, so a client holding that digest gets a 304 and pays one
+ * cheap round trip instead of re-downloading a module that has not changed.
  */
-async function fetchModule(moduleId: string): Promise<SandboxModuleRecord> {
+async function fetchModule(
+  moduleId: string,
+  cachedDigest?: string
+): Promise<SandboxModuleRecord | typeof NOT_MODIFIED> {
   const response = await restFetch(
-    `${ROUTE_PREFIX}${encodeURIComponent(moduleId)}`
+    `${ROUTE_PREFIX}${encodeURIComponent(moduleId)}`,
+    cachedDigest === undefined
+      ? {}
+      : { headers: { "If-None-Match": `"${cachedDigest}"` } }
   );
+  if (response.status === 304) return NOT_MODIFIED;
   if (!response.ok) {
     if (response.status === 404) {
       throw deliveryError(moduleId, "is not available on this server.");
@@ -270,14 +288,42 @@ async function fetchModule(moduleId: string): Promise<SandboxModuleRecord> {
   return record;
 }
 
+/** Fetch a module unconditionally — the caller has no version to revalidate. */
+async function fetchFresh(moduleId: string): Promise<SandboxModuleRecord> {
+  const record = await fetchModule(moduleId);
+  // Unreachable: only a conditional request can be answered 304.
+  if (record === NOT_MODIFIED) {
+    throw deliveryError(moduleId, "was answered 304 for a request that set no validator.");
+  }
+  return record;
+}
+
+/**
+ * The current record for a root specifier, revalidated against the server.
+ *
+ * A root's id is stable across pack versions, so a cached record can never be
+ * *assumed* current: a pack upgrade changes the digest and the source behind
+ * the same id, and accepting the cached copy would run last version's closure
+ * until the page is reloaded. The route answers `no-cache` with a strong ETag,
+ * so asking costs a 304 when nothing moved and returns the new module when it
+ * did.
+ */
+async function revalidateRoot(moduleId: string): Promise<SandboxModuleRecord> {
+  const cached = cache.get(moduleId);
+  if (cached === undefined) return fetchFresh(moduleId);
+  const fresh = await fetchModule(moduleId, cached.contentDigest);
+  return fresh === NOT_MODIFIED ? cached : fresh;
+}
+
 /**
  * Fetch `moduleIds` and everything they import, transitively.
  *
- * The cache is consulted first, and the module-graph digest is what makes it
- * safe: a dependency's id (`<pack>::<file>`) is stable across pack versions, so
- * a cached entry from an older pack would otherwise be served forever. Every
- * file reached from one root must carry that root's digest; one that does not
- * is a leftover from a previous version and is re-fetched.
+ * Every root is revalidated; the closure below it is served from cache by
+ * digest. A dependency's id (`<pack>::<file>`) is stable across pack versions
+ * too, so what makes a cached dependency safe is that it carries the digest of
+ * the root just revalidated. One that does not is a leftover from a previous
+ * version and is re-fetched — which is also how an upgrade replaces the whole
+ * closure, not only its entry.
  *
  * Any failure rejects — a half-fetched closure only fails later inside the
  * guest, where the message says far less about what went wrong.
@@ -287,7 +333,7 @@ export async function fetchSandboxModuleClosure(
 ): Promise<SandboxModuleRecord[]> {
   const collected = new Map<string, SandboxModuleRecord>();
   for (const root of moduleIds) {
-    const rootRecord = cache.get(root) ?? (await fetchModule(root));
+    const rootRecord = await revalidateRoot(root);
     const pending = [rootRecord];
     for (let index = 0; index < pending.length; index += 1) {
       const record = pending[index];
@@ -299,7 +345,7 @@ export async function fetchSandboxModuleClosure(
           cached !== undefined &&
             cached.contentDigest === rootRecord.contentDigest
             ? cached
-            : await fetchModule(moduleId)
+            : await fetchFresh(moduleId)
         );
       }
     }


### PR DESCRIPTION
Fixes three P1 defects found in review of the squash-merged M1–M4 sandbox stack (`f57e97e`).

## 1. Stable module URLs were cached as immutable

`GET /api/sandbox-modules/*` served `public, max-age=31536000, immutable` on a URL that never changes when a pack upgrades — browsers and shared caches could execute the previous package version for up to a year, with `immutable` suppressing the ETag revalidation entirely, and `public` exposing an authorization-gated endpoint to shared caches. The policy is now `private, no-cache`: cached but always revalidated, one cheap 304 round trip via the existing strong ETag. New test: a superseded `If-None-Match` gets 200 with the new body — the exact case `immutable` hid.

## 2. The browser's root-module cache never detected upgrades

`sandboxModuleCatalog` accepted the cached root unconditionally, so after a pack upgrade the whole old closure ran until a full page reload. The root is now conditionally revalidated on every prefetch (`If-None-Match` with the cached digest): 304 keeps the cached record, 200 verifies `contentSha256`, replaces the record, and invalidates every dependency whose digest moved. An unchanged pack costs one conditional round trip per declared root. The test that pinned the never-refetch assumption is rewritten to the new contract, plus a warm-v1/server-v2 upgrade case asserting the new closure runs.

## 3. Concurrent WASM calls bypassed the aggregate wall clock

The wall-clock remainder was read before the concurrency gate and charged only after completion, so two concurrent calls could each receive the full remaining budget (~2× the advertised cap at the default concurrency). Budget is now **reserved atomically at admission** — inside the gate, synchronously, `min(perCallTimeout, remaining)` — the pool runs the call under its reservation, and completion settles to the actual duration (refunding fast calls). Sum-of-call-durations semantics are preserved. Tests: the reviewer's `Promise.all` case proving two concurrent admissions cannot exceed `wallClockMs` (the old code handed out 100 ms of a 60 ms budget), and a sequential-refund case that reservation-without-refund would fail.

## Checks

websocket 2253, agents 2266, node-sdk 839, web 12659 — all green; lint and typecheck clean.

The open M5 (#4818) and M6 (#4819) branches carry the same defective code and inherit these fixes on their next main merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qs9wjSb7DE5wMu4HLhjDM

---
_Generated by [Claude Code](https://claude.ai/code/session_014qs9wjSb7DE5wMu4HLhjDM)_