### PR TITLE
Preserve custom image size capabilities in fal manifests

### DIFF
--- a/packages/fal-codegen/src/configs/image-to-image.ts
+++ b/packages/fal-codegen/src/configs/image-to-image.ts
@@ -5076,7 +5076,16 @@ export const config: ModuleConfig = {
         "Batch processing",
         "Professional applications",
         "Rapid prototyping"
-      ]
+      ],
+      fieldOverrides: {
+        image_size: {
+          customSizeConstraints: {
+            maxEdge: 3840,
+            maxPixels: 8_294_400,
+            multipleOf: 16
+          }
+        }
+      }
     },
     "fal-ai/bytedance/seedream/v5/lite/edit": {
       className: "BytedanceSeedreamV5LiteEdit",

--- a/packages/fal-codegen/src/configs/text-to-image.ts
+++ b/packages/fal-codegen/src/configs/text-to-image.ts
@@ -2675,7 +2675,16 @@ export const config: ModuleConfig = {
         "Batch processing",
         "Professional applications",
         "Rapid prototyping"
-      ]
+      ],
+      fieldOverrides: {
+        image_size: {
+          customSizeConstraints: {
+            maxEdge: 3840,
+            maxPixels: 8_294_400,
+            multipleOf: 16
+          }
+        }
+      }
     },
     "imagineart/imagineart-2.0-preview/text-to-image": {
       className: "ImagineartImagineart20PreviewTextToImage",

--- a/packages/fal-codegen/src/schema-parser.ts
+++ b/packages/fal-codegen/src/schema-parser.ts
@@ -325,6 +325,7 @@ export class SchemaParser {
 
       const propRec = prop as AnyRecord;
       const bounds = this._getBounds(propRec, propType);
+      const acceptsObject = this._acceptsObjectVariant(propRec);
       fields.push({
         name,
         tsType,
@@ -335,12 +336,30 @@ export class SchemaParser {
         required: required.includes(name),
         enumRef,
         enumValues: enumRef ? enumValues : undefined,
+        ...(acceptsObject && { acceptsObject: true }),
         ...(bounds.min !== undefined && { min: bounds.min }),
         ...(bounds.max !== undefined && { max: bounds.max })
       });
     }
 
     return fields;
+  }
+
+  /** Whether an anyOf/oneOf branch resolves to an object schema. */
+  private _acceptsObjectVariant(prop: AnyRecord): boolean {
+    const variants = (prop["anyOf"] ?? prop["oneOf"]) as
+      | AnyRecord[]
+      | undefined;
+    return (
+      variants?.some((variant) => {
+        const resolved = this._resolveRef(this._rootSchema, variant);
+        return (
+          resolved["type"] === "object" ||
+          (resolved["properties"] != null &&
+            typeof resolved["properties"] === "object")
+        );
+      }) ?? false
+    );
   }
 
   private _numericValue(value: unknown): number | undefined {

--- a/packages/fal-codegen/src/types.ts
+++ b/packages/fal-codegen/src/types.ts
@@ -15,6 +15,14 @@ export interface FieldDef {
   required: boolean;
   enumRef?: string; // Name of referenced enum
   enumValues?: string[]; // Raw values for @prop values array
+  /** The schema accepts an object in addition to the primary propType. */
+  acceptsObject?: boolean;
+  /** Declarative limits for object-shaped image_size values. */
+  customSizeConstraints?: {
+    maxEdge?: number;
+    maxPixels?: number;
+    multipleOf?: number;
+  };
   nestedAssetKey?: string; // Key inside nested object for asset URL
   parentField?: string; // If part of a nested structure
   min?: number;

--- a/packages/fal-codegen/tests/schema-parser.test.ts
+++ b/packages/fal-codegen/tests/schema-parser.test.ts
@@ -190,6 +190,20 @@ describe("parse() with flux-dev schema", () => {
     expect(field?.enumRef).toBe("Acceleration");
   });
 
+  it("preserves object capability for enum-or-object fields", () => {
+    const spec = parser.parse(fluxDevSchema);
+    const imageSize = spec.inputFields.find((f) => f.name === "image_size");
+    const outputFormat = spec.inputFields.find(
+      (f) => f.name === "output_format"
+    );
+
+    expect(imageSize).toMatchObject({
+      propType: "enum",
+      acceptsObject: true
+    });
+    expect(outputFormat?.acceptsObject).toBeUndefined();
+  });
+
   it("determines output type as image (images array in output)", () => {
     const spec = parser.parse(fluxDevSchema);
     // FluxDevOutput has "images" property → output type should be "image"

--- a/packages/fal-nodes/src/fal-manifest.json
+++ b/packages/fal-nodes/src/fal-manifest.json
@@ -84075,7 +84075,13 @@
           "landscape_4_3",
           "landscape_16_9",
           "auto"
-        ]
+        ],
+        "acceptsObject": true,
+        "customSizeConstraints": {
+          "maxEdge": 3840,
+          "maxPixels": 8294400,
+          "multipleOf": 16
+        }
       },
       {
         "name": "prompt",
@@ -197921,7 +197927,13 @@
           "landscape_4_3",
           "landscape_16_9",
           "auto"
-        ]
+        ],
+        "acceptsObject": true,
+        "customSizeConstraints": {
+          "maxEdge": 3840,
+          "maxPixels": 8294400,
+          "multipleOf": 16
+        }
       },
       {
         "name": "prompt",

--- a/packages/runtime/src/providers/fal-provider.ts
+++ b/packages/runtime/src/providers/fal-provider.ts
@@ -94,6 +94,12 @@ interface FalManifestField {
   name: string;
   apiParamName?: string;
   propType: string;
+  acceptsObject?: boolean;
+  customSizeConstraints?: {
+    maxEdge?: number;
+    maxPixels?: number;
+    multipleOf?: number;
+  };
 }
 interface FalManifestEntry {
   endpointId?: string;
@@ -282,17 +288,52 @@ class FalArgsBuilder {
 
   /**
    * Set `image_size`. fal endpoints typically declare it as an enum string
-   * ("square_hd", ...) — passing `{width, height}` to those returns 422. Only
-   * write the dict shape when the manifest field exists and isn't enum.
+   * ("square_hd", ...), but OpenAPI may declare an object as another accepted
+   * branch. Use object dimensions only when the manifest preserves that
+   * capability, fitting them to any declarative constraints it carries.
    */
   setImageSize(width?: number | null, height?: number | null): this {
-    if (!width || !height) return this;
-    const t = this.propType("image_size");
-    if (!this.known) {
+    if (!width || !height || width < 1 || height < 1) return this;
+    const field = this.accepted.get("image_size");
+    const acceptsObject =
+      !this.known ||
+      field?.acceptsObject === true ||
+      (field != null && field.propType.toLowerCase() !== "enum");
+    if (!acceptsObject) return this;
+
+    const constraints = field?.customSizeConstraints;
+    if (!constraints) {
       this.args.image_size = { width, height };
-    } else if (t && t !== "enum") {
-      this.args.image_size = { width, height };
+      return this;
     }
+
+    const multiple = Math.max(1, constraints.multipleOf ?? 1);
+    const maxScale = Math.min(
+      1,
+      constraints.maxEdge ? constraints.maxEdge / width : 1,
+      constraints.maxEdge ? constraints.maxEdge / height : 1,
+      constraints.maxPixels
+        ? Math.sqrt(constraints.maxPixels / (width * height))
+        : 1
+    );
+    const snap = (value: number) =>
+      Math.max(multiple, Math.round(value / multiple) * multiple);
+    let fittedWidth = snap(width * maxScale);
+    let fittedHeight = snap(height * maxScale);
+    if (constraints.maxEdge) {
+      const snappedMaxEdge =
+        Math.floor(constraints.maxEdge / multiple) * multiple;
+      fittedWidth = Math.min(fittedWidth, snappedMaxEdge);
+      fittedHeight = Math.min(fittedHeight, snappedMaxEdge);
+    }
+    while (
+      constraints.maxPixels &&
+      fittedWidth * fittedHeight > constraints.maxPixels
+    ) {
+      if (fittedWidth >= fittedHeight) fittedWidth -= multiple;
+      else fittedHeight -= multiple;
+    }
+    this.args.image_size = { width: fittedWidth, height: fittedHeight };
     return this;
   }
 

--- a/packages/runtime/tests/providers/fal-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/fal-provider-coverage.test.ts
@@ -168,6 +168,37 @@ describe("FalProvider — textToImage arg shaping", () => {
     await p.textToImage({ prompt: "x", model: IMG_MODEL, seed: 99 });
     expect(captured.seed).toBe(99);
   });
+
+  it("sends a legal 4K custom size to GPT Image 2 Edit", async () => {
+    let captured: Record<string, unknown> = {};
+    const subscribeMock = vi.fn(
+      async (_id: string, opts: { input: Record<string, unknown> }) => {
+        captured = opts.input;
+        return { data: { images: [{ url: "https://fal.ai/r.png" }] } };
+      }
+    );
+    vi.stubGlobal("fetch", okFetch());
+    const p = createProvider();
+    (p as any)._client = {
+      subscribe: subscribeMock,
+      storage: {
+        upload: vi.fn().mockResolvedValue("https://fal.ai/input.png")
+      }
+    };
+
+    await p.imageToImage([new Uint8Array([1, 2, 3])], {
+      prompt: "edit",
+      model: {
+        id: "openai/gpt-image-2/edit",
+        name: "GPT Image 2 Edit",
+        provider: "fal_ai"
+      },
+      targetWidth: 7282,
+      targetHeight: 4096
+    });
+
+    expect(captured.image_size).toEqual({ width: 3840, height: 2160 });
+  });
 });
 
 describe("FalProvider — multi-image variants", () => {


### PR DESCRIPTION
## Summary

- preserve object capability when a fal OpenAPI field is declared as enum-or-object via anyOf/oneOf
- let FalArgsBuilder choose object-shaped image_size values from manifest metadata instead of endpoint IDs
- apply declarative custom-size constraints before sending dimensions
- fix GPT Image 2/Edit 4K requests, with 16:9 now sent as 3840x2160 instead of falling back to the approximately 1K landscape preset

## Root cause

The fal schemas define image_size as a union of an ImageSize object and a string enum. SchemaParser extracted the enum branch and collapsed the whole field to propType enum, losing the object branch. FalArgsBuilder therefore skipped explicit dimensions and later selected landscape_16_9.

This change records acceptsObject for any union containing an object schema. The provider consumes that capability generically. Endpoint-specific size limits live as declarative field metadata rather than runtime branching.

Fal schema: https://fal.ai/api/openapi/queue/openapi.json?endpoint_id=openai%2Fgpt-image-2%2Fedit

## Verification

- fal-codegen schema parser tests: 72 passed
- runtime fal provider coverage: 31 passed
- runtime TypeScript check passed
- changed fal-codegen files pass a standalone TypeScript check
- manifest JSON validation and git diff --check passed

The complete fal-codegen workspace typecheck could not resolve the unbuilt @nodetool-ai/node-sdk entry after the local dependency install was interrupted; the changed codegen files and tests pass independently.