### PR TITLE
ci: skip code checks on documentation-only pushes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -119,6 +119,28 @@ F2 wires this table into the actual gates:
   today, so no real spend yet — its header comment requires an explicit
   per-run cost budget on any future paid-model addition).
 
+## Documentation-only pushes
+
+A change to prose runs no code CI. Most workflows already carry a `paths`
+filter that prose cannot match. `test.yml` cannot: its `quality` job is a
+required status check, and a path-filtered required check is left Pending
+forever on a push that matches nothing. So it triggers on every PR and decides
+inside: a `changes` job classifies the diff, and the gate, the integration
+tests and the browser E2E job skip when nothing but prose changed. A skipped
+job counts as a pass for a required check, so the check still lands.
+
+The prose set is `docs/**`, the Markdown at the repo root, `AGENTS.md` and
+`CLAUDE.md` anywhere, and the Markdown under `.github/`. Markdown that code
+reads at run time is deliberately outside it — a sandbox pack's `SKILL.md` or a
+package `README.md` runs the full gate.
+
+It fails safe in both directions: the filter step is `continue-on-error` and
+its output falls back to "there is code here", and the legs skip only on an
+explicit "prose only", so a `changes` job that never reported runs everything.
+
+Prose still gets its own checks: `docs-lint.yml` on any `**/*.md`, and
+`docs-ci.yml` (site build plus link check) on `docs/**`.
+
 ## Manual Trigger
 
 ```bash

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -17,6 +17,17 @@ on:
         required: false
         type: boolean
         default: false
+      docs-only:
+        description: >-
+          Whether this push changes documentation only. When true every check
+          leg is skipped — none of them has anything to say about prose — while
+          the `quality` gate job still runs and reports, so a required status
+          check that must land on every push is not left Pending. The caller
+          decides (test.yml computes it from the diff); the default runs
+          everything.
+        required: false
+        type: boolean
+        default: false
     outputs:
       all-passed:
         description: 'Whether every quality check leg passed.'
@@ -45,6 +56,9 @@ jobs:
   # cannot resolve a base builds the image rather than waving it through.
   changes:
     name: changes
+    # Nothing to decide when the caller already knows the diff is prose: the
+    # only consumer of this job is the `docker` leg, which is skipped too.
+    if: ${{ !inputs.docs-only }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -77,6 +91,7 @@ jobs:
   # ~minutes-long package build. Each leg surfaces its own status check.
   static:
     name: ${{ matrix.check }}
+    if: ${{ !inputs.docs-only }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -129,6 +144,9 @@ jobs:
   # as a cache hit rather than rebuilding its `^build` dependencies.
   build:
     name: build
+    # `built` needs this job, so skipping it skips every leg that consumes the
+    # dist artifact too.
+    if: ${{ !inputs.docs-only }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -346,7 +364,7 @@ jobs:
   docker:
     name: docker
     needs: changes
-    if: needs.changes.outputs.docker == 'true'
+    if: ${{ !inputs.docs-only && needs.changes.outputs.docker == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Does this push touch anything but prose? A documentation-only change has
+  # nothing for typecheck, lint, the test suites, the image build or the
+  # browser E2E runs to say, and every leg it starts holds a runner other PRs
+  # queue behind (the account cap is ~20 concurrent jobs). The workflow still
+  # triggers on every PR — see the `paths` note above — so the required check
+  # is always reported; the legs inside it skip instead, and a skipped job
+  # counts as a pass for a required check.
+  #
+  # The prose set is deliberately narrow: `docs/**` (the Jekyll site), the
+  # Markdown at the repo root, the agent instruction files anywhere, and the
+  # Markdown under `.github/`. Markdown that code reads at run time — a
+  # sandbox pack's `SKILL.md`, a package `README.md` — is NOT in it and keeps
+  # running the full gate.
+  #
+  # Fails open: the step is `continue-on-error` and the output falls back to
+  # "true", so a filter that cannot resolve a base runs everything rather than
+  # waving a change through.
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.filter.outputs.code || 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Detect non-documentation changes
+        id: filter
+        continue-on-error: true
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            code:
+              - '!{docs/**,*.md,**/AGENTS.md,**/CLAUDE.md,.github/**/*.md}'
+
   quality:
     name: Quality Gate (npm run check)
+    needs: changes
+    # `always()` plus the explicit `== 'false'` test below so a `changes` job
+    # that never reported (infrastructure failure, not a filter result) runs the
+    # full gate. Only an explicit "this diff is prose" skips work — a required
+    # check must never go green because the job that decides was broken.
+    if: always()
     uses: ./.github/workflows/quality-checks.yml
     # A called workflow's permissions are capped by the caller's, so the gate's
     # `docker` leg only gets its read-only GHCR buildcache access if it is
@@ -55,8 +99,12 @@ jobs:
       # job, surfaced unchanged as "Quality Gate (npm run check) / quality".
       fail-fast: false
       skip-tests: false
+      # A documentation-only push skips every leg inside the gate. The gate job
+      # itself still runs and reports, so the required check lands green.
+      docs-only: ${{ needs.changes.outputs.code == 'false' }}
 
-  # Heavy jobs run concurrently with the quality gate rather than after it, so
+  # Heavy jobs run concurrently with the quality gate (both wait only on the
+  # seconds-long `changes` job) rather than after it, so
   # the critical path is max(quality, integration, e2e) instead of
   # quality + max(integration, e2e). Trade-off: a PR that fails a static check
   # still spends these runner minutes. They build packages themselves (they are
@@ -65,6 +113,9 @@ jobs:
   # the decoupling).
   integration:
     name: Workflow Integration Tests
+    needs: changes
+    # Same fail-safe reading as the gate above: skip only on an explicit "prose".
+    if: ${{ always() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -80,6 +131,8 @@ jobs:
 
   workflow-runner-e2e:
     name: Workflow Runner Browser E2E
+    needs: changes
+    if: ${{ always() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 


### PR DESCRIPTION
## What

A prose-only PR no longer runs the Quality Gate legs, the workflow integration tests, or the browser E2E job.

## Why

`test.yml` triggers on every PR with no `paths` filter, because its `quality` job is a required status check and a path-filtered required check is left Pending forever on a push that matches nothing (a clean "merge main" commit, a docs edit). That is the right call for the check and the wrong outcome for the work behind it: a documentation-only PR spent a full gate plus the integration and E2E runners, and the account-wide job cap turns those minutes into queue time for every other PR.

Every other PR-triggered workflow already filters by path, so prose could not reach them.

## How

- `test.yml` gains a seconds-long `changes` job (`dorny/paths-filter`, the action and pinned SHA already used in `quality-checks.yml`) that answers one question: does this diff touch anything but prose?
- `quality-checks.yml` gains a `docs-only` input. When true, its `changes`, `static`, `build` and `docker` jobs skip — and `built` follows, since it needs `build`. The aggregating `quality` job still runs and reports, and it already treats a skipped leg as a pass, so the required check lands green with no branch-protection change.
- `integration` and `workflow-runner-e2e` in `test.yml` skip on the same signal. They still start off `changes` rather than off the gate, so the critical path is unchanged.
- `.github/workflows/README.md` documents the rule, the prose set, and the fail-safe behavior.

## Scope of "prose"

Deliberately narrow: `docs/**` (the Jekyll site), the Markdown at the repo root, `AGENTS.md`/`CLAUDE.md` anywhere, and Markdown under `.github/`. Markdown the code reads at run time — a sandbox pack's `SKILL.md`, a package `README.md` — is **not** in the set and keeps running the full gate.

## Fail-safe

Both directions:

- The filter step is `continue-on-error` and its output falls back to "there is code here", so a filter that cannot resolve a base runs everything.
- The legs skip only on an explicit `code == 'false'`, and the gate carries `if: always()`, so a `changes` job that never reported (infrastructure failure, not a filter result) runs the full gate rather than going green by being skipped.

## Prose still gets checked

`docs-lint.yml` (any `**/*.md`) and `docs-ci.yml` (site build + link check on `docs/**`) are unchanged.

## Testing

`npm run lint` passes (pre-existing warnings only). Both workflow files parse. The filter pattern was verified against picomatch over a sample of real paths: `docs/x.md`, root `README.md`, `packages/agents/CLAUDE.md` and `.github/ISSUE_TEMPLATE/bug.md` classify as prose; `web/src/a.ts`, `packages/x/README.md` and `.github/workflows/test.yml` classify as code. This PR itself is a live test — it touches `.github/workflows/**`, so it is code, and the full gate should run on it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkdsSGQq6YUEGo4ARAsmpy)_