### PR TITLE
chore(lint): enforce anti-slop/no-unknown-type-aliases

### DIFF
--- a/.oxlintrc.anti-slop-enforced.json
+++ b/.oxlintrc.anti-slop-enforced.json
@@ -4,6 +4,7 @@
   "categories": {},
   "rules": {
     "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-unknown-type-aliases": "error",
     "anti-slop/no-widen-then-assert": "error"
   },
   "jsPlugins": [

--- a/.oxlintrc.anti-slop-enforced.json
+++ b/.oxlintrc.anti-slop-enforced.json
@@ -3,7 +3,8 @@
   "plugins": [],
   "categories": {},
   "rules": {
-    "anti-slop/no-reflect-apply": "error"
+    "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-widen-then-assert": "error"
   },
   "jsPlugins": [
     {

--- a/.oxlintrc.anti-slop-enforced.json
+++ b/.oxlintrc.anti-slop-enforced.json
@@ -4,6 +4,7 @@
   "categories": {},
   "rules": {
     "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-reflect-get": "error",
     "anti-slop/no-unknown-type-aliases": "error",
     "anti-slop/no-widen-then-assert": "error"
   },

--- a/.oxlintrc.anti-slop.json
+++ b/.oxlintrc.anti-slop.json
@@ -13,7 +13,6 @@
     "anti-slop/no-shape-in-symbol-names": "error",
     "anti-slop/no-unknown-parameters": "error",
     "anti-slop/no-unknown-returns": "error",
-    "anti-slop/no-unknown-type-aliases": "error",
     "anti-slop/no-unsafe-dictionary-type": "error",
     "anti-slop/require-safety-comment-for-type-assertion": "error"
   },

--- a/.oxlintrc.anti-slop.json
+++ b/.oxlintrc.anti-slop.json
@@ -8,7 +8,6 @@
     "anti-slop/no-known-value-widening": "error",
     "anti-slop/no-module-mocking": "error",
     "anti-slop/no-object-parameters": "error",
-    "anti-slop/no-reflect-get": "error",
     "anti-slop/no-runtime-typeof": "error",
     "anti-slop/no-shape-in-symbol-names": "error",
     "anti-slop/no-unknown-parameters": "error",

--- a/.oxlintrc.anti-slop.json
+++ b/.oxlintrc.anti-slop.json
@@ -15,7 +15,6 @@
     "anti-slop/no-unknown-returns": "error",
     "anti-slop/no-unknown-type-aliases": "error",
     "anti-slop/no-unsafe-dictionary-type": "error",
-    "anti-slop/no-widen-then-assert": "error",
     "anti-slop/require-safety-comment-for-type-assertion": "error"
   },
   "jsPlugins": [

--- a/web/src/lib/supabaseClient.ts
+++ b/web/src/lib/supabaseClient.ts
@@ -91,6 +91,9 @@ export const initSupabaseFromConfig = (config: RuntimeConfig): void => {
   innerClient = current.client;
 };
 
+// SAFETY: the proxy target is never read — every access is forwarded to
+// `innerClient`, which is a real SupabaseClient — so the empty object only has
+// to satisfy the type, and `prop` can only be a key callers reached through it.
 export const supabase = new Proxy({} as SupabaseClient, {
-  get: (_target, prop) => Reflect.get(innerClient, prop)
+  get: (_target, prop) => innerClient[prop as keyof SupabaseClient]
 });


### PR DESCRIPTION
Stack 3/15, on top of #4919.

`no-unknown-type-aliases` has zero findings, so clearing it is a config move from the backlog config to `.oxlintrc.anti-slop-enforced.json`, which runs inside `npm run lint`. A type alias that hides `unknown` behind a name now fails the build.

Verified the rule fires rather than matching nothing: a probe declaring `type T = unknown` reports `anti-slop(no-unknown-type-aliases)`.

Enforced 2 → 3 rules; that is every rule already at zero. The next PR in the stack (`no-reflect-get`, 1 finding) starts on the ones that need code changes.

`npm run lint` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPXapRVTWZDbebtC3xaL8z)_