### PR TITLE
web: edit the code property with Monaco in the inspector

### DIFF
--- a/web/src/components/node/PropertyInput.resolver.tsx
+++ b/web/src/components/node/PropertyInput.resolver.tsx
@@ -3,6 +3,7 @@ import { Property } from "../../stores/ApiTypes";
 import reduceUnionType from "../../hooks/reduceUnionType";
 import StringProperty from "../properties/StringProperty";
 import TextProperty from "../properties/TextProperty";
+import CodeProperty from "../properties/CodeProperty";
 import ImageProperty from "../properties/ImageProperty";
 import AudioProperty from "../properties/AudioProperty";
 import VideoProperty from "../properties/VideoProperty";
@@ -51,10 +52,20 @@ import {
 } from "../properties/MediaPickerProperties";
 import { InputProperty } from "./InputProperty";
 import type { PropertyProps } from "./PropertyInput.types";
+import useMetadataStore from "../../stores/MetadataStore";
+import { hasCodeProperty } from "./codeNodeUi";
 
 export function getComponentForProperty(
-  property: Property
+  property: Property,
+  nodeType?: string
 ): ComponentType<PropertyProps> {
+  // A node's inline `code` string gets the Monaco editor the node body uses,
+  // so the same value is edited the same way on the canvas and in the
+  // inspector.
+  if (isCodePropertyOf(property, nodeType)) {
+    return CodeProperty;
+  }
+
   // Dynamic schemas (e.g. FalAI) may attach `values` or `enum` directly to the
   // property object rather than inside `property.type`.
   const propertyWithExtras = property as Property & {
@@ -97,6 +108,20 @@ export function getComponentForProperty(
     default:
       return componentForType(property.type.type);
   }
+}
+
+/**
+ * True for the inline `code` string of a node that declares one (the same
+ * nodes `CodeBody` gives a Monaco body on the canvas).
+ */
+function isCodePropertyOf(
+  property: Property,
+  nodeType: string | undefined
+): boolean {
+  if (property.name !== "code" || property.type.type !== "str" || !nodeType) {
+    return false;
+  }
+  return hasCodeProperty(useMetadataStore.getState().getMetadata(nodeType));
 }
 
 function customComponentForType(

--- a/web/src/components/node/PropertyInput.tsx
+++ b/web/src/components/node/PropertyInput.tsx
@@ -25,6 +25,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { useNodes } from "../../contexts/NodeContext";
 import JSONProperty from "../properties/JSONProperty";
+import CodeProperty from "../properties/CodeProperty";
 import useMetadataStore from "../../stores/MetadataStore";
 import { useDynamicProperty } from "../../hooks/nodes/useDynamicProperty";
 import { NodeData } from "../../stores/NodeData";
@@ -172,9 +173,10 @@ function isImageInputType(property: Property): boolean {
 }
 
 function componentFor(
-  property: Property
+  property: Property,
+  nodeType: string
 ): React.ComponentType<PropertyProps> | null {
-  return getComponentForProperty(property);
+  return getComponentForProperty(property, nodeType);
 }
 
 export type PropertyInputProps = {
@@ -440,7 +442,7 @@ const PropertyInput: React.FC<PropertyInputProps> = ({
     [handleUpdatePropertyName, property.name, editedName]
   );
 
-  const componentType = componentFor(property);
+  const componentType = componentFor(property, nodeType);
 
   const handleNameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setEditedName(e.target.value);
@@ -518,6 +520,7 @@ const PropertyInput: React.FC<PropertyInputProps> = ({
   const hasTopRightPropertyActions =
     componentType === StringProperty ||
     componentType === JSONProperty ||
+    componentType === CodeProperty ||
     componentType === DataframeProperty;
 
   const canvasResetButton =

--- a/web/src/components/properties/CodeProperty.tsx
+++ b/web/src/components/properties/CodeProperty.tsx
@@ -1,0 +1,320 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * CodeProperty — Monaco editor for a node's inline `code` property.
+ *
+ * The node body already renders code in Monaco (`CodeBody`); the inspector
+ * used to fall back to the generic three-row text field, so the same string
+ * was edited with syntax highlighting on the canvas and without it in the
+ * inspector. This component closes that gap.
+ */
+import { css } from "@emotion/react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type * as monaco from "monaco-editor";
+import { useTheme } from "@mui/material/styles";
+
+import PropertyLabel from "../node/PropertyLabel";
+import { PropertyProps } from "../node/PropertyInput";
+import TextEditorModal from "./TextEditorModal";
+import ConnectedBadge from "./ConnectedBadge";
+import isEqual from "../../utils/isEqual";
+import {
+  BORDER_RADIUS,
+  CopyButton,
+  LoadingSpinner,
+  SPACING,
+  ToolbarIconButton,
+  Z_INDEX,
+  getSpacingPx
+} from "../ui_primitives";
+import OpenInFullIcon from "@mui/icons-material/OpenInFull";
+import { useMonacoEditor } from "../../hooks/editor/useMonacoEditor";
+import { useInspectorHeaderSupplementalRegistration } from "../../hooks/useInspectorHeaderSupplemental";
+import { useIsConnectedSelector } from "../../hooks/nodes/useIsConnected";
+import { useNodes } from "../../contexts/NodeContext";
+import { getCodeNodeLanguage } from "../node/codeNodeUi";
+
+const EDITOR_OPTIONS: Record<string, unknown> = {
+  minimap: { enabled: false },
+  automaticLayout: true,
+  scrollBeyondLastLine: false,
+  lineNumbers: "on",
+  folding: false,
+  glyphMargin: false,
+  lineDecorationsWidth: 4,
+  lineNumbersMinChars: 2,
+  fontSize: 12,
+  wordWrap: "off",
+  renderLineHighlight: "none",
+  tabSize: 2,
+  scrollbar: {
+    verticalScrollbarSize: 8,
+    horizontalScrollbarSize: 8
+  }
+};
+
+const CodeProperty = ({
+  property,
+  propertyIndex,
+  value,
+  onChange,
+  onChangeComplete,
+  nodeId,
+  nodeType,
+  isDynamicProperty,
+  isInspector,
+  onPropertyContextMenu
+}: PropertyProps) => {
+  const theme = useTheme();
+  const id = `code-${property.name}-${propertyIndex}`;
+  const storeValue = typeof value === "string" ? value : "";
+  const language = getCodeNodeLanguage(nodeType);
+
+  const [code, setCode] = useState(storeValue);
+  const [isFocused, setIsFocused] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+
+  // Follow external writes (undo/redo, snippet load, agent edits) while the
+  // user is not typing.
+  useEffect(() => {
+    if (!isFocused && storeValue !== code) {
+      setCode(storeValue);
+    }
+  }, [storeValue, isFocused, code]);
+
+  const isConnectedSelector = useIsConnectedSelector(nodeId, property.name);
+  const isConnected = useNodes(isConnectedSelector);
+
+  const {
+    MonacoEditor,
+    monacoLoadError,
+    isMonacoLoading,
+    loadMonacoIfNeeded,
+    monacoOnMount
+  } = useMonacoEditor();
+
+  // The inspector is an editing surface — a selected code node is about to be
+  // edited, so fetch the bundle instead of waiting for a hover.
+  useEffect(() => {
+    void loadMonacoIfNeeded();
+  }, [loadMonacoIfNeeded]);
+
+  const handleChange = useCallback(
+    (next: string | undefined) => {
+      const nextCode = next ?? "";
+      setCode(nextCode);
+      onChange(nextCode);
+    },
+    [onChange]
+  );
+
+  const completeRef = useRef(onChangeComplete);
+  useEffect(() => {
+    completeRef.current = onChangeComplete;
+  }, [onChangeComplete]);
+
+  const handleEditorMount = useCallback(
+    (editor: monaco.editor.IStandaloneCodeEditor) => {
+      monacoOnMount(editor);
+      const focus = editor.onDidFocusEditorText(() => setIsFocused(true));
+      const blur = editor.onDidBlurEditorText(() => {
+        setIsFocused(false);
+        completeRef.current?.();
+      });
+      editor.onDidDispose(() => {
+        focus.dispose();
+        blur.dispose();
+      });
+    },
+    [monacoOnMount]
+  );
+
+  const toggleExpand = useCallback(() => {
+    setIsExpanded((prev) => {
+      const next = !prev;
+      if (next) {
+        window.dispatchEvent(new Event("close-text-editor-modal"));
+      }
+      return next;
+    });
+  }, []);
+
+  const handleModalChange = useCallback(
+    (next: string) => {
+      setCode(next);
+      onChange(next);
+      onChangeComplete?.();
+    },
+    [onChange, onChangeComplete]
+  );
+
+  const inspectorToolbarActionSx = useMemo(
+    () => ({
+      color: theme.vars.palette.common.white,
+      "& svg": { fontSize: "var(--fontSizeNormal)" }
+    }),
+    [theme]
+  );
+
+  const editorActions = useMemo(
+    () => (
+      <>
+        <ToolbarIconButton
+          className="inspector-supplemental-action"
+          tooltip="Open Editor"
+          icon={<OpenInFullIcon />}
+          onClick={toggleExpand}
+          size="small"
+          sx={inspectorToolbarActionSx}
+        />
+        <CopyButton
+          className="inspector-supplemental-action"
+          value={code}
+          buttonSize="small"
+          sx={inspectorToolbarActionSx}
+        />
+      </>
+    ),
+    [code, inspectorToolbarActionSx, toggleExpand]
+  );
+
+  useInspectorHeaderSupplementalRegistration(
+    editorActions,
+    isInspector === true
+  );
+
+  const styles = useMemo(
+    () =>
+      css({
+        ".property-row": {
+          position: "relative",
+          display: "flex",
+          flexDirection: "column",
+          gap: getSpacingPx(SPACING.xs)
+        },
+        ".code-action-buttons": {
+          position: "absolute",
+          right: 0,
+          top: "-3px",
+          opacity: 0.8,
+          zIndex: Z_INDEX.dropdown
+        },
+        ".code-action-buttons .MuiIconButton-root": {
+          margin: `0 0 0 ${theme.spacing(SPACING.sm)}`,
+          padding: 0
+        },
+        ".code-action-buttons .MuiIconButton-root svg": {
+          fontSize: "var(--fontSizeSmall)"
+        },
+        ".editor-wrapper": {
+          height: isInspector ? "320px" : "160px",
+          overflow: "hidden",
+          backgroundColor: "var(--palette-grey-600)",
+          border: "1px solid var(--palette-grey-500)",
+          borderRadius: BORDER_RADIUS.sm
+        },
+        ".editor-wrapper:focus-within": {
+          borderColor: "var(--palette-grey-400)"
+        },
+        ".editor-loading, .editor-error, .editor-placeholder": {
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: "var(--fontSizeSmaller)",
+          color: "var(--palette-text-secondary)"
+        },
+        ".editor-placeholder": {
+          padding: `${getSpacingPx(SPACING.sm)} ${getSpacingPx(SPACING.md)}`,
+          fontFamily: theme.fontFamily2,
+          whiteSpace: "pre-wrap",
+          overflow: "hidden",
+          alignItems: "flex-start",
+          cursor: "text"
+        }
+      }),
+    [isInspector, theme]
+  );
+
+  if (isConnected) {
+    return (
+      <div className="code-property connected">
+        <PropertyLabel
+          name={property.name}
+          description={property.description}
+          id={id}
+        />
+        <ConnectedBadge />
+      </div>
+    );
+  }
+
+  return (
+    <div className="code-property" css={styles}>
+      <div
+        className="property-row"
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        onContextMenuCapture={onPropertyContextMenu}
+      >
+        <PropertyLabel
+          name={property.name}
+          description={property.description}
+          id={id}
+          isDynamicProperty={isDynamicProperty}
+        />
+        {!isInspector && isHovered ? (
+          <div className="code-action-buttons">
+            <ToolbarIconButton
+              tooltip="Open Editor"
+              icon={<OpenInFullIcon />}
+              onClick={toggleExpand}
+              size="small"
+            />
+            <CopyButton value={code} buttonSize="small" />
+          </div>
+        ) : null}
+        <div
+          className={`editor-wrapper nodrag ${isFocused ? "nowheel" : ""}`}
+          onMouseDown={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          {MonacoEditor ? (
+            <MonacoEditor
+              value={code}
+              onChange={handleChange}
+              language={language === "text" ? "plaintext" : language}
+              theme="vs-dark"
+              width="100%"
+              height="100%"
+              onMount={handleEditorMount}
+              options={EDITOR_OPTIONS}
+            />
+          ) : monacoLoadError ? (
+            <div className="editor-error">{monacoLoadError}</div>
+          ) : isMonacoLoading ? (
+            <div className="editor-loading">
+              <LoadingSpinner />
+            </div>
+          ) : (
+            <div className="editor-placeholder">{code}</div>
+          )}
+        </div>
+      </div>
+      {isExpanded && (
+        <TextEditorModal
+          value={code}
+          language={language}
+          nodeType={nodeType}
+          propertyType={property.type?.type}
+          onChange={handleModalChange}
+          onClose={toggleExpand}
+          propertyName={property.name}
+          propertyDescription={property.description || ""}
+        />
+      )}
+    </div>
+  );
+};
+
+export default memo(CodeProperty, isEqual);

--- a/web/src/components/properties/__tests__/CodeProperty.test.tsx
+++ b/web/src/components/properties/__tests__/CodeProperty.test.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import "@testing-library/jest-dom";
+
+// Stub Monaco with a textarea so the editor can be driven without the real bundle.
+jest.mock("../../../hooks/editor/useMonacoEditor", () => ({
+  useMonacoEditor: () => ({
+    MonacoEditor: ({
+      value,
+      onChange,
+      language
+    }: {
+      value: string;
+      onChange?: (val?: string) => void;
+      language?: string;
+    }) => (
+      <textarea
+        data-testid="monaco"
+        data-language={language}
+        value={value}
+        onChange={(e) => onChange?.(e.target.value)}
+      />
+    ),
+    monacoLoadError: null,
+    isMonacoLoading: false,
+    loadMonacoIfNeeded: jest.fn().mockResolvedValue(undefined),
+    monacoRef: { current: null },
+    monacoOnMount: jest.fn(),
+    handleMonacoFind: jest.fn(),
+    handleMonacoFormat: jest.fn()
+  })
+}));
+
+let mockEdges: Array<{ target: string; targetHandle: string }> = [];
+jest.mock("../../../contexts/NodeContext", () => ({
+  useNodes: (selector: (state: unknown) => unknown) =>
+    selector({ edges: mockEdges })
+}));
+
+import CodeProperty from "../CodeProperty";
+
+const defaultProps = {
+  property: {
+    name: "code",
+    description: "JavaScript to run",
+    type: { type: "str", optional: false, type_args: [] }
+  } as any,
+  propertyIndex: "0",
+  value: "return {};",
+  onChange: jest.fn(),
+  nodeId: "node1",
+  nodeType: "nodetool.code.Code"
+};
+
+const renderProperty = (props: Record<string, unknown> = {}) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <CodeProperty {...defaultProps} {...(props as any)} />
+    </ThemeProvider>
+  );
+
+describe("CodeProperty", () => {
+  beforeEach(() => {
+    mockEdges = [];
+    jest.clearAllMocks();
+  });
+
+  it("renders the code in a JavaScript editor", () => {
+    renderProperty();
+    const editor = screen.getByTestId("monaco");
+    expect(editor).toHaveValue("return {};");
+    expect(editor).toHaveAttribute("data-language", "javascript");
+  });
+
+  it("writes edits back through onChange", () => {
+    const onChange = jest.fn();
+    renderProperty({ onChange });
+    fireEvent.change(screen.getByTestId("monaco"), {
+      target: { value: "return { a: 1 };" }
+    });
+    expect(onChange).toHaveBeenCalledWith("return { a: 1 };");
+  });
+
+  it("follows external writes while the editor is not focused", () => {
+    const { rerender } = renderProperty();
+    rerender(
+      <ThemeProvider theme={mockTheme}>
+        <CodeProperty {...(defaultProps as any)} value="return { b: 2 };" />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId("monaco")).toHaveValue("return { b: 2 };");
+  });
+
+  it("shows a connected badge instead of the editor when an edge drives it", () => {
+    mockEdges = [{ target: "node1", targetHandle: "code" }];
+    renderProperty();
+    expect(screen.queryByTestId("monaco")).not.toBeInTheDocument();
+  });
+
+  it("falls back to plain text for a non-JavaScript code node", () => {
+    renderProperty({ nodeType: "some.other.Node" });
+    expect(screen.getByTestId("monaco")).toHaveAttribute(
+      "data-language",
+      "plaintext"
+    );
+  });
+});


### PR DESCRIPTION
The node body renders a code node's inline `code` property in Monaco (`CodeBody`), but the inspector fell back to the generic three-row text field — the same string was edited with syntax highlighting on the canvas and without it in the inspector.

## Changes

- **`web/src/components/properties/CodeProperty.tsx`** (new) — Monaco editor for an inline `code` string. Language comes from `getCodeNodeLanguage` (the node body's own derivation: JavaScript for `nodetool.code.Code`, plain text otherwise). Carries the expand-to-modal and copy actions the other string editors have (in the inspector header when `isInspector`, on hover otherwise), shows a connected badge when an edge drives the property, follows external writes (undo/redo, snippet load, agent edits) while the editor is not focused, and calls `onChangeComplete` on blur. Monaco is loaded lazily through `useMonacoEditor`.
- **`web/src/components/node/PropertyInput.resolver.tsx`** — `getComponentForProperty` takes an optional `nodeType` and routes a `str` property named `code` to `CodeProperty` when the node's metadata declares an inline code property (the same `hasCodeProperty` predicate `CodeBody` routes on). Other callers are unchanged.
- **`web/src/components/node/PropertyInput.tsx`** — passes `nodeType` to the resolver and includes `CodeProperty` in the set that offsets the canvas reset button for top-right actions.
- **`web/src/components/properties/__tests__/CodeProperty.test.tsx`** (new) — renders with the Monaco stub: language selection, edits written back through `onChange`, external-write sync, and the connected-input path.

Property writes still flow through `PropertyInput.onChange`, so the Code node's input/output inference from the edited body is unchanged.

## Verification

- `npx tsc --noEmit` (web) — clean
- `npx eslint` on the changed files — no errors
- `npx jest src/components/node src/components/properties` — 837 passed, 3 skipped

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtfurV3TjSNfTgEfkm8oZ7)_