### PR TITLE
fix: unbreak main CI (lint, sandbox worker bundle, browser sandbox, reliability golden, db dir)

### DIFF
--- a/electron/src/__tests__/verifyBackendBundle.test.ts
+++ b/electron/src/__tests__/verifyBackendBundle.test.ts
@@ -43,6 +43,11 @@ function writeValidBundle(dir: string): void {
   });
   writeStagedPackage(dir, "@img/sharp-libvips-linux-x64", { version: "1.3.2" });
   writeShippedSandboxPacks(dir);
+  fs.mkdirSync(path.join(dir, "js-sandbox-worker"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "js-sandbox-worker", "worker-entry.js"),
+    "export {};"
+  );
 }
 
 const SANDBOX_PACKS_DIR = path.join(

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -443,6 +443,15 @@ export function describeEngineFailure(error: unknown): string {
 }
 
 async function guardHostProcess<T>(run: Promise<T>): Promise<T> {
+  // `process` is a Node global; the browser bundle (the in-process fallback
+  // path there) has none, and there is no host process to guard against an
+  // engine abort escaping as an unhandled rejection anyway.
+  const nodeProcess = (
+    globalThis as { process?: NodeJS.Process }
+  ).process;
+  if (!nodeProcess?.on || !nodeProcess?.off) {
+    return run;
+  }
   let onRejection: ((reason: unknown) => void) | undefined;
   const escaped = new Promise<never>((_resolve, reject) => {
     onRejection = (reason: unknown) => {
@@ -456,12 +465,12 @@ async function guardHostProcess<T>(run: Promise<T>): Promise<T> {
         throw reason;
       });
     };
-    process.on("unhandledRejection", onRejection);
+    nodeProcess.on("unhandledRejection", onRejection);
   });
   try {
     return await Promise.race([run, escaped]);
   } finally {
-    if (onRejection) process.off("unhandledRejection", onRejection);
+    if (onRejection) nodeProcess.off("unhandledRejection", onRejection);
     // The loser of the race stays pending forever; make sure neither promise
     // can later re-trigger the default handler.
     void escaped.catch(() => {});

--- a/packages/chat/tests/codeact-turn.test.ts
+++ b/packages/chat/tests/codeact-turn.test.ts
@@ -113,6 +113,8 @@ function toolCall(
 
 describe("a CodeAct chat turn", () => {
   it("calls belt tools from sandboxed code and answers from the observation", async () => {
+    // A real QuickJS worker thread starts for this run, which can take
+    // longer than the default 5s under contended CI load.
     const echo = new EchoTool();
     const context = createMockContext();
     const session = createChatCodeActSession({
@@ -159,7 +161,7 @@ describe("a CodeAct chat turn", () => {
       result: "HI",
       toolCalls: 1
     });
-  });
+  }, 20000);
 
   it("forwards a tool's pixels as an image message, not as base64 text", async () => {
     const context = createMockContext();

--- a/packages/code-nodes/vitest.config.ts
+++ b/packages/code-nodes/vitest.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
-    passWithNoTests: true
+    passWithNoTests: true,
+    // Every CodeNode test spins up the real QuickJS worker thread
+    // (packages/agents/src/js-sandbox-worker/) — its startup cost can exceed
+    // the default 5s under CI's contended parallel task load.
+    testTimeout: 20000
   }
 });

--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -6,6 +6,8 @@
  */
 
 import Database from "better-sqlite3";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
 import {
   drizzle as drizzleSqlite,
   type BetterSQLite3Database
@@ -18,6 +20,18 @@ import {
   MigrationRunner,
   SQLiteMigrationAdapter
 } from "./migrations/index.js";
+
+/**
+ * better-sqlite3 refuses to create a database file whose parent directory
+ * does not exist yet ("Cannot open database because the directory does not
+ * exist") — a first run on a fresh machine (a new CI container, a fresh
+ * install) hits this before anything else has had a chance to create the
+ * data directory. `:memory:` has no parent directory to create.
+ */
+function ensureDbDirExists(dbPath: string): void {
+  if (dbPath === ":memory:") return;
+  mkdirSync(dirname(dbPath), { recursive: true });
+}
 
 export type DbDialect = "sqlite" | "postgres";
 
@@ -47,6 +61,7 @@ export function initDb(dbPath: string): BetterSQLite3Database<typeof schema> {
       "A PostgreSQL connection is already active. Call closeDb() before switching to SQLite."
     );
   }
+  ensureDbDirExists(dbPath);
   const sqlite = new Database(dbPath);
   sqlite.pragma("journal_mode = WAL");
   sqlite.pragma("busy_timeout = 30000");
@@ -178,6 +193,7 @@ export async function pingDb(): Promise<void> {
  * global Drizzle connection. Used by local backend startup before initDb().
  */
 export async function migrateSqliteDb(dbPath: string): Promise<string[]> {
+  ensureDbDirExists(dbPath);
   const sqlite = new Database(dbPath);
   sqlite.pragma("journal_mode = WAL");
   sqlite.pragma("busy_timeout = 30000");

--- a/reliability/harness/src/drivers/relay-fields.ts
+++ b/reliability/harness/src/drivers/relay-fields.ts
@@ -54,8 +54,11 @@ export const RELAY_ONLY_WORKFLOW_ID_TYPES: ReadonlySet<string> = new Set([
  * are never part of a run's stream. `sdk_execution_target` is sent once per
  * socket, at upgrade time and BEFORE any workflow is submitted, by the
  * production Fastify plugin when an SDK live-runner registry is wired
- * (`packages/websocket/src/plugins/websocket.ts`). The kernel oracle has no
- * connection to announce, so there is nothing to compare it against.
+ * (`packages/websocket/src/plugins/websocket.ts`). `renderer_registered` is
+ * the same shape for the frontend-renderer registry: sent once per socket
+ * right after `connect()`, naming a `renderer_id` no other surface has
+ * anything to compare against. The kernel oracle has no connection to
+ * announce, so there is nothing to compare either against.
  *
  * The rest are the relay's own timers and observers, which fire on wall-clock
  * cadence rather than on anything the run does
@@ -72,6 +75,7 @@ export const RELAY_ONLY_WORKFLOW_ID_TYPES: ReadonlySet<string> = new Set([
  */
 export const CONNECTION_CONTROL_MESSAGE_TYPES: ReadonlySet<string> = new Set([
   "sdk_execution_target",
+  "renderer_registered",
   "system_stats",
   "resource_change",
   "ping",

--- a/web/src/components/appbuilder/__tests__/ApplicationAppBuilder.test.tsx
+++ b/web/src/components/appbuilder/__tests__/ApplicationAppBuilder.test.tsx
@@ -96,7 +96,7 @@ const ADDED_OPERATION = {
 
 jest.mock("../AppBuilderShell", () => ({
   __esModule: true,
-  default: ({
+  default: function MockAppBuilderShell({
     document,
     workflow,
     operationWorkflows,
@@ -110,7 +110,7 @@ jest.mock("../AppBuilderShell", () => ({
     banner?: React.ReactNode;
     onSave: (document: AppDocument) => void;
     onOperationsChange?: (operations: AppDocument["operations"]) => void;
-  }) => {
+  }) {
     // The real shell reports its seeded operations on mount, then again on
     // every change the agent's ui_app_* tools make.
     React.useEffect(() => {

--- a/web/src/components/workspace/__tests__/ApplicationSurface.test.tsx
+++ b/web/src/components/workspace/__tests__/ApplicationSurface.test.tsx
@@ -44,7 +44,11 @@ jest.mock("../LinkedWorkflowsMenu", () => ({
 const builderMounted = jest.fn();
 jest.mock("../../appbuilder/ApplicationAppBuilder", () => ({
   __esModule: true,
-  default: ({ applicationId }: { applicationId: string }) => {
+  default: function MockApplicationAppBuilder({
+    applicationId
+  }: {
+    applicationId: string;
+  }) {
     React.useEffect(() => {
       builderMounted(applicationId);
     }, [applicationId]);

--- a/web/tests/globalSetup.ts
+++ b/web/tests/globalSetup.ts
@@ -138,11 +138,15 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   });
 
   // Surface an early exit (bad key, port race, import failure) as itself rather
-  // than as a startup timeout 90s later.
-  let exited: { code: number | null; signal: NodeJS.Signals | null } | null =
-    null;
+  // than as a startup timeout 90s later. Held in a mutable object rather than
+  // reassigning a `let` directly — TS narrows a variable only ever assigned
+  // inside a callback to its initializer's literal type, which turns
+  // `exited.code` below into a `never` access.
+  const exitState: {
+    exited: { code: number | null; signal: NodeJS.Signals | null } | null;
+  } = { exited: null };
   serverProcess.once("exit", (code, signal) => {
-    exited = { code, signal };
+    exitState.exited = { code, signal };
   });
 
   // Wait for the server to accept TCP connections
@@ -163,9 +167,9 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     serverProcess.kill("SIGKILL");
     throw err;
   }
-  if (exited) {
+  if (exitState.exited) {
     throw new Error(
-      `[globalSetup] Backend exited during startup (code=${exited.code}).`
+      `[globalSetup] Backend exited during startup (code=${exitState.exited.code}).`
     );
   }
 


### PR DESCRIPTION
## Summary

Main's CI had several independent regressions failing across different workflows. This fixes the code-level ones:

- **Lint (`Quality Gate / lint`)**: two test mock components were anonymous arrow functions assigned to an object property, which `react-hooks/rules-of-hooks` can't classify as a component (`ApplicationSurface.test.tsx`, `ApplicationAppBuilder.test.tsx`). Named them.
- **`test-app` (electron)**: `verify-backend-bundle`'s test fixture didn't stage the `js-sandbox-worker/worker-entry.js` the worker-thread refactor (`a0ed9a1a`) now requires. Added it to the fixture.
- **`test-packages` (`@nodetool-ai/chat`)**: `codeact-turn.test.ts` spins up a real QuickJS worker thread and occasionally exceeded the default 5s Vitest timeout under contended CI load. Raised to 20s.
- **Browser E2E (`Workflow Runner Browser E2E`)**: `guardHostProcess` in `js-sandbox.ts` called bare `process.on`/`process.off` unconditionally, which throws `process is not defined` in the browser bundle (no Node `process` global) — breaking **every** sandboxed Code-node run there (17 failing tests). Feature-detected `process` and skip the guard when unavailable.
- **`User Journeys` typecheck**: `web/tests/globalSetup.ts` reassigned a `let` only inside a callback, which TS narrows to its initializer's literal type (`never` on the `if (exited)` branch). Moved it into a mutable wrapper object.
- **Reliability Ring 1 (`packaged` surface, `linear-text-pipeline`)**: the new `renderer_registered` control message (from routing live editor tools over websocket) wasn't classified as connection-scoped transport control, so the golden diffed against the kernel oracle. Added it to `CONNECTION_CONTROL_MESSAGE_TYPES`, the same bucket `sdk_execution_target`/`ping`/`system_stats` already live in.
- **Example Smoke Debug** (failing nightly for 10+ days): `initDb`/`migrateSqliteDb` never created the sqlite file's parent directory, so a fresh machine (new CI container, first install) failed with `Cannot open database because the directory does not exist`. Added `ensureDbDirExists`.

Not fixed here (infra, not code): **App Build Eval** fails because `ANTHROPIC_API_KEY` isn't configured as a repo secret for that workflow.

## Test plan

- [x] `npm run lint --workspace=web` — 0 errors (warnings only, pre-existing)
- [x] `tsc --noEmit` clean for `web`, `electron`, `packages/agents`, `packages/models`
- [x] `electron` jest suite: 673/673 passing, including `verifyBackendBundle.test.ts`
- [x] `packages/chat` vitest: 32/32 passing
- [x] `packages/models` vitest: 829/829 passing
- [x] `reliability/harness` vitest: 156/161 passing (5 skipped, pre-existing)
- [x] Reproduced the `js-sandbox.ts` browser fix by verifying `guardHostProcess` no longer references bare `process` when unavailable (feature-detected via `globalThis.process`)
- [x] Reproduced the DB-dir fix directly: `initDb('/tmp/nested/nodetool.sqlite3')` on a non-existent path now succeeds
- [x] Reproduced the reliability golden fix end-to-end: `nodetool reliability run linear-text-pipeline --surface packaged --diff` now reports `verdict: OK` (previously failed with a `streamShape` mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01A9rqP57AWWnZdgCTCafMsW)_