### PR TITLE
Run Code nodes with sandbox packs as example workflows

### DIFF
--- a/examples/workflows/code_config_diff_cli.json
+++ b/examples/workflows/code_config_diff_cli.json
@@ -1,0 +1,122 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "before",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "service: nodetool-api\nreplicas: 2\nimage: ghcr.io/nodetool-ai/api:0.7.6\n"
+        }
+      },
+      {
+        "id": "after",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "service: nodetool-api\nreplicas: 3\nimage: ghcr.io/nodetool-ai/api:0.7.7\n"
+        }
+      },
+      {
+        "id": "drift",
+        "type": "nodetool.code.Code",
+        "data": {
+          "code": "import { unified } from \"@nodetool-ai/sandbox-diff\";\n\nconst patch = await unified(inputs.before, inputs.after, {\n  oldName: \"deploy.yaml@old\",\n  newName: \"deploy.yaml@new\",\n  context: 1\n});\nreturn {\n  changed: patch.includes(\"@@\"),\n  added_lines: patch.split(\"\\n\").filter((l) => l.startsWith(\"+\") && !l.startsWith(\"+++\")).length,\n  removed_lines: patch.split(\"\\n\").filter((l) => l.startsWith(\"-\") && !l.startsWith(\"---\")).length\n};\n",
+          "packages": [
+            {
+              "specifier": "@nodetool-ai/sandbox-diff"
+            }
+          ],
+          "timeout": 30,
+          "max_response_mb": 8,
+          "allow_local_network": false,
+          "allow_host_filesystem": false
+        },
+        "ui_properties": {
+          "title": "Diff two config revisions"
+        },
+        "dynamic_properties": {
+          "before": "",
+          "after": ""
+        },
+        "dynamic_outputs": {
+          "changed": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          },
+          "added_lines": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          },
+          "removed_lines": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          }
+        }
+      },
+      {
+        "id": "out_changed",
+        "type": "nodetool.output.Output",
+        "name": "changed",
+        "data": {
+          "name": "changed"
+        }
+      },
+      {
+        "id": "out_added",
+        "type": "nodetool.output.Output",
+        "name": "added_lines",
+        "data": {
+          "name": "added_lines"
+        }
+      },
+      {
+        "id": "out_removed",
+        "type": "nodetool.output.Output",
+        "name": "removed_lines",
+        "data": {
+          "name": "removed_lines"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e_before_output_drift_before",
+        "source": "before",
+        "sourceHandle": "output",
+        "target": "drift",
+        "targetHandle": "before"
+      },
+      {
+        "id": "e_after_output_drift_after",
+        "source": "after",
+        "sourceHandle": "output",
+        "target": "drift",
+        "targetHandle": "after"
+      },
+      {
+        "id": "e_drift_changed_out_changed_value",
+        "source": "drift",
+        "sourceHandle": "changed",
+        "target": "out_changed",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_drift_added_lines_out_added_value",
+        "source": "drift",
+        "sourceHandle": "added_lines",
+        "target": "out_added",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_drift_removed_lines_out_removed_value",
+        "source": "drift",
+        "sourceHandle": "removed_lines",
+        "target": "out_removed",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/code_csv_report_cli.json
+++ b/examples/workflows/code_csv_report_cli.json
@@ -1,0 +1,139 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "csv",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "order_id,region,product,amount_eur\nNT-1001,EMEA,Studio,120.00\nNT-1002,AMER,Runner,80.50\nNT-1003,EMEA,Cloud,240.25\nNT-1004,APAC,Studio,60.00\nNT-1005,AMER,Studio,199.50\nNT-1006,EMEA,Runner,45.25\n"
+        }
+      },
+      {
+        "id": "aggregate",
+        "type": "nodetool.code.Code",
+        "data": {
+          "code": "import { parse, stringify } from \"@nodetool-ai/sandbox-csv\";\n\nconst orders = await parse(inputs.csv);\nconst byRegion = new Map();\nfor (const order of orders) {\n  const bucket = byRegion.get(order.region) ?? { region: order.region, orders: 0, revenue_eur: 0 };\n  bucket.orders += 1;\n  bucket.revenue_eur += Number(order.amount_eur);\n  byRegion.set(order.region, bucket);\n}\nconst segments = [...byRegion.values()]\n  .map((b) => ({ ...b, revenue_eur: Math.round(b.revenue_eur * 100) / 100 }))\n  .sort((a, b) => b.revenue_eur - a.revenue_eur);\n\nreturn {\n  order_count: orders.length,\n  segments,\n  summary_csv: (await stringify(segments)).trim()\n};\n",
+          "packages": [
+            {
+              "specifier": "@nodetool-ai/sandbox-csv"
+            }
+          ],
+          "timeout": 30,
+          "max_response_mb": 8,
+          "allow_local_network": false,
+          "allow_host_filesystem": false
+        },
+        "ui_properties": {
+          "title": "Aggregate orders by region"
+        },
+        "dynamic_properties": {
+          "csv": ""
+        },
+        "dynamic_outputs": {
+          "order_count": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          },
+          "segments": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          },
+          "summary_csv": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          }
+        }
+      },
+      {
+        "id": "render",
+        "type": "nodetool.code.Code",
+        "data": {
+          "code": "const lines = inputs.segments.map(\n  (s) => `${s.region}: ${s.orders} orders, EUR ${s.revenue_eur.toFixed(2)}`\n);\nreturn { report: lines.join(\"\\n\") };\n",
+          "packages": [],
+          "timeout": 30,
+          "max_response_mb": 8,
+          "allow_local_network": false,
+          "allow_host_filesystem": false
+        },
+        "ui_properties": {
+          "title": "Render a text report"
+        },
+        "dynamic_properties": {
+          "segments": ""
+        },
+        "dynamic_outputs": {
+          "report": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          }
+        }
+      },
+      {
+        "id": "out_count",
+        "type": "nodetool.output.Output",
+        "name": "order_count",
+        "data": {
+          "name": "order_count"
+        }
+      },
+      {
+        "id": "out_summary",
+        "type": "nodetool.output.Output",
+        "name": "summary_csv",
+        "data": {
+          "name": "summary_csv"
+        }
+      },
+      {
+        "id": "out_report",
+        "type": "nodetool.output.Output",
+        "name": "report",
+        "data": {
+          "name": "report"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e_csv_output_aggregate_csv",
+        "source": "csv",
+        "sourceHandle": "output",
+        "target": "aggregate",
+        "targetHandle": "csv"
+      },
+      {
+        "id": "e_aggregate_segments_render_segments",
+        "source": "aggregate",
+        "sourceHandle": "segments",
+        "target": "render",
+        "targetHandle": "segments"
+      },
+      {
+        "id": "e_aggregate_order_count_out_count_value",
+        "source": "aggregate",
+        "sourceHandle": "order_count",
+        "target": "out_count",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_aggregate_summary_csv_out_summary_value",
+        "source": "aggregate",
+        "sourceHandle": "summary_csv",
+        "target": "out_summary",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_render_report_out_report_value",
+        "source": "render",
+        "sourceHandle": "report",
+        "target": "out_report",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/code_html_extract_cli.json
+++ b/examples/workflows/code_html_extract_cli.json
@@ -1,0 +1,112 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "html",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "<!doctype html>\n<html>\n  <head><title>Sandbox packages</title></head>\n  <body>\n    <h1>Sandbox packages</h1>\n    <p>Every library the sandbox offers is an <strong>importable module</strong>.</p>\n    <h2>Guest modules</h2>\n    <p>See <a href=\"https://nodetool.ai/docs\">the docs</a> and <a href=\"/local\">a local page</a>.</p>\n    <h2>Host modules</h2>\n  </body>\n</html>\n"
+        }
+      },
+      {
+        "id": "extract",
+        "type": "nodetool.code.Code",
+        "data": {
+          "code": "import { select, toMarkdown } from \"@nodetool-ai/sandbox-html\";\n\nconst [titles, headings, hrefs] = await Promise.all([\n  select(inputs.html, \"h1\"),\n  select(inputs.html, \"h2\"),\n  select(inputs.html, \"a[href]\", { attr: \"href\" })\n]);\nconst markdown = await toMarkdown(inputs.html);\nreturn {\n  title: titles[0] ?? \"\",\n  headings,\n  external_links: hrefs.filter((h) => h.startsWith(\"http\")).length,\n  markdown\n};\n",
+          "packages": [
+            {
+              "specifier": "@nodetool-ai/sandbox-html"
+            }
+          ],
+          "timeout": 30,
+          "max_response_mb": 8,
+          "allow_local_network": false,
+          "allow_host_filesystem": false
+        },
+        "ui_properties": {
+          "title": "Select and convert the page"
+        },
+        "dynamic_properties": {
+          "html": ""
+        },
+        "dynamic_outputs": {
+          "title": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          },
+          "headings": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          },
+          "external_links": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          },
+          "markdown": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          }
+        }
+      },
+      {
+        "id": "out_title",
+        "type": "nodetool.output.Output",
+        "name": "title",
+        "data": {
+          "name": "title"
+        }
+      },
+      {
+        "id": "out_headings",
+        "type": "nodetool.output.Output",
+        "name": "headings",
+        "data": {
+          "name": "headings"
+        }
+      },
+      {
+        "id": "out_links",
+        "type": "nodetool.output.Output",
+        "name": "external_links",
+        "data": {
+          "name": "external_links"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e_html_output_extract_html",
+        "source": "html",
+        "sourceHandle": "output",
+        "target": "extract",
+        "targetHandle": "html"
+      },
+      {
+        "id": "e_extract_title_out_title_value",
+        "source": "extract",
+        "sourceHandle": "title",
+        "target": "out_title",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_extract_headings_out_headings_value",
+        "source": "extract",
+        "sourceHandle": "headings",
+        "target": "out_headings",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_extract_external_links_out_links_value",
+        "source": "extract",
+        "sourceHandle": "external_links",
+        "target": "out_links",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/code_xml_feed_cli.json
+++ b/examples/workflows/code_xml_feed_cli.json
@@ -1,0 +1,105 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "xml",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<feed xmlns=\"http://www.w3.org/2005/Atom\">\n  <title>Release notes from nodetool</title>\n  <entry><title>v0.7.7</title><updated>2026-08-04T09:15:00Z</updated></entry>\n  <entry><title>v0.7.6</title><updated>2026-07-21T16:40:00Z</updated></entry>\n  <entry><title>v0.7.5</title><updated>2026-07-02T11:05:00Z</updated></entry>\n</feed>\n"
+        }
+      },
+      {
+        "id": "feed",
+        "type": "nodetool.code.Code",
+        "data": {
+          "code": "import { parse } from \"@nodetool-ai/sandbox-xml\";\n\nconst feed = await parse(inputs.xml);\nconst entries = [].concat(feed?.feed?.entry ?? []);\nreturn {\n  feed_title: String(feed?.feed?.title ?? \"\"),\n  count: entries.length,\n  titles: entries.map((e) => String(e.title))\n};\n",
+          "packages": [
+            "@nodetool-ai/sandbox-xml"
+          ],
+          "timeout": 30,
+          "max_response_mb": 8,
+          "allow_local_network": false,
+          "allow_host_filesystem": false
+        },
+        "ui_properties": {
+          "title": "Parse the release feed"
+        },
+        "dynamic_properties": {
+          "xml": ""
+        },
+        "dynamic_outputs": {
+          "feed_title": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          },
+          "count": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          },
+          "titles": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          }
+        }
+      },
+      {
+        "id": "out_title",
+        "type": "nodetool.output.Output",
+        "name": "feed_title",
+        "data": {
+          "name": "feed_title"
+        }
+      },
+      {
+        "id": "out_count",
+        "type": "nodetool.output.Output",
+        "name": "count",
+        "data": {
+          "name": "count"
+        }
+      },
+      {
+        "id": "out_titles",
+        "type": "nodetool.output.Output",
+        "name": "titles",
+        "data": {
+          "name": "titles"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e_xml_output_feed_xml",
+        "source": "xml",
+        "sourceHandle": "output",
+        "target": "feed",
+        "targetHandle": "xml"
+      },
+      {
+        "id": "e_feed_feed_title_out_title_value",
+        "source": "feed",
+        "sourceHandle": "feed_title",
+        "target": "out_title",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_feed_count_out_count_value",
+        "source": "feed",
+        "sourceHandle": "count",
+        "target": "out_count",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_feed_titles_out_titles_value",
+        "source": "feed",
+        "sourceHandle": "titles",
+        "target": "out_titles",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/examples/workflows/code_zip_bundle_cli.json
+++ b/examples/workflows/code_zip_bundle_cli.json
@@ -1,0 +1,115 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "csv",
+        "type": "nodetool.constant.String",
+        "data": {
+          "value": "order_id,region,product,amount_eur\nNT-1001,EMEA,Studio,120.00\nNT-1002,AMER,Runner,80.50\nNT-1003,EMEA,Cloud,240.25\nNT-1004,APAC,Studio,60.00\nNT-1005,AMER,Studio,199.50\nNT-1006,EMEA,Runner,45.25\n"
+        }
+      },
+      {
+        "id": "bundle",
+        "type": "nodetool.code.Code",
+        "data": {
+          "code": "import { zip, unzip } from \"@nodetool-ai/sandbox-zip\";\nimport { parse } from \"@nodetool-ai/sandbox-csv\";\n\nconst archive = await zip({\n  \"orders/sales.csv\": inputs.csv,\n  \"README.md\": \"# Export\\n\"\n});\nconst files = await unzip(archive);\nconst decoder = new TextDecoder();\nconst rows = await parse(decoder.decode(files[\"orders/sales.csv\"]));\n\nreturn {\n  entry_names: Object.keys(files).sort(),\n  row_count: rows.length,\n  columns: Object.keys(rows[0] ?? {}),\n  readme: decoder.decode(files[\"README.md\"]).trim()\n};\n",
+          "packages": [
+            {
+              "specifier": "@nodetool-ai/sandbox-zip"
+            },
+            {
+              "specifier": "@nodetool-ai/sandbox-csv"
+            }
+          ],
+          "timeout": 30,
+          "max_response_mb": 8,
+          "allow_local_network": false,
+          "allow_host_filesystem": false
+        },
+        "ui_properties": {
+          "title": "Zip, read back, and parse"
+        },
+        "dynamic_properties": {
+          "csv": ""
+        },
+        "dynamic_outputs": {
+          "entry_names": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          },
+          "row_count": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          },
+          "columns": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          },
+          "readme": {
+            "type": "any",
+            "type_args": [],
+            "optional": false
+          }
+        }
+      },
+      {
+        "id": "out_entries",
+        "type": "nodetool.output.Output",
+        "name": "entry_names",
+        "data": {
+          "name": "entry_names"
+        }
+      },
+      {
+        "id": "out_rows",
+        "type": "nodetool.output.Output",
+        "name": "row_count",
+        "data": {
+          "name": "row_count"
+        }
+      },
+      {
+        "id": "out_columns",
+        "type": "nodetool.output.Output",
+        "name": "columns",
+        "data": {
+          "name": "columns"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "id": "e_csv_output_bundle_csv",
+        "source": "csv",
+        "sourceHandle": "output",
+        "target": "bundle",
+        "targetHandle": "csv"
+      },
+      {
+        "id": "e_bundle_entry_names_out_entries_value",
+        "source": "bundle",
+        "sourceHandle": "entry_names",
+        "target": "out_entries",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_bundle_row_count_out_rows_value",
+        "source": "bundle",
+        "sourceHandle": "row_count",
+        "target": "out_rows",
+        "targetHandle": "value"
+      },
+      {
+        "id": "e_bundle_columns_out_columns_value",
+        "source": "bundle",
+        "sourceHandle": "columns",
+        "target": "out_columns",
+        "targetHandle": "value"
+      }
+    ]
+  },
+  "params": {}
+}

--- a/packages/base-nodes/tests/code-node-examples-run.test.ts
+++ b/packages/base-nodes/tests/code-node-examples-run.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Executes the Code-node example workflows in `examples/workflows/` and asserts
+ * the value every node produced.
+ *
+ * The gap this closes: none of the 42 example workflows the other run-suites
+ * execute contains a `nodetool.code.Code` node, and the Code node's own package
+ * tests serve a hand-written module from a hand-written catalog. So the seam
+ * between a *shipped* pack and a *running graph* — discovery, the catalog on
+ * the ProcessingContext, the node's `packages` declaration, the guest loader —
+ * was covered nowhere.
+ *
+ * Here the catalog is built from the pack directories under
+ * `packages/sandbox-packs/`, which are the ones users install, and the graphs
+ * run through `ExecutionSession` — the path `nodetool workflows run` and the
+ * websocket server both take.
+ *
+ * Only **host** packs appear. A guest pack (`sandbox-yaml`, `sandbox-dates`)
+ * has to be compiled by `@nodetool-ai/sandbox-compiler` first, which this
+ * package does not depend on; reading a warm compile cache instead would make
+ * the suite pass here and fail on a clean checkout. `packs.test.ts` in the
+ * compiler covers the guest half.
+ *
+ * Nothing touches a model, the network, or the filesystem: every input is a
+ * string constant in the graph.
+ *
+ * One thing to know before running `nodetool validate` on these files: it
+ * reports `code_package_unavailable` for each of them. That is not a defect in
+ * the example. The CLI builds its catalog by scanning node_modules, and the
+ * packs are deliberately not workspaces, so in a repo checkout nothing has
+ * installed them. On a real install they are present and the check passes.
+ * This suite discovers them from `packages/sandbox-packs/` instead, which is
+ * what makes it run here at all. `scripts/validate-examples.mjs` and the
+ * workflow-example-validation CI job scan only `packages/**\/examples/`, so
+ * these files are outside that gate.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  NodeRegistry,
+  createGraphNodeTypeResolver,
+  createSandboxModuleCatalog,
+  discoverSandboxPack
+} from "@nodetool-ai/node-sdk";
+import { setProcessSandboxModuleCatalog } from "@nodetool-ai/runtime";
+import { ExecutionSession } from "@nodetool-ai/execution";
+import { registerBaseNodes } from "../src/index.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const EXAMPLES_DIR = path.resolve(__dirname, "../../../examples/workflows");
+const PACKS_ROOT = path.resolve(__dirname, "../../sandbox-packs");
+
+/** The host packs these examples import. None needs the compiler. */
+const HOST_PACKS = [
+  "sandbox-csv",
+  "sandbox-diff",
+  "sandbox-html",
+  "sandbox-xml",
+  "sandbox-zip"
+];
+
+beforeAll(() => {
+  const discoveries = HOST_PACKS.map((dir) => {
+    const discovery = discoverSandboxPack(path.join(PACKS_ROOT, dir));
+    if (discovery === undefined) throw new Error(`${dir} is not a sandbox pack`);
+    return discovery;
+  });
+  setProcessSandboxModuleCatalog(createSandboxModuleCatalog(discoveries));
+});
+
+// The catalog is process-wide state; leaving it set would follow this file.
+afterAll(() => setProcessSandboxModuleCatalog(null));
+
+async function run(file: string): Promise<Record<string, unknown[]>> {
+  const { graph } = JSON.parse(
+    fs.readFileSync(path.join(EXAMPLES_DIR, file), "utf8")
+  ) as { graph: unknown };
+  const registry = new NodeRegistry();
+  registerBaseNodes(registry);
+  const session = await ExecutionSession.create({
+    graph,
+    registry,
+    resolveNodeType: createGraphNodeTypeResolver(registry).resolveNodeType,
+    jobId: `code-example-${file}`,
+    params: {}
+  } as never);
+  const result = await session.result;
+  expect(result.error ?? null, `${file} errored`).toBeNull();
+  expect(result.status, `${file} did not complete`).toBe("completed");
+  return (result.outputs ?? {}) as Record<string, unknown[]>;
+}
+
+describe("code_csv_report_cli", () => {
+  it("aggregates six orders by region, then formats them in a second node", async () => {
+    const out = await run("code_csv_report_cli.json");
+
+    // EMEA 120.00 + 240.25 + 45.25, AMER 80.50 + 199.50, APAC 60.00.
+    expect(out["order_count"]).toEqual([6]);
+
+    // The header row is the keys of the first record; the rounding drops a
+    // trailing zero, so 405.50 is written 405.5. Rows are separated by "\n" —
+    // the host facade does not use papaparse's default "\r\n".
+    expect(out["summary_csv"]).toEqual([
+      [
+        "region,orders,revenue_eur",
+        "EMEA,3,405.5",
+        "AMER,2,280",
+        "APAC,1,60"
+      ].join("\n")
+    ]);
+
+    // The second Code node declares no packages and reads the first one's rows.
+    expect(out["report"]).toEqual([
+      [
+        "EMEA: 3 orders, EUR 405.50",
+        "AMER: 2 orders, EUR 280.00",
+        "APAC: 1 orders, EUR 60.00"
+      ].join("\n")
+    ]);
+  });
+});
+
+describe("code_xml_feed_cli", () => {
+  it("parses an Atom feed into a title and an entry list", async () => {
+    const out = await run("code_xml_feed_cli.json");
+    expect(out["feed_title"]).toEqual(["Release notes from nodetool"]);
+    expect(out["count"]).toEqual([3]);
+    expect(out["titles"]).toEqual([["v0.7.7", "v0.7.6", "v0.7.5"]]);
+  });
+});
+
+describe("code_html_extract_cli", () => {
+  it("selects headings and links, and converts the page to markdown", async () => {
+    const out = await run("code_html_extract_cli.json");
+    expect(out["title"]).toEqual(["Sandbox packages"]);
+    expect(out["headings"]).toEqual([["Guest modules", "Host modules"]]);
+    // Two anchors, but "/local" is relative — only one is external.
+    expect(out["external_links"]).toEqual([1]);
+  });
+});
+
+describe("code_config_diff_cli", () => {
+  it("reports the two lines that moved between config revisions", async () => {
+    const out = await run("code_config_diff_cli.json");
+    expect(out["changed"]).toEqual([true]);
+    // `replicas` and `image` changed; `service` did not.
+    expect(out["added_lines"]).toEqual([2]);
+    expect(out["removed_lines"]).toEqual([2]);
+  });
+});
+
+describe("code_zip_bundle_cli", () => {
+  it("uses two packs in one node: zip an archive, read it back, parse the CSV", async () => {
+    const out = await run("code_zip_bundle_cli.json");
+    expect(out["entry_names"]).toEqual([["README.md", "orders/sales.csv"]]);
+    expect(out["row_count"]).toEqual([6]);
+    expect(out["columns"]).toEqual([
+      ["order_id", "region", "product", "amount_eur"]
+    ]);
+  });
+});


### PR DESCRIPTION
## Why

Two suites exist on either side of a seam, and nothing crosses it:

- The `*-examples-run` suites execute 42 example workflows. **None contains a `nodetool.code.Code` node.**
- `packages/code-nodes/tests/code-node-packages.test.ts` covers the node's `packages` property — against a hand-written catalog serving a hand-written `@acme/geo` module, with no graph.

So discovery → catalog on the ProcessingContext → the node's `packages` declaration → the guest loader was never exercised end to end with a **shipped** pack inside a **running graph**. This PR adds that.

## What

Five example workflows in `examples/workflows/`, executed by `packages/base-nodes/tests/code-node-examples-run.test.ts` through `ExecutionSession` — the path `nodetool workflows run` and the websocket server both take. The catalog is built from the pack directories under `packages/sandbox-packs/`, which are the ones users install.

| Example | Covers |
|---|---|
| `code_csv_report_cli` | a csv-pack node feeding a **plain** Code node (no packages) |
| `code_xml_feed_cli` | an Atom feed to a title and entry list |
| `code_html_extract_cli` | `select` + `toMarkdown` over one page, concurrently |
| `code_config_diff_cli` | a unified diff of two config revisions |
| `code_zip_bundle_cli` | **two packs in one node**: zip an archive, read it back, parse the CSV |

Every assertion is on a value computed by hand from the input, matching the convention `pure-node-examples-run.test.ts` set — a pack that silently changes its output fails here, rather than passing a "did it complete" check. The examples cover both authoring forms of `packages`: bare specifiers (xml) and the `{specifier}` objects the editor stamps (the rest).

## Scope

**Host packs only.** A guest pack (`sandbox-yaml`, `sandbox-dates`) must be compiled by `@nodetool-ai/sandbox-compiler` first, which `base-nodes` does not depend on. Reading a warm compile cache instead would make this suite pass on my machine and fail on a clean checkout. `packs.test.ts` in the compiler covers the guest half.

**`nodetool validate` reports `code_package_unavailable` on these files.** That is not a defect in the examples: the CLI builds its catalog by scanning node_modules, and the packs are deliberately not workspaces, so a repo checkout has never installed them. On a real install they are present. `scripts/validate-examples.mjs` and the workflow-example-validation job scan only `packages/**/examples/`, so these files are outside that gate — I checked before assuming. Noted in the test file for whoever runs `validate` next.

## Verification

- New suite: **5 passed**.
- `example-workflows-validation` + `example-workflows-execute`, which also pick up the new files: **1825 passed**.
- Full `base-nodes` suite: **2722 passed, 22 skipped, 14 failed** — all 14 are `image-*` tests failing with `No WebGPU adapter available (Node/Dawn)`. That is the missing-Vulkan-driver condition CLAUDE.md documents; CI installs `mesa-vulkan-drivers`. No image node is touched here.
- `tsc --noEmit` clean.
- Mutation-checked: dropping `sandbox-csv` from the catalog fails exactly the two csv-using workflows, with `Sandbox module @nodetool-ai/sandbox-csv is not installed`.

While writing this I hit a stale-`dist` trap worth recording: `packages/code-nodes/dist/` predated the M1 sandbox-packages commit and contained **zero** references to the package-resolution code, so every workflow failed with a guest-loader error that looked like a product bug. base-nodes loads code-nodes from `dist/`. `npm run build:packages` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)