### PR TITLE
docs(code-nodes): design emit/output contract replacing return mechanics

### DIFF
--- a/docs/code-node-emit-design.md
+++ b/docs/code-node-emit-design.md
@@ -1,4 +1,4 @@
-# Code Node Output Interface: `emit` + final result
+# Code Node Output Interface: `emit` and `output`
 
 Status: proposed. Owner: code-nodes / node-sdk. 2026-08-12.
 
@@ -22,76 +22,89 @@ pay all of them:
    shape of every return path does. The validator must prove each declared
    output is set on each return path, and its own error message tells authors
    to avoid branching in code and use `nodetool.control.If` nodes instead —
-   the check is fighting normal code shape.
+   the check is fighting normal code shape. On top of the return-path
+   analysis sit two more inference layers: implicit-return wrapping of the
+   last expression (`wrapImplicitReturn`) and shape normalization of whatever
+   came back (`normalizeCodeOutput`).
 3. **There is no call an agent can reason about.** CodePlanner, `validate_code`
    and repair loops infer outputs from data shape. A function call —
-   `emit(name, value)` — is a fact an AST query answers directly.
+   `emit("x", value)` — is a fact an AST query answers directly.
 
 ## Guest contract
 
-Two additions to the sandbox API, both host-bridged:
+Outputs leave the body only through two host-bridged calls. The body's return
+value is **ignored** — `return` is what it is in JavaScript, control flow, and
+carries no output semantics.
 
 ```js
-await emit(name, value)   // stream one value to output handle `name`, now
-return { ...outputs }     // final result, unchanged
+await emit(name, value)     // stream one value to output handle `name`, now
+await output(name, value)   // set the final value of output handle `name`
 ```
 
 - **`emit(name, value)`** delivers `{ [name]: value }` downstream immediately,
-  while the body keeps running. It is `await`-able; awaiting it applies
-  backpressure (see Limits). `name` must be a string matching an output
-  handle; `value` goes through the same marshaling as a returned value
-  (JSON-safe data, media refs from `media.toImage` etc.).
-- **The final result stays `return`.** `return { sum, report }` posts one last
-  bag, exactly as today. A body that only emits may `return` nothing — with at
-  least one `emit` call in the body, the implicit `return {}` is valid and the
-  "output unset on a return path" rule no longer applies to emitted handles.
-- **`emit(bag)`** (single object argument) is accepted as sugar for one call
-  per key, so a legacy `yield {a, b}` maps 1:1.
+  while the body keeps running. Call it any number of times per handle.
+- **`output(name, value)`** records the handle's final value. It is delivered
+  when the body completes, all final values as one bag — so a downstream node
+  that consumes one value per handle sees exactly one. A second `output` call
+  for the same handle throws: a final value that changes is a bug, and a
+  deterministic error beats a silent last-write-wins.
+- Both are `await`-able; awaiting `emit` applies backpressure (see Limits).
+  `name` must be a string naming a declared output handle; values go through
+  the same marshaling as today (JSON-safe data, media refs from
+  `media.toImage` etc.).
+- **`return` does nothing to outputs.** Use it to exit early. A body may end
+  without calling either function only when the node declares no outputs.
 
-Not added: a separate `done(outputs)` function. `return` already is the final
-send, it is ordinary JavaScript, and one way to finish is easier to validate
-and to teach a model than two.
+The symmetry is the point: one verb for "here is an item" and one for "here is
+the answer", both explicit, both statically visible, nothing inferred from
+data shape.
+
+Deleted with the return contract: `hasReturnStatement` routing,
+`wrapImplicitReturn` (implicit return of the last expression), and
+`normalizeCodeOutput` (shape normalization). A body that today reads
+`inputs.a + inputs.b` becomes `await output("output", inputs.a + inputs.b)` —
+one line longer, zero inference.
 
 ### Semantics
 
 | Situation | Behavior |
 |---|---|
 | `emit("out", v)` | `{out: v}` streams downstream in call order, live |
-| `return {a: 1}` after emits | final bag `{a: 1}` is the last message |
-| `return` nothing, ≥1 `emit` in body | valid; run ends after last emit drains |
-| body with neither `emit` nor `return` value | implicit-return of last expression, unchanged |
-| `emit` to a name that is not a declared output | validation error before run; at runtime the call throws |
-| non-serializable value | same marshal rules as return (JSON deep-copy; media via `media.to*`) |
-| error thrown after emits | already-emitted values were delivered; the node fails; downstream consumers see the stream end in error, per normal kernel semantics |
-| timeout mid-stream | same as error: delivered emits stand, node fails |
+| `output("sum", v)` then body ends | final bag `{sum: v}` is the last message |
+| several `output` calls, distinct handles | one final bag carrying all of them |
+| `output` twice on one handle | throws in the guest |
+| `return v` with any value | `v` is discarded; control flow only |
+| body ends, declared output neither emitted nor output | validation error before run (see below); at runtime the handle stays empty |
+| `emit`/`output` to an undeclared name | validation error before run; at runtime the call throws |
+| non-serializable value | same marshal rules as today (JSON deep-copy; media via `media.to*`) |
+| error thrown after emits | already-emitted values were delivered; recorded `output` values are **not** posted; the node fails |
+| timeout mid-stream | same as error: delivered emits stand, finals dropped, node fails |
 
 ## Host mechanics
 
-`emit` joins `EXPOSED_BRIDGE_NAMES` in `packages/agents/src/js-sandbox.ts` as
-an **awaitable** host call (the `__callTool`/asyncified path, not the
-fire-and-forget `progress` path — values cannot be rate-limited or dropped).
+`emit` and `output` join `EXPOSED_BRIDGE_NAMES` in
+`packages/agents/src/js-sandbox.ts` as **awaitable** host calls (the
+asyncified path, not the fire-and-forget `progress` path — values cannot be
+rate-limited or dropped).
 
-`CodeNode.genProcess` becomes a pump instead of a replay:
+`process()` disappears from `CodeNode`; every body runs through one
+`genProcess` pump:
 
 ```
-start runInSandbox(...)          → promise P
+start runInSandbox(...)            → promise P
 while P pending or queue non-empty:
-    yield next bag from queue    (each emit pushed one)
-await P
-yield normalizeCodeOutput(P.result)   (unless empty)
+    yield next bag from queue      (each emit pushed one)
+await P                            (failure → throw, finals discarded)
+yield the collected output() bag   (unless empty)
 ```
 
 The queue is a bounded async channel owned by the node invocation. The host
 side of `emit` resolves the guest's promise only after its bag is accepted by
 the channel, so a fast producer awaiting `emit` blocks until the kernel has
-consumed — backpressure with no new kernel concept. A body that calls `emit`
-without `await` still works; the channel bound (below) caps unacknowledged
-values.
-
-Routing between `process` and `genProcess` follows a static probe,
-`hasEmitCall(code)` next to `hasReturnStatement` in `code-body.ts` — an AST
-check, not a regex, since `emit` is an ordinary call expression. Bodies with
-neither `emit` nor `yield` keep the single-shot `process` path.
+consumed — backpressure with no new kernel concept. `output` never queues; the
+host stores the value and posts the bag after `P` resolves. A body that calls
+`emit` without `await` still works; the channel bound (below) caps
+unacknowledged values.
 
 ### Limits
 
@@ -102,53 +115,73 @@ neither `emit` nor `yield` keep the single-shot `process` path.
 
 ## Validation and analysis
 
-`code-analysis.ts` / `code-node-validation.ts` (shared by the validator, the
-`submit_code` planner, and the editor) learn one fact: an `emit("x", …)` call
-marks output `x` as **streamed**.
+The return-path analysis in `code-node-validation.ts` — "every declared output
+set on every return path" — is deleted, not amended. Its replacement is one
+reachability rule over two call names:
 
-- A declared output must be either streamed (≥1 reachable `emit` with that
-  literal name) or set on every return path — the current rule, per handle.
-- `emit` with a non-literal first argument downgrades that body to a warning
-  ("cannot check emitted names statically") instead of failing it.
-- `emit` to a name not in the node's declared dynamic outputs is an error,
-  symmetric with the existing undeclared-`inputs.<name>` read check.
-- `emit` counts as a known global; a bare `emit` read stops being a
-  ReferenceError candidate.
+- Every declared output must have ≥1 reachable `emit` or `output` call with
+  that literal name. Branching freely is fine; the rule is per-handle
+  existence, not per-path coverage.
+- A call with a non-literal first argument downgrades that body to a warning
+  ("cannot check output names statically") instead of failing it.
+- A call naming an undeclared handle is an error, symmetric with the existing
+  undeclared-`inputs.<name>` read check.
+- `emit` and `output` count as known globals; a bare read of either stops
+  being a ReferenceError candidate.
+- A top-level `return <value>` (non-`undefined` argument) is a warning naming
+  the new contract, since under the old one it meant "these are the outputs".
+
+The analysis lives where it does today (`code-analysis.ts` /
+`code-node-validation.ts` in node-sdk), shared by the graph validator, the
+`submit_code` planner, and the editor.
 
 ## Surface parity
 
 - **`run_code` / `test_code`** (`packages/agents/src/capabilities/code.ts`):
   emitted values land in the existing `streamed` array as `{name, value}`
-  entries, in order; `test_code` cases may assert on `streamed` as well as
-  final outputs.
-- **CodePlanner / code-gen eval**: prompt and cases updated to prefer `emit`
-  for incremental output; the `code-gen` suite gains one streaming case.
+  entries, in order; final values land in `outputs`. `test_code` cases may
+  assert on both.
+- **CodePlanner / code-gen eval**: prompts and cases rewritten to the
+  emit/output contract; the `code-gen` suite gains one streaming case.
 - **Editor**: the Code node description and the assistant dialog prompt teach
-  `emit`; no UI change — streamed values render through the same
-  `node_update`/output messages every streaming node already produces.
-- **Docs**: `docs/javascript-sandbox.md` § Streaming rewritten around `emit`.
+  the two calls; no UI change — streamed values render through the same
+  messages every streaming node already produces.
+- **Docs**: `docs/javascript-sandbox.md` § Outputs and § Streaming rewritten.
 
 ## Backwards compatibility and migration
 
-- `return {}` bodies: unchanged, byte for byte.
-- `yield` bodies: keep working for one release. The legacy path is re-expressed
-  on top of the new one — the rewrite becomes `yield x` → `await emit(x)`
-  (bag form), which turns collect-and-replay into live streaming for free.
-  `validate_code` emits a deprecation warning naming `emit`.
-- After the deprecation window the `yield` rewrite and `hasYieldStatement`
-  routing are deleted; `yield` in a body becomes what it is in JavaScript — a
-  syntax error at top level.
+Removing the return contract breaks every existing body, so the old path
+stays executable for one release behind a per-body probe:
+
+- A body that calls `emit` or `output` runs on the new contract; its return
+  value is ignored.
+- A body that calls neither runs on the legacy path (return bag, implicit
+  return, `yield` replay), and `validate_code` emits a deprecation warning
+  naming the two calls. Saving such a node in the editor surfaces the same
+  warning.
+- The workflow migration is mechanical and shippable as a codemod on the
+  stored `code` string: `return {a, b}` → `await output("a", a); await
+  output("b", b); return;`, `yield x` → `await emit("output", x)`. The codemod
+  runs through `validate_code` on its own result and refuses any body it
+  cannot prove equivalent, leaving those for hand migration.
+- After the window, `hasReturnStatement`, `hasYieldStatement`,
+  `wrapImplicitReturn`, `normalizeCodeOutput`, the `yield_` rewrite, and the
+  return-path validator all delete.
 
 ## Testing
 
-- Unit (`packages/code-nodes`): emit ordering, emit+return interleave,
-  backpressure (producer faster than consumer), cap exceeded, error after
-  emit, `emit` to undeclared handle throws, legacy `yield` maps to live emits.
-- Analysis (`packages/node-sdk`): streamed-output satisfies the declared-output
-  rule; non-literal name warns; undeclared name errors. Each new check is
-  proven failable with an inverted fixture before landing.
-- Harness: a `test_code` case asserting `streamed` contents; one `code-gen`
-  eval case whose expectation requires incremental emission.
+- Unit (`packages/code-nodes`): emit ordering; emit+output interleave; finals
+  post as one bag; double `output` throws; `return` value discarded;
+  backpressure (producer faster than consumer); cap exceeded; error after
+  emit drops finals; undeclared handle throws; legacy body still runs and
+  warns.
+- Analysis (`packages/node-sdk`): reachable-call rule satisfies declared
+  outputs; non-literal name warns; undeclared name errors; top-level valued
+  `return` warns. Each new check is proven failable with an inverted fixture
+  before landing.
+- Codemod: round-trips the shipped example workflows' Code bodies and the
+  code-gen eval fixtures; every migrated body passes `validate_code` and
+  `test_code` with unchanged expectations.
 - End-to-end: a workflow where a Code node emits into a downstream collector
   runs under `nodetool debug` and shows per-item messages arriving before the
   node completes.
@@ -156,7 +189,7 @@ marks output `x` as **streamed**.
 ## Out of scope
 
 - CodeAct (`execute_code`) — its scripts act on the toolbelt and return one
-  result; streaming there is a separate question.
-- New kernel message types — emits ride the existing `genProcess` bag
-  semantics.
+  result; this contract is for *node* code.
+- New kernel message types — emits and the final bag ride the existing
+  `genProcess` semantics.
 - Per-output typing of emitted values beyond the handle's declared type.

--- a/docs/code-node-emit-design.md
+++ b/docs/code-node-emit-design.md
@@ -1,0 +1,162 @@
+# Code Node Output Interface: `emit` + final result
+
+Status: proposed. Owner: code-nodes / node-sdk. 2026-08-12.
+
+## Problem
+
+The Code node's output contract is a return value: "return an object — its
+keys become output handles" (`normalizeCodeOutput` in
+`packages/node-sdk/src/code-body.ts`). That shape has three costs, and agents
+pay all of them:
+
+1. **Streaming is replay, not streaming.** A body with `yield` runs through
+   `genProcess`, but the guest collects every yielded value into an array and
+   the host replays them after the run completes
+   (`packages/code-nodes/src/nodes/code-node.ts`, the `yield_` rewrite).
+   A loop that fetches 50 pages delivers nothing downstream until page 50.
+   The rewrite itself is a regex (`code.replace(/\byield\b/g, "yield_")`), so
+   the body the node runs is not the body the author wrote, and top-level
+   `yield` is not valid JavaScript — real parsers, including our own
+   `code-analysis.ts`, must special-case it.
+2. **The contract is implicit.** Nothing in the body names an output; the
+   shape of every return path does. The validator must prove each declared
+   output is set on each return path, and its own error message tells authors
+   to avoid branching in code and use `nodetool.control.If` nodes instead —
+   the check is fighting normal code shape.
+3. **There is no call an agent can reason about.** CodePlanner, `validate_code`
+   and repair loops infer outputs from data shape. A function call —
+   `emit(name, value)` — is a fact an AST query answers directly.
+
+## Guest contract
+
+Two additions to the sandbox API, both host-bridged:
+
+```js
+await emit(name, value)   // stream one value to output handle `name`, now
+return { ...outputs }     // final result, unchanged
+```
+
+- **`emit(name, value)`** delivers `{ [name]: value }` downstream immediately,
+  while the body keeps running. It is `await`-able; awaiting it applies
+  backpressure (see Limits). `name` must be a string matching an output
+  handle; `value` goes through the same marshaling as a returned value
+  (JSON-safe data, media refs from `media.toImage` etc.).
+- **The final result stays `return`.** `return { sum, report }` posts one last
+  bag, exactly as today. A body that only emits may `return` nothing — with at
+  least one `emit` call in the body, the implicit `return {}` is valid and the
+  "output unset on a return path" rule no longer applies to emitted handles.
+- **`emit(bag)`** (single object argument) is accepted as sugar for one call
+  per key, so a legacy `yield {a, b}` maps 1:1.
+
+Not added: a separate `done(outputs)` function. `return` already is the final
+send, it is ordinary JavaScript, and one way to finish is easier to validate
+and to teach a model than two.
+
+### Semantics
+
+| Situation | Behavior |
+|---|---|
+| `emit("out", v)` | `{out: v}` streams downstream in call order, live |
+| `return {a: 1}` after emits | final bag `{a: 1}` is the last message |
+| `return` nothing, ≥1 `emit` in body | valid; run ends after last emit drains |
+| body with neither `emit` nor `return` value | implicit-return of last expression, unchanged |
+| `emit` to a name that is not a declared output | validation error before run; at runtime the call throws |
+| non-serializable value | same marshal rules as return (JSON deep-copy; media via `media.to*`) |
+| error thrown after emits | already-emitted values were delivered; the node fails; downstream consumers see the stream end in error, per normal kernel semantics |
+| timeout mid-stream | same as error: delivered emits stand, node fails |
+
+## Host mechanics
+
+`emit` joins `EXPOSED_BRIDGE_NAMES` in `packages/agents/src/js-sandbox.ts` as
+an **awaitable** host call (the `__callTool`/asyncified path, not the
+fire-and-forget `progress` path — values cannot be rate-limited or dropped).
+
+`CodeNode.genProcess` becomes a pump instead of a replay:
+
+```
+start runInSandbox(...)          → promise P
+while P pending or queue non-empty:
+    yield next bag from queue    (each emit pushed one)
+await P
+yield normalizeCodeOutput(P.result)   (unless empty)
+```
+
+The queue is a bounded async channel owned by the node invocation. The host
+side of `emit` resolves the guest's promise only after its bag is accepted by
+the channel, so a fast producer awaiting `emit` blocks until the kernel has
+consumed — backpressure with no new kernel concept. A body that calls `emit`
+without `await` still works; the channel bound (below) caps unacknowledged
+values.
+
+Routing between `process` and `genProcess` follows a static probe,
+`hasEmitCall(code)` next to `hasReturnStatement` in `code-body.ts` — an AST
+check, not a regex, since `emit` is an ordinary call expression. Bodies with
+neither `emit` nor `yield` keep the single-shot `process` path.
+
+### Limits
+
+- Channel capacity: 64 pending bags. `emit` awaits drain beyond that.
+- Max emits per run: 10 000 (same spirit as `MAX_PROGRESS_CALLS`; exceeding
+  throws in the guest, naming the cap).
+- Per-value size: bounded by the existing sandbox marshal limits; no new cap.
+
+## Validation and analysis
+
+`code-analysis.ts` / `code-node-validation.ts` (shared by the validator, the
+`submit_code` planner, and the editor) learn one fact: an `emit("x", …)` call
+marks output `x` as **streamed**.
+
+- A declared output must be either streamed (≥1 reachable `emit` with that
+  literal name) or set on every return path — the current rule, per handle.
+- `emit` with a non-literal first argument downgrades that body to a warning
+  ("cannot check emitted names statically") instead of failing it.
+- `emit` to a name not in the node's declared dynamic outputs is an error,
+  symmetric with the existing undeclared-`inputs.<name>` read check.
+- `emit` counts as a known global; a bare `emit` read stops being a
+  ReferenceError candidate.
+
+## Surface parity
+
+- **`run_code` / `test_code`** (`packages/agents/src/capabilities/code.ts`):
+  emitted values land in the existing `streamed` array as `{name, value}`
+  entries, in order; `test_code` cases may assert on `streamed` as well as
+  final outputs.
+- **CodePlanner / code-gen eval**: prompt and cases updated to prefer `emit`
+  for incremental output; the `code-gen` suite gains one streaming case.
+- **Editor**: the Code node description and the assistant dialog prompt teach
+  `emit`; no UI change — streamed values render through the same
+  `node_update`/output messages every streaming node already produces.
+- **Docs**: `docs/javascript-sandbox.md` § Streaming rewritten around `emit`.
+
+## Backwards compatibility and migration
+
+- `return {}` bodies: unchanged, byte for byte.
+- `yield` bodies: keep working for one release. The legacy path is re-expressed
+  on top of the new one — the rewrite becomes `yield x` → `await emit(x)`
+  (bag form), which turns collect-and-replay into live streaming for free.
+  `validate_code` emits a deprecation warning naming `emit`.
+- After the deprecation window the `yield` rewrite and `hasYieldStatement`
+  routing are deleted; `yield` in a body becomes what it is in JavaScript — a
+  syntax error at top level.
+
+## Testing
+
+- Unit (`packages/code-nodes`): emit ordering, emit+return interleave,
+  backpressure (producer faster than consumer), cap exceeded, error after
+  emit, `emit` to undeclared handle throws, legacy `yield` maps to live emits.
+- Analysis (`packages/node-sdk`): streamed-output satisfies the declared-output
+  rule; non-literal name warns; undeclared name errors. Each new check is
+  proven failable with an inverted fixture before landing.
+- Harness: a `test_code` case asserting `streamed` contents; one `code-gen`
+  eval case whose expectation requires incremental emission.
+- End-to-end: a workflow where a Code node emits into a downstream collector
+  runs under `nodetool debug` and shows per-item messages arriving before the
+  node completes.
+
+## Out of scope
+
+- CodeAct (`execute_code`) — its scripts act on the toolbelt and return one
+  result; streaming there is a separate question.
+- New kernel message types — emits ride the existing `genProcess` bag
+  semantics.
+- Per-output typing of emitted values beyond the handle's declared type.

--- a/docs/javascript-sandbox.md
+++ b/docs/javascript-sandbox.md
@@ -326,8 +326,9 @@ return { kept, count: kept.length };
 - **Media inputs** arrive as refs. Read one with `media.bytes` / `media.text`,
   and return one built by `media.toDocument` / `toImage` / `toAudio` / `toVideo`.
 - **Streaming.** Code containing `yield` runs through `genProcess`: the yields
-  are collected in the guest and emitted one message at a time. A live
-  `emit(name, value)` replacement is designed in
+  are collected in the guest and emitted one message at a time. A replacement
+  contract — live `emit(name, value)` streaming plus `output(name, value)`
+  finals, with the return mechanics removed — is designed in
   [code-node-emit-design.md](code-node-emit-design.md).
 - **`state`** is a plain object that survives across streaming invocations and
   resets at the start of each workflow run.

--- a/docs/javascript-sandbox.md
+++ b/docs/javascript-sandbox.md
@@ -326,7 +326,9 @@ return { kept, count: kept.length };
 - **Media inputs** arrive as refs. Read one with `media.bytes` / `media.text`,
   and return one built by `media.toDocument` / `toImage` / `toAudio` / `toVideo`.
 - **Streaming.** Code containing `yield` runs through `genProcess`: the yields
-  are collected in the guest and emitted one message at a time.
+  are collected in the guest and emitted one message at a time. A live
+  `emit(name, value)` replacement is designed in
+  [code-node-emit-design.md](code-node-emit-design.md).
 - **`state`** is a plain object that survives across streaming invocations and
   resets at the start of each workflow run.
 - **`progress(percent, message)`** posts `node_progress` to the kernel — the


### PR DESCRIPTION
## What

Adds `docs/code-node-emit-design.md`: a design that replaces the Code node's output contract entirely. Outputs leave a body only through two host-bridged calls — `emit(name, value)` streams a value to an output handle while the body runs, and `output(name, value)` sets a handle's final value. `return` becomes plain control flow with no output semantics. Also points the Streaming bullet in `docs/javascript-sandbox.md` at the design.

## Why

The current contract ("return an object; keys become handles") costs agents three ways:

- **Streaming is replay, not streaming.** `yield` bodies collect values in the guest via a regex rewrite and the host replays them only after the run completes, so nothing reaches downstream nodes until the end.
- **The contract is implicit.** Three inference layers — return-path analysis, implicit-return wrapping, and shape normalization — infer outputs from data shape, and the validator's own error steers authors away from branching in code.
- **No call to reason about.** CodePlanner, `validate_code`, and repair loops infer outputs from every return path; `emit("x", v)` / `output("x", v)` are facts an AST query answers directly.

## Design highlights

- `emit` and `output` join `EXPOSED_BRIDGE_NAMES` as awaitable host calls; `genProcess` becomes a pump over a bounded async channel, so awaiting `emit` gives backpressure with no new kernel concept. `output` values post as one final bag when the body completes; a second `output` on the same handle throws.
- The return-path validator, `wrapImplicitReturn`, and `normalizeCodeOutput` delete in favor of one rule: every declared output has ≥1 reachable `emit`/`output` call with that literal name.
- Legacy bodies run for one deprecation release behind a per-body probe, with a mechanical codemod (`return {a}` → `await output("a", a)`, `yield x` → `await emit("output", x)`) that refuses any body it cannot prove equivalent.
- Parity across `run_code`/`test_code` (`streamed` + `outputs`), CodePlanner prompts, the code-gen eval, and the editor docs.

Design only — no runtime behavior changes in this PR.