### PR TITLE
feat(storyboard): board-level preview player

### DIFF
--- a/packages/timeline/src/storyboard.ts
+++ b/packages/timeline/src/storyboard.ts
@@ -11,6 +11,9 @@
  * later shot revision can round-trip into the cut. Narration and music become
  * draft text-to-audio clips on their own tracks — the timeline's generation
  * machinery renders them on demand.
+ *
+ * `buildStoryboardPreviewTimeline` is the same mapping for the in-editor
+ * player, where a board that is only half rendered still has to play.
  */
 
 import type { Shot } from "@nodetool-ai/protocol";
@@ -46,6 +49,18 @@ export const isAssemblableShot = (shot: Shot): boolean =>
   typeof shot.clip.asset_id === "string" &&
   shot.clip.asset_id.length > 0;
 
+/** The persisted asset id on a media ref, or undefined when it has none. */
+const assetIdOf = (ref: { asset_id?: string | null } | null | undefined) =>
+  typeof ref?.asset_id === "string" && ref.asset_id.length > 0
+    ? ref.asset_id
+    : undefined;
+
+/** Clip length for a shot: its target duration, or the default. */
+const shotDurationMs = (shot: Shot): number =>
+  typeof shot.duration_seconds === "number" && shot.duration_seconds > 0
+    ? Math.round(shot.duration_seconds * 1000)
+    : DEFAULT_SHOT_MS;
+
 export function buildStoryboardTimeline(
   input: StoryboardAssemblyInput
 ): AssembledTimeline {
@@ -61,10 +76,7 @@ export function buildStoryboardTimeline(
 
   let cursorMs = 0;
   for (const shot of assemblable) {
-    const durationMs =
-      typeof shot.duration_seconds === "number" && shot.duration_seconds > 0
-        ? Math.round(shot.duration_seconds * 1000)
-        : DEFAULT_SHOT_MS;
+    const durationMs = shotDurationMs(shot);
     clips.push(
       makeClip({
         trackId: shotTrack.id,
@@ -128,4 +140,84 @@ export function buildStoryboardTimeline(
   }
 
   return { tracks, clips, durationMs: cursorMs, skippedShotIds };
+}
+
+export interface StoryboardPreviewInput {
+  /** Board id stamped onto each clip. */
+  boardId: string;
+  shots: Shot[];
+}
+
+export interface StoryboardPreviewTimeline {
+  tracks: TimelineTrack[];
+  clips: TimelineClip[];
+  /** Total duration of the shot track in ms. */
+  durationMs: number;
+  /** Shots skipped because neither clip nor keyframe has a persisted asset. */
+  skippedShotIds: string[];
+  /** Shots shown as held keyframe stills because no clip asset exists. */
+  stillShotIds: string[];
+}
+
+/**
+ * Assemble a board into the cut an in-editor player scrubs.
+ *
+ * Unlike {@link buildStoryboardTimeline}, which only lays down finished shots,
+ * this fills the gaps: a shot with a selected clip asset plays that clip, a
+ * shot that so far has only a keyframe holds that still for the shot's length,
+ * and a shot with neither is dropped. A selected take plays whatever the shot's
+ * lifecycle status says, so a preview keeps working while the board is still
+ * rendering. Narration and music are left out — they are draft prompts with no
+ * audio behind them yet.
+ */
+export function buildStoryboardPreviewTimeline(
+  input: StoryboardPreviewInput
+): StoryboardPreviewTimeline {
+  const ordered = [...input.shots].sort((a, b) => a.index - b.index);
+
+  const shotTrack = makeTrack({ type: "video", name: "Shots", index: 0 });
+  const tracks: TimelineTrack[] = [shotTrack];
+  const clips: TimelineClip[] = [];
+  const skippedShotIds: string[] = [];
+  const stillShotIds: string[] = [];
+
+  let cursorMs = 0;
+  for (const shot of ordered) {
+    const clipAssetId = assetIdOf(shot.clip);
+    const stillAssetId = clipAssetId ? undefined : assetIdOf(shot.keyframe);
+    const assetId = clipAssetId ?? stillAssetId;
+    if (!assetId) {
+      skippedShotIds.push(shot.id);
+      continue;
+    }
+    if (stillAssetId) {
+      stillShotIds.push(shot.id);
+    }
+
+    const durationMs = shotDurationMs(shot);
+    clips.push(
+      makeClip({
+        trackId: shotTrack.id,
+        name: shot.slug ?? `Shot ${shot.index + 1}`,
+        startMs: cursorMs,
+        durationMs,
+        mediaType: clipAssetId ? "video" : "image",
+        sourceType: "imported",
+        status: "generated",
+        currentAssetId: assetId,
+        storyboardBoardId: input.boardId,
+        storyboardShotId: shot.id,
+        versions: []
+      })
+    );
+    cursorMs += durationMs;
+  }
+
+  return {
+    tracks,
+    clips,
+    durationMs: cursorMs,
+    skippedShotIds,
+    stillShotIds
+  };
 }

--- a/packages/timeline/tests/storyboard.test.ts
+++ b/packages/timeline/tests/storyboard.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for storyboard → timeline assembly (storyboard.ts).
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Shot } from "@nodetool-ai/protocol";
+import {
+  DEFAULT_SHOT_MS,
+  buildStoryboardPreviewTimeline,
+  buildStoryboardTimeline
+} from "../src/storyboard.js";
+
+function makeShot(overrides: Partial<Shot> & Pick<Shot, "id" | "index">): Shot {
+  return {
+    type: "shot",
+    action: "a lighthouse at dusk",
+    status: "planned",
+    ...overrides
+  };
+}
+
+const clipRef = (assetId: string) =>
+  ({ type: "video", asset_id: assetId }) as const;
+const keyframeRef = (assetId: string) =>
+  ({ type: "image", asset_id: assetId }) as const;
+
+// ── buildStoryboardTimeline ───────────────────────────────────────────
+
+describe("buildStoryboardTimeline", () => {
+  it("keeps only rendered shots with a clip asset", () => {
+    const result = buildStoryboardTimeline({
+      boardId: "board-1",
+      shots: [
+        makeShot({
+          id: "a",
+          index: 0,
+          status: "rendered",
+          clip: clipRef("asset-a")
+        }),
+        makeShot({
+          id: "b",
+          index: 1,
+          status: "keyframe_ready",
+          keyframe: keyframeRef("still-b")
+        }),
+        makeShot({ id: "c", index: 2, status: "rendered" })
+      ]
+    });
+
+    expect(result.clips).toHaveLength(1);
+    expect(result.clips[0].currentAssetId).toBe("asset-a");
+    expect(result.skippedShotIds).toEqual(["b", "c"]);
+    expect(result.durationMs).toBe(DEFAULT_SHOT_MS);
+  });
+
+  it("lays narration across the full cut as a draft audio clip", () => {
+    const result = buildStoryboardTimeline({
+      boardId: "board-1",
+      narration: "  the light turns  ",
+      shots: [
+        makeShot({
+          id: "a",
+          index: 0,
+          status: "rendered",
+          duration_seconds: 2.5,
+          clip: clipRef("asset-a")
+        })
+      ]
+    });
+
+    const narration = result.clips.find((c) => c.mediaType === "audio");
+    expect(narration).toBeDefined();
+    expect(narration?.prompt).toBe("the light turns");
+    expect(narration?.status).toBe("draft");
+    expect(narration?.startMs).toBe(0);
+    expect(narration?.durationMs).toBe(2500);
+    expect(result.tracks.map((t) => t.name)).toEqual(["Shots", "Narration"]);
+  });
+});
+
+// ── buildStoryboardPreviewTimeline ────────────────────────────────────
+
+describe("buildStoryboardPreviewTimeline", () => {
+  it("turns a clip-backed shot into a video clip", () => {
+    const result = buildStoryboardPreviewTimeline({
+      boardId: "board-1",
+      shots: [
+        makeShot({
+          id: "a",
+          index: 0,
+          slug: "Lighthouse",
+          status: "rendered",
+          duration_seconds: 3,
+          clip: clipRef("asset-a")
+        })
+      ]
+    });
+
+    expect(result.clips).toHaveLength(1);
+    const clip = result.clips[0];
+    expect(clip.mediaType).toBe("video");
+    expect(clip.sourceType).toBe("imported");
+    expect(clip.status).toBe("generated");
+    expect(clip.currentAssetId).toBe("asset-a");
+    expect(clip.name).toBe("Lighthouse");
+    expect(clip.startMs).toBe(0);
+    expect(clip.durationMs).toBe(3000);
+    expect(result.stillShotIds).toEqual([]);
+    expect(result.skippedShotIds).toEqual([]);
+  });
+
+  it("holds a keyframe still when the shot has no clip asset", () => {
+    const result = buildStoryboardPreviewTimeline({
+      boardId: "board-1",
+      shots: [
+        makeShot({
+          id: "a",
+          index: 0,
+          status: "keyframe_ready",
+          keyframe: keyframeRef("still-a")
+        })
+      ]
+    });
+
+    expect(result.clips[0].mediaType).toBe("image");
+    expect(result.clips[0].sourceType).toBe("imported");
+    expect(result.clips[0].status).toBe("generated");
+    expect(result.clips[0].currentAssetId).toBe("still-a");
+    expect(result.stillShotIds).toEqual(["a"]);
+  });
+
+  it("plays a selected take whose shot is not yet marked rendered", () => {
+    const result = buildStoryboardPreviewTimeline({
+      boardId: "board-1",
+      shots: [
+        makeShot({
+          id: "a",
+          index: 0,
+          status: "clip_generating",
+          clip: clipRef("asset-a"),
+          keyframe: keyframeRef("still-a")
+        })
+      ]
+    });
+
+    expect(result.clips).toHaveLength(1);
+    expect(result.clips[0].mediaType).toBe("video");
+    expect(result.clips[0].currentAssetId).toBe("asset-a");
+    expect(result.stillShotIds).toEqual([]);
+  });
+
+  it("skips a shot with neither clip nor keyframe asset", () => {
+    const result = buildStoryboardPreviewTimeline({
+      boardId: "board-1",
+      shots: [
+        makeShot({ id: "a", index: 0 }),
+        makeShot({
+          id: "b",
+          index: 1,
+          clip: { type: "video", asset_id: null },
+          keyframe: { type: "image", asset_id: "" }
+        })
+      ]
+    });
+
+    expect(result.clips).toEqual([]);
+    expect(result.skippedShotIds).toEqual(["a", "b"]);
+    expect(result.durationMs).toBe(0);
+  });
+
+  it("orders clips by shot index and lays them end to end", () => {
+    const result = buildStoryboardPreviewTimeline({
+      boardId: "board-1",
+      shots: [
+        makeShot({
+          id: "c",
+          index: 2,
+          duration_seconds: 1,
+          clip: clipRef("asset-c")
+        }),
+        makeShot({
+          id: "a",
+          index: 0,
+          duration_seconds: 2,
+          clip: clipRef("asset-a")
+        }),
+        makeShot({
+          id: "b",
+          index: 1,
+          keyframe: keyframeRef("still-b")
+        })
+      ]
+    });
+
+    expect(result.clips.map((c) => c.storyboardShotId)).toEqual([
+      "a",
+      "b",
+      "c"
+    ]);
+    expect(result.clips.map((c) => c.startMs)).toEqual([0, 2000, 6000]);
+    expect(result.clips.map((c) => c.durationMs)).toEqual([
+      2000,
+      DEFAULT_SHOT_MS,
+      1000
+    ]);
+    expect(result.durationMs).toBe(7000);
+    expect(result.stillShotIds).toEqual(["b"]);
+  });
+
+  it("falls back to the default length when duration_seconds is missing", () => {
+    const result = buildStoryboardPreviewTimeline({
+      boardId: "board-1",
+      shots: [
+        makeShot({ id: "a", index: 0, clip: clipRef("asset-a") }),
+        makeShot({
+          id: "b",
+          index: 1,
+          duration_seconds: 0,
+          clip: clipRef("asset-b")
+        })
+      ]
+    });
+
+    expect(result.clips.map((c) => c.durationMs)).toEqual([
+      DEFAULT_SHOT_MS,
+      DEFAULT_SHOT_MS
+    ]);
+    expect(result.durationMs).toBe(DEFAULT_SHOT_MS * 2);
+  });
+
+  it("stamps board and shot provenance onto a single Shots track", () => {
+    const result = buildStoryboardPreviewTimeline({
+      boardId: "board-42",
+      shots: [
+        makeShot({ id: "a", index: 0, clip: clipRef("asset-a") }),
+        makeShot({ id: "b", index: 1, keyframe: keyframeRef("still-b") })
+      ]
+    });
+
+    expect(result.tracks).toHaveLength(1);
+    expect(result.tracks[0].type).toBe("video");
+    expect(result.tracks[0].name).toBe("Shots");
+    for (const clip of result.clips) {
+      expect(clip.storyboardBoardId).toBe("board-42");
+      expect(clip.trackId).toBe(result.tracks[0].id);
+      expect(clip.versions).toEqual([]);
+    }
+    expect(result.clips.map((c) => c.storyboardShotId)).toEqual(["a", "b"]);
+    expect(result.clips.map((c) => c.name)).toEqual(["Shot 1", "Shot 2"]);
+  });
+});

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -21,6 +21,7 @@ import {
   FormField,
   FormGrid,
   FormSection,
+  LoadingSpinner,
   Panel,
   ScrollArea,
   SelectField,
@@ -49,6 +50,9 @@ import ImageModelSelect from "../properties/ImageModelSelect";
 import VideoModelSelect from "../properties/VideoModelSelect";
 import ShotCard from "./ShotCard";
 import StoryboardEntitiesField from "./StoryboardEntitiesField";
+
+// The preview mounts the timeline compositor; keep it out of the board bundle.
+const LazyStoryboardPreview = React.lazy(() => import("./StoryboardPreview"));
 
 interface StoryboardBoardProps {
   boardId: string;
@@ -150,6 +154,8 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
 
   const [shotCount, setShotCount] = useState<number>(6);
   const [confirmRedirect, setConfirmRedirect] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const togglePreview = useCallback(() => setPreviewOpen((open) => !open), []);
 
   const hasShots = shots.length > 0;
 
@@ -184,6 +190,13 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
 
   const hasRenderedShot = useMemo(
     () => shots.some((s) => s.status === "rendered" && !!s.clip?.asset_id),
+    [shots]
+  );
+
+  // The preview plays clips and falls back to held keyframe stills, so any
+  // shot carrying either asset is enough to have something to watch.
+  const hasPlayableShot = useMemo(
+    () => shots.some((s) => !!s.clip?.asset_id || !!s.keyframe?.asset_id),
     [shots]
   );
 
@@ -359,6 +372,13 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
                 </EditorButton>
                 <EditorButton
                   variant="outlined"
+                  onClick={togglePreview}
+                  disabled={!hasPlayableShot}
+                >
+                  {previewOpen ? "Hide preview" : "Preview"}
+                </EditorButton>
+                <EditorButton
+                  variant="outlined"
                   onClick={onAssemble}
                   disabled={!onAssemble || assembling || !hasRenderedShot}
                 >
@@ -396,6 +416,14 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
           </Caption>
         </FlexColumn>
       </Dialog>
+
+      {previewOpen && (
+        <React.Suspense
+          fallback={<LoadingSpinner size="small" text="Loading preview" />}
+        >
+          <LazyStoryboardPreview boardId={boardId} />
+        </React.Suspense>
+      )}
 
       {directing ? (
         <FlexColumn gap={SPACING.md}>

--- a/web/src/components/storyboard/StoryboardPreview.tsx
+++ b/web/src/components/storyboard/StoryboardPreview.tsx
@@ -1,0 +1,112 @@
+/**
+ * StoryboardPreview
+ *
+ * Plays a whole board in shot order: clips where they exist, held keyframe
+ * stills where they do not. The cut is an in-memory sequence handed to
+ * {@link TimelineRenderer}, so nothing is written to the timeline library.
+ */
+
+import React, { memo, useMemo } from "react";
+
+import TimelineRenderer from "../timeline/TimelineRenderer";
+import {
+  BORDER_RADIUS,
+  Box,
+  Caption,
+  FlexColumn,
+  FlexRow,
+  PADDING,
+  SPACING
+} from "../ui_primitives";
+import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
+import { buildPreviewSequence, previewSignature } from "./previewSequence";
+
+const PREVIEW_HEIGHT = 400;
+
+const frameSx = {
+  width: "100%",
+  height: PREVIEW_HEIGHT,
+  minHeight: 0,
+  overflow: "hidden"
+} as const;
+
+const emptySx = {
+  width: "100%",
+  border: "1px dashed",
+  borderColor: "divider",
+  borderRadius: BORDER_RADIUS.sm,
+  padding: PADDING.comfortable,
+  textAlign: "center"
+} as const;
+
+/** "3 shots · 1 still · 2 not rendered", dropping the zero parts. */
+const statusLine = (
+  clipCount: number,
+  stillCount: number,
+  skippedCount: number
+): string => {
+  const parts = [`${clipCount} shot${clipCount === 1 ? "" : "s"}`];
+  if (stillCount > 0) {
+    parts.push(`${stillCount} still${stillCount === 1 ? "" : "s"}`);
+  }
+  if (skippedCount > 0) {
+    parts.push(`${skippedCount} not rendered`);
+  }
+  return parts.join(" · ");
+};
+
+interface StoryboardPreviewProps {
+  boardId: string;
+}
+
+const StoryboardPreviewInner: React.FC<StoryboardPreviewProps> = ({
+  boardId
+}) => {
+  // Subscribe to a signature string, not the board: a board object is replaced
+  // on every edit (typing in the brief, changing selection), and a fresh
+  // `sequence` prop resets playback in TimelineRenderer.
+  const signature = useStoryboardStore((state) =>
+    previewSignature(state.boards[boardId])
+  );
+
+  const preview = useMemo(() => {
+    const board = useStoryboardStore.getState().boards[boardId];
+    return board ? buildPreviewSequence(board) : null;
+  }, [boardId, signature]);
+
+  if (!preview) {
+    return (
+      <Box sx={emptySx} className="storyboard-preview storyboard-preview--empty">
+        <Caption color="secondary">
+          Nothing to preview yet — generate stills or clips first.
+        </Caption>
+      </Box>
+    );
+  }
+
+  return (
+    <FlexColumn gap={SPACING.sm} className="storyboard-preview">
+      <Box sx={frameSx}>
+        <TimelineRenderer
+          sequence={preview.sequence}
+          showMetadata={false}
+          ariaLabel="Storyboard preview"
+        />
+      </Box>
+      <FlexRow gap={SPACING.sm} align="center">
+        <Caption color="secondary">
+          {statusLine(
+            preview.sequence.clips.length,
+            preview.stillShotIds.length,
+            preview.skippedShotIds.length
+          )}
+        </Caption>
+      </FlexRow>
+    </FlexColumn>
+  );
+};
+
+export const StoryboardPreview = memo(StoryboardPreviewInner);
+StoryboardPreview.displayName = "StoryboardPreview";
+
+export default StoryboardPreview;

--- a/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
@@ -53,6 +53,8 @@ jest.mock("../../properties/LanguageModelSelect", () => stub("lang-model"));
 jest.mock("../../properties/ImageModelSelect", () => stub("image-model"));
 jest.mock("../../properties/VideoModelSelect", () => stub("video-model"));
 jest.mock("../ShotCard", () => stub("shot-card"));
+// The real preview mounts the timeline compositor — not viable under jsdom.
+jest.mock("../StoryboardPreview", () => stub("storyboard-preview"));
 jest.mock("../StoryboardEntitiesField", () => stub("entities"));
 
 import StoryboardBoard from "../StoryboardBoard";
@@ -114,6 +116,34 @@ describe("StoryboardBoard direct guard", () => {
     await user.click(within(dialog).getByRole("button", { name: "Re-direct" }));
 
     expect(onDirect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("StoryboardBoard preview", () => {
+  it("stays disabled until a shot has a still or a clip", () => {
+    mockShots = [makeShot("s1")];
+    renderBoard(jest.fn());
+
+    expect(screen.getByRole("button", { name: "Preview" })).toBeDisabled();
+  });
+
+  it("toggles the preview panel", async () => {
+    mockShots = [
+      {
+        ...makeShot("s1"),
+        keyframe: { type: "image", asset_id: "still-1", uri: "asset://s1" }
+      }
+    ];
+    const user = userEvent.setup();
+    renderBoard(jest.fn());
+
+    expect(screen.queryByTestId("storyboard-preview")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Preview" }));
+    expect(await screen.findByTestId("storyboard-preview")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Hide preview" }));
+    expect(screen.queryByTestId("storyboard-preview")).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/components/storyboard/__tests__/previewSequence.test.ts
+++ b/web/src/components/storyboard/__tests__/previewSequence.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @jest-environment node
+ */
+import type { Shot } from "@nodetool-ai/protocol";
+import type { StoryboardBoard } from "../../../stores/storyboard/StoryboardStore";
+import {
+  buildPreviewSequence,
+  previewDimensions,
+  previewSignature
+} from "../previewSequence";
+
+const shot = (overrides: Partial<Shot>): Shot => ({
+  type: "shot",
+  id: "shot-0",
+  index: 0,
+  action: "A lighthouse at dusk",
+  status: "planned",
+  ...overrides
+});
+
+const clipShot = (id: string, index: number, extra: Partial<Shot> = {}): Shot =>
+  shot({
+    id,
+    index,
+    status: "rendered",
+    clip: { type: "video", asset_id: `clip-${id}`, uri: `asset://${id}` },
+    ...extra
+  });
+
+const stillShot = (id: string, index: number, extra: Partial<Shot> = {}): Shot =>
+  shot({
+    id,
+    index,
+    status: "keyframe_ready",
+    keyframe: { type: "image", asset_id: `still-${id}`, uri: `asset://${id}` },
+    ...extra
+  });
+
+const board = (overrides: Partial<StoryboardBoard>): StoryboardBoard => ({
+  id: "board-1",
+  screenplay: null,
+  shots: [],
+  title: "My film",
+  brief: "",
+  style: "",
+  entityIds: [],
+  aspectRatio: "16:9",
+  directorModel: null,
+  imageModel: null,
+  videoModel: null,
+  updatedAt: 0,
+  activeShotId: null,
+  timelineId: null,
+  ...overrides
+});
+
+describe("previewDimensions", () => {
+  it("maps landscape, portrait and square ratios onto a 1080 long edge", () => {
+    expect(previewDimensions("16:9")).toEqual({ width: 1920, height: 1080 });
+    expect(previewDimensions("9:16")).toEqual({ width: 1080, height: 1920 });
+    expect(previewDimensions("1:1")).toEqual({ width: 1080, height: 1080 });
+    expect(previewDimensions("4:3")).toEqual({ width: 1440, height: 1080 });
+  });
+
+  it("falls back to 1920×1080 for a malformed ratio", () => {
+    expect(previewDimensions("nonsense")).toEqual({
+      width: 1920,
+      height: 1080
+    });
+    expect(previewDimensions("16:0")).toEqual({ width: 1920, height: 1080 });
+    expect(previewDimensions(undefined)).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it("rounds an odd width to an even one", () => {
+    // 1080 * 5/3 = 1800; 1080 * 7/5 = 1512 — pick a ratio that lands odd.
+    expect(previewDimensions("1001:1000").width % 2).toBe(0);
+  });
+});
+
+describe("buildPreviewSequence", () => {
+  it("plays clips, holds keyframe stills, and drops shots with neither", () => {
+    const preview = buildPreviewSequence(
+      board({
+        shots: [
+          stillShot("b", 1, { duration_seconds: 3 }),
+          clipShot("a", 0, { duration_seconds: 5, slug: "Opening" }),
+          shot({ id: "empty", index: 2 })
+        ]
+      })
+    );
+
+    expect(preview).not.toBeNull();
+    const { sequence, stillShotIds, skippedShotIds } = preview!;
+
+    expect(sequence.clips).toHaveLength(2);
+    const [first, second] = sequence.clips;
+    expect(first.name).toBe("Opening");
+    expect(first.mediaType).toBe("video");
+    expect(first.currentAssetId).toBe("clip-a");
+    expect(first.startMs).toBe(0);
+    expect(first.durationMs).toBe(5000);
+
+    expect(second.mediaType).toBe("image");
+    expect(second.currentAssetId).toBe("still-b");
+    expect(second.startMs).toBe(5000);
+    expect(second.durationMs).toBe(3000);
+
+    expect(sequence.durationMs).toBe(8000);
+    expect(sequence.tracks).toHaveLength(1);
+    expect(stillShotIds).toEqual(["b"]);
+    expect(skippedShotIds).toEqual(["empty"]);
+  });
+
+  it("defaults a shot with no duration to four seconds", () => {
+    const preview = buildPreviewSequence(board({ shots: [clipShot("a", 0)] }));
+    expect(preview!.sequence.clips[0].durationMs).toBe(4000);
+  });
+
+  it("sizes the sequence from the board aspect ratio at 30 fps", () => {
+    const preview = buildPreviewSequence(
+      board({ aspectRatio: "9:16", shots: [clipShot("a", 0)] })
+    );
+    expect(preview!.sequence.width).toBe(1080);
+    expect(preview!.sequence.height).toBe(1920);
+    expect(preview!.sequence.fps).toBe(30);
+  });
+
+  it("derives a stable sequence id from the board id", () => {
+    const shots = [clipShot("a", 0)];
+    const one = buildPreviewSequence(board({ shots }));
+    const two = buildPreviewSequence(board({ shots }));
+    expect(one!.sequence.id).toBe("storyboard-preview-board-1");
+    expect(two!.sequence.id).toBe(one!.sequence.id);
+  });
+
+  it("returns null when no shot has playable media", () => {
+    expect(buildPreviewSequence(board({ shots: [] }))).toBeNull();
+    expect(
+      buildPreviewSequence(board({ shots: [shot({}), shot({ id: "x", index: 1 })] }))
+    ).toBeNull();
+  });
+});
+
+describe("previewSignature", () => {
+  it("ignores board edits that do not change the cut", () => {
+    const shots = [clipShot("a", 0), stillShot("b", 1)];
+    const base = board({ shots });
+    expect(previewSignature({ ...base, brief: "new brief" })).toBe(
+      previewSignature(base)
+    );
+    expect(previewSignature({ ...base, activeShotId: "a" })).toBe(
+      previewSignature(base)
+    );
+  });
+
+  it("changes when media, order, duration or ratio changes", () => {
+    const base = board({ shots: [clipShot("a", 0), stillShot("b", 1)] });
+    const signature = previewSignature(base);
+
+    expect(previewSignature({ ...base, aspectRatio: "9:16" })).not.toBe(
+      signature
+    );
+    expect(
+      previewSignature(
+        board({ shots: [clipShot("a", 0, { duration_seconds: 9 }), stillShot("b", 1)] })
+      )
+    ).not.toBe(signature);
+    expect(
+      previewSignature(board({ shots: [clipShot("a", 1), stillShot("b", 0)] }))
+    ).not.toBe(signature);
+    expect(
+      previewSignature(board({ shots: [clipShot("a", 0), clipShot("b", 1)] }))
+    ).not.toBe(signature);
+  });
+
+  it("is empty for a board that does not exist", () => {
+    expect(previewSignature(undefined)).toBe("");
+  });
+});

--- a/web/src/components/storyboard/previewSequence.ts
+++ b/web/src/components/storyboard/previewSequence.ts
@@ -1,0 +1,102 @@
+/**
+ * previewSequence — pure mapping from a storyboard board to the in-memory
+ * timeline sequence the board-level preview player scrubs.
+ *
+ * The cut itself is built in `@nodetool-ai/timeline` so a headless caller and
+ * the editor preview the same shots; this module only wraps it in a
+ * `TimelineSequence` with the board's frame size.
+ */
+
+import {
+  buildStoryboardPreviewTimeline,
+  makeSequence,
+  type TimelineSequence
+} from "@nodetool-ai/timeline";
+import type { StoryboardBoard } from "../../stores/storyboard/StoryboardStore";
+
+export interface StoryboardPreview {
+  sequence: TimelineSequence;
+  /** Shots left out: neither a clip nor a keyframe asset to show. */
+  skippedShotIds: string[];
+  /** Shots shown as a held keyframe still because no clip exists yet. */
+  stillShotIds: string[];
+}
+
+const DEFAULT_ASPECT_RATIO = "16:9";
+const LONG_EDGE = 1080;
+
+/** Round to an even number — codecs and the compositor dislike odd sizes. */
+const even = (n: number): number => Math.max(2, Math.round(n / 2) * 2);
+
+/**
+ * Frame size for an aspect ratio written "W:H". Landscape and square boards
+ * are 1080 tall, portrait boards 1080 wide; anything unparseable falls back to
+ * 1920×1080.
+ */
+export function previewDimensions(aspectRatio: string | undefined): {
+  width: number;
+  height: number;
+} {
+  const [w, h] = (aspectRatio ?? DEFAULT_ASPECT_RATIO)
+    .split(":")
+    .map((part) => Number(part.trim()));
+  if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) {
+    return { width: 1920, height: 1080 };
+  }
+  return w >= h
+    ? { width: even((LONG_EDGE * w) / h), height: LONG_EDGE }
+    : { width: LONG_EDGE, height: even((LONG_EDGE * h) / w) };
+}
+
+/**
+ * Signature of everything the preview depends on. `TimelineRenderer` restarts
+ * playback whenever the `sequence` prop changes identity, so callers memoize on
+ * this instead of on the board object, which is replaced on every edit.
+ */
+export function previewSignature(board: StoryboardBoard | undefined): string {
+  if (!board) {
+    return "";
+  }
+  const shots = [...board.shots]
+    .sort((a, b) => a.index - b.index)
+    .map(
+      (s) =>
+        `${s.id}:${s.clip?.asset_id ?? ""}:${s.keyframe?.asset_id ?? ""}:${
+          s.duration_seconds ?? ""
+        }`
+    )
+    .join("|");
+  return `${board.id}@${board.aspectRatio}#${shots}`;
+}
+
+/**
+ * Build the preview sequence for a board, or null when no shot has a clip or
+ * keyframe asset to play.
+ */
+export function buildPreviewSequence(
+  board: StoryboardBoard
+): StoryboardPreview | null {
+  const built = buildStoryboardPreviewTimeline({
+    boardId: board.id,
+    shots: board.shots
+  });
+  if (built.clips.length === 0) {
+    return null;
+  }
+
+  const { width, height } = previewDimensions(board.aspectRatio);
+  return {
+    sequence: makeSequence({
+      id: `storyboard-preview-${board.id}`,
+      name: board.title || "Storyboard preview",
+      fps: 30,
+      width,
+      height,
+      durationMs: built.durationMs,
+      tracks: built.tracks,
+      clips: built.clips
+    }),
+    skippedShotIds: built.skippedShotIds,
+    stillShotIds: built.stillShotIds
+  };
+}


### PR DESCRIPTION
## What

Adds a **Preview** toggle to the storyboard board that plays the whole board in shot order, reusing the timeline preview machinery (`TimelineRenderer` → `PreviewArea` → compositor). A director can watch the cut without assembling a timeline first.

## How

- **`packages/timeline`**: new `buildStoryboardPreviewTimeline` next to `buildStoryboardTimeline`. It maps a board to an in-memory cut: a shot with a clip asset plays as video, a shot with only a keyframe holds the still as an image clip for the shot's duration (`duration_seconds`, default 4 s), and shots with neither are skipped (reported in `skippedShotIds`/`stillShotIds`). Unlike the assemble path it ignores shot lifecycle status — a selected take with an asset is playable while the board is still rendering — and leaves out narration/music, which are draft prompts with no audio behind them. `buildStoryboardTimeline` is unchanged apart from sharing a duration helper.
- **`web`**: `previewSequence.ts` wraps the cut in a `TimelineSequence` sized from the board's aspect ratio (1080 long-edge, even-rounded, 1920×1080 fallback). `StoryboardPreview` subscribes to a signature string of only the media-relevant board fields, so typing in the brief or changing selection does not replace the `sequence` prop and reset playback. `StoryboardBoard` gets a lazy-loaded Preview/Hide-preview button, disabled until some shot has a still or clip asset.

Clips resolve through `currentAssetId` → asset store → `get_url`, the production-correct path (not raw `asset://` URIs).

## Testing

- `packages/timeline`: 228 tests pass (9 new in `tests/storyboard.test.ts`, including a falsification check).
- `web`: full Jest suite green — 1110 suites, 12,853 tests (11 new for `previewSequence`, 2 new for the board toggle with the preview mocked out of jsdom).
- Web + electron `tsc --noEmit` clean; `npm run lint` clean (design-token rules included). Mobile typecheck fails only on missing Expo deps in this sandbox (no `mobile/node_modules`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtdBoYjYn9kPL4qdtHpvYw

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtdBoYjYn9kPL4qdtHpvYw)_