### PR TITLE
docs: PRD, design, and tasks for the script–storyboard link

### DIFF
--- a/docs/script-storyboard-link/design.md
+++ b/docs/script-storyboard-link/design.md
@@ -1,0 +1,281 @@
+# Script ↔ Storyboard Link — Technical Design
+
+> Status: Proposed · Companion: [prd.md](prd.md), [tasks.md](tasks.md).
+
+The design links the two documents with keys and derives everything else. No
+document is merged, no ownership moves: the script keeps words and voice, the
+storyboard keeps visuals and motion, the timeline keeps placement. Every
+mapping is a pure function in a shared package, consumed identically by the
+web editors, the server-side agent tools, and the evals — the pattern
+`buildStoryboardTimeline` and `buildScriptTimeline` already follow.
+
+## 1. Data model
+
+### 1.1 Storyboard document (the link lives here)
+
+The storyboard references the script, not the other way around, because the
+board is the consumer of the words: it projects line text into shots and
+reads take durations for timing. Additions to
+`packages/protocol/src/api-schemas/storyboards.ts` and the mirrored
+interfaces in `packages/protocol/src/creative.ts`:
+
+```
+Screenplay
+└─ script_id?: string | null        // the linked script resource
+
+Shot
+├─ script_line_ids?: string[]       // ordered lines this shot covers
+├─ script_text_snapshot?: string    // linked line texts as last projected,
+│                                   // joined "\n" — drift comparison only
+└─ duration_source?: "audio" | "manual"
+                                    // "audio": derived from takes (default
+                                    // when linked); "manual": user override,
+                                    // audio never touches duration_seconds
+```
+
+Tool-surface aliases (`SHOT_KEY_ALIASES` / `SCREENPLAY_KEY_ALIASES` in
+`api-schemas/storyboards.ts`): `scriptId` → `script_id`, `scriptLineIds` →
+`script_line_ids`, `scriptTextSnapshot` → `script_text_snapshot`,
+`durationSource` → `duration_source`.
+
+All fields optional; the schemas are `passthrough`, so old documents load
+unchanged and new fields travel through old clients.
+
+### 1.2 Script resource (back-pointer for navigation)
+
+`scripts` table and `scriptResponse` / `patchScriptInput`
+(`packages/protocol/src/api-schemas/scripts.ts`,
+`packages/models/src/schema/scripts.ts`): add nullable `storyboard_id`,
+exactly like the existing `timeline_id` back-pointer. Set when a board is
+derived from or linked to the script; cleared when the board is deleted
+(same log-and-continue posture as timeline back-sync). The script document
+itself gains **no** shot references — line↔shot membership is owned by the
+board and read by inverting `script_line_ids`.
+
+### 1.3 Invariants (validated, not assumed)
+
+Checked by a new pure `validateScriptLink(screenplay, scriptDoc)`:
+
+- A line id appears in at most one shot's `script_line_ids` (error).
+- Every referenced line id exists in the script (error, names the shot).
+- `script_id` set but script missing/deleted (warning — board still works,
+  link affordances disable).
+- A shot with `script_line_ids` on a board without `script_id` (error).
+
+Runs wherever storyboard documents are normalized and saved (the
+`normalizeStoryboard*` path every `ui_storyboard_*` write already goes
+through), and in the headless tools before acting.
+
+## 2. Pure mappings (shared packages)
+
+### 2.1 Extract: screenplay → script document
+
+New module `packages/protocol/src/script-link.ts` (protocol because it maps
+between two protocol document shapes and must stay dependency-free, like
+`entitiesForShot`):
+
+```ts
+extractScriptFromScreenplay(
+  screenplay: Screenplay,
+  entities: Entity[]
+): { document: ScriptDocumentSchema; lineIdsByShotId: Record<string, string[]> }
+```
+
+Deterministic, no model call:
+
+- One section per screenplay (or per scene grouping if shots carry scene
+  slugs later — V1: single section titled from the screenplay).
+- Per shot, in `index` order: `dialogue` becomes a line whose `speakerId` is
+  the character entity matched by the existing `entitiesForShot` rules;
+  `narration` becomes a line with the narrator speaker.
+- Cast: one narrator speaker plus one speaker per character entity that
+  contributed a line; `Entity.voice_id` seeds `voice.voice` when the entity
+  carries one (provider/model left for the cast panel or Studio's curated
+  lineup to fill).
+- Returns the shot→lines map so the caller can stamp `script_line_ids` and
+  `script_text_snapshot` onto the shots in the same save.
+
+### 2.2 Derive: script → shot scaffold
+
+Same module:
+
+```ts
+deriveShotScaffold(
+  script: { id: string; cast: Speaker[]; sections: ScriptSection[] },
+  options?: { maxLinesPerShot?: number }   // default 1; sections never split
+): ShotScaffold[]   // { script_line_ids, dialogue|narration, index }
+```
+
+The scaffold pins linkage, order, and the projected text deterministically.
+Shot *content* — `action`, `camera`, `motion`, `slug`, entities — is the
+Director agent's job: the director prompt gains a variant that receives the
+scaffold plus line texts and must return shots that keep `script_line_ids`
+untouched (the normalizer enforces it: a director response that drops or
+reassigns linkage keys is rejected and retried, the same posture the
+storyboard normalizer takes on missing `action`). Headless fallback when no
+model is configured: scaffold shots with `action` copied from line text,
+status `planned`.
+
+### 2.3 Timing: takes → shot durations
+
+`packages/timeline/src/script-link.ts` (timeline package because it needs
+`currentTake` from `script.ts`):
+
+```ts
+linkedShotDurationMs(shot: Shot, linesById: Map<string, ScriptLine>): number | null
+```
+
+Sum of linked lines' current-take durations plus `pauseAfterMs`, or `null`
+when any linked line is unvoiced (caller falls back to `duration_seconds` /
+`DEFAULT_SHOT_MS`). Applied only when `duration_source !== "manual"`. The
+storyboard editor recomputes on script changes through the existing
+server-sync refresh; nothing is stored — `duration_seconds` is only written
+on assemble and render so prompts see the real target length.
+
+### 2.4 Joint assemble: linked pair → one timeline
+
+`packages/timeline/src/linked.ts`:
+
+```ts
+buildLinkedTimeline(input: {
+  boardId: string;
+  shots: Shot[];
+  musicPrompt?: string | null;
+  script: { scriptId: string; cast: Speaker[]; sections: ScriptSection[] };
+}): AssembledTimeline & { skippedLineIds: string[] }
+```
+
+- Video track: as `buildStoryboardTimeline` — assemblable shots end to end —
+  except each shot's duration is `linkedShotDurationMs(...) ?? shotDurationMs(...)`.
+- Voiceover track: one clip per voiced line, starting at
+  `shotStartMs + offset` where offset is the sum of preceding linked takes
+  and pauses within the same shot. Clip payload identical to
+  `buildScriptTimeline`'s (caption words, speaker, voice, `scriptId` +
+  `scriptLineId`) **plus** `storyboardBoardId`/`storyboardShotId`, so both
+  existing back-sync paths (`stores/storyboard/timelineSync`,
+  `stores/script/timelineSync`) patch the same clips with no changes.
+- Music: as today. The whole-cut narration draft clip is **not** emitted —
+  the script supersedes it.
+- Lines whose shot is skipped (unrendered) are reported in `skippedLineIds`,
+  not silently dropped.
+
+`buildStoryboardTimeline` and `buildScriptTimeline` stay untouched; linked
+assembly is a third function, so unlinked behavior is provably unchanged
+(regression tests assert identical output on existing fixtures).
+
+### 2.5 Drift
+
+Derived helpers next to `needsVoicing` (same "derived, never stored" rule):
+
+```ts
+shotDialogueDrifted(shot, linesById): boolean   // joined texts ≠ snapshot
+orphanedLineIds(screenplay, scriptDoc): string[] // lines with no shot, on a linked board
+```
+
+"Re-project" recomputes `script_text_snapshot` and the shot's
+`dialogue`/`narration` projection in one document update; it never touches
+rendered assets — re-rendering stays a separate, explicit action.
+
+## 3. Server surface
+
+### 3.1 tRPC
+
+- `scripts` router: `patchScriptInput` accepts `storyboardId` (nullable),
+  same CAS update as `timelineId`.
+- `storyboards` router: no new procedures — the link is document content.
+- New procedures are not needed for derive/extract in the web app: both run
+  client-side over the stores (they are document→document mappings) and save
+  through the existing CAS updates. Headless runs use the agent tools below.
+
+### 3.2 Agent tools (headless, `packages/agents/src/tools/`)
+
+Extend the storyboard/script tool files
+(`storyboard-render-tools.ts` re-exports, `capabilities/storyboards.ts`,
+`capabilities/scripts.ts`):
+
+- **`extract_script_from_storyboard`** `{storyboard_id, name?}` — runs
+  `extractScriptFromScreenplay`, creates the script row, stamps
+  `script_id`/`script_line_ids`/snapshots onto the board, sets the script's
+  `storyboard_id`. Errors if the board already links a script (idempotence:
+  pass `relink: true` to re-project instead).
+- **`derive_storyboard_from_script`** `{script_id, provider?, model?, name?}` —
+  scaffold + director pass (provider/model resolved like the render tools:
+  from the call or the board's selection, unset is an error naming
+  `find_model`); creates the board linked and back-pointed. With no
+  provider: deterministic scaffold only, shots `planned`.
+- **`assemble_storyboard_timeline`** (existing) — when the board carries
+  `script_id`, load the script and call `buildLinkedTimeline`; otherwise
+  unchanged. One tool, no new name: "assemble this board" always does the
+  right thing.
+- `get_storyboard` / `get_script` responses gain the link fields and derived
+  drift/orphan summaries so an agent can decide what to fix without a second
+  round trip.
+
+### 3.3 `ui_*` tools (web, `web/src/lib/tools/builtin/`)
+
+- `ui_storyboard_extract_script`, `ui_storyboard_relink_script`,
+  `ui_storyboard_set_duration_source` in `builtin/storyboard.ts`.
+- `ui_script_derive_storyboard` in `builtin/script.ts`.
+- `ui_storyboard_assemble_timeline` and `ui_script_send_to_timeline` gain the
+  linked path (both call `buildLinkedTimeline` when linked; the script-side
+  button becomes "Assemble video" when a board is linked).
+- The headless eval bridges (`packages/agents/src/evals/surfaces/storyboard.ts`,
+  `script.ts`, `creative-pipeline.ts`) mirror the new tools, keeping the
+  tool-loop suites honest.
+
+## 4. Web UX
+
+- **Storyboard shot inspector**: a "Script" section listing linked lines with
+  speaker chip, voice status (draft/stale/voiced — `needsVoicing`), play
+  button on the current take, and the drift badge with *Re-project*. Voicing
+  a line from here calls the script store's existing `scriptVoicing` path.
+- **Storyboard header**: *Extract script* (unlinked) / *Open script* (linked).
+  Assemble button label unchanged; behavior switches on the link.
+- **Script editor gutter**: per line, the linked shot's keyframe thumbnail
+  chip (click → open board, select shot). Orphan badge when linked board has
+  no shot for the line.
+- **Script header**: *Create storyboard* (unlinked) / *Open storyboard*.
+- **Studio** (`web/src/studio/`): home groups documents sharing a link into
+  one project card (script + board + timeline); the prompt-first flow runs
+  derive right after the director drafts, so the user lands linked. Curated
+  models stamp as today.
+- **Deletion**: deleting a linked script downgrades the board to unlinked
+  (link fields cleared, projected text kept — it is ordinary shot text);
+  deleting a board clears the script's `storyboard_id`. Both are
+  log-and-continue, never blocking the delete.
+
+## 5. What deliberately does not change
+
+- `buildStoryboardTimeline`, `buildScriptTimeline`, both `timelineSync`
+  modules, the transcript layer, and all timeline editor code.
+- Unlinked storyboards keep the narration/music draft-clip behavior.
+- The `nodetool.script.*` and storyboard node families (a `LinkedAssemble`
+  node can come later; the agent tools cover headless first).
+
+## 6. Testing and harnesses
+
+- Unit (Vitest, `packages/protocol` + `packages/timeline`): extract, scaffold,
+  duration, joint assemble, drift, link validation — including regression
+  fixtures proving unlinked assembly output is byte-identical.
+- Tool-loop evals: extend `storyboard-tools` and `script-tools` cases for the
+  new tools; add a `creative-pipeline` case script → derive → render (stub) →
+  joint assemble → `validate_timeline`.
+- Web (Jest): inspector line panel, gutter chips, assemble switch, deletion
+  downgrade.
+- `nodetool timeline validate` already checks the assembled output; the joint
+  assembler's tests feed it the built document.
+- Harness registry (`packages/cli/src/harness/registry.ts`): the linked
+  flow is part of the storyboard and script surfaces; extend their harness
+  entries' selfchecks with the new deterministic tests so `harness gate`
+  picks them up on diffs touching these paths.
+
+## 7. Risks
+
+- **Director drops linkage keys.** Mitigated by normalizer enforcement +
+  retry, and the deterministic scaffold as the floor.
+- **Drift snapshot bloat.** `script_text_snapshot` is bounded by line text
+  length; no take/audio data is ever copied into the board.
+- **Two documents, one save race.** Extract/derive write two resources; both
+  writes are CAS and the link is only stamped after the created row exists.
+  A failed second write leaves an unlinked-but-valid document and a toast,
+  never a half-link that fails validation.

--- a/docs/script-storyboard-link/prd.md
+++ b/docs/script-storyboard-link/prd.md
@@ -1,0 +1,165 @@
+# Script ↔ Storyboard Link — PRD
+
+> Status: Proposed · Owner: matti
+>
+> Companion documents: [design.md](design.md) (technical design),
+> [tasks.md](tasks.md) (implementation checklist).
+
+## Problem
+
+NodeTool has two pre-production documents that both feed the timeline, and no
+connection between them:
+
+- The **script** owns words and voice: lines, cast, takes, word timings
+  (`packages/protocol/src/api-schemas/scripts.ts`).
+- The **storyboard** owns visuals and motion: shots, stills, clips, style
+  (`packages/protocol/src/api-schemas/storyboards.ts`).
+
+A shot already carries `dialogue` and `narration` text fields
+(`packages/protocol/src/creative.ts`), but that text is dead weight: storyboard
+assembly turns the whole screenplay's narration into a single **draft**
+text-to-audio clip with no cast, no takes, and no word timings
+(`packages/timeline/src/storyboard.ts`), while the script editor has the full
+voicing machinery and no way to receive that text. A user who wants both
+picture and voice must maintain the words twice and assemble two timelines.
+
+The entry order also varies by video. Sometimes the script exists first (a
+narrated explainer, an ad with approved copy); sometimes the visuals come
+first (a director brief broken into shots); sometimes neither (a one-line
+prompt in Studio). Today only one order works per document type.
+
+## Goals
+
+1. One video project can have a script and a storyboard that agree on the
+   words, with each document edited in its own editor.
+2. Either document can exist first. The other is derived from it in one
+   action, with the link established automatically.
+3. One "Assemble" produces one timeline: shot clips on the video track,
+   voiced takes on the voiceover track, aligned shot by shot.
+4. Voiced audio drives shot timing. A shot linked to voiced lines gets its
+   duration from the takes, not from a guessed `duration_seconds`.
+5. Drift is visible. When line text changes after a shot was rendered, or a
+   linked shot is deleted, the affected document shows it.
+6. The whole flow works headlessly through agent tools, so "here is my
+   script, make it a video" is one chat conversation.
+
+## Non-goals
+
+- **No merged document.** Script and storyboard stay separate resources with
+  separate editors. The same reasoning that kept the script separate from the
+  in-timeline transcript applies (see
+  [script-editor-concept.md](../script-editor-concept.md) § Relation to the
+  in-timeline transcript): one document per source of truth.
+- **No automatic three-way merge.** Structural drift after assembly (lines or
+  shots added, removed, reordered) prompts a re-derive or re-assemble; it is
+  not silently merged.
+- **No change to unlinked behavior.** A storyboard without a linked script
+  assembles exactly as today, narration draft clip included. A script without
+  a board keeps "Send to timeline" unchanged.
+- **No lip-sync or in-shot audio placement.** Alignment is shot-granular: a
+  take starts when its shot starts.
+
+## Users and entry orders
+
+| Entry order | User | First action |
+| --- | --- | --- |
+| Script first | Writer with approved copy; narrated explainers, ads | "Create storyboard" in the script editor |
+| Storyboard first | Visual thinker; director-agent output with dialogue | "Extract script" in the storyboard editor |
+| Prompt first | Studio beginner | Studio prompt flow creates both, already linked |
+
+## User stories
+
+1. **Script-first.** I wrote and voiced a 20-line script. I press *Create
+   storyboard*. A board opens with one shot per beat, each shot linked to its
+   lines, shot durations matching my voiced takes. I render stills and clips,
+   press *Assemble*, and get one timeline where every take starts with its
+   shot.
+2. **Storyboard-first.** The director agent gave me a 12-shot board with
+   dialogue on each shot. I press *Extract script*. A script opens with one
+   line per shot dialogue, speakers seeded from the board's character
+   entities (their `voice_id` becomes the cast voice). I voice all lines,
+   return to the board — shot durations now follow the takes — and assemble.
+3. **Prompt-first.** In Studio I type an idea. The director drafts the
+   screenplay and the script together, linked. I land on a project card that
+   shows board, script, and (later) timeline as one project.
+4. **Drift.** I rewrite line 7 after its shot was rendered. The shot shows a
+   "dialogue drifted" badge; one click re-projects the text (and offers a
+   re-render). I delete a shot; its lines show an "unlinked" badge.
+5. **Headless.** In chat: "Turn script X into a video." The agent derives a
+   board, renders stills and clips, voices the remaining lines, assembles one
+   timeline, and validates it — no editor open.
+
+## Requirements
+
+### Functional
+
+- **R1 — Link.** A storyboard can reference one script. Each shot can
+  reference an ordered list of that script's line ids. A line belongs to at
+  most one shot; the link is validated.
+- **R2 — Derive board from script.** From the script editor and from chat:
+  create a linked storyboard whose shots cover the script's lines in order.
+  Uses the director agent for shot content; linkage assignment is
+  deterministic.
+- **R3 — Extract script from board.** From the storyboard editor and from
+  chat: create a linked script from shot `dialogue`/`narration` text, cast
+  seeded from character entities (`voice_id`). Deterministic; no model call.
+- **R4 — Audio-led timing.** A shot linked to lines with voiced current takes
+  derives its duration from take durations plus authored pauses. A per-shot
+  manual override wins and is marked as such.
+- **R5 — Joint assemble.** Assembling a linked board produces one timeline:
+  shots on the video track, one clip per voiced line on the voiceover track
+  starting at its shot's start, music as today. The single narration draft
+  clip is not created when a script link exists. Clips carry both linkage key
+  families, so both existing back-sync paths keep working.
+- **R6 — Drift visibility.** Line-text drift against the shot's projected
+  snapshot, orphaned lines, and dangling line references are derived (never
+  stored as status) and shown in both editors.
+- **R7 — Navigation.** "Open script" / "Open storyboard" from either editor.
+  Studio home groups linked documents into one project card.
+- **R8 — Agent surface.** Headless tools for derive, extract, and linked
+  assemble; `ui_*` equivalents in both editors; the creative-pipeline eval
+  covers script→board→timeline end to end.
+
+### Non-functional
+
+- Derive/extract/assemble mappings are pure functions in shared packages,
+  used identically by the editors, the server tools, and the evals — the
+  established pattern (`buildStoryboardTimeline`, `buildScriptTimeline`).
+- All new document fields are optional; existing storyboards and scripts load
+  unchanged. Schemas stay `passthrough` where they are today.
+- Extract and derive-scaffold are deterministic and covered by unit tests;
+  only shot *content* (action, camera, motion) comes from a model.
+
+## Success measures
+
+- A script-first video needs zero manual re-typing of words into shots, and
+  zero manual shot-duration entry for voiced shots.
+- The prompt-first Studio flow lands the user on a linked pair in one step.
+- The creative-pipeline eval passes a case that goes script → derived board →
+  rendered → joint assemble → `validate_timeline` green.
+- Unlinked flows produce byte-identical assembly output to today (regression
+  tests on `buildStoryboardTimeline` / `buildScriptTimeline`).
+
+## Rollout
+
+Four phases, each shippable alone — see [tasks.md](tasks.md):
+
+1. Link schema + extract-script-from-storyboard (unblocks board-first with
+   real voicing; cheapest).
+2. Derive-storyboard-from-script + audio-led timing.
+3. Joint assemble + navigation.
+4. Drift badges, Studio project cards, eval case, polish.
+
+## Open questions
+
+- **Multi-speaker in-shot dialogue.** A shot whose lines belong to several
+  speakers assembles fine (clips carry `speaker`), but the ElevenLabs
+  dialogue-mode question from the script concept doc applies here too.
+  Deferred with it.
+- **Narration vs. dialogue tracks.** V1 lays all takes on one voiceover
+  track. One-track-per-speaker is a script-side option that already exists
+  conceptually; revisit after use.
+- **Re-derive semantics.** When the script gains a section after the board
+  was derived, V1 offers "derive again" which appends/updates shots for
+  unlinked lines and never deletes rendered shots. Anything smarter waits for
+  evidence the simple rule hurts.

--- a/docs/script-storyboard-link/tasks.md
+++ b/docs/script-storyboard-link/tasks.md
@@ -1,0 +1,98 @@
+# Script ↔ Storyboard Link — Tasks
+
+> Companion: [prd.md](prd.md), [design.md](design.md). Each phase ships
+> alone. After any code change: `npm run typecheck && npm run lint &&
+> npm run test && npm run test:packages` (scope package runs with
+> `nodetool affected`).
+
+## Phase 1 — Link schema + extract script from storyboard
+
+- [ ] **Protocol: link fields.** Add `script_id` to `Screenplay` and
+      `script_line_ids`, `script_text_snapshot`, `duration_source` to `Shot`
+      in `packages/protocol/src/creative.ts`; mirror in the zod shapes and
+      key aliases in `packages/protocol/src/api-schemas/storyboards.ts`.
+      Tests: normalization round-trips camelCase aliases; old documents
+      parse unchanged.
+- [ ] **Protocol: `script-link.ts`.** `extractScriptFromScreenplay` +
+      `validateScriptLink` per design §2.1/§1.3, with unit tests covering
+      speaker matching via `entitiesForShot`, `voice_id` seeding, the
+      shot→lines map, duplicate/dangling line references.
+- [ ] **Script back-pointer.** Nullable `storyboard_id` on the `scripts`
+      table (`packages/models/src/schema/scripts.ts` + migration),
+      `scriptResponse`/`patchScriptInput` in
+      `packages/protocol/src/api-schemas/scripts.ts`, CAS patch in the
+      `scripts` tRPC router.
+- [ ] **Headless tool: `extract_script_from_storyboard`.** In
+      `packages/agents/src/capabilities/storyboards.ts` (creates script row,
+      stamps link, sets back-pointer, `relink` re-projects). Tool-loop eval
+      case in `packages/agents/src/evals/surfaces/storyboard.ts`.
+- [ ] **Web: extract + navigation.** `ui_storyboard_extract_script` in
+      `web/src/lib/tools/builtin/storyboard.ts`; *Extract script* / *Open
+      script* in the storyboard header; *Open storyboard* in the script
+      header. Deletion downgrade both directions (design §4).
+- [ ] **Link validation on save.** Wire `validateScriptLink` into the
+      storyboard normalize/save path; surface issues in both editors.
+
+## Phase 2 — Derive board from script + audio-led timing
+
+- [ ] **Protocol: `deriveShotScaffold`.** In `script-link.ts` per design
+      §2.2, unit-tested (order, one-line-per-shot default, narration vs.
+      dialogue projection).
+- [ ] **Director variant.** Scaffold-constrained director pass; normalizer
+      rejects responses that drop or reassign `script_line_ids` (retry, then
+      fall back to scaffold-only shots). Lives with the existing director
+      prompt path used by the storyboard agent.
+- [ ] **Headless tool: `derive_storyboard_from_script`.** In
+      `packages/agents/src/capabilities/scripts.ts`; no-provider mode emits
+      the deterministic scaffold. Eval case in
+      `packages/agents/src/evals/surfaces/script.ts`.
+- [ ] **Timing.** `linkedShotDurationMs` in
+      `packages/timeline/src/script-link.ts` (design §2.3); storyboard
+      editor and render tools read it when `duration_source !== "manual"`;
+      `ui_storyboard_set_duration_source` toggle + inspector control.
+- [ ] **Web: derive.** `ui_script_derive_storyboard` in
+      `web/src/lib/tools/builtin/script.ts`; *Create storyboard* button in
+      the script editor.
+
+## Phase 3 — Joint assemble
+
+- [ ] **`buildLinkedTimeline`.** `packages/timeline/src/linked.ts` per
+      design §2.4. Unit tests: shot-aligned take starts, in-shot offsets
+      with pauses, both linkage key families on voiceover clips, narration
+      draft clip suppressed, `skippedLineIds`/`skippedShotIds`; regression
+      fixtures proving unlinked `buildStoryboardTimeline` /
+      `buildScriptTimeline` output is unchanged. Feed the built document to
+      the timeline validator in tests.
+- [ ] **Assemble switch.** `assemble_storyboard_timeline` (headless) and
+      `ui_storyboard_assemble_timeline` / `ui_script_send_to_timeline` (web)
+      call `buildLinkedTimeline` when linked; script-side button relabels to
+      *Assemble video*. Re-assemble in place preserves foreign tracks (reuse
+      the script re-assemble pattern).
+- [ ] **Back-sync verification.** Jest tests that a re-voiced line and a
+      revised shot both patch the same jointly-assembled sequence through
+      the existing `timelineSync` modules, unmodified.
+- [ ] **Creative-pipeline eval.** Case: script → derive → render (stubbed
+      assets) → joint assemble → `validate_timeline` green, in
+      `packages/agents/src/evals/surfaces/creative-pipeline.ts`.
+
+## Phase 4 — Drift, Studio, polish
+
+- [ ] **Drift helpers.** `shotDialogueDrifted`, `orphanedLineIds` (design
+      §2.5) with tests; *Re-project* action updating snapshot + projected
+      text in one CAS save.
+- [ ] **Badges.** Drift badge + Re-project in the shot inspector; orphan
+      badge in the script gutter; linked-line panel (speaker chip, voice
+      status, play, voice-from-board) in the shot inspector; keyframe
+      thumbnail chips in the script gutter.
+- [ ] **Studio.** Prompt-first flow derives script + board linked in one
+      pass; home groups linked documents into one project card
+      (`web/src/studio/`).
+- [ ] **Tool/summary surface.** `get_storyboard` / `get_script` report link
+      state, drift, and orphans (design §3.2).
+- [ ] **Harness registry.** Extend the storyboard/script surface entries in
+      `packages/cli/src/harness/registry.ts` with the new deterministic
+      selfchecks; `nodetool harness audit` stays clean.
+- [ ] **Docs.** Update `docs/script-editor-concept.md` (phase table) and
+      `docs/agentic-video-product.md` (reuse table, home cards) to reflect
+      the link; move this feature's status lines from Proposed to shipped
+      per phase.


### PR DESCRIPTION
Adds `docs/script-storyboard-link/` — a PRD, technical design, and phased task list for linking the script and storyboard documents.

## Summary

- **`prd.md`** — problem, goals/non-goals, the three entry orders (script-first, storyboard-first, prompt-first in Studio), user stories, requirements, success measures.
- **`design.md`** — the link model (`script_id` on the screenplay, `script_line_ids` + `script_text_snapshot` + `duration_source` on shots, `storyboard_id` back-pointer on scripts), pure shared mappings (`extractScriptFromScreenplay`, `deriveShotScaffold`, `linkedShotDurationMs`, `buildLinkedTimeline`), agent/`ui_*` tool surface, web UX, and what deliberately does not change.
- **`tasks.md`** — four independently shippable phases with file paths and verification steps.

Core decisions: link the documents with line↔shot keys rather than merging them (script owns words + voice, storyboard owns visuals + motion, timeline owns placement); either document can be created first and derived from the other; voiced take durations drive shot timing; one assemble lays shots and takes into a single timeline with both existing back-sync paths untouched; unlinked flows stay byte-identical.

Docs only — no code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_015juo8p2gNmYSBjbHFvLYZq)_