### PR TITLE
feat(protocol): script↔storyboard link fields and mappings

### DIFF
--- a/packages/protocol/src/api-schemas/storyboards.ts
+++ b/packages/protocol/src/api-schemas/storyboards.ts
@@ -25,7 +25,12 @@ export const storyboardShot = z
     motion: z.string().optional(),
     duration_seconds: z.number().optional(),
     keyframe: mediaRef.nullable().optional(),
-    clip: mediaRef.nullable().optional()
+    clip: mediaRef.nullable().optional(),
+    /** Ordered ids of the linked script's lines this shot covers. */
+    script_line_ids: z.array(z.string()).optional(),
+    /** Linked line texts as last projected, joined "\n" — drift only. */
+    script_text_snapshot: z.string().optional(),
+    duration_source: z.enum(["audio", "manual"]).optional()
   })
   .passthrough();
 export type StoryboardShot = z.infer<typeof storyboardShot>;
@@ -35,7 +40,9 @@ export const storyboardScreenplay = z
     type: z.literal("screenplay"),
     id: z.string(),
     title: z.string(),
-    shots: z.array(storyboardShot)
+    shots: z.array(storyboardShot),
+    /** The linked script resource, when this board's words come from one. */
+    script_id: z.string().nullable().optional()
   })
   .passthrough();
 export type StoryboardScreenplay = z.infer<typeof storyboardScreenplay>;
@@ -55,7 +62,10 @@ const SHOT_KEY_ALIASES: Readonly<Record<string, string>> = {
   locationId: "location_id",
   keyframeVersions: "keyframe_versions",
   clipVersions: "clip_versions",
-  costEstimate: "cost_estimate"
+  costEstimate: "cost_estimate",
+  scriptLineIds: "script_line_ids",
+  scriptTextSnapshot: "script_text_snapshot",
+  durationSource: "duration_source"
 };
 
 /** Tool-surface screenplay key → wire key. `style` is the Director's alias. */
@@ -65,6 +75,7 @@ const SCREENPLAY_KEY_ALIASES: Readonly<Record<string, string>> = {
   aspectRatio: "aspect_ratio",
   musicPrompt: "music_prompt",
   entityIds: "entity_ids",
+  scriptId: "script_id",
   createdAt: "created_at",
   updatedAt: "updated_at"
 };

--- a/packages/protocol/src/creative.ts
+++ b/packages/protocol/src/creative.ts
@@ -138,7 +138,28 @@ export interface Shot {
   /** Estimated cost to render this shot's clip, for the gate. */
   cost_estimate?: number | null;
   notes?: string;
+  /**
+   * Ordered ids of the linked script's lines this shot covers. Only meaningful
+   * on a board whose {@link Screenplay.script_id} is set; a line belongs to at
+   * most one shot.
+   */
+  script_line_ids?: string[];
+  /**
+   * The linked line texts joined with "\n" as they were last projected into
+   * this shot. Compared against the live texts to detect drift — never read as
+   * content.
+   */
+  script_text_snapshot?: string;
+  /**
+   * Where {@link duration_seconds} comes from. `"audio"` (the default on a
+   * linked shot) derives it from the linked lines' takes; `"manual"` pins the
+   * user's own value and keeps audio from touching it.
+   */
+  duration_source?: ShotDurationSource;
 }
+
+/** Whether a shot's length follows its linked audio or a pinned user value. */
+export type ShotDurationSource = "audio" | "manual";
 
 /**
  * The direction artifact: a full screenplay a Director agent produces from a
@@ -162,6 +183,12 @@ export interface Screenplay {
   music_prompt?: string;
   /** Entities referenced anywhere in the screenplay. */
   entity_ids?: string[];
+  /**
+   * The script resource this board's words come from. The board references the
+   * script, never the reverse: line↔shot membership lives in the shots'
+   * {@link Shot.script_line_ids}.
+   */
+  script_id?: string | null;
   created_at?: string;
   updated_at?: string;
 }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -20,6 +20,7 @@ export {
 } from "./wrap-primitives.js";
 export * from "./toolSchemas.js";
 export * from "./creative.js";
+export * from "./script-link.js";
 export * from "./builtin-packs.js";
 export * from "./triggers.js";
 export * from "./cloud-profile.js";

--- a/packages/protocol/src/script-link.ts
+++ b/packages/protocol/src/script-link.ts
@@ -314,12 +314,17 @@ export function deriveShotScaffold(
       const narration = group
         .filter((line) => isNarrationLine(line, script.cast))
         .map((line) => line.text.trim());
-      scaffolds.push({
+      const scaffold: ShotScaffold = {
         index: scaffolds.length,
-        script_line_ids: group.map((line) => line.id),
-        ...(dialogue.length > 0 ? { dialogue: joinLineTexts(dialogue) } : {}),
-        ...(narration.length > 0 ? { narration: joinLineTexts(narration) } : {})
-      });
+        script_line_ids: group.map((line) => line.id)
+      };
+      if (dialogue.length > 0) {
+        scaffold.dialogue = joinLineTexts(dialogue);
+      }
+      if (narration.length > 0) {
+        scaffold.narration = joinLineTexts(narration);
+      }
+      scaffolds.push(scaffold);
     }
   }
   return scaffolds;

--- a/packages/protocol/src/script-link.ts
+++ b/packages/protocol/src/script-link.ts
@@ -1,0 +1,371 @@
+/**
+ * @nodetool-ai/protocol – Script ↔ storyboard link
+ *
+ * The two pre-production documents stay separate: the script owns words and
+ * voice, the storyboard owns visuals and motion. What connects them is a set of
+ * keys on the board — {@link Screenplay.script_id} and each shot's
+ * {@link Shot.script_line_ids} — and the pure mappings in this module:
+ *
+ *   - {@link extractScriptFromScreenplay}: board → script document.
+ *   - {@link deriveShotScaffold}: script → the linkage half of a board.
+ *   - {@link validateScriptLink}: the invariants both directions must hold.
+ *   - {@link shotDialogueDrifted} / {@link orphanedLineIds}: derived, never
+ *     stored, like `needsVoicing` in `@nodetool-ai/timeline`.
+ *
+ * Protocol, because it maps between two protocol document shapes and must stay
+ * dependency-free — the web editors, the agent tools, and the evals all read
+ * these same answers.
+ */
+
+import { entitiesForShot, type Entity, type Screenplay, type Shot } from "./creative.js";
+import type {
+  ScriptDocumentSchema,
+  ScriptLine,
+  ScriptSection,
+  Speaker
+} from "./api-schemas/scripts.js";
+
+/** Cast id of the voice that reads narration, minted by the extractor. */
+export const NARRATOR_SPEAKER_ID = "speaker_narrator";
+
+/** Display name of the narrator speaker. */
+export const NARRATOR_SPEAKER_NAME = "Narrator";
+
+/** Text of the linked lines as one block, the form a snapshot is stored in. */
+export const joinLineTexts = (texts: string[]): string => texts.join("\n");
+
+// ---------------------------------------------------------------------------
+// Extract: screenplay → script document
+// ---------------------------------------------------------------------------
+
+/** What {@link extractScriptFromScreenplay} produces. */
+export interface ExtractedScript {
+  document: ScriptDocumentSchema;
+  /** Ordered line ids per shot, ready to stamp onto `script_line_ids`. */
+  lineIdsByShotId: Record<string, string[]>;
+}
+
+const dialogueLineId = (shotId: string): string => `line_${shotId}_dialogue`;
+const narrationLineId = (shotId: string): string => `line_${shotId}_narration`;
+
+const speakerIdForEntity = (entityId: string): string => `speaker_${entityId}`;
+
+const nonEmpty = (value: string | undefined): string | undefined => {
+  const text = value?.trim();
+  return text ? text : undefined;
+};
+
+/**
+ * The character entity that speaks a shot's dialogue: the first character in
+ * the board's own {@link entitiesForShot} selection, so an extracted script
+ * casts a shot exactly the way a render seasons it.
+ */
+function speakingEntity(shot: Shot, entities: Entity[]): Entity | undefined {
+  return entitiesForShot(shot, entities).find(
+    (entity) => entity.kind === "character"
+  );
+}
+
+/**
+ * A character's cast entry. `voice_id` seeds the voice selection; provider and
+ * model stay empty for the cast panel (or Studio's curated lineup) to fill,
+ * because the board never records which TTS provider a voice id belongs to.
+ */
+function speakerForEntity(entity: Entity): Speaker {
+  const voiceId = nonEmpty(entity.voice_id ?? undefined);
+  return {
+    id: speakerIdForEntity(entity.id),
+    name: entity.name,
+    voice: voiceId ? { provider: "", model: "", voice: voiceId } : null
+  };
+}
+
+function emptyLine(id: string, speakerId: string | null, text: string): ScriptLine {
+  return { id, speakerId, text, takes: [] };
+}
+
+/**
+ * Project a screenplay's words into a script document, deterministically and
+ * without a model call: one section for the board, one line per shot dialogue
+ * and one per shot narration, in `index` order.
+ *
+ * The returned `lineIdsByShotId` is what the caller stamps onto the shots in
+ * the same save, so extraction and linking are one transaction.
+ */
+export function extractScriptFromScreenplay(
+  screenplay: Screenplay,
+  entities: Entity[]
+): ExtractedScript {
+  const shots = [...screenplay.shots].sort((a, b) => a.index - b.index);
+  const lines: ScriptLine[] = [];
+  const lineIdsByShotId: Record<string, string[]> = {};
+  const cast: Speaker[] = [];
+  const castIds = new Set<string>();
+
+  const addSpeaker = (speaker: Speaker): void => {
+    if (castIds.has(speaker.id)) {
+      return;
+    }
+    castIds.add(speaker.id);
+    cast.push(speaker);
+  };
+
+  for (const shot of shots) {
+    const shotLineIds: string[] = [];
+    const dialogue = nonEmpty(shot.dialogue);
+    if (dialogue) {
+      const entity = speakingEntity(shot, entities);
+      if (entity) {
+        addSpeaker(speakerForEntity(entity));
+      }
+      const id = dialogueLineId(shot.id);
+      lines.push(
+        emptyLine(id, entity ? speakerIdForEntity(entity.id) : null, dialogue)
+      );
+      shotLineIds.push(id);
+    }
+    const narration = nonEmpty(shot.narration);
+    if (narration) {
+      addSpeaker({
+        id: NARRATOR_SPEAKER_ID,
+        name: NARRATOR_SPEAKER_NAME,
+        voice: null
+      });
+      const id = narrationLineId(shot.id);
+      lines.push(emptyLine(id, NARRATOR_SPEAKER_ID, narration));
+      shotLineIds.push(id);
+    }
+    if (shotLineIds.length > 0) {
+      lineIdsByShotId[shot.id] = shotLineIds;
+    }
+  }
+
+  const section: ScriptSection = {
+    id: `section_${screenplay.id}`,
+    title: screenplay.title,
+    lines
+  };
+  return { document: { cast, sections: [section] }, lineIdsByShotId };
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/** Why a link is broken. One code per rule in the design's invariant list. */
+export type ScriptLinkIssueCode =
+  | "duplicate_line_reference"
+  | "unknown_line_reference"
+  | "missing_script"
+  | "unlinked_board_reference";
+
+/** One finding. `severity` decides whether a save is refused or annotated. */
+export interface ScriptLinkIssue {
+  severity: "error" | "warning";
+  code: ScriptLinkIssueCode;
+  message: string;
+  shotId?: string;
+  lineId?: string;
+}
+
+export interface ScriptLinkValidation {
+  errors: ScriptLinkIssue[];
+  warnings: ScriptLinkIssue[];
+}
+
+/** Just the part of a script document the link rules read. */
+export interface ScriptLinkDocument {
+  sections: ScriptSection[];
+}
+
+/** Every line of a script in reading order. */
+export const linkedScriptLines = (
+  script: ScriptLinkDocument
+): ScriptLine[] => script.sections.flatMap((section) => section.lines);
+
+/**
+ * Check a board against the script it links, per design §1.3. A missing script
+ * (deleted, or not loadable) is a warning — the board still works, only the
+ * link affordances go dead — while a reference that cannot be satisfied is an
+ * error naming the shot that carries it.
+ */
+export function validateScriptLink(
+  screenplay: Screenplay,
+  scriptDoc: ScriptLinkDocument | null | undefined
+): ScriptLinkValidation {
+  const errors: ScriptLinkIssue[] = [];
+  const warnings: ScriptLinkIssue[] = [];
+  const linked = !!nonEmpty(screenplay.script_id ?? undefined);
+  const knownLineIds = scriptDoc
+    ? new Set(linkedScriptLines(scriptDoc).map((line) => line.id))
+    : null;
+  const ownerByLineId = new Map<string, string>();
+
+  for (const shot of screenplay.shots) {
+    const lineIds = shot.script_line_ids ?? [];
+    if (lineIds.length > 0 && !linked) {
+      errors.push({
+        severity: "error",
+        code: "unlinked_board_reference",
+        shotId: shot.id,
+        message: `Shot ${shot.id} references script lines, but the board has no \`script_id\`.`
+      });
+    }
+    for (const lineId of lineIds) {
+      const owner = ownerByLineId.get(lineId);
+      if (owner === undefined) {
+        ownerByLineId.set(lineId, shot.id);
+      } else {
+        errors.push({
+          severity: "error",
+          code: "duplicate_line_reference",
+          shotId: shot.id,
+          lineId,
+          message: `Line ${lineId} is referenced by shot ${owner} and shot ${shot.id}; a line belongs to one shot.`
+        });
+      }
+      if (knownLineIds && !knownLineIds.has(lineId)) {
+        errors.push({
+          severity: "error",
+          code: "unknown_line_reference",
+          shotId: shot.id,
+          lineId,
+          message: `Shot ${shot.id} references line ${lineId}, which the linked script does not have.`
+        });
+      }
+    }
+  }
+
+  if (linked && !scriptDoc) {
+    warnings.push({
+      severity: "warning",
+      code: "missing_script",
+      message: `Linked script ${screenplay.script_id} was not found; the board keeps its text but link actions are unavailable.`
+    });
+  }
+  return { errors, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// Derive: script → shot scaffold
+// ---------------------------------------------------------------------------
+
+/**
+ * The linkage half of a shot: which lines it covers, in what order, and the
+ * text projected from them. Shot *content* — action, camera, motion, slug,
+ * entities — is the Director agent's job.
+ */
+export interface ShotScaffold {
+  index: number;
+  script_line_ids: string[];
+  /** Joined text of the covered lines spoken by a cast member. */
+  dialogue?: string;
+  /** Joined text of the covered narrator lines. */
+  narration?: string;
+}
+
+export interface DeriveShotScaffoldOptions {
+  /** Lines one shot may cover. Default 1; a shot never spans two sections. */
+  maxLinesPerShot?: number;
+}
+
+/** Just the part of a script {@link deriveShotScaffold} reads. */
+export interface ScaffoldScript {
+  id: string;
+  cast: Speaker[];
+  sections: ScriptSection[];
+}
+
+/**
+ * A line reads as narration when nothing casts it or its speaker is the
+ * narrator — the inverse of what {@link extractScriptFromScreenplay} writes, so
+ * a board extracted from a script and derived back projects the same fields.
+ */
+function isNarrationLine(line: ScriptLine, cast: Speaker[]): boolean {
+  if (!line.speakerId) {
+    return true;
+  }
+  if (line.speakerId === NARRATOR_SPEAKER_ID) {
+    return true;
+  }
+  const speaker = cast.find((entry) => entry.id === line.speakerId);
+  return speaker?.name.trim().toLowerCase() === NARRATOR_SPEAKER_NAME.toLowerCase();
+}
+
+/**
+ * Chunk a script's lines into shots: reading order, at most
+ * `maxLinesPerShot` per shot, never crossing a section boundary. Lines with no
+ * text are skipped — there is nothing for a shot to cover.
+ */
+export function deriveShotScaffold(
+  script: ScaffoldScript,
+  options: DeriveShotScaffoldOptions = {}
+): ShotScaffold[] {
+  const perShot = Math.max(1, Math.floor(options.maxLinesPerShot ?? 1));
+  const scaffolds: ShotScaffold[] = [];
+
+  for (const section of script.sections) {
+    const lines = section.lines.filter((line) => !!nonEmpty(line.text));
+    for (let start = 0; start < lines.length; start += perShot) {
+      const group = lines.slice(start, start + perShot);
+      const dialogue = group
+        .filter((line) => !isNarrationLine(line, script.cast))
+        .map((line) => line.text.trim());
+      const narration = group
+        .filter((line) => isNarrationLine(line, script.cast))
+        .map((line) => line.text.trim());
+      scaffolds.push({
+        index: scaffolds.length,
+        script_line_ids: group.map((line) => line.id),
+        ...(dialogue.length > 0 ? { dialogue: joinLineTexts(dialogue) } : {}),
+        ...(narration.length > 0 ? { narration: joinLineTexts(narration) } : {})
+      });
+    }
+  }
+  return scaffolds;
+}
+
+// ---------------------------------------------------------------------------
+// Drift
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether the linked lines now read differently from what was last projected
+ * into the shot. A line the map does not carry contributes nothing, so a
+ * deleted line drifts the shot it belonged to.
+ */
+export function shotDialogueDrifted(
+  shot: Shot,
+  linesById: Map<string, ScriptLine>
+): boolean {
+  const lineIds = shot.script_line_ids ?? [];
+  if (lineIds.length === 0) {
+    return false;
+  }
+  const live = joinLineTexts(
+    lineIds
+      .map((id) => linesById.get(id)?.text)
+      .filter((text): text is string => text !== undefined)
+  );
+  return live !== (shot.script_text_snapshot ?? "");
+}
+
+/**
+ * Lines of the linked script that no shot covers, in reading order. Empty for
+ * an unlinked board: without a `script_id` there is nothing to be orphaned
+ * from.
+ */
+export function orphanedLineIds(
+  screenplay: Screenplay,
+  scriptDoc: ScriptLinkDocument
+): string[] {
+  if (!nonEmpty(screenplay.script_id ?? undefined)) {
+    return [];
+  }
+  const covered = new Set(
+    screenplay.shots.flatMap((shot) => shot.script_line_ids ?? [])
+  );
+  return linkedScriptLines(scriptDoc)
+    .map((line) => line.id)
+    .filter((id) => !covered.has(id));
+}

--- a/packages/protocol/tests/api-schemas-storyboards.test.ts
+++ b/packages/protocol/tests/api-schemas-storyboards.test.ts
@@ -110,6 +110,67 @@ describe("normalizeStoryboardScreenplay", () => {
   });
 });
 
+describe("script link fields", () => {
+  it("normalizes the camelCase link aliases onto the wire keys", () => {
+    const play = normalizeStoryboardScreenplay({
+      type: "screenplay",
+      title: "Linked",
+      scriptId: "script_1",
+      shots: [
+        {
+          action: "Maren climbs the stair",
+          scriptLineIds: ["l1", "l2"],
+          scriptTextSnapshot: "One more night.\nIt will hold.",
+          durationSource: "audio"
+        }
+      ]
+    });
+    expect(play.script_id).toBe("script_1");
+    expect(play.shots[0].script_line_ids).toEqual(["l1", "l2"]);
+    expect(play.shots[0].script_text_snapshot).toBe(
+      "One more night.\nIt will hold."
+    );
+    expect(play.shots[0].duration_source).toBe("audio");
+  });
+
+  it("prefers the wire key over its alias", () => {
+    const play = normalizeStoryboardScreenplay({
+      type: "screenplay",
+      title: "Both",
+      script_id: "wire",
+      scriptId: "alias",
+      shots: [
+        {
+          action: "A shot",
+          duration_source: "manual",
+          durationSource: "audio"
+        }
+      ]
+    });
+    expect(play.script_id).toBe("wire");
+    expect(play.shots[0].duration_source).toBe("manual");
+  });
+
+  it("leaves a document without link fields unchanged", () => {
+    const play = normalizeStoryboardScreenplay(agentScreenplay);
+    expect(play.script_id).toBeUndefined();
+    expect(play.shots[0].script_line_ids).toBeUndefined();
+    expect(play.shots[0].script_text_snapshot).toBeUndefined();
+    expect(play.shots[0].duration_source).toBeUndefined();
+    expect(() => storyboardScreenplay.parse(play)).not.toThrow();
+  });
+
+  it("refuses a duration_source outside the two known values", () => {
+    expect(() =>
+      normalizeStoryboardScreenplay({
+        type: "screenplay",
+        title: "Bad",
+        shots: [{ action: "A shot", durationSource: "vibes" }]
+      })
+    ).toThrow(/duration_source/);
+  });
+});
+
 describe("normalizeStoryboardShot", () => {
   it("fills in what the save requires", () => {
     const shot = normalizeStoryboardShot(

--- a/packages/protocol/tests/script-link.test.ts
+++ b/packages/protocol/tests/script-link.test.ts
@@ -1,0 +1,414 @@
+import { describe, expect, it } from "vitest";
+import type { Entity, Screenplay, Shot } from "../src/creative.js";
+import type { ScriptLine } from "../src/api-schemas/scripts.js";
+import {
+  NARRATOR_SPEAKER_ID,
+  deriveShotScaffold,
+  extractScriptFromScreenplay,
+  orphanedLineIds,
+  shotDialogueDrifted,
+  validateScriptLink
+} from "../src/script-link.js";
+
+const shot = (overrides: Partial<Shot> & Pick<Shot, "id" | "index">): Shot => ({
+  type: "shot",
+  action: "A lighthouse against a darkening sky",
+  status: "planned",
+  ...overrides
+});
+
+const screenplay = (shots: Shot[], overrides: Partial<Screenplay> = {}): Screenplay => ({
+  type: "screenplay",
+  id: "sp_1",
+  title: "Lighthouse Dawn",
+  shots,
+  ...overrides
+});
+
+const character = (id: string, name: string, voiceId?: string): Entity => ({
+  type: "entity",
+  id,
+  kind: "character",
+  name,
+  descriptor: `${name}, weathered face`,
+  voice_id: voiceId ?? null
+});
+
+const line = (id: string, text: string, speakerId: string | null): ScriptLine => ({
+  id,
+  speakerId,
+  text,
+  takes: []
+});
+
+describe("extractScriptFromScreenplay", () => {
+  const maren = character("ent_maren", "Maren", "voice_maren");
+  const otto = character("ent_otto", "Otto");
+  const style: Entity = {
+    type: "entity",
+    id: "ent_noir",
+    kind: "style",
+    name: "Noir",
+    descriptor: "high contrast"
+  };
+
+  const play = screenplay([
+    shot({
+      id: "shot_a",
+      index: 0,
+      action: "Maren climbs the stair",
+      dialogue: "One more night.",
+      narration: "The keeper had counted every dawn."
+    }),
+    shot({
+      id: "shot_b",
+      index: 1,
+      action: "Otto watches the beam",
+      dialogue: "It will hold."
+    }),
+    shot({ id: "shot_c", index: 2, action: "The beam dies" })
+  ]);
+
+  it("casts a shot's dialogue with the character entitiesForShot matched", () => {
+    const { document } = extractScriptFromScreenplay(play, [maren, otto, style]);
+    const lines = document.sections[0].lines;
+    expect(lines.map((l) => l.text)).toEqual([
+      "One more night.",
+      "The keeper had counted every dawn.",
+      "It will hold."
+    ]);
+    expect(lines[0].speakerId).toBe("speaker_ent_maren");
+    expect(lines[1].speakerId).toBe(NARRATOR_SPEAKER_ID);
+    expect(lines[2].speakerId).toBe("speaker_ent_otto");
+    // The style entity applies to every shot but casts nobody.
+    expect(document.cast.map((s) => s.id)).toEqual([
+      "speaker_ent_maren",
+      NARRATOR_SPEAKER_ID,
+      "speaker_ent_otto"
+    ]);
+  });
+
+  it("seeds voice_id onto the cast entry and leaves the rest unset", () => {
+    const { document } = extractScriptFromScreenplay(play, [maren, otto]);
+    expect(document.cast[0].voice).toEqual({
+      provider: "",
+      model: "",
+      voice: "voice_maren"
+    });
+    expect(document.cast[2].voice).toBeNull();
+  });
+
+  it("returns a shot→lines map covering only shots with words", () => {
+    const { lineIdsByShotId } = extractScriptFromScreenplay(play, [maren, otto]);
+    expect(lineIdsByShotId).toEqual({
+      shot_a: ["line_shot_a_dialogue", "line_shot_a_narration"],
+      shot_b: ["line_shot_b_dialogue"]
+    });
+    expect(lineIdsByShotId.shot_c).toBeUndefined();
+  });
+
+  it("reads shots in index order, not array order", () => {
+    const reversed = screenplay([
+      shot({ id: "shot_late", index: 1, action: "b", narration: "second" }),
+      shot({ id: "shot_early", index: 0, action: "a", narration: "first" })
+    ]);
+    const { document } = extractScriptFromScreenplay(reversed, []);
+    expect(document.sections[0].lines.map((l) => l.text)).toEqual([
+      "first",
+      "second"
+    ]);
+  });
+
+  it("honours an explicit entity_ids override on a shot", () => {
+    const override = screenplay([
+      shot({
+        id: "shot_x",
+        index: 0,
+        action: "Maren climbs the stair",
+        dialogue: "One more night.",
+        entity_ids: ["ent_otto"]
+      })
+    ]);
+    const { document } = extractScriptFromScreenplay(override, [maren, otto]);
+    expect(document.sections[0].lines[0].speakerId).toBe("speaker_ent_otto");
+  });
+
+  it("leaves a line uncast when no character matches", () => {
+    const { document } = extractScriptFromScreenplay(
+      screenplay([
+        shot({ id: "shot_y", index: 0, action: "A door opens", dialogue: "Hello?" })
+      ]),
+      []
+    );
+    expect(document.sections[0].lines[0].speakerId).toBeNull();
+    expect(document.cast).toEqual([]);
+  });
+
+  it("titles the single section from the screenplay", () => {
+    const { document } = extractScriptFromScreenplay(play, []);
+    expect(document.sections).toHaveLength(1);
+    expect(document.sections[0].title).toBe("Lighthouse Dawn");
+    expect(document.sections[0].id).toBe("section_sp_1");
+  });
+});
+
+describe("validateScriptLink", () => {
+  const scriptDoc = {
+    sections: [
+      {
+        id: "sec_1",
+        lines: [line("l1", "One", null), line("l2", "Two", null)]
+      }
+    ]
+  };
+
+  it("accepts a board whose references all resolve", () => {
+    const play = screenplay(
+      [
+        shot({ id: "s1", index: 0, script_line_ids: ["l1"] }),
+        shot({ id: "s2", index: 1, script_line_ids: ["l2"] })
+      ],
+      { script_id: "script_1" }
+    );
+    expect(validateScriptLink(play, scriptDoc)).toEqual({
+      errors: [],
+      warnings: []
+    });
+  });
+
+  it("reports a line claimed by two shots", () => {
+    const play = screenplay(
+      [
+        shot({ id: "s1", index: 0, script_line_ids: ["l1"] }),
+        shot({ id: "s2", index: 1, script_line_ids: ["l1"] })
+      ],
+      { script_id: "script_1" }
+    );
+    const { errors } = validateScriptLink(play, scriptDoc);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe("duplicate_line_reference");
+    expect(errors[0].shotId).toBe("s2");
+    expect(errors[0].message).toContain("s1");
+  });
+
+  it("reports a reference the script cannot satisfy, naming the shot", () => {
+    const play = screenplay(
+      [shot({ id: "s1", index: 0, script_line_ids: ["l1", "l_gone"] })],
+      { script_id: "script_1" }
+    );
+    const { errors } = validateScriptLink(play, scriptDoc);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe("unknown_line_reference");
+    expect(errors[0].lineId).toBe("l_gone");
+    expect(errors[0].shotId).toBe("s1");
+  });
+
+  it("warns, but does not error, when the linked script is gone", () => {
+    const play = screenplay([shot({ id: "s1", index: 0 })], {
+      script_id: "script_1"
+    });
+    const { errors, warnings } = validateScriptLink(play, null);
+    expect(errors).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].code).toBe("missing_script");
+  });
+
+  it("errors on line references without a script_id", () => {
+    const play = screenplay([
+      shot({ id: "s1", index: 0, script_line_ids: ["l1"] })
+    ]);
+    const { errors } = validateScriptLink(play, scriptDoc);
+    expect(errors.map((issue) => issue.code)).toEqual([
+      "unlinked_board_reference"
+    ]);
+  });
+
+  it("passes an unlinked board with no references", () => {
+    const play = screenplay([shot({ id: "s1", index: 0 })]);
+    expect(validateScriptLink(play, null)).toEqual({ errors: [], warnings: [] });
+  });
+});
+
+describe("deriveShotScaffold", () => {
+  const cast = [
+    { id: NARRATOR_SPEAKER_ID, name: "Narrator", voice: null },
+    { id: "speaker_maren", name: "Maren", voice: null }
+  ];
+  const script = {
+    id: "script_1",
+    cast,
+    sections: [
+      {
+        id: "sec_1",
+        lines: [
+          line("l1", "The keeper had counted every dawn.", NARRATOR_SPEAKER_ID),
+          line("l2", "One more night.", "speaker_maren")
+        ]
+      },
+      {
+        id: "sec_2",
+        lines: [line("l3", "It will hold.", "speaker_maren")]
+      }
+    ]
+  };
+
+  it("gives one shot per line by default, in reading order", () => {
+    const scaffold = deriveShotScaffold(script);
+    expect(scaffold.map((s) => s.script_line_ids)).toEqual([
+      ["l1"],
+      ["l2"],
+      ["l3"]
+    ]);
+    expect(scaffold.map((s) => s.index)).toEqual([0, 1, 2]);
+  });
+
+  it("projects narrator lines as narration and cast lines as dialogue", () => {
+    const scaffold = deriveShotScaffold(script);
+    expect(scaffold[0]).toEqual({
+      index: 0,
+      script_line_ids: ["l1"],
+      narration: "The keeper had counted every dawn."
+    });
+    expect(scaffold[1]).toEqual({
+      index: 1,
+      script_line_ids: ["l2"],
+      dialogue: "One more night."
+    });
+  });
+
+  it("treats an uncast line as narration", () => {
+    const scaffold = deriveShotScaffold({
+      id: "script_2",
+      cast: [],
+      sections: [{ id: "sec_1", lines: [line("l1", "Silence.", null)] }]
+    });
+    expect(scaffold[0].narration).toBe("Silence.");
+    expect(scaffold[0].dialogue).toBeUndefined();
+  });
+
+  it("groups up to maxLinesPerShot lines but never crosses a section", () => {
+    const scaffold = deriveShotScaffold(script, { maxLinesPerShot: 2 });
+    expect(scaffold.map((s) => s.script_line_ids)).toEqual([
+      ["l1", "l2"],
+      ["l3"]
+    ]);
+    expect(scaffold[0].narration).toBe("The keeper had counted every dawn.");
+    expect(scaffold[0].dialogue).toBe("One more night.");
+  });
+
+  it("skips empty lines", () => {
+    const scaffold = deriveShotScaffold({
+      id: "script_3",
+      cast,
+      sections: [
+        {
+          id: "sec_1",
+          lines: [line("l1", "  ", null), line("l2", "Spoken.", "speaker_maren")]
+        }
+      ]
+    });
+    expect(scaffold).toHaveLength(1);
+    expect(scaffold[0].script_line_ids).toEqual(["l2"]);
+  });
+
+  it("round-trips an extracted script back to the same projection", () => {
+    const play = screenplay([
+      shot({
+        id: "shot_a",
+        index: 0,
+        action: "Maren climbs",
+        dialogue: "One more night."
+      }),
+      shot({
+        id: "shot_b",
+        index: 1,
+        action: "The beam turns",
+        narration: "Dawn came anyway."
+      })
+    ]);
+    const maren = character("ent_maren", "Maren");
+    const { document } = extractScriptFromScreenplay(play, [maren]);
+    const scaffold = deriveShotScaffold({ id: "script_1", ...document });
+    expect(scaffold[0].dialogue).toBe("One more night.");
+    expect(scaffold[1].narration).toBe("Dawn came anyway.");
+  });
+});
+
+describe("shotDialogueDrifted", () => {
+  const linesById = new Map<string, ScriptLine>([
+    ["l1", line("l1", "One more night.", null)],
+    ["l2", line("l2", "It will hold.", null)]
+  ]);
+
+  it("is false when the snapshot matches the joined live texts", () => {
+    const target = shot({
+      id: "s1",
+      index: 0,
+      script_line_ids: ["l1", "l2"],
+      script_text_snapshot: "One more night.\nIt will hold."
+    });
+    expect(shotDialogueDrifted(target, linesById)).toBe(false);
+  });
+
+  it("is true after a linked line's text changes", () => {
+    const target = shot({
+      id: "s1",
+      index: 0,
+      script_line_ids: ["l1"],
+      script_text_snapshot: "One last night."
+    });
+    expect(shotDialogueDrifted(target, linesById)).toBe(true);
+  });
+
+  it("is true when a linked line is gone", () => {
+    const target = shot({
+      id: "s1",
+      index: 0,
+      script_line_ids: ["l1", "l_gone"],
+      script_text_snapshot: "One more night.\nIt will hold."
+    });
+    expect(shotDialogueDrifted(target, linesById)).toBe(true);
+  });
+
+  it("is false for a shot that links nothing", () => {
+    expect(shotDialogueDrifted(shot({ id: "s1", index: 0 }), linesById)).toBe(
+      false
+    );
+  });
+});
+
+describe("orphanedLineIds", () => {
+  const scriptDoc = {
+    sections: [
+      {
+        id: "sec_1",
+        lines: [line("l1", "One", null), line("l2", "Two", null)]
+      },
+      { id: "sec_2", lines: [line("l3", "Three", null)] }
+    ]
+  };
+
+  it("lists linked-script lines no shot covers, in reading order", () => {
+    const play = screenplay(
+      [shot({ id: "s1", index: 0, script_line_ids: ["l2"] })],
+      { script_id: "script_1" }
+    );
+    expect(orphanedLineIds(play, scriptDoc)).toEqual(["l1", "l3"]);
+  });
+
+  it("is empty when every line has a shot", () => {
+    const play = screenplay(
+      [
+        shot({ id: "s1", index: 0, script_line_ids: ["l1", "l2"] }),
+        shot({ id: "s2", index: 1, script_line_ids: ["l3"] })
+      ],
+      { script_id: "script_1" }
+    );
+    expect(orphanedLineIds(play, scriptDoc)).toEqual([]);
+  });
+
+  it("is empty on an unlinked board", () => {
+    const play = screenplay([shot({ id: "s1", index: 0 })]);
+    expect(orphanedLineIds(play, scriptDoc)).toEqual([]);
+  });
+});


### PR DESCRIPTION
First slice of [Script ↔ Storyboard Link](../blob/main/docs/script-storyboard-link/design.md), entirely inside `packages/protocol`. No behavior changes anywhere else — the fields are optional and nothing reads them yet.

## What

**Link fields (design §1.1).** The board references the script, never the reverse:

- `Screenplay.script_id`
- `Shot.script_line_ids`, `Shot.script_text_snapshot`, `Shot.duration_source`

Mirrored in the zod shapes in `api-schemas/storyboards.ts` (which stay `passthrough`, so old documents load unchanged) with the tool-surface aliases `scriptId`, `scriptLineIds`, `scriptTextSnapshot`, `durationSource`. `duration_source` is a two-value enum, so an unknown value fails the normalize instead of reaching storage.

**New module `src/script-link.ts`**, dependency-free like `entitiesForShot`:

- `extractScriptFromScreenplay(screenplay, entities)` (§2.1) — deterministic, no model call. One section per board, one line per shot dialogue and narration in `index` order; a dialogue line is cast by the first character in the shot's own `entitiesForShot` selection, so an extracted script casts a shot the way a render seasons it. `Entity.voice_id` seeds `voice.voice`; provider and model stay empty for the cast panel. Returns `lineIdsByShotId` so the caller stamps the linkage in the same save.
- `validateScriptLink(screenplay, scriptDoc)` (§1.3) — the four invariants: a line in two shots and a reference the script cannot satisfy are errors naming the shot; a missing script is a warning (the board still works); line references on a board with no `script_id` are an error.
- `deriveShotScaffold(script, options?)` (§2.2) — reading order, one line per shot by default, never crossing a section, narrator lines projected as `narration` and cast lines as `dialogue` (the inverse of what the extractor writes, so extract → derive round-trips).
- `shotDialogueDrifted(shot, linesById)` and `orphanedLineIds(screenplay, scriptDoc)` (§2.5) — derived, never stored, next to how `needsVoicing` works.

Exported from `src/index.ts`.

## Testing

`packages/protocol/tests/script-link.test.ts` (new, 27 cases) and additions to `tests/api-schemas-storyboards.test.ts`: alias round-trip, wire key winning over its alias, an old document unchanged, a rejected `duration_source`, speaker matching through `entitiesForShot` (including an `entity_ids` override and an uncast line), `voice_id` seeding, the shot→lines map, index-order reads, duplicate and dangling references, scaffold order / grouping / section boundaries, drift after an edit and after a deleted line, and orphan listing.

Commands run in this worktree:

- `npm run build --workspace=packages/protocol` — pass (after building `packages/gpu`, whose `dist` was missing in the sandbox)
- `npm run test --workspace=packages/protocol` — 48 files, 878 tests, all pass
- `npm run lint --workspace=packages/protocol` (`tsc --noEmit`) — pass
- `oxlint` on the changed files — clean

Not run here: root `npm run typecheck` (web/electron/mobile resolve `@nodetool-ai/protocol` from the main checkout's `dist` in this sandbox, so the result would not reflect this branch) and the anti-slop enforced config (`@oxlint/plugins` is not installed in this environment — it fails on `main` too). CI covers both.

## Scope

Phase 1 protocol work plus the Phase 2 scaffold and Phase 4 drift helpers from `docs/script-storyboard-link/tasks.md`. Deliberately left out: the `scripts` table back-pointer, agent and `ui_*` tools, wiring `validateScriptLink` into the storyboard save path, `linkedShotDurationMs`, and `buildLinkedTimeline` — all owned by later PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qg4JML6CFGtajqVticjmEt)_