### PR TITLE
Tidy the media composer layout on phones

### DIFF
--- a/web/src/components/chat/composer/MediaChatComposer.styles.ts
+++ b/web/src/components/chat/composer/MediaChatComposer.styles.ts
@@ -218,20 +218,47 @@ export const createMediaComposerStyles = (theme: Theme) =>
     },
 
     // Mobile: the chip cluster plus the buttons never fit on one phone-width
-    // line, so the row wraps and the card sheds padding to keep the textarea
-    // full-width.
+    // line, so the card sheds padding and the chips scroll sideways instead of
+    // wrapping into a block that pushes the composer up under the keyboard.
     [theme.breakpoints.down("sm")]: {
       ".media-compose-card": {
         padding: `${theme.spacing(1.5)} ${theme.spacing(1.5)} ${theme.spacing(1)}`,
         gap: theme.spacing(1)
       },
       ".media-compose-card textarea.media-compose-input": {
-        padding: `${theme.spacing(1)} ${theme.spacing(1)}`
+        padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+        // The keyboard takes most of the screen — cap the growth well below
+        // the desktop 220 (matches MOBILE_TEXTAREA_MAX_HEIGHT).
+        maxHeight: 140
       },
       ".media-chip-row": {
         flexWrap: "wrap",
         rowGap: theme.spacing(1),
         padding: 0
+      },
+      // One scrolling strip, never a wrapped block: chips keep their touch
+      // size and the row keeps its height whatever the mode puts in it.
+      ".media-chip-main": {
+        flexWrap: "nowrap",
+        overflowX: "auto",
+        overflowY: "hidden",
+        scrollbarWidth: "none",
+        WebkitOverflowScrolling: "touch",
+        "&::-webkit-scrollbar": {
+          display: "none"
+        },
+        "> *": {
+          flexShrink: 0
+        }
+      },
+      ".media-chip-row .media-control-chip": {
+        height: 38
+      },
+      // Narrower than the desktop pill so the chip strip keeps most of the
+      // line, and tall enough to stay a comfortable touch target.
+      ".media-generate-btn": {
+        height: 40,
+        padding: `0 ${theme.spacing(2)}`
       },
       // With host workflow actions (the canvas dock), give the chips their own
       // full line so every button — send plus the workflow actions — lands
@@ -247,11 +274,6 @@ export const createMediaComposerStyles = (theme: Theme) =>
       },
       ".media-chip-row.has-trailing .media-primary-action": {
         order: 2
-      },
-      // No host actions (the chat panel): the lone send button shares the chip
-      // line, pinned to the right.
-      ".media-chip-row:not(.has-trailing) .media-primary-action": {
-        marginLeft: "auto"
       }
     }
   });

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -9,6 +9,7 @@ import React, {
   useState
 } from "react";
 import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import AspectRatioIcon from "@mui/icons-material/CropOriginal";
 import AppsIcon from "@mui/icons-material/Apps";
@@ -94,6 +95,11 @@ import { StopGenerationButton } from "./StopGenerationButton";
 import PermissionSelector from "./PermissionSelector";
 import { useElapsedTime } from "../../../hooks/useElapsedTime";
 import { useAutoFocusEnabled } from "../../../hooks/useAutoFocusEnabled";
+
+/** Textarea growth caps. The mobile one matches the composer stylesheet — on a
+ *  phone the keyboard already owns most of the screen. */
+const TEXTAREA_MAX_HEIGHT = 220;
+const MOBILE_TEXTAREA_MAX_HEIGHT = 140;
 
 function formatElapsed(seconds: number): string {
   if (seconds < 5) return "Starting…";
@@ -185,6 +191,7 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
   threadId
 }) => {
   const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const styles = useMemo(() => createMediaComposerStyles(theme), [theme]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const autoFocusEnabled = useAutoFocusEnabled();
@@ -327,11 +334,13 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     if (!el) {
       return;
     }
+    const max = isMobile
+      ? MOBILE_TEXTAREA_MAX_HEIGHT
+      : TEXTAREA_MAX_HEIGHT;
     el.style.height = "auto";
-    const next = Math.min(el.scrollHeight, 220);
-    el.style.height = `${next}px`;
-    el.style.overflowY = el.scrollHeight > 220 ? "auto" : "hidden";
-  }, []);
+    el.style.height = `${Math.min(el.scrollHeight, max)}px`;
+    el.style.overflowY = el.scrollHeight > max ? "auto" : "hidden";
+  }, [isMobile]);
 
   useLayoutEffect(() => {
     adjustHeight();
@@ -494,19 +503,29 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
       return placeholderOverride;
     }
     if (isPi) {
-      return "Message the Pi agent — it works in your workspace…";
+      return isMobile
+        ? "Message the Pi agent…"
+        : "Message the Pi agent — it works in your workspace…";
     }
     if (mode === "image") {
-      return "Describe the image you want to generate…";
+      return isMobile
+        ? "Describe an image…"
+        : "Describe the image you want to generate…";
     }
     if (mode === "image_edit") {
-      return "Describe the edits to apply to the dropped image…";
+      return isMobile
+        ? "Describe the edits…"
+        : "Describe the edits to apply to the dropped image…";
     }
     if (mode === "video") {
-      return "Describe your video… like a man drinking a cup of coffee…";
+      return isMobile
+        ? "Describe a video…"
+        : "Describe your video… like a man drinking a cup of coffee…";
     }
     if (mode === "image_to_video") {
-      return "Describe how the dropped image should animate…";
+      return isMobile
+        ? "Describe the animation…"
+        : "Describe how the dropped image should animate…";
     }
     if (mode === "audio") {
       return "Type the text you want spoken…";
@@ -523,8 +542,10 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     if (mode === "motion_control") {
       return "Describe the motion…";
     }
-    return "Continue the thread — or type @ to add an asset…";
-  }, [mode, isPi, placeholderOverride]);
+    return isMobile
+      ? "Message… or @ to add an asset"
+      : "Continue the thread — or type @ to add an asset…";
+  }, [mode, isPi, isMobile, placeholderOverride]);
 
   const isMediaMode =
     mode === "image" ||


### PR DESCRIPTION
On a phone the composer's chip cluster wrapped into a ragged block, which left the send button — or, during a run, the elapsed timer and stop button — stranded in the middle of the wrapped chips, and grew the card upward under the keyboard.

## Changes

`web/src/components/chat/composer/MediaChatComposer.styles.ts`
- Under `sm`, the chip cluster is one horizontally scrolling strip (`flex-wrap: nowrap`, `overflow-x: auto`, scrollbar hidden, children `flex-shrink: 0`) instead of a wrapping block. The row keeps a fixed height whatever the mode puts in it, and the send button stays pinned right because the strip still holds `flex: 1`.
- Chips are 38px tall on mobile and the Generate pill 40px with tighter horizontal padding — touch sizes, and a narrower pill leaves the strip most of the line. The circular chat-send button keeps its own 40px rule.
- Textarea `max-height` drops to 140px on mobile.

`web/src/components/chat/composer/MediaChatComposer.tsx`
- The JS auto-grow now clamps to the same 140px on mobile (220px elsewhere) via `useMediaQuery`; the two caps are named constants so the stylesheet and the inline height cannot drift apart and strand text below a clipped box.
- Mode placeholders get short mobile variants, the way `ChatComposer` already does, so they fit one line.

## Verification

`npx tsc --noEmit` reports nothing in `chat/composer` (the remaining errors are the pre-existing unbuilt `*-nodes` package imports in `browserRunnerCore.ts`). ESLint clean on both files. `CanvasMediaComposer.test.tsx` plus the chat component suites pass (84 tests). Not checked in a real browser at a phone viewport — the change is CSS-only in the `down("sm")` block plus the placeholder strings, so a visual pass on a phone is worth doing before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5V2X2fheHa1LcCry1Q1ZA)_