### PR TITLE
fix(mobile): let a document snapshot name its label field

### DIFF
--- a/mobile/src/documents/agentBridge.ts
+++ b/mobile/src/documents/agentBridge.ts
@@ -25,9 +25,16 @@ export interface OpenDocument {
   title: string;
 }
 
-/** What every kind's snapshot carries; each kind adds its own fields on top. */
+/**
+ * The human-facing label a snapshot carries. Storyboards, timelines and
+ * scripts call it `title`; the JS-script surface calls it `name`. Both are
+ * optional here because the authoritative title is the one passed to
+ * `registerDocumentHandler` — this type exists so the marker below names a
+ * real member rather than accepting anything.
+ */
 export interface DocumentSnapshot {
-  title: string;
+  title?: string;
+  name?: string;
 }
 
 /**


### PR DESCRIPTION
**`main` is red: `npm --prefix mobile run typecheck` fails.** This fixes it. My regression, from a semantic conflict between two PRs that each passed alone.

```
src/screens/__tests__/JsScriptEditorScreen.test.tsx(167,22): error TS2344:
  Type 'JsScriptAgentHandler' does not satisfy the constraint 'DocumentAgentHandler'.
  The types returned by 'getSnapshot()' are incompatible between these types.
    Property 'title' is missing in type 'JsScriptSnapshot' but required in type 'DocumentSnapshot'.
```

#4922 replaced `type DocumentAgentHandler = object` with an interface whose `getSnapshot()` returns a `DocumentSnapshot` requiring `title` — true of the three handler kinds that existed when I wrote it (storyboard, timeline, script). The JS-script surface landed on a separate branch and calls the same field `name`. Neither PR could see the other; `main` got both.

`DocumentSnapshot` now names both labels, optionally. Making `title` merely optional is **not** sufficient on its own: an all-optional interface triggers TypeScript's weak-type check, which rejects an object sharing no member with it —

```
Type 'JsScriptSnapshot' has no properties in common with type 'DocumentSnapshot'.
```

— so listing `name` is what actually lets `JsScriptSnapshot` fit, and the marker still names a real member instead of going back to accepting anything. The authoritative title is unchanged: it is the one passed to `registerDocumentHandler`, and the bridge never reads the snapshot.

## Checks

- `npm --prefix mobile run typecheck` → **0 errors** (red on `main` before this).
- `npm --prefix mobile test` → 75 suites, 1038 tests, all passing.
- The enforced anti-slop config over `mobile/src` → 0 findings, so the marker still satisfies `no-object-parameters`, which is what removed the original `object` type.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPXapRVTWZDbebtC3xaL8z)_