### PR TITLE
Hide the chat memory rail by default and make it toggleable

### DIFF
--- a/web/src/components/chat/containers/ChatView.tsx
+++ b/web/src/components/chat/containers/ChatView.tsx
@@ -16,7 +16,9 @@ import {
   TodoItem
 } from "../../../stores/ApiTypes";
 import AddIcon from "@mui/icons-material/Add";
+import PsychologyOutlinedIcon from "@mui/icons-material/PsychologyOutlined";
 import {
+  FlexRow,
   SPACING,
   ToolbarIconButton,
   getSpacingPx,
@@ -27,6 +29,7 @@ import ChatInputSection, { type ChatComposerVariant } from "./ChatInputSection";
 import { TodoSidebar } from "../sidebar/TodoSidebar";
 import { ThreadMemorySidebar } from "../sidebar/ThreadMemorySidebar";
 import useGlobalChatStore from "../../../stores/GlobalChatStore";
+import { useThreadMemoryPanelStore } from "../../../stores/ThreadMemoryPanelStore";
 import {
   buildUiContext,
   type BuildUiContextOptions
@@ -59,7 +62,7 @@ const styles = (theme: Theme) =>
       paddingRight: 8
     },
     // Floats over the thread rather than reserving a row of its own.
-    ".new-chat-overlay": {
+    ".chat-overlay-actions": {
       position: "absolute",
       top: getSpacingPx(SPACING.md),
       right: getSpacingPx(SPACING.lg),
@@ -277,18 +280,32 @@ const ChatView = ({
   // phones and narrow panels.
   const railsFit = useMediaQuery(theme.breakpoints.up("md"));
   const showTodoSidebar = railsFit && todos.length > 0;
+  const memoryPanelOpen = useThreadMemoryPanelStore((state) => state.isOpen);
+  const toggleMemoryPanel = useThreadMemoryPanelStore((state) => state.toggle);
+  const closeMemoryPanel = useThreadMemoryPanelStore((state) => state.setOpen);
+  const canShowMemorySidebar = railsFit && Boolean(effectiveThreadId);
 
   return (
     <div className="chat-view" css={cssStyles}>
       <div className="chat-main">
-        {showNewChatButton && onNewChat && (
-          <div className="new-chat-overlay">
-            <ToolbarIconButton
-              onClick={onNewChat}
-              tooltip="New chat"
-              icon={<AddIcon fontSize="small" />}
-            />
-          </div>
+        {(canShowMemorySidebar || (showNewChatButton && onNewChat)) && (
+          <FlexRow className="chat-overlay-actions" align="center" gap={2}>
+            {canShowMemorySidebar && (
+              <ToolbarIconButton
+                onClick={toggleMemoryPanel}
+                tooltip={memoryPanelOpen ? "Hide memory" : "Show memory"}
+                active={memoryPanelOpen}
+                icon={<PsychologyOutlinedIcon fontSize="small" />}
+              />
+            )}
+            {showNewChatButton && onNewChat && (
+              <ToolbarIconButton
+                onClick={onNewChat}
+                tooltip="New chat"
+                icon={<AddIcon fontSize="small" />}
+              />
+            )}
+          </FlexRow>
         )}
         <div className="chat-thread-container">
           {messages.length > 0 ? (
@@ -331,8 +348,11 @@ const ChatView = ({
         />
       </div>
       {showTodoSidebar && <TodoSidebar todos={todos} />}
-      {railsFit && effectiveThreadId && (
-        <ThreadMemorySidebar threadId={effectiveThreadId} />
+      {canShowMemorySidebar && memoryPanelOpen && effectiveThreadId && (
+        <ThreadMemorySidebar
+          threadId={effectiveThreadId}
+          onClose={() => closeMemoryPanel(false)}
+        />
       )}
     </div>
   );

--- a/web/src/components/chat/sidebar/ThreadMemorySidebar.tsx
+++ b/web/src/components/chat/sidebar/ThreadMemorySidebar.tsx
@@ -9,6 +9,7 @@ import {
   Text,
   Chip,
   ScrollArea,
+  CloseButton,
   DeleteButton,
   MOTION,
   BORDER_RADIUS,
@@ -30,6 +31,8 @@ type Resource = Memory["resources"][number];
 
 interface ThreadMemorySidebarProps {
   threadId: string;
+  /** Hides the rail. Omit when the surface has no way to reopen it. */
+  onClose?: () => void;
 }
 
 const styles = (theme: Theme) =>
@@ -46,7 +49,7 @@ const styles = (theme: Theme) =>
       padding: theme.spacing(4, 4, 3),
       borderBottom: `1px solid rgb(${theme.vars.palette.common.whiteChannel} / 0.06)`,
       display: "flex",
-      alignItems: "baseline",
+      alignItems: "center",
       justifyContent: "space-between",
       gap: getSpacingPx(SPACING.md)
     },
@@ -182,7 +185,7 @@ MemoryCard.displayName = "MemoryCard";
  * view of project notes and the assets/workflows/resources referenced.
  */
 export const ThreadMemorySidebar: React.FC<ThreadMemorySidebarProps> = memo(
-  ({ threadId }) => {
+  ({ threadId, onClose }) => {
     const theme = useTheme();
     const cssStyles = useMemo(() => styles(theme), [theme]);
     const utils = trpc.useUtils();
@@ -216,7 +219,7 @@ export const ThreadMemorySidebar: React.FC<ThreadMemorySidebarProps> = memo(
 
     return (
       <aside className="thread-memory-sidebar" css={cssStyles}>
-        <FlexRow className="memory-header" align="baseline" justify="space-between">
+        <FlexRow className="memory-header" align="center" justify="space-between">
           <Text
             size="small"
             weight={600}
@@ -224,11 +227,14 @@ export const ThreadMemorySidebar: React.FC<ThreadMemorySidebarProps> = memo(
           >
             Memory
           </Text>
-          {memories.length > 0 && (
-            <Text size="smaller" sx={{ opacity: 0.6 }}>
-              {memories.length}
-            </Text>
-          )}
+          <FlexRow align="center" gap={2}>
+            {memories.length > 0 && (
+              <Text size="smaller" sx={{ opacity: 0.6 }}>
+                {memories.length}
+              </Text>
+            )}
+            {onClose && <CloseButton onClick={onClose} tooltip="Hide memory" />}
+          </FlexRow>
         </FlexRow>
         <ScrollArea className="memory-list">
           {memories.length === 0 ? (

--- a/web/src/stores/ThreadMemoryPanelStore.ts
+++ b/web/src/stores/ThreadMemoryPanelStore.ts
@@ -1,0 +1,23 @@
+/**
+ * Visibility of the thread memory rail in chat surfaces. Off by default —
+ * the rail is opt-in and the choice persists across sessions.
+ */
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface ThreadMemoryPanelState {
+  isOpen: boolean;
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+}
+
+export const useThreadMemoryPanelStore = create<ThreadMemoryPanelState>()(
+  persist(
+    (set) => ({
+      isOpen: false,
+      setOpen: (open: boolean) => set({ isOpen: open }),
+      toggle: () => set((state) => ({ isOpen: !state.isOpen }))
+    }),
+    { name: "thread-memory-panel" }
+  )
+);


### PR DESCRIPTION
The thread memory sidebar was always on in every chat surface wide enough for it (`md` and up), taking 300px from the conversation whether or not the user wanted it.

## Changes

- **`web/src/stores/ThreadMemoryPanelStore.ts`** (new): persisted Zustand store holding the rail's visibility. Default `false`.
- **`ChatView.tsx`**: renders the rail only when the store says open. A toggle button (`PsychologyOutlinedIcon`, `active` when open) sits in a floating overlay at the top right of the thread, and renders on **every** `ChatView` surface — the workspace chat tab, the Agent panel, the canvas dock — not just those that ask for the new-chat button. When both are present they share one `FlexRow`.
- **`ThreadMemorySidebar.tsx`**: takes an optional `onClose` and shows a close button in its header, so the rail can be dismissed from itself. Header alignment moved from `baseline` to `center` to sit with the button.

The toggle appears only where the rail could actually show (wide enough, and a thread is open), so it never offers something that would do nothing.

This is the *panel visibility* toggle. The existing `memoryEnabled` composer chip — whether the agent records memories at all — is unchanged and unrelated.

## Verification

- `npx tsc --noEmit` (web) — passes
- `eslint` on the changed files — clean
- `jest src/components/chat src/components/panels/__tests__/CanvasMediaComposer.test.tsx` — 171 tests, 22 suites, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4KooiowcwUJ2y9x7A6tLY

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KooiowcwUJ2y9x7A6tLY)_