### PR TITLE
fix(base-nodes): alias the execution js-script-debug subpath in vitest

### DIFF
--- a/packages/base-nodes/tests/vitest-execution-aliases.test.ts
+++ b/packages/base-nodes/tests/vitest-execution-aliases.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Guards the `@nodetool-ai/execution` aliases in this package's vitest config.
+ *
+ * Vite matches object-form aliases by prefix, so a subpath with no alias of its
+ * own falls through to the bare `@nodetool-ai/execution` entry and resolves to
+ * `execution/src/index.ts/<subpath>` — a path inside a file, which fails at
+ * transform time with `ENOTDIR: not a directory`. Adding `./js-script-debug` to
+ * the execution exports map without adding the matching alias here broke the
+ * `test:integration` leg that way, and the error never names the missing alias.
+ *
+ * Two rules, both mechanical: every exported subpath needs an alias, and each
+ * one must be declared before the bare package alias.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const PACKAGE = "@nodetool-ai/execution";
+
+const executionExports = (): string[] => {
+  const pkg = JSON.parse(
+    readFileSync(resolve(__dirname, "../../execution/package.json"), "utf8")
+  ) as { exports?: Record<string, unknown> };
+  return Object.keys(pkg.exports ?? {})
+    .filter((key) => key !== ".")
+    .map((key) => `${PACKAGE}/${key.replace(/^\.\//, "")}`);
+};
+
+const configSource = (): string =>
+  readFileSync(resolve(__dirname, "../vitest.config.ts"), "utf8");
+
+describe("vitest execution aliases", () => {
+  it("aliases every execution subpath export", () => {
+    const subpaths = executionExports();
+    // A registry that matched nothing would pass every assertion below.
+    expect(subpaths.length).toBeGreaterThan(0);
+
+    const source = configSource();
+    const missing = subpaths.filter(
+      (specifier) => !source.includes(`"${specifier}"`)
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it("declares each subpath alias before the bare package alias", () => {
+    const source = configSource();
+    const bare = source.indexOf(`"${PACKAGE}":`);
+    expect(bare).toBeGreaterThan(-1);
+
+    const shadowed = executionExports().filter((specifier) => {
+      const at = source.indexOf(`"${specifier}"`);
+      return at > bare;
+    });
+
+    expect(shadowed).toEqual([]);
+  });
+});

--- a/packages/base-nodes/vitest.config.ts
+++ b/packages/base-nodes/vitest.config.ts
@@ -20,6 +20,10 @@ export default defineConfig({
         __dirname,
         "../execution/src/sketch-debug/index.ts"
       ),
+      "@nodetool-ai/execution/js-script-debug": resolve(
+        __dirname,
+        "../execution/src/js-script-debug/index.ts"
+      ),
       "@nodetool-ai/execution/service": resolve(
         __dirname,
         "../execution/src/service/index.ts"


### PR DESCRIPTION
## What is broken

`test:integration` (the **Workflow Integration Tests** check) has failed on every PR since `./js-script-debug` was added to the `@nodetool-ai/execution` exports map. It fails before a single test runs:

```
Error: ENOTDIR: not a directory, open
  '/home/runner/work/nodetool/nodetool/packages/execution/src/index.ts/js-script-debug'
 ❯ ../agents/src/evals/surfaces/js-script.ts:41:1
 ❯ ../agents/src/index.ts:587:1

 Test Files  1 failed (1)
      Tests  no tests
```

## Why

Vite matches object-form aliases **by prefix**. `packages/base-nodes/vitest.config.ts` aliased five of the six execution subpaths, but not `js-script-debug`, so that specifier fell through to the bare `@nodetool-ai/execution` entry and became `execution/src/index.ts` + `/js-script-debug` — a path *inside a file*, hence `ENOTDIR`.

The error names the bogus path but never the missing alias, so it reads as a broken import in `agents/src/evals/surfaces/js-script.ts` rather than a config gap. The config already carries the comment `// Subpaths before the root alias (Vite alias is prefix-based)` — the rule was known, the entry was just missed.

## The fix

One alias, ahead of the bare entry. Confirmed against Vite's own resolver:

| | resolves to | exists |
|---|---|---|
| before | `packages/execution/src/index.ts/js-script-debug` | `false` |
| after | `packages/execution/src/js-script-debug/index.ts` | `true` |

## Guard against recurrence

`tests/vitest-execution-aliases.test.ts` makes the two rules mechanical: every subpath in the execution exports map needs an alias, and each must be declared before the bare package alias.

Both assertions were inverted and confirmed red before landing:

- alias removed → `expected [ "@nodetool-ai/execution/js-script-debug" ] to deeply equal []`
- alias moved after the bare entry → the ordering assertion fails and names it

The coverage check also asserts it found subpaths at all, so it cannot pass by matching nothing.

## Verification

```
npm run test:integration
  before:  Test Files 1 failed (1) | Tests: no tests
  after:   Test Files 1 passed (1) | Tests: 198 passed

npx vitest run --root packages/base-nodes vitest-execution-aliases example-workflows-execute
  Test Files 2 passed (2) | Tests 200 passed (200)
```

`npm run build:packages` — 56/56 tasks green.

## Not fixed here

**Workflow Runner Browser E2E** is red for an unrelated reason: all 27 specs time out at the same boot step, `page.waitForFunction(() => window.workflowRunnerReady === true)`, so the harness page never becomes ready.

I could not reproduce it — locally the harness boots and reports `READY: true`. I did hit one failure mode with the matching symptom (a stale Vite dep-optimizer cache serving `504 Outdated Optimize Dep` for every module), and CI does cache `packages/*/node_modules`, which contains `.vite`. But deliberately staling the optimizer metadata let Vite self-heal, so that hypothesis is unconfirmed and I have not shipped a speculative `--force` for it. Flagging rather than guessing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSf21gz5TvYcb5oA7K6tGb)_