### PR TITLE
ci: add ten scheduled maintenance routines

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -43,22 +43,30 @@ see below.
 | `user-journeys.yml` | `journeys`: nightly Playwright journey suite (build a graph and run it, chat, mini app, library). `reliability-ring1` (on push to `main`, schedule, dispatch): full `reliability/journeys/*` suite on kernel+ws-server with `--diff`, plus one packaged-backend journey — gates `fly-deploy.yml` | 1 | `journeys`: advisory until 2026-08-15, then required. `reliability-ring1`: required |
 | `release.yaml` | Cross-platform signed release artifacts, packed-tree smoke, a packed-backend reliability journey per OS, updater assets | 2 | Required |
 | `example-smoke-debug.yml` | Nightly + manual real-provider smoke via `nodetool debug` | 2 | Nightly (spend-capped), also dispatch-only |
+| `abstraction-improver.yaml` | Scheduled agent flattens single-implementation interfaces, forwarding wrappers, re-export-only barrels | none/maintenance | Advisory (`continue-on-error`) |
+| `abstraction-police.yaml` | Scheduled agent fixes layering violations found by `check:*` plus the import greps no script covers | none/maintenance | Advisory (`continue-on-error`) |
 | `app-build-eval.yml` | Nightly `app-build` eval suite; reports the one-shot rate, gates nothing | none/maintenance | Advisory (report only) |
 | `aur-publish.yml` | Publish the AUR package on a GitHub release | none/maintenance | Required for its own job |
 | `claude-code-review.yml` | Claude reviews new/updated PRs | none/maintenance | Advisory |
 | `claude.yml` | Claude responds to `@claude` mentions and comments | none/maintenance | Advisory |
 | `copilot-setup-steps.yml` | Environment setup for the Copilot coding agent | none/maintenance | n/a (setup only) |
+| `crash-fuzzer.yaml` | Weekly fuzz of `validate` / `jsscript validate` / `node run` over mutated documents; agent root-causes each crash or hang | none/maintenance | Advisory (`continue-on-error`) |
 | `dead-code-cleanup.yaml` | Scheduled agent removes unused exports/imports/code | none/maintenance | Advisory (`continue-on-error`) |
 | `dependency-cleanup.yaml` | Scheduled agent prunes unused deps, aligns/updates versions | none/maintenance | Advisory (`continue-on-error`) |
 | `docs-ci.yml` | Docs site build + internal link/image check on PR | none/maintenance | Required for `docs/**` |
 | `docs-completeness.yaml` | Daily agent documents undocumented CLI commands, routes, env vars, packages | none/maintenance | Advisory |
 | `docs-correctness.yaml` | Daily agent checks docs claims against the code and fixes stale ones | none/maintenance | Advisory |
 | `docs-lint.yml` | Markdown lint on push/PR | none/maintenance | Required for `**/*.md` |
+| `duplicate-unifier.yaml` | Scheduled agent merges duplicated implementations found by a sliding-window hash | none/maintenance | Advisory (`continue-on-error`) |
 | `eas-build.yml` | Cloud-build the Expo app in `mobile/` on EAS | none/maintenance | Manual / tag-gated |
+| `flaky-test-fixer.yaml` | Twice-weekly agent root-causes flakes from CI re-run history and randomized repeat runs | none/maintenance | Advisory (`continue-on-error`) |
 | `flatpak-ci.yml` | Build the Flatpak desktop package | none/maintenance | Required for its own job |
 | `genspend-pricing.yml` | Nightly GenSpend price sync; opens a PR when a price moved | none/maintenance | Advisory |
+| `internal-only-shipper.yaml` | Scheduled agent ships or deletes features gated to dev/internal builds | none/maintenance | Advisory (`continue-on-error`) |
 | `issue-triage.yml` | Labels new issues, flags duplicates, requests repro details | none/maintenance | n/a (read-only) |
 | `jekyll.yml` | Build and deploy the docs site to GitHub Pages | none/maintenance | Required for docs deploy |
+| `logic-bugfixer.yaml` | Scheduled agent models one decidable function, enumerates its inputs, and fixes divergences with a reproduction | none/maintenance | Advisory (`continue-on-error`) |
+| `logic-simplifier.yaml` | Scheduled agent simplifies the logic in one branch-dense function | none/maintenance | Advisory (`continue-on-error`) |
 | `marketing-ci.yml` | Typecheck/lint/build/Playwright smoke for the marketing site; deploys to Cloudflare Workers on push to main | none/maintenance | Required for `marketing/**` |
 | `model-watch.yml` | Weekly scan for new/changed provider models, files issues | none/maintenance | n/a |
 | `mutation-testing.yaml` | Weekly Stryker mutation-testing report | none/maintenance | Advisory |
@@ -70,12 +78,14 @@ see below.
 | `screenshots.yml` | Capture and commit documentation screenshots | none/maintenance | Manual |
 | `security-audit.yaml` | Manual scan for dependency CVEs, dangerous patterns, Electron misconfig | none/maintenance | Advisory (`continue-on-error`) |
 | `seo-seed.yml` | Seed SEO showcase assets via generation providers | none/maintenance | Manual |
+| `shipped-feature-inliner.yaml` | Scheduled agent inlines flags whose feature has fully shipped | none/maintenance | Advisory (`continue-on-error`) |
 | `test-coverage.yaml` | Scheduled agent adds tests for uncovered code | none/maintenance | Advisory (`continue-on-error`) |
 | `type-safety.yaml` | Scheduled agent removes `any`, tightens types | none/maintenance | Advisory (`continue-on-error`) |
 | `ui-primitives-compliance.yaml` | Scheduled agent migrates raw MUI imports to `ui_primitives/`, fixes hardcoded design tokens | none/maintenance | Advisory (`continue-on-error`) |
+| `useless-test-pruner.yaml` | Scheduled agent deletes or strengthens tests proven unable to fail under mutation | none/maintenance | Advisory (`continue-on-error`) |
 | `workflow-example-validation.yaml` | Weekly `nodetool validate` + repair of shipped example workflows | none/maintenance | Advisory (`continue-on-error`) |
 
-43 workflow files, 12 in the three rings (5 Ring 0, 5 Ring 1, 2 Ring 2), 31 none/maintenance.
+51 workflow files, 10 in the three rings (3 Ring 0, 5 Ring 1, 2 Ring 2), 41 none/maintenance.
 
 F2 wires this table into the actual gates:
 
@@ -153,6 +163,16 @@ gh workflow run ui-primitives-compliance.yaml
 gh workflow run workflow-example-validation.yaml
 gh workflow run docs-correctness.yaml
 gh workflow run docs-completeness.yaml
+gh workflow run crash-fuzzer.yaml
+gh workflow run internal-only-shipper.yaml
+gh workflow run logic-simplifier.yaml
+gh workflow run logic-bugfixer.yaml
+gh workflow run duplicate-unifier.yaml
+gh workflow run useless-test-pruner.yaml
+gh workflow run shipped-feature-inliner.yaml
+gh workflow run flaky-test-fixer.yaml
+gh workflow run abstraction-improver.yaml
+gh workflow run abstraction-police.yaml
 gh workflow run example-smoke-debug.yml
 gh workflow run user-journeys.yml
 ```

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -50,7 +50,7 @@ see below.
 | `claude-code-review.yml` | Claude reviews new/updated PRs | none/maintenance | Advisory |
 | `claude.yml` | Claude responds to `@claude` mentions and comments | none/maintenance | Advisory |
 | `copilot-setup-steps.yml` | Environment setup for the Copilot coding agent | none/maintenance | n/a (setup only) |
-| `crash-fuzzer.yaml` | Weekly fuzz of `validate` / `jsscript validate` / `node run` over mutated documents; agent root-causes each crash or hang | none/maintenance | Advisory (`continue-on-error`) |
+| `crash-fuzzer.yaml` | Daily fuzz of `validate` / `jsscript validate` / `node run` over mutated documents; agent root-causes each crash or hang | none/maintenance | Advisory (`continue-on-error`) |
 | `dead-code-cleanup.yaml` | Scheduled agent removes unused exports/imports/code | none/maintenance | Advisory (`continue-on-error`) |
 | `dependency-cleanup.yaml` | Scheduled agent prunes unused deps, aligns/updates versions | none/maintenance | Advisory (`continue-on-error`) |
 | `docs-ci.yml` | Docs site build + internal link/image check on PR | none/maintenance | Required for `docs/**` |
@@ -59,7 +59,7 @@ see below.
 | `docs-lint.yml` | Markdown lint on push/PR | none/maintenance | Required for `**/*.md` |
 | `duplicate-unifier.yaml` | Scheduled agent merges duplicated implementations found by a sliding-window hash | none/maintenance | Advisory (`continue-on-error`) |
 | `eas-build.yml` | Cloud-build the Expo app in `mobile/` on EAS | none/maintenance | Manual / tag-gated |
-| `flaky-test-fixer.yaml` | Twice-weekly agent root-causes flakes from CI re-run history and randomized repeat runs | none/maintenance | Advisory (`continue-on-error`) |
+| `flaky-test-fixer.yaml` | Daily agent root-causes flakes from CI re-run history and randomized repeat runs | none/maintenance | Advisory (`continue-on-error`) |
 | `flatpak-ci.yml` | Build the Flatpak desktop package | none/maintenance | Required for its own job |
 | `genspend-pricing.yml` | Nightly GenSpend price sync; opens a PR when a price moved | none/maintenance | Advisory |
 | `internal-only-shipper.yaml` | Scheduled agent ships or deletes features gated to dev/internal builds | none/maintenance | Advisory (`continue-on-error`) |

--- a/.github/workflows/abstraction-improver.yaml
+++ b/.github/workflows/abstraction-improver.yaml
@@ -11,7 +11,7 @@ name: Abstraction Improver
 
 on:
   schedule:
-    - cron: "0 6 * * 6" # Saturdays at 06:00 UTC
+    - cron: "30 8 * * *" # Daily at 08:30 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/abstraction-improver.yaml
+++ b/.github/workflows/abstraction-improver.yaml
@@ -1,0 +1,254 @@
+name: Abstraction Improver
+
+# Flattens abstractions that carry no variation: an interface with one
+# implementation, a factory that returns one thing, a wrapper that only
+# forwards, a barrel that only re-exports, a type parameter used once.
+#
+# Each of them costs a hop when reading and a file when navigating, and pays for
+# it only if a second implementation ever arrives. This routine removes the ones
+# where it did not. The seams that carry real variation — LLM providers, storage
+# backends, vector stores, execution surfaces — are explicitly out of scope.
+
+on:
+  schedule:
+    - cron: "0 6 * * 6" # Saturdays at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  abstraction-improver:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      - name: Install mobile dependencies
+        run: cd mobile && npm ci
+
+      - name: Find abstractions with one implementation
+        id: scan
+        continue-on-error: true
+        shell: bash
+        run: |
+          node --input-type=module - <<'JS' > thin-abstractions.log
+          import { readFileSync } from "node:fs";
+          import { execFileSync } from "node:child_process";
+
+          const files = execFileSync(
+            "bash",
+            [
+              "-c",
+              "git ls-files 'web/src/*.ts' 'web/src/*.tsx' 'electron/src/*.ts' " +
+                "'mobile/src/*.ts' 'mobile/src/*.tsx' 'packages/*/src/*.ts' " +
+                "| grep -vE '__tests__|\\.test\\.|\\.spec\\.|/generated/|\\.d\\.ts$'",
+            ],
+            { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+          )
+            .split("\n")
+            .filter(Boolean);
+
+          const sources = new Map(files.map((file) => [file, readFileSync(file, "utf8")]));
+          const corpus = [...sources.values()].join("\n");
+
+          const countRefs = (name) =>
+            (corpus.match(new RegExp(`\\b${name}\\b`, "g")) ?? []).length;
+
+          console.log("## Interfaces with exactly one implementer");
+          // A props/options/result type is a record shape, not an abstraction —
+          // it has nothing to flatten. What matters here is an interface that
+          // declares behavior and has one implementation of it.
+          const SHAPE_SUFFIX = /(Props|Options|Params|Result|Deps|Config|State|Snapshot|Payload|Args)$/;
+          for (const [file, source] of sources) {
+            for (const match of source.matchAll(
+              /export (?:interface|abstract class) ([A-Z][A-Za-z0-9]*)[^{]*\{([\s\S]*?)\n\}/g,
+            )) {
+              const [, name, body] = match;
+              if (SHAPE_SUFFIX.test(name)) continue;
+              const methods = (body.match(/^\s+[a-zA-Z][A-Za-z0-9]*(\??\s*\(|\??:\s*\()/gm) ?? []).length;
+              if (methods === 0) continue;
+              const implementers = (corpus.match(new RegExp(`(?:implements|extends) ${name}\\b`, "g")) ?? []).length;
+              if (implementers === 1) {
+                console.log(`  ${file}  ${name}  methods=${methods}  implementers=1  refs=${countRefs(name)}`);
+              }
+            }
+          }
+
+          console.log("");
+          console.log("## Barrel files that only re-export");
+          for (const [file, source] of sources) {
+            const lines = source.split("\n").filter((line) => line.trim() && !line.trim().startsWith("//"));
+            if (lines.length < 3) continue;
+            if (lines.every((line) => /^\s*export .*from ["']/.test(line))) {
+              // Importers of the barrel, by the directory it fronts. Counting
+              // the word "index" instead would match every occurrence of it in
+              // the repo and report a number that means nothing.
+              const dir = file.replace(/\/index\.tsx?$/, "").split("/").pop();
+              const importers = (corpus.match(new RegExp(`from "[^"]*/${dir}(/index)?"`, "g")) ?? []).length;
+              console.log(`  ${file}  ${lines.length} re-exports  importers=${importers}`);
+            }
+          }
+
+          console.log("");
+          console.log("## Exported functions that only forward to one call");
+          for (const [file, source] of sources) {
+            // export const f = (a) => g(a)  /  export function f(a) { return g(a) }
+            for (const match of source.matchAll(
+              /export (?:const ([a-zA-Z][A-Za-z0-9]*) *(?::[^=]+)?= *(?:async )?\([^)]*\) *=> *([a-zA-Z][A-Za-z0-9.]*)\([^)]*\);?|function ([a-zA-Z][A-Za-z0-9]*)\([^)]*\)[^{]*\{\s*return ([a-zA-Z][A-Za-z0-9.]*)\([^)]*\);?\s*\})/g,
+            )) {
+              const name = match[1] ?? match[4];
+              const delegate = match[2] ?? match[5];
+              if (!name || name === delegate) continue;
+              console.log(`  ${file}  ${name} -> ${delegate}  refs=${countRefs(name)}`);
+            }
+          }
+
+          console.log("");
+          console.log("## Single-method classes");
+          for (const [file, source] of sources) {
+            for (const match of source.matchAll(/export class ([A-Z][A-Za-z0-9]*)[^{]*\{([\s\S]*?)\n\}/g)) {
+              const [, name, body] = match;
+              const methods = (body.match(/^\s{2}(?:public |private |protected )?(?:async )?[a-zA-Z][A-Za-z0-9]*\s*\(/gm) ?? []).length;
+              if (methods === 1 && !/extends|implements/.test(match[0].slice(0, 120))) {
+                console.log(`  ${file}  ${name}  methods=1  refs=${countRefs(name)}`);
+              }
+            }
+          }
+          JS
+
+          echo "## Thin Abstractions" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          head -70 thin-abstractions.log >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          # The scan prints its four section headers whatever it finds, so
+          # emptiness is measured by the indented findings under them.
+          FINDINGS=$(grep -c "^  " thin-abstractions.log || true)
+          echo "Findings: $FINDINGS" >> $GITHUB_STEP_SUMMARY
+          if [ "${FINDINGS:-0}" -gt 0 ]; then echo "THIN_FOUND=1" >> $GITHUB_ENV; else echo "THIN_FOUND=0" >> $GITHUB_ENV; fi
+
+      - name: Run quality checks baseline
+        if: env.THIN_FOUND == '1'
+        id: pre-check
+        continue-on-error: true
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+          echo "TYPECHECK_PRE_EXIT=$TYPECHECK_EXIT" >> $GITHUB_ENV
+          echo "LINT_PRE_EXIT=$LINT_EXIT" >> $GITHUB_ENV
+          echo "TEST_PRE_EXIT=$TEST_EXIT" >> $GITHUB_ENV
+
+      - name: Run Claude Code
+        if: env.THIN_FOUND == '1'
+        uses: anthropics/claude-code-action@v1.0.189
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
+            --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, and prose throat-clearing."
+          prompt: |
+            # Flatten an Over-Engineered Abstraction
+
+            `thin-abstractions.log` groups candidates into four kinds:
+            interfaces with a single implementer, barrel files that only
+            re-export, exported functions that only forward to one call, and
+            classes with one method.
+
+            Read `.claude/skills/codebase-design/SKILL.md` for the vocabulary
+            this repo uses to talk about module depth. Prefer removing a shallow
+            layer over deepening it.
+
+            Pick **one** abstraction and remove the indirection.
+
+            ## What to remove
+            - **Interface with one implementer** and no second one in sight:
+              delete the interface, use the concrete type. Keep it when it exists
+              to break a dependency cycle or to let tests substitute a fake —
+              check for both before deleting.
+            - **Wrapper that only forwards**: inline it at the call sites and
+              delete it. Keep it when it adapts types, narrows a surface
+              deliberately, or is a package's public entry point.
+            - **Barrel that only re-exports**: point the importers at the real
+              modules and delete the barrel. Keep a package's own `index.ts` —
+              that is its API.
+            - **Class with one method** that holds no state: make it a function.
+            - **Generic parameter used once**: replace it with the concrete type.
+            - **Config object with one caller** passing the same literal every
+              time: take the value as an argument.
+
+            ## What to leave alone
+            These seams carry real variation and are load-bearing:
+            - `packages/runtime/src/providers/**` — one interface, many providers.
+            - Storage backends, vector stores, secret stores.
+            - `@nodetool-ai/execution`'s `ExecutionSession` facade — several
+              surfaces go through it on purpose
+              (`scripts/check-execution-boundary.mjs` enforces that).
+            - `web/src/components/ui_primitives/**` — the primitives layer is
+              mandatory by AGENTS.md, however thin an individual primitive looks.
+            - The protocol types shared by web, mobile and the backend.
+            - Anything a public API, a plugin, or a sandbox pack depends on.
+
+            An abstraction with one implementation **today** but an obvious
+            second one arriving (a provider, a backend, an OS) stays.
+
+            ## Rules
+            - Behavior-preserving. No feature or bug-fix changes.
+            - Update every call site. Do not leave a deprecated alias behind.
+            - Do not replace one abstraction with another. The diff should be
+              net-negative in lines and in files.
+            - One abstraction per PR. Maximum 15 files.
+            - Do not touch CI workflow files.
+
+            ## Before starting
+            - Run `gh pr list --state open --limit 20` — skip if an abstraction PR
+              is already open.
+
+            ## Verification
+            ```bash
+            npm run typecheck && npm run lint && npm run test
+            ```
+            Backend packages also need `npm run build:packages && npm run test:packages`.
+
+            ## Submit
+            Create a PR titled "refactor: flatten <abstraction>" explaining what
+            the layer was for, why nothing needs it, and what now calls what.
+
+      - name: Post-change verification
+        if: always() && env.THIN_FOUND == '1'
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+
+          if [ "$TYPECHECK_PRE_EXIT" -eq 0 ] && [ $TYPECHECK_EXIT -ne 0 ]; then
+            echo "New TypeScript errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$LINT_PRE_EXIT" -eq 0 ] && [ $LINT_EXIT -ne 0 ]; then
+            echo "New lint errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$TEST_PRE_EXIT" -eq 0 ] && [ $TEST_EXIT -ne 0 ]; then
+            echo "New test failures introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi

--- a/.github/workflows/abstraction-police.yaml
+++ b/.github/workflows/abstraction-police.yaml
@@ -12,7 +12,7 @@ name: Abstraction Police
 
 on:
   schedule:
-    - cron: "0 4 * * 3" # Wednesdays at 04:00 UTC
+    - cron: "30 4 * * *" # Daily at 04:30 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/abstraction-police.yaml
+++ b/.github/workflows/abstraction-police.yaml
@@ -1,0 +1,242 @@
+name: Abstraction Police
+
+# Enforces the layering AGENTS.md describes: the package dependency order, the
+# `@nodetool-ai/<package>` import rule, no reaching into another package's
+# `dist/` or `src/`, the ui_primitives boundary in the frontend, and the
+# Electron main/renderer split.
+#
+# The repo already ships boundary checks — check:deps, check:circular,
+# check:keys, check:coupled-deps, check:execution-boundary — and they run in
+# `npm run check`. This runs them plus the greps for violations no script covers
+# yet, and has the agent fix the layering rather than widen an allowlist.
+
+on:
+  schedule:
+    - cron: "0 4 * * 3" # Wednesdays at 04:00 UTC
+  workflow_dispatch:
+
+jobs:
+  abstraction-police:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      - name: Install mobile dependencies
+        run: cd mobile && npm ci
+
+      - name: Run the repo's boundary checks
+        id: checks
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "## Boundary Checks" >> $GITHUB_STEP_SUMMARY
+          : > layering-violations.log
+          VIOLATIONS=0
+
+          for check in check:deps check:circular check:keys check:coupled-deps check:execution-boundary; do
+            if npm run "$check" > "/tmp/$check.log" 2>&1; then
+              echo "- OK: $check" >> $GITHUB_STEP_SUMMARY
+            else
+              VIOLATIONS=1
+              echo "- FAIL: $check" >> $GITHUB_STEP_SUMMARY
+              { echo "### npm run $check"; echo '```'; tail -60 "/tmp/$check.log"; echo '```'; echo; } >> layering-violations.log
+            fi
+          done
+
+          echo "SCRIPT_VIOLATIONS=$VIOLATIONS" >> $GITHUB_ENV
+
+      - name: Grep for violations no script covers
+        id: grep
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "## Import-Rule Violations" >> $GITHUB_STEP_SUMMARY
+          FOUND=0
+
+          record() {
+            local title="$1"; local file="$2"
+            if [ -s "$file" ]; then
+              FOUND=1
+              COUNT=$(wc -l < "$file" | tr -d ' ')
+              echo "- $title: $COUNT" >> $GITHUB_STEP_SUMMARY
+              { echo "### $title"; echo '```'; head -40 "$file"; echo '```'; echo; } >> layering-violations.log
+            else
+              echo "- $title: 0" >> $GITHUB_STEP_SUMMARY
+            fi
+          }
+
+          # AGENTS.md: never import from dist/, and never reach into another
+          # package's src/ — inter-package imports go through the package name.
+          grep -rEn "from \"[^\"]*@nodetool-ai/[a-z-]+/(dist|src)/" \
+            --include="*.ts" --include="*.tsx" \
+            packages/*/src web/src electron/src mobile/src 2>/dev/null > /tmp/deep-imports.log || true
+          record "Deep imports into another package's dist/ or src/" /tmp/deep-imports.log
+
+          # Relative paths that climb out of one workspace into another.
+          grep -rEn "from \"(\.\./)+(packages|web|electron|mobile)/" \
+            --include="*.ts" --include="*.tsx" \
+            packages/*/src web/src electron/src mobile/src 2>/dev/null > /tmp/relative-crossing.log || true
+          record "Relative imports crossing a workspace boundary" /tmp/relative-crossing.log
+
+          # AGENTS.md: raw MUI is allowed only inside ui_primitives/ and editor_ui/.
+          grep -rEn "from \"@mui/(material|icons-material)" \
+            --include="*.tsx" --include="*.ts" web/src 2>/dev/null \
+            | grep -vE "web/src/components/(ui_primitives|editor_ui)/" > /tmp/raw-mui.log || true
+          record "Raw MUI imports outside ui_primitives/ and editor_ui/" /tmp/raw-mui.log
+
+          # Node builtins in the renderer: the frontend has no Node runtime, and
+          # reaching for one means the boundary was crossed somewhere upstream.
+          grep -rEn "from \"(node:)?(fs|path|child_process|os|net|worker_threads)\"" \
+            --include="*.ts" --include="*.tsx" web/src mobile/src 2>/dev/null > /tmp/node-builtins.log || true
+          record "Node builtins imported in a renderer surface" /tmp/node-builtins.log
+
+          # Electron: the renderer talks to the main process through the
+          # contextBridge preload, never through electron's own module.
+          grep -rEn "from \"electron\"" --include="*.ts" --include="*.tsx" \
+            electron/src/renderer 2>/dev/null > /tmp/electron-renderer.log || true
+          record "electron imported from the renderer" /tmp/electron-renderer.log
+
+          echo "GREP_VIOLATIONS=$FOUND" >> $GITHUB_ENV
+
+      - name: Decide whether there is anything to fix
+        run: |
+          if [ "$SCRIPT_VIOLATIONS" = "1" ] || [ "$GREP_VIOLATIONS" = "1" ]; then
+            echo "LAYERING_VIOLATIONS=1" >> $GITHUB_ENV
+          else
+            echo "LAYERING_VIOLATIONS=0" >> $GITHUB_ENV
+          fi
+
+      - name: Run quality checks baseline
+        if: env.LAYERING_VIOLATIONS == '1'
+        id: pre-check
+        continue-on-error: true
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+          echo "TYPECHECK_PRE_EXIT=$TYPECHECK_EXIT" >> $GITHUB_ENV
+          echo "LINT_PRE_EXIT=$LINT_EXIT" >> $GITHUB_ENV
+          echo "TEST_PRE_EXIT=$TEST_EXIT" >> $GITHUB_ENV
+
+      - name: Run Claude Code
+        if: env.LAYERING_VIOLATIONS == '1'
+        uses: anthropics/claude-code-action@v1.0.189
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
+            --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, and prose throat-clearing."
+          prompt: |
+            # Fix Layering Violations
+
+            `layering-violations.log` holds the output of the repo's boundary
+            checks and the import greps that found something.
+
+            ## The layering, from AGENTS.md
+            Package dependency order — imports go left to right, never back:
+            ```
+            protocol → config → security → auth → storage
+                                         → runtime → kernel → node-sdk → base-nodes
+                                         → models → agents → chat → websocket ← cli
+            ```
+            Plus:
+            - Inter-package imports use `@nodetool-ai/<package>`. Never
+              `dist/`, never another package's `src/`, never a relative path
+              that climbs out of the workspace.
+            - `web/` and `mobile/` are renderer surfaces: no Node builtins.
+            - Mobile shares exactly two packages: `@nodetool-ai/protocol` and
+              `@nodetool-ai/app-runtime`.
+            - Raw MUI imports belong only in `web/src/components/ui_primitives/`
+              and `editor_ui/`. Everything else uses the primitives.
+            - The Electron renderer reaches the main process through the
+              `contextBridge` preload API, never by importing `electron`.
+            - `WorkflowRunner` is constructed only in `@nodetool-ai/execution`
+              (`scripts/check-execution-boundary.mjs`).
+
+            ## How to fix a violation
+            Fix the direction of the dependency, not the check:
+            - **Wrong-direction import** → move the shared type or helper down to
+              a package both sides already depend on (often `protocol` or
+              `config`), or invert the dependency by passing the value in.
+            - **Deep import** → export the symbol from the package's entry point
+              and import it by package name. If it is not meant to be public,
+              that is the real finding: say so and move the caller instead.
+            - **Relative crossing** → same fix, via the workspace package name.
+              Add the dependency to the importing package's `package.json`
+              (`npm run check:deps` verifies that).
+            - **Node builtin in a renderer** → move the work behind the API the
+              renderer already talks to (HTTP route, IPC handler, preload).
+            - **Raw MUI** → use the primitive, or add one to `ui_primitives/`
+              following its STRATEGY.md.
+            - **Cycle** → break it by extracting the shared piece into the lower
+              package. Do not paper over it with a dynamic import.
+
+            ## Rules
+            - **Never widen an allowlist to make a check pass.** The grandfathered
+              list in `check-execution-boundary.mjs` may only shrink. If a
+              violation genuinely cannot be fixed now, leave it, and say why in
+              the PR body — do not add an entry.
+            - Do not delete or weaken a check script.
+            - Do not move code across a package boundary to hide a violation
+              unless the destination is where the code belongs on its own merits.
+            - One boundary per PR. Maximum 15 files.
+            - Do not touch CI workflow files.
+
+            ## Before starting
+            - Run `gh pr list --state open --limit 20` — skip if a layering PR is
+              already open.
+
+            ## Verification
+            ```bash
+            npm run check:deps && npm run check:circular && npm run check:keys && \
+              npm run check:coupled-deps && npm run check:execution-boundary
+            npm run build:packages && npm run typecheck && npm run lint && npm run test
+            ```
+            Re-run the grep that found your violation and show it returns nothing.
+
+            ## Submit
+            Create a PR titled "refactor: fix <boundary> layering violation"
+            naming the rule, the violating imports, and the direction the
+            dependency now runs.
+
+      - name: Post-change verification
+        if: always() && env.LAYERING_VIOLATIONS == '1'
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+
+          if [ "$TYPECHECK_PRE_EXIT" -eq 0 ] && [ $TYPECHECK_EXIT -ne 0 ]; then
+            echo "New TypeScript errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$LINT_PRE_EXIT" -eq 0 ] && [ $LINT_EXIT -ne 0 ]; then
+            echo "New lint errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$TEST_PRE_EXIT" -eq 0 ] && [ $TEST_EXIT -ne 0 ]; then
+            echo "New test failures introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi

--- a/.github/workflows/crash-fuzzer.yaml
+++ b/.github/workflows/crash-fuzzer.yaml
@@ -17,7 +17,7 @@ name: Crash Fuzzer
 
 on:
   schedule:
-    - cron: "0 5 * * 1" # Mondays at 05:00 UTC
+    - cron: "0 5 * * *" # Daily at 05:00 UTC
   workflow_dispatch:
     inputs:
       seed:

--- a/.github/workflows/crash-fuzzer.yaml
+++ b/.github/workflows/crash-fuzzer.yaml
@@ -1,0 +1,373 @@
+name: Crash Fuzzer
+
+# Feeds malformed input to the surfaces that parse untrusted documents —
+# `nodetool validate` over workflow graphs, `jsscript validate` over script
+# documents, `node run` over single nodes — and reports the cases that crash
+# instead of failing cleanly.
+#
+# A validator is allowed to reject its input. It is not allowed to throw a
+# TypeError, blow the stack, or hang: those reach users as an unhandled
+# exception in the editor, the CLI, or the server, and they are the bugs this
+# looks for. The oracle is therefore the *shape* of the failure (a JS stack
+# trace or a timeout), never a non-zero exit code.
+#
+# Mutants come from the shipped examples and the CLI's own fixtures, so every
+# seed is a real document the registry knows. The seed is printed and settable,
+# so a crash the fuzzer finds can be reproduced by hand.
+
+on:
+  schedule:
+    - cron: "0 5 * * 1" # Mondays at 05:00 UTC
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: "PRNG seed (default: the run number) — reuse to replay a crash"
+        required: false
+        default: ""
+      mutants:
+        description: "Mutants to generate per source document"
+        required: false
+        default: "8"
+
+jobs:
+  crash-fuzzer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      # validate and node run load the node registry, which the decorator
+      # packages (base-nodes, node-sdk, ...) expose from dist/.
+      - name: Build packages
+        run: npm run build:packages
+
+      - name: Generate mutants
+        id: mutate
+        shell: bash
+        run: |
+          SEED="${{ github.event.inputs.seed }}"
+          if [ -z "$SEED" ]; then SEED="${{ github.run_number }}"; fi
+          COUNT="${{ github.event.inputs.mutants }}"
+          if [ -z "$COUNT" ]; then COUNT=8; fi
+          echo "FUZZ_SEED=$SEED" >> $GITHUB_ENV
+          echo "Seed: $SEED, mutants per document: $COUNT" >> $GITHUB_STEP_SUMMARY
+
+          FUZZ_SEED="$SEED" FUZZ_COUNT="$COUNT" node --input-type=module - <<'JS'
+          import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+          import { execFileSync } from "node:child_process";
+
+          // Mulberry32 — same seed, same corpus, so a crash replays.
+          let state = (Number(process.env.FUZZ_SEED) || 1) >>> 0;
+          const rand = () => {
+            state = (state + 0x6d2b79f5) >>> 0;
+            let t = state;
+            t = Math.imul(t ^ (t >>> 15), t | 1);
+            t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+            return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+          };
+          const pick = (xs) => xs[Math.floor(rand() * xs.length)];
+
+          const sources = execFileSync(
+            "bash",
+            [
+              "-c",
+              "find packages -path '*examples*' -name '*.json' ! -name '*.app.json' | head -40; " +
+                "find packages/cli/tests/fixtures -name 'js-script-*.json' 2>/dev/null",
+            ],
+            { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+          )
+            .split("\n")
+            .filter(Boolean);
+
+          const HOSTILE = [
+            null,
+            [],
+            {},
+            "",
+            "\u0000",
+            "x".repeat(200000),
+            -1,
+            1e308,
+            true,
+            { $ref: "#/" },
+            [[[[[[[[[[1]]]]]]]]]],
+          ];
+
+          // Every mutation keeps the document parseable as JSON — the point is
+          // to break the *schema*, not the parser.
+          const MUTATIONS = {
+            dropKey(node) {
+              const keys = Object.keys(node);
+              if (keys.length) delete node[pick(keys)];
+            },
+            hostileValue(node) {
+              const keys = Object.keys(node);
+              if (keys.length) node[pick(keys)] = pick(HOSTILE);
+            },
+            retypeKey(node) {
+              const keys = Object.keys(node);
+              if (!keys.length) return;
+              const key = pick(keys);
+              node[key] = Array.isArray(node[key]) ? {} : [];
+            },
+            danglingRef(doc) {
+              for (const edge of doc?.graph?.edges ?? doc?.edges ?? []) {
+                edge.source = "node-that-does-not-exist";
+                break;
+              }
+            },
+            duplicateId(doc) {
+              const nodes = doc?.graph?.nodes ?? doc?.nodes ?? [];
+              if (nodes.length > 1) nodes[1].id = nodes[0].id;
+            },
+            selfCycle(doc) {
+              const nodes = doc?.graph?.nodes ?? doc?.nodes ?? [];
+              const edges = doc?.graph?.edges ?? doc?.edges;
+              if (nodes.length && Array.isArray(edges)) {
+                edges.push({
+                  id: "fuzz-cycle",
+                  source: nodes[0].id,
+                  target: nodes[0].id,
+                  sourceHandle: "output",
+                  targetHandle: "input",
+                });
+              }
+            },
+          };
+
+          const walk = (value, visit) => {
+            if (Array.isArray(value)) {
+              for (const item of value) walk(item, visit);
+            } else if (value && typeof value === "object") {
+              visit(value);
+              for (const item of Object.values(value)) walk(item, visit);
+            }
+          };
+
+          mkdirSync("/tmp/fuzz", { recursive: true });
+          const manifest = [];
+          const count = Number(process.env.FUZZ_COUNT) || 8;
+          const nodeTypes = new Set();
+
+          for (const source of sources) {
+            let original;
+            try {
+              original = JSON.parse(readFileSync(source, "utf8"));
+            } catch {
+              continue; // not our problem: the file on disk is already invalid
+            }
+            walk(original, (node) => {
+              if (typeof node.type === "string" && node.type.includes(".")) nodeTypes.add(node.type);
+            });
+
+            for (let i = 0; i < count; i += 1) {
+              const doc = JSON.parse(JSON.stringify(original));
+              const name = pick(Object.keys(MUTATIONS));
+              if (name === "dropKey" || name === "hostileValue" || name === "retypeKey") {
+                const targets = [];
+                walk(doc, (node) => targets.push(node));
+                if (targets.length) MUTATIONS[name](pick(targets));
+              } else {
+                MUTATIONS[name](doc);
+              }
+              const out = `/tmp/fuzz/${source.replace(/[^a-z0-9]+/gi, "_")}-${i}.json`;
+              writeFileSync(out, JSON.stringify(doc));
+              manifest.push({ mutant: out, source, mutation: name });
+            }
+          }
+
+          writeFileSync("/tmp/fuzz/manifest.json", JSON.stringify(manifest, null, 2));
+          writeFileSync("/tmp/fuzz/node-types.txt", [...nodeTypes].join("\n"));
+          console.log(`generated ${manifest.length} mutants from ${sources.length} documents`);
+          JS
+
+      - name: Fuzz the parsers
+        id: fuzz
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "## Crash Fuzzer (seed $FUZZ_SEED)" >> $GITHUB_STEP_SUMMARY
+          : > crash-report.log
+          CRASHES=0
+          CASES=0
+
+          # A crash is a stack trace or a hang. A validation failure — however
+          # loud — is the harness working.
+          classify() {
+            local out="$1"
+            if grep -qE "^[[:space:]]+at .+:[0-9]+:[0-9]+|TypeError|RangeError|ReferenceError|Maximum call stack|Unhandled|is not a function|Cannot read properties" "$out"; then
+              return 0
+            fi
+            return 1
+          }
+
+          run_case() {
+            local label="$1"; shift
+            CASES=$((CASES + 1))
+            if timeout 60 "$@" > /tmp/case.out 2>&1; then
+              STATUS=ok
+            else
+              STATUS=$?
+            fi
+            if [ "$STATUS" = "124" ]; then
+              CRASHES=$((CRASHES + 1))
+              { echo "### HANG: $label"; echo '```'; echo "$@"; tail -40 /tmp/case.out; echo '```'; echo; } >> crash-report.log
+              echo "- HANG: $label" >> $GITHUB_STEP_SUMMARY
+            elif classify /tmp/case.out; then
+              CRASHES=$((CRASHES + 1))
+              { echo "### CRASH: $label"; echo '```'; echo "$@"; tail -60 /tmp/case.out; echo '```'; echo; } >> crash-report.log
+              echo "- CRASH: $label" >> $GITHUB_STEP_SUMMARY
+            fi
+          }
+
+          while IFS= read -r mutant; do
+            case "$mutant" in
+              *js_script*) run_case "jsscript validate $mutant" npm run dev:nodetool -- jsscript validate "$mutant" --json ;;
+              *) run_case "validate $mutant" npm run dev:nodetool -- validate "$mutant" --json ;;
+            esac
+          done < <(node -e 'JSON.parse(require("fs").readFileSync("/tmp/fuzz/manifest.json","utf8")).forEach(m=>console.log(m.mutant))')
+
+          # Single nodes get hostile property bags. --no-secrets keeps the run
+          # hermetic: no database, no provider keys.
+          while IFS= read -r type; do
+            [ -z "$type" ] && continue
+            for props in '{}' '{"__proto__":{"polluted":true}}' '[]' '{"value":null}' '{"value":"'"$(head -c 2000 /dev/zero | tr '\0' 'x')"'"}'; do
+              run_case "node run $type $props" npm run dev:nodetool -- node run "$type" --props "$props" --no-secrets --json
+            done
+          done < <(head -25 /tmp/fuzz/node-types.txt)
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "$CASES cases, $CRASHES crashes" >> $GITHUB_STEP_SUMMARY
+          echo "FUZZ_CRASHES=$CRASHES" >> $GITHUB_ENV
+
+      - name: Copy the manifest into the workspace
+        if: env.FUZZ_CRASHES != '0'
+        run: cp /tmp/fuzz/manifest.json fuzz-manifest.json
+
+      - name: Upload crash corpus
+        if: env.FUZZ_CRASHES != '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: crash-corpus
+          path: |
+            crash-report.log
+            fuzz-manifest.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Run quality checks baseline
+        if: env.FUZZ_CRASHES != '0'
+        id: pre-check
+        continue-on-error: true
+        run: |
+          LINT_EXIT=0; TEST_EXIT=0
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test:packages 2>&1 || TEST_EXIT=1
+          echo "LINT_PRE_EXIT=$LINT_EXIT" >> $GITHUB_ENV
+          echo "TEST_PRE_EXIT=$TEST_EXIT" >> $GITHUB_ENV
+
+      - name: Run Claude Code
+        if: env.FUZZ_CRASHES != '0'
+        uses: anthropics/claude-code-action@v1.0.189
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
+            --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, and prose throat-clearing."
+          prompt: |
+            # Fix Crashes Found by the Fuzzer
+
+            A fuzzing run fed malformed documents to `nodetool validate`,
+            `nodetool jsscript validate`, and `nodetool node run`. Each case in
+            `crash-report.log` produced a stack trace or a hang instead of a
+            clean rejection. `/tmp/fuzz/manifest.json` maps every mutant back to
+            the document it came from and the mutation applied.
+
+            The fuzzer ran with seed `${{ env.FUZZ_SEED }}`. Regenerate the same
+            corpus by dispatching this workflow with that seed.
+
+            ## What counts as a bug here
+            Rejecting bad input is correct. Crashing on it is not. Each entry in
+            the report is one of:
+            - an unhandled `TypeError` / `RangeError` / `ReferenceError`
+            - a stack overflow on deeply nested or cyclic input
+            - a hang (the case was killed at 60s)
+
+            ## How to work
+            1. Reproduce the crash first. Run the exact command from the report:
+               ```bash
+               npm run dev:nodetool -- validate /tmp/fuzz/<mutant>.json --json
+               ```
+               If it does not reproduce, say so and move to the next one — do not
+               fix from the log alone.
+            2. Read the stack trace to the frame in NodeTool's own code. Fix it
+               **there**, not at the call site and not with a catch-all wrapper
+               around the whole command.
+            3. Add a regression test next to the code you fixed, with the
+               minimal input that triggers the crash. Copy the mutant's relevant
+               fragment into the test as a literal — do not read from `/tmp`.
+            4. Re-run the reproduction and confirm it now reports a validation
+               issue (or a clean error) instead of throwing.
+
+            ## Rules
+            - Root-cause fixes only. A `try { … } catch { return [] }` around the
+              crashing call hides the bug and is not acceptable.
+            - Do not make the validator accept invalid input to stop it crashing.
+              The correct outcome is usually a reported issue, not a pass.
+            - Do not touch the fuzzer or CI workflow files.
+            - One crash class per commit. Maximum 6 fixes per PR — several
+              reports usually share one root cause, so group them.
+            - If a crash is in a third-party dependency, guard the input at
+              NodeTool's boundary and name the dependency in the PR.
+
+            ## Before starting
+            - Run `gh pr list --state open --limit 20` — skip crashes already
+              covered by an open fuzzer PR.
+
+            ## Verification
+            ```bash
+            npm run lint && npm run test:packages
+            ```
+            Plus the reproduction command for every crash you fixed.
+
+            ## Submit
+            Create a PR titled "fix: crash on malformed <input kind>" listing each
+            crash, the stack frame that caused it, the fix, and the regression
+            test that now covers it.
+
+      - name: Post-change verification
+        if: always() && env.FUZZ_CRASHES != '0'
+        run: |
+          LINT_EXIT=0; TEST_EXIT=0
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test:packages 2>&1 || TEST_EXIT=1
+
+          if [ "$LINT_PRE_EXIT" -eq 0 ] && [ $LINT_EXIT -ne 0 ]; then
+            echo "New lint errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$TEST_PRE_EXIT" -eq 0 ] && [ $TEST_EXIT -ne 0 ]; then
+            echo "New test failures introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi

--- a/.github/workflows/duplicate-unifier.yaml
+++ b/.github/workflows/duplicate-unifier.yaml
@@ -11,7 +11,7 @@ name: Duplicate Unifier
 
 on:
   schedule:
-    - cron: "0 5 * * 5" # Fridays at 05:00 UTC
+    - cron: "0 7 * * *" # Daily at 07:00 UTC
   workflow_dispatch:
     inputs:
       window:

--- a/.github/workflows/duplicate-unifier.yaml
+++ b/.github/workflows/duplicate-unifier.yaml
@@ -1,0 +1,254 @@
+name: Duplicate Unifier
+
+# Finds the same implementation living in two or more places and merges it into
+# one. Copies drift: a fix lands in one and not the other, and the two behave
+# differently for a year before anyone notices.
+#
+# Detection is a sliding-window hash over normalized lines (identifiers kept,
+# whitespace and string contents dropped), so it catches copies that were
+# renamed but not restructured. It reports; the agent decides whether a match is
+# a real duplicate or two things that merely rhyme.
+
+on:
+  schedule:
+    - cron: "0 5 * * 5" # Fridays at 05:00 UTC
+  workflow_dispatch:
+    inputs:
+      window:
+        description: "Minimum duplicated lines to report"
+        required: false
+        default: "14"
+
+jobs:
+  duplicate-unifier:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      - name: Install mobile dependencies
+        run: cd mobile && npm ci
+
+      - name: Detect duplicated blocks
+        id: scan
+        continue-on-error: true
+        shell: bash
+        run: |
+          WINDOW="${{ github.event.inputs.window }}"
+          if [ -z "$WINDOW" ]; then WINDOW=14; fi
+
+          DUP_WINDOW="$WINDOW" node --input-type=module - <<'JS' > duplicate-blocks.log
+          import { createHash } from "node:crypto";
+          import { readFileSync } from "node:fs";
+          import { execFileSync } from "node:child_process";
+
+          const window = Number(process.env.DUP_WINDOW) || 14;
+
+          const files = execFileSync(
+            "bash",
+            [
+              "-c",
+              "git ls-files 'web/src/*.ts' 'web/src/*.tsx' 'electron/src/*.ts' " +
+                "'mobile/src/*.ts' 'mobile/src/*.tsx' 'packages/*/src/*.ts' " +
+                "| grep -vE '/generated/|\\.d\\.ts$'",
+            ],
+            { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+          )
+            .split("\n")
+            .filter(Boolean);
+
+          // Keep identifiers and structure, drop formatting, string contents and
+          // numbers: a copy that was reindented and had its literals swapped is
+          // still a copy.
+          const normalize = (line) =>
+            line
+              .replace(/\/\/.*$/, "")
+              .replace(/(["'`])(?:\\.|(?!\1).)*\1/g, "S")
+              .replace(/\b\d+(\.\d+)?\b/g, "N")
+              .replace(/\s+/g, " ")
+              .trim();
+
+          const blocks = new Map();
+          for (const file of files) {
+            const lines = readFileSync(file, "utf8").split("\n").map(normalize);
+            for (let i = 0; i + window <= lines.length; i += 1) {
+              const slice = lines.slice(i, i + window);
+              // A window that is mostly imports, braces or blanks is noise.
+              const substantive = slice.filter(
+                (line) => line.length > 12 && !/^(import|export|\}|\{|\)|\],?)/.test(line),
+              );
+              if (substantive.length < window * 0.6) continue;
+
+              const key = createHash("sha1").update(slice.join("\n")).digest("hex");
+              const seen = blocks.get(key) ?? [];
+              // Overlapping windows in one file are the same block, not a copy.
+              if (seen.some((hit) => hit.file === file && Math.abs(hit.line - (i + 1)) < window)) continue;
+              seen.push({ file, line: i + 1 });
+              blocks.set(key, seen);
+            }
+          }
+
+          // Copies spread across files come first: a block repeated inside one
+          // file is usually per-case boilerplate (the decorator-declared nodes
+          // look like this), while the same block in two files is drift waiting
+          // to happen.
+          const spread = (hits) => new Set(hits.map((hit) => hit.file)).size;
+          const groups = [...blocks.values()]
+            .filter((hits) => hits.length > 1)
+            .sort((a, b) => spread(b) - spread(a) || b.length - a.length);
+
+          // A file pair that duplicates ten adjacent windows is one finding.
+          const reported = new Set();
+          let count = 0;
+          for (const hits of groups) {
+            const pair = hits.map((hit) => hit.file).sort().join(" | ");
+            if (reported.has(pair)) continue;
+            reported.add(pair);
+            count += 1;
+            const files = spread(hits);
+            console.log(
+              `### ${hits.length} copies of a ${window}-line block across ${files} file${files === 1 ? "" : "s"}`,
+            );
+            for (const hit of hits.slice(0, 10)) console.log(`  ${hit.file}:${hit.line}`);
+            if (hits.length > 10) console.log(`  … ${hits.length - 10} more`);
+            console.log("");
+            if (count >= 25) break;
+          }
+          JS
+
+          echo "## Duplicated Blocks (window ${WINDOW})" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          head -60 duplicate-blocks.log >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          if [ -s duplicate-blocks.log ]; then
+            echo "DUPES_FOUND=1" >> $GITHUB_ENV
+          else
+            echo "DUPES_FOUND=0" >> $GITHUB_ENV
+          fi
+
+      - name: Run quality checks baseline
+        if: env.DUPES_FOUND == '1'
+        id: pre-check
+        continue-on-error: true
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+          echo "TYPECHECK_PRE_EXIT=$TYPECHECK_EXIT" >> $GITHUB_ENV
+          echo "LINT_PRE_EXIT=$LINT_EXIT" >> $GITHUB_ENV
+          echo "TEST_PRE_EXIT=$TEST_EXIT" >> $GITHUB_ENV
+
+      - name: Run Claude Code
+        if: env.DUPES_FOUND == '1'
+        uses: anthropics/claude-code-action@v1.0.189
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
+            --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, and prose throat-clearing."
+          prompt: |
+            # Merge Duplicated Implementations
+
+            `duplicate-blocks.log` lists blocks of code that appear in more than
+            one place, with the file and line of each copy.
+
+            Pick **one** group and merge the copies into a single implementation.
+
+            ## Decide first: is it really a duplicate?
+            Read every copy. Merge only when the copies do the same thing for the
+            same reason. Leave them alone when:
+            - They are alike by coincidence — two reducers with the same shape
+              over unrelated domains. Coupling them makes the next change worse.
+            - They sit on either side of a package boundary that exists on
+              purpose. `packages/protocol` may not import from `web/`, mobile
+              shares only `@nodetool-ai/protocol` and `@nodetool-ai/app-runtime`.
+              See the dependency order in AGENTS.md.
+            - One copy is a deliberate fork with diverging requirements, and the
+              divergence is documented.
+            - The duplicate is generated (`packages/*/src/generated/**`, DSL
+              codegen, provider manifests). Fix the generator or leave it.
+
+            ## Where the merged code goes
+            - Same package → a shared module in that package.
+            - Two backend packages → the nearest common dependency in the order
+              `protocol → config → security → auth → storage → runtime → kernel →
+              node-sdk → base-nodes`. Never introduce a back edge.
+            - Web and backend → a package both already depend on, or leave the
+              copies alone. Do not create a new package for this.
+            - React components → a primitive in
+              `web/src/components/ui_primitives/` when the duplication is UI
+              (see its STRATEGY.md).
+
+            ## The copies must differ somewhere — resolve it
+            Two copies of a function that drifted usually differ in one branch,
+            one default, or one error path. Diff them line by line, decide which
+            behavior is correct, and say so in the PR. If the callers genuinely
+            need both behaviors, take a parameter — but only when a caller
+            actually passes both values today.
+
+            ## Rules
+            - One duplicate group per PR. Maximum 10 files.
+            - Every call site must go through the merged implementation. Do not
+              leave one copy behind "for now".
+            - Keep the tests of every copy. Point them at the merged code; when
+              they overlap exactly, keep one and say which you dropped.
+            - No new abstraction layer. One function replacing three copies of
+              itself, not a strategy interface.
+            - Do not touch CI workflow files.
+
+            ## Before starting
+            - Run `gh pr list --state open --limit 20` — skip if a unification PR
+              is already open.
+
+            ## Verification
+            ```bash
+            npm run typecheck && npm run lint && npm run test
+            ```
+            Backend packages also need `npm run test:packages`.
+
+            ## Submit
+            Create a PR titled "refactor: unify duplicated <thing>" listing every
+            copy that was merged, where the single implementation now lives, and
+            each behavioral difference you found and how you resolved it.
+
+      - name: Post-change verification
+        if: always() && env.DUPES_FOUND == '1'
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+
+          if [ "$TYPECHECK_PRE_EXIT" -eq 0 ] && [ $TYPECHECK_EXIT -ne 0 ]; then
+            echo "New TypeScript errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$LINT_PRE_EXIT" -eq 0 ] && [ $LINT_EXIT -ne 0 ]; then
+            echo "New lint errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$TEST_PRE_EXIT" -eq 0 ] && [ $TEST_EXIT -ne 0 ]; then
+            echo "New test failures introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi

--- a/.github/workflows/flaky-test-fixer.yaml
+++ b/.github/workflows/flaky-test-fixer.yaml
@@ -1,0 +1,251 @@
+name: Flaky Test Fixer
+
+# Finds tests that pass and fail on the same code, and fixes the cause.
+#
+# Two sources of evidence. The GitHub API says which jobs went red and then
+# green on a re-run of the same commit — the definition of a flake, straight
+# from CI history. Locally, the suites run twice in randomized order, which
+# surfaces the largest class of flakes in this repo: order dependence through
+# shared module state.
+#
+# The only acceptable fix is the cause. Adding a retry, widening a timeout, or
+# skipping the test hides a race that will reappear in production.
+
+on:
+  schedule:
+    - cron: "0 2 * * 1,4" # Mondays and Thursdays at 02:00 UTC
+  workflow_dispatch:
+    inputs:
+      repeats:
+        description: "Randomized repeat runs of each suite"
+        required: false
+        default: "2"
+
+jobs:
+  flaky-test-fixer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      - name: Install mobile dependencies
+        run: cd mobile && npm ci
+
+      - name: Build packages
+        run: npm run build:packages
+
+      - name: Read flakes out of CI history
+        id: history
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          echo "## Flakes in CI History" >> $GITHUB_STEP_SUMMARY
+          : > ci-flakes.log
+
+          # A run with more than one attempt whose final conclusion is success
+          # went red and then green on the same commit.
+          gh api "repos/${{ github.repository }}/actions/runs?branch=${{ github.event.repository.default_branch }}&per_page=100" \
+            --jq '.workflow_runs[] | select(.run_attempt > 1) | "\(.name)\t\(.head_sha[0:8])\tattempts=\(.run_attempt)\t\(.conclusion)\t\(.html_url)"' \
+            >> ci-flakes.log 2>/dev/null || echo "(GitHub API unavailable)" >> ci-flakes.log
+
+          RERUNS=$(grep -c "attempts=" ci-flakes.log || true)
+          echo "Re-run runs on the default branch (last 100): $RERUNS" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          head -25 ci-flakes.log >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Repeat the suites in randomized order
+        id: repeat
+        continue-on-error: true
+        shell: bash
+        run: |
+          REPEATS="${{ github.event.inputs.repeats }}"
+          if [ -z "$REPEATS" ]; then REPEATS=2; fi
+          : > flaky-runs.log
+          FLAKY=0
+
+          # Jest randomizes case order within a file with --randomize; Vitest
+          # does the same with --sequence.shuffle. Order dependence — a module
+          # mock, a module-level cache, a global left dirty — shows up as a
+          # failure that moves between runs.
+          for i in $(seq 1 "$REPEATS"); do
+            echo "::group::web attempt $i"
+            if ! npm test --workspace=web -- --randomize > "/tmp/web-$i.log" 2>&1; then
+              FLAKY=1
+              { echo "### web attempt $i failed"; echo '```'; grep -E "●|✕|FAIL|Expected|Received" "/tmp/web-$i.log" | head -60; echo '```'; echo; } >> flaky-runs.log
+            fi
+            echo "::endgroup::"
+
+            echo "::group::packages attempt $i"
+            if ! npx turbo run test --filter="./packages/*" -- --sequence.shuffle > "/tmp/pkg-$i.log" 2>&1; then
+              FLAKY=1
+              { echo "### packages attempt $i failed"; echo '```'; grep -E "FAIL|✕|AssertionError|Expected|Received" "/tmp/pkg-$i.log" | head -60; echo '```'; echo; } >> flaky-runs.log
+            fi
+            echo "::endgroup::"
+          done
+
+          echo "## Randomized Repeat Runs" >> $GITHUB_STEP_SUMMARY
+          if [ "$FLAKY" -eq 0 ]; then
+            echo "All $REPEATS randomized runs passed." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "At least one randomized run failed — see flaky-runs.log." >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "REPEAT_FAILURES=$FLAKY" >> $GITHUB_ENV
+
+      - name: Decide whether there is anything to fix
+        shell: bash
+        run: |
+          # CI history alone is enough to work from: a re-run that went green is
+          # a flake even if today's randomized runs happened to pass.
+          RERUNS=$(grep -c "attempts=" ci-flakes.log || true)
+          if [ "$REPEAT_FAILURES" = "1" ] || [ "${RERUNS:-0}" -gt 0 ]; then
+            echo "FLAKES_FOUND=1" >> $GITHUB_ENV
+          else
+            echo "FLAKES_FOUND=0" >> $GITHUB_ENV
+          fi
+
+      - name: Upload run logs
+        if: env.FLAKES_FOUND == '1'
+        uses: actions/upload-artifact@v7
+        with:
+          name: flaky-run-logs
+          path: |
+            ci-flakes.log
+            flaky-runs.log
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Run Claude Code
+        if: env.FLAKES_FOUND == '1'
+        uses: anthropics/claude-code-action@v1.0.189
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
+            --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, and prose throat-clearing."
+          prompt: |
+            # Root-Cause a Flaky Test
+
+            Two sources of evidence:
+            - `ci-flakes.log` — runs on the default branch that needed more than
+              one attempt. Same commit, red then green.
+            - `flaky-runs.log` — failures from running the suites twice with
+              randomized order (`jest --randomize`,
+              `vitest --sequence.shuffle`).
+
+            Pick **one** flaky test and fix what makes it non-deterministic.
+
+            ## Reproduce it first
+            A flake you cannot reproduce is a flake you cannot claim to have
+            fixed. Try, in order:
+            ```bash
+            npm test --workspace=web -- --randomize -t "<test name>"
+            npm run test --workspace=packages/<name> -- --sequence.shuffle
+            # order dependence: run the suspected neighbour first
+            npm test --workspace=web -- <fileA> <fileB>
+            ```
+            Loop it 20 times and count the failures. Record the rate before and
+            after your fix. If it never reproduces, say so and inspect the CI
+            logs from `ci-flakes.log` instead — `gh run view <id> --log-failed`.
+
+            ## The usual causes, in this repo's terms
+            - **Shared module state** between test files: a module-level cache, a
+              Zustand store that is never reset, a registry that accumulates.
+            - **Unawaited promises**: an assertion running before the effect it
+              depends on; a `void`-ed promise that settles into the next test.
+            - **Real timers and real time**: `setTimeout`-based waits, dates near
+              midnight, durations asserted with `toBe`.
+            - **`waitFor` misuse**: asserting on the first render instead of the
+              settled state, or a `waitFor` with a side effect inside it.
+            - **Order or index assumptions** over unordered data: `Object.keys`,
+              a `Map` iteration, results from a query with no `ORDER BY`.
+            - **Ports, files, and databases** shared between parallel workers.
+            - **The network**: a test that reaches a real endpoint. Mock it.
+            - **WebSocket and MsgPack framing**: assertions that assume one
+              message per frame, or a fixed arrival order.
+
+            ## Fix the cause
+            Acceptable: reset the shared state in `beforeEach`, await what the
+            code awaits, use fake timers, assert on the settled state, sort
+            before comparing, isolate the resource, mock the boundary.
+
+            **Not acceptable**, and a PR that does any of these will be rejected:
+            - retrying the test (`jest.retryTimes`, `test.retry`)
+            - `test.skip` / `describe.skip` / `.fixme` on a flaky test
+            - raising a timeout without showing the operation genuinely needs
+              longer
+            - loosening the assertion until it always passes
+            - `await new Promise(r => setTimeout(r, 500))` as a synchronization
+              device
+
+            If the flake is caused by a **product** race rather than a test bug,
+            fix the product code and say so — that race reaches users too.
+
+            ## Rules
+            - One flake per PR. Maximum 8 files.
+            - Show the failure rate before and after, from an actual loop.
+            - Do not touch CI workflow files.
+
+            ## Before starting
+            - Run `gh pr list --state open --limit 20` — skip if a flaky-test PR
+              is already open.
+
+            ## Verification
+            ```bash
+            npm run lint && npm run test && npm run test:packages
+            ```
+            Plus the repeat loop for the test you fixed.
+
+            ## Submit
+            Create a PR titled "fix(test): deflake <test>" naming the source of
+            non-determinism, the reproduction command, the failure rate before
+            and after, and why the fix removes the cause rather than the symptom.
+
+      - name: Post-change verification
+        if: always() && env.FLAKES_FOUND == '1'
+        run: |
+          echo "## Post-Change Suites" >> $GITHUB_STEP_SUMMARY
+          FAIL=0
+          npm run lint || FAIL=1
+          npm run test || FAIL=1
+          npm run test:packages || FAIL=1
+
+          if [ $FAIL -eq 0 ]; then
+            echo "Suites passed" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          # The randomized repeats above are this run's baseline. If they were
+          # already failing, a red suite here says nothing new — the whole point
+          # of this workflow is that these suites fail intermittently.
+          if [ "$REPEAT_FAILURES" = "1" ]; then
+            echo "Suites failed, but they were already failing before the change" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+          echo "Suites failed after the deflake change, having passed before it" >> $GITHUB_STEP_SUMMARY
+          exit 1

--- a/.github/workflows/flaky-test-fixer.yaml
+++ b/.github/workflows/flaky-test-fixer.yaml
@@ -13,7 +13,7 @@ name: Flaky Test Fixer
 
 on:
   schedule:
-    - cron: "0 2 * * 1,4" # Mondays and Thursdays at 02:00 UTC
+    - cron: "0 2 * * *" # Daily at 02:00 UTC
   workflow_dispatch:
     inputs:
       repeats:

--- a/.github/workflows/internal-only-shipper.yaml
+++ b/.github/workflows/internal-only-shipper.yaml
@@ -12,7 +12,7 @@ name: Internal-Only Feature Shipper
 
 on:
   schedule:
-    - cron: "0 5 * * 3" # Wednesdays at 05:00 UTC
+    - cron: "30 5 * * *" # Daily at 05:30 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/internal-only-shipper.yaml
+++ b/.github/workflows/internal-only-shipper.yaml
@@ -1,0 +1,184 @@
+name: Internal-Only Feature Shipper
+
+# Features that only exist in a dev build are features nobody uses. Each one
+# still costs: it compiles, it ships in the bundle, it drifts, and it makes the
+# code around it harder to read.
+#
+# This finds surfaces reachable only behind a dev/internal gate — `NODETOOL_ENV
+# === "development"`, `import.meta.env.DEV`, `__DEV__`, `NODE_ENV !==
+# "production"`, hidden routes, undocumented CLI commands — and forces a
+# decision on each: ship it (drop the gate and document it) or delete it. The
+# one outcome not allowed is leaving it as it is.
+
+on:
+  schedule:
+    - cron: "0 5 * * 3" # Wednesdays at 05:00 UTC
+  workflow_dispatch:
+
+jobs:
+  internal-only-shipper:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      - name: Install mobile dependencies
+        run: cd mobile && npm ci
+
+      - name: Find internal-only gates
+        id: scan
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "## Internal-Only Gates" >> $GITHUB_STEP_SUMMARY
+          : > internal-only-gates.log
+
+          PATTERN='import\.meta\.env\.DEV|__DEV__|NODE_ENV *[!=]== *["'"'"']production|NODETOOL_ENV *[=!]== *["'"'"']development|isDev(elopment)?\b|INTERNAL_ONLY|internalOnly'
+
+          grep -rEn "$PATTERN" \
+            --include="*.ts" --include="*.tsx" \
+            web/src electron/src mobile/src packages/*/src 2>/dev/null \
+            | grep -vE "\.test\.|\.spec\.|__tests__|/tests/" \
+            > internal-only-gates.log || true
+
+          GATES=$(wc -l < internal-only-gates.log | tr -d ' ')
+          echo "Gated call sites: $GATES" >> $GITHUB_STEP_SUMMARY
+
+          # Last-touched date per gated file: a gate nobody has touched in a
+          # year is evidence of abandonment, not of caution.
+          : > gate-age.log
+          cut -d: -f1 internal-only-gates.log | sort -u | while IFS= read -r file; do
+            LAST=$(git log -1 --format=%ad --date=short -- "$file" 2>/dev/null)
+            echo "$LAST  $file" >> gate-age.log
+          done
+          sort gate-age.log | head -30 >> $GITHUB_STEP_SUMMARY
+
+          if [ "$GATES" -gt 0 ]; then echo "GATES_FOUND=1" >> $GITHUB_ENV; else echo "GATES_FOUND=0" >> $GITHUB_ENV; fi
+
+      - name: Run quality checks baseline
+        if: env.GATES_FOUND == '1'
+        id: pre-check
+        continue-on-error: true
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+          echo "TYPECHECK_PRE_EXIT=$TYPECHECK_EXIT" >> $GITHUB_ENV
+          echo "LINT_PRE_EXIT=$LINT_EXIT" >> $GITHUB_ENV
+          echo "TEST_PRE_EXIT=$TEST_EXIT" >> $GITHUB_ENV
+
+      - name: Run Claude Code
+        if: env.GATES_FOUND == '1'
+        uses: anthropics/claude-code-action@v1.0.189
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
+            --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, and prose throat-clearing."
+          prompt: |
+            # Ship or Delete an Internal-Only Feature
+
+            `internal-only-gates.log` lists every call site gated to a dev or
+            internal build. `gate-age.log` gives the last commit date per file,
+            oldest first.
+
+            Pick **one** feature — not one line, the whole feature behind the
+            gate — and either ship it or delete it.
+
+            ## Choose the feature
+            Prefer the oldest gate that is a real user-facing surface: a panel,
+            a menu entry, a route, a CLI command, a node, an API route. Skip:
+            - debug logging and dev-server plumbing (`vite`, HMR, source maps)
+            - React StrictMode and devtools wiring
+            - test-only helpers and fixtures
+            - anything under `__tests__/`, `tests/`, or `scripts/`
+
+            ## Gather the evidence, then decide
+            For the feature you picked, answer each of these with a command:
+            - When was it last touched? `git log -5 --oneline -- <paths>`
+            - Who references it? `grep -rn "<symbol>" --include="*.ts*" .`
+            - Is it documented? Search `docs/`, `AGENTS.md`, `README.md`.
+            - Is it covered by tests? Search `__tests__/` and `tests/`.
+            - Does it still work? Drive it headlessly — the CLI harnesses in
+              AGENTS.md (`nodetool validate`, `node run`, `app debug`) or the
+              package's own test suite.
+
+            **Ship it** when the feature works, is complete, and a user would
+            want it: remove the gate, wire it into the normal UI/CLI surface,
+            document it where its siblings are documented, and add a test if it
+            has none.
+
+            **Delete it** when it is abandoned — no commits for many months, no
+            references outside its own files, no docs, and no working path
+            through it. Remove the feature, its gate, its dead branches, its
+            styles, its types, and its now-unused imports.
+
+            State which one you chose and why, with the commands you ran, in the
+            PR body. "Unclear" is not a verdict — if the evidence is genuinely
+            split, delete it: it can be recovered from git, and an unused gate
+            cannot.
+
+            ## Rules
+            - One feature per PR. Do not sweep every gate in the log.
+            - Shipping means shipping: no gate left behind, no `if (false)`.
+            - Do not delete a gate that guards *correctness* rather than
+              visibility (dev-only assertions, mock providers used by tests,
+              error overlays). Those are not features.
+            - Do not touch CI workflow files.
+            - Maximum 15 files per PR.
+
+            ## Before starting
+            - Run `gh pr list --state open --limit 20` — skip if a shipper PR is
+              already open.
+
+            ## Verification
+            ```bash
+            npm run typecheck && npm run lint && npm run test
+            ```
+            For a shipped feature, also drive it once headlessly and paste what
+            it produced.
+
+            ## Submit
+            Create a PR titled "feat: ship <feature>" or "chore: remove abandoned
+            <feature>", with the evidence table and the verdict.
+
+      - name: Post-change verification
+        if: always() && env.GATES_FOUND == '1'
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+
+          if [ "$TYPECHECK_PRE_EXIT" -eq 0 ] && [ $TYPECHECK_EXIT -ne 0 ]; then
+            echo "New TypeScript errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$LINT_PRE_EXIT" -eq 0 ] && [ $LINT_EXIT -ne 0 ]; then
+            echo "New lint errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$TEST_PRE_EXIT" -eq 0 ] && [ $TEST_EXIT -ne 0 ]; then
+            echo "New test failures introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi

--- a/.github/workflows/logic-bugfixer.yaml
+++ b/.github/workflows/logic-bugfixer.yaml
@@ -1,0 +1,203 @@
+name: Logic Bugfixer
+
+# Picks one piece of tricky logic, builds an independent model of what it should
+# do, and runs both over the whole input space. Every divergence is either a bug
+# in the code or a bug in the model — and finding out which is the work.
+#
+# The candidates are pure, decidable functions: predicates, reducers, comparators,
+# state transitions, window and range math, retry and backoff, the streaming
+# fold. Anything whose behavior depends on a network, a clock, or a model is out
+# of scope: this routine only reports what it can prove.
+
+on:
+  schedule:
+    - cron: "0 6 * * 4" # Thursdays at 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Optional file or symbol to model (default: pick from the scan)"
+        required: false
+        default: ""
+
+jobs:
+  logic-bugfixer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      - name: Build packages
+        run: npm run build:packages
+
+      - name: Nominate decidable logic
+        id: scan
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "## Candidate Logic" >> $GITHUB_STEP_SUMMARY
+          : > logic-candidates.log
+
+          # Exported functions whose names say "this is a decision, and it is
+          # decidable": predicates, comparators, folds, range and state math.
+          grep -rEn "export (async )?function (is|has|can|should|needs|match|compare|merge|fold|clamp|resolve|normalize|select|next|derive|apply|reduce)[A-Z][A-Za-z0-9]*" \
+            --include="*.ts" \
+            packages/*/src web/src electron/src mobile/src 2>/dev/null \
+            | grep -vE "__tests__|\.test\.|\.spec\.|/generated/" \
+            >> logic-candidates.log || true
+
+          CANDIDATES=$(wc -l < logic-candidates.log | tr -d ' ')
+          echo "Candidates: $CANDIDATES" >> $GITHUB_STEP_SUMMARY
+
+          # Which of them nothing tests yet — those are where divergences live.
+          : > untested-candidates.log
+          while IFS= read -r hit; do
+            SYMBOL=$(echo "$hit" | sed -E 's/.*export (async )?function ([A-Za-z0-9_]+).*/\2/')
+            [ -z "$SYMBOL" ] && continue
+            if ! grep -rqE "\b$SYMBOL\b" --include="*.test.ts" --include="*.test.tsx" \
+                 --include="*.spec.ts" packages web/src electron mobile/src 2>/dev/null; then
+              echo "$hit" >> untested-candidates.log
+            fi
+          done < logic-candidates.log
+
+          UNTESTED=$(wc -l < untested-candidates.log | tr -d ' ')
+          echo "Untested candidates: $UNTESTED" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          head -20 untested-candidates.log >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          if [ "$CANDIDATES" -gt 0 ]; then echo "LOGIC_FOUND=1" >> $GITHUB_ENV; else echo "LOGIC_FOUND=0" >> $GITHUB_ENV; fi
+
+      - name: Run quality checks baseline
+        if: env.LOGIC_FOUND == '1'
+        id: pre-check
+        continue-on-error: true
+        run: |
+          LINT_EXIT=0; TEST_EXIT=0; PKG_TEST_EXIT=0
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+          npm run test:packages 2>&1 || PKG_TEST_EXIT=1
+          echo "LINT_PRE_EXIT=$LINT_EXIT" >> $GITHUB_ENV
+          echo "TEST_PRE_EXIT=$TEST_EXIT" >> $GITHUB_ENV
+          echo "PKG_TEST_PRE_EXIT=$PKG_TEST_EXIT" >> $GITHUB_ENV
+
+      - name: Run Claude Code
+        if: env.LOGIC_FOUND == '1'
+        uses: anthropics/claude-code-action@v1.0.189
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
+            --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, and prose throat-clearing."
+          prompt: |
+            # Model Tricky Logic and Fix What It Gets Wrong
+
+            Requested target: `${{ github.event.inputs.target }}` (empty means
+            choose one yourself).
+
+            `logic-candidates.log` lists exported predicates, comparators,
+            folds, and state transitions. `untested-candidates.log` is the
+            subset nothing tests yet — prefer those.
+
+            ## Method
+            1. **Pick one function** that is pure and decidable: its result
+               depends only on its arguments, and its interesting input space is
+               small enough to enumerate (a handful of enums, booleans, small
+               integers, short arrays) or to sample densely.
+
+            2. **Write down the specification** in the PR body, from the docs,
+               the call sites, and the types — not from the implementation.
+               If the spec is genuinely ambiguous, say which reading you chose.
+
+            3. **Write an independent model** in a scratch file under
+               `/tmp` — a second implementation of the spec, written from the
+               spec, deliberately structured differently from the code.
+
+            4. **Enumerate the input space** and compare the model against the
+               real function, imported from its real module. Never copy the
+               implementation into the scratch file: a copy proves nothing.
+               ```bash
+               npx tsx /tmp/model-check.ts
+               ```
+               Cover the boundaries explicitly: empty, one element, duplicates,
+               equal keys, min/max, negative, zero, `undefined` vs missing,
+               NaN, unicode, and the transitions in and out of every state.
+
+            5. **Triage every divergence.** For each one decide whether the code
+               or the model is wrong, and say how you know — a doc, a call site
+               that depends on it, a downstream test. A divergence you cannot
+               adjudicate goes in the PR body as an open question, not into a
+               fix.
+
+            6. **Ship the reproduction with the fix.** For each real bug: add a
+               failing test in the repo's own suite first (`__tests__/` next to
+               the code, Vitest for `packages/`, Jest for `web`/`electron`),
+               watch it fail, then fix the code and watch it pass. AGENTS.md
+               requires the reproduction — a fix without one does not ship.
+
+            ## Rules
+            - No behavior changes without a failing test that proves the bug.
+            - Do not "fix" a divergence by weakening the test or by rewriting
+              the model to agree with the code.
+            - Do not change a public signature to make modelling easier.
+            - The scratch model stays in `/tmp`. What lands in the repo is the
+              regression tests and the fix.
+            - If the enumeration finds nothing, that is a fine outcome: land the
+              enumeration as a table-driven test instead, and say the code held.
+            - Do not touch CI workflow files.
+            - One function per PR.
+
+            ## Before starting
+            - Run `gh pr list --state open --limit 20` — skip if a logic-bugfix
+              PR is already open.
+
+            ## Verification
+            ```bash
+            npm run lint && npm run test && npm run test:packages
+            ```
+
+            ## Submit
+            Create a PR titled "fix: <function> mishandles <case>" (or
+            "test: pin <function> behavior" when nothing diverged) containing the
+            spec, the input space enumerated, every divergence and its verdict,
+            and the tests that now cover them.
+
+      - name: Post-change verification
+        if: always() && env.LOGIC_FOUND == '1'
+        run: |
+          LINT_EXIT=0; TEST_EXIT=0; PKG_TEST_EXIT=0
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+          npm run test:packages 2>&1 || PKG_TEST_EXIT=1
+
+          if [ "$LINT_PRE_EXIT" -eq 0 ] && [ $LINT_EXIT -ne 0 ]; then
+            echo "New lint errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$TEST_PRE_EXIT" -eq 0 ] && [ $TEST_EXIT -ne 0 ]; then
+            echo "New test failures introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$PKG_TEST_PRE_EXIT" -eq 0 ] && [ $PKG_TEST_EXIT -ne 0 ]; then
+            echo "New package test failures introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi

--- a/.github/workflows/logic-bugfixer.yaml
+++ b/.github/workflows/logic-bugfixer.yaml
@@ -11,7 +11,7 @@ name: Logic Bugfixer
 
 on:
   schedule:
-    - cron: "0 6 * * 4" # Thursdays at 06:00 UTC
+    - cron: "30 6 * * *" # Daily at 06:30 UTC
   workflow_dispatch:
     inputs:
       target:

--- a/.github/workflows/logic-simplifier.yaml
+++ b/.github/workflows/logic-simplifier.yaml
@@ -1,0 +1,229 @@
+name: Logic Simplifier
+
+# Ranks source files by branch density and nesting depth, then rewrites the
+# worst offender's logic without changing what it does.
+#
+# The ranking is a crude proxy — a switch over twenty node kinds scores high and
+# is fine as it is — so the scan only nominates candidates. The agent reads the
+# code and decides whether there is a simplification worth making, and proves
+# behavior is unchanged by running the existing tests, or by adding
+# characterization tests first when there are none.
+
+on:
+  schedule:
+    - cron: "0 6 * * 2" # Tuesdays at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  logic-simplifier:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      - name: Install mobile dependencies
+        run: cd mobile && npm ci
+
+      - name: Rank complexity hotspots
+        id: scan
+        continue-on-error: true
+        shell: bash
+        run: |
+          node --input-type=module - <<'JS' > complexity-hotspots.log
+          import { readFileSync } from "node:fs";
+          import { execFileSync } from "node:child_process";
+
+          const files = execFileSync(
+            "bash",
+            [
+              "-c",
+              "git ls-files 'web/src/*.ts' 'web/src/*.tsx' 'electron/src/*.ts' " +
+                "'mobile/src/*.ts' 'mobile/src/*.tsx' 'packages/*/src/*.ts' " +
+                "| grep -vE '__tests__|\\.test\\.|\\.spec\\.|/generated/|/configs/|/data/|\\.d\\.ts$'",
+            ],
+            { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+          )
+            .split("\n")
+            .filter(Boolean);
+
+          const BRANCH = /\b(if|else if|switch|case|catch|while|for)\b|&&|\|\||\?\?|\?\./g;
+
+          const scored = [];
+          for (const file of files) {
+            const source = readFileSync(file, "utf8");
+            const lines = source.split("\n");
+            if (lines.length < 60) continue;
+
+            const branches = (source.match(BRANCH) ?? []).length;
+            // A 5000-line lookup table has no logic to simplify, however long
+            // it is. Branches are what this routine can act on.
+            if (branches < 15) continue;
+
+            // Max indent depth, tabs counted as one level, comments skipped.
+            let depth = 0;
+            for (const line of lines) {
+              if (!line.trim() || line.trim().startsWith("*") || line.trim().startsWith("//")) continue;
+              const indent = line.match(/^[ \t]*/)[0].replace(/\t/g, "  ").length;
+              depth = Math.max(depth, Math.floor(indent / 2));
+            }
+
+            // Longest run of consecutive non-blank lines: a 200-line function
+            // body and a 200-line file of small functions read very differently.
+            let run = 0;
+            let longestRun = 0;
+            for (const line of lines) {
+              run = line.trim() ? run + 1 : 0;
+              longestRun = Math.max(longestRun, run);
+            }
+
+            const score = branches + depth * 4;
+            scored.push({ file, score, branches, depth, longestRun, lines: lines.length });
+          }
+
+          scored.sort((a, b) => b.score - a.score);
+          for (const entry of scored.slice(0, 25)) {
+            console.log(
+              `${String(entry.score).padStart(5)}  branches=${entry.branches} depth=${entry.depth} ` +
+                `longest-run=${entry.longestRun} lines=${entry.lines}  ${entry.file}`,
+            );
+          }
+          JS
+
+          echo "## Complexity Hotspots" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          head -25 complexity-hotspots.log >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          if [ -s complexity-hotspots.log ]; then
+            echo "HOTSPOTS_FOUND=1" >> $GITHUB_ENV
+          else
+            echo "HOTSPOTS_FOUND=0" >> $GITHUB_ENV
+          fi
+
+      - name: Run quality checks baseline
+        if: env.HOTSPOTS_FOUND == '1'
+        id: pre-check
+        continue-on-error: true
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+          echo "TYPECHECK_PRE_EXIT=$TYPECHECK_EXIT" >> $GITHUB_ENV
+          echo "LINT_PRE_EXIT=$LINT_EXIT" >> $GITHUB_ENV
+          echo "TEST_PRE_EXIT=$TEST_EXIT" >> $GITHUB_ENV
+
+      - name: Run Claude Code
+        if: env.HOTSPOTS_FOUND == '1'
+        uses: anthropics/claude-code-action@v1.0.189
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
+            --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, and prose throat-clearing."
+          prompt: |
+            # Simplify Convoluted Logic
+
+            `complexity-hotspots.log` ranks source files by branch count, nesting
+            depth, and longest unbroken run of code. It is a proxy, not a
+            verdict — read the code before touching it.
+
+            Pick **one** function or closely related group of functions and make
+            the logic easier to follow without changing what it does.
+
+            ## What to look for
+            - **Deep nesting** that inverts cleanly: guard clauses and early
+              returns instead of an arrow of `if`s.
+            - **Boolean expressions** carrying three or more terms: name the
+              sub-conditions, or express them as a small predicate.
+            - **Repeated condition chains**: the same `a && b.c && b.c.d` test in
+              five places, computed once instead.
+            - **Flag arguments** that make a function do two unrelated things:
+              split it in two.
+            - **Manual loops** that are a `map`/`filter`/`find`/`some` in
+              disguise, and reduces that reimplement `Object.fromEntries`.
+            - **State machines written as booleans**: three `isLoading` /
+              `isError` / `isDone` flags with implicit invariants become one
+              discriminated union (AGENTS.md prefers this).
+            - **Dead branches**: conditions that cannot hold given the types.
+
+            ## What NOT to touch
+            - Exhaustive `switch` over a union. That is the language working.
+            - Ordering that looks arbitrary but is load-bearing (initialization
+              order, event ordering, `await` sequencing). If you cannot explain
+              why an order is safe to change, leave it.
+            - Anything whose complexity is inherent: parsers, schedulers, the
+              streaming fold, protocol framing.
+            - Generated code (`packages/*/src/generated/**`, DSL codegen output).
+
+            ## Method
+            1. Read the function and write down, in the PR body, what it does —
+               inputs, outputs, side effects, error paths.
+            2. Find its tests. If there are none, **write characterization tests
+               first** against the current behavior, in their own commit, and
+               confirm they pass before you change anything.
+            3. Refactor in small steps, running the tests after each.
+            4. Diff the behavior, not the shape: every branch the old code took
+               must still be reachable, including the error paths.
+
+            ## Rules
+            - Behavior-preserving only. No bug fixes, no new features. If you
+              find a bug, leave it and report it in the PR body.
+            - No new abstractions. This routine removes indirection; it does not
+              add a strategy object to flatten an `if`.
+            - One function or one tight cluster per PR. Maximum 6 files.
+            - Do not touch CI workflow files.
+
+            ## Before starting
+            - Run `gh pr list --state open --limit 20` — skip if a simplification
+              PR is already open.
+
+            ## Verification
+            ```bash
+            npm run typecheck && npm run lint && npm run test
+            ```
+            Backend packages also need `npm run test:packages`.
+
+            ## Submit
+            Create a PR titled "refactor: simplify <function> in <area>" with the
+            before/after description of the logic and the tests that pin it.
+
+      - name: Post-change verification
+        if: always() && env.HOTSPOTS_FOUND == '1'
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+
+          if [ "$TYPECHECK_PRE_EXIT" -eq 0 ] && [ $TYPECHECK_EXIT -ne 0 ]; then
+            echo "New TypeScript errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$LINT_PRE_EXIT" -eq 0 ] && [ $LINT_EXIT -ne 0 ]; then
+            echo "New lint errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$TEST_PRE_EXIT" -eq 0 ] && [ $TEST_EXIT -ne 0 ]; then
+            echo "New test failures introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi

--- a/.github/workflows/logic-simplifier.yaml
+++ b/.github/workflows/logic-simplifier.yaml
@@ -11,7 +11,7 @@ name: Logic Simplifier
 
 on:
   schedule:
-    - cron: "0 6 * * 2" # Tuesdays at 06:00 UTC
+    - cron: "0 6 * * *" # Daily at 06:00 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/shipped-feature-inliner.yaml
+++ b/.github/workflows/shipped-feature-inliner.yaml
@@ -12,7 +12,7 @@ name: Shipped Feature Inliner
 
 on:
   schedule:
-    - cron: "0 7 * * 3" # Wednesdays at 07:00 UTC
+    - cron: "0 8 * * *" # Daily at 08:00 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/shipped-feature-inliner.yaml
+++ b/.github/workflows/shipped-feature-inliner.yaml
@@ -1,0 +1,239 @@
+name: Shipped Feature Inliner
+
+# A flag for a feature that shipped is a branch nobody takes, a config knob
+# nobody sets, and a second code path nobody tests. This finds gates that are
+# permanently on — constants initialized to `true`, env vars that default to
+# enabled and are never set, settings whose "off" branch no test and no caller
+# exercises — and inlines the live branch.
+#
+# Inlining a flag deletes the fallback. That is the point, and it is also the
+# risk: the routine only removes a flag when the off-path is provably unused,
+# and the rollback is a revert.
+
+on:
+  schedule:
+    - cron: "0 7 * * 3" # Wednesdays at 07:00 UTC
+  workflow_dispatch:
+
+jobs:
+  shipped-feature-inliner:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      - name: Install mobile dependencies
+        run: cd mobile && npm ci
+
+      - name: Find flags that are always on
+        id: scan
+        continue-on-error: true
+        shell: bash
+        run: |
+          node --input-type=module - <<'JS' > shipped-flags.log
+          import { readFileSync } from "node:fs";
+          import { execFileSync } from "node:child_process";
+
+          // The config corpus is tens of megabytes; the 1 MB default throws ENOBUFS.
+          const sh = (command) =>
+            execFileSync("bash", ["-c", command], { encoding: "utf8", maxBuffer: 256 * 1024 * 1024 });
+
+          const sourceFiles = sh(
+            "git ls-files 'web/src/*.ts' 'web/src/*.tsx' 'electron/src/*.ts' " +
+              "'mobile/src/*.ts' 'mobile/src/*.tsx' 'packages/*/src/*.ts' " +
+              "| grep -vE '__tests__|\\.test\\.|\\.spec\\.|__mocks__|/generated/'",
+          )
+            .split("\n")
+            .filter(Boolean);
+
+          // Everything that could set a variable outside the source itself:
+          // env files, CI, container and deploy config, scripts, docs.
+          const configCorpus = sh(
+            "git ls-files | grep -vE '^(web|electron|mobile)/src/|^packages/[^/]+/src/' " +
+              "| grep -E '\\.(env|env\\..*|ya?ml|json|toml|sh|mjs|md|Dockerfile.*)$|Dockerfile|\\.env' " +
+              "| head -400 | xargs -r cat 2>/dev/null",
+          );
+
+          // Boolean-shaped gates only. A key or a URL read from the environment
+          // is configuration; `X === "1"` is a switch.
+          const GATE =
+            /(?:process|import\.meta)\.env\.([A-Z][A-Z0-9_]*)\s*(?:!==|===|==|!=)\s*["'](?:1|0|true|false)["']|(?:process|import\.meta)\.env\.([A-Z][A-Z0-9_]*)\s*(?:\?\?|\|\|)\s*["'](?:1|0|true|false)["']|Boolean\(\s*(?:process|import\.meta)\.env\.([A-Z][A-Z0-9_]*)\s*\)/g;
+
+          const gates = new Map();
+          for (const file of sourceFiles) {
+            const source = readFileSync(file, "utf8");
+            for (const match of source.matchAll(GATE)) {
+              const name = match[1] ?? match[2] ?? match[3];
+              const entry = gates.get(name) ?? { reads: 0, files: new Set() };
+              entry.reads += 1;
+              entry.files.add(file);
+              gates.set(name, entry);
+            }
+          }
+
+          const rows = [...gates.entries()]
+            .map(([name, entry]) => ({
+              name,
+              reads: entry.reads,
+              files: [...entry.files],
+              // Set anywhere outside the reading code? Then somebody flips it.
+              setInConfig: new RegExp(`${name}\\s*[:=]`).test(configCorpus),
+            }))
+            .sort((a, b) => Number(a.setInConfig) - Number(b.setInConfig) || a.reads - b.reads);
+
+          console.log("## Boolean env gates (never set in the repo first)");
+          for (const row of rows) {
+            console.log(
+              `  ${row.name}  reads=${row.reads}  set-in-config=${row.setInConfig}  ${row.files.join(" ")}`,
+            );
+          }
+
+          console.log("");
+          console.log("## Constants pinned to a boolean literal");
+          for (const file of sourceFiles) {
+            const source = readFileSync(file, "utf8");
+            for (const match of source.matchAll(
+              /^(?:export )?const ([A-Za-z_][A-Za-z0-9_]*)\s*(?::[^=]+)?=\s*(true|false)(?: as const)?;/gm,
+            )) {
+              console.log(`  ${file}  ${match[1]} = ${match[2]}`);
+            }
+          }
+          JS
+
+          echo "## Candidate Flags" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          head -50 shipped-flags.log >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          # The two section headers print unconditionally; findings are indented.
+          FLAGS=$(grep -c "^  " shipped-flags.log || true)
+          echo "Findings: $FLAGS" >> $GITHUB_STEP_SUMMARY
+          if [ "${FLAGS:-0}" -gt 0 ]; then echo "FLAGS_FOUND=1" >> $GITHUB_ENV; else echo "FLAGS_FOUND=0" >> $GITHUB_ENV; fi
+
+      - name: Run quality checks baseline
+        if: env.FLAGS_FOUND == '1'
+        id: pre-check
+        continue-on-error: true
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+          echo "TYPECHECK_PRE_EXIT=$TYPECHECK_EXIT" >> $GITHUB_ENV
+          echo "LINT_PRE_EXIT=$LINT_EXIT" >> $GITHUB_ENV
+          echo "TEST_PRE_EXIT=$TEST_EXIT" >> $GITHUB_ENV
+
+      - name: Run Claude Code
+        if: env.FLAGS_FOUND == '1'
+        uses: anthropics/claude-code-action@v1.0.189
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
+            --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, useEffect-for-derived-data, raw MUI imports outside ui_primitives/, whole-store Zustand subscriptions, and prose throat-clearing."
+          prompt: |
+            # Inline a Shipped Feature Flag
+
+            `shipped-flags.log` has two sections. **Boolean env gates** —
+            environment variables compared against `"1"`/`"true"`, with the
+            number of read sites and whether anything in the repo sets them;
+            those never set, read in one place, are listed first. **Constants
+            pinned to a boolean literal** — a gate whose value is in the source.
+
+            Pick **one** flag whose feature has fully shipped and remove it.
+
+            ## Establish that it has shipped
+            Answer each with a command, in the PR body:
+            - What value does it actually take in every build? Read the
+              declaration and every override (`.env*`, `fly.toml`,
+              `docker-compose.yml`, `electron-builder.json`, CI workflows,
+              `packages/config`).
+            - Does anything set the other value? `grep -rn "<FLAG>" .` including
+              docs, scripts, and workflow files.
+            - When did it last change? `git log --oneline -- <file>` and
+              `git log -S "<FLAG>" --oneline | tail -5` for when it was
+              introduced. A gate added last month is not a shipped feature.
+            - Do any tests exercise the off-path? If they do, that path is alive
+              — pick a different flag.
+
+            A flag qualifies only when every build takes one branch, nothing in
+            the repo sets the other, and the feature has been live long enough
+            that reverting the flag is not the rollback plan anymore.
+
+            ## Then inline it
+            - Replace every read with the value it always has, and delete the
+              branch that value never takes.
+            - Delete the flag's declaration, its type, its config plumbing, its
+              env-var documentation, and any settings-UI control for it.
+            - Delete the now-unreachable implementation on the other side —
+              including files, components, and helpers only that path used.
+            - Delete the tests that only covered the dead path. Keep, and if
+              necessary un-parameterize, the tests covering the live one.
+            - Update the docs that mention the flag: `docs/`, `AGENTS.md`,
+              `README.md`, `.env.example`.
+
+            ## Rules
+            - One flag per PR. Maximum 20 files.
+            - Never inline a **kill switch** or a safety gate: rate limits, spend
+              caps, SSRF and sandbox guards, `NODETOOL_TRUST_*`, auth mode. Those
+              are configuration, not shipped features.
+            - Never inline a flag that selects between platforms or environments
+              (`NODETOOL_ENV`, `process.platform`, dev vs production).
+            - Never inline a flag that any test sets.
+            - Do not touch CI workflow files.
+
+            ## Before starting
+            - Run `gh pr list --state open --limit 20` — skip if a flag-inlining
+              PR is already open.
+
+            ## Verification
+            ```bash
+            npm run typecheck && npm run lint && npm run test
+            ```
+            Backend packages also need `npm run test:packages`. Confirm the flag
+            name appears nowhere afterwards: `grep -rn "<FLAG>" . | grep -v .git`
+
+            ## Submit
+            Create a PR titled "chore: inline the <feature> flag" with the
+            evidence that it shipped, the branch that was removed, and everything
+            deleted along with it.
+
+      - name: Post-change verification
+        if: always() && env.FLAGS_FOUND == '1'
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+
+          if [ "$TYPECHECK_PRE_EXIT" -eq 0 ] && [ $TYPECHECK_EXIT -ne 0 ]; then
+            echo "New TypeScript errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$LINT_PRE_EXIT" -eq 0 ] && [ $LINT_EXIT -ne 0 ]; then
+            echo "New lint errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$TEST_PRE_EXIT" -eq 0 ] && [ $TEST_EXIT -ne 0 ]; then
+            echo "New test failures introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi

--- a/.github/workflows/useless-test-pruner.yaml
+++ b/.github/workflows/useless-test-pruner.yaml
@@ -1,0 +1,276 @@
+name: Useless Test Pruner
+
+# A test that cannot fail is worse than no test: it costs CI time and it reads
+# as coverage. This finds the usual shapes — no assertion at all, assertions
+# only about mocks the test itself wrote, tautologies, snapshots of a literal —
+# and requires proof before anything is deleted.
+#
+# The proof is a mutation: break the code the test claims to cover, run the test,
+# and watch it pass anyway. Only then is it established that the test cannot
+# fail. A candidate that turns red under mutation is doing its job and stays.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Mondays at 07:00 UTC
+  workflow_dispatch:
+
+jobs:
+  useless-test-pruner:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      - name: Install mobile dependencies
+        run: cd mobile && npm ci
+
+      - name: Find tests that cannot fail
+        id: scan
+        continue-on-error: true
+        shell: bash
+        run: |
+          node --input-type=module - <<'JS' > useless-tests.log
+          import { readFileSync } from "node:fs";
+          import { execFileSync } from "node:child_process";
+
+          const files = execFileSync(
+            "bash",
+            [
+              "-c",
+              // Playwright suites are out of scope: the proof loop below runs
+              // single cases under Jest and Vitest.
+              "git ls-files '*.test.ts' '*.test.tsx' '*.spec.ts' '*.spec.tsx' " +
+                "| grep -vE '^(marketing|reliability)/|^web/(tests|e2e)/'",
+            ],
+            { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+          )
+            .split("\n")
+            .filter(Boolean);
+
+          // Split a test file into cases by `it(`/`test(` at the start of a line,
+          // which is how every suite in this repo is written. `describe` is not
+          // a case: counting it as one would report every suite whose header
+          // sits above its first assertion.
+          const splitCases = (source) => {
+            const lines = source.split("\n");
+            const cases = [];
+            let current = null;
+            for (let i = 0; i < lines.length; i += 1) {
+              const start = /^\s*(it|test)(\.(each|concurrent|failing|only))?\s*[(`]/.test(lines[i]);
+              if (start) {
+                if (current) cases.push(current);
+                current = { line: i + 1, body: [] };
+              }
+              if (current) current.body.push(lines[i]);
+            }
+            if (current) cases.push(current);
+            return cases;
+          };
+
+          const findings = [];
+          for (const file of files) {
+            const source = readFileSync(file, "utf8");
+            for (const testCase of splitCases(source)) {
+              const body = testCase.body.join("\n");
+              const title = testCase.body[0].trim().slice(0, 90);
+              const reasons = [];
+
+              const assertions = body.match(/\bexpect\s*\(|\bassert[.(]/g) ?? [];
+              if (assertions.length === 0) {
+                reasons.push("no assertion");
+              }
+              if (/expect\(true\)\.(toBe|toEqual)\(true\)|expect\(1\)\.toBe\(1\)/.test(body)) {
+                reasons.push("tautological assertion");
+              }
+              // Every assertion is `toBeDefined`/`toBeTruthy` on something the
+              // test just constructed: it asserts that JavaScript works.
+              if (
+                assertions.length > 0 &&
+                /expect\([^)]*\)\.(toBeDefined|toBeTruthy|not\.toBeNull|not\.toBeUndefined)\(\)/.test(body) &&
+                !/toBe\(|toEqual\(|toMatch|toThrow|toHaveBeenCalledWith|toContain|toStrictEqual/.test(body)
+              ) {
+                reasons.push("only existence assertions");
+              }
+              // Asserting a mock returns what the same test told it to return.
+              // The subject of every assertion has to be the mock itself —
+              // asserting the *code under test* while a dependency is mocked is
+              // just normal testing.
+              const subjects = [...body.matchAll(/expect\(\s*([A-Za-z0-9_.]+)/g)].map((m) => m[1]);
+              if (
+                subjects.length > 0 &&
+                /mockReturnValue|mockResolvedValue|mockImplementation/.test(body) &&
+                !/toHaveBeenCalled/.test(body) &&
+                subjects.every((subject) => /^mock|Mock$|^jest\./.test(subject))
+              ) {
+                reasons.push("asserts its own mock");
+              }
+              if (/expect\([^)]*\)\.toMatchSnapshot\(\)/.test(body) && assertions.length === 1) {
+                reasons.push("snapshot-only");
+              }
+
+              if (reasons.length) {
+                findings.push(`${file}:${testCase.line}  [${reasons.join(", ")}]  ${title}`);
+              }
+            }
+          }
+
+          for (const finding of findings.slice(0, 60)) console.log(finding);
+          console.error(`${findings.length} candidates`);
+          JS
+
+          echo "## Tests That May Not Be Able To Fail" >> $GITHUB_STEP_SUMMARY
+          CANDIDATES=$(wc -l < useless-tests.log | tr -d ' ')
+          echo "Candidates: $CANDIDATES" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          head -40 useless-tests.log >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          if [ "$CANDIDATES" -gt 0 ]; then echo "USELESS_FOUND=1" >> $GITHUB_ENV; else echo "USELESS_FOUND=0" >> $GITHUB_ENV; fi
+
+      - name: Run quality checks baseline
+        if: env.USELESS_FOUND == '1'
+        id: pre-check
+        continue-on-error: true
+        run: |
+          LINT_EXIT=0; TEST_EXIT=0; PKG_TEST_EXIT=0
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+          npm run test:packages 2>&1 || PKG_TEST_EXIT=1
+          echo "LINT_PRE_EXIT=$LINT_EXIT" >> $GITHUB_ENV
+          echo "TEST_PRE_EXIT=$TEST_EXIT" >> $GITHUB_ENV
+          echo "PKG_TEST_PRE_EXIT=$PKG_TEST_EXIT" >> $GITHUB_ENV
+
+      - name: Run Claude Code
+        if: env.USELESS_FOUND == '1'
+        uses: anthropics/claude-code-action@v1.0.189
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
+            --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff. Strip speculative abstractions, narrating comments, defensive try/catch on trusted paths, and prose throat-clearing."
+          prompt: |
+            # Delete Tests That Cannot Fail
+
+            `useless-tests.log` lists test cases whose shape suggests they assert
+            nothing real: no assertion, a tautology, existence checks only, an
+            assertion about a mock the test itself configured, a lone snapshot.
+
+            The scan is a heuristic. **Nothing gets deleted without proof.**
+
+            ## The proof
+            For each candidate, before touching it:
+            1. Find the code it claims to cover.
+            2. Break that code — invert a condition, return a wrong constant,
+               drop a call. One mutation at a time.
+            3. Run only that test:
+               ```bash
+               npm test --workspace=web -- -t "<test name>"
+               npm run test --workspace=packages/<name> -- -t "<test name>"
+               ```
+            4. If it **still passes**, it cannot fail: it is a candidate for
+               real. If it **fails**, the test is doing its job — revert the
+               mutation, drop the candidate, and say so.
+            5. Revert the mutation before moving on. `git diff` must be clean of
+               it before you commit anything.
+
+            Paste the mutation and the result for every case you act on.
+
+            ## Then choose: strengthen or delete
+            - **Strengthen** when the behavior deserves coverage and the test is
+              merely weak: assert the value, not its existence; assert
+              `toHaveBeenCalledWith`, not that a mock was configured; assert the
+              error, not that something threw.
+            - **Delete** when the behavior is already covered elsewhere, or the
+              test only exercises the framework, the mock, or the type system.
+              Name the test that covers it instead, or say plainly that the
+              behavior is untested and worth someone's attention.
+
+            Prefer strengthening. A deleted test is coverage lost; a strengthened
+            one is coverage gained.
+
+            ## Rules
+            - Never delete a test to make CI green. This routine runs against a
+              green tree.
+            - Do not touch `test.skip`, `describe.skipIf`, or `test.fixme`
+              markers — those are tracked debt, not useless tests (AGENTS.md).
+            - Do not delete a test whose mutation you could not run.
+            - Snapshot tests over rendered components are not automatically
+              useless — check whether the snapshot has content.
+            - Do not touch CI workflow files.
+            - Maximum 12 test cases per PR.
+
+            ## Before starting
+            - Run `gh pr list --state open --limit 20` — skip if a test-pruning
+              PR is already open.
+
+            ## Verification
+            ```bash
+            npm run lint && npm run test && npm run test:packages
+            ```
+
+            ## Submit
+            Create a PR titled "test: remove tests that cannot fail in <area>"
+            with a table: test, mutation applied, result, verdict (strengthened /
+            deleted), and where the behavior is covered now.
+
+      - name: Post-change verification
+        if: always() && env.USELESS_FOUND == '1'
+        run: |
+          LINT_EXIT=0; TEST_EXIT=0; PKG_TEST_EXIT=0
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+          npm run test:packages 2>&1 || PKG_TEST_EXIT=1
+
+          if [ "$LINT_PRE_EXIT" -eq 0 ] && [ $LINT_EXIT -ne 0 ]; then
+            echo "New lint errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$TEST_PRE_EXIT" -eq 0 ] && [ $TEST_EXIT -ne 0 ]; then
+            echo "New test failures introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$PKG_TEST_PRE_EXIT" -eq 0 ] && [ $PKG_TEST_EXIT -ne 0 ]; then
+            echo "New package test failures introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+
+      - name: Confirm no mutation was committed
+        if: always() && env.USELESS_FOUND == '1'
+        shell: bash
+        run: |
+          # A mutation left behind by the proof step would land as a source
+          # change in a PR that is meant to touch tests only.
+          BASE="origin/${{ github.event.repository.default_branch }}"
+          if ! git rev-parse --verify --quiet "$BASE" > /dev/null; then
+            echo "Base ref $BASE not available — skipping the test-only check" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+          CHANGED_SRC=$(git diff --name-only "$BASE"...HEAD \
+            | grep -vE "\.test\.|\.spec\.|__tests__|__snapshots__" || true)
+          if [ -n "$CHANGED_SRC" ]; then
+            echo "Non-test files changed by a test-pruning run:" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "$CHANGED_SRC" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi

--- a/.github/workflows/useless-test-pruner.yaml
+++ b/.github/workflows/useless-test-pruner.yaml
@@ -11,7 +11,7 @@ name: Useless Test Pruner
 
 on:
   schedule:
-    - cron: "0 7 * * 1" # Mondays at 07:00 UTC
+    - cron: "30 7 * * *" # Daily at 07:30 UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Completes the routine set the repo already started with `dead-code-cleanup.yaml`, `type-safety.yaml`, `performance-optimization.yaml` and friends. Ten new workflows, each following the house pattern: a deterministic scan writes an evidence file and sets an env flag, the agent step runs only when the scan found something, and a post-change step re-runs the quality checks against a pre-change baseline so a routine can only fail the run by *introducing* a failure.

All ten run daily, spread across 02:00–08:30 UTC at half-hour intervals so no two start together and none lands on the 03:00 slot the existing routines share.

| Workflow | What it does | Daily at |
|---|---|---|
| `flaky-test-fixer.yaml` | CI re-run history plus randomized repeat runs | 02:00 |
| `abstraction-police.yaml` | The five `check:*` scripts plus the import greps no script covers | 04:30 |
| `crash-fuzzer.yaml` | Mutates shipped examples and CLI fixtures, feeds them to `validate` / `jsscript validate` / `node run`, reports stack traces and hangs | 05:00 |
| `internal-only-shipper.yaml` | Finds dev/internal-gated surfaces, forces a ship-or-delete verdict on one | 05:30 |
| `logic-simplifier.yaml` | Ranks files by branch density and nesting; rewrites one, behavior-preserving | 06:00 |
| `logic-bugfixer.yaml` | Models one decidable function against an independent implementation, enumerates its inputs | 06:30 |
| `duplicate-unifier.yaml` | Sliding-window hash over normalized lines; merges one duplicate group | 07:00 |
| `useless-test-pruner.yaml` | Nominates tests that assert nothing, requires a mutation proof before touching one | 07:30 |
| `shipped-feature-inliner.yaml` | Boolean env gates and pinned constants, ranked by whether the repo ever sets them | 08:00 |
| `abstraction-improver.yaml` | Single-implementer interfaces, forwarding wrappers, re-export-only barrels | 08:30 |

Each opens at most one PR per run and skips when a PR from the same routine is already open, so the daily cadence raises the rate the backlog is worked through, not the number of PRs in flight.

## Design notes

**The scans are grounded in this repo, not generic.** `abstraction-police` runs `check:deps`, `check:circular`, `check:keys`, `check:coupled-deps` and `check:execution-boundary`, and its prompt states the package dependency order and the `ui_primitives` rule from AGENTS.md. `crash-fuzzer` seeds from the shipped examples and `packages/cli/tests/fixtures/js-script-*.json`, and derives its node types from those graphs so it only fuzzes types the registry actually has. `flaky-test-fixer` uses `jest --randomize` and `vitest --sequence.shuffle`, which target the order-dependence class of flake directly.

**Each routine names what it must not do.** Fuzzer fixes may not be a catch-all wrapper. Deflaking may not use retries, skips or widened timeouts. Flag inlining may not touch a kill switch or a safety gate. Layering fixes may not widen the grandfathered allowlist in `check-execution-boundary.mjs` — that list may only shrink. Test pruning may not delete a test whose mutation was never run.

**`useless-test-pruner` requires proof, not a heuristic.** The scan nominates; the agent must break the code under test and watch the test pass anyway before deleting it. A dedicated step then fails the run if a mutation was left behind in a non-test file.

## Verification

Every scan script was extracted and run against the working tree before landing, and each returns real findings — e.g. `electron/src/__tests__/ipc.test.ts:553` and `window.test.ts:219` are tests with zero assertions and a comment saying so.

Two bugs surfaced by running them, both of which would have shipped silently:

- `git ls-files 'dir/**/*.ts'` does not match files sitting directly in `dir` — it was skipping 42 of 119 electron sources, and the largest backend files entirely. Switched to `dir/*.ts`, which globs recursively under git's default pathspec (4395 → 4977 files scanned).
- Reading the config corpus through `execFileSync` overflowed the 1 MB default buffer with `ENOBUFS`, which crashed `shipped-feature-inliner`'s scan outright. Raised `maxBuffer` there and in the other four scans.

The first version of `shipped-feature-inliner` also found zero flags, because this repo gates on env vars rather than `const ENABLE_X = true` — a workflow that could never fire. It was rewritten around boolean env gates and now reports 5 of them with whether anything in the repo sets each one.

All 51 workflow files parse as YAML with no control characters, every `if: env.X` in the new workflows refers to a variable an earlier step sets, and no two schedules collide.

## Docs

`.github/workflows/README.md` gains the ten rows, the maintenance section is re-sorted alphabetically, and the summary line is corrected to the counts the table actually holds (51 files, 10 in rings, 41 maintenance — it read 43/12/31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H1r8Hmer6rdHjwdkfgzvM