### PR TITLE
fix: load Node builtins synchronously instead of via top-level await

### DIFF
--- a/packages/config/src/environment.ts
+++ b/packages/config/src/environment.ts
@@ -9,15 +9,15 @@
  * outside Node.
  */
 import { loadEnvFile } from "./env-file.js";
-import { IS_NODE, importNodeBuiltin } from "./node-import.js";
+import { IS_NODE, getNodeBuiltinSync } from "./node-import.js";
 
 type FsApi = {
   existsSync: (path: string) => boolean;
   readFileSync: (path: string, encoding: "utf8") => string;
 };
 type PathApi = { resolve: (...parts: string[]) => string };
-const fsSync = await importNodeBuiltin<FsApi>("node:fs");
-const pathSync = await importNodeBuiltin<PathApi>("node:path");
+const fsSync = getNodeBuiltinSync<FsApi>("node:fs");
+const pathSync = getNodeBuiltinSync<PathApi>("node:path");
 
 let loaded = false;
 const envStore = new Map<string, string>();

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -3,6 +3,8 @@ export {
   safeProcessEnv,
   safeProcessPlatform,
   importNodeBuiltin,
+  getNodeBuiltinSync,
+  importNodeBuiltinSync,
   importHidden
 } from "./node-import.js";
 

--- a/packages/config/src/logging.ts
+++ b/packages/config/src/logging.ts
@@ -8,7 +8,7 @@
  *   log.debug("Node executing", { nodeId, type });
  */
 
-import { IS_NODE, importNodeBuiltin } from "./node-import.js";
+import { IS_NODE, getNodeBuiltinSync } from "./node-import.js";
 
 /**
  * Minimal sync-fs surface, loaded lazily on Node only — outside Node
@@ -18,7 +18,7 @@ type FsSync = {
   openSync: (path: string, flags: string) => number;
   writeSync: (fd: number, data: string) => number;
 };
-const fsSync = await importNodeBuiltin<FsSync>("node:fs");
+const fsSync = getNodeBuiltinSync<FsSync>("node:fs");
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 

--- a/packages/config/src/node-import.ts
+++ b/packages/config/src/node-import.ts
@@ -76,6 +76,35 @@ export async function importNodeBuiltin<T>(name: string): Promise<T | null> {
 }
 
 /**
+ * Synchronous Node builtin loader for use in modules that must remain
+ * CJS-compatible (no top-level await). Uses `process.getBuiltinModule`
+ * where available (Node 18.19+, works in both ESM and CJS) and falls
+ * back to `globalThis.require` for CJS bundles. Returns `null` on
+ * non-Node runtimes or when the builtin cannot be resolved.
+ */
+export function getNodeBuiltinSync<T>(name: string): T | null {
+  if (!IS_NODE) return null;
+  try {
+    const proc = globalThis.process as unknown as {
+      getBuiltinModule?: (id: string) => unknown;
+    };
+    if (typeof proc?.getBuiltinModule === "function") {
+      return proc.getBuiltinModule(name) as T;
+    }
+    const g = globalThis as unknown as { require?: (id: string) => unknown };
+    if (typeof g.require === "function") {
+      return g.require(name) as T;
+    }
+  } catch {
+    // fall through to null
+  }
+  return null;
+}
+
+/** Alias for `getNodeBuiltinSync` — synchronous counterpart to `importNodeBuiltin`. */
+export const importNodeBuiltinSync = getNodeBuiltinSync;
+
+/**
  * Dynamic import of an arbitrary module specifier hidden from bundler
  * static analysis. Use for native/Node-only npm packages (e.g. `sharp`,
  * `better-sqlite3`) so a browser/edge bundle doesn't try to bundle them.

--- a/packages/config/src/package-assets.ts
+++ b/packages/config/src/package-assets.ts
@@ -16,7 +16,7 @@
  * recorded and queryable via `getPackageAssetResolutions()` for diagnostics.
  */
 
-import { IS_NODE, importNodeBuiltin } from "./node-import.js";
+import { IS_NODE, getNodeBuiltinSync } from "./node-import.js";
 import { createLogger } from "./logging.js";
 import {
   PACKAGE_RUNTIME_ASSETS,
@@ -26,13 +26,13 @@ import {
 
 const log = createLogger("nodetool.config.package-assets");
 
-const nodeModule = await importNodeBuiltin<typeof import("node:module")>(
+const nodeModule = getNodeBuiltinSync<typeof import("node:module")>(
   "node:module"
 );
-const nodeFs = await importNodeBuiltin<{
+const nodeFs = getNodeBuiltinSync<{
   existsSync: (path: string) => boolean;
 }>("node:fs");
-const nodeUrl = await importNodeBuiltin<{
+const nodeUrl = getNodeBuiltinSync<{
   fileURLToPath: (url: URL | string) => string;
 }>("node:url");
 

--- a/packages/config/src/paths.ts
+++ b/packages/config/src/paths.ts
@@ -11,7 +11,7 @@
  * (browser, Edge). All exported functions throw if invoked off-Node.
  */
 
-import { IS_NODE, importNodeBuiltin } from "./node-import.js";
+import { IS_NODE, getNodeBuiltinSync } from "./node-import.js";
 
 type PathApi = {
   join: (...parts: string[]) => string;
@@ -19,9 +19,9 @@ type PathApi = {
 type OsApi = { homedir: () => string };
 type UrlApi = { fileURLToPath: (url: string | URL) => string };
 
-const pathLib = await importNodeBuiltin<PathApi>("node:path");
-const osLib = await importNodeBuiltin<OsApi>("node:os");
-const urlLib = await importNodeBuiltin<UrlApi>("node:url");
+const pathLib = getNodeBuiltinSync<PathApi>("node:path");
+const osLib = getNodeBuiltinSync<OsApi>("node:os");
+const urlLib = getNodeBuiltinSync<UrlApi>("node:url");
 
 function notOnNode(name: string): never {
   throw new Error(

--- a/packages/image-nodes/tests/image-io-sharp-unavailable.test.ts
+++ b/packages/image-nodes/tests/image-io-sharp-unavailable.test.ts
@@ -34,7 +34,9 @@ describe("image-io loadSharp graceful degradation", () => {
       // Force the Node branch of encodeRgbaToPng. Other config exports that the
       // module graph may touch are stubbed minimally.
       IS_NODE: true,
-      importNodeBuiltin: async (name: string) => import(name)
+      importNodeBuiltin: async (name: string) => import(name),
+      getNodeBuiltinSync: (name: string) => process.getBuiltinModule(name),
+      importNodeBuiltinSync: (name: string) => process.getBuiltinModule(name)
     }));
   });
 

--- a/packages/kernel/src/inbox.ts
+++ b/packages/kernel/src/inbox.ts
@@ -11,15 +11,15 @@
  *   - MessageEnvelope wrapping for metadata propagation.
  */
 
-import { importNodeBuiltin } from "@nodetool-ai/config";
+import { getNodeBuiltinSync } from "@nodetool-ai/config";
 import type {
   CorrelationLineage,
   LineageDone,
   LineageScopeClosed
 } from "@nodetool-ai/protocol";
 
-// Stryker disable next-line StringLiteral: module name; on failure importNodeBuiltin returns null and randomUUID falls back, so the literal is not behaviourally observable
-const _nodeCrypto = await importNodeBuiltin<typeof import("node:crypto")>("node:crypto");
+// Stryker disable next-line StringLiteral: module name; on failure getNodeBuiltinSync returns null and randomUUID falls back, so the literal is not behaviourally observable
+const _nodeCrypto = getNodeBuiltinSync<typeof import("node:crypto")>("node:crypto");
 
 /**
  * RFC4122 v4 UUID derived from a `[0, 1)` random source. This is the fallback

--- a/packages/node-sdk/src/metadata.ts
+++ b/packages/node-sdk/src/metadata.ts
@@ -4,7 +4,7 @@ import type {
   OutputCorrelation,
   Platform
 } from "@nodetool-ai/protocol";
-import { IS_NODE, importNodeBuiltin } from "@nodetool-ai/config";
+import { IS_NODE, getNodeBuiltinSync } from "@nodetool-ai/config";
 
 // `node:fs`/`path`/`crypto`/`os` are loaded lazily so this module loads
 // in browser / Edge runtimes. Python metadata loading is Node-only;
@@ -19,16 +19,16 @@ function asDefault<T>(mod: Ns<T> | null): T {
   return (mod as { default?: T }).default ?? (mod as T);
 }
 const fs = asDefault(
-  await importNodeBuiltin<Ns<typeof import("node:fs")>>("node:fs")
+  getNodeBuiltinSync<Ns<typeof import("node:fs")>>("node:fs")
 );
 const path = asDefault(
-  await importNodeBuiltin<Ns<typeof import("node:path")>>("node:path")
+  getNodeBuiltinSync<Ns<typeof import("node:path")>>("node:path")
 );
 const crypto = asDefault(
-  await importNodeBuiltin<Ns<typeof import("node:crypto")>>("node:crypto")
+  getNodeBuiltinSync<Ns<typeof import("node:crypto")>>("node:crypto")
 );
 const os = asDefault(
-  await importNodeBuiltin<Ns<typeof import("node:os")>>("node:os")
+  getNodeBuiltinSync<Ns<typeof import("node:os")>>("node:os")
 );
 
 export interface TypeMetadata {

--- a/packages/runtime/src/async-local-storage.ts
+++ b/packages/runtime/src/async-local-storage.ts
@@ -7,12 +7,11 @@
  * that depends on per-async-context isolation must say what that costs it.
  */
 
-import { importNodeBuiltin } from "@nodetool-ai/config";
+import { getNodeBuiltinSync } from "@nodetool-ai/config";
 
-const _asyncHooks =
-  await importNodeBuiltin<typeof import("node:async_hooks")>(
-    "node:async_hooks"
-  );
+const _asyncHooks = getNodeBuiltinSync<typeof import("node:async_hooks")>(
+  "node:async_hooks"
+);
 
 class FallbackStore<T> {
   private _value: T | undefined;

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -31,7 +31,7 @@ import {
   expandAssetReferences,
   inlineTextAssetRefs
 } from "./prompt-asset-refs.js";
-import { importNodeBuiltin } from "@nodetool-ai/config";
+import { getNodeBuiltinSync } from "@nodetool-ai/config";
 
 // `node:fs/promises`, `node:path`, `node:url`, `node:crypto` are loaded
 // lazily so this module loads in browser / Edge runtimes. The
@@ -58,15 +58,12 @@ export interface ActiveModelSelection {
   model: string;
 }
 
-const nodeCrypto =
-  await importNodeBuiltin<typeof import("node:crypto")>("node:crypto");
-const nodeFsP =
-  await importNodeBuiltin<typeof import("node:fs/promises")>(
-    "node:fs/promises"
-  );
-const nodePath =
-  await importNodeBuiltin<typeof import("node:path")>("node:path");
-const nodeUrl = await importNodeBuiltin<typeof import("node:url")>("node:url");
+const nodeCrypto = getNodeBuiltinSync<typeof import("node:crypto")>("node:crypto");
+const nodeFsP = getNodeBuiltinSync<typeof import("node:fs/promises")>(
+  "node:fs/promises"
+);
+const nodePath = getNodeBuiltinSync<typeof import("node:path")>("node:path");
+const nodeUrl = getNodeBuiltinSync<typeof import("node:url")>("node:url");
 
 const randomUUID = nodeCrypto?.randomUUID
   ? nodeCrypto.randomUUID

--- a/packages/runtime/src/media-ref-bytes.ts
+++ b/packages/runtime/src/media-ref-bytes.ts
@@ -1,12 +1,12 @@
 import { isPackageAssetUri, isRawRgbaImage } from "@nodetool-ai/protocol";
-import { importNodeBuiltin } from "@nodetool-ai/config";
+import { getNodeBuiltinSync } from "@nodetool-ai/config";
 import type { ProcessingContext } from "./context.js";
 import { encodeRawRgbaToPng } from "./image-codec.js";
 
-const _nodeFsP = await importNodeBuiltin<typeof import("node:fs/promises")>(
+const _nodeFsP = getNodeBuiltinSync<typeof import("node:fs/promises")>(
   "node:fs/promises"
 );
-const _nodeUrl = await importNodeBuiltin<typeof import("node:url")>("node:url");
+const _nodeUrl = getNodeBuiltinSync<typeof import("node:url")>("node:url");
 const readFile = (
   ...args: Parameters<typeof import("node:fs/promises").readFile>
 ): Promise<Buffer> =>

--- a/packages/runtime/src/providers/cassette-provider.ts
+++ b/packages/runtime/src/providers/cassette-provider.ts
@@ -13,7 +13,7 @@
  * video, audio, embeddings) delegates straight to the inner provider.
  */
 
-import { importNodeBuiltin } from "@nodetool-ai/config";
+import { getNodeBuiltinSync, importNodeBuiltin } from "@nodetool-ai/config";
 import { BaseProvider } from "./base-provider.js";
 import type { UsageInfo } from "./cost-calculator.js";
 import { createUsageSlot } from "../tracing-helpers.js";
@@ -25,7 +25,7 @@ import type {
   ProviderTool
 } from "./types.js";
 
-const _nodeCrypto = await importNodeBuiltin<typeof import("node:crypto")>(
+const _nodeCrypto = getNodeBuiltinSync<typeof import("node:crypto")>(
   "node:crypto"
 );
 

--- a/packages/runtime/src/providers/fake-provider.ts
+++ b/packages/runtime/src/providers/fake-provider.ts
@@ -1,8 +1,8 @@
-import { importNodeBuiltin } from "@nodetool-ai/config";
+import { getNodeBuiltinSync } from "@nodetool-ai/config";
 import type { Chunk } from "@nodetool-ai/protocol";
 import { BaseProvider } from "./base-provider.js";
 
-const _nodeCrypto = await importNodeBuiltin<typeof import("node:crypto")>(
+const _nodeCrypto = getNodeBuiltinSync<typeof import("node:crypto")>(
   "node:crypto"
 );
 const randomUUID = (): string => {

--- a/packages/runtime/src/providers/scripted-provider.ts
+++ b/packages/runtime/src/providers/scripted-provider.ts
@@ -14,11 +14,11 @@
  *   ]);
  */
 
-import { importNodeBuiltin } from "@nodetool-ai/config";
+import { getNodeBuiltinSync } from "@nodetool-ai/config";
 import type { Chunk } from "@nodetool-ai/protocol";
 import { BaseProvider } from "./base-provider.js";
 
-const _nodeCrypto = await importNodeBuiltin<typeof import("node:crypto")>(
+const _nodeCrypto = getNodeBuiltinSync<typeof import("node:crypto")>(
   "node:crypto"
 );
 const randomUUID = (): string => {

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -11,16 +11,14 @@
  * is shared; only framing/transport differs per subclass.
  */
 
-import { importNodeBuiltin, safeProcessEnv } from "@nodetool-ai/config";
+import { getNodeBuiltinSync, safeProcessEnv } from "@nodetool-ai/config";
 
 // The base only needs crypto (request IDs) and events (EventEmitter).
 // Lazy-load so the module *graph* loads off-Node; instantiating a concrete
 // bridge there throws at construction. Notably the base does NOT require
 // child_process — that belongs to the stdio subclass only.
-const nodeCrypto =
-  await importNodeBuiltin<typeof import("node:crypto")>("node:crypto");
-const nodeEvents =
-  await importNodeBuiltin<typeof import("node:events")>("node:events");
+const nodeCrypto = getNodeBuiltinSync<typeof import("node:crypto")>("node:crypto");
+const nodeEvents = getNodeBuiltinSync<typeof import("node:events")>("node:events");
 
 function notOnNode(api: string): never {
   throw new Error(`${api} requires Node — PythonBridgeBase is Node-only`);

--- a/packages/runtime/src/python-node-executor.ts
+++ b/packages/runtime/src/python-node-executor.ts
@@ -5,7 +5,7 @@ import type {
   ProgressEvent
 } from "./python-bridge-types.js";
 import { loadMediaRefBytes, type MediaRefValue } from "./media-ref-bytes.js";
-import { createLogger, importNodeBuiltin } from "@nodetool-ai/config";
+import { createLogger, getNodeBuiltinSync } from "@nodetool-ai/config";
 
 const log = createLogger("nodetool.runtime.python-node-executor");
 
@@ -26,7 +26,7 @@ interface PythonBridgeLike {
     onProgress?: (event: ProgressEvent) => void
   ): AsyncGenerator<ExecuteResult>;
 }
-const _nodeCrypto = await importNodeBuiltin<typeof import("node:crypto")>(
+const _nodeCrypto = getNodeBuiltinSync<typeof import("node:crypto")>(
   "node:crypto"
 );
 const randomUUID = (): string =>

--- a/packages/runtime/src/python-stdio-bridge.ts
+++ b/packages/runtime/src/python-stdio-bridge.ts
@@ -14,19 +14,17 @@
  */
 
 import { pack, unpack } from "msgpackr";
-import { importNodeBuiltin } from "@nodetool-ai/config";
+import { getNodeBuiltinSync } from "@nodetool-ai/config";
 
 // Python bridge is fundamentally Node-only (subprocess + raw FDs).
 // Lazy-load the builtins so the module *graph* loads off-Node;
 // instantiating PythonStdioBridge there throws at construction.
-const nodeCp =
-  await importNodeBuiltin<typeof import("node:child_process")>(
-    "node:child_process"
-  );
-const nodeFs = await importNodeBuiltin<typeof import("node:fs")>("node:fs");
-const nodeOs = await importNodeBuiltin<typeof import("node:os")>("node:os");
-const nodePath =
-  await importNodeBuiltin<typeof import("node:path")>("node:path");
+const nodeCp = getNodeBuiltinSync<typeof import("node:child_process")>(
+  "node:child_process"
+);
+const nodeFs = getNodeBuiltinSync<typeof import("node:fs")>("node:fs");
+const nodeOs = getNodeBuiltinSync<typeof import("node:os")>("node:os");
+const nodePath = getNodeBuiltinSync<typeof import("node:path")>("node:path");
 
 function notOnNode(api: string): never {
   throw new Error(`${api} requires Node — PythonStdioBridge is Node-only`);

--- a/packages/runtime/src/testing.ts
+++ b/packages/runtime/src/testing.ts
@@ -7,17 +7,17 @@
  * the user's file system. Imports are kept lean so the module stays cheap
  * to load from any package's tests.
  */
-import { importNodeBuiltin } from "@nodetool-ai/config";
+import { getNodeBuiltinSync } from "@nodetool-ai/config";
 
-const os = (await importNodeBuiltin<typeof import("node:os")>(
+const os = getNodeBuiltinSync<typeof import("node:os")>(
   "node:os"
-)) as typeof import("node:os");
-const path = (await importNodeBuiltin<typeof import("node:path")>(
+) as typeof import("node:os");
+const path = getNodeBuiltinSync<typeof import("node:path")>(
   "node:path"
-)) as typeof import("node:path");
-const fs = (await importNodeBuiltin<typeof import("node:fs")>(
+) as typeof import("node:path");
+const fs = getNodeBuiltinSync<typeof import("node:fs")>(
   "node:fs"
-)) as typeof import("node:fs");
+) as typeof import("node:fs");
 import { ProcessingContext, InMemoryStorageAdapter, MemoryCache } from "./context.js";
 import { FakeProvider } from "./providers/fake-provider.js";
 import type { BaseProvider } from "./providers/base-provider.js";

--- a/packages/runtime/src/trace-exporters.ts
+++ b/packages/runtime/src/trace-exporters.ts
@@ -9,17 +9,15 @@
  * file or stdout output gets identical fields.
  */
 
-import { importNodeBuiltin } from "@nodetool-ai/config";
+import { getNodeBuiltinSync } from "@nodetool-ai/config";
 
 // Trace-exporter file/stream APIs require Node — lazy-load so this
 // module loads on non-Node runtimes (where file exporters are unused).
-const nodeFs = await importNodeBuiltin<typeof import("node:fs")>("node:fs");
-const nodeFsP = await importNodeBuiltin<typeof import("node:fs/promises")>(
+const nodeFs = getNodeBuiltinSync<typeof import("node:fs")>("node:fs");
+const nodeFsP = getNodeBuiltinSync<typeof import("node:fs/promises")>(
   "node:fs/promises"
 );
-const nodePath = await importNodeBuiltin<typeof import("node:path")>(
-  "node:path"
-);
+const nodePath = getNodeBuiltinSync<typeof import("node:path")>("node:path");
 
 type WriteStream = ReturnType<typeof import("node:fs").createWriteStream>;
 // The `!node*` guards below only fire in a non-Node runtime (browser/edge),

--- a/packages/websocket/src/sandbox-catalog.ts
+++ b/packages/websocket/src/sandbox-catalog.ts
@@ -54,9 +54,15 @@ export function getSandboxCatalogDiagnostics(): readonly SandboxModuleStatus[] {
 async function compileAndDiscover(
   searchPaths: readonly string[] | undefined
 ): Promise<SandboxCatalogHost | undefined> {
-  let compileSandboxCatalog: typeof import("@nodetool-ai/sandbox-compiler").compileSandboxCatalog;
+  let compileSandboxCatalog: (options?: {
+    searchPaths?: readonly string[];
+  }) => Promise<SandboxCatalogHost>;
   try {
-    ({ compileSandboxCatalog } = await import("@nodetool-ai/sandbox-compiler"));
+    ({ compileSandboxCatalog } = (await import(
+      "@nodetool-ai/sandbox-compiler"
+    )) as {
+      compileSandboxCatalog: typeof compileSandboxCatalog;
+    });
   } catch (error) {
     compileFailure = {
       packName: "@nodetool-ai/sandbox-compiler",


### PR DESCRIPTION
## What

Replaces `await importNodeBuiltin(...)` at module top level with a new synchronous loader across `config`, `kernel`, `node-sdk`, `runtime`, and `websocket`.

Every module that pulled a Node builtin through `importNodeBuiltin` carried a top-level await. That forces the module into ESM-only output and blocks CJS consumers and bundlers.

`getNodeBuiltinSync` (new, in `@nodetool-ai/config`) uses `process.getBuiltinModule` — Node 18.19+, works in both ESM and CJS — and falls back to `globalThis.require` for CJS bundles. It returns `null` off-Node, so every existing null guard keeps working unchanged. `importNodeBuiltinSync` is exported as an alias.

Also types the lazy `sandbox-compiler` import locally, so `sandbox-catalog.ts` no longer needs that package's types at compile time.

## Verification

- `npm run build:packages`, `npm run typecheck`, `npm run lint` — pass
- Tests for `config`, `kernel`, `node-sdk`, `runtime` — pass
- `websocket`: 2199/2200 pass. The one failure (`tests/trigger-file-watch.test.ts`) also fails on a clean `main` checkout — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)