### PR TITLE
feat(costs): parameter-based cost estimation from GenSpend data

### DIFF
--- a/.github/workflows/genspend-pricing.yml
+++ b/.github/workflows/genspend-pricing.yml
@@ -1,7 +1,7 @@
 name: GenSpend Pricing Sync
 
 # Nightly: pull generative-media prices from the GenSpend catalog
-# (https://genspend.io/api/v1/models) into
+# (https://genspend.io/api/v1/export) into
 # `packages/model-pricing/src/generated/genspend-pricing.json`, and open a PR
 # when a price moved.
 #
@@ -52,6 +52,15 @@ jobs:
 
       - name: Sync prices
         run: npm run sync:genspend -- --report genspend-coverage.json
+
+      - name: Check our arithmetic against GenSpend's calculator
+        # The catalog is a snapshot we price locally from, so the risk is that
+        # our port of the selection rules drifts from theirs. This re-prices
+        # fixed cases from the file just written and asserts each equals
+        # POST /api/v1/quote. It needs the network, which is why it lives here
+        # and not in the PR quality gate. A drift fails the job rather than
+        # opening a PR that ships a wrong number.
+        run: node scripts/genspend/parity-check.mjs
 
       - name: Upload coverage report
         if: always()

--- a/packages/model-pricing/src/generated/genspend-pricing.json
+++ b/packages/model-pricing/src/generated/genspend-pricing.json
@@ -1,12 +1,12 @@
 {
-  "schemaVersion": 2,
-  "source": "https://genspend.io/api/v1/models",
+  "schemaVersion": 3,
+  "source": "https://genspend.io/api/v1/export",
   "attribution": "Prices via genspend.io",
-  "updatedAt": "2026-07-30T08:45:27.754Z",
-  "catalogGeneratedAt": "2026-07-30T08:45:26.081Z",
+  "updatedAt": "2026-08-12T09:17:34.456Z",
+  "catalogGeneratedAt": "2026-08-12T09:17:32.524Z",
   "etag": "\"363cbe11286573b29e5168540f6d2da959d39eab\"",
-  "catalogModels": 135,
-  "catalogOfferings": 447,
+  "catalogModels": 141,
+  "catalogOfferings": 464,
   "providers": [
     "atlascloud",
     "elevenlabs",
@@ -18,34 +18,46 @@
     "replicate",
     "together"
   ],
-  "pricedModels": 283,
+  "pricedModels": 276,
   "prices": {
     "atlascloud:alibaba/happyhorse-1.1/image-to-video": {
-      "unit_price": 0.14,
+      "unit_price": 0.07,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "happyhorse-1-1",
       "match": "catalog",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/models/alibaba/happyhorse-1.1/text-to-video"
+      "source_url": "https://www.atlascloud.ai/models/alibaba/happyhorse-1.1/text-to-video",
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "atlascloud:alibaba/happyhorse-1.1/reference-to-video": {
-      "unit_price": 0.14,
+      "unit_price": 0.07,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "happyhorse-1-1",
       "match": "catalog",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/models/alibaba/happyhorse-1.1/text-to-video"
+      "source_url": "https://www.atlascloud.ai/models/alibaba/happyhorse-1.1/text-to-video",
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "atlascloud:alibaba/happyhorse-1.1/text-to-video": {
-      "unit_price": 0.14,
+      "unit_price": 0.07,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "happyhorse-1-1",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/models/alibaba/happyhorse-1.1/text-to-video"
+      "source_url": "https://www.atlascloud.ai/models/alibaba/happyhorse-1.1/text-to-video",
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "atlascloud:alibaba/wan-2.7/image-edit": {
       "unit_price": 0.03,
@@ -54,7 +66,11 @@
       "model_slug": "wan-2.7",
       "match": "variant",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/pricing/models"
+      "source_url": "https://www.atlascloud.ai/pricing/models",
+      "clip_seconds": {
+        "min": 2,
+        "max": 15
+      }
     },
     "atlascloud:alibaba/wan-2.7/image-to-video": {
       "unit_price": 0.1,
@@ -63,7 +79,11 @@
       "model_slug": "wan-2.7",
       "match": "variant",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/pricing/models"
+      "source_url": "https://www.atlascloud.ai/pricing/models",
+      "clip_seconds": {
+        "min": 2,
+        "max": 15
+      }
     },
     "atlascloud:alibaba/wan-2.7/text-to-image": {
       "unit_price": 0.03,
@@ -72,7 +92,11 @@
       "model_slug": "wan-2.7",
       "match": "variant",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/pricing/models"
+      "source_url": "https://www.atlascloud.ai/pricing/models",
+      "clip_seconds": {
+        "min": 2,
+        "max": 15
+      }
     },
     "atlascloud:alibaba/wan-2.7/text-to-video": {
       "unit_price": 0.1,
@@ -81,7 +105,11 @@
       "model_slug": "wan-2.7",
       "match": "variant",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/pricing/models"
+      "source_url": "https://www.atlascloud.ai/pricing/models",
+      "clip_seconds": {
+        "min": 2,
+        "max": 15
+      }
     },
     "atlascloud:bytedance/seedance-2.0-fast/image-to-video": {
       "unit_price": 0.072,
@@ -91,7 +119,31 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "fast"
+      "tier": "fast",
+      "variants": [
+        {
+          "price_usd": 0.072,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.072,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.072,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 4,
+        "max": 15
+      }
     },
     "atlascloud:bytedance/seedance-2.0-fast/reference-to-video": {
       "unit_price": 0.072,
@@ -101,7 +153,31 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "fast"
+      "tier": "fast",
+      "variants": [
+        {
+          "price_usd": 0.072,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.072,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.072,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 4,
+        "max": 15
+      }
     },
     "atlascloud:bytedance/seedance-2.0-fast/text-to-video": {
       "unit_price": 0.072,
@@ -111,61 +187,109 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "fast"
+      "tier": "fast",
+      "variants": [
+        {
+          "price_usd": 0.072,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.072,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.072,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 4,
+        "max": 15
+      }
     },
     "atlascloud:bytedance/seedance-2.0-mini/image-to-video": {
-      "unit_price": 0.045,
+      "unit_price": 0.039,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "seedance-2-mini",
       "match": "catalog",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/models/bytedance/seedance-2.0-mini/reference-to-video"
+      "source_url": "https://www.atlascloud.ai/models/bytedance/seedance-2.0-mini/reference-to-video",
+      "clip_seconds": {
+        "min": 4,
+        "max": 15
+      }
     },
     "atlascloud:bytedance/seedance-2.0-mini/reference-to-video": {
-      "unit_price": 0.045,
+      "unit_price": 0.039,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "seedance-2-mini",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/models/bytedance/seedance-2.0-mini/reference-to-video"
+      "source_url": "https://www.atlascloud.ai/models/bytedance/seedance-2.0-mini/reference-to-video",
+      "clip_seconds": {
+        "min": 4,
+        "max": 15
+      }
     },
     "atlascloud:bytedance/seedance-2.0-mini/text-to-video": {
-      "unit_price": 0.045,
+      "unit_price": 0.039,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "seedance-2-mini",
       "match": "catalog",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/models/bytedance/seedance-2.0-mini/reference-to-video"
+      "source_url": "https://www.atlascloud.ai/models/bytedance/seedance-2.0-mini/reference-to-video",
+      "clip_seconds": {
+        "min": 4,
+        "max": 15
+      }
     },
     "atlascloud:bytedance/seedance-2.0/image-to-video": {
-      "unit_price": 0.09,
+      "unit_price": 0.112,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "seedance-2",
       "match": "variant",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/pricing/models"
+      "source_url": "https://www.atlascloud.ai/pricing/models",
+      "clip_seconds": {
+        "min": 4,
+        "max": 15
+      }
     },
     "atlascloud:bytedance/seedance-2.0/reference-to-video": {
-      "unit_price": 0.09,
+      "unit_price": 0.112,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "seedance-2",
       "match": "variant",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/pricing/models"
+      "source_url": "https://www.atlascloud.ai/pricing/models",
+      "clip_seconds": {
+        "min": 4,
+        "max": 15
+      }
     },
     "atlascloud:bytedance/seedance-2.0/text-to-video": {
-      "unit_price": 0.09,
+      "unit_price": 0.112,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "seedance-2",
       "match": "variant",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/pricing/models"
+      "source_url": "https://www.atlascloud.ai/pricing/models",
+      "clip_seconds": {
+        "min": 4,
+        "max": 15
+      }
     },
     "atlascloud:bytedance/seedream-v5.0-lite": {
       "unit_price": 0.032,
@@ -186,22 +310,36 @@
       "source_url": "https://www.atlascloud.ai/models/bytedance/seedream-v5.0-lite/edit-sequential"
     },
     "atlascloud:bytedance/seedream-v5.0-pro/edit": {
-      "unit_price": 0.036,
+      "unit_price": 0.022,
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "seedream-5-pro",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/models/bytedance/seedream-v5.0-pro/edit"
+      "source_url": "https://www.atlascloud.ai/models/bytedance/seedream-v5.0-pro/edit",
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.003,
+          "free_allowance": 1
+        }
+      ]
     },
     "atlascloud:bytedance/seedream-v5.0-pro/text-to-image": {
-      "unit_price": 0.036,
+      "unit_price": 0.022,
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "seedream-5-pro",
       "match": "catalog",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/models/bytedance/seedream-v5.0-pro/edit"
+      "source_url": "https://www.atlascloud.ai/models/bytedance/seedream-v5.0-pro/edit",
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.003,
+          "free_allowance": 1
+        }
+      ]
     },
     "atlascloud:google/nano-banana-2-lite/edit": {
       "unit_price": 0.028,
@@ -247,7 +385,45 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        }
+      ]
     },
     "atlascloud:google/nano-banana-pro/edit-ultra": {
       "unit_price": 0.15,
@@ -257,7 +433,45 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        }
+      ]
     },
     "atlascloud:google/nano-banana-pro/text-to-image": {
       "unit_price": 0.14,
@@ -267,7 +481,45 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        }
+      ]
     },
     "atlascloud:google/nano-banana-pro/text-to-image-ultra": {
       "unit_price": 0.15,
@@ -277,7 +529,45 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        }
+      ]
     },
     "atlascloud:google/veo3.1-fast/image-to-video": {
       "unit_price": 0.08,
@@ -287,7 +577,29 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "fast"
+      "tier": "fast",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "atlascloud:google/veo3.1-fast/text-to-video": {
       "unit_price": 0.08,
@@ -297,7 +609,29 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "fast"
+      "tier": "fast",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "atlascloud:google/veo3.1-lite/image-to-video": {
       "unit_price": 0.05,
@@ -307,7 +641,35 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "lite"
+      "tier": "lite",
+      "variants": [
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "tier": "lite",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "tier": "lite",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "tier": "lite",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "atlascloud:google/veo3.1-lite/text-to-video": {
       "unit_price": 0.05,
@@ -317,7 +679,35 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "lite"
+      "tier": "lite",
+      "variants": [
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "tier": "lite",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "tier": "lite",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "tier": "lite",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "atlascloud:google/veo3.1/image-to-video": {
       "unit_price": 0.2,
@@ -326,7 +716,15 @@
       "model_slug": "veo-3.1",
       "match": "variant",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/pricing/models"
+      "source_url": "https://www.atlascloud.ai/pricing/models",
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "atlascloud:google/veo3.1/text-to-video": {
       "unit_price": 0.2,
@@ -335,7 +733,15 @@
       "model_slug": "veo-3.1",
       "match": "variant",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/pricing/models"
+      "source_url": "https://www.atlascloud.ai/pricing/models",
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "atlascloud:kwaivgi/kling-v3.0-pro/image-to-video": {
       "unit_price": 0.095,
@@ -345,7 +751,25 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-video-second",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-video-second",
+          "tier": "pro",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "atlascloud:kwaivgi/kling-v3.0-pro/text-to-video": {
       "unit_price": 0.095,
@@ -355,7 +779,25 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-video-second",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-video-second",
+          "tier": "pro",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "atlascloud:kwaivgi/kling-v3.0-std/image-to-video": {
       "unit_price": 0.071,
@@ -365,7 +807,25 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "std"
+      "tier": "std",
+      "variants": [
+        {
+          "price_usd": 0.071,
+          "unit_class": "per-video-second",
+          "tier": "std",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.071,
+          "unit_class": "per-video-second",
+          "tier": "std",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "atlascloud:kwaivgi/kling-v3.0-std/text-to-video": {
       "unit_price": 0.071,
@@ -375,7 +835,25 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "std"
+      "tier": "std",
+      "variants": [
+        {
+          "price_usd": 0.071,
+          "unit_class": "per-video-second",
+          "tier": "std",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.071,
+          "unit_class": "per-video-second",
+          "tier": "std",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "atlascloud:kwaivgi/kling-v3.0-turbo/image-to-video": {
       "unit_price": 0.095,
@@ -385,7 +863,25 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "turbo"
+      "tier": "turbo",
+      "variants": [
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-video-second",
+          "tier": "turbo",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-video-second",
+          "tier": "turbo",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "atlascloud:kwaivgi/kling-v3.0-turbo/text-to-video": {
       "unit_price": 0.095,
@@ -395,7 +891,25 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "turbo"
+      "tier": "turbo",
+      "variants": [
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-video-second",
+          "tier": "turbo",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-video-second",
+          "tier": "turbo",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "atlascloud:microsoft/mai-image-2.5/edit": {
       "unit_price": 0.05,
@@ -476,7 +990,11 @@
       "model_slug": "grok-imagine-video",
       "match": "variant",
       "live": true,
-      "source_url": "https://www.atlascloud.ai/pricing/models"
+      "source_url": "https://www.atlascloud.ai/pricing/models",
+      "clip_seconds": {
+        "min": 1,
+        "max": 15
+      }
     },
     "atlascloud:z-image/turbo": {
       "unit_price": 0.005,
@@ -486,7 +1004,21 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.atlascloud.ai/pricing/models",
-      "tier": "turbo"
+      "tier": "turbo",
+      "variants": [
+        {
+          "price_usd": 0.005,
+          "unit_class": "per-image",
+          "tier": "turbo",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.01,
+          "unit_class": "per-image",
+          "tier": "turbo",
+          "is_base": false
+        }
+      ]
     },
     "elevenlabs:eleven_flash_v2_5": {
       "unit_price": 50,
@@ -531,7 +1063,25 @@
       "model_slug": "happyhorse-1-1",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://fal.ai/models/alibaba/happy-horse/v1.1/image-to-video"
+      "source_url": "https://fal.ai/models/alibaba/happy-horse/v1.1/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.18,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "fal_ai:bria/fibo-edit/edit": {
       "unit_price": 0.04,
@@ -569,26 +1119,6 @@
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/bytedance/seed-speech/tts/v2"
     },
-    "fal_ai:fal-ai/bytedance/seedance/v1/pro/fast/image-to-video": {
-      "unit_price": 1,
-      "billing_unit": "1m_tokens",
-      "unit_class": "per-1m-tokens",
-      "model_slug": "seedance-1-pro",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/bytedance/seedance/v1/pro/text-to-video",
-      "tier": "pro"
-    },
-    "fal_ai:fal-ai/bytedance/seedance/v1/pro/fast/text-to-video": {
-      "unit_price": 1,
-      "billing_unit": "1m_tokens",
-      "unit_class": "per-1m-tokens",
-      "model_slug": "seedance-1-pro",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/bytedance/seedance/v1/pro/text-to-video",
-      "tier": "pro"
-    },
     "fal_ai:fal-ai/bytedance/seedance/v1/pro/text-to-video": {
       "unit_price": 2.5,
       "billing_unit": "1m_tokens",
@@ -597,7 +1127,25 @@
       "match": "variant",
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/bytedance/seedance/v1/pro/text-to-video",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 2.5,
+          "unit_class": "per-1m-tokens",
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 2.5,
+          "unit_class": "per-1m-tokens",
+          "tier": "pro",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 2,
+        "max": 12
+      }
     },
     "fal_ai:fal-ai/bytedance/seedream/v4.5/edit": {
       "unit_price": 0.04,
@@ -663,14 +1211,22 @@
       "source_url": "https://fal.ai/models/fal-ai/elevenlabs/text-to-dialogue/eleven-v3"
     },
     "fal_ai:fal-ai/elevenlabs/tts/turbo-v2.5": {
-      "unit_price": 0.05,
+      "unit_price": 50,
       "billing_unit": "1m_chars",
       "unit_class": "per-1m-chars",
       "model_slug": "eleven-turbo-v2.5",
       "match": "variant",
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/elevenlabs/tts/turbo-v2.5",
-      "tier": "turbo"
+      "tier": "turbo",
+      "variants": [
+        {
+          "price_usd": 50,
+          "unit_class": "per-1m-chars",
+          "tier": "turbo",
+          "is_base": true
+        }
+      ]
     },
     "fal_ai:fal-ai/flux-1/dev": {
       "unit_price": 0.025,
@@ -715,7 +1271,14 @@
       "model_slug": "flux-2-max",
       "match": "catalog",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/flux-2-max/edit"
+      "source_url": "https://fal.ai/models/fal-ai/flux-2-max/edit",
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.03,
+          "free_allowance": 0
+        }
+      ]
     },
     "fal_ai:fal-ai/flux-2-max/edit": {
       "unit_price": 0.07,
@@ -724,54 +1287,103 @@
       "model_slug": "flux-2-max",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/flux-2-max/edit"
+      "source_url": "https://fal.ai/models/fal-ai/flux-2-max/edit",
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.03,
+          "free_allowance": 0
+        }
+      ]
     },
     "fal_ai:fal-ai/flux-2-pro": {
       "unit_price": 0.03,
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "flux-2-pro",
-      "match": "variant",
-      "live": true,
+      "match": "provider-id",
+      "live": false,
       "source_url": "https://fal.ai/models/fal-ai/flux-2-pro",
-      "tier": "pro"
+      "variants": [
+        {
+          "price_usd": 0.045,
+          "unit_class": "per-image",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.015,
+          "free_allowance": 0
+        }
+      ]
     },
     "fal_ai:fal-ai/flux-2-pro/edit": {
       "unit_price": 0.03,
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "flux-2-pro",
-      "match": "variant",
-      "live": true,
+      "match": "catalog",
+      "live": false,
       "source_url": "https://fal.ai/models/fal-ai/flux-2-pro",
-      "tier": "pro"
+      "variants": [
+        {
+          "price_usd": 0.045,
+          "unit_class": "per-image",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.015,
+          "free_allowance": 0
+        }
+      ]
     },
     "fal_ai:fal-ai/flux-2-pro/outpaint": {
       "unit_price": 0.03,
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "flux-2-pro",
-      "match": "variant",
-      "live": true,
+      "match": "catalog",
+      "live": false,
       "source_url": "https://fal.ai/models/fal-ai/flux-2-pro",
-      "tier": "pro"
+      "variants": [
+        {
+          "price_usd": 0.045,
+          "unit_class": "per-image",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.015,
+          "free_allowance": 0
+        }
+      ]
     },
     "fal_ai:fal-ai/flux-2/klein/9b": {
-      "unit_price": 0.011,
+      "unit_price": 0.006,
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "flux-2-klein-9b",
       "match": "provider-id",
-      "live": true,
+      "live": false,
       "source_url": "https://fal.ai/models/fal-ai/flux-2/klein/9b"
     },
     "fal_ai:fal-ai/flux-2/klein/9b/edit": {
-      "unit_price": 0.011,
+      "unit_price": 0.006,
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "flux-2-klein-9b",
       "match": "catalog",
-      "live": true,
+      "live": false,
       "source_url": "https://fal.ai/models/fal-ai/flux-2/klein/9b"
     },
     "fal_ai:fal-ai/flux-pro/kontext": {
@@ -779,7 +1391,7 @@
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "flux-1-kontext-pro",
-      "match": "receipt",
+      "match": "provider-id",
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/flux-pro/kontext"
     },
@@ -791,7 +1403,33 @@
       "match": "variant",
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/flux-pro/v1.1",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.06,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/flux-pro/v1.1-ultra": {
       "unit_price": 0.06,
@@ -801,7 +1439,33 @@
       "match": "variant",
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/flux-pro/v1.1",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.06,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/flux-pro/v1.1-ultra/redux": {
       "unit_price": 0.05,
@@ -811,7 +1475,33 @@
       "match": "variant",
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/flux-pro/v1.1",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.06,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/flux-pro/v1.1/redux": {
       "unit_price": 0.05,
@@ -821,7 +1511,33 @@
       "match": "variant",
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/flux-pro/v1.1",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.06,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/flux/dev": {
       "unit_price": 0.025,
@@ -848,7 +1564,21 @@
       "model_slug": "gemini-3-pro-image",
       "match": "catalog",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/gemini-3-pro-image-preview/edit"
+      "source_url": "https://fal.ai/models/fal-ai/gemini-3-pro-image-preview/edit",
+      "variants": [
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.3,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/gemini-3-pro-image-preview/edit": {
       "unit_price": 0.15,
@@ -857,7 +1587,21 @@
       "model_slug": "gemini-3-pro-image",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/gemini-3-pro-image-preview/edit"
+      "source_url": "https://fal.ai/models/fal-ai/gemini-3-pro-image-preview/edit",
+      "variants": [
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.3,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/gemini-3.1-flash-image-preview": {
       "unit_price": 0.08,
@@ -865,8 +1609,48 @@
       "unit_class": "per-image",
       "model_slug": "gemini-3.1-flash-image",
       "match": "catalog",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/gemini-3.1-flash-image-preview/edit"
+      "live": false,
+      "source_url": "https://fal.ai/models/fal-ai/gemini-3.1-flash-image-preview/edit",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "standard",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.16,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "standard",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.135,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.175,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/gemini-3.1-flash-image-preview/edit": {
       "unit_price": 0.08,
@@ -874,8 +1658,48 @@
       "unit_class": "per-image",
       "model_slug": "gemini-3.1-flash-image",
       "match": "provider-id",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/gemini-3.1-flash-image-preview/edit"
+      "live": false,
+      "source_url": "https://fal.ai/models/fal-ai/gemini-3.1-flash-image-preview/edit",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "standard",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.16,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "standard",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.135,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.175,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/gemini-3.1-flash-tts": {
       "unit_price": 150,
@@ -902,7 +1726,27 @@
       "model_slug": "ideogram-v3-character",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://fal.ai/models/fal-ai/ideogram/character"
+      "source_url": "https://fal.ai/models/fal-ai/ideogram/character",
+      "variants": [
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-image",
+          "tier": "turbo",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-image",
+          "tier": "balanced",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.2,
+          "unit_class": "per-image",
+          "tier": "quality",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/ideogram/v2": {
       "unit_price": 0.08,
@@ -922,24 +1766,6 @@
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/ideogram/v2"
     },
-    "fal_ai:fal-ai/ideogram/v2/turbo": {
-      "unit_price": 0.05,
-      "billing_unit": "images",
-      "unit_class": "per-image",
-      "model_slug": "ideogram-v2-turbo",
-      "match": "provider-id",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/ideogram/v2/turbo"
-    },
-    "fal_ai:fal-ai/ideogram/v2/turbo/edit": {
-      "unit_price": 0.05,
-      "billing_unit": "images",
-      "unit_class": "per-image",
-      "model_slug": "ideogram-v2-turbo",
-      "match": "catalog",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/ideogram/v2/turbo"
-    },
     "fal_ai:fal-ai/ideogram/v2a/turbo": {
       "unit_price": 0.025,
       "billing_unit": "images",
@@ -954,45 +1780,58 @@
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "ideogram-v3",
-      "match": "variant",
+      "match": "provider-id",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/ideogram/v3"
+      "source_url": "https://fal.ai/models/fal-ai/ideogram/v3",
+      "variants": [
+        {
+          "price_usd": 0.03,
+          "unit_class": "per-image",
+          "tier": "turbo",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.06,
+          "unit_class": "per-image",
+          "tier": "balanced",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.09,
+          "unit_class": "per-image",
+          "tier": "quality",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/ideogram/v3/edit": {
       "unit_price": 0.03,
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "ideogram-v3",
-      "match": "variant",
+      "match": "catalog",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/ideogram/v3"
-    },
-    "fal_ai:fal-ai/ideogram/v3/reframe": {
-      "unit_price": 0.03,
-      "billing_unit": "images",
-      "unit_class": "per-image",
-      "model_slug": "ideogram-v3",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/ideogram/v3"
-    },
-    "fal_ai:fal-ai/ideogram/v3/remix": {
-      "unit_price": 0.03,
-      "billing_unit": "images",
-      "unit_class": "per-image",
-      "model_slug": "ideogram-v3",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/ideogram/v3"
-    },
-    "fal_ai:fal-ai/ideogram/v3/replace-background": {
-      "unit_price": 0.03,
-      "billing_unit": "images",
-      "unit_class": "per-image",
-      "model_slug": "ideogram-v3",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/ideogram/v3"
+      "source_url": "https://fal.ai/models/fal-ai/ideogram/v3",
+      "variants": [
+        {
+          "price_usd": 0.03,
+          "unit_class": "per-image",
+          "tier": "turbo",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.06,
+          "unit_class": "per-image",
+          "tier": "balanced",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.09,
+          "unit_class": "per-image",
+          "tier": "quality",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/imagen4/preview": {
       "unit_price": 0.04,
@@ -1001,7 +1840,27 @@
       "model_slug": "imagen-4",
       "match": "receipt",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/imagen4/preview"
+      "source_url": "https://fal.ai/models/fal-ai/imagen4/preview",
+      "variants": [
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-image",
+          "tier": "standard",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.02,
+          "unit_class": "per-image",
+          "tier": "fast",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.06,
+          "unit_class": "per-image",
+          "tier": "ultra",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/infinitalk": {
       "unit_price": 0.2,
@@ -1010,7 +1869,10 @@
       "model_slug": "infinitalk",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/infinitalk"
+      "source_url": "https://fal.ai/models/fal-ai/infinitalk",
+      "clip_seconds": {
+        "max": 28
+      }
     },
     "fal_ai:fal-ai/infinitalk/video-to-video": {
       "unit_price": 0.2,
@@ -1019,7 +1881,10 @@
       "model_slug": "infinitalk",
       "match": "catalog",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/infinitalk"
+      "source_url": "https://fal.ai/models/fal-ai/infinitalk",
+      "clip_seconds": {
+        "max": 28
+      }
     },
     "fal_ai:fal-ai/kling-image/o1": {
       "unit_price": 0.028,
@@ -1037,7 +1902,21 @@
       "model_slug": "kling-image-o3",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/kling-image/o3/image-to-image"
+      "source_url": "https://fal.ai/models/fal-ai/kling-image/o3/image-to-image",
+      "variants": [
+        {
+          "price_usd": 0.028,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.056,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/kling-image/o3/text-to-image": {
       "unit_price": 0.028,
@@ -1046,7 +1925,21 @@
       "model_slug": "kling-image-o3",
       "match": "catalog",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/kling-image/o3/image-to-image"
+      "source_url": "https://fal.ai/models/fal-ai/kling-image/o3/image-to-image",
+      "variants": [
+        {
+          "price_usd": 0.028,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.056,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/kling-image/v3/image-to-image": {
       "unit_price": 0.028,
@@ -1066,14 +1959,100 @@
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/kling-image/v3/text-to-image"
     },
+    "fal_ai:fal-ai/kling-video/v2.5-turbo/pro/image-to-video": {
+      "unit_price": 0.07,
+      "billing_unit": "seconds",
+      "unit_class": "per-video-second",
+      "model_slug": "kling-2.5-turbo-pro",
+      "match": "variant",
+      "live": true,
+      "source_url": "https://fal.ai/models/fal-ai/kling-video/v2.5-turbo/pro/text-to-video",
+      "tier": "turbo",
+      "variants": [
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-video-second",
+          "tier": "turbo",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-video-second",
+          "tier": "turbo",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          5,
+          10
+        ],
+        "max": 10
+      }
+    },
     "fal_ai:fal-ai/kling-video/v2.5-turbo/pro/text-to-video": {
       "unit_price": 0.07,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "kling-2.5-turbo-pro",
-      "match": "receipt",
+      "match": "variant",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/kling-video/v2.5-turbo/pro/text-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/kling-video/v2.5-turbo/pro/text-to-video",
+      "tier": "turbo",
+      "variants": [
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-video-second",
+          "tier": "turbo",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-video-second",
+          "tier": "turbo",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          5,
+          10
+        ],
+        "max": 10
+      }
+    },
+    "fal_ai:fal-ai/kling-video/v3/pro/image-to-video": {
+      "unit_price": 0.112,
+      "billing_unit": "seconds",
+      "unit_class": "per-video-second",
+      "model_slug": "kling-3.0-pro",
+      "match": "provider-id",
+      "live": false,
+      "source_url": "https://fal.ai/models/fal-ai/kling-video/v3/pro/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.112,
+          "unit_class": "per-video-second",
+          "with_audio": false,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.168,
+          "unit_class": "per-video-second",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.196,
+          "unit_class": "per-video-second",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "fal_ai:fal-ai/kling-video/v3/pro/motion-control": {
       "unit_price": 0.168,
@@ -1082,7 +2061,11 @@
       "model_slug": "kling-motion-control-3",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/kling-video/v3/pro/motion-control"
+      "source_url": "https://fal.ai/models/fal-ai/kling-video/v3/pro/motion-control",
+      "clip_seconds": {
+        "min": 3,
+        "max": 30
+      }
     },
     "fal_ai:fal-ai/kokoro/american-english": {
       "unit_price": 20,
@@ -1111,44 +2094,23 @@
       "live": false,
       "source_url": "https://fal.ai/models/fal-ai/luma-photon"
     },
-    "fal_ai:fal-ai/minimax-music": {
+    "fal_ai:fal-ai/luma-photon/flash/reframe": {
+      "unit_price": 0.005,
+      "billing_unit": "images",
+      "unit_class": "per-image",
+      "model_slug": "flash-modify-photon",
+      "match": "provider-id",
+      "live": false,
+      "source_url": "https://fal.ai/models/fal-ai/luma-photon/flash/reframe"
+    },
+    "fal_ai:fal-ai/minimax-music/v1.5": {
       "unit_price": 0.03,
       "billing_unit": "generations",
       "unit_class": "per-generation",
       "model_slug": "minimax-music-1.5",
       "match": "receipt",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/minimax-music"
-    },
-    "fal_ai:fal-ai/minimax/hailuo-02-fast/image-to-video": {
-      "unit_price": 0.017,
-      "billing_unit": "seconds",
-      "unit_class": "per-video-second",
-      "model_slug": "hailuo-02",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/minimax/hailuo-02/standard/text-to-video",
-      "tier": "fast"
-    },
-    "fal_ai:fal-ai/minimax/hailuo-02/pro/image-to-video": {
-      "unit_price": 0.08,
-      "billing_unit": "seconds",
-      "unit_class": "per-video-second",
-      "model_slug": "hailuo-02",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/minimax/hailuo-02/standard/text-to-video",
-      "tier": "pro"
-    },
-    "fal_ai:fal-ai/minimax/hailuo-02/pro/text-to-video": {
-      "unit_price": 0.08,
-      "billing_unit": "seconds",
-      "unit_class": "per-video-second",
-      "model_slug": "hailuo-02",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/minimax/hailuo-02/standard/text-to-video",
-      "tier": "pro"
+      "source_url": "https://fal.ai/models/fal-ai/minimax-music/v1.5"
     },
     "fal_ai:fal-ai/minimax/hailuo-02/standard/text-to-video": {
       "unit_price": 0.045,
@@ -1157,7 +2119,29 @@
       "model_slug": "hailuo-02",
       "match": "receipt",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/minimax/hailuo-02/standard/text-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/minimax/hailuo-02/standard/text-to-video",
+      "variants": [
+        {
+          "price_usd": 0.045,
+          "unit_class": "per-video-second",
+          "resolution": "768p",
+          "with_audio": false,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.017,
+          "unit_class": "per-video-second",
+          "with_audio": false,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          6,
+          10
+        ],
+        "max": 10
+      }
     },
     "fal_ai:fal-ai/minimax/image-01": {
       "unit_price": 0.01,
@@ -1169,7 +2153,7 @@
       "source_url": "https://fal.ai/models/fal-ai/minimax/image-01"
     },
     "fal_ai:fal-ai/minimax/speech-02-hd": {
-      "unit_price": 0.1,
+      "unit_price": 100,
       "billing_unit": "1m_chars",
       "unit_class": "per-1m-chars",
       "model_slug": "minimax-speech-02-hd",
@@ -1192,8 +2176,48 @@
       "unit_class": "per-image",
       "model_slug": "gemini-3.1-flash-image",
       "match": "catalog",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/gemini-3.1-flash-image-preview/edit"
+      "live": false,
+      "source_url": "https://fal.ai/models/fal-ai/gemini-3.1-flash-image-preview/edit",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "standard",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.16,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "standard",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.135,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.175,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/nano-banana-2/edit": {
       "unit_price": 0.08,
@@ -1201,8 +2225,48 @@
       "unit_class": "per-image",
       "model_slug": "gemini-3.1-flash-image",
       "match": "catalog",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/gemini-3.1-flash-image-preview/edit"
+      "live": false,
+      "source_url": "https://fal.ai/models/fal-ai/gemini-3.1-flash-image-preview/edit",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "standard",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.16,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "standard",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.135,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.175,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/nano-banana-pro": {
       "unit_price": 0.15,
@@ -1211,7 +2275,21 @@
       "model_slug": "gemini-3-pro-image",
       "match": "catalog",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/gemini-3-pro-image-preview/edit"
+      "source_url": "https://fal.ai/models/fal-ai/gemini-3-pro-image-preview/edit",
+      "variants": [
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.3,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/nano-banana-pro/edit": {
       "unit_price": 0.15,
@@ -1220,7 +2298,21 @@
       "model_slug": "gemini-3-pro-image",
       "match": "catalog",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/gemini-3-pro-image-preview/edit"
+      "source_url": "https://fal.ai/models/fal-ai/gemini-3-pro-image-preview/edit",
+      "variants": [
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.3,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ]
     },
     "fal_ai:fal-ai/nano-banana/edit": {
       "unit_price": 0.0398,
@@ -1247,7 +2339,69 @@
       "model_slug": "pixverse-c1",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://fal.ai/models/fal-ai/pixverse/c1/image-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/pixverse/c1/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.03,
+          "unit_class": "per-video-second",
+          "resolution": "360p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-video-second",
+          "resolution": "360p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-video-second",
+          "resolution": "540p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "resolution": "540p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.065,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 1,
+        "max": 15
+      }
     },
     "fal_ai:fal-ai/pixverse/c1/reference-to-video": {
       "unit_price": 0.05,
@@ -1256,7 +2410,69 @@
       "model_slug": "pixverse-c1",
       "match": "catalog",
       "live": false,
-      "source_url": "https://fal.ai/models/fal-ai/pixverse/c1/image-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/pixverse/c1/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.03,
+          "unit_class": "per-video-second",
+          "resolution": "360p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-video-second",
+          "resolution": "360p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-video-second",
+          "resolution": "540p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "resolution": "540p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.065,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 1,
+        "max": 15
+      }
     },
     "fal_ai:fal-ai/pixverse/c1/text-to-video": {
       "unit_price": 0.05,
@@ -1265,7 +2481,69 @@
       "model_slug": "pixverse-c1",
       "match": "catalog",
       "live": false,
-      "source_url": "https://fal.ai/models/fal-ai/pixverse/c1/image-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/pixverse/c1/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.03,
+          "unit_class": "per-video-second",
+          "resolution": "360p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-video-second",
+          "resolution": "360p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-video-second",
+          "resolution": "540p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "resolution": "540p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.065,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 1,
+        "max": 15
+      }
     },
     "fal_ai:fal-ai/pixverse/v6/image-to-video": {
       "unit_price": 0.045,
@@ -1274,7 +2552,69 @@
       "model_slug": "pixverse-v6-i2v",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://fal.ai/models/fal-ai/pixverse/v6/image-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/pixverse/v6/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.025,
+          "unit_class": "per-video-second",
+          "resolution": "360p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.035,
+          "unit_class": "per-video-second",
+          "resolution": "360p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.035,
+          "unit_class": "per-video-second",
+          "resolution": "540p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.045,
+          "unit_class": "per-video-second",
+          "resolution": "540p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.045,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.06,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.09,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.115,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 1,
+        "max": 15
+      }
     },
     "fal_ai:fal-ai/pixverse/v6/text-to-video": {
       "unit_price": 0.045,
@@ -1283,7 +2623,69 @@
       "model_slug": "pixverse-v6-t2v",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://fal.ai/models/fal-ai/pixverse/v6/text-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/pixverse/v6/text-to-video",
+      "variants": [
+        {
+          "price_usd": 0.025,
+          "unit_class": "per-video-second",
+          "resolution": "360p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.035,
+          "unit_class": "per-video-second",
+          "resolution": "360p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.035,
+          "unit_class": "per-video-second",
+          "resolution": "540p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.045,
+          "unit_class": "per-video-second",
+          "resolution": "540p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.045,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.06,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.09,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.115,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 1,
+        "max": 15
+      }
     },
     "fal_ai:fal-ai/qwen-3-tts/text-to-speech/1.7b": {
       "unit_price": 90,
@@ -1376,7 +2778,7 @@
       "source_url": "https://fal.ai/models/fal-ai/qwen-image-edit"
     },
     "fal_ai:fal-ai/recraft-20b": {
-      "unit_price": 0.0219,
+      "unit_price": 0.022,
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "recraft-20b",
@@ -1398,7 +2800,7 @@
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "recraft-v3",
-      "match": "variant",
+      "match": "catalog",
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/recraft/v3/text-to-image"
     },
@@ -1436,7 +2838,17 @@
       "model_slug": "sora-2",
       "match": "catalog",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/sora-2/text-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/sora-2/text-to-video",
+      "clip_seconds": {
+        "set": [
+          4,
+          8,
+          12,
+          16,
+          20
+        ],
+        "max": 20
+      }
     },
     "fal_ai:fal-ai/sora-2/text-to-video": {
       "unit_price": 0.1,
@@ -1445,7 +2857,17 @@
       "model_slug": "sora-2",
       "match": "variant",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/sora-2/text-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/sora-2/text-to-video",
+      "clip_seconds": {
+        "set": [
+          4,
+          8,
+          12,
+          16,
+          20
+        ],
+        "max": 20
+      }
     },
     "fal_ai:fal-ai/stable-diffusion-v35-large": {
       "unit_price": 0.065,
@@ -1461,105 +2883,488 @@
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "veo-3.1",
-      "match": "variant",
+      "match": "provider-id",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/veo3.1"
-    },
-    "fal_ai:fal-ai/veo3.1/extend-video": {
-      "unit_price": 0.4,
-      "billing_unit": "seconds",
-      "unit_class": "per-video-second",
-      "model_slug": "veo-3.1",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/veo3.1"
+      "source_url": "https://fal.ai/models/fal-ai/veo3.1",
+      "variants": [
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.2,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.2,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.6,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "fal_ai:fal-ai/veo3.1/fast": {
       "unit_price": 0.15,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "veo-3.1-fast",
-      "match": "variant",
+      "match": "catalog",
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/veo3/fast",
-      "tier": "fast"
-    },
-    "fal_ai:fal-ai/veo3.1/fast/extend-video": {
-      "unit_price": 0.15,
-      "billing_unit": "seconds",
-      "unit_class": "per-video-second",
-      "model_slug": "veo-3.1-fast",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/veo3/fast",
-      "tier": "fast"
+      "variants": [
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.3,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.35,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "fal_ai:fal-ai/veo3.1/fast/first-last-frame-to-video": {
       "unit_price": 0.15,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "veo-3.1-fast",
-      "match": "variant",
+      "match": "catalog",
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/veo3/fast",
-      "tier": "fast"
+      "variants": [
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.3,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.35,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "fal_ai:fal-ai/veo3.1/fast/image-to-video": {
       "unit_price": 0.15,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "veo-3.1-fast",
-      "match": "variant",
+      "match": "catalog",
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/veo3/fast",
-      "tier": "fast"
+      "variants": [
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.3,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.35,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
+    },
+    "fal_ai:fal-ai/veo3.1/fast/reference-to-video": {
+      "unit_price": 0.15,
+      "billing_unit": "seconds",
+      "unit_class": "per-video-second",
+      "model_slug": "veo-3.1-fast",
+      "match": "catalog",
+      "live": true,
+      "source_url": "https://fal.ai/models/fal-ai/veo3/fast",
+      "variants": [
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.3,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.35,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "fal_ai:fal-ai/veo3.1/first-last-frame-to-video": {
       "unit_price": 0.4,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "veo-3.1",
-      "match": "variant",
+      "match": "catalog",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/veo3.1"
+      "source_url": "https://fal.ai/models/fal-ai/veo3.1",
+      "variants": [
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.2,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.2,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.6,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "fal_ai:fal-ai/veo3.1/image-to-video": {
       "unit_price": 0.4,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "veo-3.1",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/veo3.1"
-    },
-    "fal_ai:fal-ai/veo3.1/lite": {
-      "unit_price": 0.05,
-      "billing_unit": "seconds",
-      "unit_class": "per-video-second",
-      "model_slug": "veo-3.1",
-      "match": "variant",
+      "match": "catalog",
       "live": true,
       "source_url": "https://fal.ai/models/fal-ai/veo3.1",
-      "tier": "lite"
-    },
-    "fal_ai:fal-ai/veo3.1/lite/image-to-video": {
-      "unit_price": 0.05,
-      "billing_unit": "seconds",
-      "unit_class": "per-video-second",
-      "model_slug": "veo-3.1",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/veo3.1",
-      "tier": "lite"
+      "variants": [
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.2,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.2,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.6,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "fal_ai:fal-ai/veo3.1/reference-to-video": {
       "unit_price": 0.4,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "veo-3.1",
-      "match": "variant",
+      "match": "catalog",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/veo3.1"
+      "source_url": "https://fal.ai/models/fal-ai/veo3.1",
+      "variants": [
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.2,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.2,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.6,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "fal_ai:fal-ai/veo3/fast": {
       "unit_price": 0.15,
@@ -1568,52 +3373,95 @@
       "model_slug": "veo-3.1-fast",
       "match": "receipt",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/veo3/fast"
-    },
-    "fal_ai:fal-ai/vidu/q2/reference-to-image": {
-      "unit_price": 0.05,
-      "billing_unit": "images",
-      "unit_class": "per-image",
-      "model_slug": "vidu-q2-reference-to-image",
-      "match": "provider-id",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/vidu/q2/reference-to-image"
-    },
-    "fal_ai:fal-ai/vidu/q2/text-to-image": {
-      "unit_price": 0.05,
-      "billing_unit": "images",
-      "unit_class": "per-image",
-      "model_slug": "vidu-q2-text-to-image",
-      "match": "provider-id",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/vidu/q2/text-to-image"
-    },
-    "fal_ai:fal-ai/wan-25-preview/image-to-image": {
-      "unit_price": 0.05,
-      "billing_unit": "images",
-      "unit_class": "per-image",
-      "model_slug": "wan-2.5",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/wan-25-preview/text-to-video"
-    },
-    "fal_ai:fal-ai/wan-25-preview/text-to-image": {
-      "unit_price": 0.05,
-      "billing_unit": "images",
-      "unit_class": "per-image",
-      "model_slug": "wan-2.5",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/wan-25-preview/text-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/veo3/fast",
+      "variants": [
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.3,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.35,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "fal_ai:fal-ai/wan-25-preview/text-to-video": {
       "unit_price": 0.05,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "wan-2.5",
-      "match": "variant",
-      "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/wan-25-preview/text-to-video"
+      "match": "provider-id",
+      "live": false,
+      "source_url": "https://fal.ai/models/fal-ai/wan-25-preview/text-to-video",
+      "variants": [
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          5,
+          10
+        ],
+        "max": 10
+      }
     },
     "fal_ai:fal-ai/wan/v2.2-a14b/image-to-video": {
       "unit_price": 0.08,
@@ -1622,7 +3470,27 @@
       "model_slug": "wan-2.2",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/wan/v2.2-a14b/image-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/wan/v2.2-a14b/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          5
+        ],
+        "max": 5
+      }
     },
     "fal_ai:fal-ai/wan/v2.7/image-to-video": {
       "unit_price": 0.1,
@@ -1631,7 +3499,32 @@
       "model_slug": "wan-2.7",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/wan/v2.7/image-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/wan/v2.7/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_video_second",
+          "unit_price_usd": 0.1,
+          "free_allowance": 0
+        }
+      ],
+      "clip_seconds": {
+        "min": 2,
+        "max": 15
+      }
     },
     "fal_ai:fal-ai/wan/v2.7/reference-to-video": {
       "unit_price": 0.1,
@@ -1640,7 +3533,32 @@
       "model_slug": "wan-2.7",
       "match": "catalog",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/wan/v2.7/image-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/wan/v2.7/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_video_second",
+          "unit_price_usd": 0.1,
+          "free_allowance": 0
+        }
+      ],
+      "clip_seconds": {
+        "min": 2,
+        "max": 15
+      }
     },
     "fal_ai:fal-ai/wan/v2.7/text-to-video": {
       "unit_price": 0.1,
@@ -1649,7 +3567,32 @@
       "model_slug": "wan-2.7",
       "match": "catalog",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/wan/v2.7/image-to-video"
+      "source_url": "https://fal.ai/models/fal-ai/wan/v2.7/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_video_second",
+          "unit_price_usd": 0.1,
+          "free_allowance": 0
+        }
+      ],
+      "clip_seconds": {
+        "min": 2,
+        "max": 15
+      }
     },
     "fal_ai:fal-ai/z-image/turbo": {
       "unit_price": 0.005,
@@ -1658,7 +3601,15 @@
       "model_slug": "z-image-turbo",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://fal.ai/models/fal-ai/z-image/turbo"
+      "source_url": "https://fal.ai/models/fal-ai/z-image/turbo",
+      "surcharges": [
+        {
+          "kind": "per_request",
+          "unit_price_usd": 0.0025,
+          "free_allowance": 0,
+          "label": "prompt expansion"
+        }
+      ]
     },
     "fal_ai:google/gemini-omni-flash": {
       "unit_price": 0.13,
@@ -1667,7 +3618,11 @@
       "model_slug": "gemini-omni-flash",
       "match": "catalog",
       "live": false,
-      "source_url": "https://fal.ai/models/google/gemini-omni-flash/image-to-video"
+      "source_url": "https://fal.ai/models/google/gemini-omni-flash/image-to-video",
+      "clip_seconds": {
+        "min": 3,
+        "max": 10
+      }
     },
     "fal_ai:google/gemini-omni-flash/edit": {
       "unit_price": 0.13,
@@ -1676,7 +3631,11 @@
       "model_slug": "gemini-omni-flash",
       "match": "catalog",
       "live": false,
-      "source_url": "https://fal.ai/models/google/gemini-omni-flash/image-to-video"
+      "source_url": "https://fal.ai/models/google/gemini-omni-flash/image-to-video",
+      "clip_seconds": {
+        "min": 3,
+        "max": 10
+      }
     },
     "fal_ai:google/gemini-omni-flash/image-to-video": {
       "unit_price": 0.13,
@@ -1685,7 +3644,11 @@
       "model_slug": "gemini-omni-flash",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://fal.ai/models/google/gemini-omni-flash/image-to-video"
+      "source_url": "https://fal.ai/models/google/gemini-omni-flash/image-to-video",
+      "clip_seconds": {
+        "min": 3,
+        "max": 10
+      }
     },
     "fal_ai:google/gemini-omni-flash/reference-to-video": {
       "unit_price": 0.13,
@@ -1694,7 +3657,11 @@
       "model_slug": "gemini-omni-flash",
       "match": "catalog",
       "live": false,
-      "source_url": "https://fal.ai/models/google/gemini-omni-flash/image-to-video"
+      "source_url": "https://fal.ai/models/google/gemini-omni-flash/image-to-video",
+      "clip_seconds": {
+        "min": 3,
+        "max": 10
+      }
     },
     "fal_ai:krea/v2/large/text-to-image": {
       "unit_price": 0.06,
@@ -1723,6 +3690,149 @@
       "live": false,
       "source_url": "https://fal.ai/models/luma/agent/uni-1/v1/text-to-image"
     },
+    "fal_ai:minimax/h3/image-to-video": {
+      "unit_price": 0.13,
+      "billing_unit": "seconds",
+      "unit_class": "per-video-second",
+      "model_slug": "minimax-h3",
+      "match": "catalog",
+      "live": false,
+      "source_url": "https://fal.ai/models/minimax/h3/reference-to-video",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "768p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.13,
+          "unit_class": "per-video-second",
+          "resolution": "2K",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.16,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.08,
+          "free_allowance": 5
+        }
+      ],
+      "clip_seconds": {
+        "min": 4,
+        "max": 15
+      }
+    },
+    "fal_ai:minimax/h3/reference-to-video": {
+      "unit_price": 0.13,
+      "billing_unit": "seconds",
+      "unit_class": "per-video-second",
+      "model_slug": "minimax-h3",
+      "match": "provider-id",
+      "live": false,
+      "source_url": "https://fal.ai/models/minimax/h3/reference-to-video",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "768p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.13,
+          "unit_class": "per-video-second",
+          "resolution": "2K",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.16,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.08,
+          "free_allowance": 5
+        }
+      ],
+      "clip_seconds": {
+        "min": 4,
+        "max": 15
+      }
+    },
+    "fal_ai:minimax/h3/text-to-video": {
+      "unit_price": 0.13,
+      "billing_unit": "seconds",
+      "unit_class": "per-video-second",
+      "model_slug": "minimax-h3",
+      "match": "catalog",
+      "live": false,
+      "source_url": "https://fal.ai/models/minimax/h3/reference-to-video",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "768p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.13,
+          "unit_class": "per-video-second",
+          "resolution": "2K",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.16,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.08,
+          "free_allowance": 5
+        }
+      ],
+      "clip_seconds": {
+        "min": 4,
+        "max": 15
+      }
+    },
+    "fal_ai:nvidia/cosmos-3-super/text-to-image": {
+      "unit_price": 0.04,
+      "billing_unit": "images",
+      "unit_class": "per-image",
+      "model_slug": "cosmos-3-super",
+      "match": "provider-id",
+      "live": true,
+      "source_url": "https://fal.ai/models/nvidia/cosmos-3-super/text-to-image",
+      "surcharges": [
+        {
+          "kind": "per_request",
+          "unit_price_usd": 0.02,
+          "free_allowance": 0,
+          "label": "prompt expansion"
+        }
+      ],
+      "data_flags": [
+        {
+          "kind": "surcharge",
+          "severity": "spec_gap"
+        }
+      ]
+    },
     "fal_ai:wan/v2.6/image-to-video": {
       "unit_price": 0.1,
       "billing_unit": "seconds",
@@ -1730,7 +3840,25 @@
       "model_slug": "wan-2.6-i2v",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://fal.ai/models/wan/v2.6/image-to-video"
+      "source_url": "https://fal.ai/models/wan/v2.6/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 2,
+        "max": 15
+      }
     },
     "fal_ai:xai/grok-imagine-image": {
       "unit_price": 0.02,
@@ -1739,7 +3867,14 @@
       "model_slug": "grok-imagine",
       "match": "catalog",
       "live": true,
-      "source_url": "https://fal.ai/models/xai/grok-imagine-image/edit"
+      "source_url": "https://fal.ai/models/xai/grok-imagine-image/edit",
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.002,
+          "free_allowance": 0
+        }
+      ]
     },
     "fal_ai:xai/grok-imagine-image/edit": {
       "unit_price": 0.02,
@@ -1748,7 +3883,14 @@
       "model_slug": "grok-imagine",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://fal.ai/models/xai/grok-imagine-image/edit"
+      "source_url": "https://fal.ai/models/xai/grok-imagine-image/edit",
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.002,
+          "free_allowance": 0
+        }
+      ]
     },
     "fal_ai:xai/grok-imagine-video/image-to-video": {
       "unit_price": 0.08,
@@ -1757,7 +3899,38 @@
       "model_slug": "grok-imagine-video",
       "match": "catalog",
       "live": false,
-      "source_url": "https://fal.ai/models/xai/grok-imagine-video/v1.5/image-to-video"
+      "source_url": "https://fal.ai/models/xai/grok-imagine-video/v1.5/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.25,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.01,
+          "free_allowance": 0
+        }
+      ],
+      "clip_seconds": {
+        "min": 1,
+        "max": 15
+      }
     },
     "fal_ai:xai/grok-imagine-video/reference-to-video": {
       "unit_price": 0.08,
@@ -1766,7 +3939,38 @@
       "model_slug": "grok-imagine-video",
       "match": "catalog",
       "live": false,
-      "source_url": "https://fal.ai/models/xai/grok-imagine-video/v1.5/image-to-video"
+      "source_url": "https://fal.ai/models/xai/grok-imagine-video/v1.5/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.25,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.01,
+          "free_allowance": 0
+        }
+      ],
+      "clip_seconds": {
+        "min": 1,
+        "max": 15
+      }
     },
     "fal_ai:xai/grok-imagine-video/text-to-video": {
       "unit_price": 0.08,
@@ -1775,7 +3979,38 @@
       "model_slug": "grok-imagine-video",
       "match": "catalog",
       "live": false,
-      "source_url": "https://fal.ai/models/xai/grok-imagine-video/v1.5/image-to-video"
+      "source_url": "https://fal.ai/models/xai/grok-imagine-video/v1.5/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.25,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.01,
+          "free_allowance": 0
+        }
+      ],
+      "clip_seconds": {
+        "min": 1,
+        "max": 15
+      }
     },
     "fal_ai:xai/grok-imagine-video/v1.5/image-to-video": {
       "unit_price": 0.08,
@@ -1784,7 +4019,118 @@
       "model_slug": "grok-imagine-video",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://fal.ai/models/xai/grok-imagine-video/v1.5/image-to-video"
+      "source_url": "https://fal.ai/models/xai/grok-imagine-video/v1.5/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.25,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.01,
+          "free_allowance": 0
+        }
+      ],
+      "clip_seconds": {
+        "min": 1,
+        "max": 15
+      }
+    },
+    "fal_ai:xai/grok-imagine-video/v1.5/reference-to-video": {
+      "unit_price": 0.08,
+      "billing_unit": "seconds",
+      "unit_class": "per-video-second",
+      "model_slug": "grok-imagine-video",
+      "match": "catalog",
+      "live": false,
+      "source_url": "https://fal.ai/models/xai/grok-imagine-video/v1.5/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.25,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.01,
+          "free_allowance": 0
+        }
+      ],
+      "clip_seconds": {
+        "min": 1,
+        "max": 15
+      }
+    },
+    "fal_ai:xai/grok-imagine-video/v1.5/text-to-video": {
+      "unit_price": 0.08,
+      "billing_unit": "seconds",
+      "unit_class": "per-video-second",
+      "model_slug": "grok-imagine-video",
+      "match": "catalog",
+      "live": false,
+      "source_url": "https://fal.ai/models/xai/grok-imagine-video/v1.5/image-to-video",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.25,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.01,
+          "free_allowance": 0
+        }
+      ],
+      "clip_seconds": {
+        "min": 1,
+        "max": 15
+      }
     },
     "gemini:gemini-2.5-flash-preview-tts": {
       "unit_price": 10,
@@ -1802,7 +4148,27 @@
       "model_slug": "gemini-3-pro-image",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://ai.google.dev/gemini-api/docs/pricing"
+      "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
+      "variants": [
+        {
+          "price_usd": 0.134,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.134,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.24,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ]
     },
     "gemini:gemini-3.1-flash-image": {
       "unit_price": 0.067,
@@ -1811,7 +4177,27 @@
       "model_slug": "gemini-3.1-flash-image",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://ai.google.dev/gemini-api/docs/pricing"
+      "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
+      "variants": [
+        {
+          "price_usd": 0.067,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.101,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.151,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ]
     },
     "gemini:gemini-3.1-flash-lite-image": {
       "unit_price": 0.0336,
@@ -1838,7 +4224,27 @@
       "model_slug": "imagen-4",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://ai.google.dev/gemini-api/docs/pricing"
+      "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
+      "variants": [
+        {
+          "price_usd": 0.02,
+          "unit_class": "per-image",
+          "tier": "fast",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-image",
+          "tier": "standard",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.06,
+          "unit_class": "per-image",
+          "tier": "ultra",
+          "is_base": false
+        }
+      ]
     },
     "gemini:veo-3.1-fast-generate-preview": {
       "unit_price": 0.1,
@@ -1847,7 +4253,38 @@
       "model_slug": "veo-3.1-fast",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://ai.google.dev/gemini-api/docs/pricing"
+      "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
+      "variants": [
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.3,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "gemini:veo-3.1-generate-preview": {
       "unit_price": 0.4,
@@ -1856,7 +4293,38 @@
       "model_slug": "veo-3.1",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://ai.google.dev/gemini-api/docs/pricing"
+      "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
+      "variants": [
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.6,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "gemini:veo-3.1-lite-generate-preview": {
       "unit_price": 0.05,
@@ -1865,7 +4333,31 @@
       "model_slug": "veo-3.1-lite",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://ai.google.dev/gemini-api/docs/pricing"
+      "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
+      "variants": [
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "kie:bytedance/seedance-1.5-pro": {
       "unit_price": 0.0175,
@@ -1874,7 +4366,61 @@
       "model_slug": "seedance-1.5-pro",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/seedance-1-5-pro"
+      "source_url": "https://kie.ai/seedance-1-5-pro",
+      "variants": [
+        {
+          "price_usd": 0.0175,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.075,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.0375,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.035,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.0175,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "with_audio": true,
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.00875,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "with_audio": false,
+          "tier": "pro",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 4,
+        "max": 12
+      }
     },
     "kie:bytedance/seedance-2": {
       "unit_price": 0.205,
@@ -1883,7 +4429,49 @@
       "model_slug": "seedance-2",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/seedance-2-0"
+      "source_url": "https://kie.ai/seedance-2-0",
+      "variants": [
+        {
+          "price_usd": 1.04,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "video_input": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.51,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "video_input": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.205,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "video_input": false,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.095,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "video_input": false,
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_video_second",
+          "spec": "720p",
+          "unit_price_usd": 0.125,
+          "free_allowance": 0
+        }
+      ],
+      "clip_seconds": {
+        "min": 4,
+        "max": 15
+      }
     },
     "kie:elevenlabs/text-to-speech-multilingual-v2": {
       "unit_price": 60,
@@ -1901,7 +4489,37 @@
       "model_slug": "flux-2-pro",
       "match": "catalog",
       "live": true,
-      "source_url": "https://kie.ai/flux-2"
+      "source_url": "https://kie.ai/flux-2",
+      "variants": [
+        {
+          "price_usd": 0.035,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.035,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.025,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.025,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "pro",
+          "is_base": false
+        }
+      ]
     },
     "kie:flux-2/pro-text-to-image": {
       "unit_price": 0.025,
@@ -1910,7 +4528,37 @@
       "model_slug": "flux-2-pro",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/flux-2"
+      "source_url": "https://kie.ai/flux-2",
+      "variants": [
+        {
+          "price_usd": 0.035,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.035,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.025,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.025,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "tier": "pro",
+          "is_base": false
+        }
+      ]
     },
     "kie:gemini-omni-video": {
       "unit_price": 0.315,
@@ -1918,8 +4566,110 @@
       "unit_class": "per-generation",
       "model_slug": "gemini-omni-video",
       "match": "provider-id",
-      "live": false,
-      "source_url": "https://kie.ai/gemini-omni"
+      "live": true,
+      "source_url": "https://kie.ai/gemini-omni",
+      "variants": [
+        {
+          "price_usd": 0.84,
+          "unit_class": "per-generation",
+          "resolution": "4K",
+          "duration_seconds": 6,
+          "video_input": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 1.05,
+          "unit_class": "per-generation",
+          "resolution": "4K",
+          "duration_seconds": 10,
+          "video_input": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.945,
+          "unit_class": "per-generation",
+          "resolution": "4K",
+          "duration_seconds": 8,
+          "video_input": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.735,
+          "unit_class": "per-generation",
+          "resolution": "4K",
+          "duration_seconds": 4,
+          "video_input": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.63,
+          "unit_class": "per-generation",
+          "resolution": "1080p",
+          "duration_seconds": 10,
+          "video_input": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.525,
+          "unit_class": "per-generation",
+          "resolution": "1080p",
+          "duration_seconds": 8,
+          "video_input": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.42,
+          "unit_class": "per-generation",
+          "resolution": "1080p",
+          "duration_seconds": 6,
+          "video_input": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.315,
+          "unit_class": "per-generation",
+          "resolution": "1080p",
+          "duration_seconds": 4,
+          "video_input": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.63,
+          "unit_class": "per-generation",
+          "resolution": "720p",
+          "duration_seconds": 10,
+          "video_input": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.525,
+          "unit_class": "per-generation",
+          "resolution": "720p",
+          "duration_seconds": 8,
+          "video_input": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.42,
+          "unit_class": "per-generation",
+          "resolution": "720p",
+          "duration_seconds": 6,
+          "video_input": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.315,
+          "unit_class": "per-generation",
+          "resolution": "720p",
+          "duration_seconds": 4,
+          "video_input": false,
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 10
+      }
     },
     "kie:google/nano-banana": {
       "unit_price": 0.02,
@@ -1946,7 +4696,45 @@
       "model_slug": "gpt-image-2",
       "match": "catalog",
       "live": true,
-      "source_url": "https://kie.ai/gpt-image-2"
+      "source_url": "https://kie.ai/gpt-image-2",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.03,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.03,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": true
+        }
+      ]
     },
     "kie:gpt-image-2-text-to-image": {
       "unit_price": 0.03,
@@ -1955,7 +4743,45 @@
       "model_slug": "gpt-image-2",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/gpt-image-2"
+      "source_url": "https://kie.ai/gpt-image-2",
+      "variants": [
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.03,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.03,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": true
+        }
+      ]
     },
     "kie:gpt-image/1.5-image-to-image": {
       "unit_price": 0.02,
@@ -1964,7 +4790,33 @@
       "model_slug": "gpt-image-1.5",
       "match": "catalog",
       "live": true,
-      "source_url": "https://kie.ai/gpt-image-1.5"
+      "source_url": "https://kie.ai/gpt-image-1.5",
+      "variants": [
+        {
+          "price_usd": 0.02,
+          "unit_class": "per-image",
+          "tier": "quality",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.02,
+          "unit_class": "per-image",
+          "tier": "quality",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.11,
+          "unit_class": "per-image",
+          "tier": "quality",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.11,
+          "unit_class": "per-image",
+          "tier": "quality",
+          "is_base": false
+        }
+      ]
     },
     "kie:gpt-image/1.5-text-to-image": {
       "unit_price": 0.02,
@@ -1973,25 +4825,126 @@
       "model_slug": "gpt-image-1.5",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/gpt-image-1.5"
+      "source_url": "https://kie.ai/gpt-image-1.5",
+      "variants": [
+        {
+          "price_usd": 0.02,
+          "unit_class": "per-image",
+          "tier": "quality",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.02,
+          "unit_class": "per-image",
+          "tier": "quality",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.11,
+          "unit_class": "per-image",
+          "tier": "quality",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.11,
+          "unit_class": "per-image",
+          "tier": "quality",
+          "is_base": false
+        }
+      ]
     },
     "kie:grok-imagine-video-1-5-preview": {
-      "unit_price": 0.008,
+      "unit_price": 0.012,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "grok-imagine-video",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/grok-imagine-video-1.5"
+      "source_url": "https://kie.ai/grok-imagine-video-1.5",
+      "variants": [
+        {
+          "price_usd": 0.0225,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.012,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "min": 1,
+        "max": 15
+      }
     },
     "kie:hailuo/2-3-image-to-video-standard": {
-      "unit_price": 0.025,
-      "billing_unit": "seconds",
-      "unit_class": "per-video-second",
+      "unit_price": 0.15,
+      "billing_unit": "generations",
+      "unit_class": "per-generation",
       "model_slug": "hailuo-2.3",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/hailuo-2-3"
+      "source_url": "https://kie.ai/hailuo-2-3",
+      "variants": [
+        {
+          "price_usd": 0.45,
+          "unit_class": "per-generation",
+          "resolution": "768p",
+          "duration_seconds": 10,
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.4,
+          "unit_class": "per-generation",
+          "resolution": "1080p",
+          "duration_seconds": 6,
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.225,
+          "unit_class": "per-generation",
+          "resolution": "768p",
+          "duration_seconds": 6,
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-generation",
+          "resolution": "768p",
+          "duration_seconds": 6,
+          "tier": "standard",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.25,
+          "unit_class": "per-generation",
+          "resolution": "768p",
+          "duration_seconds": 10,
+          "tier": "standard",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.25,
+          "unit_class": "per-generation",
+          "resolution": "1080p",
+          "duration_seconds": 6,
+          "tier": "standard",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          6,
+          10
+        ],
+        "max": 10
+      }
     },
     "kie:happyhorse-1-1/image-to-video": {
       "unit_price": 0.1125,
@@ -2000,7 +4953,49 @@
       "model_slug": "happyhorse-1-1",
       "match": "catalog",
       "live": true,
-      "source_url": "https://kie.ai/happyhorse-1-1"
+      "source_url": "https://kie.ai/happyhorse-1-1",
+      "variants": [
+        {
+          "price_usd": 0.1125,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.145,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.1125,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.145,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.1125,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.145,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "kie:happyhorse-1-1/reference-to-video": {
       "unit_price": 0.1125,
@@ -2009,7 +5004,49 @@
       "model_slug": "happyhorse-1-1",
       "match": "catalog",
       "live": true,
-      "source_url": "https://kie.ai/happyhorse-1-1"
+      "source_url": "https://kie.ai/happyhorse-1-1",
+      "variants": [
+        {
+          "price_usd": 0.1125,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.145,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.1125,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.145,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.1125,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.145,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "kie:happyhorse-1-1/text-to-video": {
       "unit_price": 0.1125,
@@ -2018,7 +5055,49 @@
       "model_slug": "happyhorse-1-1",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/happyhorse-1-1"
+      "source_url": "https://kie.ai/happyhorse-1-1",
+      "variants": [
+        {
+          "price_usd": 0.1125,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.145,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.1125,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.145,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.1125,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.145,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "kie:happyhorse/text-to-video": {
       "unit_price": 0.14,
@@ -2027,7 +5106,61 @@
       "model_slug": "happyhorse-1",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/happyhorse-1-0"
+      "source_url": "https://kie.ai/happyhorse-1-0",
+      "variants": [
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.24,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.24,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.24,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.14,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.24,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "kie:infinitalk/from-audio": {
       "unit_price": 0.015,
@@ -2036,7 +5169,24 @@
       "model_slug": "infinitalk",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/infinitalk"
+      "source_url": "https://kie.ai/infinitalk",
+      "variants": [
+        {
+          "price_usd": 0.015,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.06,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "max": 28
+      }
     },
     "kie:kling-3.0/motion-control": {
       "unit_price": 0.1,
@@ -2045,7 +5195,82 @@
       "model_slug": "kling-motion-control-3",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/kling-3-motion-control"
+      "source_url": "https://kie.ai/kling-3-motion-control",
+      "variants": [
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.135,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 30
+      }
+    },
+    "kie:kling-3.0/video": {
+      "unit_price": 0.07,
+      "billing_unit": "seconds",
+      "unit_class": "per-video-second",
+      "model_slug": "kling-3.0-standard",
+      "match": "provider-id",
+      "live": true,
+      "source_url": "https://kie.ai/kling-3-0",
+      "variants": [
+        {
+          "price_usd": 0.335,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.335,
+          "unit_class": "per-video-second",
+          "resolution": "4K",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.135,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.09,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "with_audio": false,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": true,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "with_audio": false,
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "kie:kling/v3-turbo-image-to-video": {
       "unit_price": 0.09,
@@ -2054,7 +5279,27 @@
       "model_slug": "kling-3.0-turbo",
       "match": "catalog",
       "live": false,
-      "source_url": "https://kie.ai/kling-3-0-turbo"
+      "source_url": "https://kie.ai/kling-3-0-turbo",
+      "variants": [
+        {
+          "price_usd": 0.09,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "tier": "turbo",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.1125,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "tier": "turbo",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "kie:kling/v3-turbo-text-to-video": {
       "unit_price": 0.09,
@@ -2063,7 +5308,27 @@
       "model_slug": "kling-3.0-turbo",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://kie.ai/kling-3-0-turbo"
+      "source_url": "https://kie.ai/kling-3-0-turbo",
+      "variants": [
+        {
+          "price_usd": 0.09,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "tier": "turbo",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.1125,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "tier": "turbo",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 3,
+        "max": 15
+      }
     },
     "kie:nano-banana-2": {
       "unit_price": 0.04,
@@ -2072,7 +5337,27 @@
       "model_slug": "gemini-3.1-flash-image",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/nano-banana-2"
+      "source_url": "https://kie.ai/nano-banana-2",
+      "variants": [
+        {
+          "price_usd": 0.09,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.06,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": true
+        }
+      ]
     },
     "kie:nano-banana-2-lite": {
       "unit_price": 0.02,
@@ -2090,7 +5375,23 @@
       "model_slug": "gemini-3-pro-image",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/nano-banana-pro"
+      "source_url": "https://kie.ai/nano-banana-pro",
+      "variants": [
+        {
+          "price_usd": 0.09,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "tier": "pro",
+          "is_base": false
+        }
+      ]
     },
     "kie:qwen/text-to-image": {
       "unit_price": 0.02,
@@ -2144,7 +5445,40 @@
       "model_slug": "seedream-5-pro",
       "match": "catalog",
       "live": true,
-      "source_url": "https://kie.ai/seedream-5-0-pro"
+      "source_url": "https://kie.ai/seedream-5-0-pro",
+      "variants": [
+        {
+          "price_usd": 0.035,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.035,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.0025,
+          "free_allowance": 1
+        }
+      ]
     },
     "kie:seedream/5-pro-text-to-image": {
       "unit_price": 0.035,
@@ -2153,7 +5487,40 @@
       "model_slug": "seedream-5-pro",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/seedream-5-0-pro"
+      "source_url": "https://kie.ai/seedream-5-0-pro",
+      "variants": [
+        {
+          "price_usd": 0.035,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.035,
+          "unit_class": "per-image",
+          "resolution": "1K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        }
+      ],
+      "surcharges": [
+        {
+          "kind": "input_image",
+          "unit_price_usd": 0.0025,
+          "free_allowance": 1
+        }
+      ]
     },
     "kie:wan/2-7-image-to-video": {
       "unit_price": 0.08,
@@ -2162,7 +5529,61 @@
       "model_slug": "wan-2.7",
       "match": "catalog",
       "live": true,
-      "source_url": "https://kie.ai/wan-2-7-video"
+      "source_url": "https://kie.ai/wan-2-7-video",
+      "variants": [
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "min": 2,
+        "max": 15
+      }
     },
     "kie:wan/2-7-r2v": {
       "unit_price": 0.08,
@@ -2171,7 +5592,61 @@
       "model_slug": "wan-2.7",
       "match": "catalog",
       "live": true,
-      "source_url": "https://kie.ai/wan-2-7-video"
+      "source_url": "https://kie.ai/wan-2-7-video",
+      "variants": [
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "min": 2,
+        "max": 15
+      }
     },
     "kie:wan/2-7-text-to-video": {
       "unit_price": 0.08,
@@ -2180,7 +5655,61 @@
       "model_slug": "wan-2.7",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://kie.ai/wan-2-7-video"
+      "source_url": "https://kie.ai/wan-2-7-video",
+      "variants": [
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.12,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.08,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "min": 2,
+        "max": 15
+      }
     },
     "kie:z-image": {
       "unit_price": 0.004,
@@ -2192,22 +5721,94 @@
       "source_url": "https://kie.ai/z-image"
     },
     "minimax:MiniMax-Hailuo-02": {
-      "unit_price": 0.047,
-      "billing_unit": "seconds",
-      "unit_class": "per-video-second",
+      "unit_price": 0.28,
+      "billing_unit": "generations",
+      "unit_class": "per-generation",
       "model_slug": "hailuo-02",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://platform.minimax.io/docs/guides/pricing-paygo"
+      "source_url": "https://platform.minimax.io/docs/guides/pricing-paygo",
+      "variants": [
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-generation",
+          "duration_seconds": 6,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-generation",
+          "duration_seconds": 10,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.28,
+          "unit_class": "per-generation",
+          "resolution": "768p",
+          "duration_seconds": 6,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.56,
+          "unit_class": "per-generation",
+          "resolution": "768p",
+          "duration_seconds": 10,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.49,
+          "unit_class": "per-generation",
+          "resolution": "1080p",
+          "duration_seconds": 6,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          6,
+          10
+        ],
+        "max": 10
+      }
     },
     "minimax:MiniMax-Hailuo-2.3": {
-      "unit_price": 0.047,
-      "billing_unit": "seconds",
-      "unit_class": "per-video-second",
+      "unit_price": 0.28,
+      "billing_unit": "generations",
+      "unit_class": "per-generation",
       "model_slug": "hailuo-2.3",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://platform.minimax.io/docs/guides/pricing-paygo"
+      "source_url": "https://platform.minimax.io/docs/guides/pricing-paygo",
+      "variants": [
+        {
+          "price_usd": 0.28,
+          "unit_class": "per-generation",
+          "resolution": "768p",
+          "duration_seconds": 6,
+          "is_base": true
+        },
+        {
+          "price_usd": 0.56,
+          "unit_class": "per-generation",
+          "resolution": "768p",
+          "duration_seconds": 10,
+          "is_base": false
+        },
+        {
+          "price_usd": 0.49,
+          "unit_class": "per-generation",
+          "resolution": "1080p",
+          "duration_seconds": 6,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          6,
+          10
+        ],
+        "max": 10
+      }
     },
     "minimax:image-01": {
       "unit_price": 0.0035,
@@ -2279,7 +5880,17 @@
       "model_slug": "sora-2",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://developers.openai.com/api/docs/pricing"
+      "source_url": "https://developers.openai.com/api/docs/pricing",
+      "clip_seconds": {
+        "set": [
+          4,
+          8,
+          12,
+          16,
+          20
+        ],
+        "max": 20
+      }
     },
     "openai:sora-2-pro": {
       "unit_price": 0.3,
@@ -2288,7 +5899,31 @@
       "model_slug": "sora-2-pro",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://developers.openai.com/api/docs/pricing"
+      "source_url": "https://developers.openai.com/api/docs/pricing",
+      "variants": [
+        {
+          "price_usd": 0.3,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.7,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          8,
+          12,
+          16,
+          20
+        ],
+        "max": 20
+      }
     },
     "openai:tts-1": {
       "unit_price": 15,
@@ -2315,7 +5950,15 @@
       "model_slug": "flux-1.1-pro",
       "match": "receipt",
       "live": true,
-      "source_url": "https://replicate.com/black-forest-labs/flux-1.1-pro"
+      "source_url": "https://replicate.com/black-forest-labs/flux-1.1-pro",
+      "variants": [
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": true
+        }
+      ]
     },
     "replicate:black-forest-labs/flux-dev": {
       "unit_price": 0.025,
@@ -2333,7 +5976,15 @@
       "model_slug": "flux-1-kontext-pro",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://replicate.com/black-forest-labs/flux-kontext-pro"
+      "source_url": "https://replicate.com/black-forest-labs/flux-kontext-pro",
+      "variants": [
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": true
+        }
+      ]
     },
     "replicate:black-forest-labs/flux-schnell": {
       "unit_price": 0.003,
@@ -2345,13 +5996,40 @@
       "source_url": "https://replicate.com/black-forest-labs/flux-schnell"
     },
     "replicate:bytedance/seedance-1-pro": {
-      "unit_price": 0.03,
+      "unit_price": 0.06,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "seedance-1-pro",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://replicate.com/bytedance/seedance-1-pro"
+      "source_url": "https://replicate.com/bytedance/seedance-1-pro",
+      "variants": [
+        {
+          "price_usd": 0.03,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "tier": "pro",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.06,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "tier": "pro",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "tier": "pro",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "min": 2,
+        "max": 12
+      }
     },
     "replicate:bytedance/seedream-4": {
       "unit_price": 0.03,
@@ -2378,7 +6056,15 @@
       "model_slug": "lyria-2",
       "match": "receipt",
       "live": true,
-      "source_url": "https://replicate.com/google/lyria-2"
+      "source_url": "https://replicate.com/google/lyria-2",
+      "variants": [
+        {
+          "price_usd": 0.002,
+          "unit_class": "per-audio-second",
+          "with_audio": true,
+          "is_base": false
+        }
+      ]
     },
     "replicate:google/veo-3": {
       "unit_price": 0.4,
@@ -2387,7 +6073,15 @@
       "model_slug": "veo-3",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://replicate.com/google/veo-3"
+      "source_url": "https://replicate.com/google/veo-3",
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "replicate:google/veo-3-fast": {
       "unit_price": 0.15,
@@ -2396,7 +6090,29 @@
       "model_slug": "veo-3-fast",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://replicate.com/google/veo-3-fast"
+      "source_url": "https://replicate.com/google/veo-3-fast",
+      "variants": [
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "tier": "fast",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "replicate:ideogram-ai/ideogram-v3-quality": {
       "unit_price": 0.09,
@@ -2414,7 +6130,22 @@
       "model_slug": "kling-2.5-turbo-pro",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://replicate.com/kwaivgi/kling-v2.5-turbo-pro"
+      "source_url": "https://replicate.com/kwaivgi/kling-v2.5-turbo-pro",
+      "variants": [
+        {
+          "price_usd": 0.07,
+          "unit_class": "per-video-second",
+          "tier": "turbo",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          5,
+          10
+        ],
+        "max": 10
+      }
     },
     "replicate:luma/ray-2-720p": {
       "unit_price": 0.18,
@@ -2423,16 +6154,50 @@
       "model_slug": "luma-ray-2",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://replicate.com/luma/ray-2-720p"
+      "source_url": "https://replicate.com/luma/ray-2-720p",
+      "clip_seconds": {
+        "set": [
+          5,
+          9
+        ],
+        "max": 9
+      }
     },
     "replicate:minimax/hailuo-02": {
-      "unit_price": 0.045,
-      "billing_unit": "seconds",
-      "unit_class": "per-video-second",
+      "unit_price": 0.1,
+      "billing_unit": "generations",
+      "unit_class": "per-generation",
       "model_slug": "hailuo-02",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://replicate.com/minimax/hailuo-02"
+      "source_url": "https://replicate.com/minimax/hailuo-02",
+      "variants": [
+        {
+          "price_usd": 0.27,
+          "unit_class": "per-generation",
+          "resolution": "768p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.45,
+          "unit_class": "per-generation",
+          "resolution": "768p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.48,
+          "unit_class": "per-generation",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          6,
+          10
+        ],
+        "max": 10
+      }
     },
     "replicate:minimax/music-1.5": {
       "unit_price": 0.03,
@@ -2441,12 +6206,20 @@
       "model_slug": "minimax-music-1.5",
       "match": "receipt",
       "live": true,
-      "source_url": "https://replicate.com/minimax/music-1.5"
+      "source_url": "https://replicate.com/minimax/music-1.5",
+      "variants": [
+        {
+          "price_usd": 0.03,
+          "unit_class": "per-generation",
+          "with_audio": true,
+          "is_base": true
+        }
+      ]
     },
     "replicate:minimax/speech-02-hd": {
       "unit_price": 100,
-      "billing_unit": "1m_chars",
-      "unit_class": "per-1m-chars",
+      "billing_unit": "1m_tokens",
+      "unit_class": "per-1m-tokens",
       "model_slug": "minimax-speech-02-hd",
       "match": "receipt",
       "live": true,
@@ -2459,7 +6232,17 @@
       "model_slug": "sora-2",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://replicate.com/openai/sora-2"
+      "source_url": "https://replicate.com/openai/sora-2",
+      "clip_seconds": {
+        "set": [
+          4,
+          8,
+          12,
+          16,
+          20
+        ],
+        "max": 20
+      }
     },
     "replicate:recraft-ai/recraft-v3": {
       "unit_price": 0.04,
@@ -2475,7 +6258,7 @@
       "billing_unit": "1m_chars",
       "unit_class": "per-1m-chars",
       "model_slug": "chatterbox",
-      "match": "receipt",
+      "match": "provider-id",
       "live": true,
       "source_url": "https://replicate.com/resemble-ai/chatterbox"
     },
@@ -2489,13 +6272,40 @@
       "source_url": "https://replicate.com/stability-ai/stable-diffusion-3.5-large"
     },
     "replicate:wan-video/wan-2.5-t2v": {
-      "unit_price": 0.05,
+      "unit_price": 0.1,
       "billing_unit": "seconds",
       "unit_class": "per-video-second",
       "model_slug": "wan-2.5",
       "match": "provider-id",
       "live": true,
-      "source_url": "https://replicate.com/wan-video/wan-2.5-t2v"
+      "source_url": "https://replicate.com/wan-video/wan-2.5-t2v",
+      "variants": [
+        {
+          "price_usd": 0.05,
+          "unit_class": "per-video-second",
+          "resolution": "480p",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.1,
+          "unit_class": "per-video-second",
+          "resolution": "720p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.15,
+          "unit_class": "per-video-second",
+          "resolution": "1080p",
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          5,
+          10
+        ],
+        "max": 10
+      }
     },
     "together:ByteDance-Seed/Seedream-4.0": {
       "unit_price": 0.03,
@@ -2514,7 +6324,19 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.together.ai/pricing",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.11299999999999999,
+          "unit_class": "per-video-second",
+          "tier": "pro",
+          "is_base": true
+        }
+      ],
+      "clip_seconds": {
+        "min": 2,
+        "max": 12
+      }
     },
     "together:black-forest-labs/FLUX.1-kontext-pro": {
       "unit_price": 0.04,
@@ -2524,7 +6346,15 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.together.ai/pricing",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": true
+        }
+      ]
     },
     "together:black-forest-labs/FLUX.1-schnell": {
       "unit_price": 0.0027,
@@ -2543,7 +6373,15 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.together.ai/pricing",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.04,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": true
+        }
+      ]
     },
     "together:black-forest-labs/FLUX.2-pro": {
       "unit_price": 0.03,
@@ -2553,7 +6391,15 @@
       "match": "variant",
       "live": true,
       "source_url": "https://www.together.ai/pricing",
-      "tier": "pro"
+      "tier": "pro",
+      "variants": [
+        {
+          "price_usd": 0.03,
+          "unit_class": "per-image",
+          "tier": "pro",
+          "is_base": true
+        }
+      ]
     },
     "together:canopylabs/orpheus-3b-0.1-ft": {
       "unit_price": 15,
@@ -2569,19 +6415,64 @@
       "billing_unit": "images",
       "unit_class": "per-image",
       "model_slug": "gemini-3-pro-image",
-      "match": "variant",
+      "match": "provider-id",
       "live": true,
       "source_url": "https://www.together.ai/pricing",
-      "tier": "pro"
+      "variants": [
+        {
+          "price_usd": 0.134,
+          "unit_class": "per-image",
+          "resolution": "1080p",
+          "is_base": true
+        },
+        {
+          "price_usd": 0.134,
+          "unit_class": "per-image",
+          "resolution": "2K",
+          "is_base": false
+        },
+        {
+          "price_usd": 0.24,
+          "unit_class": "per-image",
+          "resolution": "4K",
+          "is_base": false
+        }
+      ]
     },
     "together:google/veo-3.0": {
-      "unit_price": 0.2,
-      "billing_unit": "seconds",
-      "unit_class": "per-video-second",
+      "unit_price": 1.6,
+      "billing_unit": "generations",
+      "unit_class": "per-generation",
       "model_slug": "veo-3",
       "match": "provider-id",
       "live": false,
-      "source_url": "https://www.together.ai/pricing"
+      "source_url": "https://www.together.ai/pricing",
+      "variants": [
+        {
+          "price_usd": 1.6,
+          "unit_class": "per-generation",
+          "resolution": "720p",
+          "duration_seconds": 8,
+          "with_audio": false,
+          "is_base": true
+        },
+        {
+          "price_usd": 3.2,
+          "unit_class": "per-generation",
+          "resolution": "720p",
+          "duration_seconds": 8,
+          "with_audio": true,
+          "is_base": false
+        }
+      ],
+      "clip_seconds": {
+        "set": [
+          4,
+          6,
+          8
+        ],
+        "max": 8
+      }
     },
     "together:hexgrad/Kokoro-82M": {
       "unit_price": 4,
@@ -2599,7 +6490,14 @@
       "model_slug": "hailuo-02",
       "match": "variant",
       "live": true,
-      "source_url": "https://docs.together.ai/docs/serverless-models"
+      "source_url": "https://docs.together.ai/docs/serverless-models",
+      "clip_seconds": {
+        "set": [
+          6,
+          10
+        ],
+        "max": 10
+      }
     },
     "together:openai/sora-2": {
       "unit_price": 0.1,
@@ -2608,7 +6506,17 @@
       "model_slug": "sora-2",
       "match": "variant",
       "live": true,
-      "source_url": "https://www.together.ai/pricing"
+      "source_url": "https://www.together.ai/pricing",
+      "clip_seconds": {
+        "set": [
+          4,
+          8,
+          12,
+          16,
+          20
+        ],
+        "max": 20
+      }
     }
   }
 }

--- a/packages/model-pricing/src/genspend-calc.ts
+++ b/packages/model-pricing/src/genspend-calc.ts
@@ -88,7 +88,13 @@ const RESOLUTION_TIERS: Record<string, string> = {
 /** Normalize a resolution to a tier, or null when it names none we know. */
 export function normalizeResolution(value: unknown): string | null {
   if (typeof value !== "string") return null;
-  const key = value.trim().toLowerCase().replace(/\s*[x*×]\s*/g, "x");
+  // Collapse whitespace runs before touching the separators: an unbounded
+  // `\s*` on both sides of the class backtracks polynomially (CodeQL).
+  const key = value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/ ?[x*×] ?/g, "x");
   if (!key) return null;
   return RESOLUTION_TIERS[key] ?? null;
 }

--- a/packages/model-pricing/src/genspend-calc.ts
+++ b/packages/model-pricing/src/genspend-calc.ts
@@ -1,0 +1,365 @@
+/**
+ * Price one step from a GenSpend catalog entry given what a node states about
+ * the job: resolution, duration, audio state, reference inputs.
+ *
+ * Pure and I/O-free. The arithmetic is a port of `priceCase` in
+ * `scripts/genspend/parity-check.mjs`, which the nightly sync asserts equals
+ * `POST https://genspend.io/api/v1/quote`. Keep the two in step: a rule changed
+ * here and not there ships a number nothing checks.
+ *
+ * Two deliberate divergences from the parity script, both product decisions the
+ * plan names (a node that never set the property would otherwise show no price
+ * at all, which is less useful than an honest assumption):
+ *
+ * - Resolution unset → the provider's base-spec row plus an assumption, where
+ *   `/quote` declines a laddered offering outright.
+ * - Duration unset on a per-second class → the shortest duration the model is
+ *   receipted for (one second when it publishes no envelope) plus an
+ *   assumption, where the parity script declines.
+ *
+ * Declining is a result, not an error: we never reuse another rung for a
+ * resolution the provider does not publish, because understating is the
+ * direction that hurts.
+ */
+
+import type {
+  ModelPriceParams,
+  ModelUnitPricingLike
+} from "@nodetool-ai/node-sdk/cost-estimate";
+import type {
+  GenspendPrice,
+  GenspendSurcharge,
+  GenspendVariant
+} from "./genspend-catalog.js";
+import { GENSPEND_CURRENCY } from "./genspend-catalog.js";
+
+/**
+ * A price computed from stated parameters, with the reasoning that produced it.
+ * `unit_price` is the whole per-run figure — a per-second class comes back
+ * already multiplied by the priced duration — so `estimated_cost` stays
+ * `unit_price × fan-out`.
+ */
+export interface ModelParamPrice extends ModelUnitPricingLike {
+  /** How the figure was reached: "5 s × $0.205/s at 720p". */
+  breakdown?: string;
+  /** What we filled in because the node did not state it. */
+  assumptions?: string[];
+  /** Costs we know are missing — the figure is then a lower bound. */
+  warnings?: string[];
+  /** Set instead of a price when we refuse to extrapolate. */
+  declined?: string;
+}
+
+/**
+ * GenSpend's video ladder plus the spellings provider pages use for it, and
+ * the image tiers (`1MP` is their name for 1024×1024). Both the caller's value
+ * and the stored row are pushed through this, so the two always compare in one
+ * vocabulary.
+ */
+const RESOLUTION_TIERS: Record<string, string> = {
+  "360p": "360p",
+  "480p": "480p",
+  "540p": "480p",
+  "576p": "480p",
+  "720p": "720p",
+  "768p": "720p",
+  "1080p": "1080p",
+  fhd: "1080p",
+  "1440p": "2K",
+  "2k": "2K",
+  "2160p": "4K",
+  "4k": "4K",
+  // Image tiers.
+  "512": "512×512",
+  "512p": "512×512",
+  "512x512": "512×512",
+  "512×512": "512×512",
+  "1k": "1MP",
+  "1mp": "1MP",
+  "1 mp": "1MP",
+  "1024": "1MP",
+  "1024x1024": "1MP",
+  "1024×1024": "1MP",
+  "2048": "2K",
+  "2048x2048": "2K",
+  "4096": "4K"
+};
+
+/** Normalize a resolution to a tier, or null when it names none we know. */
+export function normalizeResolution(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const key = value.trim().toLowerCase().replace(/\s*[x*×]\s*/g, "x");
+  if (!key) return null;
+  return RESOLUTION_TIERS[key] ?? null;
+}
+
+const PER_SECOND_CLASSES = new Set(["per-video-second", "per-audio-second"]);
+
+const money = (usd: number): string =>
+  usd >= 0.01 ? `$${usd.toFixed(3).replace(/0+$/, "").replace(/\.$/, "")}` : `$${usd}`;
+
+/** The shortest duration the model is receipted for, or 1 s when unbounded. */
+function shortestClipSecond(clip: GenspendPrice["clip_seconds"]): number {
+  if (!clip) return 1;
+  if (Array.isArray(clip.set) && clip.set.length > 0) {
+    const legal = clip.set.filter((s) => Number.isFinite(s) && s > 0);
+    if (legal.length > 0) return Math.min(...legal);
+  }
+  if (typeof clip.min === "number" && Number.isFinite(clip.min) && clip.min > 1) {
+    return clip.min;
+  }
+  return 1;
+}
+
+/** A duration outside the model's receipted envelope, with the reason. */
+function outsideEnvelope(
+  clip: GenspendPrice["clip_seconds"],
+  seconds: number
+): string | null {
+  if (!clip) return null;
+  if (Array.isArray(clip.set) && !clip.set.includes(seconds)) {
+    return `no published price at ${seconds}s`;
+  }
+  if (typeof clip.min === "number" && Number.isFinite(clip.min) && seconds < clip.min) {
+    return `below the receipted clip envelope (${clip.min}s minimum)`;
+  }
+  if (typeof clip.max === "number" && Number.isFinite(clip.max) && seconds > clip.max) {
+    return `above the receipted clip envelope (${clip.max}s maximum)`;
+  }
+  return null;
+}
+
+const declined = (reason: string): ModelParamPrice => ({
+  unit_price: 0,
+  billing_unit: "",
+  currency: GENSPEND_CURRENCY,
+  source: "bundle",
+  declined: reason
+});
+
+/**
+ * Narrow the published grid to the row the job actually bills at, one axis at a
+ * time. Returns the row, or a decline when a *stated* resolution has no rung.
+ */
+function selectRow(
+  rows: GenspendVariant[],
+  baseRow: GenspendVariant | null,
+  params: ModelPriceParams,
+  resolution: string | null,
+  seconds: number | null,
+  assumptions: string[]
+): { row: GenspendVariant | null } | { declined: string } {
+  // A plain t2v/i2v job never takes a video-input row: that is a different
+  // billing axis, handled by the re-rate below.
+  let candidates = rows.filter((row) => row.video_input !== true);
+
+  const laddered = candidates.filter((row) => row.resolution);
+  if (laddered.length > 0) {
+    if (resolution) {
+      candidates = laddered.filter(
+        (row) => normalizeResolution(row.resolution) === resolution
+      );
+      if (candidates.length === 0) {
+        return { declined: `no published price at ${resolution}` };
+      }
+    } else if (baseRow?.resolution) {
+      candidates = laddered.filter((row) => row.resolution === baseRow.resolution);
+      assumptions.push(
+        `resolution not set on the node — priced at the base spec ${baseRow.resolution}`
+      );
+    }
+  }
+
+  const timed = candidates.filter((row) => Number.isFinite(row.duration_seconds));
+  if (timed.length > 0) {
+    if (seconds !== null) {
+      candidates = timed.filter((row) => row.duration_seconds === seconds);
+      if (candidates.length === 0) {
+        return { declined: `no published price at ${seconds}s` };
+      }
+    } else {
+      const based = timed.filter((row) => row.is_base);
+      candidates = based.length > 0 ? based : timed;
+    }
+  }
+
+  // Audio is a billing axis worth up to 2×. Unset, the honest default is
+  // whatever the base spec delivers — not the cheaper of the two.
+  const wantAudio =
+    typeof params.withAudio === "boolean"
+      ? params.withAudio
+      : typeof baseRow?.with_audio === "boolean"
+        ? baseRow.with_audio
+        : null;
+  if (wantAudio !== null) {
+    const audio = candidates.filter((row) => row.with_audio === wantAudio);
+    if (audio.length > 0) candidates = audio;
+  }
+
+  // Tier is the same shape of axis: a provider selling Standard and Pro under
+  // one id delivers the base spec's tier unless the caller says otherwise.
+  const wantTier = params.tier ?? baseRow?.tier ?? null;
+  if (wantTier) {
+    const tiered = candidates.filter((row) => row.tier === wantTier);
+    if (tiered.length > 0) candidates = tiered;
+  }
+
+  return { row: candidates.find((r) => r.is_base) ?? candidates[0] ?? null };
+}
+
+/**
+ * Price a catalog entry for the stated job. `params` may be empty: the result
+ * is then the base spec with its assumptions written down.
+ */
+export function priceGenspendEntry(
+  entry: GenspendPrice,
+  params: ModelPriceParams = {}
+): ModelParamPrice {
+  if ((entry.data_flags ?? []).some((f) => f.severity === "quote_wrong")) {
+    return declined("a known price discrepancy is open against this model");
+  }
+
+  const assumptions: string[] = [];
+  const warnings: string[] = [];
+
+  const resolution =
+    params.resolution === undefined || params.resolution === null
+      ? null
+      : normalizeResolution(params.resolution);
+  if (params.resolution && !resolution) {
+    assumptions.push(
+      `resolution "${params.resolution}" is not one the catalog prices — priced at the base spec`
+    );
+  }
+
+  const statedSeconds =
+    typeof params.seconds === "number" &&
+    Number.isFinite(params.seconds) &&
+    params.seconds > 0
+      ? params.seconds
+      : null;
+
+  const clip = "clip_seconds" in entry ? entry.clip_seconds : undefined;
+  if (statedSeconds !== null && clip !== undefined) {
+    if (clip === null) return declined("no receipted clip length for this model");
+    const outside = outsideEnvelope(clip, statedSeconds);
+    if (outside) return declined(outside);
+  }
+
+  const rows = entry.variants ?? [];
+  const baseRow = rows.find((row) => row.is_base) ?? null;
+  const selected = selectRow(
+    rows,
+    baseRow,
+    params,
+    resolution,
+    statedSeconds,
+    assumptions
+  );
+  if ("declined" in selected) return declined(selected.declined);
+
+  const row = selected.row;
+  const unitPrice = row ? row.price_usd : entry.unit_price;
+  // The base-spec row's class travels with its price: some models bill a
+  // duration rung per generation while the headline class is per second.
+  const unitClass = row ? row.unit_class : entry.unit_class;
+  const rungLabel = row?.resolution ? ` at ${row.resolution}` : "";
+
+  let cost: number;
+  let breakdown: string;
+  let seconds = statedSeconds;
+
+  if (PER_SECOND_CLASSES.has(unitClass)) {
+    if (seconds === null) {
+      if (clip === null) return declined("no receipted clip length for this model");
+      seconds = shortestClipSecond(clip);
+      assumptions.push(
+        `duration not set on the node — priced at ${seconds} s${
+          seconds > 1 ? " (the shortest clip this model publishes)" : ""
+        }`
+      );
+    }
+    cost = unitPrice * seconds;
+    breakdown = `${seconds} s × ${money(unitPrice)}/s${rungLabel}`;
+  } else {
+    cost = unitPrice;
+    breakdown = `${money(unitPrice)} per ${entry.billing_unit || "generation"}${rungLabel}`;
+  }
+
+  const surcharges: GenspendSurcharge[] = entry.surcharges ?? [];
+
+  // A re-rate replaces the generation cost rather than adding to it, and is
+  // scoped by resolution. No row for the requested resolution declines the
+  // re-rate — never another rung — leaving the generation cost as a floor.
+  const refVideoSeconds =
+    typeof params.referenceVideoSeconds === "number" &&
+    Number.isFinite(params.referenceVideoSeconds)
+      ? params.referenceVideoSeconds
+      : 0;
+  if (refVideoSeconds > 0) {
+    const rates = surcharges.filter((s) => s.kind === "input_video_second");
+    const rate =
+      rates.find((s) => !s.spec) ??
+      rates.find((s) => resolution && normalizeResolution(s.spec) === resolution) ??
+      null;
+    if (rate) {
+      const outSeconds = seconds ?? 1;
+      cost = rate.unit_price_usd * (outSeconds + refVideoSeconds);
+      breakdown = `${outSeconds} s out + ${refVideoSeconds} s in × ${money(
+        rate.unit_price_usd
+      )}/s`;
+    } else if (rates.length > 0) {
+      warnings.push(
+        "no video-input rate published at this resolution — the generation price is a lower bound"
+      );
+    }
+  }
+
+  const refImages =
+    typeof params.referenceImages === "number" &&
+    Number.isFinite(params.referenceImages)
+      ? params.referenceImages
+      : 0;
+  if (refImages > 0) {
+    const surcharge = surcharges.find((s) => s.kind === "input_image");
+    if (surcharge) {
+      const billable = Math.max(0, refImages - surcharge.free_allowance);
+      if (billable > 0) {
+        cost += billable * surcharge.unit_price_usd;
+        breakdown += ` + ${billable} ref image${billable === 1 ? "" : "s"} × ${money(
+          surcharge.unit_price_usd
+        )}`;
+      }
+    } else {
+      warnings.push(
+        "reference images are not priced for this model — the figure is a lower bound"
+      );
+    }
+  }
+
+  // `per_request` extras are opt-in (prompt expansion, search grounding):
+  // surfaced, never summed.
+  for (const extra of surcharges.filter((s) => s.kind === "per_request")) {
+    warnings.push(
+      `${extra.label ?? "an optional per-request extra"} costs ${money(
+        extra.unit_price_usd
+      )} more when enabled — not included`
+    );
+  }
+
+  if ((entry.data_flags ?? []).some((f) => f.severity === "spec_gap")) {
+    warnings.push(
+      "this price is exact at the model's base spec only — other specs may differ"
+    );
+  }
+
+  return {
+    unit_price: cost,
+    billing_unit: entry.billing_unit,
+    currency: GENSPEND_CURRENCY,
+    source: "bundle",
+    breakdown,
+    ...(assumptions.length > 0 ? { assumptions } : {}),
+    ...(warnings.length > 0 ? { warnings } : {})
+  };
+}

--- a/packages/model-pricing/src/genspend-catalog.ts
+++ b/packages/model-pricing/src/genspend-catalog.ts
@@ -36,7 +36,60 @@ export type GenspendMatch =
   | "provider-id"
   | "catalog";
 
+/**
+ * One rung of a provider's published price grid, reduced to the facets a
+ * calculator narrows on. GenSpend's raw `spec` prose is deliberately not
+ * carried: a row that says nothing in facets prices nothing and is dropped at
+ * sync time.
+ */
+export interface GenspendVariant {
+  price_usd: number;
+  /** May differ from the entry's class — e.g. a per-generation duration rung. */
+  unit_class: string;
+  /** "480p".."4K" for video, an image size for image models. */
+  resolution?: string;
+  duration_seconds?: number;
+  with_audio?: boolean;
+  /** True on rows that price a job with a video going in — a billing axis. */
+  video_input?: boolean;
+  tier?: string;
+  /** The provider's own default deliverable; `unit_price` quotes this row. */
+  is_base: boolean;
+}
+
+/**
+ * An input-side charge, in GenSpend's semantics:
+ * - `input_image` is **additive** past `free_allowance`.
+ * - `input_video_second` **replaces** the generation cost with
+ *   `unit_price_usd × (input + output) seconds`, scoped to `spec`'s
+ *   resolution. No row for the requested resolution means decline the re-rate,
+ *   never apply another rung.
+ * - `per_request` is opt-in (prompt expansion, search grounding): surface it,
+ *   never add it silently.
+ */
+export interface GenspendSurcharge {
+  kind: "input_image" | "input_video_second" | "per_request";
+  /** Resolution the `input_video_second` rate is scoped to. */
+  spec?: string;
+  unit_price_usd: number;
+  free_allowance: number;
+  /** What a `per_request` extra buys ("prompt expansion"). */
+  label?: string;
+}
+
+/**
+ * A known discrepancy GenSpend has open against an offering.
+ * `quote_wrong` means the number must not be shown as a cost at all;
+ * `spec_gap` means it is exact at the base spec and nowhere else. Cosmetic
+ * flags are display text and are dropped at sync time.
+ */
+export interface GenspendDataFlag {
+  kind: string;
+  severity: "quote_wrong" | "spec_gap";
+}
+
 export interface GenspendPrice {
+  /** The base-spec price: what one unit costs with nothing specified. */
   unit_price: number;
   /** "images", "seconds", "generations", … — the FAL catalog's vocabulary. */
   billing_unit: string;
@@ -52,9 +105,19 @@ export interface GenspendPrice {
   tier?: string;
   /** Resolution the priced variant is billed at, if the provider prices per one. */
   resolution?: string;
+  /** The provider's published grid. Absent when it prices one flat number. */
+  variants?: GenspendVariant[];
+  surcharges?: GenspendSurcharge[];
+  /**
+   * The clip lengths the model is receipted for. `null` is a refusal to price
+   * any duration — never read it as "no limits"; absent means none published.
+   */
+  clip_seconds?: { set?: number[]; min?: number; max?: number } | null;
+  data_flags?: GenspendDataFlag[];
 }
 
 export interface GenspendPricingCatalog {
+  /** 3 since the grid shipped; a v2 file reads fine — every new field is optional. */
   schemaVersion: number;
   source: string;
   attribution: string;

--- a/packages/model-pricing/src/index.ts
+++ b/packages/model-pricing/src/index.ts
@@ -21,9 +21,11 @@
  */
 
 import type {
+  ModelPriceParams,
   ModelUnitPricingLike,
   SelectedModel
 } from "@nodetool-ai/node-sdk/cost-estimate";
+import { priceGenspendEntry, type ModelParamPrice } from "./genspend-calc.js";
 import falUnitPricingCatalog from "@nodetool-ai/fal-nodes/unit-pricing-catalog";
 import kieUnitPricingCatalog from "@nodetool-ai/kie-nodes/unit-pricing-catalog";
 import { getGenspendPrice, GENSPEND_CURRENCY } from "./genspend-catalog.js";
@@ -73,9 +75,16 @@ function kiePrice(modelId: string): ModelUnitPricingLike | null {
   };
 }
 
-function genspendPrice(model: SelectedModel): ModelUnitPricingLike | null {
+function genspendPrice(
+  model: SelectedModel,
+  params?: ModelPriceParams
+): ModelParamPrice | null {
   const entry = getGenspendPrice(model.provider, model.id);
   if (!entry) return null;
+  // With parameters in hand the catalog's grid decides the rung, the duration
+  // multiplication, and the surcharges. Without them the base-spec scalar is
+  // the answer, exactly as before.
+  if (params) return priceGenspendEntry(entry, params);
   return {
     unit_price: entry.unit_price,
     billing_unit: entry.billing_unit,
@@ -84,21 +93,36 @@ function genspendPrice(model: SelectedModel): ModelUnitPricingLike | null {
   };
 }
 
+/**
+ * The unit price for a selected model. With `params` — what the node states
+ * about the job (duration, resolution, audio) — a GenSpend-priced model is
+ * priced off its published grid and `unit_price` comes back as the whole
+ * per-run figure, with the reasoning attached. Without `params` the answer is
+ * byte-identical to what it has always been.
+ *
+ * The FAL and kie catalogs stay parameter-unaware for now: they carry the same
+ * per-second defect, from a different generator, and are a follow-up. They keep
+ * winning the lookup order, because those numbers come from the provider.
+ */
 export function getModelUnitPrice(
-  model: SelectedModel
-): ModelUnitPricingLike | null {
+  model: SelectedModel,
+  params?: ModelPriceParams
+): ModelParamPrice | null {
   // NodeTool's managed models price at their delegate's rate: translate the
   // curated id to the underlying provider+model before the catalog lookups,
   // so credit estimates for the metered provider are real numbers.
   if (model.provider === "nodetool") {
     const delegate = resolveNodetoolDelegate(model.id);
     if (!delegate) return null;
-    return getModelUnitPrice({
-      id: delegate.model,
-      provider: delegate.provider
-    });
+    return getModelUnitPrice(
+      { id: delegate.model, provider: delegate.provider },
+      params
+    );
   }
-  return falPrice(model.id) ?? kiePrice(model.id) ?? genspendPrice(model);
+  return falPrice(model.id) ?? kiePrice(model.id) ?? genspendPrice(model, params);
 }
+
+export { priceGenspendEntry, normalizeResolution } from "./genspend-calc.js";
+export type { ModelParamPrice } from "./genspend-calc.js";
 
 export default getModelUnitPrice;

--- a/packages/model-pricing/tests/genspend-calc.test.ts
+++ b/packages/model-pricing/tests/genspend-calc.test.ts
@@ -1,0 +1,284 @@
+/**
+ * The parameter-aware calculator. Its arithmetic is the port of `priceCase` in
+ * `scripts/genspend/parity-check.mjs`, which the nightly sync asserts against
+ * GenSpend's own `/quote`; these tests pin the rules against fixtures so they
+ * do not churn when the nightly catalog moves a price.
+ */
+import { describe, expect, it } from "vitest";
+import type { GenspendPrice } from "../src/genspend-catalog.js";
+import { normalizeResolution, priceGenspendEntry } from "../src/genspend-calc.js";
+
+/** A laddered per-second video model with a re-rate scoped to 720p. */
+const LADDER: GenspendPrice = {
+  unit_price: 0.205,
+  billing_unit: "seconds",
+  unit_class: "per-video-second",
+  model_slug: "ladder-2",
+  match: "provider-id",
+  live: true,
+  source_url: "https://example.test/ladder",
+  variants: [
+    {
+      price_usd: 1.04,
+      unit_class: "per-video-second",
+      resolution: "4K",
+      video_input: false,
+      is_base: false
+    },
+    {
+      price_usd: 0.51,
+      unit_class: "per-video-second",
+      resolution: "1080p",
+      video_input: false,
+      is_base: false
+    },
+    {
+      price_usd: 0.205,
+      unit_class: "per-video-second",
+      resolution: "720p",
+      video_input: false,
+      is_base: true
+    },
+    {
+      price_usd: 0.095,
+      unit_class: "per-video-second",
+      resolution: "480p",
+      video_input: false,
+      is_base: false
+    }
+  ],
+  surcharges: [
+    {
+      kind: "input_video_second",
+      spec: "720p",
+      unit_price_usd: 0.125,
+      free_allowance: 0
+    }
+  ],
+  clip_seconds: { min: 4, max: 15 }
+};
+
+/** A flat per-image model with an additive reference-image surcharge. */
+const IMAGE_WITH_REFS: GenspendPrice = {
+  unit_price: 0.04,
+  billing_unit: "images",
+  unit_class: "per-image",
+  model_slug: "refs-1",
+  match: "catalog",
+  live: false,
+  source_url: "https://example.test/refs",
+  surcharges: [
+    { kind: "input_image", unit_price_usd: 0.01, free_allowance: 4 },
+    {
+      kind: "per_request",
+      unit_price_usd: 0.03,
+      free_allowance: 0,
+      label: "prompt expansion"
+    }
+  ]
+};
+
+describe("priceGenspendEntry", () => {
+  it("narrows the ladder to the stated resolution and multiplies by seconds", () => {
+    const price = priceGenspendEntry(LADDER, { resolution: "1080p", seconds: 5 });
+    expect(price.declined).toBeUndefined();
+    expect(price.unit_price).toBeCloseTo(2.55, 10);
+    expect(price.breakdown).toContain("5 s");
+    expect(price.breakdown).toContain("1080p");
+  });
+
+  it("prices the cheaper rung when the node states it", () => {
+    expect(
+      priceGenspendEntry(LADDER, { resolution: "480p", seconds: 5 }).unit_price
+    ).toBeCloseTo(0.475, 10);
+  });
+
+  it("declines a stated resolution the provider does not publish", () => {
+    const price = priceGenspendEntry(LADDER, { resolution: "2K", seconds: 5 });
+    expect(price.declined).toBe("no published price at 2K");
+    expect(price.unit_price).toBe(0);
+  });
+
+  it("prices the base-spec rung with an assumption when resolution is unset", () => {
+    const price = priceGenspendEntry(LADDER, { seconds: 5 });
+    expect(price.unit_price).toBeCloseTo(1.025, 10);
+    expect(price.assumptions?.join(" ")).toContain("720p");
+  });
+
+  it("reads 768p as the 720p tier rather than declining it", () => {
+    expect(normalizeResolution("768p")).toBe("720p");
+    expect(
+      priceGenspendEntry(LADDER, { resolution: "768p", seconds: 5 }).unit_price
+    ).toBeCloseTo(1.025, 10);
+  });
+
+  it("treats an unrecognized resolution as unset — an assumption, not a guess", () => {
+    const price = priceGenspendEntry(LADDER, { resolution: "cinematic", seconds: 5 });
+    expect(price.declined).toBeUndefined();
+    expect(price.unit_price).toBeCloseTo(1.025, 10);
+    expect(price.assumptions?.join(" ")).toContain("cinematic");
+  });
+
+  it("declines a duration outside the receipted clip envelope", () => {
+    expect(priceGenspendEntry(LADDER, { seconds: 30 }).declined).toContain(
+      "above the receipted clip envelope"
+    );
+    expect(priceGenspendEntry(LADDER, { seconds: 2 }).declined).toContain(
+      "below the receipted clip envelope"
+    );
+  });
+
+  it("declines every duration when the model publishes no clip length", () => {
+    const noClip: GenspendPrice = { ...LADDER, clip_seconds: null };
+    expect(priceGenspendEntry(noClip, { seconds: 5 }).declined).toBe(
+      "no receipted clip length for this model"
+    );
+    expect(priceGenspendEntry(noClip, {}).declined).toBe(
+      "no receipted clip length for this model"
+    );
+  });
+
+  it("prices the shortest receipted clip with an assumption when duration is unset", () => {
+    const price = priceGenspendEntry(LADDER, { resolution: "720p" });
+    expect(price.unit_price).toBeCloseTo(0.82, 10); // 4 s minimum × $0.205
+    expect(price.assumptions?.join(" ")).toContain("duration not set");
+  });
+
+  it("prices one second when the model publishes no envelope at all", () => {
+    const { clip_seconds: _clip, ...unbounded } = LADDER;
+    const price = priceGenspendEntry(unbounded as GenspendPrice, {
+      resolution: "720p"
+    });
+    expect(price.unit_price).toBeCloseTo(0.205, 10);
+    expect(price.assumptions?.join(" ")).toContain("duration not set");
+  });
+
+  it("takes the audio rung when the node asks for audio", () => {
+    const audio: GenspendPrice = {
+      ...LADDER,
+      variants: [
+        {
+          price_usd: 0.1,
+          unit_class: "per-video-second",
+          resolution: "1080p",
+          with_audio: false,
+          is_base: true
+        },
+        {
+          price_usd: 0.2,
+          unit_class: "per-video-second",
+          resolution: "1080p",
+          with_audio: true,
+          is_base: false
+        }
+      ],
+      surcharges: []
+    };
+    expect(
+      priceGenspendEntry(audio, { resolution: "1080p", seconds: 5 }).unit_price
+    ).toBeCloseTo(0.5, 10);
+    expect(
+      priceGenspendEntry(audio, { resolution: "1080p", seconds: 5, withAudio: true })
+        .unit_price
+    ).toBeCloseTo(1.0, 10);
+  });
+
+  it("prices a per-generation duration rung without multiplying by seconds", () => {
+    const perGeneration: GenspendPrice = {
+      ...LADDER,
+      variants: [
+        {
+          price_usd: 0.28,
+          unit_class: "per-generation",
+          resolution: "720p",
+          duration_seconds: 6,
+          is_base: true
+        },
+        {
+          price_usd: 0.56,
+          unit_class: "per-generation",
+          resolution: "720p",
+          duration_seconds: 10,
+          is_base: false
+        }
+      ],
+      surcharges: [],
+      clip_seconds: { set: [6, 10] }
+    };
+    expect(
+      priceGenspendEntry(perGeneration, { resolution: "720p", seconds: 10 }).unit_price
+    ).toBeCloseTo(0.56, 10);
+    expect(
+      priceGenspendEntry(perGeneration, { resolution: "720p", seconds: 7 }).declined
+    ).toBe("no published price at 7s");
+  });
+
+  it("adds reference images only past the free allowance", () => {
+    expect(
+      priceGenspendEntry(IMAGE_WITH_REFS, { referenceImages: 3 }).unit_price
+    ).toBeCloseTo(0.04, 10);
+    const past = priceGenspendEntry(IMAGE_WITH_REFS, { referenceImages: 8 });
+    expect(past.unit_price).toBeCloseTo(0.08, 10);
+    expect(past.breakdown).toContain("4 ref images");
+  });
+
+  it("warns instead of guessing when reference images are unpriced", () => {
+    const price = priceGenspendEntry(LADDER, {
+      resolution: "720p",
+      seconds: 5,
+      referenceImages: 2
+    });
+    expect(price.unit_price).toBeCloseTo(1.025, 10);
+    expect(price.warnings?.join(" ")).toContain("lower bound");
+  });
+
+  it("re-rates the whole job on a scoped reference-video rate", () => {
+    const price = priceGenspendEntry(LADDER, {
+      resolution: "720p",
+      seconds: 5,
+      referenceVideoSeconds: 5
+    });
+    // Replaces the generation cost: $0.125 × (5 out + 5 in), not added to it.
+    expect(price.unit_price).toBeCloseTo(1.25, 10);
+  });
+
+  it("declines the re-rate, not the step, when no rate is scoped to the resolution", () => {
+    const price = priceGenspendEntry(LADDER, {
+      resolution: "480p",
+      seconds: 5,
+      referenceVideoSeconds: 5
+    });
+    expect(price.unit_price).toBeCloseTo(0.475, 10);
+    expect(price.warnings?.join(" ")).toContain("no video-input rate");
+  });
+
+  it("surfaces per_request extras without summing them", () => {
+    const price = priceGenspendEntry(IMAGE_WITH_REFS, {});
+    expect(price.unit_price).toBeCloseTo(0.04, 10);
+    expect(price.warnings?.join(" ")).toContain("prompt expansion");
+  });
+
+  it("declines an entry with an open quote discrepancy", () => {
+    const flagged: GenspendPrice = {
+      ...IMAGE_WITH_REFS,
+      data_flags: [{ kind: "quote_mismatch", severity: "quote_wrong" }]
+    };
+    expect(priceGenspendEntry(flagged, {}).declined).toContain("discrepancy");
+  });
+
+  it("prices a spec_gap entry at its base spec and warns off it", () => {
+    const gapped: GenspendPrice = {
+      ...IMAGE_WITH_REFS,
+      surcharges: [],
+      data_flags: [{ kind: "missing_ladder", severity: "spec_gap" }]
+    };
+    const price = priceGenspendEntry(gapped, {});
+    expect(price.unit_price).toBeCloseTo(0.04, 10);
+    expect(price.warnings?.join(" ")).toContain("base spec");
+  });
+
+  it("prices a flat entry with no grid exactly as the scalar did", () => {
+    const flat: GenspendPrice = { ...IMAGE_WITH_REFS, surcharges: [] };
+    expect(priceGenspendEntry(flat, {}).unit_price).toBe(flat.unit_price);
+  });
+});

--- a/packages/model-pricing/tests/genspend-sync.test.ts
+++ b/packages/model-pricing/tests/genspend-sync.test.ts
@@ -22,6 +22,13 @@ import {
   buildCatalog,
   buildPriceIndex
 } from "../../../scripts/sync-genspend-pricing.mjs";
+import {
+  MIN_PRICED_CASES,
+  PARITY_CASES,
+  priceCase,
+  quoteRequest,
+  runComparison
+} from "../../../scripts/genspend/parity-check.mjs";
 
 const inventory = {
   fal_ai: {
@@ -532,6 +539,345 @@ describe("buildPriceIndex", () => {
   });
 });
 
+/**
+ * Schema 3 ships the provider's grid next to the scalar. Everything here is
+ * shaped like the `/api/v1/export` payload the sync now reads.
+ */
+describe("the shipped grid", () => {
+  const build = (models: unknown[]) => buildPriceIndex({ models, index, aliases: {} });
+  const key = "atlascloud:bytedance/seedance-2.0/text-to-video";
+
+  const ladder = [
+    {
+      spec: "480p · per second of output video",
+      unitClass: "per-video-second",
+      priceUsd: 0.12,
+      isBase: true,
+      resolution: "480p",
+      durationSeconds: null,
+      withAudio: null,
+      videoInput: null,
+      tier: null
+    },
+    {
+      spec: "720p · per second of output video",
+      unitClass: "per-video-second",
+      priceUsd: 0.24,
+      isBase: false,
+      resolution: "720p",
+      durationSeconds: null,
+      withAudio: null,
+      videoInput: null,
+      tier: null
+    }
+  ];
+
+  it("carries the variant ladder, its surcharges and the clip envelope", () => {
+    const { prices } = build([
+      model({
+        capabilities: { clipSeconds: { set: null, min: 4, max: 15 } },
+        offerings: [
+          offering({
+            variants: ladder,
+            surcharges: [
+              {
+                kind: "input_video_second",
+                spec: "720p",
+                unitPriceUsd: 0.15,
+                freeAllowance: 0,
+                note: "prose we do not ship",
+                sourceUrl: "https://example.test"
+              },
+              {
+                kind: "per_request",
+                spec: "prompt expansion",
+                unitPriceUsd: 0.0025,
+                freeAllowance: 0
+              }
+            ]
+          })
+        ]
+      })
+    ]);
+    expect(prices[key]).toMatchObject({
+      variants: [
+        { price_usd: 0.12, unit_class: "per-video-second", resolution: "480p", is_base: true },
+        { price_usd: 0.24, unit_class: "per-video-second", resolution: "720p", is_base: false }
+      ],
+      surcharges: [
+        { kind: "input_video_second", spec: "720p", unit_price_usd: 0.15, free_allowance: 0 },
+        { kind: "per_request", unit_price_usd: 0.0025, free_allowance: 0, label: "prompt expansion" }
+      ],
+      clip_seconds: { min: 4, max: 15 }
+    });
+    // The prose note is GenSpend's truth surface, not ours to re-render.
+    expect(JSON.stringify(prices[key])).not.toContain("prose we do not ship");
+  });
+
+  it("quotes the base-spec row, taking its unit class with it", () => {
+    // MiniMax bills Hailuo per generation while the headline quotes a
+    // per-second rate. Taking the price without the class would publish $0.28
+    // *per second* — an 6× overstatement on a six-second clip.
+    const { prices } = build([
+      model({
+        slug: "hailuo-02",
+        name: "MiniMax Hailuo 02",
+        offerings: [
+          offering({
+            provider: { slug: "minimax", name: "MiniMax" },
+            priceUsd: 0.047,
+            variants: [
+              {
+                spec: "768p · 6s",
+                unitClass: "per-generation",
+                priceUsd: 0.28,
+                isBase: true,
+                resolution: "768p",
+                durationSeconds: 6
+              },
+              {
+                spec: "768p · 10s",
+                unitClass: "per-generation",
+                priceUsd: 0.56,
+                isBase: false,
+                resolution: "768p",
+                durationSeconds: 10
+              }
+            ]
+          })
+        ]
+      })
+    ]);
+    expect(prices["minimax:MiniMax-Hailuo-02"]).toMatchObject({
+      unit_price: 0.28,
+      unit_class: "per-generation",
+      billing_unit: "generations"
+    });
+  });
+
+  it("drops variant rows that say nothing in facets", () => {
+    // AtlasCloud's `variants[]` is a list of sibling endpoint ids, which the
+    // matcher already turned into separate keys. Shipping them again as rows
+    // would double the file for nothing.
+    const { prices } = build([
+      model({
+        offerings: [
+          offering({
+            variants: [
+              {
+                spec: "bytedance/seedance-2.0/text-to-video",
+                unitClass: "per-video-second",
+                priceUsd: 0.112,
+                isBase: true,
+                resolution: null,
+                durationSeconds: null,
+                withAudio: null,
+                videoInput: null,
+                tier: null
+              }
+            ]
+          })
+        ]
+      })
+    ]);
+    expect(prices[key].variants).toBeUndefined();
+    // …and the scalar still comes from that base row.
+    expect(prices[key].unit_price).toBe(0.112);
+  });
+
+  it("leaves a flat offering looking exactly like it did under v2", () => {
+    const { prices } = build([model()]);
+    expect(Object.keys(prices[key])).toEqual([
+      "unit_price",
+      "billing_unit",
+      "unit_class",
+      "model_slug",
+      "match",
+      "live",
+      "source_url"
+    ]);
+  });
+
+  it("stores a quote_wrong flag rather than dropping the entry", () => {
+    // The calculator refuses to price a flagged entry; that decision needs the
+    // flag to survive the sync. Today this fires zero times.
+    const { prices } = build([
+      model({
+        offerings: [
+          offering({
+            dataFlags: [
+              {
+                kind: "surcharge",
+                severity: "quote_wrong",
+                confidence: "high",
+                summary: "the page moved",
+                sourceUrl: "https://example.test",
+                openedAt: "2026-08-01"
+              }
+            ]
+          })
+        ]
+      })
+    ]);
+    expect(prices[key].data_flags).toEqual([
+      { kind: "surcharge", severity: "quote_wrong" }
+    ]);
+  });
+
+  it("drops cosmetic flags, which are display text we do not render", () => {
+    const { prices } = build([
+      model({
+        offerings: [
+          offering({
+            dataFlags: [
+              { kind: "label", severity: "cosmetic", summary: "unit reads oddly" },
+              { kind: "missing_metric", severity: "spec_gap" }
+            ]
+          })
+        ]
+      })
+    ]);
+    expect(prices[key].data_flags).toEqual([
+      { kind: "missing_metric", severity: "spec_gap" }
+    ]);
+  });
+
+  it("keeps a null clip envelope as a refusal, not as an absence", () => {
+    const { prices } = build([
+      model({ capabilities: { clipSeconds: null }, offerings: [offering()] })
+    ]);
+    expect(prices[key].clip_seconds).toBeNull();
+    expect("clip_seconds" in prices[key]).toBe(true);
+  });
+
+  it("still produces no diff when nothing upstream moved", () => {
+    const withGrid = model({
+      capabilities: { clipSeconds: { set: null, min: 4, max: 15 } },
+      offerings: [offering({ variants: ladder })]
+    });
+    const first = buildCatalog({
+      models: [withGrid],
+      index,
+      aliases: {},
+      previous: null,
+      nowIso: "2026-01-01T00:00:00.000Z"
+    }).catalog;
+    const second = buildCatalog({
+      models: [withGrid],
+      index,
+      aliases: {},
+      previous: first,
+      nowIso: "2026-01-02T00:00:00.000Z"
+    }).catalog;
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+  });
+});
+
+/**
+ * The parity gate itself. Its network half runs in the nightly workflow only;
+ * what is tested here is the arithmetic and the verdict, both pure.
+ */
+describe("parity check", () => {
+  const entry = {
+    unit_price: 0.205,
+    billing_unit: "seconds",
+    unit_class: "per-video-second",
+    model_slug: "seedance-2",
+    match: "provider-id",
+    live: true,
+    source_url: "https://kie.ai/seedance-2-0",
+    variants: [
+      { price_usd: 0.095, unit_class: "per-video-second", resolution: "480p", is_base: false },
+      { price_usd: 0.205, unit_class: "per-video-second", resolution: "720p", is_base: true },
+      { price_usd: 0.51, unit_class: "per-video-second", resolution: "1080p", is_base: false }
+    ],
+    surcharges: [
+      { kind: "input_video_second", spec: "720p", unit_price_usd: 0.125, free_allowance: 0 }
+    ],
+    clip_seconds: { min: 4, max: 15 }
+  };
+
+  it("narrows the ladder to the stated resolution", () => {
+    expect(priceCase(entry, { seconds: 5, resolution: "1080p" })).toMatchObject({
+      costUsd: 2.55
+    });
+  });
+
+  it("declines a resolution the provider does not publish", () => {
+    expect(priceCase(entry, { seconds: 5, resolution: "2K" }).declined).toContain("2K");
+  });
+
+  it("declines outside the receipted clip envelope", () => {
+    expect(priceCase(entry, { seconds: 60, resolution: "720p" }).declined).toBeTruthy();
+  });
+
+  it("lets a reference video re-rate the whole job, not add to it", () => {
+    expect(
+      priceCase(entry, { seconds: 5, resolution: "720p", referenceVideoSeconds: 5 })
+    ).toMatchObject({ costUsd: 1.25 });
+  });
+
+  it("keeps the generation cost as a floor where no scoped rate exists", () => {
+    const result = priceCase(entry, {
+      seconds: 5,
+      resolution: "480p",
+      referenceVideoSeconds: 5
+    });
+    expect(result.costUsd).toBeCloseTo(0.475, 9);
+    expect(result.warnings).toEqual([expect.stringContaining("lower bound")]);
+  });
+
+  it("refuses to price an entry with a known quote discrepancy", () => {
+    expect(
+      priceCase(
+        { ...entry, data_flags: [{ kind: "surcharge", severity: "quote_wrong" }] },
+        { seconds: 5, resolution: "720p" }
+      ).declined
+    ).toBeTruthy();
+  });
+
+  it("cannot pass on a catalog it priced nothing from", () => {
+    // An audit that matches nothing is indistinguishable from one that
+    // examines nothing, so an empty catalog must fail rather than agree.
+    const verdict = runComparison({
+      catalog: { prices: {} },
+      quoteSteps: PARITY_CASES.map(() => ({ error: "unpriced" }))
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.vacuous).toBe(true);
+    expect(verdict.reason).toContain(String(MIN_PRICED_CASES));
+  });
+
+  it("fails a case whose local price moved away from the quote", () => {
+    const verdict = runComparison({
+      catalog: { prices: { "x:y": entry } },
+      cases: [
+        {
+          name: "moved",
+          key: "x:y",
+          model: "seedance-2",
+          provider: "kie",
+          params: { seconds: 5, resolution: "720p" }
+        }
+      ],
+      quoteSteps: [{ costUsd: 1.5 }]
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failures[0].detail).toContain("1.5");
+  });
+
+  it("asks the quote endpoint for exactly the cases it checks", () => {
+    const { steps } = quoteRequest();
+    expect(steps).toHaveLength(PARITY_CASES.length);
+    expect(steps.every((step: { model: string; provider: string }) => step.provider)).toBe(
+      true
+    );
+    expect(PARITY_CASES.filter((c: { expect?: string }) => c.expect === "decline").length)
+      .toBeGreaterThan(0);
+    expect(PARITY_CASES.length - MIN_PRICED_CASES).toBeGreaterThanOrEqual(0);
+  });
+});
+
 describe("buildCatalog", () => {
   const build = (models: unknown[], previous: unknown, nowIso: string) =>
     buildCatalog({ models, index, aliases: {}, previous, nowIso });
@@ -616,7 +962,7 @@ describe("buildCatalog", () => {
       catalogModels: 1,
       catalogOfferings: 1,
       providers: ["atlascloud"],
-      source: "https://genspend.io/api/v1/models"
+      source: "https://genspend.io/api/v1/export"
     });
   });
 

--- a/packages/model-pricing/tests/model-pricing.test.ts
+++ b/packages/model-pricing/tests/model-pricing.test.ts
@@ -8,6 +8,7 @@ import falUnitPricingCatalog from "@nodetool-ai/fal-nodes/unit-pricing-catalog";
 import kieUnitPricingCatalog from "@nodetool-ai/kie-nodes/unit-pricing-catalog";
 import { genspendPricingCatalog } from "../src/genspend-catalog.js";
 import { getModelUnitPrice } from "../src/index.js";
+import { priceGenspendEntry } from "../src/genspend-calc.js";
 
 const firstEntry = (
   catalog: { prices?: Record<string, unknown> },
@@ -79,5 +80,33 @@ describe("getModelUnitPrice", () => {
     expect(
       getModelUnitPrice({ id: "nodetool/nope", provider: "nodetool" })
     ).toBeNull();
+  });
+
+  it("prices a GenSpend model through the calculator when params are given", () => {
+    // A key the FAL and kie catalogs miss, so the GenSpend tier is the one asked.
+    const entry = Object.entries(genspendPricingCatalog.prices).find(
+      ([key, price]) =>
+        (price.variants ?? []).some((v) => v.resolution) &&
+        !falUnitPricingCatalog.prices?.[key.split(":").slice(1).join(":")] &&
+        !kieUnitPricingCatalog.prices?.[key.split(":").slice(1).join(":")]
+    );
+    if (!entry) throw new Error("no laddered price in the GenSpend catalog");
+    const [key, price] = entry;
+    const [provider, ...rest] = key.split(":");
+    const model = { id: rest.join(":"), provider };
+    const params = { resolution: price.variants![0].resolution, seconds: 5 };
+
+    // Routed: the scalar path carries no reasoning, the calculator does.
+    expect(getModelUnitPrice(model, params)).toEqual(
+      priceGenspendEntry(price, params)
+    );
+    expect(getModelUnitPrice(model)?.unit_price).toBe(price.unit_price);
+  });
+
+  it("leaves the FAL tier parameter-unaware for now", () => {
+    const { id } = firstEntry(falUnitPricingCatalog, "unit_price");
+    expect(getModelUnitPrice({ id, provider: "fal_ai" }, { seconds: 10 })).toEqual(
+      getModelUnitPrice({ id, provider: "fal_ai" })
+    );
   });
 });

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -42,6 +42,11 @@
       "import": "./dist/cost-estimate.js",
       "default": "./dist/cost-estimate.js"
     },
+    "./pricing-params": {
+      "types": "./dist/pricing-params.d.ts",
+      "import": "./dist/pricing-params.js",
+      "default": "./dist/pricing-params.js"
+    },
     "./sandbox-pack-discovery": {
       "nodetool-dev": "./src/sandbox-pack-discovery.ts",
       "types": "./dist/sandbox-pack-discovery.d.ts",

--- a/packages/node-sdk/src/cost-estimate.ts
+++ b/packages/node-sdk/src/cost-estimate.ts
@@ -64,6 +64,43 @@ export interface SelectedModel {
 }
 
 /**
+ * What a node states about the job it is about to run, in the vocabulary the
+ * price catalogs bill in. Every field is optional: a missing one is priced at
+ * the model's base spec and recorded as an assumption, never guessed.
+ * `extractPricingParams` (`./pricing-params.js`) reads these off node property
+ * values.
+ */
+export interface ModelPriceParams {
+  /** A resolution tier or a raw spelling of one ("720p", "1024x1024"). */
+  resolution?: string;
+  /** Output duration in seconds. */
+  seconds?: number;
+  withAudio?: boolean;
+  /** Quality tier when a provider sells several under one model id. */
+  tier?: string;
+  referenceImages?: number;
+  /** Duration of a video fed in, which some providers bill instead of output. */
+  referenceVideoSeconds?: number;
+  megapixels?: number;
+}
+
+/**
+ * A model price computed from {@link ModelPriceParams}. `unit_price` is the
+ * whole per-run figure (a per-second model comes back already multiplied by
+ * its duration), so `estimated_cost = unit_price × quantity` still composes.
+ */
+export interface ModelParamPricingLike extends ModelUnitPricingLike {
+  /** How the figure was reached: "5 s × $0.205/s at 720p". */
+  breakdown?: string;
+  /** What was filled in because the node did not state it. */
+  assumptions?: string[];
+  /** Known-missing costs — the figure is then a lower bound. */
+  warnings?: string[];
+  /** Set instead of a price when the catalog refuses to extrapolate. */
+  declined?: string;
+}
+
+/**
  * Property `type.type` values whose value is a provider-backed model selection
  * carrying a provider + model id. Kept in sync with the web `PROVIDER_MODEL_TYPES`
  * list. Local model types (`llama_model`, `hf.*`) are excluded — they aren't
@@ -88,8 +125,19 @@ export interface CostEstimateInput {
    * unknown. Without it, generic nodes stay "unknown".
    */
   getModelPrice?: (
-    model: SelectedModel
-  ) => ModelUnitPricingLike | null | undefined;
+    model: SelectedModel,
+    params?: ModelPriceParams
+  ) => ModelParamPricingLike | null | undefined;
+  /**
+   * Optional per-node read of what the node states about its job (duration,
+   * resolution, audio). Supplied by the caller so this stays hermetic; the
+   * result is handed to `getModelPrice`.
+   */
+  getParams?: (node: {
+    id: string;
+    type: string;
+    data?: Record<string, unknown>;
+  }) => ModelPriceParams | undefined;
   /** Optional per-node expected run count (fan-out). Defaults to 1. */
   quantities?: Record<string, number>;
   /**
@@ -123,6 +171,9 @@ interface ResolvedPrice {
   unitPrice: number;
   billingUnit: string;
   confidence: CostConfidence;
+  breakdown?: string;
+  assumptions?: string[];
+  warnings?: string[];
 }
 
 function isVagueBillingUnit(unit: string): boolean {
@@ -172,7 +223,8 @@ function selectedModel(
 function resolvePrice(
   metadata: NodeMetadataLike | undefined,
   data: Record<string, unknown> | undefined,
-  getModelPrice: CostEstimateInput["getModelPrice"]
+  getModelPrice: CostEstimateInput["getModelPrice"],
+  params?: ModelPriceParams
 ): ResolvedPrice | null {
   const fal = metadata?.fal_unit_pricing;
   if (fal && Number.isFinite(fal.unit_price)) {
@@ -208,14 +260,35 @@ function resolvePrice(
   if (getModelPrice) {
     const model = selectedModel(metadata, data);
     if (model) {
-      const price = getModelPrice(model);
-      if (price && Number.isFinite(price.unit_price)) {
+      const price = getModelPrice(model, params);
+      if (price?.declined) {
+        // A refusal to extrapolate is a reason, not a price: report it where a
+        // user can act on it instead of dropping the node into silent unknown.
+        return {
+          provider: model.provider ?? "model",
+          model: model.id,
+          unitPrice: 0,
+          billingUnit: "",
+          confidence: "unknown",
+          assumptions: [price.declined]
+        };
+      }
+      // A price billed in "units" or "credits" has no fixed currency value —
+      // summing it would corrupt the total, so the node stays unknown.
+      if (
+        price &&
+        Number.isFinite(price.unit_price) &&
+        !isVagueBillingUnit(price.billing_unit)
+      ) {
         return {
           provider: model.provider ?? "model",
           model: model.id,
           unitPrice: price.unit_price,
           billingUnit: price.billing_unit,
-          confidence: confidenceFromSource(price.source)
+          confidence: confidenceFromSource(price.source),
+          breakdown: price.breakdown,
+          assumptions: price.assumptions,
+          warnings: price.warnings
         };
       }
     }
@@ -240,18 +313,20 @@ export function estimateWorkflowCost(input: CostEstimateInput): WorkflowCostEsti
     const price = resolvePrice(
       input.getMetadata(node.type),
       node.data,
-      input.getModelPrice
+      input.getModelPrice,
+      input.getParams?.(node)
     );
 
-    if (!price) {
+    if (!price || price.confidence === "unknown") {
       items.push({
         node_id: node.id,
         node_type: node.type,
-        provider: null,
-        model: null,
+        provider: price?.provider ?? null,
+        model: price?.model ?? null,
         quantity,
         estimated_cost: 0,
-        confidence: "unknown"
+        confidence: "unknown",
+        ...(price?.assumptions ? { assumptions: price.assumptions } : {})
       });
       unknownCount += 1;
       continue;
@@ -268,7 +343,10 @@ export function estimateWorkflowCost(input: CostEstimateInput): WorkflowCostEsti
       billing_unit: price.billingUnit,
       quantity,
       estimated_cost: estimatedCost,
-      confidence: price.confidence
+      confidence: price.confidence,
+      ...(price.breakdown ? { breakdown: price.breakdown } : {}),
+      ...(price.assumptions ? { assumptions: price.assumptions } : {}),
+      ...(price.warnings ? { warnings: price.warnings } : {})
     });
   }
 

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -3,6 +3,7 @@ export * from "./class-name-to-title.js";
 export * from "./content-card.js";
 export * from "./pricing-bundle.js";
 export * from "./cost-estimate.js";
+export * from "./pricing-params.js";
 export * from "./field-classification.js";
 export * from "./registry.js";
 export * from "./metadata.js";

--- a/packages/node-sdk/src/pricing-params.ts
+++ b/packages/node-sdk/src/pricing-params.ts
@@ -75,7 +75,10 @@ function readSeconds(value: unknown): number | undefined {
     return Number.isFinite(value) && value > 0 ? value : undefined;
   }
   if (typeof value !== "string") return undefined;
-  const match = /^\s*(\d+(?:\.\d+)?)\s*(?:s|sec|secs|seconds)?\s*$/i.exec(value);
+  // Trim and collapse runs before matching: adjacent unbounded whitespace
+  // quantifiers around an optional group backtrack polynomially (CodeQL).
+  const compact = value.trim().replace(/\s+/g, " ");
+  const match = /^(\d+(?:\.\d+)?) ?(?:s|secs?|seconds)?$/i.exec(compact);
   if (!match) return undefined;
   const parsed = Number(match[1]);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;

--- a/packages/node-sdk/src/pricing-params.ts
+++ b/packages/node-sdk/src/pricing-params.ts
@@ -1,0 +1,196 @@
+/**
+ * Read what a node states about the job it will run — duration, resolution,
+ * audio — off its property values, in the vocabulary the price catalogs bill
+ * in. The sibling of the fan-out property list: both turn node data into the
+ * numbers `estimateWorkflowCost` multiplies.
+ *
+ * Pure and lenient in, strict out: a property we do not recognize, or a value
+ * we cannot read, leaves the field unset. Unset is priced at the model's base
+ * spec with an assumption the user can see; a guessed tier would be an invented
+ * number nobody can audit.
+ *
+ * ## Property-name census (2026-08-12)
+ *
+ * Counted over the shipped generator manifests — `packages/fal-nodes`
+ * (`fal-manifest.json`), `packages/replicate-nodes` (`replicate-manifest.json`),
+ * `packages/kie-nodes` (`kie-manifest.json`) — as distinct `inputFields[].name`
+ * occurrences, plus the hand-written `@prop` declarations in
+ * `packages/video-nodes` and `packages/image-nodes`:
+ *
+ * | name | manifests | note |
+ * |---|---|---|
+ * | `duration` | 307 | also `nodetool.video.TextToVideo`/`ImageToVideo` (int seconds) |
+ * | `num_frames` | 183 | with `fps` (94) / `frames_per_second` (74) |
+ * | `duration_seconds` | 1 | the name the video nodes pass to providers |
+ * | `seconds` | 2 | |
+ * | `video_length` | 1 | |
+ * | `duration_sec`, `max_duration`, `music_duration` | 1 each | not read: not the billed output length |
+ * | `resolution` | 387 | also the video nodes (`720p`…`4K`) |
+ * | `image_size` | 316 | `square_hd`, `1024x1024`, `1K`, `auto`, … |
+ * | `size` | 26 | `1024x1024`, `1280*720`, `2K` |
+ * | `quality` | 23 | mostly `high`/`auto`; one node uses `540p` |
+ * | `width` / `height` | 79 / 79 | |
+ * | `video_size` | 49 | not read: an aspect-ratio name on every node carrying it |
+ * | `generate_audio` | 139 | plus `generate_audio_switch` (18), `audio_enabled` (1) |
+ * | `with_audio` | 1 | |
+ * | `audio` | 184 | **not read**: on all but a handful it is an audio *input* ref |
+ *
+ * `video_duration` and `num_seconds` from the plan's draft list ship on **no**
+ * node and are omitted. `audio` is likewise omitted: 184 occurrences and nearly
+ * all of them are `audio: AudioRef` inputs, so reading it as a billing axis
+ * would flip models to their dearer audio rung on a property that means
+ * something else. `generate_audio` / `generate_audio_switch` / `audio_enabled` /
+ * `with_audio` are the booleans that really name the axis.
+ */
+
+import type { ModelPriceParams } from "./cost-estimate.js";
+
+/** Duration properties, most specific first. The first present value wins. */
+const DURATION_PROPERTIES = [
+  "duration",
+  "duration_seconds",
+  "seconds",
+  "num_seconds",
+  "video_length",
+  "video_duration"
+] as const;
+
+/** Resolution-ish properties, most specific first. */
+const RESOLUTION_PROPERTIES = ["resolution", "image_size", "size", "quality"] as const;
+
+/** Booleans that name the audio billing axis (never `audio`, an input ref). */
+const AUDIO_PROPERTIES = [
+  "generate_audio",
+  "generate_audio_switch",
+  "audio_enabled",
+  "with_audio"
+] as const;
+
+/** Frame-rate properties paired with `num_frames`. */
+const FPS_PROPERTIES = ["fps", "frames_per_second", "frame_rate"] as const;
+
+/** A finite positive number from a number or a string like `"5"` / `"5s"`. */
+function readSeconds(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value > 0 ? value : undefined;
+  }
+  if (typeof value !== "string") return undefined;
+  const match = /^\s*(\d+(?:\.\d+)?)\s*(?:s|sec|secs|seconds)?\s*$/i.exec(value);
+  if (!match) return undefined;
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function readPositiveNumber(value: unknown): number | undefined {
+  const parsed = typeof value === "string" ? Number(value.trim()) : value;
+  return typeof parsed === "number" && Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : undefined;
+}
+
+/**
+ * The pixel tiers the catalogs price image models at. A `width × height` pair
+ * lands on the nearest one by total pixels, but only inside a 1.5× band —
+ * beyond that we would be naming a tier the provider never quoted.
+ */
+const PIXEL_TIERS: Array<{ pixels: number; tier: string }> = [
+  { pixels: 512 * 512, tier: "512x512" },
+  { pixels: 1024 * 1024, tier: "1024x1024" },
+  { pixels: 2048 * 2048, tier: "2K" },
+  { pixels: 4096 * 4096, tier: "4K" }
+];
+
+/** The tier a pixel count sits closest to, or undefined when it sits far off. */
+function tierForPixels(pixels: number): string | undefined {
+  let best = PIXEL_TIERS[0];
+  let bestRatio = Infinity;
+  for (const candidate of PIXEL_TIERS) {
+    const ratio =
+      pixels > candidate.pixels ? pixels / candidate.pixels : candidate.pixels / pixels;
+    if (ratio < bestRatio) {
+      bestRatio = ratio;
+      best = candidate;
+    }
+  }
+  return bestRatio <= 1.5 ? best.tier : undefined;
+}
+
+/**
+ * A stated resolution, passed through as the raw spelling for the calculator to
+ * normalize. Names that carry no resolution at all (`auto`, `square_hd`,
+ * `high`) return undefined, which prices at the base spec instead of guessing.
+ */
+function readResolution(value: unknown): string | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value > 0 ? String(value) : undefined;
+  }
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  if (!text) return undefined;
+  // `1280*720` / `768x512`: a pixel pair, not a tier name.
+  const pair = /^(\d+)\s*[x*×]\s*(\d+)$/i.exec(text);
+  if (pair) {
+    const pixels = Number(pair[1]) * Number(pair[2]);
+    return pixels > 0 ? tierForPixels(pixels) : undefined;
+  }
+  // `720p`, `4K`, `1MP`, `1024` — spellings the calculator's tier table knows.
+  if (/^(\d+(\.\d+)?)\s*(p|k|mp)?$/i.test(text)) return text;
+  return undefined;
+}
+
+/**
+ * Read the pricing-relevant parameters off a node's property values. Pass the
+ * property bag (`node.data.properties` in the editor, `node.data` on the
+ * server's flat shape) — unknown keys are ignored.
+ */
+export function extractPricingParams(
+  values: Record<string, unknown> | undefined | null
+): ModelPriceParams {
+  const params: ModelPriceParams = {};
+  if (!values) return params;
+
+  for (const name of DURATION_PROPERTIES) {
+    const seconds = readSeconds(values[name]);
+    if (seconds !== undefined) {
+      params.seconds = seconds;
+      break;
+    }
+  }
+  if (params.seconds === undefined) {
+    const frames = readPositiveNumber(values.num_frames);
+    const fps = FPS_PROPERTIES.map((name) => readPositiveNumber(values[name])).find(
+      (value) => value !== undefined
+    );
+    if (frames !== undefined && fps !== undefined) {
+      params.seconds = frames / fps;
+    }
+  }
+
+  for (const name of RESOLUTION_PROPERTIES) {
+    const resolution = readResolution(values[name]);
+    if (resolution !== undefined) {
+      params.resolution = resolution;
+      break;
+    }
+  }
+  if (params.resolution === undefined) {
+    const width = readPositiveNumber(values.width);
+    const height = readPositiveNumber(values.height);
+    if (width !== undefined && height !== undefined) {
+      const tier = tierForPixels(width * height);
+      if (tier !== undefined) params.resolution = tier;
+    }
+  }
+
+  for (const name of AUDIO_PROPERTIES) {
+    const value = values[name];
+    if (typeof value === "boolean") {
+      params.withAudio = value;
+      break;
+    }
+  }
+
+  return params;
+}
+
+export default extractPricingParams;

--- a/packages/node-sdk/tests/cost-estimate.test.ts
+++ b/packages/node-sdk/tests/cost-estimate.test.ts
@@ -226,3 +226,135 @@ describe("estimateWorkflowCost", () => {
     expect(estimate.total).toBeCloseTo(0.02, 10);
   });
 });
+
+/**
+ * Parameters — what the node states about the job (duration, resolution) —
+ * reach the price lookup and its reasoning reaches the item.
+ */
+describe("estimateWorkflowCost with pricing parameters", () => {
+  const VIDEO_TYPE = "nodetool.video.TextToVideo";
+  const videoMetadata: Record<string, NodeMetadataLike> = {
+    ...metadataByType,
+    [VIDEO_TYPE]: {
+      properties: [{ name: "model", type: { type: "video_model" } }]
+    }
+  };
+  const getVideoMetadata = (type: string) => videoMetadata[type];
+
+  /** A per-second model: the price arrives already multiplied by duration. */
+  const getModelPriceWithParams: CostEstimateInput["getModelPrice"] = (
+    model,
+    params
+  ) => {
+    if (model.id !== "vendor/clip-2") return null;
+    if (params?.resolution === "4K") {
+      return {
+        unit_price: 0,
+        billing_unit: "",
+        currency: "USD",
+        source: "bundle" as const,
+        declined: "no published price at 4K"
+      };
+    }
+    const seconds = params?.seconds ?? 1;
+    return {
+      unit_price: 0.2 * seconds,
+      billing_unit: "seconds",
+      currency: "USD",
+      source: "bundle" as const,
+      breakdown: `${seconds} s × $0.2/s`,
+      ...(params?.seconds === undefined
+        ? { assumptions: ["duration not set on the node — priced at 1 s"] }
+        : {}),
+      ...(params?.referenceImages
+        ? { warnings: ["reference images are not priced here"] }
+        : {})
+    };
+  };
+
+  const videoNode = (data: Record<string, unknown>) => ({
+    id: "v1",
+    type: VIDEO_TYPE,
+    data: {
+      model: { type: "video_model", provider: "kie", id: "vendor/clip-2" },
+      ...data
+    }
+  });
+
+  it("threads node parameters into the model lookup and composes with fan-out", () => {
+    const estimate = estimateWorkflowCost({
+      nodes: [videoNode({ duration: 5 })],
+      getMetadata: getVideoMetadata,
+      getModelPrice: getModelPriceWithParams,
+      getParams: (node) => ({
+        seconds: Number(node.data?.duration) || undefined
+      }),
+      quantities: { v1: 2 }
+    });
+
+    const item = estimate.items[0];
+    expect(item.unit_price).toBeCloseTo(1.0, 10);
+    expect(item.quantity).toBe(2);
+    expect(item.estimated_cost).toBeCloseTo(2.0, 10);
+    expect(estimate.total).toBeCloseTo(2.0, 10);
+  });
+
+  it("copies breakdown, assumptions, and warnings onto the item", () => {
+    const estimate = estimateWorkflowCost({
+      nodes: [videoNode({})],
+      getMetadata: getVideoMetadata,
+      getModelPrice: getModelPriceWithParams,
+      getParams: () => ({ referenceImages: 2 })
+    });
+
+    const item = estimate.items[0];
+    expect(item.breakdown).toBe("1 s × $0.2/s");
+    expect(item.assumptions).toEqual([
+      "duration not set on the node — priced at 1 s"
+    ]);
+    expect(item.warnings).toEqual(["reference images are not priced here"]);
+  });
+
+  it("reports a declined price as unknown with the reason attached", () => {
+    const estimate = estimateWorkflowCost({
+      nodes: [videoNode({ resolution: "4K" })],
+      getMetadata: getVideoMetadata,
+      getModelPrice: getModelPriceWithParams,
+      getParams: (node) => ({ resolution: String(node.data?.resolution) })
+    });
+
+    const item = estimate.items[0];
+    expect(item.confidence).toBe("unknown");
+    expect(item.estimated_cost).toBe(0);
+    expect(item.assumptions).toEqual(["no published price at 4K"]);
+    expect(estimate.unknown_count).toBe(1);
+    expect(estimate.total).toBe(0);
+  });
+
+  it("treats a model price billed in vague units as unknown, never summed", () => {
+    const estimate = estimateWorkflowCost({
+      nodes: [videoNode({})],
+      getMetadata: getVideoMetadata,
+      getModelPrice: () => ({
+        unit_price: 400,
+        billing_unit: "credits",
+        currency: "credits",
+        source: "bundle" as const
+      })
+    });
+
+    expect(estimate.total).toBe(0);
+    expect(estimate.unknown_count).toBe(1);
+    expect(estimate.items[0].confidence).toBe("unknown");
+  });
+
+  it("prices a generic node unchanged when no getParams is supplied", () => {
+    const estimate = estimateWorkflowCost({
+      nodes: [videoNode({ duration: 5 })],
+      getMetadata: getVideoMetadata,
+      getModelPrice: getModelPriceWithParams
+    });
+
+    expect(estimate.items[0].unit_price).toBeCloseTo(0.2, 10);
+  });
+});

--- a/packages/node-sdk/tests/pricing-params.test.ts
+++ b/packages/node-sdk/tests/pricing-params.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Reading duration/resolution/audio off node property values. The property
+ * names come from a census of the shipped generator manifests (recorded in
+ * `src/pricing-params.ts`); these cases use values those manifests really
+ * carry as defaults.
+ */
+import { describe, expect, it } from "vitest";
+import { extractPricingParams } from "../src/pricing-params.js";
+
+describe("extractPricingParams", () => {
+  it("reads a numeric duration", () => {
+    expect(extractPricingParams({ duration: 5 }).seconds).toBe(5);
+  });
+
+  it("parses the string durations the manifests ship ('5s')", () => {
+    expect(extractPricingParams({ duration: "5s" }).seconds).toBe(5);
+    expect(extractPricingParams({ duration: "8" }).seconds).toBe(8);
+  });
+
+  it("ignores non-durations rather than guessing", () => {
+    expect(extractPricingParams({ duration: "auto" }).seconds).toBeUndefined();
+    expect(extractPricingParams({ duration: 0 }).seconds).toBeUndefined();
+    expect(extractPricingParams({}).seconds).toBeUndefined();
+  });
+
+  it("prefers the first duration property present, in order", () => {
+    expect(
+      extractPricingParams({ duration: 4, duration_seconds: 9 }).seconds
+    ).toBe(4);
+    expect(extractPricingParams({ video_length: 12 }).seconds).toBe(12);
+  });
+
+  it("derives seconds from num_frames ÷ fps when no duration is stated", () => {
+    expect(extractPricingParams({ num_frames: 96, fps: 24 }).seconds).toBe(4);
+    expect(
+      extractPricingParams({ num_frames: 81, frames_per_second: 27 }).seconds
+    ).toBe(3);
+    expect(extractPricingParams({ num_frames: 96 }).seconds).toBeUndefined();
+  });
+
+  it("passes a stated resolution through for the calculator to normalize", () => {
+    expect(extractPricingParams({ resolution: "720p" }).resolution).toBe("720p");
+    expect(extractPricingParams({ resolution: "4K" }).resolution).toBe("4K");
+    expect(extractPricingParams({ image_size: "1K" }).resolution).toBe("1K");
+  });
+
+  it("maps a pixel pair to the nearest tier", () => {
+    expect(extractPricingParams({ size: "1024x1024" }).resolution).toBe(
+      "1024x1024"
+    );
+    expect(extractPricingParams({ size: "1280*720" }).resolution).toBe(
+      "1024x1024"
+    );
+    expect(extractPricingParams({ width: 2048, height: 2048 }).resolution).toBe(
+      "2K"
+    );
+  });
+
+  it("leaves a pixel pair that sits between tiers unset", () => {
+    // 480×832 is 1.5× off the nearest tier — naming one would invent a price.
+    expect(extractPricingParams({ size: "480*832" }).resolution).toBeUndefined();
+  });
+
+  it("leaves resolution unset for names that state none", () => {
+    for (const value of ["auto", "square_hd", "high", "original", ""]) {
+      expect(extractPricingParams({ resolution: value }).resolution).toBeUndefined();
+    }
+  });
+
+  it("reads the audio axis only from the booleans that name it", () => {
+    expect(extractPricingParams({ generate_audio: true }).withAudio).toBe(true);
+    expect(extractPricingParams({ with_audio: false }).withAudio).toBe(false);
+    // `audio` is an AudioRef input on nearly every node that has it.
+    expect(extractPricingParams({ audio: { uri: "x" } }).withAudio).toBeUndefined();
+  });
+
+  it("returns nothing for a node with no pricing-relevant properties", () => {
+    expect(extractPricingParams({ prompt: "hi", seed: 3 })).toEqual({});
+    expect(extractPricingParams(undefined)).toEqual({});
+  });
+});

--- a/packages/protocol/src/creative.ts
+++ b/packages/protocol/src/creative.ts
@@ -230,9 +230,23 @@ export interface NodeCostEstimate {
   billing_unit?: string;
   /** How many times this node is expected to run (fan-out multiplies this). */
   quantity: number;
-  /** unit_price * quantity, in {@link WorkflowCostEstimate.currency}. */
+  /**
+   * unit_price * quantity, in {@link WorkflowCostEstimate.currency}.
+   * A **lower bound** whenever {@link NodeCostEstimate.warnings} is non-empty:
+   * a cost we know exists but cannot price is left out rather than guessed.
+   */
   estimated_cost: number;
   confidence: CostConfidence;
+  /** How the figure was reached — "5 s × $0.205/s at 720p". */
+  breakdown?: string;
+  /**
+   * What the estimate filled in because the node did not state it ("resolution
+   * not set — priced at the base spec 720p"). On an `unknown` item this carries
+   * the reason the catalog refused to price the step.
+   */
+  assumptions?: string[];
+  /** Costs known to be missing from `estimated_cost`, making it a lower bound. */
+  warnings?: string[];
 }
 
 /** Pre-run estimate for a whole workflow/timeline — the plan-before-spend view. */

--- a/packages/websocket/src/sdk/sdk-static-preflight-service.ts
+++ b/packages/websocket/src/sdk/sdk-static-preflight-service.ts
@@ -1,5 +1,6 @@
 import {
   estimateWorkflowCost,
+  extractPricingParams,
   validateGraph,
   type CostEstimateInput,
   type GraphValidationInput,
@@ -391,6 +392,9 @@ function costSummary(
     // registry even though simple test doubles often happen to work.
     getMetadata: (nodeType) => options.registry.getMetadata(nodeType),
     getModelPrice: options.getModelPrice,
+    // What each node states about its job — a per-second model prices the
+    // duration asked for instead of one second.
+    getParams: (node) => extractPricingParams(node.data),
     quantities: options.quantities ? { ...options.quantities } : undefined
   });
   const known = estimate.items.filter((item) => item.confidence !== "unknown");

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -72,6 +72,7 @@ import {
 import { getInstanceId } from "./lib/instance-id.js";
 import { requestRemoteJobCancel } from "./job-control.js";
 import { estimateWorkflowCost } from "@nodetool-ai/node-sdk/cost-estimate";
+import { extractPricingParams } from "@nodetool-ai/node-sdk/pricing-params";
 import { WORKFLOW_DOCUMENT_TOOL_NAMES } from "@nodetool-ai/node-sdk";
 import { getModelUnitPrice } from "@nodetool-ai/model-pricing";
 import type {
@@ -2914,7 +2915,10 @@ export class UnifiedWebSocketRunner {
         // Prices the model picked on a generic node (e.g. a FAL or kie model on
         // nodetool.image.TextToImage), which node-type metadata alone cannot.
         // Same lookup the editor's cost preview uses.
-        getModelPrice: getModelUnitPrice
+        getModelPrice: getModelUnitPrice,
+        // A per-second model bills the clip it is asked for, so the duration
+        // and resolution the node states have to reach the price lookup.
+        getParams: (node) => extractPricingParams(node.data)
       });
       return Number.isFinite(estimate.total) ? estimate.total : 0;
     } catch (err) {
@@ -2944,7 +2948,8 @@ export class UnifiedWebSocketRunner {
           data: (node.data ?? {}) as Record<string, unknown>
         })),
         getMetadata: (nodeType: string) => this.getNodeMetadata?.(nodeType),
-        getModelPrice: getModelUnitPrice
+        getModelPrice: getModelUnitPrice,
+        getParams: (node) => extractPricingParams(node.data)
       });
       const items = estimate.items.filter(
         (item) => item.provider === "nodetool"

--- a/packages/websocket/tests/application-budget-gate.test.ts
+++ b/packages/websocket/tests/application-budget-gate.test.ts
@@ -444,10 +444,20 @@ describe("application invocation settlement", () => {
  * refuse a run.
  */
 describe("pre-run cost estimate", () => {
+  // A price billed in "units" or "credits" has no fixed USD value and the
+  // estimator refuses to sum it, so the gate can only be checked against an
+  // entry billed in something concrete.
   const firstFalPriced = (): { id: string; unitPrice: number } => {
     for (const [id, entry] of Object.entries(falUnitPricingCatalog.prices ?? {})) {
-      const price = (entry as { unit_price?: unknown }).unit_price;
-      if (typeof price === "number" && price > 0) return { id, unitPrice: price };
+      const { unit_price: price, billing_unit: unit } = entry as {
+        unit_price?: unknown;
+        billing_unit?: unknown;
+      };
+      if (typeof price !== "number" || price <= 0) continue;
+      if (typeof unit === "string" && /\bunits?\b|\bcredits?\b/i.test(unit)) {
+        continue;
+      }
+      return { id, unitPrice: price };
     }
     throw new Error("FAL pricing catalog has no priced entry");
   };

--- a/packages/websocket/tests/application-budget-gate.test.ts
+++ b/packages/websocket/tests/application-budget-gate.test.ts
@@ -15,6 +15,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { unpack } from "msgpackr";
 import falUnitPricingCatalog from "@nodetool-ai/fal-nodes/unit-pricing-catalog";
 import kieUnitPricingCatalog from "@nodetool-ai/kie-nodes/unit-pricing-catalog";
+import { genspendPricingCatalog } from "@nodetool-ai/model-pricing/genspend-catalog";
 import {
   DEFAULT_RUN_JOB_EXECUTION_OPTIONS,
   UnifiedWebSocketRunner,
@@ -530,5 +531,74 @@ describe("pre-run cost estimate", () => {
     expect(estimate([{ id: "n1", type: "nodetool.text.Concat", data: {} }])).toBe(
       0
     );
+  });
+
+  /**
+   * A per-video-second entry with a receipted clip envelope: the shortest
+   * length it publishes is what an unstated duration prices at, and a length
+   * outside the envelope is refused rather than extrapolated.
+   */
+  const firstPerSecondVideo = (): {
+    provider: string;
+    id: string;
+    unitPrice: number;
+    minSeconds: number;
+    maxSeconds: number;
+  } => {
+    for (const [key, entry] of Object.entries(genspendPricingCatalog.prices)) {
+      if (entry.unit_class !== "per-video-second") continue;
+      if ((entry.data_flags ?? []).some((f) => f.severity === "quote_wrong")) {
+        continue;
+      }
+      // A laddered grid prices off a variant row; this test is about the
+      // seconds axis, so take an entry that bills one flat per-second rate.
+      if ((entry.variants ?? []).length > 0) continue;
+      const clip = entry.clip_seconds;
+      if (!clip || typeof clip.min !== "number" || typeof clip.max !== "number") {
+        continue;
+      }
+      if (!(entry.unit_price > 0) || clip.max <= clip.min) continue;
+      const separator = key.indexOf(":");
+      return {
+        provider: key.slice(0, separator),
+        id: key.slice(separator + 1),
+        unitPrice: entry.unit_price,
+        minSeconds: clip.min,
+        maxSeconds: clip.max
+      };
+    }
+    throw new Error("GenSpend catalog has no per-video-second entry to price");
+  };
+
+  it("reserves more for a per-second model once the node states a duration", () => {
+    const { provider, id, unitPrice, minSeconds, maxSeconds } =
+      firstPerSecondVideo();
+    const node = (data: Record<string, unknown>) => [
+      { id: "n1", type: "nodetool.video.TextToVideo", data }
+    ];
+
+    const withoutDuration = estimate(node({ model: { id, provider } }));
+    const withDuration = estimate(
+      node({ model: { id, provider }, duration: maxSeconds })
+    );
+
+    // Unstated, the shortest receipted clip is the honest floor.
+    expect(withoutDuration).toBeCloseTo(unitPrice * minSeconds);
+    expect(withDuration).toBeCloseTo(unitPrice * maxSeconds);
+    expect(withDuration).toBeGreaterThan(withoutDuration);
+  });
+
+  it("reserves nothing for a duration the model publishes no price for", () => {
+    const { provider, id, maxSeconds } = firstPerSecondVideo();
+
+    expect(
+      estimate([
+        {
+          id: "n1",
+          type: "nodetool.video.TextToVideo",
+          data: { model: { id, provider }, duration: maxSeconds + 1 }
+        }
+      ])
+    ).toBe(0);
   });
 });

--- a/scripts/genspend/parity-check.mjs
+++ b/scripts/genspend/parity-check.mjs
@@ -1,0 +1,533 @@
+#!/usr/bin/env node
+/**
+ * Check NodeTool's local price arithmetic against GenSpend's own calculator.
+ *
+ * The shipped catalog is a snapshot we compute on locally — nothing about what
+ * a user is building leaves the machine — so the risk is that our port of the
+ * selection rules drifts from theirs. This re-prices a fixed set of cases from
+ * `packages/model-pricing/src/generated/genspend-pricing.json` and asserts each
+ * equals `POST https://genspend.io/api/v1/quote` for the same step. It needs
+ * the network, so it runs in the nightly sync workflow only, never in the PR
+ * quality gate.
+ *
+ *   node scripts/genspend/parity-check.mjs [catalog.json]
+ *   node scripts/genspend/parity-check.mjs --json
+ *
+ * The cases are pinned to a provider, because an unpinned quote picks the
+ * cheapest priceable offering and would compare against an offering our key
+ * does not name. Each case therefore carries both vocabularies: GenSpend's
+ * `model` slug + provider slug for the quote, and our `<provider_id>:<model_id>`
+ * key for the catalog. They are chosen from what our catalog actually covers —
+ * GenSpend's documented figures include models NodeTool ships no node for, and
+ * comparing those would prove nothing about our data.
+ *
+ * Two limits, both deliberate:
+ *
+ * - Every case on a laddered offering states a resolution. `/quote` declines a
+ *   laddered offering when none is given; we price the base spec and record an
+ *   assumption instead, which is a divergence by design (a node that never set
+ *   `resolution` would otherwise show no price at all), so it is not something
+ *   parity can assert.
+ * - `per_request` extras are unasserted: both catalog entries carrying one
+ *   (`fal-ai/z-image/turbo`, `nvidia/cosmos-3-super/text-to-image`) are models
+ *   `/quote` declines outright, so there is no figure to compare. They are
+ *   excluded from the total on both sides, which is what matters.
+ *
+ * Exit code 0 only when every case matched AND at least `MIN_PRICED_CASES` were
+ * really priced: a run that resolved nothing must fail rather than pass empty.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const DEFAULT_CATALOG = join(
+  ROOT,
+  "packages/model-pricing/src/generated/genspend-pricing.json"
+);
+
+export const QUOTE_URL = "https://genspend.io/api/v1/quote";
+
+/** Sub-cent agreement; the two sides do the same multiplications in floats. */
+export const EPSILON = 1e-6;
+
+/**
+ * A parity run that priced fewer cases than this proves nothing — a catalog
+ * that lost every key would otherwise pass with zero comparisons.
+ */
+export const MIN_PRICED_CASES = 15;
+
+/** GenSpend's video ladder, plus the spellings a provider page uses for it. */
+const RESOLUTION_TIERS = {
+  "480p": "480p",
+  "540p": "480p",
+  "576p": "480p",
+  "720p": "720p",
+  "768p": "720p",
+  "1080p": "1080p",
+  "1440p": "2K",
+  "2k": "2K",
+  "4k": "4K",
+  "2160p": "4K"
+};
+
+const normalizeResolution = (value) => {
+  if (typeof value !== "string") return null;
+  const key = value.trim().toLowerCase();
+  return RESOLUTION_TIERS[key] ?? (key ? value.trim() : null);
+};
+
+const PER_SECOND_CLASSES = new Set(["per-video-second", "per-audio-second"]);
+
+const near = (a, b) => Math.abs(a - b) <= EPSILON + Math.abs(b) * 1e-9;
+
+/**
+ * Price one step from a stored catalog entry, implementing the subset of
+ * GenSpend's rules the fixed cases exercise. Pure: no I/O, no clock.
+ *
+ * Returns `{ costUsd }` or `{ declined }` — declining is a result, not an
+ * error. We never reuse another rung for a resolution the provider does not
+ * publish, because understating is the direction that hurts.
+ */
+export function priceCase(entry, params = {}) {
+  if (!entry) return { declined: "no catalog entry" };
+  if ((entry.data_flags ?? []).some((f) => f.severity === "quote_wrong")) {
+    return { declined: "known quote discrepancy" };
+  }
+
+  const resolution = normalizeResolution(params.resolution);
+  const rows = entry.variants ?? [];
+  const seconds = Number.isFinite(params.seconds) ? params.seconds : null;
+
+  // Clip envelope: `null` declines every duration, an envelope declines what
+  // falls outside it.
+  if (seconds !== null && "clip_seconds" in entry) {
+    const clip = entry.clip_seconds;
+    if (clip === null) return { declined: "no receipted clip length" };
+    if (clip) {
+      if (Array.isArray(clip.set) && !clip.set.includes(seconds)) {
+        return { declined: `no published price at ${seconds}s` };
+      }
+      if (Number.isFinite(clip.min) && seconds < clip.min) {
+        return { declined: `below the receipted clip envelope` };
+      }
+      if (Number.isFinite(clip.max) && seconds > clip.max) {
+        return { declined: `above the receipted clip envelope` };
+      }
+    }
+  }
+
+  // Narrow the grid, one axis at a time. A plain t2v/i2v job never takes a
+  // video-input row: that is a different billing axis, handled by the re-rate
+  // below.
+  const baseRow = rows.find((row) => row.is_base) ?? null;
+  let candidates = rows.filter((row) => row.video_input !== true);
+
+  const laddered = candidates.filter((row) => row.resolution);
+  if (laddered.length > 0) {
+    if (resolution) {
+      candidates = laddered.filter(
+        (row) => normalizeResolution(row.resolution) === resolution
+      );
+      if (candidates.length === 0) {
+        return { declined: `no published price at ${resolution}` };
+      }
+    } else if (baseRow) {
+      // Resolution unset: the provider's own base spec, never the cheapest rung.
+      candidates = laddered.filter(
+        (row) => row.resolution === baseRow.resolution
+      );
+    }
+  }
+
+  const timed = candidates.filter((row) => Number.isFinite(row.duration_seconds));
+  if (timed.length > 0) {
+    if (seconds !== null) {
+      candidates = timed.filter((row) => row.duration_seconds === seconds);
+      if (candidates.length === 0) {
+        return { declined: `no published price at ${seconds}s` };
+      }
+    } else {
+      candidates = timed.filter((row) => row.is_base).length > 0
+        ? timed.filter((row) => row.is_base)
+        : timed;
+    }
+  }
+
+  // Audio is a billing axis worth up to 2×. Unset, the honest default is
+  // whatever the base spec delivers — not the cheaper of the two.
+  const wantAudio =
+    typeof params.withAudio === "boolean"
+      ? params.withAudio
+      : typeof baseRow?.with_audio === "boolean"
+        ? baseRow.with_audio
+        : null;
+  if (wantAudio !== null) {
+    const audio = candidates.filter((row) => row.with_audio === wantAudio);
+    if (audio.length > 0) candidates = audio;
+  }
+
+  // Tier is the same shape of axis: a provider selling Standard and Pro under
+  // one id delivers the base spec's tier unless the caller says otherwise.
+  const wantTier = params.tier ?? baseRow?.tier ?? null;
+  if (wantTier) {
+    const tiered = candidates.filter((row) => row.tier === wantTier);
+    if (tiered.length > 0) candidates = tiered;
+  }
+
+  const row = candidates.find((r) => r.is_base) ?? candidates[0] ?? null;
+  const unitPrice = row ? row.price_usd : entry.unit_price;
+  const unitClass = row ? row.unit_class : entry.unit_class;
+
+  let cost;
+  if (PER_SECOND_CLASSES.has(unitClass)) {
+    if (seconds === null) return { declined: "duration unknown" };
+    cost = unitPrice * seconds;
+  } else {
+    cost = unitPrice;
+  }
+
+  const surcharges = entry.surcharges ?? [];
+  const refVideoSeconds = Number.isFinite(params.referenceVideoSeconds)
+    ? params.referenceVideoSeconds
+    : 0;
+  const warnings = [];
+  if (refVideoSeconds > 0) {
+    // A re-rate replaces the generation cost rather than adding to it, and is
+    // scoped by resolution. No row for the requested resolution declines the
+    // re-rate — never another rung — leaving the generation cost as a floor.
+    const rates = surcharges.filter((s) => s.kind === "input_video_second");
+    const rate =
+      rates.find((s) => !s.spec) ??
+      rates.find(
+        (s) => resolution && normalizeResolution(s.spec) === resolution
+      ) ??
+      null;
+    if (rate) {
+      if (seconds === null) return { declined: "duration unknown" };
+      cost = rate.unit_price_usd * (seconds + refVideoSeconds);
+    } else if (rates.length > 0) {
+      warnings.push("no video-input rate at this resolution — lower bound");
+    }
+  }
+
+  const refImages = Number.isFinite(params.referenceImages)
+    ? params.referenceImages
+    : 0;
+  if (refImages > 0) {
+    const surcharge = surcharges.find((s) => s.kind === "input_image");
+    if (surcharge) {
+      cost +=
+        Math.max(0, refImages - surcharge.free_allowance) *
+        surcharge.unit_price_usd;
+    } else {
+      warnings.push("reference images not priced here — lower bound");
+    }
+  }
+
+  // `per_request` extras are opt-in; they are surfaced, never summed.
+  const quantity = Number.isFinite(params.quantity) ? params.quantity : 1;
+  return { costUsd: cost * quantity, warnings };
+}
+
+/**
+ * The fixed cases. `key` is our catalog key; `model`/`provider` are GenSpend's
+ * vocabulary for the same offering. `expect: "decline"` asserts both sides
+ * refuse to price the step.
+ */
+export const PARITY_CASES = [
+  {
+    name: "flat per-image price",
+    key: "together:black-forest-labs/FLUX.1-schnell",
+    model: "flux-1-schnell",
+    provider: "together"
+  },
+  {
+    name: "flat per-image price, a second provider",
+    key: "fal_ai:fal-ai/flux-1/dev",
+    model: "flux-1-dev",
+    provider: "fal"
+  },
+  {
+    name: "per-second × duration, no ladder to narrow",
+    key: "atlascloud:bytedance/seedance-2.0/text-to-video",
+    model: "seedance-2",
+    provider: "atlascloud",
+    params: { seconds: 5, resolution: "720p" }
+  },
+  {
+    name: "per-second × a longer duration",
+    key: "atlascloud:bytedance/seedance-2.0/text-to-video",
+    model: "seedance-2",
+    provider: "atlascloud",
+    params: { seconds: 10, resolution: "720p" }
+  },
+  {
+    name: "resolution ladder, base rung",
+    key: "kie:bytedance/seedance-2",
+    model: "seedance-2",
+    provider: "kie",
+    params: { seconds: 5, resolution: "720p" }
+  },
+  {
+    name: "resolution ladder, dearer rung",
+    key: "kie:bytedance/seedance-2",
+    model: "seedance-2",
+    provider: "kie",
+    params: { seconds: 5, resolution: "1080p" }
+  },
+  {
+    name: "resolution ladder, cheaper rung",
+    key: "kie:bytedance/seedance-2",
+    model: "seedance-2",
+    provider: "kie",
+    params: { seconds: 5, resolution: "480p" }
+  },
+  {
+    name: "audio axis, silent (the base spec)",
+    key: "kie:kling-3.0/video",
+    model: "kling-3.0-standard",
+    provider: "kie",
+    params: { seconds: 5, resolution: "1080p" }
+  },
+  {
+    name: "audio axis, with audio",
+    key: "kie:kling-3.0/video",
+    model: "kling-3.0-standard",
+    provider: "kie",
+    params: { seconds: 5, resolution: "1080p", withAudio: true }
+  },
+  {
+    name: "per-generation duration rung, not multiplied",
+    key: "minimax:MiniMax-Hailuo-02",
+    model: "hailuo-02",
+    provider: "minimax",
+    params: { seconds: 6, resolution: "720p" }
+  },
+  {
+    name: "per-generation duration rung, the longer clip",
+    key: "minimax:MiniMax-Hailuo-02",
+    model: "hailuo-02",
+    provider: "minimax",
+    params: { seconds: 10, resolution: "720p" }
+  },
+  {
+    name: "tier axis, the base spec's tier",
+    key: "kie:hailuo/2-3-image-to-video-standard",
+    model: "hailuo-2.3",
+    provider: "kie",
+    params: { seconds: 6, resolution: "1080p" }
+  },
+  {
+    name: "reference images inside the free allowance",
+    key: "fal_ai:minimax/h3/text-to-video",
+    model: "minimax-h3",
+    provider: "fal",
+    params: { seconds: 6, resolution: "720p", referenceImages: 3 }
+  },
+  {
+    name: "reference images past the free allowance, additive",
+    key: "fal_ai:minimax/h3/text-to-video",
+    model: "minimax-h3",
+    provider: "fal",
+    params: { seconds: 6, resolution: "720p", referenceImages: 8 }
+  },
+  {
+    name: "reference video re-rates the whole job, scoped to 720p",
+    key: "kie:bytedance/seedance-2",
+    model: "seedance-2",
+    provider: "kie",
+    params: { seconds: 5, resolution: "720p", referenceVideoSeconds: 5 }
+  },
+  {
+    name: "reference video re-rate at an unscoped rate",
+    key: "fal_ai:fal-ai/wan/v2.7/text-to-video",
+    model: "wan-2.7",
+    provider: "fal",
+    params: { seconds: 5, resolution: "720p", referenceVideoSeconds: 5 }
+  },
+  {
+    name: "no rate at this resolution: generation only, a lower bound",
+    key: "kie:bytedance/seedance-2",
+    model: "seedance-2",
+    provider: "kie",
+    params: { seconds: 5, resolution: "480p", referenceVideoSeconds: 5 }
+  },
+  {
+    name: "stated resolution the provider does not publish",
+    key: "kie:bytedance/seedance-2",
+    model: "seedance-2",
+    provider: "kie",
+    params: { seconds: 5, resolution: "2K" },
+    expect: "decline"
+  },
+  {
+    name: "duration outside the receipted clip envelope",
+    key: "fal_ai:fal-ai/veo3.1/fast",
+    model: "veo-3.1-fast",
+    provider: "fal",
+    params: { seconds: 10, resolution: "720p" },
+    expect: "decline"
+  }
+];
+
+/** One case's verdict, for the report and the exit code. */
+function compareCase(testCase, entry, step) {
+  const local = priceCase(entry, testCase.params ?? {});
+  const remote =
+    step && typeof step.costUsd === "number" ? step.costUsd : null;
+  const declineExpected = testCase.expect === "decline";
+
+  if (local.declined || remote === null) {
+    const agree = Boolean(local.declined) && remote === null;
+    return {
+      name: testCase.name,
+      key: testCase.key,
+      priced: false,
+      declined: true,
+      ok: agree && declineExpected,
+      local: local.declined ?? local.costUsd,
+      remote: step?.error ?? remote,
+      detail: agree
+        ? declineExpected
+          ? "both declined"
+          : "both declined, but the case expected a price"
+        : `local ${local.declined ?? local.costUsd} vs quote ${
+            step?.error ?? remote
+          }`
+    };
+  }
+
+  const ok = !declineExpected && near(local.costUsd, remote);
+  return {
+    name: testCase.name,
+    key: testCase.key,
+    priced: true,
+    declined: false,
+    ok,
+    local: local.costUsd,
+    remote,
+    detail: ok
+      ? `$${remote.toFixed(6)}`
+      : `local $${local.costUsd.toFixed(6)} vs quote $${remote.toFixed(6)}`
+  };
+}
+
+/**
+ * Compare every case and decide the run. Pure — `quoteSteps` is whatever the
+ * quote endpoint answered, in case order — so the whole verdict is testable
+ * without a network.
+ */
+export function runComparison({ catalog, quoteSteps, cases = PARITY_CASES }) {
+  const results = cases.map((testCase, i) =>
+    compareCase(testCase, catalog?.prices?.[testCase.key] ?? null, quoteSteps[i])
+  );
+  const priced = results.filter((r) => r.priced && r.ok).length;
+  const failures = results.filter((r) => !r.ok);
+  const vacuous = priced < MIN_PRICED_CASES;
+  return {
+    results,
+    priced,
+    failures,
+    vacuous,
+    ok: failures.length === 0 && !vacuous,
+    reason: vacuous
+      ? `only ${priced} case(s) priced — at least ${MIN_PRICED_CASES} must match a real price, or the check passes on nothing`
+      : failures.length > 0
+        ? `${failures.length} case(s) disagree with GenSpend's calculator`
+        : null
+  };
+}
+
+/** The quote request body for a case list, in the same order. */
+export function quoteRequest(cases = PARITY_CASES) {
+  return {
+    steps: cases.map((testCase) => ({
+      model: testCase.model,
+      provider: testCase.provider,
+      ...(testCase.params?.resolution
+        ? { resolution: testCase.params.resolution }
+        : {}),
+      ...(Number.isFinite(testCase.params?.seconds)
+        ? { seconds: testCase.params.seconds }
+        : {}),
+      ...(Number.isFinite(testCase.params?.referenceImages)
+        ? { referenceImages: testCase.params.referenceImages }
+        : {}),
+      ...(Number.isFinite(testCase.params?.referenceVideoSeconds)
+        ? { referenceVideoSeconds: testCase.params.referenceVideoSeconds }
+        : {}),
+      ...(Number.isFinite(testCase.params?.quantity)
+        ? { quantity: testCase.params.quantity }
+        : {}),
+      ...(typeof testCase.params?.withAudio === "boolean"
+        ? { audioMode: testCase.params.withAudio ? "with" : "without" }
+        : {})
+    }))
+  };
+}
+
+async function fetchQuote(cases, attempts = 3) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const res = await fetch(QUOTE_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": "nodetool-cost/1.0 (+https://nodetool.ai)"
+        },
+        body: JSON.stringify(quoteRequest(cases)),
+        signal: AbortSignal.timeout(30_000)
+      });
+      if (!res.ok) throw new Error(`POST ${QUOTE_URL} → HTTP ${res.status}`);
+      const body = await res.json();
+      if (!Array.isArray(body?.steps) || body.steps.length !== cases.length) {
+        throw new Error(`POST ${QUOTE_URL} → expected ${cases.length} steps`);
+      }
+      return body.steps;
+    } catch (err) {
+      lastError = err;
+      if (attempt < attempts) {
+        await new Promise((resolve) => setTimeout(resolve, 2000 * attempt));
+      }
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const json = argv.includes("--json");
+  const path = argv.find((arg) => !arg.startsWith("--")) ?? DEFAULT_CATALOG;
+  const catalog = JSON.parse(readFileSync(path, "utf8"));
+
+  const steps = await fetchQuote(PARITY_CASES);
+  const verdict = runComparison({ catalog, quoteSteps: steps });
+
+  if (json) {
+    console.log(JSON.stringify(verdict, null, 2));
+  } else {
+    for (const result of verdict.results) {
+      console.log(
+        `${result.ok ? "ok  " : "FAIL"} ${result.name.padEnd(52)} ${result.detail}`
+      );
+    }
+    console.log(
+      `\n${verdict.priced}/${PARITY_CASES.length} case(s) priced and matched against ${QUOTE_URL}.`
+    );
+  }
+
+  if (!verdict.ok) {
+    console.error(`\nParity check failed: ${verdict.reason}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/scripts/sync-genspend-pricing.mjs
+++ b/scripts/sync-genspend-pricing.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Refresh `packages/model-pricing/src/generated/genspend-pricing.json` from the
- * GenSpend catalog (https://genspend.io/api/v1/models) — the nightly source of
+ * GenSpend catalog (https://genspend.io/api/v1/export) — the nightly source of
  * realtime generative-media prices behind `getModelUnitPrice`.
  *
  * Every provider NodeTool can run and GenSpend tracks is covered. The bridge
@@ -13,6 +13,12 @@
  *
  * Prices keep the provider's own unit and are never converted — GenSpend
  * prices are only comparable inside one `unitClass`.
+ *
+ * Schema 3 ships the provider's published *grid* alongside the scalar price:
+ * `variants[]` (resolution / duration / audio / video-input rungs),
+ * `surcharges[]`, the clip-length envelope, and the open data flags. The
+ * scalars keep their v2 meaning, so a consumer that reads only `unit_price`
+ * behaves as it did before.
  *
  *   node scripts/sync-genspend-pricing.mjs            # rewrite the catalog
  *   node scripts/sync-genspend-pricing.mjs --check    # exit 1 if out of date
@@ -43,8 +49,8 @@ const DEFAULT_OUT = join(
 );
 const ALIASES_PATH = join(ROOT, "scripts/genspend/aliases.json");
 
-export const GENSPEND_MODELS_URL = "https://genspend.io/api/v1/models";
-export const SCHEMA_VERSION = 2;
+export const GENSPEND_MODELS_URL = "https://genspend.io/api/v1/export";
+export const SCHEMA_VERSION = 3;
 
 /**
  * `unitClass` → the `billing_unit` label the cost estimator renders. Kept in
@@ -64,8 +70,153 @@ const BILLING_UNITS = {
 const isFiniteNumber = (value) =>
   typeof value === "number" && Number.isFinite(value);
 
+/** The typed facets a variant row can carry. A row with none of them prices nothing. */
+const VARIANT_FACETS = [
+  "resolution",
+  "duration_seconds",
+  "with_audio",
+  "video_input",
+  "tier"
+];
+
 /**
- * Normalize a GenSpend `/api/v1/models` response into the catalog NodeTool
+ * Surcharge kinds the calculator knows how to reason about. Anything else
+ * GenSpend adds later is dropped rather than stored as a number nobody applies.
+ */
+const SURCHARGE_KINDS = new Set([
+  "input_image",
+  "input_video_second",
+  "per_request"
+]);
+
+const nonEmptyString = (value) =>
+  typeof value === "string" && value.trim() ? value.trim() : null;
+
+/**
+ * The offering's published grid, reduced to the typed facets we compute on.
+ *
+ * GenSpend's `spec` string is its own truth surface — free prose we would have
+ * to re-parse — so it is dropped, and with it every row that says nothing in
+ * facets. That removes the common case where `variants[]` is a list of sibling
+ * endpoint ids (already resolved into separate catalog keys by the matcher) and
+ * keeps the shipped JSON to the rows a price actually varies over.
+ */
+export function typedVariants(offering) {
+  const headlineClass = nonEmptyString(offering?.unitClass) ?? "";
+  const rows = [];
+  for (const variant of Array.isArray(offering?.variants) ? offering.variants : []) {
+    if (!isFiniteNumber(variant?.priceUsd)) continue;
+    const row = {
+      price_usd: variant.priceUsd,
+      unit_class: nonEmptyString(variant.unitClass) ?? headlineClass,
+      ...(nonEmptyString(variant.resolution)
+        ? { resolution: nonEmptyString(variant.resolution) }
+        : {}),
+      ...(isFiniteNumber(variant.durationSeconds)
+        ? { duration_seconds: variant.durationSeconds }
+        : {}),
+      ...(typeof variant.withAudio === "boolean"
+        ? { with_audio: variant.withAudio }
+        : {}),
+      ...(typeof variant.videoInput === "boolean"
+        ? { video_input: variant.videoInput }
+        : {}),
+      ...(nonEmptyString(variant.tier) ? { tier: nonEmptyString(variant.tier) } : {}),
+      is_base: variant.isBase === true
+    };
+    if (!VARIANT_FACETS.some((facet) => facet in row)) continue;
+    rows.push(row);
+  }
+  return rows;
+}
+
+/**
+ * Input-side charges, in GenSpend's own semantics: `input_image` is additive
+ * past its free allowance, `input_video_second` *replaces* the generation cost
+ * and is scoped by resolution, and `per_request` is opt-in and never added
+ * silently. The prose note is left upstream; only the arithmetic is stored.
+ */
+export function typedSurcharges(offering) {
+  const rows = [];
+  for (const surcharge of Array.isArray(offering?.surcharges)
+    ? offering.surcharges
+    : []) {
+    const kind = nonEmptyString(surcharge?.kind);
+    if (!kind || !SURCHARGE_KINDS.has(kind)) continue;
+    if (!isFiniteNumber(surcharge.unitPriceUsd)) continue;
+    const spec = nonEmptyString(surcharge.spec);
+    rows.push({
+      kind,
+      // One `spec` field upstream carries two meanings: the resolution a video
+      // re-rate is scoped to, and the name of a per-request extra.
+      ...(spec && kind === "input_video_second" ? { spec } : {}),
+      unit_price_usd: surcharge.unitPriceUsd,
+      free_allowance: isFiniteNumber(surcharge.freeAllowance)
+        ? surcharge.freeAllowance
+        : 0,
+      ...(spec && kind === "per_request" ? { label: spec } : {})
+    });
+  }
+  return rows;
+}
+
+/**
+ * Open data flags, kind and severity only. `cosmetic` is display text and we
+ * render our own, so it is dropped; `quote_wrong` and `spec_gap` change what a
+ * consumer may claim, so they ship.
+ */
+export function typedDataFlags(offering) {
+  const rows = [];
+  for (const flag of Array.isArray(offering?.dataFlags) ? offering.dataFlags : []) {
+    const severity = nonEmptyString(flag?.severity);
+    const kind = nonEmptyString(flag?.kind);
+    if (!severity || !kind || severity === "cosmetic") continue;
+    rows.push({ kind, severity });
+  }
+  return rows;
+}
+
+/**
+ * The model's clip-length envelope, stored exactly as published. `null` is a
+ * refusal to price any duration, not an absence of limits, so it is kept as
+ * `null`; a model that publishes no envelope at all carries no field.
+ */
+export function clipSecondsOf(model) {
+  const capabilities = model?.capabilities;
+  if (!capabilities || !("clipSeconds" in capabilities)) return undefined;
+  const clip = capabilities.clipSeconds;
+  if (clip === null) return null;
+  if (!clip || typeof clip !== "object") return undefined;
+  const set = Array.isArray(clip.set) ? clip.set.filter(isFiniteNumber) : null;
+  const envelope = {
+    ...(set && set.length > 0 ? { set } : {}),
+    ...(isFiniteNumber(clip.min) ? { min: clip.min } : {}),
+    ...(isFiniteNumber(clip.max) ? { max: clip.max } : {})
+  };
+  return Object.keys(envelope).length > 0 ? envelope : undefined;
+}
+
+/**
+ * The row an entry's scalars should quote.
+ *
+ * An entry matched through a `variants[]` row already names its own rung, so
+ * that row is its base. Otherwise the offering's `isBase` row is the honest
+ * default deliverable — the provider's own answer to "what does this cost with
+ * nothing specified", which beats v2's arbitrary collapse. Its `unitClass`
+ * comes with it: MiniMax bills Hailuo per generation ($0.28 for a 768p 6s
+ * clip) while the headline quotes a per-second rate, and taking one without
+ * the other would publish $0.28 *per second*.
+ */
+export function baseSpecRow(offering, variantSpec) {
+  const rows = Array.isArray(offering?.variants) ? offering.variants : [];
+  const row = variantSpec
+    ? rows.find((v) => v?.spec === variantSpec)
+    : rows.find((v) => v?.isBase === true);
+  return isFiniteNumber(row?.priceUsd) ? row : null;
+}
+
+/**
+ * Normalize a GenSpend `/api/v1/export` response into the catalog NodeTool
  * ships: a flat `prices` index keyed `<provider_id>:<model_id>`.
  *
  * Dropped on purpose: offerings that aren't `available`, carry no price, belong
@@ -113,8 +264,17 @@ export function buildPriceIndex({ models, index, aliases }) {
 
       stats.priced += 1;
 
+      const variants = typedVariants(offering);
+      const surcharges = typedSurcharges(offering);
+      const dataFlags = typedDataFlags(offering);
+      const clipSeconds = clipSecondsOf(model);
+
       for (const entry of resolved.entries) {
         const key = `${providerId}:${entry.modelId}`;
+        const base = baseSpecRow(offering, entry.variantSpec);
+        const unitPrice = base ? base.priceUsd : entry.unitPrice;
+        const unitClass =
+          (base ? nonEmptyString(base.unitClass) : null) ?? entry.unitClass;
         const existing = prices[key];
         if (existing) {
           // Equal trust, same model listed twice: the cheaper number is what a
@@ -124,8 +284,8 @@ export function buildPriceIndex({ models, index, aliases }) {
           // gate must assume the dearer.
           const sameModel = existing.model_slug === model.slug;
           const tieBreak = sameModel
-            ? entry.unitPrice < existing.unit_price
-            : entry.unitPrice > existing.unit_price;
+            ? unitPrice < existing.unit_price
+            : unitPrice > existing.unit_price;
           const better =
             MATCH_RANK[entry.match] > MATCH_RANK[existing.match] ||
             (MATCH_RANK[entry.match] === MATCH_RANK[existing.match] && tieBreak);
@@ -135,16 +295,20 @@ export function buildPriceIndex({ models, index, aliases }) {
         }
 
         prices[key] = {
-          unit_price: entry.unitPrice,
-          billing_unit: BILLING_UNITS[entry.unitClass] ?? "units",
-          unit_class: entry.unitClass,
+          unit_price: unitPrice,
+          billing_unit: BILLING_UNITS[unitClass] ?? "units",
+          unit_class: unitClass,
           model_slug: model.slug,
           match: entry.match,
           live: offering.live === true,
           source_url:
             typeof offering.sourceUrl === "string" ? offering.sourceUrl : "",
           ...(entry.tier ? { tier: entry.tier } : {}),
-          ...(entry.resolution ? { resolution: entry.resolution } : {})
+          ...(entry.resolution ? { resolution: entry.resolution } : {}),
+          ...(variants.length > 0 ? { variants } : {}),
+          ...(surcharges.length > 0 ? { surcharges } : {}),
+          ...(clipSeconds !== undefined ? { clip_seconds: clipSeconds } : {}),
+          ...(dataFlags.length > 0 ? { data_flags: dataFlags } : {})
         };
       }
     }
@@ -218,13 +382,16 @@ const strongEtag = (etag) =>
   typeof etag === "string" ? etag.replace(/^W\//, "") : null;
 
 /**
- * Fetch the catalog, asking for the envelope (`generatedAt` + `count`, so the
- * payload dates itself) and offering the previous run's ETag. A 304 means the
- * upstream catalog has not moved since the shipped file was written, and the
- * whole run is a no-op — reported as `{ notModified: true }`.
+ * Fetch the catalog and offer the previous run's ETag. `/export` is the same
+ * projection `/models` serves plus surcharges, open data flags and the `usage`
+ * block, assembled server-side so the two cannot drift, and it always answers
+ * with an envelope (`{schemaVersion, generatedAt, counts, usage, models}`) that
+ * dates the payload. A 304 means the upstream catalog has not moved since the
+ * shipped file was written, and the whole run is a no-op — reported as
+ * `{ notModified: true }`.
  */
 async function fetchModels(url, { etag, attempts = 3 } = {}) {
-  const endpoint = `${url}?envelope=1`;
+  const endpoint = url;
   let lastError;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {

--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -34,6 +34,8 @@ export default {
     // pull the heavy barrel (pack-loader, registry) into jsdom.
     "^@nodetool-ai/node-sdk/cost-estimate$":
       "<rootDir>/../packages/node-sdk/src/cost-estimate.ts",
+    "^@nodetool-ai/node-sdk/pricing-params$":
+      "<rootDir>/../packages/node-sdk/src/pricing-params.ts",
     // image-editor ships ESM-only dist; map to src so Jest transforms it
     // (used by useInpaintHere → SelectionActionBar). Mirrors protocol/gpu.
     "^@nodetool-ai/image-editor$":

--- a/web/src/components/costs/WorkflowCostEstimatePanel.tsx
+++ b/web/src/components/costs/WorkflowCostEstimatePanel.tsx
@@ -14,6 +14,7 @@ import React, { memo } from "react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import type { NodeCostEstimate } from "@nodetool-ai/protocol";
 import { Box, Caption, ExternalLink, Tooltip } from "../ui_primitives";
 import { genspendPricingCatalog } from "@nodetool-ai/model-pricing/genspend-catalog";
 import { useWorkflowCostEstimate } from "../../hooks/useWorkflowCostEstimate";
@@ -21,6 +22,52 @@ import { formatMoney } from "./costsData";
 
 /** Date the shipped GenSpend prices last moved, e.g. "2026-07-29". */
 const genspendUpdatedOn = genspendPricingCatalog.updatedAt.slice(0, 10);
+/** The upstream snapshot those prices were read from, when the catalog says. */
+const genspendSnapshotOn =
+  genspendPricingCatalog.catalogGeneratedAt?.slice(0, 10) ?? null;
+
+/** True when the figure leaves out a cost we know exists — "at least $X". */
+const isLowerBound = (item: NodeCostEstimate): boolean =>
+  item.confidence !== "unknown" && (item.warnings?.length ?? 0) > 0;
+
+/** A per-second row's duration, as the calculator wrote it ("5 s × $0.1/s"). */
+const secondsFromBreakdown = (breakdown: string | undefined): string | null => {
+  const match = breakdown ? /(\d+(?:\.\d+)?)\s*s\s*×/.exec(breakdown) : null;
+  return match ? match[1] : null;
+};
+
+/** The rung a row was priced at ("… at 720p"), when the price is laddered. */
+const resolutionFromBreakdown = (
+  breakdown: string | undefined
+): string | null => {
+  const match = breakdown ? /\bat ([\d][\dA-Za-z×x]*)/.exec(breakdown) : null;
+  return match ? match[1] : null;
+};
+
+/** "image" → "images" for a count that is not one. */
+const plural = (unit: string, count: number): string =>
+  count === 1 || unit.endsWith("s") ? unit : `${unit}s`;
+
+/**
+ * What a run of this node buys, in one phrase: fan-out, clip length and the
+ * resolution rung it was priced at — "2 × 5 s @ 720p", "4 images". Falls back
+ * to the bare count when the item carries nothing else.
+ */
+export function formatUnits(item: NodeCostEstimate): string {
+  const quantity = item.quantity;
+  const seconds = secondsFromBreakdown(item.breakdown);
+  const resolution = resolutionFromBreakdown(item.breakdown);
+
+  let units: string;
+  if (seconds) {
+    units = quantity === 1 ? `${seconds} s` : `${quantity} × ${seconds} s`;
+  } else if (item.billing_unit && !/\bunits?\b/i.test(item.billing_unit)) {
+    units = `${quantity} ${plural(item.billing_unit, quantity)}`;
+  } else {
+    units = String(quantity);
+  }
+  return resolution ? `${units} @ ${resolution}` : units;
+}
 
 export interface WorkflowCostEstimatePanelProps {
   workflowId: string;
@@ -55,14 +102,16 @@ const styles = (theme: Theme) =>
       display: "flex",
       flexDirection: "column"
     },
+    ".cost-item": {
+      borderBottom: `1px solid ${theme.vars.palette.divider}`,
+      "&:last-child": { borderBottom: "none" }
+    },
     ".cost-row": {
       display: "grid",
       gridTemplateColumns: "1.6fr 1.6fr auto auto",
       gap: theme.spacing(1),
       alignItems: "center",
-      padding: `${theme.spacing(1)} 0`,
-      borderBottom: `1px solid ${theme.vars.palette.divider}`,
-      "&:last-child": { borderBottom: "none" }
+      padding: `${theme.spacing(1)} 0`
     },
     ".cost-row.is-head": {
       borderBottom: `1px solid ${theme.vars.palette.divider}`
@@ -131,6 +180,12 @@ const styles = (theme: Theme) =>
       color: theme.vars.palette.text.primary,
       fontVariantNumeric: "tabular-nums"
     },
+    ".cost-assumption": {
+      display: "block",
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.disabled,
+      paddingBottom: theme.spacing(1)
+    },
     ".cost-note": {
       fontSize: "var(--fontSizeSmaller)",
       color: theme.vars.palette.warning.main
@@ -169,42 +224,74 @@ const WorkflowCostEstimatePanelInternal: React.FC<
               <span className="cost-col-head">Node</span>
               <span className="cost-col-head">Provider / model</span>
               <span className="cost-col-head" style={{ textAlign: "right" }}>
-                Qty
+                Units
               </span>
               <span className="cost-col-head" style={{ textAlign: "right" }}>
                 Cost
               </span>
             </div>
-            {estimate.items.map((item) => (
-              <div className="cost-row" key={item.node_id}>
-                <span className="cost-cell-node" title={item.node_type}>
-                  {item.node_type}
-                </span>
-                {item.confidence === "unknown" ? (
-                  <Tooltip title="Price unknown — excluded from the total" arrow>
-                    <span className="cost-unknown" aria-label="Price unknown">
-                      <HelpOutlineIcon fontSize="inherit" />
-                    </span>
-                  </Tooltip>
-                ) : (
-                  <span className="cost-cell-model">
-                    {item.provider}
-                    {item.model ? ` · ${item.model}` : ""}
+            {estimate.items.map((item) => {
+              const unknown = item.confidence === "unknown";
+              // A declined price carries its reason in `assumptions`; that is
+              // the actionable thing to say, not "unknown".
+              const unknownReason =
+                item.assumptions?.join(" ") ??
+                "Price unknown — excluded from the total";
+              const row = (
+                <div className="cost-row">
+                  <span className="cost-cell-node" title={item.node_type}>
+                    {item.node_type}
                   </span>
-                )}
-                <span className="cost-cell-num">{item.quantity}</span>
-                <span className="cost-cell-num">
-                  {item.confidence === "unknown"
-                    ? "—"
-                    : formatMoney(item.estimated_cost)}
-                </span>
-              </div>
-            ))}
+                  {unknown ? (
+                    <Tooltip title={unknownReason} arrow>
+                      <span className="cost-unknown" aria-label="Price unknown">
+                        <HelpOutlineIcon fontSize="inherit" />
+                      </span>
+                    </Tooltip>
+                  ) : (
+                    <span className="cost-cell-model">
+                      {item.provider}
+                      {item.model ? ` · ${item.model}` : ""}
+                    </span>
+                  )}
+                  <span className="cost-cell-num">{formatUnits(item)}</span>
+                  <span className="cost-cell-num">
+                    {unknown
+                      ? "—"
+                      : `${isLowerBound(item) ? "≥ " : ""}${formatMoney(
+                          item.estimated_cost
+                        )}`}
+                  </span>
+                </div>
+              );
+              return (
+                <div className="cost-item" key={item.node_id}>
+                  {item.breakdown ? (
+                    <Tooltip
+                      title={[item.breakdown, ...(item.warnings ?? [])].join(
+                        " — "
+                      )}
+                      arrow
+                    >
+                      {row}
+                    </Tooltip>
+                  ) : (
+                    row
+                  )}
+                  {!unknown && item.assumptions?.length ? (
+                    <span className="cost-assumption">
+                      {item.assumptions.join(" · ")}
+                    </span>
+                  ) : null}
+                </div>
+              );
+            })}
           </div>
 
           <div className="cost-total">
             <span className="cost-total-key">Total ({estimate.currency})</span>
             <span className="cost-total-value">
+              {estimate.items.some(isLowerBound) ? "≥ " : ""}
               {formatMoney(estimate.total)}
             </span>
           </div>
@@ -216,13 +303,22 @@ const WorkflowCostEstimatePanelInternal: React.FC<
               total.
             </span>
           )}
-          <span className="cost-credit">
-            List prices from provider catalogs and{" "}
-            <ExternalLink href="https://genspend.io" size="small">
-              genspend.io
-            </ExternalLink>
-            , last updated {genspendUpdatedOn}.
-          </span>
+          <Tooltip
+            title={
+              genspendSnapshotOn
+                ? `Prices read from the genspend.io catalog snapshot of ${genspendSnapshotOn}`
+                : "Prices ship with the app; a nightly sync moves them"
+            }
+            arrow
+          >
+            <span className="cost-credit">
+              List prices from provider catalogs and{" "}
+              <ExternalLink href="https://genspend.io" size="small">
+                genspend.io
+              </ExternalLink>
+              , last updated {genspendUpdatedOn}.
+            </span>
+          </Tooltip>
         </>
       )}
     </Box>

--- a/web/src/components/costs/__tests__/WorkflowCostEstimatePanel.test.tsx
+++ b/web/src/components/costs/__tests__/WorkflowCostEstimatePanel.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";
 
@@ -59,6 +60,106 @@ describe("WorkflowCostEstimatePanel", () => {
     expect(screen.queryByRole("link", { name: /genspend\.io/i })).toBeNull();
     expect(
       screen.getByText(/Add a node that uses an AI model/)
+    ).toBeInTheDocument();
+  });
+
+  it("names the catalog snapshot the prices came from", async () => {
+    mockHook.mockReturnValue(estimate as never);
+    renderPanel();
+
+    await userEvent.hover(screen.getByText(/List prices from provider/));
+    const snapshot = genspendPricingCatalog.catalogGeneratedAt?.slice(0, 10);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("tooltip").textContent
+      ).toMatch(snapshot ? new RegExp(snapshot) : /nightly sync/);
+    });
+  });
+
+  it("reads fan-out, clip length and rung as one units phrase", () => {
+    mockHook.mockReturnValue({
+      ...estimate,
+      items: [
+        {
+          ...estimate.items[0],
+          quantity: 2,
+          breakdown: "5 s × $0.205/s at 720p"
+        }
+      ]
+    } as never);
+    renderPanel();
+
+    expect(screen.getByText("2 × 5 s @ 720p")).toBeInTheDocument();
+  });
+
+  it("counts a fan-out in the unit the model bills in", () => {
+    mockHook.mockReturnValue({
+      ...estimate,
+      items: [{ ...estimate.items[0], quantity: 4, billing_unit: "image" }]
+    } as never);
+    renderPanel();
+
+    expect(screen.getByText("4 images")).toBeInTheDocument();
+  });
+
+  it("labels a cost that leaves out a known charge as a lower bound", () => {
+    mockHook.mockReturnValue({
+      ...estimate,
+      items: [
+        {
+          ...estimate.items[0],
+          warnings: ["reference images are not priced for this model"]
+        }
+      ]
+    } as never);
+    renderPanel();
+
+    // Both the row and the total say "at least", never a false exact.
+    expect(screen.getAllByText(/≥/)).toHaveLength(2);
+  });
+
+  it("says why a declined price could not be quoted", async () => {
+    mockHook.mockReturnValue({
+      ...estimate,
+      total: 0,
+      unknown_count: 1,
+      items: [
+        {
+          node_id: "1",
+          node_type: "nodetool.video.TextToVideo",
+          provider: "atlascloud",
+          model: "some/video",
+          quantity: 1,
+          estimated_cost: 0,
+          confidence: "unknown",
+          assumptions: ["no published price at 1080p"]
+        }
+      ]
+    } as never);
+    renderPanel();
+
+    await userEvent.hover(screen.getByLabelText("Price unknown"));
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "no published price at 1080p"
+      );
+    });
+  });
+
+  it("shows what the estimate filled in as a sub-line under the row", () => {
+    mockHook.mockReturnValue({
+      ...estimate,
+      items: [
+        {
+          ...estimate.items[0],
+          assumptions: ["resolution not set on the node — priced at 720p"]
+        }
+      ]
+    } as never);
+    renderPanel();
+
+    expect(
+      screen.getByText("resolution not set on the node — priced at 720p")
     ).toBeInTheDocument();
   });
 });

--- a/web/src/hooks/__tests__/useWorkflowCostEstimate.test.tsx
+++ b/web/src/hooks/__tests__/useWorkflowCostEstimate.test.tsx
@@ -57,21 +57,45 @@ const mockMetadata: Record<string, unknown> = {
   "nodetool.image.TextToImage": {
     properties: [{ name: "model", type: { type: "image_model" } }]
   },
+  "nodetool.video.TextToVideo": {
+    properties: [{ name: "model", type: { type: "video_model" } }]
+  },
   "nodetool.text.Concat": {
     properties: [{ name: "a", type: { type: "str" } }]
   }
 };
 
+/** Params the mocked lookup was called with, per model id. */
+const pricedWith: Array<{ id: string; params: unknown }> = [];
+
 jest.mock("../../utils/modelUnitPricing", () => ({
-  getModelUnitPrice: (model: { id: string }) =>
-    model.id === "fal-ai/flux/schnell"
-      ? {
-          unit_price: 0.003,
-          billing_unit: "images",
-          currency: "USD",
-          source: "bundle"
-        }
-      : null
+  getModelUnitPrice: (model: { id: string }, params?: unknown) => {
+    pricedWith.push({ id: model.id, params });
+    if (model.id === "fal-ai/flux/schnell") {
+      return {
+        unit_price: 0.003,
+        billing_unit: "images",
+        currency: "USD",
+        source: "bundle"
+      };
+    }
+    if (model.id === "video/per-second") {
+      // Stands in for a per-video-second catalog entry: the calculator returns
+      // the already-multiplied figure, so the duration has to reach it.
+      const seconds =
+        typeof (params as { seconds?: number } | undefined)?.seconds === "number"
+          ? (params as { seconds: number }).seconds
+          : 1;
+      return {
+        unit_price: 0.1 * seconds,
+        billing_unit: "video",
+        currency: "USD",
+        source: "bundle",
+        breakdown: `${seconds} s × $0.1/s`
+      };
+    }
+    return null;
+  }
 }));
 
 jest.mock("../../stores/MetadataStore", () => ({
@@ -87,6 +111,7 @@ import { useWorkflowCostEstimate } from "../useWorkflowCostEstimate";
 describe("useWorkflowCostEstimate", () => {
   beforeEach(() => {
     mockNodes = baseNodes;
+    pricedWith.length = 0;
   });
 
   it("estimates cost from AI-model nodes + metadata", () => {
@@ -135,6 +160,99 @@ describe("useWorkflowCostEstimate", () => {
     expect(item?.estimated_cost).toBeCloseTo(0.006, 5);
     expect(item?.confidence).toBe("estimate");
     expect(result.current!.unknown_count).toBe(0);
+  });
+
+  it("prices an editor node, whose values live under data.properties", () => {
+    // The real editor shape (web/src/stores/NodeData.ts): property values are
+    // nested under `properties`, not spread on `data`.
+    mockNodes = [
+      {
+        id: "t2i",
+        type: "nodetool.image.TextToImage",
+        data: {
+          properties: {
+            model: {
+              type: "image_model",
+              provider: "huggingface_fal_ai",
+              id: "fal-ai/flux/schnell"
+            },
+            num_images: 2
+          }
+        }
+      }
+    ];
+
+    const { result } = renderHook(() => useWorkflowCostEstimate("wf1"));
+
+    const item = result.current!.items.find((i) => i.node_id === "t2i");
+    expect(item?.model).toBe("fal-ai/flux/schnell");
+    expect(item?.quantity).toBe(2);
+    expect(item?.estimated_cost).toBeCloseTo(0.006, 5);
+    expect(result.current!.unknown_count).toBe(0);
+  });
+
+  it("prices a per-second model at the duration the node states", () => {
+    mockNodes = [
+      {
+        id: "t2v",
+        type: "nodetool.video.TextToVideo",
+        data: {
+          properties: {
+            model: {
+              type: "video_model",
+              provider: "genspend_provider",
+              id: "video/per-second"
+            },
+            duration: 5,
+            resolution: "720p"
+          }
+        }
+      }
+    ];
+
+    const { result } = renderHook(() => useWorkflowCostEstimate("wf1"));
+
+    expect(pricedWith).toContainEqual({
+      id: "video/per-second",
+      params: { seconds: 5, resolution: "720p" }
+    });
+    const item = result.current!.items.find((i) => i.node_id === "t2v");
+    expect(item?.estimated_cost).toBeCloseTo(0.5, 5);
+    expect(item?.breakdown).toBe("5 s × $0.1/s");
+  });
+
+  it("re-prices when a duration property changes", () => {
+    const nodeWith = (duration: number): MockNode => ({
+      id: "t2v",
+      type: "nodetool.video.TextToVideo",
+      data: {
+        properties: {
+          model: {
+            type: "video_model",
+            provider: "genspend_provider",
+            id: "video/per-second"
+          },
+          duration
+        }
+      }
+    });
+    mockNodes = [nodeWith(2)];
+
+    const { result, rerender } = renderHook(() =>
+      useWorkflowCostEstimate("wf1")
+    );
+    expect(
+      result.current!.items.find((i) => i.node_id === "t2v")?.estimated_cost
+    ).toBeCloseTo(0.2, 5);
+
+    // A property edit replaces the node object in the store; the estimate
+    // follows it rather than staying pinned to the first duration.
+    mockNodes = [nodeWith(8)];
+    rerender();
+
+    expect(
+      result.current!.items.find((i) => i.node_id === "t2v")?.estimated_cost
+    ).toBeCloseTo(0.8, 5);
   });
 
   it("multiplies a node's cost by its fan-out output count", () => {

--- a/web/src/hooks/useWorkflowCostEstimate.ts
+++ b/web/src/hooks/useWorkflowCostEstimate.ts
@@ -12,6 +12,7 @@
 import { useCallback, useMemo, useSyncExternalStore } from "react";
 import type { Node } from "@xyflow/react";
 import { estimateWorkflowCost } from "@nodetool-ai/node-sdk/cost-estimate";
+import { extractPricingParams } from "@nodetool-ai/node-sdk/pricing-params";
 import type { WorkflowCostEstimate } from "@nodetool-ai/protocol";
 import { useWorkflowManager } from "../contexts/WorkflowManagerContext";
 import useMetadataStore from "../stores/MetadataStore";
@@ -23,6 +24,22 @@ import {
 import { getModelUnitPrice } from "../utils/modelUnitPricing";
 
 const EMPTY_NODES: Node<NodeData>[] = [];
+
+/**
+ * A node's property values. The editor stores them under `data.properties`
+ * (`../stores/NodeData`); graphs that arrive from the server carry them spread
+ * on `data`. Read both, the way the server preflight does — reading only the
+ * outer object priced every model-picker node as unknown.
+ */
+function propertyValues(
+  data: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!data) return undefined;
+  const nested = data.properties;
+  return nested && typeof nested === "object" && !Array.isArray(nested)
+    ? (nested as Record<string, unknown>)
+    : data;
+}
 
 export function useWorkflowCostEstimate(
   workflowId: string
@@ -55,17 +72,22 @@ export function useWorkflowCostEstimate(
     const quantities: Record<string, number> = Object.fromEntries(
       aiNodes.map((node) => [
         node.id,
-        nodeExpectedQuantity(node.data as Record<string, unknown> | undefined)
+        nodeExpectedQuantity(
+          propertyValues(node.data as Record<string, unknown> | undefined)
+        )
       ])
     );
     return estimateWorkflowCost({
       nodes: aiNodes.map((node) => ({
         id: node.id,
         type: node.type ?? "",
-        data: node.data as Record<string, unknown> | undefined
+        data: propertyValues(node.data as Record<string, unknown> | undefined)
       })),
       getMetadata: (nodeType) => getMetadata(nodeType),
       getModelPrice: getModelUnitPrice,
+      // What the node states about the job it will run (duration, resolution,
+      // audio), so a per-second model prices the clip and not one second.
+      getParams: (node) => extractPricingParams(node.data),
       quantities,
       currency: "USD"
     });


### PR DESCRIPTION
Implements the plan merged in #4867 (`docs/parameter-cost-estimation-plan.md`): workflow cost estimates now account for resolution, duration, audio state, and surcharges instead of multiplying one flat unit price by fan-out. Four commits, one per plan phase.

## 1. `feat(pricing): ship the GenSpend price grid, not one rung`

- Nightly sync now pulls `GET /api/v1/export`; catalog schema v3 carries typed `variants[]`, `surcharges[]`, `clip_seconds` envelopes, and `data_flags` per entry. Existing scalar fields keep their meaning (v2 files still typecheck), except the base-spec variant row's price **and unit class** become the headline — taking only the price would publish MiniMax Hailuo's $0.28 per-generation figure as a per-second rate. Regenerated catalog: 86 KB → 175 KB, 126 keys with grids, 26 with surcharges.
- New `scripts/genspend/parity-check.mjs` + a workflow step in `genspend-pricing.yml`: prices 19 fixed cases locally and asserts each equals `POST /api/v1/quote` (17 priced + 2 mutual declines), with a vacuity guard so it cannot pass by pricing nothing. A full sweep during development (609 priced steps) agrees 609/609.

## 2. `feat(pricing): price a model from what the node states about the job`

- `packages/model-pricing/src/genspend-calc.ts`: pure calculator ported from the parity-proven script — resolution-ladder narrowing (`768p`→`720p` tier), audio/tier defaulting to the base spec, per-second × duration with clip-envelope checks, reference-image surcharges with free allowances, resolution-scoped reference-video re-rates, decline-not-extrapolate on missing rungs, `quote_wrong` gating. Returns `breakdown`/`assumptions`/`warnings`/`declined`.
- `getModelUnitPrice(model, params?)` — no-params behavior unchanged; FAL/kie tiers still win precedence and stay param-unaware for now.
- `packages/node-sdk/src/pricing-params.ts`: `extractPricingParams` built from a census of shipped node property names (307× `duration`, 387× `resolution`, 316× `image_size`, 139× `generate_audio`, `num_frames ÷ fps`, …); unrecognized values map to *unset*, never a guessed tier.
- `estimateWorkflowCost` threads `getParams`, copies breakdown/assumptions/warnings onto items, and extends the vague-billing-unit guard to the model-lookup path — which caught the budget gate summing a unit-less `"units"` price in its own test fixture.
- Protocol: additive `breakdown`/`assumptions`/`warnings` on `NodeCostEstimate`; `estimated_cost` documented as a lower bound when `warnings` is non-empty.

## 3. `fix(costs): price editor nodes from data.properties, and state the job`

- **Bug fix (red-first):** `useWorkflowCostEstimate` read model selection and fan-out from `node.data`, but editor nodes store values under `node.data.properties` — in the live editor, generic model-picker nodes priced as "unknown" and every quantity was 1. Fixed with both shapes tolerated; the failing-first test output is in the commit.
- Params threaded through `estimateRunCost`, `estimateNodetoolSpend`, and the SDK static preflight. Budget-gate floor semantics unchanged (declines reserve 0, fail-open untouched), but note: **the gate tightens** — nodes that priced as unknown now price, and per-second models reserve at their stated duration.

## 4. `feat(costs): show units, breakdowns and lower bounds in the estimate panel`

- Qty column → Units (`2 × 5 s @ 720p`, `4 images`); breakdown in the row tooltip; assumptions as a muted sub-line; `≥ $X` per item and on the total when a surcharge is unpriced; decline tooltips state the reason; catalog snapshot date in the attribution tooltip.

## Verification

- `npm run typecheck`: web + electron clean; backend packages (`tsc -b protocol node-sdk model-pricing websocket`) clean. Mobile fails only on its uninstalled Expo/RN dependency tree in this sandbox (no mobile files in the diff).
- `npm run lint`: passes (pre-existing warnings only, none in touched files); design-lint gates clean.
- Tests: packages leg green across all 42 suites-bearing workspaces (`image-nodes` needed the documented `mesa-vulkan-drivers` install); web 12,669 passed / 1,087 suites; electron 673 passed. Package-level: model-pricing 91, node-sdk 870, protocol 838, websocket 273.
- New checks proven able to fail: parity gate red on a perturbed price; sync rules, calculator arithmetic, duration threading, panel rendering, and the budget-gate tests each shown red under mutation, then restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159YuSEYpT7ErsqMr7qRoBf

---
_Generated by [Claude Code](https://claude.ai/code/session_0159YuSEYpT7ErsqMr7qRoBf)_