### PR TITLE
feat: input streaming for Code nodes

### DIFF
--- a/docs/code-node-input-streaming-design.md
+++ b/docs/code-node-input-streaming-design.md
@@ -1,0 +1,287 @@
+# Code Node Input Streaming: `stream`
+
+Status: proposed. Owner: code-nodes / node-sdk / kernel. 2026-08-12.
+Companion: [code-node-emit-design.md](code-node-emit-design.md) — the output
+side of the same contract, already implemented.
+
+## Problem
+
+A Code node consumes its inputs buffered: the kernel invokes the body once per
+upstream item, with `inputs` holding that invocation's snapshot. Streaming
+*out* of a body is solved (`emit`), but streaming *in* is not — the body never
+sees the stream, only one frame of it. That shape has four costs:
+
+1. **Cross-item logic needs the `state` escape hatch.** A running total, a
+   window, a dedupe set — anything spanning items lives in the mutable `state`
+   object that survives invocations. The logic of one loop is split across N
+   invocations of a body that reads like a single step, and the author must
+   reason about which variables reset and which persist.
+2. **End-of-stream is invisible.** A body cannot say "when the stream ends,
+   emit the summary". The workarounds are a downstream Collect node plus a
+   second Code node, or nothing.
+3. **Two streams cannot be merged by arrival.** Each invocation is one
+   correlated frame. Interleaving two upstream streams as they arrive —
+   a chat stream plus a control stream, audio chunks plus parameter changes —
+   is not expressible in a body at all.
+4. **The kernel mode exists; the Code node cannot reach it.** Streaming-input
+   execution is shipped machinery: `is_streaming_input` nodes implement
+   `run(inputs, outputs)` and drain their inbox via `NodeInputs.stream()` /
+   `.any()` (`packages/kernel/src/io.ts`, actor path in
+   `packages/kernel/src/actor.ts`). Collect, the audio synth chain, and
+   FrameToVideo all run this way. The Code node cannot, because the flag is
+   resolved per node *type*: `hydrateGraphNodeFlags` and
+   `Graph.loadFromDict` let the class static (`cls.isStreamingInput`,
+   `false` for CodeNode) override anything saved on the node, deliberately, so
+   stale saved flags cannot survive a type migration. Whether a Code node
+   streams is a property of its *body*, and no per-type flag can carry that.
+
+## Guest contract
+
+One new global, `stream`, mirroring the kernel's `NodeInputs` verbs. It is the
+input-side twin of `emit`/`output`: explicit calls, statically visible names,
+nothing inferred from data shape.
+
+```js
+for await (const item of stream(name))        // items for handle `name`, until EOS
+for await (const [handle, item] of stream.any())  // all handles, arrival order
+const item = await stream.first(name)         // next item, or undefined at EOS
+stream.open(name)                             // true while upstream can still produce
+```
+
+- **`stream(name)`** returns an async iterable over the values arriving on
+  input handle `name`, in order, completing at end-of-stream. `name` must be a
+  string literal naming a connected input handle (see Validation).
+- **`stream.any()`** interleaves every connected handle by arrival, yielding
+  `[handle, value]` pairs, completing when all upstreams end.
+- **`stream.first(name)`** takes the next value for one handle, `undefined`
+  when the stream already ended — for a config value that arrives once.
+- **`stream.open(name)`** answers "could more arrive?" without consuming.
+- Values are marshaled exactly like buffered inputs today (JSON deep copy,
+  media as refs readable via `media.*`).
+- Outputs from a streaming body leave through **`emit`/`output` only**. The
+  legacy return contract cannot apply — there is one invocation and its return
+  value is control flow, per the emit design.
+- `inputs.<name>` still exists in a streaming body but carries the node's
+  *configured* property values (what is typed on the node), never per-item
+  edge data — connected handles are only reachable through `stream`.
+  Reading a connected handle via `inputs.<name>` is a validation error naming
+  `stream(name)` (see Validation).
+- `state` remains defined but is pointless here: one invocation, so plain
+  local variables already persist across items.
+
+Examples:
+
+```js
+// Running total, live, with a final summary — today: state + Collect + a second node.
+let sum = 0;
+for await (const n of stream("numbers")) {
+  sum += n;
+  await emit("running", sum);
+}
+await output("total", sum);
+```
+
+```js
+// Merge two streams by arrival — today: not expressible.
+for await (const [handle, value] of stream.any()) {
+  await emit("merged", { from: handle, value });
+}
+```
+
+## Mode selection
+
+Automatic from the body, exactly like the emit contract: a textual probe
+`usesStreamInputContract(code)` in `packages/node-sdk/src/code-body.ts`,
+matching a free call/member of `stream` outside strings and comments — the
+sibling of `usesEmitOutputContract` and shaped the same way, textual because it
+must answer before the parser, on bodies that may not parse.
+
+- Probe true → the node executes in streaming-input mode (`run()`).
+- Probe false → today's buffered per-item invocation, byte-for-byte unchanged.
+
+No checkbox, no new node type. The body is the declaration.
+
+## Flag hydration: per-instance resolution
+
+The kernel actor trusts `node.is_streaming_input` to pick `run()` over
+per-item invocation, and both hydration paths currently stamp it per type. The
+change is one optional class hook:
+
+```ts
+// BaseNode static, node-sdk
+static resolveStreamingInput?(node: {
+  properties?: Record<string, unknown>;
+}): boolean;
+```
+
+`CodeNode` implements it as `usesStreamInputContract(String(node.properties?.code))`.
+Consulted at both stamp sites:
+
+- **`hydrateGraphNodeFlags`** (`packages/node-sdk/src/registry.ts`):
+  `is_streaming_input: (cls ? cls.resolveStreamingInput?.(node) ?? cls.isStreamingInput : meta?.is_streaming_input) ?? node.is_streaming_input ?? false`.
+- **`Graph.loadFromDict`** (`packages/kernel/src/graph.ts`): the resolver's
+  per-type `descriptorDefaults` cannot carry a per-instance answer, so
+  `createGraphNodeTypeResolver`'s resolved shape gains an optional
+  `resolveInstanceFlags(node) => { is_streaming_input?: boolean }` closure the
+  merge site calls with the raw node; its answer takes the slot
+  `descriptorDefaults.is_streaming_input` holds today. Kernel stays
+  registry-agnostic — it calls a function it was handed, as it already does
+  for type resolution.
+
+Every existing per-type node is untouched: no hook means today's exact
+resolution. The saved `node.is_streaming_input` keeps its current role
+(applies only when the registry has no opinion), so a stale saved flag still
+cannot survive an edit that removes the last `stream` call — the hook re-reads
+the body every hydration.
+
+`is_streaming_output` needs nothing: CodeNode overrides `genProcess`, so
+`hasStreamingOutput` already answers true.
+
+## Host mechanics
+
+`CodeNode` gains `run(inputs, outputs, context)`, which the actor calls when
+the hydrated flag is true. It starts `runInSandbox` once and bridges both
+directions:
+
+- **Guest → host (outputs):** unchanged — `onEmit` routes each bag through
+  `outputs.emit(name, value)` live; recorded `output` finals post as one bag
+  after the run succeeds. The bounded emit channel and its backpressure carry
+  over from the `genProcess` pump.
+- **Host → guest (inputs):** one new awaitable bridge call,
+  `__takeInput(handle | null)`, behind the `stream` prelude. The host keeps
+  one `inputs.stream(handle)` generator per handle (created lazily) plus one
+  `inputs.any()` generator for `stream.any()`, and answers each call with
+  `{done}` or `{value}` (`{handle, value}` for any). Concurrent takes on one
+  generator serialize on a promise chain; distinct handles proceed in
+  parallel, same as concurrent `fetch` calls today. `stream.open(name)` maps
+  to `inputs.hasStream(name) || inputs.hasBuffered(name)`.
+- **Backpressure is free.** The guest pulls; an item the body has not asked
+  for stays in the kernel inbox, which already buffers for slow consumers.
+  No channel, no cap.
+- **Timeout must not count waiting.** A streaming body legitimately lives as
+  long as its upstream. The sandbox already has the mechanism: a
+  `SandboxClock` the host suspends during round-trips it cannot hurry.
+  The input bridge suspends the clock while a take is parked on an empty,
+  still-open inbox and resumes it when the value (or EOS) arrives — the
+  body's compute budget (`timeout`, default 30 s) is spent only on its own
+  execution. The suspend allowance for input waits is unbounded: the run's
+  own cancellation is the lifetime bound, and a stream that never ends is the
+  upstream's bug, surfaced by the runner, not a reason to kill a correct
+  consumer.
+- **Cancellation:** run cancel aborts the existing sandbox signal; the inbox
+  iterators observe `NodeInputs.signal` and end; parked takes resolve as done.
+- **Lineage:** `NodeInputs` records the most recently consumed envelope per
+  handle, and the actor's existing streaming-input rule gives
+  `outputs.emit()` that inherited lineage — the same treatment the unmigrated
+  stream filters (Take, Drop, Filter) get today. The guest API stays
+  data-only; per-envelope `forward()` semantics are out of scope.
+
+### Semantics
+
+| Situation | Behavior |
+|---|---|
+| `stream("a")` on a connected handle | yields each arriving value in order, completes at EOS |
+| `stream("a")` on an unconnected handle | validation warning; at runtime completes immediately (empty) |
+| `stream.any()` | `[handle, value]` pairs by arrival; completes when all upstreams end |
+| `stream.first("a")` after EOS | `undefined` |
+| two concurrent `stream("a")` iterations | items are distributed, not duplicated (one inbox iterator per handle); validation warns |
+| `emit` between takes | delivered downstream immediately, as today |
+| body ends with items unread | remaining items are dropped with the invocation, as for any streaming-input node |
+| error thrown mid-stream | already-emitted values stand, `output` finals dropped, node fails — same as emit design |
+| `timeout` | counts guest execution only; time parked on input is clock-suspended |
+| run cancelled while parked | take resolves done, body unwinds, sandbox aborts |
+| streaming body under `--supervise` | unchanged: the kernel already stamps `streamingInput` on the escalation context and computes the allowed-verdict set accordingly |
+
+## Validation and analysis
+
+All in `code-analysis.ts` / `code-node-validation.ts` (node-sdk), shared by the
+graph validator, `submit_code`, `validate_code`, and the editor:
+
+- `stream` joins `SANDBOX_GLOBALS`; a bare read stops being a
+  ReferenceError candidate.
+- `stream(<literal>)` / `stream.first(<literal>)` / `stream.open(<literal>)`
+  naming a handle the node does not declare is an **error**, symmetric with
+  the undeclared-`inputs.<name>` read check. A non-literal argument downgrades
+  to a warning ("cannot check stream names statically").
+- `stream(name)` on a declared but **unconnected** handle is a warning (it
+  runs, but yields nothing) — decidable because `validateCodeNodeBody` runs
+  inside `validateGraph` with the edges in hand.
+- In a streaming body, `inputs.<name>` where `name` has an incoming edge is an
+  **error** naming `stream(name)` — the one footgun the split contract
+  creates, closed statically.
+- A streaming body on the legacy return/yield contract is an **error**: a body
+  that calls `stream` must send outputs through `emit`/`output`. (Probe order:
+  `usesStreamInputContract` implies the emit contract is required, whatever
+  `usesEmitOutputContract` says.)
+- Buffered bodies validate exactly as today.
+
+Each new check lands with an inverted fixture proving it can fail, per the
+repo rule.
+
+## Surface parity
+
+- **`run_code` / `test_code`** (`packages/agents/src/capabilities/code.ts`):
+  a case gains optional `inputStreams: { [handle]: unknown[] }`; the harness
+  feeds them through an in-memory inbox, and streamed outputs land in the
+  existing `streamed` array. `validate_code` gains the checks above. A
+  streaming body that runs in the harness runs the same way in a workflow —
+  the body-shaping rules stay in node-sdk, shared.
+- **CodePlanner / `code-gen` eval**: the prompt teaches `stream`; the suite
+  gains a windowing case and a merge-by-arrival case.
+- **Editor**: the Code node description documents `stream`; the assistant
+  dialog prompt teaches it. The editor's streaming badge and edge rendering
+  read the hydrated flag; the web bundle computes it with the same
+  `usesStreamInputContract` probe (`code-body.ts` is dependency-free and
+  already browser-bundled).
+- **DSL** (`sandbox-dsl` and `workflows export-dsl`): the `code(...)` helper
+  stamps `is_streaming_input` from the probe so `withExplicitNodeFlags`
+  graphs run correctly without registry hydration.
+- **Docs**: `docs/javascript-sandbox.md` gains § Input streams.
+
+## Limits
+
+- No new caps. Input volume is bounded by upstream producers; take rate is
+  bounded by the body's own timeout-metered execution; emit keeps its
+  existing channel bound and `MAX_EMIT_CALLS`.
+
+## Backwards compatibility
+
+Purely additive. A body that never mentions `stream` hydrates, validates, and
+executes byte-for-byte as today — buffered per-item invocation, `state`,
+legacy return contract included. There is no migration, no codemod, and no
+deprecation: buffered mode remains the right contract for per-item transforms,
+which most Code nodes are. `stream` is for the bodies that today need
+`state`, a Collect detour, or are not expressible at all.
+
+## Testing
+
+- Unit (`packages/code-nodes`): ordered delivery per handle; `any()`
+  interleave across two handles; EOS completes the loop; `first` after EOS;
+  emit-while-parked interleave; unread items dropped at body end; error
+  mid-stream drops finals; cancellation unparks; clock suspension (a body
+  with a 1 s timeout survives a 5 s input gap, and still dies after 1 s of
+  its own compute).
+- Hydration (`packages/node-sdk`, `packages/kernel`): a graph node whose
+  `code` streams hydrates `is_streaming_input: true` through both
+  `hydrateGraphNodeFlags` and `loadFromDict`; editing the `stream` call out
+  flips it back; saved stale flags still lose; every hook-less node type
+  hydrates exactly as before (pinned against current fixtures).
+- Analysis (`packages/node-sdk`): each new rule red on an inverted fixture —
+  undeclared stream name, connected-handle `inputs.` read, streaming body on
+  the legacy contract, unconnected-handle warning.
+- End-to-end: a workflow where a generator streams into a Code node running
+  a windowed aggregate into a Preview runs under `nodetool debug` and shows
+  per-item `emit` messages arriving while upstream is still producing; the
+  same body passes `test_code` with `inputStreams`.
+
+## Out of scope
+
+- **CodeAct** (`execute_code`) — acts on the toolbelt, returns one result;
+  no inbox exists there.
+- **Per-envelope lineage in the guest** — `forward()`/`drop()` equivalents
+  and Zip/Cross-style scope reads stay host-side; the guest sees data.
+- **Windowing/batching helpers** (`stream.window(n)`, debounce) — expressible
+  in plain JavaScript over `stream()`; sugar can come later without contract
+  changes.
+- **Python Code nodes** — the worker's execution model is separate; this
+  contract is the QuickJS guest's.

--- a/docs/code-node-input-streaming-design.md
+++ b/docs/code-node-input-streaming-design.md
@@ -1,6 +1,6 @@
 # Code Node Input Streaming: `stream`
 
-Status: proposed. Owner: code-nodes / node-sdk / kernel. 2026-08-12.
+Status: implemented, 2026-08-12. Owner: code-nodes / node-sdk / kernel.
 Companion: [code-node-emit-design.md](code-node-emit-design.md) — the output
 side of the same contract, already implemented.
 
@@ -273,6 +273,31 @@ which most Code nodes are. `stream` is for the bodies that today need
   a windowed aggregate into a Preview runs under `nodetool debug` and shows
   per-item `emit` messages arriving while upstream is still producing; the
   same body passes `test_code` with `inputStreams`.
+
+## Deviations from the design as built
+
+- **Finals post through `outputs.emitGroup(finals)`**, not slot-by-slot
+  `emit`. One invocation's finals are one frame, so sibling handles share
+  minted lineage instead of arriving as N independent items.
+- **`run()` called for a body that does not stream throws.** It can only happen
+  when a stale saved flag was trusted without hydration, and the path never
+  delivers per-item invocations — a buffered body would silently see none of
+  its connected inputs, so failing names the misconfiguration instead.
+- **`stream.open` reads `hasBuffered` through an optional method.**
+  `StreamingInputs` (`packages/runtime/src/node-executor.ts`) gained
+  `hasBuffered?(name)`; the kernel's `NodeInputs` already had it, and a
+  hand-rolled test double need not.
+- **`run_code` / `test_code` name the field `input_streams`** (wire names in
+  this surface are snake_case) and define `stream.any()` order as round-robin
+  by index across the handles in declaration order — a live inbox is observed,
+  pre-staged items have to be ordered by rule.
+- **The DSL probe lives in `createNode`** (`packages/dsl/src/core.ts`), gated on
+  the Code node's type, rather than in the generated helper: `@nodetool-ai/dsl`
+  runs graphs through `withExplicitNodeFlags` with no registry hydration, and
+  the generator stamps flags per *type*. Every other surface — the server run
+  path, `Graph.loadFromDict`, `ExecutionSession` — hydrates against the
+  registry and needs nothing. `sandbox-dsl` likewise needs nothing: its graphs
+  reach execution through `create_workflow` / `run_workflow`, which hydrate.
 
 ## Out of scope
 

--- a/docs/javascript-sandbox.md
+++ b/docs/javascript-sandbox.md
@@ -349,6 +349,66 @@ await output("count", kept.length);               // final, posted at the end
   same channel the Python worker uses — so a long snippet drives the node's
   progress bar.
 
+### Input streams
+
+`stream` is the input side of `emit`: four verbs that read the node's connected
+handles as values arrive, instead of once per item.
+
+```js
+for await (const item of stream(name))            // one handle, in order, until EOS
+for await (const [handle, item] of stream.any())  // every handle, arrival order
+const item = await stream.first(name)             // next value, undefined at EOS
+stream.open(name)                                 // could more still arrive?
+```
+
+`stream(name)` and `stream.any()` are async iterables that complete at
+end-of-stream; `stream.first` is for a value that arrives once; `stream.open` is
+synchronous and consumes nothing. Values are marshaled exactly like buffered
+inputs — JSON deep copy, media as refs readable through `media.*`.
+
+```js
+// Running total, live, with a summary at the end.
+let sum = 0;
+for await (const n of stream("numbers")) {
+  sum += n;
+  await emit("running", sum);
+}
+await output("total", sum);
+```
+
+**The body decides the mode.** A body that mentions `stream` runs **once** for
+the whole stream and pulls its own items; a body that never mentions it keeps
+today's contract — one invocation per incoming item, with `inputs` holding that
+item's snapshot. Nothing is configured: hydration re-reads the body each time
+(`usesStreamInputContract`), so deleting the last `stream` call flips the node
+back.
+
+The split has three consequences worth knowing:
+
+- **`inputs.<name>` in a streaming body carries the node's *configured*
+  property values**, never per-item edge data. A connected handle is reachable
+  only through `stream(name)`; reading one via `inputs.` is a validation error
+  naming the call to use.
+- **Outputs leave through `emit`/`output` only.** There is one invocation, so
+  its return value is control flow. `output` finals post as one bag when the
+  body ends; a body that throws mid-stream keeps what it already emitted and
+  drops the finals.
+- **`state` still exists and is pointless here.** One invocation means plain
+  local variables already survive across items.
+
+Waiting is not executing: time parked on a take is clock-suspended, so
+`timeout` meters the body's own work and a slow upstream cannot kill a correct
+consumer. What bounds the run is cancellation — a cancelled run unparks every
+take as end-of-stream and the body unwinds. Backpressure is free in the other
+direction too: the guest pulls, so an item the body has not asked for stays in
+the kernel's inbox.
+
+`run_code` and `test_code` take the same bodies: stage items with
+`input_streams: {handle: [...]}` and the harness answers takes from them,
+interleaving `stream.any()` round-robin by index across the handles you
+declared. Design:
+[code-node-input-streaming-design.md](code-node-input-streaming-design.md).
+
 Node props map onto sandbox policy: `timeout` (seconds, 0 for none),
 `max_response_mb`, `allow_local_network` → `limits.allowPrivateNetwork`,
 `allow_host_filesystem` → `limits.filesystemAccess`, `secrets` →

--- a/package-lock.json
+++ b/package-lock.json
@@ -54457,6 +54457,7 @@
         "@nodetool-ai/sandbox": "*"
       },
       "devDependencies": {
+        "@nodetool-ai/kernel": "*",
         "@types/node": "^22.0.0",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2"

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -84,7 +84,7 @@ column by `resolveSandboxLimits`:
 | Limit | Default | Configured by | Ceiling |
 |-------|---------|---------------|---------|
 | Execution time | `timeoutMs` (30 s) | `setInterruptHandler` (CPU budget) + wall-clock race | — |
-| Suspended time | `DEFAULT_SUSPEND_ALLOWANCE_MS` (30 min) | `RunSandboxOptions.suspendAllowanceMs`, only with a `clock` | — |
+| Suspended time | `DEFAULT_SUSPEND_ALLOWANCE_MS` (30 min), or `INPUT_STREAM_SUSPEND_ALLOWANCE_MS` (unbounded) for a run with `onTakeInput` | `RunSandboxOptions.suspendAllowanceMs`, only with a `clock` | — |
 | Guest heap | `GUEST_MEMORY_LIMIT` = 64 MB | `runtime.setMemoryLimit` (`limits.memoryLimitBytes`) | 512 MB |
 | Call stack | `GUEST_STACK_LIMIT` = 512 KB | `runtime.setMaxStackSize` (`limits.stackLimitBytes`) | 8 MB |
 | Fetch calls | `MAX_FETCH_CALLS` = 20 per run | counter inside bridge (`limits.maxFetchCalls`) | 100 |
@@ -135,6 +135,20 @@ aliases are gone),
 `createCanvas(...).toBytes()`), and any caller-supplied `globals`. `fetch` sends
 a `Uint8Array` body as raw bytes instead of JSON. Every one of these is a
 **capability**, not a library — libraries are imports (below).
+
+`stream` is the input side of `emit`, built in the guest prelude over one
+awaitable host bridge: `for await (const item of stream(name))` reads one input
+handle in order until end-of-stream, `stream.any()` interleaves every handle as
+`[handle, value]` pairs, `await stream.first(name)` takes the next value
+(`undefined` at end-of-stream), and `stream.open(name)` answers synchronously
+whether more can arrive. The host supplies the values through
+`RunSandboxOptions.onTakeInput` (called with `null` for `any()`) and the probe
+through `onStreamOpen`; without an `onTakeInput` every verb throws
+`NO_INPUT_STREAM_MESSAGE`. The guest pulls, so an item nobody asked for stays in
+the host's inbox — backpressure costs nothing. Time parked on a take is
+clock-suspended: a streaming body's timeout meters its own execution, and how
+long upstream takes is the run's cancellation to bound, not the timeout's.
+Tests: `tests/js-sandbox-stream.test.ts`.
 
 `progress` is fire-and-forget: it reports to
 `RunSandboxOptions.onProgress`, clamped to 0–100 with the message truncated to

--- a/packages/agents/src/capabilities/code.specs.ts
+++ b/packages/agents/src/capabilities/code.specs.ts
@@ -36,6 +36,19 @@ export const PACKAGES_FIELD: JsonSchema = {
     'property), e.g. ["@nodetool-ai/sandbox-yaml"].'
 };
 
+export const INPUT_STREAMS_FIELD: JsonSchema = {
+  type: "object",
+  description:
+    "Items to feed a body that reads its inputs with `stream`, as " +
+    '{handle: [item, …]}, e.g. {"numbers": [1, 2, 3]}. The body runs once ' +
+    "and pulls them: `stream(name)` yields one handle's items in order, " +
+    "`stream.any()` yields [handle, value] round-robin by index across the " +
+    "handles in declaration order, `stream.first(name)` takes one, and " +
+    "`stream.open(name)` reports whether items remain. Omit it for a " +
+    "buffered body, whose values go in `inputs` instead.",
+  additionalProperties: { type: "array" }
+};
+
 export const validateCodeSpec: CapabilitySpec = {
   name: "validate_code",
   description:
@@ -75,7 +88,9 @@ export const runCodeSpec: CapabilitySpec = {
     "`output(name, value)` come back as `outputs`; values passed to " +
     "`emit(name, value)` come back as `streamed`, an ordered list of " +
     "`{name, value}`. A legacy return/yield body reports its return bag as " +
-    "`outputs` and its yielded items as `streamed`. The run is hermetic: no " +
+    "`outputs` and its yielded items as `streamed`. A body that reads its " +
+    "inputs with `stream` runs once over the items staged in " +
+    "`input_streams`. The run is hermetic: no " +
     "node toolbelt, and only the secrets named in `secrets` are readable. " +
     "Use it to debug a body before saving it onto a node.",
   inputSchema: {
@@ -87,6 +102,7 @@ export const runCodeSpec: CapabilitySpec = {
         description: "Input values the body reads from the `inputs` object.",
         additionalProperties: true
       },
+      input_streams: INPUT_STREAMS_FIELD,
       packages: PACKAGES_FIELD,
       secrets: {
         type: "array",
@@ -109,7 +125,8 @@ export const testCodeSpec: CapabilitySpec = {
   name: "test_code",
   description:
     "Run a Code-node body against a list of test cases and grade each one. " +
-    "A case supplies `inputs` and optionally `expect` — expected final " +
+    "A case supplies `inputs` (or `input_streams`, for a body that reads " +
+    "`stream`) and optionally `expect` — expected final " +
     "values per output handle, compared structurally; outputs not named in " +
     "`expect` are ignored — and `expected_streamed`, the full ordered list " +
     "of `{name, value}` the body must emit. A case with neither passes when " +
@@ -131,6 +148,7 @@ export const testCodeSpec: CapabilitySpec = {
               description: "Input values for this case.",
               additionalProperties: true
             },
+            input_streams: INPUT_STREAMS_FIELD,
             expect: {
               type: "object",
               description:

--- a/packages/agents/src/capabilities/code.ts
+++ b/packages/agents/src/capabilities/code.ts
@@ -79,6 +79,7 @@ async function runCodeBody(
     packages: readonly string[];
     secrets: readonly string[];
     timeoutSeconds: number;
+    inputStreams?: Record<string, unknown[]>;
   }
 ): Promise<HarnessRunResult> {
   const {
@@ -148,13 +149,21 @@ return __yielded;`
     state: {} as Record<string, unknown>
   };
 
+  // A body reading `stream` needs a source, or every verb throws. Only a call
+  // that staged items gets one — without `inputStreams` the harness behaves
+  // exactly as before.
+  const staged = params.inputStreams
+    ? stagedInputStreams(params.inputStreams)
+    : undefined;
+
   const result = await runInSandbox({
     code: body,
     context: run.context,
     timeoutMs: params.timeoutSeconds * 1000,
     globals,
     limits: { secretScope: [...params.secrets] },
-    ...(modules ? { modules } : {})
+    ...(modules ? { modules } : {}),
+    ...(staged ?? {})
   });
 
   const logs = result.logs ?? [];
@@ -189,9 +198,80 @@ return __yielded;`
   };
 }
 
+/**
+ * Feed pre-staged items to a body that reads its inputs with `stream`.
+ *
+ * The kernel answers a take out of a live inbox; here every item is known up
+ * front, so arrival order has to be defined rather than observed. It is
+ * round-robin by index across the handles in declaration order — item 0 of
+ * every handle, then item 1, and so on — which is what `stream.any()` yields.
+ * A named take pops that handle's own queue and drops its next slot from the
+ * arrival order, so a body mixing `stream("a")` with `stream.any()` never sees
+ * one item twice.
+ */
+function stagedInputStreams(streams: Record<string, unknown[]>): {
+  onTakeInput: (handle: string | null) => Promise<
+    { done: true } | { done: false; handle: string; value: unknown }
+  >;
+  onStreamOpen: (handle: string) => boolean;
+} {
+  const queues = new Map<string, unknown[]>(
+    Object.entries(streams).map(([handle, values]) => [
+      handle,
+      Array.isArray(values) ? [...values] : []
+    ])
+  );
+  const arrival: string[] = [];
+  const deepest = Math.max(
+    0,
+    ...[...queues.values()].map((queue) => queue.length)
+  );
+  for (let index = 0; index < deepest; index++) {
+    for (const [handle, queue] of queues) {
+      if (queue.length > index) arrival.push(handle);
+    }
+  }
+
+  const dropFromArrival = (handle: string): void => {
+    const at = arrival.indexOf(handle);
+    if (at >= 0) arrival.splice(at, 1);
+  };
+
+  return {
+    onTakeInput: async (handle) => {
+      const next = handle ?? arrival[0];
+      if (next === undefined) return { done: true };
+      const queue = queues.get(next);
+      if (!queue || queue.length === 0) return { done: true };
+      dropFromArrival(next);
+      return { done: false, handle: next, value: queue.shift() };
+    },
+    onStreamOpen: (handle) => (queues.get(handle)?.length ?? 0) > 0
+  };
+}
+
 function stringList(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.filter((item): item is string => typeof item === "string");
+}
+
+/**
+ * `{handle: [items]}` staged for a body that reads `stream`. Entries that are
+ * not arrays are dropped: a handle with nothing behind it reads as ended.
+ */
+function inputStreamBag(
+  value: unknown
+): Record<string, unknown[]> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const staged: Record<string, unknown[]> = {};
+  for (const [handle, items] of Object.entries(
+    value as Record<string, unknown>
+  )) {
+    if (Array.isArray(items)) staged[handle] = [...items];
+  }
+  return Object.keys(staged).length > 0 ? staged : undefined;
 }
 
 function inputBag(value: unknown): Record<string, unknown> {
@@ -283,7 +363,10 @@ const runCode: CapabilityExport = {
       inputs: inputBag(params["inputs"]),
       packages: stringList(params["packages"]),
       secrets: stringList(params["secrets"]),
-      timeoutSeconds: timeoutSeconds(params["timeout_seconds"])
+      timeoutSeconds: timeoutSeconds(params["timeout_seconds"]),
+      ...(inputStreamBag(params["input_streams"]) !== undefined
+        ? { inputStreams: inputStreamBag(params["input_streams"])! }
+        : {})
     })
 };
 
@@ -366,12 +449,14 @@ const testCode: CapabilityExport = {
         ? (raw["expected_streamed"] as unknown[])
         : undefined;
 
+      const staged = inputStreamBag(raw["input_streams"]);
       const outcome = await runCodeBody(run, {
         code,
         inputs: inputBag(raw["inputs"]),
         packages,
         secrets,
-        timeoutSeconds: timeout
+        timeoutSeconds: timeout,
+        ...(staged !== undefined ? { inputStreams: staged } : {})
       });
 
       const mismatches: TestCaseReport["mismatches"] = [];

--- a/packages/agents/src/code-gen/sandbox-manifest.ts
+++ b/packages/agents/src/code-gen/sandbox-manifest.ts
@@ -643,6 +643,14 @@ const GUEST_HELPER_DOCS: { [K in GuestHelperName]: SandboxMemberDoc } = {
       "Run an async function over items with at most `concurrency` in flight, preserving input order. The bounded form of Promise.all fan-out — the way to fetch many URLs in parallel. Rejects on the first failure; wrap fn in try/catch to collect errors instead.",
     async: true
   },
+  stream: {
+    name: "stream",
+    signature:
+      "for await (const item of stream(name)) // plus stream.any(), await stream.first(name), stream.open(name)",
+    description:
+      "Read an input handle as it arrives. stream(name) iterates one handle in order until end-of-stream, stream.any() interleaves every handle as [handle, value] pairs, stream.first(name) takes the next value (undefined at end-of-stream), and stream.open(name) answers synchronously whether more can arrive. Only a body the host runs in streaming-input mode has them; anywhere else every call throws.",
+    async: true
+  },
   createCanvas: {
     name: "createCanvas",
     signature:
@@ -867,6 +875,7 @@ export const GUEST_GLOBALS_SNAPSHOT: readonly string[] = [
   "queueMicrotask",
   "sandboxToAsset",
   "sleep",
+  "stream",
   "toBase64",
   "toHex",
   "undefined",

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -149,7 +149,21 @@ export const MAX_PROGRESS_MESSAGE_CHARS = 500;
  * run may stay suspended in total, so a prompt nobody ever answers still ends.
  */
 export const DEFAULT_SUSPEND_ALLOWANCE_MS = 30 * 60 * 1000;
-
+/**
+ * The engine's wall-clock abort is a `setTimeout`, and Node fires a delay past
+ * this immediately instead of never — so this is the practical "no backstop".
+ */
+const MAX_ENGINE_TIMEOUT_MS = 2_147_483_647;
+/**
+ * Suspension allowance a run with an input stream gets by default.
+ *
+ * Effectively unbounded, deliberately: a streaming body legitimately lives as
+ * long as its upstream produces, and the run's own cancellation is the lifetime
+ * bound. A stream that never ends is the upstream's bug, surfaced by the
+ * runner — not a reason to kill a correct consumer. A caller that wants a
+ * shorter leash passes {@link RunSandboxOptions.suspendAllowanceMs}.
+ */
+export const INPUT_STREAM_SUSPEND_ALLOWANCE_MS = MAX_ENGINE_TIMEOUT_MS;
 
 /** Host sink for guest `progress()` calls. */
 export type SandboxProgressCallback = (
@@ -171,6 +185,61 @@ export type SandboxEmitCallback = (
 export interface SandboxEmittedValue {
   name: string;
   value: unknown;
+}
+
+/**
+ * One answer to a guest take: the next value for a handle, or end-of-stream.
+ *
+ * `done: true` ends the iteration the guest is driving — for a named handle
+ * that upstream produced everything it will, for {@link SandboxTakeInputCallback}
+ * called with `null` that every handle has.
+ */
+export type SandboxInputTake =
+  | { done: true }
+  | { done: false; handle: string; value: unknown };
+
+/**
+ * Host source behind the guest's `stream` global.
+ *
+ * `handle` names one input handle, or is `null` for `stream.any()` — "the next
+ * value on any handle, in arrival order". The host keeps the iteration state
+ * (one inbox iterator per handle plus one for `any`); the sandbox only relays
+ * the call and marshals the answer. The returned `value` must already be
+ * JSON-safe: the sandbox tags bytes for the guest prelude to revive but does
+ * not deep-copy, exactly as with `globals`.
+ */
+export type SandboxTakeInputCallback = (
+  handle: string | null
+) => Promise<SandboxInputTake>;
+
+/**
+ * Host answer to `stream.open(name)`: could more arrive on this handle?
+ *
+ * Synchronous, because the guest call is — the value is inbox state the host
+ * already holds, and an awaitable answer would make `if (stream.open(h))` read
+ * true on a pending promise.
+ */
+export type SandboxStreamOpenCallback = (handle: string) => boolean;
+
+/**
+ * What the guest is told when it calls `stream` in a run that has no input
+ * stream behind it. Shared by the host bridge and the guest prelude so both
+ * paths say the same thing.
+ */
+export const NO_INPUT_STREAM_MESSAGE =
+  "stream() requires streaming-input mode; this run has no input stream";
+
+/** The input-side bridges {@link buildSandbox} wires behind the `stream` global. */
+export interface SandboxInputStreams {
+  /** Source of values. Without it every `stream` call throws. */
+  onTakeInput?: SandboxTakeInputCallback;
+  /** Answer to `stream.open(name)`. Without it every handle reads closed. */
+  onStreamOpen?: SandboxStreamOpenCallback;
+  /**
+   * Clock suspended while a take is parked. Waiting on upstream is not guest
+   * execution, so it must not be charged to the run's timeout.
+   */
+  clock?: SandboxClock;
 }
 
 /**
@@ -928,13 +997,17 @@ export interface SandboxResult {
  *                 guest function is a no-op.
  * @param onEmit   Optional sink for guest `emit()` calls. Without one the values
  *                 are collected and handed back through `getEmitted`.
+ * @param streams  Optional input bridges behind the guest `stream` global.
+ *                 Without an `onTakeInput` every `stream` call throws
+ *                 {@link NO_INPUT_STREAM_MESSAGE}.
  */
 export function buildSandbox(
   context?: ProcessingContext,
   signal?: AbortSignal,
   limits?: SandboxLimits,
   onProgress?: SandboxProgressCallback,
-  onEmit?: SandboxEmitCallback
+  onEmit?: SandboxEmitCallback,
+  streams?: SandboxInputStreams
 ): SandboxResult {
   const logs: string[] = [];
   const resolvedLimits = resolveSandboxLimits(limits);
@@ -1530,6 +1603,48 @@ export function buildSandbox(
     outputs.set(handle, serializeResult(value, resolvedLimits.maxOutputSize));
   };
 
+  // Input delivery, the mirror of `emit`: the guest pulls one value at a time
+  // and the host answers from the inbox it owns. Backpressure is free — an item
+  // nobody asked for stays upstream.
+  const takeInput = async (name: unknown): Promise<SandboxInputTake> => {
+    if (!streams?.onTakeInput) {
+      throw new Error(NO_INPUT_STREAM_MESSAGE);
+    }
+    if (name !== null && typeof name !== "string") {
+      throw new TypeError("stream: name must be a string");
+    }
+    // Waiting on upstream is not the guest executing, so it must not spend the
+    // guest's timeout budget. The clock stops until the value (or EOS) lands.
+    const resume = streams.clock?.suspend();
+    try {
+      const take = await streams.onTakeInput(name);
+      if (take.done) return { done: true };
+      return {
+        done: false,
+        handle: take.handle,
+        value: toGuestBytesDeep(take.value)
+      };
+    } finally {
+      resume?.();
+    }
+  };
+
+  // Synchronous and never throwing, which is what lets the guest read it as a
+  // plain boolean: an awaitable answer would make `if (stream.open(h))` true on
+  // a pending promise. `null` is the one non-answer — this run has no input
+  // stream at all — and the prelude turns it into the thrown error.
+  const streamOpen = (name: unknown): boolean | null => {
+    if (!streams?.onTakeInput) return null;
+    if (typeof name !== "string" || !streams.onStreamOpen) return false;
+    try {
+      return streams.onStreamOpen(name) === true;
+    } catch {
+      // A host probe that throws answers "closed" rather than taking the run
+      // down: the take itself is where a broken inbox must surface.
+      return false;
+    }
+  };
+
   // QuickJS ships no Intl, so locale-aware formatting has to come from the
   // host. Async + never-reject like the other bridges: a bad locale or option
   // surfaces in the guest as a thrown Error with Intl's own message.
@@ -1712,6 +1827,10 @@ export function buildSandbox(
     progress,
     emit,
     output,
+    // Behind the `stream` global the prelude builds; never reachable by name,
+    // which is why they are not in EXPOSED_BRIDGE_NAMES.
+    [SANDBOX_INPUT_TAKE_BINDING]: takeInput,
+    [SANDBOX_STREAM_OPEN_BINDING]: streamOpen,
     format,
     image,
     canvas,
@@ -1885,6 +2004,13 @@ const CAPABILITY_BRIDGE_MODULE_ID = `${GUEST_MODULE_PREFIX}capability-bridge`;
 
 /** Name the host parks the raw (never-rejecting) capability dispatcher on. */
 export const SANDBOX_CAPABILITY_BRIDGE_BINDING = "__capabilityCall";
+
+/**
+ * Names the host parks the input bridges on, which the prelude captures and
+ * then deletes — the guest reaches them only through `stream`.
+ */
+export const SANDBOX_INPUT_TAKE_BINDING = "__takeInput";
+export const SANDBOX_STREAM_OPEN_BINDING = "__streamOpen";
 
 /**
  * The platform modules one run mounts: guest specifier → generated facade
@@ -2184,6 +2310,27 @@ export interface RunSandboxOptions {
    */
   onEmit?: SandboxEmitCallback;
   /**
+   * Source behind the guest `stream` global: the host answers one take at a
+   * time, with `null` meaning "any handle, arrival order" (`stream.any()`).
+   * Without it the guest still has `stream`, and every call throws
+   * {@link NO_INPUT_STREAM_MESSAGE} — a body that streams must be run by a host
+   * that can feed it.
+   *
+   * A run with this set is metered differently: time parked on a take is
+   * clock-suspended, so the timeout bounds guest execution only, and the
+   * engine's own wall-clock backstop is widened to
+   * {@link INPUT_STREAM_SUSPEND_ALLOWANCE_MS} unless the caller names an
+   * allowance. A streaming body legitimately lives as long as its upstream;
+   * cancelling the run is what ends it.
+   */
+  onTakeInput?: SandboxTakeInputCallback;
+  /**
+   * Answer to `stream.open(name)`. Read synchronously, so the guest sees a
+   * boolean. Without it — even with {@link onTakeInput} set — every handle
+   * reads closed.
+   */
+  onStreamOpen?: SandboxStreamOpenCallback;
+  /**
    * Wall clock the host can stop while the guest waits on a round-trip it
    * cannot hurry (a permission prompt). Time suspended is added back to
    * {@link timeoutMs}, so the guest keeps its full execution budget across the
@@ -2289,14 +2436,20 @@ export const EXPOSED_BRIDGE_NAMES = [
 
 export type ExposedBridgeName = (typeof EXPOSED_BRIDGE_NAMES)[number];
 
-/** Pure helpers the guest prelude defines — no host call behind them. */
+/**
+ * Globals the guest prelude defines rather than the host marshals. All but
+ * `stream` are pure — no host call behind them; `stream` is built here because
+ * an async iterable cannot cross the bridge, so the prelude wraps the two
+ * private input bindings into one.
+ */
 export const GUEST_HELPER_NAMES = [
   "toBase64",
   "fromBase64",
   "toHex",
   "fromHex",
   "parallelMap",
-  "createCanvas"
+  "createCanvas",
+  "stream"
 ] as const;
 
 export type GuestHelperName = (typeof GUEST_HELPER_NAMES)[number];
@@ -2331,7 +2484,9 @@ export const RESERVED_SANDBOX_NAMES: ReadonlySet<string> = new Set<string>([
   SANDBOX_WASM_BRIDGE_BINDING,
   SANDBOX_WASM_DISPATCH_GLOBAL,
   SANDBOX_CAPABILITY_BRIDGE_BINDING,
-  SANDBOX_CAPABILITY_DISPATCH_GLOBAL
+  SANDBOX_CAPABILITY_DISPATCH_GLOBAL,
+  SANDBOX_INPUT_TAKE_BINDING,
+  SANDBOX_STREAM_OPEN_BINDING
 ]);
 
 /**
@@ -2352,13 +2507,22 @@ export async function runInSandbox(
     limits,
     onProgress,
     onEmit,
+    onTakeInput,
+    onStreamOpen,
     clock,
-    suspendAllowanceMs = DEFAULT_SUSPEND_ALLOWANCE_MS,
     modules,
     capabilities,
     wasmPool
   } = options;
   const resolvedLimits = resolveSandboxLimits(limits);
+  // A streaming run needs a clock whether or not the caller brought one: the
+  // time it spends parked on upstream is not its own execution.
+  const activeClock = clock ?? (onTakeInput ? createSandboxClock() : undefined);
+  const suspendAllowanceMs =
+    options.suspendAllowanceMs ??
+    (onTakeInput
+      ? INPUT_STREAM_SUSPEND_ALLOWANCE_MS
+      : DEFAULT_SUSPEND_ALLOWANCE_MS);
 
   if (!code.trim()) {
     return { success: false, error: "No code provided", logs: [] };
@@ -2403,7 +2567,12 @@ export async function runInSandbox(
     signal,
     resolvedLimits,
     onProgress,
-    onEmit
+    onEmit,
+    {
+      ...(onTakeInput === undefined ? {} : { onTakeInput }),
+      ...(onStreamOpen === undefined ? {} : { onStreamOpen }),
+      ...(activeClock === undefined ? {} : { clock: activeClock })
+    }
   );
 
   // User-supplied globals (dynamic inputs from CodeNode etc.) layer on top of
@@ -2442,7 +2611,7 @@ export async function runInSandbox(
         ctx.runtime.setInterruptHandler(
           () =>
             signal?.aborted === true ||
-            Date.now() > deadline + (clock?.suspendedMs() ?? 0)
+            Date.now() > deadline + (activeClock?.suspendedMs() ?? 0)
         );
 
         const bridges: Record<string, unknown> = {};
@@ -2463,6 +2632,15 @@ export async function runInSandbox(
         bridges.sandboxToAsset = wrap(bridges.sandboxToAsset as never);
         bridges.emit = wrap(bridges.emit as never);
         bridges.output = wrap(bridges.output as never);
+        // The input bridges are not in EXPOSED_BRIDGE_NAMES — the prelude
+        // captures them, builds `stream` on top, and deletes them. The take is
+        // async like every other host call; the open probe is synchronous and
+        // never throws, so it stays unwrapped (the `crypto.randomUUID` rule).
+        bridges[SANDBOX_INPUT_TAKE_BINDING] = wrap(
+          sandbox[SANDBOX_INPUT_TAKE_BINDING] as never
+        );
+        bridges[SANDBOX_STREAM_OPEN_BINDING] =
+          sandbox[SANDBOX_STREAM_OPEN_BINDING];
         // Object bridges whose members are all async: wrap each member.
         const wrapAllMembers = (bridge: unknown): Record<string, unknown> => {
           const out: Record<string, unknown> = {};
@@ -2694,6 +2872,49 @@ for (const __m of ${JSON.stringify(MEDIA_REF_MEMBERS)}) {
   __mediaOut[__m] = __wrapDeep(__mediaBridge[__m]);
 }
 globalThis.media = __mediaOut;
+// The input side of emit. An async iterable cannot cross the bridge, so the
+// guest builds one over a take-one-value host call: the body pulls, and an item
+// it has not asked for stays in the host's inbox. The raw bindings are captured
+// and deleted, so \`stream\` is the only way to reach them.
+const __takeInput = __wrapDeep(globalThis.${SANDBOX_INPUT_TAKE_BINDING});
+const __streamOpen = globalThis.${SANDBOX_STREAM_OPEN_BINDING};
+delete globalThis.${SANDBOX_INPUT_TAKE_BINDING};
+delete globalThis.${SANDBOX_STREAM_OPEN_BINDING};
+const __streamName = (fn, name) => {
+  if (typeof name !== "string") {
+    throw new TypeError(fn + ": name must be a string");
+  }
+  return name;
+};
+// \`handle\` is null for stream.any(), which yields [handle, value] pairs.
+const __streamIterable = (handle) => ({
+  [Symbol.asyncIterator]: () => ({
+    next: async () => {
+      const take = await __takeInput(handle);
+      if (take.done) return { done: true, value: undefined };
+      return {
+        done: false,
+        value: handle === null ? [take.handle, take.value] : take.value
+      };
+    }
+  })
+});
+globalThis.stream = (name) => __streamIterable(__streamName("stream", name));
+globalThis.stream.any = () => __streamIterable(null);
+globalThis.stream.first = async (name) => {
+  const take = await __takeInput(__streamName("stream.first", name));
+  return take.done ? undefined : take.value;
+};
+globalThis.stream.open = (name) => {
+  const open = __streamOpen(__streamName("stream.open", name));
+  // null is the host saying this run has no input stream at all. Every other
+  // stream verb reports that by throwing; this one has to do it here, because
+  // a synchronous bridge cannot.
+  if (open === null) {
+    throw new Error(${JSON.stringify(NO_INPUT_STREAM_MESSAGE)});
+  }
+  return open;
+};
 const __canvasProps = ${JSON.stringify(CANVAS_PROPERTIES)};
 const __canvasMethods = ${JSON.stringify(CANVAS_METHODS)};
 const __canvasGradients = ${JSON.stringify(CANVAS_GRADIENT_FACTORIES)};
@@ -2873,8 +3094,11 @@ export default true;`,
         // starts — it cannot be paused. With a clock in play it becomes the
         // backstop for a run that stays suspended forever, while the interrupt
         // handler above keeps the exact bound on guest execution.
-        executionTimeout: clock
-          ? timeoutMs + Math.max(0, suspendAllowanceMs)
+        executionTimeout: activeClock
+          ? Math.min(
+              timeoutMs + Math.max(0, suspendAllowanceMs),
+              MAX_ENGINE_TIMEOUT_MS
+            )
           : timeoutMs,
         memoryLimit: resolvedLimits.memoryLimitBytes,
         maxStackSize: resolvedLimits.stackLimitBytes,

--- a/packages/agents/tests/code-capabilities.test.ts
+++ b/packages/agents/tests/code-capabilities.test.ts
@@ -270,6 +270,114 @@ await output("total", inputs.items.length);`,
   });
 });
 
+describe("input streams", () => {
+  it("feeds a body that reads one handle with stream()", async () => {
+    const tool = toolForCapabilityName("run_code");
+    const result = (await tool.execute(context(), {
+      code: `let sum = 0;
+             for await (const n of stream("numbers")) {
+               sum += n;
+               await emit("running", sum);
+             }
+             await output("total", sum);`,
+      input_streams: { numbers: [1, 2, 3] }
+    })) as {
+      ok: boolean;
+      outputs: Record<string, unknown>;
+      streamed: { name: string; value: unknown }[];
+    };
+    expect(result.ok).toBe(true);
+    expect(result.streamed).toEqual([
+      { name: "running", value: 1 },
+      { name: "running", value: 3 },
+      { name: "running", value: 6 }
+    ]);
+    expect(result.outputs).toEqual({ total: 6 });
+  });
+
+  it("interleaves stream.any() round-robin by index", async () => {
+    const tool = toolForCapabilityName("run_code");
+    const result = (await tool.execute(context(), {
+      code: `for await (const [handle, value] of stream.any()) {
+               await emit("merged", handle + ":" + value);
+             }`,
+      input_streams: { left: ["l1", "l2"], right: ["r1"] }
+    })) as { ok: boolean; streamed: { value: unknown }[] };
+    expect(result.ok).toBe(true);
+    // Item 0 of each handle in declaration order, then item 1 — `right` has
+    // only one, so `left` finishes alone.
+    expect(result.streamed.map((entry) => entry.value)).toEqual([
+      "left:l1",
+      "right:r1",
+      "left:l2"
+    ]);
+  });
+
+  it("reports stream.first and stream.open over the staged items", async () => {
+    const tool = toolForCapabilityName("run_code");
+    const result = (await tool.execute(context(), {
+      code: `const first = await stream.first("config");
+             await output("first", first);
+             await output("open", stream.open("config"));
+             await output("second", (await stream.first("config")) ?? "eos");`,
+      input_streams: { config: [{ tone: "terse" }] }
+    })) as { ok: boolean; outputs: Record<string, unknown> };
+    expect(result.ok).toBe(true);
+    expect(result.outputs).toEqual({
+      first: { tone: "terse" },
+      open: false,
+      second: "eos"
+    });
+  });
+
+  it("tells a streaming body with no staged items that it has no stream", async () => {
+    const tool = toolForCapabilityName("run_code");
+    const result = (await tool.execute(context(), {
+      code: `for await (const n of stream("numbers")) { await emit("n", n); }`
+    })) as { ok: boolean; error: string };
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("streaming-input mode");
+  });
+
+  it("grades a streaming body per case in test_code", async () => {
+    const tool = toolForCapabilityName("test_code");
+    const result = (await tool.execute(context(), {
+      code: `let count = 0;
+             for await (const item of stream("items")) {
+               count += 1;
+               await emit("item", item);
+             }
+             await output("count", count);`,
+      cases: [
+        {
+          name: "two items",
+          input_streams: { items: ["a", "b"] },
+          expect: { count: 2 },
+          expected_streamed: [
+            { name: "item", value: "a" },
+            { name: "item", value: "b" }
+          ]
+        },
+        {
+          name: "empty",
+          input_streams: { items: [] },
+          expect: { count: 1 }
+        }
+      ]
+    })) as {
+      ok: boolean;
+      passed: number;
+      failed: number;
+      results: { name: string; ok: boolean; mismatches: unknown[] }[];
+    };
+    expect(result.passed).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(result.results[1]?.mismatches).toEqual([
+      { output: "count", expected: 1, actual: 0 }
+    ]);
+  });
+});
+
 describe("registration", () => {
   it("is on the builtin belt with the pinned categories", () => {
     expect(BUILTIN_TOOL_NAMES).toContain("validate_code");

--- a/packages/agents/tests/js-sandbox-stream.test.ts
+++ b/packages/agents/tests/js-sandbox-stream.test.ts
@@ -228,8 +228,11 @@ describe("the timeout meters guest execution only", () => {
     const onTakeInput: SandboxTakeInputCallback = async () => {
       if (served) return { done: true };
       served = true;
-      // Three times the run's timeout, spent waiting on upstream.
-      await new Promise((resolve) => setTimeout(resolve, 1_500));
+      // Longer than the run's whole timeout, spent waiting on upstream. The
+      // margin is wide on purpose: engine startup and prelude evaluation are
+      // charged to the budget, and on a loaded CI runner they alone have
+      // eaten a 500ms one.
+      await new Promise((resolve) => setTimeout(resolve, 4_500));
       return { done: false, handle: "slow", value: "late" };
     };
     const result = await runInSandbox({
@@ -247,7 +250,7 @@ describe("the timeout meters guest execution only", () => {
         return seen;
       `,
       onTakeInput,
-      timeoutMs: 500
+      timeoutMs: 3_000
     });
 
     expect(result.error).toBeUndefined();

--- a/packages/agents/tests/js-sandbox-stream.test.ts
+++ b/packages/agents/tests/js-sandbox-stream.test.ts
@@ -1,0 +1,303 @@
+/**
+ * The guest input contract: `stream` reads a node's input handles as the values
+ * arrive, the mirror of `emit` on the way out. The host owns the inbox and
+ * answers one take at a time; the guest pulls, so an item nobody asked for is
+ * never delivered.
+ *
+ * Every case runs real QuickJS through `runInSandbox`, with a scripted
+ * `onTakeInput` standing in for the kernel's `NodeInputs`.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  NO_INPUT_STREAM_MESSAGE,
+  runInSandbox,
+  type SandboxEmittedValue,
+  type SandboxInputTake,
+  type SandboxTakeInputCallback
+} from "../src/js-sandbox.js";
+
+const TIMEOUT_MS = 30_000;
+
+/**
+ * A take source over per-handle queues, the way the kernel's inbox behaves: a
+ * named take pops that handle's queue, `null` (`stream.any()`) pops whatever
+ * arrives first, and an exhausted queue reports end-of-stream.
+ */
+function scriptedInput(
+  streams: Record<string, unknown[]>,
+  arrival?: string[]
+): { onTakeInput: SandboxTakeInputCallback; takes: (string | null)[] } {
+  const queues = new Map<string, unknown[]>(
+    Object.entries(streams).map(([handle, values]) => [handle, [...values]])
+  );
+  const order = arrival ? [...arrival] : undefined;
+  const takes: (string | null)[] = [];
+  const onTakeInput: SandboxTakeInputCallback = async (handle) => {
+    takes.push(handle);
+    if (handle !== null) {
+      const queue = queues.get(handle);
+      if (!queue || queue.length === 0) return { done: true };
+      return { done: false, handle, value: queue.shift() };
+    }
+    const next = order
+      ? order.shift()
+      : [...queues.entries()].find(([, q]) => q.length > 0)?.[0];
+    if (next === undefined) return { done: true };
+    const queue = queues.get(next);
+    if (!queue || queue.length === 0) return { done: true };
+    return { done: false, handle: next, value: queue.shift() };
+  };
+  return { onTakeInput, takes };
+}
+
+describe("stream(name)", () => {
+  it("yields one handle's values in order and completes at end-of-stream", async () => {
+    const { onTakeInput, takes } = scriptedInput({ numbers: [1, 2, 3] });
+    const result = await runInSandbox({
+      code: `
+        const seen = [];
+        for await (const n of stream("numbers")) {
+          seen.push(n);
+        }
+        return seen;
+      `,
+      onTakeInput,
+      timeoutMs: TIMEOUT_MS
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual([1, 2, 3]);
+    // Three values plus the take that reported end-of-stream.
+    expect(takes).toEqual(["numbers", "numbers", "numbers", "numbers"]);
+  });
+
+  it("carries objects and bytes across the boundary", async () => {
+    const { onTakeInput } = scriptedInput({
+      items: [{ label: "a" }, new Uint8Array([1, 2, 255])]
+    });
+    const result = await runInSandbox({
+      code: `
+        const seen = [];
+        for await (const item of stream("items")) {
+          seen.push(item instanceof Uint8Array ? Array.from(item) : item);
+        }
+        return seen;
+      `,
+      onTakeInput,
+      timeoutMs: TIMEOUT_MS
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual([{ label: "a" }, [1, 2, 255]]);
+  });
+
+  it("throws a TypeError on a name that is not a string", async () => {
+    const { onTakeInput } = scriptedInput({ a: [1] });
+    const result = await runInSandbox({
+      code: `stream(42);`,
+      onTakeInput,
+      timeoutMs: TIMEOUT_MS
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("stream: name must be a string");
+  });
+});
+
+describe("stream.any()", () => {
+  it("interleaves handles in arrival order as [handle, value] pairs", async () => {
+    const { onTakeInput } = scriptedInput(
+      { left: ["l1", "l2"], right: ["r1"] },
+      ["left", "right", "left"]
+    );
+    const result = await runInSandbox({
+      code: `
+        const seen = [];
+        for await (const [handle, value] of stream.any()) {
+          seen.push(handle + ":" + value);
+        }
+        return seen;
+      `,
+      onTakeInput,
+      timeoutMs: TIMEOUT_MS
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual(["left:l1", "right:r1", "left:l2"]);
+  });
+});
+
+describe("stream.first(name)", () => {
+  it("returns the next value, then undefined once the stream ended", async () => {
+    const { onTakeInput } = scriptedInput({ config: ["only"] });
+    const result = await runInSandbox({
+      code: `
+        const first = await stream.first("config");
+        const second = await stream.first("config");
+        return { first, second: second === undefined ? "undefined" : second };
+      `,
+      onTakeInput,
+      timeoutMs: TIMEOUT_MS
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual({ first: "only", second: "undefined" });
+  });
+});
+
+describe("stream.open(name)", () => {
+  it("answers the host's probe synchronously", async () => {
+    const { onTakeInput } = scriptedInput({ live: [1] });
+    const result = await runInSandbox({
+      code: `return { live: stream.open("live"), done: stream.open("done") };`,
+      onTakeInput,
+      onStreamOpen: (handle) => handle === "live",
+      timeoutMs: TIMEOUT_MS
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual({ live: true, done: false });
+  });
+
+  it("reads every handle as closed when the host answers no probe", async () => {
+    const { onTakeInput } = scriptedInput({ live: [1] });
+    const result = await runInSandbox({
+      code: `return stream.open("live");`,
+      onTakeInput,
+      timeoutMs: TIMEOUT_MS
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBe(false);
+  });
+});
+
+describe("a run with no input stream", () => {
+  it("has `stream`, and every verb on it throws", async () => {
+    for (const call of [
+      `stream("a")[Symbol.asyncIterator]().next()`,
+      `stream.any()[Symbol.asyncIterator]().next()`,
+      `stream.first("a")`,
+      `stream.open("a")`
+    ]) {
+      const result = await runInSandbox({
+        code: `await ${call};`,
+        timeoutMs: TIMEOUT_MS
+      });
+      expect(result.success, call).toBe(false);
+      expect(result.error, call).toContain(NO_INPUT_STREAM_MESSAGE);
+    }
+  }, 60_000);
+});
+
+describe("emit while streaming", () => {
+  it("delivers each emit between takes, in call order", async () => {
+    const { onTakeInput } = scriptedInput({ numbers: [1, 2, 3] });
+    const seen: SandboxEmittedValue[] = [];
+    const result = await runInSandbox({
+      code: `
+        let sum = 0;
+        for await (const n of stream("numbers")) {
+          sum += n;
+          await emit("running", sum);
+        }
+        await output("total", sum);
+      `,
+      onTakeInput,
+      onEmit: (name, value) => {
+        seen.push({ name, value });
+      },
+      timeoutMs: TIMEOUT_MS
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(seen).toEqual([
+      { name: "running", value: 1 },
+      { name: "running", value: 3 },
+      { name: "running", value: 6 }
+    ]);
+    expect(result.outputs).toEqual({ total: 6 });
+  });
+});
+
+describe("the timeout meters guest execution only", () => {
+  it("survives an upstream gap longer than the whole budget", async () => {
+    let served = false;
+    const onTakeInput: SandboxTakeInputCallback = async () => {
+      if (served) return { done: true };
+      served = true;
+      // Three times the run's timeout, spent waiting on upstream.
+      await new Promise((resolve) => setTimeout(resolve, 1_500));
+      return { done: false, handle: "slow", value: "late" };
+    };
+    const result = await runInSandbox({
+      code: `
+        const seen = [];
+        for await (const item of stream("slow")) {
+          seen.push(item);
+        }
+        // A little real work after the wait: the interrupt handler is polled
+        // from inside the interpreter, so a body that only awaits would never
+        // notice a budget the wait had spent.
+        let n = 0;
+        for (let i = 0; i < 2000000; i++) n += i;
+        seen.push(n > 0);
+        return seen;
+      `,
+      onTakeInput,
+      timeoutMs: 500
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual(["late", true]);
+  }, 30_000);
+
+  it("still cuts a body that computes past its budget", async () => {
+    const onTakeInput: SandboxTakeInputCallback = async () =>
+      ({ done: true }) as SandboxInputTake;
+    const result = await runInSandbox({
+      code: `
+        for await (const item of stream("nothing")) {
+          void item;
+        }
+        // Nothing suspends the clock here, so this is charged in full.
+        let n = 0;
+        while (true) {
+          n = (n + 1) % 1000000;
+        }
+      `,
+      onTakeInput,
+      timeoutMs: 500
+    });
+
+    expect(result.success).toBe(false);
+  }, 30_000);
+});
+
+describe("cancellation", () => {
+  it("unwinds a run parked on a take", async () => {
+    const controller = new AbortController();
+    const onTakeInput: SandboxTakeInputCallback = () =>
+      new Promise<SandboxInputTake>(() => {
+        // Never resolves: upstream has produced nothing and has not ended.
+      });
+    setTimeout(() => controller.abort(), 300);
+
+    const result = await runInSandbox({
+      code: `
+        for await (const item of stream("never")) {
+          void item;
+        }
+        return "finished";
+      `,
+      onTakeInput,
+      signal: controller.signal,
+      timeoutMs: TIMEOUT_MS
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Execution cancelled");
+  }, 30_000);
+});

--- a/packages/code-nodes/package.json
+++ b/packages/code-nodes/package.json
@@ -26,6 +26,7 @@
     "@nodetool-ai/sandbox": "*"
   },
   "devDependencies": {
+    "@nodetool-ai/kernel": "*",
     "@types/node": "^22.0.0",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2"

--- a/packages/code-nodes/src/nodes/code-node.ts
+++ b/packages/code-nodes/src/nodes/code-node.ts
@@ -29,6 +29,13 @@
  *   // streams { word: … } per word, then the final bag { sum: 15 }
  *
  * A body that calls neither runs the deprecated return/yield contract.
+ *
+ * Inputs arrive one of two ways. A body that never mentions `stream` runs once
+ * per incoming item with `inputs` holding that item's snapshot. A body that
+ * calls `stream` runs once for the whole stream and pulls values itself
+ * (`stream(name)`, `stream.any()`, `stream.first`, `stream.open`), executing
+ * through {@link CodeNode.run} — the kernel's streaming-input mode, which
+ * hydration selects per node from the body itself.
  */
 
 import {
@@ -41,15 +48,22 @@ import {
   hasYieldStatement,
   wrapImplicitReturn,
   normalizeCodeOutput,
-  usesEmitOutputContract
+  usesEmitOutputContract,
+  usesStreamInputContract
 } from "@nodetool-ai/node-sdk";
-import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type {
+  ProcessingContext,
+  StreamingInputs,
+  StreamingOutputs
+} from "@nodetool-ai/runtime";
 import {
   runInSandbox,
   TOOLS_PRELUDE,
   NODETOOL_API_PRELUDE_FULL,
   type SandboxLimits,
-  type RunSandboxResult
+  type RunSandboxOptions,
+  type RunSandboxResult,
+  type SandboxInputTake
 } from "@nodetool-ai/agents/js-sandbox";
 import { importHidden } from "@nodetool-ai/config";
 import { ALL_PLATFORMS, type SandboxModuleResolution } from "@nodetool-ai/protocol";
@@ -267,6 +281,91 @@ class BoundedChannel<T> {
   }
 }
 
+/** Answer the guest gets for a take that never resolved into a value. */
+const END_OF_STREAM: SandboxInputTake = { done: true };
+
+/**
+ * The host side of the guest's `stream` global: one inbox iterator per handle
+ * (plus one `any()` iterator), created on first use and driven one take at a
+ * time.
+ *
+ * Two takes on the same handle cannot run concurrently — an async generator
+ * rejects a `next()` while another is pending — so calls are serialized on a
+ * per-key promise chain. Distinct handles keep their own chain and proceed in
+ * parallel, which is what lets a body await two streams at once.
+ */
+class InputStreamBridge {
+  private readonly perHandle = new Map<string, AsyncGenerator<unknown>>();
+  private anyIterator: AsyncGenerator<[string, unknown]> | undefined;
+  /** Per-key serialization: `null` is the `any()` iterator's own chain. */
+  private readonly chains = new Map<
+    string | null,
+    Promise<SandboxInputTake>
+  >();
+  private readonly cancelled: Promise<SandboxInputTake>;
+
+  constructor(private readonly inputs: StreamingInputs) {
+    // A cancelled run must not leave the guest parked on a take that can no
+    // longer be answered: every pending and future take resolves as EOS, the
+    // body unwinds, and the sandbox's own abort ends the run.
+    this.cancelled = new Promise<SandboxInputTake>((resolve) => {
+      const signal = inputs.signal;
+      if (signal.aborted) {
+        resolve(END_OF_STREAM);
+        return;
+      }
+      signal.addEventListener("abort", () => resolve(END_OF_STREAM), {
+        once: true
+      });
+    });
+  }
+
+  take(handle: string | null): Promise<SandboxInputTake> {
+    const previous = this.chains.get(handle);
+    const next = previous
+      ? previous.then(
+          () => this.pull(handle),
+          () => this.pull(handle)
+        )
+      : this.pull(handle);
+    this.chains.set(handle, next);
+    return next;
+  }
+
+  /** `stream.open(name)`: could this handle still produce a value? */
+  isOpen(handle: string): boolean {
+    return (
+      this.inputs.hasStream(handle) ||
+      this.inputs.hasBuffered?.(handle) === true
+    );
+  }
+
+  private async pull(handle: string | null): Promise<SandboxInputTake> {
+    if (this.inputs.signal.aborted) return END_OF_STREAM;
+    if (handle === null) {
+      const iterator = (this.anyIterator ??= this.inputs.any());
+      const result = await Promise.race([iterator.next(), this.cancelled]);
+      if ("done" in result && result.done === true) return END_OF_STREAM;
+      const [source, value] = (result as IteratorYieldResult<
+        [string, unknown]
+      >).value;
+      return { done: false, handle: source, value: jsonSafe(value) };
+    }
+    let iterator = this.perHandle.get(handle);
+    if (!iterator) {
+      iterator = this.inputs.stream(handle);
+      this.perHandle.set(handle, iterator);
+    }
+    const result = await Promise.race([iterator.next(), this.cancelled]);
+    if ("done" in result && result.done === true) return END_OF_STREAM;
+    return {
+      done: false,
+      handle,
+      value: jsonSafe((result as IteratorYieldResult<unknown>).value)
+    };
+  }
+}
+
 export class CodeNode extends BaseNode {
   static readonly nodeType = "nodetool.code.Code";
   static readonly platforms = ALL_PLATFORMS;
@@ -285,7 +384,10 @@ export class CodeNode extends BaseNode {
     "permission gating. " +
     "Dynamic inputs arrive on the `inputs` object; outputs leave through " +
     "await emit(name, value) to stream a value now and await output(name, value) " +
-    "to set a handle's final value. The return value carries no outputs." +
+    "to set a handle's final value. The return value carries no outputs. " +
+    "A body that calls stream(name), stream.any(), stream.first(name) or " +
+    "stream.open(name) runs once and reads its connected inputs as they " +
+    "arrive, instead of once per item." +
     "\n    code, javascript, script, function, dynamic, custom, logic, " +
     "parse, transform, convert, format, compute, calculate, filter, map, " +
     "merge, extract, json, csv, text, string, math, " +
@@ -294,6 +396,16 @@ export class CodeNode extends BaseNode {
   static readonly inputFields = [];
   static readonly supportsDynamicInputs = true;
   static readonly supportsDynamicOutputs = true;
+  /**
+   * Whether this node streams its inputs is a property of its body, not of the
+   * type: a body that calls `stream` drains its own inbox in {@link run},
+   * every other body keeps the buffered per-item invocation. Both hydration
+   * paths re-read the body through this hook, so editing the last `stream`
+   * call out flips the mode back with no saved flag involved.
+   */
+  static readonly resolveStreamingInput = (node: {
+    properties?: Record<string, unknown>;
+  }): boolean => usesStreamInputContract(String(node?.properties?.code ?? ""));
 
   /** Persistent state across streaming invocations; reset each workflow run. */
   private _state: Record<string, unknown> = {};
@@ -329,8 +441,17 @@ export class CodeNode extends BaseNode {
       "`await output(name, value)` records that handle's final value, delivered " +
       "as one bag when the body ends. `return` is control flow only — the " +
       "returned value carries no outputs. " +
-      "Deprecated: a body that calls neither still runs the old contract, where " +
-      "a returned object's keys become output handles and yield(value) streams."
+      "Inputs: `for await (const item of stream(name))` reads a connected " +
+      "handle as values arrive, `stream.any()` yields [handle, value] across " +
+      "all handles in arrival order, `stream.first(name)` takes one value " +
+      "(undefined at end of stream), and `stream.open(name)` says whether more " +
+      "can still arrive. A body using any of them runs once for the whole " +
+      "stream — waiting on input does not spend the timeout — and `inputs.*` " +
+      "then carries only the values configured on the node. A body that never " +
+      "mentions `stream` runs once per incoming item, as before. " +
+      "Deprecated: a body that calls neither emit nor output still runs the old " +
+      "contract, where a returned object's keys become output handles and " +
+      "yield(value) streams."
   })
   declare code: string;
 
@@ -550,6 +671,27 @@ export class CodeNode extends BaseNode {
     return timeout > 0 ? timeout * 1000 : undefined;
   }
 
+  /**
+   * Everything a run of this node's body needs regardless of contract: the
+   * prelude, the node's own policy, its globals and its module resolution.
+   * Every execution path starts from this and adds only what its own contract
+   * needs (an emit sink, an input bridge, a cancellation signal).
+   */
+  private async sandboxOptions(
+    code: string,
+    context: ProcessingContext | undefined
+  ): Promise<RunSandboxOptions> {
+    return {
+      code: `${NODETOOL_PRELUDE}\n${code}`,
+      context,
+      timeoutMs: this.timeoutMs(),
+      globals: await this.sandboxGlobals(context),
+      limits: this.sandboxLimits(),
+      onProgress: this.progressSink(context),
+      modules: this.resolveModules(context)
+    };
+  }
+
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     const code = String(this.code ?? "return {};");
     if (!usesEmitOutputContract(code)) {
@@ -559,15 +701,9 @@ export class CodeNode extends BaseNode {
       return this.runLegacySingleShot(code, context);
     }
 
-    const result = await runInSandbox({
-      code: `${NODETOOL_PRELUDE}\n${code}`,
-      context,
-      timeoutMs: this.timeoutMs(),
-      globals: await this.sandboxGlobals(context),
-      limits: this.sandboxLimits(),
-      onProgress: this.progressSink(context),
-      modules: this.resolveModules(context)
-    });
+    const result = await runInSandbox(
+      await this.sandboxOptions(code, context)
+    );
 
     if (!result.success) {
       throw new Error(result.error ?? "Code execution failed");
@@ -583,21 +719,86 @@ export class CodeNode extends BaseNode {
     return { ...merged, ...(result.outputs ?? {}) };
   }
 
+  /**
+   * Streaming-input execution: one invocation that drains its own inbox.
+   *
+   * The kernel calls this instead of the per-item path when the hydrated
+   * `is_streaming_input` flag is true, which for this node means the body
+   * calls `stream` (see {@link CodeNode.resolveStreamingInput}). The body runs
+   * once; `stream(name)` / `stream.any()` pull values out of `inputs` one take
+   * at a time, `emit` routes live through `outputs.emit`, and the `output`
+   * finals post as one bag when the body ends.
+   */
+  async run(
+    inputs: StreamingInputs,
+    outputs: StreamingOutputs,
+    context?: ProcessingContext
+  ): Promise<void> {
+    const code = String(this.code ?? "return {};");
+    if (!usesStreamInputContract(code)) {
+      // The kernel only routes here when hydration said the body streams, and
+      // hydration re-reads the body every time. Reaching this means a stale
+      // saved flag was trusted (a graph built with `withExplicitNodeFlags` and
+      // never hydrated), and there is no safe recovery: this path never
+      // delivers per-item invocations, so a buffered body would silently see
+      // none of its connected inputs. Fail loudly instead.
+      throw new Error(
+        "Code node is flagged streaming-input but its body never calls " +
+          "stream(...). Hydrate the graph against the node registry, or add " +
+          "a stream(name) call to consume the connected inputs."
+      );
+    }
+
+    const bridge = new InputStreamBridge(inputs);
+    const abort = new AbortController();
+    const onCancel = () => abort.abort();
+    if (inputs.signal.aborted) {
+      abort.abort();
+    } else {
+      inputs.signal.addEventListener("abort", onCancel, { once: true });
+    }
+
+    try {
+      const result = await runInSandbox({
+        ...(await this.sandboxOptions(code, context)),
+        signal: abort.signal,
+        // Awaited, so a downstream inbox at its bound blocks the guest's
+        // `emit` — the same backpressure the buffered pump gets from its
+        // channel, one link earlier.
+        onEmit: async (name: string, value: unknown) => {
+          await outputs.emit(name, value);
+        },
+        onTakeInput: (handle) => bridge.take(handle),
+        onStreamOpen: (handle) => bridge.isOpen(handle)
+      });
+
+      // A cancelled run has nothing to report: the takes were unparked as
+      // end-of-stream and the body unwound on a signal it did not choose.
+      if (inputs.signal.aborted) return;
+      if (!result.success) {
+        throw new Error(result.error ?? "Code execution failed");
+      }
+      // One bag, one frame: the finals of a single invocation belong together,
+      // so sibling handles share lineage instead of arriving as N items.
+      const finals = result.outputs ?? {};
+      if (Object.keys(finals).length > 0) {
+        await outputs.emitGroup(finals);
+      }
+    } finally {
+      inputs.signal.removeEventListener("abort", onCancel);
+      abort.abort();
+    }
+  }
+
   /** The deprecated return-bag path: implicit return, normalized output. */
   private async runLegacySingleShot(
     code: string,
     context: ProcessingContext | undefined
   ): Promise<Record<string, unknown>> {
     const body = hasReturnStatement(code) ? code : wrapImplicitReturn(code);
-    const result = await runInSandbox({
-      code: `${NODETOOL_PRELUDE}\n${body}`,
-      context,
-      timeoutMs: this.timeoutMs(),
-      globals: await this.sandboxGlobals(context),
-      limits: this.sandboxLimits(),
-      onProgress: this.progressSink(context),
-      modules: this.resolveModules(context)
-    });
+    const result = await runInSandbox(
+      await this.sandboxOptions(body, context)
+    );
     if (!result.success) {
       throw new Error(result.error ?? "Code execution failed");
     }
@@ -645,13 +846,7 @@ export class CodeNode extends BaseNode {
     const run = (async () => {
       try {
         result = await runInSandbox({
-          code: `${NODETOOL_PRELUDE}\n${code}`,
-          context,
-          timeoutMs: this.timeoutMs(),
-          globals: await this.sandboxGlobals(context),
-          limits: this.sandboxLimits(),
-          onProgress: this.progressSink(context),
-          modules: this.resolveModules(context),
+          ...(await this.sandboxOptions(code, context)),
           signal: abort.signal,
           onEmit: (name: string, value: unknown) =>
             channel.push({ [name]: value })
@@ -707,13 +902,8 @@ export class CodeNode extends BaseNode {
     `;
 
     const result = await runInSandbox({
-      code: wrappedBody,
-      context,
-      timeoutMs: this.timeoutMs(),
-      globals: await this.sandboxGlobals(context),
-      limits: this.sandboxLimits(),
-      onProgress: this.progressSink(context),
-      modules: this.resolveModules(context)
+      ...(await this.sandboxOptions("", context)),
+      code: wrappedBody
     });
 
     if (!result.success) {
@@ -759,6 +949,21 @@ function extractDynamicInputs(
 }
 
 /**
+ * One value, deep-copied into JSON-safe form for the guest. The marshal rule
+ * for a streamed item is the buffered one: plain data crosses, anything that
+ * cannot be serialized becomes `null`. Media inputs are refs — plain objects —
+ * so they survive and stay readable through `media.*`.
+ */
+function jsonSafe(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Deep-copy all input values to make them safe for the sandbox.
  * Strips functions, symbols, and other non-serializable types.
  */
@@ -767,15 +972,7 @@ function deepCopyInputs(
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(inputs)) {
-    if (value === null || value === undefined) {
-      result[key] = value;
-      continue;
-    }
-    try {
-      result[key] = JSON.parse(JSON.stringify(value));
-    } catch {
-      result[key] = null;
-    }
+    result[key] = jsonSafe(value);
   }
   return result;
 }

--- a/packages/code-nodes/tests/code-node-stream-workflow.test.ts
+++ b/packages/code-nodes/tests/code-node-stream-workflow.test.ts
@@ -1,0 +1,140 @@
+/**
+ * End to end: an upstream generator streams into a Code node whose body keeps
+ * a running total, through the real `WorkflowRunner`.
+ *
+ * The graph is hydrated against a registry that carries `CodeNode`, so this
+ * also pins the per-instance flag path: nothing declares the node streaming —
+ * `resolveStreamingInput` reads it out of the body.
+ */
+
+import { describe, expect, it } from "vitest";
+import { Graph, WorkflowRunner } from "@nodetool-ai/kernel";
+import {
+  BaseNode,
+  NodeRegistry,
+  createGraphNodeTypeResolver,
+  prop
+} from "@nodetool-ai/node-sdk";
+import type { Edge, NodeDescriptor } from "@nodetool-ai/protocol";
+import type { StreamingInputs } from "@nodetool-ai/runtime";
+import { CodeNode } from "@nodetool-ai/code-nodes";
+
+/** Values the sink saw, per run, in arrival order. */
+const collected: unknown[] = [];
+
+class NumbersNode extends BaseNode {
+  static readonly nodeType = "test.stream.Numbers";
+  static readonly description = "Emit three numbers, one at a time.";
+
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async *genProcess(): AsyncGenerator<Record<string, unknown>> {
+    for (const n of [1, 2, 3]) yield { output: n };
+  }
+}
+
+/**
+ * Records every value that arrives. Streaming-input, so each emitted value is
+ * one item: a buffered consumer would keep only the last, because the Code
+ * node's emits carry no iteration correlation of their own.
+ */
+class SinkNode extends BaseNode {
+  static readonly nodeType = "test.stream.Sink";
+  static readonly description = "Record every value it receives.";
+  static readonly isStreamingInput = true;
+
+  @prop({ type: "any", default: null, title: "Value" })
+  declare value: unknown;
+
+  async process(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async run(inputs: StreamingInputs): Promise<void> {
+    for await (const value of inputs.stream("value")) collected.push(value);
+  }
+}
+
+const RUNNING_TOTAL = `let sum = 0;
+for await (const n of stream("numbers")) {
+  sum += n;
+  await emit("running", sum);
+}
+await output("total", sum);`;
+
+describe("Code node streaming input, end to end", () => {
+  it(
+    "sees each upstream item live and posts the final total",
+    async () => {
+      collected.length = 0;
+      const registry = new NodeRegistry();
+      registry.register(NumbersNode);
+      registry.register(SinkNode);
+      registry.register(CodeNode);
+
+      const nodes: NodeDescriptor[] = [
+        { id: "src", type: NumbersNode.nodeType, properties: {} },
+        {
+          id: "code",
+          type: CodeNode.nodeType,
+          properties: { code: RUNNING_TOTAL },
+          dynamic_inputs: { numbers: "any" },
+          dynamic_outputs: { running: "any", total: "any" }
+        },
+        { id: "running_sink", type: SinkNode.nodeType, properties: {} },
+        { id: "total_sink", type: SinkNode.nodeType, properties: {} }
+      ] as unknown as NodeDescriptor[];
+      const edges: Edge[] = [
+        {
+          id: "e1",
+          source: "src",
+          sourceHandle: "output",
+          target: "code",
+          targetHandle: "numbers"
+        },
+        {
+          id: "e2",
+          source: "code",
+          sourceHandle: "running",
+          target: "running_sink",
+          targetHandle: "value"
+        },
+        {
+          id: "e3",
+          source: "code",
+          sourceHandle: "total",
+          target: "total_sink",
+          targetHandle: "value"
+        }
+      ] as unknown as Edge[];
+
+      const graph = await Graph.loadFromDict(
+        { nodes, edges },
+        { resolver: createGraphNodeTypeResolver(registry) }
+      );
+      // Nothing on the node says "streaming"; the body did.
+      expect(
+        graph.nodes.find((node) => node.id === "code")?.is_streaming_input
+      ).toBe(true);
+
+      const runner = new WorkflowRunner("code-stream-e2e", {
+        resolveExecutor: (node) => registry.resolve(node)
+      });
+      const result = await runner.run(
+        { job_id: "code-stream-e2e" },
+        {
+          nodes: [...graph.nodes] as NodeDescriptor[],
+          edges: [...graph.edges] as Edge[]
+        }
+      );
+
+      expect(result.status).toBe("completed");
+      // Three live partial sums, then the final total — one value per item,
+      // which the buffered contract could not produce without a Collect node.
+      expect(collected).toEqual([1, 3, 6, 6]);
+    },
+    60_000
+  );
+});

--- a/packages/code-nodes/tests/code-node-stream.test.ts
+++ b/packages/code-nodes/tests/code-node-stream.test.ts
@@ -1,0 +1,364 @@
+/**
+ * The Code node's streaming-input mode: a body that calls `stream` runs once
+ * and drains its own inbox, the way `run(inputs, outputs)` is called by the
+ * kernel actor.
+ *
+ * Every case drives `run()` directly over a real `NodeInbox` wrapped in the
+ * kernel's own `NodeInputs`/`NodeOutputs`, so what these tests exercise is the
+ * bridge the actor uses, not a stand-in for it.
+ */
+
+import { describe, it, expect } from "vitest";
+import { CodeNode } from "@nodetool-ai/code-nodes";
+import { NodeInbox, NodeInputs, NodeOutputs } from "@nodetool-ai/kernel";
+
+/** One routed value, in the order the node emitted it. */
+interface Routed {
+  slot: string;
+  value: unknown;
+  group?: true;
+}
+
+interface Harness {
+  inbox: NodeInbox;
+  inputs: NodeInputs;
+  outputs: NodeOutputs;
+  routed: Routed[];
+  cancel: () => void;
+}
+
+function harness(handles: string[] = []): Harness {
+  const inbox = new NodeInbox();
+  for (const handle of handles) inbox.addUpstream(handle, 1);
+  const controller = new AbortController();
+  const inputs = new NodeInputs(inbox, null, undefined, controller.signal);
+  const routed: Routed[] = [];
+  const outputs = new NodeOutputs({
+    sendFn: async (slot, value) => {
+      routed.push({ slot, value });
+    },
+    emitGroupFn: async (values) => {
+      for (const [slot, value] of Object.entries(values)) {
+        routed.push({ slot, value, group: true });
+      }
+    }
+  });
+  return { inbox, inputs, outputs, routed, cancel: () => controller.abort() };
+}
+
+/** Feed a handle's items and close it. */
+async function feed(
+  inbox: NodeInbox,
+  handle: string,
+  items: readonly unknown[]
+): Promise<void> {
+  for (const item of items) await inbox.put(handle, item);
+  inbox.markSourceDone(handle);
+}
+
+function node(code: string, props: Record<string, unknown> = {}): CodeNode {
+  return new CodeNode({ code, ...props });
+}
+
+const TIMEOUT_MS = 30_000;
+
+describe("CodeNode.run — per-handle delivery", () => {
+  it(
+    "reads a handle in order and posts the final bag after the body ends",
+    async () => {
+      const h = harness(["numbers"]);
+      const run = node(
+        `let sum = 0;
+         for await (const n of stream("numbers")) {
+           sum += n;
+           await emit("running", sum);
+         }
+         await output("total", sum);`
+      ).run!(h.inputs, h.outputs);
+
+      await feed(h.inbox, "numbers", [1, 2, 3]);
+      await run;
+
+      expect(h.routed).toEqual([
+        { slot: "running", value: 1 },
+        { slot: "running", value: 3 },
+        { slot: "running", value: 6 },
+        { slot: "total", value: 6, group: true }
+      ]);
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    "emits live: values reach the consumer before end-of-stream",
+    async () => {
+      const h = harness(["items"]);
+      const run = node(
+        `for await (const item of stream("items")) {
+           await emit("echo", item);
+         }`
+      ).run!(h.inputs, h.outputs);
+
+      await h.inbox.put("items", "first");
+      // No EOS yet, so the body is still parked on its next take — but the
+      // first value must already be downstream.
+      await waitFor(() => h.routed.length === 1);
+      expect(h.routed).toEqual([{ slot: "echo", value: "first" }]);
+
+      await feed(h.inbox, "items", ["second"]);
+      await run;
+      expect(h.routed.map((entry) => entry.value)).toEqual([
+        "first",
+        "second"
+      ]);
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    "posts every final in one bag",
+    async () => {
+      const h = harness(["a"]);
+      const run = node(
+        `for await (const _ of stream("a")) {}
+         await output("x", 1);
+         await output("y", 2);`
+      ).run!(h.inputs, h.outputs);
+
+      await feed(h.inbox, "a", ["go"]);
+      await run;
+
+      expect(h.routed).toEqual([
+        { slot: "x", value: 1, group: true },
+        { slot: "y", value: 2, group: true }
+      ]);
+    },
+    TIMEOUT_MS
+  );
+});
+
+describe("CodeNode.run — stream.any and stream.first", () => {
+  it(
+    "interleaves two handles in arrival order",
+    async () => {
+      const h = harness(["left", "right"]);
+      const run = node(
+        `for await (const [handle, value] of stream.any()) {
+           await emit("merged", handle + ":" + value);
+         }`
+      ).run!(h.inputs, h.outputs);
+
+      await h.inbox.put("left", "l1");
+      await waitFor(() => h.routed.length === 1);
+      await h.inbox.put("right", "r1");
+      await waitFor(() => h.routed.length === 2);
+      await h.inbox.put("left", "l2");
+      h.inbox.markSourceDone("left");
+      h.inbox.markSourceDone("right");
+      await run;
+
+      expect(h.routed.map((entry) => entry.value)).toEqual([
+        "left:l1",
+        "right:r1",
+        "left:l2"
+      ]);
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    "gives stream.first one value and undefined after end-of-stream",
+    async () => {
+      const h = harness(["config"]);
+      const run = node(
+        `const first = await stream.first("config");
+         const second = await stream.first("config");
+         await output("first", first);
+         await output("second", second === undefined ? "eos" : second);`
+      ).run!(h.inputs, h.outputs);
+
+      await feed(h.inbox, "config", [{ tone: "terse" }]);
+      await run;
+
+      expect(h.routed).toEqual([
+        { slot: "first", value: { tone: "terse" }, group: true },
+        { slot: "second", value: "eos", group: true }
+      ]);
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    "reports stream.open per handle",
+    async () => {
+      const h = harness(["a"]);
+      const run = node(
+        `const before = stream.open("a");
+         for await (const _ of stream("a")) {}
+         await output("before", before);
+         await output("after", stream.open("a"));`
+      ).run!(h.inputs, h.outputs);
+
+      await feed(h.inbox, "a", [1]);
+      await run;
+
+      expect(h.routed).toEqual([
+        { slot: "before", value: true, group: true },
+        { slot: "after", value: false, group: true }
+      ]);
+    },
+    TIMEOUT_MS
+  );
+});
+
+describe("CodeNode.run — failure and cancellation", () => {
+  it(
+    "drops the finals when the body throws mid-stream, keeping prior emits",
+    async () => {
+      const h = harness(["numbers"]);
+      const run = node(
+        `for await (const n of stream("numbers")) {
+           if (n === 2) throw new Error("boom");
+           await emit("ok", n);
+         }
+         await output("total", "never");`
+      ).run!(h.inputs, h.outputs);
+
+      const settled = run.then(
+        () => "resolved",
+        (error: Error) => error.message
+      );
+      await feed(h.inbox, "numbers", [1, 2, 3]);
+
+      expect(await settled).toContain("boom");
+      expect(h.routed).toEqual([{ slot: "ok", value: 1 }]);
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    "unwinds when the run is cancelled while parked on a take",
+    async () => {
+      const h = harness(["items"]);
+      const run = node(
+        `for await (const item of stream("items")) {
+           await emit("echo", item);
+         }
+         await output("done", true);`
+      ).run!(h.inputs, h.outputs);
+
+      await h.inbox.put("items", "one");
+      await waitFor(() => h.routed.length === 1);
+      h.cancel();
+
+      await expect(run).resolves.toBeUndefined();
+      // The cancelled invocation posts no final bag.
+      expect(h.routed).toEqual([{ slot: "echo", value: "one" }]);
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    "fails clearly when a non-streaming body is routed here",
+    async () => {
+      const h = harness([]);
+      await expect(
+        node(`await output("x", 1);`).run!(h.inputs, h.outputs)
+      ).rejects.toThrow(/never calls stream/);
+    },
+    TIMEOUT_MS
+  );
+});
+
+describe("CodeNode.run — timeout metering", () => {
+  it(
+    "survives an input gap longer than the body's own timeout",
+    async () => {
+      const h = harness(["slow"]);
+      const run = node(
+        `for await (const n of stream("slow")) {
+           await emit("out", n);
+         }
+         await output("done", true);`,
+        { timeout: 1 }
+      ).run!(h.inputs, h.outputs);
+
+      // Two seconds parked on an empty, still-open inbox: double the body's
+      // one-second budget, which the clock must not be charged for.
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await feed(h.inbox, "slow", [7]);
+      await run;
+
+      expect(h.routed).toEqual([
+        { slot: "out", value: 7 },
+        { slot: "done", value: true, group: true }
+      ]);
+    },
+    TIMEOUT_MS
+  );
+});
+
+describe("CodeNode.run — the inputs bag", () => {
+  it(
+    "carries the node's configured properties, never per-item edge data",
+    async () => {
+      const h = harness(["items"]);
+      const run = node(
+        `for await (const item of stream("items")) {
+           await emit("seen", { item, prefix: inputs.prefix });
+         }`,
+        { prefix: "cfg" }
+      ).run!(h.inputs, h.outputs);
+
+      await feed(h.inbox, "items", ["a"]);
+      await run;
+
+      expect(h.routed).toEqual([
+        { slot: "seen", value: { item: "a", prefix: "cfg" } }
+      ]);
+    },
+    TIMEOUT_MS
+  );
+});
+
+describe("CodeNode.resolveStreamingInput", () => {
+  it("is true for a body that calls a stream verb", () => {
+    for (const code of [
+      `for await (const n of stream("a")) {}`,
+      `for await (const [h, v] of stream.any()) {}`,
+      `const v = await stream.first("a");`,
+      `if (stream.open("a")) {}`
+    ]) {
+      expect(CodeNode.resolveStreamingInput({ properties: { code } })).toBe(
+        true
+      );
+    }
+  });
+
+  it("is false for a buffered body, including a lookalike name", () => {
+    for (const code of [
+      `await output("x", inputs.a);`,
+      `await mystream("a");`,
+      `await thing.stream("a");`,
+      `// stream("a")`,
+      ""
+    ]) {
+      expect(CodeNode.resolveStreamingInput({ properties: { code } })).toBe(
+        false
+      );
+    }
+    expect(CodeNode.resolveStreamingInput({})).toBe(false);
+  });
+});
+
+/** Spin until `predicate` holds, so a test never sleeps longer than it must. */
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 10_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error("condition never held");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}

--- a/packages/dsl/src/core.ts
+++ b/packages/dsl/src/core.ts
@@ -1,5 +1,5 @@
 import { WorkflowRunner, withExplicitNodeFlags } from "@nodetool-ai/kernel";
-import { NodeRegistry } from "@nodetool-ai/node-sdk";
+import { NodeRegistry, usesStreamInputContract } from "@nodetool-ai/node-sdk";
 import {
   ProcessingContext,
   connectPythonBridgeForGraph,
@@ -11,6 +11,9 @@ import type {
   Edge,
   NodeUpdate
 } from "@nodetool-ai/protocol";
+
+/** The one node type whose streaming-input mode is decided per instance. */
+const CODE_NODE_TYPE = "nodetool.code.Code";
 
 export interface OutputHandle<T> {
   readonly __brand: "OutputHandle";
@@ -123,7 +126,15 @@ export function createNode<
 ): DslNode<TOutputs, TDefault> {
   const nodeId = crypto.randomUUID();
   const streaming = opts?.streaming ?? false;
-  const streamingInput = opts?.streamingInput ?? false;
+  // The generated helpers stamp `streamingInput` from per-type metadata, which
+  // cannot carry the Code node's answer: its mode is a property of the body.
+  // `run()` executes a DSL graph through `withExplicitNodeFlags`, never through
+  // registry hydration, so the probe has to run here or a streaming body would
+  // be invoked per item and never see its inputs.
+  const streamingInput =
+    opts?.streamingInput ??
+    (nodeType === CODE_NODE_TYPE &&
+      usesStreamInputContract(String(inputs?.["code"] ?? "")));
   const outputNames = opts?.outputNames
     ? [...opts.outputNames]
     : opts?.multiOutput

--- a/packages/dsl/tests/core.test.ts
+++ b/packages/dsl/tests/core.test.ts
@@ -36,6 +36,23 @@ describe("isOutputHandle", () => {
 });
 
 describe("createNode", () => {
+  test("stamps the Code node's streaming-input flag from its body", () => {
+    const streaming = createNode<SingleOutput<number>>("nodetool.code.Code", {
+      code: 'for await (const n of stream("numbers")) { await emit("n", n); }'
+    });
+    const buffered = createNode<SingleOutput<number>>("nodetool.code.Code", {
+      code: 'await output("n", inputs.numbers);'
+    });
+    // A DSL graph runs through `withExplicitNodeFlags`, so the flag on the
+    // descriptor is the only thing that puts the body in streaming mode.
+    const graph = workflow(streaming, buffered);
+    const flags = Object.fromEntries(
+      graph.nodes.map((node) => [node.id, node.streamingInput])
+    );
+    expect(flags[streaming.nodeId]).toBe(true);
+    expect(flags[buffered.nodeId]).toBe(false);
+  });
+
   test("returns frozen object with unique nodeId", () => {
     const node = createNode<SingleOutput<number>>("nodetool.math.Add", {
       lhs: 1,

--- a/packages/kernel/src/graph.ts
+++ b/packages/kernel/src/graph.ts
@@ -62,6 +62,18 @@ export interface ResolvedNodeType {
   outputs?: Record<string, string>;
   supportsDynamicInputs?: boolean;
   descriptorDefaults?: Partial<NodeDescriptor>;
+  /**
+   * Flags only the individual node can answer, resolved from its saved
+   * properties. `descriptorDefaults` carries one value per node *type*, which
+   * cannot express a mode that lives in a node's own properties — a Code node
+   * streams its inputs when its body says so. When present, the answer takes
+   * the slot the matching `descriptorDefaults` flag holds, and the kernel stays
+   * registry-agnostic: it calls a function it was handed, as it already does
+   * for type resolution.
+   */
+  resolveInstanceFlags?: (node: {
+    properties?: Record<string, unknown>;
+  }) => { is_streaming_input?: boolean };
 }
 
 export type NodeTypeResolver =
@@ -399,6 +411,9 @@ export class Graph {
 
       const descriptorDefaults: Partial<NodeDescriptor> =
         resolved.descriptorDefaults ?? {};
+      // A per-instance answer, when the resolver has one for this type, is read
+      // from the node as saved — the same properties the node will run with.
+      const instanceFlags = resolved.resolveInstanceFlags?.(node) ?? {};
       const hydratedNode: HydratedNodeDescriptor = {
         ...descriptorDefaults,
         ...node,
@@ -425,7 +440,11 @@ export class Graph {
         // the flag (undefined), e.g. for unresolved/dynamic types. OR-ing here
         // would let a stale saved `true` survive a registry that migrated the
         // type to buffered/uncontrolled, silently running the wrong mode.
+        // A per-instance answer takes the slot the per-type default holds: it
+        // was resolved from this node's own properties, so it is the more
+        // specific registry opinion, not a saved claim.
         is_streaming_input:
+          instanceFlags.is_streaming_input ??
           descriptorDefaults.is_streaming_input ??
           node.is_streaming_input ??
           false,

--- a/packages/kernel/tests/graph-instance-flags.test.ts
+++ b/packages/kernel/tests/graph-instance-flags.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { Graph, type ResolvedNodeType } from "../src/graph.js";
+
+/**
+ * A resolver whose type says "buffered" but which can answer per node, the way
+ * node-sdk's `createGraphNodeTypeResolver` does for a class declaring
+ * `resolveStreamingInput`.
+ */
+const resolverWith = (withInstanceFlags: boolean) => ({
+  async resolveNodeType(nodeType: string): Promise<ResolvedNodeType | null> {
+    if (nodeType !== "test.BodyMode") return null;
+    return {
+      nodeType,
+      propertyTypes: { code: "str" },
+      outputs: { output: "any" },
+      descriptorDefaults: { is_streaming_input: false },
+      ...(withInstanceFlags && {
+        resolveInstanceFlags: (node: {
+          properties?: Record<string, unknown>;
+        }) => ({
+          is_streaming_input: String(node.properties?.code ?? "").includes(
+            "stream("
+          )
+        })
+      })
+    };
+  }
+});
+
+const load = async (
+  code: string,
+  withInstanceFlags: boolean,
+  saved?: boolean
+): Promise<boolean | undefined> => {
+  const graph = await Graph.loadFromDict(
+    {
+      nodes: [
+        {
+          id: "n1",
+          type: "test.BodyMode",
+          properties: { code },
+          ...(saved === undefined ? {} : { is_streaming_input: saved })
+        }
+      ],
+      edges: []
+    },
+    { resolver: resolverWith(withInstanceFlags) }
+  );
+  return graph.findNode("n1")?.is_streaming_input;
+};
+
+describe("Graph.loadFromDict resolveInstanceFlags", () => {
+  it("takes the slot descriptorDefaults holds when the resolver answers per node", async () => {
+    expect(await load('stream("a");', true)).toBe(true);
+    expect(await load("return {};", true)).toBe(false);
+  });
+
+  it("falls back to descriptorDefaults when the resolver has no per-node answer", async () => {
+    // The same body, the same descriptorDefaults: without the closure the
+    // per-type false is the answer, which is today's exact behavior.
+    expect(await load('stream("a");', false)).toBe(false);
+  });
+
+  it("beats a stale saved flag", async () => {
+    expect(await load("return {};", true, true)).toBe(false);
+    expect(await load('stream("a");', true, false)).toBe(true);
+  });
+
+  it("leaves the other hydrated flags alone", async () => {
+    const graph = await Graph.loadFromDict(
+      {
+        nodes: [
+          {
+            id: "n1",
+            type: "test.BodyMode",
+            properties: { code: 'stream("a");' },
+            is_streaming_output: true,
+            is_controlled: true
+          }
+        ],
+        edges: []
+      },
+      { resolver: resolverWith(true) }
+    );
+    const node = graph.findNode("n1");
+    expect(node?.is_streaming_input).toBe(true);
+    // descriptorDefaults omits both, so the saved values still apply.
+    expect(node?.is_streaming_output).toBe(true);
+    expect(node?.is_controlled).toBe(true);
+  });
+});

--- a/packages/node-sdk/src/base-node.ts
+++ b/packages/node-sdk/src/base-node.ts
@@ -147,6 +147,13 @@ export type NodeClass = {
   requiredSettings?: string[];
   requiredRuntimes?: string[];
   isStreamingInput: boolean;
+  /**
+   * Per-instance override of {@link isStreamingInput}. See
+   * `BaseNode.resolveStreamingInput`.
+   */
+  resolveStreamingInput?: (node: {
+    properties?: Record<string, unknown>;
+  }) => boolean;
   isTrigger: boolean;
   alwaysEmitOutputUpdates?: boolean;
   inputMode?: InputMode;
@@ -283,6 +290,20 @@ export abstract class BaseNode {
   static readonly requiredSettings: string[] | undefined = undefined;
   static readonly requiredRuntimes: string[] | undefined = undefined;
   static readonly isStreamingInput: boolean = false;
+  /**
+   * Decide {@link isStreamingInput} per node instance, from its saved
+   * properties. Unset on every node whose mode is a property of the type;
+   * declared only where one type covers both modes — the Code node, where the
+   * body decides (`usesStreamInputContract(node.properties.code)`).
+   *
+   * Both hydration paths consult it ahead of the static
+   * (`hydrateGraphNodeFlags`, and `Graph.loadFromDict` via the resolver's
+   * `resolveInstanceFlags`), and re-read it on every hydration, so editing the
+   * body flips the mode with no saved flag involved.
+   */
+  static readonly resolveStreamingInput:
+    | ((node: { properties?: Record<string, unknown> }) => boolean)
+    | undefined = undefined;
   /**
    * Marks a trigger node. Triggers compile to `trigger_registrations` on
    * workflow activation, and when a run starts because of a delivered event

--- a/packages/node-sdk/src/code-analysis.ts
+++ b/packages/node-sdk/src/code-analysis.ts
@@ -352,6 +352,78 @@ export function outputCallNames(
   return { names: [...names], nonLiteral };
 }
 
+/** The global a body reads its input streams through. */
+export const CODE_STREAM_GLOBAL = "stream";
+
+/** Members of `stream` that take an input handle name as first argument. */
+const STREAM_NAMED_MEMBERS: readonly string[] = ["first", "open"];
+
+/** Input handles a body names through `stream` calls. */
+export interface StreamCallNames {
+  /** Literal handle names, in source order, deduplicated. */
+  names: string[];
+  /** A call whose first argument is not a string literal hides its handle. */
+  nonLiteral: boolean;
+  /** The body iterates every connected handle via `stream.any()`. */
+  usesAny: boolean;
+}
+
+/**
+ * Handles the body takes from via `stream(name)`, `stream.first(name)` and
+ * `stream.open(name)`, plus whether it also uses `stream.any()`.
+ *
+ * Presence in the AST is the whole rule, as for {@link outputCallNames}: a call
+ * inside a branch or a loop counts. `x.stream(…)` is a method on something else,
+ * and a body that binds `stream` itself reports nothing — the calls are that
+ * binding's, not the sandbox's.
+ */
+export function streamCallNames(
+  statements: readonly CodeBodyStatement[]
+): StreamCallNames {
+  if (collectBoundNamesFrom(statements).has(CODE_STREAM_GLOBAL)) {
+    return { names: [], nonLiteral: false, usesAny: false };
+  }
+  const names = new Set<string>();
+  let nonLiteral = false;
+  let usesAny = false;
+
+  walk(statements, (node) => {
+    if (node.type !== "CallExpression") return;
+    const callee = node.callee;
+
+    if (callee.type === "Identifier" && callee.name === CODE_STREAM_GLOBAL) {
+      addStreamName(node.arguments[0]);
+      return;
+    }
+    if (
+      callee.type !== "MemberExpression" ||
+      callee.computed ||
+      callee.object.type !== "Identifier" ||
+      callee.object.name !== CODE_STREAM_GLOBAL ||
+      callee.property.type !== "Identifier"
+    ) {
+      return;
+    }
+    if (callee.property.name === "any") {
+      usesAny = true;
+      return;
+    }
+    if (STREAM_NAMED_MEMBERS.includes(callee.property.name)) {
+      addStreamName(node.arguments[0]);
+    }
+  });
+
+  function addStreamName(first: acorn.AnyNode | null | undefined): void {
+    if (first?.type === "Literal" && typeof first.value === "string") {
+      names.add(first.value);
+      return;
+    }
+    nonLiteral = true;
+  }
+
+  return { names: [...names], nonLiteral, usesAny };
+}
+
 /** Names a binding pattern introduces (`const { a, b: [c] } = x`). */
 function patternNames(pattern: unknown, out: Set<string>): void {
   if (typeof pattern !== "object" || pattern === null) return;

--- a/packages/node-sdk/src/code-body.ts
+++ b/packages/node-sdk/src/code-body.ts
@@ -53,6 +53,25 @@ export function usesEmitOutputContract(code: string): boolean {
 }
 
 /**
+ * Whether the body consumes its inputs as streams rather than as one buffered
+ * snapshot per upstream item.
+ *
+ * A body that calls `stream(name)` — or reaches any member of it, `stream.any`,
+ * `stream.first`, `stream.open` — runs once and drains its inbox itself, so the
+ * node hydrates `is_streaming_input: true`. A body that never mentions `stream`
+ * keeps today's per-item invocation.
+ *
+ * Textual for the same reason as {@link usesEmitOutputContract}: it answers
+ * before the parser, on bodies that may not parse. `x.stream(` is a method on
+ * something else, `mystream(` is another function, and a mention inside a
+ * string or a comment is not a call at all.
+ */
+export function usesStreamInputContract(code: string): boolean {
+  const stripped = stripStringsAndComments(code);
+  return /(?:^|[^.\w$])stream\s*[(.]/.test(stripped);
+}
+
+/**
  * Wrap the last expression with `return(...)` for implicit return support.
  */
 export function wrapImplicitReturn(code: string): string {

--- a/packages/node-sdk/src/code-node-validation.ts
+++ b/packages/node-sdk/src/code-node-validation.ts
@@ -27,9 +27,13 @@ import {
   parseCodeBody,
   returnShapes,
   staticImportSpecifiers,
+  streamCallNames,
   typeofGuardedNames
 } from "./code-analysis.js";
-import { usesEmitOutputContract } from "./code-body.js";
+import {
+  usesEmitOutputContract,
+  usesStreamInputContract
+} from "./code-body.js";
 import { installHintFor } from "./sandbox-bridge-packs.js";
 
 /** Node types whose `code` property is a JavaScript sandbox body. */
@@ -70,7 +74,7 @@ export const SANDBOX_GLOBALS: ReadonlySet<string> = new Set([
   // Host bridges
   "console", "fetch", "crypto", "sleep", "getSecret", "workspace",
   "assetToSandbox", "sandboxToAsset", "progress", "emit", "output", "format",
-  "image", "canvas", "media",
+  "image", "canvas", "media", "stream",
   // Pure guest helpers defined by the sandbox prelude
   "toBase64", "fromBase64", "toHex", "fromHex",
   "parallelMap", "createCanvas",
@@ -116,7 +120,9 @@ export interface CodeNodeIssue {
    * "code_output_dynamic_name" | "code_return_ignored" |
    * "code_undefined_name" | "code_undefined_input" | "code_unused_input" |
    * "code_unused_package" | "code_package_unavailable" |
-   * "code_package_mismatch".
+   * "code_package_mismatch" | "code_undefined_stream" |
+   * "code_stream_dynamic_name" | "code_unconnected_stream" |
+   * "code_stream_input_read" | "code_stream_return_contract".
    */
   code: string;
   message: string;
@@ -130,6 +136,13 @@ export interface CodeNodeValidationInput {
    * property values, and handles fed by an incoming edge.
    */
   availableInputs: readonly string[];
+  /**
+   * Input handles an incoming edge feeds. A subset of `availableInputs`, and
+   * the only handles a streaming body can take from — a declared handle with
+   * no edge yields nothing, and a connected handle is unreadable through
+   * `inputs.<name>`.
+   */
+  connectedInputs?: readonly string[];
   /** Output handles the node declares (`dynamic_outputs` keys). */
   declaredOutputs: readonly string[];
   /** Output handles other nodes are wired to. A superset check on `keys`. */
@@ -336,17 +349,108 @@ export function validateCodeNodeBody(
     });
   }
 
+  // ── Input streams ────────────────────────────────────────────────────────
+  // A body that calls `stream` runs once and drains its inbox itself. Its
+  // handles are named the same way its outputs are, so they are checkable the
+  // same way — and the split between configured values (`inputs`) and edge data
+  // (`stream`) is the one footgun the contract creates, closed here.
+  const streaming = usesStreamInputContract(code);
+  const streams = streamCallNames(parsed.statements);
+  const connectedInputs = new Set(input.connectedInputs ?? []);
+
+  if (streaming) {
+    const unknownStreams = [
+      ...new Set(streams.names.filter((name) => !inScope.has(name)))
+    ].sort();
+    if (unknownStreams.length > 0) {
+      issues.push({
+        severity: "error",
+        code: "code_undefined_stream",
+        message:
+          `The code takes from ${formatNames(unknownStreams)}, which ` +
+          `${unknownStreams.length > 1 ? "are not inputs" : "is not an input"} of this node — the stream never yields. ` +
+          `Declare ${unknownStreams.length > 1 ? "them" : "it"} as ${unknownStreams.length > 1 ? "dynamic inputs" : "a dynamic input"}, or fix the name.`
+      });
+    }
+
+    if (streams.nonLiteral) {
+      issues.push({
+        severity: "warning",
+        code: "code_stream_dynamic_name",
+        message:
+          "The code calls `stream` with a handle name that is not a string literal, " +
+          "so the stream names cannot be checked statically. Pass a literal name to " +
+          "have them checked."
+      });
+    }
+
+    const unconnectedStreams = [
+      ...new Set(
+        streams.names.filter(
+          (name) => inScope.has(name) && !connectedInputs.has(name)
+        )
+      )
+    ].sort();
+    if (unconnectedStreams.length > 0) {
+      issues.push({
+        severity: "warning",
+        code: "code_unconnected_stream",
+        message:
+          `The code takes from ${formatNames(unconnectedStreams)}, which no incoming edge feeds — ` +
+          `the stream completes immediately and yields nothing. Connect an upstream node, ` +
+          `or read the node's configured value with ${unconnectedStreams.map((n) => `\`${CODE_INPUTS_GLOBAL}.${n}\``).join(", ")}.`
+      });
+    }
+
+    const streamedThroughInputs = [
+      ...new Set(inputsRead.filter((name) => connectedInputs.has(name)))
+    ].sort();
+    if (streamedThroughInputs.length > 0) {
+      issues.push({
+        severity: "error",
+        code: "code_stream_input_read",
+        message:
+          `The code reads ${streamedThroughInputs.map((n) => `\`${CODE_INPUTS_GLOBAL}.${n}\``).join(", ")}, which ` +
+          `${streamedThroughInputs.length > 1 ? "incoming edges feed" : "an incoming edge feeds"} — in a streaming body ` +
+          `\`${CODE_INPUTS_GLOBAL}\` carries only the node's configured values, never edge data. Use ` +
+          `${streamedThroughInputs.map((n) => `\`stream("${n}")\``).join(", ")}.`
+      });
+    }
+  }
+
   // An unresolvable read (`inputs[key]`, a spread) could touch any slot, so
-  // nothing is provably unused.
-  const read = new Set([...inputsRead, ...bareInputReads]);
-  const declaredInputsUnused = inputsOpaque
-    ? []
-    : [...new Set(input.availableInputs.filter((name) => !read.has(name)))];
+  // nothing is provably unused. A streaming body reads its connected handles
+  // through `stream`, and `stream.any()` reads every one of them.
+  const read = new Set([
+    ...inputsRead,
+    ...bareInputReads,
+    ...(streaming ? streams.names : []),
+    ...(streaming && streams.usesAny ? connectedInputs : [])
+  ]);
+  const declaredInputsUnused =
+    inputsOpaque || (streaming && streams.nonLiteral)
+      ? []
+      : [...new Set(input.availableInputs.filter((name) => !read.has(name)))];
 
   // ── Outputs ──────────────────────────────────────────────────────────────
-  // Two contracts, one probe. A body that calls `emit`/`output` names its
-  // handles, so the return-path analysis below does not apply to it at all —
-  // its returns are control flow and carry nothing.
+  // Two contracts, one probe — three states with streaming. A streaming body
+  // runs once, so the legacy return contract cannot apply to it whatever the
+  // emit probe says: its outputs go through `emit`/`output` or nowhere.
+  if (streaming && !usesEmitOutputContract(code)) {
+    issues.push({
+      severity: "error",
+      code: "code_stream_return_contract",
+      message:
+        "The code calls `stream`, so it runs once and its return value is control " +
+        "flow, not outputs. Send every output through `output(name, value)` for a " +
+        "final value, or `emit(name, value)` to stream values as they are produced."
+    });
+    return withUnusedInputs(issues, declaredInputsUnused);
+  }
+
+  // A body that calls `emit`/`output` names its handles, so the return-path
+  // analysis below does not apply to it at all — its returns are control flow
+  // and carry nothing.
   if (usesEmitOutputContract(code)) {
     issues.push(...emitContractIssues(parsed.statements, declared, connected));
     return withUnusedInputs(issues, declaredInputsUnused);

--- a/packages/node-sdk/src/graph-validation.ts
+++ b/packages/node-sdk/src/graph-validation.ts
@@ -756,10 +756,13 @@ export function validateGraph(
     // A `code` handle fed by an edge carries a body nothing here can see.
     if (isJsCodeNodeType(type) && !connectedByNode.get(id)?.has("code")) {
       const props = readProperties(node);
+      const connectedInputs = [...(connectedByNode.get(id) ?? [])].filter(
+        (name) => !isReservedHandle(name)
+      );
       const availableInputs = new Set<string>([
         ...Object.keys(readDynamicInputs(node)),
         ...Object.keys(readDynamicProperties(node)),
-        ...(connectedByNode.get(id) ?? [])
+        ...connectedInputs
       ]);
       const { declarations, invalid } = parseSandboxModuleDeclarations(
         props.packages
@@ -780,6 +783,7 @@ export function validateGraph(
         availableInputs: [...availableInputs].filter(
           (name) => !isReservedHandle(name)
         ),
+        connectedInputs,
         declaredOutputs: Object.keys(readDynamicOutputs(node)),
         connectedOutputs: [...(consumedByNode.get(id) ?? [])],
         declaredPackages: declarations,

--- a/packages/node-sdk/src/registry.ts
+++ b/packages/node-sdk/src/registry.ts
@@ -539,8 +539,14 @@ export function hydrateGraphNodeFlags(
       // saved `true` when a node type migrates away from streaming/control.
       // OR let the saved value win forever. Saved flags apply only when the
       // registry has no opinion (unknown type, or metadata omitting the flag).
+      // A class may also decide streaming input per instance, from the node's
+      // own properties (`resolveStreamingInput` — the Code node, where the body
+      // decides). It is consulted ahead of the static and re-read on every
+      // hydration, so it cannot go stale.
       is_streaming_input:
-        (cls ? cls.isStreamingInput : meta?.is_streaming_input) ??
+        (cls
+          ? cls.resolveStreamingInput?.(node) ?? cls.isStreamingInput
+          : meta?.is_streaming_input) ??
         node.is_streaming_input ??
         false,
       is_streaming_output:
@@ -605,6 +611,14 @@ export function createGraphNodeTypeResolver(
 
       if (!metadata) return null;
 
+      // Per-instance streaming-input resolution, when the class declares it.
+      // Metadata carries one boolean per type and cannot answer for a node
+      // whose mode lives in its own properties, so the closure travels to the
+      // merge site instead. Absent for every class without the hook, which
+      // keeps `Graph.loadFromDict` on exactly today's path.
+      const cls = registry.getClass(nodeType);
+      const resolveStreamingInput = cls?.resolveStreamingInput;
+
       const propertyTypes = Object.fromEntries(
         (metadata.properties ?? []).map((prop) => [
           prop.name,
@@ -635,6 +649,11 @@ export function createGraphNodeTypeResolver(
         propertyTypes,
         outputs,
         supportsDynamicInputs: metadata.supports_dynamic_inputs ?? false,
+        ...(resolveStreamingInput && {
+          resolveInstanceFlags: (node: {
+            properties?: Record<string, unknown>;
+          }) => ({ is_streaming_input: resolveStreamingInput(node) })
+        }),
         descriptorDefaults: {
           name: metadata.title,
           // Explicit booleans, never omitted: Graph.loadFromDict resolves each

--- a/packages/node-sdk/tests/code-stream-contract.test.ts
+++ b/packages/node-sdk/tests/code-stream-contract.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect } from "vitest";
+import { usesStreamInputContract } from "../src/code-body.js";
+import { parseCodeBody, streamCallNames } from "../src/code-analysis.js";
+import {
+  validateCodeNodeBody,
+  type CodeNodeValidationInput
+} from "../src/code-node-validation.js";
+
+const codes = (input: CodeNodeValidationInput): string[] =>
+  validateCodeNodeBody(input).map((issue) => issue.code);
+
+const messageFor = (input: CodeNodeValidationInput, code: string): string => {
+  const issue = validateCodeNodeBody(input).find((i) => i.code === code);
+  if (!issue) throw new Error(`no ${code} issue in ${JSON.stringify(codes(input))}`);
+  return issue.message;
+};
+
+describe("usesStreamInputContract", () => {
+  it.each([
+    ['for await (const x of stream("a")) { emit("o", x); }', "a free call"],
+    ['const v = await stream.first("a");', "stream.first"],
+    ['if (stream.open("a")) { emit("o", 1); }', "stream.open"],
+    ['for await (const [h, v] of stream.any()) { emit("o", v); }', "stream.any"],
+    ['const s = stream("a");', "assigned"],
+    ['stream ("a");', "space before the paren"]
+  ])("is true for %s (%s)", (code) => {
+    expect(usesStreamInputContract(code)).toBe(true);
+  });
+
+  it.each([
+    ["const r = {}; r.stream(1);", "a method named stream"],
+    ["const r = {}; r.stream.first(1);", "a member named stream"],
+    ["mystream(1);", "a name ending in stream"],
+    ["const x = $stream(1);", "a name ending in stream after $"],
+    ["const stream_a = 1; emit('o', stream_a);", "a name starting with stream"],
+    ["const p = { s: stream };", "a bare read that is neither a call nor a member"],
+    ['const s = "call stream(name) here";', "inside a string literal"],
+    ['// stream("a")\nreturn { a: 1 };', "inside a line comment"],
+    ['/* stream.any() */\nreturn { a: 1 };', "inside a block comment"],
+    ["return { total: inputs.a + inputs.b };", "no mention at all"]
+  ])("is false for %s (%s)", (code) => {
+    expect(usesStreamInputContract(code)).toBe(false);
+  });
+});
+
+describe("streamCallNames", () => {
+  const names = (code: string) => {
+    const parsed = parseCodeBody(code);
+    if ("error" in parsed) throw new Error(parsed.error);
+    return streamCallNames(parsed.statements);
+  };
+
+  it("collects literal names from stream(), stream.first() and stream.open()", () => {
+    expect(
+      names(
+        'for await (const x of stream("a")) {}\n' +
+          'await stream.first("b");\n' +
+          'stream.open("c");'
+      )
+    ).toEqual({ names: ["a", "b", "c"], nonLiteral: false, usesAny: false });
+  });
+
+  it("flags a non-literal first argument without inventing a name", () => {
+    expect(names("const k = 'a'; stream(k);")).toEqual({
+      names: [],
+      nonLiteral: true,
+      usesAny: false
+    });
+  });
+
+  it("reports stream.any() separately and takes no name from it", () => {
+    expect(names("for await (const [h, v] of stream.any()) {}")).toEqual({
+      names: [],
+      nonLiteral: false,
+      usesAny: true
+    });
+  });
+
+  it("ignores stream-named methods on other objects", () => {
+    expect(names('const r = { stream(n) {} }; r.stream("a");').names).toEqual([]);
+  });
+
+  it("reports nothing when the body binds `stream` itself", () => {
+    expect(
+      names('const stream = (n) => []; for (const x of stream("a")) {}')
+    ).toEqual({ names: [], nonLiteral: false, usesAny: false });
+  });
+});
+
+// ── Rule a: a stream naming a handle the node does not declare ──────────────
+describe("undeclared stream name", () => {
+  const body = (handle: string): CodeNodeValidationInput => ({
+    code: `for await (const x of stream("${handle}")) { await emit("out", x); }`,
+    availableInputs: ["numbers"],
+    connectedInputs: ["numbers"],
+    declaredOutputs: ["out"]
+  });
+
+  it("is an error when the handle is not an input", () => {
+    expect(codes(body("nubmers"))).toContain("code_undefined_stream");
+    expect(messageFor(body("nubmers"), "code_undefined_stream")).toBe(
+      'The code takes from "nubmers", which is not an input of this node — the ' +
+        "stream never yields. Declare it as a dynamic input, or fix the name."
+    );
+  });
+
+  it("is silent on the same body with the handle spelled right", () => {
+    expect(codes(body("numbers"))).not.toContain("code_undefined_stream");
+  });
+});
+
+// ── Rule b: a stream name the reader cannot see ─────────────────────────────
+describe("non-literal stream name", () => {
+  const base = {
+    availableInputs: ["numbers"],
+    connectedInputs: ["numbers"],
+    declaredOutputs: ["out"]
+  };
+
+  it("warns that the names cannot be checked", () => {
+    const input = {
+      ...base,
+      code: 'const h = "numbers";\nfor await (const x of stream(h)) { await emit("out", x); }'
+    };
+    expect(codes(input)).toContain("code_stream_dynamic_name");
+    expect(
+      validateCodeNodeBody(input).find(
+        (i) => i.code === "code_stream_dynamic_name"
+      )?.severity
+    ).toBe("warning");
+    expect(messageFor(input, "code_stream_dynamic_name")).toBe(
+      "The code calls `stream` with a handle name that is not a string literal, " +
+        "so the stream names cannot be checked statically. Pass a literal name to " +
+        "have them checked."
+    );
+  });
+
+  it("is silent when the same name is passed as a literal", () => {
+    expect(
+      codes({
+        ...base,
+        code: 'for await (const x of stream("numbers")) { await emit("out", x); }'
+      })
+    ).not.toContain("code_stream_dynamic_name");
+  });
+});
+
+// ── Rule c: a declared but unconnected handle ───────────────────────────────
+describe("unconnected stream handle", () => {
+  const body = (connected: string[]): CodeNodeValidationInput => ({
+    code: 'for await (const x of stream("numbers")) { await emit("out", x); }',
+    availableInputs: ["numbers"],
+    connectedInputs: connected,
+    declaredOutputs: ["out"]
+  });
+
+  it("warns when no edge feeds the handle", () => {
+    expect(codes(body([]))).toContain("code_unconnected_stream");
+    expect(messageFor(body([]), "code_unconnected_stream")).toBe(
+      'The code takes from "numbers", which no incoming edge feeds — the stream ' +
+        "completes immediately and yields nothing. Connect an upstream node, or " +
+        "read the node's configured value with `inputs.numbers`."
+    );
+  });
+
+  it("is silent once an edge feeds it", () => {
+    expect(codes(body(["numbers"]))).not.toContain("code_unconnected_stream");
+  });
+});
+
+// ── Rule d: reading a connected handle through `inputs` ─────────────────────
+describe("inputs read of a connected handle in a streaming body", () => {
+  const body = (connected: string[]): CodeNodeValidationInput => ({
+    code:
+      'for await (const x of stream("numbers")) {\n' +
+      '  await emit("out", x * inputs.factor);\n' +
+      "}",
+    availableInputs: ["numbers", "factor"],
+    connectedInputs: connected,
+    declaredOutputs: ["out"]
+  });
+
+  it("is an error when an edge feeds the handle read through inputs", () => {
+    expect(codes(body(["numbers", "factor"]))).toContain(
+      "code_stream_input_read"
+    );
+    expect(
+      messageFor(body(["numbers", "factor"]), "code_stream_input_read")
+    ).toBe(
+      "The code reads `inputs.factor`, which an incoming edge feeds — in a " +
+        "streaming body `inputs` carries only the node's configured values, never " +
+        'edge data. Use `stream("factor")`.'
+    );
+  });
+
+  it("is silent when the handle is configured rather than wired", () => {
+    expect(codes(body(["numbers"]))).not.toContain("code_stream_input_read");
+  });
+
+  it("does not apply to a buffered body reading the same connected handle", () => {
+    expect(
+      codes({
+        code: "return { out: inputs.numbers * inputs.factor };",
+        availableInputs: ["numbers", "factor"],
+        connectedInputs: ["numbers", "factor"],
+        declaredOutputs: ["out"]
+      })
+    ).not.toContain("code_stream_input_read");
+  });
+});
+
+// ── Rule e: a streaming body on the legacy return contract ──────────────────
+describe("streaming body outputs", () => {
+  const base = {
+    availableInputs: ["numbers"],
+    connectedInputs: ["numbers"],
+    declaredOutputs: ["total"]
+  };
+
+  it("is an error when the body returns its outputs instead of emitting", () => {
+    const input = {
+      ...base,
+      code:
+        "let sum = 0;\n" +
+        'for await (const n of stream("numbers")) { sum += n; }\n' +
+        "return { total: sum };"
+    };
+    expect(codes(input)).toContain("code_stream_return_contract");
+    expect(messageFor(input, "code_stream_return_contract")).toBe(
+      "The code calls `stream`, so it runs once and its return value is control " +
+        "flow, not outputs. Send every output through `output(name, value)` for a " +
+        "final value, or `emit(name, value)` to stream values as they are produced."
+    );
+  });
+
+  it("is silent once the same body sends through `output`", () => {
+    expect(
+      codes({
+        ...base,
+        code:
+          "let sum = 0;\n" +
+          'for await (const n of stream("numbers")) { sum += n; }\n' +
+          'await output("total", sum);'
+      })
+    ).not.toContain("code_stream_return_contract");
+  });
+
+  it("leaves the legacy return contract intact for a buffered body", () => {
+    expect(
+      codes({
+        ...base,
+        code: "return { total: inputs.numbers };"
+      })
+    ).toEqual([]);
+  });
+});
+
+// ── Rule f: buffered bodies validate exactly as today ───────────────────────
+describe("streaming does not disturb the buffered checks", () => {
+  it("treats `stream` as a sandbox global, not an invented name", () => {
+    expect(
+      codes({
+        code: 'for await (const x of stream("a")) { await emit("o", x); }',
+        availableInputs: ["a"],
+        connectedInputs: ["a"],
+        declaredOutputs: ["o"]
+      })
+    ).toEqual([]);
+  });
+
+  it("counts a streamed handle as read, so it is not reported unused", () => {
+    expect(
+      codes({
+        code: 'for await (const x of stream("a")) { await emit("o", x); }',
+        availableInputs: ["a"],
+        connectedInputs: ["a"],
+        declaredOutputs: ["o"]
+      })
+    ).not.toContain("code_unused_input");
+  });
+
+  it("counts every connected handle as read when the body uses stream.any()", () => {
+    expect(
+      codes({
+        code: 'for await (const [h, v] of stream.any()) { await emit("o", v); }',
+        availableInputs: ["a", "b"],
+        connectedInputs: ["a", "b"],
+        declaredOutputs: ["o"]
+      })
+    ).toEqual([]);
+  });
+
+  it("still reports a handle the streaming body never touches", () => {
+    expect(
+      codes({
+        code: 'for await (const x of stream("a")) { await emit("o", x); }',
+        availableInputs: ["a", "unused"],
+        connectedInputs: ["a"],
+        declaredOutputs: ["o"]
+      })
+    ).toContain("code_unused_input");
+  });
+});

--- a/packages/node-sdk/tests/graph-validation.test.ts
+++ b/packages/node-sdk/tests/graph-validation.test.ts
@@ -931,6 +931,70 @@ describe("Code nodes", () => {
     expect(report.issues.some((i) => i.code === "code_undefined_name")).toBe(false);
   });
 
+  // The streaming-input checks need to know which handles an edge feeds, which
+  // only the graph knows — these prove `validateGraph` hands them over.
+  it("takes a connected handle as a legal stream, and an unconnected one as a warning", () => {
+    const streamingGraph = (targetHandle: string) => ({
+      nodes: [
+        { id: "src", type: "a.Sink", properties: {} },
+        {
+          id: "c",
+          type: CODE,
+          properties: {
+            code: 'for await (const x of stream("text")) { await emit("out", x); }'
+          },
+          dynamic_inputs: {
+            text: { type: { type: "str" } },
+            other: { type: { type: "str" } }
+          },
+          dynamic_outputs: { out: { type: "str" } }
+        }
+      ],
+      edges: [
+        { id: "e", source: "src", sourceHandle: "in", target: "c", targetHandle }
+      ]
+    });
+
+    const connected = validateGraph(streamingGraph("text"), registry);
+    expect(
+      connected.issues.some((i) => i.code === "code_unconnected_stream")
+    ).toBe(false);
+
+    const unconnected = validateGraph(streamingGraph("other"), registry);
+    const issue = unconnected.issues.find(
+      (i) => i.code === "code_unconnected_stream"
+    );
+    expect(issue?.severity).toBe("warning");
+    expect(issue?.nodeId).toBe("c");
+  });
+
+  it("reports an `inputs` read of a handle an edge feeds in a streaming body", () => {
+    const report = validateGraph(
+      {
+        nodes: [
+          { id: "src", type: "a.Sink", properties: {} },
+          {
+            id: "c",
+            type: CODE,
+            properties: {
+              code:
+                'for await (const x of stream("text")) { await emit("out", inputs.text); }'
+            },
+            dynamic_inputs: { text: { type: { type: "str" } } },
+            dynamic_outputs: { out: { type: "str" } }
+          }
+        ],
+        edges: [
+          { id: "e", source: "src", sourceHandle: "in", target: "c", targetHandle: "text" }
+        ]
+      },
+      registry
+    );
+    const issue = report.issues.find((i) => i.code === "code_stream_input_read");
+    expect(issue?.severity).toBe("error");
+    expect(issue?.message).toContain('stream("text")');
+  });
+
   it("uses the edges into the node when nothing declares an output", () => {
     const report = validateGraph(
       graph({ properties: { code: "const x = 1;" } }),

--- a/packages/node-sdk/tests/hydrate-instance-flags.test.ts
+++ b/packages/node-sdk/tests/hydrate-instance-flags.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import {
+  NodeRegistry,
+  createGraphNodeTypeResolver,
+  hydrateGraphNodeFlags
+} from "../src/registry.js";
+import { BaseNode } from "../src/base-node.js";
+import { prop } from "../src/decorators.js";
+import { usesStreamInputContract } from "../src/code-body.js";
+
+/**
+ * A node whose input mode lives in its own properties, not in its type — the
+ * shape `nodetool.code.Code` takes: the body decides whether it streams.
+ */
+class BodyModeNode extends BaseNode {
+  static readonly nodeType = "test.BodyMode";
+  static readonly title = "Body Mode";
+  static readonly description = "";
+  static readonly supportsDynamicInputs = true;
+  static readonly resolveStreamingInput = (node: {
+    properties?: Record<string, unknown>;
+  }): boolean => usesStreamInputContract(String(node.properties?.code ?? ""));
+
+  @prop({ type: "str", default: "" })
+  declare code: string;
+
+  async process() {
+    return {};
+  }
+}
+
+/** The same node without the hook — today's per-type resolution. */
+class TypeModeNode extends BaseNode {
+  static readonly nodeType = "test.TypeMode";
+  static readonly title = "Type Mode";
+  static readonly description = "";
+
+  @prop({ type: "str", default: "" })
+  declare code: string;
+
+  async process() {
+    return {};
+  }
+}
+
+const registryWith = (...classes: typeof BodyModeNode[]): NodeRegistry => {
+  const registry = new NodeRegistry();
+  for (const cls of classes) registry.register(cls as never);
+  return registry;
+};
+
+const hydrateOne = (
+  registry: NodeRegistry,
+  node: Record<string, unknown>
+): boolean =>
+  hydrateGraphNodeFlags({ nodes: [node], edges: [] } as never, registry).nodes[0]
+    .is_streaming_input === true;
+
+describe("hydrateGraphNodeFlags with resolveStreamingInput", () => {
+  it("resolves the flag per instance from the node's own properties", () => {
+    const registry = registryWith(BodyModeNode);
+    expect(
+      hydrateOne(registry, {
+        id: "n1",
+        type: "test.BodyMode",
+        properties: { code: 'for await (const x of stream("a")) {}' }
+      })
+    ).toBe(true);
+  });
+
+  it("flips back when the stream call is edited out", () => {
+    const registry = registryWith(BodyModeNode);
+    expect(
+      hydrateOne(registry, {
+        id: "n1",
+        type: "test.BodyMode",
+        properties: { code: 'return { out: inputs.a };' }
+      })
+    ).toBe(false);
+  });
+
+  it("beats a stale saved flag in both directions", () => {
+    const registry = registryWith(BodyModeNode);
+    // Saved true, body no longer streams.
+    expect(
+      hydrateOne(registry, {
+        id: "n1",
+        type: "test.BodyMode",
+        properties: { code: "return {};" },
+        is_streaming_input: true
+      })
+    ).toBe(false);
+    // Saved false, body streams.
+    expect(
+      hydrateOne(registry, {
+        id: "n1",
+        type: "test.BodyMode",
+        properties: { code: 'await stream.first("a");' },
+        is_streaming_input: false
+      })
+    ).toBe(true);
+  });
+
+  it("falls back to the static for a class with no hook", () => {
+    const registry = registryWith(TypeModeNode);
+    // The identical body: without the hook the answer is the type's static.
+    expect(
+      hydrateOne(registry, {
+        id: "n1",
+        type: "test.TypeMode",
+        properties: { code: 'for await (const x of stream("a")) {}' }
+      })
+    ).toBe(false);
+  });
+
+  it("leaves every other flag on a hook class untouched", () => {
+    const registry = registryWith(BodyModeNode);
+    const hydrated = hydrateGraphNodeFlags(
+      {
+        nodes: [
+          {
+            id: "n1",
+            type: "test.BodyMode",
+            properties: { code: 'stream("a");' },
+            is_controlled: true,
+            is_join_node: true,
+            is_trigger: true
+          }
+        ],
+        edges: []
+      } as never,
+      registry
+    );
+    expect(hydrated.nodes[0]).toMatchObject({
+      is_streaming_input: true,
+      is_streaming_output: false,
+      is_controlled: false,
+      is_join_node: false,
+      is_trigger: false,
+      retry_safe: false
+    });
+  });
+});
+
+describe("createGraphNodeTypeResolver instance flags", () => {
+  it("exposes resolveInstanceFlags only for a class that declares the hook", async () => {
+    const registry = registryWith(BodyModeNode, TypeModeNode as never);
+    const resolver = createGraphNodeTypeResolver(registry);
+
+    const withHook = await resolver.resolveNodeType("test.BodyMode");
+    const withoutHook = await resolver.resolveNodeType("test.TypeMode");
+
+    expect(typeof withHook?.resolveInstanceFlags).toBe("function");
+    expect(withoutHook?.resolveInstanceFlags).toBeUndefined();
+    // The per-type default keeps saying what the static says; the closure is
+    // what carries the per-instance answer to the merge site.
+    expect(withHook?.descriptorDefaults?.is_streaming_input).toBe(false);
+  });
+
+  it("answers from the node it is handed", async () => {
+    const resolver = createGraphNodeTypeResolver(registryWith(BodyModeNode));
+    const resolved = await resolver.resolveNodeType("test.BodyMode");
+
+    expect(
+      resolved?.resolveInstanceFlags?.({
+        properties: { code: 'for await (const x of stream("a")) {}' }
+      })
+    ).toEqual({ is_streaming_input: true });
+    expect(
+      resolved?.resolveInstanceFlags?.({ properties: { code: "return {};" } })
+    ).toEqual({ is_streaming_input: false });
+  });
+
+  it("is absent for a class-less (metadata-only) node type", async () => {
+    const registry = new NodeRegistry();
+    registry.loadMetadata("python.pkg.Node", {
+      node_type: "python.pkg.Node",
+      title: "Py Node",
+      description: "",
+      namespace: "python.pkg",
+      properties: [],
+      outputs: []
+    } as never);
+    const resolved =
+      await createGraphNodeTypeResolver(registry).resolveNodeType(
+        "python.pkg.Node"
+      );
+    expect(resolved?.resolveInstanceFlags).toBeUndefined();
+  });
+});

--- a/packages/runtime/src/node-executor.ts
+++ b/packages/runtime/src/node-executor.ts
@@ -59,6 +59,15 @@ export interface StreamingInputs {
   hasStream(name: string): boolean;
 
   /**
+   * True if the handle has items already queued and not yet consumed.
+   * Optional: the kernel's `NodeInputs` implements it, hand-rolled test
+   * doubles need not. Together with {@link hasStream} it answers "could a
+   * take on this handle still produce a value?" — what the Code node's
+   * `stream.open(name)` reports to the guest.
+   */
+  hasBuffered?(name: string): boolean;
+
+  /**
    * Aborted when the run is cancelled. Producers that emit without waiting
    * on inputs (generators, wall-clock pacers) must observe it — inbox
    * closure only unblocks consumers, it does not stop a producing loop.


### PR DESCRIPTION
Design and implementation of input streaming for `nodetool.code.Code`, per `docs/code-node-input-streaming-design.md` (status: implemented) — the input-side twin of the shipped emit/output contract.

## What a body can now do

```js
let sum = 0;
for await (const n of stream("numbers")) {
  sum += n;
  await emit("running", sum);
}
await output("total", sum);
```

`stream(name)` iterates one handle until EOS, `stream.any()` merges all handles by arrival, `stream.first(name)` takes one value, `stream.open(name)` peeks. Mode is chosen by the body (`usesStreamInputContract` probe) — no checkbox, and buffered bodies run byte-for-byte as before.

## Changes by layer

- **Sandbox** (`packages/agents/src/js-sandbox.ts`): `onTakeInput`/`onStreamOpen` host bridges, the guest `stream` prelude, and `SandboxClock` suspension so the body's `timeout` counts its own compute, not time parked on upstream.
- **Contract + hydration** (`packages/node-sdk`, `packages/kernel`): `usesStreamInputContract` probe; per-instance `resolveStreamingInput` class hook consulted by `hydrateGraphNodeFlags` and (via `resolveInstanceFlags` on the resolver) `Graph.loadFromDict`; hook-less node types hydrate exactly as before.
- **Validation** (`packages/node-sdk`): five new static rules — undeclared stream name (error), non-literal name (warning), unconnected handle (warning), `inputs.<name>` read of a connected handle in a streaming body (error, names `stream(name)`), streaming body on the legacy return contract (error). Each shipped with an inverted fixture proving it can fail.
- **CodeNode** (`packages/code-nodes`): `run(inputs, outputs, context)` bridging kernel `NodeInputs` to the guest — lazy per-handle iterators, serialized takes, live emits with backpressure, finals posted as one `emitGroup` frame, cancellation unparks as EOS.
- **Harness** (`packages/agents/src/capabilities/code.ts`): `run_code` and `test_code` accept `input_streams`; streamed outputs land in `streamed`, finals in `outputs`.
- **DSL** (`packages/dsl`): `createNode` probes Code bodies so `withExplicitNodeFlags` graphs (`nodetool run file.ts`) execute in the right mode; server paths already hydrate via the registry.
- **Docs**: `docs/javascript-sandbox.md` § Input streams; node and `code`-prop descriptions teach `stream`.

## Testing

New suites: `js-sandbox-stream` (12), `code-node-stream` (13) + a kernel end-to-end workflow test (generator → running total → streaming sinks through `Graph.loadFromDict`), `code-stream-contract`, `hydrate-instance-flags`, `graph-instance-flags`, plus harness and DSL cases. Full package suites green locally: agents 2705, node-sdk 953, kernel 1010, runtime 2738, code-nodes 311, dsl 139, execution 177. Timeout-suspension and final-bag grouping checks were proven failable by inverting them and watching red before restoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VgfWkKaHuXqnRukZqqaDU