### PR TITLE
feat(mobile): open JS scripts as a document, like the other editors

### DIFF
--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -61,13 +61,13 @@ read the comment at the top of `metro.config.js` before changing any of it.
   `/api/applications/*` by `hooks/useApplications.ts`) with native widgets on
   top of `@nodetool-ai/app-runtime` — the same core the web runtime and the CLI `app debug`
   harness use. See [ARCHITECTURE.md § Mini apps](ARCHITECTURE.md#mini-apps-srccomponentsapp_runtime).
-- **Documents**: `documents/` + the document screens open storyboards, scripts, timelines,
-  and sketches. No tabs — one document per pushed screen. Edits are expected to come from
+- **Documents**: `documents/` + the document screens open storyboards, scripts, JS scripts,
+  timelines, and sketches. No tabs — one document per pushed screen. Edits are expected to come from
   the chat agent through the `ui_*` tools registered there, so `kinds.ts` tracks
   `agentEditable` separately from `surface`: the timeline has no touch editor but the agent
   writes it. Each kind's transport lives in `backends.ts` (scripts are not a
-  `resources.*` kind — their table has no `revision`), which is why the store's
-  concurrency token is opaque.
+  `resources.*` kind — neither their table nor the JS scripts table has a
+  `revision`), which is why the store's concurrency token is opaque.
   See [ARCHITECTURE.md § Documents](ARCHITECTURE.md#documents-srcdocuments).
 
 ## Testing
@@ -101,7 +101,7 @@ Two things to know:
   login wall. Restore it afterwards.
 - **Parameterized routes** (a document, an asset, a job) need real ids; pass them
   with `--ids ids.json` (keys: `workflowId`, `threadId`, `applicationId`,
-  `assetId`, `jobId`, `scriptId`, `storyboardId`, `timelineId`, `sketchId`,
+  `assetId`, `jobId`, `scriptId`, `jsScriptId`, `storyboardId`, `timelineId`, `sketchId`,
   `noteId`). Routes whose id is missing are skipped, so a partial seed still runs.
 
 The emitted `report.json` flags any screen whose document scrolls horizontally —

--- a/mobile/ARCHITECTURE.md
+++ b/mobile/ARCHITECTURE.md
@@ -210,9 +210,9 @@ The shared package is compiled from source rather than from `dist`: see
 
 ## Documents (`src/documents/`)
 
-Storyboards, scripts, timelines, and sketches are documents on the server.
-Mobile browses them all in `DocumentsScreen` and opens each in its own pushed
-screen.
+Storyboards, scripts, JS scripts, timelines, and sketches are documents on the
+server. Mobile browses them all in `DocumentsScreen` and opens each in its own
+pushed screen.
 
 **No tabs.** Web keys its whole document UX off `WorkspaceTabType` and keeps
 every tab mounted at once. On a phone the navigation stack *is* the tab model:
@@ -229,14 +229,15 @@ documentStore.ts  # one Zustand store per open document (cached by kind+id)
 agentBridge.ts    # handler registry keyed by kind+id, plus the focus claim
 uiContext.ts      # the open/focused/selection block sent with each chat turn
 timelineEdits.ts  # pure, link-aware edits over {tracks, clips, markers}
+jsScriptTypes.ts  # JS script document shape, its checks, and the case grader
 tools/            # the ui_* tools: registry, manifest, tool_call dispatch
 ```
 
 **Two transports, one interface.** Three kinds ride the `resources.*` envelope,
-whose concurrency token is a numeric `revision`. Scripts cannot: the `scripts`
-table has no `revision` column, so the provider's conflict check would compare
-`undefined` to `undefined`, pass, and silently clobber concurrent writes. Their
-own router does the same job with `baseUpdatedAt`. Rather than migrate two
+whose concurrency token is a numeric `revision`. Scripts and JS scripts cannot:
+neither table has a `revision` column, so the provider's conflict check would
+compare `undefined` to `undefined`, pass, and silently clobber concurrent
+writes. Their own routers do the same job with `baseUpdatedAt`. Rather than migrate two
 schemas — which would also make `{kind:"script"}` a legal resource binding in
 every app document — `backends.ts` makes the token **opaque**: a backend hands
 one out on read and echoes it back on write, and only it knows the shape.
@@ -279,7 +280,10 @@ browser stays on desktop, where its progress can actually be supervised. So
 storyboards get shot and board editing but not generation or timeline assembly;
 scripts get cast, section, and line editing but not TTS voicing, subtitle
 export, or send-to-timeline; timelines get the full set of structural edits but
-not clip generation or frame extraction. Each tool's description says which side
+not clip generation or frame extraction. JS scripts are the one surface whose
+tools also *execute*: the body runs in the server's QuickJS sandbox, so
+`ui_jsscript_run` and `ui_jsscript_test` are a request the phone waits on, not a
+job it supervises — they save first, because the endpoint runs the saved row. Each tool's description says which side
 of that line it is on, so the agent does not promise what it cannot do.
 
 **Timeline edits are link-aware** (`timelineEdits.ts`, pure functions over

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -17,6 +17,7 @@ import AppsScreen from './src/screens/AppsScreen';
 import AppScreen from './src/screens/AppScreen';
 import DocumentViewerScreen from './src/screens/DocumentViewerScreen';
 import ScriptEditorScreen from './src/screens/ScriptEditorScreen';
+import JsScriptEditorScreen from './src/screens/JsScriptEditorScreen';
 import StoryboardEditorScreen from './src/screens/StoryboardEditorScreen';
 import TimelineViewerScreen from './src/screens/TimelineViewerScreen';
 import SketchViewerScreen from './src/screens/SketchViewerScreen';
@@ -178,6 +179,11 @@ export default function App() {
                   name="ScriptEditor"
                   component={ScriptEditorScreen}
                   options={{ title: 'Script' }}
+                />
+                <Stack.Screen
+                  name="JsScriptEditor"
+                  component={JsScriptEditorScreen}
+                  options={{ title: 'JS Script' }}
                 />
                 <Stack.Screen
                   name="TimelineViewer"

--- a/mobile/scripts/screenshot-screens.mjs
+++ b/mobile/scripts/screenshot-screens.mjs
@@ -67,6 +67,7 @@ const ROUTES = [
   { name: 'model-selection', path: 'settings/models' },
   { name: 'graph-editor', path: (v) => `workflow/${v}`, needs: 'workflowId' },
   { name: 'script-editor', path: (v) => `document/script/${v}`, needs: 'scriptId' },
+  { name: 'jsscript-editor', path: (v) => `document/jsscript/${v}`, needs: 'jsScriptId' },
   { name: 'storyboard-editor', path: (v) => `document/storyboard/${v}`, needs: 'storyboardId' },
   { name: 'timeline-viewer', path: (v) => `document/timeline/${v}`, needs: 'timelineId' },
   { name: 'sketch-viewer', path: (v) => `document/sketch/${v}`, needs: 'sketchId' },

--- a/mobile/src/documents/__tests__/backends.test.ts
+++ b/mobile/src/documents/__tests__/backends.test.ts
@@ -23,10 +23,19 @@ const mockScripts = {
   delete: { mutate: jest.fn() },
 };
 
+const mockJsScripts = {
+  get: { query: jest.fn() },
+  update: { mutate: jest.fn() },
+  list: { query: jest.fn() },
+  create: { mutate: jest.fn() },
+  delete: { mutate: jest.fn() },
+};
+
 jest.mock('../../trpc/client', () => ({
   createMobileTRPCClient: () => ({
     resources: mockResources,
     scripts: mockScripts,
+    jsScripts: mockJsScripts,
   }),
 }));
 
@@ -218,9 +227,108 @@ describe('scripts backend', () => {
   });
 });
 
+describe('js scripts backend', () => {
+  const response = {
+    id: 'js1',
+    projectId: 'default',
+    name: 'Sum numbers',
+    document: { schemaVersion: 1, code: 'await output("total", 3);' },
+    createdAt: '2026-08-01T00:00:00Z',
+    updatedAt: '2026-08-02T00:00:00Z',
+  };
+
+  it('reads updatedAt out as the token', async () => {
+    mockJsScripts.get.query.mockResolvedValue(response);
+
+    const loaded = await documentBackend('jsscript').read('js1');
+
+    expect(mockJsScripts.get.query).toHaveBeenCalledWith({ id: 'js1' });
+    expect(loaded).toEqual({
+      doc: response.document,
+      name: 'Sum numbers',
+      token: '2026-08-02T00:00:00Z',
+      updatedAt: '2026-08-02T00:00:00Z',
+    });
+  });
+
+  it('echoes a string token back as baseUpdatedAt', async () => {
+    mockJsScripts.update.mutate.mockResolvedValue(response);
+
+    await documentBackend('jsscript').save('js1', {
+      doc: response.document,
+      name: 'Sum numbers',
+      token: '2026-08-01T00:00:00Z',
+    });
+
+    expect(mockJsScripts.update.mutate).toHaveBeenCalledWith({
+      id: 'js1',
+      name: 'Sum numbers',
+      document: response.document,
+      baseUpdatedAt: '2026-08-01T00:00:00Z',
+    });
+  });
+
+  it('omits baseUpdatedAt when the token is not a string', async () => {
+    mockJsScripts.update.mutate.mockResolvedValue(response);
+
+    await documentBackend('jsscript').save('js1', {
+      doc: {},
+      name: 'x',
+      token: 5,
+    });
+
+    expect(mockJsScripts.update.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUpdatedAt: undefined })
+    );
+  });
+
+  it('surfaces the declared port counts as the row detail', async () => {
+    mockJsScripts.list.query.mockResolvedValue([
+      {
+        id: 'js1',
+        projectId: 'p',
+        name: 'Sum numbers',
+        description: '',
+        inputs: [{ name: 'numbers', type: 'list[int]' }],
+        outputs: [{ name: 'total', type: 'int' }],
+        updatedAt: 'x',
+      },
+    ]);
+
+    const rows = await documentBackend('jsscript').list(50);
+
+    expect(rows).toEqual([
+      { id: 'js1', name: 'Sum numbers', updatedAt: 'x', detail: '1 in · 1 out' },
+    ]);
+  });
+
+  it('creates and deletes through the jsScripts router, never the others', async () => {
+    mockJsScripts.create.mutate.mockResolvedValue(response);
+    mockJsScripts.delete.mutate.mockResolvedValue({ ok: true });
+
+    const created = await documentBackend('jsscript').create('Sum numbers');
+    await documentBackend('jsscript').remove('js1');
+
+    expect(created).toEqual({
+      id: 'js1',
+      name: 'Sum numbers',
+      updatedAt: '2026-08-02T00:00:00Z',
+    });
+    expect(mockJsScripts.delete.mutate).toHaveBeenCalledWith({ id: 'js1' });
+    expect(mockScripts.create.mutate).not.toHaveBeenCalled();
+    expect(mockResources.create.mutate).not.toHaveBeenCalled();
+  });
+});
+
 describe('every document kind', () => {
   it('is writable', () => {
-    for (const kind of ['storyboard', 'script', 'timeline', 'sketch'] as const) {
+    for (const kind of [
+      'storyboard',
+      'script',
+      'jsscript',
+      'timeline',
+      'sketch',
+    ] as const) {
       expect(documentBackend(kind).writable).toBe(true);
     }
   });

--- a/mobile/src/documents/__tests__/jsScriptTypes.test.ts
+++ b/mobile/src/documents/__tests__/jsScriptTypes.test.ts
@@ -1,0 +1,245 @@
+/**
+ * The two things `jsScriptTypes` decides on its own: which documents the editor
+ * calls broken, and how a saved case is graded. Both mirror server-side rules —
+ * `validateJsScriptDocument` in the protocol package and `test_code`'s compare —
+ * so these tests pin the mobile copies against the same expectations.
+ */
+
+import {
+  emptyJsScriptDocument,
+  gradeJsScriptCase,
+  gradeJsScriptTests,
+  normalizeJsScriptDocument,
+  streamMismatches,
+  summarizeJsScriptTests,
+  validateJsScriptDocument,
+  type JsScriptDocument,
+  type JsScriptRunOutcome,
+} from '../jsScriptTypes';
+
+const doc = (overrides: Partial<JsScriptDocument> = {}): JsScriptDocument => ({
+  ...emptyJsScriptDocument(),
+  code: 'await output("total", 1);',
+  inputs: [{ name: 'numbers', type: 'list[int]' }],
+  outputs: [{ name: 'total', type: 'int' }],
+  tests: [{ name: 'sums', inputs: { numbers: [1, 2] }, expect: { total: 3 } }],
+  ...overrides,
+});
+
+const outcome = (
+  overrides: Partial<JsScriptRunOutcome> = {}
+): JsScriptRunOutcome => ({
+  ok: true,
+  outputs: { total: 3 },
+  logs: [],
+  duration_ms: 4,
+  ...overrides,
+});
+
+const codes = (document: JsScriptDocument): string[] =>
+  validateJsScriptDocument(document).map((issue) => issue.code);
+
+describe('validateJsScriptDocument', () => {
+  it('passes a complete document', () => {
+    expect(validateJsScriptDocument(doc())).toEqual([]);
+  });
+
+  it('rejects a port name the body could not read as inputs.<name>', () => {
+    expect(codes(doc({ inputs: [{ name: 'my input', type: 'str' }] }))).toContain(
+      'js_script_port_name'
+    );
+  });
+
+  it('rejects duplicate ports on either side', () => {
+    expect(
+      codes(
+        doc({
+          outputs: [
+            { name: 'total', type: 'int' },
+            { name: 'total', type: 'int' },
+          ],
+        })
+      )
+    ).toContain('js_script_duplicate_port');
+  });
+
+  it('rejects an empty secret name', () => {
+    expect(codes(doc({ secrets: ['OPENAI_API_KEY', '  '] }))).toContain(
+      'js_script_secret_name'
+    );
+  });
+
+  it('rejects a timeout outside the sandbox ceiling', () => {
+    expect(codes(doc({ timeoutSeconds: 0 }))).toContain('js_script_timeout');
+    expect(codes(doc({ timeoutSeconds: 121 }))).toContain('js_script_timeout');
+    expect(codes(doc({ timeoutSeconds: 120 }))).not.toContain('js_script_timeout');
+  });
+
+  it('rejects a case naming a handle the script does not declare', () => {
+    const issues = codes(
+      doc({
+        tests: [
+          {
+            name: 'wrong handles',
+            inputs: { nope: 1 },
+            inputStreams: { alsoNope: [1] },
+            expect: { missing: 2 },
+          },
+        ],
+      })
+    );
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        'js_script_test_input',
+        'js_script_test_input',
+        'js_script_test_output',
+      ])
+    );
+  });
+
+  it('rejects two cases with one name', () => {
+    expect(
+      codes(
+        doc({
+          tests: [
+            { name: 'sums', inputs: {} },
+            { name: 'sums', inputs: {} },
+          ],
+        })
+      )
+    ).toContain('js_script_duplicate_test');
+  });
+
+  it('warns — rather than errors — about an empty body and no cases', () => {
+    const issues = validateJsScriptDocument(doc({ code: '  ', tests: [] }));
+    expect(issues.every((issue) => issue.severity === 'warning')).toBe(true);
+    expect(issues.map((issue) => issue.code)).toEqual([
+      'js_script_empty_body',
+      'js_script_no_tests',
+    ]);
+  });
+});
+
+describe('normalizeJsScriptDocument', () => {
+  it('fills in the fields an older document is missing', () => {
+    expect(
+      normalizeJsScriptDocument({ code: 'await output("a", 1);' })
+    ).toEqual({ ...emptyJsScriptDocument(), code: 'await output("a", 1);' });
+  });
+
+  it('answers a null document with the empty one', () => {
+    expect(normalizeJsScriptDocument(null)).toEqual(emptyJsScriptDocument());
+  });
+});
+
+describe('streamMismatches', () => {
+  it('reports a length difference as one mismatch on the whole stream', () => {
+    expect(streamMismatches([1, 2], [1])).toEqual([
+      { output: 'streamed', expected: [1, 2], actual: [1] },
+    ]);
+  });
+
+  it('reports a differing entry by index', () => {
+    expect(streamMismatches([1, 2], [1, 3])).toEqual([
+      { output: 'streamed[1]', expected: 2, actual: 3 },
+    ]);
+  });
+
+  it('compares structurally, not by reference', () => {
+    expect(streamMismatches([{ a: [1] }], [{ a: [1] }])).toEqual([]);
+  });
+});
+
+describe('gradeJsScriptCase', () => {
+  it('passes a case whose outputs match', () => {
+    const report = gradeJsScriptCase(
+      { name: 'sums', inputs: {}, expect: { total: 3 } },
+      outcome()
+    );
+    expect(report.ok).toBe(true);
+    expect(report.mismatches).toEqual([]);
+  });
+
+  it('reports a mismatch per expected handle', () => {
+    const report = gradeJsScriptCase(
+      { name: 'sums', inputs: {}, expect: { total: 4 } },
+      outcome()
+    );
+    expect(report.ok).toBe(false);
+    expect(report.mismatches).toEqual([
+      { output: 'total', expected: 4, actual: 3 },
+    ]);
+  });
+
+  it('does not bury a failed run under output mismatches', () => {
+    const report = gradeJsScriptCase(
+      { name: 'sums', inputs: {}, expect: { total: 3 } },
+      outcome({ ok: false, outputs: undefined, error: 'boom' })
+    );
+    expect(report.ok).toBe(false);
+    expect(report.mismatches).toEqual([]);
+    expect(report.error).toBe('boom');
+  });
+});
+
+describe('gradeJsScriptTests', () => {
+  it('runs cases in order and rolls the grades up', async () => {
+    const seen: unknown[] = [];
+    const report = await gradeJsScriptTests(
+      [
+        { name: 'one', inputs: { n: 1 }, expect: { total: 3 } },
+        { name: 'two', inputs: { n: 2 }, expect: { total: 9 } },
+      ],
+      async (inputs) => {
+        seen.push(inputs);
+        return outcome();
+      }
+    );
+
+    expect(seen).toEqual([{ n: 1 }, { n: 2 }]);
+    expect(report.passed).toBe(1);
+    expect(report.failed).toBe(1);
+    expect(report.cases.map((entry) => entry.name)).toEqual(['one', 'two']);
+  });
+
+  it('stages inputStreams for a body that reads with stream', async () => {
+    const staged: unknown[] = [];
+    await gradeJsScriptTests(
+      [{ name: 'streamed', inputs: {}, inputStreams: { numbers: [1, 2] } }],
+      async (_inputs, inputStreams) => {
+        staged.push(inputStreams);
+        return outcome();
+      }
+    );
+    expect(staged).toEqual([{ numbers: [1, 2] }]);
+  });
+
+  it('turns a thrown run into a failed case rather than a failed report', async () => {
+    const report = await gradeJsScriptTests(
+      [{ name: 'network down', inputs: {} }],
+      async () => {
+        throw new Error('offline');
+      }
+    );
+    expect(report.failed).toBe(1);
+    expect(report.cases[0].error).toBe('offline');
+  });
+});
+
+describe('summarizeJsScriptTests', () => {
+  it('counts passes and failures', () => {
+    expect(
+      summarizeJsScriptTests([
+        { name: 'a', ok: true, logs: [], mismatches: [] },
+        { name: 'b', ok: false, logs: [], mismatches: [] },
+      ])
+    ).toEqual({
+      passed: 1,
+      failed: 1,
+      cases: [
+        { name: 'a', ok: true, logs: [], mismatches: [] },
+        { name: 'b', ok: false, logs: [], mismatches: [] },
+      ],
+    });
+  });
+});

--- a/mobile/src/documents/backends.ts
+++ b/mobile/src/documents/backends.ts
@@ -1,10 +1,11 @@
 /**
  * Per-kind transport for reading and writing a document.
  *
- * Three of the four kinds ride the `resources.*` envelope, which carries a
- * numeric `revision` as its concurrency token. Scripts do not: the `scripts`
- * table has no `revision` column, so the `resources` provider cannot represent
- * one, and its own router does the same job with `baseUpdatedAt`. Rather than
+ * Three of the five kinds ride the `resources.*` envelope, which carries a
+ * numeric `revision` as its concurrency token. Scripts and JS scripts do not:
+ * neither table has a `revision` column, so the `resources` provider cannot
+ * represent one, and their own routers do the same job with
+ * `baseUpdatedAt`. Rather than
  * migrate two schemas to unify the token, the store treats it as **opaque** —
  * a backend hands one out on read and echoes it back on write, and only the
  * backend knows whether it is a number or a timestamp.
@@ -180,11 +181,78 @@ function scriptsBackend(): DocumentBackend {
   };
 }
 
+/**
+ * The `jsScripts.*` router: same `baseUpdatedAt` scheme as `scripts.*`, and a
+ * different table again — a JS script is a body with declared ports, not lines.
+ */
+function jsScriptsBackend(): DocumentBackend {
+  const portSummary = (inputs: number, outputs: number): string =>
+    `${inputs} in · ${outputs} out`;
+
+  return {
+    writable: true,
+    list: async () => {
+      const scripts = await createMobileTRPCClient().jsScripts.list.query({});
+      return scripts.map((script) => ({
+        id: script.id,
+        name: script.name,
+        updatedAt: script.updatedAt,
+        detail: portSummary(script.inputs.length, script.outputs.length),
+      }));
+    },
+    create: async (name) => {
+      const script = await createMobileTRPCClient().jsScripts.create.mutate({
+        name,
+        projectId: 'default',
+      });
+      return {
+        id: script.id,
+        name: script.name,
+        updatedAt: script.updatedAt,
+      };
+    },
+    rename: async (id, name) => {
+      await createMobileTRPCClient().jsScripts.update.mutate({ id, name });
+    },
+    remove: async (id) => {
+      await createMobileTRPCClient().jsScripts.delete.mutate({ id });
+    },
+    read: async (id) => {
+      const script = await createMobileTRPCClient().jsScripts.get.query({ id });
+      return {
+        doc: script.document,
+        name: script.name,
+        token: script.updatedAt,
+        updatedAt: script.updatedAt,
+      };
+    },
+    save: async (id, { doc, name, token }) => {
+      const script = await createMobileTRPCClient().jsScripts.update.mutate({
+        id,
+        name,
+        document: doc as Parameters<
+          ReturnType<
+            typeof createMobileTRPCClient
+          >['jsScripts']['update']['mutate']
+        >[0]['document'],
+        baseUpdatedAt: typeof token === 'string' ? token : undefined,
+      });
+      return {
+        doc: script.document,
+        name: script.name,
+        token: script.updatedAt,
+        updatedAt: script.updatedAt,
+      };
+    },
+  };
+}
+
 const backends: Record<DocumentKind, DocumentBackend> = {
   timeline: resourcesBackend('timeline'),
   storyboard: resourcesBackend('storyboard'),
   sketch: resourcesBackend('sketch'),
   script: scriptsBackend(),
+  jsscript: jsScriptsBackend(),
 };
 
 export function documentBackend<Doc>(kind: DocumentKind): DocumentBackend<Doc> {

--- a/mobile/src/documents/jsScriptTypes.ts
+++ b/mobile/src/documents/jsScriptTypes.ts
@@ -1,0 +1,403 @@
+/**
+ * The agent-facing JS script contract on mobile.
+ *
+ * Ported from web's `jsScriptAgentBridge` plus `gradeJsScriptTests`, trimmed to
+ * what a phone should do: the body, the declared ports, the metadata, the saved
+ * cases, and running both. Sandbox package declarations are not editable here —
+ * a script imports whatever the host installs, so the field only round-trips.
+ *
+ * The document shape mirrors `jsScriptDocument` in
+ * `@nodetool-ai/protocol/api-schemas/js-scripts`, declared structurally because
+ * that schema module is zod and mobile has no zod. Same rationale as
+ * `scriptTypes.ts` and `storyboardTypes.ts`.
+ */
+
+/** The only document version that exists. */
+export const JS_SCRIPT_SCHEMA_VERSION = 1;
+
+export const JS_SCRIPT_DEFAULT_TIMEOUT_SECONDS = 30;
+
+/** Matches the sandbox harness ceiling (`MAX_TIMEOUT_SECONDS`). */
+export const JS_SCRIPT_MAX_TIMEOUT_SECONDS = 120;
+
+/** A port name has to be readable as `inputs.<name>` inside the body. */
+const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/** One declared port: the name the body reads or writes, and its NodeTool type. */
+export interface JsScriptPort {
+  name: string;
+  /** A TypeMetadata type name ("str", "int", "list[str]", "ImageRef", …). */
+  type: string;
+}
+
+/** A sandbox module declaration. Round-tripped, never written from here. */
+export interface JsScriptPackage {
+  specifier: string;
+  resolvedPackVersion?: string;
+  contentDigest?: string;
+}
+
+/** One saved case, the shape the grader below reads. */
+export interface JsScriptTestCase {
+  name: string;
+  inputs: Record<string, unknown>;
+  /** Items staged per input handle for a body that reads with `stream`. */
+  inputStreams?: Record<string, unknown[]>;
+  /** Per-handle structural compare against the run's final outputs. */
+  expect?: Record<string, unknown>;
+  /** The `emit` calls the run must make, in order. */
+  expectedStreamed?: { name: string; value: unknown }[];
+}
+
+export interface JsScriptDocument {
+  schemaVersion: number;
+  description: string;
+  code: string;
+  inputs: JsScriptPort[];
+  outputs: JsScriptPort[];
+  packages: JsScriptPackage[];
+  secrets: string[];
+  timeoutSeconds: number;
+  tests: JsScriptTestCase[];
+}
+
+export function emptyJsScriptDocument(): JsScriptDocument {
+  return {
+    schemaVersion: JS_SCRIPT_SCHEMA_VERSION,
+    description: '',
+    code: '',
+    inputs: [],
+    outputs: [],
+    packages: [],
+    secrets: [],
+    timeoutSeconds: JS_SCRIPT_DEFAULT_TIMEOUT_SECONDS,
+    tests: [],
+  };
+}
+
+/**
+ * Fill in a document read from the server.
+ *
+ * The router validates and defaults every field, so this is about the one case
+ * the type system cannot see: a document written by an older client, or the
+ * `null` a screen renders before the load resolves.
+ */
+export function normalizeJsScriptDocument(
+  document: Partial<JsScriptDocument> | null | undefined
+): JsScriptDocument {
+  return { ...emptyJsScriptDocument(), ...(document ?? {}) };
+}
+
+// ── Run and test results ────────────────────────────────────────────────────
+
+/** What `POST /api/js-scripts/:id/run` answers with. */
+export interface JsScriptRunOutcome {
+  ok: boolean;
+  outputs?: Record<string, unknown>;
+  streamed?: unknown[];
+  logs: string[];
+  error?: string;
+  duration_ms: number;
+}
+
+export interface JsScriptMismatch {
+  output: string;
+  expected: unknown;
+  actual: unknown;
+}
+
+export interface JsScriptTestCaseReport {
+  name: string;
+  ok: boolean;
+  outputs?: Record<string, unknown>;
+  streamed?: unknown[];
+  logs: string[];
+  error?: string;
+  mismatches: JsScriptMismatch[];
+}
+
+export interface JsScriptTestReport {
+  passed: number;
+  failed: number;
+  cases: JsScriptTestCaseReport[];
+}
+
+// ── Document-level validation ───────────────────────────────────────────────
+
+export interface JsScriptIssue {
+  severity: 'error' | 'warning';
+  code: string;
+  message: string;
+}
+
+function checkPorts(
+  ports: readonly JsScriptPort[],
+  kind: 'input' | 'output',
+  issues: JsScriptIssue[]
+): void {
+  const seen = new Set<string>();
+  for (const port of ports) {
+    if (!IDENTIFIER.test(port.name)) {
+      issues.push({
+        severity: 'error',
+        code: 'js_script_port_name',
+        message: `${kind} "${port.name}" is not a valid identifier`,
+      });
+    }
+    if (seen.has(port.name)) {
+      issues.push({
+        severity: 'error',
+        code: 'js_script_duplicate_port',
+        message: `duplicate ${kind} port "${port.name}"`,
+      });
+    }
+    seen.add(port.name);
+  }
+}
+
+/**
+ * The document-level checks that need no parser, mirroring
+ * `validateJsScriptDocument` in the protocol package. Body analysis (syntax,
+ * imports, undefined names) stays server-side: it needs the node SDK, which is
+ * not on the phone.
+ */
+export function validateJsScriptDocument(
+  document: JsScriptDocument
+): JsScriptIssue[] {
+  const issues: JsScriptIssue[] = [];
+
+  checkPorts(document.inputs, 'input', issues);
+  checkPorts(document.outputs, 'output', issues);
+
+  for (const name of document.secrets) {
+    if (name.trim() === '') {
+      issues.push({
+        severity: 'error',
+        code: 'js_script_secret_name',
+        message: 'a declared secret name is empty',
+      });
+    }
+  }
+
+  if (
+    document.timeoutSeconds <= 0 ||
+    document.timeoutSeconds > JS_SCRIPT_MAX_TIMEOUT_SECONDS
+  ) {
+    issues.push({
+      severity: 'error',
+      code: 'js_script_timeout',
+      message: `timeout must be between 1 and ${JS_SCRIPT_MAX_TIMEOUT_SECONDS} seconds`,
+    });
+  }
+
+  const inputNames = new Set(document.inputs.map((port) => port.name));
+  const outputNames = new Set(document.outputs.map((port) => port.name));
+  const caseNames = new Set<string>();
+
+  for (const testCase of document.tests) {
+    if (caseNames.has(testCase.name)) {
+      issues.push({
+        severity: 'error',
+        code: 'js_script_duplicate_test',
+        message: `duplicate test case "${testCase.name}"`,
+      });
+    }
+    caseNames.add(testCase.name);
+
+    for (const handle of Object.keys(testCase.inputs)) {
+      if (!inputNames.has(handle)) {
+        issues.push({
+          severity: 'error',
+          code: 'js_script_test_input',
+          message: `test "${testCase.name}" sets "${handle}", which is not a declared input`,
+        });
+      }
+    }
+    for (const handle of Object.keys(testCase.inputStreams ?? {})) {
+      if (!inputNames.has(handle)) {
+        issues.push({
+          severity: 'error',
+          code: 'js_script_test_input',
+          message: `test "${testCase.name}" stages "${handle}", which is not a declared input`,
+        });
+      }
+    }
+    for (const handle of Object.keys(testCase.expect ?? {})) {
+      if (!outputNames.has(handle)) {
+        issues.push({
+          severity: 'error',
+          code: 'js_script_test_output',
+          message: `test "${testCase.name}" expects "${handle}", which is not a declared output`,
+        });
+      }
+    }
+  }
+
+  if (document.code.trim() === '') {
+    issues.push({
+      severity: 'warning',
+      code: 'js_script_empty_body',
+      message: 'the script has no body yet',
+    });
+  }
+  if (document.tests.length === 0) {
+    issues.push({
+      severity: 'warning',
+      code: 'js_script_no_tests',
+      message: 'the script has no saved test cases',
+    });
+  }
+
+  return issues;
+}
+
+// ── Grading saved cases ─────────────────────────────────────────────────────
+
+/**
+ * Structural equality by JSON normalization — the values already crossed the
+ * sandbox boundary as plain data.
+ */
+const deepEqual = (a: unknown, b: unknown): boolean =>
+  JSON.stringify(a) === JSON.stringify(b);
+
+/**
+ * Grade a case's `expectedStreamed` against what the run streamed: the same
+ * entries, in the same order. A length difference is one mismatch on
+ * `streamed`; a differing entry is one mismatch on `streamed[i]`.
+ */
+export function streamMismatches(
+  expected: readonly unknown[],
+  actual: readonly unknown[]
+): JsScriptMismatch[] {
+  if (expected.length !== actual.length) {
+    return [{ output: 'streamed', expected, actual }];
+  }
+  const mismatches: JsScriptMismatch[] = [];
+  for (let i = 0; i < expected.length; i++) {
+    if (!deepEqual(expected[i], actual[i])) {
+      mismatches.push({
+        output: `streamed[${i}]`,
+        expected: expected[i],
+        actual: actual[i],
+      });
+    }
+  }
+  return mismatches;
+}
+
+/** Grade one case against the outcome of running it. */
+export function gradeJsScriptCase(
+  testCase: JsScriptTestCase,
+  outcome: JsScriptRunOutcome
+): JsScriptTestCaseReport {
+  const mismatches: JsScriptMismatch[] = [];
+
+  // A failed run is already a failed case; comparing its (absent) outputs would
+  // only bury the error under a pile of mismatches.
+  if (outcome.ok && testCase.expect) {
+    const actualBag = outcome.outputs ?? {};
+    for (const [key, expected] of Object.entries(testCase.expect)) {
+      const actual = actualBag[key];
+      if (!deepEqual(expected, actual)) {
+        mismatches.push({ output: key, expected, actual });
+      }
+    }
+  }
+  if (outcome.ok && testCase.expectedStreamed) {
+    mismatches.push(
+      ...streamMismatches(testCase.expectedStreamed, outcome.streamed ?? [])
+    );
+  }
+
+  return {
+    name: testCase.name,
+    ok: outcome.ok && mismatches.length === 0,
+    ...(outcome.outputs !== undefined ? { outputs: outcome.outputs } : {}),
+    ...(outcome.streamed !== undefined ? { streamed: outcome.streamed } : {}),
+    logs: outcome.logs,
+    ...(outcome.error !== undefined ? { error: outcome.error } : {}),
+    mismatches,
+  };
+}
+
+export function summarizeJsScriptTests(
+  cases: readonly JsScriptTestCaseReport[]
+): JsScriptTestReport {
+  return {
+    passed: cases.filter((report) => report.ok).length,
+    failed: cases.filter((report) => !report.ok).length,
+    cases: [...cases],
+  };
+}
+
+/**
+ * Run every saved case through `runCase` (the run endpoint) and grade it. Cases
+ * run in order: a script may reach a rate-limited API, and a serial run keeps
+ * the failure report readable.
+ */
+export async function gradeJsScriptTests(
+  tests: readonly JsScriptTestCase[],
+  runCase: (
+    inputs: Record<string, unknown>,
+    inputStreams?: Record<string, unknown[]>
+  ) => Promise<JsScriptRunOutcome>
+): Promise<JsScriptTestReport> {
+  const reports: JsScriptTestCaseReport[] = [];
+  for (const testCase of tests) {
+    let outcome: JsScriptRunOutcome;
+    try {
+      outcome = await runCase(testCase.inputs, testCase.inputStreams);
+    } catch (error) {
+      outcome = {
+        ok: false,
+        logs: [],
+        error: error instanceof Error ? error.message : String(error),
+        duration_ms: 0,
+      };
+    }
+    reports.push(gradeJsScriptCase(testCase, outcome));
+  }
+  return summarizeJsScriptTests(reports);
+}
+
+// ── The agent-facing surface ────────────────────────────────────────────────
+
+/** Full snapshot of the open script the agent reads before it edits. */
+export interface JsScriptSnapshot {
+  scriptId: string;
+  name: string;
+  document: JsScriptDocument;
+  /** Document-level issues, recomputed on every read. */
+  issues: JsScriptIssue[];
+  /** The last run this surface performed, if any. */
+  lastRun: JsScriptRunOutcome | null;
+  /** The last graded test report, if any. */
+  lastTest: JsScriptTestReport | null;
+}
+
+/** Metadata `ui_jsscript_set_meta` can write. Omitted fields stay as they are. */
+export interface JsScriptMetaInput {
+  name?: string;
+  description?: string;
+  secrets?: string[];
+  timeoutSeconds?: number;
+}
+
+/** Operations the mounted JsScriptEditorScreen exposes to the tool layer. */
+export interface JsScriptAgentHandler {
+  getSnapshot: () => JsScriptSnapshot;
+  setCode: (code: string) => JsScriptSnapshot;
+  setPorts: (ports: {
+    inputs?: JsScriptPort[];
+    outputs?: JsScriptPort[];
+  }) => JsScriptSnapshot;
+  setMeta: (meta: JsScriptMetaInput) => JsScriptSnapshot;
+  setTests: (tests: JsScriptTestCase[]) => JsScriptSnapshot;
+  /** Persist the document, so the run endpoint executes what the agent wrote. */
+  save: () => Promise<{ ok: true; updatedAt: string | null }>;
+  run: (
+    inputs: Record<string, unknown>,
+    inputStreams?: Record<string, unknown[]>
+  ) => Promise<JsScriptRunOutcome>;
+  test: () => Promise<JsScriptTestReport>;
+}

--- a/mobile/src/documents/kinds.ts
+++ b/mobile/src/documents/kinds.ts
@@ -14,15 +14,15 @@ import type { ResourceKind } from '@nodetool-ai/app-runtime';
  * The kinds mobile opens as documents.
  *
  * Not the same set as the server's `ResourceKind`: `asset` is a library entry
- * with its own screen rather than a document, and `script` is a document the
- * `resources` envelope cannot carry (its table has no `revision` column), so it
- * travels over `scripts.*` instead. `backends.ts` maps each kind to its
- * transport.
+ * with its own screen rather than a document, and `script` and `jsscript` are
+ * documents the `resources` envelope cannot carry (neither table has a
+ * `revision` column), so they travel over `scripts.*` and `jsScripts.*`
+ * instead. `backends.ts` maps each kind to its transport.
  */
-export type DocumentKind = Exclude<ResourceKind, 'asset'> | 'script';
+export type DocumentKind = Exclude<ResourceKind, 'asset'> | 'script' | 'jsscript';
 
 /** The kinds the `resources.*` envelope can list and write. */
-export type ResourceDocumentKind = Exclude<DocumentKind, 'script'>;
+export type ResourceDocumentKind = Exclude<DocumentKind, 'script' | 'jsscript'>;
 
 /**
  * How much the surface lets a person do directly.
@@ -48,6 +48,7 @@ export interface DocumentKindInfo {
     | 'StoryboardEditor'
     | 'TimelineViewer'
     | 'ScriptEditor'
+    | 'JsScriptEditor'
     | 'SketchViewer'
     | 'DocumentViewer';
   /** Whether the browser offers a "new document" action for this kind. */
@@ -78,6 +79,16 @@ export const DOCUMENT_KINDS: readonly DocumentKindInfo[] = [
     icon: 'document-text-outline',
     surface: 'editor',
     route: 'ScriptEditor',
+    creatable: true,
+    agentEditable: true,
+  },
+  {
+    kind: 'jsscript',
+    label: 'JS Script',
+    plural: 'JS Scripts',
+    icon: 'code-slash-outline',
+    surface: 'editor',
+    route: 'JsScriptEditor',
     creatable: true,
     agentEditable: true,
   },
@@ -132,6 +143,8 @@ export function uiSurfaceForKind(kind: DocumentKind): string | null {
       return 'timeline';
     case 'script':
       return 'script';
+    case 'jsscript':
+      return 'jsscript';
     case 'sketch':
       return 'sketch';
     default:

--- a/mobile/src/documents/tools/__tests__/jsScriptTools.test.ts
+++ b/mobile/src/documents/tools/__tests__/jsScriptTools.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for the ui_jsscript_* tools.
+ *
+ * The tools are thin: they resolve a handler off the agent bridge and forward.
+ * So these tests check the forwarding contract — argument names, shapes, and the
+ * payload envelope — plus the failure the agent will actually hit most often,
+ * naming a script that is not open.
+ */
+
+import { MobileToolRegistry } from '../registry';
+import '../jsScriptTools';
+import {
+  registerDocumentHandler,
+  resetDocumentHandlers,
+} from '../../agentBridge';
+import {
+  emptyJsScriptDocument,
+  type JsScriptAgentHandler,
+  type JsScriptRunOutcome,
+  type JsScriptSnapshot,
+} from '../../jsScriptTypes';
+
+const snapshot = (): JsScriptSnapshot => ({
+  scriptId: 'js-1',
+  name: 'Sum numbers',
+  document: {
+    ...emptyJsScriptDocument(),
+    code: 'await output("total", 3);',
+    inputs: [{ name: 'numbers', type: 'list[int]' }],
+    outputs: [{ name: 'total', type: 'int' }],
+  },
+  issues: [],
+  lastRun: null,
+  lastTest: null,
+});
+
+const runOutcome = (ok: boolean): JsScriptRunOutcome => ({
+  ok,
+  outputs: { total: 3 },
+  logs: [],
+  duration_ms: 7,
+  ...(ok ? {} : { error: 'boom' }),
+});
+
+type MockHandler = {
+  [K in keyof JsScriptAgentHandler]: jest.Mock;
+};
+
+const makeHandler = (): MockHandler => ({
+  getSnapshot: jest.fn(() => snapshot()),
+  setCode: jest.fn(() => snapshot()),
+  setPorts: jest.fn(() => snapshot()),
+  setMeta: jest.fn(() => snapshot()),
+  setTests: jest.fn(() => snapshot()),
+  save: jest.fn(async () => ({ ok: true, updatedAt: '2026-08-01T00:00:00Z' })),
+  run: jest.fn(async () => runOutcome(true)),
+  test: jest.fn(async () => ({ passed: 1, failed: 0, cases: [] })),
+});
+
+const call = (name: string, args: Record<string, unknown>): Promise<unknown> =>
+  MobileToolRegistry.call(name, args, `${name}-call`);
+
+describe('JS script tools', () => {
+  let handler: MockHandler;
+  let unregister: () => void;
+
+  beforeEach(() => {
+    resetDocumentHandlers();
+    handler = makeHandler();
+    unregister = registerDocumentHandler(
+      'jsscript',
+      'js-1',
+      'Sum numbers',
+      handler as unknown as JsScriptAgentHandler
+    );
+  });
+
+  afterEach(() => {
+    unregister();
+  });
+
+  it('registers every JS script tool in the manifest', () => {
+    expect(MobileToolRegistry.names()).toEqual(
+      expect.arrayContaining([
+        'ui_jsscript_get_state',
+        'ui_jsscript_set_code',
+        'ui_jsscript_set_ports',
+        'ui_jsscript_set_meta',
+        'ui_jsscript_set_tests',
+        'ui_jsscript_save',
+        'ui_jsscript_run',
+        'ui_jsscript_test',
+      ])
+    );
+  });
+
+  it('registers no package tool — a phone cannot install a sandbox pack', () => {
+    const names = MobileToolRegistry.names().filter((name) =>
+      name.startsWith('ui_jsscript_')
+    );
+    expect(names).toHaveLength(8);
+    for (const name of names) {
+      expect(name).not.toMatch(/package/);
+    }
+  });
+
+  it('every JS script tool requires script_id and documents itself', () => {
+    const entries = MobileToolRegistry.getManifest().filter((entry) =>
+      entry.name.startsWith('ui_jsscript_')
+    );
+    expect(entries.length).toBeGreaterThan(0);
+    for (const entry of entries) {
+      expect(entry.parameters.required).toContain('script_id');
+      expect(entry.description.length).toBeGreaterThan(40);
+    }
+  });
+
+  it('reads the whole document back on get_state', async () => {
+    await expect(
+      call('ui_jsscript_get_state', { script_id: 'js-1' })
+    ).resolves.toEqual({ ok: true, ...snapshot() });
+  });
+
+  it('forwards the body and reports its size', async () => {
+    const code = 'await output("total", 4);';
+
+    await expect(
+      call('ui_jsscript_set_code', { script_id: 'js-1', code })
+    ).resolves.toEqual({ ok: true, chars: code.length, issues: [] });
+    expect(handler.setCode).toHaveBeenCalledWith(code);
+  });
+
+  it('forwards only the port side the agent named', async () => {
+    await call('ui_jsscript_set_ports', {
+      script_id: 'js-1',
+      outputs: [{ name: 'total', type: 'int' }],
+    });
+
+    expect(handler.setPorts).toHaveBeenCalledWith({
+      inputs: undefined,
+      outputs: [{ name: 'total', type: 'int' }],
+    });
+  });
+
+  it('forwards metadata with the omitted fields left undefined', async () => {
+    await call('ui_jsscript_set_meta', {
+      script_id: 'js-1',
+      description: 'Adds the numbers.',
+    });
+
+    expect(handler.setMeta).toHaveBeenCalledWith({
+      name: undefined,
+      description: 'Adds the numbers.',
+      secrets: undefined,
+      timeoutSeconds: undefined,
+    });
+  });
+
+  it('replaces the saved cases wholesale', async () => {
+    const tests = [{ name: 'sums', inputs: { numbers: [1, 2] } }];
+
+    await call('ui_jsscript_set_tests', { script_id: 'js-1', tests });
+
+    expect(handler.setTests).toHaveBeenCalledWith(tests);
+  });
+
+  it('runs with an empty bag when the agent names no inputs', async () => {
+    await call('ui_jsscript_run', { script_id: 'js-1' });
+
+    expect(handler.run).toHaveBeenCalledWith({}, undefined);
+  });
+
+  it('passes staged items through as input streams', async () => {
+    await call('ui_jsscript_run', {
+      script_id: 'js-1',
+      inputs: { numbers: [] },
+      input_streams: { numbers: [1, 2] },
+    });
+
+    expect(handler.run).toHaveBeenCalledWith({ numbers: [] }, { numbers: [1, 2] });
+  });
+
+  it('reports a failed run as a failed tool call', async () => {
+    handler.run.mockResolvedValueOnce(runOutcome(false));
+
+    await expect(
+      call('ui_jsscript_run', { script_id: 'js-1' })
+    ).resolves.toEqual({ ok: false, run: runOutcome(false) });
+  });
+
+  it('returns the grade report from test', async () => {
+    await expect(
+      call('ui_jsscript_test', { script_id: 'js-1' })
+    ).resolves.toEqual({ ok: true, passed: 1, failed: 0, cases: [] });
+  });
+
+  it('names the open ids when the agent addresses a script that is not open', async () => {
+    await expect(
+      call('ui_jsscript_set_code', { script_id: 'js-9', code: '' })
+    ).rejects.toThrow(/No jsscript "js-9" is open.*js-1/s);
+  });
+});

--- a/mobile/src/documents/tools/index.ts
+++ b/mobile/src/documents/tools/index.ts
@@ -9,6 +9,7 @@
  * user can't currently use is harmless — it fails naming the open ids.
  */
 
+import './jsScriptTools';
 import './scriptTools';
 import './storyboardTools';
 import './timelineTools';

--- a/mobile/src/documents/tools/jsScriptTools.ts
+++ b/mobile/src/documents/tools/jsScriptTools.ts
@@ -1,0 +1,292 @@
+/**
+ * `ui_jsscript_*` — the tools that let the agent author an open JS script.
+ *
+ * A port of web's `builtin/jsscript.ts` with zod swapped for plain JSON Schema
+ * and the package-declaration tool dropped: a script imports whatever the host
+ * installs, and a phone cannot install a pack. Every tool takes an explicit
+ * `script_id` and delegates to the handler the mounted JsScriptEditorScreen
+ * registered; when that script is not open the getter throws naming the open
+ * ids, and the tool layer hands that message to the agent verbatim.
+ *
+ * The one behavioral difference from web: edits here mark the document dirty
+ * rather than autosaving, so `run` and `test` save first — the endpoint
+ * executes the saved row, not the screen's buffer.
+ */
+
+import { getDocumentHandler } from '../agentBridge';
+import { MobileToolRegistry } from './registry';
+import type {
+  JsScriptAgentHandler,
+  JsScriptPort,
+  JsScriptTestCase,
+} from '../jsScriptTypes';
+
+const handlerFor = (scriptId: string): JsScriptAgentHandler =>
+  getDocumentHandler<JsScriptAgentHandler>('jsscript', scriptId);
+
+const scriptIdProperty = {
+  type: 'string',
+  description:
+    'Id of the JS script to act on. Valid ids are listed in the ui_context block of the system prompt; there is no "current script" fallback.',
+} as const;
+
+const portSchema = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      description: 'Port name — a JavaScript identifier the body reads or emits.',
+    },
+    type: {
+      type: 'string',
+      description:
+        "NodeTool type name, e.g. 'str', 'int', 'float', 'bool', 'list', 'dict', 'image', 'audio', 'video', 'any'.",
+    },
+  },
+  required: ['name', 'type'],
+} as const;
+
+const testCaseSchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string', description: 'Case name, unique within the script.' },
+    inputs: {
+      type: 'object',
+      description: 'Input bag, keyed by declared input port name.',
+    },
+    inputStreams: {
+      type: 'object',
+      description:
+        'Items staged per input handle for a body that reads `stream`, e.g. {"numbers": [1, 2, 3]}.',
+    },
+    expect: {
+      type: 'object',
+      description: 'Expected final value per declared output handle.',
+    },
+    expectedStreamed: {
+      type: 'array',
+      description: 'The emit calls the run must make, in order.',
+      items: {
+        type: 'object',
+        properties: { name: { type: 'string' }, value: {} },
+        required: ['name', 'value'],
+      },
+    },
+  },
+  required: ['name', 'inputs'],
+} as const;
+
+interface ScriptIdArgs {
+  script_id: string;
+}
+
+MobileToolRegistry.register<ScriptIdArgs>({
+  name: 'ui_jsscript_get_state',
+  description:
+    'Read a JS script: its name and full document (description, code, declared inputs and outputs, secrets, timeout, saved test cases), the document-level validation issues, and the last run and test results from this editor. Call this first — every other tool writes into what it returns.',
+  parameters: {
+    type: 'object',
+    properties: { script_id: scriptIdProperty },
+    required: ['script_id'],
+  },
+  async execute({ script_id }) {
+    return { ok: true, ...handlerFor(script_id).getSnapshot() };
+  },
+});
+
+interface SetCodeArgs extends ScriptIdArgs {
+  code: string;
+}
+
+MobileToolRegistry.register<SetCodeArgs>({
+  name: 'ui_jsscript_set_code',
+  description:
+    'Replace the script body; the editor repaints immediately. Write top-level statements only — the host wraps the body in an async function. Do not write `export` or `function run`. Declared inputs arrive on `inputs.<name>`; outputs leave through `await emit(name, value)` / `await output(name, value)`, never through `return`. Import any installed sandbox pack or `@nodetool-ai/sandbox-nodetool/<namespace>` directly — there is no packages setting.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      code: { type: 'string', description: 'The full new JavaScript body.' },
+    },
+    required: ['script_id', 'code'],
+  },
+  async execute({ script_id, code }) {
+    const snapshot = handlerFor(script_id).setCode(code);
+    return { ok: true, chars: code.length, issues: snapshot.issues };
+  },
+});
+
+interface SetPortsArgs extends ScriptIdArgs {
+  inputs?: JsScriptPort[];
+  outputs?: JsScriptPort[];
+}
+
+MobileToolRegistry.register<SetPortsArgs>({
+  name: 'ui_jsscript_set_ports',
+  description:
+    'Replace the declared input and/or output ports wholesale. Pass `inputs` and/or `outputs` as arrays of {name, type}; an omitted array leaves that side unchanged. Names must match what the body reads from `inputs.<name>` and what it emits.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      inputs: {
+        type: 'array',
+        description: 'The complete new input port list, when changing inputs.',
+        items: portSchema,
+      },
+      outputs: {
+        type: 'array',
+        description: 'The complete new output port list, when changing outputs.',
+        items: portSchema,
+      },
+    },
+    required: ['script_id'],
+  },
+  async execute({ script_id, inputs, outputs }) {
+    const snapshot = handlerFor(script_id).setPorts({ inputs, outputs });
+    return {
+      ok: true,
+      inputs: snapshot.document.inputs,
+      outputs: snapshot.document.outputs,
+      issues: snapshot.issues,
+    };
+  },
+});
+
+interface SetMetaArgs extends ScriptIdArgs {
+  name?: string;
+  description?: string;
+  secrets?: string[];
+  timeoutSeconds?: number;
+}
+
+MobileToolRegistry.register<SetMetaArgs>({
+  name: 'ui_jsscript_set_meta',
+  description:
+    "Set the script's name, description, declared secret names, and/or timeout in seconds. Omitted fields are left alone. The description is how a later agent picks this script out of a list, so make it say what the script does. Secrets are the only ones the body may read; the timeout is capped at 120 seconds.",
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      name: { type: 'string', description: 'The script name.' },
+      description: {
+        type: 'string',
+        description: 'What the script does, in one or two sentences.',
+      },
+      secrets: {
+        type: 'array',
+        description: 'Secret names the body may read; [] for none.',
+        items: { type: 'string' },
+      },
+      timeoutSeconds: {
+        type: 'number',
+        description: 'Run timeout in seconds, 1 to 120.',
+      },
+    },
+    required: ['script_id'],
+  },
+  async execute({ script_id, name, description, secrets, timeoutSeconds }) {
+    const snapshot = handlerFor(script_id).setMeta({
+      name,
+      description,
+      secrets,
+      timeoutSeconds,
+    });
+    return {
+      ok: true,
+      name: snapshot.name,
+      description: snapshot.document.description,
+      secrets: snapshot.document.secrets,
+      timeoutSeconds: snapshot.document.timeoutSeconds,
+      issues: snapshot.issues,
+    };
+  },
+});
+
+interface SetTestsArgs extends ScriptIdArgs {
+  tests: JsScriptTestCase[];
+}
+
+MobileToolRegistry.register<SetTestsArgs>({
+  name: 'ui_jsscript_set_tests',
+  description:
+    'Replace the saved test cases. Each case names its inputs and, optionally, the expected final outputs (`expect`, keyed by output handle) and the expected emit sequence (`expectedStreamed`). These are the cases ui_jsscript_test runs.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      tests: {
+        type: 'array',
+        description: 'The complete new case list.',
+        items: testCaseSchema,
+      },
+    },
+    required: ['script_id', 'tests'],
+  },
+  async execute({ script_id, tests }) {
+    const snapshot = handlerFor(script_id).setTests(tests);
+    return { ok: true, tests: snapshot.document.tests, issues: snapshot.issues };
+  },
+});
+
+MobileToolRegistry.register<ScriptIdArgs>({
+  name: 'ui_jsscript_save',
+  description:
+    'Persist the script. Edits made through these tools are local until saved, exactly like the user\'s own edits — but ui_jsscript_run and ui_jsscript_test save on their own, so this is for finishing an editing pass without running anything.',
+  parameters: {
+    type: 'object',
+    properties: { script_id: scriptIdProperty },
+    required: ['script_id'],
+  },
+  async execute({ script_id }) {
+    return handlerFor(script_id).save();
+  },
+});
+
+interface RunArgs extends ScriptIdArgs {
+  inputs?: Record<string, unknown>;
+  input_streams?: Record<string, unknown[]>;
+}
+
+MobileToolRegistry.register<RunArgs>({
+  name: 'ui_jsscript_run',
+  description:
+    'Save the script, then run it server-side in the QuickJS sandbox with the given inputs — or, for a body that reads `stream`, with items staged per handle in `input_streams` — and return its outputs, emitted stream, logs, error and duration. Nothing runs on the phone. The run fails when the declared outputs all come back empty.',
+  parameters: {
+    type: 'object',
+    properties: {
+      script_id: scriptIdProperty,
+      inputs: {
+        type: 'object',
+        description: 'Input bag keyed by declared input port name.',
+      },
+      input_streams: {
+        type: 'object',
+        description:
+          'Items staged per input handle for a body that reads `stream`. The body runs once and pulls them; a buffered body uses `inputs` instead.',
+      },
+    },
+    required: ['script_id'],
+  },
+  async execute({ script_id, inputs, input_streams }) {
+    const outcome = await handlerFor(script_id).run(inputs ?? {}, input_streams);
+    // The nested `run.ok` is what the body did. Mirror it on the tool result so
+    // a failed run is not a successful tool call.
+    return { ok: outcome.ok, run: outcome };
+  },
+});
+
+MobileToolRegistry.register<ScriptIdArgs>({
+  name: 'ui_jsscript_test',
+  description:
+    'Save the script, then run every saved test case and return the grade report: how many passed and failed, and for each case its outputs, emitted stream, logs, error, and the mismatches. Fails when there are no saved cases — add them first with ui_jsscript_set_tests.',
+  parameters: {
+    type: 'object',
+    properties: { script_id: scriptIdProperty },
+    required: ['script_id'],
+  },
+  async execute({ script_id }) {
+    const report = await handlerFor(script_id).test();
+    return { ok: true, ...report };
+  },
+});

--- a/mobile/src/documents/useDocuments.ts
+++ b/mobile/src/documents/useDocuments.ts
@@ -59,7 +59,7 @@ export function useDocumentsOfKind(
   });
 }
 
-/** Four kinds' queries collapsed into one list, one status, one error. */
+/** Every kind's queries collapsed into one list, one status, one error. */
 export interface AllDocuments {
   documents: DocumentListEntry[];
   isLoading: boolean;
@@ -77,6 +77,7 @@ export interface AllDocuments {
 export function useAllDocuments(limit = 50): AllDocuments {
   const storyboards = useDocumentsOfKind('storyboard', limit);
   const scripts = useDocumentsOfKind('script', limit);
+  const jsScripts = useDocumentsOfKind('jsscript', limit);
   const timelines = useDocumentsOfKind('timeline', limit);
   const sketches = useDocumentsOfKind('sketch', limit);
 
@@ -85,19 +86,26 @@ export function useAllDocuments(limit = 50): AllDocuments {
       [
         ...(storyboards.data ?? []),
         ...(scripts.data ?? []),
+        ...(jsScripts.data ?? []),
         ...(timelines.data ?? []),
         ...(sketches.data ?? []),
       ].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
-    [storyboards.data, scripts.data, timelines.data, sketches.data]
+    [
+      storyboards.data,
+      scripts.data,
+      jsScripts.data,
+      timelines.data,
+      sketches.data,
+    ]
   );
 
-  const queries = [storyboards, scripts, timelines, sketches];
+  const queries = [storyboards, scripts, jsScripts, timelines, sketches];
 
   return {
     documents,
     isLoading: queries.some((query) => query.isLoading),
     isRefetching: queries.some((query) => query.isRefetching),
-    // Surface the first failure; the browser shows one banner, not four.
+    // Surface the first failure; the browser shows one banner, not one per kind.
     error: queries.find((query) => query.error)?.error ?? null,
     refetch: () => {
       for (const query of queries) {

--- a/mobile/src/navigation/linking.test.ts
+++ b/mobile/src/navigation/linking.test.ts
@@ -60,6 +60,7 @@ describe('linking', () => {
       'App',
       'StoryboardEditor',
       'ScriptEditor',
+      'JsScriptEditor',
       'TimelineViewer',
       'SketchViewer',
       'DocumentViewer',
@@ -101,6 +102,7 @@ describe('linking', () => {
 
     it('prefers the dedicated document screens over the fallback viewer', () => {
       expect(routeForPath('/document/script/d1').name).toBe('ScriptEditor');
+      expect(routeForPath('/document/jsscript/d1').name).toBe('JsScriptEditor');
       expect(routeForPath('/document/storyboard/d1').name).toBe('StoryboardEditor');
       expect(routeForPath('/document/timeline/d1').name).toBe('TimelineViewer');
       expect(routeForPath('/document/mindmap/d1')).toEqual({

--- a/mobile/src/navigation/linking.ts
+++ b/mobile/src/navigation/linking.ts
@@ -51,6 +51,7 @@ export const linking: LinkingOptions<RootStackParamList> = {
       // swallow all of them.
       StoryboardEditor: 'document/storyboard/:id',
       ScriptEditor: 'document/script/:id',
+      JsScriptEditor: 'document/jsscript/:id',
       TimelineViewer: 'document/timeline/:id',
       SketchViewer: 'document/sketch/:id',
       DocumentViewer: 'document/:kind/:id',

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -33,6 +33,11 @@ export type RootStackParamList = {
     id: string;
     name?: string;
   };
+  /** JS script editor. `name` seeds the header before the load resolves. */
+  JsScriptEditor: {
+    id: string;
+    name?: string;
+  };
   /** Read-only timeline. */
   TimelineViewer: {
     id: string;

--- a/mobile/src/screens/DocumentsScreen.tsx
+++ b/mobile/src/screens/DocumentsScreen.tsx
@@ -191,6 +191,9 @@ export default function DocumentsScreen({ navigation }: DocumentsScreenProps) {
         case 'ScriptEditor':
           navigation.navigate('ScriptEditor', { id: entry.id, name: entry.name });
           break;
+        case 'JsScriptEditor':
+          navigation.navigate('JsScriptEditor', { id: entry.id, name: entry.name });
+          break;
         case 'TimelineViewer':
           navigation.navigate('TimelineViewer', { id: entry.id, name: entry.name });
           break;

--- a/mobile/src/screens/JsScriptEditorScreen.tsx
+++ b/mobile/src/screens/JsScriptEditorScreen.tsx
@@ -1,0 +1,1055 @@
+/**
+ * JS script editor.
+ *
+ * The phone half of the JS script surface: read a script, write its body,
+ * declared ports and metadata, run it, and run its saved cases. The body only
+ * ever executes in the server's QuickJS sandbox — `POST /api/js-scripts/:id/run`
+ * runs the *saved* document, which is why every run here saves first.
+ *
+ * Two things the desktop editor has and this one does not: authoring test cases
+ * (a case is a JSON bag per handle — typing one on a phone is worse than asking
+ * the assistant for it, so the cases are shown and run but not edited) and
+ * installing sandbox packs. Package declarations round-trip untouched.
+ *
+ * It is also the agent's hands on the script. The handler registered here
+ * mutates the same `documentStore` the render reads, so a `ui_jsscript_*` call
+ * repaints the screen the user is holding, and `ui_jsscript_run` is the same
+ * code path as the Run button.
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+  useWindowDimensions,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { RouteProp, useFocusEffect } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useShallow } from 'zustand/react/shallow';
+
+import { RootStackParamList } from '../navigation/types';
+import { useTheme } from '../hooks/useTheme';
+import { apiService } from '../services/api';
+import { documentStore } from '../documents/documentStore';
+import {
+  registerDocumentHandler,
+  setDocumentTitle,
+  setFocusedDocument,
+} from '../documents/agentBridge';
+import {
+  JS_SCRIPT_MAX_TIMEOUT_SECONDS,
+  gradeJsScriptTests,
+  normalizeJsScriptDocument,
+  validateJsScriptDocument,
+  type JsScriptAgentHandler,
+  type JsScriptDocument,
+  type JsScriptPort,
+  type JsScriptRunOutcome,
+  type JsScriptSnapshot,
+  type JsScriptTestCase,
+  type JsScriptTestReport,
+} from '../documents/jsScriptTypes';
+
+type Props = {
+  navigation: NativeStackNavigationProp<RootStackParamList, 'JsScriptEditor'>;
+  route: RouteProp<RootStackParamList, 'JsScriptEditor'>;
+};
+
+/** 18pt icon + 10pt padding = 38pt; the slop lifts it to the 46pt touch target. */
+const ICON_HIT_SLOP = { top: 4, bottom: 4, left: 4, right: 4 };
+
+/** Back button + chat bubble + Save + the gutters around them. */
+const HEADER_RESERVED_WIDTH = 164;
+
+const CODE_MIN_HEIGHT = 200;
+
+const MONOSPACE = Platform.select({
+  ios: 'Menlo',
+  android: 'monospace',
+  default: 'monospace',
+});
+
+/** Pretty-print a value for one of the read-only result panes. */
+const asText = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    // Circular or otherwise unserializable: the sandbox returns plain data, so
+    // this is the "should not happen" branch rather than a real case.
+    return String(value);
+  }
+};
+
+/**
+ * Read one run-console field.
+ *
+ * The console is text fields, but a script's inputs are typed. Anything that
+ * parses as JSON goes in as that value — numbers, booleans, arrays, objects —
+ * and everything else goes in as the string the user typed, which is what makes
+ * `hello` work without quotes.
+ */
+export function parseRunInput(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    return '';
+  }
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return raw;
+  }
+}
+
+export default function JsScriptEditorScreen({ navigation, route }: Props) {
+  const { id, name: initialName } = route.params;
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const store = documentStore<JsScriptDocument>('jsscript', id);
+  const { doc, name, dirty, status, error } = store(
+    useShallow((state) => ({
+      doc: state.doc,
+      name: state.name,
+      dirty: state.dirty,
+      status: state.status,
+      error: state.error,
+    }))
+  );
+
+  const [runInputs, setRunInputs] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState<'run' | 'test' | null>(null);
+  const [lastRun, setLastRun] = useState<JsScriptRunOutcome | null>(null);
+  const [lastTest, setLastTest] = useState<JsScriptTestReport | null>(null);
+  // The agent handler runs outside React, so it reads results from refs.
+  const lastRunRef = useRef<JsScriptRunOutcome | null>(null);
+  const lastTestRef = useRef<JsScriptTestReport | null>(null);
+
+  // The store's actions live in its state, so every caller goes through
+  // getState() — including the agent handler, which runs outside React.
+  const edit = useCallback(
+    (mutate: (script: JsScriptDocument) => JsScriptDocument) => {
+      store.getState().edit(mutate);
+    },
+    [store]
+  );
+  const runLoad = useCallback(() => void store.getState().load(), [store]);
+  const runRevert = useCallback(() => void store.getState().revert(), [store]);
+
+  /** Save and turn a conflict or failure into a throw the caller can report. */
+  const saveOrThrow = useCallback(async (): Promise<string | null> => {
+    await store.getState().save();
+    const state = store.getState();
+    if (state.status === 'conflict' || state.status === 'error') {
+      throw new Error(state.error ?? 'Failed to save the script.');
+    }
+    return state.updatedAt;
+  }, [store]);
+
+  useEffect(() => {
+    // Re-read on every open. The store is cached for the app's lifetime, so a
+    // script reopened after an edit elsewhere would otherwise render a stale
+    // body and save against an `updatedAt` the server has already moved past.
+    if (!store.getState().dirty) {
+      runLoad();
+    }
+  }, [store, runLoad]);
+
+  // ── Run and test ─────────────────────────────────────────────────────────
+  const runScript = useCallback(
+    async (
+      inputs: Record<string, unknown>,
+      inputStreams?: Record<string, unknown[]>
+    ): Promise<JsScriptRunOutcome> => {
+      // The endpoint executes the saved row, so an unsaved edit would run the
+      // previous body and report a result the user never asked for.
+      await saveOrThrow();
+      const outcome = await apiService.runJsScript(id, inputs, inputStreams);
+      lastRunRef.current = outcome;
+      setLastRun(outcome);
+      return outcome;
+    },
+    [id, saveOrThrow]
+  );
+
+  const testScript = useCallback(async (): Promise<JsScriptTestReport> => {
+    const tests = store.getState().doc?.tests ?? [];
+    if (tests.length === 0) {
+      throw new Error(
+        'This script has no saved test cases. Add them with ui_jsscript_set_tests first.'
+      );
+    }
+    await saveOrThrow();
+    const report = await gradeJsScriptTests(tests, (inputs, inputStreams) =>
+      apiService.runJsScript(id, inputs, inputStreams)
+    );
+    lastTestRef.current = report;
+    setLastTest(report);
+    return report;
+  }, [id, store, saveOrThrow]);
+
+  // ── Agent handler ────────────────────────────────────────────────────────
+  useEffect(() => {
+    const requireDoc = (): JsScriptDocument => {
+      const current = store.getState().doc;
+      if (current === null) {
+        throw new Error(
+          `JS script "${id}" has not finished loading. Retry in a moment.`
+        );
+      }
+      return current;
+    };
+
+    const snapshot = (): JsScriptSnapshot => {
+      const state = store.getState();
+      const document = normalizeJsScriptDocument(state.doc);
+      return {
+        scriptId: id,
+        name: state.name || initialName || 'Untitled JS script',
+        document,
+        issues: validateJsScriptDocument(document),
+        lastRun: lastRunRef.current,
+        lastTest: lastTestRef.current,
+      };
+    };
+
+    const write = (
+      mutate: (script: JsScriptDocument) => JsScriptDocument
+    ): JsScriptSnapshot => {
+      requireDoc();
+      edit(mutate);
+      return snapshot();
+    };
+
+    const handler: JsScriptAgentHandler = {
+      getSnapshot: snapshot,
+
+      setCode: (code: string) => write((script) => ({ ...script, code })),
+
+      setPorts: ({ inputs, outputs }) =>
+        write((script) => ({
+          ...script,
+          ...(inputs ? { inputs } : {}),
+          ...(outputs ? { outputs } : {}),
+        })),
+
+      setMeta: ({ name: nextName, description, secrets, timeoutSeconds }) => {
+        requireDoc();
+        if (nextName !== undefined) {
+          store.getState().rename(nextName);
+        }
+        if (
+          description !== undefined ||
+          secrets !== undefined ||
+          timeoutSeconds !== undefined
+        ) {
+          edit((script) => ({
+            ...script,
+            ...(description !== undefined ? { description } : {}),
+            ...(secrets !== undefined ? { secrets } : {}),
+            ...(timeoutSeconds !== undefined ? { timeoutSeconds } : {}),
+          }));
+        }
+        return snapshot();
+      },
+
+      setTests: (tests: JsScriptTestCase[]) =>
+        write((script) => ({ ...script, tests })),
+
+      save: async () => {
+        const updatedAt = await saveOrThrow();
+        return { ok: true, updatedAt };
+      },
+
+      run: runScript,
+      test: testScript,
+    };
+
+    return registerDocumentHandler(
+      'jsscript',
+      id,
+      store.getState().name || initialName || 'JS script',
+      handler
+    );
+  }, [store, id, initialName, edit, saveOrThrow, runScript, testScript]);
+
+  // Claim focus on focus, but do not release it on blur: navigating to Chat
+  // blurs this screen, and the chat turn is the one moment `ui_context.focused`
+  // is read. Unmount drops the registration, which is what makes it stale.
+  useFocusEffect(
+    useCallback(() => {
+      setFocusedDocument('jsscript', id);
+    }, [id])
+  );
+
+  useEffect(() => {
+    if (name) {
+      setDocumentTitle('jsscript', id, name);
+    }
+  }, [name, id]);
+
+  const handleSave = useCallback(() => {
+    void store.getState().save();
+  }, [store]);
+
+  const openChat = useCallback(() => {
+    navigation.navigate('Chat');
+  }, [navigation]);
+
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const handleRun = useCallback(() => {
+    const declared = store.getState().doc?.inputs ?? [];
+    const inputs: Record<string, unknown> = {};
+    for (const port of declared) {
+      inputs[port.name] = parseRunInput(runInputs[port.name] ?? '');
+    }
+    setActionError(null);
+    setBusy('run');
+    void runScript(inputs)
+      .catch((runError: unknown) => {
+        setActionError(
+          runError instanceof Error ? runError.message : 'The run failed.'
+        );
+      })
+      .finally(() => setBusy(null));
+  }, [store, runInputs, runScript]);
+
+  const handleTest = useCallback(() => {
+    setActionError(null);
+    setBusy('test');
+    void testScript()
+      .catch((testError: unknown) => {
+        setActionError(
+          testError instanceof Error ? testError.message : 'The tests failed to run.'
+        );
+      })
+      .finally(() => setBusy(null));
+  }, [testScript]);
+
+  // The header lays the title out at its natural width and never shrinks it, so
+  // a long name would push Save off the screen. Cap the title instead.
+  const { width: windowWidth } = useWindowDimensions();
+  const titleMaxWidth = Math.max(96, windowWidth - HEADER_RESERVED_WIDTH);
+
+  useLayoutEffect(() => {
+    const saving = status === 'saving';
+    navigation.setOptions({
+      title: name || initialName || 'JS script',
+      headerTitle: ({ children, tintColor }) => (
+        <Text
+          numberOfLines={1}
+          style={[
+            styles.headerTitle,
+            { maxWidth: titleMaxWidth, color: tintColor ?? colors.text },
+          ]}
+        >
+          {children}
+        </Text>
+      ),
+      headerRight: () => (
+        <View style={styles.headerActions}>
+          <TouchableOpacity
+            onPress={openChat}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Write this script by chat"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Ionicons
+              name="chatbubble-ellipses-outline"
+              size={22}
+              color={colors.primary}
+            />
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={handleSave}
+            activeOpacity={0.7}
+            disabled={!dirty || saving}
+            accessibilityRole="button"
+            accessibilityLabel="Save JS script"
+            accessibilityState={{ disabled: !dirty || saving }}
+          >
+            {saving ? (
+              <ActivityIndicator size="small" color={colors.primary} />
+            ) : (
+              <Text
+                style={[
+                  styles.saveText,
+                  { color: dirty ? colors.primary : colors.textTertiary },
+                ]}
+              >
+                Save
+              </Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      ),
+    });
+  }, [
+    navigation,
+    name,
+    initialName,
+    dirty,
+    status,
+    colors.primary,
+    colors.text,
+    colors.textTertiary,
+    handleSave,
+    openChat,
+    titleMaxWidth,
+  ]);
+
+  // ── Local edits ──────────────────────────────────────────────────────────
+  const patchPort = useCallback(
+    (side: 'inputs' | 'outputs', index: number, patch: Partial<JsScriptPort>) => {
+      edit((script) => ({
+        ...script,
+        [side]: script[side].map((port, at) =>
+          at === index ? { ...port, ...patch } : port
+        ),
+      }));
+    },
+    [edit]
+  );
+
+  const addPort = useCallback(
+    (side: 'inputs' | 'outputs') => {
+      edit((script) => ({
+        ...script,
+        [side]: [
+          ...script[side],
+          { name: `${side === 'inputs' ? 'input' : 'output'}${script[side].length + 1}`, type: 'str' },
+        ],
+      }));
+    },
+    [edit]
+  );
+
+  const removePort = useCallback(
+    (side: 'inputs' | 'outputs', index: number) => {
+      edit((script) => ({
+        ...script,
+        [side]: script[side].filter((_, at) => at !== index),
+      }));
+    },
+    [edit]
+  );
+
+  if (doc === null) {
+    return (
+      <View style={[styles.center, { backgroundColor: colors.background }]}>
+        {status === 'error' ? (
+          <>
+            <Ionicons name="alert-circle-outline" size={36} color={colors.error} />
+            <Text style={[styles.centerText, { color: colors.textSecondary }]}>
+              {error ?? 'Failed to load this JS script.'}
+            </Text>
+            <TouchableOpacity
+              onPress={runLoad}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel="Retry loading JS script"
+              style={[styles.primaryButton, { backgroundColor: colors.primary }]}
+            >
+              <Text
+                style={[styles.primaryButtonText, { color: colors.textOnPrimary }]}
+              >
+                Retry
+              </Text>
+            </TouchableOpacity>
+          </>
+        ) : (
+          <ActivityIndicator size="large" color={colors.primary} />
+        )}
+      </View>
+    );
+  }
+
+  const script = normalizeJsScriptDocument(doc);
+  const issues = validateJsScriptDocument(script);
+  const errors = issues.filter((issue) => issue.severity === 'error');
+  const warnings = issues.filter((issue) => issue.severity === 'warning');
+
+  const portSection = (side: 'inputs' | 'outputs', label: string) => (
+    <>
+      <View style={styles.metaRow}>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>
+          {`${label} (${script[side].length})`}
+        </Text>
+        <TouchableOpacity
+          onPress={() => addPort(side)}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel={`Add ${label.toLowerCase().slice(0, -1)}`}
+          style={styles.addButton}
+        >
+          <Ionicons name="add-circle-outline" size={22} color={colors.primary} />
+          <Text style={[styles.addButtonText, { color: colors.primary }]}>Add</Text>
+        </TouchableOpacity>
+      </View>
+      {script[side].map((port, index) => (
+        <View key={`${side}-${index}`} style={styles.portRow}>
+          <TextInput
+            style={[
+              styles.input,
+              styles.portName,
+              {
+                backgroundColor: colors.inputBg,
+                borderColor: colors.borderLight,
+                color: colors.text,
+              },
+            ]}
+            value={port.name}
+            onChangeText={(next) => patchPort(side, index, { name: next })}
+            autoCapitalize="none"
+            autoCorrect={false}
+            placeholder="name"
+            placeholderTextColor={colors.textTertiary}
+            accessibilityLabel={`${label} ${index + 1} name`}
+          />
+          <TextInput
+            style={[
+              styles.input,
+              styles.portType,
+              {
+                backgroundColor: colors.inputBg,
+                borderColor: colors.borderLight,
+                color: colors.text,
+              },
+            ]}
+            value={port.type}
+            onChangeText={(next) => patchPort(side, index, { type: next })}
+            autoCapitalize="none"
+            autoCorrect={false}
+            placeholder="str"
+            placeholderTextColor={colors.textTertiary}
+            accessibilityLabel={`${label} ${index + 1} type`}
+          />
+          <TouchableOpacity
+            onPress={() => removePort(side, index)}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel={`Remove ${label.toLowerCase().slice(0, -1)} ${index + 1}`}
+            hitSlop={ICON_HIT_SLOP}
+            style={styles.iconButton}
+          >
+            <Ionicons name="trash-outline" size={18} color={colors.error} />
+          </TouchableOpacity>
+        </View>
+      ))}
+    </>
+  );
+
+  return (
+    <KeyboardAvoidingView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 90 : 0}
+    >
+      {status === 'conflict' && (
+        <View
+          style={[styles.banner, { backgroundColor: colors.warning + '22' }]}
+          accessibilityLabel="JS script changed elsewhere"
+        >
+          <Ionicons name="git-compare-outline" size={16} color={colors.warning} />
+          <Text style={[styles.bannerText, { color: colors.text }]}>
+            Someone else saved this script. Reload to get their version — your
+            unsaved edits here will be lost.
+          </Text>
+          <TouchableOpacity
+            onPress={runRevert}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel="Reload JS script"
+            style={[styles.bannerButton, { backgroundColor: colors.warning }]}
+          >
+            <Text style={styles.bannerButtonText}>Reload</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {status === 'error' && error !== null && (
+        <View style={[styles.banner, { backgroundColor: colors.error + '18' }]}>
+          <Ionicons name="warning-outline" size={16} color={colors.error} />
+          <Text style={[styles.bannerText, { color: colors.error }]}>{error}</Text>
+        </View>
+      )}
+
+      <ScrollView
+        contentContainerStyle={[
+          styles.scroll,
+          { paddingBottom: insets.bottom + 40 },
+        ]}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.metaRow}>
+          <Text style={[styles.sectionTitle, { color: colors.text }]}>Body</Text>
+          {dirty && (
+            <View style={styles.dirtyRow} accessibilityLabel="Unsaved changes">
+              <View style={[styles.dirtyDot, { backgroundColor: colors.warning }]} />
+              <Text style={[styles.dirtyText, { color: colors.textSecondary }]}>
+                Unsaved
+              </Text>
+            </View>
+          )}
+        </View>
+
+        <TextInput
+          style={[
+            styles.input,
+            styles.code,
+            {
+              backgroundColor: colors.inputBg,
+              borderColor: colors.borderLight,
+              color: colors.text,
+            },
+          ]}
+          value={script.code}
+          onChangeText={(code) => edit((current) => ({ ...current, code }))}
+          multiline
+          autoCapitalize="none"
+          autoCorrect={false}
+          autoComplete="off"
+          spellCheck={false}
+          placeholder={'const total = inputs.numbers.reduce((a, b) => a + b, 0);\nawait output("total", total);'}
+          placeholderTextColor={colors.textTertiary}
+          accessibilityLabel="Script body"
+        />
+
+        <Text style={[styles.hint, { color: colors.textSecondary }]}>
+          Top-level statements only. Inputs arrive on `inputs.name`; results
+          leave through `await output(name, value)` or `await emit(name, value)`,
+          never through `return`.
+        </Text>
+
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>
+          Description
+        </Text>
+        <TextInput
+          style={[
+            styles.input,
+            styles.description,
+            {
+              backgroundColor: colors.inputBg,
+              borderColor: colors.borderLight,
+              color: colors.text,
+            },
+          ]}
+          value={script.description}
+          onChangeText={(description) =>
+            edit((current) => ({ ...current, description }))
+          }
+          multiline
+          placeholder="What this script does — how an agent picks it out of a list."
+          placeholderTextColor={colors.textTertiary}
+          accessibilityLabel="Script description"
+        />
+
+        {portSection('inputs', 'Inputs')}
+        {portSection('outputs', 'Outputs')}
+
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Settings</Text>
+        <View style={styles.settingRow}>
+          <Text style={[styles.settingLabel, { color: colors.textSecondary }]}>
+            Timeout (s)
+          </Text>
+          <TextInput
+            style={[
+              styles.input,
+              styles.timeoutInput,
+              {
+                backgroundColor: colors.inputBg,
+                borderColor: colors.borderLight,
+                color: colors.text,
+              },
+            ]}
+            value={String(script.timeoutSeconds)}
+            onChangeText={(next) => {
+              const seconds = Number.parseInt(next, 10);
+              edit((current) => ({
+                ...current,
+                timeoutSeconds: Number.isNaN(seconds)
+                  ? 0
+                  : Math.min(seconds, JS_SCRIPT_MAX_TIMEOUT_SECONDS),
+              }));
+            }}
+            keyboardType="number-pad"
+            accessibilityLabel="Run timeout in seconds"
+          />
+        </View>
+        <TextInput
+          style={[
+            styles.input,
+            {
+              backgroundColor: colors.inputBg,
+              borderColor: colors.borderLight,
+              color: colors.text,
+            },
+          ]}
+          value={script.secrets.join(', ')}
+          onChangeText={(next) =>
+            edit((current) => ({
+              ...current,
+              secrets: next
+                .split(',')
+                .map((secret) => secret.trim())
+                .filter((secret) => secret.length > 0),
+            }))
+          }
+          autoCapitalize="characters"
+          autoCorrect={false}
+          placeholder="Secret names the body may read, comma separated"
+          placeholderTextColor={colors.textTertiary}
+          accessibilityLabel="Declared secrets"
+        />
+
+        {issues.length > 0 && (
+          <View
+            style={[
+              styles.issues,
+              {
+                backgroundColor:
+                  (errors.length > 0 ? colors.error : colors.warning) + '14',
+              },
+            ]}
+            accessibilityLabel="Validation issues"
+          >
+            {[...errors, ...warnings].map((issue, index) => (
+              <View key={`${issue.code}-${index}`} style={styles.issueRow}>
+                <Ionicons
+                  name={
+                    issue.severity === 'error'
+                      ? 'close-circle-outline'
+                      : 'alert-circle-outline'
+                  }
+                  size={15}
+                  color={issue.severity === 'error' ? colors.error : colors.warning}
+                />
+                <Text style={[styles.issueText, { color: colors.textSecondary }]}>
+                  {issue.message}
+                </Text>
+              </View>
+            ))}
+          </View>
+        )}
+
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Run</Text>
+        {script.inputs.length === 0 ? (
+          <Text style={[styles.hint, { color: colors.textSecondary }]}>
+            No declared inputs — the body runs with an empty bag.
+          </Text>
+        ) : (
+          script.inputs.map((port) => (
+            <View key={`run-${port.name}`} style={styles.settingRow}>
+              <Text
+                style={[styles.settingLabel, { color: colors.textSecondary }]}
+                numberOfLines={1}
+              >
+                {`${port.name}: ${port.type}`}
+              </Text>
+              <TextInput
+                style={[
+                  styles.input,
+                  styles.runInput,
+                  {
+                    backgroundColor: colors.inputBg,
+                    borderColor: colors.borderLight,
+                    color: colors.text,
+                  },
+                ]}
+                value={runInputs[port.name] ?? ''}
+                onChangeText={(next) =>
+                  setRunInputs((current) => ({ ...current, [port.name]: next }))
+                }
+                autoCapitalize="none"
+                autoCorrect={false}
+                placeholder="JSON, or plain text"
+                placeholderTextColor={colors.textTertiary}
+                accessibilityLabel={`Value for input ${port.name}`}
+              />
+            </View>
+          ))
+        )}
+
+        <View style={styles.actions}>
+          <TouchableOpacity
+            onPress={handleRun}
+            activeOpacity={0.7}
+            disabled={busy !== null}
+            accessibilityRole="button"
+            accessibilityLabel="Run script"
+            accessibilityState={{ disabled: busy !== null }}
+            style={[styles.primaryButton, { backgroundColor: colors.primary }]}
+          >
+            {busy === 'run' ? (
+              <ActivityIndicator size="small" color={colors.textOnPrimary} />
+            ) : (
+              <Text
+                style={[styles.primaryButtonText, { color: colors.textOnPrimary }]}
+              >
+                Run
+              </Text>
+            )}
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={handleTest}
+            activeOpacity={0.7}
+            disabled={busy !== null || script.tests.length === 0}
+            accessibilityRole="button"
+            accessibilityLabel="Run saved test cases"
+            accessibilityState={{
+              disabled: busy !== null || script.tests.length === 0,
+            }}
+            style={[
+              styles.secondaryButton,
+              { borderColor: colors.borderLight },
+            ]}
+          >
+            {busy === 'test' ? (
+              <ActivityIndicator size="small" color={colors.primary} />
+            ) : (
+              <Text
+                style={[
+                  styles.primaryButtonText,
+                  {
+                    color:
+                      script.tests.length === 0
+                        ? colors.textTertiary
+                        : colors.primary,
+                  },
+                ]}
+              >
+                {`Test (${script.tests.length})`}
+              </Text>
+            )}
+          </TouchableOpacity>
+        </View>
+
+        {actionError !== null && (
+          <Text style={[styles.issueText, { color: colors.error }]}>
+            {actionError}
+          </Text>
+        )}
+
+        {lastRun !== null && (
+          <View
+            style={[styles.card, { borderColor: colors.borderLight }]}
+            accessibilityLabel="Last run result"
+          >
+            <View style={styles.cardHeader}>
+              <Ionicons
+                name={lastRun.ok ? 'checkmark-circle' : 'close-circle'}
+                size={18}
+                color={lastRun.ok ? colors.success : colors.error}
+              />
+              <Text style={[styles.cardTitle, { color: colors.text }]}>
+                {lastRun.ok ? 'Run succeeded' : 'Run failed'}
+              </Text>
+              <Text style={[styles.dirtyText, { color: colors.textSecondary }]}>
+                {`${lastRun.duration_ms} ms`}
+              </Text>
+            </View>
+            {lastRun.error !== undefined && (
+              <Text style={[styles.mono, { color: colors.error }]}>
+                {lastRun.error}
+              </Text>
+            )}
+            {lastRun.outputs !== undefined && (
+              <Text style={[styles.mono, { color: colors.text }]}>
+                {asText(lastRun.outputs)}
+              </Text>
+            )}
+            {lastRun.streamed !== undefined && lastRun.streamed.length > 0 && (
+              <Text style={[styles.mono, { color: colors.textSecondary }]}>
+                {asText(lastRun.streamed)}
+              </Text>
+            )}
+            {lastRun.logs.length > 0 && (
+              <Text style={[styles.mono, { color: colors.textSecondary }]}>
+                {lastRun.logs.join('\n')}
+              </Text>
+            )}
+          </View>
+        )}
+
+        {lastTest !== null && (
+          <View
+            style={[styles.card, { borderColor: colors.borderLight }]}
+            accessibilityLabel="Last test report"
+          >
+            <View style={styles.cardHeader}>
+              <Ionicons
+                name={lastTest.failed === 0 ? 'checkmark-circle' : 'close-circle'}
+                size={18}
+                color={lastTest.failed === 0 ? colors.success : colors.error}
+              />
+              <Text style={[styles.cardTitle, { color: colors.text }]}>
+                {`${lastTest.passed} passed, ${lastTest.failed} failed`}
+              </Text>
+            </View>
+            {lastTest.cases.map((report) => (
+              <View key={report.name} style={styles.caseRow}>
+                <Ionicons
+                  name={report.ok ? 'checkmark' : 'close'}
+                  size={15}
+                  color={report.ok ? colors.success : colors.error}
+                />
+                <View style={styles.caseBody}>
+                  <Text style={[styles.caseName, { color: colors.text }]}>
+                    {report.name}
+                  </Text>
+                  {report.error !== undefined && (
+                    <Text style={[styles.mono, { color: colors.error }]}>
+                      {report.error}
+                    </Text>
+                  )}
+                  {report.mismatches.map((mismatch, index) => (
+                    <Text
+                      key={`${report.name}-${mismatch.output}-${index}`}
+                      style={[styles.mono, { color: colors.textSecondary }]}
+                    >
+                      {`${mismatch.output}: expected ${asText(mismatch.expected)}, got ${asText(mismatch.actual)}`}
+                    </Text>
+                  ))}
+                </View>
+              </View>
+            ))}
+          </View>
+        )}
+
+        {script.tests.length === 0 && (
+          <Text style={[styles.hint, { color: colors.textSecondary }]}>
+            No saved test cases. Ask the assistant for them — a case is a JSON
+            bag per handle, which is faster to describe than to type here.
+          </Text>
+        )}
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    gap: 12,
+  },
+  centerText: { fontSize: 14, textAlign: 'center' },
+  headerTitle: { fontSize: 17, fontWeight: '700' },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    // Native headers inset their own items; the web header does not.
+    paddingRight: Platform.OS === 'web' ? 12 : 0,
+  },
+  saveText: { fontSize: 16, fontWeight: '600' },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  bannerText: { flex: 1, fontSize: 13 },
+  bannerButton: { paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8 },
+  bannerButtonText: { fontSize: 13, fontWeight: '600', color: '#fff' },
+  scroll: { padding: 16 },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 8,
+    marginBottom: 4,
+  },
+  sectionTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+    marginTop: 14,
+    marginBottom: 6,
+  },
+  addButton: { flexDirection: 'row', alignItems: 'center', gap: 4 },
+  addButtonText: { fontSize: 15, fontWeight: '600' },
+  dirtyRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  dirtyDot: { width: 8, height: 8, borderRadius: 4 },
+  dirtyText: { fontSize: 12, fontWeight: '600' },
+  input: {
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    fontSize: 15,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    marginBottom: 8,
+  },
+  code: {
+    minHeight: CODE_MIN_HEIGHT,
+    textAlignVertical: 'top',
+    fontFamily: MONOSPACE,
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  description: { minHeight: 68, textAlignVertical: 'top' },
+  hint: { fontSize: 12, lineHeight: 17, marginBottom: 8 },
+  portRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  // `minWidth: 0` is what lets a field give way to the buttons beside it: a web
+  // text input will not shrink past its default intrinsic width otherwise.
+  portName: { flex: 2, minWidth: 0, marginBottom: 0 },
+  portType: { flex: 1, minWidth: 0, marginBottom: 0 },
+  settingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginBottom: 8,
+  },
+  settingLabel: { flex: 1, fontSize: 13 },
+  timeoutInput: { width: 90, marginBottom: 0, textAlign: 'right' },
+  runInput: { flex: 2, minWidth: 0, marginBottom: 0 },
+  issues: { borderRadius: 10, padding: 10, gap: 6, marginBottom: 8 },
+  issueRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 6 },
+  issueText: { flex: 1, fontSize: 12, lineHeight: 17 },
+  actions: { flexDirection: 'row', alignItems: 'center', gap: 10, marginTop: 6 },
+  primaryButton: {
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  primaryButtonText: { fontSize: 15, fontWeight: '600' },
+  secondaryButton: {
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center',
+  },
+  card: { borderRadius: 14, borderWidth: 1, padding: 12, marginTop: 12, gap: 8 },
+  cardHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  cardTitle: { flex: 1, fontSize: 15, fontWeight: '600' },
+  mono: { fontFamily: MONOSPACE, fontSize: 12, lineHeight: 17 },
+  caseRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 8 },
+  caseBody: { flex: 1, gap: 4 },
+  caseName: { fontSize: 14, fontWeight: '600' },
+  iconButton: { padding: 10 },
+});

--- a/mobile/src/screens/__tests__/JsScriptEditorScreen.test.tsx
+++ b/mobile/src/screens/__tests__/JsScriptEditorScreen.test.tsx
@@ -1,0 +1,416 @@
+/**
+ * Tests for JsScriptEditorScreen.
+ *
+ * The document store is replaced with a real (but network-free) Zustand store,
+ * so the screen exercises the same read/edit/save paths it does in the app
+ * without a tRPC client, and the run endpoint is mocked at `apiService`. The
+ * agent handler is reached through the real bridge, which is the contract the
+ * ui_jsscript_* tools depend on.
+ */
+
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { create } from 'zustand';
+
+import JsScriptEditorScreen, { parseRunInput } from '../JsScriptEditorScreen';
+import {
+  getDocumentHandler,
+  resetDocumentHandlers,
+} from '../../documents/agentBridge';
+import {
+  emptyJsScriptDocument,
+  type JsScriptAgentHandler,
+  type JsScriptDocument,
+  type JsScriptRunOutcome,
+} from '../../documents/jsScriptTypes';
+import type { DocumentState } from '../../documents/documentStore';
+
+// ── Module mocks ───────────────────────────────────────────────────────────
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: (callback: () => void | (() => void)) => {
+    const ReactModule = require('react');
+    ReactModule.useEffect(callback, [callback]);
+  },
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#000',
+      surface: '#111',
+      primary: '#6DB3F8',
+      primaryMuted: '#123',
+      text: '#fff',
+      textSecondary: '#aaa',
+      textTertiary: '#777',
+      textOnPrimary: '#fff',
+      border: '#222',
+      borderLight: '#333',
+      error: '#f00',
+      warning: '#fc0',
+      success: '#0c6',
+      inputBg: '#222',
+      cardBg: '#111',
+      accent: '#a7f',
+      accentMuted: '#334',
+    },
+    shadows: { small: {}, medium: {}, large: {} },
+  }),
+}));
+
+const mockRunJsScript = jest.fn(
+  async (
+    _scriptId: string,
+    _inputs: Record<string, unknown>,
+    _inputStreams?: Record<string, unknown[]>
+  ): Promise<JsScriptRunOutcome> => ({
+    ok: true,
+    outputs: { total: 3 },
+    logs: ['ran'],
+    duration_ms: 12,
+  })
+);
+
+// Referenced lazily: the factory runs while the module graph is still being
+// initialized, so reading the const eagerly would capture it before assignment.
+jest.mock('../../services/api', () => ({
+  apiService: {
+    runJsScript: (...args: Parameters<typeof mockRunJsScript>) =>
+      mockRunJsScript(...args),
+  },
+}));
+
+const saveMock = jest.fn(async () => {});
+const loadMock = jest.fn(async () => {});
+const revertMock = jest.fn(async () => {});
+
+type TestState = DocumentState<JsScriptDocument>;
+
+const makeDocument = (
+  overrides: Partial<JsScriptDocument> = {}
+): JsScriptDocument => ({
+  ...emptyJsScriptDocument(),
+  description: 'Adds the numbers.',
+  code: 'await output("total", inputs.numbers.length);',
+  inputs: [{ name: 'numbers', type: 'list[int]' }],
+  outputs: [{ name: 'total', type: 'int' }],
+  tests: [{ name: 'sums', inputs: { numbers: [1, 2] }, expect: { total: 3 } }],
+  ...overrides,
+});
+
+let mockStore: ReturnType<typeof makeStore>;
+
+function makeStore(overrides: Partial<TestState> = {}) {
+  return create<TestState>((set, get) => ({
+    kind: 'jsscript',
+    id: 'js-1',
+    doc: makeDocument(),
+    name: 'Sum numbers',
+    token: '2026-08-01T00:00:00Z',
+    updatedAt: '2026-08-01T00:00:00Z',
+    dirty: false,
+    status: 'idle',
+    error: null,
+    load: loadMock,
+    edit: (mutate) => {
+      const current = get().doc;
+      if (current === null) {
+        return;
+      }
+      set({ doc: mutate(current), dirty: true });
+    },
+    rename: (name) => set({ name, dirty: true }),
+    save: saveMock,
+    revert: revertMock,
+    ...overrides,
+  }));
+}
+
+jest.mock('../../documents/documentStore', () => ({
+  documentStore: () => mockStore,
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const navigation = {
+  navigate: jest.fn(),
+  setOptions: jest.fn(),
+  goBack: jest.fn(),
+};
+
+const route = { params: { id: 'js-1', name: 'Sum numbers' } };
+
+const renderScreen = () =>
+  render(
+    <JsScriptEditorScreen
+      navigation={navigation as never}
+      route={route as never}
+    />
+  );
+
+/** The header component the screen last handed to the navigator. */
+const renderHeaderRight = () => {
+  const calls = navigation.setOptions.mock.calls;
+  const options = calls[calls.length - 1][0] as {
+    headerRight: () => React.ReactElement;
+  };
+  const HeaderRight = options.headerRight;
+  return render(<HeaderRight />);
+};
+
+const handler = (): JsScriptAgentHandler =>
+  getDocumentHandler<JsScriptAgentHandler>('jsscript', 'js-1');
+
+describe('parseRunInput', () => {
+  it('reads JSON when the field holds JSON', () => {
+    expect(parseRunInput('[1, 2]')).toEqual([1, 2]);
+    expect(parseRunInput('42')).toBe(42);
+    expect(parseRunInput('{"a": 1}')).toEqual({ a: 1 });
+  });
+
+  it('reads anything else as the string the user typed', () => {
+    expect(parseRunInput('hello')).toBe('hello');
+    expect(parseRunInput('  ')).toBe('');
+  });
+});
+
+describe('JsScriptEditorScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetDocumentHandlers();
+    mockStore = makeStore();
+  });
+
+  it('renders the body, metadata, and declared ports', () => {
+    renderScreen();
+
+    expect(
+      screen.getByDisplayValue('await output("total", inputs.numbers.length);')
+    ).toBeTruthy();
+    expect(screen.getByDisplayValue('Adds the numbers.')).toBeTruthy();
+    expect(screen.getByDisplayValue('numbers')).toBeTruthy();
+    expect(screen.getByDisplayValue('total')).toBeTruthy();
+    expect(screen.getByLabelText('Inputs 1 name')).toBeTruthy();
+    expect(screen.getByLabelText('Outputs 1 type')).toBeTruthy();
+  });
+
+  it('edits the body in place and marks the document dirty', () => {
+    renderScreen();
+
+    fireEvent.changeText(
+      screen.getByLabelText('Script body'),
+      'await emit("total", 1);'
+    );
+
+    expect(mockStore.getState().doc?.code).toBe('await emit("total", 1);');
+    expect(screen.getByLabelText('Unsaved changes')).toBeTruthy();
+  });
+
+  it('adds, renames, and removes a port', () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Add input'));
+    expect(mockStore.getState().doc?.inputs).toHaveLength(2);
+
+    fireEvent.changeText(screen.getByLabelText('Inputs 1 name'), 'values');
+    expect(mockStore.getState().doc?.inputs[0].name).toBe('values');
+
+    fireEvent.press(screen.getByLabelText('Remove input 2'));
+    expect(mockStore.getState().doc?.inputs).toHaveLength(1);
+  });
+
+  it('caps the timeout at the sandbox ceiling', () => {
+    renderScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Run timeout in seconds'), '999');
+
+    expect(mockStore.getState().doc?.timeoutSeconds).toBe(120);
+  });
+
+  it('reads the declared secrets out of one comma-separated field', () => {
+    renderScreen();
+
+    fireEvent.changeText(
+      screen.getByLabelText('Declared secrets'),
+      'OPENAI_API_KEY, FAL_API_KEY'
+    );
+
+    expect(mockStore.getState().doc?.secrets).toEqual([
+      'OPENAI_API_KEY',
+      'FAL_API_KEY',
+    ]);
+  });
+
+  it('shows the document-level issues the editor can decide on its own', () => {
+    mockStore = makeStore({
+      doc: makeDocument({ inputs: [{ name: 'my input', type: 'str' }] }),
+    });
+    renderScreen();
+
+    expect(
+      screen.getByText('input "my input" is not a valid identifier')
+    ).toBeTruthy();
+  });
+
+  it('saves before running, and runs with the typed inputs', async () => {
+    renderScreen();
+
+    fireEvent.changeText(screen.getByLabelText('Value for input numbers'), '[1, 2]');
+    fireEvent.press(screen.getByLabelText('Run script'));
+
+    await waitFor(() => expect(mockRunJsScript).toHaveBeenCalled());
+    // The endpoint runs the saved row, so an unsaved body must be flushed first.
+    expect(saveMock).toHaveBeenCalled();
+    expect(mockRunJsScript).toHaveBeenCalledWith(
+      'js-1',
+      { numbers: [1, 2] },
+      undefined
+    );
+    expect(await screen.findByText('Run succeeded')).toBeTruthy();
+  });
+
+  it('reports a failed run without claiming the tool call failed', async () => {
+    mockRunJsScript.mockResolvedValueOnce({
+      ok: false,
+      outputs: {},
+      logs: [],
+      duration_ms: 3,
+    });
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Run script'));
+
+    expect(await screen.findByText('Run failed')).toBeTruthy();
+  });
+
+  it('grades the saved cases and reports the tally', async () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Run saved test cases'));
+
+    expect(await screen.findByText('1 passed, 0 failed')).toBeTruthy();
+  });
+
+  it('disables the test button when there are no saved cases', () => {
+    mockStore = makeStore({ doc: makeDocument({ tests: [] }) });
+    renderScreen();
+
+    const button = screen.getByLabelText('Run saved test cases');
+    expect(button.props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('loads the document when it is not in the store yet', () => {
+    mockStore = makeStore({ doc: null, status: 'loading' });
+
+    renderScreen();
+
+    expect(loadMock).toHaveBeenCalled();
+  });
+
+  it('does not reload over unsaved edits', () => {
+    mockStore = makeStore({ dirty: true });
+
+    renderScreen();
+
+    expect(loadMock).not.toHaveBeenCalled();
+  });
+
+  it('offers a reload when the server rejected the write as stale', () => {
+    mockStore = makeStore({ status: 'conflict', error: 'modified since' });
+    renderScreen();
+
+    fireEvent.press(screen.getByLabelText('Reload JS script'));
+
+    expect(revertMock).toHaveBeenCalled();
+  });
+
+  it('saves through the store when the header button is pressed', () => {
+    mockStore = makeStore({ dirty: true });
+    renderScreen();
+
+    fireEvent.press(renderHeaderRight().getByLabelText('Save JS script'));
+
+    expect(saveMock).toHaveBeenCalled();
+  });
+
+  describe('agent handler', () => {
+    it('writes the body, ports, metadata, and cases through the same store', async () => {
+      renderScreen();
+
+      await act(async () => {
+        handler().setCode('await output("total", 9);');
+        handler().setPorts({ outputs: [{ name: 'sum', type: 'int' }] });
+        handler().setMeta({
+          name: 'Renamed',
+          description: 'Now it sums.',
+          secrets: ['FAL_API_KEY'],
+          timeoutSeconds: 15,
+        });
+        handler().setTests([{ name: 'one', inputs: { numbers: [1] } }]);
+      });
+
+      const state = mockStore.getState();
+      expect(state.doc?.code).toBe('await output("total", 9);');
+      expect(state.doc?.outputs).toEqual([{ name: 'sum', type: 'int' }]);
+      // The port side the agent did not name is left alone.
+      expect(state.doc?.inputs).toEqual([{ name: 'numbers', type: 'list[int]' }]);
+      expect(state.name).toBe('Renamed');
+      expect(state.doc?.description).toBe('Now it sums.');
+      expect(state.doc?.secrets).toEqual(['FAL_API_KEY']);
+      expect(state.doc?.timeoutSeconds).toBe(15);
+      expect(state.doc?.tests).toEqual([{ name: 'one', inputs: { numbers: [1] } }]);
+    });
+
+    it('reports the issues its own edit introduced', async () => {
+      renderScreen();
+
+      let issues: string[] = [];
+      await act(async () => {
+        issues = handler()
+          .setPorts({ inputs: [{ name: '2bad', type: 'str' }] })
+          .issues.map((issue) => issue.code);
+      });
+
+      expect(issues).toContain('js_script_port_name');
+    });
+
+    it('saves before it runs, and remembers the outcome for the next snapshot', async () => {
+      renderScreen();
+
+      await act(async () => {
+        await handler().run({ numbers: [1, 2] });
+      });
+
+      expect(saveMock).toHaveBeenCalled();
+      expect(mockRunJsScript).toHaveBeenCalledWith(
+        'js-1',
+        { numbers: [1, 2] },
+        undefined
+      );
+      expect(handler().getSnapshot().lastRun?.ok).toBe(true);
+    });
+
+    it('refuses to test a script with no saved cases', async () => {
+      mockStore = makeStore({ doc: makeDocument({ tests: [] }) });
+      renderScreen();
+
+      await expect(handler().test()).rejects.toThrow(/no saved test cases/);
+      expect(mockRunJsScript).not.toHaveBeenCalled();
+    });
+
+    it('turns a rejected save into a throw the agent can report', async () => {
+      mockStore = makeStore({ dirty: true });
+      saveMock.mockImplementationOnce(async () => {
+        mockStore.setState({ status: 'conflict', error: 'modified since' });
+      });
+      renderScreen();
+
+      await expect(handler().save()).rejects.toThrow('modified since');
+    });
+  });
+});

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -7,6 +7,7 @@ import type {
 import type {
   Workflow as AppWorkflow,
 } from '../types/ApiTypes';
+import type { JsScriptRunOutcome } from '../documents/jsScriptTypes';
 import { useAuthStore } from '../stores/AuthStore';
 import { createMobileTRPCClient } from '../trpc/client';
 import {
@@ -283,6 +284,55 @@ class ApiService {
     return this.request<ApplicationReleaseResponse | null>(
       `/api/applications/${encodeURIComponent(id)}/released-document`
     );
+  }
+
+  /**
+   * Execute a saved JS script in the server's QuickJS sandbox —
+   * `POST /api/js-scripts/:id/run`, the one non-tRPC door onto a script, shared
+   * with the web run console and the CLI harness. Nothing runs on the phone,
+   * and the endpoint runs the *saved* document, so callers save first.
+   *
+   * The timeout leaves room for the document's own ceiling
+   * (`JS_SCRIPT_MAX_TIMEOUT_SECONDS`, 120s) plus the round trip; the 30s
+   * default would abort a long run the server was still honoring.
+   */
+  async runJsScript(
+    scriptId: string,
+    inputs: Record<string, unknown>,
+    inputStreams?: Record<string, unknown[]>
+  ): Promise<JsScriptRunOutcome> {
+    try {
+      return await this.request<JsScriptRunOutcome>(
+        `/api/js-scripts/${encodeURIComponent(scriptId)}/run`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            inputs,
+            ...(inputStreams ? { input_streams: inputStreams } : {}),
+          }),
+        },
+        130_000
+      );
+    } catch (error) {
+      if (!(error instanceof ApiError)) {
+        throw error;
+      }
+      // The endpoint answers failures as `{detail}`; `ApiError.message` is the
+      // raw body. Unwrap it so the user (and the agent) reads the reason
+      // instead of a JSON blob.
+      let detail: unknown;
+      try {
+        detail = (JSON.parse(error.message) as { detail?: unknown }).detail;
+      } catch {
+        // Not JSON — fall through to the status message below.
+      }
+      throw new Error(
+        typeof detail === 'string' && detail.length > 0
+          ? detail
+          : `The script run failed (HTTP ${error.status}).`
+      );
+    }
   }
 
   async saveWorkflow(workflow: {


### PR DESCRIPTION
A JS script becomes the fifth document kind on the phone: it lists in the browser, opens in a pushed screen, and is writable by the chat agent through `ui_jsscript_*` — the same shape storyboards, scripts, timelines, and sketches already have.

## What changed

- **`documents/kinds.ts`** — new `jsscript` kind (`editor` surface, agent-editable, creatable), routed to a new `JsScriptEditor` screen, deep-linked at `document/jsscript/:id`.
- **`documents/backends.ts`** — a `jsScripts.*` transport. Its concurrency token is `baseUpdatedAt`, so it joins scripts on the non-`resources` side of the opaque-token split (the `js_scripts` table has no `revision` column). Row detail is the declared port counts.
- **`documents/jsScriptTypes.ts`** — the document shape, the document-level checks that need no parser (port identifiers, duplicates, empty secret names, timeout bounds, cases naming undeclared handles), and the saved-case grader. Both mirror their server-side originals: `validateJsScriptDocument` in the protocol package and `test_code`'s compare.
- **`screens/JsScriptEditorScreen.tsx`** — edits the body, declared ports, description, secrets and timeout; renders the validation issues; runs the script with per-input fields (JSON when it parses, plain text otherwise) and runs the saved cases. Nothing executes on the phone — `POST /api/js-scripts/:id/run` runs it in the server's QuickJS sandbox.
- **`documents/tools/jsScriptTools.ts`** — `ui_jsscript_get_state / set_code / set_ports / set_meta / set_tests / save / run / test`.
- **`services/api.ts`** — `runJsScript`, with a timeout above the document's own 120s ceiling and the endpoint's `{detail}` unwrapped into the error message.

## Deliberate differences from the web editor

- **No package tool.** A script imports whatever the host installs, and a phone cannot install a sandbox pack; the field round-trips untouched.
- **No autosave.** Edits mark the document dirty, as they do on every other mobile document screen — so `run` and `test` save first, because the endpoint executes the saved row.
- **Cases are shown and graded, not authored.** A case is a JSON bag per handle, which is faster to ask the assistant for than to type on a phone.

## Testing

`npm run typecheck`, `npm run lint`, and `npm test` all pass in `mobile/` (75 suites, 1038 tests). New coverage: `jsScriptTypes.test.ts` (validation + grading), `jsScriptTools.test.ts` (tool forwarding, and the not-open failure), `JsScriptEditorScreen.test.tsx` (21 cases: editing, run/test, conflict reload, and the agent handler), plus additions to `backends.test.ts` and `linking.test.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRiA3u6UgB9o7MCCRznE8D)_