### PR TITLE
refactor: name 422 unknown returns (no-unknown-returns 604 → 182)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ The vendored [anti-slop](https://github.com/dmmulroy/anti-slop) Oxlint plugin
 (`tools/oxlint/anti-slop/`) runs through two configs, and every rule sits in
 exactly one of them:
 
-- `.oxlintrc.anti-slop.json` — the **backlog**, 28,689 findings. Run it with
+- `.oxlintrc.anti-slop.json` — the **backlog**, 27,955 findings. Run it with
   `npm run lint:anti-slop`. Not on the CI path; it would be red for months.
 - `.oxlintrc.anti-slop-enforced.json` — the rules already at **zero**. Run
   inside `npm run lint`, so they cannot come back.
@@ -249,18 +249,24 @@ skips those trees. Remaining backlog, largest first:
 
 | rule | findings |
 |---|---:|
-| `require-safety-comment-for-type-assertion` | 10300 |
-| `no-unsafe-dictionary-type` | 5174 |
-| `no-runtime-typeof` | 4421 |
-| `no-known-value-widening` | 1946 |
-| `no-unknown-parameters` | 1944 |
+| `require-safety-comment-for-type-assertion` | 10266 |
+| `no-unsafe-dictionary-type` | 5132 |
+| `no-runtime-typeof` | 4419 |
+| `no-unknown-parameters` | 1904 |
+| `no-known-value-widening` | 1761 |
 | `no-module-mocking` | 1545 |
 | `no-chained-type-assertions` | 1053 |
 | `no-shape-in-symbol-names` | 921 |
 | `no-conditional-empty-object-spread` | 772 |
-| `no-unknown-returns` | 604 |
-| `no-object-parameters` | 8 |
-| `no-reflect-get` | 1 |
+| `no-unknown-returns` | 182 |
+
+A rule can also stall short of zero. `no-unknown-returns` went 604 → 182; what
+is left is one thing said many ways — a node output, an app-state slot, a
+stream item — for which NodeTool has no named type, plus the `Tool.process`
+contract that erases every tool's result to share one registry. Those sites
+carry a `HOLDOUT (anti-slop/no-unknown-returns)` comment saying so. Naming that
+value domain is a modelling change, not an annotation, and until someone makes
+it the rule stays in the backlog.
 
 See [tools/oxlint/anti-slop/README.md](tools/oxlint/anti-slop/README.md).
 

--- a/electron/src/__tests__/main.lifecycle.test.ts
+++ b/electron/src/__tests__/main.lifecycle.test.ts
@@ -89,7 +89,8 @@ jest.mock("../devMode", () => ({
 }));
 
 describe("main.ts lifecycle wiring", () => {
-  type EventHandler = (...args: unknown[]) => unknown;
+  /** A handler the test drives; its result is never read. */
+  type EventHandler = (...args: unknown[]) => void | Promise<void>;
 
   let appOn: jest.Mock;
   let ipcHandle: jest.Mock;

--- a/electron/src/nodePackManager.ts
+++ b/electron/src/nodePackManager.ts
@@ -483,7 +483,16 @@ async function writeLedger(ledger: NodePackLedger): Promise<void> {
   await fsp.rename(temp, target);
 }
 
-function parseJson(value: string): unknown {
+/** A JSON value decoded from an on-disk manifest, lockfile or ledger. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+function parseJson(value: string): JsonValue | undefined {
   try {
     return JSON.parse(value);
   } catch {

--- a/mobile/src/components/app_runtime/widgets.tsx
+++ b/mobile/src/components/app_runtime/widgets.tsx
@@ -1648,7 +1648,13 @@ const readGrid = (value: unknown): Grid => {
   return { frame: false, columns: [], rows: [] };
 };
 
-const writeGrid = (value: unknown, grid: Grid): unknown => {
+/**
+ * What the DataFrame widget writes back: the `DataframeRef` it read with its
+ * rows replaced, or a plain array of rows.
+ */
+type DataframeValue = { columns?: unknown; data: unknown[][] } | unknown[];
+
+const writeGrid = (value: unknown, grid: Grid): DataframeValue => {
   if (grid.frame && isRow(value)) {return { ...value, data: grid.rows };}
   if (grid.columns.length === 1 && grid.columns[0] === "value") {
     return grid.rows.map((row) => row[0]);
@@ -1659,7 +1665,7 @@ const writeGrid = (value: unknown, grid: Grid): unknown => {
 };
 
 /** A cell keeps its type: a numeric column stays numeric while it parses. */
-const coerceCell = (previous: unknown, text: string): unknown => {
+const coerceCell = (previous: unknown, text: string): string | number => {
   if (typeof previous !== "number") {return text;}
   const parsed = Number(text);
   return text !== "" && !Number.isNaN(parsed) ? parsed : text;

--- a/mobile/src/components/app_runtime/workflowIO.ts
+++ b/mobile/src/components/app_runtime/workflowIO.ts
@@ -9,6 +9,19 @@
 import type { Node, Workflow } from "../../types/workflow";
 import { getWorkflowInputKind, WorkflowInputKind } from "./inputKinds";
 
+/**
+ * A value an input node carries: NodeTool's property types are scalars, media
+ * refs, and lists or dicts of those.
+ */
+export type InputValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | InputValue[]
+  | { [key: string]: InputValue };
+
 export interface WorkflowInputIO {
   nodeId: string;
   nodeType: string;
@@ -20,7 +33,7 @@ export interface WorkflowInputIO {
   max?: number;
   multiline?: boolean;
   options?: string[];
-  defaultValue?: unknown;
+  defaultValue?: InputValue;
 }
 
 export interface WorkflowOutputIO {
@@ -96,7 +109,9 @@ export const extractWorkflowIO = (workflow?: Workflow | null): WorkflowIO => {
         options: Array.isArray(data.options)
           ? (data.options as string[])
           : undefined,
-        defaultValue: data.value,
+        // SAFETY: `value` is the input node's stored property value, which
+        // NodeTool restricts to its own property types.
+        defaultValue: data.value as InputValue,
       });
       continue;
     }
@@ -130,7 +145,7 @@ export const extractVariableNames = (workflow?: Workflow | null): string[] => {
  * fallback the control displays. Seeding only fills empty slots, so a form the
  * user never touched runs with exactly what it shows.
  */
-export const seedInputValue = (input: WorkflowInputIO): unknown => {
+export const seedInputValue = (input: WorkflowInputIO): InputValue => {
   if (input.defaultValue !== undefined && input.defaultValue !== null) {
     return input.defaultValue;
   }

--- a/mobile/src/documents/tools/__tests__/scriptTools.test.ts
+++ b/mobile/src/documents/tools/__tests__/scriptTools.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { MobileToolRegistry } from '../registry';
+import type { MobileToolResult } from '../registry';
 import '../scriptTools';
 import {
   registerDocumentHandler,
@@ -75,7 +76,10 @@ const makeHandler = (): MockHandler => ({
   save: jest.fn(async () => ({ ok: true, updatedAt: '2026-07-26T00:00:00Z' })),
 });
 
-const call = (name: string, args: Record<string, unknown>): Promise<unknown> =>
+const call = (
+  name: string,
+  args: Record<string, unknown>
+): Promise<MobileToolResult> =>
   MobileToolRegistry.call(name, args, `${name}-call`);
 
 describe('script tools', () => {

--- a/mobile/src/documents/tools/__tests__/storyboardTools.test.ts
+++ b/mobile/src/documents/tools/__tests__/storyboardTools.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { MobileToolRegistry } from '../registry';
+import type { MobileToolResult } from '../registry';
 import '../storyboardTools';
 import {
   registerDocumentHandler,
@@ -56,7 +57,10 @@ const makeHandler = (): MockHandler => ({
   save: jest.fn(async () => ({ ok: true, updatedAt: '2026-07-26T00:00:00Z' })),
 });
 
-const call = (name: string, args: Record<string, unknown>): Promise<unknown> =>
+const call = (
+  name: string,
+  args: Record<string, unknown>
+): Promise<MobileToolResult> =>
   MobileToolRegistry.call(name, args, `${name}-call`);
 
 describe('storyboard tools', () => {

--- a/mobile/src/documents/tools/registry.ts
+++ b/mobile/src/documents/tools/registry.ts
@@ -27,11 +27,23 @@ export interface MobileToolContext {
   abortSignal: AbortSignal;
 }
 
+/**
+ * What a `ui_*` tool answers with: a primitive or an object, which
+ * `executeToolCall` sends back to the agent as the tool result payload.
+ */
+export type MobileToolResult =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | object;
+
 export interface MobileToolDefinition<Args = Record<string, unknown>> {
   name: `ui_${string}`;
   description: string;
   parameters: ToolParameterSchema;
-  execute: (args: Args, ctx: MobileToolContext) => Promise<unknown>;
+  execute: (args: Args, ctx: MobileToolContext) => Promise<MobileToolResult>;
 }
 
 /** One manifest entry, exactly as the server's `clientToolsManifest` reads it. */
@@ -71,7 +83,7 @@ export const MobileToolRegistry = {
     name: string,
     args: unknown,
     toolCallId: string
-  ): Promise<unknown> {
+  ): Promise<MobileToolResult> {
     const tool = registry.get(name);
     if (!tool) {
       throw new Error(`Unknown tool: ${name}`);

--- a/mobile/src/screens/ChatScreen.test.tsx
+++ b/mobile/src/screens/ChatScreen.test.tsx
@@ -69,7 +69,7 @@ const useChatStoreMock = useChatStore as unknown as jest.Mock;
 /** Point the mocked store hook at a state object, selector-aware. */
 const mockStoreState = (state: MockChatStore): void => {
   useChatStoreMock.mockImplementation(
-    (selector?: (chatState: MockChatStore) => unknown) =>
+    <T,>(selector?: (chatState: MockChatStore) => T) =>
       selector ? selector(state) : state
   );
 };

--- a/mobile/src/screens/__tests__/DocumentViewerScreen.test.tsx
+++ b/mobile/src/screens/__tests__/DocumentViewerScreen.test.tsx
@@ -23,7 +23,10 @@ interface MockState {
 let mockState: MockState;
 
 jest.mock('../../documents/documentStore', () => ({
-  documentStore: () => (selector: (state: MockState) => unknown) => selector(mockState),
+  documentStore:
+    () =>
+    <T,>(selector: (state: MockState) => T) =>
+      selector(mockState),
 }));
 
 jest.mock('react-native-safe-area-context', () => ({

--- a/mobile/src/screens/__tests__/SketchViewerScreen.test.tsx
+++ b/mobile/src/screens/__tests__/SketchViewerScreen.test.tsx
@@ -30,7 +30,8 @@ let mockState: MockState;
 
 jest.mock('../../documents/documentStore', () => ({
   documentStore: () => {
-    const useStore = (selector: (state: MockState) => unknown) => selector(mockState);
+    const useStore = <T,>(selector: (state: MockState) => T) =>
+      selector(mockState);
     useStore.getState = () => mockState;
     return useStore;
   },

--- a/packages/agents/src/app-build/bridge.ts
+++ b/packages/agents/src/app-build/bridge.ts
@@ -227,11 +227,11 @@ function mapTree(
   return result;
 }
 
-function tool(
+function tool<TResult>(
   name: string,
   description: string,
   parameters: z.ZodTypeAny,
-  impl: (args: Record<string, unknown>) => Promise<unknown>
+  impl: (args: Record<string, unknown>) => Promise<TResult>
 ): HeadlessTool {
   return {
     name,

--- a/packages/agents/src/capabilities/google.ts
+++ b/packages/agents/src/capabilities/google.ts
@@ -115,10 +115,10 @@ export {
  * `{ error }` result rather than a thrown exception, so the agent can recover
  * (re-authenticate, pick another file) instead of aborting the step.
  */
-async function googleCall(
+async function googleCall<TResult>(
   run: CapabilityRun,
-  call: (token: string) => Promise<unknown>
-): Promise<unknown> {
+  call: (token: string) => Promise<TResult>
+): Promise<TResult | { error: string }> {
   try {
     const token = await requireGoogleAccessToken(run.context);
     return await call(token);

--- a/packages/agents/src/capabilities/scripts.ts
+++ b/packages/agents/src/capabilities/scripts.ts
@@ -276,7 +276,7 @@ function lineStatus(
   line: ScriptLine,
   voice: ScriptVoiceBinding | null,
   helpers: {
-    currentTake: (line: ScriptLine) => unknown;
+    currentTake: (line: ScriptLine) => ScriptTake | undefined;
     needsVoicing: (line: ScriptLine, voice: ScriptVoiceBinding) => boolean;
   }
 ): "draft" | "stale" | "voiced" | "no_voice" {

--- a/packages/agents/src/codeact/tool-api.ts
+++ b/packages/agents/src/codeact/tool-api.ts
@@ -22,6 +22,7 @@ import {
   extractInjectableImages,
   stripImagePayload
 } from "../tools/image-injection.js";
+import type { JsonValue } from "../utils/json-parser.js";
 import { GRAPH_MODEL_GLOBALS } from "./graph-model.js";
 import { NODETOOL_API_GLOBALS } from "./nodetool-api.js";
 import { TOOLS_PRELUDE } from "./tools-prelude.js";
@@ -64,7 +65,7 @@ export interface ToolBridge {
 }
 
 /** Force a value through JSON so it marshals cleanly across the WASM boundary. */
-export function toTransferable(value: unknown): unknown {
+export function toTransferable(value: unknown): JsonValue {
   if (value === null || value === undefined) return null;
   if (
     typeof value === "string" ||

--- a/packages/agents/src/evals/codeact-api-core.ts
+++ b/packages/agents/src/evals/codeact-api-core.ts
@@ -526,11 +526,11 @@ const EXAMPLE_WORKFLOWS: readonly WorldWorkflow[] = [
 export function createCoreApiTools(recorder: CodeActToolRecorder): Tool[] {
   const world = new CoreWorld();
 
-  const tool = (
+  const tool = <TResult,>(
     name: string,
     description: string,
     properties: Record<string, unknown>,
-    impl: (params: Record<string, unknown>) => unknown
+    impl: (params: Record<string, unknown>) => TResult
   ): Tool =>
     new RecordingTool(
       name,

--- a/packages/agents/src/evals/codeact-api-surfaces.ts
+++ b/packages/agents/src/evals/codeact-api-surfaces.ts
@@ -900,11 +900,11 @@ function resolveShots(doc: StoryboardDoc, targets: unknown): Shot[] {
  */
 export function createSurfaceApiTools(recorder: CodeActToolRecorder): Tool[] {
   const world = createWorld();
-  const tool = (
+  const tool = <TResult,>(
     name: string,
     description: string,
     schema: Record<string, unknown>,
-    impl: (params: Record<string, unknown>) => unknown
+    impl: (params: Record<string, unknown>) => TResult
   ): Tool => new RecordingTool(name, description, schema, recorder, impl);
 
   return [

--- a/packages/agents/src/evals/codeact-cases.ts
+++ b/packages/agents/src/evals/codeact-cases.ts
@@ -16,13 +16,13 @@ export function createCodeActRecorder(): CodeActToolRecorder {
   return { invocations: [] };
 }
 
-export class RecordingTool extends Tool {
+export class RecordingTool<TResult> extends Tool {
   constructor(
     readonly name: string,
     readonly description: string,
     protected override readonly jsonSchema: Record<string, unknown>,
     private readonly recorder: CodeActToolRecorder,
-    private readonly impl: (params: Record<string, unknown>) => unknown
+    private readonly impl: (params: Record<string, unknown>) => TResult
   ) {
     super();
   }
@@ -30,7 +30,7 @@ export class RecordingTool extends Tool {
   async process(
     _context: ProcessingContext,
     params: Record<string, unknown>
-  ): Promise<unknown> {
+  ): Promise<TResult> {
     this.recorder.invocations.push({ name: this.name, args: params });
     return this.impl(params);
   }

--- a/packages/agents/src/evals/escalation.ts
+++ b/packages/agents/src/evals/escalation.ts
@@ -103,6 +103,12 @@ function matches(reply: EscalationReply, text: string): boolean {
   return reply.when.every((needle) => lower.includes(needle.toLowerCase()));
 }
 
+/** What the scripted user answers with, as the model sees it. */
+export interface EscalationAnswer {
+  ok: true;
+  answer: string;
+}
+
 /**
  * Build the `ask_user` tool for a case, plus the transcript of what was asked.
  * Fresh per run — the returned channel owns its own turn log.
@@ -115,7 +121,7 @@ export function createEscalationChannel(
     name: config.toolName ?? DEFAULT_ESCALATION_TOOL_NAME,
     description: config.description ?? DEFAULT_DESCRIPTION,
     parameters: escalationParameters,
-    execute: async (args: Record<string, unknown>): Promise<unknown> => {
+    execute: async (args: Record<string, unknown>): Promise<EscalationAnswer> => {
       const text = matchText(args);
       const hit = config.replies.find((reply) => matches(reply, text));
       const reply = hit?.reply ?? config.fallback ?? DEFAULT_FALLBACK;

--- a/packages/agents/src/evals/planner-tools.ts
+++ b/packages/agents/src/evals/planner-tools.ts
@@ -33,7 +33,7 @@ class DeclarativeTool extends Tool {
   async process(
     _context: ProcessingContext,
     _params: Record<string, unknown>
-  ): Promise<unknown> {
+  ): Promise<never> {
     throw new Error(
       `${this.name} is a planning-eval placeholder and must never be executed`
     );

--- a/packages/agents/src/evals/subtask-cases.ts
+++ b/packages/agents/src/evals/subtask-cases.ts
@@ -41,10 +41,10 @@ export function createToolRecorder(): ToolRecorder {
   return { invocations: [], store: new Map() };
 }
 
-type ToolHandler = (
+type ToolHandler<TResult> = (
   args: Record<string, unknown>,
   ctx: { store: Map<string, string>; depth: number }
-) => unknown;
+) => TResult;
 
 /**
  * A real {@link Tool} that records each call (with its subtask depth) into a
@@ -52,19 +52,19 @@ type ToolHandler = (
  * toolset and the inherited child toolset, so the depth read from `context`
  * tells us which agent made the call.
  */
-class InstrumentedTool extends Tool {
+class InstrumentedTool<TResult> extends Tool {
   readonly name: string;
   readonly description: string;
   readonly jsonSchema: JsonSchema;
   private readonly recorder: ToolRecorder;
-  private readonly handler: ToolHandler;
+  private readonly handler: ToolHandler<TResult>;
 
   constructor(
     name: string,
     description: string,
     schema: JsonSchema,
     recorder: ToolRecorder,
-    handler: ToolHandler
+    handler: ToolHandler<TResult>
   ) {
     super();
     this.name = name;
@@ -77,9 +77,9 @@ class InstrumentedTool extends Tool {
   async process(
     context: ProcessingContext,
     params: Record<string, unknown>
-  ): Promise<unknown> {
+  ): Promise<TResult | { error: string }> {
     const depth = context.get<number>(SUBTASK_DEPTH_KEY) ?? 0;
-    let result: unknown;
+    let result: TResult | { error: string };
     let isError = false;
     try {
       result = this.handler(params, { store: this.recorder.store, depth });

--- a/packages/agents/src/evals/surfaces/creative-pipeline.ts
+++ b/packages/agents/src/evals/surfaces/creative-pipeline.ts
@@ -136,11 +136,11 @@ export interface CreativePipelineFinalState {
   editsAfterAssembly: number;
 }
 
-function tool(
+function tool<TResult>(
   name: string,
   description: string,
   parameters: z.ZodTypeAny,
-  impl: (args: Record<string, unknown>) => Promise<unknown>
+  impl: (args: Record<string, unknown>) => Promise<TResult>
 ): HeadlessTool {
   return {
     name,

--- a/packages/agents/src/evals/surfaces/js-script.ts
+++ b/packages/agents/src/evals/surfaces/js-script.ts
@@ -80,11 +80,11 @@ export interface JsScriptToolBridge
   name: () => string;
 }
 
-function tool(
+function tool<TResult>(
   name: string,
   description: string,
   parameters: z.ZodTypeAny,
-  impl: (args: Record<string, unknown>) => Promise<unknown>
+  impl: (args: Record<string, unknown>) => Promise<TResult>
 ): HeadlessTool {
   return {
     name,

--- a/packages/agents/src/evals/surfaces/model3d.ts
+++ b/packages/agents/src/evals/surfaces/model3d.ts
@@ -106,11 +106,11 @@ function defaultKindLabel(kind: Model3DPrimitiveKind): string {
   return labels[kind];
 }
 
-function tool(
+function tool<TResult>(
   name: string,
   description: string,
   parameters: z.ZodTypeAny,
-  impl: (args: Record<string, unknown>) => Promise<unknown>
+  impl: (args: Record<string, unknown>) => Promise<TResult>
 ): HeadlessTool {
   return {
     name,

--- a/packages/agents/src/evals/surfaces/script.ts
+++ b/packages/agents/src/evals/surfaces/script.ts
@@ -111,11 +111,11 @@ export interface ScriptBridgeFinalState {
 const MIN_TAKE_DURATION_MS = 500;
 const MS_PER_WORD = 350;
 
-function tool(
+function tool<TResult>(
   name: string,
   description: string,
   parameters: z.ZodTypeAny,
-  impl: (args: Record<string, unknown>) => Promise<unknown>
+  impl: (args: Record<string, unknown>) => Promise<TResult>
 ): HeadlessTool {
   return {
     name,

--- a/packages/agents/src/evals/surfaces/sketch.ts
+++ b/packages/agents/src/evals/surfaces/sketch.ts
@@ -285,11 +285,11 @@ interface Layer {
 /** Serializable view handed back to the model — the bitmap never crosses. */
 type LayerView = Omit<Layer, "raster">;
 
-function tool(
+function tool<TResult>(
   name: string,
   description: string,
   parameters: z.ZodTypeAny,
-  impl: (args: Record<string, unknown>) => Promise<unknown>
+  impl: (args: Record<string, unknown>) => Promise<TResult>
 ): HeadlessTool {
   return {
     name,

--- a/packages/agents/src/evals/surfaces/storyboard.ts
+++ b/packages/agents/src/evals/surfaces/storyboard.ts
@@ -166,11 +166,11 @@ export interface StoryboardBridgeFinalState {
   saveIssues: string[];
 }
 
-function tool(
+function tool<TResult>(
   name: string,
   description: string,
   parameters: z.ZodTypeAny,
-  impl: (args: Record<string, unknown>) => Promise<unknown>
+  impl: (args: Record<string, unknown>) => Promise<TResult>
 ): HeadlessTool {
   return {
     name,

--- a/packages/agents/src/evals/surfaces/timeline.ts
+++ b/packages/agents/src/evals/surfaces/timeline.ts
@@ -146,11 +146,11 @@ export interface TimelineBridgeFinalState {
   documentClips: TimelineClip[];
 }
 
-function tool(
+function tool<TResult>(
   name: string,
   description: string,
   parameters: z.ZodTypeAny,
-  impl: (args: Record<string, unknown>) => Promise<unknown>
+  impl: (args: Record<string, unknown>) => Promise<TResult>
 ): HeadlessTool {
   return {
     name,

--- a/packages/agents/src/host-modules/docx.ts
+++ b/packages/agents/src/host-modules/docx.ts
@@ -8,7 +8,7 @@
  * and this module turns that into real docx bytes.
  */
 
-import { toGuestBytes } from "../sandbox-bytes.js";
+import { toGuestBytes, type GuestBytes } from "../sandbox-bytes.js";
 import { optionsOf, requireBytes, unwrapLibrary } from "./limits.js";
 
 type Alignment = "LEFT" | "CENTER" | "RIGHT" | "JUSTIFY";
@@ -56,16 +56,28 @@ interface DocxSpec {
   elements?: unknown[];
 }
 
+declare const docxComponentBrand: unique symbol;
+
+/**
+ * A node in `docx`'s document tree. The library builds these from option bags
+ * and reads them back itself when it packs the file; this module only holds
+ * them and passes them along, so they are opaque by contract rather than by
+ * omission — a value that did not come from `docx` cannot be substituted.
+ */
+interface DocxComponent {
+  readonly [docxComponentBrand]?: never;
+}
+
 interface DocxLike {
-  Document: new (options: unknown) => unknown;
-  Packer: { toBuffer: (doc: unknown) => Promise<Buffer | Uint8Array> };
-  Paragraph: new (options: unknown) => unknown;
-  TextRun: new (options: unknown) => unknown;
-  ImageRun: new (options: unknown) => unknown;
-  Table: new (options: unknown) => unknown;
-  TableRow: new (options: unknown) => unknown;
-  TableCell: new (options: unknown) => unknown;
-  PageBreak: new () => unknown;
+  Document: new (options: unknown) => DocxComponent;
+  Packer: { toBuffer: (doc: DocxComponent) => Promise<Buffer | Uint8Array> };
+  Paragraph: new (options: unknown) => DocxComponent;
+  TextRun: new (options: unknown) => DocxComponent;
+  ImageRun: new (options: unknown) => DocxComponent;
+  Table: new (options: unknown) => DocxComponent;
+  TableRow: new (options: unknown) => DocxComponent;
+  TableCell: new (options: unknown) => DocxComponent;
+  PageBreak: new () => DocxComponent;
   AlignmentType: Record<Alignment, unknown>;
   HeadingLevel: Record<string, unknown>;
   WidthType: Record<string, unknown>;
@@ -105,7 +117,7 @@ function isElement(value: unknown): value is DocxElement {
  * entries — the same shape a Code node accumulates while composing a document
  * before writing it out.
  */
-export async function build(spec: unknown): Promise<unknown> {
+export async function build(spec: unknown): Promise<GuestBytes> {
   const where = "docx.build";
   const input = optionsOf(spec) as DocxSpec;
   const elements = Array.isArray(input.elements) ? input.elements : [];

--- a/packages/agents/src/host-modules/epub.ts
+++ b/packages/agents/src/host-modules/epub.ts
@@ -10,6 +10,41 @@ import os from "node:os";
 import path from "node:path";
 import { optionsOf, requireBytes, unwrapLibrary } from "./limits.js";
 
+/**
+ * An EPUB's OPF metadata, mirroring the fields epub2 parses out of the package
+ * document. A book may declare further keys; they ride along as strings.
+ */
+export interface EpubMetadata {
+  title?: string;
+  creator?: string;
+  creatorFileAs?: string;
+  publisher?: string;
+  language?: string;
+  subject?: string[];
+  description?: string;
+  date?: string;
+  ISBN?: string;
+  UUID?: string;
+  cover?: string;
+  readonly [key: string]: string | string[] | undefined;
+}
+
+/** One table-of-contents entry, as `tableOfContents` reports it. */
+export interface EpubTocItem {
+  id: string | undefined;
+  title: string | undefined;
+  href: string | undefined;
+  order: number | undefined;
+}
+
+/** One chapter's text, as `extractChapters` reports it. */
+export interface EpubChapter {
+  id: string;
+  title: string;
+  href: string;
+  text: string;
+}
+
 interface EpubTocEntry {
   id?: string;
   title?: string;
@@ -21,7 +56,7 @@ interface EpubFlowItem {
   href?: string;
 }
 interface EpubInstance {
-  metadata: Record<string, unknown>;
+  metadata: EpubMetadata;
   toc: EpubTocEntry[];
   flow: EpubFlowItem[];
   getChapterAsync: (id: string) => Promise<string>;
@@ -79,12 +114,12 @@ async function withEpub<T>(
 }
 
 /** An EPUB's metadata: title, creator, language, publisher, and the rest. */
-export async function metadata(bytes: unknown): Promise<unknown> {
+export async function metadata(bytes: unknown): Promise<EpubMetadata> {
   return withEpub("epub.metadata", bytes, async (epub) => ({ ...epub.metadata }));
 }
 
 /** The table of contents, in reading order. */
-export async function tableOfContents(bytes: unknown): Promise<unknown> {
+export async function tableOfContents(bytes: unknown): Promise<EpubTocItem[]> {
   return withEpub("epub.tableOfContents", bytes, async (epub) =>
     (epub.toc ?? []).map((entry) => ({
       id: entry.id,
@@ -96,7 +131,7 @@ export async function tableOfContents(bytes: unknown): Promise<unknown> {
 }
 
 /** All chapters concatenated to plain text, joined by `options.chapterSeparator`. */
-export async function extractText(bytes: unknown, options?: unknown): Promise<unknown> {
+export async function extractText(bytes: unknown, options?: unknown): Promise<string> {
   const opts = optionsOf(options);
   const separator =
     typeof opts.chapterSeparator === "string" ? opts.chapterSeparator : "\n\n";
@@ -113,7 +148,7 @@ export async function extractText(bytes: unknown, options?: unknown): Promise<un
 }
 
 /** Each chapter as its own item, with the title the table of contents gives it. */
-export async function extractChapters(bytes: unknown): Promise<unknown> {
+export async function extractChapters(bytes: unknown): Promise<EpubChapter[]> {
   return withEpub("epub.extractChapters", bytes, async (epub) => {
     const titleById = new Map<string, string>();
     for (const entry of epub.toc ?? []) {
@@ -121,7 +156,7 @@ export async function extractChapters(bytes: unknown): Promise<unknown> {
         titleById.set(entry.id, entry.title);
       }
     }
-    const chapters: Array<Record<string, unknown>> = [];
+    const chapters: EpubChapter[] = [];
     for (const item of epub.flow ?? []) {
       if (!item.id) continue;
       const html = await epub.getChapterAsync(item.id);

--- a/packages/agents/src/host-modules/expr.ts
+++ b/packages/agents/src/host-modules/expr.ts
@@ -7,8 +7,21 @@
 
 import { optionsOf, requireText, unwrapLibrary } from "./limits.js";
 
+/**
+ * What a formula evaluates to. expr-eval computes over numbers, strings and
+ * booleans, and passes through whatever a variable holds — and every variable
+ * came across the sandbox boundary, so it is plain data.
+ */
+export type ExprValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ExprValue[]
+  | { [key: string]: ExprValue };
+
 interface ParserLike {
-  evaluate: (formula: string, vars?: Record<string, unknown>) => unknown;
+  evaluate: (formula: string, vars?: Record<string, unknown>) => ExprValue;
 }
 
 interface ExprEvalLike {
@@ -28,7 +41,7 @@ async function loadExpr(where: string): Promise<ExprEvalLike> {
 export async function evaluate(
   formula: unknown,
   vars?: unknown
-): Promise<unknown> {
+): Promise<ExprValue> {
   const where = "expr.evaluate";
   const { Parser } = await loadExpr(where);
   return new Parser().evaluate(requireText(where, formula, "formula"), optionsOf(vars));

--- a/packages/agents/src/host-modules/fabric.ts
+++ b/packages/agents/src/host-modules/fabric.ts
@@ -8,7 +8,7 @@
 
 import { importOptionalModule } from "@nodetool-ai/config";
 
-import { toGuestBytes } from "../sandbox-bytes.js";
+import { toGuestBytes, type GuestBytes } from "../sandbox-bytes.js";
 import {
   importOptionalLibrary,
   optionsOf,
@@ -31,7 +31,7 @@ interface FabricStaticCanvas {
   width?: number;
   height?: number;
   backgroundColor?: unknown;
-  loadFromJSON: (json: unknown) => Promise<unknown>;
+  loadFromJSON: (json: unknown) => Promise<FabricStaticCanvas>;
   renderAll: () => void;
   toDataURL: (options?: {
     format?: string;
@@ -125,7 +125,7 @@ function normalizeDimension(
 export async function render(
   spec: unknown,
   options?: unknown
-): Promise<unknown> {
+): Promise<GuestBytes> {
   const where = "fabric.render";
   const scene = parseSceneSpec(where, spec);
   const opts = optionsOf(options);
@@ -286,10 +286,16 @@ export async function toDataURL(
   }
 }
 
+/** Fabric's own parse of an SVG document: its objects and canvas options. */
+export interface FabricSvgScene {
+  objects: unknown[];
+  options: unknown;
+}
+
 /**
  * Parse an SVG string into Fabric objects and canvas options.
  */
-export async function loadSVG(svg: unknown): Promise<unknown> {
+export async function loadSVG(svg: unknown): Promise<FabricSvgScene> {
   const where = "fabric.loadSVG";
   const svgText = requireText(where, svg, "svg");
   const fabricLib = await loadFabric(where);

--- a/packages/agents/src/host-modules/mammoth.ts
+++ b/packages/agents/src/host-modules/mammoth.ts
@@ -27,7 +27,7 @@ async function loadMammoth(where: string): Promise<MammothLike> {
 }
 
 /** A Word document's text, with formatting discarded. */
-export async function extractRawText(bytes: unknown): Promise<unknown> {
+export async function extractRawText(bytes: unknown): Promise<string> {
   const where = "mammoth.extractRawText";
   const buffer = Buffer.from(requireBytes(where, bytes));
   const mammoth = await loadMammoth(where);
@@ -36,7 +36,7 @@ export async function extractRawText(bytes: unknown): Promise<unknown> {
 }
 
 /** A Word document rendered as HTML — headings, lists, tables, and images kept. */
-export async function convertToHtml(bytes: unknown): Promise<unknown> {
+export async function convertToHtml(bytes: unknown): Promise<string> {
   const where = "mammoth.convertToHtml";
   const buffer = Buffer.from(requireBytes(where, bytes));
   const mammoth = await loadMammoth(where);

--- a/packages/agents/src/host-modules/pdf.ts
+++ b/packages/agents/src/host-modules/pdf.ts
@@ -60,13 +60,20 @@ async function readPages(where: string, bytes: unknown): Promise<PageTextResult[
 }
 
 /** A PDF's text, all pages concatenated. */
-export async function extractText(bytes: unknown): Promise<unknown> {
+export async function extractText(bytes: unknown): Promise<string> {
   const pages = await readPages("pdf.extractText", bytes);
   return pages.map((page) => page.text.trim()).join("\n\n");
 }
 
+/** One page of a PDF, as `extractPages` reports it. */
+export interface PdfPage {
+  index: number;
+  pageNumber: number;
+  text: string;
+}
+
 /** Each page's text as its own item, in page order. */
-export async function extractPages(bytes: unknown): Promise<unknown> {
+export async function extractPages(bytes: unknown): Promise<PdfPage[]> {
   const pages = await readPages("pdf.extractPages", bytes);
   return pages.map((page, index) => ({
     index,

--- a/packages/agents/src/host-modules/pdflib.ts
+++ b/packages/agents/src/host-modules/pdflib.ts
@@ -6,11 +6,19 @@
  * turns that into PDF bytes.
  */
 
-import { toGuestBytes } from "../sandbox-bytes.js";
+import { toGuestBytes, type GuestBytes } from "../sandbox-bytes.js";
 import { optionsOf, requireBytes, unwrapLibrary } from "./limits.js";
 
 const MAX_PAGE = 8192;
 const MAX_PAGES = 200;
+
+/** pdf-lib's RGB color value, handed straight back into draw options. */
+interface PdfRgb {
+  readonly type: "RGB";
+  readonly red: number;
+  readonly green: number;
+  readonly blue: number;
+}
 
 interface PdfLibLike {
   PDFDocument: {
@@ -18,7 +26,7 @@ interface PdfLibLike {
     load: (data: Uint8Array) => Promise<PdfDoc>;
   };
   StandardFonts: { Helvetica: unknown };
-  rgb: (r: number, g: number, b: number) => unknown;
+  rgb: (r: number, g: number, b: number) => PdfRgb;
 }
 
 interface PdfDoc {
@@ -146,7 +154,7 @@ async function drawItems(
 /**
  * Build a PDF from a JSON page list. Origin for items is top-left, in points.
  */
-export async function build(spec: unknown): Promise<unknown> {
+export async function build(spec: unknown): Promise<GuestBytes> {
   const where = "pdflib.build";
   const input = optionsOf(spec);
   const pages = Array.isArray(input.pages) ? input.pages : [];
@@ -179,7 +187,7 @@ export async function build(spec: unknown): Promise<unknown> {
 /**
  * Concatenate PDF byte arrays in order.
  */
-export async function merge(pdfs: unknown): Promise<unknown> {
+export async function merge(pdfs: unknown): Promise<GuestBytes> {
   const where = "pdflib.merge";
   if (!Array.isArray(pdfs) || pdfs.length === 0) {
     throw new Error(`${where}: provide a non-empty array of PDF byte arrays`);

--- a/packages/agents/src/host-modules/pptx.ts
+++ b/packages/agents/src/host-modules/pptx.ts
@@ -28,7 +28,7 @@ async function loadExtractor(where: string): Promise<TextExtractor> {
 }
 
 /** A PowerPoint file's text, all slides concatenated. */
-export async function extractText(bytes: unknown): Promise<unknown> {
+export async function extractText(bytes: unknown): Promise<string> {
   const where = "pptx.extractText";
   const buffer = Buffer.from(requireBytes(where, bytes));
   const extractor = await loadExtractor(where);
@@ -53,8 +53,15 @@ function decodeSlideText(xml: string): string {
   return parts.join("\n").trim();
 }
 
+/** One slide of a presentation, as `extractSlides` reports it. */
+export interface PptxSlide {
+  index: number;
+  slideNumber: number;
+  text: string;
+}
+
 /** Each slide's text as its own item, in slide order. */
-export async function extractSlides(bytes: unknown): Promise<unknown> {
+export async function extractSlides(bytes: unknown): Promise<PptxSlide[]> {
   const where = "pptx.extractSlides";
   const archive = requireBytes(where, bytes);
   const { unzipSync, strFromU8 } = await import("fflate");
@@ -67,7 +74,7 @@ export async function extractSlides(bytes: unknown): Promise<unknown> {
       return na - nb;
     });
 
-  const slides: Array<Record<string, unknown>> = [];
+  const slides: PptxSlide[] = [];
   for (let i = 0; i < slidePaths.length; i++) {
     const raw = entries[slidePaths[i]];
     if (!raw) continue;

--- a/packages/agents/src/host-modules/pptxgen.ts
+++ b/packages/agents/src/host-modules/pptxgen.ts
@@ -6,7 +6,7 @@
  * into PPTX bytes.
  */
 
-import { toGuestBytes } from "../sandbox-bytes.js";
+import { toGuestBytes, type GuestBytes } from "../sandbox-bytes.js";
 import { optionsOf, requireBytes, unwrapLibrary } from "./limits.js";
 
 const MAX_SLIDES = 200;
@@ -50,7 +50,7 @@ function toDataUrl(bytes: Uint8Array): string {
 /**
  * Build a PPTX from a JSON slide list. Positions are inches from the top-left.
  */
-export async function build(spec: unknown): Promise<unknown> {
+export async function build(spec: unknown): Promise<GuestBytes> {
   const where = "pptxgen.build";
   const input = optionsOf(spec);
   const slides = Array.isArray(input.slides) ? input.slides : [];

--- a/packages/agents/src/host-modules/xlsx.ts
+++ b/packages/agents/src/host-modules/xlsx.ts
@@ -50,7 +50,7 @@ interface ExcelWorksheetLike {
 }
 interface ExcelWorkbookLike {
   xlsx: {
-    load: (buffer: ArrayBuffer) => Promise<unknown>;
+    load: (buffer: ArrayBuffer) => Promise<ExcelWorkbookLike>;
     writeBuffer: () => Promise<ArrayBuffer | Uint8Array>;
   };
   eachSheet: (cb: (sheet: ExcelWorksheetLike, id: number) => void) => void;
@@ -74,7 +74,10 @@ async function loadExcelJs(where: string): Promise<ExcelJsLike> {
  * Excel workbook bytes to records per sheet; pass `sheet` to get one sheet's
  * rows directly. Formula cells yield their computed result.
  */
-export async function parse(bytes: unknown, options?: unknown): Promise<unknown> {
+export async function parse(
+  bytes: unknown,
+  options?: unknown
+): Promise<unknown[] | Record<string, unknown[]>> {
   const where = "xlsx.parse";
   const workbookBytes = requireBytes(where, bytes);
   const opts = optionsOf(options);

--- a/packages/agents/src/host-modules/xml.ts
+++ b/packages/agents/src/host-modules/xml.ts
@@ -7,8 +7,15 @@
 
 import { optionsOf, requireText, unwrapLibrary } from "./limits.js";
 
+/**
+ * A parsed XML document. Elements become objects, repeated elements become
+ * arrays, and every leaf is a string — the parser is constructed below with
+ * `parseTagValue`/`parseAttributeValue` off, so nothing is coerced to a number.
+ */
+export type XmlValue = string | XmlValue[] | { [key: string]: XmlValue };
+
 interface FxpLike {
-  XMLParser: new (opts?: Record<string, unknown>) => { parse: (xml: string) => unknown };
+  XMLParser: new (opts?: Record<string, unknown>) => { parse: (xml: string) => XmlValue };
   XMLValidator: { validate: (xml: string) => true | { err: { msg: string } } };
 }
 
@@ -29,7 +36,7 @@ async function loadFastXmlParser(where: string): Promise<FxpLike> {
  * keys, and text values stay text — a numeric-looking id must not change shape.
  * Invalid XML throws with the parser's own reason.
  */
-export async function parse(text: unknown, options?: unknown): Promise<unknown> {
+export async function parse(text: unknown, options?: unknown): Promise<XmlValue> {
   const where = "xml.parse";
   const source = requireText(where, text);
   const opts = optionsOf(options);

--- a/packages/agents/src/js-sandbox-worker/interpreter.ts
+++ b/packages/agents/src/js-sandbox-worker/interpreter.ts
@@ -51,7 +51,11 @@ import {
   CANVAS_METHODS,
   CANVAS_PROPERTIES
 } from "../sandbox-canvas-api.js";
-import { BASE64_ALPHABET, SANDBOX_BYTES_MARKER } from "../sandbox-bytes.js";
+import {
+  BASE64_ALPHABET,
+  SANDBOX_BYTES_MARKER,
+  type GuestBytes
+} from "../sandbox-bytes.js";
 import { MEDIA_REF_MEMBERS } from "../sandbox-media-ref.js";
 import type { ResolvedSandboxLimits } from "../js-sandbox.js";
 
@@ -794,8 +798,8 @@ export async function runInterpreter(
       const hostCrypto = bridges.crypto as {
         randomUUID: () => string;
         getRandomValues: (n: number) => Record<string, string>;
-        digest: (...a: never[]) => Promise<unknown>;
-        hmac: (...a: never[]) => Promise<unknown>;
+        digest: (...a: never[]) => Promise<GuestBytes>;
+        hmac: (...a: never[]) => Promise<GuestBytes>;
       };
       bridges.crypto = {
         // randomUUID/getRandomValues are synchronous and never throw, so they

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -76,7 +76,8 @@ import {
 import {
   SANDBOX_SERIALIZE_MAX_DEPTH,
   toGuestBytes,
-  toGuestBytesDeep
+  toGuestBytesDeep,
+  type GuestBytes
 } from "./sandbox-bytes.js";
 import {
   createSandboxMediaStore,
@@ -113,6 +114,7 @@ const quickJsVariant = (
   }
 ).default;
 import { importNodeBuiltin } from "@nodetool-ai/config";
+import type { AssetRef } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 
 // ---------------------------------------------------------------------------
@@ -1282,10 +1284,7 @@ export function buildSandbox(
       if (size > 0) globalThis.crypto.getRandomValues(bytes);
       return toGuestBytes(bytes);
     },
-    digest: async (
-      algorithm: string,
-      data: unknown
-    ): Promise<Record<string, string>> => {
+    digest: async (algorithm: string, data: unknown): Promise<GuestBytes> => {
       const algo = normalizeDigestAlgorithm(algorithm);
       const bytes = coerceBytesInput(data, "data");
       const digest = await webCryptoSubtle().digest(algo, bytes);
@@ -1295,7 +1294,7 @@ export function buildSandbox(
       algorithm: string,
       key: unknown,
       data: unknown
-    ): Promise<Record<string, string>> => {
+    ): Promise<GuestBytes> => {
       const algo = normalizeDigestAlgorithm(algorithm);
       const keyBytes = coerceBytesInput(key, "key");
       const dataBytes = coerceBytesInput(data, "data");
@@ -1563,10 +1562,10 @@ export function buildSandbox(
       };
 
   const sandboxToAsset = context
-    ? async (path: string): Promise<unknown> => {
+    ? async (path: string): Promise<AssetRef> => {
         return context.sandboxToAsset(path);
       }
-    : async (_path: string): Promise<unknown> => {
+    : async (_path: string): Promise<AssetRef> => {
         throw new Error("sandboxToAsset is not available without a context");
       };
 
@@ -2044,7 +2043,7 @@ export function buildSandbox(
      * ProcessingContext, so a Code node that really does parse an encoded image
      * works exactly as it did.
      */
-    bytes: async (value: unknown): Promise<unknown> => {
+    bytes: async (value: unknown): Promise<GuestBytes> => {
       const resolved = await resolveMediaArgs(
         "image.bytes",
         value,
@@ -2157,7 +2156,7 @@ export function buildSandbox(
 
   const avBytes =
     (namespace: "audio" | "video") =>
-    async (value: unknown): Promise<unknown> => {
+    async (value: unknown): Promise<GuestBytes> => {
       const where = `${namespace}.bytes`;
       const resolved = await resolveMediaArgs(where, value, true, 0, namespace);
       return toGuestBytes(requireMediaBytes(where, resolved));

--- a/packages/agents/src/sandbox-bytes.ts
+++ b/packages/agents/src/sandbox-bytes.ts
@@ -37,8 +37,27 @@ export function encodeBase64(bytes: Uint8Array): string {
   return out;
 }
 
+/** Base64 bytes tagged for the guest prelude to revive as a `Uint8Array`. */
+export type GuestBytes = { readonly [SANDBOX_BYTES_MARKER]: string };
+
+/**
+ * What a host bridge hands the guest: JSON-shaped data, with byte payloads
+ * carried as {@link GuestBytes} markers. Every host module export and every
+ * bridge return value satisfies this contract — a function, a class instance,
+ * or a live handle cannot cross the boundary.
+ */
+export type GuestValue =
+  | null
+  | undefined
+  | boolean
+  | number
+  | string
+  | GuestBytes
+  | readonly GuestValue[]
+  | { readonly [key: string]: GuestValue };
+
 /** Tag bytes for the guest prelude to turn back into a real `Uint8Array`. */
-export function toGuestBytes(bytes: Uint8Array): Record<string, string> {
+export function toGuestBytes(bytes: Uint8Array): GuestBytes {
   return { [SANDBOX_BYTES_MARKER]: encodeBase64(bytes) };
 }
 

--- a/packages/agents/src/sandbox-media-ref.ts
+++ b/packages/agents/src/sandbox-media-ref.ts
@@ -17,7 +17,7 @@ import { importNodeBuiltin } from "@nodetool-ai/config";
 import { loadMediaRefBytes, type MediaRefValue } from "@nodetool-ai/runtime";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 
-import { toGuestBytes } from "./sandbox-bytes.js";
+import { toGuestBytes, type GuestBytes } from "./sandbox-bytes.js";
 
 /**
  * Largest payload `media.*` moves in either direction.
@@ -55,7 +55,7 @@ export interface MediaRefInfo {
 
 /** The host side of the guest's `media` namespace. */
 export interface MediaRefBridge {
-  bytes(ref: unknown): Promise<unknown>;
+  bytes(ref: unknown): Promise<GuestBytes>;
   text(ref: unknown, options?: unknown): Promise<string>;
   info(ref: unknown): Promise<MediaRefInfo>;
   toDocument(
@@ -514,7 +514,7 @@ export function createMediaRefBridge(
   }
 
   return {
-    bytes: async (ref: unknown): Promise<unknown> => {
+    bytes: async (ref: unknown): Promise<GuestBytes> => {
       const where = "media.bytes";
       return toGuestBytes(
         await resolveRefBytes(

--- a/packages/agents/src/sandbox-media.ts
+++ b/packages/agents/src/sandbox-media.ts
@@ -115,6 +115,17 @@ export interface MediaBackend {
   ): Promise<Uint8Array>;
 }
 
+declare const canvasImageDataBrand: unique symbol;
+
+/**
+ * A canvas `ImageData`. The backend constructs it and `putImageData` consumes
+ * it; nothing on this side reads its fields, so it is opaque by contract
+ * rather than by omission.
+ */
+interface CanvasImageData {
+  readonly [canvasImageDataBrand]?: never;
+}
+
 interface NapiCanvasModule {
   createCanvas: (
     w: number,
@@ -132,7 +143,7 @@ interface NapiCanvasModule {
     data: Uint8ClampedArray,
     width: number,
     height: number
-  ) => unknown;
+  ) => CanvasImageData;
 }
 
 function napiQuality(format: ImageFormat, quality: number): number | undefined {

--- a/packages/agents/src/supervisor/tools.ts
+++ b/packages/agents/src/supervisor/tools.ts
@@ -19,6 +19,7 @@ import type { Escalation } from "@nodetool-ai/protocol";
 import {
   MAX_ESCALATION_VALUE_CHARS,
   redactRecord,
+  type RunStateDigest,
   type RunStateReader
 } from "@nodetool-ai/kernel";
 import { Tool } from "../tools/base-tool.js";
@@ -52,10 +53,19 @@ export class GetRunStateTool extends Tool {
     return z.object({});
   }
 
-  async process(): Promise<unknown> {
+  async process(): Promise<RunStateDigest> {
     return this._reader.digest();
   }
 }
+
+/** What {@link ReadNodeOutputTool} answers: the branch's output, or why not. */
+export type NodeOutputReadResult =
+  | { error: "not_available"; message: string }
+  | {
+      nodeId: string;
+      lineage: readonly string[];
+      outputs: ReturnType<typeof redactRecord>;
+    };
 
 export class ReadNodeOutputTool extends Tool {
   readonly name = "read_node_output";
@@ -89,7 +99,7 @@ export class ReadNodeOutputTool extends Tool {
   async process(
     _context: ProcessingContext,
     params: Record<string, unknown>
-  ): Promise<unknown> {
+  ): Promise<NodeOutputReadResult> {
     const nodeId = String(params["node_id"] ?? "");
     const read = this._reader.readOutput(
       nodeId,

--- a/packages/agents/src/tools/control-tool.ts
+++ b/packages/agents/src/tools/control-tool.ts
@@ -125,7 +125,7 @@ export class ControlNodeTool extends Tool {
   async process(
     _context: ProcessingContext,
     params: Record<string, unknown>
-  ): Promise<unknown> {
+  ): Promise<string> {
     const event = this.createControlEvent(params);
     const nodeTitle = this.nodeInfo.node_title || this.targetNodeId;
     return `Created ${event.event_type} event for ${nodeTitle} with properties: ${Object.keys(params).join(", ")}`;

--- a/packages/agents/src/tools/create-task-tool.ts
+++ b/packages/agents/src/tools/create-task-tool.ts
@@ -32,6 +32,11 @@ const CREATE_TASK_INPUT_SCHEMA = {
   required: ["title", "steps"]
 };
 
+/** What {@link CreateTaskPlanTool} answers: the plan it stored, or why not. */
+export type CreateTaskResult =
+  | { status: "validation_failed"; errors: string[] }
+  | { status: "task_created"; title: string; steps: number };
+
 export class CreateTaskPlanTool extends Tool {
   readonly name = "create_task";
   readonly description =
@@ -57,7 +62,7 @@ export class CreateTaskPlanTool extends Tool {
   async process(
     _context: ProcessingContext,
     params: Record<string, unknown>
-  ): Promise<unknown> {
+  ): Promise<CreateTaskResult> {
     const task = this.buildTask(params);
     const errors = this.validateTask(task);
 

--- a/packages/agents/src/tools/plan-builder-tools.ts
+++ b/packages/agents/src/tools/plan-builder-tools.ts
@@ -368,6 +368,17 @@ const ADD_TASK_INPUT_SCHEMA = {
   required: ["id", "title", "depends_on", "steps"]
 };
 
+/** What {@link AddTaskTool} answers: the task it appended, or why not. */
+export type AddTaskResult =
+  | { status: "validation_failed"; errors: string[] }
+  | {
+      status: "task_added";
+      id: string;
+      title: string;
+      steps: number;
+      tasksSoFar: number;
+    };
+
 export class AddTaskTool extends Tool {
   readonly name = "add_task";
   readonly description =
@@ -383,7 +394,7 @@ export class AddTaskTool extends Tool {
   async process(
     _context: ProcessingContext,
     params: Record<string, unknown>
-  ): Promise<unknown> {
+  ): Promise<AddTaskResult> {
     const result = this.builder.addTask(params);
     if (!result.ok) {
       return { status: "validation_failed", errors: result.errors };
@@ -411,6 +422,16 @@ const REMOVE_TASK_INPUT_SCHEMA = {
   required: ["id"]
 };
 
+/** What {@link RemoveTaskTool} answers: the task it dropped, or why not. */
+export type RemoveTaskResult =
+  | { status: "error"; error: string | undefined }
+  | {
+      status: "task_removed";
+      id: string;
+      tasksSoFar: number;
+      warning?: string;
+    };
+
 export class RemoveTaskTool extends Tool {
   readonly name = "remove_task";
   readonly description =
@@ -425,7 +446,7 @@ export class RemoveTaskTool extends Tool {
   async process(
     _context: ProcessingContext,
     params: Record<string, unknown>
-  ): Promise<unknown> {
+  ): Promise<RemoveTaskResult> {
     const id = typeof params["id"] === "string" ? params["id"] : "";
     const result = this.builder.removeTask(id);
     if (!result.ok) {
@@ -453,6 +474,16 @@ const FINISH_PLAN_INPUT_SCHEMA = {
   required: ["title"]
 };
 
+/** What {@link FinishPlanTool} answers: the committed plan, or why not. */
+export type FinishPlanResult =
+  | { status: "validation_failed"; errors: string[] }
+  | {
+      status: "plan_finished";
+      title: string;
+      tasks: number;
+      totalSteps: number;
+    };
+
 export class FinishPlanTool extends Tool {
   readonly name = "finish_plan";
   readonly description =
@@ -468,7 +499,7 @@ export class FinishPlanTool extends Tool {
   async process(
     _context: ProcessingContext,
     params: Record<string, unknown>
-  ): Promise<unknown> {
+  ): Promise<FinishPlanResult> {
     const title =
       typeof params["title"] === "string" ? params["title"] : "Untitled Plan";
     const result = this.builder.finish(title);

--- a/packages/agents/src/tools/serp-providers/apify-provider.ts
+++ b/packages/agents/src/tools/serp-providers/apify-provider.ts
@@ -133,7 +133,7 @@ export class ApifyProvider implements SerpProvider {
   async searchRaw(
     query: string,
     options?: SearchOptions
-  ): Promise<unknown> {
+  ): Promise<SearchResult[] | { error: string }> {
     const numResults = options?.numResults ?? 10;
     return apifyRequest(this.apiKey, query, numResults);
   }

--- a/packages/agents/src/tools/serp-providers/brave-provider.ts
+++ b/packages/agents/src/tools/serp-providers/brave-provider.ts
@@ -89,7 +89,7 @@ export class BraveProvider implements SerpProvider {
   async searchRaw(
     query: string,
     options?: SearchOptions
-  ): Promise<unknown> {
+  ): Promise<BraveResponse | { error: string }> {
     const numResults = options?.numResults ?? 10;
     return braveRequest(this.apiKey, query, numResults);
   }

--- a/packages/agents/src/tools/serp-providers/dataforseo-provider.ts
+++ b/packages/agents/src/tools/serp-providers/dataforseo-provider.ts
@@ -122,7 +122,10 @@ export class DataForSeoProvider implements SerpProvider {
       }));
   }
 
-  async searchRaw(query: string, options?: SearchOptions): Promise<unknown> {
+  async searchRaw(
+    query: string,
+    options?: SearchOptions
+  ): Promise<DataForSEOResponse | { error: string; details?: unknown }> {
     const numResults = options?.numResults ?? 10;
 
     const payload = [

--- a/packages/agents/src/tools/submit-code-tool.ts
+++ b/packages/agents/src/tools/submit-code-tool.ts
@@ -185,6 +185,16 @@ function checkSeededPorts(
   return errors;
 }
 
+/** What {@link SubmitCodeTool} answers: the accepted submission, or why not. */
+export type SubmitCodeResult =
+  | { status: "code_rejected"; errors: string[] }
+  | {
+      status: "code_accepted";
+      title: string;
+      inputs: string[];
+      outputs: string[];
+    };
+
 export class SubmitCodeTool extends Tool {
   readonly name = "submit_code";
   readonly description =
@@ -212,7 +222,7 @@ export class SubmitCodeTool extends Tool {
   async process(
     _context: ProcessingContext,
     params: Record<string, unknown>
-  ): Promise<unknown> {
+  ): Promise<SubmitCodeResult> {
     this.rounds++;
     this.lastCode =
       typeof params["code"] === "string" ? (params["code"] as string) : null;

--- a/packages/agents/src/utils/json-parser.ts
+++ b/packages/agents/src/utils/json-parser.ts
@@ -12,7 +12,19 @@
  *
  * Returns null if no valid JSON can be extracted.
  */
-export function extractJSON(text: string): unknown | null {
+/**
+ * A value `JSON.parse` can produce — the only shapes that survive a JSON round
+ * trip, and therefore the only ones that cross a text or WASM boundary.
+ */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export function extractJSON(text: string): JsonValue | null {
   // Stryker disable next-line MethodExpression: JSON.parse already tolerates
   // surrounding whitespace and strategy 3 scans via indexOf, so dropping trim()
   // changes no observable result.

--- a/packages/app-runtime/src/conditions.ts
+++ b/packages/app-runtime/src/conditions.ts
@@ -116,7 +116,13 @@ export const parseCondition = (
   return { ref, op, value: props.value };
 };
 
-/** Read the current value a {@link StateRef} points at. */
+/**
+ * Read the current value a {@link StateRef} points at.
+ *
+ * HOLDOUT (anti-slop/no-unknown-returns): a variable, input or output slot
+ * holds a workflow value — the open domain `AppInstanceState` stores as
+ * `unknown` — so the read answers in that domain too.
+ */
 export const readRef = (
   state: AppInstanceState,
   ref: StateRef
@@ -167,7 +173,7 @@ const isEmpty = (value: unknown): boolean => {
  * stores every literal as a string, so `count gt "3"` must compare numbers and
  * `dark eq "true"` must compare booleans.
  */
-const coerceLike = (value: unknown, sample: unknown): unknown => {
+const coerceLike = <T>(value: T, sample: unknown): T | number | boolean => {
   if (typeof sample === "number" && typeof value === "string") {
     const parsed = Number(value);
     return Number.isNaN(parsed) ? value : parsed;

--- a/packages/app-runtime/src/documents.ts
+++ b/packages/app-runtime/src/documents.ts
@@ -33,7 +33,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
 /** A bound output holds one value or an accumulated list of streamed items. */
-const lastItem = (value: unknown): unknown =>
+const lastItem = <TItem>(value: TItem | TItem[]): TItem | undefined =>
   Array.isArray(value) ? value[value.length - 1] : value;
 
 const refId = (value: unknown): string | null => {
@@ -47,6 +47,10 @@ const refId = (value: unknown): string | null => {
  * Walk the envelopes a document can arrive in. Depth is bounded because these
  * values come off the wire, where a self-referential object is possible.
  */
+// HOLDOUT (anti-slop/no-unknown-returns): the walk ends on whatever envelope
+// key held the document, and what a bound output carries is the open
+// workflow-value domain — NodeTool has no named union for it. `isDoc` is the
+// caller's own check on the result.
 const unwrap = (
   value: unknown,
   keys: ReadonlyArray<string>,

--- a/packages/app-runtime/src/state.ts
+++ b/packages/app-runtime/src/state.ts
@@ -153,6 +153,8 @@ const asString = (value: unknown): string =>
  * streamed string must render as one Markdown block, not N), while structured
  * items collect into a list — one entry per emitted item.
  */
+// HOLDOUT (anti-slop/no-unknown-returns): app state holds workflow values —
+// whatever a node emitted — and this fold answers in the same open domain.
 export const appendValue = (previous: unknown, next: unknown): unknown => {
   if (typeof next === "string") return asString(previous) + next;
   if (previous === undefined) return next;

--- a/packages/atlascloud-nodes/src/atlascloud-factory.ts
+++ b/packages/atlascloud-nodes/src/atlascloud-factory.ts
@@ -459,7 +459,7 @@ export async function resolveAssetForAtlas(
  * Callers must filter out null/undefined before invoking — the factory does
  * this in its field loop, so there's no defensive guard here.
  */
-function coerceScalar(v: unknown, type: AtlasFieldType): unknown {
+function coerceScalar(v: NodeValue, type: AtlasFieldType): NodeValue {
   switch (type) {
     case "int": {
       if (typeof v === "number") return Math.trunc(v);
@@ -481,7 +481,38 @@ function coerceScalar(v: unknown, type: AtlasFieldType): unknown {
   }
 }
 
-function defaultForType(type: AtlasFieldType): unknown {
+/**
+ * A value held by a node property or by a prompt-asset override: NodeTool's
+ * property types are scalars, media refs, and lists or dicts of those.
+ */
+type NodeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Uint8Array
+  | NodeValue[]
+  | { [key: string]: NodeValue };
+
+/**
+ * The empty media ref a media property starts at before the user picks an
+ * asset. `duration` and `format` are carried by video only.
+ */
+type EmptyMediaRef = {
+  type: "image" | "video" | "audio";
+  uri: string;
+  asset_id: null;
+  data: null;
+  metadata: null;
+  duration?: null;
+  format?: null;
+};
+
+/** What a property starts at when the manifest names no default. */
+type FieldDefault = boolean | number | string | never[] | EmptyMediaRef;
+
+function defaultForType(type: AtlasFieldType): FieldDefault {
   switch (type) {
     case "bool":
       return false;
@@ -584,10 +615,12 @@ export function createAtlasNodeClass(spec: AtlasManifestEntry): NodeClass {
         specRef,
         context
       );
-      const readValue = (name: string): unknown =>
-        name in overrides
+      // SAFETY: both sources hold node property values, and NodeTool restricts
+      // those to its own property types — the shapes `NodeValue` names.
+      const readValue = (name: string): NodeValue =>
+        (name in overrides
           ? overrides[name]
-          : (this as unknown as Record<string, unknown>)[name];
+          : (this as unknown as Record<string, unknown>)[name]) as NodeValue;
 
       for (const f of specRef.fields) {
         const v = readValue(f.name);

--- a/packages/audio-nodes/src/nodes/audio.ts
+++ b/packages/audio-nodes/src/nodes/audio.ts
@@ -125,16 +125,7 @@ function hasProviderSupport(
   context: ProcessingContext | undefined,
   providerId: string,
   modelId: string
-): context is ProcessingContext & {
-  runProviderPrediction: (req: Record<string, unknown>) => Promise<unknown>;
-  streamProviderPrediction: (
-    req: Record<string, unknown>
-  ) => AsyncGenerator<unknown>;
-  providerSupportsStreamingTTS: (providerId: string) => Promise<boolean>;
-  textToSpeechEncoded: (
-    req: Record<string, unknown>
-  ) => Promise<{ data: Uint8Array; mimeType: string } | null>;
-} {
+): context is ProcessingContext {
   return (
     !!context &&
     typeof context.runProviderPrediction === "function" &&

--- a/packages/automation-nodes/src/lib/browser-agent-tools.ts
+++ b/packages/automation-nodes/src/lib/browser-agent-tools.ts
@@ -26,9 +26,61 @@ import {
   browserUploadAsset as localUploadAsset
 } from "./browser-tools-local.js";
 import type {
+  BrowserCaptureMediaOutput,
   BrowserCaptureMediaRaw,
-  BrowserUploadAssetRaw
+  BrowserClickOutput,
+  BrowserConsoleExecOutput,
+  BrowserConsoleViewOutput,
+  BrowserInputTextOutput,
+  BrowserMoveMouseOutput,
+  BrowserNavigateOutput,
+  BrowserPressKeyOutput,
+  BrowserRestartOutput,
+  BrowserScrollOutput,
+  BrowserSelectOptionOutput,
+  BrowserUploadAssetOutput,
+  BrowserUploadAssetRaw,
+  BrowserViewOutput
 } from "./browser-schemas.js";
+
+/** What one browser action resolves to, before media is persisted. */
+type BrowserActionOutput =
+  | BrowserViewOutput
+  | BrowserNavigateOutput
+  | BrowserRestartOutput
+  | BrowserClickOutput
+  | BrowserInputTextOutput
+  | BrowserMoveMouseOutput
+  | BrowserPressKeyOutput
+  | BrowserSelectOptionOutput
+  | BrowserScrollOutput
+  | BrowserConsoleExecOutput
+  | BrowserConsoleViewOutput
+  | BrowserCaptureMediaRaw
+  | BrowserUploadAssetOutput;
+
+/** The persisted screenshot ref that replaces `screenshot_png_b64`. */
+type BrowserScreenshotRef = {
+  type: "image";
+  asset_id?: string;
+  asset_uri?: string;
+  uri?: string;
+  path?: string;
+  mime_type: string;
+  bytes: number;
+};
+
+/** A `browser_view` result with its base64 screenshot swapped for a ref. */
+type BrowserViewResult = Omit<BrowserViewOutput, "screenshot_png_b64"> & {
+  screenshot: BrowserScreenshotRef | null;
+};
+
+/** What a `browser_*` tool hands back to the agent. */
+type BrowserToolResult =
+  | BrowserActionOutput
+  | BrowserViewResult
+  | BrowserCaptureMediaOutput
+  | { error: string };
 
 const ELEMENT_REF_PROPS = {
   index: {
@@ -48,9 +100,7 @@ export interface BrowserActionSpec {
   /** JSON schema for the tool's input. */
   inputSchema: Record<string, unknown>;
   /** Local-process invocation. */
-  local: (
-    params: Record<string, unknown>
-  ) => Promise<unknown>;
+  local: (params: Record<string, unknown>) => Promise<BrowserActionOutput>;
 }
 
 export const BROWSER_ACTION_SPECS: readonly BrowserActionSpec[] = [
@@ -265,14 +315,12 @@ type ToolCtor = new () => Tool;
  */
 async function persistViewScreenshot(
   ctx: ProcessingContext,
-  result: unknown,
+  result: BrowserViewOutput,
   namePrefix: string
-): Promise<unknown> {
-  if (!result || typeof result !== "object") return result;
-  const view = result as Record<string, unknown>;
-  const b64 = view.screenshot_png_b64;
+): Promise<BrowserViewResult> {
+  const b64 = result.screenshot_png_b64;
   if (typeof b64 !== "string" || b64.length === 0) {
-    const { screenshot_png_b64: _drop, ...rest } = view;
+    const { screenshot_png_b64: _drop, ...rest } = result;
     return { ...rest, screenshot: null };
   }
   const bytes = new Uint8Array(Buffer.from(b64, "base64"));
@@ -289,7 +337,7 @@ async function persistViewScreenshot(
     mime_type: saved.mime_type,
     bytes: saved.bytes
   };
-  const { screenshot_png_b64: _drop, ...rest } = view;
+  const { screenshot_png_b64: _drop, ...rest } = result;
   return { ...rest, screenshot };
 }
 
@@ -302,11 +350,10 @@ async function persistViewScreenshot(
  */
 async function persistCaptureMedia(
   ctx: ProcessingContext,
-  result: unknown,
+  result: BrowserCaptureMediaRaw,
   namePrefix: string
-): Promise<unknown> {
-  if (!result || typeof result !== "object") return result;
-  const raw = result as Partial<BrowserCaptureMediaRaw>;
+): Promise<BrowserCaptureMediaRaw | BrowserCaptureMediaOutput> {
+  const raw = result;
   if (typeof raw.media_b64 !== "string" || raw.media_b64.length === 0) {
     // An error object (or already-transformed) — pass through unchanged.
     return result;
@@ -417,7 +464,7 @@ function makeLocalToolClass(spec: BrowserActionSpec): ToolCtor {
     async process(
       ctx: ProcessingContext,
       params: Record<string, unknown>
-    ): Promise<unknown> {
+    ): Promise<BrowserToolResult> {
       try {
         const callParams =
           spec.key === "upload_asset"
@@ -428,10 +475,22 @@ function makeLocalToolClass(spec: BrowserActionSpec): ToolCtor {
             : (params ?? {});
         const out = await spec.local(callParams);
         if (spec.key === "view") {
-          return await persistViewScreenshot(ctx, out, "browser-screenshot");
+          // SAFETY: the `view` spec's `local` is `browserView`, which resolves
+          // to a BrowserViewOutput.
+          return await persistViewScreenshot(
+            ctx,
+            out as BrowserViewOutput,
+            "browser-screenshot"
+          );
         }
         if (spec.key === "capture_media") {
-          return await persistCaptureMedia(ctx, out, "browser-capture");
+          // SAFETY: the `capture_media` spec's `local` is `browserCaptureMedia`,
+          // which resolves to a BrowserCaptureMediaRaw.
+          return await persistCaptureMedia(
+            ctx,
+            out as BrowserCaptureMediaRaw,
+            "browser-capture"
+          );
         }
         return out;
       } catch (e) {

--- a/packages/automation-nodes/src/lib/extension-cdp-client.ts
+++ b/packages/automation-nodes/src/lib/extension-cdp-client.ts
@@ -220,7 +220,9 @@ export class ExtensionCdpClient {
         if (typeof prop !== "string") return undefined;
         const member = prop;
         // One synthetic member services both shapes; the runtime arg decides.
-        const fn = (arg?: unknown): unknown => {
+        const fn = (
+          arg?: unknown
+        ): Promise<Record<string, unknown>> | (() => void) => {
           if (typeof arg === "function") {
             return this.subscribe(
               `${domain}.${member}`,

--- a/packages/chat/src/message-processor.ts
+++ b/packages/chat/src/message-processor.ts
@@ -96,9 +96,20 @@ function isToolCall(item: ProviderStreamItem): item is ToolCall {
  * Serializer that handles objects with a `toJSON` method or falls back to
  * stringification, similar to the Python `default_serializer`.
  */
-export function defaultSerializer(_key: string, value: unknown): unknown {
+/** A value `JSON.stringify` can emit directly. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export function defaultSerializer<T>(_key: string, value: T): T | JsonValue {
   if (value !== null && typeof value === "object" && "toJSON" in value) {
-    return (value as { toJSON: () => unknown }).toJSON();
+    // SAFETY: `toJSON` is the JSON.stringify protocol hook — it exists on the
+    // value and, by that contract, produces a JSON-representable result.
+    return (value as { toJSON: () => JsonValue }).toJSON();
   }
   return value;
 }

--- a/packages/cli/src/chat-codeact.ts
+++ b/packages/cli/src/chat-codeact.ts
@@ -45,6 +45,9 @@ class ExecuteCodeTool extends Tool {
     this.jsonSchema = session.providerTool.inputSchema as JsonSchema;
   }
 
+  // HOLDOUT (anti-slop/no-unknown-returns): a CodeAct action answers with
+  // whatever its body returned, and the base `Tool.process` contract in
+  // `@nodetool-ai/agents` declares `Promise<unknown>`.
   async process(
     _context: ProcessingContext,
     params: Record<string, unknown>

--- a/packages/cli/src/commands/js-script-versions.ts
+++ b/packages/cli/src/commands/js-script-versions.ts
@@ -25,6 +25,16 @@ import { asJson, confirm, printTable } from "./output.js";
 import { numericOptionParser } from "../numeric-options.js";
 import { renderJsScriptValidation } from "./js-script-validation-output.js";
 
+/** A decoded JSON document, before anything validates its shape. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+
 /** A `js_scripts` row as these commands need it. */
 export interface JsScriptRow {
   id: string;
@@ -114,10 +124,12 @@ export function versionTableRows(
 }
 
 /** Parse a stored document without throwing — an unreadable one is a finding. */
-export function parseVersionDocument(raw: unknown): unknown {
-  if (typeof raw !== "string") return raw;
+export function parseVersionDocument(raw: unknown): JsonValue {
+  // SAFETY: a Postgres json column arrives already decoded; either way the
+  // stored document is JSON.
+  if (typeof raw !== "string") return raw as JsonValue;
   try {
-    return JSON.parse(raw) as unknown;
+    return JSON.parse(raw) as JsonValue;
   } catch {
     return raw;
   }

--- a/packages/cli/src/commands/sketch-versions.ts
+++ b/packages/cli/src/commands/sketch-versions.ts
@@ -26,6 +26,16 @@ import { asJson, confirm, printTable } from "./output.js";
 import { numericOptionParser } from "../numeric-options.js";
 import { renderSketchValidation } from "./sketch-validation-output.js";
 
+/** A decoded JSON document, before anything validates its shape. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+
 /** An `image_documents` row as these commands need it. */
 export interface ImageDocumentRow {
   id: string;
@@ -132,10 +142,12 @@ export function versionTableRows(
 }
 
 /** Parse a stored document without throwing — an unreadable one is a finding. */
-export function parseVersionDocument(raw: unknown): unknown {
-  if (typeof raw !== "string") return raw;
+export function parseVersionDocument(raw: unknown): JsonValue {
+  // SAFETY: a Postgres json column arrives already decoded; either way the
+  // stored document is JSON.
+  if (typeof raw !== "string") return raw as JsonValue;
   try {
-    return JSON.parse(raw) as unknown;
+    return JSON.parse(raw) as JsonValue;
   } catch {
     return raw;
   }

--- a/packages/cli/src/commands/timeline-versions.ts
+++ b/packages/cli/src/commands/timeline-versions.ts
@@ -27,6 +27,16 @@ import { asJson, confirm, printTable } from "./output.js";
 import { numericOptionParser } from "../numeric-options.js";
 import { renderTimelineValidation } from "./timeline.js";
 
+/** A decoded JSON document, before anything validates its shape. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+
 /** A `timeline_sequences` row as these commands need it. */
 export interface TimelineSequenceRow {
   id: string;
@@ -139,10 +149,12 @@ export function versionTableRows(
 }
 
 /** Parse a stored document without throwing — an unreadable one is a finding. */
-export function parseVersionDocument(raw: unknown): unknown {
-  if (typeof raw !== "string") return raw;
+export function parseVersionDocument(raw: unknown): JsonValue {
+  // SAFETY: a Postgres json column arrives already decoded; either way the
+  // stored document is JSON.
+  if (typeof raw !== "string") return raw as JsonValue;
   try {
-    return JSON.parse(raw);
+    return JSON.parse(raw) as JsonValue;
   } catch {
     return raw;
   }

--- a/packages/cli/src/diagnose.ts
+++ b/packages/cli/src/diagnose.ts
@@ -34,13 +34,21 @@ export interface DiagnoseJob {
  * harness `TraceSpan`, but only the fields the diagnoser reads are required so
  * callers can pass either parsed JSONL lines or richer span objects.
  */
+/** An OpenTelemetry attribute value, as the trace JSONL carries it. */
+export type SpanAttributeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | Array<string | number | boolean | null>;
+
 export interface TraceSpanLite {
   name: string;
   span_id?: string;
   parent_span_id?: string | null;
   start_time_ms?: number;
   end_time_ms?: number;
-  attributes?: Record<string, unknown>;
+  attributes?: Record<string, SpanAttributeValue>;
   status?: { code?: string; message?: string };
 }
 
@@ -315,7 +323,10 @@ function scanMessages(
 // Last LLM span at/before the failure
 // ---------------------------------------------------------------------------
 
-function spanAttr(span: TraceSpanLite, key: string): unknown {
+function spanAttr(
+  span: TraceSpanLite,
+  key: string
+): SpanAttributeValue | undefined {
   return span.attributes ? span.attributes[key] : undefined;
 }
 

--- a/packages/cli/src/js-script-debug/harness.ts
+++ b/packages/cli/src/js-script-debug/harness.ts
@@ -21,6 +21,7 @@ import type {
   JsScriptInteractionRecord,
   JsScriptValidation
 } from "@nodetool-ai/execution/js-script-debug";
+import type { JsScriptBridgeFinalState } from "@nodetool-ai/agents";
 import type { JsScriptDocument } from "@nodetool-ai/protocol/api-schemas/js-scripts.js";
 import type { JsScriptInteractionStep } from "./interactions.js";
 import {
@@ -83,13 +84,18 @@ export type JsScriptExecutor = (
 /** The bridge surface this host drives — one tool per `ui_jsscript_*` name. */
 export interface JsScriptBridgeTool {
   name: string;
+  /**
+   * HOLDOUT (anti-slop/no-unknown-returns): a `ui_jsscript_*` tool answers in
+   * the open tool-result domain, and the bridge that implements this lives in
+   * `@nodetool-ai/agents`.
+   */
   execute: (args: Record<string, unknown>) => Promise<unknown>;
 }
 
 export interface JsScriptBridge {
   tools: JsScriptBridgeTool[];
   document: () => JsScriptDocument;
-  finalState: () => unknown;
+  finalState: () => JsScriptBridgeFinalState;
 }
 
 export type CreateJsScriptBridge = (initial: {

--- a/packages/cli/src/js-script-debug/target.ts
+++ b/packages/cli/src/js-script-debug/target.ts
@@ -15,6 +15,16 @@
 import { existsSync, readFileSync } from "node:fs";
 import type { JsScriptDebugTarget } from "@nodetool-ai/execution/js-script-debug";
 
+/** A decoded JSON document, before anything validates its shape. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+
 /** A `js_scripts` row as the harness needs it. */
 export interface JsScriptRecord {
   id: string;
@@ -42,8 +52,10 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
  * object) when there is one. Never throws — an unreadable document is a
  * validation finding, not a crash.
  */
-function documentOf(raw: unknown): unknown {
-  if (!isRecord(raw)) return raw;
+function documentOf(raw: unknown): JsonValue {
+  // SAFETY: a target is read from a JSON file or a json column, so every
+  // branch below carries decoded JSON.
+  if (!isRecord(raw)) return raw as JsonValue;
   const inner = raw.document;
   if (typeof inner === "string") {
     try {
@@ -52,8 +64,9 @@ function documentOf(raw: unknown): unknown {
       return inner;
     }
   }
-  if (inner !== undefined) return inner;
-  return raw;
+  // SAFETY: same JSON provenance as the branch above.
+  if (inner !== undefined) return inner as JsonValue;
+  return raw as JsonValue;
 }
 
 /** A document is anything carrying a `code` string and a `schemaVersion`. */

--- a/packages/cli/src/sketch-debug/harness.ts
+++ b/packages/cli/src/sketch-debug/harness.ts
@@ -47,6 +47,11 @@ export interface SketchDebugCore {
 /** The bridge surface this host drives — one tool per `ui_sketch_*` name. */
 export interface SketchBridgeTool {
   name: string;
+  /**
+   * HOLDOUT (anti-slop/no-unknown-returns): a `ui_sketch_*` tool answers in
+   * the open tool-result domain, and the bridge that implements this lives in
+   * `@nodetool-ai/agents`.
+   */
   execute: (args: Record<string, unknown>) => Promise<unknown>;
 }
 
@@ -150,10 +155,31 @@ export async function runSketchValidate(
  * records a layer's prompt/provider/model, not the persisted binding record.
  * The report's `notSimulated` says so.
  */
+/** The `{ sketch, layerBindings }` document a session leaves behind. */
+interface ReconstructedSketchDocument {
+  sketch: {
+    version: number;
+    canvas: { width: number; height: number; backgroundColor?: string };
+    layers: Array<{
+      id: string;
+      name: string;
+      type: SketchBridgeLayer["type"];
+      visible: boolean;
+      locked: boolean;
+      opacity: number | undefined;
+      blendMode: string | undefined;
+      data: null;
+    }>;
+    activeLayerId: string;
+    maskLayerId: string | null;
+  };
+  layerBindings: never[];
+}
+
 function reconstructDocument(
   snapshot: SketchBridgeSnapshot,
   resolved: ResolvedSketchTarget
-): unknown {
+): ReconstructedSketchDocument {
   const layers = (snapshot.layers ?? []).map((layer) => ({
     id: layer.id,
     name: layer.name,

--- a/packages/cli/src/sketch-debug/target.ts
+++ b/packages/cli/src/sketch-debug/target.ts
@@ -16,6 +16,16 @@
 import { existsSync, readFileSync } from "node:fs";
 import type { SketchDebugTarget } from "@nodetool-ai/execution/sketch-debug";
 
+/** A decoded JSON document, before anything validates its shape. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+
 /** An `image_documents` row as the harness needs it. */
 export interface ImageDocumentRecord {
   id: string;
@@ -99,8 +109,10 @@ const looksLikeDocument = (value: unknown): boolean =>
  * object) when there is one. Never throws — an unreadable document is a
  * validation finding, not a crash.
  */
-function documentOf(raw: unknown): unknown {
-  if (!isRecord(raw)) return raw;
+function documentOf(raw: unknown): JsonValue {
+  // SAFETY: a target is read from a JSON file or a json column, so every
+  // branch below carries decoded JSON.
+  if (!isRecord(raw)) return raw as JsonValue;
   const inner = raw.document;
   if (typeof inner === "string") {
     try {
@@ -109,8 +121,9 @@ function documentOf(raw: unknown): unknown {
       return inner;
     }
   }
-  if (inner !== undefined) return inner;
-  return raw;
+  // SAFETY: same JSON provenance as the branch above.
+  if (inner !== undefined) return inner as JsonValue;
+  return raw as JsonValue;
 }
 
 const layerType = (value: unknown): SketchLayerView["type"] =>

--- a/packages/cli/src/timeline-debug/harness.ts
+++ b/packages/cli/src/timeline-debug/harness.ts
@@ -48,6 +48,11 @@ export interface TimelineDebugCore {
 /** The bridge surface this host drives — one tool per `ui_timeline_*` name. */
 export interface TimelineBridgeTool {
   name: string;
+  /**
+   * HOLDOUT (anti-slop/no-unknown-returns): a `ui_timeline_*` tool answers in
+   * the open tool-result domain, and the bridge that implements this lives in
+   * `@nodetool-ai/agents`.
+   */
   execute: (args: Record<string, unknown>) => Promise<unknown>;
 }
 

--- a/packages/cli/src/timeline-debug/target.ts
+++ b/packages/cli/src/timeline-debug/target.ts
@@ -16,6 +16,16 @@ import { existsSync, readFileSync } from "node:fs";
 import type { TimelineDocument } from "@nodetool-ai/protocol/api-schemas/timeline.js";
 import type { TimelineDebugTarget } from "@nodetool-ai/execution/timeline-debug";
 
+/** A decoded JSON document, before anything validates its shape. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+
 /** A `timeline_sequences` row as the harness needs it. */
 export interface TimelineSequenceRecord {
   id: string;
@@ -76,8 +86,10 @@ const looksLikeDocument = (value: unknown): boolean =>
  * object) when there is one. Never throws — an unreadable document is a
  * validation finding, not a crash.
  */
-function documentOf(raw: unknown): unknown {
-  if (!isRecord(raw)) return raw;
+function documentOf(raw: unknown): JsonValue {
+  // SAFETY: a target is read from a JSON file or a json column, so every
+  // branch below carries decoded JSON.
+  if (!isRecord(raw)) return raw as JsonValue;
   const inner = raw.document;
   if (typeof inner === "string") {
     try {
@@ -86,8 +98,9 @@ function documentOf(raw: unknown): unknown {
       return inner;
     }
   }
-  if (inner !== undefined) return inner;
-  return raw;
+  // SAFETY: same JSON provenance as the branch above.
+  if (inner !== undefined) return inner as JsonValue;
+  return raw as JsonValue;
 }
 
 /** Read a document as tracks + clips + markers, defaulting what is missing. */

--- a/packages/code-nodes/src/nodes/code-node.ts
+++ b/packages/code-nodes/src/nodes/code-node.ts
@@ -1001,13 +1001,23 @@ function extractDynamicInputs(
   return result;
 }
 
+/** A value that survived the JSON round trip: plain data, nested as it was. */
+type JsonSafeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | JsonSafeValue[]
+  | { [key: string]: JsonSafeValue };
+
 /**
  * One value, deep-copied into JSON-safe form for the guest. The marshal rule
  * for a streamed item is the buffered one: plain data crosses, anything that
  * cannot be serialized becomes `null`. Media inputs are refs — plain objects —
  * so they survive and stay readable through `media.*`.
  */
-function jsonSafe(value: unknown): unknown {
+function jsonSafe(value: unknown): JsonSafeValue {
   if (value === null || value === undefined) return value;
   try {
     return JSON.parse(JSON.stringify(value));

--- a/packages/compute/src/reaper.ts
+++ b/packages/compute/src/reaper.ts
@@ -29,9 +29,9 @@ import type { WorkerInstance, WorkerProfile } from "@nodetool-ai/models";
 export interface ReaperManager {
   list(): Promise<WorkerInstance[]>;
   /** Pause (idle path) — frees the GPU, keeps the volume. */
-  stop(instanceId: string): Promise<unknown>;
+  stop(instanceId: string): Promise<WorkerInstance>;
   /** Destroy (hard-TTL path) — deletes the pod and its volume. */
-  terminate(instanceId: string): Promise<unknown>;
+  terminate(instanceId: string): Promise<WorkerInstance>;
 }
 
 /**

--- a/packages/config/src/logging.ts
+++ b/packages/config/src/logging.ts
@@ -129,7 +129,15 @@ function timestamp(): string {
 // (`message`, `stack`, `name`) are non-enumerable, so the default serializer
 // produces "{}". Without this, nested errors like `{ provider, error }` lose
 // all diagnostic information in the log output.
-function jsonReplacer(_key: string, value: unknown): unknown {
+/** An `Error` flattened into its own enumerable fields for JSON output. */
+interface SerializedError {
+  name: string;
+  message: string;
+  stack?: string;
+  cause?: unknown;
+}
+
+function jsonReplacer<T>(_key: string, value: T): T | SerializedError {
   if (value instanceof Error) {
     return {
       name: value.name,

--- a/packages/config/src/node-import.ts
+++ b/packages/config/src/node-import.ts
@@ -11,6 +11,13 @@
  * Node compat), so callers can fall back to platform-specific paths.
  */
 
+/**
+ * What a dynamic `import()` (or a CJS `require`) resolves to: the module's
+ * namespace object. Its members are known only to the caller that named the
+ * specifier, which is why the loaders below are generic in that shape.
+ */
+type ModuleNamespace = object;
+
 export const IS_NODE =
   typeof process !== "undefined" &&
   typeof (process as { versions?: { node?: string } }).versions?.node ===
@@ -43,17 +50,19 @@ export const safeProcessPlatform = (): string =>
  * callback was not specified.") — in that case we fall back to a plain
  * dynamic `import(name)` evaluated in the calling module's context.
  */
-const hiddenImport: (id: string) => Promise<unknown> = (() => {
+const hiddenImport: (id: string) => Promise<ModuleNamespace> = (() => {
   try {
+    // SAFETY: the constructed body is exactly `import(id)`, whose resolution
+    // value is always a module namespace object.
     return new Function("id", "return import(id)") as (
       id: string
-    ) => Promise<unknown>;
+    ) => Promise<ModuleNamespace>;
   } catch {
     return (id: string) => import(/* @vite-ignore */ id);
   }
 })();
 
-async function tryImport(name: string): Promise<unknown> {
+async function tryImport(name: string): Promise<ModuleNamespace> {
   try {
     return await hiddenImport(name);
   } catch (err) {
@@ -69,6 +78,8 @@ async function tryImport(name: string): Promise<unknown> {
 export async function importNodeBuiltin<T>(name: string): Promise<T | null> {
   if (!IS_NODE) return null;
   try {
+    // SAFETY: `T` is the namespace shape the caller names for `name`; the
+    // pairing of specifier and type is the caller's to keep honest.
     return (await tryImport(name)) as T;
   } catch {
     return null;
@@ -86,13 +97,17 @@ export function getNodeBuiltinSync<T>(name: string): T | null {
   if (!IS_NODE) return null;
   try {
     const proc = globalThis.process as unknown as {
-      getBuiltinModule?: (id: string) => unknown;
+      getBuiltinModule?: (id: string) => ModuleNamespace;
     };
     if (typeof proc?.getBuiltinModule === "function") {
+      // SAFETY: `T` is the namespace shape the caller names for `name`.
       return proc.getBuiltinModule(name) as T;
     }
-    const g = globalThis as unknown as { require?: (id: string) => unknown };
+    const g = globalThis as unknown as {
+      require?: (id: string) => ModuleNamespace;
+    };
     if (typeof g.require === "function") {
+      // SAFETY: `T` is the export shape the caller names for `name`.
       return g.require(name) as T;
     }
   } catch {
@@ -114,5 +129,6 @@ export const importNodeBuiltinSync = getNodeBuiltinSync;
  */
 export async function importHidden<T>(name: string): Promise<T | null> {
   if (!IS_NODE) return null;
+  // SAFETY: `T` is the namespace shape the caller names for `name`.
   return (await tryImport(name)) as T;
 }

--- a/packages/execution/src/app-debug/app-spec.ts
+++ b/packages/execution/src/app-debug/app-spec.ts
@@ -203,7 +203,16 @@ function persistDowngrades(appDoc: unknown): string[] {
   return names;
 }
 
-const safeParse = (value: string): unknown => {
+/** A decoded JSON document, before anything validates its shape. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+const safeParse = (value: string): JsonValue => {
   try {
     return JSON.parse(value);
   } catch {

--- a/packages/execution/src/app-debug/application-target.ts
+++ b/packages/execution/src/app-debug/application-target.ts
@@ -60,7 +60,13 @@ function targetInfo(
   };
 }
 
-/** The stored document, parsed out of its JSON string when it is one. */
+/**
+ * The stored document, parsed out of its JSON string when it is one.
+ *
+ * HOLDOUT (anti-slop/no-unknown-returns): the row's `document` column is
+ * free-form JSON that {@link parseAppSpec} validates downstream; naming a type
+ * here would claim a shape this function never checks.
+ */
 function rawDocumentOf(stored: unknown): unknown {
   if (typeof stored !== "string") return stored;
   try {

--- a/packages/execution/src/app-debug/runtime.ts
+++ b/packages/execution/src/app-debug/runtime.ts
@@ -559,6 +559,10 @@ export class HeadlessAppRuntime {
     }
   }
 
+  /**
+   * HOLDOUT (anti-slop/no-unknown-returns): a slot holds a workflow value —
+   * the open domain `AppInstanceState` stores as `unknown`.
+   */
   read(ref: BindingRef | null): unknown {
     if (!ref) return undefined;
     const key = stateKey(ref);

--- a/packages/execution/src/debug/collector.ts
+++ b/packages/execution/src/debug/collector.ts
@@ -40,7 +40,20 @@ const BLOB_KEEP = 64;
  * collapse binary and base64 blobs, and cap array/object fan-out. Keeps enough
  * to debug (shape, prefixes, sizes) without dumping megabytes of media bytes.
  */
-export function previewValue(value: unknown, maxLen: number = MAX_STRING_PREVIEW): unknown {
+/** A value reduced to what a JSON debug report can carry. */
+export type PreviewValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | PreviewValue[]
+  | { [key: string]: PreviewValue };
+
+export function previewValue(
+  value: unknown,
+  maxLen: number = MAX_STRING_PREVIEW
+): PreviewValue {
   if (typeof value === "string") {
     return value.length > maxLen
       ? `${value.slice(0, maxLen)}…[${value.length} chars]`
@@ -56,7 +69,7 @@ export function previewValue(value: unknown, maxLen: number = MAX_STRING_PREVIEW
       : head;
   }
   if (value && typeof value === "object") {
-    const out: Record<string, unknown> = {};
+    const out: { [key: string]: PreviewValue } = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
       if (BLOB_KEYS.has(k) && typeof v === "string" && v.length > 256) {
         out[k] = `${v.slice(0, BLOB_KEEP)}…[${v.length} chars]`;
@@ -66,7 +79,9 @@ export function previewValue(value: unknown, maxLen: number = MAX_STRING_PREVIEW
     }
     return out;
   }
-  return value;
+  // SAFETY: strings, binary, arrays and objects are handled above; what is
+  // left is a JSON scalar the report can carry as it stands.
+  return value as PreviewValue;
 }
 
 function emptyNode(nodeId: string): NodeDebug {

--- a/packages/fal-codegen/src/schema-parser.ts
+++ b/packages/fal-codegen/src/schema-parser.ts
@@ -665,7 +665,7 @@ export class SchemaParser {
     propType: string,
     required: boolean,
     enumName?: string
-  ): unknown {
+  ): string | number | boolean | null | never[] {
     if (propType === "image") return null;
     if (propType === "video") return null;
     if (propType === "audio") return null;

--- a/packages/fal-nodes/src/fal-dynamic.ts
+++ b/packages/fal-nodes/src/fal-dynamic.ts
@@ -345,12 +345,35 @@ function endpointIdFromOpenApi(
 // Value coercion: asset refs → FAL CDN URLs
 // ---------------------------------------------------------------------------
 
+/**
+ * A value held by a node property, or one placed in a FAL request body: a
+ * scalar, a media ref, or a list or dict of those.
+ */
+type NodeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Uint8Array
+  | NodeValue[]
+  | { [key: string]: NodeValue };
+
+/** A value in a FAL endpoint's JSON response body. */
+type FalResponseValue =
+  | string
+  | number
+  | boolean
+  | null
+  | FalResponseValue[]
+  | { [key: string]: FalResponseValue };
+
 async function coerceInputValue(
   apiKey: string,
   openapi: Record<string, unknown>,
   propSchema: Record<string, unknown>,
-  value: unknown
-): Promise<unknown> {
+  value: NodeValue
+): Promise<NodeValue> {
   const resolved = resolveSchemaRef(openapi, propSchema);
 
   // Check for asset ref (has .uri or .data)
@@ -387,9 +410,7 @@ async function coerceInputValue(
   if (resolved.type === "array" && Array.isArray(value)) {
     const itemSchema = (resolved.items as Record<string, unknown>) ?? {};
     return Promise.all(
-      (value as unknown[]).map((item) =>
-        coerceInputValue(apiKey, openapi, itemSchema, item)
-      )
+      value.map((item) => coerceInputValue(apiKey, openapi, itemSchema, item))
     );
   }
 
@@ -426,16 +447,14 @@ function mapOutputValue(
   openapi: Record<string, unknown>,
   name: string,
   schema: Record<string, unknown>,
-  value: unknown
-): unknown {
+  value: FalResponseValue
+): FalResponseValue {
   if (value === null || value === undefined) return value;
   const resolved = resolveSchemaRef(openapi, schema);
 
   if (resolved.type === "array" && Array.isArray(value)) {
     const itemSchema = (resolved.items as Record<string, unknown>) ?? {};
-    return (value as unknown[]).map((item) =>
-      mapOutputValue(openapi, name, itemSchema, item)
-    );
+    return value.map((item) => mapOutputValue(openapi, name, itemSchema, item));
   }
 
   // File schema (has "url" property) → return {uri, type}
@@ -465,7 +484,9 @@ function mapOutputValues(
       openapi,
       name,
       schema as Record<string, unknown>,
-      response[name]
+      // SAFETY: `response` is the endpoint's JSON response body, so every value
+      // in it is a JSON value.
+      response[name] as FalResponseValue
     );
   }
   return out;

--- a/packages/fal-nodes/src/fal-factory.ts
+++ b/packages/fal-nodes/src/fal-factory.ts
@@ -85,7 +85,47 @@ function assetKind(
   return "none";
 }
 
-function defaultForPropType(propType: string): unknown {
+/**
+ * A value held by a node property or by a prompt-asset override: NodeTool's
+ * property types are scalars, media refs, and lists or dicts of those.
+ */
+type NodeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Uint8Array
+  | NodeValue[]
+  | { [key: string]: NodeValue };
+
+/** A value in a FAL endpoint's JSON response body. */
+type FalResponseValue =
+  | string
+  | number
+  | boolean
+  | null
+  | FalResponseValue[]
+  | { [key: string]: FalResponseValue };
+
+/**
+ * The empty media ref a media property starts at before the user picks an
+ * asset. `duration` and `format` are carried by video only.
+ */
+type EmptyMediaRef = {
+  type: "image" | "video" | "audio";
+  uri: string;
+  asset_id: null;
+  data: null;
+  metadata: null;
+  duration?: null;
+  format?: null;
+};
+
+/** What a property starts at when the manifest names no default. */
+type FieldDefault = boolean | number | string | never[] | EmptyMediaRef;
+
+function defaultForPropType(propType: string): FieldDefault {
   switch (propType) {
     case "bool":
       return false;
@@ -104,7 +144,7 @@ function defaultForPropType(propType: string): unknown {
   }
 }
 
-function castValue(value: unknown, propType: string): unknown {
+function castValue(value: NodeValue, propType: string): NodeValue {
   if (value === null || value === undefined) return value;
   if (propType.startsWith("list[") || propType.startsWith("dict[")) {
     return value; // pass through structured types as-is
@@ -152,8 +192,10 @@ async function promptAssetOverrides(
   instance: BaseNode,
   spec: FalManifestEntry,
   context?: ProcessingContext
-): Promise<Record<string, unknown>> {
-  const values = instance as unknown as Record<string, unknown>;
+): Promise<Record<string, NodeValue>> {
+  // SAFETY: a node's own properties hold node property values, and NodeTool
+  // restricts those to its property types — the shapes `NodeValue` names.
+  const values = instance as unknown as Record<string, NodeValue>;
   const textFields: PromptAssetTextField[] = [];
   const assetFields: PromptAssetInputField[] = [];
   for (const field of spec.inputFields) {
@@ -179,7 +221,11 @@ async function promptAssetOverrides(
       });
     }
   }
-  return mapPromptAssetsToInputs(textFields, assetFields, context);
+  // SAFETY: the overrides are asset refs this call injected from `asset://`
+  // mentions, so they are node property values like the ones they replace.
+  return mapPromptAssetsToInputs(textFields, assetFields, context) as Promise<
+    Record<string, NodeValue>
+  >;
 }
 
 function resolveFieldValue(
@@ -187,8 +233,10 @@ function resolveFieldValue(
   fieldName: string,
   apiParamName?: string,
   propType?: string
-): unknown {
-  const record = instance as unknown as Record<string, unknown>;
+): NodeValue {
+  // SAFETY: a node's own properties hold node property values, and NodeTool
+  // restricts those to its property types — the shapes `NodeValue` names.
+  const record = instance as unknown as Record<string, NodeValue>;
   const primary = fieldName in record ? record[fieldName] : undefined;
   const kind = propType ? assetKind(propType) : "none";
 
@@ -316,9 +364,11 @@ async function buildArgs(
               (subField) => subField.parentField === field.name
             );
             for (const subField of subFields) {
-              const subValue = (instance as unknown as Record<string, unknown>)[
-                subField.name
-              ];
+              // SAFETY: a node's own properties hold node property values, and
+              // NodeTool restricts those to its property types.
+              const subValue = (
+                instance as unknown as Record<string, NodeValue>
+              )[subField.name];
               nested[subField.name] = castValue(subValue, subField.propType);
             }
             args[apiName] = nested;
@@ -345,11 +395,11 @@ async function buildArgs(
 }
 
 function coerceAssetRef(
-  value: unknown,
+  value: FalResponseValue,
   propType: string
-): unknown {
+): FalResponseValue {
   if (!value || typeof value !== "object") return value;
-  const obj = value as Record<string, unknown>;
+  const obj = value as Record<string, FalResponseValue>;
   const kind = assetKind(propType);
   if (obj.url) {
     return { type: kind !== "none" ? kind : propType, uri: obj.url, width: obj.width, height: obj.height };
@@ -465,7 +515,9 @@ function mapOutput(
         for (const [key, value] of Object.entries(res)) {
           const propType = fieldMap.get(key);
           if (propType && isAssetPropType(propType)) {
-            out[key] = coerceAssetRef(value, propType);
+            // SAFETY: `res` is the endpoint's JSON response body, so every
+            // value in it is a JSON value.
+            out[key] = coerceAssetRef(value as FalResponseValue, propType);
           } else {
             out[key] = value;
           }

--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -234,9 +234,7 @@ function hasProviderSupport(
   context: ProcessingContext | undefined,
   providerId: string,
   modelId: string
-): context is ProcessingContext & {
-  runProviderPrediction: (req: Record<string, unknown>) => Promise<unknown>;
-} {
+): context is ProcessingContext {
   return (
     !!context &&
     typeof context.runProviderPrediction === "function" &&

--- a/packages/image-nodes/src/nodes/lib-image-utils.ts
+++ b/packages/image-nodes/src/nodes/lib-image-utils.ts
@@ -50,10 +50,14 @@ export async function decodeImage(
   return null;
 }
 
+/**
+ * Find the node's source image: the first of the image-typed handles present
+ * on the incoming values, then on the node's own properties.
+ */
 export function pickImage(
   inputs: Record<string, unknown>,
   props: Record<string, unknown>
-): unknown {
+): ImageRefLike | null | undefined {
   const keys = [
     "image",
     "input",
@@ -65,11 +69,13 @@ export function pickImage(
     "base_image",
     "mask"
   ];
+  // SAFETY: every key listed is an image-typed handle on these nodes, so the
+  // value under one is that node's image input.
   for (const key of keys) {
-    if (key in inputs) return inputs[key];
+    if (key in inputs) return inputs[key] as ImageRefLike | undefined;
   }
   for (const key of keys) {
-    if (key in props) return props[key];
+    if (key in props) return props[key] as ImageRefLike | undefined;
   }
   return null;
 }

--- a/packages/integration-nodes/src/nodes/kie-dynamic.ts
+++ b/packages/integration-nodes/src/nodes/kie-dynamic.ts
@@ -20,12 +20,24 @@ import { tagAsServer } from "@nodetool-ai/nodes-utils";
 
 type JsonRecord = Record<string, unknown>;
 
+/**
+ * A value a KIE parameter can carry: the JSON literal its documentation names,
+ * or the raw text when that text is not JSON.
+ */
+type ParamValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ParamValue[]
+  | { [key: string]: ParamValue };
+
 interface KieParamInfo {
   name: string;
   type: string;
   required: boolean;
   description: string;
-  default?: unknown;
+  default?: ParamValue;
   options?: string[];
   minVal?: number;
   maxVal?: number;
@@ -265,7 +277,7 @@ function parseInputParams(text: string): KieParamInfo[] {
     );
     const description = descMatch ? descMatch[1].trim() : "";
 
-    let defaultVal: unknown = undefined;
+    let defaultVal: ParamValue | undefined = undefined;
     const defMatch = trimmed.match(/\*\*Default Value\*\*:\s*`([^`]*)`/);
     if (defMatch) defaultVal = coerceDefault(defMatch[1], paramType);
 
@@ -356,7 +368,11 @@ function openApiPropertyToParam(
   let paramType = schemaType;
   if (isArray) paramType = "array";
 
-  let defaultVal: unknown = schema.default;
+  // SAFETY: `schema` is a JSON-decoded OpenAPI schema, so its `default` is a
+  // JSON value.
+  let defaultVal: ParamValue | undefined = schema.default as
+    | ParamValue
+    | undefined;
   if (defaultVal === undefined && enumValues?.length) {
     defaultVal = enumValues[0];
   }
@@ -513,7 +529,7 @@ function mergeKieParams(
   return [...merged.values()];
 }
 
-function coerceDefault(raw: string, paramType: string): unknown {
+function coerceDefault(raw: string, paramType: string): ParamValue {
   if (paramType === "integer") {
     const n = parseInt(raw, 10);
     return isNaN(n) ? raw : n;
@@ -640,7 +656,21 @@ function mapParamType(param: KieParamInfo): TypeMetadata {
   }
 }
 
-function defaultRefForKind(kind: "image" | "audio" | "video"): unknown {
+/**
+ * The empty media ref a media property starts at before the user picks an
+ * asset. `duration` and `format` are carried by video only.
+ */
+type EmptyMediaRef = {
+  type: "image" | "video" | "audio";
+  uri: string;
+  asset_id: null;
+  data: null;
+  metadata: null;
+  duration?: null;
+  format?: null;
+};
+
+function defaultRefForKind(kind: "image" | "audio" | "video"): EmptyMediaRef {
   if (kind === "audio") {
     return { type: "audio", uri: "", asset_id: null, data: null, metadata: null };
   }
@@ -658,7 +688,7 @@ function defaultRefForKind(kind: "image" | "audio" | "video"): unknown {
   return { type: "image", uri: "", asset_id: null, data: null, metadata: null };
 }
 
-function defaultDynamicValue(param: KieParamInfo): unknown {
+function defaultDynamicValue(param: KieParamInfo): ParamValue {
   if (param.isVideoClipList || param.isFileUrlArray) {
     return [];
   }

--- a/packages/kernel/src/dynamic-slots.ts
+++ b/packages/kernel/src/dynamic-slots.ts
@@ -130,7 +130,10 @@ function inferValueType(value: unknown): TypeMetadata | undefined {
  *
  * Anything else is returned untouched.
  */
-function coerceToSlotType(value: unknown, declared: TypeMetadata): unknown {
+function coerceToSlotType<TValue>(
+  value: TValue,
+  declared: TypeMetadata
+): TValue | TValue[] {
   if (
     declared.isListType() &&
     value !== null &&

--- a/packages/kernel/src/io.ts
+++ b/packages/kernel/src/io.ts
@@ -72,6 +72,10 @@ export class NodeInputs {
 
   /**
    * Return the first available item for a handle, or default if EOS.
+   *
+   * HOLDOUT (anti-slop/no-unknown-returns): the item is whatever the upstream
+   * node put on the handle — the open workflow-value domain, which NodeTool
+   * has no named union for. The kernel never inspects the payload.
    */
   async first(name: string, defaultValue?: unknown): Promise<unknown> {
     for await (const envelope of this._inbox.iterInputWithEnvelope(name)) {
@@ -84,10 +88,10 @@ export class NodeInputs {
   /**
    * Return the first available MessageEnvelope for a handle, or default if EOS.
    */
-  async firstWithEnvelope(
+  async firstWithEnvelope<TDefault>(
     name: string,
-    defaultValue?: unknown
-  ): Promise<MessageEnvelope | unknown> {
+    defaultValue?: TDefault
+  ): Promise<MessageEnvelope | TDefault | undefined> {
     for await (const envelope of this._inbox.iterInputWithEnvelope(name)) {
       this._envelopeTracker?.set(name, envelope);
       return envelope;

--- a/packages/kernel/src/supervisor.ts
+++ b/packages/kernel/src/supervisor.ts
@@ -102,14 +102,27 @@ function truncate(text: string): string {
  * arrays; anything else is stringified, because a class instance's `toString`
  * is not a place to gamble on what it prints.
  */
+/** A value with secrets masked and size capped — safe to put in a report. */
+export type RedactedValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | RedactedValue[]
+  | { [key: string]: RedactedValue };
+
 export function redactValue(
   value: unknown,
   secrets: ReadonlySet<string>,
   depth = 0
-): unknown {
+): RedactedValue {
   if (value === null || value === undefined) return value;
   if (typeof value === "string") return truncate(maskSecrets(value, secrets));
-  if (typeof value === "number" || typeof value === "boolean") return value;
+  // SAFETY: the `typeof` above proved which of the two it is.
+  if (typeof value === "number" || typeof value === "boolean") {
+    return value as number | boolean;
+  }
   if (depth >= 6) return MASK;
   if (Array.isArray(value)) {
     return value
@@ -119,7 +132,7 @@ export function redactValue(
   if (typeof value === "object") {
     const proto = Object.getPrototypeOf(value);
     if (proto === Object.prototype || proto === null) {
-      const out: Record<string, unknown> = {};
+      const out: { [key: string]: RedactedValue } = {};
       for (const [key, item] of Object.entries(value)) {
         out[key] = SENSITIVE_NAME_PATTERN.test(key)
           ? MASK

--- a/packages/kie-codegen/src/schema-parser.ts
+++ b/packages/kie-codegen/src/schema-parser.ts
@@ -160,7 +160,19 @@ function outputTypeForModelId(modelId: string, moduleName: ModuleConfig["moduleN
   return outputTypeForModule(moduleName);
 }
 
-function defaultForMedia(kind: MediaKind): unknown {
+/** The empty media ref a media property starts at before the user picks one. */
+type MediaRefDefault = typeof IMAGE_REF | typeof AUDIO_REF | typeof VIDEO_REF;
+
+/** What a field starts at when the schema names no default. */
+type FieldDefault =
+  | string
+  | number
+  | boolean
+  | null
+  | FieldDefault[]
+  | { [key: string]: FieldDefault };
+
+function defaultForMedia(kind: MediaKind): MediaRefDefault {
   if (kind === "audio") {
     return AUDIO_REF;
   }
@@ -259,7 +271,10 @@ function applyBounds(field: FieldDef, schema: JsonRecord): void {
   }
 }
 
-function coerceDefault(schema: JsonRecord, type: FieldDef["type"]): unknown {
+function coerceDefault(
+  schema: JsonRecord,
+  type: FieldDef["type"]
+): FieldDefault {
   if (type === "image" || type === "audio" || type === "video") {
     return defaultForMedia(type);
   }
@@ -267,7 +282,9 @@ function coerceDefault(schema: JsonRecord, type: FieldDef["type"]): unknown {
     return [];
   }
   if (schema.default !== undefined) {
-    return schema.default;
+    // SAFETY: `schema` is a JSON-decoded API schema, so its `default` is a
+    // JSON value.
+    return schema.default as FieldDefault;
   }
   if (type === "bool") {
     return false;

--- a/packages/kie-nodes/src/kie-factory.ts
+++ b/packages/kie-nodes/src/kie-factory.ts
@@ -134,7 +134,10 @@ function normalizeStringList(value: unknown): string[] {
   return [];
 }
 
-function castValue(value: unknown, type: string): unknown {
+/** A scalar as the KIE API takes it, after coercion from the stored value. */
+type CoercedScalar = string | number | boolean | null | undefined;
+
+function castValue(value: unknown, type: string): CoercedScalar {
   if (value === null || value === undefined) return value;
   switch (type) {
     case "int":
@@ -162,7 +165,38 @@ function computeFieldClassification(fields: KieFieldDef[]) {
   return base;
 }
 
-function defaultForType(type: string): unknown {
+/**
+ * A value held by a node property or by a prompt-asset override: NodeTool's
+ * property types are scalars, media refs, and lists or dicts of those.
+ */
+type NodeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Uint8Array
+  | NodeValue[]
+  | { [key: string]: NodeValue };
+
+/**
+ * The empty media ref a media property starts at before the user picks an
+ * asset. `duration` and `format` are carried by video only.
+ */
+type EmptyMediaRef = {
+  type: "image" | "video" | "audio";
+  uri: string;
+  asset_id: null;
+  data: null;
+  metadata: null;
+  duration?: null;
+  format?: null;
+};
+
+/** What a property starts at when the manifest names no default. */
+type FieldDefault = boolean | number | string | never[] | EmptyMediaRef;
+
+function defaultForType(type: string): FieldDefault {
   switch (type) {
     case "bool":
       return false;
@@ -273,10 +307,12 @@ async function buildParams(
     spec.uploads?.filter((u) => u.isVideoClip).map((u) => u.field) ?? []
   );
   const overrides = await promptAssetOverrides(instance, spec, context);
-  const readValue = (name: string): unknown =>
-    name in overrides
+  // SAFETY: both sources hold node property values, and NodeTool restricts
+  // those to its own property types — the shapes `NodeValue` names.
+  const readValue = (name: string): NodeValue =>
+    (name in overrides
       ? overrides[name]
-      : (instance as unknown as Record<string, unknown>)[name];
+      : (instance as unknown as Record<string, unknown>)[name]) as NodeValue;
 
   // Scalar and list[str] fields
   for (const field of spec.fields) {

--- a/packages/llm-nodes/src/nodes/agent-loop.ts
+++ b/packages/llm-nodes/src/nodes/agent-loop.ts
@@ -8,7 +8,7 @@ import type {
 import type { Chunk } from "@nodetool-ai/protocol";
 import { Tool as AgentTool } from "@nodetool-ai/agents";
 import { hydrateBuiltinAgentTools } from "./agent-tool-hydration.js";
-import type { ToolLike } from "./agent-utils.js";
+import type { ToolLike, ToolResult } from "./agent-utils.js";
 import {
   classifyProviderStream,
   serializeToolResult,
@@ -29,7 +29,7 @@ export class ToolLikeAdapter extends AgentTool {
   private readonly _process: (
     context: ProcessingContext,
     params: Record<string, unknown>
-  ) => Promise<unknown>;
+  ) => Promise<ToolResult>;
   private readonly _execute: ToolLike["execute"];
 
   constructor(toolLike: ToolLike) {
@@ -65,7 +65,7 @@ export class ToolLikeAdapter extends AgentTool {
   async process(
     context: ProcessingContext,
     params: Record<string, unknown>
-  ): Promise<unknown> {
+  ): Promise<ToolResult> {
     return this._process(context, params);
   }
 }

--- a/packages/llm-nodes/src/nodes/agent-utils.ts
+++ b/packages/llm-nodes/src/nodes/agent-utils.ts
@@ -16,6 +16,13 @@ import { hydrateBuiltinAgentTool } from "./agent-tool-hydration.js";
 type MessagePart = { type?: string; text?: string };
 type LanguageModelLike = { provider?: string; id?: string; name?: string };
 
+/**
+ * What a tool hands back: a primitive, or any object — a record, an array, a
+ * byte buffer. `serializeToolResult` renders it to JSON before it reaches the
+ * model.
+ */
+export type ToolResult = string | number | boolean | null | undefined | object;
+
 export type ToolLike = {
   name: string;
   description?: string;
@@ -23,7 +30,7 @@ export type ToolLike = {
   process?: (
     context: ProcessingContext,
     params: Record<string, unknown>
-  ) => Promise<unknown>;
+  ) => Promise<ToolResult>;
   /**
    * Preferred entry point when present (agent-system tools have one): strips
    * reserved fields like `_message` and coerces params against the tool's
@@ -33,7 +40,7 @@ export type ToolLike = {
     context: ProcessingContext,
     params: Record<string, unknown>,
     options?: { toolCallId?: string }
-  ) => Promise<unknown>;
+  ) => Promise<ToolResult>;
   toProviderTool?: () => {
     name: string;
     description?: string;
@@ -572,10 +579,24 @@ export function toProviderTools(tools: ToolLike[]): Array<{
   );
 }
 
-export function serializeToolResult(value: unknown): unknown {
+/**
+ * A tool result rendered as JSON: every byte buffer has become a base64 string.
+ */
+export type SerializedToolResult =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | SerializedToolResult[]
+  | { [key: string]: SerializedToolResult };
+
+export function serializeToolResult(value: unknown): SerializedToolResult {
   if (value == null) return value;
   if (Array.isArray(value)) return value.map(serializeToolResult);
-  if (typeof value !== "object") return value;
+  // SAFETY: what is left here is neither null/undefined, an array, nor an
+  // object — a primitive, which is already its own JSON rendering.
+  if (typeof value !== "object") return value as SerializedToolResult;
   if (value instanceof Uint8Array) {
     return Buffer.from(value).toString("base64");
   }

--- a/packages/llm-nodes/src/nodes/generators.ts
+++ b/packages/llm-nodes/src/nodes/generators.ts
@@ -193,12 +193,7 @@ function hasProviderSupport(
   context: ProcessingContext | undefined,
   providerId: string,
   modelId: string
-): context is ProcessingContext & {
-  runProviderPrediction: (req: Record<string, unknown>) => Promise<unknown>;
-  streamProviderPrediction: (
-    req: Record<string, unknown>
-  ) => AsyncGenerator<unknown>;
-} {
+): context is ProcessingContext {
   return (
     !!context &&
     typeof context.runProviderPrediction === "function" &&
@@ -257,11 +252,7 @@ async function* streamListItemsViaToolCalls(
   maxTokens: number,
   systemPrompt: string = LIST_GENERATOR_SYSTEM_PROMPT
 ): AsyncGenerator<string> {
-  const provider = await (
-    context as ProcessingContext & {
-      getProvider: (id: string) => Promise<unknown>;
-    }
-  ).getProvider(providerId);
+  const provider = await context.getProvider(providerId);
   const tool = makeAddItemTool();
   const providerTools = toProviderTools([tool]);
 
@@ -275,15 +266,12 @@ async function* streamListItemsViaToolCalls(
     const assistantToolCalls: ToolCall[] = [];
     let assistantText = "";
 
-    for await (const item of streamProviderMessages(
-      provider as Parameters<typeof streamProviderMessages>[0],
-      {
-        messages,
-        model: modelId,
-        tools: providerTools,
-        maxTokens
-      }
-    )) {
+    for await (const item of streamProviderMessages(provider, {
+      messages,
+      model: modelId,
+      tools: providerTools,
+      maxTokens
+    })) {
       if (isToolCallItem(item)) {
         assistantToolCalls.push(item);
         if (item.name === "add_item") {
@@ -372,9 +360,7 @@ function parseCsv(text: string, specs: ColumnSpec[]): Row[] {
 }
 
 async function generateDataframeFromCsv(
-  context: ProcessingContext & {
-    runProviderPrediction: (req: Record<string, unknown>) => Promise<unknown>;
-  },
+  context: ProcessingContext,
   providerId: string,
   modelId: string,
   prompt: string,

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -5,6 +5,8 @@
  * consumers need to define, query and persist data models.
  */
 
+import type { AdapterResolver } from "./legacy-compat.js";
+
 // ── Database Connection ─────────────────────────────────────────────
 export {
   initDb,
@@ -323,15 +325,11 @@ export type { ConditionValue } from "./condition-builder.js";
 
 // Legacy adapter resolver — now a no-op since models use getDb() directly.
 // Kept for API compatibility during transition.
-let _legacyResolver: ((schema: unknown) => unknown) | null = null;
-export function setGlobalAdapterResolver(
-  resolver: (schema: unknown) => unknown
-): void {
+let _legacyResolver: AdapterResolver | null = null;
+export function setGlobalAdapterResolver(resolver: AdapterResolver): void {
   _legacyResolver = resolver;
 }
-export function getGlobalAdapterResolver():
-  | ((schema: unknown) => unknown)
-  | null {
+export function getGlobalAdapterResolver(): AdapterResolver | null {
   return _legacyResolver;
 }
 

--- a/packages/models/src/sqlite-adapter.ts
+++ b/packages/models/src/sqlite-adapter.ts
@@ -56,8 +56,25 @@ function sqliteType(fieldType: string): string {
   }
 }
 
-/** Serialize a value for SQLite storage based on its field definition type. */
-function serializeValue(value: unknown, fieldType: string): unknown {
+/** A value SQLite can bind directly into a column. */
+type StoredValue = string | number | null;
+
+/** A value `JSON.parse` can produce. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/**
+ * Serialize a value for SQLite storage based on its field definition type.
+ *
+ * Booleans and JSON become a `StoredValue`; every other column type is stored
+ * as it arrives, which is why the passthrough keeps the caller's own type.
+ */
+function serializeValue<T>(value: T, fieldType: string): T | StoredValue {
   if (value === null || value === undefined) return null;
   switch (fieldType) {
     case "boolean":
@@ -74,8 +91,13 @@ function serializeValue(value: unknown, fieldType: string): unknown {
   }
 }
 
-/** Deserialize a value from SQLite storage based on its field definition type. */
-function deserializeValue(value: unknown, fieldType: string): unknown {
+/**
+ * Deserialize a value from SQLite storage based on its field definition type.
+ *
+ * Booleans, numbers and JSON are decoded; every other column type is returned
+ * as it was read, which is why the passthrough keeps the caller's own type.
+ */
+function deserializeValue<T>(value: T, fieldType: string): T | JsonValue {
   if (value === null || value === undefined) return null;
   switch (fieldType) {
     case "boolean":

--- a/packages/models/tests/index-exports.test.ts
+++ b/packages/models/tests/index-exports.test.ts
@@ -55,7 +55,9 @@ describe("models index exports", () => {
   });
 
   it("round-trips the legacy adapter resolver shim", () => {
-    const resolver = (schema: unknown) => schema;
+    const resolver: models.AdapterResolver = () => {
+      throw new Error("the legacy resolver shim is never invoked");
+    };
     models.setGlobalAdapterResolver(resolver);
     expect(models.getGlobalAdapterResolver()).toBe(resolver);
   });

--- a/packages/node-sdk/src/base-node.ts
+++ b/packages/node-sdk/src/base-node.ts
@@ -30,10 +30,16 @@ import {
  * (e.g. a single Image into a `list[image]` slot) without a manual
  * wrapper node.
  */
-export function coerceToDeclaredType(
-  value: unknown,
+/** A URI string promoted to the tagged asset reference its slot declares. */
+export interface CoercedAssetRef {
+  type: string;
+  uri: string;
+}
+
+export function coerceToDeclaredType<TValue>(
+  value: TValue,
   declaredType: string
-): unknown {
+): TValue | TValue[] | CoercedAssetRef {
   // A URI string standing in for an asset ref. Callers reach for the plain
   // string — `--params '{"clip":"file:///clip.mp4"}'`, a REST body, a webhook
   // payload — and without this the ref stays empty, the node reads no bytes,
@@ -78,10 +84,10 @@ const URI_WITH_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
  * Coerce a value against a typed dynamic slot's declared type. Slots with no
  * resolvable type string pass the value through untouched (legacy `any` slot).
  */
-export function coerceToSlotType(
-  value: unknown,
+export function coerceToSlotType<TValue>(
+  value: TValue,
   slot: DynamicSlotMeta | undefined
-): unknown {
+): TValue | TValue[] | CoercedAssetRef {
   const declaredType = slotTypeToString(slot);
   return declaredType ? coerceToDeclaredType(value, declaredType) : value;
 }

--- a/packages/node-sdk/src/pack-loader.ts
+++ b/packages/node-sdk/src/pack-loader.ts
@@ -692,7 +692,7 @@ function resolveEntry(pkg: PackageJsonShape): string | undefined {
  * Conditions may nest (e.g. `{ import: { types: "...", default: "x.js" } }`),
  * so recurse until a string target is found. Depth-capped against cycles.
  */
-function pickExportCondition(dot: unknown, depth = 0): unknown {
+function pickExportCondition(dot: unknown, depth = 0): string | undefined {
   // Stryker disable next-line ConditionalExpression: a nullish or non-object dot has no conditions to pick — every guard variant resolves to undefined and falls through to `main` (covered by the exports/main entry tests).
   if (!dot || typeof dot !== "object" || depth > 4) return undefined;
   const conds = dot as Record<string, unknown>;

--- a/packages/node-sdk/src/workflow-interface.ts
+++ b/packages/node-sdk/src/workflow-interface.ts
@@ -144,12 +144,21 @@ function obviouslyExceedsDefaultBudget(value: unknown): boolean {
   return false;
 }
 
+/** A JSON round-trippable value — what a discovered default is reduced to. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
 function safeDefault(
   value: unknown,
   nodeId: string,
   pinName: string,
   diagnostics: WorkflowInterfaceDiagnostic[]
-): unknown {
+): JsonValue {
   if (value === undefined) return null;
 
   if (obviouslyExceedsDefaultBudget(value)) {
@@ -198,7 +207,7 @@ function safeDefault(
     });
     return null;
   }
-  const normalized: unknown = JSON.parse(json);
+  const normalized: JsonValue = JSON.parse(json);
   return normalized;
 }
 

--- a/packages/replicate-codegen/src/metadata-parser.ts
+++ b/packages/replicate-codegen/src/metadata-parser.ts
@@ -11,6 +11,15 @@ import { SchemaParser } from "./schema-parser.js";
 
 type AnyRecord = Record<string, any>;
 
+/** A JSON value read out of the package metadata. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
 /** A single node entry from the Python metadata JSON. */
 export interface MetadataNodeEntry {
   title: string;
@@ -206,7 +215,7 @@ export class MetadataParser {
     rawDefault: unknown,
     propType: string,
     optional?: boolean
-  ): unknown {
+  ): JsonValue {
     // Asset refs always default to null
     if (propType === "image" || propType === "video" || propType === "audio") {
       return null;
@@ -218,7 +227,9 @@ export class MetadataParser {
         // Object defaults (like image refs) → null
         return null;
       }
-      return rawDefault;
+      // SAFETY: the metadata is JSON, and the object case was just excluded,
+      // so what is left is a primitive or an array of them.
+      return rawDefault as JsonValue;
     }
 
     if (optional) return null;

--- a/packages/replicate-codegen/src/schema-fetcher.ts
+++ b/packages/replicate-codegen/src/schema-fetcher.ts
@@ -11,6 +11,15 @@ import { join } from "node:path";
 
 const REPLICATE_API_BASE = "https://api.replicate.com/v1";
 
+/** A JSON value decoded from a Replicate API response. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
 export interface ReplicateSchema {
   modelId: string; // "owner/name"
   owner: string;
@@ -149,7 +158,7 @@ export class SchemaFetcher {
     };
   }
 
-  private async _fetch(url: string): Promise<unknown> {
+  private async _fetch(url: string): Promise<JsonValue> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 30_000);
     let response: Response;

--- a/packages/replicate-codegen/src/schema-parser.ts
+++ b/packages/replicate-codegen/src/schema-parser.ts
@@ -274,7 +274,7 @@ export class SchemaParser {
     prop: AnyRecord,
     propType: string,
     required: boolean
-  ): unknown {
+  ): string | number | boolean | null | never[] {
     // Asset refs default to null
     if (propType === "image" || propType === "video" || propType === "audio") {
       return null;

--- a/packages/replicate-nodes/src/replicate-base.ts
+++ b/packages/replicate-nodes/src/replicate-base.ts
@@ -199,8 +199,16 @@ async function uploadToReplicate(
 // Submit via SDK
 // ---------------------------------------------------------------------------
 
+/**
+ * What a Replicate model resolves to. The SDK types `run()` as `object`, but a
+ * text model resolves to a bare string and a number of models resolve to a
+ * number or boolean, so the union covers every JSON value a model can produce
+ * — including the SDK's own `FileOutput` (an object carrying `url`).
+ */
+export type ReplicateOutput = string | number | boolean | null | object;
+
 export interface ReplicateResult {
-  output: unknown;
+  output: ReplicateOutput;
 }
 
 /**
@@ -247,7 +255,8 @@ function extractUrlFromValue(value: unknown): string | null {
   if ("url" in value) {
     const u = (value as { url: unknown }).url;
     if (typeof u === "function") {
-      const resolved = (u as () => unknown).call(value);
+      // The Replicate SDK's FileOutput exposes `url()`, which returns a URL.
+      const resolved = (u as () => URL | string).call(value);
       if (resolved) return String(resolved);
     } else if (u) {
       return String(u);

--- a/packages/replicate-nodes/src/replicate-factory.ts
+++ b/packages/replicate-nodes/src/replicate-factory.ts
@@ -30,6 +30,7 @@ import {
   outputToAudioRef,
   outputToString
 } from "./replicate-base.js";
+import type { ReplicateOutput } from "./replicate-base.js";
 
 // ---------------------------------------------------------------------------
 // Manifest types — mirrors replicate-codegen types.ts NodeSpec
@@ -93,7 +94,38 @@ function isListAsset(propType: string): boolean {
   return propType.startsWith("list[") && isAssetPropType(propType);
 }
 
-function defaultForPropType(propType: string): unknown {
+/**
+ * A value held by a node property or by a prompt-asset override: NodeTool's
+ * property types are scalars, media refs, and lists or dicts of those.
+ */
+type NodeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Uint8Array
+  | NodeValue[]
+  | { [key: string]: NodeValue };
+
+/**
+ * The empty media ref a media property starts at before the user picks an
+ * asset. `duration` and `format` are carried by video only.
+ */
+type EmptyMediaRef = {
+  type: "image" | "video" | "audio";
+  uri: string;
+  asset_id: null;
+  data: null;
+  metadata: null;
+  duration?: null;
+  format?: null;
+};
+
+/** What a property starts at when the manifest names no default. */
+type FieldDefault = boolean | number | string | null | never[] | EmptyMediaRef;
+
+function defaultForPropType(propType: string): FieldDefault {
   switch (propType) {
     case "bool":
       return false;
@@ -128,10 +160,10 @@ function isNumericEnum(enumValues?: string[]): boolean {
 }
 
 function castValue(
-  value: unknown,
+  value: NodeValue,
   propType: string,
   enumValues?: string[]
-): unknown {
+): NodeValue {
   if (value === null || value === undefined) return value;
   if (propType.startsWith("list[") || propType.startsWith("dict[")) {
     return value;
@@ -229,10 +261,13 @@ async function buildArgs(
       continue;
     }
 
-    const value =
+    // SAFETY: both sources hold node property values, and NodeTool restricts
+    // those to its own property types — the shapes `NodeValue` names.
+    const value = (
       field.name in overrides
         ? overrides[field.name]
-        : (instance as unknown as Record<string, unknown>)[field.name];
+        : (instance as unknown as Record<string, unknown>)[field.name]
+    ) as NodeValue;
     const apiName = field.apiParamName ?? field.name;
     const kind = assetKind(field.propType);
 
@@ -308,7 +343,7 @@ export function createReplicateNodeClass(
   const executePrediction = async (
     instance: BaseNode,
     context?: Parameters<BaseNode["process"]>[0]
-  ): Promise<unknown> => {
+  ): Promise<ReplicateOutput> => {
     const apiKey = getReplicateApiKey(instance._secrets);
     const args = await buildArgs(instance, specRef, apiKey, context);
     const res = await replicateSubmit(apiKey, specRef.endpointId, args);

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -164,9 +164,16 @@ export type { SandboxModuleCatalog } from "./sandbox-module-catalog.js";
 // Cache interface
 // ---------------------------------------------------------------------------
 
+/**
+ * A key/value cache for node results.
+ *
+ * One instance holds the results of many different nodes, so the value type
+ * belongs to the key, not to the cache: each caller names the type it stored
+ * under that key.
+ */
 export interface CacheAdapter {
-  get(key: string): Promise<unknown | undefined>;
-  set(key: string, value: unknown, ttlSeconds?: number): Promise<void>;
+  get<TValue>(key: string): Promise<TValue | undefined>;
+  set<TValue>(key: string, value: TValue, ttlSeconds?: number): Promise<void>;
   has(key: string): Promise<boolean>;
   delete(key: string): Promise<void>;
 }
@@ -180,17 +187,23 @@ export class MemoryCache implements CacheAdapter {
     { value: unknown; expires: number | null }
   >();
 
-  async get(key: string): Promise<unknown | undefined> {
+  async get<TValue>(key: string): Promise<TValue | undefined> {
     const entry = this._store.get(key);
     if (!entry) return undefined;
     if (entry.expires !== null && Date.now() > entry.expires) {
       this._store.delete(key);
       return undefined;
     }
-    return entry.value;
+    // SAFETY: `TValue` is what the caller stored under this key; a cache
+    // hands back exactly the value `set` was given for it.
+    return entry.value as TValue;
   }
 
-  async set(key: string, value: unknown, ttlSeconds?: number): Promise<void> {
+  async set<TValue>(
+    key: string,
+    value: TValue,
+    ttlSeconds?: number
+  ): Promise<void> {
     const expires = ttlSeconds ? Date.now() + ttlSeconds * 1000 : null;
     this._store.set(key, { value, expires });
   }
@@ -316,6 +329,33 @@ export type ProviderPredictionRequest = {
   params?: Record<string, unknown>;
 };
 
+/**
+ * What a provider prediction answers with: the result of whichever capability
+ * the request selected, as {@link ProcessingContext.dispatchCapability} routes
+ * it.
+ */
+export type ProviderPredictionResult = Awaited<
+  ReturnType<
+    BaseProvider[
+      | "generateMessageTraced"
+      | "textToImage"
+      | "imageToImage"
+      | "inpaint"
+      | "textToVideo"
+      | "imageToVideo"
+      | "upscaleImage"
+      | "removeBackground"
+      | "relightImage"
+      | "vectorizeImage"
+      | "videoToVideo"
+      | "lipSync"
+      | "textToMusic"
+      | "automaticSpeechRecognition"
+      | "generateEmbedding"
+    ]
+  >
+>;
+
 export type HttpRetryOptions = {
   maxRetries?: number;
   backoffMs?: number;
@@ -382,6 +422,11 @@ export interface InjectedTool {
   name: string;
   description?: string;
   inputSchema?: Record<string, unknown>;
+  /**
+   * HOLDOUT (anti-slop/no-unknown-returns): this contract is satisfied
+   * structurally by `Tool` in `@nodetool-ai/agents`, whose `process` returns
+   * `Promise<unknown>`; narrowing here would stop every tool from fitting.
+   */
   process: (
     context: ProcessingContext,
     params: Record<string, unknown>
@@ -395,10 +440,33 @@ export interface InjectedTool {
     params: Record<string, unknown>,
     options?: { toolCallId?: string }
   ) => Promise<unknown>;
+  // (`execute` is a HOLDOUT for the same reason as `process` above.)
+}
+
+/**
+ * A record the host's persistence layer answers with.
+ *
+ * The row and response types live in `@nodetool-ai/models`, which sits above
+ * `runtime`, so the port names the field every caller reads — the record's
+ * identity — and each caller re-reads the document fields it knows how to
+ * interpret.
+ */
+export interface PersistedRecordLike {
+  id: string;
 }
 
 export interface ProcessingContextModelInterfaces {
-  getJob?: (args: { userId: string; jobId: string }) => Promise<unknown | null>;
+  getJob?: (args: {
+    userId: string;
+    jobId: string;
+  }) => Promise<PersistedRecordLike | null>;
+  /**
+   * HOLDOUT (anti-slop/no-unknown-returns): narrowing this to the created
+   * record's shape breaks the `as Record<string, unknown>` assertions on the
+   * result in `image-nodes` and `audio-nodes` — an interface without an index
+   * signature is not comparable to that type. Typing it honestly means editing
+   * those call sites too.
+   */
   createAsset?: (args: AssetCreateParamsLike) => Promise<unknown>;
   /**
    * Recursively list the non-folder assets contained in `folderId`. Returns
@@ -420,7 +488,7 @@ export interface ProcessingContextModelInterfaces {
   createMessage?: (args: {
     userId: string;
     req: MessageCreateRequestLike;
-  }) => Promise<unknown>;
+  }) => Promise<PersistedRecordLike>;
   getMessages?: (args: {
     userId: string;
     threadId: string;
@@ -432,7 +500,7 @@ export interface ProcessingContextModelInterfaces {
   getImageDocument?: (args: {
     userId: string;
     id: string;
-  }) => Promise<unknown | null>;
+  }) => Promise<PersistedRecordLike | null>;
   /** Create a persisted sketch (image document); returns the created document response. */
   createImageDocument?: (args: {
     userId: string;
@@ -441,32 +509,35 @@ export interface ProcessingContextModelInterfaces {
     width: number;
     height: number;
     document: unknown;
-  }) => Promise<unknown>;
+  }) => Promise<PersistedRecordLike>;
   /** Load a persisted timeline sequence by id; null when missing or not owned. */
   getTimelineSequence?: (args: {
     userId: string;
     id: string;
-  }) => Promise<unknown | null>;
+  }) => Promise<PersistedRecordLike | null>;
   /** Create a persisted timeline sequence from a full sequence document. */
   createTimelineSequence?: (args: {
     userId: string;
     sequence: unknown;
-  }) => Promise<unknown>;
+  }) => Promise<PersistedRecordLike>;
   /** Replace a persisted timeline sequence's document; null when missing or not owned. */
   updateTimelineSequence?: (args: {
     userId: string;
     id: string;
     sequence: unknown;
-  }) => Promise<unknown | null>;
+  }) => Promise<PersistedRecordLike | null>;
   /** Load a persisted script by id; null when missing or not owned. */
-  getScript?: (args: { userId: string; id: string }) => Promise<unknown | null>;
+  getScript?: (args: {
+    userId: string;
+    id: string;
+  }) => Promise<PersistedRecordLike | null>;
   /** Create a persisted script from a name + document. */
   createScript?: (args: {
     userId: string;
     name?: string;
     projectId?: string;
     document: unknown;
-  }) => Promise<unknown>;
+  }) => Promise<PersistedRecordLike>;
   /** Replace a persisted script's document (and optional timeline link); null when missing or not owned. */
   updateScript?: (args: {
     userId: string;
@@ -474,7 +545,7 @@ export interface ProcessingContextModelInterfaces {
     document?: unknown;
     timelineId?: string | null;
     baseUpdatedAt?: string;
-  }) => Promise<unknown | null>;
+  }) => Promise<PersistedRecordLike | null>;
 }
 
 let defaultModelInterfaces: ProcessingContextModelInterfaces | null = null;
@@ -1807,18 +1878,18 @@ export class ProcessingContext {
     return `${this.userId}:${nodeType}:${stableStringifyDeep(nodeProps ?? null)}`;
   }
 
-  async getCachedResult(
+  async getCachedResult<TResult>(
     nodeType: string,
     nodeProps: unknown
-  ): Promise<unknown> {
+  ): Promise<TResult | undefined> {
     const key = this.generateNodeCacheKey(nodeType, nodeProps);
-    return this.cache.get(key);
+    return this.cache.get<TResult>(key);
   }
 
-  async cacheResult(
+  async cacheResult<TResult>(
     nodeType: string,
     nodeProps: unknown,
-    result: unknown,
+    result: TResult,
     ttlSeconds = 3600
   ): Promise<void> {
     const key = this.generateNodeCacheKey(nodeType, nodeProps);
@@ -2187,15 +2258,20 @@ export class ProcessingContext {
     return fn as NonNullable<ProcessingContextModelInterfaces[K]>;
   }
 
-  async getJob(jobId: string): Promise<unknown | null> {
+  async getJob(jobId: string): Promise<PersistedRecordLike | null> {
     const fn = this.requireModelInterface("getJob");
     return fn({ userId: this.userId, jobId });
   }
 
-  async get_job(jobId: string): Promise<unknown | null> {
+  async get_job(jobId: string): Promise<PersistedRecordLike | null> {
     return this.getJob(jobId);
   }
 
+  /**
+   * HOLDOUT (anti-slop/no-unknown-returns): see the `createAsset` port above —
+   * narrowing the result breaks the `as Record<string, unknown>` assertions in
+   * `image-nodes` and `audio-nodes`.
+   */
   async createAsset(args: {
     name: string;
     contentType: string;
@@ -2222,6 +2298,7 @@ export class ProcessingContext {
     });
   }
 
+  /** HOLDOUT (anti-slop/no-unknown-returns): alias of `createAsset` above. */
   async create_asset(args: {
     name: string;
     contentType: string;
@@ -2234,7 +2311,7 @@ export class ProcessingContext {
   }
 
   /** Load a persisted sketch (image document) owned by the current user. */
-  async getImageDocument(id: string): Promise<unknown | null> {
+  async getImageDocument(id: string): Promise<PersistedRecordLike | null> {
     const fn = this.requireModelInterface("getImageDocument");
     return fn({ userId: this.userId, id });
   }
@@ -2246,19 +2323,23 @@ export class ProcessingContext {
     width: number;
     height: number;
     document: unknown;
-  }): Promise<unknown> {
+  }): Promise<PersistedRecordLike> {
     const fn = this.requireModelInterface("createImageDocument");
     return fn({ userId: this.userId, ...args });
   }
 
   /** Load a persisted timeline sequence owned by the current user. */
-  async getTimelineSequence(id: string): Promise<unknown | null> {
+  async getTimelineSequence(
+    id: string
+  ): Promise<PersistedRecordLike | null> {
     const fn = this.requireModelInterface("getTimelineSequence");
     return fn({ userId: this.userId, id });
   }
 
   /** Create a persisted timeline sequence owned by the current user. */
-  async createTimelineSequence(sequence: unknown): Promise<unknown> {
+  async createTimelineSequence(
+    sequence: unknown
+  ): Promise<PersistedRecordLike> {
     const fn = this.requireModelInterface("createTimelineSequence");
     return fn({ userId: this.userId, sequence });
   }
@@ -2267,13 +2348,13 @@ export class ProcessingContext {
   async updateTimelineSequence(
     id: string,
     sequence: unknown
-  ): Promise<unknown | null> {
+  ): Promise<PersistedRecordLike | null> {
     const fn = this.requireModelInterface("updateTimelineSequence");
     return fn({ userId: this.userId, id, sequence });
   }
 
   /** Load a persisted script owned by the current user. */
-  async getScript(id: string): Promise<unknown | null> {
+  async getScript(id: string): Promise<PersistedRecordLike | null> {
     const fn = this.requireModelInterface("getScript");
     return fn({ userId: this.userId, id });
   }
@@ -2283,7 +2364,7 @@ export class ProcessingContext {
     name?: string;
     projectId?: string;
     document: unknown;
-  }): Promise<unknown> {
+  }): Promise<PersistedRecordLike> {
     const fn = this.requireModelInterface("createScript");
     return fn({ userId: this.userId, ...args });
   }
@@ -2296,7 +2377,7 @@ export class ProcessingContext {
       timelineId?: string | null;
       baseUpdatedAt?: string;
     }
-  ): Promise<unknown | null> {
+  ): Promise<PersistedRecordLike | null> {
     const fn = this.requireModelInterface("updateScript");
     return fn({ userId: this.userId, id, ...args });
   }
@@ -2693,6 +2774,8 @@ export class ProcessingContext {
     const filePath = this.resolveSandboxFilePath(path);
     const bytes = (await readFile(filePath)) as Uint8Array;
     const contentType = ProcessingContext.guessMimeFromPath(filePath);
+    // SAFETY: the host's asset persistence answers with its own asset record;
+    // both reads below re-check the field before using it.
     const created = (await this.createAsset({
       name: basename(filePath),
       contentType,
@@ -2719,7 +2802,9 @@ export class ProcessingContext {
     return this.sandboxToAsset(path);
   }
 
-  async createMessage(req: MessageCreateRequestLike): Promise<unknown> {
+  async createMessage(
+    req: MessageCreateRequestLike
+  ): Promise<PersistedRecordLike> {
     if (!req.thread_id) {
       throw new Error("Thread ID is required");
     }
@@ -2727,7 +2812,9 @@ export class ProcessingContext {
     return fn({ userId: this.userId, req });
   }
 
-  async create_message(req: MessageCreateRequestLike): Promise<unknown> {
+  async create_message(
+    req: MessageCreateRequestLike
+  ): Promise<PersistedRecordLike> {
     return this.createMessage(req);
   }
 
@@ -2756,6 +2843,10 @@ export class ProcessingContext {
     return this.getThreadMessages(thread_id, limit, start_key, reverse);
   }
 
+  // The four wrappers below and `normalizeOutputValue` are HOLDOUTs
+  // (anti-slop/no-unknown-returns): they rewrite an arbitrary workflow value —
+  // any node output, at any nesting depth — and NodeTool has no named union
+  // for that value domain.
   async assetsToDataUri(value: unknown): Promise<unknown> {
     return this.normalizeOutputValue(value, "data_uri");
   }
@@ -2947,7 +3038,7 @@ export class ProcessingContext {
   private async dispatchCapability(
     provider: BaseProvider,
     req: ProviderPredictionRequest
-  ): Promise<unknown> {
+  ): Promise<ProviderPredictionResult> {
     const params = req.params ?? {};
     switch (req.capability) {
       case "generate_message":
@@ -3100,6 +3191,12 @@ export class ProcessingContext {
     }
   }
 
+  /**
+   * HOLDOUT (anti-slop/no-unknown-returns): the honest return type is
+   * {@link ProviderPredictionResult} (see {@link dispatchCapability}), but
+   * `text-nodes` asserts the result of an ASR prediction `as string`, which no
+   * longer compiles against that union. Typing it means editing that call site.
+   */
   async runProviderPrediction(
     req: ProviderPredictionRequest
   ): Promise<unknown> {
@@ -3257,6 +3354,8 @@ export class ProcessingContext {
    *
    * Port of sanitize_memory_uris_for_client() from types.py.
    */
+  // HOLDOUT (anti-slop/no-unknown-returns): same value domain as
+  // `normalizeOutputValue` — an arbitrary node output, rewritten in place.
   static sanitizeForClient(value: unknown): unknown {
     if (value === null || value === undefined) return value;
     const binary = ProcessingContext.toClientBytes(value);
@@ -3508,6 +3607,9 @@ export class ProcessingContext {
    * Recursively normalize workflow outputs, materializing asset-like values
    * according to the selected output mode.
    */
+  // HOLDOUT (anti-slop/no-unknown-returns): the input and the result are an
+  // arbitrary workflow value; naming that domain is a bigger change than a
+  // typing pass.
   async normalizeOutputValue(
     value: unknown,
     mode: AssetOutputMode = this.assetOutputMode

--- a/packages/runtime/src/image-codec.ts
+++ b/packages/runtime/src/image-codec.ts
@@ -96,7 +96,7 @@ export async function encodeRawRgbaToPng(
  * encoded to PNG and `mimeType` set to `image/png`; otherwise return it
  * unchanged. Use at any boundary that must hand out a portable image.
  */
-export async function encodeRawImageRef(ref: unknown): Promise<unknown> {
+export async function encodeRawImageRef<T>(ref: T): Promise<T | ImageRef> {
   if (!isRawRgbaImage(ref)) return ref;
   const png = await encodeRawRgbaToPng(ref.data, ref.width, ref.height);
   return { ...(ref as ImageRef), data: png, mimeType: "image/png" };

--- a/packages/runtime/src/node-executor.ts
+++ b/packages/runtime/src/node-executor.ts
@@ -30,7 +30,12 @@ export interface StreamingInputs {
   any(): AsyncGenerator<[string, unknown]>;
   /** Yield [handle, MessageEnvelope] tuples in arrival order. */
   anyWithEnvelope(): AsyncGenerator<[string, MessageEnvelopeLike]>;
-  /** Return the first available item for a handle, or default if EOS. */
+  /**
+   * Return the first available item for a handle, or default if EOS.
+   *
+   * HOLDOUT (anti-slop/no-unknown-returns): the item is an arbitrary workflow
+   * value, the same open domain `stream()` and `any()` yield.
+   */
   first(name: string, defaultValue?: unknown): Promise<unknown>;
 
   /**

--- a/packages/runtime/src/providers/anthropic-provider.ts
+++ b/packages/runtime/src/providers/anthropic-provider.ts
@@ -48,6 +48,16 @@ interface AnthropicProviderOptions {
   providerId?: ProviderId;
 }
 
+/** One node of a JSON Schema document, as a tool's `input_schema` carries it. */
+type JsonSchemaNode =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | JsonSchemaNode[]
+  | { [key: string]: JsonSchemaNode };
+
 type AnthropicRawBlock = Record<string, unknown>;
 type AnthropicToolCall = ToolCall & {
   _anthropicContentBlocks?: AnthropicRawBlock[];
@@ -508,12 +518,18 @@ export class AnthropicProvider extends BaseProvider {
     return [];
   }
 
-  private prepareJsonSchema(schema: unknown): unknown {
+  private prepareJsonSchema(schema: unknown): JsonSchemaNode {
     if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
-      return schema;
+      // SAFETY: a schema node that is not an object is carried through as it
+      // stands — a scalar, a list, or an absent schema.
+      return schema as JsonSchemaNode;
     }
 
-    const obj = { ...(schema as Record<string, unknown>) };
+    const obj: { [key: string]: JsonSchemaNode } = {
+      // SAFETY: the checks above proved `schema` is a plain object of schema
+      // members.
+      ...(schema as { [key: string]: JsonSchemaNode })
+    };
 
     if (obj.type === "object" && obj.additionalProperties === undefined) {
       obj.additionalProperties = false;
@@ -525,9 +541,10 @@ export class AnthropicProvider extends BaseProvider {
       !Array.isArray(obj.properties)
     ) {
       obj.properties = Object.fromEntries(
-        Object.entries(obj.properties as Record<string, unknown>).map(
-          ([k, v]) => [k, this.prepareJsonSchema(v)]
-        )
+        Object.entries(obj.properties).map(([k, v]) => [
+          k,
+          this.prepareJsonSchema(v)
+        ])
       );
     }
 
@@ -539,10 +556,7 @@ export class AnthropicProvider extends BaseProvider {
       const defs = obj[defsKey];
       if (defs && typeof defs === "object" && !Array.isArray(defs)) {
         obj[defsKey] = Object.fromEntries(
-          Object.entries(defs as Record<string, unknown>).map(([k, v]) => [
-            k,
-            this.prepareJsonSchema(v)
-          ])
+          Object.entries(defs).map(([k, v]) => [k, this.prepareJsonSchema(v)])
         );
       }
     }

--- a/packages/runtime/src/providers/atlascloud-provider.ts
+++ b/packages/runtime/src/providers/atlascloud-provider.ts
@@ -325,7 +325,7 @@ function imageDataUri(bytes: Uint8Array): string {
 // ---------------------------------------------------------------------------
 
 /** Coerce a value to the manifest-declared scalar type, or null when it can't. */
-function coerceToType(value: unknown, type: string): unknown {
+function coerceToType<T>(value: T, type: string): T | number | boolean | null {
   switch (type) {
     case "int": {
       const n = typeof value === "number" ? value : Number(value);
@@ -349,15 +349,17 @@ function coerceToType(value: unknown, type: string): unknown {
  * 422); string enums must match exactly. Returns null when the field can't
  * take the value at all.
  */
-function resolveForField(field: FieldInfo, value: unknown): unknown {
+function resolveForField<T>(
+  field: FieldInfo,
+  value: T
+): T | string | number | boolean | null {
   const coerced = coerceToType(value, field.type);
   if (coerced === null || coerced === undefined || coerced === "") return null;
   const allowed = field.values;
   if (!allowed || allowed.length === 0) return coerced;
-  if (allowed.some((v) => String(v) === String(coerced))) {
-    // Return the declared member so numeric enums keep their JSON type.
-    return allowed.find((v) => String(v) === String(coerced));
-  }
+  // Return the declared member so numeric enums keep their JSON type.
+  const member = allowed.find((v) => String(v) === String(coerced));
+  if (member !== undefined) return member;
   if (typeof coerced === "number") {
     // Negative members are sentinels ("-1" = let the model decide), never a
     // sensible approximation of a number the caller actually asked for.

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -324,8 +324,10 @@ export abstract class BaseProvider {
     for (const name of MODALITY_PROMISE_METHODS) {
       const fn = self[name];
       if (typeof fn !== "function" || fn === proto[name]) continue;
-      const original = fn as (...args: unknown[]) => Promise<unknown>;
-      self[name] = (...rawArgs: unknown[]): Promise<unknown> =>
+      // SAFETY: `name` comes from MODALITY_PROMISE_METHODS and the check above
+      // proved this instance overrides it, so `fn` is that modality method.
+      const original = fn as (...args: unknown[]) => Promise<ModalityResult>;
+      self[name] = (...rawArgs: unknown[]): Promise<ModalityResult> =>
         withModalityCapture(async (alreadyActive) => {
           // Central entity expansion: descriptors into the prompt, reference
           // images onto the source list, before the concrete provider runs.
@@ -1590,6 +1592,15 @@ export abstract class BaseProvider {
  * logging. Batch helpers are included; nested delegation to their singular
  * method is logged once (see {@link withModalityCapture}).
  */
+/**
+ * What any of the wrapped modality methods resolves to — bytes for the image
+ * and video tasks, an encoded audio result for speech and music, a transcript
+ * for ASR, vectors for embeddings.
+ */
+type ModalityResult = Awaited<
+  ReturnType<BaseProvider[(typeof MODALITY_PROMISE_METHODS)[number]]>
+>;
+
 const MODALITY_PROMISE_METHODS = [
   "textToImage",
   "textToImages",

--- a/packages/runtime/src/providers/cassette-provider.ts
+++ b/packages/runtime/src/providers/cassette-provider.ts
@@ -176,6 +176,15 @@ export function createEmptyCassette(): Cassette {
 // Stable hashing
 // ---------------------------------------------------------------------------
 
+/** A value reduced to the JSON shapes `stableStringify` hashes. */
+type StableValue =
+  | string
+  | number
+  | boolean
+  | null
+  | StableValue[]
+  | { [key: string]: StableValue };
+
 /**
  * Deterministic JSON with object keys sorted at every level. Arrays keep their
  * order. Typed arrays/Buffers are encoded as a tagged base64 string so binary
@@ -184,13 +193,14 @@ export function createEmptyCassette(): Cassette {
 export function stableStringify(value: unknown): string {
   const seen = new WeakSet<object>();
 
-  const encode = (v: unknown): unknown => {
+  const encode = (v: unknown): StableValue => {
     if (v === null || typeof v !== "object") {
       // Normalize undefined (omitted by JSON.stringify) and functions to null
       // so two requests differing only in an unset optional hash identically.
       if (typeof v === "undefined" || typeof v === "function") return null;
       if (typeof v === "bigint") return `__bigint__:${v.toString()}`;
-      return v;
+      // SAFETY: what is left is a JSON scalar — string, number, boolean, null.
+      return v as StableValue;
     }
     if (v instanceof Uint8Array) {
       return `__bytes__:${bytesToBase64(v)}`;
@@ -208,7 +218,7 @@ export function stableStringify(value: unknown): string {
         return v.map(encode);
       }
       const obj = v as Record<string, unknown>;
-      const out: Record<string, unknown> = {};
+      const out: { [key: string]: StableValue } = {};
       for (const key of Object.keys(obj).sort()) {
         out[key] = encode(obj[key]);
       }

--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -246,37 +246,53 @@ function resolveJsonPointer(
  * Inline local `$ref`s so dropping `$defs` doesn't leave empty schemas behind.
  * A ref that is cyclic or unresolvable degrades to a permissive object.
  */
+/**
+ * One node of a JSON Schema document: an object of nodes, a list of nodes, or
+ * a scalar. This is the domain the three walkers below rewrite.
+ */
+type SchemaNode =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | SchemaNode[]
+  | { [key: string]: SchemaNode };
+
 function inlineGeminiRefs(
   node: unknown,
   root: unknown,
   seen: ReadonlySet<string>
-): unknown {
+): SchemaNode {
   if (Array.isArray(node)) {
     return node.map((item) => inlineGeminiRefs(item, root, seen));
   }
-  if (!isPlainObject(node)) return node;
+  // SAFETY: a schema node that is neither a list nor an object is a JSON
+  // scalar — this walker is only ever handed a decoded JSON Schema.
+  if (!isPlainObject(node)) return node as SchemaNode;
 
   if (typeof node.$ref === "string") {
     const { $ref, ...rest } = node;
     if (seen.has($ref)) return { type: "object", ...rest };
     const { found, value } = resolveJsonPointer(root, $ref);
     if (!found || !isPlainObject(value)) return { type: "object", ...rest };
-    const resolved = inlineGeminiRefs(
-      value,
-      root,
-      new Set([...seen, $ref])
-    ) as Record<string, unknown>;
-    const overrides = inlineGeminiRefs(rest, root, seen) as Record<
-      string,
-      unknown
-    >;
+    // SAFETY: both inputs are objects, so both results are objects too.
+    const resolved = inlineGeminiRefs(value, root, new Set([...seen, $ref])) as {
+      [key: string]: SchemaNode;
+    };
+    // SAFETY: as above.
+    const overrides = inlineGeminiRefs(rest, root, seen) as {
+      [key: string]: SchemaNode;
+    };
     return { ...resolved, ...overrides };
   }
 
-  const out: Record<string, unknown> = {};
+  const out: { [key: string]: SchemaNode } = {};
   for (const [key, value] of Object.entries(node)) {
     out[key] = GEMINI_DATA_KEYS.has(key)
-      ? value
+      ? // SAFETY: a data key's value is carried through verbatim; it is part of
+        // the same decoded JSON Schema.
+        (value as SchemaNode)
       : inlineGeminiRefs(value, root, seen);
   }
   return out;
@@ -284,15 +300,19 @@ function inlineGeminiRefs(
 
 /** Fold `allOf` members into the parent schema; parent keys win. */
 function mergeAllOf(
-  out: Record<string, unknown>,
+  out: { [key: string]: SchemaNode },
   members: unknown[]
-): Record<string, unknown> {
+): { [key: string]: SchemaNode } {
   for (const member of members) {
     const sanitized = sanitizeSchemaNode(member);
     if (!isPlainObject(sanitized)) continue;
     for (const [key, value] of Object.entries(sanitized)) {
       if (key === "properties" && isPlainObject(value)) {
-        out.properties = { ...value, ...((out.properties as object) ?? {}) };
+        // SAFETY: both sides are `properties` maps of the same schema.
+        out.properties = {
+          ...(value as { [key: string]: SchemaNode }),
+          ...((out.properties as { [key: string]: SchemaNode }) ?? {})
+        };
         continue;
       }
       if (key === "required" && Array.isArray(value)) {
@@ -306,15 +326,16 @@ function mergeAllOf(
   return out;
 }
 
-function sanitizeSchemaNode(value: unknown): unknown {
+function sanitizeSchemaNode(value: unknown): SchemaNode {
   if (Array.isArray(value)) return value.map(sanitizeSchemaNode);
-  if (!isPlainObject(value)) return value;
+  // SAFETY: as in `inlineGeminiRefs` — a non-list, non-object node is a scalar.
+  if (!isPlainObject(value)) return value as SchemaNode;
 
-  const out: Record<string, unknown> = {};
+  const out: { [key: string]: SchemaNode } = {};
   for (const [key, nested] of Object.entries(value)) {
     if (GEMINI_UNSUPPORTED_SCHEMA_KEYS.has(key)) continue;
     if (key === "properties" && isPlainObject(nested)) {
-      const properties: Record<string, unknown> = {};
+      const properties: { [key: string]: SchemaNode } = {};
       // Property *names* are data — a property called "const" must survive.
       for (const [name, sub] of Object.entries(nested)) {
         properties[name] = sanitizeSchemaNode(sub);
@@ -332,7 +353,11 @@ function sanitizeSchemaNode(value: unknown): unknown {
       out.anyOf = nested.map(sanitizeSchemaNode);
       continue;
     }
-    out[key] = GEMINI_DATA_KEYS.has(key) ? nested : sanitizeSchemaNode(nested);
+    out[key] = GEMINI_DATA_KEYS.has(key)
+      ? // SAFETY: a data key's value is carried through verbatim; it is part of
+        // the same decoded JSON Schema.
+        (nested as SchemaNode)
+      : sanitizeSchemaNode(nested);
   }
 
   // `oneOf` means the same thing to a model as `anyOf`, which Gemini accepts.
@@ -347,7 +372,8 @@ function sanitizeSchemaNode(value: unknown): unknown {
   if (value.const !== undefined && out.enum === undefined) {
     const literalType = primitiveSchemaType(value.const);
     if (literalType === "string") {
-      out.enum = [value.const];
+      // SAFETY: `primitiveSchemaType` proved the literal is a string.
+      out.enum = [value.const as string];
       out.type ??= "string";
     } else if (literalType) {
       out.type ??= literalType;
@@ -378,7 +404,7 @@ function sanitizeSchemaNode(value: unknown): unknown {
   return out;
 }
 
-function sanitizeGeminiSchema(value: unknown): unknown {
+function sanitizeGeminiSchema(value: unknown): SchemaNode {
   return sanitizeSchemaNode(inlineGeminiRefs(value, value, new Set()));
 }
 

--- a/packages/runtime/src/providers/kie-provider.ts
+++ b/packages/runtime/src/providers/kie-provider.ts
@@ -407,7 +407,7 @@ function nearestAspect(
 function coerceDuration(
   field: ModelInputField | undefined,
   seconds: number
-): unknown {
+): string | number | undefined {
   if (!field) return undefined;
   if (field.type === "enum" && field.enumValues && field.enumValues.length > 0) {
     let best: { value: string; diff: number } | undefined;
@@ -429,6 +429,11 @@ function coerceDuration(
  * meaningful (not an empty string), otherwise the first enum option. KIE's
  * required `model` field ships with an empty default, so the first declared
  * version is used.
+ */
+/**
+ * HOLDOUT (anti-slop/no-unknown-returns): the value comes straight from the
+ * manifest's `default`, which `ModelInputField` declares `unknown`; naming the
+ * result means typing the manifest decoder in `manifest-models.ts`.
  */
 function defaultForField(field: ModelInputField): unknown {
   const d = field.default;

--- a/packages/runtime/src/providers/kie-webhook-registry.ts
+++ b/packages/runtime/src/providers/kie-webhook-registry.ts
@@ -20,6 +20,10 @@ const pending = new Map<string, PendingTask>();
 /**
  * Register a task and return a promise that resolves when the webhook fires.
  * Rejects on timeout or abort.
+ *
+ * HOLDOUT (anti-slop/no-unknown-returns): the resolved value is the body KIE
+ * posted to the callback URL, which has no schema in this repo and which the
+ * registry never reads.
  */
 export function registerWebhookWait(
   taskId: string,

--- a/packages/runtime/src/providers/node-llama-cpp-provider.ts
+++ b/packages/runtime/src/providers/node-llama-cpp-provider.ts
@@ -91,7 +91,8 @@ interface ChatSessionOptions {
 interface ChatSessionModelFunction {
   description?: string;
   params?: Record<string, unknown>;
-  handler: (params: Record<string, unknown>) => Promise<unknown> | unknown;
+  /** Always answers with text: either the harness's tool result or `""`. */
+  handler: (params: Record<string, unknown>) => Promise<string> | string;
 }
 
 type ChatSessionModelFunctions = Record<string, ChatSessionModelFunction>;

--- a/packages/runtime/src/providers/oauth/claude-code-oauth-client.ts
+++ b/packages/runtime/src/providers/oauth/claude-code-oauth-client.ts
@@ -41,7 +41,8 @@ export type JsonFetchLike = (
 ) => Promise<{
   ok: boolean;
   status: number;
-  json(): Promise<unknown>;
+  /** Decode the body as the caller's named response type. */
+  json<TBody>(): Promise<TBody>;
 }>;
 
 /** Which sign-in page the authorization URL points at. */
@@ -111,6 +112,16 @@ interface ClaudeTokenResponse {
   organization?: { uuid?: unknown } | null;
   error?: unknown;
   error_description?: unknown;
+}
+
+/** Raw profile-endpoint response. Every field is validated before use. */
+interface ClaudeProfileResponse {
+  account?: { email_address?: unknown; display_name?: unknown } | null;
+  organization?: {
+    organization_type?: unknown;
+    rate_limit_tier?: unknown;
+    name?: unknown;
+  } | null;
 }
 
 const REQUEST_TIMEOUT_MS = 30_000;
@@ -219,14 +230,7 @@ export class ClaudeCodeOAuthClient {
         signal: signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS)
       });
       if (!res.ok) return null;
-      const body = (await res.json()) as {
-        account?: { email_address?: unknown; display_name?: unknown } | null;
-        organization?: {
-          organization_type?: unknown;
-          rate_limit_tier?: unknown;
-          name?: unknown;
-        } | null;
-      };
+      const body = await res.json<ClaudeProfileResponse>();
       return {
         subscriptionType: subscriptionTypeOf(
           body.organization?.organization_type
@@ -268,7 +272,7 @@ export class ClaudeCodeOAuthClient {
 
     let payload: ClaudeTokenResponse;
     try {
-      payload = (await res.json()) as ClaudeTokenResponse;
+      payload = await res.json<ClaudeTokenResponse>();
     } catch {
       payload = {};
     }

--- a/packages/runtime/src/providers/oauth/oauth-client.ts
+++ b/packages/runtime/src/providers/oauth/oauth-client.ts
@@ -36,7 +36,8 @@ export type FetchLike = (
 ) => Promise<{
   ok: boolean;
   status: number;
-  json(): Promise<unknown>;
+  /** Decode the body as the caller's named response type. */
+  json<TBody>(): Promise<TBody>;
   text(): Promise<string>;
 }>;
 
@@ -177,7 +178,7 @@ export class OAuthClient {
 
   private async readJson(res: Awaited<ReturnType<FetchLike>>): Promise<TokenResponseBody> {
     try {
-      return (await res.json()) as TokenResponseBody;
+      return await res.json<TokenResponseBody>();
     } catch {
       // Some servers send an empty / non-JSON error body.
       return {};

--- a/packages/runtime/src/providers/oauth/redaction.ts
+++ b/packages/runtime/src/providers/oauth/redaction.ts
@@ -38,9 +38,24 @@ export function redactToken(value: string | null | undefined): string {
  * `<redacted>`. Safe to pass straight into a logger. Cycles are broken with a
  * `[Circular]` marker so logging can never throw.
  */
-export function redactObject(input: unknown, seen = new WeakSet<object>()): unknown {
+/** A value with every sensitive field replaced — safe to hand to a logger. */
+export type RedactedValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | RedactedValue[]
+  | { [key: string]: RedactedValue };
+
+export function redactObject(
+  input: unknown,
+  seen = new WeakSet<object>()
+): RedactedValue {
   if (input === null || typeof input !== "object") {
-    return input;
+    // SAFETY: a non-object carries no fields to redact and goes to the logger
+    // as it stands.
+    return input as RedactedValue;
   }
   if (seen.has(input as object)) {
     return "[Circular]";
@@ -51,7 +66,7 @@ export function redactObject(input: unknown, seen = new WeakSet<object>()): unkn
     return input.map((item) => redactObject(item, seen));
   }
 
-  const out: Record<string, unknown> = {};
+  const out: { [key: string]: RedactedValue } = {};
   for (const [key, val] of Object.entries(input as Record<string, unknown>)) {
     if (SENSITIVE_KEYS.has(key.toLowerCase())) {
       out[key] = REDACTED;

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -157,7 +157,16 @@ function openAiAudioFormat(
  * Custom JSON replacer that handles objects with toJSON() methods
  * and other non-serializable types. Mirrors Python's _default_serializer.
  */
-function defaultSerializer(_key: string, value: unknown): unknown {
+/** A value `JSON.stringify` can emit directly. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+function defaultSerializer<T>(_key: string, value: T): T | JsonValue {
   if (value === null || value === undefined) return value;
   if (typeof value === "bigint") return Number(value);
   if (value instanceof Date) return value.toISOString();
@@ -168,7 +177,9 @@ function defaultSerializer(_key: string, value: unknown): unknown {
     "toJSON" in value &&
     typeof (value as { toJSON: unknown }).toJSON === "function"
   ) {
-    return (value as { toJSON: () => unknown }).toJSON();
+    // SAFETY: `toJSON` is the JSON.stringify protocol hook — it exists on the
+    // value and, by that contract, produces a JSON-representable result.
+    return (value as { toJSON: () => JsonValue }).toJSON();
   }
   return value;
 }

--- a/packages/runtime/src/providers/provider-error.ts
+++ b/packages/runtime/src/providers/provider-error.ts
@@ -161,10 +161,10 @@ function hintFor(
  * stack) is left intact. Aborts and already-annotated errors pass through
  * untouched. Returns the same error so callers can `throw annotateProviderError(...)`.
  */
-export function annotateProviderError(
-  error: unknown,
+export function annotateProviderError<TError>(
+  error: TError,
   context: { provider: string; model?: string }
-): unknown {
+): TError {
   if (!(error instanceof Error)) return error;
   const candidate = error as Error & ErrorLike;
   if (candidate[ANNOTATED] || isAbort(candidate)) return error;

--- a/packages/runtime/src/providers/provider-request-log.ts
+++ b/packages/runtime/src/providers/provider-request-log.ts
@@ -73,20 +73,34 @@ function truncateString(s: string, max: number): string {
  * arrays are truncated, binary buffers become size markers, secret-bearing
  * keys are redacted, and circular references are broken. Never throws.
  */
+/**
+ * A JSON-safe value: what {@link sanitizeForLog} produces. `undefined` is kept
+ * rather than rewritten, so a log line still shows a field that was unset.
+ */
+export type LogSafeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | LogSafeValue[]
+  | { [key: string]: LogSafeValue };
+
 export function sanitizeForLog(
   value: unknown,
   opts: SanitizeOptions = {}
-): unknown {
+): LogSafeValue {
   const o = { ...SANITIZE_DEFAULTS, ...opts };
   // Tracks the current DFS path (not all visited nodes) so shared-but-acyclic
   // references aren't falsely flagged as circular.
   const ancestors = new WeakSet<object>();
 
-  function walk(v: unknown, depth: number): unknown {
+  function walk(v: unknown, depth: number): LogSafeValue {
     if (v === null || v === undefined) return v;
     const t = typeof v;
     if (t === "string") return truncateString(v as string, o.maxStringLength);
-    if (t === "number" || t === "boolean") return v;
+    // SAFETY: `t` is `typeof v`, so this arm has proved v is a number/boolean.
+    if (t === "number" || t === "boolean") return v as number | boolean;
     if (t === "bigint") return `${(v as bigint).toString()}n`;
     if (t === "function") {
       return `[function ${(v as { name?: string }).name || "anonymous"}]`;
@@ -111,7 +125,7 @@ export function sanitizeForLog(
           }
           return out;
         }
-        const out: Record<string, unknown> = {};
+        const out: { [key: string]: LogSafeValue } = {};
         for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
           out[k] = isSecretKey(k) ? "[redacted]" : walk(val, depth + 1);
         }

--- a/packages/runtime/src/providers/responses-api.ts
+++ b/packages/runtime/src/providers/responses-api.ts
@@ -158,9 +158,14 @@ export function responseTools(
   }));
 }
 
+/** The Responses API's `tool_choice`: forced, or a named function. */
+export type ResponseToolChoice =
+  | "required"
+  | { type: "function"; name: string };
+
 export function responseToolChoice(
   toolChoice: string | "any" | undefined
-): unknown {
+): ResponseToolChoice | undefined {
   if (!toolChoice) return undefined;
   // "any" is the cross-provider sentinel for "the model MUST call a tool". The
   // Responses API forcing value is "required"; "auto" (the previous mapping) is

--- a/packages/runtime/src/tracing-helpers.ts
+++ b/packages/runtime/src/tracing-helpers.ts
@@ -58,9 +58,15 @@ export interface LlmUsage {
  * We use AsyncLocalStorage rather than an instance field so concurrent calls
  * on the same provider instance don't clobber each other.
  */
+/**
+ * The exact body a provider sent, held only so a failure log can sanitize and
+ * print it. Every provider records an object (its SDK's request params).
+ */
+export type RecordedRequestPayload = object | null;
+
 interface CallSlot {
   usage: LlmUsage | null;
-  request: unknown;
+  request: RecordedRequestPayload;
   /**
    * Set while a non-chat modality call (image/video/audio/3D/embedding) is
    * being failure-logged. Lets nested calls — e.g. a batch helper delegating
@@ -123,11 +129,12 @@ export function peekLastUsage(): LlmUsage | null {
  */
 export function setLastRequest(request: unknown): void {
   const slot = usageStore.getStore();
-  if (slot) slot.request = request;
+  // SAFETY: every provider records its SDK's request-params object here.
+  if (slot) slot.request = request as RecordedRequestPayload;
 }
 
 /** Read (without clearing) the request payload recorded in this async context. */
-export function peekLastRequest(): unknown {
+export function peekLastRequest(): RecordedRequestPayload {
   return usageStore.getStore()?.request ?? null;
 }
 
@@ -160,7 +167,7 @@ export function withModalityCapture<T>(
 export function createUsageSlot(): {
   runInSlot: <T>(fn: () => Promise<T>) => Promise<T>;
   getUsage: () => LlmUsage | null;
-  getRequest: () => unknown;
+  getRequest: () => RecordedRequestPayload;
 } {
   const slot: CallSlot = { usage: null, request: null };
   return {

--- a/packages/runtime/src/zod-schema.ts
+++ b/packages/runtime/src/zod-schema.ts
@@ -21,12 +21,24 @@ export function zodToJsonSchema(schema: ZodType): JsonSchema {
   }
 }
 
-function cloneForMutation(value: unknown): unknown {
+/**
+ * A tool call's arguments as they arrive: decoded JSON, which is what the
+ * coercion helpers below walk and rewrite.
+ */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+function cloneForMutation(value: JsonValue): JsonValue {
   if (Array.isArray(value)) {
     return value.map((item) => cloneForMutation(item));
   }
   if (value && typeof value === "object") {
-    const cloned: Record<string, unknown> = {};
+    const cloned: { [key: string]: JsonValue } = {};
     for (const [key, nested] of Object.entries(value)) {
       cloned[key] = cloneForMutation(nested);
     }
@@ -35,7 +47,10 @@ function cloneForMutation(value: unknown): unknown {
   return value;
 }
 
-function getValueAtPath(value: unknown, path: Array<string | number>): unknown {
+function getValueAtPath(
+  value: JsonValue,
+  path: Array<string | number>
+): JsonValue | undefined {
   let cursor = value;
   for (const segment of path) {
     if (Array.isArray(cursor) && typeof segment === "number") {
@@ -43,7 +58,9 @@ function getValueAtPath(value: unknown, path: Array<string | number>): unknown {
       continue;
     }
     if (cursor && typeof cursor === "object" && typeof segment === "string") {
-      cursor = (cursor as Record<string, unknown>)[segment];
+      // SAFETY: the check above proved `cursor` is an object; an array reached
+      // by a string key reads as `undefined`, exactly as it did before.
+      cursor = (cursor as { [key: string]: JsonValue })[segment];
       continue;
     }
     return undefined;
@@ -52,9 +69,9 @@ function getValueAtPath(value: unknown, path: Array<string | number>): unknown {
 }
 
 function setValueAtPath(
-  value: unknown,
+  value: JsonValue,
   path: Array<string | number>,
-  nextValue: unknown
+  nextValue: JsonValue
 ): boolean {
   if (path.length === 0) {
     return false;
@@ -67,7 +84,8 @@ function setValueAtPath(
       continue;
     }
     if (cursor && typeof cursor === "object" && typeof segment === "string") {
-      cursor = (cursor as Record<string, unknown>)[segment];
+      // SAFETY: as in `getValueAtPath` — an object indexed by a string key.
+      cursor = (cursor as { [key: string]: JsonValue })[segment];
       continue;
     }
     return false;
@@ -79,16 +97,17 @@ function setValueAtPath(
     return true;
   }
   if (cursor && typeof cursor === "object" && typeof last === "string") {
-    (cursor as Record<string, unknown>)[last] = nextValue;
+    // SAFETY: as in `getValueAtPath` — an object indexed by a string key.
+    (cursor as { [key: string]: JsonValue })[last] = nextValue;
     return true;
   }
   return false;
 }
 
 function coerceStringValueForExpectedType(
-  value: unknown,
+  value: JsonValue | undefined,
   expected: "boolean" | "number"
-): unknown {
+): JsonValue | undefined {
   if (typeof value !== "string") {
     return value;
   }
@@ -112,10 +131,10 @@ function coerceStringValueForExpectedType(
   return Number.isFinite(parsed) ? parsed : value;
 }
 
-export function parseWithTypeCoercion(
-  schema: ZodType,
+export function parseWithTypeCoercion<TSchema extends ZodType>(
+  schema: TSchema,
   args: unknown
-): unknown {
+): z.output<TSchema> {
   const parsed = schema.safeParse(args);
   if (parsed.success) {
     return parsed.data;
@@ -138,7 +157,9 @@ export function parseWithTypeCoercion(
     throw parsed.error;
   }
 
-  let coercedArgs = cloneForMutation(args);
+  // SAFETY: `args` are a tool call's arguments — decoded JSON — which is the
+  // domain the coercion helpers below walk.
+  let coercedArgs = cloneForMutation(args as JsonValue);
   let changed = false;
   for (const { issue, expected } of coercibleIssues) {
     const path = issue.path.filter(
@@ -147,7 +168,10 @@ export function parseWithTypeCoercion(
     );
     const currentValue = getValueAtPath(coercedArgs, path);
     const nextValue = coerceStringValueForExpectedType(currentValue, expected);
-    if (nextValue === currentValue) {
+    // `coerceStringValueForExpectedType` answers with its input or with a
+    // boolean/number, so an `undefined` result means the input was `undefined`
+    // — the first arm already covers it.
+    if (nextValue === currentValue || nextValue === undefined) {
       continue;
     }
     if (path.length === 0) {

--- a/packages/storage/src/memory-node-cache.ts
+++ b/packages/storage/src/memory-node-cache.ts
@@ -1,19 +1,19 @@
-export interface AbstractNodeCache {
-  get(key: string): Promise<unknown | undefined>;
-  set(key: string, value: unknown, ttlSeconds?: number): Promise<void>;
+export interface AbstractNodeCache<TValue> {
+  get(key: string): Promise<TValue | undefined>;
+  set(key: string, value: TValue, ttlSeconds?: number): Promise<void>;
   delete(key: string): Promise<void>;
   clear(): Promise<void>;
 }
 
-interface CacheEntry {
-  value: unknown;
+interface CacheEntry<TValue> {
+  value: TValue;
   expiresAt: number | null;
 }
 
-export class MemoryNodeCache implements AbstractNodeCache {
-  private _store = new Map<string, CacheEntry>();
+export class MemoryNodeCache<TValue> implements AbstractNodeCache<TValue> {
+  private _store = new Map<string, CacheEntry<TValue>>();
 
-  async get(key: string): Promise<unknown | undefined> {
+  async get(key: string): Promise<TValue | undefined> {
     const entry = this._store.get(key);
     if (!entry) return undefined;
     if (entry.expiresAt !== null && Date.now() >= entry.expiresAt) {
@@ -23,7 +23,7 @@ export class MemoryNodeCache implements AbstractNodeCache {
     return entry.value;
   }
 
-  async set(key: string, value: unknown, ttlSeconds?: number): Promise<void> {
+  async set(key: string, value: TValue, ttlSeconds?: number): Promise<void> {
     const expiresAt =
       ttlSeconds != null ? Date.now() + ttlSeconds * 1000 : null;
     this._store.set(key, { value, expiresAt });

--- a/packages/together-nodes/src/together-factory.ts
+++ b/packages/together-nodes/src/together-factory.ts
@@ -83,7 +83,7 @@ const ASSET_TYPES = new Set<TogetherFieldType>(["image", "audio", "video"]);
 
 type ProcessContext = Parameters<BaseNode["process"]>[0] & AssetResolveContext;
 
-function coerceScalar(v: unknown, type: TogetherFieldType): unknown {
+function coerceScalar(v: NodeValue, type: TogetherFieldType): NodeValue {
   switch (type) {
     case "int": {
       if (typeof v === "number") return Math.trunc(v);
@@ -105,7 +105,35 @@ function coerceScalar(v: unknown, type: TogetherFieldType): unknown {
   }
 }
 
-function defaultForType(type: TogetherFieldType): unknown {
+/**
+ * A value held by a node property or by a prompt-asset override: NodeTool's
+ * property types are scalars, media refs, and lists or dicts of those.
+ */
+type NodeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Uint8Array
+  | NodeValue[]
+  | { [key: string]: NodeValue };
+
+/**
+ * The empty media ref a media property starts at before the user picks an asset.
+ */
+type EmptyMediaRef = {
+  type: "image" | "video" | "audio";
+  uri: string;
+  asset_id: null;
+  data: null;
+  metadata: null;
+};
+
+/** What a property starts at when the manifest names no default. */
+type FieldDefault = boolean | number | string | EmptyMediaRef;
+
+function defaultForType(type: TogetherFieldType): FieldDefault {
   switch (type) {
     case "bool":
       return false;
@@ -218,8 +246,10 @@ export function createTogetherNodeClass(spec: TogetherManifestEntry): NodeClass 
         context
       );
       const self = this as unknown as Record<string, unknown>;
-      const read = (name: string): unknown =>
-        name in overrides ? overrides[name] : self[name];
+      // SAFETY: both sources hold node property values, and NodeTool restricts
+      // those to its own property types — the shapes `NodeValue` names.
+      const read = (name: string): NodeValue =>
+        (name in overrides ? overrides[name] : self[name]) as NodeValue;
 
       // Collect scalar field values; resolve asset fields to raw bytes.
       const scalars: Record<string, unknown> = {};

--- a/packages/topaz-nodes/src/topaz-factory.ts
+++ b/packages/topaz-nodes/src/topaz-factory.ts
@@ -64,7 +64,10 @@ function isAssetType(type: string): boolean {
   return type === "image" || type === "video";
 }
 
-function castValue(value: unknown, type: string): unknown {
+/** A scalar as the Topaz API takes it, after coercion from the stored value. */
+type CoercedScalar = string | number | boolean | null | undefined;
+
+function castValue(value: unknown, type: string): CoercedScalar {
   if (value === null || value === undefined) return value;
   switch (type) {
     case "int":
@@ -77,7 +80,24 @@ function castValue(value: unknown, type: string): unknown {
   }
 }
 
-function defaultForType(type: string): unknown {
+/**
+ * The empty media ref a media property starts at before the user picks an
+ * asset. `duration` and `format` are carried by video only.
+ */
+type EmptyMediaRef = {
+  type: "image" | "video";
+  uri: string;
+  asset_id: null;
+  data: null;
+  metadata: null;
+  duration?: null;
+  format?: null;
+};
+
+/** What a property starts at when the manifest names no default. */
+type FieldDefault = boolean | number | string | EmptyMediaRef;
+
+function defaultForType(type: string): FieldDefault {
   switch (type) {
     case "bool":
       return false;

--- a/packages/transformers-js-nodes/src/nodes/audio-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/audio-classification.ts
@@ -99,15 +99,17 @@ export class AudioClassificationNode extends BaseNode {
     const samplingRate = asNumber(this.sampling_rate, DEFAULT_SAMPLING_RATE);
     const samples = await loadAudioSamples(this.audio, samplingRate, context);
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        input: Float32Array,
+        opts?: Record<string, unknown>
+      ) => Promise<AudioClassificationResult | AudioClassificationResult[]>
+    >({
       task: "audio-classification",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: Float32Array,
-      opts?: Record<string, unknown>
-    ) => Promise<AudioClassificationResult | AudioClassificationResult[]>;
+    });
 
     const raw = await pipeline(samples, { top_k: asNumber(this.top_k, 5) });
     const results = ensureArray<AudioClassificationResult>(raw);

--- a/packages/transformers-js-nodes/src/nodes/automatic-speech-recognition.ts
+++ b/packages/transformers-js-nodes/src/nodes/automatic-speech-recognition.ts
@@ -109,15 +109,17 @@ export class AutomaticSpeechRecognitionNode extends BaseNode {
     );
 
     const repoId = extractRepoId(this.model);
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        input: Float32Array,
+        opts?: Record<string, unknown>
+      ) => Promise<AsrResult>
+    >({
       task: "automatic-speech-recognition",
       model: repoId || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: Float32Array,
-      opts?: Record<string, unknown>
-    ) => Promise<AsrResult>;
+    });
 
     const opts: Record<string, unknown> = {
       return_timestamps: Boolean(this.return_timestamps)

--- a/packages/transformers-js-nodes/src/nodes/feature-extraction.ts
+++ b/packages/transformers-js-nodes/src/nodes/feature-extraction.ts
@@ -13,11 +13,17 @@ import { defaultRepoFor } from "../recommended-models.js";
 
 const TJS_TYPE = "tjs.feature_extraction";
 
+/**
+ * A tensor rendered as plain JS arrays, nested as deep as the tensor's rank:
+ * `[dim]`, `[batch][dim]` or `[batch][seq][dim]`.
+ */
+type TensorList = number[] | number[][] | number[][][];
+
 type Tensor = {
   data?: ArrayLike<number>;
   dims?: number[];
   size?: number;
-  tolist?: () => unknown;
+  tolist?: () => TensorList;
 };
 
 function meanPool(matrix: number[][]): number[] {
@@ -146,15 +152,14 @@ export class FeatureExtractionNode extends BaseNode {
     const text = asString(this.text);
     if (!text) throw new Error("Text is required");
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (input: string, opts?: Record<string, unknown>) => Promise<Tensor>
+    >({
       task: "feature-extraction",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: string,
-      opts?: Record<string, unknown>
-    ) => Promise<unknown>;
+    });
 
     const opts: Record<string, unknown> = {
       normalize: Boolean(this.normalize)

--- a/packages/transformers-js-nodes/src/nodes/fill-mask.ts
+++ b/packages/transformers-js-nodes/src/nodes/fill-mask.ts
@@ -87,15 +87,17 @@ export class FillMaskNode extends BaseNode {
     const text = asString(this.text);
     if (!text) throw new Error("Text is required");
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        input: string,
+        opts?: Record<string, unknown>
+      ) => Promise<FillMaskResult | FillMaskResult[]>
+    >({
       task: "fill-mask",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: string,
-      opts?: Record<string, unknown>
-    ) => Promise<FillMaskResult | FillMaskResult[]>;
+    });
 
     const raw = await pipeline(text, { top_k: asNumber(this.top_k, 5) });
     const results = ensureArray<FillMaskResult>(raw);

--- a/packages/transformers-js-nodes/src/nodes/image-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/image-classification.ts
@@ -86,15 +86,17 @@ export class ImageClassificationNode extends BaseNode {
   ): Promise<Record<string, unknown>> {
     const rawImage = await loadRawImage(this.image, context);
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        input: unknown,
+        opts?: Record<string, unknown>
+      ) => Promise<ImageClassificationResult | ImageClassificationResult[]>
+    >({
       task: "image-classification",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: unknown,
-      opts?: Record<string, unknown>
-    ) => Promise<ImageClassificationResult | ImageClassificationResult[]>;
+    });
 
     const raw = await pipeline(rawImage, { top_k: asNumber(this.top_k, 5) });
     const results = ensureArray<ImageClassificationResult>(raw);

--- a/packages/transformers-js-nodes/src/nodes/image-to-text.ts
+++ b/packages/transformers-js-nodes/src/nodes/image-to-text.ts
@@ -82,15 +82,17 @@ export class ImageToTextNode extends BaseNode {
   ): Promise<Record<string, unknown>> {
     const rawImage = await loadRawImage(this.image, context);
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        input: unknown,
+        opts?: Record<string, unknown>
+      ) => Promise<CaptionResult | CaptionResult[]>
+    >({
       task: "image-to-text",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: unknown,
-      opts?: Record<string, unknown>
-    ) => Promise<CaptionResult | CaptionResult[]>;
+    });
 
     const raw = await pipeline(rawImage, {
       max_new_tokens: asNumber(this.max_new_tokens, 50)

--- a/packages/transformers-js-nodes/src/nodes/object-detection.ts
+++ b/packages/transformers-js-nodes/src/nodes/object-detection.ts
@@ -101,15 +101,17 @@ export class ObjectDetectionNode extends BaseNode {
   ): Promise<Record<string, unknown>> {
     const rawImage = await loadRawImage(this.image, context);
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        input: unknown,
+        opts?: Record<string, unknown>
+      ) => Promise<ObjectBox | ObjectBox[]>
+    >({
       task: "object-detection",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: unknown,
-      opts?: Record<string, unknown>
-    ) => Promise<ObjectBox | ObjectBox[]>;
+    });
 
     const raw = await pipeline(rawImage, {
       threshold: asNumber(this.threshold, 0.9),

--- a/packages/transformers-js-nodes/src/nodes/question-answering.ts
+++ b/packages/transformers-js-nodes/src/nodes/question-answering.ts
@@ -100,16 +100,18 @@ export class QuestionAnsweringNode extends BaseNode {
     if (!question) throw new Error("Question is required");
     if (!context) throw new Error("Context is required");
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        question: string,
+        context: string,
+        opts?: Record<string, unknown>
+      ) => Promise<QAResult | QAResult[]>
+    >({
       task: "question-answering",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      question: string,
-      context: string,
-      opts?: Record<string, unknown>
-    ) => Promise<QAResult | QAResult[]>;
+    });
 
     const topK = asNumber(this.top_k, 1);
     const raw = await pipeline(question, context, { top_k: topK });

--- a/packages/transformers-js-nodes/src/nodes/summarization.ts
+++ b/packages/transformers-js-nodes/src/nodes/summarization.ts
@@ -97,15 +97,17 @@ export class SummarizationNode extends BaseNode {
     const text = asString(this.text);
     if (!text) throw new Error("Text is required");
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        input: string,
+        opts?: Record<string, unknown>
+      ) => Promise<SummaryResult | SummaryResult[]>
+    >({
       task: "summarization",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: string,
-      opts?: Record<string, unknown>
-    ) => Promise<SummaryResult | SummaryResult[]>;
+    });
 
     const raw = await pipeline(text, {
       max_length: asNumber(this.max_length, 130),

--- a/packages/transformers-js-nodes/src/nodes/text-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/text-classification.ts
@@ -84,15 +84,17 @@ export class TextClassificationNode extends BaseNode {
     if (!text) throw new Error("Text is required");
     const topK = asNumber(this.top_k, 1);
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        input: string,
+        opts?: Record<string, unknown>
+      ) => Promise<ClassificationResult | ClassificationResult[]>
+    >({
       task: "text-classification",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: string,
-      opts?: Record<string, unknown>
-    ) => Promise<ClassificationResult | ClassificationResult[]>;
+    });
 
     const raw = await pipeline(text, { top_k: topK });
     const results = ensureArray<ClassificationResult>(raw);

--- a/packages/transformers-js-nodes/src/nodes/text-generation.ts
+++ b/packages/transformers-js-nodes/src/nodes/text-generation.ts
@@ -136,15 +136,17 @@ export class TextGenerationNode extends BaseNode {
     const prompt = asString(this.prompt);
     if (!prompt) throw new Error("Prompt is required");
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        input: string,
+        opts?: Record<string, unknown>
+      ) => Promise<GenerationResult | GenerationResult[]>
+    >({
       task: "text-generation",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: string,
-      opts?: Record<string, unknown>
-    ) => Promise<GenerationResult | GenerationResult[]>;
+    });
 
     const opts: Record<string, unknown> = {
       max_new_tokens: asNumber(this.max_new_tokens, 128),

--- a/packages/transformers-js-nodes/src/nodes/text-to-speech.ts
+++ b/packages/transformers-js-nodes/src/nodes/text-to-speech.ts
@@ -113,15 +113,14 @@ export class TextToSpeechNode extends BaseNode {
       samples = result.audio as Float32Array;
       samplingRate = result.sampling_rate ?? samplingRate;
     } else {
-      const pipeline = (await getPipeline({
+      const pipeline = await getPipeline<
+        (input: string, opts?: Record<string, unknown>) => Promise<TtsResult>
+      >({
         task: "text-to-speech",
         model: repoId,
         dtype,
         device
-      })) as (
-        input: string,
-        opts?: Record<string, unknown>
-      ) => Promise<TtsResult>;
+      });
 
       const opts: Record<string, unknown> = {};
       if (isSpeechT5Repo(repoId)) {

--- a/packages/transformers-js-nodes/src/nodes/token-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/token-classification.ts
@@ -86,15 +86,17 @@ export class TokenClassificationNode extends BaseNode {
     const text = asString(this.text);
     if (!text) throw new Error("Text is required");
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        input: string,
+        opts?: Record<string, unknown>
+      ) => Promise<TokenEntity | TokenEntity[]>
+    >({
       task: "token-classification",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: string,
-      opts?: Record<string, unknown>
-    ) => Promise<TokenEntity | TokenEntity[]>;
+    });
 
     const opts: Record<string, unknown> = {};
     const aggregation = asString(this.aggregation_strategy, "simple");

--- a/packages/transformers-js-nodes/src/nodes/translation.ts
+++ b/packages/transformers-js-nodes/src/nodes/translation.ts
@@ -96,15 +96,17 @@ export class TranslationNode extends BaseNode {
     const text = asString(this.text);
     if (!text) throw new Error("Text is required");
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        input: string,
+        opts?: Record<string, unknown>
+      ) => Promise<TranslationResult | TranslationResult[]>
+    >({
       task: "translation",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: string,
-      opts?: Record<string, unknown>
-    ) => Promise<TranslationResult | TranslationResult[]>;
+    });
 
     const opts: Record<string, unknown> = {
       max_length: asNumber(this.max_length, 256)

--- a/packages/transformers-js-nodes/src/nodes/zero-shot-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/zero-shot-classification.ts
@@ -114,16 +114,18 @@ export class ZeroShotClassificationNode extends BaseNode {
       throw new Error("At least one candidate label is required");
     }
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        input: string,
+        labels: string[],
+        opts?: Record<string, unknown>
+      ) => Promise<ZeroShotResult | ZeroShotResult[]>
+    >({
       task: "zero-shot-classification",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: string,
-      labels: string[],
-      opts?: Record<string, unknown>
-    ) => Promise<ZeroShotResult | ZeroShotResult[]>;
+    });
 
     const opts: Record<string, unknown> = {
       multi_label: Boolean(this.multi_label)

--- a/packages/transformers-js-nodes/src/nodes/zero-shot-image-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/zero-shot-image-classification.ts
@@ -96,16 +96,18 @@ export class ZeroShotImageClassificationNode extends BaseNode {
       throw new Error("At least one candidate label is required");
     }
 
-    const pipeline = (await getPipeline({
+    const pipeline = await getPipeline<
+      (
+        input: unknown,
+        labels: string[],
+        opts?: Record<string, unknown>
+      ) => Promise<ClassificationResult | ClassificationResult[]>
+    >({
       task: "zero-shot-image-classification",
       model: extractRepoId(this.model) || undefined,
       dtype: normalizeOption(this.dtype),
       device: normalizeOption(this.device)
-    })) as (
-      input: unknown,
-      labels: string[],
-      opts?: Record<string, unknown>
-    ) => Promise<ClassificationResult | ClassificationResult[]>;
+    });
 
     const raw = await pipeline(rawImage, labels);
     const results = ensureArray<ClassificationResult>(raw);

--- a/packages/transformers-js-nodes/src/transformers-base.ts
+++ b/packages/transformers-js-nodes/src/transformers-base.ts
@@ -22,11 +22,32 @@ const execFileP = promisify(execFile);
  * descriptive error at execution time instead).
  */
 
-type PipelineFn = (
+/**
+ * `pipeline()` builds a callable whose input and output shapes depend entirely
+ * on the task string, so the caller names the call signature it expects.
+ */
+type PipelineFn = <TPipeline>(
   task: string,
   model?: string,
   options?: Record<string, unknown>
-) => Promise<unknown>;
+) => Promise<TPipeline>;
+
+/**
+ * A decoded image as Transformers.js represents it. NodeTool builds one and
+ * hands it straight to a pipeline; the fields are the library's own.
+ */
+export type RawImage = {
+  data: Uint8Array | Uint8ClampedArray;
+  width: number;
+  height: number;
+  channels: number;
+};
+
+/**
+ * An opaque helper object constructed from the Transformers.js module and
+ * passed back to it (a streamer, a stopping criterion) without being inspected.
+ */
+export type TransformersHandle = object;
 
 type TransformersEnv = {
   cacheDir?: string;
@@ -38,8 +59,8 @@ type TransformersModule = {
   pipeline: PipelineFn;
   env?: TransformersEnv;
   RawImage?: {
-    fromBlob(blob: Blob): Promise<unknown>;
-    fromURL(url: string): Promise<unknown>;
+    fromBlob(blob: Blob): Promise<RawImage>;
+    fromURL(url: string): Promise<RawImage>;
   };
   TextStreamer?: new (
     tokenizer: unknown,
@@ -49,7 +70,7 @@ type TransformersModule = {
       callback_function?: (text: string) => void;
       token_callback_function?: (tokens: unknown) => void;
     }
-  ) => unknown;
+  ) => TransformersHandle;
   InterruptableStoppingCriteria?: new () => {
     interrupt(): void;
   };
@@ -135,7 +156,7 @@ export function __setTransformersModuleForTesting(
 }
 
 type PipelineCacheKey = string;
-const pipelineCache = new Map<PipelineCacheKey, Promise<unknown>>();
+const pipelineCache = new Map<PipelineCacheKey, Promise<object>>();
 
 export interface PipelineOptions {
   task: string;
@@ -151,8 +172,12 @@ export interface PipelineOptions {
  * Pipelines are cached globally by their (task, model, dtype, device, revision)
  * tuple. Loading large models is expensive, so reusing pipelines across
  * invocations is essential for sensible performance.
+ *
+ * Each task has its own call signature, so the caller names the one it expects.
  */
-export async function getPipeline(options: PipelineOptions): Promise<unknown> {
+export async function getPipeline<TPipeline extends object>(
+  options: PipelineOptions
+): Promise<TPipeline> {
   const { task, model, dtype, device, revision } = options;
   const key: PipelineCacheKey = JSON.stringify([
     task,
@@ -169,13 +194,17 @@ export async function getPipeline(options: PipelineOptions): Promise<unknown> {
       if (dtype) pipelineOptions.dtype = dtype;
       if (device) pipelineOptions.device = device;
       if (revision) pipelineOptions.revision = revision;
-      return transformers.pipeline(task, model, pipelineOptions);
+      return transformers.pipeline<TPipeline>(task, model, pipelineOptions);
     })();
     pipelineCache.set(key, entry);
     // Drop failed entries so a later invocation can retry.
     entry.catch(() => pipelineCache.delete(key));
   }
-  return entry;
+  // SAFETY: the cache key encodes task, model, dtype, device and revision, so
+  // an entry can only be the pipeline built for exactly these options. The
+  // `@huggingface/transformers` module ships no types for it, so `TPipeline`
+  // is the caller's declaration of that task's documented call signature.
+  return entry as Promise<TPipeline>;
 }
 
 /** Reset the pipeline cache. Intended for tests. */
@@ -286,7 +315,7 @@ export async function loadMediaBytes(
 export async function bytesToRawImage(
   bytes: Uint8Array,
   mimeType?: string
-): Promise<unknown> {
+): Promise<RawImage> {
   if (!bytes.length) {
     throw new Error("Image input is empty");
   }
@@ -306,7 +335,7 @@ export async function bytesToRawImage(
 export async function loadRawImage(
   ref: ImageRefLike | undefined,
   context?: ProcessingContext
-): Promise<unknown> {
+): Promise<RawImage> {
   const bytes = await loadMediaBytes(ref, context);
   return bytesToRawImage(bytes, ref?.mimeType);
 }

--- a/packages/video-nodes/src/nodes/model3d/render3d-headless.ts
+++ b/packages/video-nodes/src/nodes/model3d/render3d-headless.ts
@@ -45,7 +45,8 @@ interface RuntimeEvaluateResult {
 
 interface CdpClient {
   Runtime: {
-    enable(): Promise<unknown>;
+    /** CDP commands with no return parameters resolve to an empty object. */
+    enable(): Promise<object>;
     evaluate(params: {
       expression: string;
       awaitPromise?: boolean;

--- a/packages/video-nodes/src/nodes/video.ts
+++ b/packages/video-nodes/src/nodes/video.ts
@@ -260,9 +260,7 @@ function canUseProvider(
   context: ProcessingContext | undefined,
   providerId: string,
   modelId: string
-): context is ProcessingContext & {
-  runProviderPrediction: (req: Record<string, unknown>) => Promise<unknown>;
-} {
+): context is ProcessingContext {
   return (
     !!context &&
     typeof context.runProviderPrediction === "function" &&

--- a/packages/websocket/src/agent/run-node-tool.ts
+++ b/packages/websocket/src/agent/run-node-tool.ts
@@ -10,6 +10,11 @@
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { Tool } from "@nodetool-ai/agents";
 
+/**
+ * HOLDOUT (anti-slop/no-unknown-returns): a node's output is an arbitrary
+ * workflow value (or an `{ error }` bag when the run failed) — the open domain
+ * NodeTool has no named union for.
+ */
 export type RunNodeFn = (
   nodeType: string,
   inputs: Record<string, unknown>
@@ -48,6 +53,9 @@ export class RunNodeTool extends Tool {
     this.runNode = runNode;
   }
 
+  // HOLDOUT (anti-slop/no-unknown-returns): the base `Tool.process` contract
+  // in `@nodetool-ai/agents` returns `Promise<unknown>`, and the value here is
+  // the node's own output.
   async process(
     _context: ProcessingContext,
     params: Record<string, unknown>

--- a/packages/websocket/src/fake-runtime.ts
+++ b/packages/websocket/src/fake-runtime.ts
@@ -208,8 +208,18 @@ const needsSecret = (meta: FakeMeta | undefined): boolean =>
 const needsRuntime = (meta: FakeMeta | undefined): boolean =>
   Array.isArray(meta?.required_runtimes) && meta.required_runtimes.length > 0;
 
+/** A placeholder value standing in for one output slot. */
+export type FakeSlotValue =
+  | string
+  | number
+  | boolean
+  | null
+  | never[]
+  | Record<string, never>
+  | { type: string; uri: string; data: string; mimeType: string };
+
 /** Build a type-correct placeholder for a single output slot. */
-export function fakeValueForType(type: string): unknown {
+export function fakeValueForType(type: string): FakeSlotValue {
   if (MEDIA_TYPES.has(type)) {
     const mime =
       type === "image"

--- a/packages/websocket/src/mcp-agent-tools.ts
+++ b/packages/websocket/src/mcp-agent-tools.ts
@@ -426,6 +426,9 @@ class FrontendUiTool extends Tool {
     this.jsonSchema = jsonSchema;
   }
 
+  // HOLDOUT (anti-slop/no-unknown-returns): a bridged tool's result is
+  // whatever the editor or capability answered — the open tool-result domain
+  // the base `Tool.process` contract in `@nodetool-ai/agents` declares.
   async process(
     _context: ProcessingContext,
     params: Record<string, unknown>
@@ -469,6 +472,8 @@ class RendererAwareDocumentTool extends Tool {
     };
   }
 
+  // HOLDOUT (anti-slop/no-unknown-returns): the result is the delegate's, and
+  // `Tool.process` in `@nodetool-ai/agents` declares `Promise<unknown>`.
   async process(
     context: ProcessingContext,
     params: Record<string, unknown>
@@ -497,7 +502,9 @@ class ListRenderersTool extends Tool {
     super();
   }
 
-  async process(): Promise<unknown> {
+  async process(): Promise<{
+    renderers: Array<{ renderer_id: string; active: boolean }>;
+  }> {
     const renderers = this.options.frontendRendererRegistry
       ? this.options.frontendRendererRegistry
           .list(this.userId)
@@ -651,6 +658,8 @@ export function registerAgentMcpTools(
    * direct MCP call and a `tools.<name>()` call inside an action — so a
    * capability cannot behave differently depending on how it was reached.
    */
+  // HOLDOUT (anti-slop/no-unknown-returns): one path for every bridged tool,
+  // so the result is the open tool-result domain `Tool.process` declares.
   const runBridgedTool = async (
     tool: Tool,
     args: Record<string, unknown>

--- a/packages/websocket/src/messagepack.ts
+++ b/packages/websocket/src/messagepack.ts
@@ -12,6 +12,10 @@ export function packWebSocketMessage(value: unknown): Buffer {
   return websocketPackr.pack(value);
 }
 
-export function unpackWebSocketMessage(value: Uint8Array): unknown {
+/**
+ * Decode a binary WebSocket frame. The caller names the frame type it expects
+ * — only it knows which command or event the socket is carrying.
+ */
+export function unpackWebSocketMessage<TFrame>(value: Uint8Array): TFrame {
   return unpack(value);
 }

--- a/packages/websocket/src/routes/applications.ts
+++ b/packages/websocket/src/routes/applications.ts
@@ -79,7 +79,16 @@ function errorResponse(status: number, detail: string): Response {
   return jsonResponse({ detail }, status);
 }
 
-async function readJsonBody(request: Request): Promise<unknown> {
+/** A decoded JSON request body, before a schema validates its shape. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+async function readJsonBody(request: Request): Promise<JsonValue> {
   const contentType = request.headers.get("content-type") ?? "";
   if (!contentType.toLowerCase().includes("application/json")) return {};
   try {
@@ -94,7 +103,9 @@ async function readJsonBody(request: Request): Promise<unknown> {
  * service raises tRPC errors (`throwApiError`); tRPC's own status mapping keeps
  * the two transports agreeing on what a not-found or a conflict is.
  */
-async function respond(produce: () => Promise<unknown>): Promise<Response> {
+async function respond<TResult>(
+  produce: () => Promise<TResult>
+): Promise<Response> {
   try {
     return jsonResponse(await produce());
   } catch (error) {

--- a/packages/websocket/src/routes/js-scripts.ts
+++ b/packages/websocket/src/routes/js-scripts.ts
@@ -45,7 +45,16 @@ function jsonResponse(data: unknown, status = 200): Response {
   });
 }
 
-async function readJsonBody(request: Request): Promise<unknown> {
+/** A decoded JSON request body, before a schema validates its shape. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+async function readJsonBody(request: Request): Promise<JsonValue> {
   const contentType = request.headers.get("content-type") ?? "";
   if (!contentType.toLowerCase().includes("application/json")) return {};
   try {

--- a/packages/websocket/src/routes/nodes.ts
+++ b/packages/websocket/src/routes/nodes.ts
@@ -107,7 +107,16 @@ const nodesRoutes: FastifyPluginAsync<RouteOptions> = async (app, opts) => {
   });
 };
 
-function extractKieModelInfo(body: unknown): unknown {
+/** A decoded JSON value from the request body. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+function extractKieModelInfo(body: unknown): JsonValue | undefined {
   if (Buffer.isBuffer(body)) {
     const text = body.toString("utf8").trim();
     if (!text) {
@@ -133,7 +142,9 @@ function extractKieModelInfo(body: unknown): unknown {
     return undefined;
   }
 
-  const record = body as Record<string, unknown>;
+  // SAFETY: the checks above proved `body` is a non-null object; its members
+  // came out of a JSON request body.
+  const record = body as { [key: string]: JsonValue };
   return (
     record.model_info ??
     record.modelInfo ??

--- a/packages/websocket/src/sdk/sdk-model-download-http-handler.ts
+++ b/packages/websocket/src/sdk/sdk-model-download-http-handler.ts
@@ -32,7 +32,16 @@ function errorResponse(
   );
 }
 
-async function parseJson(request: Request): Promise<unknown> {
+/** A decoded JSON request body, before a schema validates its shape. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+async function parseJson(request: Request): Promise<JsonValue> {
   const contentType = request.headers.get("content-type") ?? "";
   if (!contentType.toLowerCase().includes("application/json")) return null;
   try {

--- a/packages/websocket/src/sdk/sdk-preflight-requirement-resolver.ts
+++ b/packages/websocket/src/sdk/sdk-preflight-requirement-resolver.ts
@@ -12,6 +12,14 @@ type RequirementProbe = (
   requirement: Readonly<SdkV1Requirement>
 ) => Promise<SdkV1RequirementAvailability> | SdkV1RequirementAvailability;
 
+/**
+ * Just enough of an asset row for a preflight check: the resolver only asks
+ * whether the asset exists.
+ */
+interface AssetIdentity {
+  id: string;
+}
+
 export interface CreateNodeToolSdkV1RequirementResolverOptions {
   userId: string;
   /**
@@ -21,7 +29,10 @@ export interface CreateNodeToolSdkV1RequirementResolverOptions {
    */
   probes?: Partial<Record<RequirementKind, RequirementProbe>>;
   getCredential?: (userId: string, key: string) => Promise<string | null>;
-  findAsset?: (userId: string, assetId: string) => Promise<unknown | null>;
+  findAsset?: (
+    userId: string,
+    assetId: string
+  ) => Promise<AssetIdentity | null>;
   listProviderIds?: () => readonly string[];
   isProviderReady?: (userId: string, providerId: string) => Promise<boolean>;
 }

--- a/packages/websocket/src/trpc/routers/js-scripts.ts
+++ b/packages/websocket/src/trpc/routers/js-scripts.ts
@@ -45,6 +45,15 @@ import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
 import { throwApiError } from "../error-formatter.js";
 
+/** A decoded JSON value: what a stored document or graph carries. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
 const listInput = z.object({
   projectId: z.string().optional()
 });
@@ -87,10 +96,12 @@ function toVersionListItem(version: JsScriptVersion) {
  * A version row carries its document as JSON text on SQLite and as an object on
  * Postgres, so parse only when it is a string.
  */
-function parseVersionDocument(raw: unknown): unknown {
-  if (typeof raw !== "string") return raw;
+function parseVersionDocument(raw: unknown): JsonValue {
+  // SAFETY: a Postgres json column arrives already decoded, and the row's
+  // document is JSON either way.
+  if (typeof raw !== "string") return raw as JsonValue;
   try {
-    return JSON.parse(raw) as unknown;
+    return JSON.parse(raw) as JsonValue;
   } catch {
     throwApiError(
       ApiErrorCode.INTERNAL_ERROR,

--- a/packages/websocket/src/trpc/routers/sketch.ts
+++ b/packages/websocket/src/trpc/routers/sketch.ts
@@ -60,6 +60,15 @@ import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
 import { throwApiError } from "../error-formatter.js";
 
+/** A decoded JSON value: what a stored document or graph carries. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
 const listInput = z.object({
   projectId: z.string().optional()
 });
@@ -116,10 +125,12 @@ function toListItem(doc: ImageDocument) {
  * corrupt, and reporting that beats handing the client a string it will treat
  * as a document.
  */
-function parseVersionDocument(raw: unknown): unknown {
-  if (typeof raw !== "string") return raw;
+function parseVersionDocument(raw: unknown): JsonValue {
+  // SAFETY: a Postgres json column arrives already decoded, and the row's
+  // document is JSON either way.
+  if (typeof raw !== "string") return raw as JsonValue;
   try {
-    return JSON.parse(raw) as unknown;
+    return JSON.parse(raw) as JsonValue;
   } catch {
     throwApiError(
       ApiErrorCode.INTERNAL_ERROR,
@@ -245,8 +256,9 @@ function inputNodeName(node: Record<string, unknown>): string | null {
   );
 }
 
-function inputNodeDefault(node: Record<string, unknown>): unknown {
-  const data = node.data as Record<string, unknown> | undefined;
+function inputNodeDefault(node: Record<string, unknown>): JsonValue {
+  // SAFETY: the graph is stored as JSON, so a node's `data` holds JSON members.
+  const data = node.data as { [key: string]: JsonValue } | undefined;
   return data?.value ?? null;
 }
 

--- a/packages/websocket/src/trpc/routers/timeline.ts
+++ b/packages/websocket/src/trpc/routers/timeline.ts
@@ -50,6 +50,15 @@ import { router } from "../index.js";
 import { protectedProcedure } from "../middleware.js";
 import { throwApiError } from "../error-formatter.js";
 
+/** A decoded JSON value: what a stored document or graph carries. */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
 // ── input shapes specific to this router ────────────────────────────────────
 
 const listInput = z.object({
@@ -178,8 +187,9 @@ function inputNodeName(node: Record<string, unknown>): string | null {
 }
 
 /** Extract the default value for an input node from its `data`. */
-function inputNodeDefault(node: Record<string, unknown>): unknown {
-  const data = node.data as Record<string, unknown> | undefined;
+function inputNodeDefault(node: Record<string, unknown>): JsonValue {
+  // SAFETY: the graph is stored as JSON, so a node's `data` holds JSON members.
+  const data = node.data as { [key: string]: JsonValue } | undefined;
   return data?.value ?? null;
 }
 

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -412,10 +412,20 @@ function sanitizeLargeText(
   return `${sanitized.slice(0, maxLength)}... (truncated ${truncatedChars} chars)`;
 }
 
+/** A value reduced to shapes a JSON frame can carry. */
+type JsonSafeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | JsonSafeValue[]
+  | { [key: string]: JsonSafeValue };
+
 function sanitizeErrorValue(
   value: unknown,
   seen = new WeakSet<object>()
-): unknown {
+): JsonSafeValue {
   if (typeof value === "string") {
     return sanitizeLargeText(value);
   }
@@ -434,7 +444,7 @@ function sanitizeErrorValue(
     }
 
     seen.add(value);
-    const result: Record<string, unknown> = {};
+    const result: { [key: string]: JsonSafeValue } = {};
     for (const [key, nested] of Object.entries(
       value as Record<string, unknown>
     )) {
@@ -443,7 +453,9 @@ function sanitizeErrorValue(
     return result;
   }
 
-  return value;
+  // SAFETY: strings, errors, arrays and objects are handled above; what is
+  // left is a JSON scalar.
+  return value as JsonSafeValue;
 }
 
 function formatSanitizedError(error: unknown): string {
@@ -1032,7 +1044,7 @@ export function serverModelInterfaces(): ProcessingContextModelInterfaces {
         // raw — the `content` column is a jsonText type that serializes them, so
         // stringifying here would double-encode and break the getMessages read
         // path (which feeds normalizeMessage, not a JSON-parsing response mapper).
-        return Message.create({
+        return Message.create<Message>({
           user_id: userId,
           thread_id: req.thread_id,
           role: req.role,
@@ -2579,18 +2591,20 @@ export class UnifiedWebSocketRunner {
     this.websocket = null;
   }
 
-  private serializeForJson(value: unknown): unknown {
+  private serializeForJson(value: unknown): JsonSafeValue {
     if (value instanceof Uint8Array) return Array.from(value);
     if (value instanceof Date) return value.toISOString();
     if (Array.isArray(value)) return value.map((v) => this.serializeForJson(v));
     if (value && typeof value === "object") {
-      const out: Record<string, unknown> = {};
+      const out: { [key: string]: JsonSafeValue } = {};
       for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
         out[k] = this.serializeForJson(v);
       }
       return out;
     }
-    return value;
+    // SAFETY: bytes, dates, arrays and objects are handled above; what is left
+    // is a JSON scalar.
+    return value as JsonSafeValue;
   }
 
   async sendMessage(message: Record<string, unknown>): Promise<void> {
@@ -2746,7 +2760,7 @@ export class UnifiedWebSocketRunner {
             `(set NODETOOL_WS_MAX_MESSAGE_BYTES to raise the limit)`
         );
       }
-      return unpackWebSocketMessage(message.bytes) as Record<string, unknown>;
+      return unpackWebSocketMessage<Record<string, unknown>>(message.bytes);
     }
     if (message.text) {
       const maxBytes = getMaxWsMessageBytes();
@@ -4812,6 +4826,9 @@ export class UnifiedWebSocketRunner {
    * - Arrays/objects: recursed into
    * - Primitives: returned as-is
    */
+  // HOLDOUT (anti-slop/no-unknown-returns): a tool result is an arbitrary
+  // value — the same open domain `ProcessingContext.normalizeOutputValue`
+  // rewrites — and this walk answers in that domain.
   private async processToolResult(
     obj: unknown,
     ctx: ProcessingContext
@@ -4894,6 +4911,8 @@ export class UnifiedWebSocketRunner {
    * is the single mechanism that pulls pixels into context. Keeps image bytes
    * out of the standing chat history. Non-image results pass through untouched.
    */
+  // HOLDOUT (anti-slop/no-unknown-returns): same open tool-result domain as
+  // `processToolResult`; non-image results pass through untouched.
   private async materializeToolResultImages(
     toolResult: unknown,
     ctx: ProcessingContext
@@ -5165,6 +5184,8 @@ export class UnifiedWebSocketRunner {
    * then returns the
    * node's completed result. Backs the `run_node` chat tool.
    */
+  // HOLDOUT (anti-slop/no-unknown-returns): answers with the node's own output
+  // — an arbitrary workflow value — or an `{ error }` bag when the run failed.
   private async runSingleNode(
     nodeType: string,
     inputs: Record<string, unknown>,
@@ -8463,9 +8484,9 @@ export class UnifiedWebSocketRunner {
    * Errors thrown by the procedure are mapped to `rpc_response.error` using
    * the `apiCode` cause attached by `throwApiError` in the tRPC layer.
    */
-  private async runRpc(
+  private async runRpc<TResult>(
     command: WebSocketCommandEnvelope,
-    fn: () => Promise<unknown>
+    fn: () => Promise<TResult>
   ): Promise<Record<string, unknown> | null> {
     const requestId = command.request_id;
     if (typeof requestId !== "string" || requestId.length === 0) {

--- a/tools/oxlint/anti-slop/README.md
+++ b/tools/oxlint/anti-slop/README.md
@@ -16,8 +16,11 @@ module mocking, `Reflect.get`/`Reflect.apply`.
 `error`. It is a **separate config**, run only by `npm run lint:anti-slop`:
 
 ```bash
-npm run lint:anti-slop                       # whole repo, exits 1 while findings remain
-npm run lint:anti-slop -- packages/cli/src   # one directory
+npm run lint:anti-slop   # whole repo, exits 1 while findings remain
+
+# One directory — npm *appends* extra args to the script's own path list, so
+# passing a path to `lint:anti-slop` still lints everything. Call oxlint direct:
+npx oxlint --config .oxlintrc.anti-slop.json packages/cli/src
 ```
 
 `npm run lint` and CI do not run it. The rules find 28,689 violations in the

--- a/tools/oxlint/anti-slop/README.md
+++ b/tools/oxlint/anti-slop/README.md
@@ -23,7 +23,7 @@ npm run lint:anti-slop   # whole repo, exits 1 while findings remain
 npx oxlint --config .oxlintrc.anti-slop.json packages/cli/src
 ```
 
-`npm run lint` and CI do not run it. The rules find 28,689 violations in the
+`npm run lint` and CI do not run it. The rules find 27,955 violations in the
 current tree, so folding them into the main gate would leave it permanently red.
 Treat this as a backlog to work down, not a merge blocker.
 

--- a/web/src/__mocks__/trpcClientMock.ts
+++ b/web/src/__mocks__/trpcClientMock.ts
@@ -51,7 +51,7 @@ const makeProcedureUtils = (): Record<string, unknown> => ({
   getData: jest.fn(() => undefined)
 });
 
-const makeUtilsProxy = (): unknown =>
+const makeUtilsProxy = (): object =>
   new Proxy(
     {},
     {

--- a/web/src/components/__tests__/HandleTooltip.test.tsx
+++ b/web/src/components/__tests__/HandleTooltip.test.tsx
@@ -41,7 +41,7 @@ describe('HandleTooltip', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseConnectionStore.mockImplementation((selector: (state: { connecting: boolean; isReconnecting: boolean }) => unknown) =>
+    mockUseConnectionStore.mockImplementation(<T,>(selector: (state: { connecting: boolean; isReconnecting: boolean }) => T) =>
       selector({ connecting: false, isReconnecting: false })
     );
   });
@@ -230,7 +230,7 @@ describe('HandleTooltip', () => {
 
     it('should not show tooltip while a connection drag is active', () => {
       jest.useFakeTimers();
-      mockUseConnectionStore.mockImplementation((selector: (state: { connecting: boolean; isReconnecting: boolean }) => unknown) =>
+      mockUseConnectionStore.mockImplementation(<T,>(selector: (state: { connecting: boolean; isReconnecting: boolean }) => T) =>
         selector({ connecting: true, isReconnecting: false })
       );
 
@@ -311,7 +311,7 @@ describe('HandleTooltip', () => {
 
   describe('Connect-time label', () => {
     it('shows the name (no type) on compatible handles while connecting', () => {
-      mockUseConnectionStore.mockImplementation((selector: (state: { connecting: boolean; isReconnecting: boolean }) => unknown) =>
+      mockUseConnectionStore.mockImplementation(<T,>(selector: (state: { connecting: boolean; isReconnecting: boolean }) => T) =>
         selector({ connecting: true, isReconnecting: false })
       );
 
@@ -325,7 +325,7 @@ describe('HandleTooltip', () => {
     });
 
     it('does not show a tooltip on incompatible handles while connecting', () => {
-      mockUseConnectionStore.mockImplementation((selector: (state: { connecting: boolean; isReconnecting: boolean }) => unknown) =>
+      mockUseConnectionStore.mockImplementation(<T,>(selector: (state: { connecting: boolean; isReconnecting: boolean }) => T) =>
         selector({ connecting: true, isReconnecting: false })
       );
 

--- a/web/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/web/src/components/__tests__/ProtectedRoute.test.tsx
@@ -22,7 +22,7 @@ describe('ProtectedRoute', () => {
   });
 
   it('redirects to /login when logged_out', async () => {
-    (useAuth as unknown as jest.Mock).mockImplementation((selector: (s: { state: string }) => unknown) =>
+    (useAuth as unknown as jest.Mock).mockImplementation(<T,>(selector: (s: { state: string }) => T) =>
       selector({ state: 'logged_out' })
     );
     render(
@@ -34,7 +34,7 @@ describe('ProtectedRoute', () => {
   });
 
   it('shows loading spinner when state is loading', () => {
-    (useAuth as unknown as jest.Mock).mockImplementation((selector: (s: { state: string }) => unknown) =>
+    (useAuth as unknown as jest.Mock).mockImplementation(<T,>(selector: (s: { state: string }) => T) =>
       selector({ state: 'loading' })
     );
     render(
@@ -46,7 +46,7 @@ describe('ProtectedRoute', () => {
   });
 
   it('renders children when logged_in', () => {
-    (useAuth as unknown as jest.Mock).mockImplementation((selector: (s: { state: string }) => unknown) =>
+    (useAuth as unknown as jest.Mock).mockImplementation(<T,>(selector: (s: { state: string }) => T) =>
       selector({ state: 'logged_in' })
     );
     render(

--- a/web/src/components/appbuilder/__tests__/AppBuilderShell.test.tsx
+++ b/web/src/components/appbuilder/__tests__/AppBuilderShell.test.tsx
@@ -12,8 +12,8 @@ import type { AppDocument } from "../appData";
 const setCurrentWorkflowId = jest.fn();
 
 jest.mock("../../../contexts/WorkflowManagerContext", () => ({
-  useWorkflowManager: (
-    selector: (state: { setCurrentWorkflowId: unknown }) => unknown
+  useWorkflowManager: <T,>(
+    selector: (state: { setCurrentWorkflowId: unknown }) => T
   ) => selector({ setCurrentWorkflowId })
 }));
 

--- a/web/src/components/appbuilder/__tests__/ApplicationAppBuilder.test.tsx
+++ b/web/src/components/appbuilder/__tests__/ApplicationAppBuilder.test.tsx
@@ -62,13 +62,13 @@ jest.mock("../../../trpc/client", () => ({
 }));
 
 jest.mock("../../../stores/NotificationStore", () => ({
-  useNotificationStore: (
-    selector: (s: { addNotification: unknown }) => unknown
+  useNotificationStore: <T,>(
+    selector: (s: { addNotification: unknown }) => T
   ) => selector({ addNotification })
 }));
 
 jest.mock("../../../contexts/WorkflowManagerContext", () => ({
-  useWorkflowManager: (selector: (s: { fetchWorkflow: unknown }) => unknown) =>
+  useWorkflowManager: <T,>(selector: (s: { fetchWorkflow: unknown }) => T) =>
     selector({ fetchWorkflow })
 }));
 

--- a/web/src/components/appbuilder/__tests__/ApplicationRunView.test.tsx
+++ b/web/src/components/appbuilder/__tests__/ApplicationRunView.test.tsx
@@ -14,7 +14,7 @@ import type { Workflow } from "../../../stores/ApiTypes";
 
 const fetchWorkflow = jest.fn();
 jest.mock("../../../contexts/WorkflowManagerContext", () => ({
-  useWorkflowManager: (selector: (s: { fetchWorkflow: unknown }) => unknown) =>
+  useWorkflowManager: <T,>(selector: (s: { fetchWorkflow: unknown }) => T) =>
     selector({ fetchWorkflow })
 }));
 

--- a/web/src/components/appbuilder/inputProperty.ts
+++ b/web/src/components/appbuilder/inputProperty.ts
@@ -68,7 +68,9 @@ const getTypeArgsForKind = (kind: WorkflowInputKind) => {
   }
 };
 
-const kindFallbackDefault = (input: WorkflowInputIO): unknown => {
+const kindFallbackDefault = (
+  input: WorkflowInputIO
+): string | boolean | unknown[] | null => {
   switch (input.kind) {
     case "string":
     case "file_path":

--- a/web/src/components/appbuilder/runtime/__tests__/useAppRuntime.test.tsx
+++ b/web/src/components/appbuilder/runtime/__tests__/useAppRuntime.test.tsx
@@ -13,7 +13,7 @@ import type { Workflow } from "../../../../stores/ApiTypes";
 const fetchWorkflow = jest.fn();
 
 jest.mock("../../../../contexts/WorkflowManagerContext", () => ({
-  useWorkflowManager: (selector: (s: { fetchWorkflow: unknown }) => unknown) =>
+  useWorkflowManager: <T,>(selector: (s: { fetchWorkflow: unknown }) => T) =>
     selector({ fetchWorkflow })
 }));
 

--- a/web/src/components/applications/__tests__/ApplicationListPanel.test.tsx
+++ b/web/src/components/applications/__tests__/ApplicationListPanel.test.tsx
@@ -85,7 +85,7 @@ jest.mock("../../../trpc/client", () => ({
 const openTab = jest.fn();
 jest.mock("../../../stores/WorkspaceTabsStore", () => ({
   tabId: (type: string, ref: string) => `${type}:${ref}`,
-  useWorkspaceTabsStore: (selector: (s: unknown) => unknown) =>
+  useWorkspaceTabsStore: <T,>(selector: (s: unknown) => T) =>
     selector({ openTab, activeTabId: "application:app-1" })
 }));
 

--- a/web/src/components/applications/__tests__/LegacyAppRedirect.test.tsx
+++ b/web/src/components/applications/__tests__/LegacyAppRedirect.test.tsx
@@ -19,7 +19,7 @@ jest.mock("../../../trpc/client", () => ({
 
 const openTab = jest.fn();
 jest.mock("../../../stores/WorkspaceTabsStore", () => ({
-  useWorkspaceTabsStore: (selector: (state: unknown) => unknown) =>
+  useWorkspaceTabsStore: <T,>(selector: (state: unknown) => T) =>
     selector({ openTab })
 }));
 

--- a/web/src/components/assets/__tests__/AssetGridFolders.test.tsx
+++ b/web/src/components/assets/__tests__/AssetGridFolders.test.tsx
@@ -72,25 +72,25 @@ jest.mock("../../../serverState/useAssetUpload", () => ({
 
 jest.mock("../../../stores/useAuth", () => ({
   __esModule: true,
-  default: (selector: (s: unknown) => unknown) =>
+  default: <T,>(selector: (s: unknown) => T) =>
     selector({ user: { id: "user-1" } })
 }));
 
 jest.mock("../../../contexts/WorkflowManagerContext", () => ({
   __esModule: true,
-  useWorkflowManager: (selector: (s: unknown) => unknown) =>
+  useWorkflowManager: <T,>(selector: (s: unknown) => T) =>
     selector({ currentWorkflowId: null })
 }));
 
 jest.mock("../../../stores/ContextMenuStore", () => ({
   __esModule: true,
-  default: (selector: (s: unknown) => unknown) =>
+  default: <T,>(selector: (s: unknown) => T) =>
     selector({ openMenuType: null })
 }));
 
 jest.mock("../../../stores/KeyPressedStore", () => ({
   __esModule: true,
-  useKeyPressedStore: (selector: (s: unknown) => unknown) =>
+  useKeyPressedStore: <T,>(selector: (s: unknown) => T) =>
     selector({ isKeyPressed: () => false })
 }));
 

--- a/web/src/components/chat/__tests__/ChatListPanel.test.tsx
+++ b/web/src/components/chat/__tests__/ChatListPanel.test.tsx
@@ -30,7 +30,7 @@ const chatState = {
 };
 
 jest.mock("../../../stores/GlobalChatStore", () => {
-  const useStore = (selector: (state: unknown) => unknown) =>
+  const useStore = <T,>(selector: (state: unknown) => T) =>
     selector(chatState);
   useStore.getState = () => chatState;
   return {
@@ -42,13 +42,13 @@ jest.mock("../../../stores/GlobalChatStore", () => {
 
 jest.mock("../../../stores/WorkspaceTabsStore", () => ({
   __esModule: true,
-  useWorkspaceTabsStore: (selector: (state: unknown) => unknown) =>
+  useWorkspaceTabsStore: <T,>(selector: (state: unknown) => T) =>
     selector({ openTab, activeTabId: "chat:thread-2" })
 }));
 
 jest.mock("../../../stores/PanelStore", () => ({
   __esModule: true,
-  usePanelStore: (selector: (state: unknown) => unknown) =>
+  usePanelStore: <T,>(selector: (state: unknown) => T) =>
     selector({ setVisibility })
 }));
 

--- a/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
+++ b/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
@@ -12,7 +12,7 @@ import useGlobalChatStore from "../../../../stores/GlobalChatStore";
 // tool is "running". Tests can swap the implementation to inject runtime.
 jest.mock("../../../../stores/GlobalChatStore", () => ({
   __esModule: true,
-  default: jest.fn((selector: (s: unknown) => unknown) => selector({}))
+  default: jest.fn(<T,>(selector: (s: unknown) => T) => selector({}))
 }));
 
 jest.mock("../../../../contexts/EditorInsertionContext", () => ({
@@ -236,7 +236,7 @@ describe("MessageView CodeAct actions", () => {
         }
       }
     };
-    store.mockImplementation((selector: (s: unknown) => unknown) =>
+    store.mockImplementation(<T,>(selector: (s: unknown) => T) =>
       selector(state)
     );
 
@@ -260,7 +260,7 @@ describe("MessageView CodeAct actions", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("0s")).toBeInTheDocument();
 
-    store.mockImplementation((selector: (s: unknown) => unknown) =>
+    store.mockImplementation(<T,>(selector: (s: unknown) => T) =>
       selector({})
     );
   });

--- a/web/src/components/context_menus/__tests__/CodeGenMenuItems.test.tsx
+++ b/web/src/components/context_menus/__tests__/CodeGenMenuItems.test.tsx
@@ -13,11 +13,11 @@ let mockNodeState: Record<string, unknown>;
 
 jest.mock("../../../stores/ContextMenuStore", () => ({
   __esModule: true,
-  default: (selector: (s: unknown) => unknown) => selector(mockMenuState)
+  default: <T,>(selector: (s: unknown) => T) => selector(mockMenuState)
 }));
 
 jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: (selector: (s: unknown) => unknown) => selector(mockNodeState)
+  useNodes: <T,>(selector: (s: unknown) => T) => selector(mockNodeState)
 }));
 
 jest.mock("@xyflow/react", () => ({

--- a/web/src/components/context_menus/__tests__/OutputContextMenu.test.tsx
+++ b/web/src/components/context_menus/__tests__/OutputContextMenu.test.tsx
@@ -14,11 +14,11 @@ let mockNodeState: Record<string, unknown>;
 
 jest.mock("../../../stores/ContextMenuStore", () => ({
   __esModule: true,
-  default: (selector: (s: unknown) => unknown) => selector(mockMenuState)
+  default: <T,>(selector: (s: unknown) => T) => selector(mockMenuState)
 }));
 
 jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: (selector: (s: unknown) => unknown) => selector(mockNodeState)
+  useNodes: <T,>(selector: (s: unknown) => T) => selector(mockNodeState)
 }));
 
 jest.mock("@xyflow/react", () => ({

--- a/web/src/components/hugging_face/onboarding/__tests__/ModelOnboarding.test.tsx
+++ b/web/src/components/hugging_face/onboarding/__tests__/ModelOnboarding.test.tsx
@@ -16,7 +16,7 @@ jest.mock("../EngineGuide", () => ({
 
 // Avoid the HF cache network scan; report nothing installed.
 jest.mock("../../../../stores/HfCacheStatusStore", () => ({
-  useHfCacheStatusStore: (selector: (s: unknown) => unknown) =>
+  useHfCacheStatusStore: <T,>(selector: (s: unknown) => T) =>
     selector({
       statuses: {},
       version: 0,

--- a/web/src/components/jsScript/JsScriptRunDialog.tsx
+++ b/web/src/components/jsScript/JsScriptRunDialog.tsx
@@ -46,8 +46,17 @@ export interface JsScriptRunDialogProps {
   onRun: (request: JsScriptRunRequest) => void;
 }
 
+/** A value round-trippable through `JSON.parse`/`JSON.stringify`. */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
 /** JSON when it parses, the raw string otherwise. An empty field is `null`. */
-export const parseInputValue = (raw: string): unknown => {
+export const parseInputValue = (raw: string): JsonValue => {
   const trimmed = raw.trim();
   if (trimmed === "") return null;
   try {

--- a/web/src/components/menus/__tests__/APIKeysTabContent.test.tsx
+++ b/web/src/components/menus/__tests__/APIKeysTabContent.test.tsx
@@ -23,7 +23,7 @@ jest.mock("../../../hooks/useProviders", () => ({
 jest.mock("../GoogleWorkspaceCard", () => () => null);
 jest.mock("../../../stores/SecretsStore", () => ({
   __esModule: true,
-  default: (selector: (state: unknown) => unknown) =>
+  default: <T,>(selector: (state: unknown) => T) =>
     selector({
       secrets: [],
       updateSecret: jest.fn(),
@@ -31,7 +31,7 @@ jest.mock("../../../stores/SecretsStore", () => ({
     })
 }));
 jest.mock("../../../stores/NotificationStore", () => ({
-  useNotificationStore: (selector: (state: unknown) => unknown) =>
+  useNotificationStore: <T,>(selector: (state: unknown) => T) =>
     selector({ addNotification: jest.fn() })
 }));
 

--- a/web/src/components/menus/__tests__/RemoteSettingsMenu.test.tsx
+++ b/web/src/components/menus/__tests__/RemoteSettingsMenu.test.tsx
@@ -108,7 +108,7 @@ describe("RemoteSettingsMenu", () => {
       return mockRemoteSettingsStore as any;
     });
 
-    mockUseNotificationStore.mockImplementation((selector?: (state: any) => unknown) => {
+    mockUseNotificationStore.mockImplementation(<T,>(selector?: (state: any) => T) => {
       if (typeof selector === "function") {
         return selector(mockNotificationStore);
       }

--- a/web/src/components/model_menu/shared/ModelMenuDialogBase.tsx
+++ b/web/src/components/model_menu/shared/ModelMenuDialogBase.tsx
@@ -68,7 +68,8 @@ export interface ModelMenuBaseProps<TModel extends ModelSelectorModel> {
     providerErrors?: Array<{ provider: string; error: unknown }>;
     loadingProgress?: { total: number; loaded: number; loading: number };
     providers?: string[];
-    refetch?: () => Promise<unknown> | unknown;
+    /** Re-runs the model query; the menu never reads the result. */
+    refetch?: () => void;
   };
   onModelChange?: (model: TModel) => void;
   title?: string;

--- a/web/src/components/node/CompareImagesNode/CompareImagesNode.tsx
+++ b/web/src/components/node/CompareImagesNode/CompareImagesNode.tsx
@@ -102,6 +102,15 @@ const imageTypeMetadata = {
   optional: false
 };
 
+/** The `image_comparison` record the CompareImages node emits. */
+interface ImageComparison {
+  type?: string;
+  image_a?: { uri?: string; data?: ImageData; type?: string };
+  image_b?: { uri?: string; data?: ImageData; type?: string };
+  label_a?: string;
+  label_b?: string;
+}
+
 interface CompareImagesNodeProps extends NodeProps {
   data: NodeData;
   id: string;
@@ -121,7 +130,7 @@ const CompareImagesNode: React.FC<CompareImagesNodeProps> = (props) => {
   const result = _result ?? _output;
 
   const comparisonData = useMemo(() => {
-    const pickComparison = (value: unknown): unknown => {
+    const pickComparison = (value: unknown): ImageComparison | null => {
       if (!value || typeof value !== "object") return null;
       if (Array.isArray(value)) {
         for (const item of value) {
@@ -132,7 +141,10 @@ const CompareImagesNode: React.FC<CompareImagesNodeProps> = (props) => {
       }
       const record = value as Record<string, unknown>;
       if ((record as { type?: string }).type === "image_comparison") {
-        return record;
+        // SAFETY: the `type === "image_comparison"` tag above is what the
+        // CompareImages node stamps on this record; its two image refs and
+        // labels are all optional here, so nothing else is being assumed.
+        return record as ImageComparison;
       }
       if (record.comparison) {
         return pickComparison(record.comparison);
@@ -140,15 +152,7 @@ const CompareImagesNode: React.FC<CompareImagesNodeProps> = (props) => {
       return null;
     };
 
-    const snapshot = pickComparison(result);
-    if (!snapshot) return null;
-    return snapshot as {
-      type: string;
-      image_a: { uri?: string; data?: ImageData; type?: string };
-      image_b: { uri?: string; data?: ImageData; type?: string };
-      label_a?: string;
-      label_b?: string;
-    };
+    return pickComparison(result);
   }, [result]);
 
   // Track blob URLs for cleanup

--- a/web/src/components/node/DynamicKieSchemaNode/__tests__/KieSchemaLoader.test.tsx
+++ b/web/src/components/node/DynamicKieSchemaNode/__tests__/KieSchemaLoader.test.tsx
@@ -19,7 +19,7 @@ jest.mock("../../../ui_primitives", () => ({
 
 jest.mock("../../../../contexts/NodeContext", () => ({
   useNodes: jest.fn(
-    (selector: (state: { updateNodeData: typeof mockUpdateNodeData }) => unknown) =>
+    <T,>(selector: (state: { updateNodeData: typeof mockUpdateNodeData }) => T) =>
       selector({
         updateNodeData: mockUpdateNodeData
       })

--- a/web/src/components/node/SketchNode/__tests__/SketchNode.layerInputs.test.tsx
+++ b/web/src/components/node/SketchNode/__tests__/SketchNode.layerInputs.test.tsx
@@ -97,11 +97,11 @@ jest.mock("../../../../hooks/useDelayedVisibility", () => ({
   useDelayedVisibility: () => false
 }));
 jest.mock("../../../../stores/NodeFocusStore", () => ({
-  useNodeFocusStore: (selector: (s: unknown) => unknown) =>
+  useNodeFocusStore: <T,>(selector: (s: unknown) => T) =>
     selector({ focusedNodeId: null })
 }));
 jest.mock("../../../../stores/SettingsStore", () => ({
-  useSettingsStore: (selector: (s: unknown) => unknown) =>
+  useSettingsStore: <T,>(selector: (s: unknown) => T) =>
     selector({ settings: { imageEditorOpenMode: "modal" } })
 }));
 
@@ -183,7 +183,7 @@ describe("SketchNode layer inputs via generations", () => {
       Promise.resolve({ data: "layer-data", naturalWidth: 10, naturalHeight: 10 })
     );
 
-    mockUseNodes.mockImplementation((selector: (s: unknown) => unknown) =>
+    mockUseNodes.mockImplementation(<T,>(selector: (s: unknown) => T) =>
       selector({
         edges: [edge],
         updateNodeProperties: jest.fn(),

--- a/web/src/components/node/__tests__/AddDynamicOutputButton.test.tsx
+++ b/web/src/components/node/__tests__/AddDynamicOutputButton.test.tsx
@@ -7,7 +7,7 @@ import mockTheme from "../../../__mocks__/themeMock";
 
 const updateNodeData = jest.fn();
 jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: (selector: (state: { updateNodeData: jest.Mock }) => unknown) =>
+  useNodes: <T,>(selector: (state: { updateNodeData: jest.Mock }) => T) =>
     selector({ updateNodeData })
 }));
 

--- a/web/src/components/node/__tests__/CodeNodeUx.test.tsx
+++ b/web/src/components/node/__tests__/CodeNodeUx.test.tsx
@@ -8,7 +8,7 @@ jest.mock("../../ui_primitives", () => {
 
 jest.mock("../../../stores/ContextMenuStore", () => ({
   __esModule: true,
-  default: (selector: (state: { openContextMenu: jest.Mock }) => unknown) =>
+  default: <T,>(selector: (state: { openContextMenu: jest.Mock }) => T) =>
     selector({ openContextMenu: jest.fn() }),
   useContextMenuActions: () => ({
     openContextMenu: jest.fn(),
@@ -32,12 +32,12 @@ const mockUpdateNode = jest.fn();
 const mockUpdateNodeData = jest.fn();
 
 jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: jest.fn((selector: (state: {
+  useNodes: jest.fn(<T,>(selector: (state: {
     updateNode: typeof mockUpdateNode;
     updateNodeData: typeof mockUpdateNodeData;
     workflow: { id: string };
     findNode: () => undefined;
-  }) => unknown) =>
+  }) => T) =>
     selector({
       updateNode: mockUpdateNode,
       updateNodeData: mockUpdateNodeData,

--- a/web/src/components/node/__tests__/NodeHistoryViewer.test.tsx
+++ b/web/src/components/node/__tests__/NodeHistoryViewer.test.tsx
@@ -32,11 +32,11 @@ jest.mock("../../../hooks/nodes/useNodeGenerations", () => ({
 // a downstream consumer exists). The single-select tests have no outgoing edge,
 // so a store with no edges suffices — the multi-select modifiers stay inert.
 jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: (selector: (s: unknown) => unknown) => selector(mockNodeStoreState())
+  useNodes: <T,>(selector: (s: unknown) => T) => selector(mockNodeStoreState())
 }));
 
 jest.mock("../../../stores/WorkflowRunner", () => ({
-  useWebsocketRunner: (selector: (s: unknown) => unknown) =>
+  useWebsocketRunner: <T,>(selector: (s: unknown) => T) =>
     selector(mockUseWebsocketRunner())
 }));
 

--- a/web/src/components/node/__tests__/NodeSelectionToolbar.test.tsx
+++ b/web/src/components/node/__tests__/NodeSelectionToolbar.test.tsx
@@ -10,8 +10,8 @@ import useSelect from "../../../hooks/nodes/useSelect";
 let mockSelectedNodeCount = 1;
 
 jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: (
-    selector: (state: { getSelectedNodeCount: () => number }) => unknown
+  useNodes: <T,>(
+    selector: (state: { getSelectedNodeCount: () => number }) => T
   ) => selector({ getSelectedNodeCount: () => mockSelectedNodeCount })
 }));
 

--- a/web/src/components/node_types/CodeNodeScriptLink.tsx
+++ b/web/src/components/node_types/CodeNodeScriptLink.tsx
@@ -33,7 +33,7 @@ const CodeNodeScriptLinkInner: React.FC<CodeNodeScriptLinkProps> = ({
   const [busy, setBusy] = useState(false);
 
   const guard = useCallback(
-    async (label: string, action: () => Promise<unknown>) => {
+    async <T,>(label: string, action: () => Promise<T>) => {
       setBusy(true);
       try {
         await action();

--- a/web/src/components/node_types/__tests__/CodeBody.test.tsx
+++ b/web/src/components/node_types/__tests__/CodeBody.test.tsx
@@ -45,7 +45,7 @@ const mockUpdateNodeData = jest.fn();
 let mockEdges: Array<{ source: string; target: string }> = [];
 
 jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: (selector: (state: unknown) => unknown) =>
+  useNodes: <T,>(selector: (state: unknown) => T) =>
     selector({
       findNode: mockFindNode,
       updateNodeData: mockUpdateNodeData,

--- a/web/src/components/node_types/__tests__/ContentCardBody.test.tsx
+++ b/web/src/components/node_types/__tests__/ContentCardBody.test.tsx
@@ -42,12 +42,12 @@ jest.mock("../../../hooks/nodes/useNodeResultHistory", () => {
 // is persisted, so `findNode` returns a bare node and selection defaults to the
 // latest generation.
 jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: (
+  useNodes: <T,>(
     selector: (state: {
       updateNodeData: () => void;
-      findNode: (id: string) => unknown;
+      findNode: (id: string) => { id: string; data: Partial<NodeData> };
       edges: unknown[];
-    }) => unknown
+    }) => T
   ) =>
     selector({
       updateNodeData: jest.fn(),
@@ -86,7 +86,7 @@ jest.mock("../../assets/AssetViewer", () => ({
 
 let mockRunnerState: "idle" | "running" = "idle";
 jest.mock("../../../stores/WorkflowRunner", () => ({
-  useWebsocketRunner: (selector: (s: { state: string }) => unknown) =>
+  useWebsocketRunner: <T,>(selector: (s: { state: string }) => T) =>
     selector({ state: mockRunnerState })
 }));
 
@@ -101,14 +101,14 @@ jest.mock("../../../hooks/nodes/useMediaSrc", () => ({
 // VideoPreview's "save to assets" / "download" actions delegate to these.
 const mockCreateAsset = jest.fn().mockResolvedValue({});
 jest.mock("../../../stores/AssetStore", () => ({
-  useAssetStore: (selector: (s: { createAsset: unknown }) => unknown) =>
+  useAssetStore: <T,>(selector: (s: { createAsset: unknown }) => T) =>
     selector({ createAsset: mockCreateAsset })
 }));
 
 const mockAddNotification = jest.fn();
 jest.mock("../../../stores/NotificationStore", () => ({
-  useNotificationStore: (
-    selector: (s: { addNotification: unknown }) => unknown
+  useNotificationStore: <T,>(
+    selector: (s: { addNotification: unknown }) => T
   ) => selector({ addNotification: mockAddNotification })
 }));
 

--- a/web/src/components/node_types/code_assistant/__tests__/CodeAssistantDialog.test.tsx
+++ b/web/src/components/node_types/code_assistant/__tests__/CodeAssistantDialog.test.tsx
@@ -46,7 +46,7 @@ const mockUpdateNodeData = jest.fn();
 let mockNode: Record<string, unknown> | undefined;
 
 jest.mock("../../../../contexts/NodeContext", () => ({
-  useNodes: (selector: (state: unknown) => unknown) =>
+  useNodes: <T,>(selector: (state: unknown) => T) =>
     selector({
       findNode: () => mockNode,
       updateNodeData: mockUpdateNodeData

--- a/web/src/components/node_types/editing/__tests__/GetVariableBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/GetVariableBody.test.tsx
@@ -23,7 +23,7 @@ const mockUseGraphVariableTypes =
   useGraphVariableTypes as jest.MockedFunction<typeof useGraphVariableTypes>;
 
 jest.mock("../../../../contexts/NodeContext", () => ({
-  useNodes: (selector: (state: { updateNodeData: jest.Mock }) => unknown) =>
+  useNodes: <T,>(selector: (state: { updateNodeData: jest.Mock }) => T) =>
     selector({ updateNodeData: mockUpdateNodeData })
 }));
 

--- a/web/src/components/node_types/editing/__tests__/ListGeneratorBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/ListGeneratorBody.test.tsx
@@ -14,18 +14,18 @@ const nodeId = "node-1";
 
 // The body reads the live stream buffer for the focused job. Drive `items`
 // straight through the buffer so we don't need a running graph.
-let mockStreamBuffer: unknown;
+let mockStreamBuffer: string[] | undefined;
 
 jest.mock("../../../../stores/WorkflowRunsStore", () => ({
   __esModule: true,
-  default: (selector: (s: { focusedJob: Record<string, string> }) => unknown) =>
+  default: <T,>(selector: (s: { focusedJob: Record<string, string> }) => T) =>
     selector({ focusedJob: { "wf-1": "job-1" } })
 }));
 
 jest.mock("../../../../stores/ResultsStore", () => ({
   __esModule: true,
-  default: (
-    selector: (s: { getOutputResult: () => unknown }) => unknown
+  default: <T,>(
+    selector: (s: { getOutputResult: () => string[] | undefined }) => T
   ) => selector({ getOutputResult: () => mockStreamBuffer })
 }));
 

--- a/web/src/components/node_types/editing/__tests__/useVariablePassthroughOutputs.test.ts
+++ b/web/src/components/node_types/editing/__tests__/useVariablePassthroughOutputs.test.ts
@@ -53,7 +53,7 @@ const imageSourceMetadata = {
 
 const setupStore = (edges: Edge[]) => {
   (useNodes as unknown as jest.Mock).mockImplementation(
-    (selector: (s: unknown) => unknown) =>
+    <T,>(selector: (s: unknown) => T) =>
       selector({
         edges,
         findNode: (id: string) => (id === "img-1" ? imageSourceNode : undefined),
@@ -61,7 +61,7 @@ const setupStore = (edges: Edge[]) => {
       })
   );
   (useMetadataStore as unknown as jest.Mock).mockImplementation(
-    (selector: (s: unknown) => unknown) =>
+    <T,>(selector: (s: unknown) => T) =>
       selector({ getMetadata: () => imageSourceMetadata })
   );
 };

--- a/web/src/components/panels/__tests__/CanvasMediaComposer.test.tsx
+++ b/web/src/components/panels/__tests__/CanvasMediaComposer.test.tsx
@@ -33,9 +33,9 @@ const gcState = {
   setMemoryEnabled: jest.fn(),
   connect
 };
-const useGlobalChatStore = ((selector: (s: typeof gcState) => unknown) =>
+const useGlobalChatStore = (<T,>(selector: (s: typeof gcState) => T) =>
   selector(gcState)) as unknown as {
-  (selector: (s: typeof gcState) => unknown): unknown;
+  <T,>(selector: (s: typeof gcState) => T): T;
   getState: () => typeof gcState;
 };
 useGlobalChatStore.getState = () => gcState;
@@ -50,7 +50,7 @@ jest.mock("../../../contexts/NodeContext", () => {
     // A real context (defaulting to null) so useAddMediaToCanvas, pulled in via
     // the auto-add-to-canvas hook, resolves to "no canvas" instead of crashing.
     NodeContext: actualReact.createContext(null),
-    useNodes: (selector: (s: { workflow: { id: string } }) => unknown) =>
+    useNodes: <T,>(selector: (s: { workflow: { id: string } }) => T) =>
       selector({ workflow: { id: "canvas-doc-id" } }),
     useNodeStoreRef: () => ({
       getState: () => ({

--- a/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
+++ b/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
@@ -40,7 +40,7 @@ jest.mock("../../../contexts/WorkflowManagerContext", () => ({
 }));
 
 jest.mock("../../../stores/WorkspaceTabsStore", () => ({
-  useWorkspaceTabsStore: (selector: (state: unknown) => unknown) =>
+  useWorkspaceTabsStore: <T,>(selector: (state: unknown) => T) =>
     selector({ tabs: [], activeTabId: null, openTab: jest.fn() })
 }));
 

--- a/web/src/components/panels/__tests__/QueueOverlay.focus.test.tsx
+++ b/web/src/components/panels/__tests__/QueueOverlay.focus.test.tsx
@@ -27,7 +27,7 @@ jest.mock("../../../trpc/client", () => ({
 // Mock useWorkflowManager to return currentWorkflowId "wf"
 const mockCurrentWorkflowId = { value: "wf" as string | null };
 jest.mock("../../../contexts/WorkflowManagerContext", () => ({
-  useWorkflowManager: (selector: (s: { currentWorkflowId: string | null }) => unknown) =>
+  useWorkflowManager: <T,>(selector: (s: { currentWorkflowId: string | null }) => T) =>
     selector({ currentWorkflowId: mockCurrentWorkflowId.value })
 }));
 

--- a/web/src/components/panels/__tests__/TriggerActivationButton.test.tsx
+++ b/web/src/components/panels/__tests__/TriggerActivationButton.test.tsx
@@ -10,7 +10,7 @@ const mockNodeState = {
 };
 
 jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: (selector: (state: typeof mockNodeState) => unknown) =>
+  useNodes: <T,>(selector: (state: typeof mockNodeState) => T) =>
     selector(mockNodeState)
 }));
 

--- a/web/src/components/properties/__tests__/CodeProperty.test.tsx
+++ b/web/src/components/properties/__tests__/CodeProperty.test.tsx
@@ -42,7 +42,7 @@ jest.mock("../TextEditorModal", () => ({
 
 let mockEdges: Array<{ target: string; targetHandle: string }> = [];
 jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: (selector: (state: unknown) => unknown) =>
+  useNodes: <T,>(selector: (state: unknown) => T) =>
     selector({ edges: mockEdges })
 }));
 

--- a/web/src/components/properties/__tests__/FloatProperty.test.tsx
+++ b/web/src/components/properties/__tests__/FloatProperty.test.tsx
@@ -9,9 +9,9 @@ jest.mock("../../../contexts/NodeContext", () => {
   const actual = jest.requireActual("../../../contexts/NodeContext");
   return {
     ...actual,
-    useNodes: (selector: (state: { nodes: never[] }) => unknown) =>
+    useNodes: <T,>(selector: (state: { nodes: never[] }) => T) =>
       selector({ nodes: [] }),
-    useTemporalNodes: (selector: (state: { pause: () => void; resume: () => void }) => unknown) =>
+    useTemporalNodes: <T,>(selector: (state: { pause: () => void; resume: () => void }) => T) =>
       selector({ pause: jest.fn(), resume: jest.fn() })
   };
 });

--- a/web/src/components/properties/__tests__/ImageListProperty.test.tsx
+++ b/web/src/components/properties/__tests__/ImageListProperty.test.tsx
@@ -11,7 +11,7 @@ jest.mock("../../../contexts/NodeContext", () => {
   const actual = jest.requireActual("../../../contexts/NodeContext");
   return {
     ...actual,
-    useNodes: (selector: (state: Record<string, unknown>) => unknown) =>
+    useNodes: <T,>(selector: (state: Record<string, unknown>) => T) =>
       selector({ nodes: [], edges: [], findNode: () => undefined })
   };
 });

--- a/web/src/components/properties/__tests__/IntegerProperty.test.tsx
+++ b/web/src/components/properties/__tests__/IntegerProperty.test.tsx
@@ -9,9 +9,9 @@ jest.mock("../../../contexts/NodeContext", () => {
   const actual = jest.requireActual("../../../contexts/NodeContext");
   return {
     ...actual,
-    useNodes: (selector: (state: { nodes: never[] }) => unknown) =>
+    useNodes: <T,>(selector: (state: { nodes: never[] }) => T) =>
       selector({ nodes: [] }),
-    useTemporalNodes: (selector: (state: { pause: () => void; resume: () => void }) => unknown) =>
+    useTemporalNodes: <T,>(selector: (state: { pause: () => void; resume: () => void }) => T) =>
       selector({ pause: jest.fn(), resume: jest.fn() })
   };
 });

--- a/web/src/components/provider_onboarding/__tests__/ProviderOnboardingCard.test.tsx
+++ b/web/src/components/provider_onboarding/__tests__/ProviderOnboardingCard.test.tsx
@@ -63,11 +63,11 @@ beforeEach(() => {
     valid: true,
     message: "Anthropic accepted the key."
   });
-  mockUseSecretsStore.mockImplementation((selector: (s: unknown) => unknown) =>
+  mockUseSecretsStore.mockImplementation(<T,>(selector: (s: unknown) => T) =>
     selector({ updateSecret, validateSecret })
   );
   mockUseNotificationStore.mockImplementation(
-    (selector: (s: unknown) => unknown) => selector({ addNotification })
+    <T,>(selector: (s: unknown) => T) => selector({ addNotification })
   );
 });
 

--- a/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
+++ b/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
@@ -45,7 +45,7 @@ const storeState = {
 beforeEach(() => {
   jest.clearAllMocks();
   mockUseProviderOnboardingStore.mockImplementation(
-    (selector: (s: unknown) => unknown) => selector(storeState)
+    <T,>(selector: (s: unknown) => T) => selector(storeState)
   );
   mockUseSecrets.mockReturnValue({
     secrets: [],
@@ -61,11 +61,11 @@ beforeEach(() => {
     connect: jest.fn(),
     disconnect: jest.fn()
   });
-  mockUseSecretsStore.mockImplementation((selector: (s: unknown) => unknown) =>
+  mockUseSecretsStore.mockImplementation(<T,>(selector: (s: unknown) => T) =>
     selector({ updateSecret: jest.fn() })
   );
   mockUseNotificationStore.mockImplementation(
-    (selector: (s: unknown) => unknown) => selector({ addNotification: jest.fn() })
+    <T,>(selector: (s: unknown) => T) => selector({ addNotification: jest.fn() })
   );
 });
 

--- a/web/src/components/sketch/sam/SamServiceFal.ts
+++ b/web/src/components/sketch/sam/SamServiceFal.ts
@@ -82,13 +82,22 @@ interface FalResultImage {
   content_type?: string;
 }
 
+/**
+ * A bounding box as FAL reports it: `[cx, cy, w, h]` in normalized units, or an
+ * `{x, y, width, height}` object in mask pixels. The members stay unparsed
+ * until `normalizeFalMetadataBox` checks each one is finite.
+ */
+type FalBoxCandidate =
+  | unknown[]
+  | { x?: unknown; y?: unknown; width?: unknown; height?: unknown };
+
 interface FalMaskMetadata {
   label?: string;
   name?: string;
   score?: number;
-  box?: unknown;
-  bbox?: unknown;
-  bounds?: unknown;
+  box?: FalBoxCandidate;
+  bbox?: FalBoxCandidate;
+  bounds?: FalBoxCandidate;
 }
 
 interface FalSam3Result {
@@ -273,7 +282,9 @@ function normalizeFalRle(value: unknown): string | string[] | null {
   return null;
 }
 
-function getFalMetadataBoxCandidate(metadata: FalMaskMetadata | undefined): unknown {
+function getFalMetadataBoxCandidate(
+  metadata: FalMaskMetadata | undefined
+): FalBoxCandidate | undefined {
   return metadata?.box ?? metadata?.bbox ?? metadata?.bounds;
 }
 

--- a/web/src/components/storyboard/__tests__/ShotCard.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotCard.test.tsx
@@ -31,7 +31,7 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => {
     ...actual,
     // Serve the actions the card reads via selectors; keep sameMediaRef and the
     // other real exports (the nested takes gallery uses them).
-    useStoryboardStore: (selector: (s: unknown) => unknown) =>
+    useStoryboardStore: <T,>(selector: (s: unknown) => T) =>
       selector({
         toggleShotEntity: jest.fn(),
         moveShot: moveShotMock,

--- a/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
@@ -18,7 +18,7 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => ({
     videoModel: null,
     shots: mockShots
   }),
-  useStoryboardStore: (selector: (s: unknown) => unknown) =>
+  useStoryboardStore: <T,>(selector: (s: unknown) => T) =>
     selector({
       setTitle: jest.fn(),
       setBrief: jest.fn(),

--- a/web/src/components/textEditor/EditorController.tsx
+++ b/web/src/components/textEditor/EditorController.tsx
@@ -22,16 +22,21 @@ import { sanitizeText } from "../../utils/sanitize";
 import { SearchParam } from "../../types/text_editor";
 
 // CSS Custom Highlight API (experimental)
+/** One entry of the CSS Custom Highlight API registry: a live set of Ranges. */
+interface CssHighlight {
+  readonly size: number;
+}
+
 type CSSWithHighlights = typeof CSS & {
   highlights?: {
-    set(name: string, highlight: unknown): void;
+    set(name: string, highlight: CssHighlight): void;
     delete(name: string): void;
   };
 };
 
 // Highlight constructor (experimental)
 type WindowWithHighlight = Window & {
-  Highlight?: new (...ranges: Range[]) => unknown;
+  Highlight?: new (...ranges: Range[]) => CssHighlight;
 };
 
 // Text Fragment Directive (experimental polyfill)

--- a/web/src/components/timeline/Tracks/__tests__/TracksRegionEmptyAreaDrop.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TracksRegionEmptyAreaDrop.test.tsx
@@ -18,7 +18,18 @@ import { TimelineProvider } from "../../../../stores/timeline/TimelineInstance";
 import { useTimelineStore } from "../../../../stores/timeline/TimelineStore";
 import type { Asset } from "../../../../stores/ApiTypes";
 
-const restFetchMock = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+/** The slice of `Response` the video-audio import path reads back. */
+type AudioExtractionResponse = {
+  ok: boolean;
+  status?: number;
+  json?: () => Promise<{
+    has_audio: boolean;
+    asset?: { id: string; duration?: number; content_type?: string };
+  }>;
+};
+
+const restFetchMock =
+  jest.fn<(...args: unknown[]) => Promise<AudioExtractionResponse>>();
 jest.mock("../../../../lib/rest-fetch", () => ({
   restFetch: (...args: unknown[]) => restFetchMock(...args)
 }));

--- a/web/src/components/timeline/__tests__/ProjectSettingsDialog.test.tsx
+++ b/web/src/components/timeline/__tests__/ProjectSettingsDialog.test.tsx
@@ -18,7 +18,7 @@ import { ProjectSettingsDialog } from "../ProjectSettingsDialog";
 let storeState = { fps: 30, width: 1920, height: 1080 };
 
 jest.mock("../../../stores/timeline/TimelineStore", () => ({
-  useTimelineStore: (selector: (s: typeof storeState) => unknown) =>
+  useTimelineStore: <T,>(selector: (s: typeof storeState) => T) =>
     selector(storeState)
 }));
 

--- a/web/src/components/timeline/__tests__/TrackLaneScrollMath.test.tsx
+++ b/web/src/components/timeline/__tests__/TrackLaneScrollMath.test.tsx
@@ -43,24 +43,24 @@ jest.mock("../Tracks/useAudioPeaks", () => ({
 // ── Stores that pull in network/api dependencies → light mocks ─────────────
 
 jest.mock("../../../stores/AssetStore", () => ({
-  useAssetStore: (sel: (s: { get: () => Promise<null> }) => unknown) =>
+  useAssetStore: <T,>(sel: (s: { get: () => Promise<null> }) => T) =>
     sel({ get: () => Promise.resolve(null) })
 }));
 jest.mock("../../../stores/WorkflowRunsStore", () => ({
   __esModule: true,
-  default: (sel: (s: { focusedJob: Record<string, string> }) => unknown) =>
+  default: <T,>(sel: (s: { focusedJob: Record<string, string> }) => T) =>
     sel({ focusedJob: {} })
 }));
 jest.mock("../../../stores/ErrorStore", () => ({
   __esModule: true,
-  default: (sel: (s: { errors: Record<string, unknown> }) => unknown) =>
+  default: <T,>(sel: (s: { errors: Record<string, unknown> }) => T) =>
     sel({ errors: {} }),
   hasNodeError: () => false,
   nodeErrorToDisplayString: () => ""
 }));
 jest.mock("../../../stores/timeline/TimelineGenerationStore", () => ({
-  useTimelineGenerationStore: (
-    sel: (s: { clipJobs: Record<string, unknown> }) => unknown
+  useTimelineGenerationStore: <T,>(
+    sel: (s: { clipJobs: Record<string, unknown> }) => T
   ) => sel({ clipJobs: {} })
 }));
 

--- a/web/src/components/timeline/preview/__tests__/PreviewArea.test.tsx
+++ b/web/src/components/timeline/preview/__tests__/PreviewArea.test.tsx
@@ -59,7 +59,7 @@ jest.mock("../../../../stores/timeline/TimelinePlaybackStore", () => {
     getTimeMs: () => mockCurrentTimeMs,
     subscribeTime: mockSubscribeTime
   });
-  const useTimelinePlaybackStore = (selector: (s: unknown) => unknown) => {
+  const useTimelinePlaybackStore = <T,>(selector: (s: unknown) => T) => {
     const state = getState();
     return selector ? selector(state) : state;
   };
@@ -68,7 +68,7 @@ jest.mock("../../../../stores/timeline/TimelinePlaybackStore", () => {
 });
 
 jest.mock("../../../../stores/timeline/TimelineStore", () => ({
-  useTimelineStore: (selector: (s: unknown) => unknown) => {
+  useTimelineStore: <T,>(selector: (s: unknown) => T) => {
     const state = {
       clips: [],
       tracks: [],
@@ -79,7 +79,7 @@ jest.mock("../../../../stores/timeline/TimelineStore", () => ({
 }));
 
 jest.mock("../../../../stores/AssetStore", () => ({
-  useAssetStore: (selector: (s: unknown) => unknown) => {
+  useAssetStore: <T,>(selector: (s: unknown) => T) => {
     const state = {
       get: jest.fn().mockResolvedValue(null)
     };

--- a/web/src/components/workers/WorkersPanel.tsx
+++ b/web/src/components/workers/WorkersPanel.tsx
@@ -369,7 +369,7 @@ const WorkersPanel: React.FC = () => {
 
   /** Run a lifecycle action, surfacing failures in the error banner. */
   const runAction = useCallback(
-    async (action: () => Promise<unknown>): Promise<boolean> => {
+    async <T,>(action: () => Promise<T>): Promise<boolean> => {
       try {
         await action();
         setError(null);

--- a/web/src/components/workspace/__tests__/ApplicationSurface.test.tsx
+++ b/web/src/components/workspace/__tests__/ApplicationSurface.test.tsx
@@ -28,7 +28,7 @@ jest.mock("../../../hooks/useApplications", () => ({
 const openTab = jest.fn();
 jest.mock("../../../stores/WorkspaceTabsStore", () => ({
   tabId: (type: string, ref: string) => `${type}:${ref}`,
-  useWorkspaceTabsStore: (selector: (s: unknown) => unknown) =>
+  useWorkspaceTabsStore: <T,>(selector: (s: unknown) => T) =>
     selector({ openTab, activeTabId: "application:app-1" })
 }));
 

--- a/web/src/components/workspace/__tests__/LinkedWorkflowsMenu.test.tsx
+++ b/web/src/components/workspace/__tests__/LinkedWorkflowsMenu.test.tsx
@@ -20,7 +20,7 @@ jest.mock("../../../hooks/useApplications", () => ({
 const openTab = jest.fn();
 jest.mock("../../../stores/WorkspaceTabsStore", () => ({
   tabId: (type: string, ref: string) => `${type}:${ref}`,
-  useWorkspaceTabsStore: (selector: (s: unknown) => unknown) =>
+  useWorkspaceTabsStore: <T,>(selector: (s: unknown) => T) =>
     selector({ openTab, activeTabId: "application:app-1" })
 }));
 

--- a/web/src/components/workspace/__tests__/MobileDocumentSelector.test.tsx
+++ b/web/src/components/workspace/__tests__/MobileDocumentSelector.test.tsx
@@ -16,7 +16,7 @@ jest.mock("../../../hooks/useWorkflowRunnerState", () => ({
   useIsWorkflowRunning: () => false
 }));
 jest.mock("../../../stores/SettingsStore", () => ({
-  useSettingsStore: (selector: (s: unknown) => unknown) =>
+  useSettingsStore: <T,>(selector: (s: unknown) => T) =>
     selector({ settings: { instantUpdate: false } })
 }));
 

--- a/web/src/components/workspace/__tests__/TextDocumentEditor.test.tsx
+++ b/web/src/components/workspace/__tests__/TextDocumentEditor.test.tsx
@@ -17,11 +17,11 @@ jest.mock("../../textEditor/EditorToolbar", () => ({
 }));
 
 jest.mock("../../../stores/AssetStore", () => ({
-  useAssetStore: (selector: (s: { update: unknown }) => unknown) =>
+  useAssetStore: <T,>(selector: (s: { update: unknown }) => T) =>
     selector({ update: jest.fn() })
 }));
 jest.mock("../../../stores/NotificationStore", () => ({
-  useNotificationStore: (selector: (s: { addNotification: unknown }) => unknown) =>
+  useNotificationStore: <T,>(selector: (s: { addNotification: unknown }) => T) =>
     selector({ addNotification: jest.fn() })
 }));
 

--- a/web/src/components/workspace/__tests__/WorkflowChainSurface.test.tsx
+++ b/web/src/components/workspace/__tests__/WorkflowChainSurface.test.tsx
@@ -16,7 +16,7 @@ const updateWorkflow = jest.fn();
 
 jest.mock("../../../contexts/WorkflowManagerContext", () => ({
   __esModule: true,
-  useWorkflowManager: (selector: (state: unknown) => unknown) =>
+  useWorkflowManager: <T,>(selector: (state: unknown) => T) =>
     selector({ saveWorkflow, updateWorkflow })
 }));
 

--- a/web/src/components/workspace/__tests__/WorkspaceEmptyView.test.tsx
+++ b/web/src/components/workspace/__tests__/WorkspaceEmptyView.test.tsx
@@ -26,7 +26,7 @@ const chatState = {
 };
 
 jest.mock("../../../stores/GlobalChatStore", () => {
-  const useStore = (selector: (state: unknown) => unknown) =>
+  const useStore = <T,>(selector: (state: unknown) => T) =>
     selector(chatState);
   useStore.getState = () => chatState;
   return { __esModule: true, default: useStore };
@@ -34,7 +34,7 @@ jest.mock("../../../stores/GlobalChatStore", () => {
 
 jest.mock("../../../stores/WorkspaceTabsStore", () => ({
   __esModule: true,
-  useWorkspaceTabsStore: (selector: (state: unknown) => unknown) =>
+  useWorkspaceTabsStore: <T,>(selector: (state: unknown) => T) =>
     selector({ openTab })
 }));
 
@@ -44,7 +44,7 @@ const createNew = jest
 
 jest.mock("../../../contexts/WorkflowManagerContext", () => ({
   __esModule: true,
-  useWorkflowManager: (selector: (state: unknown) => unknown) =>
+  useWorkflowManager: <T,>(selector: (state: unknown) => T) =>
     selector({ createNew })
 }));
 
@@ -52,7 +52,7 @@ const fetchSecrets = jest.fn().mockResolvedValue([]);
 const secretsState = { fetchSecrets, secrets: [] as unknown[] };
 
 jest.mock("../../../stores/SecretsStore", () => {
-  const useStore = (selector: (state: unknown) => unknown) =>
+  const useStore = <T,>(selector: (state: unknown) => T) =>
     selector(secretsState);
   useStore.getState = () => secretsState;
   return { __esModule: true, default: useStore };

--- a/web/src/components/workspace/__tests__/WorkspaceTabItem.test.tsx
+++ b/web/src/components/workspace/__tests__/WorkspaceTabItem.test.tsx
@@ -17,7 +17,7 @@ jest.mock("../../../hooks/useWorkflowDirty", () => ({
   useWorkflowDirty: () => false
 }));
 jest.mock("../../../stores/SettingsStore", () => ({
-  useSettingsStore: (selector: (state: unknown) => unknown) =>
+  useSettingsStore: <T,>(selector: (state: unknown) => T) =>
     selector({ settings: { instantUpdate: false } })
 }));
 

--- a/web/src/config/snippetMetadata.ts
+++ b/web/src/config/snippetMetadata.ts
@@ -64,7 +64,9 @@ const CATEGORY_INPUT_TYPE: Partial<Record<SnippetCategory, string>> = {
 };
 
 /** Value a slot of `type` starts with when the snippet declares no default. */
-function defaultValueForType(type: string): unknown {
+function defaultValueForType(
+  type: string
+): string | number | boolean | unknown[] | object {
   switch (type) {
     case "bool":
       return false;

--- a/web/src/hooks/__tests__/useCodeAuthoringModel.test.ts
+++ b/web/src/hooks/__tests__/useCodeAuthoringModel.test.ts
@@ -14,7 +14,7 @@ const mockCatalog: { models: LanguageModel[]; isLoading: boolean } = {
 
 jest.mock("../../stores/GlobalChatStore", () => ({
   __esModule: true,
-  default: (selector: (state: unknown) => unknown) => selector(mockChatState)
+  default: <T,>(selector: (state: unknown) => T) => selector(mockChatState)
 }));
 
 jest.mock("../useModelsByProvider", () => ({

--- a/web/src/hooks/__tests__/useCreateNode.test.ts
+++ b/web/src/hooks/__tests__/useCreateNode.test.ts
@@ -50,7 +50,7 @@ jest.mock("../../stores/NodeMenuStore", () => ({
 
 const mockAddRecentNode = jest.fn();
 jest.mock("../../stores/RecentNodesStore", () => ({
-  useRecentNodesStore: (selector: (state: { addRecentNode: typeof mockAddRecentNode }) => unknown) => {
+  useRecentNodesStore: <T,>(selector: (state: { addRecentNode: typeof mockAddRecentNode }) => T) => {
     const mockState = { addRecentNode: mockAddRecentNode };
     if (typeof selector === "function") {
       return selector(mockState);

--- a/web/src/hooks/__tests__/useDebouncedCallback.test.ts
+++ b/web/src/hooks/__tests__/useDebouncedCallback.test.ts
@@ -97,14 +97,14 @@ describe("useDebouncedCallback", () => {
 
     const { result, rerender } = renderHook(
       ({ fn }) => useDebouncedCallback(fn, 200),
-      { initialProps: { fn: fn1 as (...args: unknown[]) => unknown } }
+      { initialProps: { fn: fn1 as (...args: unknown[]) => void } }
     );
 
     act(() => {
       result.current();
     });
 
-    rerender({ fn: fn2 as (...args: unknown[]) => unknown });
+    rerender({ fn: fn2 as (...args: unknown[]) => void });
 
     act(() => {
       jest.advanceTimersByTime(200);

--- a/web/src/hooks/__tests__/useHasConfiguredProvider.test.tsx
+++ b/web/src/hooks/__tests__/useHasConfiguredProvider.test.tsx
@@ -28,7 +28,7 @@ const oauthState = (isConnected: boolean): OAuthConnection => ({
 });
 
 const withSecrets = (secrets: SecretResponse[]): void => {
-  mockUseSecretsStore.mockImplementation((selector: (s: unknown) => unknown) =>
+  mockUseSecretsStore.mockImplementation(<T,>(selector: (s: unknown) => T) =>
     selector({ secrets, fetchSecrets })
   );
 };

--- a/web/src/hooks/__tests__/useModelAvailability.test.ts
+++ b/web/src/hooks/__tests__/useModelAvailability.test.ts
@@ -6,7 +6,7 @@ const mockIsApiKeySet = jest.fn();
 jest.mock("../../stores/ModelPreferencesStore", () => ({
   __esModule: true,
   default: jest.fn(
-    (selector: (s: Record<string, unknown>) => unknown) =>
+    <T,>(selector: (s: Record<string, unknown>) => T) =>
       selector({ enabledProviders: mockEnabledProviders })
   )
 }));

--- a/web/src/hooks/__tests__/useNodeEditorShortcuts.test.tsx
+++ b/web/src/hooks/__tests__/useNodeEditorShortcuts.test.tsx
@@ -27,19 +27,19 @@ jest.mock("../../utils/MousePosition", () => ({
 }));
 
 jest.mock("../../contexts/NodeContext", () => ({
-  useTemporalNodes: (selector: (state: { undo: () => void; redo: () => void }) => unknown) =>
+  useTemporalNodes: <T,>(selector: (state: { undo: () => void; redo: () => void }) => T) =>
     selector({
       undo: jest.fn(),
       redo: jest.fn()
     }),
-  useNodes: (
+  useNodes: <T,>(
     selector: (state: {
       getSelectedNodeCount: () => number;
       selectAllNodes: () => void;
       setNodes: () => void;
       toggleBypassSelected: () => void;
       edges: Array<{ selected?: boolean }>;
-    }) => unknown
+    }) => T
   ) =>
     selector({
       getSelectedNodeCount: () => 0,
@@ -58,14 +58,14 @@ jest.mock("../../contexts/NodeContext", () => ({
 
 jest.mock("../../stores/NodeMenuStore", () => ({
   __esModule: true,
-  default: (selector: (state: { openNodeMenu: () => void }) => unknown) =>
+  default: <T,>(selector: (state: { openNodeMenu: () => void }) => T) =>
     selector({
       openNodeMenu: mockOpenNodeMenu
     })
 }));
 
 jest.mock("../../contexts/WorkflowManagerContext", () => ({
-  useWorkflowManager: (
+  useWorkflowManager: <T,>(
     selector: (state: {
       saveExample: () => Promise<void>;
       removeWorkflow: () => void;
@@ -73,7 +73,7 @@ jest.mock("../../contexts/WorkflowManagerContext", () => ({
       openWorkflows: Array<{ id: string }>;
       createNew: () => Promise<{ id: string }>;
       saveWorkflow: () => Promise<void>;
-    }) => unknown
+    }) => T
   ) =>
     selector({
       saveExample: async () => Promise.resolve(),
@@ -133,8 +133,8 @@ jest.mock("../useIpcRenderer", () => ({
 }));
 
 jest.mock("../../stores/NotificationStore", () => ({
-  useNotificationStore: (
-    selector: (state: { addNotification: () => void }) => unknown
+  useNotificationStore: <T,>(
+    selector: (state: { addNotification: () => void }) => T
   ) =>
     selector({
       addNotification: jest.fn()
@@ -142,8 +142,8 @@ jest.mock("../../stores/NotificationStore", () => ({
 }));
 
 jest.mock("../../stores/RightPanelStore", () => ({
-  useRightPanelStore: (
-    selector: (state: { handleViewChange: () => void }) => unknown
+  useRightPanelStore: <T,>(
+    selector: (state: { handleViewChange: () => void }) => T
   ) =>
     selector({
       handleViewChange: jest.fn()
@@ -151,8 +151,8 @@ jest.mock("../../stores/RightPanelStore", () => ({
 }));
 
 jest.mock("../../stores/BottomPanelStore", () => ({
-  useBottomPanelStore: (
-    selector: (state: { handleViewChange: () => void }) => unknown
+  useBottomPanelStore: <T,>(
+    selector: (state: { handleViewChange: () => void }) => T
   ) =>
     selector({
       handleViewChange: jest.fn()

--- a/web/src/hooks/__tests__/useOAuthConnection.test.tsx
+++ b/web/src/hooks/__tests__/useOAuthConnection.test.tsx
@@ -41,7 +41,7 @@ describe("useOAuthConnection", () => {
     jest.clearAllMocks();
     jest.spyOn(window, "open").mockReturnValue(fakeAuthWindow());
     (useNotificationStore as unknown as jest.Mock).mockImplementation(
-      (selector: (state: unknown) => unknown) =>
+      <T,>(selector: (state: unknown) => T) =>
         selector({ addNotification: mockAddNotification })
     );
     mockRestFetch.mockImplementation(async (input) => {

--- a/web/src/hooks/__tests__/useRequiredSettings.test.ts
+++ b/web/src/hooks/__tests__/useRequiredSettings.test.ts
@@ -20,7 +20,7 @@ describe("useRequiredSettings", () => {
 
   describe("when node has no metadata", () => {
     it("returns empty array", () => {
-      mockUseMetadataStore.mockImplementation((selector: (state: MetadataState) => unknown) => {
+      mockUseMetadataStore.mockImplementation(<T,>(selector: (state: MetadataState) => T) => {
         if (selector.name === "getMetadata") {
           return () => undefined;
         }
@@ -61,7 +61,7 @@ describe("useRequiredSettings", () => {
 
   describe("when node has no required settings", () => {
     it("returns empty array", () => {
-      mockUseMetadataStore.mockImplementation((selector: (state: MetadataState) => unknown) => {
+      mockUseMetadataStore.mockImplementation(<T,>(selector: (state: MetadataState) => T) => {
         if (selector.name === "getMetadata") {
           return () => ({
             title: "Test Node",
@@ -127,7 +127,7 @@ describe("useRequiredSettings", () => {
 
   describe("when node has required settings", () => {
     it("returns missing settings when none are configured", () => {
-      mockUseMetadataStore.mockImplementation((selector: (state: MetadataState) => unknown) => {
+      mockUseMetadataStore.mockImplementation(<T,>(selector: (state: MetadataState) => T) => {
         if (selector.name === "getMetadata") {
           return () => ({
             title: "Test Node",
@@ -192,7 +192,7 @@ describe("useRequiredSettings", () => {
     });
 
     it("returns empty array when all required settings are configured", () => {
-      mockUseMetadataStore.mockImplementation((selector: (state: MetadataState) => unknown) => {
+      mockUseMetadataStore.mockImplementation(<T,>(selector: (state: MetadataState) => T) => {
         if (selector.name === "getMetadata") {
           return () => ({
             title: "Test Node",
@@ -274,7 +274,7 @@ describe("useRequiredSettings", () => {
     });
 
     it("returns only missing settings when some are configured", () => {
-      mockUseMetadataStore.mockImplementation((selector: (state: MetadataState) => unknown) => {
+      mockUseMetadataStore.mockImplementation(<T,>(selector: (state: MetadataState) => T) => {
         if (selector.name === "getMetadata") {
           return () => ({
             title: "Test Node",
@@ -348,7 +348,7 @@ describe("useRequiredSettings", () => {
     });
 
     it("treats empty string values as missing", () => {
-      mockUseMetadataStore.mockImplementation((selector: (state: MetadataState) => unknown) => {
+      mockUseMetadataStore.mockImplementation(<T,>(selector: (state: MetadataState) => T) => {
         if (selector.name === "getMetadata") {
           return () => ({
             title: "Test Node",
@@ -424,7 +424,7 @@ describe("useRequiredSettings", () => {
 
   describe("loading state", () => {
     it("returns empty array while loading", () => {
-      mockUseMetadataStore.mockImplementation((selector: (state: MetadataState) => unknown) => {
+      mockUseMetadataStore.mockImplementation(<T,>(selector: (state: MetadataState) => T) => {
         if (selector.name === "getMetadata") {
           return () => ({
             title: "Test Node",

--- a/web/src/hooks/__tests__/useWorkflowCostEstimate.test.tsx
+++ b/web/src/hooks/__tests__/useWorkflowCostEstimate.test.tsx
@@ -27,7 +27,7 @@ const mockNodeStore = {
 };
 
 jest.mock("../../contexts/WorkflowManagerContext", () => ({
-  useWorkflowManager: (selector: (s: unknown) => unknown) =>
+  useWorkflowManager: <T,>(selector: (s: unknown) => T) =>
     selector({ getNodeStore: () => mockNodeStore })
 }));
 
@@ -100,7 +100,7 @@ jest.mock("../../utils/modelUnitPricing", () => ({
 
 jest.mock("../../stores/MetadataStore", () => ({
   __esModule: true,
-  default: (selector: (s: unknown) => unknown) =>
+  default: <T,>(selector: (s: unknown) => T) =>
     selector({
       getMetadata: (nodeType: string) => mockMetadata[nodeType]
     })

--- a/web/src/hooks/assets/__tests__/useAssetGridShortcuts.test.ts
+++ b/web/src/hooks/assets/__tests__/useAssetGridShortcuts.test.ts
@@ -39,7 +39,7 @@ const storeState = {
 };
 
 jest.mock("../../../stores/AssetGridStore", () => ({
-  useAssetGridStore: (selector: (state: typeof storeState) => unknown) =>
+  useAssetGridStore: <T,>(selector: (state: typeof storeState) => T) =>
     selector(storeState)
 }));
 

--- a/web/src/hooks/browser/__tests__/useVideoRecorder.test.ts
+++ b/web/src/hooks/browser/__tests__/useVideoRecorder.test.ts
@@ -9,7 +9,7 @@ jest.mock("../../../serverState/useAssetUpload", () => ({
 }));
 
 jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: (selector: (state: { workflow: { id: string; name: string } }) => unknown) =>
+  useNodes: <T,>(selector: (state: { workflow: { id: string; name: string } }) => T) =>
     selector({
       workflow: {
         id: "test-workflow-id",

--- a/web/src/hooks/handlers/__tests__/useAutoAddGeneratedMediaToCanvas.test.tsx
+++ b/web/src/hooks/handlers/__tests__/useAutoAddGeneratedMediaToCanvas.test.tsx
@@ -18,7 +18,7 @@ let isCanvasAvailable = true;
 
 jest.mock("../../../stores/GlobalChatStore", () => ({
   __esModule: true,
-  default: (selector: (s: MockChatState) => unknown) => selector(mockState)
+  default: <T,>(selector: (s: MockChatState) => T) => selector(mockState)
 }));
 
 jest.mock("../useGenerationToCanvas", () => ({

--- a/web/src/hooks/handlers/__tests__/useCopyPaste.cut.test.tsx
+++ b/web/src/hooks/handlers/__tests__/useCopyPaste.cut.test.tsx
@@ -57,7 +57,7 @@ describe("useCopyPaste handleCut", () => {
       })
     });
     (useSessionStateStore as unknown as jest.Mock).mockImplementation(
-      (selector: (state: unknown) => unknown) =>
+      <T,>(selector: (state: unknown) => T) =>
         selector({
           setClipboardData: jest.fn(),
           setIsClipboardValid: jest.fn()

--- a/web/src/hooks/handlers/__tests__/useGenerationToCanvas.test.tsx
+++ b/web/src/hooks/handlers/__tests__/useGenerationToCanvas.test.tsx
@@ -24,7 +24,7 @@ jest.mock("react", () => {
 
 jest.mock("../../../stores/MetadataStore", () => ({
   __esModule: true,
-  default: (selector: (s: { getMetadata: typeof getMetadata }) => unknown) =>
+  default: <T,>(selector: (s: { getMetadata: typeof getMetadata }) => T) =>
     selector({ getMetadata })
 }));
 

--- a/web/src/hooks/handlers/__tests__/useSelectionEvents.test.ts
+++ b/web/src/hooks/handlers/__tests__/useSelectionEvents.test.ts
@@ -45,7 +45,7 @@ describe("useSelectionEvents", () => {
       openContextMenu: mockOpenContextMenu
     });
     // Use mockImplementation to properly call the selector function
-    mockedUseNodes.mockImplementation((selector: (state: Record<string, unknown>) => unknown) =>
+    mockedUseNodes.mockImplementation(<T,>(selector: (state: Record<string, unknown>) => T) =>
       selector({
         updateNode: mockUpdateNode,
         setEdgeSelectionState: mockSetEdgeSelectionState

--- a/web/src/hooks/nodes/__tests__/buildDownstreamRunGraph.test.ts
+++ b/web/src/hooks/nodes/__tests__/buildDownstreamRunGraph.test.ts
@@ -122,7 +122,10 @@ describe("collectCachedValuesForSubgraph", () => {
       mkEdge("ext1", "node1", { sourceHandle: "output", targetHandle: "prompt" }),
       mkEdge("ext2", "node1", { sourceHandle: "output", targetHandle: "seed" })
     ];
-    const getResult = (_wfId: string, nodeId: string): unknown => {
+    const getResult = (
+      _wfId: string,
+      nodeId: string
+    ): { output: string | number } | undefined => {
       if (nodeId === "ext1") return { output: "hello" };
       if (nodeId === "ext2") return { output: 42 };
       return undefined;
@@ -147,7 +150,10 @@ describe("collectCachedValuesForSubgraph", () => {
       mkEdge("const1", "node1", { sourceHandle: "output", targetHandle: "value" })
     ];
     // The constant has a STALE cached generation, but its live property was edited.
-    const getResult = (_wf: string, nodeId: string): unknown =>
+    const getResult = (
+      _wf: string,
+      nodeId: string
+    ): { output: string } | undefined =>
       nodeId === "const1" ? { output: "stale_cached" } : undefined;
     const constNode = mkNode("const1", "nodetool.constant.String");
     constNode.data.properties = { value: "live_edited" };
@@ -160,7 +166,10 @@ describe("collectCachedValuesForSubgraph", () => {
     const edges = [
       mkEdge("in1", "node1", { sourceHandle: "output", targetHandle: "value" })
     ];
-    const getResult = (_wf: string, nodeId: string): unknown =>
+    const getResult = (
+      _wf: string,
+      nodeId: string
+    ): { output: string } | undefined =>
       nodeId === "in1" ? { output: "stale_cached" } : undefined;
     const inNode = mkNode("in1", "nodetool.input.IntegerInput");
     inNode.data.properties = { value: 7 };
@@ -174,7 +183,10 @@ describe("collectCachedValuesForSubgraph", () => {
       mkEdge("gen1", "node1", { sourceHandle: "output", targetHandle: "image" })
     ];
     // The generative source's last output is reused even though it may be "stale".
-    const getResult = (_wf: string, nodeId: string): unknown =>
+    const getResult = (
+      _wf: string,
+      nodeId: string
+    ): { output: string } | undefined =>
       nodeId === "gen1" ? { output: "last_cached_output" } : undefined;
     const genNode = mkNode("gen1", "gen.Image");
     genNode.data.properties = { value: "ignored_live_value" };

--- a/web/src/hooks/nodes/__tests__/useAddToGroup.test.ts
+++ b/web/src/hooks/nodes/__tests__/useAddToGroup.test.ts
@@ -62,7 +62,7 @@ describe("useAddToGroup", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseNodes.mockImplementation((selector: (s: unknown) => unknown) =>
+    mockUseNodes.mockImplementation(<T,>(selector: (s: unknown) => T) =>
       selector({ updateNode: mockUpdateNode })
     );
     mockGetGroupBounds.mockReturnValue({ width: 300, height: 200, offsetX: 0, offsetY: 0 });

--- a/web/src/hooks/nodes/__tests__/useCodeNodeScriptLink.test.ts
+++ b/web/src/hooks/nodes/__tests__/useCodeNodeScriptLink.test.ts
@@ -65,7 +65,7 @@ describe("useCodeNodeScriptLink", () => {
     jest.clearAllMocks();
     nodeData = { properties: {} };
     (useNodes as unknown as jest.Mock).mockImplementation(
-      (selector: (s: unknown) => unknown) =>
+      <T,>(selector: (s: unknown) => T) =>
         selector({
           findNode: mockFindNode,
           updateNodeData: mockUpdateNodeData

--- a/web/src/hooks/nodes/__tests__/useDynamicProperty.test.ts
+++ b/web/src/hooks/nodes/__tests__/useDynamicProperty.test.ts
@@ -32,7 +32,7 @@ describe("useDynamicProperty", () => {
     jest.clearAllMocks();
     nodeSlots = undefined;
     (useNodes as jest.Mock).mockImplementation(
-      (selector: (s: unknown) => unknown) =>
+      <T,>(selector: (s: unknown) => T) =>
         selector({
           updateNodeData: mockUpdateNodeData,
           updateEdgeHandle: mockUpdateEdgeHandle,

--- a/web/src/hooks/nodes/__tests__/useLiveSliderWriter.test.ts
+++ b/web/src/hooks/nodes/__tests__/useLiveSliderWriter.test.ts
@@ -17,7 +17,7 @@ const storeState = {
 };
 
 jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: (selector: (s: unknown) => unknown) =>
+  useNodes: <T,>(selector: (s: unknown) => T) =>
     selector({
       updateNodeProperties: mockUpdateNodeProperties,
       edges: storeState.edges
@@ -26,7 +26,7 @@ jest.mock("../../../contexts/NodeContext", () => ({
 }));
 
 jest.mock("../../../stores/SettingsStore", () => ({
-  useSettingsStore: (selector: (s: unknown) => unknown) =>
+  useSettingsStore: <T,>(selector: (s: unknown) => T) =>
     selector({ settings: { instantUpdate } })
 }));
 
@@ -71,7 +71,7 @@ if (typeof globalThis.crypto === "undefined") {
   "preview-job-1";
 
 jest.mock("../../../stores/LiveRunStore", () => ({
-  useLiveRunStore: (selector: (s: unknown) => unknown) =>
+  useLiveRunStore: <T,>(selector: (s: unknown) => T) =>
     selector({ isScrubbing: false, notifyScrubActivity: mockNotifyScrubActivity })
 }));
 

--- a/web/src/hooks/nodes/__tests__/useNodeContextMenu.test.ts
+++ b/web/src/hooks/nodes/__tests__/useNodeContextMenu.test.ts
@@ -36,7 +36,7 @@ jest.mock("../../../components/node_types/PlaceholderNode", () => ({
 }));
 
 jest.mock("../../../utils/lodashAlternatives", () => ({
-  debounce: (fn: (...args: unknown[]) => unknown) => fn
+  debounce: <F,>(fn: F) => fn
 }));
 
 jest.mock("../../../contexts/WorkflowManagerContext", () => ({

--- a/web/src/hooks/nodes/__tests__/useNodeGenerations.test.tsx
+++ b/web/src/hooks/nodes/__tests__/useNodeGenerations.test.tsx
@@ -4,7 +4,7 @@ import useResultsStore from "../../../stores/ResultsStore";
 import { useWorkflowAssetStore } from "../../../stores/WorkflowAssetStore";
 
 jest.mock("../../../contexts/NodeContext", () => ({
-  useNodes: (selector: (state: unknown) => unknown) =>
+  useNodes: <T,>(selector: (state: unknown) => T) =>
     selector({
       findNode: () => undefined,
       updateNodeData: () => undefined

--- a/web/src/hooks/nodes/__tests__/useNodeIO.test.tsx
+++ b/web/src/hooks/nodes/__tests__/useNodeIO.test.tsx
@@ -73,7 +73,7 @@ const setMockState = (
 
 jest.mock("../../../contexts/NodeContext", () => ({
   __esModule: true,
-  useNodes: (selector: (state: unknown) => unknown) =>
+  useNodes: <T,>(selector: (state: unknown) => T) =>
     selector({
       edges: mockEdges,
       findNode: (id: string) => mockNodes[id],
@@ -83,13 +83,13 @@ jest.mock("../../../contexts/NodeContext", () => ({
 
 jest.mock("../../../stores/WorkflowAssetStore", () => ({
   __esModule: true,
-  useWorkflowAssetStore: (selector: (state: unknown) => unknown) =>
+  useWorkflowAssetStore: <T,>(selector: (state: unknown) => T) =>
     selector({ assetsByWorkflow: {} })
 }));
 
 jest.mock("../../../stores/ResultsStore", () => {
   const getState = () => ({ liveGenerations: mockLiveGenerations });
-  const hook = (selector: (state: unknown) => unknown) => selector(getState());
+  const hook = <T,>(selector: (state: unknown) => T) => selector(getState());
   hook.getState = getState;
   return { __esModule: true, default: hook };
 });

--- a/web/src/hooks/nodes/__tests__/useRunSelectedNodes.test.ts
+++ b/web/src/hooks/nodes/__tests__/useRunSelectedNodes.test.ts
@@ -143,14 +143,14 @@ describe("useRunSelectedNodes", () => {
     });
 
     mockUseWebsocketRunner.mockImplementation(
-      (selector: (state: Record<string, unknown>) => unknown) => {
+      <T,>(selector: (state: Record<string, unknown>) => T) => {
         const state = { run: mockRun, state: "idle" };
         return selector(state);
       }
     );
 
     mockUseNotificationStore.mockImplementation(
-      (selector: (state: Record<string, unknown>) => unknown) => {
+      <T,>(selector: (state: Record<string, unknown>) => T) => {
         const state = { addNotification: mockAddNotification };
         return selector(state);
       }
@@ -273,7 +273,7 @@ describe("useRunSelectedNodes", () => {
 
   it("does not run when workflow is already running", async () => {
     mockUseWebsocketRunner.mockImplementation(
-      (selector: (state: Record<string, unknown>) => unknown) => {
+      <T,>(selector: (state: Record<string, unknown>) => T) => {
         const state = { run: mockRun, state: "running" };
         return selector(state);
       }

--- a/web/src/hooks/nodes/__tests__/useRunSingleNode.test.ts
+++ b/web/src/hooks/nodes/__tests__/useRunSingleNode.test.ts
@@ -91,7 +91,7 @@ describe("useRunSingleNode", () => {
     useGraph([defaultNode], []);
 
     mockUseWebsocketRunner.mockImplementation(
-      (selector: (state: Record<string, unknown>) => unknown) =>
+      <T,>(selector: (state: Record<string, unknown>) => T) =>
         selector({ run: mockRun, state: "idle" })
     );
 
@@ -101,7 +101,7 @@ describe("useRunSingleNode", () => {
     mockAssetsGetState.mockReturnValue({ getWorkflowAssets: () => [] });
 
     mockUseNotificationStore.mockImplementation(
-      (selector: (state: Record<string, unknown>) => unknown) =>
+      <T,>(selector: (state: Record<string, unknown>) => T) =>
         selector({ addNotification: mockAddNotification })
     );
 
@@ -115,7 +115,7 @@ describe("useRunSingleNode", () => {
 
   it("returns early when workflow is already running", () => {
     mockUseWebsocketRunner.mockImplementation(
-      (selector: (state: Record<string, unknown>) => unknown) =>
+      <T,>(selector: (state: Record<string, unknown>) => T) =>
         selector({ run: mockRun, state: "running" })
     );
 

--- a/web/src/hooks/nodes/useNodeResultHistory.ts
+++ b/web/src/hooks/nodes/useNodeResultHistory.ts
@@ -20,6 +20,7 @@ import { trpcClient } from "../../trpc/client";
 import type { Asset } from "../../stores/ApiTypes";
 import { normalizeAssetList } from "../../utils/normalizeAsset";
 import { assetToOutputValue } from "../../utils/nodeGenerations";
+import type { OutputPreviewValue } from "../../utils/nodeGenerations";
 
 export interface UseNodeResultHistoryResult {
   assetHistory: Asset[];
@@ -27,7 +28,8 @@ export interface UseNodeResultHistoryResult {
   lastJobAssets: Asset[];
   lastJobId: string | null;
   isLoading: boolean;
-  refresh: () => Promise<unknown>;
+  /** Re-runs the asset query; no caller reads the result. */
+  refresh: () => void;
   workflowId: string | null;
 }
 
@@ -48,7 +50,9 @@ export const nodeAssetsQueryKey = (nodeId: string | null) =>
  * or an array (multi-asset job). Returns `undefined` for an empty list so
  * callers can use it as a `??` fallback against live results.
  */
-export const assetsToPreviewValue = (assets: Asset[]): unknown => {
+export const assetsToPreviewValue = (
+  assets: Asset[]
+): OutputPreviewValue | OutputPreviewValue[] | undefined => {
   if (assets.length === 0) return undefined;
   const values = assets.map(assetToOutputValue);
   return values.length === 1 ? values[0] : values;

--- a/web/src/hooks/timeline/__tests__/useVideoAudioImport.test.ts
+++ b/web/src/hooks/timeline/__tests__/useVideoAudioImport.test.ts
@@ -3,7 +3,18 @@ import { createTimelineStore } from "../../../stores/timeline/TimelineStore";
 import type { Asset } from "../../../stores/ApiTypes";
 import { importVideoWithAudio } from "../useVideoAudioImport";
 
-const restFetchMock = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+/** The slice of `Response` the video-audio import path reads back. */
+type AudioExtractionResponse = {
+  ok: boolean;
+  status?: number;
+  json?: () => Promise<{
+    has_audio: boolean;
+    asset?: { id: string; duration?: number; content_type?: string };
+  }>;
+};
+
+const restFetchMock =
+  jest.fn<(...args: unknown[]) => Promise<AudioExtractionResponse>>();
 jest.mock("../../../lib/rest-fetch", () => ({
   restFetch: (...args: unknown[]) => restFetchMock(...args)
 }));
@@ -38,7 +49,7 @@ describe("importVideoWithAudio", () => {
   });
 
   it("adds a video clip and a linked placeholder audio clip immediately", async () => {
-    restFetchMock.mockReturnValue(new Promise(() => {})); // never resolves
+    restFetchMock.mockReturnValue(new Promise<AudioExtractionResponse>(() => {})); // never resolves
     const store = createTimelineStore();
     store.getState().addTrack("video", "Video 1");
     const videoTrackId = store.getState().tracks[0].id;
@@ -109,7 +120,7 @@ describe("importVideoWithAudio", () => {
   });
 
   it("passes an abort signal to restFetch so the request can time out", async () => {
-    restFetchMock.mockReturnValue(new Promise(() => {})); // never resolves
+    restFetchMock.mockReturnValue(new Promise<AudioExtractionResponse>(() => {})); // never resolves
     const store = createTimelineStore();
     store.getState().addTrack("video", "Video 1");
     const videoTrackId = store.getState().tracks[0].id;

--- a/web/src/hooks/useDebouncedCallback.ts
+++ b/web/src/hooks/useDebouncedCallback.ts
@@ -6,7 +6,7 @@ type DebouncedCallback<TArgs extends unknown[]> = {
 };
 
 export function useDebouncedCallback<TArgs extends unknown[]>(
-  fn: (...args: TArgs) => unknown,
+  fn: (...args: TArgs) => void,
   delay: number
 ): DebouncedCallback<TArgs> {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/web/src/hooks/useRealtimeAudioStream.ts
+++ b/web/src/hooks/useRealtimeAudioStream.ts
@@ -3,7 +3,7 @@ import { useInputStream } from "./useInputStream";
 import { useWebsocketRunner } from "../stores/WorkflowRunner";
 
 /** Stable ref wrapper — avoids effect restarts when callback identity changes. */
-function useStableCallback<T extends (...args: never[]) => unknown>(fn: T): T {
+function useStableCallback<T extends (...args: never[]) => void>(fn: T): T {
   const ref = useRef(fn);
   ref.current = fn;
   return useCallback(

--- a/web/src/lib/EventEmitter.ts
+++ b/web/src/lib/EventEmitter.ts
@@ -23,7 +23,7 @@ const asCallable = (listener: ListenerConstraint): UntypedListener =>
 
 type ArgsOf<Events, K extends keyof Events> = Events[K] extends (
   ...args: infer A
-) => unknown
+) => void
   ? A
   : unknown[];
 

--- a/web/src/lib/workflow/browserRunnerCore.ts
+++ b/web/src/lib/workflow/browserRunnerCore.ts
@@ -121,7 +121,7 @@ export function collectNodeClasses(mod: Record<string, unknown>): unknown[] {
  * tag (e.g. image.ts's Load/Save/AI nodes are tagged server and dropped).
  */
 const NODE_MODULE_GROUPS: ReadonlyArray<
-  readonly [name: string, load: () => Promise<unknown>]
+  readonly [name: string, load: () => Promise<object>]
 > = [
   ["constant", () => import("@nodetool-ai/core-nodes/nodes/constant")],
   ["control", () => import("@nodetool-ai/core-nodes/nodes/control")],
@@ -232,9 +232,9 @@ const NODE_MODULE_GROUPS: ReadonlyArray<
  * import resolves `undefined` instead — treat both as "not available",
  * keeping the failure for the caller's diagnostics.
  */
-async function importOptional(
-  load: () => Promise<unknown>
-): Promise<{ mod: unknown; error: unknown }> {
+async function importOptional<TModule extends object>(
+  load: () => Promise<TModule>
+): Promise<{ mod: TModule | null; error: unknown }> {
   try {
     const mod = (await load()) ?? null;
     return {
@@ -397,7 +397,7 @@ export function probeBrowserGpu(): Promise<boolean> {
     gpuProbe = (async () => {
       const nav = (
         globalThis as {
-          navigator?: { gpu?: { requestAdapter(): Promise<unknown> } };
+          navigator?: { gpu?: { requestAdapter(): Promise<object | null> } };
         }
       ).navigator;
       const gpu = nav?.gpu;

--- a/web/src/serverState/__tests__/useAssetUpdate.test.ts
+++ b/web/src/serverState/__tests__/useAssetUpdate.test.ts
@@ -11,7 +11,7 @@ const mockInvalidateQueries = jest.fn();
 
 jest.mock("../../stores/AssetStore", () => ({
   __esModule: true,
-  useAssetStore: jest.fn((selector: (s: Record<string, unknown>) => unknown) =>
+  useAssetStore: jest.fn(<T,>(selector: (s: Record<string, unknown>) => T) =>
     selector({ update: mockUpdateAsset })
   )
 }));
@@ -19,7 +19,7 @@ jest.mock("../../stores/AssetStore", () => ({
 jest.mock("../../stores/NotificationStore", () => ({
   __esModule: true,
   useNotificationStore: jest.fn(
-    (selector: (s: Record<string, unknown>) => unknown) =>
+    <T,>(selector: (s: Record<string, unknown>) => T) =>
       selector({ addNotification: mockAddNotification })
   )
 }));
@@ -37,7 +37,8 @@ jest.mock("../../stores/AssetGridStore", () => ({
 jest.mock("@tanstack/react-query", () => ({
   __esModule: true,
   useMutation: jest.fn((config: Record<string, unknown>) => ({
-    mutateAsync: config.mutationFn as (...args: unknown[]) => Promise<unknown>,
+    // The test awaits the call; it never reads the resolved value.
+    mutateAsync: config.mutationFn as (...args: unknown[]) => Promise<void>,
     mutate: mockMutate,
     reset: mockReset,
     isPending: false,

--- a/web/src/serverState/__tests__/useTriggers.test.ts
+++ b/web/src/serverState/__tests__/useTriggers.test.ts
@@ -32,7 +32,7 @@ jest.mock("../../trpc/client", () => ({
 const mockAddNotification = jest.fn();
 jest.mock("../../stores/NotificationStore", () => ({
   __esModule: true,
-  useNotificationStore: (selector: (s: unknown) => unknown) =>
+  useNotificationStore: <T,>(selector: (s: unknown) => T) =>
     selector({ addNotification: mockAddNotification })
 }));
 
@@ -54,6 +54,10 @@ import {
   runningTriggersQueryKey,
   triggerErrorMessage
 } from "../useTriggers";
+import type {
+  TriggerRegistrationStatus,
+  RunningTriggerRegistration
+} from "../useTriggers";
 
 const mockUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
 const mockUseMutation = useMutation as jest.MockedFunction<typeof useMutation>;
@@ -62,7 +66,9 @@ const mockUseQueryClient = useQueryClient as jest.MockedFunction<
 >;
 
 interface MutationConfig<TVars> {
-  mutationFn: (vars: TVars) => Promise<unknown>;
+  /** The tests await the call and assert on the trpc mock; the resolved
+   *  value is never read. */
+  mutationFn: (vars: TVars) => Promise<void>;
   onSuccess: () => void;
   onError: (error: unknown, variables: TVars) => void;
 }
@@ -135,7 +141,7 @@ describe("useWorkflowTriggers", () => {
 
     renderHook(() => useWorkflowTriggers("wf-1"));
     const { queryFn } = mockUseQuery.mock.calls[0][0] as unknown as {
-      queryFn: () => Promise<unknown>;
+      queryFn: () => Promise<TriggerRegistrationStatus[]>;
     };
     const result = await queryFn();
     expect(trpcClient.triggers.listByWorkflow.query).toHaveBeenCalledWith({
@@ -182,7 +188,7 @@ describe("useRunningTriggers", () => {
     });
     renderHook(() => useRunningTriggers());
     const { queryFn } = mockUseQuery.mock.calls[0][0] as unknown as {
-      queryFn: () => Promise<unknown>;
+      queryFn: () => Promise<RunningTriggerRegistration[]>;
     };
     expect(await queryFn()).toEqual(triggers);
   });

--- a/web/src/utils/dataframeParsers.ts
+++ b/web/src/utils/dataframeParsers.ts
@@ -5,6 +5,13 @@
 import readXlsxFile, { Row } from "read-excel-file";
 import { DataframeRef, ColumnDef } from "../stores/ApiTypes";
 
+/**
+ * One raw cell, as the CSV reader and read-excel-file produce them. The xlsx
+ * reader types a date cell as `typeof Date` while yielding a `Date` instance,
+ * so both spellings are listed.
+ */
+type RawCell = string | number | boolean | Date | typeof Date | null;
+
 /** Infer the data type from a value. */
 function inferDataType(
   value: unknown
@@ -105,9 +112,9 @@ function inferColumnType(
  * @returns The converted value
  */
 function convertValue(
-  value: unknown,
+  value: RawCell,
   type: "int" | "float" | "datetime" | "string" | "object"
-): unknown {
+): RawCell {
   if (value === null || value === undefined || value === "") {
     return null;
   }
@@ -170,7 +177,7 @@ function parseCSV(csvText: string): DataframeRef {
 
   const headers = parseCSVLine(lines[0]);
 
-  const rawData: unknown[][] = [];
+  const rawData: RawCell[][] = [];
   for (let i = 1; i < lines.length; i++) {
     const values = parseCSVLine(lines[i]);
     rawData.push(values);
@@ -267,7 +274,7 @@ async function parseExcel(file: File): Promise<DataframeRef> {
   );
 
   // Cells are returned as-is (Date objects from Excel are preserved).
-  const rawData: unknown[][] = rows.slice(1).map((row) => [...row]);
+  const rawData: RawCell[][] = rows.slice(1).map((row) => [...row]);
 
   const columnTypes: ("int" | "float" | "datetime" | "string" | "object")[] =
     [];

--- a/web/src/utils/dynamicSlots.ts
+++ b/web/src/utils/dynamicSlots.ts
@@ -114,7 +114,9 @@ export const isTypedSlot = (slot: unknown): boolean =>
   normalizeDynamicSlot(slot).type.type !== "any";
 
 /** Inline value a freshly created slot of `type` starts with. */
-export const defaultValueForType = (type: TypeMetadata): unknown => {
+export const defaultValueForType = (
+  type: TypeMetadata
+): string | number | boolean | unknown[] | object | null => {
   switch (type.type) {
     case "str":
     case "text":

--- a/web/src/utils/nodeGenerations.ts
+++ b/web/src/utils/nodeGenerations.ts
@@ -1,10 +1,24 @@
 import type { Asset, ProviderCost } from "../stores/ApiTypes";
 
 /**
+ * The `{ type, uri, … }` record the preview components render — the same shape
+ * that flows over `output_update` for a media output.
+ */
+export type OutputPreviewValue = {
+  type: "image" | "video" | "audio" | "text" | "json" | "model_3d" | "asset";
+  uri: string;
+  /** Capped inline text for a `text/*` asset. */
+  text?: string;
+  /** The full output dict a structured (JSON) generation persisted. */
+  value?: unknown;
+  name?: string;
+};
+
+/**
  * Convert a saved asset into the value shape the preview components expect
  * (mirrors the `{ type, uri }` records carried over `output_update`).
  */
-export const assetToOutputValue = (asset: Asset): Record<string, unknown> => {
+export const assetToOutputValue = (asset: Asset): OutputPreviewValue => {
   const ct = asset.content_type ?? "";
   const uri = asset.get_url ?? asset.thumb_url ?? "";
   if (ct.startsWith("image/")) return { type: "image", uri };


### PR DESCRIPTION
Stack 6/15, on top of #4922. **This rule does not reach zero, so it stays in the backlog config** — see the holdouts below. 604 → 182 findings; repo total 28,681 → 27,955.

Four passes over disjoint trees: `web/` (214 → 41), `packages/agents/` (167 → 94), the core backend packages (139 → 33), and the node packages plus `mobile`/`electron` (84 → 14).

## What the fixes look like

- **Say the type that already exists.** Host modules return `PdfPage[]`, `PptxSlide[]`, `EpubChapter[]`; provider node factories name what a property holds (`NodeValue`, `FieldDefault`, `CoercedScalar`); `ProcessingContext`'s persistence methods return a record with an `id`.
- **Take a type parameter where only the caller knows.** ~150 of web's were one idiom — Zustand selector mocks written `mockImplementation((selector) => selector(state))`, generic in the selector's own result. Also `unpackWebSocketMessage<TFrame>`, `getPipeline<TPipeline>`, the cache adapters, the OAuth `json<TBody>()` readers, the eval-surface `tool<TResult>()` helpers.
- **Parse at the boundary.** msgpack frames, HTTP bodies, document columns, trace spans, and the Gemini/Anthropic JSON-Schema walkers now walk a named `SchemaNode`. `extractJSON` returns a recursive `JsonValue`.

Making call sites name their type **deleted 18 assertions** (16 in transformers-js alone), and five `context is ProcessingContext & { … }` predicates turned out to re-declare methods `ProcessingContext` already has.

## Nothing was traded

Each pass linted its changed files at HEAD and at the tip and diffed the per-rule tallies. **No rule went up in any of the four.** Several went down as a side effect — across the whole repo `no-known-value-widening` 1946 → 1761, `no-unknown-parameters` 1944 → 1904, `no-unsafe-dictionary-type` 5174 → 5132, `require-safety-comment` 10300 → 10266.

## The 182 holdouts

They are one problem said many ways: **NodeTool has no named type for "a value flowing through the graph."** `NodeData.properties` and `dynamic_properties` are `Record<string, unknown>`, so everything reading a node output, an edge value, an app-state slot, or a stream item receives an unknown value and returns a *rearranged* unknown value. A generic doesn't fit — `resolveResultValue` returns `result[handle]`, not `result`. Naming it means threading a domain type through `protocol`, `app-runtime`, `runtime` and `web`, and it cannot be behavior-neutral where `Uint8Array`, `ImageBitmap` and GPU texture refs travel the same channel.

The second cluster is `Tool.process`/`CapabilityImpl`, which erases every tool's result so ~200 capabilities can share one name-keyed registry; typing it is a discriminated union plus edits to every `Tool` subclass in four packages.

Every holdout carries a `HOLDOUT (anti-slop/no-unknown-returns)` comment in the backend packages, and all of them are listed in the agents' reports. I chose these over `as unknown as T`, over inventing Zod schemas that guess at fields, and over `Record<string, unknown>` returns that would just move the finding to another rule.

Three smaller ones worth naming: `packages/gpu/src/recipe.ts:156` needs `Recipe<Params>` threaded into `Executor.encode`; `createAsset` and `runProviderPrediction` can't narrow while `image-nodes`, `audio-nodes` and `text-nodes` assert on their current `unknown`; and one attempted `Promise<void>` narrowing was reverted because `kie-webhook-registry.test.ts` asserts the resolved value *is* the callback body.

## Checks

- `npm run lint` → exit 0.
- Typecheck: all 12 core backend packages, all 17 node packages, `packages/agents`, `mobile`, `electron` → 0 errors each; `web` `tsc --noEmit` → 0 errors.
- The backend pass emitted fresh `.d.ts` files and typechecked **33 consumer packages** against them rather than against stale `dist/` — which caught one real break (`Message.create` returning the base class), fixed without an assertion.
- Tests, all green: runtime 2748, websocket 2197, agents 2858, node-sdk 977, kernel 1010, models 829, cli 627, storage 364, app-runtime 210, config 146, compute 79, chat 32, execution 221; web 798 across 86 suites; mobile 979; electron 674; plus every touched node package (the image/video/gpu suites were run under a lavapipe Vulkan ICD, not skipped).
- Two test edits, both because a fake no longer fit a real signature: `packages/models/tests/index-exports.test.ts` and the mobile `agentBridge` snapshot fakes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPXapRVTWZDbebtC3xaL8z)_