### PR TITLE
feat(web): make the JS script tab usable on a phone

### DIFF
--- a/web/src/components/jsScript/JsScriptEditorPane.tsx
+++ b/web/src/components/jsScript/JsScriptEditorPane.tsx
@@ -4,6 +4,8 @@
  * keystroke lands in the store and autosaves.
  */
 import { memo, useCallback, useEffect, useMemo } from "react";
+import { useMediaQuery } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 
 import {
   Box,
@@ -29,6 +31,8 @@ const JsScriptEditorPane = ({
   scriptId,
   readOnly = false
 }: JsScriptEditorPaneProps) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const code = useJsScriptCode(scriptId);
   const setCode = useJsScriptStore((state) => state.setCode);
 
@@ -45,15 +49,25 @@ const JsScriptEditorPane = ({
     [scriptId, setCode]
   );
 
+  // On a phone there is no horizontal room to pan and no gutter to spare, so
+  // lines wrap, the line numbers and folding controls go away, and the
+  // scrollbars shrink to what a thumb can still hit.
   const editorOptions = useMemo(
     () => ({
       minimap: { enabled: false },
       automaticLayout: true,
       scrollBeyondLastLine: false,
       tabSize: 2,
-      readOnly
+      readOnly,
+      wordWrap: isMobile ? ("on" as const) : ("off" as const),
+      lineNumbers: isMobile ? ("off" as const) : ("on" as const),
+      folding: !isMobile,
+      lineDecorationsWidth: isMobile ? 0 : 10,
+      scrollbar: isMobile
+        ? { horizontal: "hidden" as const, verticalScrollbarSize: 8 }
+        : undefined
     }),
-    [readOnly]
+    [readOnly, isMobile]
   );
 
   return (

--- a/web/src/components/jsScript/JsScriptRunConsole.tsx
+++ b/web/src/components/jsScript/JsScriptRunConsole.tsx
@@ -123,7 +123,7 @@ const JsScriptRunConsole = ({
 
   return (
     <FlexColumn fullWidth gap={SPACING.sm} sx={{ minHeight: 0, flex: 1 }}>
-      <FlexRow gap={SPACING.sm} align="center" padding={1}>
+      <FlexRow gap={SPACING.sm} align="center" wrap padding={1}>
         <EditorButton
           density="compact"
           variant="contained"

--- a/web/src/components/jsScript/JsScriptRunDialog.tsx
+++ b/web/src/components/jsScript/JsScriptRunDialog.tsx
@@ -148,6 +148,8 @@ const JsScriptRunDialog = ({
       open={open}
       onClose={onClose}
       title="Run script"
+      fullWidth
+      maxWidth="sm"
       actions={
         <FlexRow gap={SPACING.md}>
           <EditorButton onClick={onClose}>Cancel</EditorButton>
@@ -159,7 +161,9 @@ const JsScriptRunDialog = ({
     >
       <NodeContext.Provider value={store}>
         <EditorUiProvider scope="inspector">
-          <FlexColumn gap={SPACING.md} sx={{ minWidth: 380 }}>
+          {/* Phones are narrower than the 380px the controls want, so the
+              floor only applies once there is room for it. */}
+          <FlexColumn gap={SPACING.md} sx={{ minWidth: { xs: 0, sm: 380 } }}>
             {inputs.length === 0 ? (
               <Text size="small" color="secondary">
                 This script declares no inputs. Run it as it is.

--- a/web/src/components/workspace/JsScriptSurface.tsx
+++ b/web/src/components/workspace/JsScriptSurface.tsx
@@ -1,6 +1,9 @@
 /** @jsxImportSource @emotion/react */
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTheme } from "@mui/material/styles";
+import { useMediaQuery } from "@mui/material";
+import CodeIcon from "@mui/icons-material/Code";
+import TerminalIcon from "@mui/icons-material/Terminal";
 import TuneIcon from "@mui/icons-material/Tune";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 
@@ -20,6 +23,7 @@ import {
   hasJsScriptAgentHandler
 } from "../jsScript/jsScriptAgentBridge";
 import {
+  Box,
   FlexColumn,
   FlexRow,
   TabGroup
@@ -40,11 +44,29 @@ interface JsScriptSurfaceProps {
 }
 
 type DockTab = "settings" | "assistant";
+type MobilePane = "code" | "console" | "settings" | "assistant";
 
 const DOCK_WIDTH = 340;
 const CONSOLE_HEIGHT = 220;
 
 const DEFAULT_NAME = "Untitled JS script";
+
+const MOBILE_TABS = [
+  { value: "code", label: "Code", icon: <CodeIcon /> },
+  { value: "console", label: "Run", icon: <TerminalIcon /> },
+  { value: "settings", label: "Script", icon: <TuneIcon /> },
+  { value: "assistant", label: "Assistant", icon: <AutoAwesomeIcon /> }
+];
+
+const MOBILE_PANES: readonly MobilePane[] = [
+  "code",
+  "console",
+  "settings",
+  "assistant"
+];
+
+const isMobilePane = (value: string): value is MobilePane =>
+  (MOBILE_PANES as readonly string[]).includes(value);
 
 /**
  * Workspace surface for a JS script tab. `refId` is the js_scripts row id. It
@@ -53,9 +75,15 @@ const DEFAULT_NAME = "Untitled JS script";
  * keeps the tab label in sync, and lays out the Code-assistant layout as a full
  * document editor: Monaco on the left, a dock that toggles between the
  * execution envelope and the assistant on the right, and the run console below.
+ *
+ * On phones neither the 340px dock nor the 220px console leaves room for the
+ * editor, so the four regions collapse to a single pane with a segmented
+ * switcher. Every pane stays mounted (toggled via `display`) so Monaco's model,
+ * the console output, and the assistant thread survive a switch.
  */
 const JsScriptSurface = ({ refId, mode, active }: JsScriptSurfaceProps) => {
   const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const ensureScript = useJsScriptStore((state) => state.ensureScript);
   const undo = useJsScriptStore((state) => state.undo);
   const redo = useJsScriptStore((state) => state.redo);
@@ -63,6 +91,7 @@ const JsScriptSurface = ({ refId, mode, active }: JsScriptSurfaceProps) => {
   const name = useJsScriptName(refId);
   const readOnly = mode === "view";
   const [dockTab, setDockTab] = useState<DockTab>("settings");
+  const [mobilePane, setMobilePane] = useState<MobilePane>("code");
 
   useEffect(() => {
     ensureScript(refId);
@@ -118,6 +147,66 @@ const JsScriptSurface = ({ refId, mode, active }: JsScriptSurfaceProps) => {
     []
   );
 
+  const editor = <JsScriptEditorPane scriptId={refId} readOnly={readOnly} />;
+  const runConsole = (
+    <JsScriptRunConsole
+      scriptId={refId}
+      readOnly={readOnly}
+      onRun={handleRun}
+      onTest={handleTest}
+    />
+  );
+  const settings = (
+    <JsScriptSettingsPanel scriptId={refId} readOnly={readOnly} />
+  );
+  const assistant = <JsScriptAgentPanel scriptId={refId} />;
+
+  if (isMobile) {
+    return (
+      <FlexColumn fullHeight sx={{ minHeight: 0 }}>
+        <TabGroup
+          tabs={MOBILE_TABS}
+          value={mobilePane}
+          onChange={(value) => {
+            if (isMobilePane(value)) {
+              setMobilePane(value);
+            }
+          }}
+          size="small"
+          fullWidth
+          sx={{
+            flexShrink: 0,
+            borderBottom: `1px solid ${theme.vars.palette.divider}`
+          }}
+        />
+        <Box sx={{ flex: 1, minHeight: 0, position: "relative" }}>
+          {MOBILE_PANES.map((pane) => (
+            <FlexColumn
+              key={pane}
+              fullWidth
+              padding={pane === "code" ? 1 : 0}
+              sx={{
+                position: "absolute",
+                inset: 0,
+                minHeight: 0,
+                overflow: "hidden",
+                display: mobilePane === pane ? "flex" : "none"
+              }}
+            >
+              {pane === "code"
+                ? editor
+                : pane === "console"
+                  ? runConsole
+                  : pane === "settings"
+                    ? settings
+                    : assistant}
+            </FlexColumn>
+          ))}
+        </Box>
+      </FlexColumn>
+    );
+  }
+
   return (
     <FlexRow fullHeight sx={{ minHeight: 0 }}>
       <FlexColumn fullHeight sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
@@ -126,7 +215,7 @@ const JsScriptSurface = ({ refId, mode, active }: JsScriptSurfaceProps) => {
           padding={1}
           sx={{ flex: 1, minHeight: 0 }}
         >
-          <JsScriptEditorPane scriptId={refId} readOnly={readOnly} />
+          {editor}
         </FlexColumn>
 
         <FlexColumn
@@ -138,12 +227,7 @@ const JsScriptSurface = ({ refId, mode, active }: JsScriptSurfaceProps) => {
             borderTop: `1px solid ${theme.vars.palette.divider}`
           }}
         >
-          <JsScriptRunConsole
-            scriptId={refId}
-            readOnly={readOnly}
-            onRun={handleRun}
-            onTest={handleTest}
-          />
+          {runConsole}
         </FlexColumn>
       </FlexColumn>
 
@@ -164,11 +248,7 @@ const JsScriptSurface = ({ refId, mode, active }: JsScriptSurfaceProps) => {
           }}
         />
         <FlexColumn fullWidth sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
-          {dockTab === "settings" ? (
-            <JsScriptSettingsPanel scriptId={refId} readOnly={readOnly} />
-          ) : (
-            <JsScriptAgentPanel scriptId={refId} />
-          )}
+          {dockTab === "settings" ? settings : assistant}
         </FlexColumn>
       </ResizableSideDock>
     </FlexRow>

--- a/web/src/components/workspace/__tests__/JsScriptSurfaceMobile.test.tsx
+++ b/web/src/components/workspace/__tests__/JsScriptSurfaceMobile.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * JsScriptSurface — mobile layout
+ *
+ * On a phone the editor, run console, script settings, and assistant collapse
+ * to one pane behind a segmented switcher. Every pane stays mounted so Monaco's
+ * model and the console output survive a switch; only one is displayed.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+
+import JsScriptSurface from "../JsScriptSurface";
+import mockTheme from "../../../__mocks__/themeMock";
+
+jest.mock("@mui/material/useMediaQuery", () => () => true);
+
+jest.mock("../../../hooks/jsScript/useJsScriptServerSync", () => ({
+  useJsScriptServerSync: jest.fn()
+}));
+jest.mock("../../../hooks/jsScript/useJsScriptAgentBridge", () => ({
+  useJsScriptAgentBridge: jest.fn()
+}));
+jest.mock("../../../hooks/useDocumentUndoShortcuts", () => ({
+  useDocumentUndoShortcuts: jest.fn()
+}));
+
+jest.mock("../../jsScript/JsScriptEditorPane", () => () => (
+  <div data-testid="editor-pane" />
+));
+jest.mock("../../jsScript/JsScriptRunConsole", () => () => (
+  <div data-testid="run-console" />
+));
+jest.mock("../../jsScript/JsScriptSettingsPanel", () => () => (
+  <div data-testid="settings-panel" />
+));
+jest.mock("../../jsScript/JsScriptAgentPanel", () => () => (
+  <div data-testid="agent-panel" />
+));
+
+jest.mock("../../../stores/jsScript/JsScriptStore", () => ({
+  useJsScriptName: () => "My script",
+  useJsScriptStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      ensureScript: jest.fn(),
+      undo: jest.fn(),
+      redo: jest.fn()
+    })
+}));
+
+jest.mock("../../../stores/WorkspaceTabsStore", () => ({
+  useWorkspaceTabsStore: (selector: (state: unknown) => unknown) =>
+    selector({ setTitle: jest.fn() })
+}));
+
+const renderSurface = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <JsScriptSurface refId="script-1" mode="edit" active />
+    </ThemeProvider>
+  );
+
+/** The pane wrapper is the displayed ancestor of the mocked child. */
+const paneOf = (testId: string): HTMLElement =>
+  screen.getByTestId(testId).parentElement as HTMLElement;
+
+describe("JsScriptSurface on mobile", () => {
+  it("keeps every pane mounted and shows the code pane first", () => {
+    renderSurface();
+
+    expect(screen.getByTestId("editor-pane")).toBeInTheDocument();
+    expect(screen.getByTestId("run-console")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-panel")).toBeInTheDocument();
+
+    expect(paneOf("editor-pane")).toHaveStyle({ display: "flex" });
+    expect(paneOf("run-console")).toHaveStyle({ display: "none" });
+  });
+
+  it("switches the displayed pane without unmounting the editor", async () => {
+    const user = userEvent.setup();
+    renderSurface();
+
+    await user.click(screen.getByRole("tab", { name: /run/i }));
+
+    expect(screen.getByTestId("editor-pane")).toBeInTheDocument();
+    expect(paneOf("editor-pane")).toHaveStyle({ display: "none" });
+    expect(paneOf("run-console")).toHaveStyle({ display: "flex" });
+  });
+
+  it("does not render the desktop side dock", () => {
+    renderSurface();
+
+    expect(
+      screen.queryByLabelText("Resize JS script assistant")
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

The JS script surface put a 340px assistant dock beside the editor and a 220px run console under it. On a phone that leaves almost nothing for the editor itself.

Below the `sm` breakpoint the four regions now collapse to one pane behind a segmented switcher — **Code / Run / Script / Assistant** — the same shape `StoryboardSurface` uses. Every pane stays mounted and is toggled via `display`, so Monaco's model, the console output, and the assistant thread survive a switch.

Three smaller fixes on the same path:

- **Monaco**: wraps lines and drops line numbers, folding, and the horizontal scrollbar on mobile — there is no room to pan sideways, and the gutter costs characters.
- **Run dialog**: its `minWidth: 380` floor overflowed a 360px viewport. The floor now applies from `sm` up, and the dialog goes full width.
- **Run console toolbar**: wraps, so the "Runs use the saved script" status text no longer pushes off screen next to the Run/Test buttons.

The desktop layout is unchanged.

## Testing

New `JsScriptSurfaceMobile.test.tsx` covers the mobile branch: every pane mounted, code pane shown first, switching to Run without unmounting the editor, and no side dock. All three assertions were confirmed to fail when the `useMediaQuery` mock is flipped to the desktop layout, so they test the branch rather than passing vacuously.

- `npx jest` in `web/` — 1112 suites, 12868 tests, all green.
- `oxlint` clean on `src/components/jsScript` and `src/components/workspace`.
- `tsc --noEmit` reports no errors in the touched files. The 197 errors it does report are all in unbuilt `packages/*` and predate this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Si5QLZgck12wCTrEsFEGWD)_