### PR TITLE
Open settings as a workspace tab, drop the settings route

### DIFF
--- a/web/src/components/menus/SettingsMenu.tsx
+++ b/web/src/components/menus/SettingsMenu.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @emotion/react */
 // Full-page settings (formerly a Dialog).
 import React, { memo, useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
 import {
   useMediaQuery
 } from "@mui/material";
@@ -50,6 +49,10 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import SettingsSidebar from "./SettingsSidebar";
 import useSecretsStore from "../../stores/SecretsStore";
 import { settingsStyles } from "./settingsMenuStyles";
+import {
+  useSettingsPageStore,
+  type SettingsSection
+} from "../../stores/SettingsPageStore";
 
 // Tab indices. Models, Collections, Workspaces, and the Package Manager now
 // live as standalone full-screen pages reachable from the logo menu.
@@ -57,6 +60,21 @@ const TAB_GENERAL = 0;
 const TAB_API_KEYS = 1;
 const TAB_INTEGRATIONS = 2;
 const aboutTabIndex = 3;
+
+// Section names are the public handle — `openSettingsTab("providers")` — so a
+// caller never depends on the tab order.
+const SECTION_TO_TAB: Record<SettingsSection, number> = {
+  general: TAB_GENERAL,
+  providers: TAB_API_KEYS,
+  integrations: TAB_INTEGRATIONS,
+  about: aboutTabIndex
+};
+const TAB_TO_SECTION: SettingsSection[] = [
+  "general",
+  "providers",
+  "integrations",
+  "about"
+];
 
 const settingsDocsTopic = (tab: number): DocsTopic =>
   tab === TAB_API_KEYS ? "providers" : "configuration";
@@ -162,7 +180,8 @@ const SearchItem = React.memo(function SearchItem({
 });
 
 function SettingsPage() {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const section = useSettingsPageStore((state) => state.section);
+  const setSection = useSettingsPageStore((state) => state.setSection);
   const session = useAuth((state) => state.session);
 
   const tabSubtitle = (tab: number): string => {
@@ -178,11 +197,7 @@ function SettingsPage() {
     }
   };
 
-  const settingsTab = useMemo(() => {
-    const raw = Number(searchParams.get("tab") ?? 0);
-    if (Number.isNaN(raw)) return 0;
-    return Math.min(aboutTabIndex, Math.max(0, raw));
-  }, [searchParams]);
+  const settingsTab = SECTION_TO_TAB[section];
 
   const setGridSnap = useSettingsStore((state) => state.setGridSnap);
   const setConnectionSnap = useSettingsStore(
@@ -339,13 +354,11 @@ function SettingsPage() {
 
   const handleTabChange = useCallback(
     (_event: React.SyntheticEvent, newValue: number) => {
-      const next = new URLSearchParams(searchParams);
-      next.set("tab", String(newValue));
-      setSearchParams(next, { replace: true });
+      setSection(TAB_TO_SECTION[newValue] ?? "general");
       setApiSearchTerm("");
       setGeneralSearchTerm("");
     },
-    [searchParams, setSearchParams]
+    [setSection]
   );
 
   // Memoized handlers for settings controls to prevent re-renders

--- a/web/src/components/model_menu/ModelList.tsx
+++ b/web/src/components/model_menu/ModelList.tsx
@@ -32,7 +32,7 @@ import type { UnifiedModel } from "../../stores/ApiTypes";
 
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useModelAvailability } from "../../hooks/useModelAvailability";
-import { useNavigate } from "react-router-dom";
+import { openSettingsTab } from "../workspace/openPageTab";
 
 import type { Theme } from "@mui/material/styles";
 
@@ -181,12 +181,11 @@ function ModelList<TModel extends ModelSelectorModel>({
   const isFavorite = useModelPreferencesStore((s) => s.isFavorite);
   const getAvailability = useModelAvailability();
   const theme = useTheme();
-  const navigate = useNavigate();
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const handleOpenSettings = useCallback(() => {
-    navigate("/settings?tab=1");
-  }, [navigate]);
+    openSettingsTab("providers");
+  }, []);
 
   const badgeStyle = useMemo<React.CSSProperties>(() => ({
     flex: "0 0 auto",

--- a/web/src/components/node/RequiredSettingsWarning.tsx
+++ b/web/src/components/node/RequiredSettingsWarning.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
 import { Text, EditorButton } from "../ui_primitives";
+import { openSettingsTab } from "../workspace/openPageTab";
 import { useRequiredSettings } from "../../hooks/useRequiredSettings";
 
 interface RequiredSettingsWarningProps {
@@ -9,16 +9,11 @@ interface RequiredSettingsWarningProps {
 
 const RequiredSettingsWarning: React.FC<RequiredSettingsWarningProps> = React.memo(
   ({ nodeType }) => {
-    const navigate = useNavigate();
     const missingSettings = useRequiredSettings(nodeType);
 
     const handleOpenSettings = useCallback(() => {
-      const searchKey = missingSettings.length > 0 ? missingSettings[0] : undefined;
-      const qs = searchKey
-        ? `?tab=1&q=${encodeURIComponent(searchKey)}`
-        : "?tab=1";
-      navigate(`/settings${qs}`);
-    }, [navigate, missingSettings]);
+      openSettingsTab("providers");
+    }, []);
 
     const content = useMemo(() => {
       if (missingSettings.length === 0) {

--- a/web/src/components/node_menu/OptionalPacksSection.tsx
+++ b/web/src/components/node_menu/OptionalPacksSection.tsx
@@ -23,6 +23,7 @@ import { memo, useCallback, useMemo, useState, type MouseEvent } from "react";
 import Inventory2OutlinedIcon from "@mui/icons-material/Inventory2Outlined";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import { useNavigate } from "react-router-dom";
+import { openSettingsTab } from "../workspace/openPageTab";
 import { useShallow } from "zustand/react/shallow";
 
 import {
@@ -196,8 +197,8 @@ const OptionalPacksSection = () => {
   const openApiKeys = useCallback(() => {
     setAnchorEl(null);
     closeNodeMenu();
-    navigate("/settings?tab=1");
-  }, [navigate, closeNodeMenu]);
+    openSettingsTab("providers");
+  }, [closeNodeMenu]);
 
   const handleManagePacks = useCallback(() => {
     setAnchorEl(null);

--- a/web/src/components/panels/RailAppMenu.tsx
+++ b/web/src/components/panels/RailAppMenu.tsx
@@ -22,11 +22,8 @@ import { isProduction } from "../../lib/env";
 import { useCombo } from "../../stores/KeyPressedStore";
 import { useAppHeaderStore } from "../../stores/AppHeaderStore";
 import { useModelDownloadStore } from "../../stores/ModelDownloadStore";
-import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
-import {
-  PAGE_TAB_TITLES,
-  type PageTabKey
-} from "../workspace/pageTabs";
+import { openPageTab, openSettingsTab } from "../workspace/openPageTab";
+import { type PageTabKey } from "../workspace/pageTabs";
 import PermMediaOutlinedIcon from "@mui/icons-material/PermMediaOutlined";
 import Help from "../content/Help/Help";
 import Logo from "../Logo";
@@ -104,28 +101,29 @@ const RailAppMenu: React.FC<RailAppMenuProps> = ({ onAction }) => {
   useCombo(["Meta", "/"], handleShowKeyboardShortcuts);
   useCombo(["Control", "/"], handleShowKeyboardShortcuts);
 
+  // Cmd+, (Mac) or Ctrl+, (Win/Linux) opens Settings as a workspace tab. The
+  // rail is mounted for every surface, so the shortcut works on any tab — not
+  // only while the node editor has focus.
+  const handleOpenSettingsShortcut = useCallback(() => {
+    openSettingsTab();
+  }, []);
+  useCombo(["Meta", ","], handleOpenSettingsShortcut);
+  useCombo(["Control", ","], handleOpenSettingsShortcut);
+
   const close = useCallback(() => setOpen(false), []);
   // Closing after an item was picked, as opposed to dismissing the popover.
   const finish = useCallback(() => {
     setOpen(false);
     onAction?.();
   }, [onAction]);
-  const openTab = useWorkspaceTabsStore((state) => state.openTab);
-
   // Open an app page (Settings, Costs, …) as a workspace tab and focus the
   // workspace, instead of navigating to a dedicated route.
   const openPage = useCallback(
     (key: PageTabKey) => {
-      openTab({
-        type: "page",
-        ref: key,
-        mode: "view",
-        title: PAGE_TAB_TITLES[key]
-      });
-      navigate("/workspace");
+      openPageTab(key);
       finish();
     },
-    [openTab, navigate, finish]
+    [finish]
   );
 
   const goDashboard = useCallback(() => {

--- a/web/src/components/panels/__tests__/RailAppMenu.test.tsx
+++ b/web/src/components/panels/__tests__/RailAppMenu.test.tsx
@@ -22,6 +22,12 @@ jest.mock("react-router-dom", () => ({
   useNavigate: () => mockNavigate
 }));
 
+// Page tabs are opened through the router singleton, which no test registers.
+const mockNavigateTo = jest.fn();
+jest.mock("../../../lib/appNavigation", () => ({
+  navigateTo: (to: string) => mockNavigateTo(to)
+}));
+
 jest.mock("../../content/Help/Help", () => () => null);
 jest.mock("../../Logo", () => () => <span data-testid="logo" />);
 
@@ -51,6 +57,7 @@ const renderMenu = (onAction?: () => void) =>
 
 beforeEach(() => {
   mockNavigate.mockClear();
+  mockNavigateTo.mockClear();
   useWorkspaceTabsStore.setState({ tabs: [], activeTabId: null });
 });
 
@@ -73,7 +80,7 @@ it("opens Settings as a page tab and focuses the workspace", async () => {
     })
   ]);
   expect(activeTabId).toBe(expectedId);
-  expect(mockNavigate).toHaveBeenCalledWith("/workspace");
+  expect(mockNavigateTo).toHaveBeenCalledWith("/workspace");
 });
 
 it("keeps Dashboard on its route (not a tab)", async () => {

--- a/web/src/components/portal/Portal.tsx
+++ b/web/src/components/portal/Portal.tsx
@@ -20,6 +20,7 @@ import DashboardTutorials from "./DashboardTutorials";
 import DashboardWorkflows from "./DashboardWorkflows";
 import DashboardFooter from "./DashboardFooter";
 import { useStartTrackChat } from "../../hooks/useStartTrackChat";
+import { openSettingsTab } from "../workspace/openPageTab";
 import { WELCOME_TRACKS, type WelcomeTrackId } from "./welcomeTracks";
 import { Box, SPACING, getSpacingPx } from "../ui_primitives";
 
@@ -103,8 +104,8 @@ const Portal: React.FC = () => {
   );
 
   const handleOpenSettings = useCallback(() => {
-    navigate("/settings");
-  }, [navigate]);
+    openSettingsTab();
+  }, []);
 
   // Already on the dashboard, so "browse templates" is a scroll, not a route
   // change. The templates section owns the anchor id.

--- a/web/src/components/provider_onboarding/ProviderOnboardingDialog.tsx
+++ b/web/src/components/provider_onboarding/ProviderOnboardingDialog.tsx
@@ -22,7 +22,7 @@ import {
 } from "../ui_primitives";
 import { useSecrets } from "../../hooks/useSecrets";
 import useProviderOnboardingStore from "../../stores/ProviderOnboardingStore";
-import { navigateTo } from "../../lib/appNavigation";
+import { openSettingsTab } from "../workspace/openPageTab";
 import ollamaIcon from "../../icons/providers/ollama.svg";
 import ProviderOnboardingCard from "./ProviderOnboardingCard";
 import CostGuide from "./CostGuide";
@@ -106,7 +106,7 @@ const ProviderOnboardingDialog: React.FC = () => {
 
   const handleOpenSettings = useCallback(() => {
     dismiss();
-    navigateTo("/settings?tab=1");
+    openSettingsTab("providers");
   }, [dismiss]);
 
   if (!open) {

--- a/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
+++ b/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
@@ -9,6 +9,8 @@ import ProviderOnboardingDialog from "../ProviderOnboardingDialog";
 import useProviderOnboardingStore from "../../../stores/ProviderOnboardingStore";
 import { useSecrets } from "../../../hooks/useSecrets";
 import { navigateTo } from "../../../lib/appNavigation";
+import { useWorkspaceTabsStore } from "../../../stores/WorkspaceTabsStore";
+import { useSettingsPageStore } from "../../../stores/SettingsPageStore";
 import { useOAuthConnection } from "../../../hooks/useOAuthConnection";
 import useSecretsStore from "../../../stores/SecretsStore";
 import { useNotificationStore } from "../../../stores/NotificationStore";
@@ -82,12 +84,17 @@ describe("ProviderOnboardingDialog", () => {
     expect(screen.getByText("Connect an AI provider")).toBeInTheDocument();
   });
 
-  it("navigates to settings via the router singleton, not useNavigate", async () => {
+  it("opens the settings tab via the router singleton, not useNavigate", async () => {
+    useWorkspaceTabsStore.setState({ tabs: [], activeTabId: null });
     renderDialog();
     await userEvent.click(
       screen.getByRole("button", { name: /see all providers in settings/i })
     );
     expect(dismiss).toHaveBeenCalledTimes(1);
-    expect(mockNavigateTo).toHaveBeenCalledWith("/settings?tab=1");
+    expect(mockNavigateTo).toHaveBeenCalledWith("/workspace");
+    expect(useWorkspaceTabsStore.getState().tabs).toEqual([
+      expect.objectContaining({ type: "page", ref: "settings" })
+    ]);
+    expect(useSettingsPageStore.getState().section).toBe("providers");
   });
 });

--- a/web/src/components/workspace/RouteRedirects.tsx
+++ b/web/src/components/workspace/RouteRedirects.tsx
@@ -1,8 +1,13 @@
 import { useEffect } from "react";
-import { Navigate, useParams } from "react-router-dom";
+import { Navigate, useParams, useSearchParams } from "react-router-dom";
 
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import { usePanelStore } from "../../stores/PanelStore";
+import {
+  SETTINGS_SECTIONS,
+  useSettingsPageStore,
+  type SettingsSection
+} from "../../stores/SettingsPageStore";
 
 /**
  * Legacy `/editor/:workflow` links now resolve into the workspace: open the
@@ -23,6 +28,27 @@ export const WorkflowEditorRedirect = () => {
       openTab({ type: "workflow", ref, mode: "edit" });
     }
   }, [ref, openTab]);
+
+  return <Navigate to="/workspace" replace />;
+};
+
+/**
+ * Settings used to be its own page at `/settings?tab=<n>`. It is a workspace
+ * tab now, so the old links — Electron deep links, bookmarks — open that tab
+ * and land in the workspace. The legacy tab index maps back to a section.
+ */
+export const SettingsRedirect = () => {
+  const [searchParams] = useSearchParams();
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const setSection = useSettingsPageStore((state) => state.setSection);
+  const legacyTab = Number(searchParams.get("tab"));
+
+  useEffect(() => {
+    const section: SettingsSection =
+      SETTINGS_SECTIONS[legacyTab] ?? "general";
+    setSection(section);
+    openTab({ type: "page", ref: "settings", mode: "view", title: "Settings" });
+  }, [legacyTab, openTab, setSection]);
 
   return <Navigate to="/workspace" replace />;
 };

--- a/web/src/components/workspace/__tests__/SettingsRedirect.test.tsx
+++ b/web/src/components/workspace/__tests__/SettingsRedirect.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { SettingsRedirect } from "../RouteRedirects";
+import { useWorkspaceTabsStore, tabId } from "../../../stores/WorkspaceTabsStore";
+import { useSettingsPageStore } from "../../../stores/SettingsPageStore";
+
+const renderAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/settings" element={<SettingsRedirect />} />
+        <Route path="/workspace" element={<div>workspace</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  useWorkspaceTabsStore.setState({ tabs: [], activeTabId: null });
+  useSettingsPageStore.setState({ section: "general" });
+});
+
+it("opens the settings tab and lands in the workspace", () => {
+  renderAt("/settings");
+
+  expect(screen.getByText("workspace")).toBeInTheDocument();
+  expect(useWorkspaceTabsStore.getState().activeTabId).toBe(
+    tabId("page", "settings")
+  );
+  expect(useSettingsPageStore.getState().section).toBe("general");
+});
+
+it("maps the legacy tab index onto a section", () => {
+  renderAt("/settings?tab=1");
+
+  expect(useSettingsPageStore.getState().section).toBe("providers");
+});
+
+it("falls back to general for an out-of-range tab index", () => {
+  renderAt("/settings?tab=5");
+
+  expect(useSettingsPageStore.getState().section).toBe("general");
+});

--- a/web/src/components/workspace/__tests__/openPageTab.test.ts
+++ b/web/src/components/workspace/__tests__/openPageTab.test.ts
@@ -1,0 +1,57 @@
+import { openPageTab, openSettingsTab } from "../openPageTab";
+import { useWorkspaceTabsStore, tabId } from "../../../stores/WorkspaceTabsStore";
+import { useSettingsPageStore } from "../../../stores/SettingsPageStore";
+
+const mockNavigateTo = jest.fn();
+jest.mock("../../../lib/appNavigation", () => ({
+  navigateTo: (to: string) => mockNavigateTo(to)
+}));
+
+beforeEach(() => {
+  mockNavigateTo.mockClear();
+  useWorkspaceTabsStore.setState({ tabs: [], activeTabId: null });
+  useSettingsPageStore.setState({ section: "general" });
+});
+
+describe("openPageTab", () => {
+  it("opens the page as a tab and focuses the workspace", () => {
+    openPageTab("costs");
+
+    const { tabs, activeTabId } = useWorkspaceTabsStore.getState();
+    expect(tabs).toEqual([
+      expect.objectContaining({
+        type: "page",
+        ref: "costs",
+        mode: "view",
+        title: "Costs"
+      })
+    ]);
+    expect(activeTabId).toBe(tabId("page", "costs"));
+    expect(mockNavigateTo).toHaveBeenCalledWith("/workspace");
+  });
+});
+
+describe("openSettingsTab", () => {
+  it("defaults to the general section", () => {
+    openSettingsTab();
+
+    expect(useSettingsPageStore.getState().section).toBe("general");
+    expect(useWorkspaceTabsStore.getState().activeTabId).toBe(
+      tabId("page", "settings")
+    );
+  });
+
+  it("selects the requested section before opening the tab", () => {
+    openSettingsTab("providers");
+
+    expect(useSettingsPageStore.getState().section).toBe("providers");
+  });
+
+  it("focuses the existing tab rather than duplicating it", () => {
+    openSettingsTab();
+    openSettingsTab("integrations");
+
+    expect(useWorkspaceTabsStore.getState().tabs).toHaveLength(1);
+    expect(useSettingsPageStore.getState().section).toBe("integrations");
+  });
+});

--- a/web/src/components/workspace/openPageTab.ts
+++ b/web/src/components/workspace/openPageTab.ts
@@ -1,0 +1,29 @@
+// Open an app page (Settings, Costs, Model Manager, …) as a workspace tab.
+// Works from any context — including components mounted outside the router
+// tree — because it drives the tab store and the router singleton directly.
+
+import { navigateTo } from "../../lib/appNavigation";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import {
+  useSettingsPageStore,
+  type SettingsSection
+} from "../../stores/SettingsPageStore";
+import { PAGE_TAB_TITLES, type PageTabKey } from "./pageTabs";
+
+export const openPageTab = (key: PageTabKey): void => {
+  useWorkspaceTabsStore.getState().openTab({
+    type: "page",
+    ref: key,
+    mode: "view",
+    title: PAGE_TAB_TITLES[key]
+  });
+  navigateTo("/workspace");
+};
+
+/** Open Settings, optionally on a given section. */
+export const openSettingsTab = (
+  section: SettingsSection = "general"
+): void => {
+  useSettingsPageStore.getState().setSection(section);
+  openPageTab("settings");
+};

--- a/web/src/components/workspaces/WorkspaceTree.tsx
+++ b/web/src/components/workspaces/WorkspaceTree.tsx
@@ -16,7 +16,7 @@ import AddIcon from "@mui/icons-material/Add";
 import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import { RefreshButton, SettingsButton } from "../ui_primitives";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
-import { useNavigate } from "react-router-dom";
+import { openPageTab } from "../workspace/openPageTab";
 import { useCurrentWorkspace } from "../../hooks/useCurrentWorkspace";
 import WorkspaceSelect from "./WorkspaceSelect";
 import PanelHeadline from "../ui/PanelHeadline";
@@ -286,7 +286,6 @@ const WorkspaceTree: React.FC = () => {
     }))
   );
 
-  const navigate = useNavigate();
 
   const currentWorkflow = getCurrentWorkflow();
   const workflowId = currentWorkflowId ?? currentWorkflow?.id;
@@ -381,9 +380,10 @@ const WorkspaceTree: React.FC = () => {
     refetchFiles();
   }, [refetchFiles]);
 
+  // Workspaces left the settings page — they are their own workspace tab now.
   const handleManageWorkspace = useCallback(() => {
-    navigate("/settings?tab=5");
-  }, [navigate]);
+    openPageTab("workspaces");
+  }, []);
 
   const handleTreeDoubleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     const target = e.target as HTMLElement;

--- a/web/src/config/shortcuts.ts
+++ b/web/src/config/shortcuts.ts
@@ -708,8 +708,9 @@ export const NODE_EDITOR_SHORTCUTS: Shortcut[] = [
     title: "Open Settings",
     slug: "openSettings",
     keyCombo: ["Control", ","],
+    keyComboMac: ["Meta", ","],
     category: "editor",
-    description: "Open application settings",
+    description: "Open settings in a workspace tab",
     registerCombo: true
   },
 

--- a/web/src/hooks/useNodeEditorShortcuts.ts
+++ b/web/src/hooks/useNodeEditorShortcuts.ts
@@ -14,6 +14,7 @@ import useNodeMenuStore from "../stores/NodeMenuStore";
 import { useWorkflowManager } from "../contexts/WorkflowManagerContext";
 import { useWorkspaceTabsStore } from "../stores/WorkspaceTabsStore";
 import { useNavigate } from "react-router-dom";
+import { openSettingsTab } from "../components/workspace/openPageTab";
 import { useFitView } from "./useFitView";
 import { useMenuHandler } from "./useIpcRenderer";
 import { useReactFlow } from "@xyflow/react";
@@ -502,7 +503,7 @@ export const useNodeEditorShortcuts = (
       toggleWorkflowSettings: { callback: handleWorkflowSettingsToggle },
       showKeyboardShortcuts: { callback: handleShowKeyboardShortcuts },
       openSettings: {
-        callback: () => navigate("/settings")
+        callback: () => openSettingsTab()
       },
       saveWorkflow: { callback: handleSave },
       saveExample: { callback: handleSaveExample },

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -124,9 +124,6 @@ const CodeEditorDebug = React.lazy(
 const ComponentPreview = React.lazy(
   () => import("./components/preview/ComponentPreview")
 );
-const SettingsPage = React.lazy(
-  () => import("./components/menus/SettingsMenu")
-);
 const TimelineEditor = React.lazy(
   () => import("./components/timeline/TimelineEditor")
 );
@@ -150,8 +147,10 @@ const StudioAccountPage = React.lazy(
 );
 import {
   ChatThreadRedirect,
+  SettingsRedirect,
   WorkflowEditorRedirect
 } from "./components/workspace/RouteRedirects";
+import { openSettingsTab } from "./components/workspace/openPageTab";
 const LegacyAppRedirect = React.lazy(
   () => import("./components/applications/LegacyAppRedirect")
 );
@@ -234,19 +233,11 @@ function getRoutes() {
       element: <Navigate to="/workspace" replace />
     },
     {
+      // Settings is a workspace tab now; the old route only redirects.
       path: "/settings",
       element: (
         <ProtectedRoute>
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              width: "100%",
-              height: "100%"
-            }}
-          >
-            <SettingsPage />
-          </div>
+          <SettingsRedirect />
         </ProtectedRoute>
       )
     },
@@ -544,14 +535,15 @@ if (!rootElement) throw new Error("Root element #root not found");
 const root = ReactDOM.createRoot(rootElement);
 
 /**
- * Routes Electron menu/tray "Settings" actions to the in-app settings page.
+ * Routes Electron menu/tray "Settings" actions to the in-app settings tab.
  * The desktop shell sends an `openSettings` menu event (instead of opening a
- * separate window); navigating via the router singleton works from any route.
+ * separate window); the tab opens and the router singleton focuses the
+ * workspace, which works from any route.
  */
 const MenuNavigationBridge = () => {
   const handleMenuEvent = useCallback((data: MenuEventData) => {
     if (data.type === "openSettings") {
-      void router.navigate("/settings");
+      openSettingsTab();
     }
   }, []);
   useMenuHandler(handleMenuEvent);

--- a/web/src/stores/SettingsPageStore.ts
+++ b/web/src/stores/SettingsPageStore.ts
@@ -1,0 +1,28 @@
+// SettingsPageStore.ts
+// -----------------------------------------------------------------
+// Which section the Settings page shows. Settings used to be a route
+// and kept the section in `?tab=<n>`; it is a workspace tab now, so
+// the selection lives here — a caller that wants a specific section
+// (e.g. "open the provider keys") sets it before opening the tab.
+// -----------------------------------------------------------------
+
+import { create } from "zustand";
+
+export const SETTINGS_SECTIONS = [
+  "general",
+  "providers",
+  "integrations",
+  "about"
+] as const;
+
+export type SettingsSection = (typeof SETTINGS_SECTIONS)[number];
+
+interface SettingsPageState {
+  section: SettingsSection;
+  setSection: (section: SettingsSection) => void;
+}
+
+export const useSettingsPageStore = create<SettingsPageState>((set) => ({
+  section: "general",
+  setSection: (section) => set({ section })
+}));

--- a/web/tests/visual/settings.spec.ts
+++ b/web/tests/visual/settings.spec.ts
@@ -7,8 +7,10 @@
  *   - General tab (editor / appearance / default models)
  *   - About tab
  *
- * Settings is a routed page (not a modal). Tabs are MUI Tab elements labelled
- * "General", "API Keys", "Integrations", "About".
+ * Settings opens as a workspace tab, so these captures include the workspace
+ * shell around it. `/settings` still redirects there, which is what the tests
+ * navigate to. Tabs are MUI Tab elements labelled "General", "API Keys",
+ * "Integrations", "About".
  */
 
 import { test, expect, type Page } from "@playwright/test";


### PR DESCRIPTION
Cmd+, (Ctrl+, on Windows/Linux) opens Settings as a workspace tab, and the `/settings` page route is gone.

## What changed

**The shortcut works everywhere.** `openSettings` was registered only by the node editor, so it fired only while a workflow tab had focus. The combo is now also registered on the rail app menu — mounted for every surface — next to the existing Cmd+/ binding. The shortcut config gets an explicit `keyComboMac`.

**Settings is a tab, not a route.** The `/settings` path no longer renders a page; it redirects, opening the settings tab and landing in the workspace. Old bookmarks and Electron deep links (`#/settings?tab=1`) still reach the right section — the legacy tab index maps back onto a section name.

**The section moved out of the URL.** Settings kept its selected section in `?tab=<n>`, which a tab has no place for. It lives in `SettingsPageStore` now and callers name it: `openSettingsTab("providers")` instead of `navigate("/settings?tab=1")`.

**One helper for page tabs.** `openPageTab(key)` / `openSettingsTab(section?)` drive the tab store and the router singleton, so they work outside the router tree too — the provider onboarding dialog and the Electron menu bridge both use them. The rail menu's own `openPage` now calls it instead of duplicating the logic.

**One fix along the way.** "Manage workspace" in the workspace tree pointed at `?tab=5`, a settings section that no longer exists (it clamped to About). It opens the Workspaces tab.

## Call sites updated

Portal, WorkspaceTree, ModelList, OptionalPacksSection, ProviderOnboardingDialog, RequiredSettingsWarning, the node editor shortcut, and the Electron menu bridge. `q=<key>` on the old link was read by nothing, so it is dropped.

## Verification

- `npm run typecheck` — no new errors (the remaining ones are pre-existing: unbuilt `packages/` and one `useWorkflowCostEstimate.ts` implicit-any).
- `npm run lint` — clean.
- `npx jest` in `web/` — 1087 suites, 12656 tests pass. New tests cover `openPageTab`/`openSettingsTab` and the legacy `/settings` redirect; the RailAppMenu and ProviderOnboardingDialog tests were updated to the tab behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMdHtyrX3PuCBH7NHE5K8y)_