### PR TITLE
Eval sandbox packages in CodeAct, and repair a stale code-gen case

### DIFF
--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -775,6 +775,16 @@ follows (CodeAct, ICML 2024): docs/codeact-design.md.
   `codeact-api-surfaces.ts`) whose fakes are named like real belt tools so
   the object-model prelude lights up. `tests/codeact-api-coverage.test.ts`
   fails when a namespace loses its last case.
+  Four more cases (`src/evals/codeact-sandbox-pack-cases.ts`) cover sandbox
+  packages: importing a pack the session allows and computing from what it
+  parses, reading a pack's SKILL.md through `get_sandbox_package_docs` instead
+  of guessing its API, reporting a pack as unavailable rather than working
+  around it, and using two packs in one action. A case names its allowlist in
+  `sandboxPackages`, and the runner puts a catalog over the shipped **host**
+  packs on the context — a guest pack would need `@nodetool-ai/sandbox-compiler`,
+  which this package does not depend on. `requiredSessionTools` scores tools the
+  executor adds rather than the case, which the recorder cannot see.
+  Measured on `claude_agent_sdk`/sonnet: 4/4, mean score 1.00, ~2 actions each.
   `scripts/dump-codeact-run.ts <case> <provider> <model>` replays one case
   live and writes every action's code to `nodetool-debug/` — the tool to
   reach for before touching the action-contract prompt. Measured on

--- a/packages/agents/scripts/dump-codeact-run.ts
+++ b/packages/agents/scripts/dump-codeact-run.ts
@@ -26,14 +26,20 @@ import {
   createCodeActTools
 } from "../src/evals/codeact-cases.js";
 import { CODEACT_API_EVAL_CASES } from "../src/evals/codeact-api-cases.js";
+import {
+  CODEACT_SANDBOX_PACK_EVAL_CASES,
+  shippedHostPackCatalog
+} from "../src/evals/codeact-sandbox-pack-cases.js";
 import { checkCodeActExpectations } from "../src/evals/codeact-eval.js";
 
 const [caseId, providerId = "claude_agent_sdk", model = "sonnet", iterations] =
   process.argv.slice(2);
 
-const evalCase = [...CODEACT_EVAL_CASES, ...CODEACT_API_EVAL_CASES].find(
-  (c) => c.id === caseId
-);
+const evalCase = [
+  ...CODEACT_EVAL_CASES,
+  ...CODEACT_API_EVAL_CASES,
+  ...CODEACT_SANDBOX_PACK_EVAL_CASES
+].find((c) => c.id === caseId);
 if (!evalCase) {
   console.error(`Unknown case "${caseId}".`);
   process.exit(1);
@@ -42,9 +48,13 @@ if (!evalCase) {
 const provider = await createProviderStrict(providerId);
 const recorder = createCodeActRecorder();
 const tools = (evalCase.createTools ?? createCodeActTools)(recorder);
+const sandboxPackages = evalCase.sandboxPackages ?? [];
 const context = new ProcessingContext({
   jobId: `codeact-dump-${randomUUID()}`,
-  userId: "eval-user"
+  userId: "eval-user",
+  ...(sandboxPackages.length > 0
+    ? { sandboxModuleCatalog: shippedHostPackCatalog() }
+    : {})
 });
 const step: Step = {
   id: randomUUID(),
@@ -65,7 +75,8 @@ const executor = new CodeActExecutor({
   provider,
   model,
   tools,
-  maxIterations: iterations ? Number(iterations) : 40
+  maxIterations: iterations ? Number(iterations) : 40,
+  sandboxPackages
 });
 
 const lines: string[] = [

--- a/packages/agents/src/evals/code-gen-cases.ts
+++ b/packages/agents/src/evals/code-gen-cases.ts
@@ -74,13 +74,14 @@ export const CODE_GEN_EVAL_CASES: readonly CodeGenEvalCase[] = [
   },
   {
     id: "extract-parse",
-    description: "Parse CSV text with the sandbox's own parser",
+    description: "Parse a delimited text format by hand",
     instruction:
-      "Parse the CSV text into rows using the sandbox's CSV parser, and also return the header names.",
-    inputs: [{ name: "csvText", type: STR }],
+      "Each line of the log text is `level|timestamp|message`. Parse it into one record per line, and also return how many records have level 'ERROR'.",
+    inputs: [{ name: "logText", type: STR }],
     expect: {
       minOutputs: 2,
-      requiredCodePatterns: ["data\\.parseCsv"],
+      // This authoring surface declares no sandbox packages, so `analyzeGeneratedCode`
+      // refuses a module declaration outright. Parsing has to be hand-rolled.
       forbiddenCodePatterns: ["\\brequire\\(", "\\bimport\\s"]
     }
   },

--- a/packages/agents/src/evals/codeact-cases.ts
+++ b/packages/agents/src/evals/codeact-cases.ts
@@ -113,6 +113,12 @@ export interface CodeActEvalExpectations {
   /** Tools that must have been invoked (through the bridge or directly). */
   requiredTools?: string[];
   forbiddenTools?: string[];
+  /**
+   * Tools the executor adds to the session rather than the case — the package
+   * docs tool, the memory tools. The recorder only wraps a case's own toolbelt,
+   * so these are observed on the event stream instead.
+   */
+  requiredSessionTools?: string[];
   /** Bounds on provider turns that carried a code action. */
   maxActions?: number;
   /** Bounds on bridged tool invocations. */
@@ -137,6 +143,12 @@ export interface CodeActEvalCase {
   createTools?: (recorder: CodeActToolRecorder) => Tool[];
   /** Override the suite-level action-round cap for this case. */
   maxIterations?: number;
+  /**
+   * Sandbox packages this session allows an action to import. An action may
+   * import these and nothing else; a case that declares none imports nothing,
+   * which is the default every other case runs under.
+   */
+  sandboxPackages?: readonly string[];
   /**
    * `nodetool.*` namespaces this case exercises — the coverage test asserts
    * the API cases collectively cover every namespace the object model has.

--- a/packages/agents/src/evals/codeact-eval.ts
+++ b/packages/agents/src/evals/codeact-eval.ts
@@ -24,12 +24,19 @@ import {
   type CodeActEvalCase,
   type CodeActEvalExpectations
 } from "./codeact-cases.js";
+import { shippedHostPackCatalog } from "./codeact-sandbox-pack-cases.js";
 
 const DEFAULT_MAX_ITERATIONS = 8;
 
 /** Everything the pure checker needs — no provider, no I/O. */
 export interface CodeActObservation {
   toolsInvoked: Set<string>;
+  /**
+   * Every tool name seen on the event stream, including the ones the executor
+   * adds to the session — which the case's recorder never wraps and so cannot
+   * see.
+   */
+  sessionToolsInvoked: Set<string>;
   /** Provider turns that carried a code action. */
   actions: number;
   /** Bridged tool invocations. */
@@ -97,6 +104,14 @@ export function checkCodeActExpectations(
       detail: hit ? `invoked forbidden tool ${name}` : undefined
     });
   }
+  for (const name of expect.requiredSessionTools ?? []) {
+    const pass = obs.sessionToolsInvoked.has(name);
+    checks.push({
+      name: `session-tool:${name}`,
+      pass,
+      detail: pass ? undefined : `never invoked ${name}`
+    });
+  }
   if (expect.maxActions !== undefined) {
     checks.push({
       name: `actions<=${expect.maxActions}`,
@@ -138,9 +153,15 @@ async function runCase(
   const maxIterations =
     evalCase.maxIterations ?? opts.maxIterations ?? DEFAULT_MAX_ITERATIONS;
 
+  // A case that allows packages needs a catalog to resolve them; one that does
+  // not stays on the process default, which is what every other case runs with.
+  const sandboxPackages = evalCase.sandboxPackages ?? [];
   const context = new ProcessingContext({
     jobId: `codeact-eval-${randomUUID()}`,
-    userId: "eval-user"
+    userId: "eval-user",
+    ...(sandboxPackages.length > 0
+      ? { sandboxModuleCatalog: shippedHostPackCatalog() }
+      : {})
   });
 
   const step: Step = {
@@ -167,7 +188,8 @@ async function runCase(
     model: opts.model,
     tools,
     maxIterations,
-    signal: opts.signal
+    signal: opts.signal,
+    sandboxPackages
   });
 
   const costBefore = opts.provider.getTotalCost();
@@ -175,12 +197,14 @@ async function runCase(
   let result: unknown = null;
   let actions = 0;
   let error: string | undefined;
+  const sessionToolsInvoked = new Set<string>();
 
   try {
     for await (const item of executor.execute()) {
       if (opts.signal?.aborted) break;
       if (item.type === "tool_call_update") {
         const tc = item as ToolCallUpdate;
+        if (tc.name) sessionToolsInvoked.add(tc.name);
         // A "round" is one execute_code turn.
         if (tc.name === EXECUTE_CODE_TOOL_NAME) actions++;
       }
@@ -200,6 +224,7 @@ async function runCase(
 
   const observation: CodeActObservation = {
     toolsInvoked: new Set(recorder.invocations.map((i) => i.name)),
+    sessionToolsInvoked,
     actions,
     toolCalls: recorder.invocations.length,
     result

--- a/packages/agents/src/evals/codeact-sandbox-pack-cases.ts
+++ b/packages/agents/src/evals/codeact-sandbox-pack-cases.ts
@@ -1,0 +1,195 @@
+/**
+ * CodeAct eval cases for sandbox packages.
+ *
+ * A CodeAct action is code the model just wrote, so the packages it may import
+ * are the session's allowlist and nothing else (`codeact/sandbox-packages.ts`).
+ * Three behaviours follow from that, and none of them was measured against a
+ * real model before: importing an allowed pack and using it correctly, reading
+ * a pack's SKILL.md through `get_sandbox_package_docs` rather than guessing its
+ * API, and recovering when an import is refused.
+ *
+ * The packs here are the shipped ones under `packages/sandbox-packs/`, resolved
+ * through the real catalog. Only **host** packs appear: a guest pack must be
+ * compiled by `@nodetool-ai/sandbox-compiler` first, which this package does not
+ * depend on.
+ *
+ * Every objective carries its own data, so a case answers from the pack or not
+ * at all — the expected values cannot be reached by reasoning over the prompt.
+ */
+
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  createSandboxModuleCatalog,
+  discoverSandboxPack
+} from "@nodetool-ai/node-sdk";
+import type { SandboxModuleCatalog } from "@nodetool-ai/runtime";
+
+import type { CodeActEvalCase } from "./codeact-cases.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const PACKS_ROOT = join(here, "..", "..", "..", "sandbox-packs");
+
+export const SANDBOX_PACK_DOCS_TOOL = "get_sandbox_package_docs";
+
+/** The host packs these cases allow. None needs the compiler. */
+const SHIPPED_HOST_PACKS = ["sandbox-csv", "sandbox-xml", "sandbox-zip"];
+
+let cached: SandboxModuleCatalog | undefined;
+
+/**
+ * A catalog over the shipped host packs, built once per process.
+ *
+ * Discovery reads the pack directories users install; nothing is stubbed, so a
+ * case that imports a pack runs the same library a Code node would.
+ */
+export function shippedHostPackCatalog(): SandboxModuleCatalog {
+  if (cached) return cached;
+  const discoveries = SHIPPED_HOST_PACKS.map((dir) => {
+    const discovery = discoverSandboxPack(join(PACKS_ROOT, dir));
+    if (discovery === undefined) throw new Error(`${dir} is not a sandbox pack`);
+    return discovery;
+  });
+  cached = createSandboxModuleCatalog(discoveries);
+  return cached;
+}
+
+const CSV = "@nodetool-ai/sandbox-csv";
+const XML = "@nodetool-ai/sandbox-xml";
+const ZIP = "@nodetool-ai/sandbox-zip";
+
+/** Six orders; EMEA totals 405.50, which is the answer only parsing produces. */
+const ORDERS_CSV = [
+  "order_id,region,amount_eur",
+  "NT-1001,EMEA,120.00",
+  "NT-1002,AMER,80.50",
+  "NT-1003,EMEA,240.25",
+  "NT-1004,APAC,60.00",
+  "NT-1005,AMER,199.50",
+  "NT-1006,EMEA,45.25"
+].join("\\n");
+
+const TOTAL_SCHEMA = {
+  type: "object",
+  properties: { total: { type: "number" } },
+  required: ["total"]
+};
+
+export const CODEACT_SANDBOX_PACK_EVAL_CASES: readonly CodeActEvalCase[] = [
+  {
+    id: "sandbox-pack-import",
+    description: "Import an allowed pack and compute from what it parses",
+    objective:
+      "This CSV is your input:\\n\\n" +
+      ORDERS_CSV +
+      "\\n\\nParse it with the `" +
+      CSV +
+      "` sandbox package and finish with " +
+      "{total: <the summed amount_eur of the EMEA rows only>}. Parse it — do " +
+      "not add the numbers up yourself in your reply.",
+    sandboxPackages: [CSV],
+    outputSchema: TOTAL_SCHEMA,
+    expect: {
+      // 120.00 + 240.25 + 45.25. Wrong parsing gives a different sum, and the
+      // whole-file total (745.50) is the tell that the filter was skipped.
+      resultCheck: (r) =>
+        typeof r === "object" &&
+        r !== null &&
+        Math.abs(Number((r as { total?: unknown }).total) - 405.5) < 0.001,
+      resultCheckLabel: "total=405.50 (EMEA only)",
+      maxActions: 4
+    }
+  },
+  {
+    id: "sandbox-pack-docs",
+    description: "Read a pack's SKILL.md instead of guessing its API",
+    objective:
+      "You may import the `" +
+      XML +
+      "` sandbox package. Before you write any code, read that package's " +
+      "documentation to find out how attributes are represented in the parsed " +
+      "object. Then parse this feed:\\n\\n" +
+      '<?xml version="1.0"?><catalog><item sku="A-1"><name>Widget</name>' +
+      '</item></catalog>' +
+      "\\n\\nFinish with {prefix: <the exact key prefix the parser puts on " +
+      "attributes>}. It is two characters.",
+    sandboxPackages: [XML],
+    outputSchema: {
+      type: "object",
+      properties: { prefix: { type: "string" } },
+      required: ["prefix"]
+    },
+    expect: {
+      // The SKILL.md says attributes ride along prefixed `@_`. A model that
+      // guesses usually answers "@" or "$".
+      requiredSessionTools: [SANDBOX_PACK_DOCS_TOOL],
+      resultCheck: (r) =>
+        typeof r === "object" &&
+        r !== null &&
+        String((r as { prefix?: unknown }).prefix).trim() === "@_",
+      resultCheckLabel: 'prefix="@_"',
+      maxActions: 4
+    }
+  },
+  {
+    id: "sandbox-pack-denied",
+    // Graded on the outcome, not the route. A model reaches `available: false`
+    // either by attempting the import and reading the refusal, or by reading
+    // the allowlist the prompt advertises; both are correct, and live runs do
+    // both. What the case rules out is the failure that matters — hand-parsing
+    // the text and reporting success. The refusal mechanism itself is pinned
+    // deterministically in `tests/codeact-sandbox-packs.test.ts`.
+    description: "Report a pack as unavailable instead of working around it",
+    objective:
+      "Try to parse this YAML with the `@nodetool-ai/sandbox-yaml` sandbox " +
+      "package:\\n\\nservice: nodetool-api\\nreplicas: 3\\n\\n" +
+      "If that package cannot be imported in this session, do not work around " +
+      "it and do not hand-parse the text. Finish with " +
+      "{available: false, reason: <a short reason>} instead. If it can be " +
+      "imported, finish with {available: true, reason: 'imported'}.",
+    // The session allows csv, so the yaml import is refused by the mount check.
+    sandboxPackages: [CSV],
+    outputSchema: {
+      type: "object",
+      properties: {
+        available: { type: "boolean" },
+        reason: { type: "string" }
+      },
+      required: ["available", "reason"]
+    },
+    expect: {
+      resultCheck: (r) =>
+        typeof r === "object" &&
+        r !== null &&
+        (r as { available?: unknown }).available === false,
+      resultCheckLabel: "available=false",
+      maxActions: 5
+    }
+  },
+  {
+    id: "sandbox-pack-two",
+    description: "Use two allowed packs in one action",
+    objective:
+      "This CSV is your input:\\n\\n" +
+      ORDERS_CSV +
+      "\\n\\nUsing the `" +
+      ZIP +
+      "` and `" +
+      CSV +
+      "` sandbox packages: put the CSV into a zip archive under the entry " +
+      "name `orders.csv`, read that archive back, parse the entry you " +
+      "extracted, and finish with {total: <the number of parsed data rows>}. " +
+      "Go through the archive — do not count the lines in the prompt.",
+    sandboxPackages: [ZIP, CSV],
+    outputSchema: TOTAL_SCHEMA,
+    expect: {
+      resultCheck: (r) =>
+        typeof r === "object" &&
+        r !== null &&
+        Number((r as { total?: unknown }).total) === 6,
+      resultCheckLabel: "total=6 rows",
+      maxActions: 5
+    }
+  }
+];

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -803,6 +803,11 @@ export {
 } from "./evals/codeact-api-cases.js";
 export { CODEACT_API_CORE_CASES } from "./evals/codeact-api-core.js";
 export { CODEACT_API_SURFACE_CASES } from "./evals/codeact-api-surfaces.js";
+export {
+  CODEACT_SANDBOX_PACK_EVAL_CASES,
+  SANDBOX_PACK_DOCS_TOOL,
+  shippedHostPackCatalog
+} from "./evals/codeact-sandbox-pack-cases.js";
 
 // Planning-mode evaluation harnesses (TaskPlanner DAG, ScriptPlanner script)
 export {

--- a/packages/agents/tests/_helpers/scripted-loop-provider.ts
+++ b/packages/agents/tests/_helpers/scripted-loop-provider.ts
@@ -1,0 +1,58 @@
+/**
+ * A provider that answers each `generateLoop` call with a scripted list of
+ * code actions.
+ *
+ * Everything below the provider is real: the executor, the bridge, the QuickJS
+ * sandbox, and — for a session that allows packages — the module mount. That
+ * makes a scripted run a proof that a case is satisfiable and that the wiring
+ * under it works, without a model or a network.
+ */
+
+import type {
+  BaseProvider,
+  ProviderStreamItem,
+  ToolCall
+} from "@nodetool-ai/runtime";
+
+export function createScriptedLoopProvider(
+  actionsByCall: string[][]
+): BaseProvider {
+  let call = 0;
+  return {
+    provider: "fake",
+    hasToolSupport: async () => true,
+    getTotalCost: () => 0,
+    async *generateLoop(args: {
+      tools?: Array<{
+        name: string;
+        execute?: (a: Record<string, unknown>) => Promise<string | unknown>;
+      }>;
+      signal?: AbortSignal;
+    }): AsyncGenerator<ProviderStreamItem> {
+      const actions = actionsByCall[call++] ?? [];
+      const toolMap = new Map((args.tools ?? []).map((t) => [t.name, t]));
+      let idx = 0;
+      for (const code of actions) {
+        if (args.signal?.aborted) break;
+        const tc: ToolCall = {
+          id: `tc_${call}_${idx++}`,
+          name: "execute_code",
+          args: { code }
+        };
+        yield tc;
+        const tool = toolMap.get(tc.name);
+        const content = tool?.execute ? await tool.execute(tc.args) : "";
+        yield {
+          type: "message",
+          message: {
+            role: "tool",
+            toolCallId: tc.id,
+            content:
+              typeof content === "string" ? content : JSON.stringify(content)
+          }
+        };
+      }
+      yield { type: "chunk", content: "", done: true };
+    }
+  } as unknown as BaseProvider;
+}

--- a/packages/agents/tests/codeact-eval.test.ts
+++ b/packages/agents/tests/codeact-eval.test.ts
@@ -8,55 +8,7 @@ import {
   formatCodeActReport
 } from "../src/evals/codeact-eval.js";
 import { CODEACT_EVAL_CASES } from "../src/evals/codeact-cases.js";
-import type {
-  BaseProvider,
-  ProviderStreamItem,
-  ToolCall
-} from "@nodetool-ai/runtime";
-
-/** Provider that answers every case with a scripted list of code actions. */
-function createScriptedLoopProvider(
-  actionsByCall: string[][]
-): BaseProvider {
-  let call = 0;
-  return {
-    provider: "fake",
-    hasToolSupport: async () => true,
-    getTotalCost: () => 0,
-    async *generateLoop(args: {
-      tools?: Array<{
-        name: string;
-        execute?: (a: Record<string, unknown>) => Promise<string | unknown>;
-      }>;
-      signal?: AbortSignal;
-    }): AsyncGenerator<ProviderStreamItem> {
-      const actions = actionsByCall[call++] ?? [];
-      const toolMap = new Map((args.tools ?? []).map((t) => [t.name, t]));
-      let idx = 0;
-      for (const code of actions) {
-        if (args.signal?.aborted) break;
-        const tc: ToolCall = {
-          id: `tc_${call}_${idx++}`,
-          name: "execute_code",
-          args: { code }
-        };
-        yield tc;
-        const tool = toolMap.get(tc.name);
-        const content = tool?.execute ? await tool.execute(tc.args) : "";
-        yield {
-          type: "message",
-          message: {
-            role: "tool",
-            toolCallId: tc.id,
-            content:
-              typeof content === "string" ? content : JSON.stringify(content)
-          }
-        };
-      }
-      yield { type: "chunk", content: "", done: true };
-    }
-  } as unknown as BaseProvider;
-}
+import { createScriptedLoopProvider } from "./_helpers/scripted-loop-provider.js";
 
 const SOLUTIONS: Record<string, string[]> = {
   "chain-in-one-action": [

--- a/packages/agents/tests/codeact-sandbox-packs.test.ts
+++ b/packages/agents/tests/codeact-sandbox-packs.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Sandbox packages inside CodeAct — the mechanism, and the cases that measure
+ * a model against it.
+ *
+ * The eval suite grades a model's behaviour and so cannot pin the machinery: a
+ * live run reaches the right answer by more than one route. These tests pin it.
+ * Everything below the scripted provider is real — the executor, the bridge,
+ * the QuickJS guest and the module mount — so a scripted run proves both that
+ * each case is satisfiable and that a shipped pack really is importable from a
+ * CodeAct action.
+ *
+ * Only host packs appear: a guest pack needs `@nodetool-ai/sandbox-compiler`,
+ * which this package does not depend on.
+ */
+import { describe, it, expect } from "vitest";
+
+import { runCodeActEval } from "../src/evals/codeact-eval.js";
+import {
+  CODEACT_SANDBOX_PACK_EVAL_CASES,
+  SANDBOX_PACK_DOCS_TOOL,
+  shippedHostPackCatalog
+} from "../src/evals/codeact-sandbox-pack-cases.js";
+import { mountActionModules } from "../src/codeact/sandbox-packages.js";
+import { createScriptedLoopProvider } from "./_helpers/scripted-loop-provider.js";
+
+const CSV = "@nodetool-ai/sandbox-csv";
+const YAML = "@nodetool-ai/sandbox-yaml";
+
+/**
+ * The CSV the cases carry in their objective. A live model reads it out of the
+ * prompt; a scripted action has no model, so it embeds the same text.
+ */
+const ORDERS_CSV = [
+  "order_id,region,amount_eur",
+  "NT-1001,EMEA,120.00",
+  "NT-1002,AMER,80.50",
+  "NT-1003,EMEA,240.25",
+  "NT-1004,APAC,60.00",
+  "NT-1005,AMER,199.50",
+  "NT-1006,EMEA,45.25"
+].join("\n");
+
+const CSV_LITERAL = JSON.stringify(ORDERS_CSV);
+
+/** One scripted action list per case, in the order the suite declares them. */
+const SOLUTIONS: Record<string, string[]> = {
+  "sandbox-pack-import": [
+    `import { parse } from "${CSV}";
+     const rows = await parse(${CSV_LITERAL});
+     const total = rows
+       .filter((r) => r.region === "EMEA")
+       .reduce((sum, r) => sum + Number(r.amount_eur), 0);
+     await finish({ total: Math.round(total * 100) / 100 });`
+  ],
+  "sandbox-pack-docs": [
+    `const docs = await tools.${SANDBOX_PACK_DOCS_TOOL}({
+       specifier: "@nodetool-ai/sandbox-xml"
+     });
+     await finish({ prefix: "@_" });`
+  ],
+  "sandbox-pack-denied": [
+    // Refused at the mount, before the guest starts — the action never runs.
+    `import yaml from "${YAML}";
+     await finish({ available: true, reason: 'imported' });`,
+    `await finish({
+       available: false,
+       reason: "not on this session's package allowlist"
+     });`
+  ],
+  "sandbox-pack-two": [
+    `import { zip, unzip } from "@nodetool-ai/sandbox-zip";
+     import { parse } from "${CSV}";
+     const archive = await zip({ "orders.csv": ${CSV_LITERAL} });
+     const files = await unzip(archive);
+     const text = new TextDecoder().decode(files["orders.csv"]);
+     await finish({ total: (await parse(text)).length });`
+  ]
+};
+
+describe("the shipped host packs, through the CodeAct catalog", () => {
+  it("resolves every pack the cases allow", () => {
+    const catalog = shippedHostPackCatalog();
+    for (const specifier of [CSV, "@nodetool-ai/sandbox-xml", "@nodetool-ai/sandbox-zip"]) {
+      const resolution = catalog.resolveForExecution([{ specifier }]);
+      expect(
+        resolution.statuses.filter((s) => s.status === "error"),
+        specifier
+      ).toEqual([]);
+      expect(resolution.modules).toHaveLength(1);
+    }
+  });
+
+  it("is cached, so a suite compiles the packs once", () => {
+    expect(shippedHostPackCatalog()).toBe(shippedHostPackCatalog());
+  });
+});
+
+describe("the session allowlist decides what an action may import", () => {
+  const catalog = shippedHostPackCatalog();
+
+  it("mounts a pack the session allows", () => {
+    const mount = mountActionModules(
+      `import { parse } from "${CSV}";\nreturn await parse("a,b\\n1,2\\n");`,
+      [CSV],
+      catalog
+    );
+    expect(mount.ok).toBe(true);
+    if (mount.ok) expect(mount.modules?.modules).toHaveLength(1);
+  });
+
+  it("refuses one it does not, naming what is allowed", () => {
+    const mount = mountActionModules(
+      `import yaml from "${YAML}";\nreturn yaml.load("a: 1");`,
+      [CSV],
+      catalog
+    );
+    expect(mount.ok).toBe(false);
+    if (!mount.ok) {
+      expect(mount.error).toContain(YAML);
+      expect(mount.error).toContain("not on this session's package allowlist");
+      expect(mount.error).toContain(CSV);
+    }
+  });
+
+  it("refuses every import when the session allows nothing", () => {
+    const mount = mountActionModules(
+      `import { parse } from "${CSV}";\nreturn await parse("a\\n1\\n");`,
+      [],
+      catalog
+    );
+    expect(mount.ok).toBe(false);
+    if (!mount.ok) {
+      expect(mount.error).toContain("No sandbox package is available");
+    }
+  });
+
+  it("mounts nothing for an action that imports nothing", () => {
+    const mount = mountActionModules(`return 1 + 1;`, [CSV], catalog);
+    expect(mount.ok).toBe(true);
+    if (mount.ok) expect(mount.modules).toBeUndefined();
+  });
+});
+
+describe("the sandbox-pack eval cases", () => {
+  it("every case is satisfiable by a scripted run and scores 1.0", async () => {
+    const provider = createScriptedLoopProvider(
+      CODEACT_SANDBOX_PACK_EVAL_CASES.map((c) => SOLUTIONS[c.id] ?? [])
+    );
+
+    const report = await runCodeActEval({
+      provider,
+      model: "scripted",
+      cases: CODEACT_SANDBOX_PACK_EVAL_CASES
+    });
+
+    for (const result of report.cases) {
+      expect(
+        result.accepted,
+        `${result.caseId}: ${JSON.stringify(result.checks)}`
+      ).toBe(true);
+      expect(result.score).toBe(1);
+    }
+    expect(report.summary.successRate).toBe(1);
+  }, 120_000);
+});

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -312,10 +312,16 @@ const codeActSuite: EvalSuite = {
   description:
     "Run the CodeAct execution eval suite (steps act by writing sandboxed JavaScript over the toolbelt — docs/codeact-design.md) against a provider/model",
   async listCases() {
-    const { CODEACT_EVAL_CASES, CODEACT_API_EVAL_CASES } = await import(
-      "@nodetool-ai/agents"
-    );
-    return [...CODEACT_EVAL_CASES, ...CODEACT_API_EVAL_CASES].map((c) => ({
+    const {
+      CODEACT_EVAL_CASES,
+      CODEACT_API_EVAL_CASES,
+      CODEACT_SANDBOX_PACK_EVAL_CASES
+    } = await import("@nodetool-ai/agents");
+    return [
+      ...CODEACT_EVAL_CASES,
+      ...CODEACT_API_EVAL_CASES,
+      ...CODEACT_SANDBOX_PACK_EVAL_CASES
+    ].map((c) => ({
       id: c.id,
       description: c.description
     }));
@@ -324,12 +330,17 @@ const codeActSuite: EvalSuite = {
     const {
       CODEACT_EVAL_CASES,
       CODEACT_API_EVAL_CASES,
+      CODEACT_SANDBOX_PACK_EVAL_CASES,
       runCodeActEval,
       formatCodeActReport
     } = await import("@nodetool-ai/agents");
 
     const cases = selectCases(
-      [...CODEACT_EVAL_CASES, ...CODEACT_API_EVAL_CASES],
+      [
+        ...CODEACT_EVAL_CASES,
+        ...CODEACT_API_EVAL_CASES,
+        ...CODEACT_SANDBOX_PACK_EVAL_CASES
+      ],
       deps.caseIds
     );
     deps.log(


### PR DESCRIPTION
## Why

No eval measured a model against sandbox packages. The Code node's `packages` property has unit coverage against a **hand-written** catalog serving a hand-written module; `codeact/sandbox-packages.ts` — the path a CodeAct action takes — had none. So three behaviours were unmeasured: does a model import an allowed pack and use it correctly, does it read a pack's SKILL.md or guess the API, and what does it do when an import is refused.

## What

Four cases in the `codeact` suite (`src/evals/codeact-sandbox-pack-cases.ts`). A case names its allowlist in `sandboxPackages`; the runner puts a catalog over the shipped packs on the ProcessingContext and passes the allowlist to `CodeActExecutor`.

| Case | Measures |
|---|---|
| `sandbox-pack-import` | imports `sandbox-csv`, filters and sums — the answer is only reachable by parsing |
| `sandbox-pack-docs` | must call `get_sandbox_package_docs` to learn that `sandbox-xml` prefixes attributes `@_` |
| `sandbox-pack-denied` | reports a pack unavailable instead of hand-parsing around it |
| `sandbox-pack-two` | `sandbox-zip` + `sandbox-csv` in one action |

**`requiredSessionTools` is new** because the existing check could not see this. The recorder wraps only a case's own toolbelt, and `get_sandbox_package_docs` is added by the executor — session tools are now read off the event stream instead.

**Host packs only.** A guest pack must be compiled by `@nodetool-ai/sandbox-compiler`, which `packages/agents` does not depend on; reading a warm compile cache instead would pass here and fail on a clean checkout.

**`sandbox-pack-denied` grades the outcome, not the route.** A live model reaches `available: false` two ways — attempting the import and reading the refusal, or reading the allowlist the prompt advertises — and it did both across runs (the eval run took 1 action, `dump-codeact-run` took 2 and showed a real attempt). Pinning one order would repeat the mistake this repo already documented on the creative-pipeline predicates. The refusal *mechanism* is pinned deterministically in the new harness test instead.

## A stale case, repaired

`code-gen`'s `extract-parse` was **unsatisfiable**:

- it required the body to match `data\.parseCsv` and forbade `import`;
- M6 removed the `data.*` globals — `parseCsv` now appears nowhere in the repo but that case;
- the scorer's `no-invented-apis` check rejects any body referencing `data`, since it is neither a sandbox API nor a declared port (verified directly: `unknownApiReferences` returns `['data']`).

So satisfying `requiredCodePatterns` guaranteed failing another check. It now parses a delimited format by hand, which keeps the authoring shape the suite is built around. The `import` ban stays — `analyzeGeneratedCode` really does refuse a module declaration on that surface, because it declares no packages.

## Verification

- **Live, `claude_agent_sdk`/sonnet:** 4/4, mean score 1.00, ~2 actions per case (`IS_SANDBOX=1 … --max-iterations 40 --no-find-model`).
- **Live, repaired case:** `code-gen --cases extract-parse` → first-pass 1.00.
- **Deterministic:** new `tests/codeact-sandbox-packs.test.ts` — the shipped packs resolve, the allowlist mounts what it allows and refuses what it does not (with the exact message), and every case is satisfiable by a scripted run through the real executor, bridge, QuickJS guest and module mount.
- Mutation-checked: dropping the docs-tool call from the scripted solution fails exactly `session-tool:get_sandbox_package_docs`.
- `tsc --noEmit` clean for `agents` and `cli`. Full agents suite: **2304 passed**, 1 failed.

That one failure is `wasm-sandbox-host.test.ts > WASM budgets`, and it is **pre-existing flakiness**, not this change — a different test in that block fails each run, and over 4 runs a side it failed 2/4 on `main` and 3/4 here. The assertions are wall-clock budget reservations on a 4-core box. Worth a separate look.

The scripted-provider helper moved to `tests/_helpers/scripted-loop-provider.ts` so the new test and `codeact-eval.test.ts` share one copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)