### PR TITLE
fix(reliability): drop ambient relay control frames from run records

### DIFF
--- a/reliability/harness/src/drivers/relay-fields.ts
+++ b/reliability/harness/src/drivers/relay-fields.ts
@@ -56,9 +56,26 @@ export const RELAY_ONLY_WORKFLOW_ID_TYPES: ReadonlySet<string> = new Set([
  * production Fastify plugin when an SDK live-runner registry is wired
  * (`packages/websocket/src/plugins/websocket.ts`). The kernel oracle has no
  * connection to announce, so there is nothing to compare it against.
+ *
+ * The rest are the relay's own timers and observers, which fire on wall-clock
+ * cadence rather than on anything the run does
+ * (`unified-websocket-runner.ts`): `system_stats` ~1s after connect and every
+ * 5s after (outside `NODE_ENV=production`), `ping` every 25s, `pong` in reply
+ * to a client ping, `resource_change` whenever a model or resource event
+ * lands. Whether one of them interleaves into a run depends on how long the
+ * run happens to take, so recording them makes the stream non-deterministic —
+ * a `system_stats` landing mid-run is what failed `linear-text-pipeline` on
+ * the packaged surface in Ring 1 (run 31619279663), which in turn blocked
+ * the Fly deploy of 2868cffe. They are all outbound *control* frames in the
+ * protocol's own taxonomy (`outboundControlMessageSchemas`), not
+ * `ProcessingMessage`s, so no run assertion loses coverage by dropping them.
  */
 export const CONNECTION_CONTROL_MESSAGE_TYPES: ReadonlySet<string> = new Set([
-  "sdk_execution_target"
+  "sdk_execution_target",
+  "system_stats",
+  "resource_change",
+  "ping",
+  "pong"
 ]);
 
 /** True when `message` is transport control rather than a run frame — callers

--- a/reliability/harness/src/drivers/ws-server.ts
+++ b/reliability/harness/src/drivers/ws-server.ts
@@ -35,7 +35,7 @@ import {
 import { AnchorWaiter } from "./anchors.js";
 import { registerFixtureNodes } from "./fixture-nodes.js";
 import { journeyPythonBridgeFactory } from "./python-bridge.js";
-import { stripRelayOnlyFields } from "./relay-fields.js";
+import { isConnectionControlMessage, stripRelayOnlyFields } from "./relay-fields.js";
 import type { RunDriver } from "./types.js";
 import { maybeFrontWithProxy, type WsProxyFrontEnd } from "../faults/ws-proxy.js";
 
@@ -273,6 +273,9 @@ export class WsServerDriver implements RunDriver {
           ? unpackWebSocketMessage(data)
           : JSON.parse(data.toString("utf8"))
       ) as Record<string, unknown>;
+      // This surface runs the same relay as `packaged.ts`, so it receives the
+      // same connection-scoped control frames on the same wall-clock timers.
+      if (isConnectionControlMessage(raw)) return;
       const message = stripRelayOnlyFields(raw);
       waiter.notify(message);
       if (typeof message["job_id"] === "string") {

--- a/reliability/harness/tests/ambient-control-frames.test.ts
+++ b/reliability/harness/tests/ambient-control-frames.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Reproduction for Ring 1 run 31619279663, which failed `linear-text-pipeline`
+ * on the packaged surface and blocked the Fly deploy of 2868cffe.
+ *
+ * `UnifiedWebSocketRunner` starts two wall-clock timers on every connection —
+ * a stats broadcast (first sample ~1s after connect, then every 5s, outside
+ * `NODE_ENV=production`) and a 25s heartbeat ping. Neither has anything to do
+ * with the run, but a relay driver that records them puts them in the stream
+ * at whatever position the run's own duration happens to put them, which
+ * shifts every later entry in the channel and mismatches the golden. Whether
+ * a run is long enough for that is a coin flip, which is why it took until
+ * 2868cffe to fail.
+ *
+ * This asserts the hazard is real (the server does emit an unsolicited
+ * `system_stats` on an idle socket) and that the relay drivers' shared policy
+ * classifies it as connection control, which is what makes them drop it
+ * before recording.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { createTestUiServer, unpackWebSocketMessage } from "@nodetool-ai/websocket";
+import { isConnectionControlMessage } from "../src/drivers/relay-fields.js";
+
+/** The first stats sample lands ~1s after connect; allow slack for a loaded CI box. */
+const STATS_WAIT_MS = 8000;
+
+let cleanup: (() => Promise<void>) | null = null;
+
+afterEach(async () => {
+  const fn = cleanup;
+  cleanup = null;
+  if (fn) await fn();
+});
+
+describe("ambient control frames on an idle connection", () => {
+  it(
+    "arrive unsolicited, and the relay drivers' policy drops them",
+    { timeout: 30000 },
+    async () => {
+      const srv = createTestUiServer({ host: "127.0.0.1", port: 0 });
+      await srv.listen();
+      const address = srv.server.address();
+      const port =
+        typeof address === "object" && address !== null ? address.port : 7777;
+
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+      cleanup = async () => {
+        ws.close();
+        await srv.close();
+      };
+
+      const statsFrame = await new Promise<Record<string, unknown>>(
+        (resolve, reject) => {
+          const timer = setTimeout(
+            () => reject(new Error("no system_stats frame within the wait window")),
+            STATS_WAIT_MS
+          );
+          ws.on("error", reject);
+          ws.on("message", (data: Buffer, isBinary: boolean) => {
+            const message = (
+              isBinary
+                ? unpackWebSocketMessage(data)
+                : JSON.parse(data.toString("utf8"))
+            ) as Record<string, unknown>;
+            // Nothing was ever submitted on this socket, so any frame here is
+            // ambient by construction.
+            if (message["type"] !== "system_stats") return;
+            clearTimeout(timer);
+            resolve(message);
+          });
+        }
+      );
+
+      expect(statsFrame["stats"]).toBeTypeOf("object");
+      expect(isConnectionControlMessage(statsFrame)).toBe(true);
+    }
+  );
+});

--- a/reliability/harness/tests/relay-fields.test.ts
+++ b/reliability/harness/tests/relay-fields.test.ts
@@ -63,10 +63,43 @@ describe("isConnectionControlMessage", () => {
     );
   });
 
+  it("recognizes the relay's wall-clock control frames", () => {
+    for (const type of ["system_stats", "resource_change", "ping", "pong"]) {
+      expect(isConnectionControlMessage({ type })).toBe(true);
+    }
+  });
+
   it("leaves run frames alone", () => {
     for (const type of ["job_update", "node_update", "edge_update", "output_update"]) {
       expect(isConnectionControlMessage({ type })).toBe(false);
     }
+  });
+});
+
+/**
+ * Regression guard for Ring 1 run 31619279663, which failed
+ * `linear-text-pipeline` on the packaged surface and blocked the Fly deploy of
+ * 2868cffe. `UnifiedWebSocketRunner.startStatsBroadcast` fires its first
+ * sample ~1s after connect; that run took just long enough for it to land
+ * between two `edge_update`s, shifting every later entry in the control
+ * channel and mismatching the stream-shape golden by three. This is the exact
+ * frame from that failure's log.
+ */
+describe("the frame that failed Ring 1 on 2868cffe", () => {
+  it("is connection control, so no relay driver records it", () => {
+    expect(
+      isConnectionControlMessage({
+        type: "system_stats",
+        stats: {
+          cpu_percent: 30.76923076923077,
+          memory_percent: 13.05219544311343,
+          memory_total: 16766423040,
+          memory_total_gb: 15.614948272705078,
+          memory_used: 2188386304,
+          memory_used_gb: 2.0380935668945312
+        }
+      })
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What broke

[fly-deploy run 31620308626](https://github.com/nodetool-ai/nodetool/actions/runs/31620308626/job/94193202861) never deployed. The job itself worked as designed — it refused to release `2868cffe` because its gate saw `user-journeys.yml=failure`:

```
attempt 1/60: docker.yml=success user-journeys.yml=failure
::error::user-journeys.yml (reliability-ring1) concluded 'failure' for 2868cffe…; not deploying.
```

The real failure is one commit upstream, in [Ring 1 run 31619279663](https://github.com/nodetool-ai/nodetool/actions/runs/31619279663) — `linear-text-pipeline` on the packaged surface, three stream-shape mismatches:

```
[streamShape] control[2]: expected {"type":"edge_update",…,"status":"active"},
                          got      {"type":"system_stats","stats":{…}}
[streamShape] control[3]: expected …"status":"completed", got …"status":"active"
[streamShape] control[4]: unexpected …"status":"completed"
```

One frame arrived that the golden had no slot for, and everything after it shifted by one.

## Why

`UnifiedWebSocketRunner` starts two wall-clock timers on every connection: a stats broadcast (first sample ~1s after connect, then every 5s, outside `NODE_ENV=production`) and a 25s heartbeat ping. Neither has anything to do with the run. Both relay drivers recorded whatever landed on the socket, so whether a golden matched depended on how long the run happened to take — a coin flip that finally came up tails on `2868cffe`.

`packaged.ts` already had the filter hook (`isConnectionControlMessage`) but the set held only `sdk_execution_target`. `ws-server.ts` runs the same relay on the same timers and had no filter at all.

## Change

- Add `system_stats`, `resource_change`, `ping` and `pong` to the shared `CONNECTION_CONTROL_MESSAGE_TYPES` both relay drivers drop before recording.
- Apply that filter in `ws-server.ts`, so the two relay surfaces follow one policy rather than diverging the way `packaged.ts` did before the Ring 2 fix.

All four are outbound *control* frames in the protocol's own taxonomy (`outboundControlMessageSchemas`), not `ProcessingMessage`s, so no run assertion loses coverage by dropping them.

## Verification

- New `tests/ambient-control-frames.test.ts` boots the same server the driver uses, leaves the socket idle with nothing submitted, and waits for the unsolicited `system_stats`. The emission the failure depended on is asserted, not inferred from the log.
- `tests/relay-fields.test.ts` pins the exact frame from the failing run as connection control.
- Harness suite: 27 files, 156 passed / 5 skipped.
- `reliability run linear-text-pipeline --surface ws-server --diff` → OK.
- `reliability run linear-text-pipeline --surface packaged --diff` (against a freshly staged backend bundle) → OK. This is the exact invocation that failed in CI.
- `nodetool harness gate --base origin/main` → 3/3 selfchecks, all 5 Ring 0 journeys.
- `tsc --noEmit` clean. `nodetool affected` reports no workspace touched; `reliability/harness` is outside the root workspace globs and was checked with its own scripts.

Note that `2868cffe` is already superseded on `main` by `f87c0be3`, so this does not unblock that specific deploy — it stops the next one from dying the same way.

---
_Generated by [Claude Code](https://claude.ai/code/session_016bR19ZkWaVMtgEFTnmxG6D)_