### PR TITLE
Test what the sandbox pack system refuses, and packs composed together

### DIFF
--- a/packages/sandbox-compiler/tests/pack-boundaries.test.ts
+++ b/packages/sandbox-compiler/tests/pack-boundaries.test.ts
@@ -1,0 +1,150 @@
+/**
+ * What the pack system must refuse.
+ *
+ * `packs.test.ts` proves a declared pack is importable. This file proves the
+ * other half of the contract: that the only importable thing is a declared
+ * pack, and that the host modules enforce their limits where the guest cannot
+ * decline to call them. Every case here expects a refusal — a case that
+ * returns a value is a hole, not a pass.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { runInSandbox } from "@nodetool-ai/agents";
+
+import { resolveFor, resolveOne } from "./pack-harness.js";
+
+const YAML = "@nodetool-ai/sandbox-yaml";
+
+/** Run guest code against a resolution and return whatever error came back. */
+async function refusalOf(code: string, specifiers: string[], declared = specifiers) {
+  const { resolution } = await resolveFor(specifiers, declared);
+  const result = await runInSandbox({ code, modules: resolution, timeoutMs: 60_000 });
+  return { error: result.error, value: result.result };
+}
+
+describe("the import surface is exactly what the node declared", () => {
+  it("refuses a real pack the node did not declare", async () => {
+    // The catalog holds csv; this node's declaration does not.
+    const { error, value } = await refusalOf(
+      `
+        import { parse } from "@nodetool-ai/sandbox-csv";
+        return await parse("a,b\\n1,2\\n");
+      `,
+      [YAML, "@nodetool-ai/sandbox-csv"],
+      [YAML]
+    );
+    expect(value).toBeUndefined();
+    expect(error).toMatch(/"@nodetool-ai\/sandbox-csv" is not a sandbox package declared by this node/);
+  });
+
+  it("refuses a specifier nobody has ever shipped", async () => {
+    const { error, value } = await refusalOf(
+      `
+        import evil from "@acme/totally-legit";
+        return evil;
+      `,
+      [YAML]
+    );
+    expect(value).toBeUndefined();
+    expect(error).toMatch(/"@acme\/totally-legit" is not a sandbox package declared by this node/);
+  });
+
+  it("refuses a Node builtin the wrapper's virtual FS really does mount", async () => {
+    // `createVirtualFileSystem` mounts node-compat modules unconditionally, so
+    // this resolves under the wrapper's defaults. The loader is what says no.
+    const { error, value } = await refusalOf(
+      `
+        import buf from "node:buffer";
+        return { got: typeof buf };
+      `,
+      [YAML]
+    );
+    expect(value).toBeUndefined();
+    expect(error).toMatch(/"node:buffer" is not a sandbox package declared by this node/);
+  });
+
+  it("refuses a computed dynamic import, which no static check can see", async () => {
+    const { error, value } = await refusalOf(
+      `
+        const mod = await import("node:" + "fs");
+        return { keys: Object.keys(mod).slice(0, 3) };
+      `,
+      [YAML]
+    );
+    expect(value).toBeUndefined();
+    expect(error).toMatch(/dynamic import\(\) is not allowed in the sandbox \(requested "node:fs"\)/);
+  });
+
+  it("refuses a dynamic import even of a pack that is declared", async () => {
+    // Declaration is not the gate here: the form is. Allowing this would make
+    // the static declaration check advisory.
+    const { error, value } = await refusalOf(
+      `
+        const yaml = await import("${YAML}");
+        return { loaded: yaml.default.load("a: 1") };
+      `,
+      [YAML]
+    );
+    expect(value).toBeUndefined();
+    expect(error).toMatch(
+      /dynamic import\(\) is not allowed in the sandbox \(requested "@nodetool-ai\/sandbox-yaml"\)/
+    );
+  });
+});
+
+describe("a host module enforces its limits on the host", () => {
+  it("stops a zip bomb at the inflation cap", async () => {
+    // ~120 MB of zeros compresses to nearly nothing. The cap has to sit between
+    // the archive and the guest, because fflate inflates into host memory.
+    const { error, value } = await refusalOf(
+      `
+        import { zip, unzip } from "@nodetool-ai/sandbox-zip";
+        const chunk = "0".repeat(1024 * 1024);
+        const entries = {};
+        for (let i = 0; i < 120; i++) entries["f" + i + ".txt"] = chunk;
+        return { inflated: Object.keys(await unzip(await zip(entries))).length };
+      `,
+      ["@nodetool-ai/sandbox-zip"]
+    );
+    expect(value).toBeUndefined();
+    expect(error).toMatch(/exceed the 52428800 byte limit/);
+  });
+
+  it("refuses input over the per-call text cap, by name", async () => {
+    const { error, value } = await refusalOf(
+      `
+        import { select } from "@nodetool-ai/sandbox-html";
+        return { n: (await select("<p>x</p>".repeat(900000), "p")).length };
+      `,
+      ["@nodetool-ai/sandbox-html"]
+    );
+    expect(value).toBeUndefined();
+    expect(error).toMatch(/html\.select: input exceeds the 5242880 character limit/);
+  });
+});
+
+describe("the guest keeps its hardening once modules are loaded", () => {
+  // An ES module's dependencies evaluate before the entry body, so hardening
+  // has to be in place before any imported module runs — not emitted by the
+  // entry. These two are the observable end of that.
+  it("has no eval, so the guest cannot self-generate code", async () => {
+    const { error } = await refusalOf(`return { v: eval("1+1") };`, [YAML]);
+    expect(error).toMatch(/'eval' is not defined/);
+  });
+
+  it("has no timers", async () => {
+    const { error } = await refusalOf(`return { r: setTimeout(() => {}, 1) };`, [YAML]);
+    expect(error).toMatch(/'setTimeout' is not defined/);
+  });
+});
+
+describe("a saved declaration that no longer matches what is installed", () => {
+  it("refuses a run whose content digest drifted", async () => {
+    const { catalog } = await resolveOne(YAML);
+    const drifted = catalog.resolveForExecution([
+      { specifier: YAML, contentDigest: "0".repeat(64) }
+    ]);
+    expect(drifted.statuses[0]?.code).toBe("content-digest-mismatch");
+  });
+});

--- a/packages/sandbox-compiler/tests/pack-harness.ts
+++ b/packages/sandbox-compiler/tests/pack-harness.ts
@@ -1,0 +1,77 @@
+/**
+ * The road a shipped pack travels, shared by the pack test files.
+ *
+ * Discovery reads the pack directory under `packages/sandbox-packs/`, the
+ * compiler bundles an npm entry if there is one, discovery runs again over the
+ * compiled result, and the catalog resolves what a Code node declaring those
+ * specifiers would execute with. Nothing is stubbed and nothing is fetched.
+ */
+
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  createSandboxModuleCatalog,
+  discoverSandboxPack,
+  type SandboxPackDiscovery
+} from "@nodetool-ai/node-sdk";
+
+import { CompiledModuleCache } from "../src/cache.js";
+import { compileDiscoveries, createCompiledNpmLookup } from "../src/catalog.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export const PACKS_ROOT = join(here, "..", "..", "sandbox-packs");
+
+/** One cache for the process: compiling date-fns once per file is enough. */
+const cache = new CompiledModuleCache(
+  join(mkdtempSync(join(tmpdir(), "nodetool-pack-harness-")), "cache")
+);
+
+/** `@nodetool-ai/sandbox-csv` → the directory it ships from. */
+export function packDir(packName: string): string {
+  return join(PACKS_ROOT, packName.slice("@nodetool-ai/".length));
+}
+
+/** Discover a shipped pack, compile its npm entry if it has one, discover again. */
+export async function discoverPack(specifier: string): Promise<SandboxPackDiscovery> {
+  const dir = packDir(specifier);
+  const first = discoverSandboxPack(dir);
+  if (first === undefined) throw new Error(`${specifier} is not a sandbox pack`);
+  const reports = await compileDiscoveries([first], { cache });
+  const second = discoverSandboxPack(dir, {
+    compiled: createCompiledNpmLookup(reports)
+  });
+  if (second === undefined) throw new Error(`${specifier} stopped being a sandbox pack`);
+  return second;
+}
+
+/** A catalog over several packs — what a host offers a node that declares them. */
+export async function catalogFor(specifiers: string[]) {
+  const discoveries = await Promise.all(specifiers.map((s) => discoverPack(s)));
+  return createSandboxModuleCatalog(discoveries);
+}
+
+/**
+ * The resolution a Code node declaring exactly `specifiers` would run with.
+ *
+ * `declared` defaults to `specifiers`; pass a shorter list to model a node that
+ * imports more than it declared.
+ */
+export async function resolveFor(specifiers: string[], declared = specifiers) {
+  const catalog = await catalogFor(specifiers);
+  return {
+    catalog,
+    resolution: catalog.resolveForExecution(declared.map((specifier) => ({ specifier })))
+  };
+}
+
+/** The resolution for a single pack, plus the pieces behind it. */
+export async function resolveOne(specifier: string) {
+  const discovery = await discoverPack(specifier);
+  const catalog = createSandboxModuleCatalog([discovery]);
+  const resolution = catalog.resolveForExecution([{ specifier }]);
+  return { discovery, catalog, resolution };
+}

--- a/packages/sandbox-compiler/tests/pack-pipelines.test.ts
+++ b/packages/sandbox-compiler/tests/pack-pipelines.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Several packs composed inside one Code node.
+ *
+ * `packs.test.ts` imports one pack at a time. Real nodes do not: they parse a
+ * CSV, do date arithmetic on it, dump YAML and zip the result — four packs, one
+ * guest, one module loader. These pipelines are the shape that breaks when the
+ * loader mounts a pack's siblings wrong, when a host facade collides with
+ * another, or when two host modules disagree about how bytes cross the bridge.
+ *
+ * Inputs are generated here rather than fetched, and the expected values come
+ * from a host-side oracle computed independently of the guest.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { runInSandbox } from "@nodetool-ai/agents";
+
+import { resolveFor } from "./pack-harness.js";
+
+const CSV = "@nodetool-ai/sandbox-csv";
+const DATES = "@nodetool-ai/sandbox-dates";
+const DIFF = "@nodetool-ai/sandbox-diff";
+const HTML = "@nodetool-ai/sandbox-html";
+const XML = "@nodetool-ai/sandbox-xml";
+const YAML = "@nodetool-ai/sandbox-yaml";
+const ZIP = "@nodetool-ai/sandbox-zip";
+
+/** Run a node body with the packs it declares, failing loudly on a guest error. */
+async function runNode(code: string, packs: string[], globals: Record<string, unknown> = {}) {
+  const { resolution } = await resolveFor(packs);
+  expect(resolution.statuses.filter((s) => s.status === "error")).toEqual([]);
+  const result = await runInSandbox({ code, modules: resolution, globals, timeoutMs: 60_000 });
+  expect(result.error).toBeUndefined();
+  return result.result as Record<string, unknown>;
+}
+
+/* ------------------------------------------------------------------ fixtures */
+
+interface Order {
+  order_id: string;
+  date: string;
+  region: string;
+  amount_eur: number;
+}
+
+/** A deterministic order book, so the oracle below is stable across runs. */
+function makeOrders(count: number): Order[] {
+  const regions = ["EMEA", "AMER", "APAC"];
+  let seed = 42;
+  const rand = () => ((seed = (seed * 1103515245 + 12345) % 2147483648) / 2147483648);
+  const orders: Order[] = [];
+  for (let i = 0; i < count; i++) {
+    const month = 1 + Math.floor(rand() * 12);
+    const day = 1 + Math.floor(rand() * 28);
+    orders.push({
+      order_id: `NT-${10000 + i}`,
+      date: `2026-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`,
+      region: regions[Math.floor(rand() * regions.length)]!,
+      amount_eur: Math.round((49 + rand() * 4000) * 100) / 100
+    });
+  }
+  return orders;
+}
+
+function toCsv(orders: Order[]): string {
+  return [
+    "order_id,date,region,amount_eur",
+    ...orders.map((o) => `${o.order_id},${o.date},${o.region},${o.amount_eur.toFixed(2)}`)
+  ].join("\n");
+}
+
+/**
+ * The same aggregation, in plain host JS.
+ *
+ * The quarter comes off the month digits rather than a Date, so this agrees
+ * with the guest (which is always UTC) whatever the host's zone is.
+ */
+function oracle(orders: Order[]) {
+  const buckets = new Map<string, { region: string; quarter: string; orders: number; revenue: number }>();
+  for (const o of orders) {
+    const quarter = `Q${Math.floor((Number(o.date.slice(5, 7)) - 1) / 3) + 1}`;
+    const key = `${o.region}|${quarter}`;
+    const bucket = buckets.get(key) ?? { region: o.region, quarter, orders: 0, revenue: 0 };
+    bucket.orders += 1;
+    bucket.revenue += o.amount_eur;
+    buckets.set(key, bucket);
+  }
+  const segments = [...buckets.values()].map((b) => ({ ...b, revenue: Math.round(b.revenue * 100) / 100 }));
+  return {
+    segments: segments.length,
+    total: Math.round(segments.reduce((s, b) => s + b.revenue, 0) * 100) / 100,
+    top: segments.sort((a, b) => b.revenue - a.revenue)[0]!
+  };
+}
+
+const ATOM_FEED = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Release notes from nodetool</title>
+  <entry>
+    <title>v0.7.7</title>
+    <updated>2026-08-04T09:15:00Z</updated>
+  </entry>
+  <entry>
+    <title>v0.7.6</title>
+    <updated>2026-07-21T16:40:00Z</updated>
+  </entry>
+  <entry>
+    <title>v0.7.5</title>
+    <updated>2026-07-02T11:05:00Z</updated>
+  </entry>
+</feed>
+`;
+
+const PAGE_HTML = `<!doctype html>
+<html>
+  <head><title>Sandbox packages</title></head>
+  <body>
+    <h1>Sandbox packages</h1>
+    <p>Every library the sandbox offers is an <strong>importable module</strong>.</p>
+    <h2>Guest modules</h2>
+    <p>See <a href="https://nodetool.ai/docs">the docs</a> and <a href="/local/page">a local page</a>.</p>
+    <h2>Host modules</h2>
+    <p>A host module carries an id, <em>never</em> an implementation.</p>
+    <ul><li><a href="https://github.com/nodetool-ai/nodetool">source</a></li></ul>
+  </body>
+</html>
+`;
+
+const DEPLOY_BEFORE = `service: nodetool-api
+replicas: 2
+image: ghcr.io/nodetool-ai/api:0.7.6
+env:
+  - name: LOG_LEVEL
+    value: info
+`;
+
+const DEPLOY_AFTER = `service: nodetool-api
+replicas: 3
+image: ghcr.io/nodetool-ai/api:0.7.7
+env:
+  - name: LOG_LEVEL
+    value: debug
+  - name: SANDBOX_PACKS
+    value: "1"
+`;
+
+/* ----------------------------------------------------------------- pipelines */
+
+describe("four packs in one node", () => {
+  it("aggregates a CSV by quarter, dumps YAML, and round-trips it through a zip", async () => {
+    const orders = makeOrders(200);
+    const expected = oracle(orders);
+
+    const result = await runNode(
+      `
+        import { parse, stringify } from "${CSV}";
+        import { parseISO, getQuarter } from "${DATES}";
+        import yaml from "${YAML}";
+        import { zip, unzip } from "${ZIP}";
+
+        const orders = await parse(inputs.csv);
+
+        const buckets = new Map();
+        for (const o of orders) {
+          const quarter = "Q" + getQuarter(parseISO(o.date));
+          const key = o.region + "|" + quarter;
+          const bucket = buckets.get(key) ?? { region: o.region, quarter, orders: 0, revenue: 0 };
+          bucket.orders += 1;
+          bucket.revenue += Number(o.amount_eur);
+          buckets.set(key, bucket);
+        }
+
+        const segments = [...buckets.values()]
+          .map((b) => ({ ...b, revenue: Math.round(b.revenue * 100) / 100 }))
+          .sort((a, b) => b.revenue - a.revenue);
+
+        const summaryCsv = await stringify(segments);
+        const meta = yaml.dump({ orders: orders.length, segments: segments.length });
+
+        // Out through fflate and back, so the archive is proven readable.
+        const entries = await unzip(await zip({ "summary.csv": summaryCsv, "meta.yaml": meta }));
+        const decoder = new TextDecoder();
+
+        return {
+          parsedOrders: orders.length,
+          segments: segments.length,
+          total: Math.round(segments.reduce((s, b) => s + b.revenue, 0) * 100) / 100,
+          top: segments[0],
+          roundTripped: decoder.decode(entries["summary.csv"]) === summaryCsv,
+          meta: yaml.load(decoder.decode(entries["meta.yaml"]))
+        };
+      `,
+      [CSV, DATES, YAML, ZIP],
+      { inputs: { csv: toCsv(orders) } }
+    );
+
+    expect(result.parsedOrders).toBe(200);
+    expect(result.segments).toBe(expected.segments);
+    expect(result.total).toBeCloseTo(expected.total, 2);
+    expect(result.top).toMatchObject({ region: expected.top.region, quarter: expected.top.quarter });
+    expect(result.roundTripped).toBe(true);
+    expect(result.meta).toEqual({ orders: 200, segments: expected.segments });
+  });
+});
+
+describe("a feed digest across xml, dates and yaml", () => {
+  it("parses an Atom feed, dates each entry, and emits YAML", async () => {
+    const result = await runNode(
+      `
+        import { parse } from "${XML}";
+        import { parseISO, format, differenceInCalendarDays, isValid } from "${DATES}";
+        import yaml from "${YAML}";
+
+        const feed = await parse(inputs.xml);
+        const entries = [].concat(feed?.feed?.entry ?? []);   // one entry is not an array
+        const today = parseISO("2026-08-10T00:00:00Z");
+
+        const releases = entries.map((e) => {
+          const when = parseISO(String(e.updated));
+          return {
+            title: String(e.title),
+            released: isValid(when) ? format(when, "yyyy-MM-dd") : "unknown",
+            age_days: isValid(when) ? differenceInCalendarDays(today, when) : null
+          };
+        });
+
+        return {
+          feedTitle: String(feed?.feed?.title ?? ""),
+          releases,
+          digest: yaml.dump(releases).trim()
+        };
+      `,
+      [XML, DATES, YAML],
+      { inputs: { xml: ATOM_FEED } }
+    );
+
+    expect(result.feedTitle).toBe("Release notes from nodetool");
+    expect(result.releases).toEqual([
+      { title: "v0.7.7", released: "2026-08-04", age_days: 6 },
+      { title: "v0.7.6", released: "2026-07-21", age_days: 20 },
+      { title: "v0.7.5", released: "2026-07-02", age_days: 39 }
+    ]);
+    expect(result.digest).toContain("age_days: 6");
+  });
+});
+
+describe("page ingestion through the html pack", () => {
+  it("selects and converts in the same node, concurrently", async () => {
+    const result = await runNode(
+      `
+        import { select, toMarkdown } from "${HTML}";
+
+        // Host calls start when invoked, so these three overlap.
+        const [titles, headings, hrefs] = await Promise.all([
+          select(inputs.html, "h1"),
+          select(inputs.html, "h2"),
+          select(inputs.html, "a[href]", { attr: "href" })
+        ]);
+
+        return {
+          title: titles[0] ?? null,
+          headings,
+          hrefs,
+          external: hrefs.filter((h) => h.startsWith("http")).length,
+          markdown: await toMarkdown(inputs.html),
+          missing: await select(inputs.html, "blockquote.does-not-exist")
+        };
+      `,
+      [HTML],
+      { inputs: { html: PAGE_HTML } }
+    );
+
+    expect(result.title).toBe("Sandbox packages");
+    expect(result.headings).toEqual(["Guest modules", "Host modules"]);
+    expect(result.hrefs).toEqual([
+      "https://nodetool.ai/docs",
+      "/local/page",
+      "https://github.com/nodetool-ai/nodetool"
+    ]);
+    expect(result.external).toBe(2);
+    // A selector matching nothing is an empty array, never null.
+    expect(result.missing).toEqual([]);
+    expect(result.markdown).toContain("# Sandbox packages");
+    expect(result.markdown).toContain("**importable module**");
+  });
+});
+
+describe("config drift across yaml and diff", () => {
+  it("compares two revisions structurally and as a patch", async () => {
+    const result = await runNode(
+      `
+        import yaml from "${YAML}";
+        import { unified } from "${DIFF}";
+
+        const before = yaml.load(inputs.before);
+        const after = yaml.load(inputs.after);
+
+        const patch = await unified(inputs.before, inputs.after, {
+          oldName: "deploy.yaml@old",
+          newName: "deploy.yaml@new",
+          context: 2
+        });
+
+        return {
+          replicas: [before.replicas, after.replicas],
+          image: after.image,
+          envAdded: after.env.length - before.env.length,
+          changed: patch.includes("@@"),
+          // jsdiff opens with a "=====" separator, then the two file lines.
+          names: patch.split("\\n").filter((l) => l.startsWith("---") || l.startsWith("+++"))
+        };
+      `,
+      [YAML, DIFF],
+      { inputs: { before: DEPLOY_BEFORE, after: DEPLOY_AFTER } }
+    );
+
+    expect(result.replicas).toEqual([2, 3]);
+    expect(result.image).toBe("ghcr.io/nodetool-ai/api:0.7.7");
+    expect(result.envAdded).toBe(1);
+    expect(result.changed).toBe(true);
+    expect(result.names).toEqual(["--- deploy.yaml@old", "+++ deploy.yaml@new"]);
+  });
+
+  it("reports no hunks when the two sides are identical", async () => {
+    const result = await runNode(
+      `
+        import { unified } from "${DIFF}";
+        const patch = await unified(inputs.text, inputs.text, { oldName: "a", newName: "a" });
+        return { changed: patch.includes("@@") };
+      `,
+      [DIFF],
+      { inputs: { text: DEPLOY_AFTER } }
+    );
+    expect(result.changed).toBe(false);
+  });
+});
+
+describe("a mixed archive dispatched by extension", () => {
+  it("unzips once and routes each entry to the pack that handles it", async () => {
+    const orders = makeOrders(20);
+
+    const result = await runNode(
+      `
+        import { zip, unzip } from "${ZIP}";
+        import { parse as parseCsv } from "${CSV}";
+        import { parse as parseXml } from "${XML}";
+        import yaml from "${YAML}";
+
+        // The archive a customer would send, built here so the test owns both ends.
+        const archive = await zip({
+          "orders/sales.csv": inputs.csv,
+          "config/deploy.yaml": inputs.yaml,
+          "feed/releases.atom": inputs.xml,
+          "README.md": "# Export\\n"
+        });
+
+        const files = await unzip(archive);
+        const decoder = new TextDecoder();
+        const handled = {};
+
+        for (const [name, bytes] of Object.entries(files)) {
+          const text = decoder.decode(bytes);
+          if (name.endsWith(".csv")) {
+            const rows = await parseCsv(text);
+            handled[name] = { pack: "csv", rows: rows.length, columns: Object.keys(rows[0] ?? {}) };
+          } else if (name.endsWith(".yaml")) {
+            const doc = yaml.load(text);
+            handled[name] = { pack: "yaml", service: doc.service, replicas: doc.replicas };
+          } else if (name.endsWith(".atom")) {
+            const feed = await parseXml(text);
+            handled[name] = { pack: "xml", entries: [].concat(feed?.feed?.entry ?? []).length };
+          } else {
+            handled[name] = { pack: "none", chars: text.length };
+          }
+        }
+
+        return { entries: Object.keys(files).length, handled };
+      `,
+      [ZIP, CSV, XML, YAML],
+      { inputs: { csv: toCsv(orders), yaml: DEPLOY_AFTER, xml: ATOM_FEED } }
+    );
+
+    expect(result.entries).toBe(4);
+    expect(result.handled).toEqual({
+      "orders/sales.csv": {
+        pack: "csv",
+        rows: 20,
+        columns: ["order_id", "date", "region", "amount_eur"]
+      },
+      "config/deploy.yaml": { pack: "yaml", service: "nodetool-api", replicas: 3 },
+      "feed/releases.atom": { pack: "xml", entries: 3 },
+      "README.md": { pack: "none", chars: 9 }
+    });
+  });
+});

--- a/packages/sandbox-compiler/tests/packs.test.ts
+++ b/packages/sandbox-compiler/tests/packs.test.ts
@@ -13,55 +13,22 @@
 import { afterAll, describe, expect, it } from "vitest";
 import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
 import { SANDBOX_HOST_MODULES } from "@nodetool-ai/protocol";
 import {
   BRIDGE_PACKS,
-  createSandboxModuleCatalog,
   discoverSandboxPack,
-  SandboxPackDiscoveryError,
-  type SandboxPackDiscovery
+  SandboxPackDiscoveryError
 } from "@nodetool-ai/node-sdk";
 import { runInSandbox } from "@nodetool-ai/agents";
 
-import { CompiledModuleCache } from "../src/cache.js";
-import { compileDiscoveries, createCompiledNpmLookup } from "../src/catalog.js";
 import { cleanup, writeFixturePack } from "./fixtures.js";
+import { discoverPack, packDir, resolveOne } from "./pack-harness.js";
 
-const here = dirname(fileURLToPath(import.meta.url));
-const PACKS_ROOT = join(here, "..", "..", "sandbox-packs");
 const workspace = mkdtempSync(join(tmpdir(), "nodetool-packs-test-"));
-const cache = new CompiledModuleCache(join(workspace, "cache"));
 
 afterAll(() => cleanup(workspace));
-
-/** `@nodetool-ai/sandbox-csv` → `sandbox-csv`. */
-function packDir(packName: string): string {
-  return join(PACKS_ROOT, packName.slice("@nodetool-ai/".length));
-}
-
-/** Discover a shipped pack, compile its npm entry if it has one, discover again. */
-async function discoverPack(specifier: string): Promise<SandboxPackDiscovery> {
-  const dir = packDir(specifier);
-  const first = discoverSandboxPack(dir);
-  if (first === undefined) throw new Error(`${specifier} is not a sandbox pack`);
-  const reports = await compileDiscoveries([first], { cache });
-  const second = discoverSandboxPack(dir, {
-    compiled: createCompiledNpmLookup(reports)
-  });
-  if (second === undefined) throw new Error(`${specifier} stopped being a sandbox pack`);
-  return second;
-}
-
-/** The resolution a Code node declaring this one specifier would execute with. */
-async function resolveOne(specifier: string) {
-  const discovery = await discoverPack(specifier);
-  const catalog = createSandboxModuleCatalog([discovery]);
-  const resolution = catalog.resolveForExecution([{ specifier }]);
-  return { discovery, catalog, resolution };
-}
 
 describe("every shipped pack", () => {
   for (const pack of BRIDGE_PACKS) {


### PR DESCRIPTION
## Why

`packs.test.ts` walks every shipped pack through discovery → compile → catalog → guest import, one pack at a time, on the happy path. Two things that follow from the design were not asserted anywhere:

- **the refusals** — the value of the system is that a declared pack is the *only* importable thing, and nothing tested that;
- **composition** — real nodes import four packs at once, which is where a loader that mounts a pack's siblings wrong, or two host facades that collide, would show up.

I found these while exercising the pack system against real inputs after #4821. Everything shipped behaved correctly; this PR is the coverage, not a fix.

## What

**`pack-boundaries.test.ts` — 10 cases, all expecting a refusal.** A case that returns a value is a hole, not a pass.

| Case | Refusal |
|---|---|
| imports a pack it did not declare (catalog *does* hold it) | `is not a sandbox package declared by this node` |
| imports an unknown specifier | same |
| `import "node:buffer"` | same |
| `import("node:" + "fs")` | `dynamic import() is not allowed` |
| dynamic import of a pack that **is** declared | `dynamic import() is not allowed` |
| zip bomb (~120 MB inflating) | `exceed the 52428800 byte limit` |
| 7 MB of HTML into `select` | `html.select: input exceeds the 5242880 character limit` |
| `eval`, `setTimeout` | `not defined` |
| saved `contentDigest` drifted | `content-digest-mismatch` |

Two of these are worth calling out. `node:buffer` matters because `createVirtualFileSystem` mounts the node-compat modules unconditionally — the specifier really does resolve under the wrapper's defaults, so the loader is the only thing refusing it. And a dynamic import of an *allowed* pack is refused on form rather than on declaration; if it were not, the static declaration check would be advisory.

**`pack-pipelines.test.ts` — 6 cases, several packs per guest.** csv + dates + yaml + zip aggregate an order book by quarter and round-trip the result through an archive; xml + dates + yaml build a feed digest; yaml + diff compare two config revisions; zip + csv + xml + yaml dispatch a mixed archive by extension.

Expected values come from a host-side oracle computed independently of the guest, so the assertions are not the guest checking its own arithmetic. The oracle derives the quarter from the month digits rather than a `Date`, so it agrees with the guest (always UTC) whatever zone the host runs in.

Inputs are generated in the test. The package's existing fixtures are built so that nothing is fetched at test time; these keep that.

**`pack-harness.ts`** holds the shared discover → compile → catalog → resolve road. `packs.test.ts` now imports it instead of keeping its own copy — that is the only change to an existing file.

## Verification

- `npm run test --workspace=@nodetool-ai/sandbox-compiler` → **85 passed, 7 files** (was 69 in 5 files).
- `npm run typecheck --workspace=@nodetool-ai/sandbox-compiler` → clean.
- Mutation-checked rather than assumed: declaring `sandbox-csv` in the first boundary case makes the guest import succeed, and the test goes red on the returned `[{ a: '1', b: '2' }]`. Three assertions in the boundaries file initially failed because I had guessed the old `not installed or available` wording; the shipped message is better, and the tests assert the real one.

## Not covered

`sandbox-xlsx` is the one shipped pack with no end-to-end case here — it needs a binary workbook, so either a checked-in fixture or an `exceljs` devDependency on this package. Left as a follow-up rather than bundled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)