### PR TITLE
fix(fal-nodes): declare required asset inputs as required

### DIFF
--- a/packages/fal-nodes/src/fal-factory.ts
+++ b/packages/fal-nodes/src/fal-factory.ts
@@ -234,20 +234,24 @@ function validateRequiredAssetArgs(
       field.propType
     );
     const suffix =
-      field.name === "mask" ? " and match image dimensions" : "";
+      field.name === "mask" ? " (it must match the image dimensions)" : "";
+    // The node is reachable outside a graph — `run_node`, the single-node
+    // harness, a CodeAct script — so the message names both ways to supply
+    // the asset instead of assuming an incoming edge.
+    const message =
+      `${nodeTitle}: ${fieldLabel(field)} is not set — connect an input or ` +
+      `set the property to ${kind === "video" ? "a" : "an"} ${kind} with a ` +
+      `uri, asset_id, or inline data` +
+      suffix;
     if (isListAsset(field.propType)) {
       const list = value as Record<string, unknown>[] | undefined;
       if (!list?.some((ref) => isRefSet(ref))) {
-        throw new Error(
-          `${nodeTitle}: ${fieldLabel(field)} must be connected${suffix}`
-        );
+        throw new Error(message);
       }
       continue;
     }
     if (!isRefSet(value)) {
-      throw new Error(
-        `${nodeTitle}: ${fieldLabel(field)} must be connected${suffix}`
-      );
+      throw new Error(message);
     }
   }
 }
@@ -650,6 +654,15 @@ export function createFalNodeClass(spec: FalManifestEntry): NodeClass {
       type: field.propType,
       default: manifestDefault ?? defaultForPropType(field.propType)
     };
+    // A required asset input left empty fails inside process() with no way to
+    // see it coming. Declaring it required puts it in front of the static
+    // validators (`validate_workflow`, the runner's pre-flight), which report
+    // it before the run starts — and before an agent pays for the upstream
+    // half of a graph. Only asset fields: the non-asset ones carry manifest
+    // defaults that already satisfy the requirement.
+    if (field.required && isAssetPropType(field.propType)) {
+      propOptions.required = true;
+    }
     if (field.description) propOptions.description = field.description;
     if (field.enumValues?.length) propOptions.values = field.enumValues;
     if (field.min !== undefined) propOptions.min = field.min;

--- a/packages/fal-nodes/tests/fal-factory.test.ts
+++ b/packages/fal-nodes/tests/fal-factory.test.ts
@@ -348,9 +348,84 @@ describe("FAL factory argument building", () => {
     });
 
     await expect(new NodeClass({}).process()).rejects.toThrow(
-      "Flux Pro Fill: Mask must be connected and match image dimensions"
+      "Flux Pro Fill: Mask is not set — connect an input or set the property to an image with a uri, asset_id, or inline data (it must match the image dimensions)"
     );
     expect(falSubmit).not.toHaveBeenCalled();
+  });
+
+  it("declares required asset inputs as required so validation catches them", () => {
+    const NodeClass = createFalNodeClass({
+      endpointId: "fal-ai/bria/background/remove",
+      className: "BriaBackgroundRemove",
+      moduleName: "image_to_image",
+      docstring: "test",
+      tags: [],
+      useCases: [],
+      outputType: "image",
+      outputFields: [],
+      enums: [],
+      inputFields: [
+        {
+          name: "image",
+          propType: "image",
+          tsType: "image",
+          default: null,
+          description: "",
+          fieldType: "input",
+          required: true,
+          apiParamName: "image_url"
+        },
+        {
+          name: "sync_mode",
+          propType: "bool",
+          tsType: "boolean",
+          default: false,
+          description: "",
+          fieldType: "input",
+          required: false
+        }
+      ]
+    });
+
+    const declared = new Map(
+      (
+        NodeClass as unknown as {
+          getDeclaredProperties(): Array<{
+            name: string;
+            options: { required?: boolean };
+          }>;
+        }
+      )
+        .getDeclaredProperties()
+        .map((entry) => [entry.name, entry.options.required])
+    );
+    expect(declared.get("image")).toBe(true);
+    // Non-asset fields keep their manifest default, so they stay optional.
+    expect(declared.get("sync_mode")).toBeUndefined();
+
+    const issues = (
+      NodeClass as unknown as {
+        validateProperties(
+          properties: Record<string, unknown>
+        ): Array<{ property: string; code: string; message: string }>;
+      }
+    ).validateProperties({ image: { type: "image" } });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.property).toBe("image");
+    expect(issues[0]?.code).toBe("required");
+
+    // A ref carrying a uri validates.
+    expect(
+      (
+        NodeClass as unknown as {
+          validateProperties(
+            properties: Record<string, unknown>
+          ): unknown[];
+        }
+      ).validateProperties({
+        image: { type: "image", uri: "https://example.com/a.png" }
+      })
+    ).toEqual([]);
   });
 
   const makeNode = (overrides: Partial<Parameters<typeof createFalNodeClass>[0]>) =>


### PR DESCRIPTION
## What

FAL nodes built from the manifest never carried `required` on their declared properties, even when the manifest marks an input required. Two consequences for `fal.image_to_image.BriaBackgroundRemove` and every other FAL node with a required image/video/audio input:

1. Nothing checked the input before the run. `nodetool validate` / `validate_workflow` and the runner's pre-flight both passed a graph whose `image` was an empty ref, and the failure only surfaced inside `process()` — after the upstream half of the graph had already been paid for.
2. The runtime message assumed a graph edge: `Bria Background Remove: image must be connected`. Reached through `run_node` (or CodeAct's `nodetool.nodes.run`), where there are no edges, it says nothing an agent can act on.

Reported from a CodeAct script that called `nodetool.nodes.run("fal.image_to_image.BriaBackgroundRemove", { image: { type: "image", uri: assetUri } })` with an empty `assetUri`.

## Changes

- `fal-factory.ts`: required **asset** inputs are declared `required: true`, so `validateNodeProperties` reports `Property "image" requires a image (asset, uri, or inline data)` before the run starts. Non-asset fields stay optional — their manifest defaults already satisfy the requirement, and declaring them required would refuse runs that legitimately pass an empty string.
- Reworded the runtime error to name both ways to supply the asset: `Bria Background Remove: image is not set — connect an input or set the property to an image with a uri, asset_id, or inline data`.
- Tests: the required flag reaches declared metadata, `validateProperties` flags an empty ref and accepts one carrying a uri; the existing mask-error test tracks the new wording.

## Verification

- Reproduced first: a one-node graph run through `ExecutionSession` fails with the old message exactly when the ref carries no `uri`/`asset_id`/`data`, and passes through to the FAL call otherwise.
- After the change, that same graph is refused by the pre-flight validator instead, and `nodetool validate` on a one-node fixture reports the property error.
- `npm run dev:nodetool -- harness gate --all` — 8/8 selfchecks pass, including `validate:examples` (no shipped example workflow is newly refused).
- `packages/fal-nodes`, `cli`, `deploy`, `model-pricing`, `websocket` suites pass; `tsc --noEmit` and `oxlint` clean on the changed package.
- The repo-wide `npm run lint` and `npm run typecheck` fail in this sandbox for unrelated reasons that predate the change: `@oxlint/plugins` is not installed for the anti-slop leg, and `mobile/` has no Expo dependency tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLhZvJuvBbPMtgFXqSsA2z)_