### PR TITLE
feat(models): add a storyboard back-pointer to scripts

### DIFF
--- a/packages/models/src/db.ts
+++ b/packages/models/src/db.ts
@@ -1203,6 +1203,7 @@ function getCreateSchemaSql(): string {
       "name" text NOT NULL,
       "document" text NOT NULL,
       "timeline_id" text,
+      "storyboard_id" text,
       "created_at" text NOT NULL,
       "updated_at" text NOT NULL
     );

--- a/packages/models/src/migrations/versions.ts
+++ b/packages/models/src/migrations/versions.ts
@@ -2700,6 +2700,26 @@ export const migrations: MigrationDef[] = [
       await db.execute("DROP INDEX IF EXISTS idx_jsv_script");
       await db.execute("DROP TABLE IF EXISTS js_script_versions");
     }
+  },
+
+  // ── Link a script back to its storyboard ────────────────────────────
+  // The storyboard owns the link (it projects line text into shots); the
+  // script keeps a back-pointer so "open storyboard" works from the script
+  // editor, exactly like the existing timeline_id back-pointer.
+  {
+    version: "20260816_000000",
+    name: "add_storyboard_id_to_scripts",
+    createsTables: [],
+    modifiesTables: ["scripts"],
+    async up(db) {
+      if (!(await db.tableExists("scripts"))) return;
+      if (!(await db.columnExists("scripts", "storyboard_id"))) {
+        await db.execute("ALTER TABLE scripts ADD COLUMN storyboard_id TEXT");
+      }
+    },
+    async down() {
+      // no-op: dropping columns is unsafe across dialects and versions
+    }
   }
 ];
 

--- a/packages/models/src/schema-pg/scripts.ts
+++ b/packages/models/src/schema-pg/scripts.ts
@@ -12,6 +12,8 @@ export const scripts = pgTable(
     document: jsonText<ScriptDocument>()("document").notNull(),
     /** Timeline sequence this script was assembled into, if any. */
     timeline_id: text("timeline_id"),
+    /** Storyboard this script is linked to, if any. */
+    storyboard_id: text("storyboard_id"),
     created_at: text("created_at").notNull(),
     updated_at: text("updated_at").notNull()
   },

--- a/packages/models/src/schema/scripts.ts
+++ b/packages/models/src/schema/scripts.ts
@@ -10,6 +10,8 @@ export const scripts = sqliteTable(
     document: text("document").notNull(),
     /** Timeline sequence this script was assembled into, if any. */
     timeline_id: text("timeline_id"),
+    /** Storyboard this script is linked to, if any. */
+    storyboard_id: text("storyboard_id"),
     created_at: text("created_at").notNull(),
     updated_at: text("updated_at").notNull()
   },

--- a/packages/models/src/script.ts
+++ b/packages/models/src/script.ts
@@ -75,6 +75,7 @@ export interface ScriptResponse {
   name: string;
   document: ScriptDocument;
   timelineId?: string;
+  storyboardId?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -125,6 +126,7 @@ export class Script extends DBModel {
   declare name: string;
   declare document: string;
   declare timeline_id: string | null;
+  declare storyboard_id: string | null;
   declare created_at: string;
   declare updated_at: string;
 
@@ -136,6 +138,7 @@ export class Script extends DBModel {
     this.name ??= "Untitled script";
     this.document ??= JSON.stringify(emptyScriptDocument());
     this.timeline_id ??= null;
+    this.storyboard_id ??= null;
     this.created_at ??= now;
     this.updated_at ??= now;
   }
@@ -159,6 +162,7 @@ export class Script extends DBModel {
       name: this.name,
       document: this.toDocument(),
       timelineId: this.timeline_id ?? undefined,
+      storyboardId: this.storyboard_id ?? undefined,
       createdAt: this.created_at,
       updatedAt: this.updated_at
     };
@@ -208,6 +212,7 @@ export class Script extends DBModel {
       name: string;
       document: string;
       timeline_id: string | null;
+      storyboard_id: string | null;
     }>
   ): Promise<Script | null> {
     if (fields.document !== undefined) {

--- a/packages/models/tests/migrations.test.ts
+++ b/packages/models/tests/migrations.test.ts
@@ -423,7 +423,7 @@ describe("MigrationRunner", () => {
 // ── Built-in migrations smoke test ───────────────────────────────────
 
 describe("Built-in migrations", () => {
-  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 62;
+  const EXPECTED_BUILT_IN_MIGRATION_COUNT = 63;
 
   it("should have correct count of migrations", () => {
     expect(migrations.length).toBe(EXPECTED_BUILT_IN_MIGRATION_COUNT);

--- a/packages/models/tests/script.test.ts
+++ b/packages/models/tests/script.test.ts
@@ -103,6 +103,31 @@ describe("Script model", () => {
     expect(updated!.updated_at).not.toBe(created.updated_at);
   });
 
+  it("round-trips the storyboard back-pointer and clears it", async () => {
+    const created = await createScript("u1", "p1", "Linked");
+    expect(created.storyboard_id).toBeNull();
+    expect(created.toResponse().storyboardId).toBeUndefined();
+
+    const linked = await Script.updateFieldsIfUnchanged(
+      created.id,
+      created.updated_at,
+      { storyboard_id: "sb-1" }
+    );
+    expect(linked!.storyboard_id).toBe("sb-1");
+
+    const reloaded = await Script.findById(created.id);
+    expect(reloaded!.storyboard_id).toBe("sb-1");
+    expect(reloaded!.toResponse().storyboardId).toBe("sb-1");
+
+    const cleared = await Script.updateFieldsIfUnchanged(
+      created.id,
+      reloaded!.updated_at,
+      { storyboard_id: null }
+    );
+    expect(cleared!.storyboard_id).toBeNull();
+    expect((await Script.findById(created.id))!.storyboard_id).toBeNull();
+  });
+
   it("rejects a CAS update on a stale token", async () => {
     const created = await createScript("u1", "p1", "Old");
     // First write advances the token.

--- a/packages/models/tests/versions-coverage.test.ts
+++ b/packages/models/tests/versions-coverage.test.ts
@@ -136,6 +136,20 @@ describe("built-in migration versions", () => {
     await expect(runMode.up(adapter)).resolves.toBeUndefined();
   });
 
+  it("add_storyboard_id_to_scripts adds the column only when missing", async () => {
+    const runner = new MigrationRunner(adapter);
+    await runner.migrate({ target: "20260812_000001" });
+
+    expect(await adapter.columnExists("scripts", "storyboard_id")).toBe(false);
+    const backPointer = migrations.find(
+      (m) => m.name === "add_storyboard_id_to_scripts"
+    )!;
+    await backPointer.up(adapter);
+    expect(await adapter.columnExists("scripts", "storyboard_id")).toBe(true);
+    // Second call takes the guard's false branch and is a no-op.
+    await expect(backPointer.up(adapter)).resolves.toBeUndefined();
+  });
+
   it("column-guarded prediction migrations early-return when the table is absent", async () => {
     // On a totally empty DB (no nodetool_predictions), the tableExists guard
     // must short-circuit these ups without throwing.

--- a/packages/protocol/src/api-schemas/scripts.ts
+++ b/packages/protocol/src/api-schemas/scripts.ts
@@ -86,6 +86,8 @@ export const scriptResponse = z.object({
   document: scriptDocument,
   /** Timeline sequence this script was assembled into, if any. */
   timelineId: z.string().optional(),
+  /** Storyboard this script is linked to, if any. */
+  storyboardId: z.string().optional(),
   createdAt: z.string(),
   updatedAt: z.string()
 });
@@ -113,7 +115,8 @@ export const patchScriptInput = z
   .object({
     name: z.string().min(1).optional(),
     document: scriptDocument.optional(),
-    timelineId: z.string().nullable().optional()
+    timelineId: z.string().nullable().optional(),
+    storyboardId: z.string().nullable().optional()
   })
   .refine((value) => Object.keys(value).length > 0, {
     message: "At least one field must be provided"

--- a/packages/websocket/src/trpc/routers/scripts.ts
+++ b/packages/websocket/src/trpc/routers/scripts.ts
@@ -126,6 +126,8 @@ export const scriptsRouter = router({
         fields.document = JSON.stringify(input.document);
       if (input.timelineId !== undefined)
         fields.timeline_id = input.timelineId;
+      if (input.storyboardId !== undefined)
+        fields.storyboard_id = input.storyboardId;
 
       const updated = await Script.updateFieldsIfUnchanged(
         input.id,

--- a/packages/websocket/tests/trpc-scripts.test.ts
+++ b/packages/websocket/tests/trpc-scripts.test.ts
@@ -1,0 +1,103 @@
+/**
+ * scripts router — the resource back-pointers.
+ *
+ * Real DB, real models: a patch of `storyboardId` (and its `timelineId`
+ * sibling) has to survive the write and come back on `get`, and clearing it
+ * to null has to stick.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initTestDb, ModelObserver } from "@nodetool-ai/models";
+import { appRouter } from "../src/trpc/router.js";
+import { createCallerFactory } from "../src/trpc/index.js";
+import type { Context } from "../src/trpc/context.js";
+
+const createCaller = createCallerFactory(appRouter);
+
+function makeCtx(userId: string): Context {
+  return {
+    userId,
+    registry: {} as never,
+    apiOptions: { metadataRoots: [], registry: {} as never } as never,
+    pythonBridge: {} as never,
+    getPythonBridgeReady: () => false
+  } as Context;
+}
+
+const caller = () => createCaller(makeCtx("user-1"));
+
+describe("scripts router back-pointers", () => {
+  beforeEach(() => initTestDb());
+  afterEach(() => ModelObserver.clear());
+
+  it("patches, round-trips and clears the storyboard back-pointer", async () => {
+    const created = await caller().scripts.create({
+      name: "Trailer",
+      projectId: "p1"
+    });
+    expect(created.storyboardId).toBeUndefined();
+
+    const linked = await caller().scripts.update({
+      id: created.id,
+      storyboardId: "sb-1",
+      baseUpdatedAt: created.updatedAt
+    });
+    expect(linked.storyboardId).toBe("sb-1");
+
+    const fetched = await caller().scripts.get({ id: created.id });
+    expect(fetched.storyboardId).toBe("sb-1");
+
+    const cleared = await caller().scripts.update({
+      id: created.id,
+      storyboardId: null,
+      baseUpdatedAt: fetched.updatedAt
+    });
+    expect(cleared.storyboardId).toBeUndefined();
+    expect(
+      (await caller().scripts.get({ id: created.id })).storyboardId
+    ).toBeUndefined();
+  });
+
+  it("leaves the storyboard back-pointer alone when the patch omits it", async () => {
+    const created = await caller().scripts.create({
+      name: "Trailer",
+      projectId: "p1"
+    });
+    const linked = await caller().scripts.update({
+      id: created.id,
+      storyboardId: "sb-1",
+      baseUpdatedAt: created.updatedAt
+    });
+
+    const renamed = await caller().scripts.update({
+      id: created.id,
+      name: "Trailer v2",
+      baseUpdatedAt: linked.updatedAt
+    });
+    expect(renamed.name).toBe("Trailer v2");
+    expect(renamed.storyboardId).toBe("sb-1");
+  });
+
+  it("keeps the timeline and storyboard back-pointers independent", async () => {
+    const created = await caller().scripts.create({
+      name: "Trailer",
+      projectId: "p1"
+    });
+    const both = await caller().scripts.update({
+      id: created.id,
+      timelineId: "tl-1",
+      storyboardId: "sb-1",
+      baseUpdatedAt: created.updatedAt
+    });
+    expect(both.timelineId).toBe("tl-1");
+    expect(both.storyboardId).toBe("sb-1");
+
+    const unlinked = await caller().scripts.update({
+      id: created.id,
+      storyboardId: null,
+      baseUpdatedAt: both.updatedAt
+    });
+    expect(unlinked.timelineId).toBe("tl-1");
+    expect(unlinked.storyboardId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Phase 1 of the [script ↔ storyboard link](../blob/main/docs/script-storyboard-link/design.md) — the "Script back-pointer" task only (design §1.2).

The storyboard owns the link (it projects line text into shots); the script only carries a back-pointer so "open storyboard" works from the script editor. It mirrors the existing `timeline_id` column exactly.

- Nullable `storyboard_id` on the `scripts` table: `packages/models/src/schema/scripts.ts`, the Postgres mirror in `schema-pg/scripts.ts`, the fresh-database DDL in `db.ts`, and an additive migration (`20260816_000000 add_storyboard_id_to_scripts`) for existing databases — the same `tableExists`/`columnExists` guard + no-op `down()` shape `add_timeline_id_to_assets` uses.
- `Script.storyboard_id`, `toResponse().storyboardId`, and the CAS field bag in `updateFieldsIfUnchanged`.
- `storyboardId` in `scriptResponse` (optional) and `patchScriptInput` (nullable optional) in `packages/protocol/src/api-schemas/scripts.ts`.
- CAS patch support in the `scripts` tRPC router, next to `timelineId`.

Nothing else in the feature is touched: no `creative.ts`, no `api-schemas/storyboards.ts`, no `script-link.ts`, no timeline/agents/web changes.

## Tests

No tests existed for the `timeline_id` back-pointer, so this adds focused ones:

- `packages/models/tests/script.test.ts` — the back-pointer defaults to null, a CAS patch persists it, `findById` round-trips it, and clearing it to null sticks.
- `packages/websocket/tests/trpc-scripts.test.ts` (new) — patch → `get` round trip through the router, an omitted field leaves the link alone, and `timelineId`/`storyboardId` stay independent.
- `packages/models/tests/versions-coverage.test.ts` — migrating to the previous version leaves the column absent (so the assertion can fail), the migration adds it, and a second `up()` is a no-op.
- `packages/models/tests/migrations.test.ts` — built-in migration count 62 → 63.

## Verification

| Command | Result |
|---|---|
| `npm run build:packages` | 56/56 successful |
| `npm run test --workspace=packages/models` | 54 files, 831 tests passed |
| `npm run test --workspace=packages/protocol` | 47 files, 848 tests passed |
| `npm run test --workspace=packages/websocket` | 204 files, 2200 tests passed |
| `npm run typecheck` | exit 0 (web, electron, mobile) |
| `npm run lint` | exit 0 (pre-existing warnings only) |

`npm run test` (web/electron/mobile suites) was not run — this change touches no frontend code.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qg4JML6CFGtajqVticjmEt)_