### PR TITLE
Model Discovery and Media 

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -195,9 +195,10 @@ tool**, not a flat catalog.
 `execute_code` and `view_image`, which is direct because pixels cannot ride a
 sandbox action's JSON observation envelope. Everything else on that belt is
 reachable inside an action as `tools.<name>()`, through the `nodetool.*` object
-model, or found with `await searchTools("query")`. MCP has no system prompt, so
-the action contract and tool catalog ride in the `execute_code` description, and
-the machine-readable form is the `nodetool://capabilities` resource.
+model, or found with `await nodetool.searchTools("query")`. MCP has no system
+prompt, so the guest contract leads the `execute_code` description and is also
+the server `instructions` string. The machine-readable form is
+`nodetool://capabilities` (tools) plus `nodetool://sandbox` (guest surface).
 
 It used to register all ~95 bridged tools flat, which made a scoped MCP session
 NodeTool's largest surface anywhere — 120 tools and ~27k tokens of schema before

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -481,11 +481,12 @@ nodetool mcp status
 nodetool mcp uninstall
 ```
 
-The NodeTool server must be running (`nodetool serve`) for MCP to work.
+HTTP MCP (`/mcp`) needs the API server (`nodetool serve`). `nodetool mcp serve`
+is stdio and does not.
 
 ### What the MCP server exposes
 
-Exactly two tools land on `/mcp`:
+Exactly two tools land on `/mcp` and on `nodetool mcp serve`:
 
 - **`execute_code`** — the CodeAct action tool, built by the same
   `createChatCodeActSession` the in-app chat agent runs on, so the two surfaces cannot drift.
@@ -494,14 +495,19 @@ Exactly two tools land on `/mcp`:
   graph editing tools), media generation (`generate_image`, `generate_video`, `generate_speech`,
   `transcribe_audio`, …), files (`read_file`, `write_file`, `edit_file`, `glob`, `grep`), web
   (`web_search`, `browser`, `http_request`), collections, documents, code execution, image
-  critique, and thread memory — as `tools.<name>()`, through the `nodetool.*` object model, or
-  found with `await searchTools("query")`. Google Workspace tools appear only on deployments with
-  a Google login.
+  critique, and thread memory — as `nodetool.<namespace>.<method>()`, as `tools.<name>()`, or
+  found with `await nodetool.searchTools("query")`. Google Workspace tools appear only on
+  deployments with a Google login.
 - **`view_image`** — direct, because image content cannot ride a sandbox action's JSON
   observation envelope.
 
-MCP has no system prompt, so the action contract and tool catalog ride in the `execute_code`
-description; the machine-readable form is the `nodetool://capabilities` resource.
+MCP has no system prompt. The guest contract (QuickJS, not Node; `nodetool.*`;
+no `finish()`) is the server `instructions` string and the first lines of the
+`execute_code` description. The rest of the description is the CodeAct catalog.
+Two resources carry the machine-readable form: `nodetool://capabilities` (tools
+and modules) and `nodetool://sandbox` (blocked globals, unavailable bridges,
+worked examples). Prompts `sandbox-action` and `sandbox-asset` are complete
+`execute_code` bodies.
 
 The session needs a user to run as — its tools touch that user's secrets, assets, and files — so
 `createMcpServer` refuses one that is not bound to a user (`nodetool mcp serve`, the local `/mcp`

--- a/electron/src/server.ts
+++ b/electron/src/server.ts
@@ -235,6 +235,22 @@ async function startServer(): Promise<void> {
   }
 
   const basePort = 7777;
+  // Dev mode loads the renderer from the Vite dev server, whose /api and /ws
+  // proxy target is pinned to 7777 (web/vite.config.ts, PROXY_API_TARGET). A
+  // backend on any other port is unreachable from the UI: every API call comes
+  // back 502 and the websockets never connect. Fail loudly instead.
+  if (isDevMode() && !(await isPortAvailable(basePort))) {
+    const message =
+      `Port ${basePort} is already in use. In dev mode the backend must own ` +
+      `it, because the Vite dev server proxies /api and /ws there. Stop the ` +
+      `other process (lsof -nP -iTCP:${basePort} -sTCP:LISTEN) and start the ` +
+      `app again, or point Vite elsewhere with PROXY_API_TARGET.`;
+    logMessage(message, "error");
+    if (!process.env.CI) {
+      dialog.showErrorBox("Port In Use", message);
+    }
+    throw new Error(message);
+  }
   logMessage(`Finding available port starting from ${basePort}...`);
   const selectedPort = await findAvailablePort(basePort);
   serverState.serverPort = selectedPort;

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -788,6 +788,17 @@ follows (CodeAct, ICML 2024): docs/codeact-design.md.
   fan-out call them from code — but the prompt documents them once, under
   "Direct tools", instead of as a `tools.*` signature. `splitCoreTools` /
   `buildCoreProviderTools` in `src/codeact/tool-api.ts`.
+- Discovery goes top level with it. `DISCOVERY_TOOL_NAMES` (`find_model`,
+  `list_models`, `list_provider_models`, `search_nodes`, `get_node_info`,
+  `list_nodes`) answers which providers, models and node types this install
+  has — one question with one answer, and a wrong answer is a hallucinated
+  model id that fails at generation time, after the run was paid for. The two
+  sets stay apart because only the core set has SDK built-ins behind it:
+  `DIRECT_TOOL_NAMES` is their union and is what the three offer sites read
+  (`splitCoreTools`, the CLI turn, the websocket runner), while
+  `SDK_NATIVE_TOOL_REPLACEMENTS` still reads `CORE_TOOL_NAMES` alone.
+  `nodetool.models.pick` and `nodetool.nodes.search` are unchanged — the belt
+  keeps every tool, so an action still composes them.
 - On `claude_agent_sdk` the built-in wins outright. The provider drops every
   tool `SDK_NATIVE_TOOL_REPLACEMENTS` maps (`read_file`→`Read`,
   `write_file`→`Write`, `edit_file`→`Edit`, `glob`→`Glob`, `grep`→`Grep`,

--- a/packages/agents/src/capabilities/apps.ts
+++ b/packages/agents/src/capabilities/apps.ts
@@ -68,7 +68,12 @@ const debugApp: CapabilityExport = {
     const userId = userIdOf(run.context);
     try {
       return await runApplicationDebug(userId, params as AppDebugRequest, registry, {
-        runScript: createJsScriptAppRunner(userId)
+        // The run's own secrets: the server's app-debug service and the CLI
+        // harness both pass a resolver, and without one a script operation
+        // that reads `nodetool.secrets.get(...)` saw undefined here only.
+        runScript: createJsScriptAppRunner(userId, {
+          secretResolver: (key: string) => run.context.getSecret(key)
+        })
       });
     } catch (error) {
       return {

--- a/packages/agents/src/capabilities/assets.specs.ts
+++ b/packages/agents/src/capabilities/assets.specs.ts
@@ -203,13 +203,15 @@ export const saveAssetSpec: CapabilitySpec = {
 
 export const readAssetSpec: CapabilitySpec = {
   name: "read_asset",
-  description: "Read an asset file",
+  description:
+    "Read an asset's content. Takes the asset:// URI a generation returned (its asset_uri, with or without an extension), a bare asset id, a /api/storage/ key, or a stored file name. Returns `content` for text and `content_base64` for binary; for bytes you intend to compute on, read_media_bytes is the direct route.",
   inputSchema: {
     type: "object",
     properties: {
       name: {
         type: "string",
-        description: "Name of the asset file to read"
+        description:
+          "What to read: an asset:// URI, an asset id, a /api/storage/ key, or a stored file name."
       }
     },
     required: ["name"] as string[]

--- a/packages/agents/src/capabilities/assets.ts
+++ b/packages/agents/src/capabilities/assets.ts
@@ -31,6 +31,7 @@ import {
   type JsonSchema
 } from "@nodetool-ai/runtime";
 import type { Asset as AssetRow } from "@nodetool-ai/models";
+import { loadMediaRefBytes } from "@nodetool-ai/runtime";
 import { userIdOf } from "../tools/mcp-tool-support.js";
 import type {
   CapabilityExport,
@@ -334,31 +335,58 @@ const readAsset: CapabilityExport = {
         };
       }
 
-      if (!context.storage) {
-        return { success: false, error: "No storage adapter configured" };
-      }
-
-      const key = `assets/${name}`;
-
-      // Try the URI schemes the storage adapter might have used to store it.
-      const schemes = [`memory://${key}`, `file://${key}`, `s3://${key}`];
-
       let data: Uint8Array | null = null;
       let matchedUri: string | null = null;
 
-      for (const uri of schemes) {
-        const result = await context.storage.retrieve(uri);
-        if (result) {
-          data = result;
-          matchedUri = uri;
-          break;
+      // The legacy shape: a bare file name stored under `assets/<name>`. Tried
+      // first so a name that means a storage key keeps meaning one.
+      const looksLikeUri = name.includes("://") || name.startsWith("/api/");
+      if (!looksLikeUri && context.storage) {
+        const key = `assets/${name}`;
+        for (const uri of [
+          `memory://${key}`,
+          `file://${key}`,
+          `s3://${key}`
+        ]) {
+          const result = await context.storage.retrieve(uri);
+          if (result) {
+            data = result;
+            matchedUri = uri;
+            break;
+          }
+        }
+      }
+
+      // Everything an agent actually holds: the `asset://<id>` URI a
+      // generation returns (with or without an extension), the bare id off
+      // `asset_id`, a `/api/storage/` key, a `package://` URI, a data URI.
+      // `loadMediaRefBytes` is the one resolver that knows all of them, so
+      // this tool and `read_media_bytes` cannot disagree about what a ref means.
+      if (!data) {
+        // A bare name is tried as an asset id in canonical form:
+        // `loadMediaRefBytes` reads `asset_id` only when there is no uri, so
+        // handing it both a raw name and the id would resolve neither.
+        const ref = looksLikeUri
+          ? { uri: name }
+          : { uri: `asset://${name}`, asset_id: name };
+        try {
+          data = await loadMediaRefBytes(ref, context);
+          if (data) matchedUri = name;
+        } catch {
+          // A context without an asset resolver or storage cannot answer this
+          // form. That is "not found" for the caller, not a different failure
+          // to report — the message below names the forms that do work.
         }
       }
 
       if (!data) {
         return {
           success: false,
-          error: `Asset not found: ${name}`
+          error:
+            `Asset not found: ${name}. Pass the asset:// URI a generation ` +
+            `returned (its asset_uri), the asset_id itself, or a ` +
+            `/api/storage/ key — and use list_assets or asset_search to find ` +
+            `one. For a workspace file use read_file instead.`
         };
       }
 

--- a/packages/agents/src/capabilities/assets.ts
+++ b/packages/agents/src/capabilities/assets.ts
@@ -262,7 +262,10 @@ const saveAsset: CapabilityExport = {
       // Prefer the model interface (DB + storage). This is what the chat
       // UI surfaces in the asset browser and what other tools can reference
       // by `asset://<id>.<ext>` URIs.
-      if (typeof context.createAsset === "function") {
+      // The interface, not the method — see `persistOutput`. Without this
+      // the storage-adapter fallback below was dead code and a run with no
+      // asset persistence answered with an error instead of using it.
+      if (context.hasModelInterface?.("createAsset")) {
         const asset = (await context.createAsset({
           name,
           contentType: mime,

--- a/packages/agents/src/capabilities/media.specs.ts
+++ b/packages/agents/src/capabilities/media.specs.ts
@@ -319,6 +319,27 @@ export const transcribeAudioSpec: CapabilitySpec = {
     `Transcribing audio with ${String(params["provider"])}:${String(params["model"])}`
 };
 
+export const READ_MEDIA_BYTES_SCHEMA = {
+  type: "object",
+  properties: {
+    uri: {
+      type: "string",
+      description:
+        "The media to read: an asset:// URI (what generate_image returns as asset_uri), a bare asset id, a /api/storage/ key, a package:// URI, a data: URI, or an http(s) URL."
+    }
+  },
+  required: ["uri"] as string[]
+} as const;
+
+export const readMediaBytesSpec: CapabilitySpec = {
+  name: "read_media_bytes",
+  description:
+    "Read the bytes behind a media reference — the way to get at an image, audio or video you just generated. Returns `content_base64` (revive it with fromBase64), `mime_type` and `size`, so the bytes feed image.* or a sandbox pack directly. Takes an asset:// URI, a bare asset id, a /api/storage/ key, a package:// URI, a data: URI, or an http(s) URL. For a file in the workspace use read_file instead.",
+  inputSchema: READ_MEDIA_BYTES_SCHEMA,
+  category: "read",
+  userMessage: (params) => `Reading ${String(params["uri"])}`
+};
+
 export const embedTextSpec: CapabilitySpec = {
   name: "embed_text",
   description:
@@ -384,6 +405,7 @@ export const mediaSpecs: readonly CapabilitySpec[] = [
   generateSpeechSpec,
   transcribeAudioSpec,
   embedTextSpec,
+  readMediaBytesSpec,
   critiqueImageSpec,
   compareImagesSpec,
   scoreImageAdherenceSpec

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -24,6 +24,14 @@ import { randomInt } from "node:crypto";
 import path from "node:path";
 import type { Message, MessageContent } from "@nodetool-ai/protocol";
 import type { JsonSchema, ProcessingContext } from "@nodetool-ai/runtime";
+import { loadMediaRefBytes } from "@nodetool-ai/runtime";
+import { encodeBase64 as encodeMediaBase64 } from "../sandbox-bytes.js";
+import {
+  DEFAULT_MIME,
+  MAX_MEDIA_REF_BYTES,
+  filesystemPathForUri,
+  mimeForRef
+} from "../sandbox-media-ref.js";
 import { inferImageMime, persistOutput } from "../tools/asset-persist.js";
 import { extractJSON } from "../utils/json-parser.js";
 import type { CapabilityExport, CapabilityModule } from "./types.js";
@@ -35,6 +43,7 @@ import {
   generateSpeechSpec,
   transcribeAudioSpec,
   embedTextSpec,
+  readMediaBytesSpec,
   critiqueImageSpec,
   compareImagesSpec,
   scoreImageAdherenceSpec,
@@ -46,6 +55,7 @@ import {
   GENERATE_SPEECH_SCHEMA,
   TRANSCRIBE_AUDIO_SCHEMA,
   EMBED_TEXT_SCHEMA,
+  READ_MEDIA_BYTES_SCHEMA,
   CRITIQUE_IMAGE_SCHEMA,
   COMPARE_IMAGES_SCHEMA,
   SCORE_ADHERENCE_SCHEMA
@@ -60,6 +70,7 @@ export {
   GENERATE_SPEECH_SCHEMA,
   TRANSCRIBE_AUDIO_SCHEMA,
   EMBED_TEXT_SCHEMA,
+  READ_MEDIA_BYTES_SCHEMA,
   CRITIQUE_IMAGE_SCHEMA,
   COMPARE_IMAGES_SCHEMA,
   SCORE_ADHERENCE_SCHEMA
@@ -1010,6 +1021,62 @@ const scoreImageAdherence: CapabilityExport = {
   }
 };
 
+/**
+ * The gated read behind a media reference.
+ *
+ * The sandbox's own `media.bytes` needs a `ProcessingContext`, which a chat
+ * action deliberately runs without (#4780) — so a chat user could generate an
+ * image and never read it back. This is the same resolution past the
+ * permission gate, with the context the run already carries.
+ *
+ * A filesystem path is refused rather than contained here: `read_file` is the
+ * gated way to a workspace file, and a second containment rule beside
+ * `resolveGuestPath` is the thing worth not having.
+ */
+const readMediaBytes: CapabilityExport = {
+  spec: readMediaBytesSpec,
+  impl: async (run, params) => {
+    const uri = params.uri;
+    if (typeof uri !== "string" || uri.trim() === "") {
+      return { error: "uri is required and must be a non-empty string" };
+    }
+    const trimmed = uri.trim();
+    if (filesystemPathForUri(trimmed) !== null) {
+      return {
+        error: `read_media_bytes does not read filesystem paths (${trimmed}). Use read_file for a workspace file, or pass an asset:// URI.`
+      };
+    }
+    // A bare id is what an agent reaches for after reading `asset_id` off a
+    // generation result; accept it rather than making that a failed round trip.
+    const ref = trimmed.includes("://")
+      ? { uri: trimmed }
+      : { uri: trimmed, asset_id: trimmed };
+    try {
+      const bytes = await loadMediaRefBytes(ref, run.context);
+      if (!bytes) {
+        return {
+          error: `Could not read ${trimmed}. Pass the asset:// URI a generation returned (its asset_uri), or list_assets to find one.`
+        };
+      }
+      if (bytes.length > MAX_MEDIA_REF_BYTES) {
+        return {
+          error: `${trimmed} is ${bytes.length} bytes, over the ${MAX_MEDIA_REF_BYTES} byte limit`
+        };
+      }
+      return {
+        uri: trimmed,
+        size: bytes.length,
+        mime_type: mimeForRef(ref, DEFAULT_MIME.document),
+        content_base64: encodeMediaBase64(bytes)
+      };
+    } catch (e) {
+      return {
+        error: `read_media_bytes failed: ${e instanceof Error ? e.message : String(e)}`
+      };
+    }
+  }
+};
+
 /** Every media capability, in the order `getAllMcpTools` offered them. */
 export const MEDIA_CAPABILITIES: readonly CapabilityExport[] = [
   generateImage,
@@ -1019,6 +1086,7 @@ export const MEDIA_CAPABILITIES: readonly CapabilityExport[] = [
   generateSpeech,
   transcribeAudio,
   embedText,
+  readMediaBytes,
   critiqueImage,
   compareImages,
   scoreImageAdherence
@@ -1037,6 +1105,7 @@ export {
   generateSpeech,
   transcribeAudio,
   embedText,
+  readMediaBytes,
   critiqueImage,
   compareImages,
   scoreImageAdherence

--- a/packages/agents/src/capabilities/models.specs.ts
+++ b/packages/agents/src/capabilities/models.specs.ts
@@ -32,10 +32,15 @@ export const FIND_MODEL_INPUT_SCHEMA: JsonSchema = {
       description:
         "Provider capability needed by the generic AI node (e.g. text_to_image, generate_embedding)."
     },
+    query: {
+      type: "string" as const,
+      description:
+        "Free-text search over model id and name (e.g. 'flux schnell', 'gpt image'). All words must appear; separators are ignored, so 'flux 1 schnell' matches 'FLUX.1-schnell'. Matching models are returned first and ranked above everything else."
+    },
     task: {
       type: "string" as const,
       description:
-        "Optional task hint matched against model.supportedTasks (e.g. 'text_to_image' vs 'image_to_image')."
+        "Optional task hint matched against model.supportedTasks (e.g. 'text_to_image' vs 'image_to_image'). This is NOT a search box — use `query` to search by name."
     },
     provider_hint: {
       type: "string" as const,
@@ -46,7 +51,7 @@ export const FIND_MODEL_INPUT_SCHEMA: JsonSchema = {
       type: "array" as const,
       items: { type: "string" as const },
       description:
-        "Optional preferred model ids. Strongly boosts matching models in the ranking."
+        "Optional preferred model ids. Strongly boosts matching models in the ranking. Matches a full id or a fragment of one."
     },
     prefer_local: {
       type: "boolean" as const,
@@ -106,7 +111,7 @@ export const LIST_MODELS_SCHEMA: JsonSchema = {
 export const findModelSpec: CapabilitySpec = {
   name: "find_model",
   description:
-    "Find a real {provider, model_id} for a generic AI node by capability. Returns models from providers the user has configured, ranked by recommended/downloaded/preferences. Each result carries `ref` — the typed value to assign to a node's model property verbatim. Call this before adding any generic AI node (TextToImage, TextToVideo, TextToSpeech, etc.).",
+    "Find a real {provider, model_id} for a generic AI node by capability. Pass `query` to search by name when the user named a model ('flux schnell'), otherwise omit it to get the recommended ranking. Returns models from providers the user has configured, ranked by match/recommended/downloaded/preferences. Each result carries `ref` — the typed value to assign to a node's model property verbatim. Call this before adding any generic AI node (TextToImage, TextToVideo, TextToSpeech, etc.).",
   inputSchema: FIND_MODEL_INPUT_SCHEMA,
   category: "read",
   userMessage: (params) =>

--- a/packages/agents/src/capabilities/models.ts
+++ b/packages/agents/src/capabilities/models.ts
@@ -211,6 +211,40 @@ function taskMatch(model: AnyModel, task: string | undefined): boolean {
   return model.supportedTasks.includes(task);
 }
 
+/**
+ * Lowercase, with every separator collapsed to a single space, so a query
+ * word matches across the punctuation a model id happens to use:
+ * `black-forest-labs/FLUX.1-schnell` → `black forest labs flux 1 schnell`.
+ */
+function searchable(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function queryWords(query: string): string[] {
+  const words = searchable(query).split(" ").filter(Boolean);
+  return words;
+}
+
+/** Every word of the query appears somewhere in the model's id or name. */
+function queryMatch(model: AnyModel, words: string[]): boolean {
+  if (words.length === 0) return true;
+  const haystack = ` ${searchable(`${model.id} ${model.name}`)} `;
+  return words.every((w) => haystack.includes(w));
+}
+
+function hintMatch(model: AnyModel, hints: Set<string>): boolean {
+  if (hints.size === 0) return false;
+  const id = searchable(model.id);
+  for (const hint of hints) {
+    const h = searchable(hint);
+    if (h && (id === h || id.includes(h))) return true;
+  }
+  return false;
+}
+
 const findModel: CapabilityExport = {
   spec: findModelSpec,
   impl: async (run, params) => {
@@ -227,6 +261,10 @@ const findModel: CapabilityExport = {
     const task =
       typeof params["task"] === "string"
         ? (params["task"] as string)
+        : undefined;
+    const query =
+      typeof params["query"] === "string"
+        ? (params["query"] as string)
         : undefined;
     const providerHint =
       typeof params["provider_hint"] === "string"
@@ -257,7 +295,7 @@ const findModel: CapabilityExport = {
     }
 
     const recommendedSet = getRecommendedSet(capability);
-    const collected: FindModelResult[] = [];
+    const candidates: Array<{ providerId: string; model: AnyModel }> = [];
 
     for (const [providerId, instance] of providerEntries) {
       let supports: boolean;
@@ -278,30 +316,68 @@ const findModel: CapabilityExport = {
       }
 
       for (const m of models) {
-        if (!taskMatch(m, task)) continue;
-        const recommended = recommendedSet.has(`${providerId}::${m.id}`);
-        const downloaded = LOCAL_PROVIDER_IDS.has(providerId);
-
-        let score = 0;
-        if (recommended) score += 100;
-        if (downloaded) score += 30;
-        // Explicit user preferences outrank the default recommended bonus.
-        if (providerHint && providerId === providerHint) score += 200;
-        if (modelHints.has(m.id)) score += 250;
-        if (preferLocal && LOCAL_PROVIDER_IDS.has(providerId)) score += 150;
-        else if (preferLocal && !LOCAL_PROVIDER_IDS.has(providerId)) score -= 5;
-
-        collected.push({
-          provider: providerId,
-          model_id: m.id,
-          name: m.name,
-          downloaded,
-          recommended,
-          score,
-          ref: modelRef(capability, providerId, m.id, m.name)
-        });
+        candidates.push({ providerId, model: m });
       }
     }
+
+    const notes: string[] = [];
+    let words = queryWords(typeof query === "string" ? query : "");
+
+    // The `task` filter reads `supportedTasks`. A caller who typed a model name
+    // into it used to get an empty list — or, when no model declares tasks at
+    // all, the unfiltered default ranking — and no way to tell why. A task no
+    // model declares is read as a name search instead.
+    const declaredTasks = new Set<string>();
+    for (const { model } of candidates) {
+      for (const t of model.supportedTasks ?? []) declaredTasks.add(t);
+    }
+    let pool: typeof candidates;
+    if (task && !declaredTasks.has(task)) {
+      pool = candidates;
+      words = [...words, ...queryWords(task)];
+      notes.push(
+        `No model declares task '${task}'; searched model names for it instead. Use \`query\` to search by name.`
+      );
+    } else {
+      pool = candidates.filter(({ model }) => taskMatch(model, task));
+    }
+
+    let queryMatched: boolean | undefined;
+    if (words.length > 0) {
+      const matched = pool.filter(({ model }) => queryMatch(model, words));
+      queryMatched = matched.length > 0;
+      if (matched.length > 0) {
+        pool = matched;
+      } else {
+        notes.push(
+          `No model name matched '${words.join(" ")}'. Showing the ranked models for ${capability} instead.`
+        );
+      }
+    }
+
+    const collected: FindModelResult[] = pool.map(({ providerId, model }) => {
+      const recommended = recommendedSet.has(`${providerId}::${model.id}`);
+      const downloaded = LOCAL_PROVIDER_IDS.has(providerId);
+
+      let score = 0;
+      if (recommended) score += 100;
+      if (downloaded) score += 30;
+      // Explicit user preferences outrank the default recommended bonus.
+      if (providerHint && providerId === providerHint) score += 200;
+      if (hintMatch(model, modelHints)) score += 250;
+      if (preferLocal && LOCAL_PROVIDER_IDS.has(providerId)) score += 150;
+      else if (preferLocal && !LOCAL_PROVIDER_IDS.has(providerId)) score -= 5;
+
+      return {
+        provider: providerId,
+        model_id: model.id,
+        name: model.name,
+        downloaded,
+        recommended,
+        score,
+        ref: modelRef(capability, providerId, model.id, model.name)
+      };
+    });
 
     collected.sort((a, b) => {
       if (b.score !== a.score) return b.score - a.score;
@@ -313,7 +389,9 @@ const findModel: CapabilityExport = {
     return {
       capability,
       total: collected.length,
-      results: collected.slice(0, limit)
+      results: collected.slice(0, limit),
+      ...(queryMatched === undefined ? {} : { query_matched: queryMatched }),
+      ...(notes.length > 0 ? { note: notes.join(" ") } : {})
     };
   }
 };
@@ -328,6 +406,15 @@ const MODEL_TYPE_ALIASES: Record<string, ModelType> = {
   text_generation: "language",
   image_model: "image",
   video_model: "video",
+  // The capability names `find_model` takes — a caller who knows one surface
+  // should not have to learn the other's vocabulary to browse.
+  generate_message: "language",
+  text_to_image: "image",
+  image_to_image: "image",
+  text_to_video: "video",
+  image_to_video: "video",
+  text_to_music: "music",
+  generate_embedding: "embedding",
   speech: "tts",
   text_to_speech: "tts",
   audio: "tts",

--- a/packages/agents/src/capabilities/models.ts
+++ b/packages/agents/src/capabilities/models.ts
@@ -60,15 +60,39 @@ type SupportedCapability = (typeof SUPPORTED_CAPABILITIES)[number];
  * A provider is treated as offering downloaded models when it runs locally.
  * Neither `find_model` nor `list_models` inspects the on-disk cache, so both
  * report the same `downloaded` for the same model.
+ *
+ * `huggingface` is not one of them: it is the HF Inference API, a remote call
+ * like any other. Counting it as local gave every HF model the `downloaded`
+ * bonus and put `FLUX.1-schnell` ahead of the fal_ai copy that could actually
+ * run, on a host with no `@huggingface/inference` installed.
  */
 const LOCAL_PROVIDER_IDS = new Set([
   "ollama",
   "lmstudio",
   "vllm",
   "llama_cpp",
-  "node_llama_cpp",
-  "huggingface"
+  "node_llama_cpp"
 ]);
+
+/**
+ * Why a configured provider still cannot serve a call, or `null` when it can.
+ * A provider that answers with a reason is dropped from the ranking and named
+ * in the result's note — ranking a model nothing can run turns a discovery
+ * call into a failed generation call.
+ */
+async function unavailableReasonOf(
+  provider: BaseProvider
+): Promise<string | null> {
+  // Guarded rather than called outright: a provider from an older build has no
+  // such method, and hiding every provider over that would be a far worse
+  // failure than the one this prevents.
+  if (typeof provider.unavailableReason !== "function") return null;
+  try {
+    return await provider.unavailableReason();
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e);
+  }
+}
 
 interface AnyModel {
   id: string;
@@ -296,6 +320,7 @@ const findModel: CapabilityExport = {
 
     const recommendedSet = getRecommendedSet(capability);
     const candidates: Array<{ providerId: string; model: AnyModel }> = [];
+    const unavailable: string[] = [];
 
     for (const [providerId, instance] of providerEntries) {
       let supports: boolean;
@@ -307,6 +332,12 @@ const findModel: CapabilityExport = {
         continue;
       }
       if (!supports) continue;
+
+      const blocked = await unavailableReasonOf(instance);
+      if (blocked) {
+        unavailable.push(`${providerId} (${blocked})`);
+        continue;
+      }
 
       let models: AnyModel[];
       try {
@@ -321,6 +352,9 @@ const findModel: CapabilityExport = {
     }
 
     const notes: string[] = [];
+    if (unavailable.length > 0) {
+      notes.push(`Skipped providers that cannot run here: ${unavailable.join(", ")}.`);
+    }
     let words = queryWords(typeof query === "string" ? query : "");
 
     // The `task` filter reads `supportedTasks`. A caller who typed a model name
@@ -523,6 +557,7 @@ const listModels: CapabilityExport = {
 
     const wantedTypes = modelType ? [modelType] : [...MODEL_TYPES];
     const collected: ListedModel[] = [];
+    const unavailable: string[] = [];
 
     for (const [providerId, instance] of entries) {
       const downloaded = LOCAL_PROVIDER_IDS.has(providerId);
@@ -532,6 +567,12 @@ const listModels: CapabilityExport = {
       try {
         capabilities = instance.getCapabilities();
       } catch {
+        continue;
+      }
+
+      const blocked = await unavailableReasonOf(instance);
+      if (blocked) {
+        unavailable.push(`${providerId} (${blocked})`);
         continue;
       }
 
@@ -570,7 +611,12 @@ const listModels: CapabilityExport = {
     return {
       total: collected.length,
       truncated: collected.length > limit,
-      results: collected.slice(0, limit)
+      results: collected.slice(0, limit),
+      ...(unavailable.length > 0
+        ? {
+            note: `Skipped providers that cannot run here: ${unavailable.join(", ")}.`
+          }
+        : {})
     };
   }
 };

--- a/packages/agents/src/code-gen/sandbox-manifest.ts
+++ b/packages/agents/src/code-gen/sandbox-manifest.ts
@@ -551,45 +551,52 @@ const BRIDGE_DOCS: { [K in ExposedBridgeName]: SandboxBridgeDoc } = {
         name: "media.bytes",
         signature: "await media.bytes(ref) -> Uint8Array",
         description: "The bytes behind any media ref.",
-        async: true
+        async: true,
+        requiresContext: true
       },
       {
         name: "media.text",
         signature: "await media.text(ref, { encoding? }) -> string",
         description: "Decode the ref's bytes as text (default utf-8).",
-        async: true
+        async: true,
+        requiresContext: true
       },
       {
         name: "media.info",
         signature:
           "await media.info(ref) -> { type, mimeType, uri, size }",
         description: "What the ref is and how big it is.",
-        async: true
+        async: true,
+        requiresContext: true
       },
       {
         name: "media.toDocument",
         signature:
           "await media.toDocument(bytes, { mimeType?, filename? }) -> DocumentRef",
         description: "Bytes to a document ref, ready to return as an output.",
-        async: true
+        async: true,
+        requiresContext: true
       },
       {
         name: "media.toImage",
         signature: "await media.toImage(bytes, { mimeType? }) -> ImageRef",
         description: "Bytes to an image ref.",
-        async: true
+        async: true,
+        requiresContext: true
       },
       {
         name: "media.toAudio",
         signature: "await media.toAudio(bytes, { mimeType? }) -> AudioRef",
         description: "Bytes to an audio ref.",
-        async: true
+        async: true,
+        requiresContext: true
       },
       {
         name: "media.toVideo",
         signature: "await media.toVideo(bytes, { mimeType? }) -> VideoRef",
         description: "Bytes to a video ref.",
-        async: true
+        async: true,
+        requiresContext: true
       }
     ]
   },

--- a/packages/agents/src/codeact/mcp-guest-contract.ts
+++ b/packages/agents/src/codeact/mcp-guest-contract.ts
@@ -62,7 +62,7 @@ Rules:
 - \`return\` a small summary. Keep large data in \`state\`.
 - A failed tool throws. Use \`try/catch\`.
 - This is a chat turn: there is no \`finish()\`. A plain assistant message ends the turn.
-- \`fetch\`, \`workspace\`, \`media\`, and \`getSecret\` are not available here. Files and assets go through \`nodetool.*\`.
+- \`fetch\`, \`workspace\`, \`media\`, and \`getSecret\` are not available here. Files and assets go through \`nodetool.*\`: \`nodetool.media.bytes(ref)\` reads the bytes behind a generated image, \`nodetool.assets.read/save\` the library, \`nodetool.web.fetch\` the network. \`image.*\` works on those bytes without a context.
 - Full guest surface: resource \`${MCP_SANDBOX_RESOURCE_URI}\`. Tool catalog: \`nodetool://capabilities\`.`;
 
 export interface McpSandboxBridge {

--- a/packages/agents/src/codeact/mcp-guest-contract.ts
+++ b/packages/agents/src/codeact/mcp-guest-contract.ts
@@ -1,0 +1,144 @@
+/**
+ * The short guest contract MCP clients are guaranteed to see.
+ *
+ * MCP has no system prompt. The full CodeAct catalog still rides in the
+ * `execute_code` description; this block leads that description, is the
+ * server `instructions` string, and is echoed on `nodetool://sandbox`.
+ * Keep it short — many clients truncate a long tool description.
+ */
+
+import {
+  getSandboxManifest,
+  type SandboxManifest
+} from "../code-gen/sandbox-manifest.js";
+import { chatUnavailableBridges } from "./prompt.js";
+
+/** Structured guest surface for MCP clients that read resources. */
+export const MCP_SANDBOX_RESOURCE_URI = "nodetool://sandbox";
+
+/**
+ * A complete action that lists, picks a model, and generates one image.
+ * Teaching example — do not run it in CI (pick/generate need a configured model).
+ */
+export const MCP_SANDBOX_ACTION_SNIPPET = `const listed = await nodetool.workflows.list();
+const model = await nodetool.models.pick("text_to_image");
+const image = await nodetool.media.generateImage("a red fox", model);
+return { count: listed.workflows.length, uri: image.asset_uri };`;
+
+/**
+ * List one asset and fetch it as a ref. Pass the ref through.
+ * Do not open it with fs or fetch. Runs against an empty library.
+ */
+export const MCP_SANDBOX_ASSET_SNIPPET = `const listed = await nodetool.assets.list({ limit: 1 });
+const row = listed.assets[0];
+if (!row) return { found: 0 };
+const asset = await nodetool.assets.get(row.id);
+return { id: asset.id, uri: asset.uri };`;
+
+/**
+ * Cheap probe: list workflows and look up a deferred tool.
+ * Safe to run in tests — no model, no spend.
+ */
+export const MCP_SANDBOX_PROBE_SNIPPET = `const listed = await nodetool.workflows.list();
+const hits = await nodetool.searchTools("validate_workflow");
+return { count: listed.workflows.length, tools: hits.map((h) => h.name) };`;
+
+/** Lead-in every MCP client is supposed to inject next to the system prompt. */
+export const MCP_GUEST_CONTRACT = `# Guest JavaScript (not Node)
+
+\`execute_code\` runs in a QuickJS guest. There is no Node and no host filesystem.
+Do not use \`fs\`, \`require\`, \`process\`, \`Buffer\`, \`setTimeout\`, or \`eval\`.
+
+Write one action:
+
+\`\`\`js
+${MCP_SANDBOX_ACTION_SNIPPET}
+\`\`\`
+
+Rules:
+- Call \`nodetool.<namespace>.<method>()\`. Do not invent MCP tools. Do not call \`tools.*\` when a \`nodetool.*\` method exists.
+- Unknown tool: \`await nodetool.searchTools("query")\` first. Do not guess arguments.
+- Static \`import\` only for allowed packs. This session lists them below; anything else fails.
+- \`return\` a small summary. Keep large data in \`state\`.
+- A failed tool throws. Use \`try/catch\`.
+- This is a chat turn: there is no \`finish()\`. A plain assistant message ends the turn.
+- \`fetch\`, \`workspace\`, \`media\`, and \`getSecret\` are not available here. Files and assets go through \`nodetool.*\`.
+- Full guest surface: resource \`${MCP_SANDBOX_RESOURCE_URI}\`. Tool catalog: \`nodetool://capabilities\`.`;
+
+export interface McpSandboxBridge {
+  name: string;
+  members: string[];
+}
+
+export interface McpSandboxCatalog {
+  server: "nodetool";
+  runtime: string;
+  resource: typeof MCP_SANDBOX_RESOURCE_URI;
+  contract: string;
+  native_globals: readonly string[];
+  blocked_globals: readonly string[];
+  unavailable_bridges: readonly string[];
+  available_bridges: McpSandboxBridge[];
+  packages: readonly string[];
+  examples: {
+    action: string;
+    asset: string;
+    probe: string;
+  };
+}
+
+export interface McpSandboxCatalogOptions {
+  packageSpecifiers?: readonly string[];
+  manifest?: SandboxManifest;
+}
+
+/** Machine-readable guest surface, derived from the sandbox manifest. */
+export function buildMcpSandboxCatalog(
+  options: McpSandboxCatalogOptions = {}
+): McpSandboxCatalog {
+  const manifest = options.manifest ?? getSandboxManifest();
+  const unavailable = chatUnavailableBridges(manifest);
+  const hidden = new Set(unavailable);
+  const available_bridges: McpSandboxBridge[] = [];
+  for (const bridge of Object.values(manifest.bridges)) {
+    if (bridge.internal || bridge.members.length === 0) continue;
+    if (hidden.has(bridge.name)) continue;
+    available_bridges.push({
+      name: bridge.name,
+      members: bridge.members.map((member) => member.signature)
+    });
+  }
+  return {
+    server: "nodetool",
+    runtime: manifest.runtime,
+    resource: MCP_SANDBOX_RESOURCE_URI,
+    contract: MCP_GUEST_CONTRACT,
+    native_globals: manifest.nativeGlobals,
+    blocked_globals: manifest.blockedGlobals,
+    unavailable_bridges: unavailable,
+    available_bridges,
+    packages: options.packageSpecifiers ?? [],
+    examples: {
+      action: MCP_SANDBOX_ACTION_SNIPPET,
+      asset: MCP_SANDBOX_ASSET_SNIPPET,
+      probe: MCP_SANDBOX_PROBE_SNIPPET
+    }
+  };
+}
+
+export const MCP_SANDBOX_PROMPTS = [
+  {
+    name: "sandbox-action",
+    title: "Sandbox action",
+    description:
+      "A complete execute_code body: list workflows, pick a model, generate one image.",
+    snippet: MCP_SANDBOX_ACTION_SNIPPET
+  },
+  {
+    name: "sandbox-asset",
+    title: "Sandbox asset",
+    description:
+      "A complete execute_code body: list one asset and fetch the ref. Do not open bytes with fs.",
+    snippet: MCP_SANDBOX_ASSET_SNIPPET
+  }
+] as const;

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -601,6 +601,19 @@ const nodetool = (() => {
               (found && found.note ? " — " + found.note : "")
           );
         }
+        // A missed search must not resolve to an unrelated model — the caller
+        // asked for a named one.
+        if (found && found.query_matched === false) {
+          throw new Error(
+            "nodetool.models.pick: no model matches " +
+              JSON.stringify(opts && opts.query) +
+              " for " +
+              capability +
+              '. Call nodetool.models.find("' +
+              capability +
+              '") to see what is configured.'
+          );
+        }
         return results[0];
       },
       list: (opts) => __need("list_models")(__merge(opts)),
@@ -1017,8 +1030,12 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   {
     namespace: "models",
     doc: `- \`nodetool.models\` — \`await pick(capability)\` resolves ONE ranked model
-  (e.g. \`pick("text_to_image")\` → \`{provider, model_id, ref}\`), \`find(capability,
-  {task, provider_hint, prefer_local, limit})\` for the ranked list (returns
+  (e.g. \`pick("text_to_image")\` → \`{provider, model_id, ref}\`). When the user
+  named a model, search for it in the SAME call:
+  \`pick("text_to_image", {query: "flux schnell"})\` — \`query\` is free text over
+  model id and name, and \`pick\` throws when nothing matches instead of
+  returning something else. \`find(capability,
+  {query, provider_hint, prefer_local, limit})\` for the ranked list (returns
   \`{results}\`),
   \`list({provider, model_type})\` to browse, \`forProvider(provider)\` for one
   provider's own catalog. Never guess a model id — pick one, then pass it to

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -47,7 +47,8 @@ export const NODETOOL_API_NAMESPACE_TOOLS: Record<string, readonly string[]> = {
     "embed_text",
     "critique_image",
     "compare_images",
-    "score_image_adherence"
+    "score_image_adherence",
+    "read_media_bytes"
   ],
   documents: [
     "convert_document",
@@ -217,6 +218,24 @@ const nodetool = (() => {
       "nodetool: a model is required — pass a nodetool.models.find/pick " +
       'result, {provider, model_id}, or "provider/model_id". Use ' +
       'await nodetool.models.pick("<capability>") to resolve one.'
+    );
+  };
+
+  /**
+   * Normalize what a generation returns into the one reference
+   * \`read_media_bytes\` takes. A generation result carries \`asset_uri\`,
+   * \`asset_id\`, \`url\` and a host \`uri\` — the last is a filesystem path the
+   * guest may not read, so it is never chosen. A bare string passes through.
+   */
+  const __mediaUri = (ref) => {
+    if (typeof ref === "string" && ref) return ref;
+    if (ref && typeof ref === "object") {
+      const uri = ref.asset_uri || ref.asset_id || ref.url || ref.uri;
+      if (typeof uri === "string" && uri) return uri;
+    }
+    throw new Error(
+      "nodetool.media.bytes: pass what a generation returned (its " +
+      "asset_uri), an asset id, a /api/storage/ key, or a data:/http(s) URL."
     );
   };
 
@@ -634,6 +653,22 @@ const nodetool = (() => {
             __merge(__model(model), { input_file: inputFile, prompt: prompt })
           )
         ),
+      /**
+       * The bytes behind anything a generation returned — the way to get at an
+       * image you just made and hand it to \`image.*\`. Takes the result object
+       * itself, its \`asset_uri\`, a bare asset id, a /api/storage/ key, or a
+       * data:/http(s) URL. Returns a Uint8Array.
+       */
+      bytes: (ref) =>
+        __need("read_media_bytes")({ uri: __mediaUri(ref) }).then((r) => {
+          if (!r || typeof r.content_base64 !== "string") {
+            throw new Error(
+              "nodetool.media.bytes: " +
+              ((r && r.error) || "no bytes came back for this reference")
+            );
+          }
+          return fromBase64(r.content_base64);
+        }),
       generateVideo: (prompt, model, opts) =>
         __need("generate_video")(
           __merge(opts, __merge(__model(model), { prompt: prompt }))
@@ -1007,7 +1042,10 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   },
   {
     namespace: "nodes",
-    doc: `- \`nodetool.nodes\` — the graph author's discovery half. NEVER guess a node
+    doc: `- \`nodetool.nodes\` — the graph author's discovery half. \`search_nodes\`,
+  \`get_node_info\` and \`list_nodes\` are direct tool calls — reach for those
+  when you are only looking something up; these are the same lookups inside an
+  action. NEVER guess a node
   type: \`await search(["summarize text"], {n_results, input_type, output_type})\`
   (a bare string works too) to find candidates — it returns
   \`{total, results}\`, and each result carries its node type on \`type\`
@@ -1029,7 +1067,10 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   },
   {
     namespace: "models",
-    doc: `- \`nodetool.models\` — \`await pick(capability)\` resolves ONE ranked model
+    doc: `- \`nodetool.models\` — model discovery. \`find_model\` / \`list_models\` are
+  direct tool calls, so a plain lookup is one call and not an action; these are
+  the same lookups from inside an action, where a picked model feeds the next
+  call. \`await pick(capability)\` resolves ONE ranked model
   (e.g. \`pick("text_to_image")\` → \`{provider, model_id, ref}\`). When the user
   named a model, search for it in the SAME call:
   \`pick("text_to_image", {query: "flux schnell"})\` — \`query\` is free text over
@@ -1052,6 +1093,9 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   \`animateImage(inputFile, model)\`, \`speak(text, model, {voice})\`,
   \`transcribe(inputFile, model)\`, \`embed(text, model)\`. Results are saved as
   assets (\`asset://\` URI); pass \`output_file\` for a workspace copy too.
+  \`await nodetool.media.bytes(result)\` reads the bytes back — pass the
+  generation result itself, its \`asset_uri\`, or an asset id — so
+  generate → \`image.resize/composite\` → \`nodetool.assets.save\` is one action.
   Judging lives here too, so generate → critique → regenerate is one namespace:
   \`critique(image, brief, visionModel, {taste_profile})\`,
   \`compare([imageA, imageB, ...], brief, visionModel)\` (pairwise knockout),
@@ -1113,7 +1157,11 @@ const NAMESPACE_DOCS: PromptEntry[] = [
     namespace: "assets",
     doc: `- \`nodetool.assets\` — \`list({content_type, limit})\`, \`search(query)\`,
   \`images({query, limit})\` (image handles — pass an id to \`view_image\`),
-  \`get(assetId)\`, \`save(name, {...})\`, \`read(name)\`.`
+  \`get(assetId)\` (the row — no bytes), \`save(name, {content_base64,
+  content_type})\`, \`read(nameOrUri)\` (an \`asset://\` URI, an asset id, a
+  /api/storage/ key, or a stored file name → \`{content, content_base64}\`).
+  For bytes you intend to compute on, \`nodetool.media.bytes(ref)\` is the
+  direct route.`
   },
   {
     namespace: "jobs",

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -92,6 +92,12 @@ function actionContractChat(
   so permission checks and approvals cannot be bypassed. Unusable here:
   ${unavailable.map((name) => `\`${name}\``).join(", ")} — a chat action runs
   with no context and a zero-request fetch limit.
+- The \`nodetool\` object model covers what those bridges did, past the gate:
+  \`nodetool.media.bytes(ref)\` for the bytes behind an image you generated
+  (pass the generation result or its \`asset_uri\`), \`nodetool.assets.read\` /
+  \`save\` for the library, \`nodetool.web.fetch\` / \`browse\` for the network.
+  \`image.*\` and \`canvas\` need no context, so decode, resize, composite and
+  encode in the same action you read the bytes in.
 - When you need the user's decision, stop writing code and ask in a plain
   assistant message.`;
 }
@@ -343,11 +349,13 @@ export function buildCodeActSystemPrompt(
   if (direct.length > 0) {
     sections.push(
       `# Direct tools (call them, do not write code for them)\n` +
-        `These are ordinary tool calls, not sandbox functions. They are not ` +
-        `in \`tools.*\` and \`nodetool.searchTools()\` does not list them. Call one ` +
-        `directly when you need exactly what it does; write a code action ` +
-        `when you need to compose several calls, loop, or transform the ` +
-        `results.\n\n` +
+        `These are ordinary tool calls — the file set, the web set, ` +
+        `delegation, and discovery: which providers, models and node types ` +
+        `this install has. Call one directly when you need exactly what it ` +
+        `does; a code action whose only job is to forward one is a wasted ` +
+        `round trip. Write the action when you compose several calls, loop, ` +
+        `or transform the results — they stay reachable inside one as ` +
+        `\`tools.<name>()\` and through \`nodetool.*\`.\n\n` +
         direct.join(", ")
     );
   }

--- a/packages/agents/src/codeact/tool-api.ts
+++ b/packages/agents/src/codeact/tool-api.ts
@@ -10,7 +10,7 @@
  * never hit.
  */
 
-import { CORE_TOOL_NAMES, type ProcessingContext } from "@nodetool-ai/runtime";
+import { DIRECT_TOOL_NAMES, type ProcessingContext } from "@nodetool-ai/runtime";
 import type {
   JsonSchema,
   MessageContent,
@@ -191,15 +191,16 @@ export function buildToolBridge(options: ToolBridgeOptions): ToolBridge {
 /**
  * Split a toolbelt into the tools also offered top level and the rest.
  *
- * Membership is {@link CORE_TOOL_NAMES} — the tools that mirror a Claude Agent
- * SDK built-in. They are the shapes every frontier model is trained on, so a
- * plain tool call beats a sandbox round trip whose only job is to forward one.
+ * Membership is {@link DIRECT_TOOL_NAMES}: the core set that mirrors a Claude
+ * Agent SDK built-in, plus discovery — which providers, models and node types
+ * this install has. Both are shapes a plain tool call fits, so a sandbox round
+ * trip whose only job is to forward one buys nothing.
  *
  * `core` is a view, not a removal: the belt keeps every tool, because the
- * object model (`nodetool.web`, `nodetool.agents`) and any hand-written
- * fan-out call them from inside an action. What the top-level offer changes is
- * the *documented* path — the prompt catalog lists them as direct tools, and
- * the default way to reach one is a tool call.
+ * object model (`nodetool.models.pick`, `nodetool.web`, `nodetool.agents`) and
+ * any hand-written fan-out call them from inside an action. What the top-level
+ * offer changes is the *documented* path — the prompt catalog lists them as
+ * direct tools, and the default way to reach one is a tool call.
  */
 export function splitCoreTools(tools: Tool[]): {
   core: Tool[];
@@ -208,7 +209,7 @@ export function splitCoreTools(tools: Tool[]): {
   const core: Tool[] = [];
   const belt: Tool[] = [];
   for (const tool of tools) {
-    (CORE_TOOL_NAMES.has(tool.name) ? core : belt).push(tool);
+    (DIRECT_TOOL_NAMES.has(tool.name) ? core : belt).push(tool);
   }
   return { core, belt };
 }

--- a/packages/agents/src/evals/codeact-api-core.ts
+++ b/packages/agents/src/evals/codeact-api-core.ts
@@ -912,6 +912,23 @@ export function createCoreApiTools(recorder: CodeActToolRecorder): Tool[] {
       (params) => generate(params, "text_to_image", "image/png", "image")
     ),
     tool(
+      "read_media_bytes",
+      "Read the bytes behind a media reference (asset:// URI or asset id).",
+      { uri: s },
+      (params) => {
+        const asset = world.asset(params["uri"]);
+        const content_base64 = Buffer.from(asset.content, "utf8").toString(
+          "base64"
+        );
+        return {
+          uri: asset.uri,
+          size: content_base64.length,
+          mime_type: asset.content_type,
+          content_base64
+        };
+      }
+    ),
+    tool(
       "edit_image",
       "Edit an existing image asset.",
       { provider: s, model: s, prompt: s, input_file: s },

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -302,6 +302,20 @@ export {
 export type { CodeActExecutorOptions } from "./codeact/codeact-executor.js";
 export { buildCodeActSystemPrompt } from "./codeact/prompt.js";
 export {
+  MCP_GUEST_CONTRACT,
+  MCP_SANDBOX_ACTION_SNIPPET,
+  MCP_SANDBOX_ASSET_SNIPPET,
+  MCP_SANDBOX_PROBE_SNIPPET,
+  MCP_SANDBOX_RESOURCE_URI,
+  MCP_SANDBOX_PROMPTS,
+  buildMcpSandboxCatalog
+} from "./codeact/mcp-guest-contract.js";
+export type {
+  McpSandboxCatalog,
+  McpSandboxCatalogOptions,
+  McpSandboxBridge
+} from "./codeact/mcp-guest-contract.js";
+export {
   sandboxPackageSkills,
   wrapUntrustedPackageDocs
 } from "./codeact/sandbox-package-docs.js";

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -1764,7 +1764,15 @@ export function buildSandbox(
   // Media refs in and out. Unlike `image`/`canvas` this one needs a
   // ProcessingContext — it resolves `asset://`, storage keys and package assets
   // through the host's own resolver — so without one every member throws.
-  const media = createMediaRefBridge(context);
+  // `media.*` reads files, so it resolves paths through the same
+  // `resolveGuestPath` `workspace.*` uses — one containment rule, one
+  // `filesystemAccess` scope, no second scheme to keep in step.
+  const media = createMediaRefBridge(
+    context,
+    context
+      ? { resolvePath: (path: string) => resolveGuestPath(context, path, false) }
+      : {}
+  );
 
   const sandbox: Record<string, unknown> = {
     // Core JS globals are native in QuickJS; we still reflect them in the

--- a/packages/agents/src/sandbox-media-ref.ts
+++ b/packages/agents/src/sandbox-media-ref.ts
@@ -64,7 +64,7 @@ export interface MediaRefBridge {
   toVideo(bytes: unknown, options?: unknown): Promise<Record<string, unknown>>;
 }
 
-const DEFAULT_MIME: Record<MediaRefKind, string> = {
+export const DEFAULT_MIME: Record<MediaRefKind, string> = {
   document: "application/octet-stream",
   image: "image/png",
   audio: "audio/mpeg",
@@ -159,31 +159,63 @@ function describeRef(ref: MediaRefValue): string {
   return `a ${ref.type ?? "media"} ref with no uri, asset_id, or data`;
 }
 
+/** URI prefixes that name something other than a file on this host. */
+const NON_FILESYSTEM_PREFIXES = ["data:", "asset://", "package://", "/api/"];
+
 /**
- * The filesystem fallback `resolveDocumentBytes` has: `loadMediaRefBytes`
- * deliberately reads only absolute and `file://` paths, so a relative or
- * `~`-prefixed path — what the `lib.os` nodes and a hand-written workflow
- * produce — resolves to nothing without this.
+ * The filesystem path a ref's `uri` names, or `null` when it names something
+ * else (a data URI, an asset, a storage key, an http URL).
+ *
+ * Every form that reaches disk goes through here — `file://`, an absolute
+ * path, a `~`-prefixed path, and a bare relative path — so the caller has one
+ * place to apply containment. `loadMediaRefBytes` reads the first two itself
+ * with no check at all, which is why a filesystem-shaped uri never reaches it.
  */
-async function readFallbackPath(uri: string): Promise<Uint8Array | null> {
-  if (!uri || /^[a-z][a-z0-9+.-]*:\/\//i.test(uri) || uri.startsWith("data:")) {
+export function filesystemPathForUri(uri: unknown): string | null {
+  if (typeof uri !== "string" || uri === "") return null;
+  const lower = uri.toLowerCase();
+  if (NON_FILESYSTEM_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
     return null;
   }
+  if (lower.startsWith("file://")) {
+    // Strip the scheme rather than calling fileURLToPath: this feeds a
+    // resolver, not an fs call, and a malformed URL should be refused by
+    // containment rather than throw a different error here.
+    const path = uri.slice("file://".length);
+    return path === "" ? null : decodeURIComponent(path);
+  }
+  // Any other scheme (http, https, memory, s3, …) is not a path.
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(uri)) return null;
+  return uri;
+}
+
+/**
+ * Read a path the run is allowed to read.
+ *
+ * `resolvePath` is the sandbox's own `resolveGuestPath`, so this honors the
+ * run's `filesystemAccess` scope: workspace mode resolves under the workspace
+ * root and refuses an escape, host mode expands `~` and reads anywhere. A run
+ * built without a resolver reads no files at all — failing closed matters more
+ * than serving a caller that never passed one.
+ */
+async function readContainedPath(
+  where: string,
+  path: string,
+  resolvePath?: (path: string) => Promise<string>
+): Promise<Uint8Array | null> {
+  if (!resolvePath) {
+    throw new Error(
+      `${where}: reading a filesystem path is not available in this run`
+    );
+  }
+  const fullPath = await resolvePath(path);
   const fs =
     await importNodeBuiltin<typeof import("node:fs/promises")>(
       "node:fs/promises"
     );
-  const os = await importNodeBuiltin<typeof import("node:os")>("node:os");
-  const path = await importNodeBuiltin<typeof import("node:path")>("node:path");
-  if (!fs || !os || !path) return null;
-  const expanded =
-    uri === "~"
-      ? os.homedir()
-      : uri.startsWith("~/")
-        ? path.join(os.homedir(), uri.slice(2))
-        : uri;
+  if (!fs) return null;
   try {
-    return new Uint8Array(await fs.readFile(expanded));
+    return new Uint8Array(await fs.readFile(fullPath));
   } catch {
     return null;
   }
@@ -192,11 +224,18 @@ async function readFallbackPath(uri: string): Promise<Uint8Array | null> {
 async function resolveRefBytes(
   where: string,
   ref: MediaRefValue,
-  context: ProcessingContext
+  context: ProcessingContext,
+  resolvePath?: (path: string) => Promise<string>
 ): Promise<Uint8Array> {
+  // A filesystem-shaped uri is withheld from `loadMediaRefBytes`, whose own
+  // absolute and `file://` branches read any path this process can reach. The
+  // ref's inline data, asset id and storage key still resolve there; only the
+  // path is ours to contain.
+  const path = filesystemPathForUri(ref.uri);
+  const safeRef = path === null ? ref : { ...ref, uri: undefined };
   const resolved =
-    (await loadMediaRefBytes(ref, context)) ??
-    (typeof ref.uri === "string" ? await readFallbackPath(ref.uri) : null);
+    (await loadMediaRefBytes(safeRef, context)) ??
+    (path === null ? null : await readContainedPath(where, path, resolvePath));
   if (!resolved) {
     throw new Error(`${where}: could not read ${describeRef(ref)}`);
   }
@@ -209,7 +248,7 @@ async function resolveRefBytes(
 }
 
 /** The ref's mime type, from the ref itself, its data URI header, or its path. */
-function mimeForRef(ref: MediaRefValue, fallback: string): string {
+export function mimeForRef(ref: MediaRefValue, fallback: string): string {
   const declared = (ref as { mimeType?: unknown }).mimeType;
   if (typeof declared === "string" && declared.length > 0) return declared;
   const uri = typeof ref.uri === "string" ? ref.uri : "";
@@ -304,13 +343,24 @@ function withoutContext(member: string): never {
   throw new Error(`media.${member} is not available without a context`);
 }
 
+/** What a host supplies alongside the context when it builds the bridge. */
+export interface MediaRefBridgeOptions {
+  /**
+   * Resolve a guest-supplied filesystem path to the one path this run may
+   * read, or throw. The sandbox passes its own `resolveGuestPath`, so
+   * `media.*` and `workspace.*` are contained by one rule rather than two.
+   */
+  resolvePath?: (path: string) => Promise<string>;
+}
+
 /**
  * Build the guest's `media` namespace. Every member is async, and every one
  * fails with a named error when the run has no `ProcessingContext` — the same
  * contract `workspace.*` follows, so nothing half-works.
  */
 export function createMediaRefBridge(
-  context?: ProcessingContext
+  context?: ProcessingContext,
+  options: MediaRefBridgeOptions = {}
 ): MediaRefBridge {
   if (!context) {
     return {
@@ -328,19 +378,25 @@ export function createMediaRefBridge(
     bytes: async (ref: unknown): Promise<unknown> => {
       const where = "media.bytes";
       return toGuestBytes(
-        await resolveRefBytes(where, requireRef(where, ref), context)
+        await resolveRefBytes(
+          where,
+          requireRef(where, ref),
+          context,
+          options.resolvePath
+        )
       );
     },
 
-    text: async (ref: unknown, options?: unknown): Promise<string> => {
+    text: async (ref: unknown, opts?: unknown): Promise<string> => {
       const where = "media.text";
       const bytes = await resolveRefBytes(
         where,
         requireRef(where, ref),
-        context
+        context,
+        options.resolvePath
       );
       const encoding =
-        optionalString(asRecord(options), "encoding", where) ?? "utf-8";
+        optionalString(asRecord(opts), "encoding", where) ?? "utf-8";
       try {
         return new TextDecoder(encoding).decode(bytes);
       } catch {
@@ -351,7 +407,12 @@ export function createMediaRefBridge(
     info: async (ref: unknown): Promise<MediaRefInfo> => {
       const where = "media.info";
       const value = requireRef(where, ref);
-      const bytes = await resolveRefBytes(where, value, context);
+      const bytes = await resolveRefBytes(
+        where,
+        value,
+        context,
+        options.resolvePath
+      );
       const kind = typeof value.type === "string" ? value.type : "document";
       const fallback =
         DEFAULT_MIME[kind as MediaRefKind] ?? DEFAULT_MIME.document;

--- a/packages/agents/src/tools/asset-persist.ts
+++ b/packages/agents/src/tools/asset-persist.ts
@@ -94,7 +94,9 @@ export async function persistOutput(
   const ext = MIME_TO_EXT[opts.mime] ?? "bin";
   const result: SavedOutput = { bytes: bytes.length, mime_type: opts.mime };
 
-  if (typeof context.createAsset === "function") {
+  // The interface, not the method: `createAsset` is on the prototype either
+  // way, so this used to be a check that could not fail.
+  if (context.hasModelInterface?.("createAsset")) {
     try {
       const name = opts.outputFile ?? timestampedName(opts.namePrefix, ext);
       const asset = (await context.createAsset({

--- a/packages/agents/src/tools/tool-permissions.ts
+++ b/packages/agents/src/tools/tool-permissions.ts
@@ -87,6 +87,7 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   list_assets: "read",
   get_asset: "read",
   read_asset: "read",
+  read_media_bytes: "read",
   list_models: "read",
   list_provider_models: "read",
   find_model: "read",

--- a/packages/agents/tests/capabilities-media.test.ts
+++ b/packages/agents/tests/capabilities-media.test.ts
@@ -74,6 +74,7 @@ describe("media and style capability modules", () => {
       "generate_speech",
       "transcribe_audio",
       "embed_text",
+      "read_media_bytes",
       "critique_image",
       "compare_images",
       "score_image_adherence"

--- a/packages/agents/tests/capabilities-models.test.ts
+++ b/packages/agents/tests/capabilities-models.test.ts
@@ -193,6 +193,70 @@ describe("find_model through the adapter", () => {
     expect(result.note).toMatch(/No model name matched/);
   });
 
+  it("does not rank a remote provider as if its models were downloaded", async () => {
+    // `huggingface` is the HF Inference API. Counting it as local gave every
+    // HF model a +30 bonus and put FLUX.1-schnell ahead of the fal_ai copy
+    // that could actually run.
+    const tool = asTool(findModel, {
+      fal_ai: new FakeImageProvider("fal_ai" as ProviderId, [
+        {
+          id: "fal-ai/flux/schnell",
+          name: "Flux Schnell",
+          provider: "fal_ai"
+        } as ImageModel
+      ]),
+      huggingface: new FakeImageProvider("huggingface" as ProviderId, [
+        {
+          id: "black-forest-labs/FLUX.1-schnell",
+          name: "FLUX.1 Schnell",
+          provider: "huggingface"
+        } as ImageModel
+      ])
+    });
+    const result = (await tool.process(ctx, {
+      capability: "text_to_image",
+      query: "flux schnell"
+    })) as { results: { provider: string; downloaded: boolean }[] };
+    expect(result.results.map((r) => r.downloaded)).toEqual([false, false]);
+    expect(result.results[0].provider).toBe("fal_ai");
+  });
+
+  it("skips a provider that cannot run here, and says which", async () => {
+    // A configured provider whose optional SDK was never installed. The old
+    // ranking offered it first and the failure surfaced on the paid call.
+    class BrokenImageProvider extends FakeImageProvider {
+      override async unavailableReason(): Promise<string | null> {
+        return "@huggingface/inference is required for HuggingFaceProvider.";
+      }
+    }
+    const tool = asTool(findModel, {
+      fal_ai: new FakeImageProvider("fal_ai" as ProviderId, [
+        {
+          id: "fal-ai/flux/schnell",
+          name: "Flux Schnell",
+          provider: "fal_ai"
+        } as ImageModel
+      ]),
+      huggingface: new BrokenImageProvider("huggingface" as ProviderId, [
+        {
+          id: "black-forest-labs/FLUX.1-schnell",
+          name: "FLUX.1 Schnell",
+          provider: "huggingface"
+        } as ImageModel
+      ])
+    });
+    const result = (await tool.process(ctx, {
+      capability: "text_to_image",
+      query: "flux schnell"
+    })) as {
+      total: number;
+      note: string;
+      results: { provider: string }[];
+    };
+    expect(result.results.map((r) => r.provider)).toEqual(["fal_ai"]);
+    expect(result.note).toMatch(/huggingface .*@huggingface\/inference/);
+  });
+
   it("says so when the run carries no providers", async () => {
     const result = (await asTool(findModel).process(ctx, {
       capability: "text_to_image"
@@ -233,6 +297,28 @@ describe("list_models through the adapter", () => {
     expect(result.results.map((r) => r.provider)).toEqual(["ollama", "openai"]);
     // ollama runs locally, so its models report as downloaded.
     expect(result.results[0].downloaded).toBe(true);
+  });
+
+  it("drops a provider that cannot run here from the listing", async () => {
+    class BrokenLanguageProvider extends FakeLanguageProvider {
+      override async unavailableReason(): Promise<string | null> {
+        return "missing SDK";
+      }
+    }
+    const result = (await asTool(listModels, {
+      openai: new FakeLanguageProvider("openai" as ProviderId, [
+        { id: "gpt-5", name: "GPT-5", provider: "openai" } as LanguageModel
+      ]),
+      huggingface: new BrokenLanguageProvider("huggingface" as ProviderId, [
+        { id: "hf-1", name: "HF One", provider: "huggingface" } as LanguageModel
+      ])
+    }).process(ctx, { model_type: "language" })) as {
+      total: number;
+      note: string;
+      results: { provider: string }[];
+    };
+    expect(result.results.map((r) => r.provider)).toEqual(["openai"]);
+    expect(result.note).toMatch(/huggingface \(missing SDK\)/);
   });
 
   it("rejects an unknown model type", async () => {

--- a/packages/agents/tests/capabilities-models.test.ts
+++ b/packages/agents/tests/capabilities-models.test.ts
@@ -118,6 +118,81 @@ describe("find_model through the adapter", () => {
     expect(result.results[0].model_id).toBe("gpt-image-1");
   });
 
+  it("finds a model by name across the punctuation its id uses", async () => {
+    // The session this fixes lost four rounds here: the model was configured
+    // the whole time and every search answered with something else.
+    const providers = {
+      openai: new FakeImageProvider("openai" as ProviderId, [
+        {
+          id: "gpt-image-2",
+          name: "GPT Image 2",
+          provider: "openai"
+        } as ImageModel
+      ]),
+      huggingface: new FakeImageProvider("huggingface" as ProviderId, [
+        {
+          id: "black-forest-labs/FLUX.1-schnell",
+          name: "FLUX.1 Schnell",
+          provider: "huggingface"
+        } as ImageModel,
+        {
+          id: "black-forest-labs/FLUX.1-dev",
+          name: "FLUX.1 Dev",
+          provider: "huggingface"
+        } as ImageModel
+      ])
+    };
+    const tool = asTool(findModel, providers);
+
+    const byQuery = (await tool.process(ctx, {
+      capability: "text_to_image",
+      query: "flux schnell"
+    })) as {
+      total: number;
+      query_matched: boolean;
+      results: { model_id: string }[];
+    };
+    expect(byQuery.query_matched).toBe(true);
+    expect(byQuery.total).toBe(1);
+    expect(byQuery.results[0].model_id).toBe(
+      "black-forest-labs/FLUX.1-schnell"
+    );
+
+    // A model name typed into `task` used to filter everything out.
+    const byTask = (await tool.process(ctx, {
+      capability: "text_to_image",
+      task: "flux schnell"
+    })) as { total: number; note: string; results: { model_id: string }[] };
+    expect(byTask.results[0].model_id).toBe("black-forest-labs/FLUX.1-schnell");
+    expect(byTask.note).toMatch(/searched model names/);
+
+    // A fragment of an id is enough for model_hint.
+    const byHint = (await tool.process(ctx, {
+      capability: "text_to_image",
+      model_hint: ["FLUX.1-dev"]
+    })) as { results: { model_id: string }[] };
+    expect(byHint.results[0].model_id).toBe("black-forest-labs/FLUX.1-dev");
+  });
+
+  it("reports a missed search instead of ranking an unrelated model first", async () => {
+    const tool = asTool(findModel, {
+      openai: new FakeImageProvider("openai" as ProviderId, [
+        {
+          id: "gpt-image-2",
+          name: "GPT Image 2",
+          provider: "openai"
+        } as ImageModel
+      ])
+    });
+    const result = (await tool.process(ctx, {
+      capability: "text_to_image",
+      query: "flux schnell"
+    })) as { total: number; query_matched: boolean; note: string };
+    expect(result.query_matched).toBe(false);
+    expect(result.total).toBe(1);
+    expect(result.note).toMatch(/No model name matched/);
+  });
+
   it("says so when the run carries no providers", async () => {
     const result = (await asTool(findModel).process(ctx, {
       capability: "text_to_image"

--- a/packages/agents/tests/capabilities-registry.test.ts
+++ b/packages/agents/tests/capabilities-registry.test.ts
@@ -75,6 +75,7 @@ const CAPABILITY_CATEGORY_SNAPSHOT: Record<string, PermissionCategory> = {
   debug_workflow: "execute",
   edit_image: "write",
   embed_text: "write",
+  read_media_bytes: "read",
   export_workflow_digraph: "read",
   find_model: "read",
   generate_image: "write",

--- a/packages/agents/tests/capabilities-scripts.test.ts
+++ b/packages/agents/tests/capabilities-scripts.test.ts
@@ -70,6 +70,7 @@ function ctx(userId = "u1") {
       textToSpeechEncoded,
       automaticSpeechRecognition
     })),
+    hasModelInterface: (name: string) => name === "createAsset",
     createAsset: vi.fn(
       async (args: {
         name: string;

--- a/packages/agents/tests/capabilities-storyboards.test.ts
+++ b/packages/agents/tests/capabilities-storyboards.test.ts
@@ -36,6 +36,7 @@ function ctx(userId = "u1") {
       const request = req as unknown as { capability: string };
       return request.capability === "text_to_image" ? PNG : MP4;
     }),
+    hasModelInterface: (name: string) => name === "createAsset",
     createAsset: vi.fn(
       async (args: {
         name: string;

--- a/packages/agents/tests/codeact-executor.test.ts
+++ b/packages/agents/tests/codeact-executor.test.ts
@@ -496,6 +496,54 @@ describe("CodeAct core tools", () => {
     expect(systemPrompt).toContain("tools.lookup_customer(");
   });
 
+  it("offers model and node discovery as direct tools too", async () => {
+    // A lookup is one question with one answer. Behind `execute_code` it cost
+    // a sandbox round trip and the answer arrived only as whatever the action
+    // chose to return.
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const context = createMockContext();
+    let offered: string[] = [];
+    let systemPrompt = "";
+    const provider = createLoopProvider([
+      { toolCalls: [codeAction("tc_1", `await finish({answer: 1});`)] }
+    ]);
+    const inner = provider.generateLoop.bind(provider);
+    provider.generateLoop = ((args: {
+      tools?: Array<{ name: string }>;
+      messages: Array<{ role: string; content?: unknown }>;
+    }) => {
+      offered = (args.tools ?? []).map((t) => t.name);
+      systemPrompt = String(
+        args.messages.find((m) => m.role === "system")?.content ?? ""
+      );
+      return inner(args as never);
+    }) as typeof provider.generateLoop;
+
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: context as never,
+      provider,
+      model: "m",
+      tools: [
+        new NamedTool("find_model", "Find a model."),
+        new NamedTool("search_nodes", "Search node types."),
+        new NamedTool("get_node_info", "Describe a node type."),
+        new NamedTool("run_node", "Run one node."),
+        new NamedTool("lookup_customer", "Look up a customer record by id.")
+      ]
+    });
+    for await (const msg of executor.execute()) void msg;
+
+    for (const name of ["find_model", "search_nodes", "get_node_info"]) {
+      expect(offered, `${name} should be a direct tool`).toContain(name);
+    }
+    // Running a node is execution, not discovery — it stays in the sandbox.
+    expect(offered).not.toContain("run_node");
+    expect(offered).not.toContain("lookup_customer");
+    expect(systemPrompt).toContain("# Direct tools");
+  });
+
   it("still reaches a core tool from inside a code action", async () => {
     // The belt keeps them: `nodetool.web`, `nodetool.agents` and any
     // hand-written fan-out call these from code, in one action.

--- a/packages/agents/tests/codeact-prompt-drift.test.ts
+++ b/packages/agents/tests/codeact-prompt-drift.test.ts
@@ -286,6 +286,7 @@ describe("chat variant exclusions", () => {
       "assetToSandbox",
       "fetch",
       "getSecret",
+      "media",
       "sandboxToAsset",
       "workspace"
     ]);
@@ -297,6 +298,33 @@ describe("chat variant exclusions", () => {
     const args = call.slice(0, call.indexOf("\n    });"));
     expect(args).not.toMatch(/^\s*context:/m);
     expect(args).toContain("maxFetchCalls: 0");
+  });
+
+  it("cannot call media.* from a chat action", async () => {
+    const session = createChatCodeActSession({
+      tools: [],
+      executeTool: async () => ({})
+    });
+    const observation = JSON.parse(
+      await session.executeAction({
+        code: 'return await media.bytes({ type: "document", uri: "data:text/plain;base64,aGk=" });'
+      })
+    ) as { ok: boolean; error?: string };
+    expect(observation.ok).toBe(false);
+    expect(observation.error).toContain(
+      "media.bytes is not available without a context"
+    );
+  }, 60_000);
+
+  it("does not advertise media.* to a chat action", () => {
+    const manifest = getSandboxManifest();
+    const chat = buildCodeActSystemPrompt({ tools: [], variant: "chat" });
+    const step = buildCodeActSystemPrompt({ tools: [], variant: "step" });
+    expect(manifest.bridges.media.members.length).toBeGreaterThan(0);
+    for (const member of manifest.bridges.media.members) {
+      expect(step).toContain(member.signature);
+      expect(chat).not.toContain(member.signature);
+    }
   });
 
   it("hides every excluded bridge from the chat prompt", () => {

--- a/packages/agents/tests/mcp-guest-contract.test.ts
+++ b/packages/agents/tests/mcp-guest-contract.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  MCP_GUEST_CONTRACT,
+  MCP_SANDBOX_ACTION_SNIPPET,
+  MCP_SANDBOX_ASSET_SNIPPET,
+  MCP_SANDBOX_PROBE_SNIPPET,
+  MCP_SANDBOX_RESOURCE_URI,
+  MCP_SANDBOX_PROMPTS,
+  buildMcpSandboxCatalog
+} from "../src/codeact/mcp-guest-contract.js";
+import { chatUnavailableBridges } from "../src/codeact/prompt.js";
+import { CODEACT_INJECTED_GLOBALS } from "../src/codeact/tool-api.js";
+import { getSandboxManifest } from "../src/code-gen/sandbox-manifest.js";
+import { unknownApiReferences } from "../src/code-gen/sandbox-prompt.js";
+
+/**
+ * Locals the snippets bind. extractApiReferences treats `listed.workflows`
+ * as an API named `listed`; they are not guest globals.
+ */
+const SNIPPET_LOCALS = new Set(["listed", "model", "row", "asset", "hits", "h"]);
+
+function undocumented(text: string): string[] {
+  const known = new Set<string>([...CODEACT_INJECTED_GLOBALS, ...SNIPPET_LOCALS]);
+  return unknownApiReferences(text).filter((name) => !known.has(name));
+}
+
+describe("MCP guest contract", () => {
+  it("leads with the guest rules an MCP agent needs first", () => {
+    expect(MCP_GUEST_CONTRACT.startsWith("# Guest JavaScript (not Node)")).toBe(
+      true
+    );
+    expect(MCP_GUEST_CONTRACT).toContain("QuickJS");
+    expect(MCP_GUEST_CONTRACT).toContain("nodetool.searchTools");
+    expect(MCP_GUEST_CONTRACT).toContain("there is no `finish()`");
+    expect(MCP_GUEST_CONTRACT).toContain(MCP_SANDBOX_RESOURCE_URI);
+    expect(MCP_GUEST_CONTRACT).toContain(MCP_SANDBOX_ACTION_SNIPPET);
+  });
+
+  it("names no API the sandbox lacks", () => {
+    expect(undocumented(MCP_GUEST_CONTRACT)).toEqual([]);
+    expect(undocumented(MCP_SANDBOX_ACTION_SNIPPET)).toEqual([]);
+    expect(undocumented(MCP_SANDBOX_ASSET_SNIPPET)).toEqual([]);
+    expect(undocumented(MCP_SANDBOX_PROBE_SNIPPET)).toEqual([]);
+  });
+
+  it("builds the sandbox catalog from the live manifest", () => {
+    const manifest = getSandboxManifest();
+    const catalog = buildMcpSandboxCatalog();
+    expect(catalog.server).toBe("nodetool");
+    expect(catalog.runtime).toBe(manifest.runtime);
+    expect(catalog.resource).toBe(MCP_SANDBOX_RESOURCE_URI);
+    expect(catalog.contract).toBe(MCP_GUEST_CONTRACT);
+    expect(catalog.blocked_globals).toEqual(manifest.blockedGlobals);
+    expect(catalog.unavailable_bridges).toEqual(chatUnavailableBridges(manifest));
+    expect(catalog.unavailable_bridges).toEqual(
+      expect.arrayContaining(["fetch", "workspace", "media", "getSecret"])
+    );
+    expect(catalog.available_bridges.map((b) => b.name)).not.toContain(
+      "workspace"
+    );
+    expect(catalog.packages).toEqual([]);
+    expect(catalog.examples.action).toBe(MCP_SANDBOX_ACTION_SNIPPET);
+    expect(catalog.examples.asset).toBe(MCP_SANDBOX_ASSET_SNIPPET);
+    expect(catalog.examples.probe).toBe(MCP_SANDBOX_PROBE_SNIPPET);
+  });
+
+  it("records the two MCP prompts against the same snippets", () => {
+    expect(MCP_SANDBOX_PROMPTS.map((p) => p.name)).toEqual([
+      "sandbox-action",
+      "sandbox-asset"
+    ]);
+    expect(MCP_SANDBOX_PROMPTS[0].snippet).toBe(MCP_SANDBOX_ACTION_SNIPPET);
+    expect(MCP_SANDBOX_PROMPTS[1].snippet).toBe(MCP_SANDBOX_ASSET_SNIPPET);
+  });
+});

--- a/packages/agents/tests/media-read-bytes.test.ts
+++ b/packages/agents/tests/media-read-bytes.test.ts
@@ -1,0 +1,123 @@
+/**
+ * `read_media_bytes` — the gated way a chat action reads the bytes behind a
+ * media ref.
+ *
+ * A chat action runs without a `ProcessingContext`, by design (#4780), so the
+ * `media.*` sandbox bridge throws there. The capability is the sanctioned route
+ * to the same answer: it runs host-side with the run's context, past the
+ * permission gate, and hands the bytes back as base64 the guest revives with
+ * `fromBase64`. Without it, a chat user can generate an image and never read it
+ * back, so generate-then-composite is impossible from chat.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { UNGATED, createCapabilityRun } from "../src/capabilities/index.js";
+import type { CapabilityRun } from "../src/capabilities/types.js";
+import { createChatCodeActSession } from "../src/codeact/chat-codeact.js";
+
+const PNG = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3]);
+const ASSET_ID = "asset-generated-1";
+
+/** A context whose asset store holds one generated image. */
+function contextWithAsset(): ProcessingContext {
+  return {
+    userId: "user-media",
+    resolveAssetBytes: async (uri: string) =>
+      uri.startsWith(`asset://${ASSET_ID}`)
+        ? { bytes: PNG, attempts: [uri] }
+        : { bytes: null, attempts: [uri] },
+    resolveWorkspacePath: (p: string) => p
+  } as unknown as ProcessingContext;
+}
+
+function run(context: ProcessingContext): CapabilityRun {
+  return createCapabilityRun({ context, gate: UNGATED });
+}
+
+/** One chat action whose only platform surface is the capability run. */
+async function action(
+  capabilityRun: CapabilityRun,
+  code: string
+): Promise<{ ok: boolean; result?: unknown; error?: string }> {
+  const session = createChatCodeActSession({
+    tools: [],
+    executeTool: async (call) => capabilityRun.invoke(call.name, call.args),
+    capabilityRun
+  });
+  return JSON.parse(await session.executeAction({ code })) as {
+    ok: boolean;
+    result?: unknown;
+    error?: string;
+  };
+}
+
+describe("read_media_bytes from a chat action", () => {
+  it("reads back the bytes of a generated asset", async () => {
+    const observation = await action(
+      run(contextWithAsset()),
+      `
+        import { read_media_bytes } from "@nodetool-ai/sandbox-nodetool/media";
+        const result = await read_media_bytes({ uri: "asset://${ASSET_ID}.png" });
+        const bytes = fromBase64(result.content_base64);
+        return {
+          size: result.size,
+          mimeType: result.mime_type,
+          head: Array.from(bytes.slice(0, 4)),
+          isBytes: bytes instanceof Uint8Array
+        };
+      `
+    );
+    expect(observation.ok).toBe(true);
+    expect(observation.result).toEqual({
+      size: PNG.length,
+      mimeType: "image/png",
+      head: [137, 80, 78, 71],
+      isBytes: true
+    });
+  }, 60_000);
+
+  it("feeds the bytes straight into the image bridge", async () => {
+    // The point of the capability: generate → read → composite, all in chat.
+    const observation = await action(
+      run(contextWithAsset()),
+      `
+        import { read_media_bytes } from "@nodetool-ai/sandbox-nodetool/media";
+        const result = await read_media_bytes({ uri: "asset://${ASSET_ID}.png" });
+        return { bytes: fromBase64(result.content_base64).length };
+      `
+    );
+    expect(observation.ok).toBe(true);
+    expect(observation.result).toEqual({ bytes: PNG.length });
+  }, 60_000);
+
+  it("names the ref it could not read", async () => {
+    const observation = await action(
+      run(contextWithAsset()),
+      `
+        import { read_media_bytes } from "@nodetool-ai/sandbox-nodetool/media";
+        try {
+          await read_media_bytes({ uri: "asset://nope.png" });
+          return "resolved";
+        } catch (e) {
+          return e.message;
+        }
+      `
+    );
+    expect(observation.ok).toBe(true);
+    expect(String(observation.result)).toContain("asset://nope.png");
+  }, 60_000);
+
+  it("still refuses the ungated media.* bridge in the same action", async () => {
+    // The capability is an addition, not a reopening: the sandbox bridge stays
+    // context-less in chat.
+    const observation = await action(
+      run(contextWithAsset()),
+      `return await media.bytes({ type: "image", uri: "asset://${ASSET_ID}.png" });`
+    );
+    expect(observation.ok).toBe(false);
+    expect(observation.error).toContain(
+      "media.bytes is not available without a context"
+    );
+  }, 60_000);
+});

--- a/packages/agents/tests/media-tools.test.ts
+++ b/packages/agents/tests/media-tools.test.ts
@@ -37,6 +37,9 @@ function makeContext(opts: MockCtxOptions = {}): any {
     runProviderPrediction: opts.runProviderPrediction,
     streamProviderPrediction: opts.streamProviderPrediction,
     getProvider: opts.getProvider,
+    // A duck-typed context: the interface check is what the code reads, so a
+    // fake that only defines the method reads as "no asset persistence".
+    hasModelInterface: (name: string) => name === "createAsset",
     createAsset,
     workspaceStorage: opts.workspaceStorage
   };
@@ -154,6 +157,7 @@ describe("GenerateImageTool", () => {
     const r = (await tool.process(
       makeContext({
         runProviderPrediction,
+        hasModelInterface: (name: string) => name === "createAsset",
         createAsset: vi.fn().mockResolvedValue({ id: "img-1" }),
         workspaceStorage: storage
       }),
@@ -208,6 +212,7 @@ describe("EditImageTool", () => {
     const r = (await tool.process(
       makeContext({
         runProviderPrediction,
+        hasModelInterface: (name: string) => name === "createAsset",
         createAsset: vi.fn().mockResolvedValue({ id: "e1" }),
         workspaceStorage: makeStorage({ "in.png": src })
       }),
@@ -331,6 +336,7 @@ describe("AnimateImageTool", () => {
     const r = (await tool.process(
       makeContext({
         runProviderPrediction,
+        hasModelInterface: (name: string) => name === "createAsset",
         createAsset: vi.fn().mockResolvedValue({ id: "a1" }),
         workspaceStorage: makeStorage({ "src.png": src })
       }),
@@ -412,6 +418,7 @@ describe("GenerateSpeechTool", () => {
     await tool.process(
       makeContext({
         getProvider,
+        hasModelInterface: (name: string) => name === "createAsset",
         createAsset: vi.fn().mockResolvedValue({ id: "x" })
       }),
       { provider: "openai", model: "tts", text: "hi", output_file: "a.flac" }

--- a/packages/agents/tests/nodetool-api-media-docs.test.ts
+++ b/packages/agents/tests/nodetool-api-media-docs.test.ts
@@ -26,6 +26,8 @@ const CRITIQUE_TOOLS = [
   "score_image_adherence"
 ].map(toolDef);
 
+const READ_BYTES_TOOLS = ["generate_image", "read_media_bytes"].map(toolDef);
+
 const DOCUMENT_TOOLS = [
   "convert_document",
   "extract_pdf_text",
@@ -49,7 +51,24 @@ function createFakeRouter() {
           ]
         });
       case "generate_image":
-        return JSON.stringify({ type: "image", asset_uri: "asset://img1.png" });
+        // The shape a real generation returns: an asset URI and id, plus a
+        // host `uri` the guest may not read.
+        return JSON.stringify({
+          type: "image",
+          asset_id: "img1",
+          asset_uri: "asset://img1.png",
+          url: "asset://img1",
+          uri: "file:///var/assets/img1.png"
+        });
+      case "read_media_bytes":
+        return args["uri"] === "asset://img1.png"
+          ? JSON.stringify({
+              uri: args["uri"],
+              size: 3,
+              mime_type: "image/png",
+              content_base64: "AQID"
+            })
+          : JSON.stringify({ error: `Could not read ${String(args["uri"])}` });
       case "critique_image":
         return JSON.stringify({
           type: "critique",
@@ -189,6 +208,67 @@ describe("nodetool.media judging", () => {
     );
     expect(obs.ok).toBe(true);
     expect(String(obs.result)).toContain("nodetool.models.pick");
+  });
+});
+
+describe("nodetool.media.bytes", () => {
+  it("reads the bytes behind a generation result", async () => {
+    const { executeTool, calls } = createFakeRouter();
+    const session = makeSession(READ_BYTES_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `const image = await nodetool.media.generateImage("a fox",
+         { provider: "fal_ai", model_id: "fal-ai/flux/schnell" });
+       const bytes = await nodetool.media.bytes(image);
+       return [bytes.length, Array.from(bytes)];`
+    );
+    expect(obs.ok).toBe(true);
+    expect(obs.result).toEqual([3, [1, 2, 3]]);
+    // The generation's `uri` is a host path; the asset URI is what goes over.
+    expect(calls[1]).toMatchObject({
+      name: "read_media_bytes",
+      args: { uri: "asset://img1.png" }
+    });
+  });
+
+  it("takes a bare URI too", async () => {
+    const { executeTool } = createFakeRouter();
+    const session = makeSession(READ_BYTES_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `const bytes = await nodetool.media.bytes("asset://img1.png");
+       return bytes.length;`
+    );
+    expect(obs.ok).toBe(true);
+    expect(obs.result).toBe(3);
+  });
+
+  it("throws the tool's own error instead of returning undefined bytes", async () => {
+    const { executeTool } = createFakeRouter();
+    const session = makeSession(READ_BYTES_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `try {
+         await nodetool.media.bytes("asset://missing.png");
+         return "no throw";
+       } catch (e) { return e.message; }`
+    );
+    expect(obs.ok).toBe(true);
+    expect(String(obs.result)).toContain("Could not read asset://missing.png");
+  });
+
+  it("names the accepted references when handed nothing usable", async () => {
+    const { executeTool } = createFakeRouter();
+    const session = makeSession(READ_BYTES_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `try {
+         await nodetool.media.bytes({ type: "image" });
+         return "no throw";
+       } catch (e) { return e.message; }`
+    );
+    expect(obs.ok).toBe(true);
+    expect(String(obs.result)).toContain("asset_uri");
   });
 });
 

--- a/packages/agents/tests/read-asset-uris.test.ts
+++ b/packages/agents/tests/read-asset-uris.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `read_asset` accepts the forms an agent actually holds.
+ *
+ * The tool was written against one shape — a `assets/<name>` storage key — so
+ * an agent holding the `asset://<id>` URI a generation returned had nothing
+ * that worked. A real session burned four round trips guessing (bare id,
+ * `asset://<id>`, `asset://<id>.png`, `file://…`) and got "Asset not found"
+ * every time. Each of those forms now resolves, and a genuine miss names the
+ * form that does work.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { UNGATED, createCapabilityRun } from "../src/capabilities/index.js";
+
+const ID = "abc123";
+const TEXT = "generated report";
+const BYTES = new TextEncoder().encode(TEXT);
+
+/** A context whose asset resolver answers for one id, plus a storage map. */
+function context(): ProcessingContext {
+  const stored = new Map<string, Uint8Array>([
+    ["memory://assets/notes.txt", BYTES],
+    ["/api/storage/blob.bin", BYTES]
+  ]);
+  return {
+    userId: "user-read-asset",
+    storage: {
+      retrieve: async (uri: string) => stored.get(uri) ?? null,
+      store: async () => "",
+      uriForKey: (key: string) => key
+    },
+    resolveAssetBytes: async (uri: string) =>
+      uri.startsWith(`asset://${ID}`)
+        ? { bytes: BYTES, attempts: [uri] }
+        : { bytes: null, attempts: [uri] }
+  } as unknown as ProcessingContext;
+}
+
+async function readAsset(name: string): Promise<Record<string, unknown>> {
+  const run = createCapabilityRun({ context: context(), gate: UNGATED });
+  return (await run.invoke("read_asset", { name })) as Record<string, unknown>;
+}
+
+describe("read_asset accepts every form an agent holds", () => {
+  it("resolves an asset:// URI", async () => {
+    const result = await readAsset(`asset://${ID}`);
+    expect(result.success).toBe(true);
+    expect(result.content).toBe(TEXT);
+  });
+
+  it("resolves an asset:// URI carrying an extension", async () => {
+    const result = await readAsset(`asset://${ID}.png`);
+    expect(result.success).toBe(true);
+    expect(result.content).toBe(TEXT);
+  });
+
+  it("resolves a bare asset id", async () => {
+    const result = await readAsset(ID);
+    expect(result.success).toBe(true);
+    expect(result.content).toBe(TEXT);
+  });
+
+  it("resolves a storage key URI", async () => {
+    const result = await readAsset("/api/storage/blob.bin");
+    expect(result.success).toBe(true);
+    expect(result.content).toBe(TEXT);
+  });
+
+  it("still resolves a legacy assets/<name> key", async () => {
+    const result = await readAsset("notes.txt");
+    expect(result.success).toBe(true);
+    expect(result.content).toBe(TEXT);
+  });
+
+  it("names the form that works when nothing resolves", async () => {
+    const result = await readAsset("asset://not-a-real-asset");
+    expect(result.success).toBe(false);
+    expect(String(result.error)).toContain("asset://");
+    expect(String(result.error)).toContain("list_assets");
+  });
+});

--- a/packages/agents/tests/sandbox-media-ref.test.ts
+++ b/packages/agents/tests/sandbox-media-ref.test.ts
@@ -7,7 +7,7 @@
 
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { runInSandbox } from "../src/js-sandbox.js";
@@ -81,22 +81,26 @@ describe("media.bytes / media.text", () => {
     expect(result.result).toBe("hello");
   });
 
-  it("reads an absolute file path", async () => {
+  it("reads an absolute file path under host filesystem access", async () => {
+    // Host mode is the scope where an absolute path means what it says. Under
+    // the default workspace scope it is resolved workspace-relative instead —
+    // see the "filesystem containment" cases below.
     const path = join(dir, "note.txt");
     await writeFile(path, "from disk");
     const result = await runInSandbox({
       code: `return await media.text({ type: "document", uri: ${JSON.stringify(path)} });`,
-      context: contextWith()
+      context: contextWith(),
+      limits: { filesystemAccess: "host" }
     });
     expect(result.success).toBe(true);
     expect(result.result).toBe("from disk");
   });
 
-  it("reads a `~`-prefixed path through the filesystem fallback", async () => {
-    // `loadMediaRefBytes` never touches a `~` path — this is the fallback that
-    // `resolveDocumentBytes` has and the guest would otherwise lack. The home
-    // directory is not writable in every test environment, so the check is that
-    // the fallback ran: the error names the expanded path, not the tilde.
+  it("expands a `~`-prefixed path under host filesystem access", async () => {
+    // `loadMediaRefBytes` never touches a `~` path; `resolveGuestPath` expands
+    // it, but only in host mode. The home directory is not writable in every
+    // test environment, so the check is that expansion ran and the read then
+    // missed — not that the tilde was passed to `fs` verbatim.
     const result = await runInSandbox({
       code: `
         try {
@@ -106,7 +110,8 @@ describe("media.bytes / media.text", () => {
           return e.message;
         }
       `,
-      context: contextWith()
+      context: contextWith(),
+      limits: { filesystemAccess: "host" }
     });
     expect(result.success).toBe(true);
     expect(result.result).toContain("could not read");
@@ -234,7 +239,8 @@ describe("media.info", () => {
         const info = await media.info({ type: "document", uri: ${JSON.stringify(path)} });
         return { mimeType: info.mimeType, size: info.size };
       `,
-      context: contextWith()
+      context: contextWith(),
+      limits: { filesystemAccess: "host" }
     });
     expect(result.result).toEqual({ mimeType: "application/pdf", size: 8 });
   });
@@ -391,5 +397,89 @@ describe("media without a context", () => {
       toAudio: "media.toAudio is not available without a context",
       toVideo: "media.toVideo is not available without a context"
     });
+  });
+});
+
+/**
+ * `media.*` reaches the filesystem, so it answers to the same containment
+ * `workspace.*` does: a run resolves paths under its workspace root unless the
+ * host opted into `filesystemAccess: "host"`. Guest code cannot ask for host
+ * mode, so a model-written body cannot read a credential file by naming it.
+ */
+describe("filesystem containment", () => {
+  let workspace = "";
+  let outside = "";
+  let outsideFile = "";
+
+  beforeAll(async () => {
+    workspace = await mkdtemp(join(tmpdir(), "media-ws-"));
+    outside = await mkdtemp(join(tmpdir(), "media-outside-"));
+    outsideFile = join(outside, "secret.txt");
+    await writeFile(outsideFile, "TOP SECRET");
+  });
+
+  afterAll(async () => {
+    await rm(workspace, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  });
+
+  const workspaceContext = (): Ctx =>
+    ({
+      resolveAssetBytes: async () => ({ bytes: null, attempts: [] }),
+      resolveWorkspacePath: (p: string) =>
+        resolve(workspace, p.replace(/^[/\\]+/, ""))
+    }) as unknown as Ctx;
+
+  it("reads a file inside the workspace", async () => {
+    await writeFile(join(workspace, "note.txt"), "from the workspace");
+    const result = await runInSandbox({
+      code: `return await media.text({ type: "document", uri: "note.txt" });`,
+      context: workspaceContext()
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("from the workspace");
+  });
+
+  it("refuses a path outside the workspace", async () => {
+    const result = await runInSandbox({
+      code: `
+        try {
+          return await media.text({ type: "document", uri: ${JSON.stringify(outsideFile)} });
+        } catch (e) {
+          return e.message;
+        }
+      `,
+      context: workspaceContext()
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).not.toContain("TOP SECRET");
+  });
+
+  it("refuses a `file://` URI pointing outside the workspace", async () => {
+    const result = await runInSandbox({
+      code: `
+        try {
+          return await media.text({
+            type: "document",
+            uri: ${JSON.stringify(`file://${outsideFile}`)}
+          });
+        } catch (e) {
+          return e.message;
+        }
+      `,
+      context: workspaceContext()
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).not.toContain("TOP SECRET");
+  });
+
+  it("reads outside the workspace when the host opted into host mode", async () => {
+    const result = await runInSandbox({
+      code: `return await media.text({ type: "document", uri: ${JSON.stringify(outsideFile)} });`,
+      context: workspaceContext(),
+      limits: { filesystemAccess: "host" }
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("TOP SECRET");
   });
 });

--- a/packages/agents/tests/script-voice-tools.test.ts
+++ b/packages/agents/tests/script-voice-tools.test.ts
@@ -73,6 +73,7 @@ function ctx(options: CtxOptions = {}) {
       textToSpeechEncoded,
       automaticSpeechRecognition
     })),
+    hasModelInterface: (name: string) => name === "createAsset",
     createAsset: vi.fn(
       async (args: { name: string; contentType: string; content: Uint8Array }) => {
         const asset = await Asset.create<Asset>({

--- a/packages/agents/tests/storyboard-render-tools.test.ts
+++ b/packages/agents/tests/storyboard-render-tools.test.ts
@@ -40,6 +40,7 @@ function ctx(options: CtxOptions = {}) {
           : MP4;
       return result;
     }),
+    hasModelInterface: (name: string) => name === "createAsset",
     createAsset: vi.fn(
       async (args: { name: string; contentType: string; content: Uint8Array }) => {
         const asset = await Asset.create<Asset>({

--- a/packages/agents/tests/tools/asset-tools.test.ts
+++ b/packages/agents/tests/tools/asset-tools.test.ts
@@ -97,6 +97,7 @@ describe("SaveAssetTool", () => {
       content: Uint8Array;
     }> = [];
     const ctx = {
+      hasModelInterface: (name: string) => name === "createAsset",
       createAsset: vi.fn(async (args) => {
         calls.push(args);
         return { id: "abc123" };
@@ -121,6 +122,7 @@ describe("SaveAssetTool", () => {
 
   it("prefers createAsset over storage for text content too", async () => {
     const ctx = {
+      hasModelInterface: (name: string) => name === "createAsset",
       createAsset: vi.fn(async () => ({ id: "txt-1" })),
       storage: { store: vi.fn() }
     } as unknown as ProcessingContext;
@@ -302,6 +304,7 @@ describe("SaveAssetTool + ReadAssetTool round-trip", () => {
     // assets; save_asset now mirrors the bytes to that key.
     const storage = new InMemoryStorageAdapter();
     const ctx = {
+      hasModelInterface: (name: string) => name === "createAsset",
       createAsset: vi.fn(async () => ({ id: "db-generated-id" })),
       storage
     } as unknown as ProcessingContext;

--- a/packages/agents/tests/tools/asset-tools.test.ts
+++ b/packages/agents/tests/tools/asset-tools.test.ts
@@ -186,7 +186,7 @@ describe("ReadAssetTool", () => {
 
   it("has correct name and description", () => {
     expect(tool.name).toBe("read_asset");
-    expect(tool.description).toBe("Read an asset file");
+    expect(tool.description).toContain("asset://");
   });
 
   it("reads a previously saved asset", async () => {
@@ -227,14 +227,18 @@ describe("ReadAssetTool", () => {
     expect(result.error).toMatch(/name/i);
   });
 
-  it("returns error when no storage adapter is configured", async () => {
+  it("reports not found, naming the forms that work, without storage", async () => {
+    // `read_asset` no longer requires a storage adapter: an `asset://` URI
+    // resolves through the context's asset resolver. With neither available
+    // the answer is "not found", and it names what to pass instead.
     const ctx = makeContext(null);
     const result = (await tool.process(ctx, {
       name: "test.txt"
     })) as Record<string, unknown>;
 
     expect(result.success).toBe(false);
-    expect(result.error).toMatch(/storage/i);
+    expect(result.error).toMatch(/not found/i);
+    expect(String(result.error)).toContain("asset://");
   });
 
   it("handles storage errors gracefully", async () => {

--- a/packages/agents/tests/tools/media-tools.test.ts
+++ b/packages/agents/tests/tools/media-tools.test.ts
@@ -74,6 +74,9 @@ function makeContext(stub: {
   };
   if (stub.assetMode === "enabled") {
     let n = 0;
+    // A duck-typed context: the interface check is what the code reads, so a
+    // fake that only defines the method reads as "no asset persistence".
+    ctx.hasModelInterface = (name: string) => name === "createAsset";
     ctx.createAsset = vi.fn(async (args: AssetCreateCall) => {
       stub.assetCalls?.push(args);
       n += 1;

--- a/packages/cli/src/app.tsx
+++ b/packages/cli/src/app.tsx
@@ -23,7 +23,6 @@ import { ExecutionTree } from "./ExecutionTree.js";
 import { useExecutionState } from "./useExecutionState.js";
 import type { Message, ToolCall } from "@nodetool-ai/runtime";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
-import { FileStorageAdapter, ProcessingContext } from "@nodetool-ai/runtime";
 import { processChat } from "@nodetool-ai/chat";
 import {
   RunSubtaskTool,
@@ -35,14 +34,18 @@ import { WebSocketChatClient } from "./websocket-client.js";
 import { renderMarkdown } from "./markdown.js";
 import {
   isBasicTool,
+  isCodeAction,
+  isFormattedTool,
   friendlyToolName,
+  toolStatusLabel,
   formatToolParams,
   formatToolResult,
   formatToolDiff,
+  formatToolCode,
 } from "./tool-format.js";
 import { saveSettings } from "./settings.js";
 import { applySystemPrompt, createCliCodeActTurn } from "./chat-codeact.js";
-import { getSecret } from "@nodetool-ai/models";
+import { createChatContext } from "./chat-context.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -117,9 +120,10 @@ function AssistantMessage({ content, rendered }: { content: string; rendered?: s
 
 /**
  * Renders one tool call — header (`● Verb(params)`), result summary, and (for
- * edits) a diff. Shared by the committed transcript (ToolMessage) and the live
- * in-progress area (LiveToolCall). When `running`, shows a spinner instead of
- * waiting for a summary, so the call is visible while it executes.
+ * edits) a diff. `execute_code` uses the action title as the headline and
+ * shows the program as a dimmed block. Shared by the committed transcript
+ * (ToolMessage) and the live in-progress area (LiveToolCall). When `running`,
+ * shows a spinner instead of waiting for a summary.
  */
 function ToolCallView({
   name,
@@ -133,6 +137,42 @@ function ToolCallView({
   running?: boolean;
 }) {
   const isError = !!summary && summary.startsWith("Error");
+
+  if (isCodeAction(name)) {
+    const title = formatToolParams(name, args) || "Code action";
+    const codeLines = formatToolCode(name, args);
+    const maxCodeWidth = Math.max((process.stdout.columns ?? 80) - 8, 20);
+    const summaryLines = summary ? summary.split("\n") : [];
+    return (
+      <Box flexDirection="column" marginTop={1}>
+        <Box>
+          <Text color="green">{"● "}</Text>
+          <Text bold color="cyan">Run</Text>
+          <Text>{"  "}</Text>
+          <Text bold>{title}</Text>
+          {running ? <Text color="gray" dimColor>{"  "}<Spinner type="dots" /></Text> : null}
+        </Box>
+        {codeLines?.map((line, i) => (
+          <Box key={i} marginLeft={4}>
+            <Text
+              color={line.startsWith("…") ? "gray" : undefined}
+              dimColor
+            >
+              {line.slice(0, maxCodeWidth)}
+            </Text>
+          </Box>
+        ))}
+        {summaryLines.map((line, i) => (
+          <Box key={`s${i}`} marginLeft={2}>
+            <Text color={isError ? "red" : "gray"} dimColor={!isError}>
+              {i === 0 ? "⎿  " : "   "}
+              {line}
+            </Text>
+          </Box>
+        ))}
+      </Box>
+    );
+  }
 
   if (isBasicTool(name)) {
     const params = formatToolParams(name, args);
@@ -783,15 +823,7 @@ export function App({
     setStreamLabel("thinking");
 
     try {
-      const ctx = new ProcessingContext({
-        jobId: crypto.randomUUID(),
-        userId: "1",
-        workspaceDir,
-        workspaceStorage: workspaceDir
-          ? new FileStorageAdapter(workspaceDir)
-          : null,
-        secretResolver: getSecret
-      });
+      const ctx = await createChatContext({ workspaceDir });
       const tools = buildTools();
 
       // The unified chat loop is used for every turn — there is no longer a
@@ -816,11 +848,11 @@ export function App({
             pendingToolArgs.set(event.id, event.args);
             commitStreamSegment(); // finalize any assistant text before the tool
             startLiveTool(event.id, event.name, event.args);
-            setStreamLabel(`${friendlyToolName(event.name)}…`);
+            setStreamLabel(`${toolStatusLabel(event.name, event.args)}…`);
           } else if (event.type === "tool_result") {
             const args = pendingToolArgs.get(event.id);
             pendingToolArgs.delete(event.id);
-            const display = isBasicTool(event.name)
+            const display = isFormattedTool(event.name)
               ? formatToolResult(event.name, args, event.content)
               : event.content.length > 100
                 ? event.content.slice(0, 100) + "…"
@@ -902,10 +934,10 @@ export function App({
             onToolCall: (tc: ToolCall) => {
               commitStreamSegment(); // finalize any assistant text before the tool
               startLiveTool(tc.id, tc.name, tc.args);
-              setStreamLabel(`${friendlyToolName(tc.name)}…`);
+              setStreamLabel(`${toolStatusLabel(tc.name, tc.args)}…`);
             },
             onToolResult: (tc: ToolCall, result: unknown) => {
-              const display = isBasicTool(tc.name)
+              const display = isFormattedTool(tc.name)
                 ? formatToolResult(tc.name, tc.args, result)
                 : typeof result === "string"
                   ? result

--- a/packages/cli/src/chat-codeact.ts
+++ b/packages/cli/src/chat-codeact.ts
@@ -8,10 +8,11 @@
  * whose `process()` runs one code action; the toolbelt itself moves inside the
  * sandbox and is never offered to the provider.
  *
- * Two sets also reach the provider directly, as on the server. The core tools
- * (`CORE_TOOL_NAMES` — file, search, fetch, todo, delegation) are the shapes
- * every model is trained on, so they cost less as a plain tool call than as a
- * sandbox round trip; they stay on the belt too, because code composes them.
+ * Two sets also reach the provider directly, as on the server. The direct
+ * tools (`DIRECT_TOOL_NAMES` — file, search, fetch, todo, delegation, plus
+ * model and node discovery) are the shapes every model is trained on, so they
+ * cost less as a plain tool call than as a sandbox round trip; they stay on
+ * the belt too, because code composes them.
  * And `view_image` is the one channel that puts pixels into the model's
  * context, which cannot ride the JSON observation envelope.
  */
@@ -21,7 +22,7 @@ import type {
   Message,
   ProcessingContext
 } from "@nodetool-ai/runtime";
-import { CORE_TOOL_NAMES } from "@nodetool-ai/runtime";
+import { DIRECT_TOOL_NAMES } from "@nodetool-ai/runtime";
 import {
   Tool,
   createChatCodeActSession,
@@ -84,7 +85,7 @@ export function createCliCodeActTurn(
 ): CliCodeActTurn {
   const byName = new Map(options.tools.map((tool) => [tool.name, tool]));
   const directTools = options.tools.filter(
-    (t) => t.name !== VIEW_IMAGE_TOOL && CORE_TOOL_NAMES.has(t.name)
+    (t) => t.name !== VIEW_IMAGE_TOOL && DIRECT_TOOL_NAMES.has(t.name)
   );
   const beltTools = options.tools.filter((t) => t.name !== VIEW_IMAGE_TOOL);
 

--- a/packages/cli/src/chat-context.ts
+++ b/packages/cli/src/chat-context.ts
@@ -1,0 +1,34 @@
+/**
+ * The ProcessingContext a CLI chat turn runs on.
+ *
+ * Both entrances build the same one — the Ink app and `--stdin` mode — so a
+ * turn behaves the same whichever way it was started.
+ *
+ * It carries the same persistence a local workflow run gets. Without it
+ * `persistOutput` falls back to a workspace file, and since the CLI's
+ * workspace is the current directory, a generated image landed in whatever
+ * folder the user happened to start the chat in, with no `asset://` URI for
+ * anything downstream to reference.
+ */
+
+import { getSecret } from "@nodetool-ai/models";
+import { FileStorageAdapter, ProcessingContext } from "@nodetool-ai/runtime";
+import { localModelInterfaces } from "./local-model-interfaces.js";
+
+export async function createChatContext(opts: {
+  workspaceDir?: string | null;
+  userId?: string;
+}): Promise<ProcessingContext> {
+  const workspaceDir = opts.workspaceDir ?? null;
+  const context = new ProcessingContext({
+    jobId: crypto.randomUUID(),
+    userId: opts.userId ?? "1",
+    workspaceDir,
+    workspaceStorage: workspaceDir
+      ? new FileStorageAdapter(workspaceDir)
+      : null,
+    secretResolver: getSecret
+  });
+  context.setModelInterfaces(await localModelInterfaces());
+  return context;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,8 @@ import { program } from "commander";
 import { render } from "ink";
 import React from "react";
 import { App } from "./app.js";
-import { loadSettings } from "./settings.js";
+import { ALWAYS_ENABLED_TOOLS, loadSettings } from "./settings.js";
+import { installLocalModelInterfaces } from "./local-model-interfaces.js";
 import { runStdinMode } from "./stdin.js";
 import { buildConfiguredProviders, KNOWN_PROVIDERS } from "./providers.js";
 import { initDb, getSecret } from "@nodetool-ai/models";
@@ -161,6 +162,10 @@ try {
   );
 }
 
+// The same persistence a local workflow run gets, for every context this
+// process builds (chat turns build their own on top; a sub-agent's does not).
+await installLocalModelInterfaces();
+
 // Load persisted settings and merge with CLI flags
 const settings = await loadSettings();
 
@@ -180,17 +185,18 @@ if (opts.agent !== undefined) {
 }
 
 const workspace = opts.workspace ?? process.cwd();
-const enabledTools = opts.tools
+const explicitTools = opts.tools
   ? opts.tools.split(",").map((t) => t.trim())
-  : settings.enabledTools;
+  : null;
+const enabledTools = explicitTools ?? settings.enabledTools;
 
-// Always-on tools (no credentials needed)
-for (const tool of [
-  "extract_pdf_text",
-  "convert_pdf_to_markdown",
-  "convert_document"
-]) {
-  if (!enabledTools.includes(tool)) enabledTools.push(tool);
+// Tools that gate on no credential — documents, discovery, generation — added
+// to a settings file written before they existed. `--tools` is left exactly as
+// typed: a caller who names a belt means that belt.
+if (!explicitTools) {
+  for (const tool of ALWAYS_ENABLED_TOOLS) {
+    if (!enabledTools.includes(tool)) enabledTools.push(tool);
+  }
 }
 
 // Auto-enable based on available secrets (env or encrypted DB)
@@ -209,11 +215,9 @@ await Promise.all([
     "google_news",
     "google_images"
   ]),
-  autoEnable("OPENAI_API_KEY", [
-    "web_search",
-    "generate_image",
-    "generate_speech"
-  ]),
+  // `generate_image` / `generate_speech` are not here: they route by the model
+  // they are given, so an OpenAI key is not what makes them usable.
+  autoEnable("OPENAI_API_KEY", ["web_search"]),
   autoEnable("DATA_FOR_SEO_LOGIN", ["web_search", "google_news"]),
   autoEnable("IMAP_USERNAME", ["search_email", "archive_email"])
 ]);

--- a/packages/cli/src/local-model-interfaces.ts
+++ b/packages/cli/src/local-model-interfaces.ts
@@ -1,0 +1,72 @@
+/**
+ * The persistence a local (no-server) run gets: assets and timeline sequences,
+ * against the same database `setupDb()` opens.
+ *
+ * Installed process-wide by each command that runs a graph, so every context
+ * built downstream answers the same way. Wiring it per-entrance is what let
+ * `nodetool debug` and `nodetool workflows run` disagree: a workflow that
+ * saved an image ran under one and threw "ProcessingContext model interface
+ * 'createAsset' is not configured" under the other.
+ *
+ * `createAsset` is the server's own implementation, imported rather than
+ * rewritten — the local copy this replaced wrote no thumbnail and left
+ * `parent_id` null, so a CLI-generated asset was invisible in every
+ * folder-scoped listing in the UI.
+ */
+
+import { TimelineSequence } from "@nodetool-ai/models";
+import type { ProcessingContextModelInterfaces } from "@nodetool-ai/runtime";
+import { setDefaultModelInterfaces } from "@nodetool-ai/runtime";
+
+type TimelineDocument = Parameters<
+  typeof TimelineSequence.fromTimelineSequence
+>[1];
+
+export async function localModelInterfaces(): Promise<ProcessingContextModelInterfaces> {
+  // The `/assets` subpath, not the package root: the root entry pulls in the
+  // WebSocket runner and the HTTP server, which a local run does not need.
+  const { createAssetModelInterface } = await import(
+    "@nodetool-ai/websocket/assets"
+  );
+  return {
+    createAsset: createAssetModelInterface,
+    // Timeline nodes persist their sequence rather than passing it down the
+    // graph, so `AddClips` and everything after it needs these to run at all.
+    getTimelineSequence: async ({ userId, id }) => {
+      const seq = await TimelineSequence.findById(id);
+      if (!seq || seq.user_id !== userId) return null;
+      return seq.toTimelineSequence();
+    },
+    createTimelineSequence: async ({ userId, sequence }) => {
+      const seq = TimelineSequence.fromTimelineSequence(
+        userId,
+        sequence as TimelineDocument
+      );
+      await seq.save();
+      return seq.toTimelineSequence();
+    },
+    updateTimelineSequence: async ({ userId, id, sequence }) => {
+      const existing = await TimelineSequence.findById(id);
+      if (!existing || existing.user_id !== userId) return null;
+      const next = TimelineSequence.fromTimelineSequence(
+        userId,
+        sequence as TimelineDocument
+      );
+      next.id = id;
+      await next.save();
+      return next.toTimelineSequence();
+    }
+  };
+}
+
+let installed: Promise<void> | null = null;
+
+/** Install them as this process's default, once. */
+export function installLocalModelInterfaces(): Promise<void> {
+  if (!installed) {
+    installed = localModelInterfaces().then((interfaces) => {
+      setDefaultModelInterfaces(interfaces);
+    });
+  }
+  return installed;
+}

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -34,6 +34,7 @@ import {
 } from "@nodetool-ai/models";
 import { readCachedHfModels, searchCachedHfModels } from "@nodetool-ai/huggingface";
 import { initMasterKey } from "@nodetool-ai/security";
+import { installLocalModelInterfaces } from "./local-model-interfaces.js";
 import { getDefaultDbPath, getDefaultAssetsPath } from "@nodetool-ai/config";
 import { ExecutionSession } from "@nodetool-ai/execution";
 import {
@@ -270,6 +271,13 @@ function printTable(rows: Record<string, unknown>[], columns?: string[]): void {
 function asJson(data: unknown): void {
   console.log(JSON.stringify(data, null, 2));
 }
+
+// Asset and timeline persistence for every context any command builds, here
+// rather than per-entrance: `debug` wired none while `workflows run` wired
+// four, so one workflow saved an image under one command and threw under the
+// other. The interfaces touch the database only when a node calls them, so
+// installing them before `setupDb()` is safe.
+await installLocalModelInterfaces();
 
 // ---------------------------------------------------------------------------
 // info
@@ -761,83 +769,6 @@ addSupervisorOptions(
             : null
         });
 
-        // Persist assets to the local DB + asset store. Without this, any node
-        // that saves an asset fails with "ProcessingContext model interface
-        // 'createAsset' is not configured" — the server wires this in
-        // createRuntimeContext(), the CLI previously wired nothing.
-        const MIME_TO_EXT: Record<string, string> = {
-          "image/png": "png",
-          "image/jpeg": "jpg",
-          "image/webp": "webp",
-          "image/gif": "gif",
-          "audio/mpeg": "mp3",
-          "audio/wav": "wav",
-          "audio/ogg": "ogg",
-          "video/mp4": "mp4",
-          "video/webm": "webm",
-          "application/pdf": "pdf",
-          "text/plain": "txt",
-          "text/html": "html",
-          "model/gltf-binary": "glb"
-        };
-        context.setModelInterfaces({
-          // Timeline nodes persist their sequence rather than passing it down
-          // the graph, so `AddClips` and everything after it threw
-          // "model interface 'createTimelineSequence' is not configured" and
-          // no timeline workflow could run outside the server. These mirror
-          // `unified-websocket-runner.ts` against the same models the CLI
-          // already opens with `setupDb()`.
-          getTimelineSequence: async ({ userId, id }) => {
-            const seq = await TimelineSequence.findById(id);
-            if (!seq || seq.user_id !== userId) return null;
-            return seq.toTimelineSequence();
-          },
-          createTimelineSequence: async ({ userId, sequence }) => {
-            const seq = TimelineSequence.fromTimelineSequence(
-              userId,
-              sequence as Parameters<
-                typeof TimelineSequence.fromTimelineSequence
-              >[1]
-            );
-            await seq.save();
-            return seq.toTimelineSequence();
-          },
-          updateTimelineSequence: async ({ userId, id, sequence }) => {
-            const existing = await TimelineSequence.findById(id);
-            if (!existing || existing.user_id !== userId) return null;
-            const next = TimelineSequence.fromTimelineSequence(
-              userId,
-              sequence as Parameters<
-                typeof TimelineSequence.fromTimelineSequence
-              >[1]
-            );
-            next.id = id;
-            await next.save();
-            return next.toTimelineSequence();
-          },
-          createAsset: async (args) => {
-            const asset = new Asset({
-              user_id: args.userId,
-              workflow_id: args.workflowId ?? null,
-              node_id: args.nodeId ?? null,
-              job_id: args.jobId ?? null,
-              name: args.name,
-              content_type: args.contentType,
-              parent_id: args.parentId ?? null
-            });
-            if (args.content) {
-              const ext = MIME_TO_EXT[args.contentType] ?? "bin";
-              await assetStorage.store(
-                `${asset.user_id}/${asset.id}.${ext}`,
-                args.content,
-                args.contentType
-              );
-              asset.size = args.content.length;
-            }
-            await asset.save();
-            return asset;
-          }
-        });
 
         const supervisor = supervisorConfig
           ? await createSupervisorHandle({

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -8,6 +8,36 @@ export interface ChatSettings {
   enabledTools: string[];
 }
 
+/**
+ * Tools the chat turn is broken without, added to a settings file that predates
+ * them. The `nodetool.*` object model documents these namespaces, so a belt
+ * missing one turns a documented call into "tool not in this toolbelt" —
+ * which is what `nodetool.models.pick()` did until `find_model` landed here.
+ * They need no credential of their own: each resolves its provider from the
+ * model it is handed, or reports that none is configured.
+ */
+export const ALWAYS_ENABLED_TOOLS: readonly string[] = [
+  // Documents.
+  "extract_pdf_text",
+  "convert_pdf_to_markdown",
+  "convert_document",
+  // Discovery: providers, models, node types.
+  "find_model",
+  "list_models",
+  "list_provider_models",
+  "search_nodes",
+  "get_node_info",
+  "list_nodes",
+  // Generation, and reading back what it produced.
+  "generate_image",
+  "edit_image",
+  "generate_video",
+  "animate_image",
+  "generate_speech",
+  "transcribe_audio",
+  "read_media_bytes"
+];
+
 export const DEFAULT_SETTINGS: ChatSettings = {
   provider: detectDefaultProvider(),
   model: detectDefaultModel(),
@@ -30,16 +60,16 @@ export const DEFAULT_SETTINGS: ChatSettings = {
     "validate_workflow",
     "get_example_workflow",
     "export_workflow_digraph",
-    "list_nodes",
-    "search_nodes",
-    "get_node_info",
     "list_jobs",
     "get_job",
     "get_job_logs",
     "start_background_job",
     "list_assets",
     "get_asset",
-    "list_models"
+    "asset_search",
+    "save_asset",
+    "read_asset",
+    ...ALWAYS_ENABLED_TOOLS
   ]
 };
 

--- a/packages/cli/src/stdin.ts
+++ b/packages/cli/src/stdin.ts
@@ -22,9 +22,10 @@
 
 import readline from "node:readline";
 import type { BaseProvider, Message } from "@nodetool-ai/runtime";
-import { FileStorageAdapter, ProcessingContext } from "@nodetool-ai/runtime";
+import { ProcessingContext } from "@nodetool-ai/runtime";
 import { processChat } from "@nodetool-ai/chat";
 import { applySystemPrompt, createCliCodeActTurn } from "./chat-codeact.js";
+import { createChatContext } from "./chat-context.js";
 import {
   createCapabilityRun,
   toolForCapabilityName,
@@ -35,7 +36,12 @@ import type { ProcessingMessage } from "@nodetool-ai/protocol";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
 import { createProvider, WebSocketProvider } from "./providers.js";
 import { WebSocketChatClient, type JobEvent } from "./websocket-client.js";
-import { getSecret } from "@nodetool-ai/models";
+import {
+  isCodeAction,
+  isFormattedTool,
+  toolStatusLabel,
+  formatToolResult,
+} from "./tool-format.js";
 
 export interface StdinModeOptions {
   provider: string;
@@ -280,14 +286,8 @@ export async function runStdinMode(opts: StdinModeOptions): Promise<void> {
     prov: BaseProvider,
     tools: Tool[]
   ): Promise<void> => {
-    const context = new ProcessingContext({
-      jobId: crypto.randomUUID(),
-      userId: "1",
-      workspaceDir: opts.workspaceDir,
-      workspaceStorage: opts.workspaceDir
-        ? new FileStorageAdapter(opts.workspaceDir)
-        : null,
-      secretResolver: getSecret
+    const context = await createChatContext({
+      workspaceDir: opts.workspaceDir ?? null
     });
     const turn = createCliCodeActTurn({
       tools,
@@ -307,6 +307,18 @@ export async function runStdinMode(opts: StdinModeOptions): Promise<void> {
       callbacks: {
         onChunk: (text) => {
           process.stdout.write(text);
+        },
+        onToolCall: (tc) => {
+          process.stderr.write(
+            isCodeAction(tc.name)
+              ? `[tool] Run  ${toolStatusLabel(tc.name, tc.args)}\n`
+              : `[tool] ${tc.name}\n`
+          );
+        },
+        onToolResult: (tc, result) => {
+          if (!isFormattedTool(tc.name)) return;
+          const preview = formatToolResult(tc.name, tc.args, result);
+          process.stderr.write(`[result] ${preview.split("\n")[0]}\n`);
         }
       }
     });
@@ -356,20 +368,34 @@ export async function runStdinMode(opts: StdinModeOptions): Promise<void> {
         if (event.type === "chunk") {
           process.stdout.write(event.content);
         } else if (event.type === "tool_call") {
-          const argsStr =
-            Object.keys(event.args).length > 0
-              ? JSON.stringify(event.args)
-              : "";
-          process.stderr.write(
-            `[tool] ${event.name}${argsStr ? `(${argsStr})` : ""}\n`
-          );
+          if (isCodeAction(event.name)) {
+            process.stderr.write(
+              `[tool] Run  ${toolStatusLabel(event.name, event.args)}\n`
+            );
+          } else {
+            const argsStr =
+              Object.keys(event.args).length > 0
+                ? JSON.stringify(event.args)
+                : "";
+            process.stderr.write(
+              `[tool] ${event.name}${argsStr ? `(${argsStr})` : ""}\n`
+            );
+          }
         } else if (event.type === "tool_result") {
-          // Truncate long results for display
-          const preview =
-            event.content.length > 200
-              ? event.content.slice(0, 200) + "..."
-              : event.content;
-          process.stderr.write(`[result] ${event.name}: ${preview}\n`);
+          if (isFormattedTool(event.name)) {
+            const preview = formatToolResult(
+              event.name,
+              undefined,
+              event.content
+            );
+            process.stderr.write(`[result] ${preview.split("\n")[0]}\n`);
+          } else {
+            const preview =
+              event.content.length > 200
+                ? event.content.slice(0, 200) + "..."
+                : event.content;
+            process.stderr.write(`[result] ${event.name}: ${preview}\n`);
+          }
         } else if (event.type === "output_update") {
           process.stdout.write(JSON.stringify(event.value, null, 2));
           process.stdout.write("\n");

--- a/packages/cli/src/tool-format.ts
+++ b/packages/cli/src/tool-format.ts
@@ -1,14 +1,20 @@
 /**
  * Compact, Claude-Code-style formatting for the builtin "basic" tools
- * (read/write/edit/list/glob/grep/run). For these, the chat UI shows a
- * friendly verb, a tight one-line parameter summary, and a `⎿` result line
- * derived from the tool's structured output — e.g.
+ * (read/write/edit/list/glob/grep) and CodeAct's `execute_code`. For these,
+ * the chat UI shows a friendly verb, a tight one-line parameter summary,
+ * and a `⎿` result line derived from the tool's structured output — e.g.
  *
  *   ● Read(src/app.tsx)
  *     ⎿  Read 47 lines
  *
+ *   ● Run  Rendering product images from CSV
+ *       const listed = await nodetool.workflows.list();
+ *     ⎿  { count: 3 }  ·  1 tool call
+ *
  * Every other tool keeps the generic `name(key: value)` + raw preview render.
  */
+
+const EXECUTE_CODE_TOOL_NAME = "execute_code";
 
 /** Map from canonical builtin tool name → the verb shown in the UI. */
 const FRIENDLY_NAMES: Record<string, string> = {
@@ -25,8 +31,19 @@ export function isBasicTool(name: string): boolean {
   return name in FRIENDLY_NAMES;
 }
 
-/** Friendly verb for a basic tool, or the raw name otherwise. */
+/** True when the tool is CodeAct's `execute_code` action. */
+export function isCodeAction(name: string): boolean {
+  return name === EXECUTE_CODE_TOOL_NAME;
+}
+
+/** True when the result should go through {@link formatToolResult}. */
+export function isFormattedTool(name: string): boolean {
+  return isBasicTool(name) || isCodeAction(name);
+}
+
+/** Friendly verb for a formatted tool, or the raw name otherwise. */
 export function friendlyToolName(name: string): string {
+  if (isCodeAction(name)) return "Run";
   return FRIENDLY_NAMES[name] ?? name;
 }
 
@@ -55,6 +72,18 @@ function safeJson(v: unknown): string {
   } catch {
     return String(v);
   }
+}
+
+/** Live status label: the action title for `execute_code`, else the verb. */
+export function toolStatusLabel(
+  name: string,
+  args?: Record<string, unknown>
+): string {
+  if (isCodeAction(name)) {
+    const title = str(args?.title).trim();
+    return title || "Run";
+  }
+  return friendlyToolName(name);
 }
 
 /** One-line fallback preview for an arbitrary result value. */
@@ -104,6 +133,8 @@ export function formatToolParams(
       if (path) s += ` in ${path}`;
       return s;
     }
+    case EXECUTE_CODE_TOOL_NAME:
+      return str(args.title).trim();
     default:
       return Object.entries(args)
         .map(([k, v]) => `${k}: ${JSON.stringify(v)}`)
@@ -184,8 +215,114 @@ export function formatToolResult(
         }`;
       }
       break;
+    case EXECUTE_CODE_TOOL_NAME:
+      return formatExecuteCodeResult(result);
   }
   return genericPreview(result);
+}
+
+function parseObservation(result: unknown): Record<string, unknown> | null {
+  let value: unknown = result;
+  if (typeof result === "string") {
+    const trimmed = result.trim();
+    if (!trimmed.startsWith("{")) return null;
+    try {
+      value = JSON.parse(trimmed);
+    } catch {
+      return null;
+    }
+  }
+  if (!isObj(value)) return null;
+  if (
+    typeof value.ok === "boolean" ||
+    "error" in value ||
+    "result" in value ||
+    "toolCalls" in value ||
+    "logs" in value
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function compactValue(value: unknown): string {
+  if (typeof value === "string") return firstLine(value);
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (value == null) return String(value);
+  return safeJson(value);
+}
+
+/** Observation envelope → one headline plus optional log lines. */
+function formatExecuteCodeResult(result: unknown): string {
+  const obs = parseObservation(result);
+  if (!obs) return genericPreview(result);
+
+  if (obs.ok === false || typeof obs.error === "string") {
+    const err = str(obs.error) || "failed";
+    return truncate(`Error: ${firstLine(err)}`, 200);
+  }
+
+  const parts: string[] = [];
+  if (obs.result !== undefined) {
+    parts.push(truncate(compactValue(obs.result), 160));
+  }
+  if (typeof obs.toolCalls === "number" && obs.toolCalls > 0) {
+    parts.push(plural(obs.toolCalls, "tool call", "tool calls"));
+  }
+  const logs = Array.isArray(obs.logs)
+    ? obs.logs.filter((line): line is string => typeof line === "string")
+    : [];
+  if (logs.length > 0) {
+    parts.push(plural(logs.length, "log", "logs"));
+  }
+
+  const lines = [parts.join("  ·  ") || "Done"];
+  for (const log of logs.slice(0, 3)) {
+    lines.push(truncate(firstLine(log), 160));
+  }
+  if (logs.length > 3) {
+    const more = logs.length - 3;
+    lines.push(`… +${more} more ${more === 1 ? "log" : "logs"}`);
+  }
+  return lines.join("\n");
+}
+
+const MAX_CODE_LINES = 12;
+
+function dedentCode(code: string): string[] {
+  const normalized = code.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const lines = normalized.replace(/\t/g, "  ").split("\n");
+  while (lines.length > 0 && lines[0].trim() === "") lines.shift();
+  while (lines.length > 0 && lines[lines.length - 1].trim() === "") {
+    lines.pop();
+  }
+  const indents = lines
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.match(/^ */)?.[0].length ?? 0);
+  const pad = indents.length > 0 ? Math.min(...indents) : 0;
+  return lines.map((line) => line.slice(pad));
+}
+
+/**
+ * Dedented program lines for an `execute_code` call, or null when there is
+ * no code to show. Caps long programs the way {@link formatToolDiff} does.
+ */
+export function formatToolCode(
+  name: string,
+  args?: Record<string, unknown>
+): string[] | null {
+  if (!args || !isCodeAction(name)) return null;
+  const raw = str(args.code);
+  if (!raw.trim()) return null;
+  const lines = dedentCode(raw);
+  if (lines.length === 0) return null;
+  if (lines.length <= MAX_CODE_LINES) return lines;
+  const shown = lines.slice(0, MAX_CODE_LINES);
+  const more = lines.length - MAX_CODE_LINES;
+  shown.push(`… +${more} more ${more === 1 ? "line" : "lines"}`);
+  return shown;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/tests/__stubs__/nodetool.ts
+++ b/packages/cli/tests/__stubs__/nodetool.ts
@@ -213,7 +213,39 @@ export const getProvider = async (id: string): Promise<BaseProvider> =>
 
 // runtime helpers
 export class ProcessingContext {
-  constructor(_opts?: unknown) {}
+  private _modelInterfaces: Record<string, unknown> = {};
+  private _secretResolver:
+    | ((key: string, userId: string) => Promise<string | null> | string | null)
+    | null;
+  readonly userId: string;
+  constructor(opts?: {
+    userId?: string;
+    secretResolver?: (
+      key: string,
+      userId: string
+    ) => Promise<string | null> | string | null;
+  }) {
+    this.userId = opts?.userId ?? "1";
+    this._secretResolver = opts?.secretResolver ?? null;
+  }
+  setModelInterfaces(interfaces: Record<string, unknown>): void {
+    this._modelInterfaces = interfaces;
+  }
+  hasModelInterface(name: string): boolean {
+    return typeof this._modelInterfaces[name] === "function";
+  }
+  async createAsset(args: Record<string, unknown>): Promise<unknown> {
+    const fn = this._modelInterfaces["createAsset"];
+    if (typeof fn !== "function") throw new Error("createAsset is not wired");
+    return (fn as (a: Record<string, unknown>) => Promise<unknown>)({
+      userId: this.userId,
+      ...args
+    });
+  }
+  async getSecret(key: string): Promise<string | null> {
+    if (!this._secretResolver) return null;
+    return (await this._secretResolver(key, this.userId)) ?? null;
+  }
 }
 /** Mirrors the real CORE_TOOL_NAMES so the CodeAct split behaves in tests. */
 export const CORE_TOOL_NAMES: ReadonlySet<string> = new Set([
@@ -229,6 +261,20 @@ export const CORE_TOOL_NAMES: ReadonlySet<string> = new Set([
   "download_file",
   "todo_write",
   "run_subtask"
+]);
+/** Mirrors DISCOVERY_TOOL_NAMES: providers, models, node types. */
+export const DISCOVERY_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "find_model",
+  "list_models",
+  "list_provider_models",
+  "search_nodes",
+  "get_node_info",
+  "list_nodes"
+]);
+/** What the CodeAct wiring actually offers top level. */
+export const DIRECT_TOOL_NAMES: ReadonlySet<string> = new Set([
+  ...CORE_TOOL_NAMES,
+  ...DISCOVERY_TOOL_NAMES
 ]);
 export async function initTelemetry() {}
 export async function processChat(_opts?: unknown) {}
@@ -393,3 +439,10 @@ export const JSON_SCHEMA = {};
 export const input = async (_q: unknown) => "";
 export const password = async (_q: unknown) => "";
 export const select = async (_q: unknown) => null;
+
+/** `@nodetool-ai/websocket/assets` — the chat context's asset persistence. */
+export async function createAssetModelInterface(args: {
+  name: string;
+}): Promise<{ id: string; name: string }> {
+  return { id: "stub-asset", name: args.name };
+}

--- a/packages/cli/tests/chat-context.test.ts
+++ b/packages/cli/tests/chat-context.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The chat turn's context carries the asset interface.
+ *
+ * Without it `persistOutput` falls back to a workspace file, and the CLI's
+ * workspace is the current directory — a generated image landed in whatever
+ * folder the chat was started in, with no `asset://` URI behind it.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+const createAssetModelInterface = vi.fn(async () => ({ id: "asset-1" }));
+
+vi.mock("@nodetool-ai/websocket/assets", () => ({ createAssetModelInterface }));
+vi.mock("@nodetool-ai/models", () => ({
+  getSecret: vi.fn(async (key: string) =>
+    key === "FAL_API_KEY" ? "fal-secret" : null
+  )
+}));
+
+const { createChatContext } = await import("../src/chat-context.js");
+
+describe("createChatContext", () => {
+  it("wires asset persistence and the secret store", async () => {
+    const context = await createChatContext({ workspaceDir: null });
+    expect(context.hasModelInterface("createAsset")).toBe(true);
+    await expect(context.getSecret("FAL_API_KEY")).resolves.toBe("fal-secret");
+  });
+
+  it("persists through the server's own implementation", async () => {
+    const context = await createChatContext({ workspaceDir: null });
+    const asset = await context.createAsset({
+      name: "generated.png",
+      contentType: "image/png",
+      content: new Uint8Array([1, 2, 3])
+    });
+    expect(asset).toMatchObject({ id: "asset-1" });
+    expect(createAssetModelInterface).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "1", name: "generated.png" })
+    );
+  });
+});

--- a/packages/cli/tests/settings.test.ts
+++ b/packages/cli/tests/settings.test.ts
@@ -154,6 +154,36 @@ describe("DEFAULT_SETTINGS structure", () => {
     expect(DEFAULT_SETTINGS.enabledTools).toContain("read_file");
     expect(DEFAULT_SETTINGS.enabledTools).toContain("write_file");
   });
+
+  it("enables every tool the `nodetool` object model documents", async () => {
+    // A namespace the prompt documents while the belt cannot serve it turns a
+    // documented call into "tool not in this toolbelt": `find_model` was
+    // missing here, so `nodetool.models.pick()` threw on every turn.
+    vi.resetModules();
+    const { DEFAULT_SETTINGS, ALWAYS_ENABLED_TOOLS } = await import(
+      "../src/settings.js"
+    );
+    for (const name of [
+      "find_model",
+      "list_models",
+      "list_provider_models",
+      "search_nodes",
+      "get_node_info",
+      "list_nodes",
+      "generate_image",
+      "read_media_bytes"
+    ]) {
+      expect(ALWAYS_ENABLED_TOOLS, `${name} must be always-on`).toContain(name);
+      expect(DEFAULT_SETTINGS.enabledTools).toContain(name);
+    }
+  });
+
+  it("lists each always-on tool once", async () => {
+    vi.resetModules();
+    const { DEFAULT_SETTINGS } = await import("../src/settings.js");
+    const seen = new Set(DEFAULT_SETTINGS.enabledTools);
+    expect(seen.size).toBe(DEFAULT_SETTINGS.enabledTools.length);
+  });
 });
 
 // ─── loadSettings ─────────────────────────────────────────────────────────────

--- a/packages/cli/tests/stdin.test.ts
+++ b/packages/cli/tests/stdin.test.ts
@@ -5,7 +5,10 @@
  * by mocking readline.createInterface and all external dependencies.
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { CORE_TOOL_NAMES as CORE_TOOL_NAMES_STUB } from "./__stubs__/nodetool.js";
+import {
+  DIRECT_TOOL_NAMES as DIRECT_TOOL_NAMES_STUB,
+  ProcessingContext as ProcessingContextStub
+} from "./__stubs__/nodetool.js";
 
 // ─── Top-level mocks (hoisted by vitest) ─────────────────────────────────────
 
@@ -32,15 +35,16 @@ vi.mock("@nodetool-ai/models", () => ({
 }));
 
 vi.mock("@nodetool-ai/runtime", () => ({
-  ProcessingContext: class {
-    constructor(_o?: unknown) {}
-  },
+  // The shared stub's context, not a bare class: the chat context wires asset
+  // persistence onto it, so a context without `setModelInterfaces` fails the
+  // turn before `processChat` is ever reached.
+  ProcessingContext: ProcessingContextStub,
   FileStorageAdapter: class {
     constructor(_root?: string) {}
   },
   // This mock replaces the shared stub wholesale, so re-state the one other
   // export the CodeAct wiring reads.
-  CORE_TOOL_NAMES: CORE_TOOL_NAMES_STUB
+  DIRECT_TOOL_NAMES: DIRECT_TOOL_NAMES_STUB
 }));
 
 vi.mock("@nodetool-ai/chat", () => ({

--- a/packages/cli/tests/tool-format.test.ts
+++ b/packages/cli/tests/tool-format.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from "vitest";
 import {
   isBasicTool,
+  isCodeAction,
+  isFormattedTool,
   friendlyToolName,
+  toolStatusLabel,
   formatToolParams,
   formatToolResult,
+  formatToolCode,
   formatToolDiff,
 } from "../src/tool-format.js";
 
@@ -30,6 +34,15 @@ describe("isBasicTool / friendlyToolName", () => {
   it("maps names to friendly verbs", () => {
     expect(friendlyToolName("read_file")).toBe("Read");
     expect(friendlyToolName("glob")).toBe("Search");
+    expect(friendlyToolName("execute_code")).toBe("Run");
+  });
+
+  it("treats execute_code as a formatted code action, not a basic file tool", () => {
+    expect(isBasicTool("execute_code")).toBe(false);
+    expect(isCodeAction("execute_code")).toBe(true);
+    expect(isFormattedTool("execute_code")).toBe(true);
+    expect(isFormattedTool("read_file")).toBe(true);
+    expect(isFormattedTool("google_search")).toBe(false);
   });
 });
 
@@ -61,6 +74,26 @@ describe("formatToolParams", () => {
     expect(formatToolParams("whatever", { a: 1, b: "x" })).toBe(
       'a: 1, b: "x"'
     );
+  });
+
+  it("execute_code shows only the title, never the program", () => {
+    expect(
+      formatToolParams("execute_code", {
+        title: "Rendering product images from CSV",
+        code: "const listed = await nodetool.workflows.list();",
+      })
+    ).toBe("Rendering product images from CSV");
+    expect(formatToolParams("execute_code", { code: "return 1" })).toBe("");
+  });
+});
+
+describe("toolStatusLabel", () => {
+  it("uses the execute_code title, else Run", () => {
+    expect(
+      toolStatusLabel("execute_code", { title: "Listing workflows" })
+    ).toBe("Listing workflows");
+    expect(toolStatusLabel("execute_code", { code: "return 1" })).toBe("Run");
+    expect(toolStatusLabel("read_file")).toBe("Read");
   });
 });
 
@@ -157,6 +190,69 @@ describe("formatToolResult", () => {
     expect(
       formatToolResult("grep", undefined, '{"success":true,"match_count":3}')
     ).toBe('{"success":true,"match_count":3}');
+  });
+
+  it("execute_code summarizes the observation envelope", () => {
+    expect(
+      formatToolResult("execute_code", undefined, {
+        ok: true,
+        result: { count: 3, uri: "asset://abc" },
+        toolCalls: 2,
+      })
+    ).toBe('{"count":3,"uri":"asset://abc"}  ·  2 tool calls');
+    expect(
+      formatToolResult(
+        "execute_code",
+        undefined,
+        JSON.stringify({
+          ok: true,
+          result: { count: 1 },
+          toolCalls: 1,
+          logs: ["picked flux"],
+        })
+      )
+    ).toBe('{"count":1}  ·  1 tool call  ·  1 log\npicked flux');
+    expect(
+      formatToolResult("execute_code", undefined, {
+        ok: true,
+        toolCalls: 0,
+      })
+    ).toBe("Done");
+  });
+
+  it("execute_code surfaces the observation error", () => {
+    expect(
+      formatToolResult("execute_code", undefined, {
+        ok: false,
+        error: "TypeError: x is not a function\n    at <eval>",
+        toolCalls: 1,
+      })
+    ).toBe("Error: TypeError: x is not a function");
+  });
+});
+
+describe("formatToolCode", () => {
+  it("only formats execute_code", () => {
+    expect(formatToolCode("read_file", { code: "x" })).toBeNull();
+    expect(formatToolCode("execute_code", { title: "Hi" })).toBeNull();
+  });
+
+  it("dedents the program and drops surrounding blank lines", () => {
+    expect(
+      formatToolCode("execute_code", {
+        code: "\n    const n = 1;\n    return n;\n",
+      })
+    ).toEqual(["const n = 1;", "return n;"]);
+  });
+
+  it("caps long programs with a +N more note", () => {
+    const code = Array.from({ length: 20 }, (_, i) => `const x${i} = ${i};`).join(
+      "\n"
+    );
+    const lines = formatToolCode("execute_code", { code });
+    expect(lines).not.toBeNull();
+    expect(lines!.length).toBe(13); // 12 lines + 1 note
+    expect(lines![12]).toBe("… +8 more lines");
   });
 });
 

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -39,6 +39,9 @@ function nodetoolStubPlugin(): Plugin {
     "@nodetool-ai/config",
     "@nodetool-ai/deploy",
     "@nodetool-ai/vectorstore",
+    // The chat context loads asset persistence from here; the real module pulls
+    // sharp and the storage adapters into a unit test that needs neither.
+    "@nodetool-ai/websocket/assets",
     // Direct CLI dependencies not installed at the workspace root
     "marked",
     "marked-terminal",

--- a/packages/execution/src/service/workflow-workspace.ts
+++ b/packages/execution/src/service/workflow-workspace.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "@nodetool-ai/config";
-import { Workflow, Workspace } from "@nodetool-ai/models";
+import { Workflow, Workspace, getSecret } from "@nodetool-ai/models";
 import { ProcessingContext, FileStorageAdapter } from "@nodetool-ai/runtime";
 
 const log = createLogger("nodetool.execution.workspace");
@@ -41,12 +41,24 @@ export async function resolveWorkflowWorkspace(
  * paths (REST / tRPC / MCP) that otherwise run without a ProcessingContext.
  * The streaming WebSocket runner builds a richer context of its own; this keeps
  * the workspace available everywhere else with the same resolution rules.
+ *
+ * The run's secrets come with it. Without a resolver `context.getSecret`
+ * answers `null` for every key and providers see only the process environment,
+ * so a key stored in the secret DB is invisible: an agent could generate an
+ * image in a chat turn and get a 401 from the same provider when it ran the
+ * workflow it had just built. The resolver is scoped to the run's own user,
+ * which is the only account whose secrets this run may read.
  */
 export function buildWorkspaceExecutionContext(opts: {
   jobId: string;
   workflowId?: string | null;
   userId: string;
   workspaceDir: string | null;
+  /** Overrides the per-user DB lookup (tests, a host with its own store). */
+  secretResolver?: (
+    key: string,
+    userId: string
+  ) => Promise<string | null | undefined> | string | null | undefined;
 }): ProcessingContext {
   return new ProcessingContext({
     jobId: opts.jobId,
@@ -55,6 +67,9 @@ export function buildWorkspaceExecutionContext(opts: {
     workspaceDir: opts.workspaceDir,
     workspaceStorage: opts.workspaceDir
       ? new FileStorageAdapter(opts.workspaceDir)
-      : null
+      : null,
+    secretResolver:
+      opts.secretResolver ??
+      ((key: string, userId: string) => getSecret(key, userId))
   });
 }

--- a/packages/execution/src/session.ts
+++ b/packages/execution/src/session.ts
@@ -17,6 +17,7 @@ import {
 import { ProcessingContext, connectPythonBridgeForGraph } from "@nodetool-ai/runtime";
 import type { HydratedGraphData, ProcessingMessage } from "@nodetool-ai/protocol";
 import { createExecutorResolver } from "./executor-resolver.js";
+import { buildWorkspaceExecutionContext } from "./service/workflow-workspace.js";
 import { normalizeGraph } from "./normalize-graph.js";
 import { rewriteOutputNames } from "./output-names.js";
 import { MessageStream } from "./message-stream.js";
@@ -177,12 +178,18 @@ export class ExecutionSession {
       rewriteOutputNames(hydrated);
     }
 
+    // A caller that brings no context still gets one that can reach the
+    // secret store. The bare `new ProcessingContext(...)` this replaced
+    // resolved no secret at all, so a graph with a provider node failed on
+    // credentials the install had — the same defect the service-layer run
+    // path shipped with.
     const context =
       options.context ??
-      new ProcessingContext({
+      buildWorkspaceExecutionContext({
         jobId,
         workflowId,
-        userId: "1"
+        userId: "1",
+        workspaceDir: null
       });
 
     const resolveExecutor =

--- a/packages/execution/tests/workflow-workspace-secrets.test.ts
+++ b/packages/execution/tests/workflow-workspace-secrets.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The run context a service-layer run executes on carries the run's secrets.
+ *
+ * Without them `context.getSecret` answers `null` for every key and a provider
+ * node sees only the process environment: an agent generated an image in a
+ * chat turn and got a 401 from the same provider the moment it ran the
+ * workflow it had just built.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+const getSecret = vi.fn(
+  async (key: string, userId: string): Promise<string | null> =>
+    userId === "u1" && key === "FAL_API_KEY" ? "fal-secret" : null
+);
+
+vi.mock("@nodetool-ai/models", () => ({
+  Workflow: { find: vi.fn() },
+  Workspace: { find: vi.fn() },
+  getSecret
+}));
+
+const { buildWorkspaceExecutionContext } = await import(
+  "../src/service/workflow-workspace.js"
+);
+
+describe("buildWorkspaceExecutionContext", () => {
+  it("resolves the run user's secrets", async () => {
+    const context = buildWorkspaceExecutionContext({
+      jobId: "job-1",
+      workflowId: "wf-1",
+      userId: "u1",
+      workspaceDir: null
+    });
+    await expect(context.getSecret("FAL_API_KEY")).resolves.toBe("fal-secret");
+    expect(getSecret).toHaveBeenCalledWith("FAL_API_KEY", "u1");
+  });
+
+  it("reads no other account's secrets", async () => {
+    const context = buildWorkspaceExecutionContext({
+      jobId: "job-2",
+      userId: "u2",
+      workspaceDir: null
+    });
+    await expect(context.getSecret("FAL_API_KEY")).resolves.toBeNull();
+  });
+
+  it("takes a resolver from the host instead", async () => {
+    const context = buildWorkspaceExecutionContext({
+      jobId: "job-3",
+      userId: "u1",
+      workspaceDir: null,
+      secretResolver: (key) => (key === "OPENAI_API_KEY" ? "from-host" : null)
+    });
+    await expect(context.getSecret("OPENAI_API_KEY")).resolves.toBe("from-host");
+    await expect(context.getSecret("FAL_API_KEY")).resolves.toBeNull();
+  });
+});

--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -640,7 +640,10 @@ export class SaveImageNode extends BaseNode {
     const meta = await metadataFor(bytes);
 
     // Create asset via context (persists to DB + storage)
-    if (context && typeof context.createAsset === "function") {
+    // `createAsset` is a method on every context, wired or not — checking
+    // for the function always passed and the fallback below was unreachable,
+    // so a host without asset persistence threw instead of writing a file.
+    if (context?.hasModelInterface?.("createAsset")) {
       const folderRef = this.folder as Record<string, unknown> | undefined;
       const parentId = (folderRef?.asset_id as string) ?? null;
       const asset = (await context.createAsset({

--- a/packages/image-nodes/tests/save-image-asset-fallback.test.ts
+++ b/packages/image-nodes/tests/save-image-asset-fallback.test.ts
@@ -1,0 +1,61 @@
+/**
+ * `SaveImageNode` persists through the context's asset interface, and writes a
+ * file when the host wired none.
+ *
+ * The guard used to read `typeof context.createAsset === "function"`, which is
+ * true on every context — `createAsset` is a prototype method whether or not
+ * the interface behind it exists. So the filesystem fallback below it was
+ * unreachable and a host without asset persistence (`nodetool debug`, an app
+ * build) threw "model interface 'createAsset' is not configured" instead.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import sharp from "sharp";
+import { ProcessingContext } from "@nodetool-ai/runtime";
+import { SaveImageNode } from "../src/nodes/image.js";
+
+async function testImage(): Promise<Record<string, unknown>> {
+  const buf = await sharp({
+    create: { width: 4, height: 4, channels: 3, background: { r: 1, g: 2, b: 3 } }
+  })
+    .png()
+    .toBuffer();
+  return { type: "image", data: buf.toString("base64"), uri: "", width: 4, height: 4 };
+}
+
+describe("SaveImageNode", () => {
+  it("writes a file when the context has no asset interface", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "save-image-fallback-"));
+    try {
+      const context = new ProcessingContext({ jobId: "j1", userId: "u1" });
+      const node = new SaveImageNode();
+      node.assign({ image: await testImage(), folder: dir, name: "out.png" });
+
+      const result = await node.process(context);
+
+      const output = result.output as Record<string, unknown>;
+      expect(String(output.uri)).toMatch(/^file:\/\//);
+      const path = String(output.uri).slice("file://".length);
+      expect((await readFile(path)).length).toBeGreaterThan(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists through the interface when the host wired one", async () => {
+    const createAsset = vi.fn(async () => ({ id: "asset-1" }));
+    const context = new ProcessingContext({ jobId: "j2", userId: "u1" });
+    context.setModelInterfaces({ createAsset });
+    const node = new SaveImageNode();
+    node.assign({ image: await testImage(), name: "out.png" });
+
+    const result = await node.process(context);
+
+    const output = result.output as Record<string, unknown>;
+    expect(String(output.uri)).toBe("asset://asset-1.png");
+    expect(createAsset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -477,6 +477,31 @@ export interface ProcessingContextModelInterfaces {
   }) => Promise<unknown | null>;
 }
 
+let defaultModelInterfaces: ProcessingContextModelInterfaces | null = null;
+
+/**
+ * Install the model interfaces every context in this process falls back to.
+ *
+ * A host installs its persistence once at startup instead of each entrance
+ * remembering to wire it onto the context it builds. That forgetting is a
+ * defect generator: `nodetool debug` wired none while `workflows run` wired
+ * four, so a workflow that saves an image ran under one command and threw
+ * under the other. A context that sets its own interfaces still wins — this
+ * is the floor, not an override.
+ *
+ * Pass `null` to uninstall (a test restoring global state).
+ */
+export function setDefaultModelInterfaces(
+  interfaces: ProcessingContextModelInterfaces | null
+): void {
+  defaultModelInterfaces = interfaces;
+}
+
+/** The process-wide default, or null when no host installed one. */
+export function getDefaultModelInterfaces(): ProcessingContextModelInterfaces | null {
+  return defaultModelInterfaces;
+}
+
 function isWithinRoot(root: string, target: string): boolean {
   const rel = relative(root, target);
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
@@ -1423,13 +1448,27 @@ export class ProcessingContext {
   }
 
   /**
-   * Whether a given model interface is wired on this context. Lets callers
-   * decide between the DB-backed path (interface present — let errors
-   * propagate) and an in-memory fallback (interface absent — hermetic CLI
-   * runs, tests) without invoking a method that would throw when unwired.
+   * The interfaces this context answers with: its own when a caller wired
+   * them, else the host's process-wide default.
+   *
+   * The default is what keeps a run from depending on which entrance built
+   * its context. Six hosts assembled these by hand and three of them forgot
+   * `createAsset`, so the same workflow saved an image under `workflows run`
+   * and died under `debug` with "model interface is not configured".
+   */
+  private modelInterfaces(): ProcessingContextModelInterfaces | null {
+    return this._modelInterfaces ?? getDefaultModelInterfaces();
+  }
+
+  /**
+   * Whether a given model interface is wired for this context — its own or
+   * the host default. Lets callers decide between the DB-backed path
+   * (interface present — let errors propagate) and an in-memory fallback
+   * (interface absent — hermetic CLI runs, tests) without invoking a method
+   * that would throw when unwired.
    */
   hasModelInterface(name: keyof ProcessingContextModelInterfaces): boolean {
-    return typeof this._modelInterfaces?.[name] === "function";
+    return typeof this.modelInterfaces()?.[name] === "function";
   }
 
   // -----------------------------------------------------------------------
@@ -2139,7 +2178,7 @@ export class ProcessingContext {
   private requireModelInterface<
     K extends keyof ProcessingContextModelInterfaces
   >(name: K): NonNullable<ProcessingContextModelInterfaces[K]> {
-    const fn = this._modelInterfaces?.[name];
+    const fn = this.modelInterfaces()?.[name];
     if (!fn) {
       throw new Error(
         `ProcessingContext model interface '${String(name)}' is not configured`

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -11,6 +11,8 @@ export {
   FileStorageAdapter,
   S3StorageAdapter,
   resolveWorkspacePath,
+  setDefaultModelInterfaces,
+  getDefaultModelInterfaces,
   type AssetOutputMode,
   type CacheAdapter,
   type FolderAssetEntry,

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -377,6 +377,20 @@ export abstract class BaseProvider {
   }
 
   /**
+   * Why this provider cannot serve a call right now, or `null` when it can.
+   *
+   * The credential check (`isProviderConfigured`) runs before a provider is
+   * ever constructed, so a provider that reaches this point has its keys. This
+   * answers what a key cannot: an optional SDK nobody installed, a local
+   * runtime the host lacks. `find_model` and `list_models` read it, so a model
+   * nothing here can run is not offered as the best match — the failure lands
+   * on the discovery call instead of on the paid generation call.
+   */
+  async unavailableReason(): Promise<string | null> {
+    return null;
+  }
+
+  /**
    * Explicit capability declaration. Returns `null` by default, in which case
    * {@link getCapabilities} derives capabilities by reflecting on which
    * optional methods the concrete class overrides. Providers may override this

--- a/packages/runtime/src/providers/core-tools.ts
+++ b/packages/runtime/src/providers/core-tools.ts
@@ -40,6 +40,43 @@ export const CORE_TOOL_NAMES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Discovery: which providers, models and node types this install actually has.
+ *
+ * These are lookups whose answer decides what the model writes next, and a
+ * wrong answer is expensive — a hallucinated model id or node type fails at
+ * generation time, after the run has been paid for. A lookup is also exactly
+ * the shape a tool call fits: one question, one answer, nothing to compose.
+ * Routing it through a code action costs a sandbox round trip and hides the
+ * result behind whatever the action chose to return.
+ *
+ * They stay on the belt, so `nodetool.models.pick()` inside an action and the
+ * graph planner's own searches keep working; what changes is the documented
+ * path.
+ */
+export const DISCOVERY_TOOL_NAMES: ReadonlySet<string> = new Set([
+  // Providers and models.
+  "find_model",
+  "list_models",
+  "list_provider_models",
+  // Node types.
+  "search_nodes",
+  "get_node_info",
+  "list_nodes"
+]);
+
+/**
+ * Every tool offered as an ordinary tool call next to `execute_code`:
+ * {@link CORE_TOOL_NAMES} plus {@link DISCOVERY_TOOL_NAMES}. The two sets are
+ * kept apart because only the core set has SDK built-ins behind it — the
+ * substitution in {@link SDK_NATIVE_TOOL_REPLACEMENTS} must never reach a
+ * discovery tool, which no built-in covers.
+ */
+export const DIRECT_TOOL_NAMES: ReadonlySet<string> = new Set([
+  ...CORE_TOOL_NAMES,
+  ...DISCOVERY_TOOL_NAMES
+]);
+
+/**
  * NodeTool tool name → the Claude Agent SDK built-in that replaces it. Only
  * true replacements are listed. Three members of {@link CORE_TOOL_NAMES} are
  * deliberately absent:

--- a/packages/runtime/src/providers/huggingface-provider.ts
+++ b/packages/runtime/src/providers/huggingface-provider.ts
@@ -112,20 +112,27 @@ async function toBytes(result: HfBinary): Promise<Uint8Array> {
 
 let _hfModule: HfInferenceModule | null = null;
 
-async function getHfInference(apiKey: string): Promise<HfClient> {
+/** The message every path reports when the optional dependency is absent. */
+const HF_MODULE_MISSING =
+  "@huggingface/inference is required for HuggingFaceProvider. " +
+  "Install it with: npm install @huggingface/inference";
+
+async function loadHfModule(): Promise<HfInferenceModule> {
   if (!_hfModule) {
     try {
       _hfModule = await (Function(
         'return import("@huggingface/inference")'
       )() as Promise<HfInferenceModule>);
     } catch {
-      throw new Error(
-        "@huggingface/inference is required for HuggingFaceProvider. " +
-          "Install it with: npm install @huggingface/inference"
-      );
+      throw new Error(HF_MODULE_MISSING);
     }
   }
-  const HfInference = _hfModule.HfInference ?? _hfModule.default?.HfInference;
+  return _hfModule;
+}
+
+async function getHfInference(apiKey: string): Promise<HfClient> {
+  const module = await loadHfModule();
+  const HfInference = module.HfInference ?? module.default?.HfInference;
   if (!HfInference) {
     throw new Error(
       "Could not find HfInference class in @huggingface/inference"
@@ -281,6 +288,21 @@ export class HuggingFaceProvider extends BaseProvider {
     this._apiKey = apiKey;
     if (options.hfClient) {
       this._hfClient = options.hfClient;
+    }
+  }
+
+  /**
+   * `@huggingface/inference` is an optional dependency, so a host can hold a
+   * valid HF_TOKEN and still be unable to run a single call. Report that here
+   * rather than at the first generation.
+   */
+  override async unavailableReason(): Promise<string | null> {
+    if (this._hfClient) return null;
+    try {
+      await loadHfModule();
+      return null;
+    } catch (e) {
+      return e instanceof Error ? e.message : String(e);
     }
   }
 

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -54,6 +54,8 @@ export { BaseProvider, providerCapabilities } from "./base-provider.js";
 export type { ProviderCapability } from "./base-provider.js";
 export {
   CORE_TOOL_NAMES,
+  DISCOVERY_TOOL_NAMES,
+  DIRECT_TOOL_NAMES,
   SDK_NATIVE_TOOL_REPLACEMENTS,
   SDK_NATIVE_WORKSPACE_SCOPED,
   sdkNativeReplacements

--- a/packages/runtime/tests/default-model-interfaces.test.ts
+++ b/packages/runtime/tests/default-model-interfaces.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The process-wide model-interface default.
+ *
+ * Six hosts assembled these by hand and three forgot `createAsset`, so the
+ * same workflow saved an image under `workflows run` and threw under `debug`.
+ * The default is the floor every context gets; a context that wires its own
+ * still wins.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ProcessingContext,
+  setDefaultModelInterfaces
+} from "../src/context.js";
+
+afterEach(() => {
+  setDefaultModelInterfaces(null);
+});
+
+const bytes = new Uint8Array([1, 2, 3]);
+
+describe("setDefaultModelInterfaces", () => {
+  it("backstops a context that wired nothing", async () => {
+    const createAsset = vi.fn(async () => ({ id: "asset-1" }));
+    setDefaultModelInterfaces({ createAsset });
+
+    const context = new ProcessingContext({ jobId: "j1", userId: "u1" });
+    expect(context.hasModelInterface("createAsset")).toBe(true);
+    await expect(
+      context.createAsset({
+        name: "out.png",
+        contentType: "image/png",
+        content: bytes
+      })
+    ).resolves.toEqual({ id: "asset-1" });
+    expect(createAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "u1", name: "out.png" })
+    );
+  });
+
+  it("loses to a context that wired its own", async () => {
+    setDefaultModelInterfaces({ createAsset: async () => ({ id: "default" }) });
+    const context = new ProcessingContext({ jobId: "j2", userId: "u1" });
+    context.setModelInterfaces({ createAsset: async () => ({ id: "own" }) });
+    await expect(
+      context.createAsset({
+        name: "out.png",
+        contentType: "image/png",
+        content: bytes
+      })
+    ).resolves.toEqual({ id: "own" });
+  });
+
+  it("leaves a host that installed nothing exactly as it was", async () => {
+    const context = new ProcessingContext({ jobId: "j3", userId: "u1" });
+    expect(context.hasModelInterface("createAsset")).toBe(false);
+    await expect(
+      context.createAsset({
+        name: "out.png",
+        contentType: "image/png",
+        content: bytes
+      })
+    ).rejects.toThrow(/'createAsset' is not configured/);
+  });
+});

--- a/packages/websocket/package.json
+++ b/packages/websocket/package.json
@@ -88,6 +88,12 @@
       "types": "./dist/trpc/router.d.ts",
       "import": "./dist/trpc/router.js",
       "default": "./dist/trpc/router.js"
+    },
+    "./assets": {
+      "nodetool-dev": "./src/lib/asset-model-interface.ts",
+      "types": "./dist/lib/asset-model-interface.d.ts",
+      "import": "./dist/lib/asset-model-interface.js",
+      "default": "./dist/lib/asset-model-interface.js"
     }
   },
   "license": "MIT",

--- a/packages/websocket/src/index.ts
+++ b/packages/websocket/src/index.ts
@@ -77,3 +77,7 @@ export {
   type StoreAssetInput
 } from "./lib/workflow-bundle.js";
 export { mcpToolHostDeps, createExampleWorkflowCatalog } from "./mcp-tool-deps.js";
+export {
+  createAssetModelInterface,
+  type CreateAssetArgs
+} from "./lib/asset-model-interface.js";

--- a/packages/websocket/src/mcp-agent-tools.ts
+++ b/packages/websocket/src/mcp-agent-tools.ts
@@ -8,8 +8,8 @@
  * the chat runner uses, so the two cannot drift — and `view_image`, which stays
  * direct because pixels cannot ride the sandbox's JSON observation envelope.
  * Every other capability lives inside the sandbox as `tools.<name>()` and the
- * `nodetool.*` object model, found with `nodetool.searchTools()` and catalogued on the
- * `nodetool://capabilities` resource.
+ * `nodetool.*` object model, found with `nodetool.searchTools()` and catalogued
+ * on `nodetool://capabilities` and `nodetool://sandbox`.
  *
  * The bridged set is *derived*, not hand-listed: `getAgentToolbelt()` plus
  * `getAllMcpTools()` plus the Google Workspace tools are exactly what
@@ -37,7 +37,11 @@ import {
   UNGATED,
   createCapabilityRun,
   type CapabilityRun,
-  NODETOOL_API_NAMESPACE_TOOLS
+  NODETOOL_API_NAMESPACE_TOOLS,
+  MCP_GUEST_CONTRACT,
+  MCP_SANDBOX_RESOURCE_URI,
+  MCP_SANDBOX_PROMPTS,
+  buildMcpSandboxCatalog
 } from "@nodetool-ai/agents";
 import { FileStorageAdapter, zodToJsonSchema } from "@nodetool-ai/runtime";
 import type { BaseProvider } from "@nodetool-ai/runtime";
@@ -375,6 +379,9 @@ function collectBridgedTools(
 /** URI of the structured capability catalog this mount publishes. */
 export const MCP_CAPABILITIES_RESOURCE_URI = "nodetool://capabilities";
 
+/** URI of the guest-JS surface this mount publishes. Re-exported for callers. */
+export { MCP_SANDBOX_RESOURCE_URI };
+
 const RENDERER_ID_PROPERTY = {
   type: "string" as const,
   description:
@@ -655,12 +662,13 @@ export function registerAgentMcpTools(
     capabilityRun
   });
 
-  // The action tool. MCP has no system prompt, so the contract, the tool
+  // The action tool. MCP has no system prompt, so the guest contract, the
   // catalog and the sandbox summary ride in the description — the only field
-  // every MCP client is guaranteed to show the model.
+  // every MCP client is guaranteed to show the model. The short contract
+  // leads: many clients truncate a long description.
   server.tool(
     session.providerTool.name,
-    `${session.providerTool.description}\n\n${session.systemPromptSection}`,
+    `${MCP_GUEST_CONTRACT}\n\n${session.providerTool.description}\n\n${session.systemPromptSection}`,
     jsonSchemaToZodShape(session.providerTool.inputSchema),
     async (args) => {
       try {
@@ -709,6 +717,45 @@ export function registerAgentMcpTools(
       ]
     })
   );
+
+  const sandbox = buildMcpSandboxCatalog();
+  server.registerResource(
+    "NodeTool Sandbox",
+    MCP_SANDBOX_RESOURCE_URI,
+    {
+      description:
+        "How to write execute_code: the guest contract, blocked globals, " +
+        "bridges this chat session cannot use, and two worked examples.",
+      mimeType: "application/json"
+    },
+    async (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: "application/json",
+          text: JSON.stringify(sandbox, null, 2)
+        }
+      ]
+    })
+  );
+
+  for (const prompt of MCP_SANDBOX_PROMPTS) {
+    server.registerPrompt(
+      prompt.name,
+      {
+        title: prompt.title,
+        description: prompt.description
+      },
+      async () => ({
+        messages: [
+          {
+            role: "user" as const,
+            content: { type: "text" as const, text: prompt.snippet }
+          }
+        ]
+      })
+    );
+  }
 
   log.info("Registered agent MCP tools", {
     userId: scope.userId,

--- a/packages/websocket/src/mcp-server.ts
+++ b/packages/websocket/src/mcp-server.ts
@@ -5,8 +5,8 @@
  * in-app chat agent runs on — and `view_image`, which is direct because pixels
  * cannot ride a sandbox action's JSON observation envelope. Everything else
  * NodeTool can do is reached from inside an action, through the belt and the
- * `nodetool.*` object model, and is catalogued on the `nodetool://capabilities`
- * resource.
+ * `nodetool.*` object model, and is catalogued on `nodetool://capabilities`
+ * and `nodetool://sandbox`.
  *
  * This file used to hand-build a second product surface here: native
  * `run_workflow` / `get_asset` / `get_node_info` / collection tools, a flat
@@ -18,6 +18,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { MCP_GUEST_CONTRACT } from "@nodetool-ai/agents";
 import { createLogger } from "@nodetool-ai/config";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
 import type { AgentTransport } from "./agent/transport.js";
@@ -90,8 +91,8 @@ function listFrontendRenderers(): { renderer_id: string; active: boolean }[] {
 }
 
 /**
- * Create a configured MCP server: `execute_code`, `view_image`, and the
- * capabilities resource.
+ * Create a configured MCP server: `execute_code`, `view_image`, the
+ * capabilities and sandbox resources, and the guest-contract instructions.
  *
  * Throws when `agentToolsScope` is missing — a session with no user binding
  * would hold zero tools, which is a server that answers and cannot act.
@@ -101,10 +102,13 @@ export function createMcpServer(options?: McpServerOptions): McpServer {
     throw new Error(MCP_SCOPE_REQUIRED_MESSAGE);
   }
 
-  const server = new McpServer({
-    name: "NodeTool API Server",
-    version: "1.0.0"
-  });
+  const server = new McpServer(
+    {
+      name: "NodeTool API Server",
+      version: "1.0.0"
+    },
+    { instructions: MCP_GUEST_CONTRACT }
+  );
 
   registerAgentMcpTools(server, options, {
     execute: async (toolName, args) => {

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -50,6 +50,8 @@ import {
   type PythonBridge
 } from "@nodetool-ai/runtime";
 import { initMasterKey } from "@nodetool-ai/security";
+import { setDefaultModelInterfaces } from "@nodetool-ai/runtime";
+import { serverModelInterfaces } from "./unified-websocket-runner.js";
 import {
   WorkerManager,
   startReaper,
@@ -288,6 +290,12 @@ try {
   );
   process.exit(1);
 }
+
+// Persistence for every context this process builds. Each entrance used to
+// wire its own, and the ones that forgot produced runs that could not save an
+// asset — the same workflow ran from the editor and threw over HTTP. A
+// context that wires its own still wins.
+setDefaultModelInterfaces(serverModelInterfaces());
 
 // Seed built-in workflows — non-fatal; a seed failure should not prevent startup.
 try {

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -81,6 +81,7 @@ import type {
   MessageContent,
   BaseProvider,
   ProcessingContext,
+  ProcessingContextModelInterfaces,
   ProviderSession,
   ToolCall as ProviderToolCall,
   ImageModel as ProviderImageModel,
@@ -94,7 +95,7 @@ import type {
 import {
   ProcessingContext as RuntimeProcessingContext,
   ACTIVE_MODEL_CONTEXT_KEY,
-  CORE_TOOL_NAMES,
+  DIRECT_TOOL_NAMES,
   encodeRawRgbaToPng,
   getCostReconciler,
   isProviderSessionUpdate,
@@ -1000,6 +1001,182 @@ async function autoSaveAssets(
   }
 }
 
+/**
+ * The server's persistence, as one object.
+ *
+ * Installed process-wide at startup (`setDefaultModelInterfaces`) so every
+ * context built anywhere in the server — a chat turn, an MCP session, a
+ * workflow run, an app build — persists through the same code, and a new
+ * entrance cannot forget to wire it.
+ */
+export function serverModelInterfaces(): ProcessingContextModelInterfaces {
+  return {
+      // Shared with MCP sessions and workflow runs (lib/asset-model-interface):
+      // one persistence path, one home-folder default.
+      createAsset: createAssetModelInterface,
+      createMessage: async ({ userId, req }) => {
+        // Persist an AgentNode thread message. `content` / `tool_calls` are stored
+        // raw — the `content` column is a jsonText type that serializes them, so
+        // stringifying here would double-encode and break the getMessages read
+        // path (which feeds normalizeMessage, not a JSON-parsing response mapper).
+        return Message.create({
+          user_id: userId,
+          thread_id: req.thread_id,
+          role: req.role,
+          name: req.name ?? null,
+          content: req.content ?? null,
+          tool_calls: req.tool_calls ?? null,
+          tool_call_id: req.tool_call_id ?? null,
+          workflow_id: req.workflow_id ?? null
+        });
+      },
+      getMessages: async ({ userId, threadId, limit, startKey, reverse }) => {
+        const [msgs, cursor] = await Message.paginate(threadId, {
+          limit: limit ?? 1000,
+          startKey: startKey ?? undefined,
+          reverse: reverse ?? false
+        });
+        // Scope to the requesting user — thread_id has no ownership column of its
+        // own, so filter the rows the same way the tRPC messages router does.
+        const owned = msgs.filter((m) => m.user_id === userId);
+        return {
+          messages: owned as unknown as Array<Record<string, unknown>>,
+          next: cursor || null
+        };
+      },
+      listFolderAssets: async ({ userId, folderId }) => {
+        const folder = await Asset.find(userId, folderId);
+        if (!folder || folder.content_type !== "folder") return null;
+        const out: Array<{ id: string; content_type: string; name: string }> = [];
+        const seen = new Set<string>();
+        const visit = async (parentId: string): Promise<void> => {
+          if (seen.has(parentId)) return; // guard against cyclic parent links
+          seen.add(parentId);
+          const children = await Asset.getChildren(userId, parentId, 1000);
+          for (const child of children) {
+            if (child.content_type === "folder") {
+              await visit(child.id);
+            } else {
+              out.push({
+                id: child.id,
+                content_type: child.content_type,
+                name: child.name
+              });
+            }
+          }
+        };
+        await visit(folderId);
+        out.sort((a, b) => a.name.localeCompare(b.name));
+        return out;
+      },
+      getAssetInfo: async ({ userId, assetId }) => {
+        const asset = await Asset.find(userId, assetId);
+        if (!asset) return null;
+        return {
+          id: asset.id,
+          content_type: asset.content_type,
+          name: asset.name,
+          metadata: asset.metadata ?? null
+        };
+      },
+      getImageDocument: async ({ userId, id }) => {
+        const doc = await ImageDocument.findById(id);
+        if (!doc || doc.user_id !== userId) return null;
+        return doc.toResponse();
+      },
+      createImageDocument: async ({
+        userId,
+        name,
+        projectId,
+        width,
+        height,
+        document
+      }) => {
+        const doc = new ImageDocument({
+          user_id: userId,
+          project_id: projectId ?? "default",
+          name,
+          width,
+          height,
+          document: JSON.stringify(document)
+        });
+        await doc.save();
+        return doc.toResponse();
+      },
+      getTimelineSequence: async ({ userId, id }) => {
+        const seq = await TimelineSequence.findById(id);
+        if (!seq || seq.user_id !== userId) return null;
+        return seq.toTimelineSequence();
+      },
+      createTimelineSequence: async ({ userId, sequence }) => {
+        const seq = TimelineSequence.fromTimelineSequence(
+          userId,
+          sequence as Parameters<typeof TimelineSequence.fromTimelineSequence>[1]
+        );
+        await seq.save();
+        return seq.toTimelineSequence();
+      },
+      updateTimelineSequence: async ({ userId, id, sequence }) => {
+        const existing = await TimelineSequence.findById(id);
+        if (!existing || existing.user_id !== userId) return null;
+        const next = TimelineSequence.fromTimelineSequence(
+          userId,
+          sequence as Parameters<typeof TimelineSequence.fromTimelineSequence>[1]
+        );
+        const updated = await TimelineSequence.updateFieldsIfUnchanged(
+          id,
+          next.updated_at,
+          {
+            name: next.name,
+            fps: next.fps,
+            width: next.width,
+            height: next.height,
+            duration_ms: next.duration_ms,
+            document: next.document
+          }
+        );
+        return updated ? updated.toTimelineSequence() : null;
+      },
+      getScript: async ({ userId, id }) => {
+        const script = await Script.findById(id);
+        if (!script || script.user_id !== userId) return null;
+        return script.toResponse();
+      },
+      createScript: async ({ userId, name, projectId, document }) => {
+        const script = new Script({
+          user_id: userId,
+          name: name ?? "Untitled script",
+          project_id: projectId ?? "default",
+          document: JSON.stringify(document)
+        });
+        await script.save();
+        return script.toResponse();
+      },
+      updateScript: async ({
+        userId,
+        id,
+        document,
+        timelineId,
+        baseUpdatedAt
+      }) => {
+        const existing = await Script.findById(id);
+        if (!existing || existing.user_id !== userId) return null;
+        const fields: Partial<{
+          document: string;
+          timeline_id: string | null;
+        }> = {};
+        if (document !== undefined) fields.document = JSON.stringify(document);
+        if (timelineId !== undefined) fields.timeline_id = timelineId;
+        const updated = await Script.updateFieldsIfUnchanged(
+          id,
+          baseUpdatedAt ?? existing.updated_at,
+          fields
+        );
+        return updated ? updated.toResponse() : null;
+      }
+  };
+}
+
 function createRuntimeContext(opts: {
   jobId: string;
   workflowId?: string | null;
@@ -1057,171 +1234,7 @@ function createRuntimeContext(opts: {
     }
   });
 
-  ctx.setModelInterfaces({
-    // Shared with MCP sessions and workflow runs (lib/asset-model-interface):
-    // one persistence path, one home-folder default.
-    createAsset: createAssetModelInterface,
-    createMessage: async ({ userId, req }) => {
-      // Persist an AgentNode thread message. `content` / `tool_calls` are stored
-      // raw — the `content` column is a jsonText type that serializes them, so
-      // stringifying here would double-encode and break the getMessages read
-      // path (which feeds normalizeMessage, not a JSON-parsing response mapper).
-      return Message.create({
-        user_id: userId,
-        thread_id: req.thread_id,
-        role: req.role,
-        name: req.name ?? null,
-        content: req.content ?? null,
-        tool_calls: req.tool_calls ?? null,
-        tool_call_id: req.tool_call_id ?? null,
-        workflow_id: req.workflow_id ?? null
-      });
-    },
-    getMessages: async ({ userId, threadId, limit, startKey, reverse }) => {
-      const [msgs, cursor] = await Message.paginate(threadId, {
-        limit: limit ?? 1000,
-        startKey: startKey ?? undefined,
-        reverse: reverse ?? false
-      });
-      // Scope to the requesting user — thread_id has no ownership column of its
-      // own, so filter the rows the same way the tRPC messages router does.
-      const owned = msgs.filter((m) => m.user_id === userId);
-      return {
-        messages: owned as unknown as Array<Record<string, unknown>>,
-        next: cursor || null
-      };
-    },
-    listFolderAssets: async ({ userId, folderId }) => {
-      const folder = await Asset.find(userId, folderId);
-      if (!folder || folder.content_type !== "folder") return null;
-      const out: Array<{ id: string; content_type: string; name: string }> = [];
-      const seen = new Set<string>();
-      const visit = async (parentId: string): Promise<void> => {
-        if (seen.has(parentId)) return; // guard against cyclic parent links
-        seen.add(parentId);
-        const children = await Asset.getChildren(userId, parentId, 1000);
-        for (const child of children) {
-          if (child.content_type === "folder") {
-            await visit(child.id);
-          } else {
-            out.push({
-              id: child.id,
-              content_type: child.content_type,
-              name: child.name
-            });
-          }
-        }
-      };
-      await visit(folderId);
-      out.sort((a, b) => a.name.localeCompare(b.name));
-      return out;
-    },
-    getAssetInfo: async ({ userId, assetId }) => {
-      const asset = await Asset.find(userId, assetId);
-      if (!asset) return null;
-      return {
-        id: asset.id,
-        content_type: asset.content_type,
-        name: asset.name,
-        metadata: asset.metadata ?? null
-      };
-    },
-    getImageDocument: async ({ userId, id }) => {
-      const doc = await ImageDocument.findById(id);
-      if (!doc || doc.user_id !== userId) return null;
-      return doc.toResponse();
-    },
-    createImageDocument: async ({
-      userId,
-      name,
-      projectId,
-      width,
-      height,
-      document
-    }) => {
-      const doc = new ImageDocument({
-        user_id: userId,
-        project_id: projectId ?? "default",
-        name,
-        width,
-        height,
-        document: JSON.stringify(document)
-      });
-      await doc.save();
-      return doc.toResponse();
-    },
-    getTimelineSequence: async ({ userId, id }) => {
-      const seq = await TimelineSequence.findById(id);
-      if (!seq || seq.user_id !== userId) return null;
-      return seq.toTimelineSequence();
-    },
-    createTimelineSequence: async ({ userId, sequence }) => {
-      const seq = TimelineSequence.fromTimelineSequence(
-        userId,
-        sequence as Parameters<typeof TimelineSequence.fromTimelineSequence>[1]
-      );
-      await seq.save();
-      return seq.toTimelineSequence();
-    },
-    updateTimelineSequence: async ({ userId, id, sequence }) => {
-      const existing = await TimelineSequence.findById(id);
-      if (!existing || existing.user_id !== userId) return null;
-      const next = TimelineSequence.fromTimelineSequence(
-        userId,
-        sequence as Parameters<typeof TimelineSequence.fromTimelineSequence>[1]
-      );
-      const updated = await TimelineSequence.updateFieldsIfUnchanged(
-        id,
-        next.updated_at,
-        {
-          name: next.name,
-          fps: next.fps,
-          width: next.width,
-          height: next.height,
-          duration_ms: next.duration_ms,
-          document: next.document
-        }
-      );
-      return updated ? updated.toTimelineSequence() : null;
-    },
-    getScript: async ({ userId, id }) => {
-      const script = await Script.findById(id);
-      if (!script || script.user_id !== userId) return null;
-      return script.toResponse();
-    },
-    createScript: async ({ userId, name, projectId, document }) => {
-      const script = new Script({
-        user_id: userId,
-        name: name ?? "Untitled script",
-        project_id: projectId ?? "default",
-        document: JSON.stringify(document)
-      });
-      await script.save();
-      return script.toResponse();
-    },
-    updateScript: async ({
-      userId,
-      id,
-      document,
-      timelineId,
-      baseUpdatedAt
-    }) => {
-      const existing = await Script.findById(id);
-      if (!existing || existing.user_id !== userId) return null;
-      const fields: Partial<{
-        document: string;
-        timeline_id: string | null;
-      }> = {};
-      if (document !== undefined) fields.document = JSON.stringify(document);
-      if (timelineId !== undefined) fields.timeline_id = timelineId;
-      const updated = await Script.updateFieldsIfUnchanged(
-        id,
-        baseUpdatedAt ?? existing.updated_at,
-        fields
-      );
-      return updated ? updated.toResponse() : null;
-    }
-  });
+  ctx.setModelInterfaces(serverModelInterfaces());
 
   return ctx;
 }
@@ -5502,8 +5515,8 @@ export class UnifiedWebSocketRunner {
     // is created below, once the tool router and processing context exist.
     const useCodeAct = allSchemas.length > 0;
 
-    // The tool list handed to the provider: `execute_code`, the core tools
-    // (CORE_TOOL_NAMES) and `view_image`, pushed once the session exists.
+    // The tool list handed to the provider: `execute_code`, the direct tools
+    // (DIRECT_TOOL_NAMES) and `view_image`, pushed once the session exists.
     const providerToolSchemas: ProviderTool[] = [];
     log.info("Provider tool schemas", {
       permissionMode,
@@ -5560,12 +5573,13 @@ export class UnifiedWebSocketRunner {
       | null = null;
     let codeactSession: ChatCodeActSession | null = null;
     if (useCodeAct) {
-      // The core set (file, search, fetch, todo, delegation) is also a plain
-      // tool call: those are the shapes every model is trained on, so routing
-      // them through a sandbox action buys nothing. They stay on the belt so
-      // code can still compose them; the prompt documents the direct call.
+      // The core set (file, search, fetch, todo, delegation) and discovery
+      // (which providers, models and node types this install has) are also
+      // plain tool calls: one question with one answer, which routing through
+      // a sandbox action only delays. They stay on the belt so code can still
+      // compose them; the prompt documents the direct call.
       const directSchemas = allSchemas.filter(
-        (s) => s.name !== "view_image" && CORE_TOOL_NAMES.has(s.name)
+        (s) => s.name !== "view_image" && DIRECT_TOOL_NAMES.has(s.name)
       );
       codeactSession = createChatCodeActSession({
         tools: allSchemas

--- a/packages/websocket/tests/mcp-server.test.ts
+++ b/packages/websocket/tests/mcp-server.test.ts
@@ -1,11 +1,16 @@
 /**
- * The `/mcp` surface: exactly two tools, one capability resource, and a session
- * that must be bound to a user.
+ * The `/mcp` surface: exactly two tools, capability + sandbox resources,
+ * guest-contract instructions, and a session that must be bound to a user.
  */
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import {
+  MCP_GUEST_CONTRACT,
+  MCP_SANDBOX_ASSET_SNIPPET,
+  MCP_SANDBOX_PROBE_SNIPPET
+} from "@nodetool-ai/agents";
 import { initTestDb } from "@nodetool-ai/models";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -17,7 +22,10 @@ import {
   unregisterMcpFrontendTransport,
   MCP_SCOPE_REQUIRED_MESSAGE
 } from "../src/mcp-server.js";
-import { MCP_CAPABILITIES_RESOURCE_URI } from "../src/mcp-agent-tools.js";
+import {
+  MCP_CAPABILITIES_RESOURCE_URI,
+  MCP_SANDBOX_RESOURCE_URI
+} from "../src/mcp-agent-tools.js";
 import type { AgentTransport } from "../src/agent/transport.js";
 
 const scope = { userId: "1", source: "stdio-local" as const };
@@ -141,8 +149,15 @@ describe("MCP server surface", () => {
       tools.find((t) => t.name === "execute_code")?.description ?? "";
     // MCP has no system prompt, so the description is the only place the
     // contract can reach the model. Without it the tool is unusable.
+    expect(description.startsWith(MCP_GUEST_CONTRACT)).toBe(true);
     expect(description).toContain("searchTools");
     expect(description).toContain("nodetool");
+    await client.close();
+  });
+
+  it("publishes the guest contract as server instructions", async () => {
+    const client = await connectClient();
+    expect(client.getInstructions()).toBe(MCP_GUEST_CONTRACT);
     await client.close();
   });
 
@@ -173,6 +188,65 @@ describe("MCP server surface", () => {
     expect(listWorkflows?.permission_category).toBe("read");
     expect(listWorkflows?.description.length).toBeGreaterThan(0);
     await client.close();
+  });
+
+  it("publishes the sandbox catalog as a resource", async () => {
+    const client = await connectClient();
+    const { resources } = await client.listResources();
+    expect(resources.map((r) => r.uri)).toContain(MCP_SANDBOX_RESOURCE_URI);
+
+    const read = await client.readResource({
+      uri: MCP_SANDBOX_RESOURCE_URI
+    });
+    const entry = read.contents[0];
+    expect(entry.mimeType).toBe("application/json");
+    const catalog = JSON.parse(entry.text as string) as {
+      runtime: string;
+      contract: string;
+      unavailable_bridges: string[];
+      examples: { probe: string; asset: string };
+    };
+    expect(catalog.runtime).toBe("quickjs");
+    expect(catalog.contract).toBe(MCP_GUEST_CONTRACT);
+    expect(catalog.unavailable_bridges).toEqual(
+      expect.arrayContaining(["fetch", "workspace", "media"])
+    );
+    expect(catalog.examples.probe).toBe(MCP_SANDBOX_PROBE_SNIPPET);
+    expect(catalog.examples.asset).toBe(MCP_SANDBOX_ASSET_SNIPPET);
+    await client.close();
+  });
+
+  it("lists the two sandbox prompts", async () => {
+    const client = await connectClient();
+    const { prompts } = await client.listPrompts();
+    expect(prompts.map((p) => p.name).sort()).toEqual([
+      "sandbox-action",
+      "sandbox-asset"
+    ]);
+    const action = await client.getPrompt({ name: "sandbox-action" });
+    expect(action.messages[0]?.content).toEqual({
+      type: "text",
+      text: expect.stringContaining("nodetool.media.generateImage")
+    });
+    await client.close();
+  });
+});
+
+describe("sandbox snippets run", () => {
+  it("runs the probe snippet", async () => {
+    const server = createMcpServer({ agentToolsScope: scope });
+    const observation = await act(server, MCP_SANDBOX_PROBE_SNIPPET);
+    expect(observation.ok).toBe(true);
+    const result = observation.result as { count: number; tools: string[] };
+    expect(result.count).toBe(0);
+    expect(result.tools).toContain("validate_workflow");
+  });
+
+  it("runs the asset snippet against an empty library", async () => {
+    const server = createMcpServer({ agentToolsScope: scope });
+    const observation = await act(server, MCP_SANDBOX_ASSET_SNIPPET);
+    expect(observation.ok).toBe(true);
+    expect(observation.result).toEqual({ found: 0 });
   });
 });
 

--- a/web/src/components/chat/containers/ChatView.tsx
+++ b/web/src/components/chat/containers/ChatView.tsx
@@ -16,6 +16,7 @@ import {
   TodoItem
 } from "../../../stores/ApiTypes";
 import AddIcon from "@mui/icons-material/Add";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import PsychologyOutlinedIcon from "@mui/icons-material/PsychologyOutlined";
 import {
   FlexRow,
@@ -30,6 +31,8 @@ import { TodoSidebar } from "../sidebar/TodoSidebar";
 import { ThreadMemorySidebar } from "../sidebar/ThreadMemorySidebar";
 import useGlobalChatStore from "../../../stores/GlobalChatStore";
 import { useThreadMemoryPanelStore } from "../../../stores/ThreadMemoryPanelStore";
+import { useNotificationStore } from "../../../stores/NotificationStore";
+import { useClipboard } from "../../../hooks/browser/useClipboard";
 import {
   buildUiContext,
   type BuildUiContextOptions
@@ -285,11 +288,40 @@ const ChatView = ({
   const closeMemoryPanel = useThreadMemoryPanelStore((state) => state.setOpen);
   const canShowMemorySidebar = railsFit && Boolean(effectiveThreadId);
 
+  const { writeClipboard } = useClipboard();
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification
+  );
+  const handleCopyConversation = useCallback(async () => {
+    try {
+      await writeClipboard(JSON.stringify(messages, null, 2), true);
+      addNotification({
+        type: "info",
+        content: `Copied ${messages.length} messages as JSON.`
+      });
+    } catch (error) {
+      console.error("Failed to copy the conversation:", error);
+      addNotification({
+        type: "error",
+        content: "Could not copy the conversation."
+      });
+    }
+  }, [messages, writeClipboard, addNotification]);
+
   return (
     <div className="chat-view" css={cssStyles}>
       <div className="chat-main">
-        {(canShowMemorySidebar || (showNewChatButton && onNewChat)) && (
+        {(canShowMemorySidebar ||
+          messages.length > 0 ||
+          (showNewChatButton && onNewChat)) && (
           <FlexRow className="chat-overlay-actions" align="center" gap={2}>
+            {messages.length > 0 && (
+              <ToolbarIconButton
+                onClick={handleCopyConversation}
+                tooltip="Copy conversation as JSON"
+                icon={<ContentCopyIcon fontSize="small" />}
+              />
+            )}
             {canShowMemorySidebar && (
               <ToolbarIconButton
                 onClick={toggleMemoryPanel}


### PR DESCRIPTION
Fix the agent's path from "pick a model" to "show me the image"

One chat session exposed a chain of defects, each of which broke a step an agent has to take to generate media and build a workflow around it. This branch fixes every link, plus the audit findings that followed.

The session that started it

generate 2 images with flux schnell and combine them took 7 actions and never finished. find_model couldn't search by name. The model it did pick came from a provider whose SDK wasn't installed. Reading the generated bytes back had no documented path, so the agent spent four actions probing the API. A later session hit the sequel: the workflow it built returned a 401 from a provider that had just worked in the same turn.

Model discovery

- find_model searches by name (c05165f12). query is free text over model id and name, punctuation-insensitive, so "flux schnell" finds black-forest-labs/FLUX.1-schnell. A name typed into task is read as a name search rather than filtering everything out, and a miss says so instead of ranking something unrelated first.
- Only rankable models are ranked (f1b145403). huggingface was counted as a locodel took a "downloaded" bonus and outranked the fal_ai copy that could actuallyinstalled. Reading the generated bytes back had no documented path, so the agent spent four actions probing the API. A later session hit the sequel: the workflow it built returned a 401
from a provider that had just worked in the same turn.

Model discovery

- find_model searches by name (c05165f12). query is free text over model id andtive, so "flux schnell" finds black-forest-labs/FLUX.1-schnell. A name typed into task is read as a name search rather than filtering everything out, and a miss says so instead of ranking something unrelated first.
- Only rankable models are ranked (f1b145403). huggingface was counted as a locodel took a "downloaded" bonus and outranked the fal_ai copy that could actuallyrun. BaseProvider.unavailableReason() now answers what a credential check cannot — an optional SDK nobody installed — and such a provider is skipped and named in the result note, at lookup time rather than on the paid call.
- Discovery is a direct tool call (a89abb4a5). find_model, list_models, list_provider_models, search_nodes, get_node_info, list_nodes are offered next to execute_code instead of only
behind it. DIRECT_TOOL_NAMES is the union of these and the core set; the two stubstitution can never reach a discovery tool. The belt keeps every tool, so
nodetool.models.pick still composes inside an action.

Reading media back

- media.* reads only what it may (3b7edd7ab) — paths resolve through the same c* uses.
- read_media_bytes and read_asset accept what a generation returns (f422783ed):d, a storage key, a data or http URL.
- nodetool.media.bytes(ref) makes it reachable (0bccd849d). The chat variant strips the media bridge, and the assets doc advertised only read(name) — a name no generation result carries. The new method takes the result object itself and never the host uri, which is a filesystem path the guest may not read. The chat contract now says where the stripped bridges went, so generate → image.composite → save is one action.

The 401

- Service-layer runs carry their own secrets (7da3a577a). buildWorkspaceExecutionContext set no resolver, so getSecret answered null for every key and providers saw only the environment — a key in the secret DB was invisible. This hit run_workflow, debug_workflow and POST /api/workflows/:id/run; the WebSocket paths wire their own and were unaffected, which is why the
same graph ran from the editor and 401'd from an agent. ExecutionSession's fallsame way now.

Persistence stopped depending on which entrance built the run

677411ab5, from an audit of every ProcessingContext construction site:

- Six hosts assembled model interfaces by hand and three forgot createAsset. setDefaultModelInterfaces lets a host install its persistence once; a context that wires its own still wins. The server installs serverModelInterfaces() at startup, the CLI installs an equivalent bundle from both entry points — replacing a hand-rolled createAsset that wrote no thumbnail and
left parent_id null, orphaning every CLI asset from folder listings.
- typeof context.createAsset === "function" is true on every context, wired or not. Three guards therefore could not fail, and the fallbacks behind them were dead code; SaveImage threw where it should have written a file. hasModelInterface is what they meant.
- debug_app built its script runner with no secret resolver, while the server s both pass one.

CLI

- The chat belt carries what the prompt documents (c13603e98). find_model was never in enabledTools, so nodetool.models.pick() threw "tool not in this toolbelt" on every turn. ALWAYS_ENABLED_TOOLS covers documents, discovery, generation and the read-back path, and reaches settings files written before they existed. Generation is no longer gated on OPENAI_API_KEY — these route by the model they're handed.
- Code actions render as title + program (ed786d022) instead of execute_code({.m as JSON arguments.

MCP

- /mcp teaches the guest contract (5c192598f). MCP has no system prompt, so thedbox summary ride in the execute_code description and on nodetool://sandbox.

Testing

New coverage for each fix, and each new test was checked against the old code: ior, media.bytes (4 cases in the real QuickJS sandbox), direct-tool membership,the CLI belt, secret resolution in a run context (3 cases), the interface default (3 cases), and SaveImage's two paths. Six agents test files had duck-typed fake contexts that define createAsset without hasModelInterface; they now implement the check rather than the guard being softened to accommodate them.

npm run typecheck, npm run lint and npm run test pass. Pre-existing and unrelatt.ts type errors and the vendored electron/.node-runtime/ lint output.
