### PR TITLE
test(agents): warm the sandbox pool past a cold worker boot

### DIFF
--- a/packages/agents/tests/js-sandbox.test.ts
+++ b/packages/agents/tests/js-sandbox.test.ts
@@ -1016,9 +1016,18 @@ describe("runInSandbox cancellation", () => {
  * absorb it — one CI run failed `elapsed < 3000` at 11191ms on a cancellation
  * that worked. Leaving an idle worker in the pool first keeps each budget
  * measuring what its test is named after.
+ *
+ * The warm-up has to outlive a cold boot, not just its own no-op run.
+ * `runInWorker` arms its backstop — `timeoutMs` + 5 s — before the worker has
+ * loaded a single module, so a 5 s warm-up was reaped at 10 s on a runner whose
+ * boot takes ~11 s. That terminates the worker, so the pool stayed cold and the
+ * budget below measured the boot after all: `elapsed < 3000` failed again, at
+ * 11175 ms. Asserting the warm run succeeded keeps a cold pool from arriving
+ * disguised as an interrupt-latency regression.
  */
 async function warmSandboxWorkerPool(): Promise<void> {
-  await runInSandbox({ code: "return 1;", timeoutMs: 5_000 });
+  const result = await runInSandbox({ code: "return 1;", timeoutMs: 120_000 });
+  expect(result.success).toBe(true);
 }
 
 describe("runInSandbox cancellation of CPU-bound guests", () => {


### PR DESCRIPTION
## What failed

`test-packages` on #4907 (and on #4905 before it) failed on one test:

```
FAIL tests/js-sandbox.test.ts > runInSandbox cancellation of CPU-bound guests
     > interrupts a CPU-bound loop once cancellation has landed
AssertionError: expected 11175 to be less than 3000
```

The cancellation worked. What the budget measured was a worker boot.

## Why the existing warm-up did not prevent it

#4905 added `warmSandboxWorkerPool()` for exactly this, and it still failed —
at 11175 ms against the 11191 ms it failed at before the warm-up existed. The
same number twice means the warm-up never took effect on that runner.

`runInWorker` arms its backstop — `timeoutMs` + `DEADLINE_MARGIN_MS` (5 s) —
before `postMessage`, so a worker that has not finished loading its modules is
inside the window. The warm-up ran a no-op with `timeoutMs: 5_000`, a 10 s
ceiling. On a runner whose cold boot takes ~11 s that run is reaped, the worker
is terminated (`discard: true`), and the pool is left cold — so the timed run
below paid the boot the warm-up was supposed to have absorbed.

Measured locally:

| | elapsed |
|---|---|
| cancel run, idle worker in the pool | 19 ms |
| cancel run, empty pool | 1079 ms |
| in-process path (`NODETOOL_SANDBOX_INPROC=1`) | 16 ms |

and a stub worker that never answers settles at 10004 ms with "the sandbox
worker did not answer within 10000 ms and was terminated", which is the
warm-up's fate at ~11 s of boot.

## The change

The warm-up runs with a 120 s timeout, so a slow boot lands in the pool instead
of being terminated, and asserts the run succeeded — a cold pool now names
itself instead of arriving disguised as an interrupt-latency regression. The
`elapsed < 3000` budget is unchanged: with a warm pool it measures interrupt
latency, which is what it is named after.

Not changed here: the backstop covering boot time is visible from a caller too
— a short-`timeoutMs` run on a loaded server can be reaped while its worker is
still loading. Fixing that needs a readiness message in the worker protocol,
which is more than a CI fix should carry.

## Verification

- `packages/agents/tests/js-sandbox.test.ts` — 130 passed (includes the two
  cancellation budgets and the marshaling-failure case).
- `npm run lint --workspace=packages/agents` (`tsc --noEmit`) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018FFqupZGS4gMrmQ8v9eDey)_