### PR TITLE
chore(lint): enforce anti-slop/no-widen-then-assert

### DIFF
--- a/.oxlintrc.anti-slop-enforced.json
+++ b/.oxlintrc.anti-slop-enforced.json
@@ -3,7 +3,8 @@
   "plugins": [],
   "categories": {},
   "rules": {
-    "anti-slop/no-reflect-apply": "error"
+    "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-widen-then-assert": "error"
   },
   "jsPlugins": [
     {

--- a/.oxlintrc.anti-slop.json
+++ b/.oxlintrc.anti-slop.json
@@ -15,7 +15,6 @@
     "anti-slop/no-unknown-returns": "error",
     "anti-slop/no-unknown-type-aliases": "error",
     "anti-slop/no-unsafe-dictionary-type": "error",
-    "anti-slop/no-widen-then-assert": "error",
     "anti-slop/require-safety-comment-for-type-assertion": "error"
   },
   "jsPlugins": [


### PR DESCRIPTION
Stack 2/15, on top of #4918.

`no-widen-then-assert` has zero findings, so clearing it is a config move from the backlog config to `.oxlintrc.anti-slop-enforced.json`, which runs inside `npm run lint`. The pattern it blocks — assign a known value to a wider type, then assert it back — now fails the build.

Verified the rule fires rather than matching nothing: a probe with `const widened: unknown = source; const parsed = widened as { readonly id: string }` reports `anti-slop(no-widen-then-assert)`.

Enforced 1 → 2 rules. `npm run lint` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPXapRVTWZDbebtC3xaL8z)_