### PR TITLE
docs: cut redundancy from the user interface tour

### DIFF
--- a/docs/editor-panels.md
+++ b/docs/editor-panels.md
@@ -179,8 +179,6 @@ A stack of toggles along the right canvas edge:
 
 The logo at the top of the left rail opens the app menu: **Dashboard**, **Examples**, **Costs**, **Model Manager**, **Collections**, **Workspaces** (when enabled), **Settings**, **Help**, and **Downloads**.
 
-See [User Interface → App Menu]({{ '/user-interface#the-app-menu' | relative_url }}) for details.
-
 ---
 
 ## Customizing the Layout

--- a/docs/electron-views.md
+++ b/docs/electron-views.md
@@ -73,7 +73,7 @@ A self-contained Mini-App launched from the tray. Maximum size 1200×900. Closin
 
 ### Chat Window
 
-Standalone chat opened from the tray. Same content as [/standalone-chat]({{ '/user-interface#standalone-chat-window' | relative_url }}) but in its own window.
+Standalone chat opened from the tray. Same content as the [Chats panel]({{ '/user-interface#chat' | relative_url }}) but in its own window, and threads sync with the main app.
 
 ---
 

--- a/docs/user-interface.md
+++ b/docs/user-interface.md
@@ -4,384 +4,141 @@ title: "NodeTool User Interface"
 description: "Tour of the NodeTool interface."
 ---
 
-Tour of the interface — Dashboard, Canvas, Chat, Mini-Apps, Assets. Same on desktop and in the browser.
+A tour of the interface. Same views on desktop and in the browser.
 
 > New here? Start with [Getting Started](getting-started.md), then come back.
 
 ---
 
-## Main Views
+## Where everything lives
 
-The primary destinations across the web app and desktop. Each entry links to its detailed docs page.
+| View | What it is | Docs |
+|---|---|---|
+| **Dashboard** `/dashboard` | Home: search, recent workflows, templates, quick chat | [Getting Started](getting-started.md) |
+| **Workflow Editor** `/workspace` | The node canvas, with panels on every edge | [Workflow Editor](workflow-editor.md) · [Panels](editor-panels.md) |
+| **Chain Editor** `/chain/:workflowId?` | Linear card pipeline instead of a graph | [Chain Editor](chain-editor.md) |
+| **Chat** — Chats panel | Threads open as workspace tabs; the agent edits what you have open | [Chat](global-chat.md) |
+| **Mini-Apps** — Apps panel | A form over one or more workflows | [Mini Apps](mini-apps.md) |
+| **Assets** `/assets` | Every file your workflows touch | [Assets](asset-management.md) · [Sketch Editor](sketch-editor.md) |
+| **Video Editor** `/timeline/:sequenceId` | Multi-track timeline; clips can be live workflow outputs | [Video Editor](video-editor.md) |
+| **Collections** `/collections` | Indexed documents for RAG | [Collections](collections.md) · [Indexing](indexing.md) |
+| **Examples** `/examples` | Ready-to-run workflows by tag | [Templates Gallery](templates-gallery.md) |
+| **Models** `/models` | Find, install, and manage local and cloud models | [Models Manager](models-manager.md) |
+| **Settings** — dialog | API keys, folders, secrets, remote | [Configuration](configuration.md) · [Providers](models-and-providers.md) |
 
-### Dashboard — `/dashboard`
+The logo at the top of the left rail opens the app menu, which reaches all of
+these plus **Costs**, **Workspaces**, **Downloads**, and **Help**.
 
-The home screen. Search, recent workflows, templates, and quick chat.
-
-![Dashboard Overview](assets/screenshots/dashboard-overview.png)
-
-Docs: [Getting Started](getting-started.md)
-
-### Workflow Editor — `/workspace`
-
-The main visual editor. Build workflows by connecting nodes on an infinite canvas, with panels on every edge: left drawer, right inspector, bottom diagnostics, floating toolbar, node menu, and tabs. (The legacy `/editor/:workflow` URL redirects into this unified `/workspace` shell.)
-
-![Workflow Editor](assets/screenshots/editor-empty-state.png)
-
-Docs: [Workflow Editor](workflow-editor.md) · [Editor Panels](editor-panels.md)
-
-### Chain Editor — `/chain/:workflowId?`
-
-A linear, card-based alternative to the node graph. Better for simple pipelines and guided authoring.
-
-![Chain Editor](assets/screenshots/web-chain-editor-chain.png)
-
-Docs: [Chain Editor](chain-editor.md)
-
-### Chat — the Chats panel
-
-Conversational AI with multi-thread history, an always-on agent loop, tools, and workflow integration. Threads are listed in the **Chats** panel in the left rail and open as workspace tabs. (The legacy `/chat/:thread_id?` URL redirects into `/workspace`, opening that thread as a tab.)
-
-![Chat](assets/screenshots/global-chat-interface.png)
-
-Docs: [Chat](global-chat.md)
-
-### Mini-Apps — the Apps panel
-
-Apps are their own resource, listed in the **Apps** panel in the left sidebar and opened as workspace tabs. Each one runs one or more workflows behind a form. Apps can also be launched as standalone frameless windows from the desktop tray.
-
-![Mini-App Page](assets/screenshots/mini-app-page.png)
-
-Docs: [Mini Apps](mini-apps.md) · [Electron Mini-App Window](electron-views.md#mini-app-window)
-
-### Asset Explorer — `/assets`
-
-Browse, search, organize, and tag every file used in your workflows. Opens the full-featured Sketch Editor for image assets.
-
-![Asset Explorer](assets/screenshots/asset-explorer.png)
-
-Docs: [Asset Management](asset-management.md) · [Sketch Editor](sketch-editor.md)
-
-### Video Editor — `/timeline/:sequenceId`
-
-A generation-aware timeline editor. Sequence video, audio, and image clips across multiple tracks — clips can be imported media or live workflow outputs that regenerate when you change their parameters. Composite a preview in real time and export the whole timeline to MP4.
-
-![Video Editor](assets/screenshots/video-editor-timeline.png)
-
-Docs: [Video Editor](video-editor.md)
-
-### Collections — `/collections`
-
-Group related documents into indexable collections for RAG workflows.
-
-![Collections Explorer](assets/screenshots/collections-explorer.png)
-
-Docs: [Collections](collections.md) · [Indexing](indexing.md)
-
-### Examples / Templates — `/examples`
-
-Ready-to-use example workflows organized by tag and use case. Templates also surface on the Dashboard.
-
-Docs: [Templates Gallery](templates-gallery.md)
-
-### Models Manager — `/models`
-
-Find, install, filter, and manage local and cloud AI models.
-
-![Models Manager](assets/screenshots/models-list.png)
-
-Docs: [Models Manager](models-manager.md)
-
-### Settings — Dialog
-
-Central configuration surface: general preferences, provider API keys, folders, secrets, remote, and about.
-
-![Settings Dialog](assets/screenshots/settings-dialog.png)
-
-Docs: [Configuration](configuration.md) · [Models & Providers](models-and-providers.md)
-
-### Mobile
-
-Touch-optimized Dashboard, Chat, and Graph Editor. See [Mobile App](mobile-app.md) for the full set.
-
-![Mobile Dashboard](assets/screenshots/dashboard-mobile.png)
-
-At tablet width the same layout keeps the panels but widens the content column:
-
-![Tablet Dashboard](assets/screenshots/dashboard-tablet.png)
-
-### Desktop (Electron)
-
-The desktop app shares all the views above, plus an Install Wizard, System Tray, and frameless mini-app windows. See [Desktop App Views](electron-views.md).
-
----
-
-## At a glance
-
-Five workspaces:
-
-| Workspace | Purpose |
-|-----------|---------|
-| **Dashboard** | Home, templates, recent projects |
-| **Canvas** | Build and run workflows |
-| **Chat** | Chat with models, run agents |
-| **Mini-Apps** | Run workflows behind a simple UI |
-| **Assets** | Files and media |
-
----
-
-## The App Menu
-
-The logo at the top of the left rail opens the app menu — your navigation hub:
-
-- **Dashboard** – Home screen
-- **Examples** – Browse ready-to-run example workflows
-- **Costs** – Usage and cost tracking
-- **Model Manager** – Manage your AI models (Flux, Qwen Image, etc.)
-- **Collections** – RAG document collections
-- **Workspaces** – Configure workspace folders (when enabled)
-- **Settings** – Configure API keys, preferences, account
-- **Help** – Documentation and support
-- **Downloads** – Model/asset download progress
+Two extras: [Mobile](mobile-app.md) gives you a touch-optimized Dashboard, Chat,
+and Graph Editor, and the [desktop app](electron-views.md) adds an install
+wizard, a system tray, and frameless mini-app windows.
 
 ---
 
 ## Dashboard
 
-The Dashboard is the home screen.
-
 ![Dashboard Overview](assets/screenshots/dashboard-overview.png)
 
-### Contents
-
-- **Your Workflows** – Saved projects
-- **Templates** – Ready-to-use workflows
-- **Recent Chats** – Past conversations
-- **Getting Started Panel** – Interactive onboarding guide for new users with step-by-step instructions
-
-### Common Actions
-
-| Task | How to Do It |
-|------|--------------|
-| Start a new creation | Click "New Workflow" button |
-| Open a saved workflow | Click any workflow card |
-| Try a template | Browse Templates, click to open |
-| Continue a chat | Click a recent chat thread |
+Your workflows, templates, and recent chats, plus a getting-started checklist
+that disappears once you finish or dismiss it. Click a card to open it; click
+**New Workflow** to start from nothing.
 
 ---
 
 ## Workflow Canvas
 
-Build workflows visually by connecting nodes.
-
 ![Workflow Editor](assets/screenshots/editor-empty-state.png)
 
-### The Canvas
+An infinite canvas. Pan with `Space`+drag or right-click drag, zoom with
+`Ctrl/⌘`+scroll, and press `F` when you have lost the graph off-screen.
 
-The center area is an **infinite canvas** for arranging workflows.
+**Add a node**: press `Space` or double-click empty canvas. The node library
+opens — type what you want ("generate image"), or browse Image / Video / Audio /
+Text on the left.
 
-**Navigation:**
-- **Pan**: Hold `Space` and drag, or right-click drag
-- **Zoom**: `Ctrl/⌘` + scroll wheel
-- **Fit all**: Press `F`
+**Connect two nodes**: drag from an output circle on the right of one node to an
+input circle on the left of another.
 
-### Adding Nodes
+> **Tip**: drop a connection on empty space and NodeTool offers only the nodes
+> that accept that type.
 
-To add a node:
-
-1. Press `Space` anywhere on canvas, **OR**
-2. Double-click an empty area
-
-This opens the **Node Library**:
-- **Search** by typing (e.g., "generate image", "transform video")
-- **Browse** categories on the left (Image, Video, Audio, Text)
-- **Click** a node to add it
-
-### Connecting Nodes
-
-Connections show data flow between nodes:
-
-1. Find the **circles** on nodes (outputs on right, inputs on left)
-2. **Click and drag** from an output circle
-3. **Release** on an input circle of another node
-
-> **Tip**: Drop a connection on empty space to see compatible nodes.
-
-### Properties Panel
-
-When you select a node, the right panel shows its **configuration**:
-
-- **Inputs** – What the node needs
-- **Settings** – Configuration options
-- **Output** – What the node produces
+Select a node and the right panel shows its inputs, settings, and output.
 
 ---
 
 ## Chat
 
-The agent that builds and edits your documents, one panel over from whatever you
-have open.
-
 ![Chat Interface](assets/screenshots/global-chat-interface.png)
 
-### Features
+The agent, one panel over from whatever you have open. Describe a workflow and
+it builds one; ask for a change and it edits the open document — graph, sketch,
+timeline, storyboard, script, or mini app. It also runs workflows, takes image
+and audio and document attachments, and keeps each thread's history separate.
 
-- **Build a workflow** from a description, then open and edit it
-- **Edit the open document** – graph, sketch, timeline, storyboard, script, or mini app
-- **Run workflows** from conversation
-- **Agent loop** for autonomous, multi-step task execution
-- **File sharing** – images, audio, documents
-
-### Chat Features
-
-| Feature | Description |
-|---------|-------------|
-| **Threads** | Multiple conversations, each with its own history |
-| **Model Selector** | Choose which AI model to chat with |
-| **Workflow Menu** | Attach and run your saved workflows |
-| **Agent Loop** | The AI uses tools and modifies your canvas as each task needs |
-
-### Standalone Chat Window
-
-Access chat directly from the system tray for quick conversations:
-
-- **Quick Access**: Click the tray icon → **Chat** to open a dedicated chat window
-- **Focused Interface**: Chat without the full NodeTool interface
-- **Background Access**: Start conversations while other apps are open
-- **Thread Persistence**: All threads sync with the main application
+On desktop, the tray icon opens a standalone chat window. Threads sync with the
+main app.
 
 ---
 
 ## Mini-Apps
 
-A form or dashboard over one or more workflows, with the graph hidden.
-
-### Purpose
-
-- **Hide complexity** – Users see only inputs and outputs
-- **Share easily** – No NodeTool knowledge required
-- **Focused interface** – Just what users need
-
-### How It Works
-
-1. Build the workflows in the Editor
-2. Open the **Apps** panel and click **New app**, or **New app from workflow** to scaffold one from a graph
-3. Design the app in its tab: input widgets, a run button, display widgets
-4. Switch the tab to **Run** to use it, and publish when it is ready
-
-The workflows an app runs stay separate resources. **Linked workflows** on the app tab opens one in its own workflow tab. See [Mini Apps](mini-apps.md).
-
 ![Mini App — Run view](assets/screenshots/mini-app-run.png)
 
-### Standalone Mini-App Windows
+A form or dashboard over your workflows, with the graph hidden — the version you
+hand to someone who has never heard of NodeTool.
 
-Launch mini-apps in dedicated windows from the system tray:
+1. Build the workflows in the editor.
+2. In the **Apps** panel, click **New app**, or **New app from workflow** to
+   scaffold one from a graph.
+3. Lay out input widgets, a run button, and display widgets in the app's tab.
+4. Flip the tab to **Run**, then publish.
 
-- **Quick Launch**: Right-click the tray icon to see available mini-apps
-- **Independent Windows**: Run mini-apps without opening the main editor
-- **Background Execution**: Keep mini-apps running while working on other tasks
+The workflows stay separate resources; **Linked workflows** on the app tab opens
+one in its own tab. On desktop, right-click the tray icon to launch any app in
+its own window.
 
 ---
 
 ## Assets
 
-The Asset Explorer manages all your files.
+![Asset Explorer](assets/screenshots/asset-explorer.png)
 
-### Supported Files
+Images (PNG, JPG, GIF, WebP), audio (MP3, WAV, M4A), video (MP4, MOV, WebM), and
+documents (PDF, TXT, Markdown).
 
-- **Images**: PNG, JPG, GIF, WebP
-- **Audio**: MP3, WAV, M4A
-- **Video**: MP4, MOV, WebM
-- **Documents**: PDF, TXT, Markdown
-
-### Working with Assets
-
-| Action | How |
-|--------|-----|
-| Upload files | Drag & drop into Assets panel |
-| Use in workflow | Drag asset onto the canvas |
-| Preview | Click any asset to preview |
-| Organize | Create folders, rename files |
-
-### Audio Player
-
-The built-in audio player features waveform visualization:
-
-- **Visual Waveforms**: See the audio shape with WaveSurfer.js integration
-- **Playback Controls**: Play, pause, and seek through audio files
-- **Preview in Workflows**: Audio results display with interactive waveforms
+Drag files into the panel to upload, drag one onto the canvas to use it, click to
+preview. Audio previews render a WaveSurfer waveform you can scrub, in the
+explorer and in node results.
 
 ---
 
-## Models Manager
-
-Download, organize, and configure AI models.
-
-![Models Manager](assets/screenshots/models-list.png)
-
-### Finding Models
-
-- **Search** by name or task type
-- **Filter** by provider (local, OpenAI, etc.)
-- **Sort** by size or popularity
-
-### Managing Downloads
-
-- **One-click install** for any supported model
-- **Progress tracking** in the header
-- **Space usage** shown per model
-- **Easy uninstall** to free space
-
----
-
-## Panels and Layout
-
-NodeTool's interface is flexible – customize it to your workflow.
-
-Open documents sit in a tab bar across the top — workflows, sketches, timelines, storyboards and apps all share it.
+## Panels and layout
 
 ![Workspace tab bar](assets/screenshots/editor-tabs-bar.png)
 
-With no tabs open, the workspace shows the chat composer and a few sample
-prompts: describe a workflow in plain language and the agent builds it for you.
-The getting-started checklist sits above them until you finish or dismiss it.
+Open documents share one tab bar: workflows, sketches, timelines, storyboards,
+apps. Drag a panel tab elsewhere to move it, drag it to another panel's edge to
+split, drag a border to resize. Layout saves itself; **View → Reset Layout**
+puts it back.
+
+With nothing open, the workspace is a chat composer and a few sample prompts.
 
 ![Empty workspace](assets/screenshots/onboarding-empty-workspace.png)
-
-### Rearranging Panels
-
-- **Move**: Drag a panel tab to a new location
-- **Split**: Drag a tab to the edge of another panel
-- **Resize**: Drag the borders between panels
-- **Close**: Click the X on any tab
-- **Restore**: Use View menu to add closed panels back
-
-### Saving Layouts
-
-Your layout is saved automatically. To reset:
-- **View → Reset Layout** restores defaults
 
 ---
 
 ## Command Menu
 
-Press `Ctrl+K` (Windows/Linux) or `⌘+K` (Mac) to open the **Command Menu**.
-
 ![Command Menu](assets/screenshots/editor-command-menu.png)
 
-This is the fastest way to:
-- Open any workflow
-- Switch between sections
-- Search for anything
-- Access settings
-
-Just start typing what you want!
+`Ctrl+K` / `⌘+K`, then start typing. Opens workflows, jumps between sections,
+reaches settings — the fastest route to anywhere.
 
 ---
 
 ## Keyboard Shortcuts
 
-### Essentials
+The six worth memorizing:
 
 | Shortcut | Action |
 |----------|--------|
@@ -392,35 +149,28 @@ Just start typing what you want!
 | `F` | Fit view |
 | `Esc` | Stop workflow |
 
-### All Shortcuts
-
-#### Global
+### Global
 
 | Shortcut | Action |
 |----------|--------|
-| `Ctrl+K` / `⌘+K` | Command Menu |
+| `Ctrl/⌘+K` | Command Menu |
 | `Ctrl/⌘+N` | New workflow |
 | `Ctrl/⌘+O` | Open workflow |
-| `Ctrl/⌘+S` | Save |
-| `Ctrl/⌘+Z` | Undo |
 | `Ctrl/⌘+Shift+Z` | Redo |
 | `Ctrl/⌘+1…9` | Switch tabs |
 
-#### Editor
+### Editor
 
 | Shortcut | Action |
 |----------|--------|
 | `Space + Drag` | Pan |
 | `Ctrl/⌘ + Scroll` | Zoom |
-| `F` | Fit to screen |
-| `Ctrl/⌘+Enter` | Run workflow |
-| `Esc` | Stop workflow |
 | `Ctrl/⌘+D` | Duplicate |
 | `Ctrl/⌘+G` | Group |
 | `A` | Align nodes |
 | `Delete` / `Backspace` | Delete selection |
 
-#### Chat
+### Chat
 
 | Shortcut | Action |
 |----------|--------|
@@ -432,7 +182,7 @@ Just start typing what you want!
 
 ## Next Steps
 
-- **[Workflow Editor](workflow-editor.md)** – Master the canvas
+- **[Workflow Editor](workflow-editor.md)** – The canvas in depth
 - **[Editor Panels](editor-panels.md)** – Left, right, bottom, and floating panels
-- **[Tips & Tricks](tips-and-tricks.md)** – Power user secrets
-- **[Cookbook](cookbook.md)** – Learn workflow patterns
+- **[Tips & Tricks](tips-and-tricks.md)** – Shortcuts the docs bury
+- **[Cookbook](cookbook.md)** – Workflow patterns


### PR DESCRIPTION
`docs/user-interface.md` covered the same ground three times: a "Main Views"
list of every destination, an "At a glance" table repeating five of them, and
then per-view sections repeating both. Four screenshots appeared twice on the
page (`dashboard-overview`, `editor-empty-state`, `global-chat-interface`,
`models-list`).

## Changes

- One **Where everything lives** table replaces the "Main Views" list, the
  "At a glance" table, and the standalone App Menu section — each row names
  the route and links its detailed page.
- Kept short prose sections only for the views you work inside (Canvas, Chat,
  Mini-Apps, Assets, panels, command menu); Models Manager, Settings, Chain
  Editor, Video Editor and Collections now link out instead of restating their
  own pages.
- Every screenshot appears once.
- Fixed bold-label bullets that restated their label ("**Visual Waveforms**:
  See the audio shape", "**Quick Access**: Click the tray icon") per
  [docs/WRITING_STYLE.md](../blob/main/docs/WRITING_STYLE.md), and merged the
  duplicated shortcut rows — the six essentials no longer repeat in the full
  tables below.

325 lines removed, 75 added. No content lost that isn't covered by the page it
links to.

---
_Generated by [Claude Code](https://claude.ai/code/session_016p4HVXAvcd4X13641hXtnS)_