### PR TITLE
Tell the node-editor agent which workflow is open

### DIFF
--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1469,21 +1469,51 @@ export const RESIDENT_TOOL_NAMES: ReadonlySet<string> = new Set([
  * `system_prompt` on the chat message — it is layered after the base prompt as
  * a context-specific addendum, never a replacement.
  */
-function buildChatAgentSystemPrompt(
+export function buildChatAgentSystemPrompt(
   mode: PermissionMode,
   extraSystemPrompt?: string | null,
-  uiContext?: UiContext | null
+  uiContext?: UiContext | null,
+  workflowId?: string | null
 ): string {
   const extra =
     typeof extraSystemPrompt === "string" && extraSystemPrompt.trim()
       ? `\n\n${extraSystemPrompt.trim()}\n`
       : "";
+  const uiBlock = formatUiContext(uiContext);
   return (
     CHAT_AGENT_SYSTEM_PROMPT +
     PERMISSION_MODE_PROMPTS[mode] +
-    formatUiContext(uiContext) +
+    uiBlock +
+    formatBoundWorkflow(uiContext, workflowId, uiBlock !== "") +
     extra
   );
+}
+
+/**
+ * Backstop for clients that bind a workflow to the turn (`workflow_id`) without
+ * naming it in `ui_context` — the canvas composer and every headless client.
+ * The graph `ui_*` tools take that id, so a turn carrying one and saying
+ * nothing about it leaves the agent guessing. Skipped when `ui_context` already
+ * names the workflow: that block says it better.
+ */
+function formatBoundWorkflow(
+  uiContext: UiContext | null | undefined,
+  workflowId: string | null | undefined,
+  hasUiBlock: boolean
+): string {
+  if (!workflowId) return "";
+  const named =
+    uiContext?.focused?.type === "workflow" &&
+    uiContext.focused.id === workflowId;
+  const listed = (uiContext?.open ?? []).some(
+    (ref) => ref.type === "workflow" && ref.id === workflowId
+  );
+  if (named || listed) return "";
+  const line = `The user has workflow \`${workflowId}\` open. Pass that id as \`workflow_id\` to the \`ui_*\` graph tools and to the workflow tools unless the user points at another workflow.`;
+  // Fold into the existing section rather than opening a second one.
+  return hasUiBlock
+    ? `\n${line}`
+    : `\n\n## What the user is looking at\n\n${line}`;
 }
 
 const UI_SURFACE_LABELS: Record<UiSurfaceType, string> = {
@@ -5208,7 +5238,8 @@ export class UnifiedWebSocketRunner {
       const base = buildChatAgentSystemPrompt(
         permissionMode,
         extraSystemPrompt,
-        uiContext
+        uiContext,
+        workflowId
       );
       return codeactPromptSection
         ? `${base}\n\n${codeactPromptSection}`

--- a/packages/websocket/tests/chat-system-prompt-workflow-context.test.ts
+++ b/packages/websocket/tests/chat-system-prompt-workflow-context.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { buildChatAgentSystemPrompt } from "../src/unified-websocket-runner.js";
+
+describe("buildChatAgentSystemPrompt — the workflow the turn is bound to", () => {
+  it("names the bound workflow when the client sends no ui_context", () => {
+    const prompt = buildChatAgentSystemPrompt("default", null, null, "wf-42");
+    expect(prompt).toContain("wf-42");
+    expect(prompt).toContain("`ui_*`");
+  });
+
+  it("says nothing extra when no workflow is bound", () => {
+    const prompt = buildChatAgentSystemPrompt("default", null, null, null);
+    expect(prompt).not.toContain("The user has workflow");
+  });
+
+  it("leaves the ui_context block alone when it already names the workflow", () => {
+    const uiContext = {
+      focused: { type: "workflow" as const, id: "wf-42", title: "My Graph" },
+      open: [{ type: "workflow" as const, id: "wf-42", title: "My Graph" }],
+      selection: null
+    };
+    const prompt = buildChatAgentSystemPrompt(
+      "default",
+      null,
+      uiContext,
+      "wf-42"
+    );
+    expect(prompt).toContain('workflow "My Graph" (id: wf-42)');
+    expect(prompt).not.toContain("The user has workflow");
+    // One "what the user is looking at" section, not two.
+    expect(prompt.match(/## What the user is looking at/g)).toHaveLength(1);
+  });
+
+  it("still names a bound workflow that the ui_context does not list", () => {
+    const uiContext = {
+      focused: { type: "timeline" as const, id: "tl-1", title: "Cut" },
+      open: [{ type: "timeline" as const, id: "tl-1", title: "Cut" }],
+      selection: null
+    };
+    const prompt = buildChatAgentSystemPrompt(
+      "default",
+      null,
+      uiContext,
+      "wf-42"
+    );
+    expect(prompt).toContain("The user has workflow `wf-42` open");
+    // Folded into the existing section, not a second heading.
+    expect(prompt.match(/## What the user is looking at/g)).toHaveLength(1);
+  });
+});

--- a/web/src/components/panels/CanvasMediaComposer.tsx
+++ b/web/src/components/panels/CanvasMediaComposer.tsx
@@ -3,7 +3,9 @@ import { useShallow } from "zustand/react/shallow";
 
 import MediaChatComposer from "../chat/composer/MediaChatComposer";
 import useGlobalChatStore from "../../stores/GlobalChatStore";
+import { useNodeStoreRef } from "../../contexts/NodeContext";
 import { useAutoAddGeneratedMediaToCanvas } from "../../hooks/handlers/useAutoAddGeneratedMediaToCanvas";
+import { buildUiContext } from "../../lib/chat/uiContext";
 import type { MessageContent } from "../../stores/ApiTypes";
 import type {
   ChatOutgoingMessage,
@@ -55,6 +57,10 @@ const CanvasMediaComposer: React.FC<CanvasMediaComposerProps> = ({
   // Drop each finished generation onto the canvas automatically.
   useAutoAddGeneratedMediaToCanvas();
 
+  // The open graph, read at send time rather than subscribed: the selection
+  // changes on every canvas click and this composer must not re-render with it.
+  const nodeStore = useNodeStoreRef();
+
   // Establish the chat connection lazily so generation works even when the
   // chat panel was never opened. Skip if it's already wired up by the panel.
   useEffect(() => {
@@ -71,6 +77,24 @@ const CanvasMediaComposer: React.FC<CanvasMediaComposerProps> = ({
       mediaGeneration?: MediaGenerationRequest
     ) => {
       const isMedia = !!mediaGeneration && mediaGeneration.mode !== "chat";
+      const { workflow, getSelectedNodes } = nodeStore.getState();
+      // Tell the agent which graph it is looking at. The `ui_*` graph tools
+      // take a workflow id, and the canvas is the one surface that knows it
+      // without going through the tab store.
+      const selectedNodeIds = getSelectedNodes().map((node) => node.id);
+      const uiContext = workflow?.id
+        ? buildUiContext({
+            focused: {
+              type: "workflow",
+              id: workflow.id,
+              title: workflow.name
+            },
+            selection:
+              selectedNodeIds.length > 0
+                ? { node_ids: selectedNodeIds }
+                : undefined
+          })
+        : null;
       const outgoing: ChatOutgoingMessage = {
         type: "message",
         name: "",
@@ -82,14 +106,16 @@ const CanvasMediaComposer: React.FC<CanvasMediaComposerProps> = ({
           ? mediaGeneration?.model ?? selectedModel?.id
           : selectedModel?.id,
         content,
-        // Intentionally no workflow_id: the canvas document is being edited,
-        // not run as a chat-responder. Setting it routes the backend into
-        // handleWorkflowMessage, which fails with "Workflow <id> not found".
+        ui_context: uiContext,
+        // Intentionally no workflow_target: the canvas document is being
+        // edited, not run as a chat-responder. Setting it routes the backend
+        // into handleWorkflowMessage, which runs the graph as the responder.
+        // The store still attaches the bound `workflow_id` as ambient context.
         media_generation: isMedia ? mediaGeneration : null
       } as ChatOutgoingMessage;
       void sendMessage(outgoing);
     },
-    [selectedModel, sendMessage]
+    [selectedModel, sendMessage, nodeStore]
   );
 
   return (

--- a/web/src/components/panels/__tests__/CanvasMediaComposer.test.tsx
+++ b/web/src/components/panels/__tests__/CanvasMediaComposer.test.tsx
@@ -51,7 +51,13 @@ jest.mock("../../../contexts/NodeContext", () => {
     // the auto-add-to-canvas hook, resolves to "no canvas" instead of crashing.
     NodeContext: actualReact.createContext(null),
     useNodes: (selector: (s: { workflow: { id: string } }) => unknown) =>
-      selector({ workflow: { id: "canvas-doc-id" } })
+      selector({ workflow: { id: "canvas-doc-id" } }),
+    useNodeStoreRef: () => ({
+      getState: () => ({
+        workflow: { id: "canvas-doc-id", name: "My Graph" },
+        getSelectedNodes: () => [{ id: "node-1" }, { id: "node-2" }]
+      })
+    })
   };
 });
 
@@ -98,5 +104,34 @@ describe("CanvasMediaComposer", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
     const outgoing = sendMessage.mock.calls[0][0] as { workflow_id?: unknown };
     expect(outgoing.workflow_id ?? null).toBeNull();
+  });
+
+  it("tells the agent which workflow the canvas is showing", () => {
+    render(<CanvasMediaComposer />);
+    capturedProps!.onSendMessage(
+      [{ type: "text", text: "add a node" }] as MessageContent[],
+      "add a node",
+      { mode: "chat" } as MediaGenerationRequest
+    );
+
+    const outgoing = sendMessage.mock.calls[0][0] as {
+      ui_context?: {
+        focused?: { type: string; id: string; title?: string | null } | null;
+        open?: { type: string; id: string }[] | null;
+        selection?: { node_ids?: string[] | null } | null;
+      } | null;
+    };
+    expect(outgoing.ui_context?.focused).toEqual({
+      type: "workflow",
+      id: "canvas-doc-id",
+      title: "My Graph"
+    });
+    expect(outgoing.ui_context?.open).toContainEqual(
+      expect.objectContaining({ type: "workflow", id: "canvas-doc-id" })
+    );
+    expect(outgoing.ui_context?.selection?.node_ids).toEqual([
+      "node-1",
+      "node-2"
+    ]);
   });
 });


### PR DESCRIPTION
## The gap

Chatting from the node editor left the agent with no workflow id.

The turn already carried one — `GlobalChatStore.sendMessage` binds the open workflow onto `workflow_id` — but nothing rendered it into the system prompt. Only `ui_context` is rendered (`formatUiContext`), and the canvas composer never sent one. Meanwhile that same prompt tells the agent:

> Every `ui_*` tool requires the id of the document it should act on; pass one of the ids above.

…with no ids above. The tools happened to work — both the renderer bridge (`workflow_id ?? state.currentWorkflowId`) and the server fallback (`params.workflow_id ?? context.workflowId`) resolve the graph implicitly — but the agent was guessing at an id it had been told it needed, and could not name the workflow when the user asked.

## The change

**Frontend** — `CanvasMediaComposer` now sends `ui_context`, the same block `ChatView` already sends, built from the open graph rather than the tab store: the workflow's id and name as `focused`, plus the selected node ids as `selection.node_ids`. Nothing currently sends `node_ids`, and `formatUiContext` already renders selection. The graph is read imperatively via `useNodeStoreRef` at send time — subscribing to the selection would re-render the composer on every canvas click.

**Backend** — `buildChatAgentSystemPrompt` takes the turn's `workflowId` and names it when `ui_context` does not. This covers every client that binds a workflow without describing its UI, not just this composer. It folds into the existing "What the user is looking at" section instead of opening a second one, and is skipped entirely when `ui_context` already lists that workflow — that block says it better.

No protocol change: `ui_context` and `workflow_id` both already exist on `Message`. No change to the `ui_*` tool schemas: `workflow_id` is already optional with a correct fallback.

The stale comment about `workflow_id` routing into `handleWorkflowMessage` is corrected — the routing signal is `workflow_target`, not a bare `workflow_id`.

## Tests

- `web/…/CanvasMediaComposer.test.tsx` — asserts the outgoing message names the open workflow and its selected nodes. The two existing assertions (media generation must not set `workflow_id`) still hold.
- `packages/websocket/tests/chat-system-prompt-workflow-context.test.ts` — the backstop names a bound workflow, stays silent with none, defers to `ui_context` when it already lists the workflow, and never emits two headings.

## Verification

`tsc --noEmit` over `web` (which compiles the packages), eslint on both touched files, and the affected suites: the three `CanvasMediaComposer` cases, the four new prompt cases, and `chat-agent-parity` / `resident-tools` / `workflow-message-parity` (31 passing).

One pre-existing failure in this environment is unrelated and untouched by the diff: `packages/websocket/src/sandbox-catalog.ts` cannot resolve `@nodetool-ai/sandbox-compiler`, which is not linked into `node_modules` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rix9aPJpDP5BZt4xRxDC1

---
_Generated by [Claude Code](https://claude.ai/code/session_018rix9aPJpDP5BZt4xRxDC1)_