### PR TITLE
refactor(web): drop Reflect.get from the Supabase client proxy

### DIFF
--- a/.oxlintrc.anti-slop-enforced.json
+++ b/.oxlintrc.anti-slop-enforced.json
@@ -4,6 +4,7 @@
   "categories": {},
   "rules": {
     "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-reflect-get": "error",
     "anti-slop/no-unknown-type-aliases": "error",
     "anti-slop/no-widen-then-assert": "error"
   },

--- a/.oxlintrc.anti-slop.json
+++ b/.oxlintrc.anti-slop.json
@@ -8,7 +8,6 @@
     "anti-slop/no-known-value-widening": "error",
     "anti-slop/no-module-mocking": "error",
     "anti-slop/no-object-parameters": "error",
-    "anti-slop/no-reflect-get": "error",
     "anti-slop/no-runtime-typeof": "error",
     "anti-slop/no-shape-in-symbol-names": "error",
     "anti-slop/no-unknown-parameters": "error",

--- a/web/src/lib/supabaseClient.ts
+++ b/web/src/lib/supabaseClient.ts
@@ -91,6 +91,9 @@ export const initSupabaseFromConfig = (config: RuntimeConfig): void => {
   innerClient = current.client;
 };
 
+// SAFETY: the proxy target is never read — every access is forwarded to
+// `innerClient`, which is a real SupabaseClient — so the empty object only has
+// to satisfy the type, and `prop` can only be a key callers reached through it.
 export const supabase = new Proxy({} as SupabaseClient, {
-  get: (_target, prop) => Reflect.get(innerClient, prop)
+  get: (_target, prop) => innerClient[prop as keyof SupabaseClient]
 });


### PR DESCRIPTION
Stack 4/15, on top of #4920. First rule in the stack that needed a code change.

`web/src/lib/supabaseClient.ts` exports a `Proxy` so that module-level importers keep a stable reference while the underlying client is rebuilt once `/api/config` lands. The forward went through `Reflect.get(innerClient, prop)`, which returns `any` and drops the `SupabaseClient` contract. It now reads the key directly:

```ts
get: (_target, prop) => innerClient[prop as keyof SupabaseClient]
```

Same semantics — `Reflect.get` with no receiver argument returned the raw property too, so method `this` binding at the call site is unchanged. The assertion carries a `SAFETY:` comment covering both it and the `{} as SupabaseClient` target, since the target is never read.

Clears `no-reflect-get` (1 finding) and promotes it: enforced 3 → 4 rules, backlog 12 → 11.

## Checks

- `npm run lint` passes, now including `no-reflect-get` at `error`.
- `web` typecheck reports 197 errors, all pre-existing: 124 `TS2307` for unbuilt `@nodetool-ai/*` packages plus the implicit-`any` cascade behind them (`npm run build:packages` clears them; CI builds first). None mention `supabaseClient`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPXapRVTWZDbebtC3xaL8z)_