### PR TITLE
fix(assets): resolve asset:// locators to the asset's signed get_url

### DIFF
--- a/mobile/src/components/app_runtime/__tests__/catalogWidgets.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/catalogWidgets.test.tsx
@@ -13,6 +13,15 @@ import {
 
 import type { Workflow } from "../../../types/workflow";
 
+jest.mock("../../../trpc/client", () => ({
+  // Media widgets resolve an `asset://` locator through `assets.get`; these
+  // cases render non-asset sources, so the lookup never settles.
+  trpc: {
+    assets: { get: { useQuery: () => ({ data: undefined, isLoading: false }) } },
+    useQueries: () => [],
+  },
+}));
+
 jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: jest.fn() }),
 }));

--- a/mobile/src/components/app_runtime/__tests__/newWidgets.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/newWidgets.test.tsx
@@ -17,6 +17,15 @@ import {
 
 import type { Workflow } from "../../../types/workflow";
 
+jest.mock("../../../trpc/client", () => ({
+  // Media widgets resolve an `asset://` locator through `assets.get`; these
+  // cases render non-asset sources, so the lookup never settles.
+  trpc: {
+    assets: { get: { useQuery: () => ({ data: undefined, isLoading: false }) } },
+    useQueries: () => [],
+  },
+}));
+
 jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: jest.fn() }),
 }));

--- a/mobile/src/components/app_runtime/__tests__/workflowInputKinds.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/workflowInputKinds.test.tsx
@@ -14,6 +14,15 @@ import {
 
 import type { Workflow } from "../../../types/workflow";
 
+jest.mock("../../../trpc/client", () => ({
+  // Media widgets resolve an `asset://` locator through `assets.get`; these
+  // cases render non-asset sources, so the lookup never settles.
+  trpc: {
+    assets: { get: { useQuery: () => ({ data: undefined, isLoading: false }) } },
+    useQueries: () => [],
+  },
+}));
+
 jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: jest.fn() }),
 }));

--- a/mobile/src/components/app_runtime/widgets.tsx
+++ b/mobile/src/components/app_runtime/widgets.tsx
@@ -43,7 +43,10 @@ import { useQuery } from "@tanstack/react-query";
 
 import { useTheme } from "../../hooks/useTheme";
 import type { ThemeColors } from "../../utils/theme";
-import { apiService } from "../../services/api";
+import {
+  useResolvedMediaUri,
+  useResolvedMediaUris,
+} from "../../hooks/useResolvedMediaUri";
 import { documentBackend } from "../../documents/backends";
 import {
   SketchRenderer,
@@ -91,7 +94,12 @@ const numOr = (value: unknown, fallback: number): number =>
 const asItems = (value: unknown): unknown[] =>
   Array.isArray(value) ? value : value == null ? [] : [value];
 
-const mediaUri = (value: unknown): string | null => {
+/**
+ * The locator behind a bound media value. An `asset://` reference resolves only
+ * through the asset's own `get_url`, so the hooks below do the resolving; this
+ * just digs the locator out of whatever shape the binding produced.
+ */
+const mediaLocator = (value: unknown): string | null => {
   const raw =
     typeof value === "string"
       ? value
@@ -101,10 +109,16 @@ const mediaUri = (value: unknown): string | null => {
               (value as Record<string, unknown>).url
           )
         : "";
-  if (!raw || raw.startsWith("memory://")) {return null;}
-  if (raw.startsWith("data:")) {return raw;}
-  return apiService.resolveUrl(raw);
+  return raw && !raw.startsWith("memory://") ? raw : null;
 };
+
+const useMediaUri = (value: unknown): string | null =>
+  useResolvedMediaUri(mediaLocator(value));
+
+const useMediaUris = (values: unknown[]): string[] =>
+  useResolvedMediaUris(values.map(mediaLocator)).filter(
+    (uri): uri is string => uri !== null
+  );
 
 // ── Display ─────────────────────────────────────────────────────────────────
 
@@ -152,9 +166,7 @@ const ImageWidget: React.FC<WidgetProps> = (widget) => {
   const { colors } = useTheme();
   const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
   const height = numOr(widget.props.height, 240);
-  const uris = asItems(value)
-    .map(mediaUri)
-    .filter((uri): uri is string => uri !== null);
+  const uris = useMediaUris(asItems(value));
   if (uris.length === 0) {
     return (
       <Placeholder
@@ -640,7 +652,7 @@ const StatWidget: React.FC<WidgetProps> = (widget) => {
 const DownloadWidget: React.FC<WidgetProps> = (widget) => {
   const { colors } = useTheme();
   const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
-  const uri = mediaUri(asItems(value)[0]);
+  const uri = useMediaUri(asItems(value)[0]);
   if (!uri) {
     const placeholder = str(widget.props.placeholder);
     return placeholder ? (
@@ -723,7 +735,7 @@ const Model3DWidget: React.FC<WidgetProps> = (widget) => {
   const { colors } = useTheme();
   const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
   const item = asItems(value)[0];
-  const uri = mediaUri(item);
+  const uri = useMediaUri(item);
   if (item == null) {
     return (
       <Placeholder
@@ -787,7 +799,7 @@ const PDFWidget: React.FC<WidgetProps> = (widget) => {
   const { colors } = useTheme();
   const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
   const item = asItems(value)[0];
-  const uri = mediaUri(item);
+  const uri = useMediaUri(item);
   if (item == null) {
     return (
       <Placeholder
@@ -815,9 +827,7 @@ const GalleryWidget: React.FC<WidgetProps> = (widget) => {
   const { colors } = useTheme();
   const { value } = useWidgetRuntime({ ...widget, bindingMode: "read" });
   const tileSize = numOr(widget.props.tileSize, 120);
-  const uris = asItems(value)
-    .map(mediaUri)
-    .filter((uri): uri is string => uri !== null);
+  const uris = useMediaUris(asItems(value));
 
   if (uris.length === 0) {
     return (
@@ -1279,7 +1289,7 @@ const MediaInputWidget: React.FC<WidgetProps & { kind: MediaKind }> = ({
     bindingMode: "write",
   });
   const [picking, setPicking] = useState(false);
-  const uri = mediaUri(value);
+  const uri = useMediaUri(value);
 
   const pick = useCallback(async () => {
     setPicking(true);
@@ -1449,6 +1459,46 @@ const listKindOf = (value: unknown): ListKind =>
     ? value
     : "image";
 
+/** One row of a `MediaListInput` — its own component so the media locator it
+ * shows can be resolved with a hook rather than inside the list's map. */
+const MediaListRow: React.FC<{
+  item: unknown;
+  index: number;
+  kind: ListKind;
+  colors: ThemeColors;
+  disabled: boolean;
+  onRemove: () => void;
+}> = ({ item, index, kind, colors, disabled, onRemove }) => {
+  const uri = useMediaUri(item);
+  return (
+    <View style={styles.row}>
+      {kind === "image" && uri ? (
+        <Image
+          accessibilityRole="image"
+          source={{ uri }}
+          style={[styles.tile, { borderColor: colors.border }]}
+          resizeMode="cover"
+        />
+      ) : (
+        <Text
+          numberOfLines={1}
+          style={[styles.hint, styles.flex, { color: colors.textTertiary }]}
+        >
+          {uri ?? `${kind} ${index + 1}`}
+        </Text>
+      )}
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel={`Remove ${kind} ${index + 1}`}
+        disabled={disabled}
+        onPress={onRemove}
+      >
+        <Text style={{ color: colors.error }}>Remove</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
 /**
  * Picks several values and writes them as an array — the one control behind the
  * four list input nodes. A text list is edited as lines rather than as rows: a
@@ -1511,39 +1561,20 @@ const MediaListInputWidget: React.FC<WidgetProps> = (widget) => {
   return (
     <View style={styles.field}>
       <FieldLabel text={label} colors={colors} />
-      {items.map((item, index) => {
-        const uri = mediaUri(item);
-        return (
-          <View key={index} style={styles.row}>
-            {kind === "image" && uri ? (
-              <Image
-                accessibilityRole="image"
-                source={{ uri }}
-                style={[styles.tile, { borderColor: colors.border }]}
-                resizeMode="cover"
-              />
-            ) : (
-              <Text
-                numberOfLines={1}
-                style={[styles.hint, styles.flex, { color: colors.textTertiary }]}
-              >
-                {uri ?? `${kind} ${index + 1}`}
-              </Text>
-            )}
-            <TouchableOpacity
-              accessibilityRole="button"
-              accessibilityLabel={`Remove ${kind} ${index + 1}`}
-              disabled={widget.disabled}
-              onPress={() => {
-                setValue(items.filter((_, at) => at !== index));
-                emit("change");
-              }}
-            >
-              <Text style={{ color: colors.error }}>Remove</Text>
-            </TouchableOpacity>
-          </View>
-        );
-      })}
+      {items.map((item, index) => (
+        <MediaListRow
+          key={index}
+          item={item}
+          index={index}
+          kind={kind}
+          colors={colors}
+          disabled={Boolean(widget.disabled)}
+          onRemove={() => {
+            setValue(items.filter((_, at) => at !== index));
+            emit("change");
+          }}
+        />
+      ))}
       <TouchableOpacity
         accessibilityRole="button"
         disabled={widget.disabled || picking}

--- a/mobile/src/components/chat/MessageContentRenderer.test.tsx
+++ b/mobile/src/components/chat/MessageContentRenderer.test.tsx
@@ -8,6 +8,15 @@ import { render, screen, act } from '@testing-library/react-native';
 import { MessageContentRenderer } from './MessageContentRenderer';
 import { MessageContent } from '../../types/ApiTypes';
 
+jest.mock("../../trpc/client", () => ({
+  // Media widgets resolve an `asset://` locator through `assets.get`; these
+  // cases render non-asset sources, so the lookup never settles.
+  trpc: {
+    assets: { get: { useQuery: () => ({ data: undefined, isLoading: false }) } },
+    useQueries: () => [],
+  },
+}));
+
 /** The content box MessageView's bubble gives a message at a given window width. */
 const bubbleContentWidth = (windowWidth: number) => (windowWidth - 28) * 0.85 - 28;
 

--- a/mobile/src/components/chat/MessageContentRenderer.tsx
+++ b/mobile/src/components/chat/MessageContentRenderer.tsx
@@ -16,7 +16,7 @@ import { useAudioPlayer, useAudioPlayerStatus } from 'expo-audio';
 import { MediaPlayerView } from '../media/MediaPlayerView';
 import { MessageContent } from '../../types/ApiTypes';
 import { useTheme } from '../../hooks/useTheme';
-import { apiService } from '../../services/api';
+import { useResolvedMediaUri } from '../../hooks/useResolvedMediaUri';
 
 /**
  * Media is sized to the bubble's content box, derived from the live window width
@@ -56,6 +56,15 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
   const { colors } = useTheme();
   const { width: windowWidth } = useWindowDimensions();
   const mediaWidth = mediaWidthFor(windowWidth);
+  // Persisted chat media is sanitized to `asset://<asset_id>`, which no native
+  // loader can fetch — each branch's ref resolves through the asset's own
+  // `get_url`. Hooks run unconditionally, so all three resolve here.
+  const media = content as Partial<
+    Record<'image' | 'audio' | 'video', { uri?: string; asset_id?: string }>
+  >;
+  const imageUri = useResolvedMediaUri(media.image);
+  const audioUri = useResolvedMediaUri(media.audio);
+  const videoUri = useResolvedMediaUri(media.video);
 
   switch (content.type) {
     case 'text': {
@@ -64,7 +73,6 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
     }
 
     case 'image_url': {
-      const imageUri = getMediaUri(content.image);
       if (!imageUri) {
         return <Text style={[styles.errorText, { color: colors.textSecondary }]}>Unable to load image</Text>;
       }
@@ -76,7 +84,6 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
     }
 
     case 'audio': {
-      const audioUri = getMediaUri(content.audio);
       if (!audioUri) {
         return <Text style={[styles.errorText, { color: colors.textSecondary }]}>Unable to load audio</Text>;
       }
@@ -88,7 +95,6 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
     }
 
     case 'video': {
-      const videoUri = getMediaUri(content.video);
       if (!videoUri) {
         return <Text style={[styles.errorText, { color: colors.textSecondary }]}>Unable to load video</Text>;
       }
@@ -223,24 +229,6 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({ uri, colors }) => {
     </View>
   );
 };
-
-/**
- * Extract URI from media content object
- */
-function getMediaUri(
-  media: { uri?: string; data?: unknown; type?: string } | undefined
-): string | undefined {
-  if (!media) {return undefined;}
-  
-  // If URI exists and is not empty, resolve it against the API host
-  if (media.uri && media.uri !== '') {
-    return apiService.resolveUrl(media.uri) ?? undefined;
-  }
-  
-  // For binary data, we would need to convert to base64
-  // This is typically handled server-side for mobile
-  return undefined;
-}
 
 const styles = StyleSheet.create({
   mediaContainer: {

--- a/mobile/src/components/chat/MessageView.test.tsx
+++ b/mobile/src/components/chat/MessageView.test.tsx
@@ -8,6 +8,15 @@ import { MessageView } from './MessageView';
 import { Message } from '../../types';
 
 // Mock ChatMarkdown component to simplify testing
+jest.mock("../../trpc/client", () => ({
+  // Media widgets resolve an `asset://` locator through `assets.get`; these
+  // cases render non-asset sources, so the lookup never settles.
+  trpc: {
+    assets: { get: { useQuery: () => ({ data: undefined, isLoading: false }) } },
+    useQueries: () => [],
+  },
+}));
+
 jest.mock('./ChatMarkdown', () => ({
   ChatMarkdown: ({ content }: { content: string }) => {
     const { Text } = require('react-native');

--- a/mobile/src/components/graph_editor/PropertyField.tsx
+++ b/mobile/src/components/graph_editor/PropertyField.tsx
@@ -24,6 +24,7 @@ import { useTheme } from "../../hooks/useTheme";
 import { useModelsForType } from "../../hooks/useModelsByProvider";
 import { ModelSelectModal } from "./ModelSelectModal";
 import { apiService } from "../../services/api";
+import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
 import type { Property } from "../../types/ApiTypes";
 
 // ── Shared types ────────────────────────────────────────────────────
@@ -411,7 +412,7 @@ const ImageWidget: React.FC<{
   onChange: (v: unknown) => void;
   colors: ThemeColors;
 }> = ({ value, onChange, colors }) => {
-  const uri = extractUri(value);
+  const uri = useExtractedUri(value);
 
   const pickImage = useCallback(async () => {
     const result = await ImagePicker.launchImageLibraryAsync({
@@ -495,7 +496,7 @@ const AudioWidget: React.FC<{
   onChange: (v: unknown) => void;
   colors: ThemeColors;
 }> = ({ value, onChange, colors }) => {
-  const uri = extractUri(value);
+  const uri = useExtractedUri(value);
 
   const pickAudio = useCallback(async () => {
     const result = await DocumentPicker.getDocumentAsync({
@@ -565,7 +566,7 @@ const VideoWidget: React.FC<{
   onChange: (v: unknown) => void;
   colors: ThemeColors;
 }> = ({ value, onChange, colors }) => {
-  const uri = extractUri(value);
+  const uri = useExtractedUri(value);
 
   const pickVideo = useCallback(async () => {
     const result = await ImagePicker.launchImageLibraryAsync({
@@ -629,18 +630,22 @@ const VideoWidget: React.FC<{
   );
 };
 
-/** Extract URI from value — handles {uri: ...}, {id: ...}, or raw string */
 /**
- * The URI a media widget can actually load. Property values carry `asset://`
- * URNs, which no native loader understands, so resolve before rendering.
+ * The URI a media widget can actually load, from a `{uri}`, `{id}`, or raw
+ * string value. Property values carry `asset://` URNs, which no native loader
+ * understands and which resolve only through the asset's own `get_url`.
  */
-function extractUri(value: unknown): string | null {
+function useExtractedUri(value: unknown): string | null {
+  return useResolvedMediaUri(mediaLocatorOf(value));
+}
+
+function mediaLocatorOf(value: unknown): string | null {
   if (!value) {return null;}
-  if (typeof value === "string") {return apiService.resolveUrl(value);}
+  if (typeof value === "string") {return value;}
   if (typeof value === "object") {
     const v = value as Record<string, unknown>;
-    if (typeof v.uri === "string") {return apiService.resolveUrl(v.uri);}
-    if (typeof v.id === "string") {return apiService.resolveUrl(v.id);}
+    if (typeof v.uri === "string") {return v.uri;}
+    if (typeof v.id === "string") {return v.id;}
   }
   return null;
 }

--- a/mobile/src/components/outputs/OutputRenderer.tsx
+++ b/mobile/src/components/outputs/OutputRenderer.tsx
@@ -18,6 +18,7 @@ import MarkdownRenderer from "../../utils/MarkdownRenderer";
 import { useTheme } from "../../hooks/useTheme";
 import type { ThemeColors } from "../../utils/theme";
 import { apiService } from "../../services/api";
+import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
 
 interface TypedValue {
   type: string;
@@ -53,15 +54,13 @@ const typeFor = (value: unknown): string => {
 };
 
 /**
- * Resolve a media URI — handles relative paths, data URIs, and absolute URLs.
+ * The locator a media branch should resolve: nothing for an in-memory value,
+ * and a data URI is already its own source.
  */
-const resolveMediaUri = (
-  uri: string | undefined | null
-): string | null => {
-  if (!uri || uri.startsWith("memory://")) {return null;}
-  if (uri.startsWith("data:")) {return uri;}
-  return apiService.resolveUrl(uri);
-};
+const mediaLocator = (uri: unknown): string | undefined =>
+  typeof uri === "string" && uri && !uri.startsWith("memory://")
+    ? uri
+    : undefined;
 
 /**
  * One explicit width per column so the header row and the body rows share a
@@ -113,6 +112,19 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
   const { colors, mode } = useTheme();
   const codeTheme = mode === "dark" ? atomDark : tomorrow;
   const monoFont = Platform.OS === "ios" ? "Menlo" : "monospace";
+
+  // A stored output references its asset as `asset://<id>`, which no native
+  // loader can fetch — it resolves through the asset's own `get_url`. Hooks
+  // run unconditionally, so the value's own uri and the two comparison images
+  // resolve here and the branches below read what they need.
+  const record = (value ?? {}) as Record<string, unknown>;
+  const resolvedUri = useResolvedMediaUri(mediaLocator(record.uri));
+  const resolvedComparisonA = useResolvedMediaUri(
+    mediaLocator((record.image_a as Record<string, unknown> | undefined)?.uri)
+  );
+  const resolvedComparisonB = useResolvedMediaUri(
+    mediaLocator((record.image_b as Record<string, unknown> | undefined)?.uri)
+  );
 
   if (
     value === undefined ||
@@ -181,12 +193,14 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
       }
 
       if (typeof imgSource === "string") {
-        const resolvedUri = imgSource.startsWith("data:")
+        const imageUri = imgSource.startsWith("data:")
           ? imgSource
-          : resolveMediaUri(imgSource) ?? `data:image/png;base64,${imgSource}`;
+          : (resolvedUri ??
+            apiService.resolveUrl(imgSource) ??
+            `data:image/png;base64,${imgSource}`);
         return (
           <Image
-            source={{ uri: resolvedUri }}
+            source={{ uri: imageUri }}
             style={[styles.image, { backgroundColor: colors.inputBg }]}
             resizeMode="contain"
           />
@@ -201,7 +215,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
     }
 
     case "audio": {
-      const audioUri = resolveMediaUri(v.uri as string | undefined);
+      const audioUri = resolvedUri;
       if (!audioUri) {
         return (
           <Text style={[styles.placeholder, { color: colors.textSecondary }]}>
@@ -213,7 +227,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
     }
 
     case "video": {
-      const videoUri = resolveMediaUri(v.uri as string | undefined);
+      const videoUri = resolvedUri;
       if (!videoUri) {
         return (
           <Text style={[styles.placeholder, { color: colors.textSecondary }]}>
@@ -225,7 +239,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
     }
 
     case "html": {
-      const htmlUri = resolveMediaUri(v.uri as string | undefined);
+      const htmlUri = resolvedUri;
       if (htmlUri) {
         return (
           <TouchableOpacity
@@ -246,7 +260,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
     }
 
     case "document": {
-      const docUri = resolveMediaUri(v.uri as string | undefined);
+      const docUri = resolvedUri;
       if (docUri) {
         return (
           <TouchableOpacity
@@ -532,10 +546,8 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
 
     // ── Image Comparison ─────────────────────────────────────────
     case "image_comparison": {
-      const imageA = v.image_a as Record<string, unknown> | undefined;
-      const imageB = v.image_b as Record<string, unknown> | undefined;
-      const imgA = resolveMediaUri(imageA?.uri as string | undefined);
-      const imgB = resolveMediaUri(imageB?.uri as string | undefined);
+      const imgA = resolvedComparisonA;
+      const imgB = resolvedComparisonB;
       return (
         <View style={styles.comparisonContainer}>
           {imgA && (

--- a/mobile/src/components/sketch/SketchRenderer.tsx
+++ b/mobile/src/components/sketch/SketchRenderer.tsx
@@ -41,6 +41,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../../hooks/useTheme';
 import { apiService } from '../../services/api';
 import { trpc } from '../../trpc/client';
+import { assetIdFromLocator } from '../../hooks/useResolvedMediaUri';
 import type { ThemeColors } from '../../utils/theme';
 
 // ── Document shape ─────────────────────────────────────────────────────────
@@ -277,7 +278,11 @@ export function resolveLayers(doc: SketchDocumentData): ResolvedLayer[] {
     const binding = bindings.get(layer.id) ?? null;
     const status = binding?.status ?? null;
     const inlineUri = layerDataImageUri(layer.data);
+    // `resolveUrl` returns null for an `asset://` reference — that one resolves
+    // through the asset lookup below, so route its id there rather than
+    // dropping the layer's only image.
     const referenceUri = apiService.resolveUrl(layer.imageReference?.uri);
+    const referenceAssetId = assetIdFromLocator(layer.imageReference?.uri);
     const hasPixels = !statusHasNoPixels(status);
 
     return {
@@ -288,7 +293,9 @@ export function resolveLayers(doc: SketchDocumentData): ResolvedLayer[] {
       opacity: ownOpacity * groupOpacity,
       rect,
       directUri: hasPixels ? (referenceUri ?? inlineUri) : null,
-      assetId: hasPixels ? (binding?.currentAssetId ?? null) : null,
+      assetId: hasPixels
+        ? (binding?.currentAssetId ?? referenceAssetId ?? null)
+        : null,
       status,
       prompt: binding?.prompt ?? null,
       model: binding?.model ?? null,

--- a/mobile/src/hooks/useResolvedMediaUri.ts
+++ b/mobile/src/hooks/useResolvedMediaUri.ts
@@ -1,0 +1,100 @@
+/**
+ * useResolvedMediaUri
+ *
+ * Turns a media locator into a URL React Native's loaders can actually fetch.
+ *
+ * `asset://<id>` is an identifier, not a path: the bytes live under
+ * `<user_id>/<asset_id>.<ext>` and, on the cloud backends (S3/Supabase), behind
+ * a signed URL only the server can mint. Rewriting it to
+ * `<host>/api/storage/<id>` 404s on any such deploy, so the only correct
+ * resolution is the asset's own `get_url` — the same `assets.get` +
+ * `resolveUrl` path the asset viewer and the sketch renderer already use.
+ *
+ * Returns `null` while the lookup is in flight, so a caller renders its
+ * placeholder rather than a URL known to fail.
+ */
+
+import { apiService } from '../services/api';
+import { trpc } from '../trpc/client';
+
+/** The asset id inside `asset://<id>` or `asset://<id>.<ext>`. */
+export function assetIdFromLocator(
+  uri: string | null | undefined
+): string | null {
+  if (typeof uri !== 'string' || !uri.startsWith('asset://')) {
+    return null;
+  }
+  const rest = uri.slice('asset://'.length).split(/[?#]/)[0];
+  if (!rest) {
+    return null;
+  }
+  const last = rest.includes('/') ? rest.slice(rest.lastIndexOf('/') + 1) : rest;
+  return last.replace(/\.[^.]+$/, '') || last;
+}
+
+export type MediaLocator =
+  | string
+  | { uri?: string | null; asset_id?: string | null }
+  | null
+  | undefined;
+
+const locatorUri = (source: MediaLocator): string | null => {
+  if (typeof source === 'string') {
+    return source || null;
+  }
+  return source?.uri ?? null;
+};
+
+const locatorAssetId = (source: MediaLocator): string | null => {
+  if (source && typeof source === 'object' && source.asset_id) {
+    return source.asset_id;
+  }
+  return assetIdFromLocator(locatorUri(source));
+};
+
+export function useResolvedMediaUri(source: MediaLocator): string | null {
+  const uri = locatorUri(source);
+  const assetId = locatorAssetId(source);
+  // `resolveUrl` handles every scheme but `asset://`, for which it returns
+  // null — that is the case the lookup below covers.
+  const directUrl = apiService.resolveUrl(uri);
+
+  const assetQuery = trpc.assets.get.useQuery(
+    { id: assetId ?? '' },
+    { enabled: directUrl === null && Boolean(assetId) }
+  );
+
+  if (directUrl !== null) {
+    return directUrl;
+  }
+  return apiService.resolveUrl(assetQuery.data?.get_url ?? null);
+}
+
+/**
+ * The list form: resolves a whole batch of locators in one render, keeping the
+ * result positionally aligned with the input.
+ */
+export function useResolvedMediaUris(
+  sources: MediaLocator[]
+): (string | null)[] {
+  const directUrls = sources.map((source) =>
+    apiService.resolveUrl(locatorUri(source))
+  );
+  const assetIds = sources.map(locatorAssetId);
+
+  const results = trpc.useQueries((t) =>
+    assetIds.map((assetId, i) =>
+      t.assets.get(
+        { id: assetId ?? '' },
+        { enabled: directUrls[i] === null && Boolean(assetId) }
+      )
+    )
+  );
+
+  return directUrls.map(
+    (directUrl, i) =>
+      directUrl ?? apiService.resolveUrl(results[i]?.data?.get_url ?? null)
+  );
+}
+
+export default useResolvedMediaUri;

--- a/mobile/src/screens/__tests__/JobDetailScreen.test.tsx
+++ b/mobile/src/screens/__tests__/JobDetailScreen.test.tsx
@@ -33,6 +33,9 @@ const mockCancelMutate = jest.fn();
 
 jest.mock('../../trpc/client', () => ({
   trpc: {
+    // Output media resolves an `asset://` locator through `assets.get`.
+    assets: { get: { useQuery: () => ({ data: undefined, isLoading: false }) } },
+    useQueries: () => [],
     useUtils: () => ({
       jobs: { get: { invalidate: jest.fn() }, list: { invalidate: jest.fn() } },
     }),

--- a/mobile/src/services/api.test.ts
+++ b/mobile/src/services/api.test.ts
@@ -181,14 +181,13 @@ describe('ApiService.uploadAsset', () => {
 });
 
 describe('ApiService.resolveUrl', () => {
-  it('maps an asset:// URN to the storage endpoint', () => {
-    // React Native's image loader has no asset:// handler, so an unmapped URN
-    // surfaces as "No suitable image URL loader found".
+  it('refuses an asset:// URN', () => {
+    // The bytes live under `<user_id>/<asset_id>.<ext>` behind a signed URL,
+    // so there is no correct rewrite here — `useResolvedMediaUri` looks the
+    // asset up and reads its `get_url` instead.
     expect(
       apiService.resolveUrl('asset://5262eb0ff8f14873ac673ace9eff8ad8.png')
-    ).toBe(
-      'http://localhost:7777/api/storage/5262eb0ff8f14873ac673ace9eff8ad8.png'
-    );
+    ).toBeNull();
   });
 
   it('leaves absolute URLs untouched', () => {

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -354,12 +354,12 @@ class ApiService {
 
   resolveUrl(urlOrPath: string | null | undefined): string | null {
     if (!urlOrPath) {return null;}
-    // Workflow outputs and node properties reference stored assets by URN.
-    // React Native's image loader has no handler for the scheme, so map it to
-    // the HTTP endpoint (same mapping as web's resolveUri).
+    // An `asset://` URN is an identifier, not a path: the bytes live under
+    // `<user_id>/<asset_id>.<ext>` behind a signed URL, so `/api/storage/<id>`
+    // 404s on any cloud deploy. Resolving it needs an `assets.get` lookup —
+    // callers use `useResolvedMediaUri`, and get null here.
     if (urlOrPath.startsWith('asset://')) {
-      const assetId = urlOrPath.slice('asset://'.length);
-      return `${getSharedApiHost()}/api/storage/${assetId}`;
+      return null;
     }
     // Anything else already carrying a scheme (http, https, file, data,
     // content, blob) is fetchable as-is; only bare paths get the API host.

--- a/web/src/components/appbuilder/puck/__tests__/catalogWidgets.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/catalogWidgets.test.tsx
@@ -23,6 +23,11 @@ import {
   TabsWidget
 } from "../widgets";
 
+// Media sources resolve through TanStack Query; these suites render no
+// QueryClientProvider, so use the manual mock (resolution itself is covered
+// by hooks/__tests__/useResolvedMediaUri.test.tsx).
+jest.mock("../../../../hooks/useResolvedMediaUri");
+
 const renderWidget = (
   element: React.ReactElement,
   initial: Partial<AppInstanceState> = {}

--- a/web/src/components/appbuilder/puck/widgets.tsx
+++ b/web/src/components/appbuilder/puck/widgets.tsx
@@ -37,6 +37,7 @@ import {
 } from "../../ui_primitives";
 import { AppEvent } from "../types";
 import { useWidgetRuntime, WidgetBindingMode } from "./useWidgetRuntime";
+import { useResolvedMediaUri } from "../../../hooks/useResolvedMediaUri";
 
 const REMARK_PLUGINS: Options["remarkPlugins"] = [remarkGfm];
 
@@ -135,44 +136,58 @@ const MediaPlaceholder: React.FC<{ height: number; text: string }> = ({
   </FlexColumn>
 );
 
+/**
+ * A bound media value carries an `asset://` locator, which fetches nowhere —
+ * every media leaf resolves its source to the asset's own `get_url` first.
+ * Anything else (data:, blob:, http:, package://) passes through unchanged.
+ */
 const ImageItem: React.FC<{ src: string; fit?: string; height: number }> = ({
   src,
   fit,
   height
-}) => (
-  <Box
-    component="img"
-    src={src}
-    alt=""
-    sx={{
-      width: "100%",
-      height,
-      objectFit: fit === "cover" ? "cover" : "contain",
-      borderRadius: BORDER_RADIUS.md
-    }}
-  />
-);
+}) => {
+  const resolved = useResolvedMediaUri(src);
+  return (
+    <Box
+      component="img"
+      src={resolved}
+      alt=""
+      sx={{
+        width: "100%",
+        height,
+        objectFit: fit === "cover" ? "cover" : "contain",
+        borderRadius: BORDER_RADIUS.md
+      }}
+    />
+  );
+};
 
-const AudioItem: React.FC<{ src: string }> = ({ src }) => (
-  <Box component="audio" controls src={src} sx={{ width: "100%" }} />
-);
+const AudioItem: React.FC<{ src: string }> = ({ src }) => {
+  const resolved = useResolvedMediaUri(src);
+  return (
+    <Box component="audio" controls src={resolved} sx={{ width: "100%" }} />
+  );
+};
 
 const VideoItem: React.FC<{ src: string; height: number }> = ({
   src,
   height
-}) => (
-  <Box
-    component="video"
-    controls
-    src={src}
-    sx={{
-      width: "100%",
-      maxHeight: height,
-      borderRadius: BORDER_RADIUS.md,
-      backgroundColor: "common.black"
-    }}
-  />
-);
+}) => {
+  const resolved = useResolvedMediaUri(src);
+  return (
+    <Box
+      component="video"
+      controls
+      src={resolved}
+      sx={{
+        width: "100%",
+        maxHeight: height,
+        borderRadius: BORDER_RADIUS.md,
+        backgroundColor: "common.black"
+      }}
+    />
+  );
+};
 
 export const MarkdownBlock: React.FC<{ text: string }> = React.memo(
   ({ text }) => (
@@ -727,7 +742,7 @@ export const DownloadWidget: React.FC<WidgetCommon & {
   placeholder?: string;
 }> = (props) => {
   const { value, designMode } = useBinding(props, "read");
-  const href = resolveImageSrc(asItems(value)[0]);
+  const href = useResolvedMediaUri(resolveImageSrc(asItems(value)[0])) ?? null;
   if (!href && !designMode) {
     return (
       <Caption color="secondary">

--- a/web/src/components/chat/message/MediaOutputGroup.tsx
+++ b/web/src/components/chat/message/MediaOutputGroup.tsx
@@ -42,7 +42,10 @@ import {
   type MediaContentBlock
 } from "../../../hooks/handlers/useGenerationToCanvas";
 import { serializeDragData } from "../../../lib/dragdrop";
-import { resolveUri } from "../../../utils/imageUtils";
+import {
+  useResolvedMediaUris,
+  type MediaLocator
+} from "../../../hooks/useResolvedMediaUri";
 
 /** Edge length of a generated-media thumbnail tile (px). */
 const THUMBNAIL_SIZE = 120;
@@ -272,6 +275,21 @@ const MediaOutputGroup: React.FC<MediaOutputGroupProps> = ({
     [addBlocksToCanvas, mediaContents]
   );
 
+  // Generated media persists as `asset://<asset_id>`, which no renderer can
+  // fetch — resolve every tile's ref to the asset's `get_url` up front, since
+  // the grid below maps over the list and cannot call a hook per item.
+  const mediaLocators = useMemo(
+    (): MediaLocator[] =>
+      mediaContents.map((c) => {
+        if (isImageContent(c)) return c.image;
+        if (isVideoContent(c)) return c.video;
+        if (isAudioContent(c)) return c.audio;
+        return undefined;
+      }),
+    [mediaContents]
+  );
+  const resolvedMediaSrcs = useResolvedMediaUris(mediaLocators);
+
   const prompt = useMemo(() => {
     const content = message.content;
     if (typeof content === "string") return content;
@@ -395,7 +413,9 @@ const MediaOutputGroup: React.FC<MediaOutputGroupProps> = ({
           : mediaContents.map((c, i) => {
           if (isImageContent(c)) {
             const src =
-              c.image?.uri || (c.image?.data as string | undefined) || "";
+              resolvedMediaSrcs[i] ||
+              (c.image?.data as string | undefined) ||
+              "";
             const key = c.image?.asset_id || c.image?.uri || `media-${i}`;
             return (
               <div
@@ -418,10 +438,7 @@ const MediaOutputGroup: React.FC<MediaOutputGroupProps> = ({
             );
           }
           if (isVideoContent(c)) {
-            // Through `resolveUri` like the image tile above: a relative
-            // `/api/storage/…` needs the BASE_URL prefix when the API lives on
-            // another origin, and a signed cloud URL passes through unchanged.
-            const src = c.video?.uri ? resolveUri(c.video.uri) : "";
+            const src = resolvedMediaSrcs[i] ?? "";
             const key = c.video?.asset_id || c.video?.uri || `media-${i}`;
             return (
               <div
@@ -451,7 +468,7 @@ const MediaOutputGroup: React.FC<MediaOutputGroupProps> = ({
             );
           }
           if (isAudioContent(c)) {
-            const src = c.audio?.uri ? resolveUri(c.audio.uri) : "";
+            const src = resolvedMediaSrcs[i] ?? "";
             const key = c.audio?.asset_id || c.audio?.uri || `media-${i}`;
             return (
               <div

--- a/web/src/components/chat/message/MessageContentRenderer.tsx
+++ b/web/src/components/chat/message/MessageContentRenderer.tsx
@@ -18,7 +18,7 @@ import {
   type MediaContentBlock
 } from "../../../hooks/handlers/useGenerationToCanvas";
 import { serializeDragData } from "../../../lib/dragdrop";
-import { resolveUri } from "../../../utils/imageUtils";
+import { useResolvedMediaUri } from "../../../hooks/useResolvedMediaUri";
 import {
   parseHarmonyContent,
   hasHarmonyTokens,
@@ -71,16 +71,27 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
   const objectUrlRef = useRef<string | null>(null);
   const { isCanvasAvailable, addBlocksToCanvas } = useAddMediaToCanvas();
 
+  // Persisted chat media is sanitized to `asset://<asset_id>`, which no
+  // renderer can fetch — resolve each branch's ref to the asset's own
+  // `get_url`. Hooks run unconditionally, so all three resolve here and the
+  // branch below picks the one it needs.
+  const resolvedVideoUri = useResolvedMediaUri(
+    content.type === "video" ? content.video : undefined
+  );
+  const resolvedImageUri = useResolvedMediaUri(
+    content.type === "image_url" ? content.image : undefined
+  );
+  const resolvedAudioUri = useResolvedMediaUri(
+    content.type === "audio" ? content.audio : undefined
+  );
+
   // Resolve the video source once, at the top level, so the blob URL below can
   // be memoized on the actual source (Uint8Array/string) identity. A byte
-  // payload uses the inline `data`; otherwise the `uri` is used directly.
-  // A stored ref carries a `/api/storage/…` (or signed) URL: `resolveUri`
-  // prefixes BASE_URL for the relative form and passes an absolute one
-  // through, the same way the image branch resolves via `createImageUrl`.
+  // payload uses the inline `data`; otherwise the resolved URL is used.
   const videoSource: string | Uint8Array | undefined =
     content.type === "video"
-      ? content.video?.uri
-        ? resolveUri(content.video.uri)
+      ? content.video?.uri || content.video?.asset_id
+        ? resolvedVideoUri
         : (content.video?.data as Uint8Array)
       : undefined;
 
@@ -184,8 +195,8 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
 
       if (content.image?.data) {
         imageSource = content.image.data as Uint8Array;
-      } else if (content.image?.uri) {
-        imageSource = content.image.uri;
+      } else if (content.image?.uri || content.image?.asset_id) {
+        imageSource = resolvedImageUri;
       } else {
         return <div>Error: No image source available</div>;
       }
@@ -202,8 +213,8 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
         <div css={wrapperStyles} {...dragProps}>
           <AudioPlayer
             source={
-              content.audio?.uri
-                ? resolveUri(content.audio.uri)
+              content.audio?.uri || content.audio?.asset_id
+                ? resolvedAudioUri
                 : (content.audio?.data as Uint8Array)
             }
           />

--- a/web/src/components/chat/message/ResourceChip.tsx
+++ b/web/src/components/chat/message/ResourceChip.tsx
@@ -22,7 +22,7 @@ import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
 import { parseResourceUri, type ResourceKind, type ResourceUri } from "@nodetool-ai/protocol";
 
 import { BORDER_RADIUS, Chip, SPACING, TYPOGRAPHY, getSpacingPx } from "../../ui_primitives";
-import { resolveUri } from "../../../utils/imageUtils";
+import { useResolvedMediaUri } from "../../../hooks/useResolvedMediaUri";
 import { canOpenResource, openResource } from "../../../lib/chat/openResource";
 import type { ToolAccent } from "./toolCallIcon";
 
@@ -63,28 +63,26 @@ const looksLikeImage = (value: string): boolean => {
 };
 
 /**
- * Only the id decides: `/api/storage/<key>` serves the file name, so an id
- * without an extension has nothing to fetch — an image-looking *label* over an
+ * Only the id decides: the storage key carries the file name, so an id without
+ * an extension has nothing to fetch — an image-looking *label* over an
  * extensionless id would render a broken thumbnail.
  */
-const thumbnailFor = (ref: ResourceUri): string | null => {
-  if (ref.kind !== "asset" || !looksLikeImage(ref.id)) {
-    return null;
-  }
-  return resolveUri(`asset://${ref.id}`);
-};
+const thumbnailLocatorFor = (ref: ResourceUri | null): string | undefined =>
+  ref && ref.kind === "asset" && looksLikeImage(ref.id)
+    ? `asset://${ref.id}`
+    : undefined;
 
 const THUMBNAIL_SIZE = 18;
 
 const ResourceChip: React.FC<ResourceChipProps> = ({ uri, label }) => {
   const ref = useMemo(() => parseResourceUri(uri), [uri]);
+  const thumbnail = useResolvedMediaUri(thumbnailLocatorFor(ref));
 
   if (!ref) {
     return <>{label}</>;
   }
 
   const { Icon, accent } = KIND_VISUALS[ref.kind];
-  const thumbnail = thumbnailFor(ref);
   const navigable = canOpenResource(ref.kind);
 
   return (

--- a/web/src/components/chat/message/__tests__/ChatMarkdown.inlinePreviews.test.tsx
+++ b/web/src/components/chat/message/__tests__/ChatMarkdown.inlinePreviews.test.tsx
@@ -8,6 +8,11 @@ const mockSketchGet = jest.fn();
 const mockTimelineGet = jest.fn();
 const mockSignUrl = jest.fn();
 
+// Media sources resolve through TanStack Query; these suites render no
+// QueryClientProvider, so use the manual mock (resolution itself is covered
+// by hooks/__tests__/useResolvedMediaUri.test.tsx).
+jest.mock("../../../../hooks/useResolvedMediaUri");
+
 jest.mock("../../../../trpc/client", () => ({
   trpc: {
     sketch: {

--- a/web/src/components/chat/message/__tests__/ChatMarkdown.resourceLinks.test.tsx
+++ b/web/src/components/chat/message/__tests__/ChatMarkdown.resourceLinks.test.tsx
@@ -12,6 +12,11 @@ import mockTheme from "../../../../__mocks__/themeMock";
  * href through `urlTransform` the way react-markdown does, and hand what
  * survives to `components.a`.
  */
+// Media sources resolve through TanStack Query; these suites render no
+// QueryClientProvider, so use the manual mock (resolution itself is covered
+// by hooks/__tests__/useResolvedMediaUri.test.tsx).
+jest.mock("../../../../hooks/useResolvedMediaUri");
+
 jest.mock("react-markdown", () => {
   const react = jest.requireActual<typeof import("react")>("react");
   const SAFE_SCHEME = /^(https?|mailto|irc|ircs|xmpp):/i;

--- a/web/src/components/chat/message/__tests__/MediaOutputGroup.test.tsx
+++ b/web/src/components/chat/message/__tests__/MediaOutputGroup.test.tsx
@@ -6,6 +6,11 @@ import mockTheme from "../../../../__mocks__/themeMock";
 import MediaOutputGroup from "../MediaOutputGroup";
 import type { Message, MessageContent } from "../../../../stores/ApiTypes";
 
+// Media sources resolve through TanStack Query; these suites render no
+// QueryClientProvider, so use the manual mock (resolution itself is covered
+// by hooks/__tests__/useResolvedMediaUri.test.tsx).
+jest.mock("../../../../hooks/useResolvedMediaUri");
+
 jest.mock("../../../../stores/BASE_URL", () => ({
   BASE_URL: "https://api.test",
   prefixBaseUrl: (url: string) => `https://api.test${url}`

--- a/web/src/components/chat/message/__tests__/ResourceChip.test.tsx
+++ b/web/src/components/chat/message/__tests__/ResourceChip.test.tsx
@@ -8,6 +8,12 @@ import mockTheme from "../../../../__mocks__/themeMock";
 
 const openResource = jest.fn();
 
+// Media sources resolve through TanStack Query; these suites render no
+// QueryClientProvider, so use the manual mock (resolution itself is covered
+// by hooks/__tests__/useResolvedMediaUri.test.tsx).
+jest.mock("../../../../hooks/useResolvedMediaUri");
+import { mockAssetUrl } from "../../../../hooks/__mocks__/useResolvedMediaUri";
+
 jest.mock("../../../../lib/chat/openResource", () => ({
   __esModule: true,
   openResource: (ref: unknown) => openResource(ref),
@@ -55,9 +61,10 @@ describe("ResourceChip", () => {
   it("renders a thumbnail for image assets", () => {
     const { container } = renderChip("asset://as_1.png", "render.png");
 
+    // Resolved through the asset record, not by rewriting the locator.
     expect(container.querySelector("img")).toHaveAttribute(
       "src",
-      expect.stringContaining("/api/storage/as_1.png")
+      mockAssetUrl("as_1.png")
     );
   });
 

--- a/web/src/components/node/ImageRefPreview.tsx
+++ b/web/src/components/node/ImageRefPreview.tsx
@@ -3,6 +3,7 @@ import { isBitmapImage } from "@nodetool-ai/protocol";
 import ImageView from "./ImageView";
 import { asImageRef, isRawRgbaRef } from "../../utils/imageRef";
 import { rawRgbaToPngDataUrl } from "../../lib/workflow/materializeBrowserOutputs";
+import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
 
 interface ImageRefPreviewProps {
   /** A node output/input value in any of the shapes `asImageRef` understands. */
@@ -24,8 +25,17 @@ const ImageRefPreview: React.FC<ImageRefPreviewProps> = ({
   value,
   placeholder
 }) => {
-  if (typeof value === "string" && value) {
-    return <ImageView source={value} />;
+  const stringSource = typeof value === "string" && value ? value : undefined;
+  const ref = asImageRef(value);
+  // An `asset://` locator resolves to the asset's signed `get_url`; every other
+  // scheme (data:, blob:, http:, package://, file://) comes back unchanged, and
+  // is `undefined` only while a lookup is in flight.
+  const resolvedUri = useResolvedMediaUri(
+    stringSource ?? (ref?.uri || ref?.asset_id ? ref : undefined)
+  );
+
+  if (stringSource) {
+    return <ImageView source={resolvedUri} />;
   }
   // Preview-bitmap ref from the in-browser runner (zero-copy transport) —
   // paint it directly. Checked on the raw value: `asImageRef` keeps only the
@@ -33,7 +43,6 @@ const ImageRefPreview: React.FC<ImageRefPreviewProps> = ({
   if (isBitmapImage(value)) {
     return <ImageView bitmap={value.bitmap as ImageBitmap} />;
   }
-  const ref = asImageRef(value);
   if (isRawRgbaRef(ref)) {
     // Defensive: in-flight raw-RGBA is normally encoded to a uri by
     // materializeBrowserOutputs before it reaches here; encode any that slips
@@ -43,7 +52,7 @@ const ImageRefPreview: React.FC<ImageRefPreviewProps> = ({
     );
   }
   if (ref?.uri) {
-    return <ImageView source={ref.uri} />;
+    return <ImageView source={resolvedUri} />;
   }
   if (typeof ref?.data === "string" && ref.data) {
     return <ImageView source={ref.data} />;
@@ -53,6 +62,11 @@ const ImageRefPreview: React.FC<ImageRefPreviewProps> = ({
   }
   if (Array.isArray(ref?.data)) {
     return <ImageView source={new Uint8Array(ref!.data as number[])} />;
+  }
+  // A ref that carries only `asset_id` (no uri, no bytes) — still displayable
+  // once the asset record resolves.
+  if (ref?.asset_id) {
+    return <ImageView source={resolvedUri} />;
   }
   return <>{placeholder ?? null}</>;
 };

--- a/web/src/components/node/ThreadMessageList.tsx
+++ b/web/src/components/node/ThreadMessageList.tsx
@@ -5,7 +5,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { Message, ToolCall } from "../../stores/ApiTypes";
 import MarkdownRenderer from "../../utils/MarkdownRenderer";
-import ImageView from "./ImageView";
+import ImageRefPreview from "./ImageRefPreview";
 import isEqual from "../../utils/isEqual";
 import { BORDER_RADIUS, Z_INDEX } from "../ui_primitives";
 
@@ -180,7 +180,14 @@ const MessageView: React.FC<{ msg: Message }> = memo(({ msg }) => {
           if (c.type === "text") {
             return <MarkdownRenderer key={`text-${i}`} content={c.text || ""} />;
           } else if (c.type === "image_url") {
-            return <ImageView key={c.image?.uri ?? `img-${i}`} source={c.image?.uri} />;
+            // Through `ImageRefPreview`, which resolves an `asset://` locator
+            // to the asset's `get_url` — a raw locator is fetchable nowhere.
+            return (
+              <ImageRefPreview
+                key={c.image?.asset_id ?? c.image?.uri ?? `img-${i}`}
+                value={c.image}
+              />
+            );
           } else {
             return null;
           }

--- a/web/src/components/node/output/__tests__/hooks.test.ts
+++ b/web/src/components/node/output/__tests__/hooks.test.ts
@@ -17,16 +17,15 @@ describe("output/hooks", () => {
       expect(resolveAssetUri("")).toBe("");
     });
 
-    it("converts asset:// URIs to the API storage URL", () => {
-      expect(resolveAssetUri("asset://abc123")).toBe(
-        "http://localhost:7777/api/storage/abc123"
-      );
+    // An asset locator carries no path: the bytes live under
+    // `<user_id>/<asset_id>.<ext>` behind a signed URL, so there is no correct
+    // rewrite here. Callers must resolve it via `useResolvedMediaUri`.
+    it("refuses asset:// URIs", () => {
+      expect(resolveAssetUri("asset://abc123")).toBe("");
     });
 
-    it("converts asset:// URIs with sub-paths", () => {
-      expect(resolveAssetUri("asset://user-1/image.png")).toBe(
-        "http://localhost:7777/api/storage/user-1/image.png"
-      );
+    it("refuses asset:// URIs with sub-paths", () => {
+      expect(resolveAssetUri("asset://user-1/image.png")).toBe("");
     });
 
     it("prepends BASE_URL to /api/storage/ relative paths", () => {

--- a/web/src/components/node/output/hooks.ts
+++ b/web/src/components/node/output/hooks.ts
@@ -5,6 +5,10 @@ import { BASE_URL } from "../../../stores/BASE_URL";
 import { trpc } from "../../../trpc/client";
 import { bitmapToPngDataUrl } from "../../../lib/workflow/materializeBrowserOutputs";
 import { fileUriToHttpUrl } from "../../../utils/localFile";
+import {
+  useResolvedMediaUris,
+  type MediaLocator
+} from "../../../hooks/useResolvedMediaUri";
 
 /**
  * Base type for typed output values with a type discriminator
@@ -82,19 +86,18 @@ function extractStorageKey(uri: string | null | undefined): string | null {
 }
 
 /**
- * Resolves asset URIs to their actual URLs.
- * Converts asset:// URIs to /api/storage/ URLs and package:// URIs to the
- * /api/assets/packages/ route. Passes through other URI schemes unchanged.
+ * Resolves a media URI to a fetchable URL, without a server round trip.
+ * Converts package:// URIs to the /api/assets/packages/ route and prefixes
+ * relative /api/storage/ paths. Passes through other URI schemes unchanged.
+ *
+ * `asset://` returns "" on purpose: it is an identifier, not a path. The bytes
+ * live under `<user_id>/<asset_id>.<ext>` behind a signed URL, so the old
+ * `${BASE_URL}/api/storage/<id>` rewrite 404s on any cloud deploy. Resolve it
+ * with `useResolvedMediaUri` (or the asset's `get_url`) instead.
  */
 export function resolveAssetUri(uri: string | undefined | null): string {
-  if (!uri) {
+  if (!uri || uri.startsWith("asset://")) {
     return "";
-  }
-
-  // Handle asset:// scheme - convert to API storage URL
-  if (uri.startsWith("asset://")) {
-    const assetId = uri.slice("asset://".length);
-    return `${BASE_URL}/api/storage/${assetId}`;
   }
 
   // Handle package:// scheme - constant assets shipped with a package
@@ -227,70 +230,78 @@ export function useVideoSrc(value: unknown): React.RefObject<HTMLVideoElement | 
 }
 
 export function useImageAssets(value: unknown): { assets: Asset[]; urls: string[] } {
-  return useMemo(() => {
-    if (!isImageValueArray(value)) {
-      return { assets: [], urls: [] };
-    }
-    const imageValues = value;
-    const urls: string[] = [];
-    const assets: Asset[] = imageValues.map(
-      (imageItem: ImageValue, index: number): Asset => {
-        const contentType = "image/png";
-        let url = "";
-        if (imageItem.uri) {
-          url = resolveAssetUri(imageItem.uri);
-        } else if (isBitmapImage(imageItem)) {
-          // Preview-bitmap ref from the in-browser runner (no uri/data) —
-          // encode it for the grid. Memoized with the value, so this runs
-          // once per output, not per render.
-          url = bitmapToPngDataUrl(imageItem.bitmap as ImageBitmap);
-        } else if (imageItem.data) {
-          try {
-            // Ensure the typed array is backed by a non-shared ArrayBuffer (BlobPart typing)
-            const safeBytes: Uint8Array<ArrayBuffer> = new Uint8Array(
-              imageItem.data
-            );
-            const blob = new Blob([safeBytes], {
-              type: contentType
-            });
-            url = URL.createObjectURL(blob);
-            urls.push(url);
-          } catch {
-            // Blob creation failed (may be due to shared ArrayBuffer), use empty URL
-            url = "";
-          }
-        } else if (imageItem.id) {
-          // A bare asset ref carrying only `id` (no uri/data/bitmap). The
-          // storage route serves by filename, so `/api/storage/<id>` with no
-          // extension 404s. Build an `asset://<id>.<ext>` ref — extension from
-          // the item name, defaulting to `png` when the name has none (these
-          // grid items carry no mime, and png is the assumed content type) —
-          // and resolve it the same way as `uri`.
-          const cleanName = (imageItem.name ?? "").split(/[?#]/)[0];
-          const dot = cleanName.lastIndexOf(".");
-          const ext =
-            dot > 0 && dot < cleanName.length - 1
-              ? cleanName.slice(dot + 1).toLowerCase()
-              : "png";
-          url = resolveAssetUri(`asset://${imageItem.id}.${ext}`);
+  const items: ImageValue[] = useMemo(
+    () => (isImageValueArray(value) ? value : []),
+    [value]
+  );
+
+  // Encoding a bitmap and creating a blob URL are side effects — do them once
+  // per value, not per render. `null` marks an item whose URL comes from the
+  // asset lookup below.
+  const { localUrls, blobUrls } = useMemo(() => {
+    const blobs: string[] = [];
+    const locals = items.map((item): string | null => {
+      if (item.uri) {
+        return null;
+      }
+      if (isBitmapImage(item)) {
+        return bitmapToPngDataUrl(item.bitmap as ImageBitmap);
+      }
+      if (item.data) {
+        try {
+          // Ensure the typed array is backed by a non-shared ArrayBuffer (BlobPart typing)
+          const safeBytes: Uint8Array<ArrayBuffer> = new Uint8Array(item.data);
+          const url = URL.createObjectURL(
+            new Blob([safeBytes], { type: "image/png" })
+          );
+          blobs.push(url);
+          return url;
+        } catch {
+          // Blob creation failed (may be due to shared ArrayBuffer), no URL
+          return "";
         }
+      }
+      return null;
+    });
+    return { localUrls: locals, blobUrls: blobs };
+  }, [items]);
+
+  // Anything left resolves through the asset record: an `asset://` uri or a
+  // bare `id` both need the asset's own `get_url`, which is signed on the
+  // cloud backends and owner-prefixed everywhere.
+  const locators = useMemo(
+    () =>
+      items.map((item, i): MediaLocator =>
+        localUrls[i] !== null
+          ? undefined
+          : item.uri ?? (item.id ? { asset_id: item.id } : undefined)
+      ),
+    [items, localUrls]
+  );
+  const resolved = useResolvedMediaUris(locators);
+
+  const assets: Asset[] = useMemo(
+    () =>
+      items.map((item, index): Asset => {
+        const url = localUrls[index] ?? resolved[index] ?? "";
         return {
-          id: imageItem.id || `output-image-${index}`,
+          id: item.id || `output-image-${index}`,
           user_id: "",
           workflow_id: null,
           parent_id: "",
-          name: imageItem.name || `Image ${index + 1}.png`,
-          content_type: contentType,
+          name: item.name || `Image ${index + 1}.png`,
+          content_type: "image/png",
           metadata: {},
           created_at: new Date().toISOString(),
           get_url: url,
           thumb_url: url,
           duration: null
         };
-      }
-    );
-    return { assets, urls };
-  }, [value]);
+      }),
+    [items, localUrls, resolved]
+  );
+
+  return { assets, urls: blobUrls };
 }
 
 export function useRevokeBlobUrls(urls: string[]): void {

--- a/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
+++ b/web/src/components/node_types/editing/MasksExtractorBody.test.tsx
@@ -7,6 +7,11 @@ import { MasksExtractorBody } from "./MasksExtractorBody";
 // Mock those boundaries directly.
 let mockNodeOutput: unknown = undefined;
 let mockUpstreamValue: unknown = undefined;
+// Media sources resolve through TanStack Query; these suites render no
+// QueryClientProvider, so use the manual mock (resolution itself is covered
+// by hooks/__tests__/useResolvedMediaUri.test.tsx).
+jest.mock("../../../hooks/useResolvedMediaUri");
+
 jest.mock("../../../hooks/nodes/useNodeIO", () => ({
   __esModule: true,
   useNodeOutput: () => mockNodeOutput,

--- a/web/src/components/node_types/editing/PainterBody.tsx
+++ b/web/src/components/node_types/editing/PainterBody.tsx
@@ -66,13 +66,12 @@ import type { NodeData } from "../../../stores/NodeData";
 import { useUpstreamValue } from "../../../hooks/nodes/useNodeIO";
 import { useBespokePropertyWriter } from "../../../hooks/nodes/useBespokePropertyWriter";
 import { useAssetUpload } from "../../../serverState/useAssetUpload";
-import { useAsset } from "../../../serverState/useAsset";
 import type { Asset } from "../../../stores/ApiTypes";
 import { resolveExposedInputNames } from "../../../utils/exposedInputs";
 import { asImageRef, isRawRgbaRef } from "../../../utils/imageRef";
 import { rawRgbaToPngDataUrl } from "../../../lib/workflow/materializeBrowserOutputs";
 import { createImageUrl } from "../../../utils/imageUtils";
-import { resolveAssetUri } from "../../node/output/hooks";
+import { useResolvedMediaUri } from "../../../hooks/useResolvedMediaUri";
 import { PAINTER_NODE_TYPE } from "../../../constants/nodeTypes";
 
 // Max number of undo states retained. Keeps memory bounded; older
@@ -364,12 +363,14 @@ const PainterBodyInner: React.FC<PainterBodyProps> = ({
         : undefined,
     [inputValue]
   );
-  const { uri: assetUri } = useAsset({ image: imageProp });
+  // An upstream ref's own `uri` is an `asset://` locator, which fetches
+  // nowhere — resolve it (and any bare `asset_id`) to the asset's `get_url`.
+  const resolvedSourceUri = useResolvedMediaUri(sourceImage ?? imageProp);
 
   // Blob URL lifecycle: revoke previous URL on change / unmount.
   const blobUrlRef = useRef<string | null>(null);
   const sourceSrc = useMemo(() => {
-    if (!sourceImage && !assetUri) {
+    if (!sourceImage && !resolvedSourceUri) {
       return undefined;
     }
     // Raw-RGBA upstream → encode via canvas; createImageUrl below would treat
@@ -383,10 +384,7 @@ const PainterBodyInner: React.FC<PainterBodyProps> = ({
         ) || undefined
       );
     }
-    const uriCandidate =
-      sourceImage?.uri && sourceImage.uri.length > 0
-        ? sourceImage.uri
-        : assetUri;
+    const uriCandidate = resolvedSourceUri;
     const result = createImageUrl(
       uriCandidate || sourceImage?.data != null
         ? {
@@ -397,8 +395,8 @@ const PainterBodyInner: React.FC<PainterBodyProps> = ({
       blobUrlRef.current
     );
     blobUrlRef.current = result.blobUrl;
-    return result.url ? resolveAssetUri(result.url) : undefined;
-  }, [sourceImage, assetUri]);
+    return result.url || undefined;
+  }, [sourceImage, resolvedSourceUri]);
   useEffect(() => {
     return () => {
       if (blobUrlRef.current) {

--- a/web/src/components/node_types/editing/ResizeImageBody.tsx
+++ b/web/src/components/node_types/editing/ResizeImageBody.tsx
@@ -21,7 +21,7 @@ import {
   ToggleGroup,
   ToggleOption, BORDER_RADIUS } from "../../ui_primitives";
 import HandleColumn from "../../node/HandleColumn";
-import ImageView from "../../node/ImageView";
+import ImageRefPreview from "../../node/ImageRefPreview";
 import { NodeOutputs } from "../../node/NodeOutputs";
 import NodeProgress from "../../node/NodeProgress";
 import NumberInput from "../../inputs/NumberInput";
@@ -156,24 +156,19 @@ const styles = (theme: Theme) =>
     }
   });
 
-const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => {
-  if (typeof value === "string" && value) {
-    return <ImageView source={value} />;
-  }
-  const ref = asImageRef(value);
-  if (ref?.uri) {
-    return <ImageView source={ref.uri} />;
-  }
-  if (ref?.data instanceof Uint8Array) {
-    return <ImageView source={ref.data} />;
-  }
-  if (Array.isArray(ref?.data)) {
-    return <ImageView source={new Uint8Array(ref!.data as number[])} />;
-  }
-  return (
-    <CheckerDropzone message="Connect an image, then run" icon={<ImageIcon />} />
-  );
-};
+const ImagePreview: React.FC<{ value: unknown }> = ({ value }) => (
+  // The shared ladder — it resolves an `asset://` locator to the asset's
+  // `get_url`, which a hand-rolled copy of this branch chain did not.
+  <ImageRefPreview
+    value={value}
+    placeholder={
+      <CheckerDropzone
+        message="Connect an image, then run"
+        icon={<ImageIcon />}
+      />
+    }
+  />
+);
 
 export interface ResizeImageBodyProps {
   id: string;

--- a/web/src/components/node_types/editing/__tests__/ChannelsBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/ChannelsBody.test.tsx
@@ -8,6 +8,11 @@ import "@testing-library/jest-dom";
 const mockSetProperty = jest.fn();
 const mockSetPropertyComplete = jest.fn();
 
+// Media sources resolve through TanStack Query; these suites render no
+// QueryClientProvider, so use the manual mock (resolution itself is covered
+// by hooks/__tests__/useResolvedMediaUri.test.tsx).
+jest.mock("../../../../hooks/useResolvedMediaUri");
+
 jest.mock("../../../../hooks/nodes/useBespokePropertyWriter", () => ({
   useBespokePropertyWriter: jest.fn(() => ({
     setProperty: mockSetProperty,

--- a/web/src/components/node_types/editing/__tests__/LevelsBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/LevelsBody.test.tsx
@@ -6,6 +6,11 @@ import LevelsBody from "../LevelsBody";
 import mockTheme from "../../../../__mocks__/themeMock";
 import { ContextMenuProvider } from "../../../../providers/ContextMenuProvider";
 
+// Media sources resolve through TanStack Query; these suites render no
+// QueryClientProvider, so use the manual mock (resolution itself is covered
+// by hooks/__tests__/useResolvedMediaUri.test.tsx).
+jest.mock("../../../../hooks/useResolvedMediaUri");
+
 jest.mock("../../../node/ImageView", () => ({
   __esModule: true,
   default: () => null

--- a/web/src/components/node_types/editing/__tests__/PainterBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/PainterBody.test.tsx
@@ -12,6 +12,11 @@ import PainterBody, { PAINTER_NODE_TYPE } from "../PainterBody";
 import { useUpstreamValue } from "../../../../hooks/nodes/useNodeIO";
 
 // ── Mocks ─────────────────────────────────────────────────────────
+// Media sources resolve through TanStack Query; these suites render no
+// QueryClientProvider, so use the manual mock (resolution itself is covered
+// by hooks/__tests__/useResolvedMediaUri.test.tsx).
+jest.mock("../../../../hooks/useResolvedMediaUri");
+
 jest.mock("../../../../contexts/NodeContext", () => ({
   useNodes: jest.fn((selector) =>
     selector({

--- a/web/src/components/sketch/LayerItem.tsx
+++ b/web/src/components/sketch/LayerItem.tsx
@@ -21,7 +21,7 @@ import FolderOutlinedIcon from "@mui/icons-material/FolderOutlined";
 import type { Layer } from "./types";
 import { summarizeLayerImageReference } from "./types";
 import { getLayerDataImageUrl } from "./serialization";
-import { resolveAssetUri } from "../node/output/hooks";
+import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
 import {
   SKETCH_FONT,
   SKETCH_SPACING,
@@ -148,10 +148,10 @@ const LayerItem: React.FC<LayerItemProps> = ({
   bindingStatus
 }) => {
   const isGroup = layer.type === "group";
-  // Resolve the image ref to a fetchable URL — a raw `asset://` scheme is
-  // blocked by the page CSP when set directly as an <img src>.
+  // Resolve the image ref to a fetchable URL — a raw `asset://` locator is not
+  // a path any <img src> can load.
   const layerImage = isGroup ? null : getLayerDataImageUrl(layer.data);
-  const thumbnailSrc = layerImage ? resolveAssetUri(layerImage) : null;
+  const thumbnailSrc = useResolvedMediaUri(layerImage) ?? null;
   const isLayerGenerating =
     bindingStatus === "queued" || bindingStatus === "generating";
 

--- a/web/src/components/sketch/__tests__/SketchLayersPanel.test.tsx
+++ b/web/src/components/sketch/__tests__/SketchLayersPanel.test.tsx
@@ -9,6 +9,11 @@ import SketchLayersPanel from "../SketchLayersPanel";
 import { createDefaultLayer } from "../types";
 import type { BlendMode } from "../types";
 
+// Media sources resolve through TanStack Query; these suites render no
+// QueryClientProvider, so use the manual mock (resolution itself is covered
+// by hooks/__tests__/useResolvedMediaUri.test.tsx).
+jest.mock("../../../hooks/useResolvedMediaUri");
+
 function buildPanelProps({
   blendMode = "normal",
   layerCount = 1,

--- a/web/src/components/sketch/__tests__/agentPaintStrokes.test.tsx
+++ b/web/src/components/sketch/__tests__/agentPaintStrokes.test.tsx
@@ -30,6 +30,11 @@ import { getSketchAgentHandler } from "../sketchAgentBridge";
 import { paintAgentStroke } from "../painting/agentStrokes";
 import { createDefaultDocument, type Layer } from "../types";
 
+// Media sources resolve through TanStack Query; these suites render no
+// QueryClientProvider, so use the manual mock (resolution itself is covered
+// by hooks/__tests__/useResolvedMediaUri.test.tsx).
+jest.mock("../../../hooks/useResolvedMediaUri");
+
 jest.mock("../SketchAgentPanel", () => ({
   __esModule: true,
   default: () => null

--- a/web/src/components/sketch/__tests__/useLayerHydration.test.tsx
+++ b/web/src/components/sketch/__tests__/useLayerHydration.test.tsx
@@ -58,7 +58,10 @@ describe("useLayerHydration", () => {
     );
   });
 
-  it("resolves asset-backed imageReference uris before hydrating locked input layers", () => {
+  // The locator is handed on verbatim: an `asset://` reference resolves to the
+  // asset's own `get_url`, an async lookup the runtime does right before it
+  // loads the image. Rewriting it to `/api/storage/<id>` here would 404.
+  it("passes an asset-backed imageReference uri through to the runtime", () => {
     const doc = createDefaultDocument(64, 64);
     const layer = doc.layers[0];
     layer.locked = true;
@@ -101,7 +104,7 @@ describe("useLayerHydration", () => {
 
     expect((runtime.setLayerData as jest.Mock)).toHaveBeenCalledWith(
       layer.id,
-      expect.stringContaining("/api/storage/input-layer.png"),
+      "asset://input-layer.png",
       expect.any(Object),
       expect.any(Function)
     );

--- a/web/src/components/sketch/rendering/Canvas2DRuntime.ts
+++ b/web/src/components/sketch/rendering/Canvas2DRuntime.ts
@@ -32,7 +32,10 @@ import {
   getLayerDataFromCanvas,
   getCanvasSerializedData
 } from "./canvas2d/layerIO";
-import { resolveAssetUri } from "../../node/output/hooks";
+import {
+  resolveMediaUri,
+  resolveStaticMediaUri
+} from "../../../utils/resolveMediaUri";
 import {
   combineMasks,
   trimSelectionMask,
@@ -371,10 +374,37 @@ export class Canvas2DRuntime implements SketchRuntime {
       onComplete?.();
     };
 
-    // For HTTP(S) URLs, use fetch + createImageBitmap for off-main-thread
-    // decoding. This reduces main-thread blocking during editor startup when
-    // multiple imageReference layers load simultaneously.
-    const imageSrc = resolveAssetUri(decoded.image);
+    // A data URL or an already-resolved http(s) source loads straight away.
+    const staticSrc = resolveStaticMediaUri(decoded.image);
+    if (staticSrc !== null) {
+      this.loadLayerImage(staticSrc, gen, layerId, finalize);
+      return;
+    }
+
+    // A layer image stored as `asset://<id>.<ext>` resolves to the asset's own
+    // `get_url` (signed on the cloud backends), which needs a lookup — the raw
+    // locator fetches nowhere. The generation guard inside `finalize` already
+    // covers the extra async hop.
+    void resolveMediaUri(decoded.image).then((imageSrc) => {
+      if (!imageSrc || this.layerLoadGenerations.get(layerId) !== gen) {
+        return;
+      }
+      this.loadLayerImage(imageSrc, gen, layerId, finalize);
+    });
+  }
+
+  /**
+   * Load a resolved image URL onto the layer canvas. HTTP(S) and root-relative
+   * URLs go through fetch + createImageBitmap for off-main-thread decoding,
+   * which keeps the main thread free during editor startup when several
+   * imageReference layers load at once.
+   */
+  private loadLayerImage(
+    imageSrc: string,
+    gen: number,
+    layerId: string,
+    finalize: (source: ImageBitmap | HTMLImageElement) => void
+  ): void {
     if (
       typeof createImageBitmap === "function" &&
       (imageSrc.startsWith("http://") ||

--- a/web/src/components/sketch/sam/__tests__/normalizeSamMasks.test.ts
+++ b/web/src/components/sketch/sam/__tests__/normalizeSamMasks.test.ts
@@ -1,6 +1,8 @@
 /** @jest-environment node */
-jest.mock("../../../node/output/hooks", () => ({
-  resolveAssetUri: (uri: string | undefined | null) => uri ?? ""
+jest.mock("../../../../utils/resolveMediaUri", () => ({
+  // Stands in for the asset lookup: every locator resolves to itself, so the
+  // assertions below read on the input they were given.
+  resolveMediaUri: async (uri: string | undefined | null) => uri ?? ""
 }));
 
 import { normalizeSamMasks } from "../normalizeSamMasks";
@@ -12,8 +14,8 @@ describe("normalizeSamMasks", () => {
     nodeType: "nodetool.segment.Sam"
   };
 
-  it("extracts masks from a flat array of image refs", () => {
-    const result = normalizeSamMasks({
+  it("extracts masks from a flat array of image refs", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       rawOutput: [
         { uri: "asset://mask1", width: 100, height: 200 },
@@ -25,8 +27,8 @@ describe("normalizeSamMasks", () => {
     expect(result.masks[1].maskDataUrl).toBe("asset://mask2");
   });
 
-  it("extracts masks from { output: [...] } wrapper", () => {
-    const result = normalizeSamMasks({
+  it("extracts masks from { output: [...] } wrapper", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       rawOutput: {
         output: [{ uri: "asset://m1", width: 64, height: 64 }]
@@ -36,8 +38,8 @@ describe("normalizeSamMasks", () => {
     expect(result.masks[0].id).toBe("mask_0");
   });
 
-  it("extracts a single image ref as a one-element mask list", () => {
-    const result = normalizeSamMasks({
+  it("extracts a single image ref as a one-element mask list", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       rawOutput: { uri: "asset://single", width: 50, height: 50 }
     });
@@ -45,16 +47,16 @@ describe("normalizeSamMasks", () => {
     expect(result.masks[0].maskDataUrl).toBe("asset://single");
   });
 
-  it("skips entries with no resolvable URI", () => {
-    const result = normalizeSamMasks({
+  it("skips entries with no resolvable URI", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       rawOutput: [{ width: 10, height: 10 }]
     });
     expect(result.masks).toHaveLength(0);
   });
 
-  it("uses url field when uri is missing", () => {
-    const result = normalizeSamMasks({
+  it("uses url field when uri is missing", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       rawOutput: [{ url: "https://example.com/mask.png", width: 32, height: 32 }]
     });
@@ -62,8 +64,8 @@ describe("normalizeSamMasks", () => {
     expect(result.masks[0].maskDataUrl).toBe("https://example.com/mask.png");
   });
 
-  it("assigns sequential mask ids", () => {
-    const result = normalizeSamMasks({
+  it("assigns sequential mask ids", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       rawOutput: [
         { uri: "a://1", width: 10, height: 10 },
@@ -78,8 +80,8 @@ describe("normalizeSamMasks", () => {
     ]);
   });
 
-  it("uses explicit label from entry", () => {
-    const result = normalizeSamMasks({
+  it("uses explicit label from entry", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       rawOutput: [
         { uri: "a://1", width: 10, height: 10, label: "Person" }
@@ -88,8 +90,8 @@ describe("normalizeSamMasks", () => {
     expect(result.masks[0].label).toBe("Person");
   });
 
-  it("uses name field as fallback label", () => {
-    const result = normalizeSamMasks({
+  it("uses name field as fallback label", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       rawOutput: [
         { uri: "a://1", width: 10, height: 10, name: "Background" }
@@ -98,16 +100,16 @@ describe("normalizeSamMasks", () => {
     expect(result.masks[0].label).toBe("Background");
   });
 
-  it("generates default label when none provided", () => {
-    const result = normalizeSamMasks({
+  it("generates default label when none provided", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       rawOutput: [{ uri: "a://1", width: 10, height: 10 }]
     });
     expect(result.masks[0].label).toBe("Mask 1");
   });
 
-  it("applies inverse scale to width and height", () => {
-    const result = normalizeSamMasks({
+  it("applies inverse scale to width and height", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       scale: 2,
       rawOutput: [{ uri: "a://1", width: 200, height: 100 }]
@@ -116,8 +118,8 @@ describe("normalizeSamMasks", () => {
     expect(result.masks[0].bounds.height).toBe(50);
   });
 
-  it("falls back to sourceMetadata dimensions", () => {
-    const result = normalizeSamMasks({
+  it("falls back to sourceMetadata dimensions", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       sourceMetadata: {
         layerId: "layer-1",
@@ -132,24 +134,24 @@ describe("normalizeSamMasks", () => {
     expect(result.masks[0].bounds.height).toBe(150);
   });
 
-  it("returns empty masks for non-array non-object input", () => {
-    const result = normalizeSamMasks({
+  it("returns empty masks for non-array non-object input", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       rawOutput: "not an object"
     });
     expect(result.masks).toHaveLength(0);
   });
 
-  it("returns empty masks for null input", () => {
-    const result = normalizeSamMasks({
+  it("returns empty masks for null input", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       rawOutput: null
     });
     expect(result.masks).toHaveLength(0);
   });
 
-  it("propagates metadata fields to the response", () => {
-    const result = normalizeSamMasks({
+  it("propagates metadata fields to the response", async () => {
+    const result = await normalizeSamMasks({
       ...baseParams,
       rawOutput: []
     });

--- a/web/src/components/sketch/sam/normalizeSamMasks.ts
+++ b/web/src/components/sketch/sam/normalizeSamMasks.ts
@@ -1,4 +1,4 @@
-import { resolveAssetUri } from "../../node/output/hooks";
+import { resolveMediaUri } from "../../../utils/resolveMediaUri";
 import type { SegmentBackend, SegmentationMask, SegmentationSourceMetadata } from "../types";
 import type { SegmentationResponse } from "./SamService";
 
@@ -46,9 +46,13 @@ function getNormalizedMaskEntries(rawOutput: unknown): Array<{
   );
 }
 
-function getResolvedMaskUri(entry: SamMaskImageRef): string | null {
-  const rawUri = entry.uri ?? entry.url ?? null;
-  return resolveAssetUri(rawUri);
+/**
+ * A node-provider mask arrives as an `asset://` locator, which resolves only
+ * through the asset's own `get_url`; a hosted provider (fal) returns an http
+ * URL, which passes through untouched.
+ */
+function getResolvedMaskUri(entry: SamMaskImageRef): Promise<string> {
+  return resolveMediaUri(entry.uri ?? entry.url ?? null);
 }
 
 function getNormalizedDimension(
@@ -73,50 +77,47 @@ function getMaskLabel(entry: SamMaskImageRef, rawIndex: number): string {
   return explicitLabel.length > 0 ? explicitLabel : `Mask ${rawIndex + 1}`;
 }
 
-export function normalizeSamMasks({
+export async function normalizeSamMasks({
   rawOutput,
   backendId,
   modelId,
   nodeType,
   scale = 1,
   sourceMetadata
-}: NormalizeSamMasksParams): SegmentationResponse {
-  const masks = getNormalizedMaskEntries(rawOutput).reduce<SegmentationMask[]>(
-    (acc, { entry, rawIndex }) => {
-      const maskUri = getResolvedMaskUri(entry);
-      if (!maskUri) {
-        return acc;
-      }
+}: NormalizeSamMasksParams): Promise<SegmentationResponse> {
+  const masks: SegmentationMask[] = [];
+  for (const { entry, rawIndex } of getNormalizedMaskEntries(rawOutput)) {
+    const maskUri = await getResolvedMaskUri(entry);
+    if (!maskUri) {
+      continue;
+    }
 
-      acc.push({
-        id: `mask_${rawIndex}`,
-        kind: "mask",
-        label: getMaskLabel(entry, rawIndex),
-        maskDataUrl: maskUri,
-        confidence: 1,
-        bounds: {
-          x: 0,
-          y: 0,
-          width: getNormalizedDimension(
-            entry.width,
-            sourceMetadata?.contentBounds.width,
-            scale
-          ),
-          height: getNormalizedDimension(
-            entry.height,
-            sourceMetadata?.contentBounds.height,
-            scale
-          )
-        },
-        backendId,
-        modelId,
-        nodeType,
-        sourceMetadata
-      });
-      return acc;
-    },
-    []
-  );
+    masks.push({
+      id: `mask_${rawIndex}`,
+      kind: "mask",
+      label: getMaskLabel(entry, rawIndex),
+      maskDataUrl: maskUri,
+      confidence: 1,
+      bounds: {
+        x: 0,
+        y: 0,
+        width: getNormalizedDimension(
+          entry.width,
+          sourceMetadata?.contentBounds.width,
+          scale
+        ),
+        height: getNormalizedDimension(
+          entry.height,
+          sourceMetadata?.contentBounds.height,
+          scale
+        )
+      },
+      backendId,
+      modelId,
+      nodeType,
+      sourceMetadata
+    });
+  }
 
   return {
     masks,

--- a/web/src/components/sketch/sketchCanvasHooks/useLayerHydration.ts
+++ b/web/src/components/sketch/sketchCanvasHooks/useLayerHydration.ts
@@ -9,7 +9,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { SketchDocument } from "../types";
 import type { SketchRuntime } from "../rendering";
-import { resolveAssetUri } from "../../node/output/hooks";
 import type { DisplayFrameCoordinator } from "./DisplayFrameCoordinator";
 
 export interface UseLayerHydrationParams {
@@ -39,14 +38,16 @@ export interface UseLayerHydrationResult {
   >;
 }
 
+/**
+ * The layer's own serialized data wins; otherwise the image reference is
+ * handed on as-is. The runtime resolves it (an `asset://` locator needs the
+ * asset's `get_url`, which is an async lookup) right before it loads.
+ */
 function resolveLayerHydrationSource(
   data: string | null | undefined,
   imageUri: string | null | undefined
 ): string | null {
-  if (data) {
-    return data;
-  }
-  return resolveAssetUri(imageUri);
+  return data || imageUri || null;
 }
 
 export function useLayerHydration({

--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -41,6 +41,7 @@ import { entitiesForShot } from "../../stores/storyboard/shotEntities";
 import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
 import { useEntities } from "../../serverState/useEntities";
 import { ENTITY_KIND_COLOR } from "../entities/entityKind";
+import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
 
 interface ShotCardProps {
   boardId: string;
@@ -136,7 +137,9 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   const isGenerating =
     shot.status === "keyframe_generating" || shot.status === "clip_generating";
   const camera = cameraLine(shot);
-  const clipUri = shot.clip?.uri;
+  // The clip's `uri` is an `asset://` locator — the player needs the asset's
+  // own `get_url`.
+  const clipUri = useResolvedMediaUri(shot.clip);
   const shotName = `${shot.index + 1}. ${shot.slug ?? "Untitled shot"}`;
 
   const handleGenerateStill = useCallback(() => {

--- a/web/src/components/storyboard/ShotTakesGallery.tsx
+++ b/web/src/components/storyboard/ShotTakesGallery.tsx
@@ -30,6 +30,7 @@ import {
   useStoryboardStore
 } from "../../stores/storyboard/StoryboardStore";
 import { syncShotClipToTimeline } from "../../stores/storyboard/timelineSync";
+import { useResolvedMediaUris } from "../../hooks/useResolvedMediaUri";
 
 interface ShotTakesGalleryProps {
   boardId: string;
@@ -89,6 +90,9 @@ const ShotTakesGalleryInner: React.FC<ShotTakesGalleryProps> = ({
     () => shot.clip_versions ?? (shot.clip ? [shot.clip] : []),
     [shot.clip_versions, shot.clip]
   );
+  // A still's `uri` is an `asset://` locator, which no browser can fetch —
+  // the thumbnails need each asset's own `get_url`.
+  const stillThumbSrcs = useResolvedMediaUris(stills);
 
   const selectedStill = shot.keyframe
     ? stills.findIndex((v) => sameMediaRef(v, shot.keyframe as ImageRef))
@@ -154,7 +158,11 @@ const ShotTakesGalleryInner: React.FC<ShotTakesGalleryProps> = ({
               onClick={() => handleSelectStill(i)}
               sx={takeThumbSx}
             >
-              {still.uri ? <img src={still.uri} alt="" /> : <span>{i + 1}</span>}
+              {stillThumbSrcs[i] ? (
+                <img src={stillThumbSrcs[i]} alt="" />
+              ) : (
+                <span>{i + 1}</span>
+              )}
             </Box>
           ))}
         </FlexRow>

--- a/web/src/components/storyboard/StoryboardEntitiesField.tsx
+++ b/web/src/components/storyboard/StoryboardEntitiesField.tsx
@@ -26,21 +26,21 @@ import {
 import { useEntities } from "../../serverState/useEntities";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
 import { ENTITY_KIND_COLOR, ENTITY_KIND_ICON } from "../entities/entityKind";
+import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
 
 export interface StoryboardEntitiesFieldProps {
   boardId: string;
   entityIds: string[];
 }
 
-const entityThumb = (entity: Entity): string | undefined =>
-  entity.reference_images?.[0]?.uri;
-
 /** Round reference-image avatar with the kind icon as its empty state. */
 const EntityAvatar: React.FC<{ entity: Entity; size?: number }> = ({
   entity,
   size = 20
 }) => {
-  const thumb = entityThumb(entity);
+  // A reference image is an `asset://` locator by construction — it needs the
+  // asset's own `get_url` before an <img> can load it.
+  const thumb = useResolvedMediaUri(entity.reference_images?.[0]);
   const Icon = ENTITY_KIND_ICON[entity.kind];
   const frameSx = {
     width: size,

--- a/web/src/components/storyboard/__tests__/ShotCard.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotCard.test.tsx
@@ -8,6 +8,11 @@ import mockTheme from "../../../__mocks__/themeMock";
 // Keep the card's generation hook and image ladder out of the render — this test
 // only asserts the card's presentation and button gating, not generation.
 const generateRevisedClipMock = jest.fn();
+// Media sources resolve through TanStack Query; these suites render no
+// QueryClientProvider, so use the manual mock (resolution itself is covered
+// by hooks/__tests__/useResolvedMediaUri.test.tsx).
+jest.mock("../../../hooks/useResolvedMediaUri");
+
 jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
   useGenerateShot: () => ({
     generateKeyframe: jest.fn(),

--- a/web/src/components/storyboard/__tests__/ShotTakesGallery.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotTakesGallery.test.tsx
@@ -7,6 +7,11 @@ import mockTheme from "../../../__mocks__/themeMock";
 
 // The gallery reuses the node-results renderer; stub it so this test asserts
 // wiring (what value it receives), not the renderer's own media pipeline.
+// Media sources resolve through TanStack Query; these suites render no
+// QueryClientProvider, so use the manual mock (resolution itself is covered
+// by hooks/__tests__/useResolvedMediaUri.test.tsx).
+jest.mock("../../../hooks/useResolvedMediaUri");
+
 jest.mock("../../node/OutputRenderer", () => ({
   __esModule: true,
   default: ({ value }: { value: unknown[] }) => (

--- a/web/src/hooks/__mocks__/useResolvedMediaUri.ts
+++ b/web/src/hooks/__mocks__/useResolvedMediaUri.ts
@@ -1,0 +1,48 @@
+/**
+ * Manual mock for `useResolvedMediaUri`.
+ *
+ * The real hook resolves an `asset://` locator through TanStack Query, so a
+ * component that renders media needs a `QueryClientProvider`. Suites that only
+ * exercise other behavior mock this module instead of standing one up. The
+ * resolution itself is covered by `hooks/__tests__/useResolvedMediaUri.test.tsx`.
+ *
+ * Non-asset locators pass through, so assertions on data/blob/http sources read
+ * exactly as they do in the app; an `asset://` locator resolves to a stand-in
+ * URL a test can assert on.
+ */
+
+import { resolveStaticMediaUri as realResolveStaticMediaUri } from "../../utils/resolveMediaUri";
+
+export type MediaLocator =
+  | string
+  | { uri?: string | null; asset_id?: string | null }
+  | null
+  | undefined;
+
+/** The URL an `asset://<id>` locator resolves to under test. */
+export const mockAssetUrl = (assetId: string): string =>
+  `https://assets.test/${assetId}`;
+
+const resolve = (source: MediaLocator): string | undefined => {
+  const uri = typeof source === "string" ? source : (source?.uri ?? undefined);
+  const declared = typeof source === "object" ? source?.asset_id : undefined;
+  if (declared) {
+    return mockAssetUrl(declared);
+  }
+  // Everything but an asset locator resolves exactly as it does in the app.
+  const staticUrl = realResolveStaticMediaUri(uri);
+  if (staticUrl !== null) {
+    return staticUrl || undefined;
+  }
+  return mockAssetUrl((uri as string).slice("asset://".length));
+};
+
+export const resolveStaticMediaUri = realResolveStaticMediaUri;
+
+export const useResolvedMediaUri = resolve;
+
+export const useResolvedMediaUris = (
+  sources: MediaLocator[]
+): (string | undefined)[] => sources.map(resolve);
+
+export default useResolvedMediaUri;

--- a/web/src/hooks/__tests__/useResolvedMediaUri.test.tsx
+++ b/web/src/hooks/__tests__/useResolvedMediaUri.test.tsx
@@ -1,0 +1,89 @@
+import { renderHook } from "@testing-library/react";
+import { useQuery } from "@tanstack/react-query";
+
+import { useResolvedMediaUri } from "../useResolvedMediaUri";
+
+const mockGetAsset = jest.fn();
+jest.mock("../../stores/AssetStore", () => ({
+  __esModule: true,
+  useAssetStore: jest.fn((selector: any) => selector({ get: mockGetAsset }))
+}));
+
+jest.mock("@tanstack/react-query", () => ({
+  __esModule: true,
+  useQuery: jest.fn(),
+  useQueries: jest.fn()
+}));
+
+const mockUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
+
+/** The asset record the lookup resolves to, when it resolves. */
+const withAsset = (getUrl: string | undefined) => {
+  mockUseQuery.mockReturnValue({
+    data: getUrl ? { get_url: getUrl } : undefined
+  } as any);
+};
+
+describe("useResolvedMediaUri", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    withAsset(undefined);
+  });
+
+  it("resolves an asset:// locator to the asset's signed get_url", () => {
+    withAsset("https://cdn.example.com/signed/user-1/abc123.png?sig=x");
+    const { result } = renderHook(() =>
+      useResolvedMediaUri("asset://abc123.png")
+    );
+    expect(result.current).toBe(
+      "https://cdn.example.com/signed/user-1/abc123.png?sig=x"
+    );
+  });
+
+  it("looks the asset up by its id, not the locator's path", () => {
+    renderHook(() => useResolvedMediaUri("asset://abc123.png"));
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["asset", "abc123"], enabled: true })
+    );
+  });
+
+  it("prefers a declared asset_id over the ref's own uri", () => {
+    renderHook(() =>
+      useResolvedMediaUri({ uri: "asset://stale.png", asset_id: "abc123" })
+    );
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["asset", "abc123"] })
+    );
+  });
+
+  // The whole point of the hook: never hand a caller a URL that 404s. An
+  // unresolved lookup renders nothing rather than `/api/storage/<id>`.
+  it("returns undefined while the asset lookup is in flight", () => {
+    const { result } = renderHook(() =>
+      useResolvedMediaUri("asset://abc123.png")
+    );
+    expect(result.current).toBeUndefined();
+  });
+
+  it.each([
+    ["https://cdn.example.com/photo.png", "https://cdn.example.com/photo.png"],
+    ["data:image/png;base64,abc", "data:image/png;base64,abc"],
+    ["blob:http://localhost/uuid", "blob:http://localhost/uuid"],
+    [
+      "package://nodetool-base/cat.png",
+      "http://localhost:7777/api/assets/packages/nodetool-base/cat.png"
+    ],
+    ["/api/storage/user-1/a.png", "http://localhost:7777/api/storage/user-1/a.png"]
+  ])("passes %s through without a lookup", (input, expected) => {
+    const { result } = renderHook(() => useResolvedMediaUri(input));
+    expect(result.current).toBe(expected);
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false })
+    );
+  });
+
+  it.each([undefined, null, ""])("returns undefined for %p", (input) => {
+    const { result } = renderHook(() => useResolvedMediaUri(input));
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/web/src/hooks/useResolvedMediaUri.ts
+++ b/web/src/hooks/useResolvedMediaUri.ts
@@ -1,0 +1,96 @@
+/**
+ * useResolvedMediaUri
+ *
+ * Turns a media locator into a URL a browser can actually fetch.
+ *
+ * `asset://<id>` is an identifier, not a path: the bytes live under
+ * `<user_id>/<asset_id>.<ext>` and, on the cloud backends (S3/Supabase), behind
+ * a signed URL that only the server can mint. Handing the raw locator to an
+ * `<img>`/`<video>` renders nothing anywhere, and the old
+ * `${BASE_URL}/api/storage/<id>` rewrite 404s on any deploy whose storage keys
+ * carry the owner prefix. The only correct resolution is the asset's own
+ * `get_url`, so this hook fetches the asset record (shared react-query cache
+ * with `useAsset`) and returns that.
+ *
+ * Returns `undefined` while the lookup is in flight — deliberately, so a caller
+ * renders nothing rather than a URL known to fail.
+ */
+
+import { useQueries, useQuery } from "@tanstack/react-query";
+
+import { useAssetStore } from "../stores/AssetStore";
+import { assetIdFromLocator } from "../utils/mediaRef";
+import { resolveStaticMediaUri } from "../utils/resolveMediaUri";
+
+/** Anything carrying a media locator: a bare URI or a `*Ref` with `asset_id`. */
+export type MediaLocator =
+  | string
+  | { uri?: string | null; asset_id?: string | null }
+  | null
+  | undefined;
+
+const locatorParts = (
+  source: MediaLocator
+): { uri?: string; assetId?: string } => {
+  if (typeof source === "string") {
+    return { uri: source || undefined, assetId: assetIdFromLocator(source) };
+  }
+  if (!source) {
+    return {};
+  }
+  const uri = typeof source.uri === "string" && source.uri ? source.uri : undefined;
+  const declared =
+    typeof source.asset_id === "string" && source.asset_id.trim() !== ""
+      ? source.asset_id.trim()
+      : undefined;
+  return { uri, assetId: declared ?? assetIdFromLocator(uri) };
+};
+
+export function useResolvedMediaUri(source: MediaLocator): string | undefined {
+  const getAsset = useAssetStore((state) => state.get);
+  const { uri, assetId } = locatorParts(source);
+
+  const staticUrl = resolveStaticMediaUri(uri);
+  // A locator that resolves without the server still needs the asset id path
+  // disabled — hooks cannot be called conditionally, so gate the query instead.
+  const needsAsset = staticUrl === null && Boolean(assetId);
+
+  const { data: asset } = useQuery({
+    queryKey: ["asset", assetId],
+    queryFn: () => getAsset(assetId as string),
+    enabled: needsAsset
+  });
+
+  if (staticUrl !== null) {
+    return staticUrl || undefined;
+  }
+  return asset?.get_url ?? undefined;
+}
+
+/**
+ * The list form: resolves a whole batch of locators in one render, keeping the
+ * result positionally aligned with the input.
+ */
+export function useResolvedMediaUris(
+  sources: MediaLocator[]
+): (string | undefined)[] {
+  const getAsset = useAssetStore((state) => state.get);
+  const parts = sources.map(locatorParts);
+  const staticUrls = parts.map(({ uri }) => resolveStaticMediaUri(uri));
+
+  const results = useQueries({
+    queries: parts.map(({ assetId }, i) => ({
+      queryKey: ["asset", assetId],
+      queryFn: () => getAsset(assetId as string),
+      enabled: staticUrls[i] === null && Boolean(assetId)
+    }))
+  });
+
+  return staticUrls.map((staticUrl, i) =>
+    staticUrl !== null
+      ? staticUrl || undefined
+      : (results[i]?.data?.get_url ?? undefined)
+  );
+}
+
+export default useResolvedMediaUri;

--- a/web/src/utils/__tests__/createAssetFile.test.ts
+++ b/web/src/utils/__tests__/createAssetFile.test.ts
@@ -187,7 +187,15 @@ describe("createAssetFile", () => {
     expect(result.file.size).toBe(64);
   });
 
-  it("fetches image from asset:// when asset_id is absent (URI-only image ref)", async () => {
+  // The locator carries no path — the bytes are behind the asset's own
+  // `get_url`, so a URI-only ref still costs one `assets.get`.
+  it("resolves an asset:// URI through the asset record when asset_id is absent", async () => {
+    assetGetQuery.mockResolvedValueOnce({
+      id: "abc123",
+      name: "abc123.png",
+      content_type: "image/png",
+      get_url: "https://cdn.example.com/signed/user-1/abc123.png?sig=x"
+    });
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       arrayBuffer: async () => new Uint8Array([137, 80, 78, 71]).buffer
@@ -201,11 +209,11 @@ describe("createAssetFile", () => {
       "node"
     );
 
-    expect(assetGetQuery).not.toHaveBeenCalled();
-    expect(global.fetch).toHaveBeenCalled();
+    expect(assetGetQuery).toHaveBeenCalledWith({ id: "abc123" });
     const fetchUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
-    expect(fetchUrl).toContain("/api/storage/");
-    expect(fetchUrl).toContain("abc123.png");
+    expect(fetchUrl).toBe(
+      "https://cdn.example.com/signed/user-1/abc123.png?sig=x"
+    );
     expect(result.file.size).toBe(4);
   });
 

--- a/web/src/utils/__tests__/downloadPreviewAssets.test.ts
+++ b/web/src/utils/__tests__/downloadPreviewAssets.test.ts
@@ -5,6 +5,11 @@ const mockCreateAssetFile = createAssetFile as jest.Mock;
 
 jest.mock("../createAssetFile");
 
+const mockGetAsset = jest.fn();
+jest.mock("../../stores/AssetStore", () => ({
+  useAssetStore: { getState: () => ({ get: mockGetAsset }) }
+}));
+
 describe("downloadPreviewAssets", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -126,8 +131,14 @@ describe("downloadPreviewAssets", () => {
     consoleWarnSpy.mockRestore();
   });
 
-  it("resolves asset:// URIs in direct-download fallback", async () => {
+  // The locator has no fetchable form of its own — the anchor gets the
+  // asset's `get_url`, which is signed on the cloud backends.
+  it("resolves asset:// URIs through the asset record in the fallback", async () => {
     mockCreateAssetFile.mockRejectedValue(new Error("Failed to create asset"));
+    mockGetAsset.mockResolvedValue({
+      id: "123",
+      get_url: "https://cdn.example.com/signed/user-1/123.mp4?sig=x"
+    });
 
     const mockAnchor = {
       href: "",
@@ -146,7 +157,10 @@ describe("downloadPreviewAssets", () => {
     });
 
     expect(consoleWarnSpy).toHaveBeenCalled();
-    expect(mockAnchor.href).toBe("http://localhost:7777/api/storage/123.mp4");
+    expect(mockGetAsset).toHaveBeenCalledWith("123");
+    expect(mockAnchor.href).toBe(
+      "https://cdn.example.com/signed/user-1/123.mp4?sig=x"
+    );
     expect(mockAnchor.download).toBe("123.mp4");
     expect(mockAnchor.click).toHaveBeenCalled();
 

--- a/web/src/utils/__tests__/imageUtils.test.ts
+++ b/web/src/utils/__tests__/imageUtils.test.ts
@@ -82,21 +82,21 @@ describe("imageUtils", () => {
       expect(result.blobUrl).toBeNull();
     });
 
-    it("resolves asset:// URI on ImageSource to /api/storage/{id}", () => {
+    // An asset locator has no fetchable rewrite — the bytes sit under
+    // `<user_id>/<asset_id>.<ext>` behind a signed URL. Callers resolve it
+    // through `useResolvedMediaUri`; here it must come back empty rather than
+    // as a URL that 404s in production.
+    it("refuses an asset:// URI on ImageSource", () => {
       const source: ImageSource = { uri: "asset://abc123.png" };
       const result = createImageUrl(source, null);
-      expect(result.url).toBe(
-        "http://localhost:7777/api/storage/abc123.png"
-      );
+      expect(result.url).toBe("");
       expect(result.blobUrl).toBeNull();
     });
 
-    it("resolves raw asset:// string to /api/storage/{id}", () => {
+    it("refuses a raw asset:// string", () => {
       const source: ImageData = "asset://abc123.png";
       const result = createImageUrl(source, null);
-      expect(result.url).toBe(
-        "http://localhost:7777/api/storage/abc123.png"
-      );
+      expect(result.url).toBe("");
       expect(result.blobUrl).toBeNull();
     });
 

--- a/web/src/utils/createAssetFile.ts
+++ b/web/src/utils/createAssetFile.ts
@@ -2,7 +2,7 @@ import { authHeader } from "../lib/auth";
 import type { Chunk } from "../stores/ApiTypes";
 import { trpcClient } from "../trpc/client";
 import { isTRPCErrorWithCode, ApiErrorCode } from "@nodetool-ai/protocol/api-schemas";
-import { resolveAssetUri } from "../components/node/output/hooks";
+import { resolveMediaUri } from "./resolveMediaUri";
 
 interface AssetFileResult {
   file: File;
@@ -425,7 +425,13 @@ const isExternalUrl = (url: string): boolean => {
 };
 
 const fetchBinaryFromUri = async (uri: string): Promise<Uint8Array> => {
-  const resolvedUri = resolveDownloadUri(resolveAssetUri(uri));
+  // An `asset://` locator resolves through the asset's own `get_url`; every
+  // other scheme needs no lookup.
+  const resolved = await resolveMediaUri(uri);
+  if (!resolved) {
+    throw new Error(`Could not resolve ${uri}`);
+  }
+  const resolvedUri = resolveDownloadUri(resolved);
   const external = isExternalUrl(resolvedUri);
 
   const fetchOptions: RequestInit = external

--- a/web/src/utils/downloadPreviewAssets.ts
+++ b/web/src/utils/downloadPreviewAssets.ts
@@ -1,6 +1,6 @@
 import { zipSync } from "fflate";
 import { createAssetFile } from "./createAssetFile";
-import { resolveAssetUri } from "../components/node/output/hooks";
+import { resolveMediaUri } from "./resolveMediaUri";
 
 interface DownloadOptions {
   nodeId: string;
@@ -38,15 +38,19 @@ export const downloadPreviewAssets = async ({
       typeof payload === "object" && payload && "uri" in payload
         ? (payload as { uri?: string }).uri
         : undefined;
-    if (uri) {
-      const resolvedUri = resolveAssetUri(uri);
+    // An `asset://` locator needs the asset's own `get_url` — the anchor
+    // cannot fetch the raw locator.
+    const resolvedUri = uri ? await resolveMediaUri(uri) : "";
+    if (resolvedUri) {
       console.warn(
         "[downloadPreviewAssets] Falling back to direct URI download due to error",
         error
       );
       const anchor = document.createElement("a");
       anchor.href = resolvedUri;
-      anchor.download = resolvedUri.split("/").pop() ?? "preview_download";
+      // A signed URL carries a query string; it is not part of the file name.
+      anchor.download =
+        resolvedUri.split(/[?#]/)[0].split("/").pop() || "preview_download";
       anchor.rel = "noopener";
       document.body.appendChild(anchor);
       anchor.click();

--- a/web/src/utils/imageRef.ts
+++ b/web/src/utils/imageRef.ts
@@ -2,6 +2,7 @@ import { RAW_RGBA_MIME } from "@nodetool-ai/protocol";
 
 export interface ImageRefLike {
   uri?: string;
+  asset_id?: string;
   width?: number;
   height?: number;
   data?: unknown;
@@ -12,6 +13,10 @@ export const asImageRef = (value: unknown): ImageRefLike | undefined => {
   if (!value || typeof value !== "object") return undefined;
   return {
     uri: "uri" in value && typeof value.uri === "string" ? value.uri : undefined,
+    asset_id:
+      "asset_id" in value && typeof value.asset_id === "string"
+        ? value.asset_id
+        : undefined,
     width: "width" in value && typeof value.width === "number" ? value.width : undefined,
     height: "height" in value && typeof value.height === "number" ? value.height : undefined,
     data: "data" in value ? value.data : undefined,

--- a/web/src/utils/imageUtils.ts
+++ b/web/src/utils/imageUtils.ts
@@ -13,16 +13,18 @@ export interface ImageSource {
 }
 
 /**
- * Resolve a URI string to a fetchable URL.
- * - `asset://{id}` → `${BASE_URL}/api/storage/{id}`.
+ * Resolve a URI string to a fetchable URL, without a server round trip.
  * - `package://{pkg}/{path}` → `${BASE_URL}/api/assets/packages/{pkg}/{path}`.
  * - `/api/...` → prefixed with `BASE_URL`.
  * - Other absolute URIs (`data:`, `blob:`, `http:`, `https:`) returned as-is.
+ * - `asset://{id}` → `""`. An asset locator is an identifier, not a path: the
+ *   bytes live under `<user_id>/<asset_id>.<ext>` behind a signed URL, so
+ *   rewriting it to `/api/storage/{id}` 404s on any cloud deploy. Resolve it
+ *   with `useResolvedMediaUri` instead.
  */
 export const resolveUri = (uri: string): string => {
   if (uri.startsWith("asset://")) {
-    const assetId = uri.slice("asset://".length);
-    return `${BASE_URL}/api/storage/${assetId}`;
+    return "";
   }
   const pkgPath = packageAssetHttpPath(uri);
   if (pkgPath) {

--- a/web/src/utils/resolveMediaUri.ts
+++ b/web/src/utils/resolveMediaUri.ts
@@ -1,0 +1,70 @@
+/**
+ * Media locator resolution, outside React.
+ *
+ * `asset://<id>` is an identifier, not a path: the bytes live under
+ * `<user_id>/<asset_id>.<ext>` and, on the cloud backends (S3/Supabase), behind
+ * a signed URL only the server can mint. The one correct resolution is the
+ * asset's own `get_url`, which needs a lookup — hence the async form.
+ *
+ * React components should use `useResolvedMediaUri`, which is built on these.
+ */
+
+import { packageAssetHttpPath } from "@nodetool-ai/protocol";
+
+import { useAssetStore } from "../stores/AssetStore";
+import { BASE_URL } from "../stores/BASE_URL";
+import { fileUriToHttpUrl } from "./localFile";
+import { assetIdFromLocator } from "./mediaRef";
+
+/**
+ * Resolve everything that needs no server round trip. Returns `null` for an
+ * `asset://` locator, which only `get_url` can resolve.
+ */
+export const resolveStaticMediaUri = (
+  uri: string | null | undefined
+): string | null => {
+  if (!uri) {
+    return "";
+  }
+  if (uri.startsWith("asset://")) {
+    return null;
+  }
+  const fileHttpUrl = fileUriToHttpUrl(uri);
+  if (fileHttpUrl !== null) {
+    return fileHttpUrl;
+  }
+  const pkgPath = packageAssetHttpPath(uri);
+  if (pkgPath) {
+    return `${BASE_URL}${pkgPath}`;
+  }
+  if (uri.startsWith("/api/")) {
+    return `${BASE_URL}${uri}`;
+  }
+  return uri;
+};
+
+/**
+ * Resolve any media locator to a fetchable URL, looking the asset up when the
+ * locator is an `asset://` reference. Returns "" when it cannot be resolved.
+ */
+export const resolveMediaUri = async (
+  uri: string | null | undefined
+): Promise<string> => {
+  const staticUrl = resolveStaticMediaUri(uri);
+  if (staticUrl !== null) {
+    return staticUrl;
+  }
+  const assetId = assetIdFromLocator(uri);
+  if (!assetId) {
+    return "";
+  }
+  try {
+    const asset = await useAssetStore.getState().get(assetId);
+    return asset?.get_url ?? "";
+  } catch (error) {
+    // Callers render or download whatever comes back; an unresolvable asset is
+    // an empty URL, reported here rather than as an unhandled rejection.
+    console.error(`[resolveMediaUri] could not resolve ${uri}`, error);
+    return "";
+  }
+};


### PR DESCRIPTION
## The bug

An `asset://<id>` locator is an identifier, not a path. The bytes live under `<user_id>/<asset_id>.<ext>` and, on the cloud backends (S3/Supabase), behind a signed URL only the server can mint.

Roughly 45 call sites across `web/` and `mobile/` handed the raw locator — or a `${BASE_URL}/api/storage/<id>` rewrite of it — straight to a render sink. Both work against a local file backend and 404 (or render blank) on the Supabase production deploy. A handful were worse: the storyboard takes thumbnails and the entity chips passed the `asset://` scheme itself to an `<img>`, which is fetchable nowhere, so those were broken locally too.

## The fix

Four shared changes cover most of the sites:

- **`useResolvedMediaUri` / `useResolvedMediaUris`** (`web/src/hooks/`) and the mobile equivalent (`mobile/src/hooks/`) resolve a locator through the asset record, sharing the react-query cache with `useAsset`. They return `undefined` while the lookup is in flight — deliberately, so a caller renders nothing rather than a URL known to fail.
- **`ImageRefPreview`** resolves before its `ref.uri` branch. One edit fixes the 21 image-editing node bodies (Blur, Curves, Levels, Mask, Resize, Rotate, …), `EntityCard`, and `ImageProperty`. The bitmap and raw-RGBA fast paths stay ahead of it.
- **`resolveUri` / `resolveAssetUri`** (web) and **`apiService.resolveUrl`** (mobile) now return empty/null for `asset://` instead of inventing a flat path, so a missed call site is empty in a test rather than silently broken in production.
- **`resolveMediaUri`** (`web/src/utils/resolveMediaUri.ts`) is the async form for the non-React callers: the sketch `Canvas2DRuntime`, `normalizeSamMasks`, `createAssetFile`, and the direct-download fallback. `Canvas2DRuntime` keeps its synchronous path for data/http sources and only awaits for an asset locator.

Individual fixes: the two storyboard `<img>` sites, `ShotCard`'s clip player, the chat message/output-group/thread/chip renderers, `ThreadMessageList`, `ResizeImageBody` (a hand-rolled copy of the preview ladder, now the shared one), `PainterBody` (it computed the correct `useAsset` URL and then preferred the raw uri over it), the app-builder Puck widgets, and mobile's five surfaces (property fields, `OutputRenderer`, chat renderer, app-runtime widgets, `SketchRenderer`).

`useImageAssets` no longer synthesizes `asset://<id>.<ext>` from an item name to build a `get_url`, so the fullscreen `AssetViewer` opens the same URL the grid thumbnail loaded.

Electron has no copies of these components. Timeline, the asset grid/browser, `useMediaSrc` consumers, and `PropertyDropzone` were already resolving through `get_url`/signed URLs and are untouched.

## Testing

- `web/src/hooks/__tests__/useResolvedMediaUri.test.tsx` — new. The load-bearing case is "returns undefined while the asset lookup is in flight": reverting the hook to the old `/api/storage/<id>` fallback turns exactly that test red, and nothing else.
- Existing tests that asserted the old flat path (`resolveAssetUri`, `createImageUrl`, `apiService.resolveUrl`, `useLayerHydration`, `createAssetFile`, `downloadPreviewAssets`, `ResourceChip`) now pin the new contract instead.
- `normalizeSamMasks` became async; its suite awaits.
- 18 component suites (13 web, 5 mobile) render media without a `QueryClientProvider`/tRPC provider. They use a new manual mock at `web/src/hooks/__mocks__/useResolvedMediaUri.ts`, which delegates to the real static resolver and stubs only the asset lookup, plus the established `jest.mock("…/trpc/client")` pattern on mobile.

All green: `npm run typecheck`, `npm run lint`, web (1111 suites / 12 865 tests), mobile (72 / 979), electron (63 / 674). No files under `packages/` changed, so `test:packages` is unaffected.

## Noted, not fixed

`mobile/src/components/graph_editor/PropertyField.tsx` writes `${host}/api/storage/${asset.id}${ext}` into the graph after an upload (3 sites, plus one at line ~1668). That is the same flat-path assumption on the *write* side, and it was outside the audited scope — changing what gets persisted deserves its own change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMwH8nypZ3nac9FH1zL6ik)_