### PR TITLE
Sandbox packages: hash resolution inputs, cancel WASM work

### DIFF
--- a/docs/sandbox-package-design.md
+++ b/docs/sandbox-package-design.md
@@ -437,8 +437,11 @@ esbuild concerns spread through node-sdk):
   output changes under linked packs, transitive updates, lockfile changes,
   esbuild upgrades, and option changes while the version stays put. The
   cache key is concrete: a hash over esbuild's **metafile input list**
-  (every input file's content hash), the esbuild version, and the
-  normalized build options. Writes are atomic; every path component is
+  (every input file's content hash), the **resolution inputs** that decided
+  which files those were (the `package.json` manifests governing each input,
+  and the places a nearer copy of the dependency could shadow it — recorded
+  present-with-hash or absent), the esbuild version, and the normalized
+  build options. Writes are atomic; every path component is
   sanitized. Bundled modules cap at 1 MB — and M-1 measures real
   candidates (zod, date-fns, cheerio) before that number is promised
   anywhere.
@@ -1000,13 +1003,21 @@ must not depend on esbuild or a JavaScript engine.
   deadline, a 64 MB heap and capped console output. Only the bundle
   resolves; every other specifier is denied by name.
 - The cache (`cache.ts`) keys on a digest over every input file's content
-  hash from esbuild's metafile, the esbuild version, the compiler's
-  contract version, and the normalized options. Entries are written
+  hash from esbuild's metafile, the resolution inputs that selected those
+  files, the esbuild version, the compiler's contract version, and the
+  normalized options. Entries are written
   temp-file-plus-rename, keys are validated against `^[a-f0-9]{64}$`
   before they reach a path, and the cache root is
   `getNodetoolCacheDir()/sandbox-modules`. A pointer per
   `(pack directory, dependency)` lets a synchronous host read an entry
-  back; it re-hashes every recorded input first, so content still decides.
+  back; it re-hashes every recorded input *and* every resolution input
+  first, so content still decides. Inputs alone cannot: a manifest that
+  re-points `exports` at another file, or a nearer install that shadows the
+  copy which won, leaves every input untouched and the bundle wrong.
+  Lockfiles are deliberately not hashed — a lockfile says what *should* be
+  installed, so hashing one thrashes every pack's cache on an unrelated
+  dependency edit while saying nothing about the tree on disk. The install
+  that follows moves an input or a manifest, which is what is watched.
 - Discovery stays synchronous and engine-free. `discoverSandboxPack` takes
   an injected `compiled` lookup: an entry with an artifact joins the source
   graph as `npm:<name>`, one without becomes `pending-compile` naming

--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -249,6 +249,13 @@ completion the reservation is replaced by the real duration — a fast call
 refunds, one cut at its timeout keeps the charge — so the budget stays the sum
 of call durations it documents.
 
+Cancelling the run reaches the worker, not just the caller. The signal is
+rechecked after every await on the way to dispatch — compiling a module and
+waiting for a concurrency slot both outlive an abort — and it is passed into
+the pool, where it terminates the worker the way a timeout does. A guest export
+has no yield point, so abandoning the promise would leave the thread spinning
+for the rest of its timeout on work nobody wants.
+
 The dispatcher is the boundary, not the hiding: it serves only the run's
 declared WASM modules and validates module identity, export allowlist, argument
 count, and argument type before any worker runs — `i32` rejects out of range

--- a/packages/agents/src/wasm-sandbox/host.ts
+++ b/packages/agents/src/wasm-sandbox/host.ts
@@ -88,6 +88,21 @@ interface PooledWorker {
   dead: boolean;
 }
 
+/** The one error a cancelled run raises, wherever it is noticed. */
+function cancelled(): SandboxWasmError {
+  return new SandboxWasmError("the run was cancelled");
+}
+
+/**
+ * Read the abort flag through a call.
+ *
+ * The point of these checks is that the answer changes across an await, which
+ * is exactly what narrowing an inline `signal.aborted` would deny.
+ */
+function isAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
 /** A fixed set of workers shared by every invocation in the process. */
 export class WasmWorkerPool {
   private readonly idle: PooledWorker[] = [];
@@ -143,16 +158,40 @@ export class WasmWorkerPool {
     this.idle.push(slot);
   }
 
-  /** Run one call, killing and replacing the worker if it overruns. */
+  /**
+   * Run one call, killing and replacing the worker if it overruns or is
+   * cancelled.
+   *
+   * Cancellation has to reach the worker, not just the caller. A guest export
+   * is a scalar function with no yield point, so abandoning the promise would
+   * leave the thread spinning for the whole timeout on work nobody wants —
+   * the same reason a timeout terminates rather than waits.
+   */
   async run(
     module: WebAssembly.Module,
     exportName: string,
     args: readonly number[],
-    timeoutMs: number
+    timeoutMs: number,
+    signal?: AbortSignal
   ): Promise<number | undefined> {
+    if (isAborted(signal)) throw cancelled();
     const slot = await this.acquire();
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let onAbort: (() => void) | undefined;
     try {
+      if (isAborted(signal)) throw cancelled();
+      const cancellation = new Promise<never>((_resolve, reject) => {
+        if (signal === undefined) return;
+        onAbort = () => {
+          slot.dead = true;
+          // Reject before terminating, for the reason the timeout does: the
+          // worker's own rejection would otherwise win the race and report a
+          // generic message instead of the cancellation.
+          reject(cancelled());
+          slot.worker.terminate();
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+      });
       const timeout = new Promise<never>((_resolve, reject) => {
         timer = setTimeout(() => {
           slot.dead = true;
@@ -170,11 +209,13 @@ export class WasmWorkerPool {
       });
       const result = await Promise.race([
         slot.worker.call({ module, exportName, args }),
-        timeout
+        timeout,
+        cancellation
       ]);
       return result.value;
     } finally {
       if (timer !== undefined) clearTimeout(timer);
+      if (onAbort !== undefined) signal?.removeEventListener("abort", onAbort);
       this.release(slot);
     }
   }
@@ -326,9 +367,8 @@ export function createSandboxWasmDispatcher(
       return peakConcurrency;
     },
     async call(moduleKey, exportName, args) {
-      if (options.signal?.aborted === true) {
-        throw new SandboxWasmError("the run was cancelled");
-      }
+      const signal = options.signal;
+      if (isAborted(signal)) throw cancelled();
       const runModule = typeof moduleKey === "string" ? byKey.get(moduleKey) : undefined;
       if (runModule === undefined) {
         throw new SandboxWasmError(
@@ -357,7 +397,18 @@ export function createSandboxWasmDispatcher(
       callsUsed += 1;
 
       const compiled = await compileSandboxWasm(runModule.contentDigest, runModule.bytes);
+      // Every await between the entry check and the dispatch is rechecked:
+      // compiling a large module and queueing behind a busy slot both take
+      // long enough for the run to be cancelled underneath them. The queue
+      // needs no cancellation of its own — the calls holding the slots share
+      // this signal, so their own aborts release them and this one is turned
+      // away as soon as it is admitted.
+      if (isAborted(signal)) throw cancelled();
       await enter();
+      if (isAborted(signal)) {
+        leave();
+        throw cancelled();
+      }
 
       // The wall clock is *reserved* here, not merely read: charging only on
       // completion let every concurrently admitted call see the whole
@@ -380,7 +431,7 @@ export function createSandboxWasmDispatcher(
       try {
         // The effective timeout is the reservation, so the call cannot outrun
         // what it was actually admitted for.
-        return await pool.run(compiled, exported.wasmName, converted, reserved);
+        return await pool.run(compiled, exported.wasmName, converted, reserved, signal);
       } finally {
         // Replace the reservation with what the call really cost: a fast call
         // refunds the difference, one that ran to its timeout charges what it

--- a/packages/agents/tests/wasm-sandbox-host.test.ts
+++ b/packages/agents/tests/wasm-sandbox-host.test.ts
@@ -37,6 +37,8 @@ class FakeFactory implements WasmWorkerFactory {
   terminated = 0;
   inFlight = 0;
   peak = 0;
+  /** Calls that reached a worker, so a test can prove one never was sent. */
+  dispatched = 0;
   constructor(private readonly delayMs = 0) {}
   create(): Promise<WasmCallWorker> {
     this.created += 1;
@@ -44,6 +46,7 @@ class FakeFactory implements WasmWorkerFactory {
     let dead = false;
     return Promise.resolve({
       async call(request: WasmCallRequest) {
+        factory.dispatched += 1;
         factory.inFlight += 1;
         if (factory.inFlight > factory.peak) factory.peak = factory.inFlight;
         try {
@@ -73,13 +76,29 @@ const hangingFactory: WasmWorkerFactory = {
     })
 };
 
+/** A hanging worker that records the terminations aimed at it. */
+class HangingFactory implements WasmWorkerFactory {
+  terminated = 0;
+  create(): Promise<WasmCallWorker> {
+    const factory = this;
+    return Promise.resolve({
+      call: () => new Promise<{ value: number | undefined }>(() => {}),
+      terminate() {
+        factory.terminated += 1;
+      }
+    });
+  }
+}
+
 function dispatcherFor(
   options: Parameters<typeof referenceWasmModule>[0] = {},
-  factory: WasmWorkerFactory = new FakeFactory()
+  factory: WasmWorkerFactory = new FakeFactory(),
+  signal?: AbortSignal
 ) {
   const pool = new WasmWorkerPool(4, factory);
   const dispatcher = createSandboxWasmDispatcher([referenceWasmModule(options)], {
-    pool
+    pool,
+    ...(signal === undefined ? {} : { signal })
   });
   if (dispatcher === undefined) throw new Error("expected a dispatcher");
   return { dispatcher, pool };
@@ -259,6 +278,58 @@ describe("WASM worker pool", () => {
       /per-call timeout/
     );
     expect(pool.replacements).toBe(2);
+    pool.dispose();
+  });
+
+  it("terminates the worker of a call cancelled while it runs", async () => {
+    // The guest export has no yield point, so abandoning the promise would
+    // leave the worker spinning for the whole 5 s timeout. Cancellation has to
+    // reach the thread, and the caller must not wait for that timeout to hear
+    // about it.
+    const factory = new HangingFactory();
+    const controller = new AbortController();
+    const { dispatcher, pool } = dispatcherFor(
+      { limits: { callTimeoutMs: 5_000, wallClockMs: 5_000 } },
+      factory,
+      controller.signal
+    );
+
+    const call = dispatcher.call(REFERENCE_SPECIFIER, "spin", []);
+    setTimeout(() => controller.abort(), 5);
+    await expect(call).rejects.toThrow(/the run was cancelled/);
+    expect(factory.terminated).toBe(1);
+    pool.dispose();
+  });
+
+  it("drops a call cancelled while it waits for a slot, without waiting for one", async () => {
+    // Concurrency is two, so the third call is parked in the queue behind two
+    // 300 ms calls. It must leave the queue when the run is cancelled — not be
+    // admitted 300 ms later only to be turned away, and never dispatched.
+    const factory = new FakeFactory(300);
+    const controller = new AbortController();
+    const { dispatcher, pool } = dispatcherFor(
+      { limits: { callTimeoutMs: 2_000, wallClockMs: 5_000 } },
+      factory,
+      controller.signal
+    );
+
+    const startedAt = Date.now();
+    let queuedElapsed = Number.POSITIVE_INFINITY;
+    const calls = Array.from({ length: 3 }, () =>
+      dispatcher.call(REFERENCE_SPECIFIER, "bump", [])
+    );
+    void calls[2]?.catch(() => {
+      queuedElapsed = Date.now() - startedAt;
+    });
+    setTimeout(() => controller.abort(), 5);
+    const settled = await Promise.allSettled(calls);
+
+    expect(settled[2]?.status).toBe("rejected");
+    expect(
+      String((settled[2] as PromiseRejectedResult).reason?.message ?? "")
+    ).toMatch(/the run was cancelled/);
+    expect(queuedElapsed).toBeLessThan(250);
+    expect(factory.dispatched).toBe(2);
     pool.dispose();
   });
 

--- a/packages/sandbox-compiler/src/bundle.ts
+++ b/packages/sandbox-compiler/src/bundle.ts
@@ -12,7 +12,7 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { isBuiltin } from "node:module";
-import { resolve } from "node:path";
+import { basename, dirname, join, relative, resolve } from "node:path";
 
 import esbuild, { type BuildFailure, type Metafile, type Plugin } from "esbuild";
 
@@ -30,12 +30,39 @@ export interface InputDigest {
   readonly sha256: string;
 }
 
+/**
+ * One file that decided *which* inputs esbuild read, with its content hash.
+ *
+ * Input hashes answer "did the files we bundled change". They cannot answer
+ * "would we still resolve to those files", because a `package.json` is
+ * consulted during resolution and never appears among the inputs: flip
+ * `exports` from `v1.js` to `v2.js` and, as long as `v1.js` is still on disk
+ * unchanged, every recorded input still matches while the bundle is wrong.
+ * These records close that gap — the manifests governing each input, plus the
+ * places a closer copy of the dependency could appear and shadow the one that
+ * won.
+ */
+export interface ResolutionDigest {
+  /**
+   * Pack-relative path. Unlike an input this may reach above the pack, because
+   * a hoisted install puts the manifest that resolved it there.
+   */
+  readonly path: string;
+  /** Content hash, or {@link ABSENT} for a file that did not exist. */
+  readonly sha256: string;
+}
+
+/** Recorded in place of a hash for a file that was not there. */
+export const ABSENT = "absent";
+
 /** A successful bundle plus what the cache key is computed from. */
 export interface BundleResult {
   readonly source: string;
   readonly bytes: number;
   /** Every input esbuild read, sorted by path. */
   readonly inputDigests: readonly InputDigest[];
+  /** Every file that decided which inputs those were, sorted by path. */
+  readonly resolutionDigests: readonly ResolutionDigest[];
   readonly inputsDigest: string;
   readonly optionsDigest: string;
   readonly esbuildVersion: string;
@@ -111,13 +138,15 @@ async function runBuild(
     }
     const source = output.text;
     const inputDigests = hashInputs(packDir, built.metafile);
+    const resolutionDigests = hashResolution(packDir, npmName, built.metafile);
     return {
       status: "bundled",
       result: {
         source,
         bytes: Buffer.byteLength(source, "utf8"),
         inputDigests,
-        inputsDigest: digestOf(inputDigests),
+        resolutionDigests,
+        inputsDigest: digestOf(inputDigests, resolutionDigests),
         optionsDigest: optionsDigest(esbuild.version),
         esbuildVersion: esbuild.version,
         defaultExport: withDefault
@@ -184,11 +213,108 @@ function hashInputs(packDir: string, metafile: Metafile | undefined): InputDiges
     }
     digests.push({ path: relativePath, sha256: createHash("sha256").update(bytes).digest("hex") });
   }
-  return digests.sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
+  return digests.sort(byPath);
 }
 
-function digestOf(inputDigests: readonly InputDigest[]): string {
-  return createHash("sha256").update(JSON.stringify(inputDigests)).digest("hex");
+/**
+ * Hash every file that decided which inputs esbuild read.
+ *
+ * Two sets, both of them `package.json` files. The *governing* manifests are
+ * the ones a resolver consults on the way to an input — the package's own
+ * manifest, whose `exports`/`main` chose the file, any nested manifest between
+ * it and the file, and the pack's own. The *shadow* candidates are the places
+ * a nearer copy of the dependency could be installed later; those are usually
+ * absent, and an absence that becomes a file is exactly the change that
+ * silently re-resolves the import.
+ *
+ * Lockfiles are deliberately not hashed. A lockfile records what *should* be
+ * installed, so hashing one invalidates every pack's cache on any unrelated
+ * dependency edit while still saying nothing about the tree on disk. Once the
+ * install actually happens it moves either an input or one of these manifests,
+ * which is what the digest is watching.
+ */
+function hashResolution(
+  packDir: string,
+  npmName: string,
+  metafile: Metafile | undefined
+): ResolutionDigest[] {
+  const paths = new Set<string>(shadowCandidates(packDir, npmName));
+  paths.add(join(packDir, "package.json"));
+  for (const relativePath of Object.keys(metafile?.inputs ?? {})) {
+    if (relativePath.startsWith(`${NAMESPACE}.js`)) continue;
+    for (const manifest of manifestsGoverning(packDir, resolve(packDir, relativePath))) {
+      paths.add(manifest);
+    }
+  }
+  const digests: ResolutionDigest[] = [];
+  for (const absolute of paths) {
+    let bytes: Buffer;
+    try {
+      bytes = readFileSync(absolute);
+    } catch {
+      digests.push({ path: relative(packDir, absolute), sha256: ABSENT });
+      continue;
+    }
+    digests.push({
+      path: relative(packDir, absolute),
+      sha256: createHash("sha256").update(bytes).digest("hex")
+    });
+  }
+  return digests.sort(byPath);
+}
+
+/**
+ * Every `package.json` between `file` and the root of the package holding it.
+ *
+ * The walk stops at the enclosing `node_modules` — above that directory is a
+ * different package, whose manifest had no say in resolving this file — or at
+ * the pack itself for a file the pack ships.
+ */
+function manifestsGoverning(packDir: string, file: string): string[] {
+  const manifests: string[] = [];
+  let dir = dirname(file);
+  while (basename(dir) !== "node_modules") {
+    manifests.push(join(dir, "package.json"));
+    const parent = dirname(dir);
+    if (parent === dir || dir === packDir) break;
+    dir = parent;
+  }
+  return manifests;
+}
+
+/**
+ * Every `node_modules/<npmName>/package.json` from the pack upward.
+ *
+ * Node resolution takes the nearest one, so a copy installed closer to the
+ * pack than the one that won replaces the dependency without touching a single
+ * recorded input.
+ */
+function shadowCandidates(packDir: string, npmName: string): string[] {
+  const segments = npmName.split("/");
+  const candidates: string[] = [];
+  let dir = packDir;
+  for (;;) {
+    if (basename(dir) !== "node_modules") {
+      candidates.push(join(dir, "node_modules", ...segments, "package.json"));
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return candidates;
+}
+
+function byPath(left: { path: string }, right: { path: string }): number {
+  return left.path < right.path ? -1 : left.path > right.path ? 1 : 0;
+}
+
+function digestOf(
+  inputDigests: readonly InputDigest[],
+  resolutionDigests: readonly ResolutionDigest[]
+): string {
+  return createHash("sha256")
+    .update(JSON.stringify({ inputs: inputDigests, resolution: resolutionDigests }))
+    .digest("hex");
 }
 
 /** Digest of the pinned options plus the esbuild that will apply them. */

--- a/packages/sandbox-compiler/src/cache.ts
+++ b/packages/sandbox-compiler/src/cache.ts
@@ -2,11 +2,12 @@
  * Content-addressed cache for compiled npm modules.
  *
  * The key is never `pack/name@version`. A linked pack, a transitive update, a
- * lockfile change, and an esbuild upgrade all change the bundle while the
- * version stays exactly where it was, so the key is a digest over what actually
+ * re-install, and an esbuild upgrade all change the bundle while the version
+ * stays exactly where it was, so the key is a digest over what actually
  * determines the output: every input file's content hash from esbuild's
- * metafile, the esbuild version, this compiler's contract version, and the
- * normalized build options.
+ * metafile, the resolution inputs that decided which files those were, the
+ * esbuild version, this compiler's contract version, and the normalized build
+ * options.
  *
  * The value carries the scan report and the probe verdict alongside the source,
  * so a warm cache skips the probe too — the expensive half of admission.
@@ -25,7 +26,7 @@ import { join, resolve } from "node:path";
 
 import { getNodetoolCacheDir } from "@nodetool-ai/config";
 
-import type { InputDigest } from "./bundle.js";
+import { ABSENT, type InputDigest, type ResolutionDigest } from "./bundle.js";
 import { normalizedCompileOptions, SANDBOX_COMPILER_VERSION } from "./options.js";
 
 /** One free reference the scan flagged. Mirrored here so the cache stays engine-free. */
@@ -50,6 +51,8 @@ export interface CachedCompilation {
   readonly bytes: number;
   /** Every input's content hash, kept so a synchronous reader can re-verify. */
   readonly inputDigests: readonly InputDigest[];
+  /** Every resolution input's hash, re-verified alongside the inputs. */
+  readonly resolutionDigests: readonly ResolutionDigest[];
   readonly scanWarnings: readonly CachedScanFinding[];
   readonly probeOk: boolean;
   readonly probeExports: readonly string[];
@@ -61,6 +64,8 @@ export interface CacheKeyInput {
   readonly esbuildVersion: string;
   /** Every input's content hash, from esbuild's metafile. */
   readonly inputDigests: readonly InputDigest[];
+  /** Every file that decided which inputs those were. */
+  readonly resolutionDigests: readonly ResolutionDigest[];
 }
 
 /** Compute the digest a compilation is stored under. */
@@ -72,12 +77,15 @@ export function computeCacheKey(input: CacheKeyInput): string {
         esbuildVersion: input.esbuildVersion,
         options: normalizedCompileOptions(),
         npmName: input.npmName,
-        inputs: [...input.inputDigests].sort((left, right) =>
-          left.path < right.path ? -1 : left.path > right.path ? 1 : 0
-        )
+        inputs: [...input.inputDigests].sort(byPath),
+        resolution: [...input.resolutionDigests].sort(byPath)
       })
     )
     .digest("hex");
+}
+
+function byPath(left: { path: string }, right: { path: string }): number {
+  return left.path < right.path ? -1 : left.path > right.path ? 1 : 0;
 }
 
 /** Default cache root: `<user cache>/sandbox-modules`. */
@@ -129,6 +137,7 @@ export class CompiledModuleCache {
       source: entry.source,
       bytes: entry.bytes ?? Buffer.byteLength(entry.source, "utf8"),
       inputDigests: entry.inputDigests ?? [],
+      resolutionDigests: entry.resolutionDigests ?? [],
       scanWarnings: entry.scanWarnings ?? [],
       probeOk: entry.probeOk,
       probeExports: entry.probeExports ?? []
@@ -144,6 +153,13 @@ export class CompiledModuleCache {
    * this reader then re-hashes every input the entry recorded before trusting
    * it. Content still decides: an entry whose inputs moved is a miss, and a
    * miss is `pending-compile`, never a stale hit.
+   *
+   * The inputs alone are not enough to decide that. Resolution metadata never
+   * appears among them, so a `package.json` that starts pointing `exports` at
+   * a different file, or a nearer copy of the dependency that shadows the one
+   * that won, leaves every input untouched while making the bundle wrong.
+   * Those files are re-hashed here too — an absent one that has appeared
+   * counts as changed.
    */
   readForPack(packDir: string, npmName: string): CachedCompilation | undefined {
     const pointerPath = this.pointerPathFor(packDir, npmName);
@@ -158,7 +174,8 @@ export class CompiledModuleCache {
     if (typeof key !== "string") return undefined;
     const entry = this.read(key);
     if (entry === undefined) return undefined;
-    return inputsUnchanged(packDir, entry.inputDigests) ? entry : undefined;
+    if (!inputsUnchanged(packDir, entry.inputDigests)) return undefined;
+    return resolutionUnchanged(packDir, entry.resolutionDigests) ? entry : undefined;
   }
 
   /** Record where a pack's dependency compiled to, for {@link readForPack}. */
@@ -247,6 +264,32 @@ function inputsUnchanged(packDir: string, inputDigests: readonly InputDigest[]):
       return false;
     }
     if (createHash("sha256").update(bytes).digest("hex") !== record.sha256) return false;
+  }
+  return true;
+}
+
+/**
+ * Re-hash every recorded resolution input and report whether all still match.
+ *
+ * A record whose file is gone must hash to {@link ABSENT}, and one recorded as
+ * absent must still be absent — an appearing `package.json` is a dependency
+ * that now resolves somewhere else.
+ */
+function resolutionUnchanged(
+  packDir: string,
+  resolutionDigests: readonly ResolutionDigest[]
+): boolean {
+  if (resolutionDigests.length === 0) return false;
+  for (const record of resolutionDigests) {
+    let current: string;
+    try {
+      current = createHash("sha256")
+        .update(readFileSync(resolve(packDir, record.path)))
+        .digest("hex");
+    } catch {
+      current = ABSENT;
+    }
+    if (current !== record.sha256) return false;
   }
   return true;
 }

--- a/packages/sandbox-compiler/src/compile.ts
+++ b/packages/sandbox-compiler/src/compile.ts
@@ -61,7 +61,8 @@ export async function compileNpmModule(
   const key = computeCacheKey({
     npmName,
     esbuildVersion: bundle.esbuildVersion,
-    inputDigests: bundle.inputDigests
+    inputDigests: bundle.inputDigests,
+    resolutionDigests: bundle.resolutionDigests
   });
   const cache = request.noCache === true ? undefined : request.cache ?? new CompiledModuleCache();
   const hit = cache?.read(key);
@@ -119,6 +120,7 @@ export async function compileNpmModule(
     source: bundle.source,
     bytes: bundle.bytes,
     inputDigests: bundle.inputDigests,
+    resolutionDigests: bundle.resolutionDigests,
     scanWarnings: scan.warnings,
     probeOk: true,
     probeExports: probe.exports

--- a/packages/sandbox-compiler/src/index.ts
+++ b/packages/sandbox-compiler/src/index.ts
@@ -25,11 +25,14 @@ export {
 } from "./options.js";
 
 export {
+  ABSENT,
   bundleNpmModule,
   optionsDigest,
   type BundleFailure,
   type BundleOutcome,
-  type BundleResult
+  type BundleResult,
+  type InputDigest,
+  type ResolutionDigest
 } from "./bundle.js";
 
 export {

--- a/packages/sandbox-compiler/src/options.ts
+++ b/packages/sandbox-compiler/src/options.ts
@@ -55,7 +55,7 @@ export const NPM_PROBE_MAX_LOG_CHARS = 500;
  * "admitted" means. It is part of the cache key, so a bump re-compiles and
  * re-probes everything rather than trusting a verdict an older compiler made.
  */
-export const SANDBOX_COMPILER_VERSION = "1";
+export const SANDBOX_COMPILER_VERSION = "2";
 
 /** The build options exactly as the cache key records them. */
 export interface NormalizedCompileOptions {

--- a/packages/sandbox-compiler/tests/cache.test.ts
+++ b/packages/sandbox-compiler/tests/cache.test.ts
@@ -6,11 +6,12 @@
  */
 
 import { afterAll, describe, expect, it } from "vitest";
-import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { CompiledModuleCache, computeCacheKey } from "../src/cache.js";
+import { SANDBOX_COMPILER_VERSION } from "../src/options.js";
 import { compileNpmModule } from "../src/compile.js";
 import { cleanup, materializePack } from "./fixtures.js";
 
@@ -22,7 +23,8 @@ afterAll(() => cleanup(workspace));
 const baseInput = {
   npmName: "fixture-clean",
   esbuildVersion: "0.28.1",
-  inputDigests: [{ path: "node_modules/fixture-clean/index.js", sha256: "abc123" }]
+  inputDigests: [{ path: "node_modules/fixture-clean/index.js", sha256: "abc123" }],
+  resolutionDigests: [{ path: "node_modules/fixture-clean/package.json", sha256: "def456" }]
 };
 
 describe("computeCacheKey", () => {
@@ -52,6 +54,14 @@ describe("computeCacheKey", () => {
       computeCacheKey(baseInput)
     );
   });
+
+  it("changes when a resolution input changes, with every input identical", () => {
+    const remapped = {
+      ...baseInput,
+      resolutionDigests: [{ path: "node_modules/fixture-clean/package.json", sha256: "999" }]
+    };
+    expect(computeCacheKey(remapped)).not.toBe(computeCacheKey(baseInput));
+  });
 });
 
 describe("CompiledModuleCache", () => {
@@ -61,13 +71,14 @@ describe("CompiledModuleCache", () => {
     cache.write({
       key,
       npmName: "fixture-clean",
-      compilerVersion: "1",
+      compilerVersion: SANDBOX_COMPILER_VERSION,
       esbuildVersion: "0.28.1",
       optionsDigest: "a".repeat(64),
       inputsDigest: "b".repeat(64),
       source: "export const x = 1;",
       bytes: 19,
       inputDigests: [],
+      resolutionDigests: [],
       scanWarnings: [],
       probeOk: true,
       probeExports: ["x"]
@@ -91,6 +102,7 @@ describe("CompiledModuleCache", () => {
       source: "export const x = 1;",
       bytes: 19,
       inputDigests: [],
+      resolutionDigests: [],
       scanWarnings: [],
       probeOk: true,
       probeExports: []
@@ -107,13 +119,14 @@ describe("CompiledModuleCache", () => {
       cache.write({
         key,
         npmName: "fixture-clean",
-        compilerVersion: "1",
+        compilerVersion: SANDBOX_COMPILER_VERSION,
         esbuildVersion: "0.28.1",
         optionsDigest: "a".repeat(64),
         inputsDigest: "b".repeat(64),
         source: `export const x = ${i};`,
         bytes: 19,
         inputDigests: [],
+        resolutionDigests: [],
         scanWarnings: [],
         probeOk: true,
         probeExports: []
@@ -131,13 +144,14 @@ describe("CompiledModuleCache", () => {
         new CompiledModuleCache(root).write({
           key,
           npmName: "fixture-clean",
-          compilerVersion: "1",
+          compilerVersion: SANDBOX_COMPILER_VERSION,
           esbuildVersion: "0.28.1",
           optionsDigest: "a".repeat(64),
           inputsDigest: "b".repeat(64),
           source: `export const x = ${"y".repeat(i * 500)};`,
           bytes: 19,
           inputDigests: [],
+          resolutionDigests: [],
           scanWarnings: [],
           probeOk: true,
           probeExports: []
@@ -180,6 +194,71 @@ describe("compileNpmModule caching", () => {
     const dependency = join(packDir, "node_modules", "fixture-clean", "index.js");
     writeFileSync(dependency, `${readFileSync(dependency, "utf8")}\nexport const later = 2;\n`);
     expect(cache.readForPack(packDir, "fixture-clean")).toBeUndefined();
+  });
+
+  it("misses when a manifest re-points the dependency at a different file", async () => {
+    // The stale-bundle case inputs alone cannot see: `exports` selects v2.js
+    // while index.js stays on disk, byte for byte what it was. Every recorded
+    // input still matches; the bundle is nonetheless the wrong code.
+    const packDir = materializePack("clean", join(workspace, "reexport"));
+    const cache = new CompiledModuleCache(join(cacheRoot, "reexport"));
+    await compileNpmModule({ packDir, npmName: "fixture-clean", cache });
+    expect(cache.readForPack(packDir, "fixture-clean")?.source).toContain("slugify");
+
+    const dependency = join(packDir, "node_modules", "fixture-clean");
+    const before = readFileSync(join(dependency, "index.js"), "utf8");
+    writeFileSync(join(dependency, "v2.js"), "export const two = 2;\n");
+    writeFileSync(
+      join(dependency, "package.json"),
+      JSON.stringify({
+        name: "fixture-clean",
+        version: "1.0.0",
+        type: "module",
+        main: "v2.js",
+        module: "v2.js",
+        exports: { ".": "./v2.js" }
+      })
+    );
+    expect(readFileSync(join(dependency, "index.js"), "utf8")).toBe(before);
+
+    expect(cache.readForPack(packDir, "fixture-clean")).toBeUndefined();
+    const recompiled = await compileNpmModule({ packDir, npmName: "fixture-clean", cache });
+    expect(recompiled.cached).toBe(false);
+    expect(cache.readForPack(packDir, "fixture-clean")?.source).toContain("two");
+  });
+
+  it("misses when a nearer copy of the dependency appears and shadows it", async () => {
+    // A pack one directory below the install that resolved: the hoisted copy
+    // decides the bundle until a closer one is installed, and that install
+    // touches nothing the bundle read.
+    const root = join(workspace, "shadow");
+    const hoisted = materializePack("clean", root);
+    const packDir = join(hoisted, "packs", "inner");
+    mkdirSync(packDir, { recursive: true });
+    writeFileSync(join(packDir, "package.json"), JSON.stringify({ name: "inner", version: "1.0.0" }));
+
+    const cache = new CompiledModuleCache(join(cacheRoot, "shadow"));
+    await compileNpmModule({ packDir, npmName: "fixture-clean", cache });
+    expect(cache.readForPack(packDir, "fixture-clean")?.source).toContain("slugify");
+
+    const nearer = join(packDir, "node_modules", "fixture-clean");
+    mkdirSync(nearer, { recursive: true });
+    writeFileSync(
+      join(nearer, "package.json"),
+      JSON.stringify({
+        name: "fixture-clean",
+        version: "2.0.0",
+        type: "module",
+        main: "index.js",
+        module: "index.js",
+        exports: { ".": "./index.js" }
+      })
+    );
+    writeFileSync(join(nearer, "index.js"), "export const shadowed = true;\n");
+
+    expect(cache.readForPack(packDir, "fixture-clean")).toBeUndefined();
+    await compileNpmModule({ packDir, npmName: "fixture-clean", cache });
+    expect(cache.readForPack(packDir, "fixture-clean")?.source).toContain("shadowed");
   });
 
   it("compiles again when the caller opts out of the cache", async () => {


### PR DESCRIPTION
Two of the three M3/M4 review findings. The third — concurrent calls each claiming the whole remaining WASM wall clock — is already fixed on `main` by the reservation in 21a871e, so nothing was needed there.

## M3: the compiler cache could execute a stale bundle

Input hashes answer "did the files we bundled change". They cannot answer "would we still resolve to those files", because a `package.json` is consulted during resolution and never appears among esbuild's metafile inputs. Flip `exports` from `v1.js` to `v2.js` and, as long as `v1.js` is still on disk unchanged, every recorded input matches while `readForPack` hands back the wrong code. A nearer copy of the dependency that shadows the one that won is the same hole.

`bundleNpmModule` now also records **resolution inputs**: the `package.json` manifests governing each input (the package root's, any nested one between it and the file, and the pack's own) plus every `node_modules/<dep>/package.json` from the pack upward where a shadowing copy could land. Each is stored present-with-hash or `absent`, an absence that becomes a file counts as changed, and `readForPack` re-verifies them alongside the inputs. They are in the cache key too.

Lockfiles are deliberately **not** hashed, despite being the suggested fix. A lockfile records what *should* be installed, so hashing one invalidates every pack's cache on any unrelated dependency edit while still saying nothing about the tree on disk. Once the install actually happens it moves either an input or one of these manifests, which is what the digest is watching. The reasoning is in the code and the design doc, not just here.

`SANDBOX_COMPILER_VERSION` goes to `2`, so entries written without the new records are re-compiled rather than trusted.

## M4: cancellation did not stop queued or running WASM work

The signal was read once, when `call()` began, and `pool.run` took none — so a call cancelled during compilation, queueing, or execution kept a worker until its timeout expired. A guest export is a scalar function with no yield point, so abandoning the promise stops nothing.

The signal is now rechecked after every await on the way to dispatch and passed into the pool, which terminates the worker the way a timeout does (rejecting before terminating, so the caller hears "cancelled" rather than the worker's generic message).

The concurrency queue needs no cancellation of its own, and an abortable version of it was written and then removed: the calls holding the slots share the run's signal, so their own aborts release the slots and a queued call is turned away as soon as it is admitted. A test that asserted this was the one that proved the extra machinery earned nothing.

## Tests

Four regression tests, each verified to fail without its fix:

- a manifest re-points the dependency at a different file, every input byte-identical → miss (5 s of stale bundle became a miss)
- a nearer copy appears and shadows the resolved one → miss
- a call cancelled mid-flight rejects promptly and terminates its worker (without the fix: 5 s of wasted worker time, which is the finding)
- a call queued behind the concurrency gate rejects at cancellation time, not 300 ms later when a slot frees, and never reaches a worker

`packages/sandbox-compiler` cache/compile/bundle suites and the `packages/agents` WASM suites pass. Three `packs.test.ts` failures and two `websocket` build errors are pre-existing in this environment (incomplete install — verified identical on clean HEAD).

---
_Generated by [Claude Code](https://claude.ai/code/session_018SFQJciQzupyv282xrsBHT)_