### PR TITLE
fix(chat): serve composer-generated media from the storage backend

### DIFF
--- a/packages/models/src/asset.ts
+++ b/packages/models/src/asset.ts
@@ -4,7 +4,7 @@
  * Port of Python's `nodetool.models.asset`.
  */
 
-import { eq, and, like, desc, isNull, lt, inArray } from "drizzle-orm";
+import { eq, and, or, like, desc, isNull, lt, inArray } from "drizzle-orm";
 import { DBModel, createTimeOrderedUuid } from "./base-model.js";
 import { getDb } from "./db.js";
 import { assets } from "./schema/assets.js";
@@ -123,6 +123,16 @@ export class Asset extends DBModel {
     if (parentId !== undefined) {
       if (parentId === null) {
         conditions.push(isNull(assets.parent_id));
+      } else if (parentId === userId) {
+        // Home. A row with no parent lives here too — that is what
+        // `getFolderInfo` reports for it, and what the asset browser has to
+        // show or the asset is unreachable. Server-side writers (chat media
+        // generation, the generate-media RPC, workflow node outputs) filed
+        // their assets with a null parent, so an exact match on the home id
+        // hid every one of them from the browser.
+        conditions.push(
+          or(eq(assets.parent_id, parentId), isNull(assets.parent_id))!
+        );
       } else {
         conditions.push(eq(assets.parent_id, parentId));
       }

--- a/packages/models/tests/asset-home-listing.test.ts
+++ b/packages/models/tests/asset-home-listing.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression: assets written server-side (chat media generation, the
+ * generate-media RPC, workflow node outputs) carry a null `parent_id`.
+ * `getFolderInfo` reports those as living in "Home", but the Home listing
+ * matched `parent_id = <userId>` exactly — so a generated image existed, was
+ * downloadable by id, and was invisible in the asset browser.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ModelObserver } from "../src/base-model.js";
+import { initTestDb } from "../src/db.js";
+import { Asset } from "../src/asset.js";
+
+describe("Asset.paginate home folder", () => {
+  beforeEach(() => initTestDb());
+  afterEach(() => ModelObserver.clear());
+
+  it("lists parentless assets in the user's home folder", async () => {
+    const generated = await Asset.create<Asset>({
+      user_id: "u1",
+      name: "image_1",
+      content_type: "image/png",
+      parent_id: null
+    });
+    const uploaded = await Asset.create<Asset>({
+      user_id: "u1",
+      name: "upload.png",
+      content_type: "image/png",
+      parent_id: "u1"
+    });
+
+    const [items] = await Asset.paginate("u1", { parentId: "u1" });
+    expect(items.map((a) => a.id).sort()).toEqual(
+      [generated.id, uploaded.id].sort()
+    );
+  });
+
+  it("keeps a nested folder's listing to its own children", async () => {
+    await Asset.create<Asset>({
+      user_id: "u1",
+      name: "image_1",
+      content_type: "image/png",
+      parent_id: null
+    });
+    const nested = await Asset.create<Asset>({
+      user_id: "u1",
+      name: "in-folder.png",
+      content_type: "image/png",
+      parent_id: "folder-1"
+    });
+
+    const [items] = await Asset.paginate("u1", { parentId: "folder-1" });
+    expect(items.map((a) => a.id)).toEqual([nested.id]);
+  });
+
+  it("still lists only parentless assets when asked for them explicitly", async () => {
+    const orphan = await Asset.create<Asset>({
+      user_id: "u1",
+      name: "image_1",
+      content_type: "image/png",
+      parent_id: null
+    });
+    await Asset.create<Asset>({
+      user_id: "u1",
+      name: "upload.png",
+      content_type: "image/png",
+      parent_id: "u1"
+    });
+
+    const [items] = await Asset.paginate("u1", { parentId: null });
+    expect(items.map((a) => a.id)).toEqual([orphan.id]);
+  });
+
+  it("does not leak another user's parentless assets into home", async () => {
+    await Asset.create<Asset>({
+      user_id: "u2",
+      name: "theirs.png",
+      content_type: "image/png",
+      parent_id: null
+    });
+
+    const [items] = await Asset.paginate("u1", { parentId: "u1" });
+    expect(items).toEqual([]);
+  });
+});

--- a/packages/websocket/src/resolve-media-urls.ts
+++ b/packages/websocket/src/resolve-media-urls.ts
@@ -2,7 +2,14 @@
  * Resolve asset IDs in message content to browser-accessible URLs.
  *
  * Media refs store an `asset_id` in the database. Before sending to a
- * client, this module resolves each to a full URL via `buildAssetUrl`.
+ * client, this module resolves each to a URL the browser can load directly
+ * from an `<img>` / `<video>` / `<audio>` element — which is why it goes
+ * through the storage backend's own URL builder, exactly like
+ * `assets.get_url` does. A media element sends no `Authorization` header, so
+ * on a deployment with auth enforced and asset bytes in S3/Supabase the old
+ * `/api/storage/<key>` path answered 401 (and pointed at a local file backend
+ * that did not hold the bytes anyway); the signed URL those backends mint is
+ * loadable as-is.
  *
  * For LLM providers use `resolveContentForProvider` instead, which maps
  * asset_id directly to a file:// URI so no HTTP round-trip is needed.
@@ -12,8 +19,12 @@
  * prefix resolves to a path that no longer exists.
  */
 
-import { buildAssetUrl, getAssetFilePath } from "@nodetool-ai/config";
-import { assetObjectKey } from "@nodetool-ai/storage";
+import {
+  buildAssetUrl,
+  getAssetFilePath,
+  loadAssetStorageConfig
+} from "@nodetool-ai/config";
+import { assetObjectKey, createAssetUrlBuilder } from "@nodetool-ai/storage";
 import { existsSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -72,22 +83,43 @@ function assetKeyFor(
   return userId ? assetObjectKey(userId, fileName) : fileName;
 }
 
-function resolveAssetId(
-  assetId: string,
-  mimeType?: string | null,
-  userId?: string
-): string {
-  return buildAssetUrl(assetKeyFor(assetId, mimeType, userId));
+/**
+ * The configured backend's URL builder, rebuilt when the backend kind changes
+ * (tests switch backends in-process). The `file` backend is served by this
+ * server's own `/api/storage` route, so it keeps going through
+ * `buildAssetUrl`, which percent-encodes each key segment; the cloud backends
+ * mint a signed URL to their own origin.
+ */
+let cachedBuilderKind: string | null = null;
+let cachedBuilder: ((key: string) => Promise<string>) | null = null;
+
+async function assetUrlForKey(key: string): Promise<string> {
+  const config = loadAssetStorageConfig();
+  if (config.kind === "file") {
+    return buildAssetUrl(key);
+  }
+  if (!cachedBuilder || cachedBuilderKind !== config.kind) {
+    cachedBuilderKind = config.kind;
+    cachedBuilder = createAssetUrlBuilder(config);
+  }
+  try {
+    return await cachedBuilder(key);
+  } catch {
+    // Signing failed (network, expired credentials). The server-side route is
+    // no worse than emitting nothing, and it still works for a caller that can
+    // authenticate.
+    return buildAssetUrl(key);
+  }
 }
 
 /**
  * Resolve a media ref object: if it has an asset_id, derive uri from it.
  */
-function resolveRef(
+async function resolveRef(
   ref: Record<string, unknown>,
   fallbackMime?: string,
   userId?: string
-): Record<string, unknown> {
+): Promise<Record<string, unknown>> {
   const resolved = { ...ref };
   const mime = (resolved.mimeType ?? resolved.mime_type ?? resolved.content_type ?? fallbackMime) as string | undefined;
 
@@ -95,7 +127,9 @@ function resolveRef(
     typeof resolved.asset_id === "string" &&
     isSafeAssetId(resolved.asset_id)
   ) {
-    resolved.uri = resolveAssetId(resolved.asset_id, mime, userId);
+    resolved.uri = await assetUrlForKey(
+      assetKeyFor(resolved.asset_id, mime, userId)
+    );
   }
 
   return resolved;
@@ -169,33 +203,59 @@ export function resolveContentForProvider(
 
 /**
  * Walk a message content array and resolve asset_id refs to URLs.
+ *
+ * Async because a cloud storage backend signs each URL; the `file` backend
+ * resolves without I/O.
  */
-export function resolveContentUrls(
+export async function resolveContentUrls(
   content: string | unknown[] | Record<string, unknown> | null,
   userId?: string
-): string | unknown[] | Record<string, unknown> | null {
+): Promise<string | unknown[] | Record<string, unknown> | null> {
   if (!Array.isArray(content)) return content;
 
-  return content.map((block) => {
-    if (!block || typeof block !== "object") return block;
-    const b = block as Record<string, unknown>;
+  return Promise.all(
+    content.map(async (block) => {
+      if (!block || typeof block !== "object") return block;
+      const b = block as Record<string, unknown>;
 
-    if (
-      (b.type === "image_url" || b.type === "image") &&
-      b.image &&
-      typeof b.image === "object"
-    ) {
-      return { ...b, image: resolveRef(b.image as Record<string, unknown>, "image/png", userId) };
-    }
+      if (
+        (b.type === "image_url" || b.type === "image") &&
+        b.image &&
+        typeof b.image === "object"
+      ) {
+        return {
+          ...b,
+          image: await resolveRef(
+            b.image as Record<string, unknown>,
+            "image/png",
+            userId
+          )
+        };
+      }
 
-    if (b.type === "video" && b.video && typeof b.video === "object") {
-      return { ...b, video: resolveRef(b.video as Record<string, unknown>, "video/mp4", userId) };
-    }
+      if (b.type === "video" && b.video && typeof b.video === "object") {
+        return {
+          ...b,
+          video: await resolveRef(
+            b.video as Record<string, unknown>,
+            "video/mp4",
+            userId
+          )
+        };
+      }
 
-    if (b.type === "audio" && b.audio && typeof b.audio === "object") {
-      return { ...b, audio: resolveRef(b.audio as Record<string, unknown>, "audio/wav", userId) };
-    }
+      if (b.type === "audio" && b.audio && typeof b.audio === "object") {
+        return {
+          ...b,
+          audio: await resolveRef(
+            b.audio as Record<string, unknown>,
+            "audio/wav",
+            userId
+          )
+        };
+      }
 
-    return block;
-  });
+      return block;
+    })
+  );
 }

--- a/packages/websocket/src/trpc/routers/messages.ts
+++ b/packages/websocket/src/trpc/routers/messages.ts
@@ -19,7 +19,9 @@ import {
   type MessageResponse
 } from "@nodetool-ai/protocol/api-schemas/messages.js";
 
-function toMessageResponse(msg: MessageModel): MessageResponse {
+async function toMessageResponse(
+  msg: MessageModel
+): Promise<MessageResponse> {
   return {
     type: "message" as const,
     id: msg.id,
@@ -27,7 +29,7 @@ function toMessageResponse(msg: MessageModel): MessageResponse {
     thread_id: msg.thread_id,
     role: msg.role,
     name: msg.name ?? null,
-    content: resolveContentUrls(
+    content: await resolveContentUrls(
       msg.content as string | unknown[] | Record<string, unknown> | null,
       msg.user_id
     ),
@@ -65,7 +67,7 @@ export const messagesRouter = router({
         }
       }
       return {
-        messages: msgs.map((m) => toMessageResponse(m)),
+        messages: await Promise.all(msgs.map((m) => toMessageResponse(m))),
         next: cursor || null
       };
     })

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -2494,7 +2494,7 @@ export class UnifiedWebSocketRunner {
     if (Array.isArray(message.content)) {
       message = {
         ...message,
-        content: resolveContentUrls(
+        content: await resolveContentUrls(
           message.content as unknown[],
           (message.user_id as string | undefined) ?? this.userId ?? undefined
         )
@@ -4583,7 +4583,8 @@ export class UnifiedWebSocketRunner {
           workflow_id: workflowId ?? null,
           name: `image_${Date.now()}`,
           content_type: mimeType,
-          parent_id: null
+          // Home — see the chat media generation path.
+          parent_id: userId
         });
         const fileName = `${asset.id}.${ext}`;
         await storeAssetWithThumbnail(
@@ -6495,7 +6496,9 @@ export class UnifiedWebSocketRunner {
         workflow_id: workflowId ?? null,
         name: `${mode}_${Date.now()}`,
         content_type: contentType,
-        parent_id: null
+        // Home, the same folder an upload lands in. A null parent is
+        // unreachable from the folder the asset browser opens on.
+        parent_id: userId
       });
       const fileName = `${asset.id}.${ext}`;
       await storeAssetWithThumbnail(
@@ -7835,7 +7838,8 @@ export class UnifiedWebSocketRunner {
         workflow_id: null,
         name: `${req.mode}_${Date.now()}`,
         content_type: contentType,
-        parent_id: null
+        // Home — see the chat media generation path above.
+        parent_id: userId
       });
       const fileName = `${asset.id}.${ext}`;
       await storeAssetWithThumbnail(

--- a/packages/websocket/tests/resolve-media-urls-cloud-backend.test.ts
+++ b/packages/websocket/tests/resolve-media-urls-cloud-backend.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression: chat media content resolved to `/api/storage/<key>` regardless of
+ * the configured storage backend. On a deployment with auth enforced and asset
+ * bytes in Supabase/S3 that URL is unloadable twice over — a media element
+ * sends no `Authorization` header (401), and the local file backend behind the
+ * route does not hold the bytes. Generated images in chat therefore showed as
+ * broken tiles while the asset browser (which resolves through
+ * `createAssetUrlBuilder`) worked. Message content now uses the same builder.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const storageMocks = vi.hoisted(() => ({
+  kind: "file" as string,
+  sign: vi.fn(async (key: string) => `https://cdn.test/${key}?token=sig`)
+}));
+
+vi.mock("@nodetool-ai/config", () => ({
+  buildAssetUrl: (key: string) => `/api/storage/${key}`,
+  getAssetFilePath: (key: string) => `/var/assets/${key}`,
+  loadAssetStorageConfig: () => ({ kind: storageMocks.kind })
+}));
+
+vi.mock("@nodetool-ai/storage", async (orig) => {
+  const actual = await orig<typeof import("@nodetool-ai/storage")>();
+  return {
+    ...actual,
+    createAssetUrlBuilder: () => storageMocks.sign
+  };
+});
+
+import { resolveContentUrls } from "../src/resolve-media-urls.js";
+
+type ImageBlock = { image: { uri: string } };
+
+const imageContent = [
+  { type: "image_url", image: { asset_id: "abc", mimeType: "image/png" } }
+];
+
+describe("resolveContentUrls across storage backends", () => {
+  beforeEach(() => {
+    storageMocks.sign.mockClear();
+  });
+
+  it("signs the asset URL when the backend is supabase", async () => {
+    storageMocks.kind = "supabase";
+    const out = (await resolveContentUrls(imageContent, "user-1")) as ImageBlock[];
+    expect(storageMocks.sign).toHaveBeenCalledWith("user-1/abc.png");
+    expect(out[0].image.uri).toBe("https://cdn.test/user-1/abc.png?token=sig");
+  });
+
+  it("signs video and audio refs too", async () => {
+    storageMocks.kind = "s3";
+    const out = (await resolveContentUrls(
+      [
+        { type: "video", video: { asset_id: "v" } },
+        { type: "audio", audio: { asset_id: "a" } }
+      ],
+      "user-1"
+    )) as Array<{ video?: { uri: string }; audio?: { uri: string } }>;
+    expect(out[0].video?.uri).toBe("https://cdn.test/user-1/v.mp4?token=sig");
+    expect(out[1].audio?.uri).toBe("https://cdn.test/user-1/a.wav?token=sig");
+  });
+
+  it("falls back to the server route when signing fails", async () => {
+    storageMocks.kind = "s3";
+    storageMocks.sign.mockRejectedValueOnce(new Error("credentials expired"));
+    const out = (await resolveContentUrls(imageContent, "user-1")) as ImageBlock[];
+    expect(out[0].image.uri).toBe("/api/storage/user-1/abc.png");
+  });
+
+  it("keeps the server route for the local file backend", async () => {
+    storageMocks.kind = "file";
+    const out = (await resolveContentUrls(imageContent, "user-1")) as ImageBlock[];
+    expect(storageMocks.sign).not.toHaveBeenCalled();
+    expect(out[0].image.uri).toBe("/api/storage/user-1/abc.png");
+  });
+});

--- a/packages/websocket/tests/resolve-media-urls-coverage.test.ts
+++ b/packages/websocket/tests/resolve-media-urls-coverage.test.ts
@@ -7,7 +7,8 @@ const fileUri = (name: string) => pathToFileURL(`/var/assets/${name}`).href;
 
 vi.mock("@nodetool-ai/config", () => ({
   buildAssetUrl: (name: string) => `https://assets.test/${name}`,
-  getAssetFilePath: (name: string) => `/var/assets/${name}`
+  getAssetFilePath: (name: string) => `/var/assets/${name}`,
+  loadAssetStorageConfig: () => ({ kind: "file" })
 }));
 
 import {
@@ -16,102 +17,107 @@ import {
 } from "../src/resolve-media-urls.js";
 
 describe("resolveContentUrls", () => {
-  it("returns non-array content unchanged (string)", () => {
-    expect(resolveContentUrls("hello")).toBe("hello");
+  it("returns non-array content unchanged (string)", async () => {
+    expect(await resolveContentUrls("hello")).toBe("hello");
   });
 
-  it("returns null unchanged", () => {
-    expect(resolveContentUrls(null)).toBeNull();
+  it("returns null unchanged", async () => {
+    expect(await resolveContentUrls(null)).toBeNull();
   });
 
-  it("returns a plain object (non-array) unchanged", () => {
+  it("returns a plain object (non-array) unchanged", async () => {
     const obj = { type: "text" };
-    expect(resolveContentUrls(obj)).toBe(obj);
+    expect(await resolveContentUrls(obj)).toBe(obj);
   });
 
-  it("passes through primitive and null blocks in an array", () => {
+  it("passes through primitive and null blocks in an array", async () => {
     const content = ["str", 42, null, true];
-    expect(resolveContentUrls(content)).toEqual(["str", 42, null, true]);
+    expect(await resolveContentUrls(content)).toEqual([
+      "str",
+      42,
+      null,
+      true
+    ]);
   });
 
-  it("resolves an image asset_id into an https asset url with mime->ext", () => {
+  it("resolves an image asset_id into an https asset url with mime->ext", async () => {
     const content = [
       { type: "image", image: { asset_id: "abc", mimeType: "image/jpeg" } }
     ];
-    const out = resolveContentUrls(content) as any[];
+    const out = (await resolveContentUrls(content)) as any[];
     expect(out[0].image.uri).toBe("https://assets.test/abc.jpg");
   });
 
-  it("resolves image_url type the same as image", () => {
+  it("resolves image_url type the same as image", async () => {
     const content = [
       { type: "image_url", image: { asset_id: "xyz", mime_type: "image/png" } }
     ];
-    const out = resolveContentUrls(content) as any[];
+    const out = (await resolveContentUrls(content)) as any[];
     expect(out[0].image.uri).toBe("https://assets.test/xyz.png");
   });
 
-  it("falls back to image/png ext when no mime present", () => {
+  it("falls back to image/png ext when no mime present", async () => {
     const content = [{ type: "image", image: { asset_id: "noext" } }];
-    const out = resolveContentUrls(content) as any[];
+    const out = (await resolveContentUrls(content)) as any[];
     expect(out[0].image.uri).toBe("https://assets.test/noext.png");
   });
 
-  it("uses content_type field when present", () => {
+  it("uses content_type field when present", async () => {
     const content = [
       { type: "image", image: { asset_id: "c", content_type: "image/webp" } }
     ];
-    const out = resolveContentUrls(content) as any[];
+    const out = (await resolveContentUrls(content)) as any[];
     expect(out[0].image.uri).toBe("https://assets.test/c.webp");
   });
 
-  it("maps unknown mime to bin extension", () => {
+  it("maps unknown mime to bin extension", async () => {
     const content = [
       { type: "image", image: { asset_id: "u", mimeType: "application/x-weird" } }
     ];
-    const out = resolveContentUrls(content) as any[];
+    const out = (await resolveContentUrls(content)) as any[];
     expect(out[0].image.uri).toBe("https://assets.test/u.bin");
   });
 
-  it("resolves video with video/mp4 fallback", () => {
+  it("resolves video with video/mp4 fallback", async () => {
     const content = [{ type: "video", video: { asset_id: "v1" } }];
-    const out = resolveContentUrls(content) as any[];
+    const out = (await resolveContentUrls(content)) as any[];
     expect(out[0].video.uri).toBe("https://assets.test/v1.mp4");
   });
 
-  it("resolves audio with audio/wav fallback", () => {
+  it("resolves audio with audio/wav fallback", async () => {
     const content = [{ type: "audio", audio: { asset_id: "a1" } }];
-    const out = resolveContentUrls(content) as any[];
+    const out = (await resolveContentUrls(content)) as any[];
     expect(out[0].audio.uri).toBe("https://assets.test/a1.wav");
   });
 
-  it("leaves a ref without asset_id untouched (no uri added)", () => {
+  it("leaves a ref without asset_id untouched (no uri added)", async () => {
     const content = [{ type: "image", image: { uri: "existing://x" } }];
-    const out = resolveContentUrls(content) as any[];
+    const out = (await resolveContentUrls(content)) as any[];
     expect(out[0].image.uri).toBe("existing://x");
   });
 
-  it("does not resolve when image field is missing", () => {
+  it("does not resolve when image field is missing", async () => {
     const content = [{ type: "image" }];
-    const out = resolveContentUrls(content) as any[];
+    const out = (await resolveContentUrls(content)) as any[];
     expect(out[0]).toEqual({ type: "image" });
   });
 
-  it("passes through a block with an unrecognized type", () => {
+  it("passes through a block with an unrecognized type", async () => {
     const content = [{ type: "text", text: "hi" }];
-    const out = resolveContentUrls(content) as any[];
+    const out = (await resolveContentUrls(content)) as any[];
     expect(out[0]).toEqual({ type: "text", text: "hi" });
   });
 
-  it("ignores non-object image field", () => {
+  it("ignores non-object image field", async () => {
     const content = [{ type: "image", image: "not-an-object" }];
-    const out = resolveContentUrls(content) as any[];
+    const out = (await resolveContentUrls(content)) as any[];
     expect(out[0]).toEqual({ type: "image", image: "not-an-object" });
   });
 
-  it("does not mutate the input ref object", () => {
+  it("does not mutate the input ref object", async () => {
     const image = { asset_id: "m", mimeType: "image/gif" };
     const content = [{ type: "image", image }];
-    resolveContentUrls(content);
+    await resolveContentUrls(content);
     expect(image).not.toHaveProperty("uri");
   });
 });

--- a/packages/websocket/tests/resolve-media-urls-owner-prefix.test.ts
+++ b/packages/websocket/tests/resolve-media-urls-owner-prefix.test.ts
@@ -15,7 +15,8 @@ const fsMocks = vi.hoisted(() => ({ existing: new Set<string>() }));
 
 vi.mock("@nodetool-ai/config", () => ({
   buildAssetUrl: (key: string) => `/api/storage/${key}`,
-  getAssetFilePath: (key: string) => `/var/assets/${key}`
+  getAssetFilePath: (key: string) => `/var/assets/${key}`,
+  loadAssetStorageConfig: () => ({ kind: "file" })
 }));
 
 vi.mock("node:fs", async (orig) => {
@@ -34,30 +35,30 @@ import {
 type Block = { image: { uri: string } };
 
 describe("resolveContentUrls with a known owner", () => {
-  it("builds the owner-prefixed key the bytes were written under", () => {
+  it("builds the owner-prefixed key the bytes were written under", async () => {
     const content = [
       { type: "image", image: { asset_id: "abc", mimeType: "image/png" } }
     ];
-    const out = resolveContentUrls(content, "user-1") as Block[];
+    const out = (await resolveContentUrls(content, "user-1")) as Block[];
     expect(out[0].image.uri).toBe("/api/storage/user-1/abc.png");
   });
 
-  it("keeps the flat legacy key when no owner is known", () => {
+  it("keeps the flat legacy key when no owner is known", async () => {
     const content = [
       { type: "image", image: { asset_id: "abc", mimeType: "image/png" } }
     ];
-    const out = resolveContentUrls(content) as Block[];
+    const out = (await resolveContentUrls(content)) as Block[];
     expect(out[0].image.uri).toBe("/api/storage/abc.png");
   });
 
-  it("prefixes video and audio refs too", () => {
-    const out = resolveContentUrls(
+  it("prefixes video and audio refs too", async () => {
+    const out = (await resolveContentUrls(
       [
         { type: "video", video: { asset_id: "v" } },
         { type: "audio", audio: { asset_id: "a" } }
       ],
       "user-1"
-    ) as Array<{ video?: { uri: string }; audio?: { uri: string } }>;
+    )) as Array<{ video?: { uri: string }; audio?: { uri: string } }>;
     expect(out[0].video?.uri).toBe("/api/storage/user-1/v.mp4");
     expect(out[1].audio?.uri).toBe("/api/storage/user-1/a.wav");
   });

--- a/web/src/components/chat/message/MediaOutputGroup.tsx
+++ b/web/src/components/chat/message/MediaOutputGroup.tsx
@@ -42,6 +42,7 @@ import {
   type MediaContentBlock
 } from "../../../hooks/handlers/useGenerationToCanvas";
 import { serializeDragData } from "../../../lib/dragdrop";
+import { resolveUri } from "../../../utils/imageUtils";
 
 /** Edge length of a generated-media thumbnail tile (px). */
 const THUMBNAIL_SIZE = 120;
@@ -417,7 +418,10 @@ const MediaOutputGroup: React.FC<MediaOutputGroupProps> = ({
             );
           }
           if (isVideoContent(c)) {
-            const src = c.video?.uri || "";
+            // Through `resolveUri` like the image tile above: a relative
+            // `/api/storage/…` needs the BASE_URL prefix when the API lives on
+            // another origin, and a signed cloud URL passes through unchanged.
+            const src = c.video?.uri ? resolveUri(c.video.uri) : "";
             const key = c.video?.asset_id || c.video?.uri || `media-${i}`;
             return (
               <div
@@ -447,7 +451,7 @@ const MediaOutputGroup: React.FC<MediaOutputGroupProps> = ({
             );
           }
           if (isAudioContent(c)) {
-            const src = c.audio?.uri || "";
+            const src = c.audio?.uri ? resolveUri(c.audio.uri) : "";
             const key = c.audio?.asset_id || c.audio?.uri || `media-${i}`;
             return (
               <div

--- a/web/src/components/chat/message/MessageContentRenderer.tsx
+++ b/web/src/components/chat/message/MessageContentRenderer.tsx
@@ -18,6 +18,7 @@ import {
   type MediaContentBlock
 } from "../../../hooks/handlers/useGenerationToCanvas";
 import { serializeDragData } from "../../../lib/dragdrop";
+import { resolveUri } from "../../../utils/imageUtils";
 import {
   parseHarmonyContent,
   hasHarmonyTokens,
@@ -73,11 +74,14 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
   // Resolve the video source once, at the top level, so the blob URL below can
   // be memoized on the actual source (Uint8Array/string) identity. A byte
   // payload uses the inline `data`; otherwise the `uri` is used directly.
+  // A stored ref carries a `/api/storage/…` (or signed) URL: `resolveUri`
+  // prefixes BASE_URL for the relative form and passes an absolute one
+  // through, the same way the image branch resolves via `createImageUrl`.
   const videoSource: string | Uint8Array | undefined =
     content.type === "video"
-      ? content.video?.uri === ""
-        ? (content.video?.data as Uint8Array)
-        : content.video?.uri
+      ? content.video?.uri
+        ? resolveUri(content.video.uri)
+        : (content.video?.data as Uint8Array)
       : undefined;
 
   // Mint the blob URL only when the source actually changes. Doing this in the
@@ -198,9 +202,9 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
         <div css={wrapperStyles} {...dragProps}>
           <AudioPlayer
             source={
-              content.audio?.uri === ""
-                ? (content.audio?.data as Uint8Array)
-                : content.audio?.uri
+              content.audio?.uri
+                ? resolveUri(content.audio.uri)
+                : (content.audio?.data as Uint8Array)
             }
           />
           {addButton}

--- a/web/src/components/chat/message/__tests__/MediaOutputGroup.test.tsx
+++ b/web/src/components/chat/message/__tests__/MediaOutputGroup.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../../__mocks__/themeMock";
+import MediaOutputGroup from "../MediaOutputGroup";
+import type { Message, MessageContent } from "../../../../stores/ApiTypes";
+
+jest.mock("../../../../stores/BASE_URL", () => ({
+  BASE_URL: "https://api.test",
+  prefixBaseUrl: (url: string) => `https://api.test${url}`
+}));
+
+jest.mock("../../../../hooks/handlers/useGenerationToCanvas", () => ({
+  useAddMediaToCanvas: () => ({
+    isCanvasAvailable: false,
+    addBlocksToCanvas: jest.fn()
+  })
+}));
+
+const message = {
+  id: "m1",
+  role: "assistant",
+  type: "message",
+  content: [],
+  media_generation: { mode: "image", model: "flux", provider: "fal_ai" }
+} as unknown as Message;
+
+const renderGroup = (mediaContents: MessageContent[]) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <MediaOutputGroup message={message} mediaContents={mediaContents} />
+    </ThemeProvider>
+  );
+
+describe("MediaOutputGroup", () => {
+  it("prefixes a relative storage uri with BASE_URL for video and audio", () => {
+    renderGroup([
+      { type: "video", video: { type: "video", uri: "/api/storage/u1/v.mp4" } },
+      { type: "audio", audio: { type: "audio", uri: "/api/storage/u1/a.wav" } }
+    ] as unknown as MessageContent[]);
+
+    expect(screen.getByLabelText("Generated video")).toHaveAttribute(
+      "src",
+      "https://api.test/api/storage/u1/v.mp4"
+    );
+    expect(screen.getByLabelText("Generated audio")).toHaveAttribute(
+      "src",
+      "https://api.test/api/storage/u1/a.wav"
+    );
+  });
+
+  it("passes a signed absolute uri through unchanged", () => {
+    renderGroup([
+      {
+        type: "video",
+        video: { type: "video", uri: "https://cdn.test/u1/v.mp4?token=sig" }
+      }
+    ] as unknown as MessageContent[]);
+
+    expect(screen.getByLabelText("Generated video")).toHaveAttribute(
+      "src",
+      "https://cdn.test/u1/v.mp4?token=sig"
+    );
+  });
+});


### PR DESCRIPTION
Media generated from the media composer did not load in the chat response on the hosted server, and the generated assets could not be found in the asset browser. Two independent causes.

## 1. The URL was not loadable

`resolveContentUrls` resolved every asset ref to `/api/storage/<userId>/<id>.png`, whatever storage backend is configured. On a deployment with auth enforced and asset bytes in Supabase (`fly.toml`: `NODETOOL_STORAGE_BACKEND=supabase`, `AUTH_PROVIDER=supabase`) that URL fails twice over:

- `/api/storage/*` is not in `isPublicAuthExemptRoute`, and an `<img>` / `<video>` element sends no `Authorization` header → 401.
- The route reads the local file backend, which does not hold the bytes.

`assets.get_url` already resolves through `createAssetUrlBuilder`, which signs a URL to the backend's own origin — which is why asset-browser thumbnails worked while chat media did not. Message content now uses the same builder. The `file` backend keeps the server route (and `buildAssetUrl`'s per-segment encoding), so local dev and the desktop app are unchanged; a signing failure falls back to the route. Signing is async, so `resolveContentUrls` and `toMessageResponse` are now async.

## 2. The asset was filed where the browser does not look

Generated assets were created with `parent_id: null`, while the Home listing matched `parent_id = <userId>` exactly. `Asset.getFolderInfo` already reports a parentless asset as living in "Home", so the reader contradicted itself and hid every server-written asset (chat media, the generate-media RPC, workflow node outputs).

`Asset.paginate` now treats Home as `parent_id = userId OR parent_id IS NULL`, which also recovers assets already generated — no migration needed — and the three media writers file new assets in Home explicitly. Explicit `parentId: null` (orphans) and nested folders are unaffected.

## Also fixed

`<video>` and `<audio>` in `MediaOutputGroup` and `MessageContentRenderer` passed the raw relative uri straight to the element, unlike the image branch which goes through `createImageUrl`. Broken whenever the API lives on another origin (`VITE_API_URL`, Electron). Both now go through `resolveUri`, which passes a signed absolute URL through unchanged.

## Tests

Each fix ships a test confirmed to fail without the change:

| Test | Failures when reverted |
|---|---|
| `packages/websocket/tests/resolve-media-urls-cloud-backend.test.ts` | 2 |
| `packages/models/tests/asset-home-listing.test.ts` | 1 |
| `web/src/components/chat/message/__tests__/MediaOutputGroup.test.tsx` | 1 |

The existing `resolve-media-urls` suites were updated for the async signature.

## Verification

- `packages/websocket`: 199 files, 2210 tests pass
- `packages/models`: 53 files, 819 tests pass
- `npm run test:packages` and web `npm test`: full runs in progress at time of writing
- `tsc --build` clean for both packages; web `tsc --noEmit` clean
- ESLint clean on changed files (design config included); the `no-explicit-any` errors in `resolve-media-urls-coverage.test.ts` and three `no-useless-assignment` warnings in `unified-websocket-runner.ts` predate this change

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQTguugG5cEGu1VNY3A5YM)_