### PR TITLE
feat(bridge): carry run identity and a run boundary over the Python bridge

### DIFF
--- a/docs/python-bridge-protocol.md
+++ b/docs/python-bridge-protocol.md
@@ -59,7 +59,10 @@ Returns the worker's executable node inventory.
 Response data:
 
 - `protocol_version`
-- `nodes`
+- `nodes` — each entry may carry `requires_vram_gb` (v4+): the approximate VRAM
+  that node type's weights need, in GiB. The JS side echoes it back on
+  `execute` so the worker's reclaim pass has a real number to target instead of
+  a percentage threshold.
 - `load_errors`
 
 Example:
@@ -108,6 +111,25 @@ Request data:
 - `secrets`
 - `blobs`
 
+Run identity, added in **v4**. Every field is optional, and a field the JS host
+cannot name is omitted rather than sent as null:
+
+- `node_id` — the graph node id. Becomes the constructed node's `_id`. Before
+  v4 the worker built every node with no id, so `self._id` was `""` for all of
+  them: a node calling `set_model(self._id, …)` registered into a single shared
+  bucket, and `release_nodes()` had nothing meaningful to release. `node_id` is
+  what makes the worker's node → model map real.
+- `job_id` — pairs the execution with the `job.start` / `job.end` boundary.
+- `workflow_id`, `user_id` — populate the worker's `WorkerContext`, which
+  previously had neither.
+- `requires_vram_gb` — the hint the worker itself reported for this node type at
+  `discover`.
+
+These are extra dict entries, so the JS side sends them **unconditionally**
+rather than behind the v4 capability gate: a pre-v4 worker reads the four keys
+it knows and ignores the rest, and gating would only starve a worker that does
+understand them whenever its `worker.status` has not landed yet.
+
 Possible response types:
 
 - `progress`
@@ -117,9 +139,9 @@ Possible response types:
 ### `execute.stream`
 
 Executes a Python node that streams results. Same request data as `execute`
-(`node_type`, `fields`, `secrets`, `blobs`), but the worker emits zero or more
-`chunk` messages (each carrying partial `outputs`/`blobs`) followed by a
-terminal `result` or `error`.
+(including the v4 identity fields), but the worker emits zero or more `chunk`
+messages (each carrying partial `outputs`/`blobs`) followed by a terminal
+`result` or `error`.
 
 ### `cancel`
 
@@ -150,6 +172,45 @@ simply does not expose them (see [Versioning](#versioning)).
 - `models.list_cached` — list models cached on the worker's `HF_HOME` (cache-only, no network)
 - `models.download` — download a model onto the worker cache, streaming ordered `progress` frames then a terminal `result`
 - `models.delete` — delete a cached model; returns whether it existed
+- `models.evict` (**v4**, gated by `supportsJobLifecycle()`) — drop loaded model
+  weights. Optional request data narrows the scope: `node_ids`, `job_id`,
+  `target_vram_gb` (stop once that many GiB are reclaimed). Response data is
+  `{evicted: string[], freed_vram_gb?: number}`. This is the path for what only
+  the JS side knows — the user switched workflows, another process wants the
+  GPU, the worker is idle. Without it the worker only ever reclaims reactively,
+  on its own thresholds. Calling it against a pre-v4 worker resolves to
+  `{evicted: []}` instead of erroring, so a host asking to free memory never has
+  to branch on the worker's version.
+
+### `job.*`
+
+The run boundary. Introduced in bridge protocol **v4** and gated by
+`supportsJobLifecycle()`.
+
+- `job.start` — opens a run. Request data: `job_id`, plus optional
+  `workflow_id` / `user_id`. Optional in the sense that the worker needs no
+  `job.start` to attribute an execution (every `execute` carries its own
+  `job_id`); it exists as the one place to do a single reclaim pass per run
+  instead of one per node.
+- `job.end` — closes a run. Same data plus `reason`
+  (`completed` | `failed` | `cancelled` | `abandoned`). The job's nodes are
+  retired and their models become eligible for release. This is the caller
+  `release_nodes()` never had: without it the worker's model cache grows across
+  runs and is only ever trimmed reactively under memory pressure.
+
+`job.end` must fire on abnormal termination too — cancelled, client
+disconnected, run abandoned — or the leak simply moves to the failure path.
+On the JS side `ExecutionSession` sends it from the same `finally` that closes
+the bridge, so completion, failure, cancellation and timeout all reach it. Both
+calls are fire-and-forget and swallow their own failures: a boundary is
+bookkeeping, and a `job.end` that fails against a worker already tearing down
+must not turn a finished run into a failed one.
+
+A host that owns a long-lived shared bridge (the WebSocket runner) and injects
+its own executor resolver must pass that bridge to the session as
+`jobLifecycleBridge` — that host's `bridgeFactory` deliberately returns null, so
+without it nothing closes the boundary for the exact deployment the shared
+bridge exists for.
 
 ### `comfy.*`
 
@@ -274,7 +335,7 @@ The JS runtime and Python worker each report a `BRIDGE_PROTOCOL_VERSION`. Two
 distinct numbers govern compatibility (see `packages/protocol/src/bridge-protocol.ts`):
 
 - **`BRIDGE_PROTOCOL_VERSION`** — the protocol the JS runtime currently speaks
-  (presently `3`).
+  (presently `4`).
 - **`MIN_BRIDGE_PROTOCOL_VERSION`** — the *hard floor* (presently `1`). The JS
   runtime rejects a worker only if it reports a protocol **below** this floor.
 
@@ -283,9 +344,16 @@ Compatibility rules:
 - **Older worker, at or above the floor** — connects normally. It does **not**
   fail startup. Additive features the worker predates are gated per-capability:
   a v1 worker connects fine and simply doesn't expose the `models.*` family
-  (gated by `supportsModelManagement()`, which requires v2+) or `comfy.*`
-  (gated by `supportsComfy()`, which requires v3+ and `comfy.enabled`). Workers
-  that predate the `protocol_version` field are treated as v1.
+  (gated by `supportsModelManagement()`, which requires v2+), `comfy.*` (gated
+  by `supportsComfy()`, which requires v3+ and `comfy.enabled`), or `job.*` /
+  `models.evict` (gated by `supportsJobLifecycle()`, which requires v4+).
+  Workers that predate the `protocol_version` field are treated as v1.
+
+  The v4 identity fields on `execute` are the exception that proves the rule:
+  they are extra keys on an existing message, not a new message, so they are
+  sent to every worker and ignored by the ones that predate them. Only new
+  message *types* need a capability gate, because those are what a worker
+  answers with `Unknown message type`.
 - **Worker below `MIN_BRIDGE_PROTOCOL_VERSION`** — rejected at `discover` with
   an actionable error (reinstall the Python environment). This is the only
   startup-failing case, reserved for genuine wire breaks.

--- a/packages/execution/src/session.ts
+++ b/packages/execution/src/session.ts
@@ -15,6 +15,7 @@ import {
   type RunResult
 } from "@nodetool-ai/kernel";
 import { ProcessingContext, connectPythonBridgeForGraph } from "@nodetool-ai/runtime";
+import type { PythonJobLifecycle } from "@nodetool-ai/runtime";
 import type { HydratedGraphData, ProcessingMessage } from "@nodetool-ai/protocol";
 import { createExecutorResolver } from "./executor-resolver.js";
 import { buildWorkspaceExecutionContext } from "./service/workflow-workspace.js";
@@ -49,6 +50,8 @@ export class ExecutionSession {
     params: Record<string, unknown>;
     triggerEvent: ExecutionSessionOptions["triggerEvent"];
     bridge: { pendingRequestCount?: number } | null;
+    lifecycle: PythonJobLifecycle | null;
+    userId: string;
     closeBridge: () => void;
     runTimeoutMs: number | undefined;
     captureMessages: boolean;
@@ -70,6 +73,18 @@ export class ExecutionSession {
       }, init.runTimeoutMs);
     }
 
+    // Open the run boundary on the Python worker before the kernel starts, so
+    // an execute frame can never arrive ahead of the job it belongs to. Fire
+    // and forget: `jobStart` is a no-op on a pre-v4 worker and swallows its own
+    // failures, and blocking the kernel on worker bookkeeping would make an
+    // unreachable worker a run failure.
+    const boundary = {
+      jobId: init.jobId,
+      workflowId: init.workflowId,
+      userId: init.userId
+    };
+    void init.lifecycle?.jobStart(boundary);
+
     this.resultPromise = init.runner
       .run(
         {
@@ -79,6 +94,22 @@ export class ExecutionSession {
           ...(init.triggerEvent ? { trigger_event: init.triggerEvent } : {})
         },
         init.graph
+      )
+      .then(
+        (result) => {
+          void init.lifecycle?.jobEnd({
+            ...boundary,
+            reason: this.endReason(result.status)
+          });
+          return result;
+        },
+        (err: unknown) => {
+          // `run()` documents that it never rejects, but the boundary must
+          // close even if that ever stops being true — an abandoned run is
+          // exactly the leak `job.end` exists to prevent.
+          void init.lifecycle?.jobEnd({ ...boundary, reason: "abandoned" });
+          throw err;
+        }
       )
       .finally(() => {
         if (this.runTimeoutHandle) {
@@ -100,6 +131,19 @@ export class ExecutionSession {
           error: err instanceof Error ? err.message : String(err)
         });
       });
+  }
+
+  /**
+   * Map a kernel run status onto the `job.end` reason. A suspended run is
+   * still `completed` as far as the worker is concerned: its nodes are done
+   * and their weights are eligible — resuming builds new ones.
+   */
+  private endReason(
+    status: RunResult["status"]
+  ): "completed" | "failed" | "cancelled" {
+    if (status === "failed") return "failed";
+    if (status === "cancelled") return "cancelled";
+    return "completed";
   }
 
   static async create(
@@ -223,6 +267,8 @@ export class ExecutionSession {
       params: options.params ?? {},
       triggerEvent: options.triggerEvent ?? null,
       bridge,
+      lifecycle: options.jobLifecycleBridge ?? bridge,
+      userId: context.userId,
       closeBridge,
       runTimeoutMs: options.limits?.runTimeoutMs,
       captureMessages: options.captureMessages === true,

--- a/packages/execution/src/types.ts
+++ b/packages/execution/src/types.ts
@@ -15,7 +15,11 @@ import type {
   SupervisorHandle
 } from "@nodetool-ai/kernel";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
-import type { PythonBridgeBase, ProcessingContext } from "@nodetool-ai/runtime";
+import type {
+  PythonBridgeBase,
+  ProcessingContext,
+  PythonJobLifecycle
+} from "@nodetool-ai/runtime";
 
 /** A raw saved graph — the shape stored in the DB / sent over the wire. */
 export interface RawGraphInput {
@@ -116,6 +120,20 @@ export interface ExecutionSessionOptions {
   resolveNodeType?: NodeTypeResolver;
   /** See {@link BridgeFactory}. Omit to use the default TS-graph-aware connector. */
   bridgeFactory?: BridgeFactory;
+  /**
+   * Python bridge to bracket this run with `job.start` / `job.end` (bridge
+   * protocol v4). Defaults to whatever `bridgeFactory` returned, which is the
+   * right answer for a host whose bridge lives and dies with the run — the
+   * session closes it anyway.
+   *
+   * A host that owns a long-lived shared bridge and injects its own
+   * `resolveExecutor` (the WS runner) gets `null` from its `bridgeFactory` on
+   * purpose, so it must pass that bridge here. Without it nothing ever closes
+   * the run boundary, `release_nodes()` on the worker keeps having no caller,
+   * and the model cache grows across runs — which is the exact case the shared
+   * bridge exists for.
+   */
+  jobLifecycleBridge?: PythonJobLifecycle | null;
   /** Fixed job id; a random one is generated when omitted. */
   jobId?: string;
   workflowId?: string | null;

--- a/packages/execution/tests/session-job-boundary.test.ts
+++ b/packages/execution/tests/session-job-boundary.test.ts
@@ -1,0 +1,175 @@
+/**
+ * `ExecutionSession` brackets every run with the Python worker's `job.start` /
+ * `job.end` boundary (bridge protocol v4).
+ *
+ * `job.end` is the caller the worker's `release_nodes()` never had, so what
+ * matters here is not the happy path but that the boundary closes on the
+ * abnormal ones too. A `job.end` that only fires on clean completion moves the
+ * model-cache leak to the failure path instead of fixing it.
+ */
+import { describe, it, expect } from "vitest";
+import type { JobBoundary, PythonJobLifecycle } from "@nodetool-ai/runtime";
+import { ExecutionSession } from "../src/index.js";
+import { buildTestRegistry } from "./fixtures.js";
+
+const NO_BRIDGE = async () => null;
+
+function recordingLifecycle(supported = true): PythonJobLifecycle & {
+  starts: JobBoundary[];
+  ends: JobBoundary[];
+} {
+  const starts: JobBoundary[] = [];
+  const ends: JobBoundary[] = [];
+  return {
+    starts,
+    ends,
+    supportsJobLifecycle: () => supported,
+    jobStart: async (job) => {
+      starts.push(job);
+    },
+    jobEnd: async (job) => {
+      ends.push(job);
+    }
+  };
+}
+
+/** A run that settles cleanly. */
+const VALUE_GRAPH = {
+  nodes: [
+    { id: "v", type: "nodetool.input.Value", properties: {} },
+    { id: "double", type: "test.execution.Double", properties: {} }
+  ],
+  edges: [
+    {
+      source: "v",
+      sourceHandle: "output",
+      target: "double",
+      targetHandle: "value"
+    }
+  ]
+};
+
+/** Start params for {@link VALUE_GRAPH}. */
+const VALUE_PARAMS = { v: 21 };
+
+/** A run that never ends on its own — cancel or time out to settle it. */
+const LOOP_GRAPH = {
+  nodes: [{ id: "loop", type: "test.execution.Loop", properties: {} }],
+  edges: []
+};
+
+describe("ExecutionSession — job.start / job.end boundary", () => {
+  it("opens the boundary before the run and closes it on completion", async () => {
+    const lifecycle = recordingLifecycle();
+    const session = await ExecutionSession.create({
+      graph: VALUE_GRAPH,
+      registry: buildTestRegistry(),
+      bridgeFactory: NO_BRIDGE,
+      jobLifecycleBridge: lifecycle,
+      jobId: "job-1",
+      workflowId: "wf-1",
+      params: VALUE_PARAMS
+    });
+
+    const result = await session.result;
+    expect(result.status).toBe("completed");
+
+    expect(lifecycle.starts).toEqual([
+      { jobId: "job-1", workflowId: "wf-1", userId: "1" }
+    ]);
+    expect(lifecycle.ends).toEqual([
+      { jobId: "job-1", workflowId: "wf-1", userId: "1", reason: "completed" }
+    ]);
+  });
+
+  it("closes the boundary on a cancelled run", async () => {
+    const lifecycle = recordingLifecycle();
+    const session = await ExecutionSession.create({
+      graph: LOOP_GRAPH,
+      registry: buildTestRegistry(),
+      bridgeFactory: NO_BRIDGE,
+      jobLifecycleBridge: lifecycle,
+      jobId: "job-2"
+    });
+
+    await new Promise((r) => setTimeout(r, 30));
+    session.cancel("user-requested");
+    expect((await session.result).status).toBe("cancelled");
+
+    expect(lifecycle.ends).toHaveLength(1);
+    expect(lifecycle.ends[0]!.reason).toBe("cancelled");
+  });
+
+  it("closes the boundary on a run abandoned by the timeout", async () => {
+    const lifecycle = recordingLifecycle();
+    const session = await ExecutionSession.create({
+      graph: LOOP_GRAPH,
+      registry: buildTestRegistry(),
+      bridgeFactory: NO_BRIDGE,
+      jobLifecycleBridge: lifecycle,
+      jobId: "job-3",
+      limits: { runTimeoutMs: 30 }
+    });
+
+    expect((await session.result).status).toBe("cancelled");
+    expect(lifecycle.ends[0]).toMatchObject({
+      jobId: "job-3",
+      reason: "cancelled"
+    });
+  });
+
+  it("closes the boundary on a failed run", async () => {
+    const lifecycle = recordingLifecycle();
+    const session = await ExecutionSession.create({
+      graph: {
+        nodes: [{ id: "x", type: "test.execution.DoesNotExist", properties: {} }],
+        edges: []
+      },
+      registry: buildTestRegistry(),
+      bridgeFactory: NO_BRIDGE,
+      jobLifecycleBridge: lifecycle,
+      jobId: "job-4"
+    });
+
+    expect((await session.result).status).toBe("failed");
+    expect(lifecycle.ends[0]).toMatchObject({
+      jobId: "job-4",
+      reason: "failed"
+    });
+  });
+
+  it("does not block the run on the boundary call", async () => {
+    // jobStart is fire-and-forget: a worker that never answers must not turn
+    // into a run that never starts.
+    let released: (() => void) | null = null;
+    const lifecycle: PythonJobLifecycle = {
+      supportsJobLifecycle: () => true,
+      jobStart: () => new Promise<void>((r) => (released = r)),
+      jobEnd: async () => {}
+    };
+
+    const session = await ExecutionSession.create({
+      graph: VALUE_GRAPH,
+      registry: buildTestRegistry(),
+      bridgeFactory: NO_BRIDGE,
+      jobLifecycleBridge: lifecycle,
+      jobId: "job-5",
+      params: VALUE_PARAMS
+    });
+
+    expect((await session.result).status).toBe("completed");
+    released?.();
+  });
+
+  it("runs unchanged when the host wires no lifecycle bridge", async () => {
+    const session = await ExecutionSession.create({
+      graph: VALUE_GRAPH,
+      registry: buildTestRegistry(),
+      bridgeFactory: NO_BRIDGE,
+      jobId: "job-6",
+      params: VALUE_PARAMS
+    });
+
+    expect((await session.result).status).toBe("completed");
+  });
+});

--- a/packages/protocol/src/bridge-frames.ts
+++ b/packages/protocol/src/bridge-frames.ts
@@ -69,7 +69,11 @@ const pythonNodeMetadataSchema = z
     description: z.string().optional(),
     properties: z.array(z.record(z.string(), z.unknown())).optional(),
     outputs: z.array(z.record(z.string(), z.unknown())).optional(),
-    required_settings: z.array(z.string()).optional()
+    required_settings: z.array(z.string()).optional(),
+    // Protocol v4: approximate VRAM the node's weights need, in GiB. The JS
+    // side echoes it back on `execute` so the worker's reclaim pass has a
+    // number to target instead of a percentage threshold.
+    requires_vram_gb: z.number().optional()
   })
   .passthrough();
 

--- a/packages/protocol/src/bridge-protocol.ts
+++ b/packages/protocol/src/bridge-protocol.ts
@@ -46,15 +46,23 @@
  *   3. Update `MIN_NODETOOL_CORE_VERSION` to that new release.
  */
 
-export const BRIDGE_PROTOCOL_VERSION = 3;
+export const BRIDGE_PROTOCOL_VERSION = 4;
 
 /**
  * Hard floor: the JS runtime rejects (at `discover`) any worker reporting a
  * protocol below this. Stays at 1 because every protocol change so far has
- * been additive — `models.*` (v2) is negotiated via `supportsModelManagement`
- * and `comfy.*` (v3) via `supportsComfy`, so a v1 worker still connects and
- * runs every pre-v2 feature; it just doesn't expose the newer families. Move
- * this only for a real wire break.
+ * been additive — `models.*` (v2) is negotiated via `supportsModelManagement`,
+ * `comfy.*` (v3) via `supportsComfy`, and run identity + `job.*` + `models.evict`
+ * (v4) via `supportsJobLifecycle` — so a v1 worker still connects and runs
+ * every pre-v2 feature; it just doesn't expose the newer families. Move this
+ * only for a real wire break.
+ *
+ * v4 is additive in both directions. The identity keys added to `execute` /
+ * `execute.stream` (`node_id`, `job_id`, `workflow_id`, `user_id`,
+ * `requires_vram_gb`) are extra dict entries a pre-v4 worker ignores, so the
+ * JS side sends them unconditionally; only the new `job.start` / `job.end` /
+ * `models.evict` message types are gated, because a pre-v4 worker answers
+ * those with `Unknown message type`.
  */
 export const MIN_BRIDGE_PROTOCOL_VERSION = 1;
 

--- a/packages/protocol/tests/error-and-protocol-coverage.test.ts
+++ b/packages/protocol/tests/error-and-protocol-coverage.test.ts
@@ -79,7 +79,7 @@ describe("error-helpers.isTRPCErrorWithCode", () => {
 
 describe("bridge-protocol constants", () => {
   it("BRIDGE_PROTOCOL_VERSION is the current speaking version", () => {
-    expect(BRIDGE_PROTOCOL_VERSION).toBe(3);
+    expect(BRIDGE_PROTOCOL_VERSION).toBe(4);
   });
 
   it("MIN_BRIDGE_PROTOCOL_VERSION is the hard floor at 1", () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -105,6 +105,11 @@ import { PythonBridgeBase } from "./python-bridge-base.js";
 export { PythonBridgeBase };
 export type {
   UnifiedModelLike,
+  ExecuteIdentity,
+  JobBoundary,
+  PythonJobLifecycle,
+  ModelEvictRequest,
+  ModelEvictResult,
   ModelDownloadRequest,
   ModelDownloadUpdate,
   ComfyStatusInfo,

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -80,6 +80,10 @@ import type {
   PythonNodeMetadata,
   ExecuteResult,
   ExecuteInputBlobs,
+  ExecuteIdentity,
+  JobBoundary,
+  ModelEvictRequest,
+  ModelEvictResult,
   ProgressEvent,
   StreamCallback,
   PythonProviderInfo,
@@ -434,12 +438,39 @@ export abstract class PythonBridgeBase
 
   // ── Node execution ─────────────────────────────────────────────────
 
+  /**
+   * Snake-case the run identity onto the `execute` / `execute.stream` payload,
+   * dropping fields the caller could not name so the worker sees an absent key
+   * rather than a null it has to special-case.
+   *
+   * Sent unconditionally, not gated on {@link supportsJobLifecycle}: these are
+   * extra dict entries, and a pre-v4 worker that reads `data["node_type"]`,
+   * `["fields"]`, `["secrets"]` and `["blobs"]` never looks at them. Gating
+   * them would only mean a worker that DOES understand them gets nothing
+   * whenever its `worker.status` hasn't landed yet.
+   */
+  protected _identityPayload(
+    identity: ExecuteIdentity | undefined
+  ): Record<string, unknown> {
+    if (!identity) return {};
+    const payload: Record<string, unknown> = {};
+    if (identity.nodeId) payload.node_id = identity.nodeId;
+    if (identity.jobId) payload.job_id = identity.jobId;
+    if (identity.workflowId) payload.workflow_id = identity.workflowId;
+    if (identity.userId) payload.user_id = identity.userId;
+    if (typeof identity.requiresVramGb === "number") {
+      payload.requires_vram_gb = identity.requiresVramGb;
+    }
+    return payload;
+  }
+
   async execute(
     nodeType: string,
     fields: Record<string, unknown>,
     secrets: Record<string, string>,
     blobs: ExecuteInputBlobs,
-    onProgress?: (event: ProgressEvent) => void
+    onProgress?: (event: ProgressEvent) => void,
+    identity?: ExecuteIdentity
   ): Promise<ExecuteResult> {
     const requestId = randomUUID();
     const timeoutMs =
@@ -453,7 +484,13 @@ export abstract class PythonBridgeBase
         this._send({
           type: "execute",
           request_id: requestId,
-          data: { node_type: nodeType, fields, secrets, blobs }
+          data: {
+            node_type: nodeType,
+            fields,
+            secrets,
+            blobs,
+            ...this._identityPayload(identity)
+          }
         });
       } catch (err) {
         this._pending.delete(requestId);
@@ -501,7 +538,8 @@ export abstract class PythonBridgeBase
     fields: Record<string, unknown>,
     secrets: Record<string, string>,
     blobs: ExecuteInputBlobs,
-    onProgress?: (event: ProgressEvent) => void
+    onProgress?: (event: ProgressEvent) => void,
+    identity?: ExecuteIdentity
   ): AsyncGenerator<ExecuteResult> {
     const requestId = randomUUID();
     const chunks: ExecuteResult[] = [];
@@ -563,7 +601,13 @@ export abstract class PythonBridgeBase
       this._send({
         type: "execute.stream",
         request_id: requestId,
-        data: { node_type: nodeType, fields, secrets, blobs }
+        data: {
+          node_type: nodeType,
+          fields,
+          secrets,
+          blobs,
+          ...this._identityPayload(identity)
+        }
       });
 
       while (true) {
@@ -1130,6 +1174,94 @@ export abstract class PythonBridgeBase
    */
   supportsModelManagement(): boolean {
     return (this._workerStatus?.protocol_version ?? 0) >= 2;
+  }
+
+  /**
+   * Drop loaded model weights on the worker. The worker reclaims reactively on
+   * its own thresholds; this is the path for what only the JS side knows — the
+   * user switched workflows, another process wants the GPU, the worker is
+   * idle. Introduced in protocol v4, so the floor here is a fixed 4.
+   *
+   * A pre-v4 worker would answer `Unknown message type`, so this resolves to an
+   * empty eviction instead of sending: eviction is an optimization, and a host
+   * asking to free memory on a worker that cannot should not have to branch.
+   */
+  async evictModels(req: ModelEvictRequest = {}): Promise<ModelEvictResult> {
+    if (!this.supportsJobLifecycle()) {
+      return { evicted: [] };
+    }
+    const result = await this._providerCall(
+      "models.evict",
+      req as unknown as Record<string, unknown>
+    );
+    return {
+      evicted: Array.isArray(result.evicted) ? (result.evicted as string[]) : [],
+      ...(typeof result.freed_vram_gb === "number"
+        ? { freed_vram_gb: result.freed_vram_gb }
+        : {})
+    };
+  }
+
+  // ── Run boundary (bridge protocol v4+) ─────────────────────────────────
+
+  /**
+   * Whether the attached worker speaks bridge protocol v4+ and therefore
+   * understands `job.start` / `job.end` / `models.evict`. Per-capability soft
+   * gate, like {@link supportsModelManagement}.
+   *
+   * This gates only the new message *types*. The identity fields v4 adds to
+   * `execute` ride along regardless — see {@link _identityPayload}.
+   */
+  supportsJobLifecycle(): boolean {
+    return (this._workerStatus?.protocol_version ?? 0) >= 4;
+  }
+
+  /**
+   * Open a run boundary. Optional: the worker needs no `job.start` to
+   * attribute an execution (every `execute` carries its own `job_id`), so this
+   * exists as the one place to do a single reclaim pass per run instead of one
+   * per node.
+   */
+  async jobStart(job: JobBoundary): Promise<void> {
+    await this._jobBoundary("job.start", job);
+  }
+
+  /**
+   * Close a run boundary: the worker's nodes for this job are retired and
+   * their models become eligible for release. This is the caller
+   * `release_nodes()` never had — without it the worker's model cache grows
+   * across runs and is only ever trimmed reactively under memory pressure.
+   *
+   * Must fire on abnormal termination too (cancelled, client disconnected, run
+   * abandoned), which is why `ExecutionSession` calls it from the same
+   * `finally` that closes the bridge rather than off the success path.
+   */
+  async jobEnd(job: JobBoundary): Promise<void> {
+    await this._jobBoundary("job.end", job);
+  }
+
+  /**
+   * Send one boundary frame. Never rejects: a boundary is bookkeeping, and a
+   * `job.end` that fails on a worker already tearing down must not turn a
+   * finished run into a failed one. Failures are logged and swallowed.
+   */
+  private async _jobBoundary(
+    type: "job.start" | "job.end",
+    job: JobBoundary
+  ): Promise<void> {
+    if (!this.supportsJobLifecycle()) return;
+    const data: Record<string, unknown> = { job_id: job.jobId };
+    if (job.workflowId) data.workflow_id = job.workflowId;
+    if (job.userId) data.user_id = job.userId;
+    if (job.reason) data.reason = job.reason;
+    try {
+      await this._providerCall(type, data);
+    } catch (err) {
+      log.warn(`Python bridge ${type} failed`, {
+        jobId: job.jobId,
+        error: err instanceof Error ? err.message : String(err)
+      });
+    }
   }
 
   // ── ComfyUI proxy (bridge protocol v3+) ────────────────────────────────

--- a/packages/runtime/src/python-bridge-types.ts
+++ b/packages/runtime/src/python-bridge-types.ts
@@ -25,6 +25,87 @@ export interface PythonNodeMetadata {
   is_streaming_output?: boolean;
   is_streaming_input?: boolean;
   is_dynamic?: boolean;
+  /**
+   * Approximate VRAM this node's weights need, in GiB, as declared by the
+   * worker at `discover` (protocol v4+). Forwarded back on `execute` as
+   * `requires_vram_gb` so the worker's pre-execution reclaim pass can free a
+   * real number instead of guessing at a percentage threshold.
+   */
+  requires_vram_gb?: number;
+}
+
+/**
+ * Run identity carried on `execute` / `execute.stream` (bridge protocol v4).
+ *
+ * Every field is optional on the wire: a worker that predates v4 ignores the
+ * extra keys, and a JS host that cannot name a field simply omits it. What the
+ * worker does with them:
+ *
+ *  - `node_id` becomes the constructed node's `_id`, so a node calling
+ *    `set_model(self._id, …)` registers under its real graph id instead of the
+ *    empty string every execution shared before v4. Without it the worker's
+ *    node → model map is a single bucket and `release_nodes()` has nothing to
+ *    release.
+ *  - `job_id` pairs the execution with the `job.start` / `job.end` boundary
+ *    (see {@link PythonJobLifecycle}).
+ *  - `workflow_id` / `user_id` populate the worker's `WorkerContext`, which
+ *    never had them.
+ *  - `requires_vram_gb` is the hint from {@link PythonNodeMetadata}.
+ */
+export interface ExecuteIdentity {
+  nodeId?: string;
+  jobId?: string;
+  workflowId?: string | null;
+  userId?: string;
+  requiresVramGb?: number;
+}
+
+/** Identity of a run, as carried by `job.start` / `job.end`. */
+export interface JobBoundary {
+  jobId: string;
+  workflowId?: string | null;
+  userId?: string;
+  /**
+   * Why the run ended. Only meaningful on `job.end`; the worker retires the
+   * job's nodes either way, so an abnormal end is not a different code path —
+   * it is the same release with a different label.
+   */
+  reason?: "completed" | "failed" | "cancelled" | "abandoned";
+}
+
+/**
+ * The run-boundary half of the bridge, split out so a host that only needs to
+ * bracket a run (see `ExecutionSession`) can depend on these three methods
+ * instead of the whole {@link PythonBridge} surface.
+ */
+export interface PythonJobLifecycle {
+  supportsJobLifecycle(): boolean;
+  jobStart(job: JobBoundary): Promise<void>;
+  jobEnd(job: JobBoundary): Promise<void>;
+}
+
+/** Scope of a `models.evict` request. */
+export interface ModelEvictRequest {
+  /**
+   * Evict only the models registered to these graph node ids. Omit to let the
+   * worker choose (it evicts everything eligible).
+   */
+  node_ids?: string[];
+  /** Evict only models registered under this job id. */
+  job_id?: string;
+  /**
+   * Free at least this many GiB. The worker stops evicting once it has
+   * reclaimed the target rather than dropping every loaded weight.
+   */
+  target_vram_gb?: number;
+}
+
+/** What the worker actually dropped in response to `models.evict`. */
+export interface ModelEvictResult {
+  /** Model keys the worker unloaded. */
+  evicted: string[];
+  /** GiB the worker believes it reclaimed, when it can measure that. */
+  freed_vram_gb?: number;
 }
 
 export interface ExecuteResult {
@@ -320,14 +401,16 @@ export interface PythonBridge extends EventEmitter {
     fields: Record<string, unknown>,
     secrets: Record<string, string>,
     blobs: ExecuteInputBlobs,
-    onProgress?: (event: ProgressEvent) => void
+    onProgress?: (event: ProgressEvent) => void,
+    identity?: ExecuteIdentity
   ): Promise<ExecuteResult>;
   executeStream(
     nodeType: string,
     fields: Record<string, unknown>,
     secrets: Record<string, string>,
     blobs: ExecuteInputBlobs,
-    onProgress?: (event: ProgressEvent) => void
+    onProgress?: (event: ProgressEvent) => void,
+    identity?: ExecuteIdentity
   ): AsyncGenerator<ExecuteResult>;
   cancel(requestId: string): void;
   getNodeMetadata(): PythonNodeMetadata[];
@@ -392,6 +475,12 @@ export interface PythonBridge extends EventEmitter {
   cancelModelDownload(requestId: string): void;
   deleteCachedModel(repoId: string): Promise<boolean>;
   supportsModelManagement(): boolean;
+  evictModels(req?: ModelEvictRequest): Promise<ModelEvictResult>;
+
+  // ── Run boundary (protocol v4+, gated by supportsJobLifecycle) ───────────
+  supportsJobLifecycle(): boolean;
+  jobStart(job: JobBoundary): Promise<void>;
+  jobEnd(job: JobBoundary): Promise<void>;
 
   // ── ComfyUI proxy (protocol v3+, gated by supportsComfy) ─────────────────
   /**

--- a/packages/runtime/src/python-graph-resolver.ts
+++ b/packages/runtime/src/python-graph-resolver.ts
@@ -113,6 +113,7 @@ export function resolvePythonNodeExecutor(
     props,
     outputTypes,
     meta?.required_settings ?? [],
-    node.id
+    node.id,
+    meta?.requires_vram_gb
   );
 }

--- a/packages/runtime/src/python-node-executor.ts
+++ b/packages/runtime/src/python-node-executor.ts
@@ -1,5 +1,6 @@
 import type { ProcessingContext } from "./context.js";
 import type {
+  ExecuteIdentity,
   ExecuteInputBlobs,
   ExecuteResult,
   ProgressEvent
@@ -16,14 +17,16 @@ interface PythonBridgeLike {
     fields: Record<string, unknown>,
     secrets: Record<string, string>,
     blobs: ExecuteInputBlobs,
-    onProgress?: (event: ProgressEvent) => void
+    onProgress?: (event: ProgressEvent) => void,
+    identity?: ExecuteIdentity
   ): Promise<ExecuteResult>;
   executeStream?(
     nodeType: string,
     fields: Record<string, unknown>,
     secrets: Record<string, string>,
     blobs: ExecuteInputBlobs,
-    onProgress?: (event: ProgressEvent) => void
+    onProgress?: (event: ProgressEvent) => void,
+    identity?: ExecuteIdentity
   ): AsyncGenerator<ExecuteResult>;
 }
 const _nodeCrypto = getNodeBuiltinSync<typeof import("node:crypto")>(
@@ -94,8 +97,35 @@ export class PythonNodeExecutor {
     private outputTypes: Record<string, string>,
     private requiredSettings: string[],
     /** Graph node id, used to surface Python worker progress as node_progress. */
-    private nodeId?: string
+    private nodeId?: string,
+    /**
+     * VRAM hint from this node type's `discover` metadata, forwarded on every
+     * execute so the worker can size its reclaim pass. Absent for a worker
+     * that does not report one.
+     */
+    private requiresVramGb?: number
   ) {}
+
+  /**
+   * Run identity for the `execute` payload (bridge protocol v4).
+   *
+   * Before v4 the worker saw an unlabeled stream of single-node executions: it
+   * constructed every node with no id, so `self._id` was `""` for all of them
+   * and its node → model map collapsed into one bucket. `node_id` is what makes
+   * that map real; `job_id` is what pairs the execution with the `job.end`
+   * boundary that releases it.
+   */
+  private identity(context?: ProcessingContext): ExecuteIdentity {
+    return {
+      ...(this.nodeId ? { nodeId: this.nodeId } : {}),
+      ...(context?.jobId ? { jobId: context.jobId } : {}),
+      ...(context?.workflowId ? { workflowId: context.workflowId } : {}),
+      ...(context?.userId ? { userId: context.userId } : {}),
+      ...(typeof this.requiresVramGb === "number"
+        ? { requiresVramGb: this.requiresVramGb }
+        : {})
+    };
+  }
 
   /**
    * Build an onProgress sink that forwards the Python worker's progress events
@@ -243,7 +273,8 @@ export class PythonNodeExecutor {
       fields,
       secrets,
       blobs,
-      this.progressHandler(context)
+      this.progressHandler(context),
+      this.identity(context)
     );
     return this.materializeOutputs(result, context);
   }
@@ -263,7 +294,8 @@ export class PythonNodeExecutor {
       fields,
       secrets,
       blobs,
-      this.progressHandler(context)
+      this.progressHandler(context),
+      this.identity(context)
     )) {
       yield await this.materializeOutputs(partial, context);
     }

--- a/packages/runtime/src/swappable-python-bridge.ts
+++ b/packages/runtime/src/swappable-python-bridge.ts
@@ -15,6 +15,10 @@ import type {
   PythonBridge,
   ExecuteResult,
   ExecuteInputBlobs,
+  ExecuteIdentity,
+  JobBoundary,
+  ModelEvictRequest,
+  ModelEvictResult,
   ProgressEvent,
   PythonNodeMetadata,
   PythonWorkerLoadError,
@@ -115,9 +119,17 @@ export class SwappableBridge extends EventEmitter implements PythonBridge {
     fields: Record<string, unknown>,
     secrets: Record<string, string>,
     blobs: ExecuteInputBlobs,
-    onProgress?: (event: ProgressEvent) => void
+    onProgress?: (event: ProgressEvent) => void,
+    identity?: ExecuteIdentity
   ): Promise<ExecuteResult> {
-    return this._target.execute(nodeType, fields, secrets, blobs, onProgress);
+    return this._target.execute(
+      nodeType,
+      fields,
+      secrets,
+      blobs,
+      onProgress,
+      identity
+    );
   }
 
   executeStream(
@@ -125,14 +137,16 @@ export class SwappableBridge extends EventEmitter implements PythonBridge {
     fields: Record<string, unknown>,
     secrets: Record<string, string>,
     blobs: ExecuteInputBlobs,
-    onProgress?: (event: ProgressEvent) => void
+    onProgress?: (event: ProgressEvent) => void,
+    identity?: ExecuteIdentity
   ): AsyncGenerator<ExecuteResult> {
     return this._target.executeStream(
       nodeType,
       fields,
       secrets,
       blobs,
-      onProgress
+      onProgress,
+      identity
     );
   }
 
@@ -260,6 +274,22 @@ export class SwappableBridge extends EventEmitter implements PythonBridge {
 
   supportsModelManagement(): boolean {
     return this._target.supportsModelManagement();
+  }
+
+  evictModels(req?: ModelEvictRequest): Promise<ModelEvictResult> {
+    return this._target.evictModels(req);
+  }
+
+  supportsJobLifecycle(): boolean {
+    return this._target.supportsJobLifecycle();
+  }
+
+  jobStart(job: JobBoundary): Promise<void> {
+    return this._target.jobStart(job);
+  }
+
+  jobEnd(job: JobBoundary): Promise<void> {
+    return this._target.jobEnd(job);
   }
 
   supportsComfy(): boolean {

--- a/packages/runtime/tests/python-bridge-models.test.ts
+++ b/packages/runtime/tests/python-bridge-models.test.ts
@@ -19,8 +19,8 @@ import {
 import type { ModelDownloadUpdate } from "../src/python-bridge-types.js";
 
 describe("bridge protocol version", () => {
-  it("is 3 (models.* + comfy.* support)", () => {
-    expect(BRIDGE_PROTOCOL_VERSION).toBe(3);
+  it("is 4 (models.* + comfy.* + run identity/job.* support)", () => {
+    expect(BRIDGE_PROTOCOL_VERSION).toBe(4);
   });
 });
 

--- a/packages/runtime/tests/python-bridge-run-identity.test.ts
+++ b/packages/runtime/tests/python-bridge-run-identity.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Bridge protocol v4: run identity on `execute` / `execute.stream`, the
+ * `job.start` / `job.end` boundary, and `models.evict`.
+ *
+ * Drives the real `WebsocketPythonBridge` against the shared fake worker and
+ * reads the frames the worker actually received, so an identity field that
+ * never leaves the JS side fails here rather than silently reaching a worker
+ * that then has nothing to key its node → model map on.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+
+import { WebsocketPythonBridge } from "../src/python-websocket-bridge.js";
+import {
+  startFakeWorker,
+  type FakeWorkerHandle
+} from "./python-websocket-bridge.test-helpers.js";
+
+describe("bridge protocol v4 — run identity and the run boundary", () => {
+  let worker: FakeWorkerHandle | null = null;
+  let bridge: WebsocketPythonBridge | null = null;
+
+  afterEach(async () => {
+    if (bridge) {
+      bridge.close();
+      bridge = null;
+    }
+    if (worker) {
+      await worker.close();
+      worker = null;
+    }
+  });
+
+  async function connect(protocolVersion: number): Promise<void> {
+    worker = await startFakeWorker(0, { protocolVersion });
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`
+    });
+    await bridge.connect();
+  }
+
+  it("puts the identity keys on the execute payload", async () => {
+    await connect(4);
+
+    await bridge!.execute(
+      "test.Node",
+      { value: "x" },
+      {},
+      {},
+      undefined,
+      {
+        nodeId: "node-7",
+        jobId: "job-1",
+        workflowId: "wf-1",
+        userId: "user-1",
+        requiresVramGb: 12
+      }
+    );
+
+    const [frame] = worker!.received("execute");
+    expect(frame!.data).toMatchObject({
+      node_type: "test.Node",
+      node_id: "node-7",
+      job_id: "job-1",
+      workflow_id: "wf-1",
+      user_id: "user-1",
+      requires_vram_gb: 12
+    });
+  });
+
+  it("carries the same identity on execute.stream", async () => {
+    await connect(4);
+
+    const stream = bridge!.executeStream(
+      "test.Node",
+      {},
+      {},
+      {},
+      undefined,
+      { nodeId: "node-7", jobId: "job-1" }
+    );
+    for await (const _chunk of stream) {
+      // drain
+    }
+
+    const [frame] = worker!.received("execute.stream");
+    expect(frame!.data).toMatchObject({ node_id: "node-7", job_id: "job-1" });
+  });
+
+  it("omits identity keys the caller could not name", async () => {
+    await connect(4);
+
+    await bridge!.execute("test.Node", {}, {}, {}, undefined, {
+      nodeId: "node-7"
+    });
+
+    const [frame] = worker!.received("execute");
+    const data = frame!.data as Record<string, unknown>;
+    expect(data.node_id).toBe("node-7");
+    // Absent, not null: the worker reads `data.get("job_id")` and must see
+    // nothing rather than a null it has to special-case.
+    expect("job_id" in data).toBe(false);
+    expect("workflow_id" in data).toBe(false);
+    expect("requires_vram_gb" in data).toBe(false);
+  });
+
+  it("sends identity to a pre-v4 worker too — the keys are additive", async () => {
+    // Gating identity on the capability check would starve a worker that DOES
+    // understand it whenever worker.status hasn't landed. A v3 worker reads
+    // four known keys off `data` and ignores the rest.
+    await connect(3);
+    expect(bridge!.supportsJobLifecycle()).toBe(false);
+
+    await bridge!.execute("test.Node", {}, {}, {}, undefined, {
+      nodeId: "node-7",
+      jobId: "job-1"
+    });
+
+    const [frame] = worker!.received("execute");
+    expect(frame!.data).toMatchObject({ node_id: "node-7", job_id: "job-1" });
+  });
+
+  it("brackets a run with job.start / job.end on a v4 worker", async () => {
+    await connect(4);
+    expect(bridge!.supportsJobLifecycle()).toBe(true);
+
+    await bridge!.jobStart({ jobId: "job-1", workflowId: "wf-1", userId: "u" });
+    await bridge!.jobEnd({
+      jobId: "job-1",
+      workflowId: "wf-1",
+      userId: "u",
+      reason: "cancelled"
+    });
+
+    expect(worker!.received("job.start")[0]!.data).toEqual({
+      job_id: "job-1",
+      workflow_id: "wf-1",
+      user_id: "u"
+    });
+    expect(worker!.received("job.end")[0]!.data).toEqual({
+      job_id: "job-1",
+      workflow_id: "wf-1",
+      user_id: "u",
+      reason: "cancelled"
+    });
+  });
+
+  it("sends no job.* frame to a pre-v4 worker", async () => {
+    // A v3 worker answers an unknown type with `Unknown message type`, so the
+    // gate must hold here — unlike the identity keys, these are new messages.
+    await connect(3);
+
+    await bridge!.jobStart({ jobId: "job-1" });
+    await bridge!.jobEnd({ jobId: "job-1", reason: "completed" });
+
+    expect(worker!.received("job.start")).toHaveLength(0);
+    expect(worker!.received("job.end")).toHaveLength(0);
+  });
+
+  it("evictModels sends its scope and reports what was dropped", async () => {
+    await connect(4);
+
+    const result = await bridge!.evictModels({
+      job_id: "job-1",
+      target_vram_gb: 8
+    });
+
+    expect(result).toEqual({ evicted: ["org/m"], freed_vram_gb: 4 });
+    expect(worker!.received("models.evict")[0]!.data).toEqual({
+      job_id: "job-1",
+      target_vram_gb: 8
+    });
+  });
+
+  it("evictModels resolves empty on a pre-v4 worker instead of erroring", async () => {
+    await connect(3);
+
+    expect(await bridge!.evictModels()).toEqual({ evicted: [] });
+    expect(worker!.received("models.evict")).toHaveLength(0);
+  });
+});

--- a/packages/runtime/tests/python-node-executor.test.ts
+++ b/packages/runtime/tests/python-node-executor.test.ts
@@ -20,6 +20,9 @@ function createMockContext(
   retrieveImpl?: (uri: string) => Promise<Uint8Array | null>
 ): ProcessingContext {
   return {
+    jobId: "job-1",
+    workflowId: "wf-1",
+    userId: "user-1",
     getSecret: vi.fn().mockResolvedValue("test-secret"),
     storage: {
       retrieve: vi.fn(retrieveImpl ?? (async () => new Uint8Array([1, 2, 3]))),
@@ -51,7 +54,8 @@ describe("PythonNodeExecutor", () => {
       { text: "hello" },
       {},
       {},
-      undefined
+      undefined,
+      {}
     );
   });
 
@@ -136,7 +140,8 @@ describe("PythonNodeExecutor", () => {
       {},
       {},
       { images: [new Uint8Array([1]), new Uint8Array([2])] },
-      undefined
+      undefined,
+      { jobId: "job-1", workflowId: "wf-1", userId: "user-1" }
     );
   });
 
@@ -235,7 +240,8 @@ describe("PythonNodeExecutor", () => {
       { prompt: "hi" },
       {},
       {},
-      undefined
+      undefined,
+      {}
     );
   });
 });

--- a/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
@@ -510,6 +510,18 @@ export function startFakeWorker(
             data: { deleted: true }
           });
           break;
+        // ── Run boundary + eviction (protocol v4) ────────────────────
+        case "job.start":
+        case "job.end":
+          send({ type: "result", request_id: requestId, data: { ok: true } });
+          break;
+        case "models.evict":
+          send({
+            type: "result",
+            request_id: requestId,
+            data: { evicted: ["org/m"], freed_vram_gb: 4 }
+          });
+          break;
         case "cancel":
           // no-op
           break;

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -485,7 +485,8 @@ export async function getWorkflowRuntimeEnvironment(
               (meta?.outputs ?? []).map((o) => [o.name, o.type.type])
             ),
             meta?.required_settings ?? [],
-            node.id
+            node.id,
+            meta?.requires_vram_gb
           );
         }
         if (registry.getMetadata(node.type) && !registry.has(node.type)) {

--- a/packages/websocket/src/plugins/websocket.ts
+++ b/packages/websocket/src/plugins/websocket.ts
@@ -147,7 +147,8 @@ const websocketPlugin: FastifyPluginAsync<WebSocketPluginOptions> = async (
               (meta?.outputs ?? []).map((o) => [o.name, o.type.type])
             ),
             meta?.required_settings ?? [],
-            node.id
+            node.id,
+            meta?.requires_vram_gb
           );
         }
         if (registry.getMetadata(node.type) && !registry.has(node.type)) {

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -3705,6 +3705,10 @@ export class UnifiedWebSocketRunner {
           node as { id: string; type: string; [key: string]: unknown }
         ),
       bridgeFactory: async () => null,
+      // This runner owns a long-lived shared bridge, so `bridgeFactory` hands
+      // the session nothing to close. The run boundary still has to reach that
+      // bridge — pass it explicitly.
+      jobLifecycleBridge: this.pythonBridge ?? null,
       jobId,
       workflowId,
       context,
@@ -5234,6 +5238,7 @@ export class UnifiedWebSocketRunner {
           node as { id: string; type: string; [key: string]: unknown }
         ),
       bridgeFactory: async () => null,
+      jobLifecycleBridge: this.pythonBridge ?? null,
       jobId,
       context,
       params: {},
@@ -7603,6 +7608,7 @@ export class UnifiedWebSocketRunner {
             node as { id: string; type: string; [key: string]: unknown }
           ),
         bridgeFactory: async () => null,
+        jobLifecycleBridge: this.pythonBridge ?? null,
         jobId,
         workflowId,
         context,


### PR DESCRIPTION
## The gap

The bridge was `discover`, `worker.status`, `execute`, `execute.stream`, `cancel`, `provider.*`, `models.*`, `comfy.*` at `BRIDGE_PROTOCOL_VERSION = 3`. None of it carried run identity or a run boundary, and `execute` was just `{node_type, fields, secrets, blobs}` — so the worker saw an unlabeled stream of single-node executions.

Two consequences on the Python side. `_prepare_node()` calls `node_class()` with no id, so `node._id` is `""` for every execution: a node calling `set_model(self._id, …)` registers under the empty string, `_models_by_node` is effectively one bucket, and `release_nodes()` has nothing meaningful to release. And nothing ever fires at the point where "these nodes are retired, their models are eligible" is actually true, so the model cache grows across runs and is only ever trimmed reactively under memory pressure.

This is the TS half. It ships protocol v4 and the wiring behind it; the matching `nodetool-core` changes land separately.

## What changed

**1. Identity on `execute` / `execute.stream`** — `node_id`, `job_id`, `workflow_id`, `user_id`.

Sent **unconditionally**, not behind the v4 capability gate. These are extra dict entries on an existing message, and a pre-v4 worker reads the four keys it knows and ignores the rest; gating them would only starve a worker that *does* understand them whenever its `worker.status` hasn't landed yet. Only new message *types* need a gate, because those are what a worker answers with `Unknown message type`. A field the host cannot name is omitted rather than sent as null, so the worker sees an absent key instead of a null it has to special-case.

Sourced in `PythonNodeExecutor` — `nodeId` from the graph node it was built for, the rest from `ProcessingContext`, which already had `jobId` / `workflowId` / `userId`.

**2. `job.start` / `job.end`** — the run boundary, gated by `supportsJobLifecycle()` (v4+).

`job.end` is the caller `release_nodes()` never had. It carries `job_id` plus a `reason` (`completed` | `failed` | `cancelled` | `abandoned`). `job.start` is optional in the sense that the worker needs none of it to attribute an execution — every `execute` carries its own `job_id` — but it gives the worker one place to do a single reclaim pass per run instead of one per node.

Both fire from `ExecutionSession`, `job.end` from the same path that closes the bridge, so completion, failure, cancellation and `runTimeoutMs` all reach it. A boundary that only closed on clean completion would move the leak to the failure path rather than fix it. Both are fire-and-forget and swallow their own failures: a `job.end` that fails against a worker already tearing down must not turn a finished run into a failed one, and a worker that never answers `job.start` must not become a run that never starts.

A host with a long-lived shared bridge (the WS runner) injects its own `resolveExecutor` and gets `null` from `bridgeFactory` on purpose, so it now passes that bridge as `jobLifecycleBridge`. Without it nothing would close the boundary for the exact deployment the shared bridge exists for.

**3. `models.evict`** — lets TS drop weights for what only TS knows: the user switched workflows, another process wants the GPU, the worker is idle. Scope is `node_ids` / `job_id` / `target_vram_gb`. Against a pre-v4 worker it resolves to `{evicted: []}` rather than erroring, so a caller asking to free memory never has to branch on the version.

**4. `requires_vram_gb`** — reported per node type by the worker at `discover`, echoed back on `execute`. Gives the reclaim pass a real number to target instead of a percentage threshold it picked because it had no idea what the node was about to load.

## Compatibility

`MIN_BRIDGE_PROTOCOL_VERSION` stays at `1` and `MIN_NODETOOL_CORE_VERSION` at `0.7.0` — nothing here is a wire break. A v1 worker still connects and runs everything it did before.

## Tests

`packages/runtime/tests/python-bridge-run-identity.test.ts` drives the real `WebsocketPythonBridge` against the fake worker and reads the frames the worker actually received, so an identity field that never leaves the JS side fails here. It covers the payload on both execute paths, omission of unnamed fields, identity reaching a v3 worker, the gate holding for `job.*` and `models.evict` on v3, and the boundary frames on v4.

`packages/execution/tests/session-job-boundary.test.ts` asserts the boundary closes with the right reason on completed, cancelled, timed-out and failed runs, that `jobStart` cannot block the run, and that a host wiring no lifecycle bridge is unaffected.

Both suites were checked against inverted implementations before being trusted: dropping the identity payload fails 4 of 8, removing the `job.*` gate fails 1, and hardcoding the end reason to `completed` fails 3 of 6.

## Verification

`build:packages`, `test:packages`, web (12,868), electron (674) all green; web and electron typecheck clean; `oxlint` on the touched packages reports no errors.

Two environment gaps, both pre-existing and unrelated to this diff:
- The 14 shader-backed `base-nodes` image tests and the `image-nodes` suite fail with `No WebGPU adapter available` on this box. Installing lavapipe per `AGENTS.md` and re-running: 14/14 and 229/229 pass.
- `typecheck:mobile` and `lint:anti-slop:enforced` fail on uninstalled dependencies (`mobile/node_modules`, `@oxlint/plugins`).

## Not in this PR

`BaseNode.initialize()` still has zero callers. It should get a defined place in the executor's `pre_process → preload_model → move_to_device → process` sequence or be deleted — a third documented-but-dead hook invites the same confusion that produced the `clear_unused` contract bug. Its `skip_cache` parameter suggests it was built for a runner that no longer exists. Picking between the two needs a check of whether any node package overrides it, which means reading `nodetool-huggingface` and the other node repos — outside this session's repo scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_017MqQfacWq86YtyzQ5xHqha)_