### PR TITLE
test(runtime): give the stdio bridge tests the production startup deadline

### DIFF
--- a/packages/runtime/tests/python-stdio-bridge.test.ts
+++ b/packages/runtime/tests/python-stdio-bridge.test.ts
@@ -22,6 +22,13 @@ const FAKE_INTERPRETER = resolve(
   "fixtures/fake-python-interpreter.mjs"
 );
 
+// Matches the bridge's own production default. At 5s a loaded CI runner lost
+// the race often enough to fail unrelated PRs: the spawn deadline elapsed
+// before the fake interpreter reported ready, so tests asserting on framing or
+// status errors saw a startup timeout instead. Tests that mean to exercise the
+// deadline itself pass an explicit short value.
+const DEFAULT_TEST_TIMEOUT_MS = 20000;
+
 function makeBridge(
   env: Record<string, string> = {},
   options: { startupTimeoutMs?: number; statusTimeoutMs?: number } = {}
@@ -33,8 +40,8 @@ function makeBridge(
   }
   const bridge = new PythonStdioBridge({
     pythonPath: FAKE_INTERPRETER,
-    startupTimeoutMs: options.startupTimeoutMs ?? 5000,
-    statusTimeoutMs: options.statusTimeoutMs ?? 5000
+    startupTimeoutMs: options.startupTimeoutMs ?? DEFAULT_TEST_TIMEOUT_MS,
+    statusTimeoutMs: options.statusTimeoutMs ?? DEFAULT_TEST_TIMEOUT_MS
   });
   // The spawned child inherits process.env synchronously when connect() is
   // called, so the env stays set for the whole test body; afterEach restores


### PR DESCRIPTION
## Problem

`tests/python-stdio-bridge.test.ts` spawns the fake interpreter with a **5s** startup deadline, while `PythonStdioBridge` itself defaults to **20s** (`src/python-stdio-bridge.ts:185`). On a loaded CI runner — `test-packages` runs 90 turbo tasks — the spawn loses that race, and tests that assert on something else fail with the startup timeout instead:

```
FAIL tests/python-stdio-bridge.test.ts
  > fails the whole connection on a framing violation (bad length prefix)
  AssertionError: expected [Function] to throw error matching /frame exceeds max size/i
  Received: "Python worker did not become ready within 5000ms."
```

It hit two pull requests this afternoon — #4946 (`packages/protocol` only) and #4948 (`packages/models` + the scripts tRPC router) — neither of which touches the bridge or its package. The assertion that fails is whichever one happens to be waiting when the deadline elapses, so it reads like a different bug each time.

## Change

One line plus a comment: the helper's default becomes the bridge's own production default of 20s.

The two tests that mean to exercise a deadline pass explicit values and are unaffected — `never-ready` still uses 300ms, and the EPIPE test already passes 30s, which is the same workaround applied locally to one case instead of the default.

This trades a faster failure on a genuinely hung worker for not failing unrelated PRs. The `never-ready` case still pins the timeout behavior itself at 300ms, so the deadline path keeps its coverage.

## Testing

`npx vitest run --root packages/runtime tests/python-stdio-bridge.test.ts` → 8 passed. The run log shows the framing-violation path reached its real assertion (`Incoming Python bridge frame exceeds max size (4294967295 > 268435456)`), which is what the flake was hiding.

Baseline, on `main` before the change: the same file passed 3/3 locally, and on the branch content 2/2 — the failure only reproduces under CI load, which is why the fix targets the deadline rather than any behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qg4JML6CFGtajqVticjmEt)_