### PR TITLE
refactor: presence pass + named-predicate consolidation (no-runtime-typeof 4277 → 3107)

### DIFF
--- a/.oxlintrc.anti-slop-enforced.json
+++ b/.oxlintrc.anti-slop-enforced.json
@@ -10,6 +10,23 @@
     "anti-slop/no-unknown-type-aliases": "error",
     "anti-slop/no-widen-then-assert": "error"
   },
+  "overrides": [
+    {
+      "files": ["packages/protocol/src/**"],
+      "rules": {
+        "anti-slop/no-runtime-typeof": [
+          "error",
+          { "allowInTypeGuards": true }
+        ]
+      }
+    },
+    {
+      "files": ["packages/protocol/src/typecheck.ts"],
+      "rules": {
+        "anti-slop/no-runtime-typeof": "off"
+      }
+    }
+  ],
   "jsPlugins": [
     {
       "name": "anti-slop",

--- a/.oxlintrc.anti-slop.json
+++ b/.oxlintrc.anti-slop.json
@@ -6,7 +6,7 @@
     "anti-slop/no-chained-type-assertions": "error",
     "anti-slop/no-known-value-widening": "error",
     "anti-slop/no-module-mocking": "error",
-    "anti-slop/no-runtime-typeof": "error",
+    "anti-slop/no-runtime-typeof": ["error", { "allowInTypeGuards": true }],
     "anti-slop/no-unknown-parameters": "error",
     "anti-slop/no-unknown-returns": "error",
     "anti-slop/no-unsafe-dictionary-type": "error",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ The vendored [anti-slop](https://github.com/dmmulroy/anti-slop) Oxlint plugin
 (`tools/oxlint/anti-slop/`) runs through two configs, and every rule sits in
 exactly one of them:
 
-- `.oxlintrc.anti-slop.json` — the **backlog**, 21,217 findings. Run it with
+- `.oxlintrc.anti-slop.json` — the **backlog**, 20,031 findings. Run it with
   `npm run lint:anti-slop`. Not on the CI path; it would be red for months.
 - `.oxlintrc.anti-slop-enforced.json` — the rules already at **zero**. Run
   inside `npm run lint`, so they cannot come back.
@@ -249,17 +249,28 @@ identifier, and here that is the sketch editor's drawing tools, tensor shapes,
 and third-party contracts. Promotion goes through the enforced config, not `.oxlintrc.json`,
 because `web/`, `electron/` and `mobile/` carry their own `.oxlintrc.json` and
 oxlint resolves the nearest config per file — a rule added at the root silently
-skips those trees. Remaining backlog, largest first:
+skips those trees. `no-runtime-typeof` runs with `allowInTypeGuards: true`: a `typeof` directly
+inside a function returning `v is T` is the rule's sanctioned form, so working
+the backlog means consolidating repeated inline checks into named predicates
+(each tree has a predicate module: `packages/protocol/src/predicates.ts`,
+`web/src/utils/typePredicates.ts`, mobile's twin, per-package siblings), never
+deleting guards. The rule is already enforced for `packages/protocol/src` via
+an override in the enforced config, with the decoder `typecheck.ts` exempt —
+in the package that owns the schemas, an inline `typeof` means someone bypassed
+the parse. One tradeoff: predicates take `value: unknown`, so consolidation
+moves a handful of findings into `no-unknown-parameters`.
+
+Remaining backlog, largest first:
 
 | rule | findings |
 |---|---:|
-| `require-safety-comment-for-type-assertion` | 8099 |
-| `no-unsafe-dictionary-type` | 4839 |
-| `no-runtime-typeof` | 4237 |
-| `no-unknown-parameters` | 1763 |
+| `require-safety-comment-for-type-assertion` | 8030 |
+| `no-unsafe-dictionary-type` | 4797 |
+| `no-runtime-typeof` | 3097 |
+| `no-unknown-parameters` | 1821 |
 | `no-module-mocking` | 1403 |
 | `no-known-value-widening` | 672 |
-| `no-unknown-returns` | 163 |
+| `no-unknown-returns` | 170 |
 | `no-chained-type-assertions` | 41 |
 
 A rule can also stall short of zero. `no-unknown-returns` went 604 → 182; what

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ The vendored [anti-slop](https://github.com/dmmulroy/anti-slop) Oxlint plugin
 (`tools/oxlint/anti-slop/`) runs through two configs, and every rule sits in
 exactly one of them:
 
-- `.oxlintrc.anti-slop.json` — the **backlog**, 21,257 findings. Run it with
+- `.oxlintrc.anti-slop.json` — the **backlog**, 21,217 findings. Run it with
   `npm run lint:anti-slop`. Not on the CI path; it would be red for months.
 - `.oxlintrc.anti-slop-enforced.json` — the rules already at **zero**. Run
   inside `npm run lint`, so they cannot come back.
@@ -255,7 +255,7 @@ skips those trees. Remaining backlog, largest first:
 |---|---:|
 | `require-safety-comment-for-type-assertion` | 8099 |
 | `no-unsafe-dictionary-type` | 4839 |
-| `no-runtime-typeof` | 4277 |
+| `no-runtime-typeof` | 4237 |
 | `no-unknown-parameters` | 1763 |
 | `no-module-mocking` | 1403 |
 | `no-known-value-widening` | 672 |

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodetool-mobile",
-  "version": "0.7.0-rc.34",
+  "version": "0.7.0-rc.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodetool-mobile",
-      "version": "0.7.0-rc.34",
+      "version": "0.7.0-rc.35",
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -7565,6 +7565,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/mobile/src/components/graph_editor/PropertyField.tsx
+++ b/mobile/src/components/graph_editor/PropertyField.tsx
@@ -26,6 +26,7 @@ import { ModelSelectModal } from "./ModelSelectModal";
 import { apiService } from "../../services/api";
 import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
 import type { Property } from "../../types/ApiTypes";
+import { isNumber, isRecord, isString } from "../../utils/typePredicates";
 
 // ── Shared types ────────────────────────────────────────────────────
 
@@ -730,15 +731,15 @@ function mediaLocatorOf(value: unknown): string | null {
   if (!value) {
     return null;
   }
-  if (typeof value === "string") {
+  if (isString(value)) {
     return value;
   }
-  if (typeof value === "object") {
-    const v = value as Record<string, unknown>;
-    if (typeof v.uri === "string") {
+  if (isRecord(value)) {
+    const v = value;
+    if (isString(v.uri)) {
       return v.uri;
     }
-    if (typeof v.id === "string") {
+    if (isString(v.id)) {
       return v.id;
     }
   }
@@ -776,12 +777,11 @@ const ColorWidget: React.FC<{
   onChange: (v: ColorValue) => void;
   colors: ThemeColors;
 }> = ({ value, onChange, colors }) => {
-  const colorValue =
-    typeof value === "object" && value !== null
-      ? ((value as Record<string, unknown>).value as string | undefined)
-      : typeof value === "string"
-        ? value
-        : undefined;
+  const colorValue = isRecord(value)
+    ? (value.value as string | undefined)
+    : isString(value)
+      ? value
+      : undefined;
 
   const [customInput, setCustomInput] = useState(colorValue ?? "");
 
@@ -897,11 +897,11 @@ const ImageSizeWidget: React.FC<{
   colors: ThemeColors;
 }> = ({ value, onChange, colors }) => {
   const safeValue = useMemo(() => {
-    if (typeof value === "object" && value !== null) {
-      const v = value as Record<string, unknown>;
+    if (isRecord(value)) {
+      const v = value;
       return {
-        width: typeof v.width === "number" ? v.width : 1024,
-        height: typeof v.height === "number" ? v.height : 1024
+        width: isNumber(v.width) ? v.width : 1024,
+        height: isNumber(v.height) ? v.height : 1024
       };
     }
     return { width: 1024, height: 1024 };
@@ -1109,12 +1109,9 @@ const JSONWidget: React.FC<{
   colors: ThemeColors;
 }> = ({ value, onChange, colors }) => {
   const dataStr =
-    typeof value === "object" &&
-    value !== null &&
-    "data" in value &&
-    typeof value.data === "string"
+    isRecord(value) && "data" in value && isString(value.data)
       ? value.data
-      : typeof value === "string"
+      : isString(value)
         ? value
         : undefined;
 
@@ -1185,8 +1182,8 @@ const DictWidget: React.FC<{
   colors: ThemeColors;
 }> = ({ value, onChange, colors }) => {
   const dict = useMemo(() => {
-    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-      return value as Record<string, unknown>;
+    if (isRecord(value) && !Array.isArray(value)) {
+      return value;
     }
     return {};
   }, [value]);
@@ -1558,7 +1555,7 @@ const FilePathWidget: React.FC<{
   colors: ThemeColors;
   isFolder?: boolean;
 }> = ({ value, onChange, colors, isFolder }) => {
-  const pathStr = typeof value === "string" ? value : "";
+  const pathStr = isString(value) ? value : "";
 
   const pickFile = useCallback(async () => {
     const result = await DocumentPicker.getDocumentAsync({
@@ -1673,11 +1670,11 @@ const ModelWidget: React.FC<{
     if (!value) {
       return { modelId: "", modelName: "" };
     }
-    if (typeof value === "string") {
+    if (isString(value)) {
       return { modelId: value, modelName: value };
     }
-    if (typeof value === "object") {
-      const v = value as Record<string, unknown>;
+    if (isRecord(value)) {
+      const v = value;
       const id = String(v.id ?? v.name ?? v.repo_id ?? "");
       const name = String(v.name ?? v.id ?? v.repo_id ?? "");
       return { modelId: id, modelName: name };
@@ -1761,10 +1758,7 @@ const ModelWidget: React.FC<{
       </TouchableOpacity>
 
       {/* Provider badge */}
-      {modelId &&
-      typeof value === "object" &&
-      value !== null &&
-      (value as Record<string, unknown>).provider ? (
+      {modelId && isRecord(value) && value.provider ? (
         <Text
           style={[modelStyles.providerBadge, { color: colors.textTertiary }]}
         >
@@ -1832,11 +1826,11 @@ const AssetRefWidget: React.FC<{
     if (!value) {
       return "";
     }
-    if (typeof value === "string") {
+    if (isString(value)) {
       return value;
     }
-    if (typeof value === "object") {
-      const v = value as Record<string, unknown>;
+    if (isRecord(value)) {
+      const v = value;
       return String(v.id ?? v.asset_id ?? v.name ?? v.uri ?? "");
     }
     return "";

--- a/mobile/src/components/outputs/OutputRenderer.tsx
+++ b/mobile/src/components/outputs/OutputRenderer.tsx
@@ -19,6 +19,14 @@ import { useTheme } from "../../hooks/useTheme";
 import type { ThemeColors } from "../../utils/theme";
 import { apiService } from "../../services/api";
 import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
+import {
+  isBoolean,
+  isNonEmptyString,
+  isNumber,
+  isRecord,
+  isString,
+  isStoredUri
+} from "../../utils/typePredicates";
 
 interface TypedValue {
   type: string;
@@ -46,8 +54,8 @@ type OutputRendererProps = {
 const typeFor = (value: unknown): string => {
   if (value === undefined || value === null) {return "null";}
   if (Array.isArray(value)) {return "array";}
-  if (typeof value === "boolean") {return "boolean";}
-  if (typeof value === "object" && value !== null && "type" in value) {
+  if (isBoolean(value)) {return "boolean";}
+  if (isRecord(value) && "type" in value) {
     return (value as { type: string }).type;
   }
   return typeof value;
@@ -58,9 +66,7 @@ const typeFor = (value: unknown): string => {
  * and a data URI is already its own source.
  */
 const mediaLocator = (uri: unknown): string | undefined =>
-  typeof uri === "string" && uri && !uri.startsWith("memory://")
-    ? uri
-    : undefined;
+  isStoredUri(uri) ? uri : undefined;
 
 /**
  * One explicit width per column so the header row and the body rows share a
@@ -129,9 +135,9 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
   if (
     value === undefined ||
     value === null ||
-    (typeof value === "string" && value.trim() === "") ||
+    (isString(value) && value.trim() === "") ||
     (Array.isArray(value) && value.length === 0) ||
-    (typeof value === "object" &&
+    (isRecord(value) &&
       !Array.isArray(value) &&
       Object.keys(value).length === 0)
   ) {
@@ -163,7 +169,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
 
     case "text": {
       const textVal = v.text ?? "";
-      if (typeof textVal !== "string" || !textVal) {return null;}
+      if (!isNonEmptyString(textVal)) {return null;}
       return <MarkdownRenderer content={textVal} />;
     }
 
@@ -192,7 +198,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
         );
       }
 
-      if (typeof imgSource === "string") {
+      if (isString(imgSource)) {
         const imageUri = imgSource.startsWith("data:")
           ? imgSource
           : (resolvedUri ??
@@ -313,7 +319,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
               </Text>
             )}
           </View>
-          {typeof v.body === "string" && <MarkdownRenderer content={v.body} />}
+          {isString(v.body) && <MarkdownRenderer content={v.body} />}
         </View>
       );
 
@@ -325,7 +331,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
               {String(v.title)}
             </Text>
           )}
-          {typeof v.description === "string" && (
+          {isString(v.description) && (
             <MarkdownRenderer content={v.description} />
           )}
           {Array.isArray(v.steps) && v.steps.length > 0 && (
@@ -338,7 +344,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
                     {i + 1}.
                   </Text>
                   <Text style={[styles.taskStepText, { color: colors.text }]}>
-                    {typeof s === "string" ? s : s?.description || s?.title || JSON.stringify(s)}
+                    {isString(s) ? s : s?.description || s?.title || JSON.stringify(s)}
                   </Text>
                 </View>
                 );
@@ -390,7 +396,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
               📍 {String(v.location)}
             </Text>
           )}
-          {typeof v.notes === "string" && <MarkdownRenderer content={v.notes} />}
+          {isString(v.notes) && <MarkdownRenderer content={v.notes} />}
         </View>
       );
 
@@ -407,7 +413,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
       if (contentType === "audio") {
         return <OutputRenderer value={{ type: "audio", uri: v.content }} />;
       }
-      const chunkText = typeof v.content === "string" ? v.content : "";
+      const chunkText = isString(v.content) ? v.content : "";
       if (!chunkText) {return null;}
       return <MarkdownRenderer content={chunkText} />;
     }
@@ -416,7 +422,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
     case "classification_result":
       return (
         <Text style={[styles.text, { color: colors.text }]}>
-          {String(v.label)}: {typeof v.score === "number" ? v.score.toFixed(4) : String(v.score)}
+          {String(v.label)}: {isNumber(v.score) ? v.score.toFixed(4) : String(v.score)}
         </Text>
       );
 
@@ -446,7 +452,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
       }
       const headers = columns.map((col) => {
         const c = col as string | DataframeColumn;
-        return typeof c === "object" && c !== null ? String(c.name) : String(c);
+        return isRecord(c) ? String(c.name) : String(c);
       });
       const bodyRows = data.slice(0, 50).map((rawRow) => {
         const row = rawRow as unknown[] | Record<string, unknown>;
@@ -576,7 +582,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
       const firstItem = arr[0];
 
       // Array of strings → list
-      if (typeof firstItem === "string" && arr.every((item) => typeof item === "string")) {
+      if (isString(firstItem) && arr.every(isString)) {
         return (
           <View style={styles.container}>
             {(arr as string[]).map((item: string, i: number) => (
@@ -592,7 +598,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
       }
 
       // Array of numbers → compact display
-      if (typeof firstItem === "number") {
+      if (isNumber(firstItem)) {
         return (
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
             <Text
@@ -612,7 +618,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
       }
 
       // Array of typed objects
-      if (typeof firstItem === "object" && firstItem !== null) {
+      if (isRecord(firstItem)) {
         const first = firstItem as Record<string, unknown>;
         // Chunks
         if (first.type === "chunk") {
@@ -624,7 +630,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
           );
           if (allText) {
             const text = (arr as TypedValue[])
-              .map((c) => (typeof c.content === "string" ? c.content : ""))
+              .map((c) => (isString(c.content) ? c.content : ""))
               .join("");
             return <MarkdownRenderer content={text} />;
           }
@@ -650,7 +656,7 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
         }
 
         // Array of other typed objects (audio, video, etc.)
-        if (typeof first.type === "string" && ["audio", "video", "html", "task"].includes(first.type)) {
+        if (isString(first.type) && ["audio", "video", "html", "task"].includes(first.type)) {
           return (
             <View style={styles.container}>
               {arr.map((item: unknown, i: number) => (
@@ -769,12 +775,12 @@ export const OutputRenderer = React.memo(({ value }: OutputRendererProps) => {
 
     // ── Fallback ─────────────────────────────────────────────────
     default:
-      if (value !== null && typeof value === "object") {
+      if (isRecord(value)) {
         return renderJSON(value, codeTheme, colors, mode, monoFont);
       }
       return (
         <Text style={[styles.text, { color: colors.text }]}>
-          {typeof value === "string" ? value : String(value ?? "")}
+          {isString(value) ? value : String(value ?? "")}
         </Text>
       );
   }

--- a/mobile/src/utils/typePredicates.ts
+++ b/mobile/src/utils/typePredicates.ts
@@ -1,0 +1,26 @@
+/**
+ * Named type predicates for the representation checks the mobile app makes on
+ * values that arrive from a workflow run or a node property.
+ */
+
+export const isString = (value: unknown): value is string =>
+  typeof value === "string";
+
+export const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value !== "";
+
+export const isNumber = (value: unknown): value is number =>
+  typeof value === "number";
+
+export const isBoolean = (value: unknown): value is boolean =>
+  typeof value === "boolean";
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+/**
+ * A URI that resolves to stored bytes. `memory://` refs are in-memory only and
+ * can never be fetched, so they do not count.
+ */
+export const isStoredUri = (value: unknown): value is string =>
+  typeof value === "string" && value !== "" && !value.startsWith("memory://");

--- a/packages/agents/src/capabilities/files.ts
+++ b/packages/agents/src/capabilities/files.ts
@@ -33,6 +33,12 @@ import type { JsonSchema, ProcessingContext } from "@nodetool-ai/runtime";
 import type { StorageAdapter } from "@nodetool-ai/storage";
 import type { TodoItem, TodoStatus, TodoUpdate } from "@nodetool-ai/protocol";
 import { Tool } from "../tools/base-tool.js";
+import {
+  isNonBlankString,
+  isNumber,
+  isObjectLike,
+  isString
+} from "../utils/type-guards.js";
 import { UNGATED, createCapabilityRun } from "./invoke.js";
 import type {
   CapabilityExport,
@@ -174,7 +180,7 @@ const readFileCapability: CapabilityExport = {
   impl: async (run, params) => {
     const context = run.context;
     const filePath = params["file_path"];
-    if (typeof filePath !== "string") {
+    if (!isString(filePath)) {
       return "Error: file_path must be a string";
     }
     const storage = getStorage(context);
@@ -203,11 +209,9 @@ const readFileCapability: CapabilityExport = {
     const rawOffset = params["offset"];
     const rawLimit = params["limit"];
     const offset =
-      typeof rawOffset === "number" && rawOffset >= 1
-        ? Math.floor(rawOffset)
-        : 1;
+      isNumber(rawOffset) && rawOffset >= 1 ? Math.floor(rawOffset) : 1;
     const limit =
-      typeof rawLimit === "number" && rawLimit >= 1
+      isNumber(rawLimit) && rawLimit >= 1
         ? Math.floor(rawLimit)
         : DEFAULT_READ_LIMIT;
 
@@ -255,10 +259,10 @@ const writeFileCapability: CapabilityExport = {
     const filePath = params["file_path"];
     const content = params["content"];
 
-    if (typeof filePath !== "string") {
+    if (!isString(filePath)) {
       return "Error: file_path must be a string";
     }
-    if (typeof content !== "string") {
+    if (!isString(content)) {
       return "Error: content must be a string";
     }
     const storage = getStorage(context);
@@ -378,7 +382,7 @@ async function listEntries(
     for (const cp of result.commonPrefixes) {
       const subKey = cp.replace(/\/+$/, "");
       const subEntries = await listEntries(context, subKey, true);
-      if (typeof subEntries === "string") continue; // skip errored subdirs
+      if (isString(subEntries)) continue; // skip errored subdirs
       const subBase = subKey.split("/").pop() ?? subKey;
       for (const child of subEntries) {
         entries.push({ ...child, name: `${subBase}/${child.name}` });
@@ -394,7 +398,7 @@ const listDirectory: CapabilityExport = {
   impl: async (run, params) => {
     const context = run.context;
     const rawPath = params["path"];
-    if (typeof rawPath !== "string") {
+    if (!isString(rawPath)) {
       return "Error: path must be a string";
     }
     const storage = getStorage(context);
@@ -402,7 +406,7 @@ const listDirectory: CapabilityExport = {
 
     const recursive = params["recursive"] === true;
     const entries = await listEntries(context, rawPath, recursive);
-    if (typeof entries === "string") return entries; // error already formatted
+    if (isString(entries)) return entries; // error already formatted
 
     if (entries.length === 0) {
       return `(empty) ${rawPath || "."}`;
@@ -762,11 +766,11 @@ const editFile: CapabilityExport = {
     const newString = params["new_string"];
     const replaceAll = params["replace_all"] === true;
 
-    if (typeof rawPath !== "string")
+    if (!isString(rawPath))
       return { success: false, error: "path must be a string" };
-    if (typeof oldString !== "string")
+    if (!isString(oldString))
       return { success: false, error: "old_string must be a string" };
-    if (typeof newString !== "string")
+    if (!isString(newString))
       return { success: false, error: "new_string must be a string" };
     if (oldString === newString)
       return {
@@ -920,14 +924,14 @@ const glob: CapabilityExport = {
     const pattern = params["pattern"];
     const rawPath = params["path"];
 
-    if (typeof pattern !== "string")
+    if (!isString(pattern))
       return { success: false, error: "pattern must be a string" };
 
     let searchDir: string;
     try {
       searchDir = resolveSafePath(
         context,
-        typeof rawPath === "string" ? rawPath : "."
+        isString(rawPath) ? rawPath : "."
       );
     } catch (e) {
       return {
@@ -1011,19 +1015,19 @@ const grep: CapabilityExport = {
     const rawPath = params["path"];
     const include = params["include"];
     const contextLines =
-      typeof params["context"] === "number" ? params["context"] : 0;
+      isNumber(params["context"]) ? params["context"] : 0;
     const caseInsensitive = params["case_insensitive"] === true;
     const maxResults =
-      typeof params["max_results"] === "number" ? params["max_results"] : 100;
+      isNumber(params["max_results"]) ? params["max_results"] : 100;
 
-    if (typeof pattern !== "string")
+    if (!isString(pattern))
       return { success: false, error: "pattern must be a string" };
 
     let searchDir: string;
     try {
       searchDir = resolveSafePath(
         context,
-        typeof rawPath === "string" ? rawPath : "."
+        isString(rawPath) ? rawPath : "."
       );
     } catch (e) {
       return {
@@ -1082,7 +1086,7 @@ const grep: CapabilityExport = {
     }
 
     // Apply include filter
-    if (typeof include === "string") {
+    if (isString(include)) {
       const includeRegex = globToRegex(include);
       filesToSearch = filesToSearch.filter((f) => {
         const rel = relative(searchDir, f);
@@ -1265,19 +1269,16 @@ function normalizeTodos(raw: unknown): TodoItem[] {
     throw new Error("`todos` must be an array");
   }
   return raw.map((item, i) => {
-    if (!item || typeof item !== "object") {
+    if (!isObjectLike(item)) {
       throw new Error(`todos[${i}] must be an object`);
     }
-    const rec = item as Record<string, unknown>;
+    const rec = item;
     const content = rec.content;
     const status = rec.status;
-    if (typeof content !== "string" || content.trim().length === 0) {
+    if (!isNonBlankString(content)) {
       throw new Error(`todos[${i}].content must be a non-empty string`);
     }
-    if (
-      typeof status !== "string" ||
-      !VALID_STATUSES.has(status as TodoStatus)
-    ) {
+    if (!isString(status) || !VALID_STATUSES.has(status as TodoStatus)) {
       throw new Error(
         `todos[${i}].status must be one of: pending, in_progress, completed`
       );

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -42,6 +42,13 @@ import {
 import { inferImageMime, persistOutput } from "../tools/asset-persist.js";
 import { persistBinaryOutput } from "../tools/binary-output.js";
 import { extractJSON } from "../utils/json-parser.js";
+import {
+  isNonBlankString,
+  isNonEmptyString,
+  isObjectLike,
+  isRecord,
+  isString
+} from "../utils/type-guards.js";
 import type { CapabilityExport, CapabilityModule } from "./types.js";
 import {
   generateImageSpec,
@@ -100,10 +107,10 @@ function parseModelArgs(
 ): MediaModelArgs | { error: string } {
   const provider = params["provider"];
   const model = params["model"];
-  if (typeof provider !== "string" || !provider) {
+  if (!isNonEmptyString(provider)) {
     return { error: "provider must be a non-empty string (use find_model)" };
   }
-  if (typeof model !== "string" || !model) {
+  if (!isNonEmptyString(model)) {
     return { error: "model must be a non-empty string (use find_model)" };
   }
   return { provider, model };
@@ -146,7 +153,7 @@ const generateImage: CapabilityExport = {
     const m = parseModelArgs(params);
     if ("error" in m) return m;
     const prompt = params["prompt"];
-    if (typeof prompt !== "string" || !prompt)
+    if (!isNonEmptyString(prompt))
       return { error: "prompt is required" };
 
     try {
@@ -165,10 +172,9 @@ const generateImage: CapabilityExport = {
       const persisted = await persistOutput(context, result, {
         namePrefix: "generated-image",
         mime: inferImageMime(result),
-        outputFile:
-          typeof params["output_file"] === "string"
-            ? (params["output_file"] as string)
-            : undefined
+        outputFile: isString(params["output_file"])
+          ? params["output_file"]
+          : undefined
       });
       return {
         type: "image",
@@ -192,9 +198,9 @@ const editImage: CapabilityExport = {
     if ("error" in m) return m;
     const inputFile = params["input_file"];
     const prompt = params["prompt"];
-    if (typeof inputFile !== "string" || !inputFile)
+    if (!isNonEmptyString(inputFile))
       return { error: "input_file is required" };
-    if (typeof prompt !== "string" || !prompt)
+    if (!isNonEmptyString(prompt))
       return { error: "prompt is required" };
 
     try {
@@ -215,10 +221,9 @@ const editImage: CapabilityExport = {
       const persisted = await persistOutput(context, result, {
         namePrefix: "edited-image",
         mime: inferImageMime(result),
-        outputFile:
-          typeof params["output_file"] === "string"
-            ? (params["output_file"] as string)
-            : undefined
+        outputFile: isString(params["output_file"])
+          ? params["output_file"]
+          : undefined
       });
       return {
         type: "image",
@@ -241,7 +246,7 @@ const generateVideo: CapabilityExport = {
     const m = parseModelArgs(params);
     if ("error" in m) return m;
     const prompt = params["prompt"];
-    if (typeof prompt !== "string" || !prompt)
+    if (!isNonEmptyString(prompt))
       return { error: "prompt is required" };
 
     try {
@@ -260,10 +265,9 @@ const generateVideo: CapabilityExport = {
       const persisted = await persistOutput(context, result, {
         namePrefix: "generated-video",
         mime: "video/mp4",
-        outputFile:
-          typeof params["output_file"] === "string"
-            ? (params["output_file"] as string)
-            : undefined
+        outputFile: isString(params["output_file"])
+          ? params["output_file"]
+          : undefined
       });
       return {
         type: "video",
@@ -286,7 +290,7 @@ const animateImage: CapabilityExport = {
     const m = parseModelArgs(params);
     if ("error" in m) return m;
     const inputFile = params["input_file"];
-    if (typeof inputFile !== "string" || !inputFile)
+    if (!isNonEmptyString(inputFile))
       return { error: "input_file is required" };
 
     try {
@@ -306,10 +310,9 @@ const animateImage: CapabilityExport = {
       const persisted = await persistOutput(context, result, {
         namePrefix: "animated-video",
         mime: "video/mp4",
-        outputFile:
-          typeof params["output_file"] === "string"
-            ? (params["output_file"] as string)
-            : undefined
+        outputFile: isString(params["output_file"])
+          ? params["output_file"]
+          : undefined
       });
       return {
         type: "video",
@@ -418,12 +421,11 @@ const generateSpeech: CapabilityExport = {
     const m = parseModelArgs(params);
     if ("error" in m) return m;
     const text = params["text"];
-    if (typeof text !== "string" || !text) return { error: "text is required" };
+    if (!isNonEmptyString(text)) return { error: "text is required" };
 
-    const outputFile =
-      typeof params["output_file"] === "string"
-        ? (params["output_file"] as string)
-        : undefined;
+    const outputFile = isString(params["output_file"])
+      ? params["output_file"]
+      : undefined;
     const desiredFormat = audioFormatFromOutputFile(outputFile) ?? "mp3";
 
     try {
@@ -476,7 +478,7 @@ const generateSpeech: CapabilityExport = {
             parts.push(chunk.data);
             if (chunk.mimeType) mimeType = chunk.mimeType;
             pcmOnly = false;
-          } else if (typeof chunk.data === "string") {
+          } else if (isString(chunk.data)) {
             parts.push(Buffer.from(chunk.data, "base64"));
             if (chunk.mimeType) mimeType = chunk.mimeType;
             pcmOnly = false;
@@ -533,7 +535,7 @@ const transcribeAudio: CapabilityExport = {
     const m = parseModelArgs(params);
     if ("error" in m) return m;
     const inputFile = params["input_file"];
-    if (typeof inputFile !== "string" || !inputFile)
+    if (!isNonEmptyString(inputFile))
       return { error: "input_file is required" };
 
     try {
@@ -576,7 +578,7 @@ const embedText: CapabilityExport = {
     const m = parseModelArgs(params);
     if ("error" in m) return m;
     const text = params["text"];
-    if (typeof text !== "string" && !Array.isArray(text))
+    if (!isString(text) && !Array.isArray(text))
       return { error: "text must be a string or array of strings" };
 
     try {
@@ -619,13 +621,13 @@ function parseJudgeModelArgs(
 ): JudgeModelArgs | { error: string } {
   const provider = params["provider"];
   const model = params["model"];
-  if (typeof provider !== "string" || !provider) {
+  if (!isNonEmptyString(provider)) {
     return {
       error:
         "provider must be a non-empty string (use find_model with a vision-capable chat model)"
     };
   }
-  if (typeof model !== "string" || !model) {
+  if (!isNonEmptyString(model)) {
     return {
       error:
         "model must be a non-empty string (use find_model with a vision-capable chat model)"
@@ -663,7 +665,7 @@ function textPart(text: string): MessageContent {
 /** Pull the text out of a provider response message. */
 function messageText(message: Message): string {
   const content = message.content;
-  if (typeof content === "string") return content;
+  if (isString(content)) return content;
   if (Array.isArray(content)) {
     return content
       .map((part) => (part.type === "text" ? part.text : ""))
@@ -693,7 +695,7 @@ async function judgeCall(
 
 function tasteBlock(params: Record<string, unknown>): string {
   const profile = params["taste_profile"];
-  if (typeof profile !== "string" || !profile.trim()) return "";
+  if (!isNonBlankString(profile)) return "";
   return `\n\nThe user's known aesthetic preferences (weigh these alongside the brief):\n${profile.trim()}`;
 }
 
@@ -715,16 +717,14 @@ interface CritiqueResult {
 
 function parseCritique(text: string): CritiqueResult | null {
   const parsed = extractJSON(text);
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+  if (!isRecord(parsed)) {
     return null;
   }
-  const obj = parsed as Record<string, unknown>;
+  const obj = parsed;
   const verdict = obj["verdict"] === "pass" ? "pass" : "revise";
   const defects: CritiqueDefect[] = Array.isArray(obj["defects"])
     ? (obj["defects"] as unknown[])
-        .filter((d): d is Record<string, unknown> =>
-          Boolean(d && typeof d === "object")
-        )
+        .filter(isObjectLike)
         .map((d) => ({
           defect: String(d["defect"] ?? ""),
           location: String(d["location"] ?? ""),
@@ -746,9 +746,9 @@ const critiqueImage: CapabilityExport = {
     if ("error" in m) return m;
     const image = params["image"];
     const brief = params["brief"];
-    if (typeof image !== "string" || !image)
+    if (!isNonEmptyString(image))
       return { error: "image is required" };
-    if (typeof brief !== "string" || !brief)
+    if (!isNonEmptyString(brief))
       return { error: "brief is required" };
 
     const prompt =
@@ -808,9 +808,8 @@ function parsePairVerdict(
   text: string
 ): { winner: 1 | 2; reason: string } | null {
   const parsed = extractJSON(text);
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
-    return null;
-  const obj = parsed as Record<string, unknown>;
+  if (!isRecord(parsed)) return null;
+  const obj = parsed;
   const winner = Number(obj["winner"]);
   if (winner !== 1 && winner !== 2) return null;
   return { winner, reason: String(obj["reason"] ?? "") };
@@ -827,7 +826,7 @@ const compareImages: CapabilityExport = {
     if (
       !Array.isArray(images) ||
       images.length < 2 ||
-      images.some((i) => typeof i !== "string" || !i)
+      images.some((i) => !isNonEmptyString(i))
     ) {
       return { error: "images must be an array of 2-8 non-empty strings" };
     }
@@ -836,7 +835,7 @@ const compareImages: CapabilityExport = {
         error: `images must contain at most ${MAX_COMPARE_IMAGES} candidates`
       };
     }
-    if (typeof brief !== "string" || !brief)
+    if (!isNonEmptyString(brief))
       return { error: "brief is required" };
 
     const prompt =
@@ -947,9 +946,9 @@ const scoreImageAdherence: CapabilityExport = {
     if ("error" in m) return m;
     const image = params["image"];
     const brief = params["brief"];
-    if (typeof image !== "string" || !image)
+    if (!isNonEmptyString(image))
       return { error: "image is required" };
-    if (typeof brief !== "string" || !brief)
+    if (!isNonEmptyString(brief))
       return { error: "brief is required" };
 
     try {
@@ -970,10 +969,7 @@ const scoreImageAdherence: CapabilityExport = {
           )
         ]);
         const parsed = extractJSON(decomposeText);
-        const list =
-          parsed && typeof parsed === "object" && !Array.isArray(parsed)
-            ? (parsed as Record<string, unknown>)["questions"]
-            : parsed;
+        const list = isRecord(parsed) ? parsed["questions"] : parsed;
         questions = Array.isArray(list) ? list.map(String).filter(Boolean) : [];
         if (questions.length === 0) {
           return {
@@ -994,19 +990,14 @@ const scoreImageAdherence: CapabilityExport = {
         imagePart(image)
       ]);
       const parsed = extractJSON(answerText);
-      const rawAnswers =
-        parsed && typeof parsed === "object" && !Array.isArray(parsed)
-          ? (parsed as Record<string, unknown>)["answers"]
-          : null;
+      const rawAnswers: unknown = isRecord(parsed) ? parsed["answers"] : null;
       if (!Array.isArray(rawAnswers) || rawAnswers.length === 0) {
         return {
           error: `Judge did not return parseable answers: ${answerText.slice(0, 300)}`
         };
       }
       const answers: AdherenceAnswer[] = rawAnswers
-        .filter((a): a is Record<string, unknown> =>
-          Boolean(a && typeof a === "object")
-        )
+        .filter(isObjectLike)
         .map((a) => ({
           question: String(a["question"] ?? ""),
           answer: a["answer"] === "yes" ? "yes" : "no",
@@ -1047,7 +1038,7 @@ const readMediaBytes: CapabilityExport = {
   spec: readMediaBytesSpec,
   impl: async (run, params) => {
     const uri = params.uri;
-    if (typeof uri !== "string" || uri.trim() === "") {
+    if (!isNonBlankString(uri)) {
       return { error: "uri is required and must be a non-empty string" };
     }
     const trimmed = uri.trim();
@@ -1089,7 +1080,7 @@ const readMediaBytes: CapabilityExport = {
 
 function requireWorkspaceDir(context: ProcessingContext): string | { error: string } {
   const dir = context.workspaceDir;
-  if (typeof dir !== "string" || !dir) {
+  if (!isNonEmptyString(dir)) {
     return { error: "workspaceDir is required to run a host media binary" };
   }
   return dir;
@@ -1101,7 +1092,7 @@ function stringArgs(raw: unknown): string[] | { error: string } {
   }
   const args: string[] = [];
   for (const item of raw) {
-    if (typeof item !== "string") {
+    if (!isString(item)) {
       return { error: "args must be a non-empty array of strings" };
     }
     args.push(item);
@@ -1136,14 +1127,13 @@ const ffmpeg: CapabilityExport = {
   spec: ffmpegSpec,
   impl: async (run, params) => {
     const workspace = requireWorkspaceDir(run.context);
-    if (typeof workspace !== "string") return workspace;
+    if (!isString(workspace)) return workspace;
     const args = stringArgs(params["args"]);
     if ("error" in args) return args;
 
-    const outputFile =
-      typeof params["output_file"] === "string" && params["output_file"].trim()
-        ? params["output_file"].trim()
-        : "";
+    const outputFile = isNonBlankString(params["output_file"])
+      ? params["output_file"].trim()
+      : "";
     const argv = [...args];
     if (outputFile && !argv.includes(outputFile)) {
       argv.push(outputFile);
@@ -1188,9 +1178,9 @@ const ytDlp: CapabilityExport = {
   spec: ytDlpSpec,
   impl: async (run, params) => {
     const workspace = requireWorkspaceDir(run.context);
-    if (typeof workspace !== "string") return workspace;
+    if (!isString(workspace)) return workspace;
     const url = params["url"];
-    if (typeof url !== "string" || !url.trim()) {
+    if (!isNonBlankString(url)) {
       return { error: "url is required" };
     }
     try {
@@ -1202,14 +1192,12 @@ const ytDlp: CapabilityExport = {
       return { error: `invalid url: ${url}` };
     }
 
-    const outputFile =
-      typeof params["output_file"] === "string" && params["output_file"].trim()
-        ? params["output_file"].trim()
-        : DEFAULT_YT_DLP_OUTPUT;
-    const format =
-      typeof params["format"] === "string" && params["format"].trim()
-        ? params["format"].trim()
-        : "";
+    const outputFile = isNonBlankString(params["output_file"])
+      ? params["output_file"].trim()
+      : DEFAULT_YT_DLP_OUTPUT;
+    const format = isNonBlankString(params["format"])
+      ? params["format"].trim()
+      : "";
     const timeoutMs =
       clampTimeoutSeconds(params["timeout_seconds"], 300, 900) * 1000;
 

--- a/packages/agents/src/capabilities/models.ts
+++ b/packages/agents/src/capabilities/models.ts
@@ -357,7 +357,7 @@ const findModel: CapabilityExport = {
         `Skipped providers that cannot run here: ${unavailable.join(", ")}.`
       );
     }
-    let words = queryWords(typeof query === "string" ? query : "");
+    let words = queryWords(query ?? "");
 
     // The `task` filter reads `supportedTasks`. A caller who typed a model name
     // into it used to get an empty list — or, when no model declares tasks at

--- a/packages/agents/src/capabilities/scripts.ts
+++ b/packages/agents/src/capabilities/scripts.ts
@@ -30,6 +30,14 @@ import type {
   ScriptVoiceBinding
 } from "@nodetool-ai/models";
 import type { CaptionWord } from "@nodetool-ai/timeline";
+import {
+  isNonBlankString,
+  isNonEmptyString,
+  isNumber,
+  isObjectLike,
+  isRecord,
+  isString
+} from "../utils/type-guards.js";
 import { UNGATED, createCapabilityRun } from "./invoke.js";
 import type {
   CapabilityExport,
@@ -90,7 +98,7 @@ async function loadScript(
   run: CapabilityRun,
   scriptId: unknown
 ): Promise<ScriptHandle | ToolError> {
-  if (typeof scriptId !== "string" || !scriptId) {
+  if (!isNonEmptyString(scriptId)) {
     return { error: "script_id is required (use list_scripts to find one)." };
   }
   const { Script } = await import("@nodetool-ai/models");
@@ -367,15 +375,12 @@ function voiceOverrideFrom(
   const provider = params["provider"];
   const model = params["model"];
   const voice = params["voice"];
-  const any = [provider, model, voice].some((v) => typeof v === "string" && v);
+  const any = [provider, model, voice].some((v) => isNonEmptyString(v));
   if (!any) return null;
   if (
-    typeof provider !== "string" ||
-    !provider ||
-    typeof model !== "string" ||
-    !model ||
-    typeof voice !== "string" ||
-    !voice
+    !isNonEmptyString(provider) ||
+    !isNonEmptyString(model) ||
+    !isNonEmptyString(voice)
   ) {
     return {
       error:
@@ -475,17 +480,14 @@ const voiceScriptLines: CapabilityExport = {
     const { generateSpeech } = await import("./media.js");
     const speechRun = createCapabilityRun({ context, gate: UNGATED });
 
-    const speed =
-      typeof params["speed"] === "number" ? params["speed"] : undefined;
+    const speed = isNumber(params["speed"]) ? params["speed"] : undefined;
     const transcribe = params["transcribe"] !== false;
-    const asrProvider =
-      typeof params["asr_provider"] === "string"
-        ? (params["asr_provider"] as string)
-        : DEFAULT_ASR_PROVIDER;
-    const asrModel =
-      typeof params["asr_model"] === "string"
-        ? (params["asr_model"] as string)
-        : DEFAULT_ASR_MODEL;
+    const asrProvider = isString(params["asr_provider"])
+      ? params["asr_provider"]
+      : DEFAULT_ASR_PROVIDER;
+    const asrModel = isString(params["asr_model"])
+      ? params["asr_model"]
+      : DEFAULT_ASR_MODEL;
 
     const results = await mapWithConcurrency(
       selected,
@@ -602,10 +604,9 @@ const assembleScriptTimeline: CapabilityExport = {
     }
 
     const fps = Math.max(1, Math.min(Number(params["fps"]) || 30, 120));
-    const name =
-      typeof params["name"] === "string" && params["name"]
-        ? (params["name"] as string)
-        : row.name;
+    const name = isNonEmptyString(params["name"])
+      ? params["name"]
+      : row.name;
 
     const existing = row.timeline_id
       ? await TimelineSequence.findById(row.timeline_id)
@@ -725,11 +726,11 @@ function parseScriptOps(raw: unknown): ParsedScriptOp[] | ToolError {
   }
   const parsed: ParsedScriptOp[] = [];
   for (const [index, entry] of raw.entries()) {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    if (!isRecord(entry)) {
       return { error: `ops[${index}] must be an object.` };
     }
-    const { op, ...args } = entry as Record<string, unknown>;
-    if (typeof op !== "string" || !isScriptOpName(op.trim())) {
+    const { op, ...args } = entry;
+    if (!isString(op) || !isScriptOpName(op.trim())) {
       return {
         error: `ops[${index}] names "${String(op)}"; expected one of ${SCRIPT_OPS.join(", ")}.`
       };
@@ -741,7 +742,7 @@ function parseScriptOps(raw: unknown): ParsedScriptOp[] | ToolError {
 
 /** Resolve a speaker reference: id or name (case-insensitive). */
 function findSpeakerIndex(doc: ScriptDocument, target: unknown): number {
-  const raw = typeof target === "string" ? target.trim() : "";
+  const raw = isString(target) ? target.trim() : "";
   const byId = doc.cast.findIndex((speaker) => speaker.id === raw);
   if (byId >= 0) return byId;
   const name = raw.toLowerCase();
@@ -752,7 +753,7 @@ function findSpeakerIndex(doc: ScriptDocument, target: unknown): number {
 
 /** The section an op addresses: by id, else the last one, else a fresh one. */
 function resolveSection(doc: ScriptDocument, target: unknown) {
-  if (typeof target === "string" && target.trim() !== "") {
+  if (isNonBlankString(target)) {
     const found = doc.sections.find((section) => section.id === target.trim());
     if (!found) throw new Error(`No section matches "${target}".`);
     return found;
@@ -778,7 +779,7 @@ function parseVoiceBinding(
   const provider = args["provider"];
   const model = args["model"];
   const voice = args["voice"];
-  const given = [provider, model, voice].filter((v) => typeof v === "string");
+  const given = [provider, model, voice].filter((v) => isString(v));
   if (given.length === 0) return null;
   if (given.length !== 3) {
     throw new Error(
@@ -790,8 +791,8 @@ function parseVoiceBinding(
     model: String(model),
     voice: String(voice)
   };
-  if (args["settings"] && typeof args["settings"] === "object") {
-    binding.settings = args["settings"] as Record<string, unknown>;
+  if (isObjectLike(args["settings"])) {
+    binding.settings = args["settings"];
   }
   return binding;
 }
@@ -812,7 +813,7 @@ function applyScriptOp(
   switch (op) {
     case "add_speaker": {
       const name = args["name"];
-      if (typeof name !== "string" || name.trim() === "") {
+      if (!isNonBlankString(name)) {
         throw new Error("add_speaker needs a non-empty `name`.");
       }
       const speaker: ScriptSpeaker = {
@@ -820,7 +821,7 @@ function applyScriptOp(
         name: name.trim(),
         voice: parseVoiceBinding(args)
       };
-      if (typeof args["color"] === "string") speaker.color = args["color"];
+      if (isString(args["color"])) speaker.color = args["color"];
       doc.cast.push(speaker);
       return { id: speaker.id, name: speaker.name, has_voice: !!speaker.voice };
     }
@@ -870,14 +871,14 @@ function applyScriptOp(
         id: mintId("section", new Set(doc.sections.map((s) => s.id))),
         lines: []
       };
-      if (typeof args["title"] === "string") section.title = args["title"];
+      if (isString(args["title"])) section.title = args["title"];
       doc.sections.push(section);
       return { id: section.id, title: section.title };
     }
 
     case "add_line": {
       const text = args["text"];
-      if (typeof text !== "string" || text.trim() === "") {
+      if (!isNonBlankString(text)) {
         throw new Error("add_line needs a non-empty `text`.");
       }
       const section = resolveSection(doc, args["section"]);
@@ -896,19 +897,15 @@ function applyScriptOp(
         text,
         takes: []
       };
-      if (typeof args["direction"] === "string") {
+      if (isString(args["direction"])) {
         line.direction = args["direction"];
       }
-      if (typeof args["pause_after_ms"] === "number") {
+      if (isNumber(args["pause_after_ms"])) {
         line.pauseAfterMs = args["pause_after_ms"];
       }
-      const at =
-        typeof args["index"] === "number"
-          ? Math.max(
-              0,
-              Math.min(Math.trunc(args["index"]), section.lines.length)
-            )
-          : section.lines.length;
+      const at = isNumber(args["index"])
+        ? Math.max(0, Math.min(Math.trunc(args["index"]), section.lines.length))
+        : section.lines.length;
       section.lines.splice(at, 0, line);
       return { id: line.id, section_id: section.id, index: at };
     }
@@ -918,7 +915,7 @@ function applyScriptOp(
       const line = findLine(scriptLines(doc.sections), target);
       if (!line) throw new Error(`No line matches "${target}".`);
       const text = args["text"];
-      if (typeof text !== "string" || text.trim() === "") {
+      if (!isNonBlankString(text)) {
         throw new Error("set_line_text needs a non-empty `text`.");
       }
       // The takes stay: each carries the text it was voiced from, so rewriting

--- a/packages/agents/src/evals/surfaces/storyboard.ts
+++ b/packages/agents/src/evals/surfaces/storyboard.ts
@@ -656,7 +656,7 @@ export const STORYBOARD_TOOL_LOOP_CASES: readonly ToolLoopEvalCase<StoryboardBri
             detail: "a shot reached the board without its duration",
             test: (s) =>
               s.shots.length > 0 &&
-              s.shots.every((sh) => typeof sh.durationSeconds === "number")
+              s.shots.every((sh) => sh.durationSeconds != null)
           },
           {
             // The check the old bridge could not make: it minted the fields a

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -81,6 +81,15 @@ import {
   type GuestBytes
 } from "./sandbox-bytes.js";
 import {
+  isBoolean,
+  isFunction,
+  isNonEmptyString,
+  isNumber,
+  isObjectLike,
+  isRecord,
+  isString
+} from "./utils/type-guards.js";
+import {
   createSandboxMediaStore,
   isSandboxMediaHandle,
   MAX_RUN_MEDIA_BYTES,
@@ -791,7 +800,7 @@ async function readBodyCapped(
 function formatArg(arg: unknown): string {
   if (arg === null) return "null";
   if (arg === undefined) return "undefined";
-  if (typeof arg === "string") return arg;
+  if (isString(arg)) return arg;
   try {
     return JSON.stringify(arg, null, 2);
   } catch {
@@ -800,7 +809,7 @@ function formatArg(arg: unknown): string {
 }
 
 function isTypedArray(value: unknown): boolean {
-  if (!value || typeof value !== "object") return false;
+  if (!isObjectLike(value)) return false;
   const name = (value as object).constructor?.name;
   return (
     name === "Uint8Array" ||
@@ -858,15 +867,11 @@ function coerceBytesInput(
   value: unknown,
   label: string
 ): Uint8Array<ArrayBuffer> {
-  if (typeof value === "string") return new TextEncoder().encode(value);
+  if (isString(value)) return new TextEncoder().encode(value);
   if (value instanceof Uint8Array) return Uint8Array.from(value);
   if (isTypedArray(value)) return toNativeUint8Array(value);
   if (Array.isArray(value)) return Uint8Array.from(value.map(Number));
-  if (
-    value &&
-    typeof value === "object" &&
-    typeof (value as { length?: unknown }).length === "number"
-  ) {
+  if (isObjectLike(value) && isNumber((value as { length?: unknown }).length)) {
     return toNativeUint8Array(value);
   }
   throw new Error(`crypto: ${label} must be a string or Uint8Array`);
@@ -895,7 +900,7 @@ function containsTypedArray(
   seen = new WeakSet<object>()
 ): boolean {
   if (isTypedArray(value)) return true;
-  if (value === null || typeof value !== "object") return false;
+  if (!isObjectLike(value)) return false;
   if (depth >= SERIALIZE_MAX_DEPTH) return false;
   const obj = value as object;
   if (seen.has(obj)) return false;
@@ -916,7 +921,7 @@ function convertTypedArraysDeep(
   seen = new WeakSet<object>()
 ): unknown {
   if (isTypedArray(value)) return toNativeUint8Array(value);
-  if (value === null || typeof value !== "object") return value;
+  if (!isObjectLike(value)) return value;
   if (depth >= SERIALIZE_MAX_DEPTH) return value;
   const obj = value as object;
   if (seen.has(obj)) return null;
@@ -941,12 +946,8 @@ export function serializeResult(
 ) {
   if (result === undefined) return null;
   if (result === null) return null;
-  if (
-    typeof result === "string" ||
-    typeof result === "number" ||
-    typeof result === "boolean"
-  ) {
-    if (typeof result === "string" && result.length > maxOutputSize) {
+  if (isString(result) || isNumber(result) || isBoolean(result)) {
+    if (isString(result) && result.length > maxOutputSize) {
       return truncate(result, maxOutputSize);
     }
     return result;
@@ -954,7 +955,7 @@ export function serializeResult(
   if (isTypedArray(result)) {
     return toNativeUint8Array(result);
   }
-  if (typeof result === "object") {
+  if (isObjectLike(result)) {
     // The scan and the rebuild are both deep. They used to look one level in,
     // so a typed array nested any deeper fell through to the JSON path below —
     // and `JSON.stringify(new Uint8Array([137, 80]))` is `{"0":137,"1":80}`,
@@ -1086,7 +1087,7 @@ export function buildSandbox(
         `Fetch limit exceeded (max ${resolvedLimits.maxFetchCalls} requests per execution)`
       );
     }
-    if (typeof url !== "string" || !url) {
+    if (!isNonEmptyString(url)) {
       throw new Error("fetch: url must be a non-empty string");
     }
     // SSRF guard: untrusted guest code must not reach loopback, link-local
@@ -1118,7 +1119,7 @@ export function buildSandbox(
       if (resolvedLimits.userAgent) {
         requestHeaders["User-Agent"] = resolvedLimits.userAgent;
       }
-      if (options?.headers && typeof options.headers === "object") {
+      if (isObjectLike(options?.headers)) {
         Object.assign(
           requestHeaders,
           options.headers as Record<string, string>
@@ -1129,7 +1130,7 @@ export function buildSandbox(
       }
       if (options?.body !== undefined) {
         const body = options.body;
-        if (typeof body === "string") {
+        if (isString(body)) {
           fetchOptions.body = body;
         } else if (isTypedArray(body)) {
           // Binary request body. A guest Uint8Array reaches the host as a
@@ -1151,7 +1152,7 @@ export function buildSandbox(
       // opaque response whose Location is unreadable, and cross-origin bodies
       // are CORS-blocked anyway, so the browser keeps the single redirect:
       // "follow" call with only the already-run initial-URL check.
-      const onNode = typeof globalThis.process?.versions?.node === "string";
+      const onNode = isString(globalThis.process?.versions?.node);
       let response: Response;
       if (!onNode) {
         response = await fetch(url, { ...fetchOptions, redirect: "follow" });
@@ -1624,7 +1625,7 @@ export function buildSandbox(
   const outputs = new Map<string, unknown>();
 
   const handleName = (fn: string, name: unknown): string => {
-    if (typeof name !== "string") {
+    if (!isString(name)) {
       throw new TypeError(`${fn}: name must be a string`);
     }
     return name;
@@ -1663,7 +1664,7 @@ export function buildSandbox(
     if (!streams?.onTakeInput) {
       throw new Error(NO_INPUT_STREAM_MESSAGE);
     }
-    if (name !== null && typeof name !== "string") {
+    if (name !== null && !isString(name)) {
       throw new TypeError("stream: name must be a string");
     }
     // Waiting on upstream is not the guest executing, so it must not spend the
@@ -1688,7 +1689,7 @@ export function buildSandbox(
   // stream at all — and the prelude turns it into the thrown error.
   const streamOpen = (name: unknown): boolean | null => {
     if (!streams?.onTakeInput) return null;
-    if (typeof name !== "string" || !streams.onStreamOpen) return false;
+    if (!isString(name) || !streams.onStreamOpen) return false;
     try {
       return streams.onStreamOpen(name) === true;
     } catch {
@@ -1907,8 +1908,8 @@ export function buildSandbox(
       return resolved;
     }
     if (resolveRefs && looksLikeMediaRef(value)) {
-      if (expectedType && value && typeof value === "object") {
-        const declared = (value as Record<string, unknown>).type;
+      if (expectedType && isObjectLike(value)) {
+        const declared = value.type;
         if (
           (declared === "image" ||
             declared === "audio" ||
@@ -1923,8 +1924,8 @@ export function buildSandbox(
       const remainingBytes = resolvedLimits.runMediaBytes - budget.used;
       return accountBytes(await loadMediaRef(where, value, remainingBytes));
     }
-    if (value !== null && typeof value === "object") {
-      const record = value as Record<string, unknown>;
+    if (isObjectLike(value)) {
+      const record = value;
       const out: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(record)) {
         out[k] = await resolveMediaArgs(
@@ -1958,13 +1959,10 @@ export function buildSandbox(
         defaultMediaMime(expectedType)
       );
     }
-    const record =
-      value !== null && typeof value === "object" && !Array.isArray(value)
-        ? (value as Record<string, unknown>)
-        : undefined;
+    const record = isRecord(value) ? value : undefined;
     const declared = record?.mimeType ?? record?.mime_type;
     const ref: MediaRefValue & { mimeType?: string } = remapMediaRef(value);
-    if (typeof declared === "string") ref.mimeType = declared;
+    if (isString(declared)) ref.mimeType = declared;
     return mimeForRef(ref, defaultMediaMime(expectedType));
   };
 
@@ -2696,11 +2694,11 @@ function replaceInPlace(target: unknown, source: unknown): void {
     }
     return;
   }
-  if (target && typeof target === "object") {
-    const t = target as Record<string, unknown>;
+  if (isObjectLike(target)) {
+    const t = target;
     for (const key of Object.keys(t)) delete t[key];
-    if (source && typeof source === "object" && !Array.isArray(source)) {
-      const s = source as Record<string, unknown>;
+    if (isRecord(source)) {
+      const s = source;
       for (const [k, v] of Object.entries(s)) t[k] = v;
     }
   }
@@ -2881,7 +2879,7 @@ export async function runInSandbox(
   // Identify object-typed globals whose contents should be synced back to the
   // host after the guest runs. Primitives are passed by value and need no sync.
   const syncTargetNames = Object.entries(userGlobals)
-    .filter(([, v]) => v !== null && typeof v === "object")
+    .filter(([, v]) => isObjectLike(v))
     .map(([k]) => k);
 
   // Write the extracted object-global snapshots back into the caller's own
@@ -2895,12 +2893,7 @@ export async function runInSandbox(
     for (const name of syncTargetNames) {
       const hostValue = userGlobals[name] as unknown;
       const guestValue = extracted[name];
-      if (
-        hostValue !== null &&
-        typeof hostValue === "object" &&
-        guestValue !== null &&
-        typeof guestValue === "object"
-      ) {
+      if (isObjectLike(hostValue) && isObjectLike(guestValue)) {
         replaceInPlace(hostValue, guestValue);
       }
     }
@@ -2953,7 +2946,7 @@ export async function runInSandbox(
     bindDispatcher("host", dispatchCallOf(hostModules));
     bindDispatcher("capability", dispatchCallOf(capabilities));
     for (const [name, value] of Object.entries(userGlobals)) {
-      if (typeof value === "function") dispatch[name] = value;
+      if (isFunction(value)) dispatch[name] = value;
     }
 
     const workerRun: WritableRun = {

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -345,7 +345,7 @@ function clampLimit(
   min: number,
   max: number
 ): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  if (value == null || !Number.isFinite(value)) return fallback;
   return Math.min(Math.max(Math.floor(value), min), max);
 }
 

--- a/packages/agents/src/sandbox-media-ref.ts
+++ b/packages/agents/src/sandbox-media-ref.ts
@@ -18,6 +18,12 @@ import { loadMediaRefBytes, type MediaRefValue } from "@nodetool-ai/runtime";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 
 import { toGuestBytes, type GuestBytes } from "./sandbox-bytes.js";
+import {
+  isNonBlankString,
+  isNonEmptyString,
+  isRecord,
+  isString
+} from "./utils/type-guards.js";
 
 /**
  * Largest payload `media.*` moves in either direction.
@@ -123,9 +129,7 @@ function mimeFromDataUri(uri: string): string | undefined {
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
+  return isRecord(value) ? value : {};
 }
 
 function optionalString(
@@ -135,7 +139,7 @@ function optionalString(
 ): string | undefined {
   const value = options[key];
   if (value === undefined || value === null) return undefined;
-  if (typeof value !== "string") {
+  if (!isString(value)) {
     throw new Error(`${where}: ${key} must be a string`);
   }
   return value;
@@ -161,15 +165,15 @@ export const MEDIA_LOCATOR_KEYS = [
  * Prefer a non-filesystem URI so a bare id does not win over `asset://…`.
  */
 export function mediaLocatorFrom(value: unknown): string {
-  if (typeof value === "string" && value.trim() !== "") {
+  if (isNonBlankString(value)) {
     return value.trim();
   }
-  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
-    const record = value as Record<string, unknown>;
+  if (isRecord(value)) {
+    const record = value;
     const values: string[] = [];
     for (const key of MEDIA_LOCATOR_KEYS) {
       const locator = record[key];
-      if (typeof locator === "string" && locator.trim() !== "") {
+      if (isNonBlankString(locator)) {
         values.push(locator.trim());
       }
     }
@@ -179,7 +183,7 @@ export function mediaLocatorFrom(value: unknown): string {
         filesystemPathForUri(candidate) === null
     );
     if (safeUri) return safeUri;
-    if (typeof record.asset_id === "string" && record.asset_id.trim() !== "") {
+    if (isNonBlankString(record.asset_id)) {
       return record.asset_id.trim();
     }
     if (values[0]) return values[0];
@@ -198,17 +202,17 @@ export function isMediaLocatorString(value: string): boolean {
 
 /** Whether `image.*` should treat the value as a media ref, not as nested data. */
 export function looksLikeMediaRef(value: unknown): boolean {
-  if (typeof value === "string") {
+  if (isString(value)) {
     return isMediaLocatorString(value);
   }
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+  if (!isRecord(value)) {
     return false;
   }
-  const record = value as Record<string, unknown>;
+  const record = value;
   return (
-    typeof record.uri === "string" ||
-    typeof record.asset_id === "string" ||
-    typeof record.asset_uri === "string" ||
+    isString(record.uri) ||
+    isString(record.asset_id) ||
+    isString(record.asset_uri) ||
     record.data !== undefined
   );
 }
@@ -219,16 +223,13 @@ export function looksLikeMediaRef(value: unknown): boolean {
  * never the path that is read.
  */
 export function remapMediaRef(value: unknown): MediaRefValue {
-  if (typeof value === "string") {
+  if (isString(value)) {
     const locator = value.trim();
     return locator.includes("://") || locator.startsWith("/api/")
       ? { uri: locator }
       : { uri: locator, asset_id: locator };
   }
-  const record =
-    value !== null && typeof value === "object" && !Array.isArray(value)
-      ? (value as Record<string, unknown>)
-      : {};
+  const record: Record<string, unknown> = isRecord(value) ? value : {};
   let locator: string | undefined;
   try {
     locator = mediaLocatorFrom(value);
@@ -236,16 +237,16 @@ export function remapMediaRef(value: unknown): MediaRefValue {
     locator = undefined;
   }
   return {
-    type: typeof record.type === "string" ? record.type : undefined,
+    type: isString(record.type) ? record.type : undefined,
     uri: locator,
-    asset_id: typeof record.asset_id === "string" ? record.asset_id : undefined,
+    asset_id: isString(record.asset_id) ? record.asset_id : undefined,
     data: record.data
   };
 }
 
 /** The ref argument, checked. A guest can pass anything, including `undefined`. */
 function requireRef(where: string, ref: unknown): MediaRefValue {
-  if (ref === null || typeof ref !== "object" || Array.isArray(ref)) {
+  if (!isRecord(ref)) {
     throw new Error(
       `${where}: expected a media ref object ({type, uri, asset_id, data})`
     );
@@ -255,10 +256,10 @@ function requireRef(where: string, ref: unknown): MediaRefValue {
 
 /** How the ref reads in an error message, so the failure names what failed. */
 function describeRef(ref: MediaRefValue): string {
-  if (typeof ref.uri === "string" && ref.uri.length > 0) {
+  if (isNonEmptyString(ref.uri)) {
     return ref.uri.length > 200 ? `${ref.uri.slice(0, 200)}…` : ref.uri;
   }
-  if (typeof ref.asset_id === "string" && ref.asset_id.length > 0) {
+  if (isNonEmptyString(ref.asset_id)) {
     return `asset ${ref.asset_id}`;
   }
   return `a ${ref.type ?? "media"} ref with no uri, asset_id, or data`;
@@ -277,7 +278,7 @@ const NON_FILESYSTEM_PREFIXES = ["data:", "asset://", "package://", "/api/"];
  * with no check at all, which is why a filesystem-shaped uri never reaches it.
  */
 export function filesystemPathForUri(uri: unknown): string | null {
-  if (typeof uri !== "string" || uri === "") return null;
+  if (!isNonEmptyString(uri)) return null;
   const lower = uri.toLowerCase();
   if (NON_FILESYSTEM_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
     return null;
@@ -365,8 +366,8 @@ export async function resolveRefBytes(
 /** The ref's mime type, from the ref itself, its data URI header, or its path. */
 export function mimeForRef(ref: MediaRefValue, fallback: string): string {
   const declared = (ref as { mimeType?: unknown }).mimeType;
-  if (typeof declared === "string" && declared.length > 0) return declared;
-  const uri = typeof ref.uri === "string" ? ref.uri : "";
+  if (isNonEmptyString(declared)) return declared;
+  const uri = isString(ref.uri) ? ref.uri : "";
   if (uri.startsWith("data:")) {
     return mimeFromDataUri(uri) ?? fallback;
   }
@@ -427,7 +428,7 @@ async function storeOrInline(
       contentType: mimeType,
       content: bytes
     })) as { id?: unknown };
-    if (typeof created?.id === "string" && created.id.length > 0) {
+    if (isNonEmptyString(created?.id)) {
       return { uri: `asset://${created.id}`, asset_id: created.id };
     }
   }
@@ -552,13 +553,13 @@ export function createMediaRefBridge(
         context,
         options.resolvePath
       );
-      const kind = typeof value.type === "string" ? value.type : "document";
+      const kind = isString(value.type) ? value.type : "document";
       const fallback =
         DEFAULT_MIME[kind as MediaRefKind] ?? DEFAULT_MIME.document;
       return {
         type: kind,
         mimeType: mimeForRef(value, fallback),
-        uri: typeof value.uri === "string" ? value.uri : "",
+        uri: isString(value.uri) ? value.uri : "",
         size: bytes.length
       };
     },

--- a/packages/agents/src/step-executor.ts
+++ b/packages/agents/src/step-executor.ts
@@ -51,6 +51,15 @@ import {
   validateAgainstSchema
 } from "./utils/json-schema-validate.js";
 import { removeThinkTags } from "./utils/think-tags.js";
+import {
+  isBoolean,
+  isFunction,
+  isNonEmptyString,
+  isNumber,
+  isObjectLike,
+  isRecord,
+  isString
+} from "./utils/type-guards.js";
 
 const log = createLogger("nodetool.agents.step-executor");
 
@@ -181,7 +190,7 @@ function validateAndSanitizeSchema(
   }
 
   let parsed: unknown = schema;
-  if (typeof parsed === "string") {
+  if (isString(parsed)) {
     parsed = JSON.parse(parsed);
   }
 
@@ -234,11 +243,9 @@ function validateAndSanitizeSchema(
     if (Array.isArray(obj)) {
       return obj.map(cleanSchemaRecursive);
     }
-    if (obj !== null && typeof obj === "object") {
+    if (isObjectLike(obj)) {
       const cleaned: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(
-        obj as Record<string, unknown>
-      )) {
+      for (const [key, value] of Object.entries(obj)) {
         cleaned[key] = cleanSchemaRecursive(value);
       }
       if (shouldDefaultAdditionalProperties(cleaned)) {
@@ -259,7 +266,7 @@ function validateAndSanitizeSchema(
 function normalizeDeclaredSchema(
   raw: unknown
 ): Record<string, unknown> | null {
-  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return null;
+  if (!isRecord(raw)) return null;
   const copy = JSON.parse(JSON.stringify(raw)) as Record<string, unknown>;
   if (!("type" in copy) && "properties" in copy) copy["type"] = "object";
   return copy;
@@ -271,16 +278,11 @@ function normalizeDeclaredSchema(
 
 function normalizeToolResult(value: unknown): unknown {
   if (value === null || value === undefined) return value;
-  if (
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  )
-    return value;
+  if (isString(value) || isNumber(value) || isBoolean(value)) return value;
   if (Array.isArray(value)) return value.map(normalizeToolResult);
-  if (typeof value === "object") {
-    const obj = value as Record<string, unknown>;
-    if (typeof obj["toJSON"] === "function") {
+  if (isObjectLike(value)) {
+    const obj = value;
+    if (isFunction(obj["toJSON"])) {
       return normalizeToolResult((obj as { toJSON(): unknown }).toJSON());
     }
     const result: Record<string, unknown> = {};
@@ -448,10 +450,9 @@ export class StepExecutor {
       ? "The task result"
       : "The step result";
     try {
-      const raw =
-        typeof this.step.outputSchema === "string"
-          ? JSON.parse(this.step.outputSchema)
-          : this.step.outputSchema;
+      const raw = isString(this.step.outputSchema)
+        ? JSON.parse(this.step.outputSchema)
+        : this.step.outputSchema;
       // Two schemas, on purpose. The sanitized one is what the provider is
       // shown — it injects `additionalProperties: false` because strict
       // structured-output modes demand it. The authored one is the contract,
@@ -630,21 +631,17 @@ export class StepExecutor {
    * Mirrors Python's StepExecutor._handle_binary_artifact().
    */
   private async handleBinaryArtifact(toolResult: unknown): Promise<unknown> {
-    if (
-      typeof toolResult !== "object" ||
-      toolResult === null ||
-      Array.isArray(toolResult)
-    ) {
+    if (!isRecord(toolResult)) {
       return toolResult;
     }
 
-    const result = { ...(toolResult as Record<string, unknown>) };
+    const result = { ...toolResult };
     const workspaceDir = this.context.workspaceDir;
     if (!workspaceDir) return result;
 
     for (const field of ["image", "audio"]) {
       const value = result[field];
-      if (typeof value !== "string") continue;
+      if (!isString(value)) continue;
 
       const dataUriMatch = value.match(/^data:([^;]+);base64,(.+)$/s);
       if (!dataUriMatch) continue;
@@ -681,15 +678,11 @@ export class StepExecutor {
     toolArgs: Record<string, unknown> | undefined,
     toolResult: unknown
   ): Promise<unknown> {
-    if (
-      typeof toolResult !== "object" ||
-      toolResult === null ||
-      Array.isArray(toolResult)
-    ) {
+    if (!isRecord(toolResult)) {
       return toolResult;
     }
 
-    const result = { ...(toolResult as Record<string, unknown>) };
+    const result = { ...toolResult };
     if (result.success === false) {
       return result;
     }
@@ -709,7 +702,7 @@ export class StepExecutor {
     };
     const maybeAdd = (label: string, value: unknown): void => {
       if (
-        typeof value === "string" &&
+        isString(value) &&
         value.trim().length > 0 &&
         !value.startsWith("data:") &&
         !isExternalUri(value)
@@ -739,7 +732,7 @@ export class StepExecutor {
         const ref = await this.context.sandboxToAsset(candidate.path);
         refs[candidate.label] = ref;
         const uri = ref.uri;
-        if (typeof uri === "string" && uri && !this.sourcesSet.has(uri)) {
+        if (isNonEmptyString(uri) && !this.sourcesSet.has(uri)) {
           this.sources.push(uri);
           this.sourcesSet.add(uri);
         }
@@ -755,11 +748,7 @@ export class StepExecutor {
 
     if (Object.keys(refs).length > 0) {
       const existing = result.asset_refs;
-      if (
-        typeof existing === "object" &&
-        existing !== null &&
-        !Array.isArray(existing)
-      ) {
+      if (isRecord(existing)) {
         result.asset_refs = { ...existing, ...refs };
       } else {
         result.asset_refs = refs;
@@ -774,13 +763,9 @@ export class StepExecutor {
    * Mirrors Python's _process_special_tool_side_effects().
    */
   private trackToolSideEffects(toolName: string, result: unknown): void {
-    if (
-      toolName === "browser" &&
-      typeof result === "object" &&
-      result !== null
-    ) {
-      const url = (result as Record<string, unknown>).url;
-      if (typeof url === "string" && url && !this.sourcesSet.has(url)) {
+    if (toolName === "browser" && isObjectLike(result)) {
+      const url = result.url;
+      if (isNonEmptyString(url) && !this.sourcesSet.has(url)) {
         this.sources.push(url);
         this.sourcesSet.add(url);
       }
@@ -953,12 +938,10 @@ export class StepExecutor {
       // object result with an `items` key is not misinterpreted.
       if (
         this.resultSchema?.["type"] === "array" &&
-        resultPayload !== null &&
-        typeof resultPayload === "object" &&
-        !Array.isArray(resultPayload) &&
-        Array.isArray((resultPayload as Record<string, unknown>)["items"])
+        isRecord(resultPayload) &&
+        Array.isArray(resultPayload["items"])
       ) {
-        resultPayload = (resultPayload as Record<string, unknown>)["items"];
+        resultPayload = resultPayload["items"];
       }
       if (resultPayload === undefined || resultPayload === null) {
         return '{"error": "Missing result in finish_step call"}';
@@ -1098,7 +1081,7 @@ export class StepExecutor {
           continue;
         }
         if (isChunk(item)) {
-          if (typeof item.content === "string" && item.content.length > 0) {
+          if (isNonEmptyString(item.content)) {
             yield {
               type: "chunk",
               node_id: this.step.id,
@@ -1112,10 +1095,9 @@ export class StepExecutor {
         if ("type" in item && (item as { type?: string }).type === "message") {
           const m = (item as { message?: Message }).message;
           if (m && m.role === "assistant") {
-            lastAssistant =
-              typeof m.content === "string"
-                ? { ...m, content: removeThinkTags(m.content) }
-                : m;
+            lastAssistant = isString(m.content)
+              ? { ...m, content: removeThinkTags(m.content) }
+              : m;
           }
         }
         yield* drainUi();

--- a/packages/agents/src/utils/json-schema-validate.ts
+++ b/packages/agents/src/utils/json-schema-validate.ts
@@ -13,6 +13,14 @@
  * validated exactly, rather than the full specification validated loosely.
  */
 
+import {
+  isBoolean,
+  isNumber,
+  isObjectLike,
+  isRecord,
+  isString
+} from "./type-guards.js";
+
 export interface SchemaViolation {
   /** JSON-path-ish location, e.g. `result.outputs.text`. */
   path: string;
@@ -33,14 +41,22 @@ const TYPE_NAMES = [
 
 type TypeName = (typeof TYPE_NAMES)[number];
 
+/** A `type` keyword this validator knows. */
+function isTypeName(value: unknown): value is TypeName {
+  return (
+    typeof value === "string" &&
+    (TYPE_NAMES as readonly string[]).includes(value)
+  );
+}
+
 function typeOf(value: unknown): TypeName {
   if (value === null) return "null";
   if (Array.isArray(value)) return "array";
-  if (typeof value === "number") {
+  if (isNumber(value)) {
     return Number.isInteger(value) ? "integer" : "number";
   }
-  if (typeof value === "string") return "string";
-  if (typeof value === "boolean") return "boolean";
+  if (isString(value)) return "string";
+  if (isBoolean(value)) return "boolean";
   return "object";
 }
 
@@ -54,7 +70,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (typeof a !== typeof b || a === null || b === null) return false;
   if (Array.isArray(a) !== Array.isArray(b)) return false;
-  if (typeof a !== "object") return false;
+  if (!isObjectLike(a)) return false;
   const ao = a as Record<string, unknown>;
   const bo = b as Record<string, unknown>;
   const aKeys = Object.keys(ao);
@@ -65,7 +81,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
 }
 
 function describe(value: unknown): string {
-  const text = typeof value === "string" ? value : JSON.stringify(value);
+  const text = isString(value) ? value : JSON.stringify(value);
   return text !== undefined && text.length > 60
     ? `${text.slice(0, 60)}…`
     : String(text);
@@ -112,12 +128,9 @@ function validate(
 
   const declared = schema["type"];
   const types: TypeName[] = Array.isArray(declared)
-    ? (declared.filter((t): t is TypeName =>
-        (TYPE_NAMES as readonly string[]).includes(t as string)
-      ) as TypeName[])
-    : typeof declared === "string" &&
-        (TYPE_NAMES as readonly string[]).includes(declared)
-      ? [declared as TypeName]
+    ? declared.filter(isTypeName)
+    : isTypeName(declared)
+      ? [declared]
       : [];
   if (types.length > 0 && !types.some((t) => matchesType(value, t))) {
     out.push({
@@ -131,8 +144,8 @@ function validate(
     validateObject(value as Record<string, unknown>, schema, path, out);
   }
   if (Array.isArray(value)) validateArray(value, schema, path, out);
-  if (typeof value === "number") validateNumber(value, schema, path, out);
-  if (typeof value === "string") validateString(value, schema, path, out);
+  if (isNumber(value)) validateNumber(value, schema, path, out);
+  if (isString(value)) validateString(value, schema, path, out);
 
   validateCombinators(value, schema, path, out);
 }
@@ -148,7 +161,7 @@ function validateObject(
     for (const key of required) {
       // Object.hasOwn, not `in`: a required key named `toString` must be
       // produced by the model, not inherited from the prototype chain.
-      if (typeof key === "string" && !Object.hasOwn(value, key)) {
+      if (isString(key) && !Object.hasOwn(value, key)) {
         out.push({ path, message: `missing required property "${key}"` });
       }
     }
@@ -157,8 +170,8 @@ function validateObject(
   const properties = (schema["properties"] as Schema | undefined) ?? {};
   for (const [key, sub] of Object.entries(properties)) {
     if (!Object.hasOwn(value, key)) continue;
-    if (sub && typeof sub === "object") {
-      validate(value[key], sub as Schema, `${path}.${key}`, out);
+    if (isObjectLike(sub)) {
+      validate(value[key], sub, `${path}.${key}`, out);
     }
   }
 
@@ -169,10 +182,10 @@ function validateObject(
         out.push({ path, message: `unexpected property "${key}"` });
       }
     }
-  } else if (additional && typeof additional === "object") {
+  } else if (isObjectLike(additional)) {
     for (const [key, entry] of Object.entries(value)) {
       if (Object.hasOwn(properties, key)) continue;
-      validate(entry, additional as Schema, `${path}.${key}`, out);
+      validate(entry, additional, `${path}.${key}`, out);
     }
   }
 }
@@ -184,17 +197,17 @@ function validateArray(
   out: SchemaViolation[]
 ): void {
   const items = schema["items"];
-  if (items && typeof items === "object" && !Array.isArray(items)) {
+  if (isRecord(items)) {
     value.forEach((entry, index) =>
-      validate(entry, items as Schema, `${path}[${index}]`, out)
+      validate(entry, items, `${path}[${index}]`, out)
     );
   }
   const min = schema["minItems"];
-  if (typeof min === "number" && value.length < min) {
+  if (isNumber(min) && value.length < min) {
     out.push({ path, message: `expected at least ${min} items` });
   }
   const max = schema["maxItems"];
-  if (typeof max === "number" && value.length > max) {
+  if (isNumber(max) && value.length > max) {
     out.push({ path, message: `expected at most ${max} items` });
   }
 }
@@ -206,11 +219,11 @@ function validateNumber(
   out: SchemaViolation[]
 ): void {
   const min = schema["minimum"];
-  if (typeof min === "number" && value < min) {
+  if (isNumber(min) && value < min) {
     out.push({ path, message: `must be >= ${min}` });
   }
   const max = schema["maximum"];
-  if (typeof max === "number" && value > max) {
+  if (isNumber(max) && value > max) {
     out.push({ path, message: `must be <= ${max}` });
   }
 }
@@ -222,11 +235,11 @@ function validateString(
   out: SchemaViolation[]
 ): void {
   const min = schema["minLength"];
-  if (typeof min === "number" && value.length < min) {
+  if (isNumber(min) && value.length < min) {
     out.push({ path, message: `must be at least ${min} characters` });
   }
   const max = schema["maxLength"];
-  if (typeof max === "number" && value.length > max) {
+  if (isNumber(max) && value.length > max) {
     out.push({ path, message: `must be at most ${max} characters` });
   }
 }
@@ -240,8 +253,8 @@ function validateCombinators(
   const allOf = schema["allOf"];
   if (Array.isArray(allOf)) {
     for (const sub of allOf) {
-      if (sub && typeof sub === "object") {
-        validate(value, sub as Schema, path, out);
+      if (isObjectLike(sub)) {
+        validate(value, sub, path, out);
       }
     }
   }
@@ -254,8 +267,8 @@ function validateCombinators(
     // ones, so an all-fail reports the closest branch — fewest violations.
     let closest: SchemaViolation[] | null = null;
     for (const branch of branches) {
-      if (!branch || typeof branch !== "object") continue;
-      const errors = validateAgainstSchema(value, branch as Schema, path);
+      if (!isObjectLike(branch)) continue;
+      const errors = validateAgainstSchema(value, branch, path);
       if (errors.length === 0) {
         closest = null;
         break;

--- a/packages/agents/src/utils/type-guards.ts
+++ b/packages/agents/src/utils/type-guards.ts
@@ -1,0 +1,49 @@
+/**
+ * Named predicates for the shapes this package reads off its untrusted
+ * boundaries: QuickJS guest results, tool call arguments, model output, and
+ * media refs. Each one is the check the call sites used to inline, so the
+ * leniency of a boundary stays exactly where it was — a value that passed
+ * before passes now.
+ */
+
+export function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+/** A string with at least one character. */
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value !== "";
+}
+
+/** A string that holds something other than whitespace. */
+export function isNonBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+export function isNumber(value: unknown): value is number {
+  return typeof value === "number";
+}
+
+export function isBoolean(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
+export function isFunction(
+  value: unknown
+): value is (...args: never[]) => unknown {
+  return typeof value === "function";
+}
+
+/** A keyed object — never `null`, never an array. */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Anything `typeof` calls an object, `null` aside — an array passes. The
+ * looser sibling of {@link isRecord}, kept apart because the boundaries that
+ * accept an array here must keep accepting it.
+ */
+export function isObjectLike(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}

--- a/packages/app-runtime/src/bindings.ts
+++ b/packages/app-runtime/src/bindings.ts
@@ -156,7 +156,7 @@ const isExecutionField = (value: string): value is ExecutionField =>
 
 /** Parse an explicit (already ID-based) binding token. Legacy names return null. */
 export const parseBinding = (binding?: string | null): BindingRef | null => {
-  if (typeof binding !== "string" || binding.length === 0) return null;
+  if (binding == null || binding.length === 0) return null;
 
   if (binding.startsWith(VARIABLE_PREFIX)) {
     const id = binding.slice(VARIABLE_PREFIX.length);
@@ -273,7 +273,7 @@ export const resolveBinding = (
     }
     return onKnownOperation(explicit, scope);
   }
-  if (typeof binding !== "string" || binding.length === 0) return null;
+  if (binding == null || binding.length === 0) return null;
 
   const op =
     scope.operations.find((o) => o.operationId === operationId) ??

--- a/packages/app-runtime/src/document.ts
+++ b/packages/app-runtime/src/document.ts
@@ -1,4 +1,11 @@
 import type { Mutable } from "./mutable.js";
+import {
+  isInteger,
+  isNonEmptyString,
+  isNumber,
+  isRecord,
+  isString
+} from "./predicates.js";
 /**
  * The application document: a UI layout plus typed bindings to workflow
  * operations, resources, and app state. Nothing here computes — every
@@ -172,9 +179,6 @@ export const createEmptyDocument = (title?: string): ApplicationDocument => ({
   variables: []
 });
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 const isPuckData = (value: unknown): value is PuckData =>
   isRecord(value) && isRecord(value.root) && Array.isArray(value.content);
 
@@ -191,14 +195,13 @@ const parseInputMapping = (value: unknown): InputMapping | null => {
     case "widget":
       return { from: "widget" };
     case "variable":
-      return typeof value.variableId === "string" && value.variableId.length > 0
+      return isNonEmptyString(value.variableId)
         ? { from: "variable", variableId: value.variableId }
         : null;
     case "constant":
       return { from: "constant", value: value.value };
     case "resource":
-      return typeof value.resourceBindingId === "string" &&
-        value.resourceBindingId.length > 0
+      return isNonEmptyString(value.resourceBindingId)
         ? { from: "resource", resourceBindingId: value.resourceBindingId }
         : null;
     default:
@@ -217,7 +220,7 @@ const parseOutputMapping = (value: unknown): OutputMapping | null => {
     case "display":
       return { to: "display" };
     case "variable":
-      return typeof value.variableId === "string" && value.variableId.length > 0
+      return isNonEmptyString(value.variableId)
         ? { to: "variable", variableId: value.variableId }
         : null;
     default:
@@ -267,8 +270,8 @@ const parseScriptTarget = (
 ): Extract<OperationTarget, { kind: "script" }> | null => {
   if (!isRecord(value) || value.kind !== "script") return null;
   const { scriptId, scriptVersion } = value;
-  if (typeof scriptId !== "string" || scriptId.length === 0) return null;
-  if (typeof scriptVersion !== "number" || !Number.isInteger(scriptVersion)) {
+  if (!isNonEmptyString(scriptId)) return null;
+  if (!isInteger(scriptVersion)) {
     return null;
   }
   return { kind: "script", scriptId, scriptVersion };
@@ -277,7 +280,7 @@ const parseScriptTarget = (
 /** The workflow id a stored `target` names, when it names one. */
 const targetWorkflowId = (value: unknown): string | null => {
   if (!isRecord(value) || value.kind !== "workflow") return null;
-  return typeof value.workflowId === "string" ? value.workflowId : null;
+  return isString(value.workflowId) ? value.workflowId : null;
 };
 
 const parseOperation = (
@@ -286,31 +289,29 @@ const parseOperation = (
 ): OperationBinding | null => {
   if (!isRecord(value)) return null;
   const { id, name, policy } = value;
-  if (typeof id !== "string") return null;
+  if (!isString(id)) return null;
   const script = parseScriptTarget(value.target);
   // v3 stored only `workflowId`; v4 may carry an explicit workflow target
   // instead. Either way the workflow id ends up in one place.
-  const workflowId =
-    typeof value.workflowId === "string"
-      ? value.workflowId
-      : targetWorkflowId(value.target);
+  const workflowId = isString(value.workflowId)
+    ? value.workflowId
+    : targetWorkflowId(value.target);
   if (!script && workflowId === null) return null;
   type BindingFields = Mutable<OperationBinding>;
   const binding: BindingFields = {
     id,
-    name: typeof name === "string" ? name : id,
+    name: isString(name) ? name : id,
     // A document that ships without a workflow — a template, which has no id
     // until it is installed — binds to whatever workflow hosts it. A script
     // operation binds no workflow at all.
     workflowId: script ? "" : workflowId || hostWorkflowId || "",
-    workflowVersion:
-      typeof value.workflowVersion === "number"
-        ? value.workflowVersion
-        : undefined,
+    workflowVersion: isNumber(value.workflowVersion)
+      ? value.workflowVersion
+      : undefined,
     inputs: parseMappings(value.inputs, parseInputMapping),
     outputs: parseMappings(value.outputs, parseOutputMapping),
     policy: policy === "parallel" || policy === "queue" ? policy : "replace",
-    timeoutMs: typeof value.timeoutMs === "number" ? value.timeoutMs : undefined
+    timeoutMs: isNumber(value.timeoutMs) ? value.timeoutMs : undefined
   };
   if (script) {
     binding.target = script;
@@ -321,13 +322,13 @@ const parseOperation = (
 const parseVariable = (value: unknown): VariableDeclaration | null => {
   if (!isRecord(value)) return null;
   const { id } = value;
-  if (typeof id !== "string" || id.length === 0) return null;
+  if (!isNonEmptyString(id)) return null;
   const scope = value.scope === "user" ? "user" : "instance";
   return {
     id,
-    name: typeof value.name === "string" ? value.name : id,
+    name: isString(value.name) ? value.name : id,
     type:
-      isRecord(value.type) && typeof value.type.type === "string"
+      isRecord(value.type) && isString(value.type.type)
         ? { type: value.type.type, optional: value.type.optional === true }
         : null,
     default: value.default,
@@ -340,7 +341,7 @@ const parseVariable = (value: unknown): VariableDeclaration | null => {
 const parseResource = (value: unknown): ResourceBinding | null => {
   if (!isRecord(value)) return null;
   const { id, kind } = value;
-  if (typeof id !== "string") return null;
+  if (!isString(id)) return null;
   if (
     kind !== "asset" &&
     kind !== "timeline" &&
@@ -357,18 +358,16 @@ const parseResource = (value: unknown): ResourceBinding | null => {
     : ["read" as const];
   return {
     id,
-    name: typeof value.name === "string" ? value.name : id,
+    name: isString(value.name) ? value.name : id,
     kind,
     scope: isRecord(value.scope)
       ? {
-          projectId:
-            typeof value.scope.projectId === "string"
-              ? value.scope.projectId
-              : undefined,
-          fixedId:
-            typeof value.scope.fixedId === "string"
-              ? value.scope.fixedId
-              : undefined
+          projectId: isString(value.scope.projectId)
+            ? value.scope.projectId
+            : undefined,
+          fixedId: isString(value.scope.fixedId)
+            ? value.scope.fixedId
+            : undefined
         }
       : {},
     operations
@@ -403,10 +402,9 @@ export const parseApplicationDocument = (
 
   // v3+: the native shape.
   if (isPuckData(value.ui)) {
-    const schemaVersion =
-      typeof value.schemaVersion === "number"
-        ? value.schemaVersion
-        : APP_SCHEMA_VERSION;
+    const schemaVersion = isNumber(value.schemaVersion)
+      ? value.schemaVersion
+      : APP_SCHEMA_VERSION;
     if (schemaVersion > APP_SCHEMA_VERSION) return null;
     return {
       schemaVersion: APP_SCHEMA_VERSION,
@@ -427,7 +425,7 @@ export const parseApplicationDocument = (
             .filter((v): v is VariableDeclaration => v !== null)
         : [],
       theme:
-        isRecord(value.theme) && typeof value.theme.id === "string"
+        isRecord(value.theme) && isString(value.theme.id)
           ? { id: value.theme.id }
           : undefined
     };
@@ -485,7 +483,7 @@ export const liftLegacyAppDoc = (
   const hostWorkflowId = workflow?.id ?? "";
 
   let value: unknown = raw;
-  if (typeof raw === "string") {
+  if (isString(raw)) {
     try {
       value = JSON.parse(raw);
     } catch {

--- a/packages/app-runtime/src/predicates.ts
+++ b/packages/app-runtime/src/predicates.ts
@@ -1,0 +1,20 @@
+/**
+ * Named type predicates for the representation checks the app runtime makes on
+ * stored application documents, which arrive as unparsed JSON.
+ */
+
+export const isString = (value: unknown): value is string =>
+  typeof value === "string";
+
+/** An id or name that is present — an empty string names nothing. */
+export const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.length > 0;
+
+export const isNumber = (value: unknown): value is number =>
+  typeof value === "number";
+
+export const isInteger = (value: unknown): value is number =>
+  typeof value === "number" && Number.isInteger(value);
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/automation-nodes/src/lib/browser-agent-tools.ts
+++ b/packages/automation-nodes/src/lib/browser-agent-tools.ts
@@ -319,7 +319,7 @@ async function persistViewScreenshot(
   namePrefix: string
 ): Promise<BrowserViewResult> {
   const b64 = result.screenshot_png_b64;
-  if (typeof b64 !== "string" || b64.length === 0) {
+  if (b64 == null || b64.length === 0) {
     const { screenshot_png_b64: _drop, ...rest } = result;
     return { ...rest, screenshot: null };
   }

--- a/packages/automation-nodes/src/lib/extension-cdp-client.ts
+++ b/packages/automation-nodes/src/lib/extension-cdp-client.ts
@@ -130,7 +130,7 @@ export class ExtensionCdpClient {
       this.channel = transport;
     } else {
       const url =
-        (typeof transport === "string" ? transport : undefined) ??
+        transport ??
         process.env.NODETOOL_EXTENSION_WS_URL ??
         DEFAULT_WS_URL;
       this.channel = createWebSocketChannel(url);

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -453,7 +453,7 @@ async function diagnoseCommand(
       opts.traceFile,
       process.env["NODETOOL_TRACE_FILE"],
       bundle ? path.join(bundle, "server", "trace.jsonl") : undefined
-    ].filter((p): p is string => typeof p === "string")
+    ].filter((p): p is string => p != null)
   );
   if (tracePath) {
     try {

--- a/packages/cli/src/sketch-debug/harness.ts
+++ b/packages/cli/src/sketch-debug/harness.ts
@@ -201,8 +201,7 @@ function reconstructDocument(
     blendMode: layer.blendMode,
     data: null
   }));
-  const activeLayerId =
-    typeof snapshot.activeLayerId === "string" ? snapshot.activeLayerId : "";
+  const activeLayerId = snapshot.activeLayerId ?? "";
   const background =
     snapshot.backgroundColor ??
     resolved.document.canvas.backgroundColor ??

--- a/packages/cli/src/tool-format.ts
+++ b/packages/cli/src/tool-format.ts
@@ -48,13 +48,25 @@ export function friendlyToolName(name: string): string {
 }
 
 function str(v: unknown): string {
-  if (typeof v === "string") return v;
+  if (isStr(v)) return v;
   if (v == null) return "";
   return String(v);
 }
 
 function isObj(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null;
+}
+
+function isStr(v: unknown): v is string {
+  return typeof v === "string";
+}
+
+function isNum(v: unknown): v is number {
+  return typeof v === "number";
+}
+
+function isBool(v: unknown): v is boolean {
+  return typeof v === "boolean";
 }
 
 function firstLine(s: string): string {
@@ -88,7 +100,7 @@ export function toolStatusLabel(
 
 /** One-line fallback preview for an arbitrary result value. */
 function genericPreview(result: unknown): string {
-  const s = typeof result === "string" ? result : safeJson(result);
+  const s = isStr(result) ? result : safeJson(result);
   return truncate(firstLine(s), 200);
 }
 
@@ -106,10 +118,11 @@ export function formatToolParams(
       const path = str(args.file_path);
       const offset = args.offset;
       const limit = args.limit;
-      if (typeof offset === "number" || typeof limit === "number") {
-        const start = typeof offset === "number" ? offset : 1;
-        const range =
-          typeof limit === "number" ? `${start}-${start + limit - 1}` : `${start}+`;
+      if (isNum(offset) || isNum(limit)) {
+        const start = isNum(offset) ? offset : 1;
+        const range = isNum(limit)
+          ? `${start}-${start + limit - 1}`
+          : `${start}+`;
         return `${path}, lines ${range}`;
       }
       return path;
@@ -167,7 +180,7 @@ export function formatToolResult(
 ): string {
   switch (name) {
     case "read_file":
-      if (typeof result === "string") {
+      if (isStr(result)) {
         if (result.startsWith("Error:")) return firstLine(result);
         const body = result.split("\n\n[")[0];
         const n = body === "" ? 0 : body.split("\n").length;
@@ -176,10 +189,10 @@ export function formatToolResult(
       break;
     case "write_file":
       // Already a clean summary: "Created X" / "Updated X" / "Error: …".
-      if (typeof result === "string") return firstLine(result);
+      if (isStr(result)) return firstLine(result);
       break;
     case "list_directory":
-      if (typeof result === "string") {
+      if (isStr(result)) {
         if (result.startsWith("Error:")) return firstLine(result);
         if (result.startsWith("(empty)")) return "Empty directory";
         const n = result.split("\n").filter(Boolean).length;
@@ -191,7 +204,7 @@ export function formatToolResult(
         if (result.success === false) return errorLine(result);
         if (result.created) return `Created ${str(result.path)}`;
         const n =
-          typeof result.replacements === "number" ? result.replacements : 1;
+          isNum(result.replacements) ? result.replacements : 1;
         return `Updated ${str(result.path)} (${plural(n, "edit", "edits")})`;
       }
       break;
@@ -199,7 +212,7 @@ export function formatToolResult(
       if (isObj(result)) {
         if (result.success === false) return errorLine(result);
         const n =
-          typeof result.match_count === "number" ? result.match_count : 0;
+          isNum(result.match_count) ? result.match_count : 0;
         return `Found ${plural(n, "file", "files")}${
           result.truncated ? " (truncated)" : ""
         }`;
@@ -209,7 +222,7 @@ export function formatToolResult(
       if (isObj(result)) {
         if (result.success === false) return errorLine(result);
         const n =
-          typeof result.match_count === "number" ? result.match_count : 0;
+          isNum(result.match_count) ? result.match_count : 0;
         return `Found ${plural(n, "match", "matches")}${
           result.truncated ? " (truncated)" : ""
         }`;
@@ -223,7 +236,7 @@ export function formatToolResult(
 
 function parseObservation(result: unknown): Record<string, unknown> | null {
   let value: unknown = result;
-  if (typeof result === "string") {
+  if (isStr(result)) {
     const trimmed = result.trim();
     if (!trimmed.startsWith("{")) return null;
     try {
@@ -234,7 +247,7 @@ function parseObservation(result: unknown): Record<string, unknown> | null {
   }
   if (!isObj(value)) return null;
   if (
-    typeof value.ok === "boolean" ||
+    isBool(value.ok) ||
     "error" in value ||
     "result" in value ||
     "toolCalls" in value ||
@@ -246,8 +259,8 @@ function parseObservation(result: unknown): Record<string, unknown> | null {
 }
 
 function compactValue(value: unknown): string {
-  if (typeof value === "string") return firstLine(value);
-  if (typeof value === "number" || typeof value === "boolean") {
+  if (isStr(value)) return firstLine(value);
+  if (isNum(value) || isBool(value)) {
     return String(value);
   }
   if (value == null) return String(value);
@@ -259,7 +272,7 @@ function formatExecuteCodeResult(result: unknown): string {
   const obs = parseObservation(result);
   if (!obs) return genericPreview(result);
 
-  if (obs.ok === false || typeof obs.error === "string") {
+  if (obs.ok === false || isStr(obs.error)) {
     const err = str(obs.error) || "failed";
     return truncate(`Error: ${firstLine(err)}`, 200);
   }
@@ -268,11 +281,11 @@ function formatExecuteCodeResult(result: unknown): string {
   if (obs.result !== undefined) {
     parts.push(truncate(compactValue(obs.result), 160));
   }
-  if (typeof obs.toolCalls === "number" && obs.toolCalls > 0) {
+  if (isNum(obs.toolCalls) && obs.toolCalls > 0) {
     parts.push(plural(obs.toolCalls, "tool call", "tool calls"));
   }
   const logs = Array.isArray(obs.logs)
-    ? obs.logs.filter((line): line is string => typeof line === "string")
+    ? obs.logs.filter(isStr)
     : [];
   if (logs.length > 0) {
     parts.push(plural(logs.length, "log", "logs"));

--- a/packages/core-nodes/src/nodes/compare.ts
+++ b/packages/core-nodes/src/nodes/compare.ts
@@ -12,10 +12,10 @@ type ImageLike = {
 function inlineBytes(image: ImageLike | undefined): Uint8Array {
   if (!image) return new Uint8Array();
   if (image.data instanceof Uint8Array) return image.data;
-  if (typeof image.data === "string" && image.data.length > 0) {
+  if (image.data != null && image.data.length > 0) {
     return Uint8Array.from(Buffer.from(image.data, "base64"));
   }
-  if (typeof image.uri === "string" && image.uri.startsWith("data:")) {
+  if (image.uri != null && image.uri.startsWith("data:")) {
     const payload = image.uri.split(",", 2)[1] ?? "";
     return Uint8Array.from(Buffer.from(payload, "base64"));
   }
@@ -25,7 +25,7 @@ function inlineBytes(image: ImageLike | undefined): Uint8Array {
 /** Non-`data:` URI that identifies the ref (empty string when absent). */
 function refUri(image: ImageLike | undefined): string {
   const uri = image?.uri;
-  if (typeof uri === "string" && uri !== "" && !uri.startsWith("data:")) {
+  if (uri != null && uri !== "" && !uri.startsWith("data:")) {
     return uri;
   }
   return "";

--- a/packages/execution/src/app-debug/runtime.ts
+++ b/packages/execution/src/app-debug/runtime.ts
@@ -355,7 +355,7 @@ export const effectiveTimeoutMs = (
   ceilingMs: number | null | undefined
 ): number | null => {
   const candidates = [operationTimeoutMs, ceilingMs].filter(
-    (value): value is number => typeof value === "number" && value > 0
+    (value): value is number => value != null && value > 0
   );
   return candidates.length > 0 ? Math.min(...candidates) : null;
 };

--- a/packages/execution/src/session.ts
+++ b/packages/execution/src/session.ts
@@ -329,10 +329,7 @@ export class ExecutionSession {
       // The session's own run-timeout timer is the only timer it owns; it is
       // cleared when the run settles.
       pendingTimers: this.runTimeoutHandle === null ? 0 : 1,
-      pythonBridgePendingRequests:
-        typeof this.bridge?.pendingRequestCount === "number"
-          ? this.bridge.pendingRequestCount
-          : 0
+      pythonBridgePendingRequests: this.bridge?.pendingRequestCount ?? 0
     };
   }
 

--- a/packages/huggingface-nodes/src/huggingface-base.ts
+++ b/packages/huggingface-nodes/src/huggingface-base.ts
@@ -81,7 +81,7 @@ export async function refToBytes(
     return new Uint8Array(Buffer.from(base64, "base64"));
   }
   const uri = ref.uri;
-  if (typeof uri === "string" && uri.length > 0) {
+  if (uri != null && uri.length > 0) {
     if (uri.startsWith("data:")) {
       const base64 = uri.slice(uri.indexOf(",") + 1);
       return new Uint8Array(Buffer.from(base64, "base64"));

--- a/packages/image-nodes/src/nodes/lib-shader-utils.ts
+++ b/packages/image-nodes/src/nodes/lib-shader-utils.ts
@@ -571,7 +571,7 @@ export function colorValueToVec4(
     const maybe = (color as { value?: unknown }).value;
     if (typeof maybe === "string") value = maybe;
   }
-  if (typeof value !== "string") return fallback;
+  if (value == null) return fallback;
   let hex = value.startsWith("#") ? value.slice(1) : value;
   // Expand 3-/4-digit shorthand (#fff, #fff8) by doubling each nibble.
   if (hex.length === 3 || hex.length === 4) {

--- a/packages/kernel/src/predicates.ts
+++ b/packages/kernel/src/predicates.ts
@@ -1,0 +1,27 @@
+/**
+ * Named type predicates for the representation checks the runner makes on
+ * values that arrive from a node's output, a graph descriptor, or a run
+ * parameter — none of which the kernel parses at a schema boundary.
+ */
+
+export const isString = (value: unknown): value is string =>
+  typeof value === "string";
+
+export const isNumber = (value: unknown): value is number =>
+  typeof value === "number";
+
+export const isBoolean = (value: unknown): value is boolean =>
+  typeof value === "boolean";
+
+/**
+ * An object value. Arrays pass — the runner's own checks never excluded them,
+ * and the sites that care test `Array.isArray` on their own.
+ */
+export const isObjectValue = (
+  value: unknown
+): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+export const isCallable = (
+  value: unknown
+): value is (...args: never[]) => unknown => typeof value === "function";

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -15,6 +15,13 @@
  */
 
 import { createLogger } from "@nodetool-ai/config";
+import {
+  isBoolean,
+  isCallable,
+  isNumber,
+  isObjectValue,
+  isString
+} from "./predicates.js";
 import type {
   NodeDescriptor,
   HydratedGraphData,
@@ -57,11 +64,21 @@ const MAX_RETAINED_MESSAGES = 10_000;
  */
 const MAX_RECORDED_LINEAGES_PER_NODE = 64;
 
+/** A value that already carries its own control-event envelope. */
+function isControlEventValue(value: unknown): value is ControlEvent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "event_type" in value &&
+    typeof (value as Record<string, unknown>).event_type === "string"
+  );
+}
+
 /** An output_update whose value is a streamed audio chunk (sample payload). */
 function isAudioChunkOutputUpdate(msg: ProcessingMessage): boolean {
   if (msg.type !== "output_update") return false;
   const value = (msg as { value?: unknown }).value;
-  if (!value || typeof value !== "object") return false;
+  if (!isObjectValue(value)) return false;
   const v = value as { type?: unknown; content_type?: unknown };
   return v.type === "chunk" && v.content_type === "audio";
 }
@@ -273,7 +290,7 @@ function clientFacingOutputName(node: NodeDescriptor, handle: string): string {
   const t = node.type ?? "";
   const props = node.properties as Record<string, unknown> | undefined;
   const workflowKey =
-    props && typeof props.name === "string" && props.name.trim().length > 0
+    props && isString(props.name) && props.name.trim().length > 0
       ? props.name.trim()
       : undefined;
 
@@ -699,7 +716,7 @@ export class WorkflowRunner {
       // control events to controlled nodes and await their results.
       if (
         this._options.executionContext &&
-        typeof this._options.executionContext.setSendControlEvent === "function"
+        isCallable(this._options.executionContext.setSendControlEvent)
       ) {
         this._options.executionContext.setSendControlEvent(
           (targetNodeId: string, properties: Record<string, unknown>) =>
@@ -1233,12 +1250,9 @@ export class WorkflowRunner {
    */
   /** Variable-channel name a Set Variable node publishes to (its `name` prop). */
   private _variableChannelName(node: NodeDescriptor): string {
-    const props =
-      node.properties && typeof node.properties === "object"
-        ? (node.properties as Record<string, unknown>)
-        : {};
+    const props = isObjectValue(node.properties) ? node.properties : {};
     const raw = props.name;
-    return typeof raw === "string" ? raw.trim() : "";
+    return isString(raw) ? raw.trim() : "";
   }
 
   /**
@@ -1248,7 +1262,7 @@ export class WorkflowRunner {
    */
   private _registerVariableChannels(): void {
     const ctx = this._options.executionContext;
-    if (!ctx || typeof ctx.registerChannelWriters !== "function") {
+    if (!ctx || !isCallable(ctx.registerChannelWriters)) {
       return;
     }
     for (const node of this._graph.nodes) {
@@ -1280,10 +1294,9 @@ export class WorkflowRunner {
       if (!this._isExternalInputNode(node)) continue;
 
       const inputName = this._getExternalInputName(node);
-      const properties =
-        node.properties && typeof node.properties === "object"
-          ? (node.properties as Record<string, unknown>)
-          : {};
+      const properties = isObjectValue(node.properties)
+        ? node.properties
+        : {};
       const hasRuntimeParam = Object.prototype.hasOwnProperty.call(
         params,
         inputName
@@ -1682,22 +1695,15 @@ export class WorkflowRunner {
         // recognises them. (Python parity: send_messages wraps
         // __control_output__ in RunEvent.)
         let controlEvent: ControlEvent;
-        if (
-          typeof value === "object" &&
-          value !== null &&
-          "event_type" in value &&
-          typeof (value as Record<string, unknown>).event_type === "string"
-        ) {
-          controlEvent = value as ControlEvent;
-        } else if (typeof value === "object" && value !== null) {
+        if (isControlEventValue(value)) {
+          controlEvent = value;
+        } else if (isObjectValue(value)) {
           // Raw property dict — wrap as RunEvent
           const raw = value as Record<string, unknown>;
           // Support nested {properties: {...}} shape from LLM output
           const properties =
-            "properties" in raw &&
-            typeof raw.properties === "object" &&
-            raw.properties !== null
-              ? (raw.properties as Record<string, unknown>)
+            "properties" in raw && isObjectValue(raw.properties)
+              ? raw.properties
               : raw;
           controlEvent = { event_type: "run", properties };
         } else {
@@ -2046,7 +2052,7 @@ export class WorkflowRunner {
     sourceNodeId: string,
     controlOutput: unknown
   ): Promise<void> {
-    if (!controlOutput || typeof controlOutput !== "object") return;
+    if (!isObjectValue(controlOutput)) return;
 
     const controlEdges = this._graph
       .findOutgoingEdges(sourceNodeId)
@@ -2058,8 +2064,7 @@ export class WorkflowRunner {
     // Extract properties if nested inside a metadata wrapper
     if (
       "properties" in properties &&
-      properties.properties &&
-      typeof properties.properties === "object" &&
+      isObjectValue(properties.properties) &&
       !Array.isArray(properties.properties)
     ) {
       properties = properties.properties as Record<string, unknown>;
@@ -2359,12 +2364,10 @@ export class WorkflowRunner {
   }
 
   private _getExternalInputName(node: NodeDescriptor): string {
-    const properties =
-      node.properties && typeof node.properties === "object"
-        ? (node.properties as Record<string, unknown>)
-        : {};
-    const propertyName =
-      typeof properties.name === "string" ? properties.name.trim() : "";
+    const properties = isObjectValue(node.properties) ? node.properties : {};
+    const propertyName = isString(properties.name)
+      ? properties.name.trim()
+      : "";
     if (propertyName) {
       return propertyName;
     }
@@ -2449,8 +2452,8 @@ export class WorkflowRunner {
       const properties: Record<string, unknown> = {};
 
       // Extract property info from the node descriptor
-      if (targetNode.properties && typeof targetNode.properties === "object") {
-        const props = targetNode.properties as Record<string, unknown>;
+      if (isObjectValue(targetNode.properties)) {
+        const props = targetNode.properties;
         const propTypes = targetNode.propertyTypes ?? {};
 
         for (const [propName, propValue] of Object.entries(props)) {
@@ -2542,9 +2545,9 @@ export class WorkflowRunner {
           jsonType = "array";
         else if (lower.startsWith("dict") || lower === "object")
           jsonType = "object";
-      } else if (typeof value === "number") {
+      } else if (isNumber(value)) {
         jsonType = Number.isInteger(value) ? "integer" : "number";
-      } else if (typeof value === "boolean") {
+      } else if (isBoolean(value)) {
         jsonType = "boolean";
       }
 

--- a/packages/llm-nodes/src/nodes/agent-utils.ts
+++ b/packages/llm-nodes/src/nodes/agent-utils.ts
@@ -12,6 +12,13 @@ import type {
 import { expandAssetReferences } from "@nodetool-ai/runtime";
 import type { Chunk } from "@nodetool-ai/protocol";
 import { hydrateBuiltinAgentTool } from "./agent-tool-hydration.js";
+import {
+  isCallable,
+  isNonEmptyString,
+  isObjectLike,
+  isRecord,
+  isString
+} from "./type-predicates.js";
 
 type MessagePart = { type?: string; text?: string };
 type LanguageModelLike = { provider?: string; id?: string; name?: string };
@@ -49,14 +56,14 @@ export type ToolLike = {
 };
 
 export function asText(value: unknown): string {
-  if (typeof value === "string") return value;
+  if (isString(value)) return value;
   if (typeof value === "number" || typeof value === "boolean")
     return String(value);
   if (!value) return "";
   if (Array.isArray(value)) return value.map(asText).join(" ");
-  if (typeof value === "object") {
+  if (isObjectLike(value)) {
     const msg = value as { content?: string | MessagePart[] };
-    if (typeof msg.content === "string") return msg.content;
+    if (isString(msg.content)) return msg.content;
     if (Array.isArray(msg.content)) {
       return msg.content
         .map((part) => (part && part.type === "text" ? (part.text ?? "") : ""))
@@ -70,19 +77,15 @@ export function asText(value: unknown): string {
 
 export function extractJson(text: string): Record<string, unknown> | null {
   try {
-    const parsed = JSON.parse(text);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : null;
+    const parsed: unknown = JSON.parse(text);
+    return isRecord(parsed) ? parsed : null;
   } catch {
     const start = text.indexOf("{");
     const end = text.lastIndexOf("}");
     if (start >= 0 && end > start) {
       try {
-        const parsed = JSON.parse(text.slice(start, end + 1));
-        return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-          ? (parsed as Record<string, unknown>)
-          : null;
+        const parsed: unknown = JSON.parse(text.slice(start, end + 1));
+        return isRecord(parsed) ? parsed : null;
       } catch {
         return null;
       }
@@ -108,6 +111,18 @@ export function getModelConfig(props: Record<string, unknown>) {
   };
 }
 
+/**
+ * Whether this context can hand out a provider. False for the bare context a
+ * hermetic single-node run supplies, which carries no provider access.
+ */
+export function hasProviderAccess(
+  context: ProcessingContext | undefined
+): context is ProcessingContext & {
+  getProvider(providerId: string): Promise<BaseProvider>;
+} {
+  return !!context && typeof context.getProvider === "function";
+}
+
 export function hasProviderSupport(
   context: ProcessingContext | undefined,
   providerId: string,
@@ -115,12 +130,7 @@ export function hasProviderSupport(
 ): context is ProcessingContext & {
   getProvider(providerId: string): Promise<BaseProvider>;
 } {
-  return (
-    !!context &&
-    typeof context.getProvider === "function" &&
-    !!providerId &&
-    !!modelId
-  );
+  return hasProviderAccess(context) && !!providerId && !!modelId;
 }
 
 /**
@@ -140,7 +150,7 @@ export async function generateStructured(
   }
 ): Promise<Record<string, unknown> | null> {
   const call =
-    typeof provider.generateMessageTraced === "function"
+    isCallable(provider.generateMessageTraced)
       ? provider.generateMessageTraced.bind(provider)
       : provider.generateMessage.bind(provider);
   const result = await call({
@@ -168,8 +178,7 @@ export function normalizeProviderStreamItem(
   item: ProviderStreamItem
 ): ProviderStreamItem {
   if (
-    !item ||
-    typeof item !== "object" ||
+    !isObjectLike(item) ||
     !("type" in item) ||
     (item as Chunk).type !== "chunk"
   ) {
@@ -177,7 +186,7 @@ export function normalizeProviderStreamItem(
   }
 
   const chunk = item as Chunk;
-  if (typeof chunk.content_type === "string" && chunk.content_type.length > 0) {
+  if (isNonEmptyString(chunk.content_type)) {
     return chunk;
   }
 
@@ -222,13 +231,13 @@ export async function* streamProviderMessages(
     messages: [...args.messages],
     tools: args.tools ? [...args.tools] : undefined
   };
-  if (typeof provider.generateMessagesTraced === "function") {
+  if (isCallable(provider.generateMessagesTraced)) {
     for await (const item of provider.generateMessagesTraced(request)) {
       yield normalizeProviderStreamItem(item);
     }
     return;
   }
-  if (typeof provider.generateMessages === "function") {
+  if (isCallable(provider.generateMessages)) {
     for await (const item of provider.generateMessages(request)) {
       yield normalizeProviderStreamItem(item);
     }
@@ -257,8 +266,8 @@ export async function* streamProviderMessages(
  */
 export function parseCategory(raw: string, categories: string[]): string {
   const parsed = extractJson(raw);
-  const categoryValue =
-    typeof parsed?.category === "string" ? parsed.category : "";
+  const category = parsed?.category;
+  const categoryValue = isString(category) ? category : "";
   for (const category of categories) {
     if (categoryValue.trim().toLowerCase() === category.trim().toLowerCase()) {
       return category;
@@ -281,11 +290,11 @@ export function parseCategory(raw: string, categories: string[]): string {
 }
 
 export function messageContentText(content: Message["content"] | unknown): string {
-  if (typeof content === "string") return content;
+  if (isString(content)) return content;
   if (!Array.isArray(content)) return asText(content);
   return content
     .map((part) => {
-      if (!part || typeof part !== "object") return asText(part);
+      if (!isObjectLike(part)) return asText(part);
       if ((part as { type?: string }).type === "text") {
         return String((part as { text?: unknown }).text ?? "");
       }
@@ -310,24 +319,22 @@ export function normalizeRole(role: unknown): Message["role"] | null {
 export function normalizeBinaryRef(
   value: unknown
 ): { uri?: string; data?: Uint8Array | string; mimeType?: string } | null {
-  if (!value || typeof value !== "object") return null;
+  if (!isObjectLike(value)) return null;
   const record = value as Record<string, unknown>;
   const out: { uri?: string; data?: Uint8Array | string; mimeType?: string } =
     {};
-  if (typeof record.uri === "string" && record.uri) out.uri = record.uri;
-  if (record.data instanceof Uint8Array || typeof record.data === "string")
+  if (isNonEmptyString(record.uri)) out.uri = record.uri;
+  if (record.data instanceof Uint8Array || isString(record.data))
     out.data = record.data;
-  if (typeof record.mimeType === "string" && record.mimeType)
-    out.mimeType = record.mimeType;
-  if (typeof record.mime_type === "string" && record.mime_type)
-    out.mimeType = record.mime_type;
+  if (isNonEmptyString(record.mimeType)) out.mimeType = record.mimeType;
+  if (isNonEmptyString(record.mime_type)) out.mimeType = record.mime_type;
   // A library-picked or freshly-generated ref carries only `asset_id` (with an
   // empty `uri`). Encode it as an `asset://<id>` URI so `buildUserMessage` keeps
   // the image/audio part and `ProcessingContext.resolveMessageMediaUris`
   // dereferences it to bytes before the provider call.
   if (!out.uri && !out.data) {
     const assetId = record.asset_id;
-    if (typeof assetId === "string" && assetId) {
+    if (isNonEmptyString(assetId)) {
       out.uri = `asset://${assetId}`;
     }
   }
@@ -335,17 +342,17 @@ export function normalizeBinaryRef(
 }
 
 export function normalizeMessageContent(value: unknown): Message["content"] {
-  if (value == null || typeof value === "string") return value ?? null;
+  if (value == null || isString(value)) return value ?? null;
   if (!Array.isArray(value)) return asText(value);
   const parts: MessageContent[] = [];
   for (const part of value) {
-    if (!part || typeof part !== "object") {
+    if (!isObjectLike(part)) {
       const text = asText(part);
       if (text) parts.push({ type: "text", text });
       continue;
     }
     const record = part as Record<string, unknown>;
-    const kind = typeof record.type === "string" ? record.type : "";
+    const kind = isString(record.type) ? record.type : "";
     if (kind === "text") {
       parts.push({ type: "text", text: asText(record.text ?? "") });
       continue;
@@ -378,20 +385,18 @@ export function normalizeToolCalls(value: unknown): ToolCall[] | null {
         !!item && typeof item === "object"
     )
     .map((item, index) => ({
-      id:
-        typeof item.id === "string" && item.id ? item.id : `tool_${index + 1}`,
-      name: typeof item.name === "string" ? item.name : "",
-      args:
-        item.args && typeof item.args === "object"
-          ? (item.args as Record<string, unknown>)
-          : {}
+      id: isNonEmptyString(item.id) ? item.id : `tool_${index + 1}`,
+      name: isString(item.name) ? item.name : "",
+      args: isObjectLike(item.args)
+        ? (item.args as Record<string, unknown>)
+        : {}
     }))
     .filter((item) => item.name.length > 0);
   return toolCalls.length > 0 ? toolCalls : null;
 }
 
 export function normalizeMessage(value: unknown): Message | null {
-  if (!value || typeof value !== "object") return null;
+  if (!isObjectLike(value)) return null;
   const record = value as Record<string, unknown>;
   const role = normalizeRole(record.role);
   if (!role) return null;
@@ -399,18 +404,16 @@ export function normalizeMessage(value: unknown): Message | null {
     role,
     content: normalizeMessageContent(record.content),
     toolCalls: normalizeToolCalls(record.toolCalls ?? record.tool_calls),
-    toolCallId:
-      typeof record.toolCallId === "string"
-        ? record.toolCallId
-        : typeof record.tool_call_id === "string"
-          ? record.tool_call_id
-          : null,
-    threadId:
-      typeof record.threadId === "string"
-        ? record.threadId
-        : typeof record.thread_id === "string"
-          ? record.thread_id
-          : null
+    toolCallId: isString(record.toolCallId)
+      ? record.toolCallId
+      : isString(record.tool_call_id)
+        ? record.tool_call_id
+        : null,
+    threadId: isString(record.threadId)
+      ? record.threadId
+      : isString(record.thread_id)
+        ? record.thread_id
+        : null
   };
 }
 
@@ -507,13 +510,12 @@ export async function* classifyProviderStream(
         yield { kind: "audio", chunk: item };
         continue;
       }
-      const delta = typeof item.content === "string" ? item.content : "";
+      const delta = isString(item.content) ? item.content : "";
       yield { kind: "text", chunk: item, delta };
       continue;
     }
     if (
-      item &&
-      typeof item === "object" &&
+      isObjectLike(item) &&
       "type" in item &&
       (item as { type?: string }).type === "message"
     ) {
@@ -566,7 +568,7 @@ export function toProviderTools(tools: ToolLike[]): Array<{
   inputSchema?: Record<string, unknown>;
 }> {
   return tools.map((tool) =>
-    typeof tool.toProviderTool === "function"
+    isCallable(tool.toProviderTool)
       ? tool.toProviderTool()
       : {
           name: tool.name,
@@ -593,7 +595,7 @@ export function serializeToolResult(value: unknown): SerializedToolResult {
   if (Array.isArray(value)) return value.map(serializeToolResult);
   // SAFETY: what is left here is neither null/undefined, an array, nor an
   // object — a primitive, which is already its own JSON rendering.
-  if (typeof value !== "object") return value as SerializedToolResult;
+  if (!isObjectLike(value)) return value as SerializedToolResult;
   if (value instanceof Uint8Array) {
     return Buffer.from(value).toString("base64");
   }
@@ -610,18 +612,13 @@ export function getStructuredOutputSchema(
   node: BaseNode
 ): Record<string, unknown> | null {
   const outputs = (node as { _dynamic_outputs?: unknown })._dynamic_outputs;
-  if (!outputs || typeof outputs !== "object" || Array.isArray(outputs))
-    return null;
+  if (!isRecord(outputs)) return null;
   const properties: Record<string, unknown> = {};
   const required: string[] = [];
-  for (const [name, spec] of Object.entries(
-    outputs as Record<string, unknown>
-  )) {
+  for (const [name, spec] of Object.entries(outputs)) {
     required.push(name);
-    const value =
-      spec && typeof spec === "object" ? (spec as Record<string, unknown>) : {};
-    const declared =
-      typeof value.type === "string" ? value.type.toLowerCase() : "str";
+    const value = isRecord(spec) ? spec : {};
+    const declared = isString(value.type) ? value.type.toLowerCase() : "str";
     let type = "string";
     if (["int", "integer"].includes(declared)) type = "integer";
     else if (["float", "number"].includes(declared)) type = "number";

--- a/packages/llm-nodes/src/nodes/agent-utils.ts
+++ b/packages/llm-nodes/src/nodes/agent-utils.ts
@@ -103,8 +103,8 @@ export function getCategories(value: unknown): string[] {
 export function getModelConfig(props: Record<string, unknown>) {
   const model = ((props.model ?? {}) as LanguageModelLike) ?? {};
   return {
-    providerId: typeof model.provider === "string" ? model.provider : "",
-    modelId: typeof model.id === "string" ? model.id : ""
+    providerId: model.provider ?? "",
+    modelId: model.id ?? ""
   };
 }
 

--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -18,6 +18,13 @@ import { tagAsServer } from "@nodetool-ai/nodes-utils";
 
 import type { ToolLike } from "./agent-utils.js";
 import {
+  isCallable,
+  isNonEmptyString,
+  isObjectLike,
+  isRecord,
+  isString
+} from "./type-predicates.js";
+import {
   asText,
   makeThreadId,
   getCategories,
@@ -37,7 +44,8 @@ import {
   toolCallChunk,
   streamProviderMessages,
   getStructuredOutputSchema,
-  hasContentType
+  hasContentType,
+  hasProviderAccess
 } from "./agent-utils.js";
 import {
   seedFallbackThread,
@@ -225,7 +233,7 @@ export class SummarizerNode extends BaseNode {
     if (!providerId || !modelId) {
       throw new Error("Select a model");
     }
-    if (!context || typeof context.getProvider !== "function") {
+    if (!hasProviderAccess(context)) {
       throw new Error("Processing context is required");
     }
 
@@ -259,7 +267,7 @@ export class SummarizerNode extends BaseNode {
       maxTokens: Math.max(64, maxSentences * 128)
     })) {
       if (isChunkItem(item) && !item.thinking) {
-        const piece = typeof item.content === "string" ? item.content : "";
+        const piece = isString(item.content) ? item.content : "";
         if (piece) {
           full += piece;
           for (const part of splitter.feed(piece)) {
@@ -284,7 +292,7 @@ export class SummarizerNode extends BaseNode {
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     let text = "";
     for await (const item of this.genProcess(context)) {
-      if (typeof item.text === "string") text = item.text;
+      if (isString(item.text)) text = item.text;
     }
     return { text, output: text };
   }
@@ -355,7 +363,7 @@ export class EnhancePromptNode extends BaseNode {
   declare target: string;
 
   private _target(): string {
-    const raw = typeof this.target === "string" ? this.target.trim() : "";
+    const raw = isString(this.target) ? this.target.trim() : "";
     return raw in ENHANCE_PROMPT_GUIDANCE ? raw : "general";
   }
 
@@ -376,7 +384,7 @@ export class EnhancePromptNode extends BaseNode {
     if (!providerId || !modelId) {
       throw new Error("Select a model");
     }
-    if (!context || typeof context.getProvider !== "function") {
+    if (!hasProviderAccess(context)) {
       throw new Error("Processing context is required");
     }
 
@@ -412,7 +420,7 @@ export class EnhancePromptNode extends BaseNode {
       maxTokens: ENHANCE_PROMPT_MAX_TOKENS
     })) {
       if (isChunkItem(item) && !item.thinking) {
-        const piece = typeof item.content === "string" ? item.content : "";
+        const piece = isString(item.content) ? item.content : "";
         if (piece) {
           full += piece;
           for (const part of splitter.feed(piece)) {
@@ -437,7 +445,7 @@ export class EnhancePromptNode extends BaseNode {
   async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
     let text = "";
     for await (const item of this.genProcess(context)) {
-      if (typeof item.text === "string") text = item.text;
+      if (isString(item.text)) text = item.text;
     }
     return { text, output: text };
   }
@@ -575,7 +583,7 @@ export class ExtractorNode extends BaseNode {
     if (!providerId || !modelId) {
       throw new Error("Select a model");
     }
-    if (!context || typeof context.getProvider !== "function") {
+    if (!hasProviderAccess(context)) {
       throw new Error("Processing context is required");
     }
 
@@ -714,7 +722,7 @@ export class ClassifierNode extends BaseNode {
     if (!providerId || !modelId) {
       throw new Error("Select a model");
     }
-    if (!context || typeof context.getProvider !== "function") {
+    if (!hasProviderAccess(context)) {
       throw new Error("Processing context is required");
     }
 
@@ -924,9 +932,7 @@ export class AgentNode extends BaseNode {
       providerId,
       modelId,
       hasContext: Boolean(context),
-      hasGetProvider: Boolean(
-        context && typeof context.getProvider === "function"
-      ),
+      hasGetProvider: hasProviderAccess(context),
       propKeys: Object.keys(this.serialize())
     });
     if (!providerId || !modelId) {
@@ -939,7 +945,7 @@ export class AgentNode extends BaseNode {
       });
       throw new Error("Select a model");
     }
-    if (!context || typeof context.getProvider !== "function") {
+    if (!hasProviderAccess(context)) {
       log.error("AgentNode missing processing context or provider access", {
         nodeId: this.__node_id ?? null,
         providerId,
@@ -1034,7 +1040,7 @@ export class AgentNode extends BaseNode {
     // URIs before the provider call. Resolution lives in the runtime layer so
     // it's shared across nodes and providers stay asset-agnostic. Saved to the
     // thread above first, so the stored message keeps the compact asset:// URI.
-    if (typeof context.resolveMessageMediaUris === "function") {
+    if (isCallable(context.resolveMessageMediaUris)) {
       const resolved = await context.resolveMessageMediaUris(messages);
       messages.splice(0, messages.length, ...resolved);
     }
@@ -1061,10 +1067,7 @@ export class AgentNode extends BaseNode {
                 args: Record<string, unknown>,
                 toolCallId?: string
               ): Promise<string | MessageContent[]> => {
-                if (
-                  typeof tool.execute !== "function" &&
-                  typeof tool.process !== "function"
-                ) {
+                if (!isCallable(tool.execute) && !isCallable(tool.process)) {
                   log.warn(
                     "AgentNode tool call had no matching executable tool",
                     {
@@ -1091,10 +1094,9 @@ export class AgentNode extends BaseNode {
                   // Forward the LLM's tool-call id: tools that spawn nested
                   // work (run_subtask, nested workflows) stamp it on their
                   // events as parent_tool_call_id.
-                  result =
-                    typeof tool.execute === "function"
-                      ? await tool.execute(context, args, { toolCallId })
-                      : await tool.process!(context, args);
+                  result = isCallable(tool.execute)
+                    ? await tool.execute(context, args, { toolCallId })
+                    : await tool.process!(context, args);
                 } catch (err) {
                   const message =
                     err instanceof Error ? err.message : String(err);
@@ -1239,7 +1241,7 @@ export class AgentNode extends BaseNode {
           const chunk = event.chunk;
           yield { chunk, thinking: null, text: null, audio: null };
           const audioBytes =
-            typeof chunk.content === "string" && chunk.content
+            isNonEmptyString(chunk.content)
               ? Buffer.from(chunk.content, "base64")
               : chunk.content instanceof Float32Array
                 ? Buffer.from(
@@ -1335,10 +1337,10 @@ export class AgentNode extends BaseNode {
         "text" in item ||
         "audio" in item
       ) {
-        if (typeof item.text === "string") {
+        if (isString(item.text)) {
           lastText = item.text;
         }
-        if (item.audio && typeof item.audio === "object") {
+        if (isObjectLike(item.audio)) {
           lastAudio = item.audio as Record<string, unknown>;
         }
       } else {
@@ -1474,8 +1476,9 @@ export class AgentNode extends BaseNode {
       } else if (pmsg.type === "step_result") {
         const result = (pmsg as any).result;
         if (result != null) {
-          const resultText =
-            typeof result === "string" ? result : JSON.stringify(result);
+          const resultText = isString(result)
+            ? result
+            : JSON.stringify(result);
           lastText = resultText;
         }
       } else if (pmsg.type === "log_update") {
@@ -1547,7 +1550,7 @@ export class AgentNode extends BaseNode {
     const resultText =
       lastText ||
       (finalResults != null
-        ? typeof finalResults === "string"
+        ? isString(finalResults)
           ? finalResults
           : JSON.stringify(finalResults)
         : "");
@@ -1558,13 +1561,8 @@ export class AgentNode extends BaseNode {
     // result as a bare object so process()/the kernel route it to those output
     // handles — mirroring loop mode's `yield structuredResult`. Without this,
     // plan mode only ever emits `text` and dynamic outputs stay empty.
-    if (
-      structuredSchema &&
-      finalResults &&
-      typeof finalResults === "object" &&
-      !Array.isArray(finalResults)
-    ) {
-      yield finalResults as Record<string, unknown>;
+    if (structuredSchema && isRecord(finalResults)) {
+      yield finalResults;
     }
   }
 }

--- a/packages/llm-nodes/src/nodes/generators.ts
+++ b/packages/llm-nodes/src/nodes/generators.ts
@@ -10,6 +10,14 @@ import {
   toProviderTools,
   type ToolLike
 } from "./agents.js";
+import { hasProviderAccess } from "./agent-utils.js";
+import {
+  isCallable,
+  isNonEmptyString,
+  isObjectLike,
+  isRecord,
+  isString
+} from "./type-predicates.js";
 
 type Row = Record<string, unknown>;
 type ColumnSpec = { name: string; data_type?: string };
@@ -28,7 +36,7 @@ type MessageContent =
   | MessageAudioContent;
 
 function asText(value: unknown): string {
-  if (typeof value === "string") return value;
+  if (isString(value)) return value;
   if (typeof value === "number" || typeof value === "boolean")
     return String(value);
   if (!value) return "";
@@ -52,29 +60,27 @@ function parseColumnSpecs(input: unknown): ColumnSpec[] {
   if (Array.isArray(input)) {
     return input
       .map((c) => {
-        if (c && typeof c === "object") {
+        if (isObjectLike(c)) {
           const record = c as {
             name?: unknown;
             data_type?: unknown;
             type?: unknown;
           };
-          const name =
-            typeof record.name === "string"
-              ? record.name
-              : String(record.name ?? "");
-          const dataType =
-            typeof record.data_type === "string"
-              ? record.data_type
-              : typeof record.type === "string"
-                ? record.type
-                : undefined;
+          const name = isString(record.name)
+            ? record.name
+            : String(record.name ?? "");
+          const dataType = isString(record.data_type)
+            ? record.data_type
+            : isString(record.type)
+              ? record.type
+              : undefined;
           return { name, data_type: dataType };
         }
         return { name: String(c) };
       })
       .filter((c) => c.name.length > 0);
   }
-  if (input && typeof input === "object") {
+  if (isObjectLike(input)) {
     const columns = (input as { columns?: unknown }).columns;
     if (Array.isArray(columns)) return parseColumnSpecs(columns);
   }
@@ -111,18 +117,13 @@ function makeRows(columns: string[], count: number, seedText: string): Row[] {
 function buildSchemaFromDynamicOutputs(
   outputs: unknown
 ): Record<string, unknown> | null {
-  if (!outputs || typeof outputs !== "object" || Array.isArray(outputs))
-    return null;
+  if (!isRecord(outputs)) return null;
   const properties: Record<string, unknown> = {};
   const required: string[] = [];
-  for (const [name, spec] of Object.entries(
-    outputs as Record<string, unknown>
-  )) {
+  for (const [name, spec] of Object.entries(outputs)) {
     required.push(name);
-    const value =
-      spec && typeof spec === "object" ? (spec as Record<string, unknown>) : {};
-    const declared =
-      typeof value.type === "string" ? value.type.toLowerCase() : "str";
+    const value = isRecord(spec) ? spec : {};
+    const declared = isString(value.type) ? value.type.toLowerCase() : "str";
     let type = "string";
     if (["int", "integer"].includes(declared)) type = "integer";
     else if (["float", "number"].includes(declared)) type = "number";
@@ -136,16 +137,14 @@ function buildSchemaFromDynamicOutputs(
 }
 
 function normalizeBinaryRef(value: unknown): BinaryRef | null {
-  if (!value || typeof value !== "object") return null;
+  if (!isObjectLike(value)) return null;
   const record = value as Record<string, unknown>;
   const out: BinaryRef = {};
-  if (typeof record.uri === "string" && record.uri) out.uri = record.uri;
-  if (record.data instanceof Uint8Array || typeof record.data === "string")
+  if (isNonEmptyString(record.uri)) out.uri = record.uri;
+  if (record.data instanceof Uint8Array || isString(record.data))
     out.data = record.data;
-  if (typeof record.mimeType === "string" && record.mimeType)
-    out.mimeType = record.mimeType;
-  if (typeof record.mime_type === "string" && record.mime_type)
-    out.mimeType = record.mime_type;
+  if (isNonEmptyString(record.mimeType)) out.mimeType = record.mimeType;
+  if (isNonEmptyString(record.mime_type)) out.mimeType = record.mime_type;
   return out.uri || out.data ? out : null;
 }
 
@@ -298,7 +297,7 @@ async function* streamListItemsViaToolCalls(
 
     for (const toolCall of assistantToolCalls) {
       const result =
-        toolCall.name === "add_item" && typeof tool.process === "function"
+        toolCall.name === "add_item" && isCallable(tool.process)
           ? await tool.process(context, toolCall.args)
           : { error: `Unknown tool: ${toolCall.name}` };
       messages.push({
@@ -504,11 +503,7 @@ export class StructuredOutputGeneratorNode extends BaseNode {
           }
         }
       });
-      if (
-        result &&
-        typeof result === "object" &&
-        "content" in (result as Record<string, unknown>)
-      ) {
+      if (isObjectLike(result) && "content" in result) {
         const content = asText((result as { content?: unknown }).content ?? "");
         try {
           return JSON.parse(content) as Record<string, unknown>;
@@ -517,7 +512,7 @@ export class StructuredOutputGeneratorNode extends BaseNode {
         }
       }
     }
-    if (schema && typeof schema === "object" && !Array.isArray(schema)) {
+    if (isRecord(schema)) {
       const props =
         (schema as { properties?: Record<string, unknown> }).properties ?? {};
       const out: Record<string, unknown> = {};
@@ -733,7 +728,7 @@ export class ListGeneratorNode extends BaseNode {
     const items: string[] = [];
     for await (const chunk of this.genProcess(context)) {
       const item = (chunk as { item?: unknown }).item;
-      if (typeof item === "string") items.push(item);
+      if (isString(item)) items.push(item);
     }
     return { output: items };
   }
@@ -749,12 +744,7 @@ export class ListGeneratorNode extends BaseNode {
     // single `output` handle (drives the saved generation + reload).
     const items: string[] = [];
 
-    if (
-      context &&
-      typeof (context as { getProvider?: unknown }).getProvider === "function" &&
-      providerId &&
-      modelId
-    ) {
+    if (hasProviderAccess(context) && providerId && modelId) {
       let index = 0;
       const maxTokens = Number(this.max_tokens ?? 128);
       // Try the neutral prompt first. If the model answers in prose and emits no

--- a/packages/llm-nodes/src/nodes/generators.ts
+++ b/packages/llm-nodes/src/nodes/generators.ts
@@ -181,8 +181,8 @@ function buildMessageContent(
 function getModelConfig(props: Record<string, unknown>) {
   const model = ((props.model ?? {}) as LanguageModelLike) ?? {};
   return {
-    providerId: typeof model.provider === "string" ? model.provider : "",
-    modelId: typeof model.id === "string" ? model.id : ""
+    providerId: model.provider ?? "",
+    modelId: model.id ?? ""
   };
 }
 

--- a/packages/llm-nodes/src/nodes/type-predicates.ts
+++ b/packages/llm-nodes/src/nodes/type-predicates.ts
@@ -1,0 +1,31 @@
+/**
+ * Narrowing predicates for values whose static type does not describe what a
+ * node actually receives at runtime — a serialized property bag, a provider
+ * stream item, a tool payload.
+ */
+
+export function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+/**
+ * An object or an array — anything `typeof` calls "object" except `null`.
+ * Use {@link isRecord} when array payloads must be rejected.
+ */
+export function isObjectLike(value: unknown): value is object {
+  return !!value && typeof value === "object";
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export function isCallable<T>(
+  value: T
+): value is T & ((...args: never[]) => unknown) {
+  return typeof value === "function";
+}

--- a/packages/model-pricing/src/genspend-calc.ts
+++ b/packages/model-pricing/src/genspend-calc.ts
@@ -116,11 +116,7 @@ function shortestClipSecond(clip: GenspendPrice["clip_seconds"]): number {
     const legal = clip.set.filter((s) => Number.isFinite(s) && s > 0);
     if (legal.length > 0) return Math.min(...legal);
   }
-  if (
-    typeof clip.min === "number" &&
-    Number.isFinite(clip.min) &&
-    clip.min > 1
-  ) {
+  if (clip.min != null && Number.isFinite(clip.min) && clip.min > 1) {
     return clip.min;
   }
   return 1;
@@ -135,18 +131,10 @@ function outsideEnvelope(
   if (Array.isArray(clip.set) && !clip.set.includes(seconds)) {
     return `no published price at ${seconds}s`;
   }
-  if (
-    typeof clip.min === "number" &&
-    Number.isFinite(clip.min) &&
-    seconds < clip.min
-  ) {
+  if (clip.min != null && Number.isFinite(clip.min) && seconds < clip.min) {
     return `below the receipted clip envelope (${clip.min}s minimum)`;
   }
-  if (
-    typeof clip.max === "number" &&
-    Number.isFinite(clip.max) &&
-    seconds > clip.max
-  ) {
+  if (clip.max != null && Number.isFinite(clip.max) && seconds > clip.max) {
     return `above the receipted clip envelope (${clip.max}s maximum)`;
   }
   return null;
@@ -215,9 +203,7 @@ function selectRow(
   const wantAudio =
     typeof params.withAudio === "boolean"
       ? params.withAudio
-      : typeof baseRow?.with_audio === "boolean"
-        ? baseRow.with_audio
-        : null;
+      : (baseRow?.with_audio ?? null);
   if (wantAudio !== null) {
     const audio = candidates.filter((row) => row.with_audio === wantAudio);
     if (audio.length > 0) candidates = audio;

--- a/packages/node-sdk/src/pack-loader.ts
+++ b/packages/node-sdk/src/pack-loader.ts
@@ -680,7 +680,7 @@ function resolveEntry(pkg: PackageJsonShape): string | undefined {
   const dot = (pkg.exports as Record<string, unknown> | undefined)?.["."];
   if (typeof dot === "string") return dot;
   const picked = pickExportCondition(dot);
-  if (typeof picked === "string") return picked;
+  if (picked != null) return picked;
   return pkg.main ?? "index.js";
 }
 

--- a/packages/protocol/src/api-schemas/js-scripts.ts
+++ b/packages/protocol/src/api-schemas/js-scripts.ts
@@ -15,6 +15,7 @@
 
 import { z } from "zod";
 import { SandboxModuleDeclarationSchema } from "../sandbox-package.js";
+import { isNumber, isRecord, isString } from "../predicates.js";
 
 /** The only document version that exists. */
 export const JS_SCRIPT_SCHEMA_VERSION = 1;
@@ -271,14 +272,14 @@ export interface JsScriptResolver {
  * not carry both. An empty object is how an unlinked node stores "no script".
  */
 export function parseJsScriptLink(value: unknown): JsScriptLink | null {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+  if (!isRecord(value)) {
     return null;
   }
-  const record = value as Record<string, unknown>;
+  const record = value;
   const id = record.id;
   const version = record.version;
-  if (typeof id !== "string" || id.trim() === "") return null;
-  if (typeof version !== "number" || !Number.isInteger(version)) return null;
+  if (!isString(id) || id.trim() === "") return null;
+  if (!isNumber(version) || !Number.isInteger(version)) return null;
   return { id: id.trim(), version };
 }
 

--- a/packages/protocol/src/api-schemas/storyboards.ts
+++ b/packages/protocol/src/api-schemas/storyboards.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 import type { Screenplay, Shot } from "../creative.js";
+import {
+  isNonEmptyString,
+  isNumber,
+  isString
+} from "../predicates.js";
 
 // ── Shot / screenplay ───────────────────────────────────────────────────────
 // Mirrors the interfaces in `creative.ts`. Loose objects: the shapes evolve
@@ -131,9 +136,9 @@ export function normalizeStoryboardShot(
     throw new Error(`Shot at position ${index} must be an object.`);
   }
   const shot = applyAliases(input, SHOT_KEY_ALIASES);
-  const slug = typeof shot.slug === "string" ? shot.slug : undefined;
+  const slug = isString(shot.slug) ? shot.slug : undefined;
   const label = slug ? `${index} ("${slug}")` : `${index}`;
-  if (typeof shot.action !== "string" || shot.action.trim() === "") {
+  if (!isString(shot.action) || shot.action.trim() === "") {
     throw new Error(
       `Shot at position ${label} needs a non-empty \`action\` — the concrete visual to render.`
     );
@@ -145,9 +150,9 @@ export function normalizeStoryboardShot(
   return {
     ...shot,
     type: "shot",
-    id: typeof shot.id === "string" && shot.id ? shot.id : newId(),
-    index: typeof shot.index === "number" ? shot.index : index,
-    status: typeof shot.status === "string" ? shot.status : DEFAULT_SHOT_STATUS
+    id: isNonEmptyString(shot.id) ? shot.id : newId(),
+    index: isNumber(shot.index) ? shot.index : index,
+    status: isString(shot.status) ? shot.status : DEFAULT_SHOT_STATUS
   } as unknown as Shot;
 }
 
@@ -177,8 +182,8 @@ export function normalizeStoryboardScreenplay(
   const candidate = {
     ...play,
     type: "screenplay",
-    id: typeof play.id === "string" && play.id ? play.id : newId(),
-    title: typeof play.title === "string" ? play.title : "",
+    id: isNonEmptyString(play.id) ? play.id : newId(),
+    title: isString(play.title) ? play.title : "",
     shots: (play.shots as unknown[]).map((shot, index) =>
       normalizeStoryboardShot(shot, index, options)
     )

--- a/packages/protocol/src/bridge-frames.ts
+++ b/packages/protocol/src/bridge-frames.ts
@@ -40,6 +40,7 @@
  */
 
 import { z } from "zod";
+import { isString } from "./predicates.js";
 
 // ---------------------------------------------------------------------------
 // Shared building blocks
@@ -314,7 +315,8 @@ export interface BridgeFrameValidationResult {
 export function validateBridgeFrame(
   frame: Record<string, unknown>
 ): BridgeFrameValidationResult {
-  const type = typeof frame["type"] === "string" ? frame["type"] : undefined;
+  const rawType = frame["type"];
+  const type = isString(rawType) ? rawType : undefined;
   const schema = getBridgeFrameSchema(type);
   if (!schema) {
     // Unrecognized/absent type: not this module's concern — the dispatcher

--- a/packages/protocol/src/graph.ts
+++ b/packages/protocol/src/graph.ts
@@ -9,6 +9,7 @@
 
 import type { EdgeType } from "./messages.js";
 import type { TypeMetadata } from "./type-metadata.js";
+import { isString } from "./predicates.js";
 
 // ---------------------------------------------------------------------------
 // Edge
@@ -806,7 +807,7 @@ export function migrateGraphNodeTypes<T extends MigratableGraph>(graph: T): T {
   let changed = false;
 
   const nodes = graph.nodes.map((node) => {
-    if (!isPlainObject(node) || typeof node.type !== "string") return node;
+    if (!isPlainObject(node) || !isString(node.type)) return node;
     const migration = MIGRATION_BY_FROM.get(node.type);
     if (!migration) return node;
     changed = true;
@@ -819,7 +820,7 @@ export function migrateGraphNodeTypes<T extends MigratableGraph>(graph: T): T {
         migration.renameProperties
       );
       if (renamedProps) next.properties = renamedProps;
-      if (typeof next.id === "string") {
+      if (isString(next.id)) {
         handleRenamesByNodeId.set(next.id, migration.renameProperties);
       }
     }
@@ -864,11 +865,11 @@ export function migrateGraphNodeTypes<T extends MigratableGraph>(graph: T): T {
   let edges = graph.edges;
   if (handleRenamesByNodeId.size > 0 && Array.isArray(edges)) {
     edges = edges.map((edge) => {
-      if (!isPlainObject(edge) || typeof edge.target !== "string") return edge;
+      if (!isPlainObject(edge) || !isString(edge.target)) return edge;
       const renames = handleRenamesByNodeId.get(edge.target);
       if (
         renames &&
-        typeof edge.targetHandle === "string" &&
+        isString(edge.targetHandle) &&
         edge.targetHandle in renames
       ) {
         return { ...edge, targetHandle: renames[edge.targetHandle] };

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -26,6 +26,7 @@
  */
 
 import { z } from "zod";
+import { isRecord, isString } from "./predicates.js";
 import {
   supervisorDecisionSchema,
   supervisorEscalationSchema,
@@ -1127,13 +1128,13 @@ export function isProcessingMessage(
  * Mirrors Python's sanitize_memory_uris_for_client().
  */
 export function sanitizeMemoryUris<T>(value: T): T {
-  if (typeof value === "string") {
+  if (isString(value)) {
     return (value.startsWith("memory://") ? "" : value) as T;
   }
   if (Array.isArray(value)) {
     return value.map(sanitizeMemoryUris) as T;
   }
-  if (value !== null && typeof value === "object") {
+  if (isRecord(value)) {
     const result: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
       result[k] = sanitizeMemoryUris(v);

--- a/packages/protocol/src/model-selection.ts
+++ b/packages/protocol/src/model-selection.ts
@@ -7,6 +7,8 @@
  * sentinel, so a placeholder never reaches provider resolution.
  */
 
+import { isNonEmptyString } from "./predicates.js";
+
 export const UNSET_PROVIDER = "empty";
 
 export interface ModelSelection {
@@ -16,11 +18,9 @@ export interface ModelSelection {
 
 export function isModelSelection(provider: unknown, id: unknown): boolean {
   return (
-    typeof provider === "string" &&
-    provider.length > 0 &&
+    isNonEmptyString(provider) &&
     provider !== UNSET_PROVIDER &&
-    typeof id === "string" &&
-    id.length > 0 &&
+    isNonEmptyString(id) &&
     // A client that stringified an absent id sends the literal "undefined".
     id !== "undefined"
   );

--- a/packages/protocol/src/predicates.ts
+++ b/packages/protocol/src/predicates.ts
@@ -1,0 +1,24 @@
+/**
+ * Named type predicates for the representation checks the protocol makes on
+ * values that arrive off the wire, out of storage, or from an agent.
+ */
+
+export function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+export function isNumber(value: unknown): value is number {
+  return typeof value === "number";
+}
+
+export function isBoolean(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/protocol/src/resource-uri.ts
+++ b/packages/protocol/src/resource-uri.ts
@@ -14,6 +14,8 @@
  * addressed as `thread`) plus `asset`, `collection`, `model3d`, and `thread`.
  * It is spelled out here rather than derived because the two sets differ.
  */
+import { isString } from "./predicates.js";
+
 export type ResourceKind =
   | "asset"
   | "workflow"
@@ -75,7 +77,7 @@ const buildRef = (
 };
 
 export function parseResourceUri(uri: string): ResourceUri | null {
-  if (typeof uri !== "string") return null;
+  if (!isString(uri)) return null;
   const trimmed = uri.trim();
   if (!trimmed) return null;
 

--- a/packages/protocol/src/sandbox-host.ts
+++ b/packages/protocol/src/sandbox-host.ts
@@ -23,6 +23,8 @@
  * from it — three places that must not disagree.
  */
 
+import { isNonEmptyString } from "./predicates.js";
+
 /** One host module NodeTool implements, and the pack allowed to declare it. */
 export interface SandboxHostModuleSpec {
   /** Registry id, as written in a manifest's `host` field. */
@@ -260,7 +262,7 @@ export function sandboxHostModuleViolation(
   packName: string,
   hostId: unknown
 ): string | undefined {
-  if (typeof hostId !== "string" || hostId.length === 0) {
+  if (!isNonEmptyString(hostId)) {
     return "a host module must name a host id";
   }
   const spec = sandboxHostModule(hostId);

--- a/packages/protocol/src/sandbox-package.ts
+++ b/packages/protocol/src/sandbox-package.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { SANDBOX_WASM_BUDGETS } from "./sandbox-wasm.js";
+import { isString } from "./predicates.js";
 
 const JS_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 const MODULE_NAME = /^(?:\.|[A-Za-z0-9._-]+)$/;
@@ -247,8 +248,8 @@ const wasmModuleSchema = z
     const aliases = new Set<string>();
     const wasmNames = new Set<string>();
     for (const exported of value.exports) {
-      const wasmName = typeof exported === "string" ? exported : exported.wasm;
-      const alias = typeof exported === "string" ? exported : exported.as;
+      const wasmName = isString(exported) ? exported : exported.wasm;
+      const alias = isString(exported) ? exported : exported.as;
       if (wasmNames.has(wasmName)) {
         ctx.addIssue({
           code: "custom",

--- a/packages/protocol/src/typecheck.ts
+++ b/packages/protocol/src/typecheck.ts
@@ -5,6 +5,7 @@
  */
 
 import { TypeMetadata } from "./type-metadata.js";
+import { isBoolean, isNumber, isString } from "./predicates.js";
 
 export interface ValidationResult {
   valid: boolean;
@@ -40,28 +41,24 @@ function validateWithMeta(
   const { type } = meta;
 
   if (type === "int") {
-    if (typeof value !== "number")
-      return fail(`Expected int, got ${typeof value}`);
+    if (!isNumber(value)) return fail(`Expected int, got ${typeof value}`);
     if (!Number.isInteger(value))
       return fail(`Expected integer, got float ${value}`);
     return VALID;
   }
 
   if (type === "float" || type === "number") {
-    if (typeof value !== "number")
-      return fail(`Expected ${type}, got ${typeof value}`);
+    if (!isNumber(value)) return fail(`Expected ${type}, got ${typeof value}`);
     return VALID;
   }
 
   if (type === "str" || type === "string") {
-    if (typeof value !== "string")
-      return fail(`Expected string, got ${typeof value}`);
+    if (!isString(value)) return fail(`Expected string, got ${typeof value}`);
     return VALID;
   }
 
   if (type === "bool" || type === "boolean") {
-    if (typeof value !== "boolean")
-      return fail(`Expected boolean, got ${typeof value}`);
+    if (!isBoolean(value)) return fail(`Expected boolean, got ${typeof value}`);
     return VALID;
   }
 

--- a/packages/protocol/src/wrap-primitives.ts
+++ b/packages/protocol/src/wrap-primitives.ts
@@ -3,6 +3,7 @@
  *
  * Converts JS primitives to typed wrappers and back.
  */
+import { isBoolean, isString } from "./predicates.js";
 
 export interface WrappedPrimitive {
   type: "int" | "float" | "str" | "bool";
@@ -12,10 +13,10 @@ export interface WrappedPrimitive {
 export function wrapPrimitive(
   value: number | string | boolean
 ): WrappedPrimitive {
-  if (typeof value === "string") {
+  if (isString(value)) {
     return { type: "str", value };
   }
-  if (typeof value === "boolean") {
+  if (isBoolean(value)) {
     return { type: "bool", value };
   }
   if (Number.isInteger(value)) {

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -1423,7 +1423,7 @@ export class ProcessingContext {
     this._variables = { ...(opts.variables ?? {}) };
     const env: Record<string, string> = {};
     for (const [k, v] of Object.entries(safeProcessEnv())) {
-      if (typeof v === "string") env[k] = v;
+      if (v != null) env[k] = v;
     }
     this.environment = { ...env, ...(opts.environment ?? {}) };
     this.authToken = opts.authToken ?? null;
@@ -1730,10 +1730,7 @@ export class ProcessingContext {
   async getSecret(key: string): Promise<string | null> {
     if (!this._secretResolver) return null;
     const value = await this._secretResolver(key, this.userId);
-    if (
-      typeof value === "string" &&
-      value.length >= MIN_MASKABLE_SECRET_LENGTH
-    ) {
+    if (value != null && value.length >= MIN_MASKABLE_SECRET_LENGTH) {
       this._resolvedSecrets.add(value);
     }
     return value ?? null;

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -28,6 +28,13 @@ import { VariableChannel } from "./variable-channel.js";
 import { loadMediaRefBytes, type MediaRefValue } from "./media-ref-bytes.js";
 import { encodeRawImageRef } from "./image-codec.js";
 import {
+  isCallable,
+  isNonEmptyString,
+  isObjectLike,
+  isRecord,
+  isString
+} from "./type-predicates.js";
+import {
   expandAssetReferences,
   inlineTextAssetRefs
 } from "./prompt-asset-refs.js";
@@ -584,7 +591,7 @@ function isWithinRoot(root: string, target: string): boolean {
  * values are equal-keyed iff they are deeply equal.
  */
 function stableStringifyDeep(value: unknown): string {
-  if (value === null || typeof value !== "object") {
+  if (!isObjectLike(value)) {
     return JSON.stringify(value ?? null);
   }
   if (Array.isArray(value)) {
@@ -634,12 +641,13 @@ async function coerceEntityList(
 
   const out: EntityReference[] = [];
   for (const item of raw) {
-    if (!item || typeof item !== "object") continue;
+    if (!isObjectLike(item)) continue;
     const entity = item as Record<string, unknown>;
-    const name = typeof entity.name === "string" ? entity.name.trim() : "";
+    const name = isString(entity.name) ? entity.name.trim() : "";
     if (!name) continue;
-    const descriptor =
-      typeof entity.descriptor === "string" ? entity.descriptor : undefined;
+    const descriptor = isString(entity.descriptor)
+      ? entity.descriptor
+      : undefined;
 
     const imageSource =
       entity.image ??
@@ -649,13 +657,13 @@ async function coerceEntityList(
     let image: Uint8Array | undefined;
     if (imageSource instanceof Uint8Array) {
       image = imageSource;
-    } else if (typeof imageSource === "string" && imageSource.length > 0) {
+    } else if (isNonEmptyString(imageSource)) {
       image =
         (await loadMediaRefBytes(
           { type: "image", uri: imageSource },
           context
         )) ?? undefined;
-    } else if (imageSource && typeof imageSource === "object") {
+    } else if (isObjectLike(imageSource)) {
       image =
         (await loadMediaRefBytes(imageSource as MediaRefValue, context)) ??
         undefined;
@@ -1540,7 +1548,7 @@ export class ProcessingContext {
    * that would throw when unwired.
    */
   hasModelInterface(name: keyof ProcessingContextModelInterfaces): boolean {
-    return typeof this.modelInterfaces()?.[name] === "function";
+    return isCallable(this.modelInterfaces()?.[name]);
   }
 
   // -----------------------------------------------------------------------
@@ -2718,7 +2726,7 @@ export class ProcessingContext {
         );
         const metadata = (await metaResponse.json()) as Record<string, unknown>;
         const getUrl = metadata.get_url;
-        if (typeof getUrl === "string" && getUrl) {
+        if (isNonEmptyString(getUrl)) {
           const downloadUrl = getUrl.startsWith("/")
             ? `${baseUrl}${getUrl}`
             : getUrl;
@@ -2729,7 +2737,7 @@ export class ProcessingContext {
           return { bytes, attempts };
         }
         const uri = metadata.uri;
-        if (typeof uri === "string") {
+        if (isString(uri)) {
           const bytes = await tryStorageUri(uri);
           if (bytes) {
             return { bytes, attempts };
@@ -2779,11 +2787,11 @@ export class ProcessingContext {
     })) as Record<string, unknown>;
 
     const type = ProcessingContext.assetTypeForMime(contentType);
-    const assetId = typeof created.id === "string" ? created.id : null;
+    const assetId = isString(created.id) ? created.id : null;
     const uri =
       assetId !== null
         ? `asset://${assetId}`
-        : typeof created.uri === "string"
+        : isString(created.uri)
           ? created.uri
           : pathToFileURL(filePath).toString();
 
@@ -3359,11 +3367,11 @@ export class ProcessingContext {
     if (Array.isArray(value)) {
       return value.map((v) => ProcessingContext.sanitizeForClient(v));
     }
-    if (typeof value !== "object") return value;
+    if (!isRecord(value)) return value;
 
-    const obj = value as Record<string, unknown>;
+    const obj = value;
     const uri = obj.uri;
-    const isAssetLike = "type" in obj && typeof uri === "string";
+    const isAssetLike = "type" in obj && isString(uri);
 
     if (isAssetLike && uri.startsWith("memory://")) {
       const sanitized: Record<string, unknown> = { ...obj };
@@ -3419,7 +3427,7 @@ export class ProcessingContext {
 
   private static guessAssetMime(asset: Record<string, unknown>): string {
     const explicit = asset.mime_type ?? asset.content_type;
-    if (typeof explicit === "string" && explicit) return explicit;
+    if (isNonEmptyString(explicit)) return explicit;
 
     const type = String(asset.type ?? "").toLowerCase();
     if (type.includes("image")) return "image/png";
@@ -3451,7 +3459,7 @@ export class ProcessingContext {
     if (Array.isArray(data) && data.every((v) => Number.isInteger(v))) {
       return new Uint8Array(data as number[]);
     }
-    if (typeof data === "string") {
+    if (isString(data)) {
       return Uint8Array.from(Buffer.from(data, "base64"));
     }
     return null;
@@ -3477,12 +3485,12 @@ export class ProcessingContext {
     if (decoded) return decoded;
 
     const uri = asset.uri;
-    if (typeof uri === "string" && this.storage) {
+    if (isString(uri) && this.storage) {
       const stored = await this.storage.retrieve(uri);
       if (stored) return stored;
     }
     if (
-      typeof uri === "string" &&
+      isString(uri) &&
       (uri.startsWith("asset://") ||
         uri.startsWith("/api/storage/") ||
         uri.startsWith("api/storage/"))
@@ -3494,7 +3502,7 @@ export class ProcessingContext {
     // resolveAssetBytes has its own HTTP fallback, so this works even without a
     // storage adapter (which the early `!this.storage` return used to preclude).
     const assetId = asset.asset_id;
-    if (typeof assetId === "string" && assetId) {
+    if (isNonEmptyString(assetId)) {
       const { bytes } = await this.resolveAssetBytes(`asset://${assetId}`);
       if (bytes) return bytes;
     }
@@ -3516,7 +3524,7 @@ export class ProcessingContext {
     // important for SDK pass-through workflows: their large input was already
     // uploaded once and should not be copied again on output.
     if (mode === "temp_url") {
-      const uri = typeof rawAsset.uri === "string" ? rawAsset.uri : "";
+      const uri = isString(rawAsset.uri) ? rawAsset.uri : "";
       const hasInlineBytes =
         ProcessingContext.decodeAssetData(rawAsset.data) !== null;
       const isStorageRoute =
@@ -3640,8 +3648,8 @@ export class ProcessingContext {
       }
     }
 
-    if (typeof value === "object") {
-      const entries = Object.entries(value as Record<string, unknown>);
+    if (isRecord(value)) {
+      const entries = Object.entries(value);
       const normalized = await Promise.all(
         entries.map(
           async ([k, v]) =>

--- a/packages/runtime/src/providers/anthropic-provider.ts
+++ b/packages/runtime/src/providers/anthropic-provider.ts
@@ -9,6 +9,12 @@ import type {
 import { createLogger } from "@nodetool-ai/config";
 import { BaseProvider } from "./base-provider.js";
 import { safeFetch } from "./safe-url.js";
+import {
+  isNumber,
+  isObjectLike,
+  isRecord,
+  isString
+} from "../type-predicates.js";
 
 const log = createLogger("nodetool.runtime.providers.anthropic");
 import type {
@@ -94,12 +100,7 @@ function retryAfterMs(value: string | null): number | null {
 }
 
 function apiErrorStatus(error: unknown): number | undefined {
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    "status" in error &&
-    typeof error.status === "number"
-  ) {
+  if (isObjectLike(error) && "status" in error && isNumber(error.status)) {
     return error.status;
   }
   return undefined;
@@ -107,8 +108,7 @@ function apiErrorStatus(error: unknown): number | undefined {
 
 function apiErrorRetryAfter(error: unknown): string | null {
   if (
-    typeof error === "object" &&
-    error !== null &&
+    isObjectLike(error) &&
     "headers" in error &&
     error.headers instanceof Headers
   ) {
@@ -174,7 +174,7 @@ function textContentFromRawBlocks(
   blocks: AnthropicRawBlock[]
 ): MessageTextContent[] {
   return blocks.flatMap((block) => {
-    if (block?.type !== "text" || typeof block.text !== "string") return [];
+    if (block?.type !== "text" || !isString(block.text)) return [];
     const citations = Array.isArray(block.citations)
       ? (block.citations as TextCitation[]).map(mapCitation)
       : undefined;
@@ -297,8 +297,7 @@ function mergeToolResultMessages(
     m.content.length > 0 &&
     m.content.every(
       (block) =>
-        typeof block === "object" &&
-        block !== null &&
+        isObjectLike(block) &&
         (block as { type?: unknown }).type === "tool_result"
     );
 
@@ -368,7 +367,7 @@ function isDocumentContent(
 
 function bytesToBase64(data: Uint8Array | string | undefined): string {
   if (!data) return "";
-  if (typeof data === "string") return data;
+  if (isString(data)) return data;
   return Buffer.from(data).toString("base64");
 }
 
@@ -567,7 +566,7 @@ export class AnthropicProvider extends BaseProvider {
   }
 
   private prepareJsonSchema(schema: unknown): JsonSchemaNode {
-    if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    if (!isRecord(schema)) {
       // SAFETY: a schema node that is not an object is carried through as it
       // stands — a scalar, a list, or an absent schema.
       return schema as JsonSchemaNode;
@@ -583,11 +582,7 @@ export class AnthropicProvider extends BaseProvider {
       obj.additionalProperties = false;
     }
 
-    if (
-      obj.properties &&
-      typeof obj.properties === "object" &&
-      !Array.isArray(obj.properties)
-    ) {
+    if (isRecord(obj.properties)) {
       obj.properties = Object.fromEntries(
         Object.entries(obj.properties).map(([k, v]) => [
           k,
@@ -596,13 +591,13 @@ export class AnthropicProvider extends BaseProvider {
       );
     }
 
-    if (obj.items && typeof obj.items === "object") {
+    if (isObjectLike(obj.items)) {
       obj.items = this.prepareJsonSchema(obj.items);
     }
 
     for (const defsKey of ["definitions", "$defs"]) {
       const defs = obj[defsKey];
-      if (defs && typeof defs === "object" && !Array.isArray(defs)) {
+      if (isRecord(defs)) {
         obj[defsKey] = Object.fromEntries(
           Object.entries(defs).map(([k, v]) => [k, this.prepareJsonSchema(v)])
         );
@@ -713,7 +708,7 @@ export class AnthropicProvider extends BaseProvider {
 
     if (data !== undefined) {
       const parsed =
-        typeof data === "string" && data.startsWith("data:")
+        isString(data) && data.startsWith("data:")
           ? parseDataUri(data)
           : undefined;
       const effectiveMime = mimeType ?? parsed?.mime ?? "application/pdf";
@@ -725,7 +720,7 @@ export class AnthropicProvider extends BaseProvider {
       if (effectiveMime === "text/plain") {
         const text = parsed
           ? Buffer.from(parsed.base64, "base64").toString("utf8")
-          : typeof data === "string"
+          : isString(data)
             ? data
             : Buffer.from(data).toString("utf8");
         source = { type: "text", media_type: "text/plain", data: text };
@@ -798,7 +793,7 @@ export class AnthropicProvider extends BaseProvider {
       // screenshot) is converted to blocks so vision models can see it; plain
       // results stay stringified as before.
       let resultContent: unknown;
-      if (typeof message.content === "string") {
+      if (isString(message.content)) {
         resultContent = message.content;
       } else if (Array.isArray(message.content)) {
         const blocks: Array<Record<string, unknown>> = [];
@@ -835,18 +830,17 @@ export class AnthropicProvider extends BaseProvider {
       // before conversion; if one still reaches here, fold it into a user
       // message rather than mislabeling it as assistant text (and avoid
       // String(array) producing "[object Object]").
-      const text =
-        typeof message.content === "string"
-          ? message.content
-          : (message.content ?? [])
-              .filter(isTextContent)
-              .map((c) => c.text)
-              .join("\n");
+      const text = isString(message.content)
+        ? message.content
+        : (message.content ?? [])
+            .filter(isTextContent)
+            .map((c) => c.text)
+            .join("\n");
       return { role: "user", content: text };
     }
 
     if (message.role === "user") {
-      if (typeof message.content === "string") {
+      if (isString(message.content)) {
         return { role: "user", content: message.content };
       }
 
@@ -898,7 +892,7 @@ export class AnthropicProvider extends BaseProvider {
       const contentBlocks: Array<Record<string, unknown>> = [
         ...(message._anthropicThinkingBlocks ?? [])
       ];
-      if (typeof message.content === "string" && message.content.trim()) {
+      if (isString(message.content) && message.content.trim()) {
         contentBlocks.push({ type: "text", text: message.content });
       }
 
@@ -925,7 +919,7 @@ export class AnthropicProvider extends BaseProvider {
       };
     }
 
-    if (typeof message.content === "string") {
+    if (isString(message.content)) {
       return { role: "assistant", content: message.content };
     }
 
@@ -980,7 +974,7 @@ export class AnthropicProvider extends BaseProvider {
     }
     const sections = systemMessages
       .map((message) => {
-        if (typeof message.content === "string") return message.content;
+        if (isString(message.content)) return message.content;
         if (Array.isArray(message.content)) {
           return message.content
             .filter(isTextContent)
@@ -1253,7 +1247,7 @@ export class AnthropicProvider extends BaseProvider {
           const raw = contentBlocks[index] ?? {};
           contentBlocks[index] = raw;
           const delta = event.delta;
-          if ("thinking" in delta && typeof delta.thinking === "string") {
+          if ("thinking" in delta && isString(delta.thinking)) {
             const thinkingDelta = delta.thinking;
             raw.thinking = String(raw.thinking ?? "") + thinkingDelta;
             const thinking = thinkingBlocks.at(-1);
@@ -1265,24 +1259,18 @@ export class AnthropicProvider extends BaseProvider {
               done: false,
               thinking: true
             };
-          } else if (
-            "signature" in delta &&
-            typeof delta.signature === "string"
-          ) {
+          } else if ("signature" in delta && isString(delta.signature)) {
             const signatureDelta = delta.signature;
             raw.signature = String(raw.signature ?? "") + signatureDelta;
             const thinking = thinkingBlocks.at(-1);
             if (thinking?.type === "thinking")
               thinking.signature += signatureDelta;
-          } else if (
-            "partial_json" in delta &&
-            typeof delta.partial_json === "string"
-          ) {
+          } else if ("partial_json" in delta && isString(delta.partial_json)) {
             jsonByIndex.set(
               index,
               (jsonByIndex.get(index) ?? "") + delta.partial_json
             );
-          } else if ("text" in delta && typeof delta.text === "string") {
+          } else if ("text" in delta && isString(delta.text)) {
             const textDelta = delta.text;
             raw.text = String(raw.text ?? "") + textDelta;
             yield { type: "chunk", content: textDelta, done: false };
@@ -1305,7 +1293,7 @@ export class AnthropicProvider extends BaseProvider {
             raw.input = input;
             jsonByIndex.delete(event.index);
             if (raw.type === "tool_use") {
-              if (!input || typeof input !== "object" || Array.isArray(input)) {
+              if (!isRecord(input)) {
                 throw new Error("Anthropic returned non-object tool input");
               }
               const toolCall: AnthropicToolCall = {

--- a/packages/runtime/src/providers/claude-agent-provider.ts
+++ b/packages/runtime/src/providers/claude-agent-provider.ts
@@ -58,6 +58,12 @@ import {
   type ToolCall
 } from "./types.js";
 import { hashSystemPrompt } from "./provider-session.js";
+import {
+  isFiniteNumber,
+  isNonEmptyString,
+  isObjectLike,
+  isString
+} from "../type-predicates.js";
 import type { TurnBudget } from "../turn-budget.js";
 
 const log = createLogger("nodetool.runtime.providers.claude-agent");
@@ -648,8 +654,7 @@ export class ClaudeAgentProvider extends BaseProvider {
         if (msg.type === "system" && msg.subtype === "init") {
           // Capture the session and surface it immediately so a streaming
           // consumer can persist it onto the assistant message it creates.
-          if (typeof msg.model === "string" && msg.model)
-            resolvedModel = msg.model;
+          if (isNonEmptyString(msg.model)) resolvedModel = msg.model;
           if (plan.threadId) {
             const session: ProviderSession = {
               providerId: this.provider,
@@ -687,8 +692,7 @@ export class ClaudeAgentProvider extends BaseProvider {
 
         if (msg.type === "assistant") {
           const m = (msg as SDKAssistantMessage).message;
-          if (m && typeof m.model === "string" && m.model)
-            resolvedModel = m.model;
+          if (m && isNonEmptyString(m.model)) resolvedModel = m.model;
           // Fallback only: no partials arrived, so render text/thinking from the
           // final content blocks — kept strictly separate, never merged.
           if (!streamedFromPartials) {
@@ -810,7 +814,7 @@ export class ClaudeAgentProvider extends BaseProvider {
         continue;
       if ("args" in item) {
         toolCalls.push(item);
-      } else if (!item.thinking && typeof item.content === "string") {
+      } else if (!item.thinking && isString(item.content)) {
         content += item.content;
       }
     }
@@ -823,7 +827,7 @@ export class ClaudeAgentProvider extends BaseProvider {
 }
 
 function num(value: unknown): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+  return isFiniteNumber(value) ? value : 0;
 }
 
 /**
@@ -871,9 +875,7 @@ function capturedModelFromPartial(
   const event = msg.event;
   if (event.type !== "message_start") return null;
   const model = event.message?.model;
-  return typeof model === "string" && model && model !== "<synthetic>"
-    ? model
-    : null;
+  return isNonEmptyString(model) && model !== "<synthetic>" ? model : null;
 }
 
 /** Text/thinking blocks of a final assistant message, kept separate. */
@@ -884,12 +886,9 @@ function finalBlocks(
   if (!Array.isArray(content)) return [];
   const out: Array<{ content: string; thinking: boolean }> = [];
   for (const block of content) {
-    if (block.type === "text" && typeof block.text === "string") {
+    if (block.type === "text" && isString(block.text)) {
       out.push({ content: block.text, thinking: false });
-    } else if (
-      block.type === "thinking" &&
-      typeof block.thinking === "string"
-    ) {
+    } else if (block.type === "thinking" && isString(block.thinking)) {
       out.push({ content: block.thinking, thinking: true });
     }
   }
@@ -906,7 +905,7 @@ function finalBlocks(
  *    top-level tool name. Without this the call reaches no tool at all.
  */
 function stripToolPrefix(name: string | undefined): string {
-  let n = typeof name === "string" ? name : "";
+  let n = isString(name) ? name : "";
   if (n.startsWith(TOOL_PREFIX)) n = n.slice(TOOL_PREFIX.length);
   if (n.startsWith(GUEST_TOOL_PREFIX)) n = n.slice(GUEST_TOOL_PREFIX.length);
   return n;
@@ -926,16 +925,15 @@ function assistantParts(msg: SDKAssistantMessage) {
         name?: string;
         input?: unknown;
       };
-      if (b.type === "text" && typeof b.text === "string") {
+      if (b.type === "text" && isString(b.text)) {
         text += b.text;
       } else if (b.type === "tool_use") {
         toolCalls.push({
-          id: typeof b.id === "string" ? b.id : `call_${toolCalls.length}`,
+          id: isString(b.id) ? b.id : `call_${toolCalls.length}`,
           name: stripToolPrefix(b.name),
-          args:
-            b.input && typeof b.input === "object"
-              ? (b.input as Record<string, unknown>)
-              : {}
+          args: isObjectLike(b.input)
+            ? (b.input as Record<string, unknown>)
+            : {}
         });
       }
     }
@@ -956,7 +954,7 @@ function toolResultsFromUser(
         tool_use_id?: string;
         content?: unknown;
       };
-      if (b.type === "tool_result" && typeof b.tool_use_id === "string") {
+      if (b.type === "tool_result" && isString(b.tool_use_id)) {
         out.push({
           toolCallId: b.tool_use_id,
           content: toolResultText(b.content)
@@ -969,12 +967,12 @@ function toolResultsFromUser(
 
 /** Flatten an MCP tool-result content payload to text. */
 function toolResultText(content: unknown): string {
-  if (typeof content === "string") return content;
+  if (isString(content)) return content;
   if (Array.isArray(content)) {
     return content
       .map((c) => {
         const cc = c as { type?: string; text?: string };
-        return cc.type === "text" && typeof cc.text === "string" ? cc.text : "";
+        return cc.type === "text" && isString(cc.text) ? cc.text : "";
       })
       .join("");
   }
@@ -1030,17 +1028,13 @@ function toMcpImageBlock(image: {
       : Buffer.from(decodeURIComponent(match[3] ?? "")).toString("base64");
   };
 
-  if (typeof image.data === "string") {
+  if (isString(image.data)) {
     if (image.data.startsWith("data:")) fromDataUri(image.data);
     else base64 = image.data;
   } else if (image.data instanceof Uint8Array) {
     base64 = Buffer.from(image.data).toString("base64");
   }
-  if (
-    !base64 &&
-    typeof image.uri === "string" &&
-    image.uri.startsWith("data:")
-  ) {
+  if (!base64 && isString(image.uri) && image.uri.startsWith("data:")) {
     fromDataUri(image.uri);
   }
   if (!base64) return null;
@@ -1055,7 +1049,7 @@ function toMcpImageBlock(image: {
 export function toolResultToMcpContent(
   result: string | MessageContent[]
 ): McpContentBlock[] {
-  if (typeof result === "string") {
+  if (isString(result)) {
     return [{ type: "text", text: result }];
   }
   const blocks: McpContentBlock[] = [];
@@ -1065,7 +1059,7 @@ export function toolResultToMcpContent(
     } else if (part.type === "image_url") {
       const img = toMcpImageBlock(part.image);
       if (img) blocks.push(img);
-      else if (typeof part.image.uri === "string") {
+      else if (isString(part.image.uri)) {
         blocks.push({ type: "text", text: `[image at ${part.image.uri}]` });
       }
     }
@@ -1093,8 +1087,7 @@ function jsonSchemaToZodShape(
 
 /** Convert one JSON-Schema property to a Zod type (the subset NodeTool uses). */
 function jsonPropToZod(prop: Record<string, unknown>): ZodTypeAny {
-  const desc =
-    typeof prop?.description === "string" ? prop.description : undefined;
+  const desc = isString(prop?.description) ? prop.description : undefined;
   let zt: ZodTypeAny;
   switch (prop?.type) {
     case "string":
@@ -1139,7 +1132,7 @@ function resultError(
   const parts: string[] = [`Claude Agent SDK query failed (${msg.subtype})`];
   if ("errors" in msg && Array.isArray(msg.errors) && msg.errors.length) {
     parts.push(msg.errors.join("; "));
-  } else if ("result" in msg && typeof msg.result === "string" && msg.result) {
+  } else if ("result" in msg && isNonEmptyString(msg.result)) {
     parts.push(msg.result);
   }
   const denials = (
@@ -1156,7 +1149,7 @@ function resultError(
 /** Flatten a message's content to plain text (text blocks only). */
 function textOf(content: Message["content"]): string {
   if (content == null) return "";
-  if (typeof content === "string") return content;
+  if (isString(content)) return content;
   return content
     .filter((c): c is MessageTextContent => c.type === "text")
     .map((c) => c.text)

--- a/packages/runtime/src/providers/elevenlabs-provider.ts
+++ b/packages/runtime/src/providers/elevenlabs-provider.ts
@@ -134,7 +134,7 @@ export class ElevenLabsProvider extends BaseProvider {
     // ElevenLabs applies playback speed via voice_settings.speed (0.7–1.2).
     // Forward it when the caller asked for a non-default tempo — omitting it
     // silently discarded the request.
-    if (typeof args.speed === "number" && args.speed !== 1.0) {
+    if (args.speed != null && args.speed !== 1.0) {
       body.voice_settings = { speed: Math.max(0.7, Math.min(1.2, args.speed)) };
     }
     const response = await this._fetch(url, {

--- a/packages/runtime/src/providers/kie-provider.ts
+++ b/packages/runtime/src/providers/kie-provider.ts
@@ -1139,7 +1139,7 @@ export class KieProvider extends BaseProvider {
     fields: ModelInputField[]
   ): void {
     for (const field of fields) {
-      const max = typeof field.max === "number" ? field.max : undefined;
+      const max = field.max;
       if (max === undefined || max <= 0) continue;
       const value = input[field.name];
       if (typeof value !== "string" || value.length <= max) continue;

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -22,13 +22,18 @@ import {
   extractResponsesImages,
   extractResponsesText,
   extractResponsesToolCalls,
-  isRecord,
   messagesToResponsesInput,
   responseToolChoice,
   responseTools,
   responseUsage,
   streamResponsesEvents
 } from "./responses-api.js";
+import {
+  isCallable,
+  isNumber,
+  isRecord,
+  isString
+} from "../type-predicates.js";
 import {
   isProviderMessageEvent,
   isProviderSessionUpdate,
@@ -98,7 +103,7 @@ function asUint8Array(data: unknown): Uint8Array {
   if (Array.isArray(data) && data.every((v) => Number.isInteger(v))) {
     return new Uint8Array(data as number[]);
   }
-  if (typeof data === "string") {
+  if (isString(data)) {
     return Uint8Array.from(Buffer.from(data, "base64"));
   }
   if (data instanceof ArrayBuffer) {
@@ -175,7 +180,7 @@ function defaultSerializer<T>(_key: string, value: T): T | JsonValue {
   if (
     typeof value === "object" &&
     "toJSON" in value &&
-    typeof (value as { toJSON: unknown }).toJSON === "function"
+    isCallable((value as { toJSON: unknown }).toJSON)
   ) {
     // SAFETY: `toJSON` is the JSON.stringify protocol hook — it exists on the
     // value and, by that contract, produces a JSON-representable result.
@@ -249,7 +254,7 @@ function isOpenAIResponsesModel(model: string): boolean {
 function responsesSystemPrompt(messages: Message[]): string {
   return messages
     .filter((m) => m.role === "system")
-    .map((m) => (typeof m.content === "string" ? m.content : ""))
+    .map((m) => (isString(m.content) ? m.content : ""))
     .filter(Boolean)
     .join("\n\n");
 }
@@ -267,13 +272,14 @@ function imageContentFromChunk(
     !isRecord(item) ||
     item.type !== "chunk" ||
     item.content_type !== "image" ||
-    typeof item.content !== "string"
+    !isString(item.content)
   ) {
     return null;
   }
   const metadata = isRecord(item.content_metadata) ? item.content_metadata : {};
-  const mimeType =
-    typeof metadata.mimeType === "string" ? metadata.mimeType : "image/png";
+  const mimeType = isString(metadata.mimeType)
+    ? metadata.mimeType
+    : "image/png";
   return { type: "image_url", image: { data: item.content, mimeType } };
 }
 
@@ -913,7 +919,7 @@ export class OpenAIProvider extends BaseProvider {
       }
 
       let content = "";
-      if (typeof message.content === "string") {
+      if (isString(message.content)) {
         content = message.content;
       } else if (message.content != null) {
         content = JSON.stringify(message.content, defaultSerializer);
@@ -929,7 +935,7 @@ export class OpenAIProvider extends BaseProvider {
     if (message.role === "system") {
       return {
         role: "system",
-        content: typeof message.content === "string" ? message.content : ""
+        content: isString(message.content) ? message.content : ""
       };
     }
 
@@ -943,7 +949,7 @@ export class OpenAIProvider extends BaseProvider {
         }
       }));
 
-      if (typeof message.content === "string" || message.content == null) {
+      if (isString(message.content) || message.content == null) {
         type AssistantFields = {
           role: "assistant";
           content: string | null | undefined;
@@ -984,7 +990,7 @@ export class OpenAIProvider extends BaseProvider {
       throw new Error(`Unsupported role: ${message.role}`);
     }
 
-    if (typeof message.content === "string") {
+    if (isString(message.content)) {
       return {
         role: "user",
         content: message.content
@@ -1044,7 +1050,7 @@ export class OpenAIProvider extends BaseProvider {
         ? {
             ...msg,
             role: "user",
-            content: `Instructions: ${typeof msg.content === "string" ? msg.content : ""}`
+            content: `Instructions: ${isString(msg.content) ? msg.content : ""}`
           }
         : msg
     );
@@ -1191,7 +1197,7 @@ export class OpenAIProvider extends BaseProvider {
         }
       }
     } finally {
-      if (typeof stream.close === "function") {
+      if (isCallable(stream.close)) {
         await stream.close();
       }
     }
@@ -1336,10 +1342,9 @@ export class OpenAIProvider extends BaseProvider {
     })) as Record<string, unknown>;
 
     this.trackUsage(args.model, responseUsage(response));
-    const outputText =
-      typeof response.output_text === "string"
-        ? response.output_text
-        : extractResponsesText(response.output);
+    const outputText = isString(response.output_text)
+      ? response.output_text
+      : extractResponsesText(response.output);
     const toolCalls = extractResponsesToolCalls(
       response.output,
       this.buildToolCall.bind(this)
@@ -1382,7 +1387,7 @@ export class OpenAIProvider extends BaseProvider {
       if (
         isRecord(item) &&
         item.type === "chunk" &&
-        typeof item.content === "string" &&
+        isString(item.content) &&
         !item.thinking
       ) {
         assistantText += item.content;
@@ -1756,7 +1761,7 @@ export class OpenAIProvider extends BaseProvider {
           state.emittedContent = true;
           continue;
         }
-        if (typeof item.content === "string" && !item.thinking) {
+        if (isString(item.content) && !item.thinking) {
           state.assistantText += item.content;
           if (item.content) state.emittedContent = true;
         }
@@ -1995,9 +2000,7 @@ export class OpenAIProvider extends BaseProvider {
     this.trackUsage(args.model, { inputCharacters: args.text.length });
 
     const bytes = asUint8Array(
-      typeof response.arrayBuffer === "function"
-        ? await response.arrayBuffer()
-        : response
+      isCallable(response.arrayBuffer) ? await response.arrayBuffer() : response
     );
     yield { samples: toInt16Samples(bytes) };
   }
@@ -2047,9 +2050,7 @@ export class OpenAIProvider extends BaseProvider {
     this.trackUsage(args.model, { inputCharacters: args.text.length });
 
     const bytes = asUint8Array(
-      typeof response.arrayBuffer === "function"
-        ? await response.arrayBuffer()
-        : response
+      isCallable(response.arrayBuffer) ? await response.arrayBuffer() : response
     );
     return { data: bytes, mimeType: formatToMime[fmt] };
   }
@@ -2118,12 +2119,11 @@ export class OpenAIProvider extends BaseProvider {
     // reported on the verbose/diarized formats (and as `usage.seconds` on the
     // newer transcribe models); skip accounting when it is absent rather than
     // guessing.
-    const durationSeconds =
-      typeof response.duration === "number"
-        ? response.duration
-        : typeof response.usage?.seconds === "number"
-          ? response.usage.seconds
-          : undefined;
+    const durationSeconds = isNumber(response.duration)
+      ? response.duration
+      : isNumber(response.usage?.seconds)
+        ? response.usage.seconds
+        : undefined;
     if (durationSeconds !== undefined) {
       this.trackUsage(args.model, { durationSeconds });
     }

--- a/packages/runtime/src/providers/responses-api.ts
+++ b/packages/runtime/src/providers/responses-api.ts
@@ -10,9 +10,9 @@ import type {
 } from "./types.js";
 import type { UsageInfo } from "./cost-calculator.js";
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
+import { isRecord } from "../type-predicates.js";
+
+export { isRecord };
 
 export function stringifyContent(
   value: string | MessageContent[] | null | undefined

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -466,7 +466,7 @@ export abstract class PythonBridgeBase
     if (identity.jobId) payload.job_id = identity.jobId;
     if (identity.workflowId) payload.workflow_id = identity.workflowId;
     if (identity.userId) payload.user_id = identity.userId;
-    if (typeof identity.requiresVramGb === "number") {
+    if (identity.requiresVramGb != null) {
       payload.requires_vram_gb = identity.requiresVramGb;
     }
     return payload;
@@ -1333,7 +1333,7 @@ export abstract class PythonBridgeBase
     if (options.blobs) data.blobs = options.blobs;
     if (options.previews) data.previews = true;
     if (options.includeTemp) data.include_temp = true;
-    if (typeof options.timeout === "number") data.timeout = options.timeout;
+    if (options.timeout != null) data.timeout = options.timeout;
 
     return new Promise<ComfyExecuteResult>((resolve, reject) => {
       let settled = false;

--- a/packages/runtime/src/python-node-executor.ts
+++ b/packages/runtime/src/python-node-executor.ts
@@ -129,7 +129,7 @@ export class PythonNodeExecutor {
     if (context?.userId) {
       identity.userId = context.userId;
     }
-    if (typeof this.requiresVramGb === "number") {
+    if (this.requiresVramGb != null) {
       identity.requiresVramGb = this.requiresVramGb;
     }
     return identity;

--- a/packages/runtime/src/type-predicates.ts
+++ b/packages/runtime/src/type-predicates.ts
@@ -1,0 +1,39 @@
+/**
+ * Narrowing predicates for values whose static type does not describe what a
+ * provider or an asset payload actually carries at runtime — JSON decoded from
+ * an API response, a message content union, an optional SDK method.
+ */
+
+export function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+export function isNumber(value: unknown): value is number {
+  return typeof value === "number";
+}
+
+export function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/**
+ * An object or an array — anything `typeof` calls "object" except `null`.
+ * Use {@link isRecord} when array payloads must be rejected.
+ */
+export function isObjectLike(value: unknown): value is object {
+  return value !== null && typeof value === "object";
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function isCallable<T>(
+  value: T
+): value is T & ((...args: never[]) => unknown) {
+  return typeof value === "function";
+}

--- a/packages/timeline/src/storyboard.ts
+++ b/packages/timeline/src/storyboard.ts
@@ -51,7 +51,7 @@ export const isAssemblableShot = (shot: Shot): boolean =>
 
 /** The persisted asset id on a media ref, or undefined when it has none. */
 const assetIdOf = (ref: { asset_id?: string | null } | null | undefined) =>
-  typeof ref?.asset_id === "string" && ref.asset_id.length > 0
+  ref?.asset_id != null && ref.asset_id.length > 0
     ? ref.asset_id
     : undefined;
 

--- a/packages/transformers-js-nodes/src/transformers-base.ts
+++ b/packages/transformers-js-nodes/src/transformers-base.ts
@@ -284,7 +284,7 @@ export async function loadMediaBytes(
   const hasInlineData =
     ref.data instanceof Uint8Array ? ref.data.length > 0 : Boolean(ref.data);
   if (hasInlineData) return decodeBase64Data(ref.data);
-  const uri = typeof ref.uri === "string" ? ref.uri : "";
+  const uri = ref.uri ?? "";
   if (!uri) return new Uint8Array();
 
   if (context?.storage) {

--- a/packages/transformers-js-provider/src/asr.ts
+++ b/packages/transformers-js-provider/src/asr.ts
@@ -39,7 +39,7 @@ export async function automaticSpeechRecognition(
 
   const opts: Record<string, unknown> = {};
   if (args.language) opts.language = args.language;
-  if (typeof args.temperature === "number") opts.temperature = args.temperature;
+  if (args.temperature != null) opts.temperature = args.temperature;
   if (args.word_timestamps) opts.return_timestamps = "word";
 
   const result = await pipeline(samples, opts);

--- a/packages/websocket/src/lib/wire-values.ts
+++ b/packages/websocket/src/lib/wire-values.ts
@@ -1,0 +1,54 @@
+/**
+ * Type predicates for values that arrive over the WebSocket wire.
+ *
+ * Client frames are MsgPack/JSON, so every field reaches the runner as
+ * `unknown` and has to be narrowed before use. These are the questions the
+ * runner asks about such a value, each with one definition so the leniency
+ * they encode (what counts as an object, whether arrays pass) is the same at
+ * every call site.
+ */
+
+/** A string field. */
+export function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+/** A string field carrying content. */
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+/** A numeric field, `NaN` and infinities included. */
+export function isNumber(value: unknown): value is number {
+  return typeof value === "number";
+}
+
+/** A numeric field safe to compute with. */
+export function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/** A boolean field. */
+export function isBoolean(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
+/**
+ * A non-null object, arrays included — the lenient check used where an array
+ * is an acceptable payload or has already been handled by an earlier branch.
+ */
+export function isObjectLike(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+/** A non-null, non-array object: a keyed payload. */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/** A callable slot on an object whose shape the runner only partly knows. */
+export function isFunctionValue(
+  value: unknown
+): value is (...args: never[]) => unknown {
+  return typeof value === "function";
+}

--- a/packages/websocket/src/sdk/sdk-static-preflight-service.ts
+++ b/packages/websocket/src/sdk/sdk-static-preflight-service.ts
@@ -433,7 +433,7 @@ function costSummary(
       .filter((item) => item.confidence === "unknown")
       .map((item) => item.node_id),
     approval_required:
-      typeof threshold === "number" && estimate.total > threshold
+      threshold != null && estimate.total > threshold
   };
 }
 

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -1307,7 +1307,7 @@ if (!isProduction) {
         for (const item of value) {
           headers.append(key, item);
         }
-      } else if (typeof value === "string") {
+      } else if (value != null) {
         headers.set(key, value);
       }
     }

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -21,6 +21,16 @@ import {
 } from "@nodetool-ai/config";
 import { getAssetAdapter, getTempAdapter } from "./lib/storage.js";
 import {
+  isBoolean,
+  isFiniteNumber,
+  isFunctionValue,
+  isNonEmptyString,
+  isNumber,
+  isObjectLike,
+  isRecord,
+  isString
+} from "./lib/wire-values.js";
+import {
   FileStorageAdapter,
   type StorageAdapter
 } from "@nodetool-ai/storage";
@@ -259,7 +269,7 @@ function shouldValidateOutboundWs(): boolean {
  */
 function assertValidOutboundMessage(message: Record<string, unknown>): void {
   if (!shouldValidateOutboundWs()) return;
-  const type = typeof message["type"] === "string" ? message["type"] : null;
+  const type = isString(message["type"]) ? message["type"] : null;
   if (!type) return;
   const schema =
     processingMessageSchemas[type as keyof typeof processingMessageSchemas] ??
@@ -399,8 +409,7 @@ function sanitizeLargeText(
   maxLength = MAX_ERROR_TEXT_LENGTH
 ): string {
   const sanitized = text.replace(DATA_URI_PATTERN, (match, mimeType) => {
-    const mime =
-      typeof mimeType === "string" && mimeType !== "" ? mimeType : "data";
+    const mime = isString(mimeType) && mimeType !== "" ? mimeType : "data";
     return `[${mime} base64 omitted, ${match.length} chars]`;
   });
 
@@ -426,7 +435,7 @@ function sanitizeErrorValue(
   value: unknown,
   seen = new WeakSet<object>()
 ): JsonSafeValue {
-  if (typeof value === "string") {
+  if (isString(value)) {
     return sanitizeLargeText(value);
   }
 
@@ -438,7 +447,7 @@ function sanitizeErrorValue(
     return value.map((item) => sanitizeErrorValue(item, seen));
   }
 
-  if (value && typeof value === "object") {
+  if (isObjectLike(value)) {
     if (seen.has(value)) {
       return "[circular]";
     }
@@ -466,7 +475,7 @@ function formatSanitizedError(error: unknown): string {
     return "";
   }
 
-  if (typeof error === "string") {
+  if (isString(error)) {
     return sanitizeLargeText(error);
   }
 
@@ -475,7 +484,7 @@ function formatSanitizedError(error: unknown): string {
   }
 
   const sanitized = sanitizeErrorValue(error);
-  if (typeof sanitized === "string") {
+  if (isString(sanitized)) {
     return sanitized;
   }
 
@@ -502,7 +511,7 @@ function getAdapterPublicUrl(
 ): string | null {
   const fn = (adapter as { getPublicUrl?: (uri: string) => string | null })
     .getPublicUrl;
-  if (typeof fn !== "function") return null;
+  if (!isFunctionValue(fn)) return null;
   try {
     return fn.call(adapter, uri) ?? null;
   } catch {
@@ -544,7 +553,7 @@ function promptMetadata(
   properties: Record<string, unknown> | undefined
 ) {
   const prompt = properties?.prompt;
-  if (typeof prompt !== "string") return {};
+  if (!isString(prompt)) return {};
   const trimmed = prompt.trim();
   if (trimmed.length === 0) return {};
   return {
@@ -585,10 +594,10 @@ const ASSET_TYPE_MIME: Record<string, string> = {
 };
 
 function isAssetLikeValue(value: unknown): value is Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  if (!isRecord(value)) return false;
   const v = value as Record<string, unknown>;
   return (
-    typeof v.type === "string" &&
+    isString(v.type) &&
     ASSET_MEDIA_TYPES.has(v.type as string) &&
     ("data" in v || "uri" in v)
   );
@@ -602,7 +611,7 @@ function isAssetLikeValue(value: unknown): value is Record<string, unknown> {
 function isNativeAudioChunk(
   value: unknown
 ): value is Record<string, unknown> & { content: Float32Array } {
-  if (!value || typeof value !== "object") return false;
+  if (!isObjectLike(value)) return false;
   const v = value as Record<string, unknown>;
   return v.type === "chunk" && v.content instanceof Float32Array;
 }
@@ -662,7 +671,7 @@ function decodeAssetBytes(data: unknown): Uint8Array | null {
   if (Array.isArray(data) && data.every((v) => Number.isInteger(v))) {
     return new Uint8Array(data as number[]);
   }
-  if (typeof data === "string") {
+  if (isString(data)) {
     return Uint8Array.from(Buffer.from(data, "base64"));
   }
   return null;
@@ -701,10 +710,9 @@ function extractEmbeddedImage(source: {
   uri?: unknown;
   mimeType?: unknown;
 }): { bytes: Uint8Array; mimeType: string } | { uri: string } | null {
-  const declaredMime =
-    typeof source.mimeType === "string" ? source.mimeType : undefined;
-  const data = typeof source.data === "string" ? source.data : undefined;
-  const uri = typeof source.uri === "string" ? source.uri : undefined;
+  const declaredMime = isString(source.mimeType) ? source.mimeType : undefined;
+  const data = isString(source.data) ? source.data : undefined;
+  const uri = isString(source.uri) ? source.uri : undefined;
 
   if (data) {
     if (data.startsWith("data:")) {
@@ -824,7 +832,7 @@ async function autoSaveAssets(
       queue.push(value);
       return;
     }
-    if (typeof value === "object") {
+    if (isRecord(value)) {
       for (const v of Object.values(value as Record<string, unknown>)) {
         collect(v);
       }
@@ -856,7 +864,7 @@ async function autoSaveAssets(
       );
     } else {
       bytes = decodeAssetBytes(assetValue.data);
-      if (!bytes && typeof assetValue.uri === "string") {
+      if (!bytes && isString(assetValue.uri)) {
         bytes = await readBytesFromUri(assetValue.uri as string);
       }
     }
@@ -867,7 +875,7 @@ async function autoSaveAssets(
       ? "image/png"
       : (assetValue.mime_type ?? assetValue.content_type);
     const contentType =
-      typeof explicitMime === "string" && explicitMime
+      isString(explicitMime) && explicitMime
         ? explicitMime
         : (ASSET_TYPE_MIME[assetType] ?? "application/octet-stream");
 
@@ -927,7 +935,7 @@ async function autoSaveAssets(
   const textKey = opts.textOutputName;
   if (textKey) {
     const textVal = result[textKey];
-    if (typeof textVal === "string" && textVal.length > 0) {
+    if (isNonEmptyString(textVal)) {
       savedText = true;
       const bytes = new TextEncoder().encode(textVal);
       const previewText = new TextDecoder().decode(
@@ -1561,7 +1569,7 @@ export function buildChatAgentSystemPrompt(
   workflowId?: string | null
 ): string {
   const extra =
-    typeof extraSystemPrompt === "string" && extraSystemPrompt.trim()
+    isString(extraSystemPrompt) && extraSystemPrompt.trim()
       ? `\n\n${extraSystemPrompt.trim()}\n`
       : "";
   const uiBlock = formatUiContext(uiContext);
@@ -1885,7 +1893,7 @@ interface ActiveJob {
 /** Highest `job_seq` a resubscribing client claims to already hold. */
 function resumeLastSeq(data: Record<string, unknown>): number {
   const raw = data["last_seq"];
-  return typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? raw : 0;
+  return isFiniteNumber(raw) && raw > 0 ? raw : 0;
 }
 
 function createRelayActivityWaiter(
@@ -2296,10 +2304,10 @@ export class UnifiedWebSocketRunner {
    * Mirrors Python's _extract_query_text / _extract_objective / _extract_text_content.
    */
   private extractTextContent(content: unknown, fallback = ""): string {
-    if (typeof content === "string") return content;
+    if (isString(content)) return content;
     if (Array.isArray(content)) {
       const texts = (content as Array<Record<string, unknown>>)
-        .filter((c) => c.type === "text" && typeof c.text === "string")
+        .filter((c) => c.type === "text" && isString(c.text))
         .map((c) => c.text as string);
       return texts.length > 0 ? texts.join(" ") : fallback;
     }
@@ -2308,12 +2316,11 @@ export class UnifiedWebSocketRunner {
 
   private inferOutputType(value: unknown): string {
     if (value === null || value === undefined) return "any";
-    if (typeof value === "string") return "str";
-    if (typeof value === "number")
-      return Number.isInteger(value) ? "int" : "float";
-    if (typeof value === "boolean") return "bool";
+    if (isString(value)) return "str";
+    if (isNumber(value)) return Number.isInteger(value) ? "int" : "float";
+    if (isBoolean(value)) return "bool";
     if (Array.isArray(value)) return "list";
-    if (value && typeof value === "object") return "dict";
+    if (isObjectLike(value)) return "dict";
     return "any";
   }
 
@@ -2324,10 +2331,10 @@ export class UnifiedWebSocketRunner {
     let fallback: { id: string; name: string } | null = null;
     for (const raw of active.graph.nodes) {
       const node = raw as { id?: unknown; name?: unknown; type?: unknown };
-      const id = typeof node.id === "string" ? node.id : null;
+      const id = isString(node.id) ? node.id : null;
       if (!id) continue;
-      const name = typeof node.name === "string" ? node.name : id;
-      const type = typeof node.type === "string" ? node.type : "";
+      const name = isString(node.name) ? node.name : id;
+      const type = isString(node.type) ? node.type : "";
       if (name === outputKey || id === outputKey) return { id, name };
       if (type === "nodetool.output.Output" && !fallback)
         fallback = { id, name };
@@ -2460,7 +2467,7 @@ export class UnifiedWebSocketRunner {
     const result = await resultPromise;
     if (result.ok !== true) {
       throw new Error(
-        typeof result.error === "string" ? result.error : "Renderer tool failed"
+        isString(result.error) ? result.error : "Renderer tool failed"
       );
     }
     return {
@@ -2606,7 +2613,7 @@ export class UnifiedWebSocketRunner {
     if (value instanceof Uint8Array) return Array.from(value);
     if (value instanceof Date) return value.toISOString();
     if (Array.isArray(value)) return value.map((v) => this.serializeForJson(v));
-    if (value && typeof value === "object") {
+    if (isObjectLike(value)) {
       const out: { [key: string]: JsonSafeValue } = {};
       for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
         out[k] = this.serializeForJson(v);
@@ -2626,7 +2633,7 @@ export class UnifiedWebSocketRunner {
     if (
       session &&
       session.status === "running" &&
-      typeof message.thread_id === "string" &&
+      isString(message.thread_id) &&
       message.thread_id === session.threadId
     ) {
       session.emit(message);
@@ -2650,7 +2657,7 @@ export class UnifiedWebSocketRunner {
    * started, or one it adopted via `reconnect_job`.
    */
   private resolveJobSession(jobId: unknown): JobRunSession | null {
-    if (typeof jobId !== "string" || jobId.length === 0) return null;
+    if (!isNonEmptyString(jobId)) return null;
     const active = this.activeJobs.get(jobId);
     if (active?.runSession) return active.runSession;
     if (!this.adoptedJobIds.has(jobId)) return null;
@@ -2802,14 +2809,12 @@ export class UnifiedWebSocketRunner {
     if (event["type"] !== "tool_call_update") return;
     const toolCallId = event["tool_call_id"];
     const name = event["name"];
-    if (typeof toolCallId !== "string" || typeof name !== "string") return;
+    if (!isString(toolCallId) || !isString(name)) return;
     if (!toolCallId || !name) return;
-    const args =
-      event["args"] && typeof event["args"] === "object"
-        ? (event["args"] as Record<string, unknown>)
-        : {};
-    const message =
-      typeof event["message"] === "string" ? event["message"] : null;
+    const args = isObjectLike(event["args"])
+      ? (event["args"] as Record<string, unknown>)
+      : {};
+    const message = isString(event["message"]) ? event["message"] : null;
     await this.sendMessage({
       type: "message",
       role: "assistant",
@@ -3588,7 +3593,7 @@ export class UnifiedWebSocketRunner {
         if (!node.type.startsWith("nodetool.output.")) continue;
         const properties = node.properties as Record<string, unknown> | null;
         const publicName = properties?.name;
-        if (typeof publicName === "string" && publicName.trim().length > 0) {
+        if (isString(publicName) && publicName.trim().length > 0) {
           node.name = publicName;
         }
       }
@@ -3631,10 +3636,9 @@ export class UnifiedWebSocketRunner {
     // sub-workflow nodes (WorkflowNode) can create child runners.
     context.setResolveExecutor((node) => this.resolveExecutor(node));
     if (this.resolveNodeType) {
-      const resolverObj =
-        typeof this.resolveNodeType === "function"
-          ? { resolveNodeType: this.resolveNodeType }
-          : this.resolveNodeType;
+      const resolverObj = isFunctionValue(this.resolveNodeType)
+        ? { resolveNodeType: this.resolveNodeType }
+        : this.resolveNodeType;
       context.setResolveNodeType(
         (nodeType) =>
           resolverObj.resolveNodeType(nodeType) as Promise<{
@@ -4081,7 +4085,7 @@ export class UnifiedWebSocketRunner {
       ).nodes ?? [];
     const graphNodeMap = new Map<string, { id?: unknown; type?: unknown }>();
     for (const n of graphNodes) {
-      if (typeof n.id === "string") {
+      if (isString(n.id)) {
         graphNodeMap.set(n.id, n);
       }
     }
@@ -4099,10 +4103,7 @@ export class UnifiedWebSocketRunner {
         if (outbound.error != null) {
           outbound.error = formatSanitizedError(outbound.error);
         }
-        if (
-          outbound.type === "notification" &&
-          typeof outbound.content === "string"
-        ) {
+        if (outbound.type === "notification" && isString(outbound.content)) {
           outbound.content = sanitizeLargeText(outbound.content);
         }
         if (outbound.type === "node_update" && outbound.status === "error") {
@@ -4130,7 +4131,7 @@ export class UnifiedWebSocketRunner {
         ) {
           const nodeId = String(outbound.node_id ?? "");
           const node = graphNodeMap.get(nodeId);
-          const nodeType = typeof node?.type === "string" ? node.type : "";
+          const nodeType = isString(node?.type) ? node.type : "";
 
           // Skip constant and input nodes entirely
           if (
@@ -4196,7 +4197,7 @@ export class UnifiedWebSocketRunner {
                     const gi = (
                       a.metadata as { generation_index?: unknown } | null
                     )?.generation_index;
-                    if (typeof gi === "number") persistedIndices.add(gi);
+                    if (isNumber(gi)) persistedIndices.add(gi);
                   }
                 } catch (err) {
                   log.warn("generation replay-dedupe read failed", {
@@ -4724,7 +4725,7 @@ export class UnifiedWebSocketRunner {
     return {
       role,
       content: rawContent ?? "",
-      toolCallId: typeof m.tool_call_id === "string" ? m.tool_call_id : null,
+      toolCallId: isString(m.tool_call_id) ? m.tool_call_id : null,
       toolCalls: Array.isArray(m.tool_calls)
         ? (m.tool_calls as Array<{
             id: string;
@@ -4746,7 +4747,7 @@ export class UnifiedWebSocketRunner {
     const data = { ...messageData };
     delete data.id;
     delete data.type;
-    const threadId = typeof data.thread_id === "string" ? data.thread_id : "";
+    const threadId = isString(data.thread_id) ? data.thread_id : "";
     delete data.thread_id;
     const userId = this.userId ?? "1";
     delete data.user_id;
@@ -4782,7 +4783,7 @@ export class UnifiedWebSocketRunner {
       let bytes: Uint8Array | null = null;
       if (rawData instanceof Uint8Array) {
         bytes = rawData;
-      } else if (typeof rawData === "string" && rawData) {
+      } else if (isString(rawData) && rawData) {
         bytes = new Uint8Array(Buffer.from(rawData, "base64"));
       }
       if (!bytes) {
@@ -4790,8 +4791,7 @@ export class UnifiedWebSocketRunner {
         out.push({ ...block });
         continue;
       }
-      const mimeType =
-        typeof image.mimeType === "string" ? image.mimeType : "image/png";
+      const mimeType = isString(image.mimeType) ? image.mimeType : "image/png";
       const ext = IMAGE_MIME_TO_EXT[mimeType] ?? "png";
       // Per-block isolation: a storage failure must not abort the whole turn —
       // the image is already generated (and billed), and the assistant text
@@ -4855,7 +4855,7 @@ export class UnifiedWebSocketRunner {
     if (obj === null || obj === undefined) return obj;
 
     // Asset-like objects: { type: "image"|"audio"|"video"|..., uri?: string, data?: ... }
-    if (typeof obj === "object" && !Array.isArray(obj)) {
+    if (isRecord(obj)) {
       const record = obj as Record<string, unknown>;
 
       // Check if it's an asset-like object (has type + uri or data)
@@ -4936,11 +4936,7 @@ export class UnifiedWebSocketRunner {
     toolResult: unknown,
     ctx: ProcessingContext
   ): Promise<unknown> {
-    if (
-      !toolResult ||
-      typeof toolResult !== "object" ||
-      Array.isArray(toolResult)
-    ) {
+    if (!isRecord(toolResult)) {
       return toolResult;
     }
     const record = toolResult as Record<string, unknown>;
@@ -4958,7 +4954,7 @@ export class UnifiedWebSocketRunner {
       const handles: unknown[] = [];
       let stored = 0;
       for (const frame of record.frames) {
-        if (!frame || typeof frame !== "object") {
+        if (!isObjectLike(frame)) {
           handles.push(frame);
           continue;
         }
@@ -4983,7 +4979,7 @@ export class UnifiedWebSocketRunner {
     }
 
     // Single image_content blob → one image handle.
-    if (record.image_content && typeof record.image_content === "object") {
+    if (isObjectLike(record.image_content)) {
       const payload = extractEmbeddedImage(
         record.image_content as Record<string, unknown>
       );
@@ -4992,8 +4988,7 @@ export class UnifiedWebSocketRunner {
       delete out.image_content;
       if (id) {
         out.image_id = id;
-        const base =
-          typeof record.note === "string" ? record.note : "Captured an image.";
+        const base = isString(record.note) ? record.note : "Captured an image.";
         out.note = `${base} Saved as image asset "${id}". Call view_image({ image_id: "${id}" }) to inspect it.`;
       }
       return out;
@@ -5163,7 +5158,7 @@ export class UnifiedWebSocketRunner {
         return { decision: "approve" };
       }
       const feedback =
-        typeof response.feedback === "string" && response.feedback.trim()
+        isString(response.feedback) && response.feedback.trim()
           ? response.feedback.trim()
           : undefined;
       return { decision: "reject", feedback };
@@ -5251,10 +5246,9 @@ export class UnifiedWebSocketRunner {
     this.attachPlanApproval(context, threadId);
     context.setResolveExecutor((node) => this.resolveExecutor(node));
     if (this.resolveNodeType) {
-      const resolverObj =
-        typeof this.resolveNodeType === "function"
-          ? { resolveNodeType: this.resolveNodeType }
-          : this.resolveNodeType;
+      const resolverObj = isFunctionValue(this.resolveNodeType)
+        ? { resolveNodeType: this.resolveNodeType }
+        : this.resolveNodeType;
       context.setResolveNodeType(
         (type) =>
           resolverObj.resolveNodeType(type) as Promise<{
@@ -5332,10 +5326,11 @@ export class UnifiedWebSocketRunner {
     requestSeq?: number,
     signal?: AbortSignal
   ): Promise<void> {
-    const messageWorkflowId =
-      typeof data.workflow_id === "string" ? data.workflow_id : null;
+    const messageWorkflowId = isString(data.workflow_id)
+      ? data.workflow_id
+      : null;
     const threadId = await this.ensureThreadExists(
-      typeof data.thread_id === "string" ? data.thread_id : undefined,
+      isString(data.thread_id) ? data.thread_id : undefined,
       messageWorkflowId
     );
     data.thread_id = threadId;
@@ -5343,15 +5338,15 @@ export class UnifiedWebSocketRunner {
     // Route this turn takes: a workflow chatbot and a media generation carry
     // their own model selection (checked in their handlers), a plain chat turn
     // is served by the language model the composer picked.
-    const workflowTargetHint =
-      typeof data.workflow_target === "string" ? data.workflow_target : null;
-    const mediaModeHint =
-      data.media_generation && typeof data.media_generation === "object"
-        ? (data.media_generation as Record<string, unknown>).mode
-        : null;
+    const workflowTargetHint = isString(data.workflow_target)
+      ? data.workflow_target
+      : null;
+    const mediaModeHint = isObjectLike(data.media_generation)
+      ? (data.media_generation as Record<string, unknown>).mode
+      : null;
     const isPlainChatTurn =
       workflowTargetHint !== "workflow" &&
-      (typeof mediaModeHint !== "string" || mediaModeHint === "chat");
+      (!isString(mediaModeHint) || mediaModeHint === "chat");
 
     // A plain chat turn without a chosen model used to fall through to the
     // built-in default and die deep in provider resolution ("No provider
@@ -5396,8 +5391,9 @@ export class UnifiedWebSocketRunner {
     // it, and that ambient id must not hijack the turn into running the
     // workflow as a chatbot. Genuine workflow-chatbot runs set `workflow_target`
     // (and carry `workflow_id`/`graph` for the processor to load/execute).
-    const workflowTarget =
-      typeof data.workflow_target === "string" ? data.workflow_target : null;
+    const workflowTarget = isString(data.workflow_target)
+      ? data.workflow_target
+      : null;
     if (workflowTarget === "workflow") {
       await this.handleWorkflowMessage(data, requestSeq, signal);
       return;
@@ -5408,13 +5404,12 @@ export class UnifiedWebSocketRunner {
     // with mode + params; when mode is a media mode we invoke the provider's
     // textToImage / textToVideo instead of a regular LLM round and return an
     // assistant message containing MessageImageContent / MessageVideoContent.
-    const mediaGeneration =
-      data.media_generation && typeof data.media_generation === "object"
-        ? (data.media_generation as Record<string, unknown>)
-        : null;
+    const mediaGeneration = isObjectLike(data.media_generation)
+      ? (data.media_generation as Record<string, unknown>)
+      : null;
     if (
       mediaGeneration &&
-      typeof mediaGeneration.mode === "string" &&
+      isString(mediaGeneration.mode) &&
       mediaGeneration.mode !== "chat"
     ) {
       await this.handleMediaGenerationMessage(
@@ -5439,16 +5434,16 @@ export class UnifiedWebSocketRunner {
 
     // A surface can send a context-specific system-prompt addendum (e.g. the
     // App Builder's build-an-app-UI guidance), layered after the base prompt.
-    const extraSystemPrompt =
-      typeof data.system_prompt === "string" ? data.system_prompt : null;
+    const extraSystemPrompt = isString(data.system_prompt)
+      ? data.system_prompt
+      : null;
 
     // Which documents the user has open, and which one has focus. The `ui_*`
     // tools all require an explicit document id, so this is what makes them
     // usable — see `formatUiContext`.
-    const uiContext =
-      data.ui_context && typeof data.ui_context === "object"
-        ? (data.ui_context as UiContext)
-        : null;
+    const uiContext = isObjectLike(data.ui_context)
+      ? (data.ui_context as UiContext)
+      : null;
 
     // Long-term memory mines the whole conversation, so it needs the full
     // history; the resume fast path below is skipped when it is enabled.
@@ -5717,10 +5712,9 @@ export class UnifiedWebSocketRunner {
             : undefined;
       clientSchemas.push({
         name,
-        description:
-          typeof manifest.description === "string"
-            ? manifest.description
-            : undefined,
+        description: isString(manifest.description)
+          ? manifest.description
+          : undefined,
         inputSchema: schema
       });
     }
@@ -6049,9 +6043,7 @@ export class UnifiedWebSocketRunner {
       toolResult = await this.materializeToolResultImages(toolResult, ctx);
 
       const processed = await this.processToolResult(toolResult, ctx);
-      return typeof processed === "string"
-        ? processed
-        : JSON.stringify(processed);
+      return isString(processed) ? processed : JSON.stringify(processed);
     };
 
     // Late-bind the codeact bridge to the router above, and route
@@ -6108,7 +6100,7 @@ export class UnifiedWebSocketRunner {
         // native-image blocks. Raw image bytes are turned into real assets
         // here so base64 never lands in the DB or on the wire.
         let persistedContent: unknown = m.content ?? null;
-        if (typeof m.content === "string") {
+        if (isString(m.content)) {
           if (echo) content = m.content;
         } else if (Array.isArray(m.content)) {
           const materialized = await this.materializeAssistantImageContent(
@@ -6119,7 +6111,7 @@ export class UnifiedWebSocketRunner {
           persistedContent = materialized;
           if (echo) {
             content = materialized
-              .filter((c) => c.type === "text" && typeof c.text === "string")
+              .filter((c) => c.type === "text" && isString(c.text))
               .map((c) => c.text as string)
               .join("");
           }
@@ -6133,7 +6125,7 @@ export class UnifiedWebSocketRunner {
             }))
           : null;
         for (const tc of toolCalls ?? []) {
-          if (typeof tc.id !== "string") continue;
+          if (!isString(tc.id)) continue;
           openToolCalls.add(tc.id);
           toolNames.set(tc.id, tc.name);
         }
@@ -6160,10 +6152,10 @@ export class UnifiedWebSocketRunner {
       // in-flight provider message, never the DB).
       const toolContent = Array.isArray(m.content)
         ? this.toolResultDisplayText(m.content)
-        : typeof m.content === "string"
+        : isString(m.content)
           ? m.content
           : "";
-      if (typeof m.toolCallId === "string") openToolCalls.delete(m.toolCallId);
+      if (isString(m.toolCallId)) openToolCalls.delete(m.toolCallId);
       const toolMsgData = {
         type: "message",
         role: "tool",
@@ -6324,7 +6316,7 @@ export class UnifiedWebSocketRunner {
         }
       }
       // HTTP status errors — check for status code in error
-      else if (err && typeof err === "object" && "status" in err) {
+      else if (isObjectLike(err) && "status" in err) {
         const status = (err as { status: number }).status;
         errorType = "http_status_error";
         statusCode = status;
@@ -6335,13 +6327,9 @@ export class UnifiedWebSocketRunner {
           if ("body" in err || "response" in err) {
             const errObj = err as Record<string, unknown>;
             const body = errObj.body ?? errObj.response;
-            if (body && typeof body === "object" && "error" in body) {
+            if (isObjectLike(body) && "error" in body) {
               const errorDetail = body.error;
-              if (
-                typeof errorDetail === "object" &&
-                errorDetail &&
-                "message" in errorDetail
-              ) {
+              if (isObjectLike(errorDetail) && "message" in errorDetail) {
                 bodyMsg = String(errorDetail.message);
               }
             }
@@ -6461,7 +6449,7 @@ export class UnifiedWebSocketRunner {
       active.workflowId
     );
     const amount = (providerCost as { amount?: unknown }).amount;
-    if (typeof amount === "number" && Number.isFinite(amount)) {
+    if (isFiniteNumber(amount)) {
       active.providerCostTotal = (active.providerCostTotal ?? 0) + amount;
     } else {
       // A non-finite amount (NaN/Infinity from a buggy provider call) can't
@@ -6484,7 +6472,7 @@ export class UnifiedWebSocketRunner {
     nodeType: string,
     workflowId: string | null
   ): Promise<void> {
-    if (typeof cost.amount !== "number" || !Number.isFinite(cost.amount)) {
+    if (!isFiniteNumber(cost.amount)) {
       return;
     }
     try {
@@ -6623,12 +6611,11 @@ export class UnifiedWebSocketRunner {
     let messagesName: string | null = null;
 
     for (const node of graph.nodes) {
-      const nodeType = typeof node.type === "string" ? node.type : "";
-      const data =
-        typeof node.data === "object" && node.data !== null
-          ? (node.data as Record<string, unknown>)
-          : {};
-      const nodeName = typeof data.name === "string" ? data.name.trim() : "";
+      const nodeType = isString(node.type) ? node.type : "";
+      const data = isObjectLike(node.data)
+        ? (node.data as Record<string, unknown>)
+        : {};
+      const nodeName = isString(data.name) ? data.name.trim() : "";
       if (!nodeName) continue;
 
       if (
@@ -6668,13 +6655,13 @@ export class UnifiedWebSocketRunner {
     for (const [, value] of Object.entries(result)) {
       if (value === null || value === undefined) continue;
 
-      if (typeof value === "string") {
+      if (isString(value)) {
         content.push({ type: "text", text: value });
       } else if (Array.isArray(value)) {
         content.push({ type: "text", text: value.map(String).join(" ") });
-      } else if (typeof value === "object") {
+      } else if (isRecord(value)) {
         const obj = value as Record<string, unknown>;
-        const assetType = typeof obj.type === "string" ? obj.type : "";
+        const assetType = isString(obj.type) ? obj.type : "";
         if (assetType === "image") {
           content.push({
             type: "image",
@@ -6737,9 +6724,8 @@ export class UnifiedWebSocketRunner {
     requestSeq?: number,
     signal?: AbortSignal
   ): Promise<void> {
-    const threadId = typeof data.thread_id === "string" ? data.thread_id : "";
-    const workflowId =
-      typeof data.workflow_id === "string" ? data.workflow_id : null;
+    const threadId = isString(data.thread_id) ? data.thread_id : "";
+    const workflowId = isString(data.workflow_id) ? data.workflow_id : null;
     const userId = this.userId ?? "1";
     const mode = String(mediaGeneration.mode ?? "");
     // The media composer's own selection first; a client without a separate
@@ -6839,14 +6825,12 @@ export class UnifiedWebSocketRunner {
           1,
           Math.min(Number(mediaGeneration.variations ?? 1), 8)
         );
-        const width =
-          typeof mediaGeneration.width === "number"
-            ? mediaGeneration.width
-            : undefined;
-        const height =
-          typeof mediaGeneration.height === "number"
-            ? mediaGeneration.height
-            : undefined;
+        const width = isNumber(mediaGeneration.width)
+          ? mediaGeneration.width
+          : undefined;
+        const height = isNumber(mediaGeneration.height)
+          ? mediaGeneration.height
+          : undefined;
         const imageModel: ProviderImageModel = {
           id: modelId,
           name: modelId,
@@ -6910,18 +6894,15 @@ export class UnifiedWebSocketRunner {
       }
 
       if (mode === "video") {
-        const aspectRatio =
-          typeof mediaGeneration.aspect_ratio === "string"
-            ? (mediaGeneration.aspect_ratio as string)
-            : null;
-        const resolution =
-          typeof mediaGeneration.resolution === "string"
-            ? (mediaGeneration.resolution as string)
-            : null;
-        const duration =
-          typeof mediaGeneration.duration === "number"
-            ? (mediaGeneration.duration as number)
-            : null;
+        const aspectRatio = isString(mediaGeneration.aspect_ratio)
+          ? (mediaGeneration.aspect_ratio as string)
+          : null;
+        const resolution = isString(mediaGeneration.resolution)
+          ? (mediaGeneration.resolution as string)
+          : null;
+        const duration = isNumber(mediaGeneration.duration)
+          ? (mediaGeneration.duration as number)
+          : null;
         const videoModel: ProviderVideoModel = {
           id: modelId,
           name: modelId,
@@ -7007,18 +6988,15 @@ export class UnifiedWebSocketRunner {
       }
 
       if (mode === "audio") {
-        const voice =
-          typeof mediaGeneration.voice === "string"
-            ? (mediaGeneration.voice as string)
-            : undefined;
-        const speed =
-          typeof mediaGeneration.speed === "number"
-            ? (mediaGeneration.speed as number)
-            : 1.0;
-        const requestedFormatRaw =
-          typeof mediaGeneration.audio_format === "string"
-            ? (mediaGeneration.audio_format as string).toLowerCase()
-            : null;
+        const voice = isString(mediaGeneration.voice)
+          ? (mediaGeneration.voice as string)
+          : undefined;
+        const speed = isNumber(mediaGeneration.speed)
+          ? (mediaGeneration.speed as number)
+          : 1.0;
+        const requestedFormatRaw = isString(mediaGeneration.audio_format)
+          ? (mediaGeneration.audio_format as string).toLowerCase()
+          : null;
         const supportedFormats = new Set([
           "mp3",
           "wav",
@@ -7236,22 +7214,20 @@ export class UnifiedWebSocketRunner {
             1,
             Math.min(Number(mediaGeneration.variations ?? 1), 8)
           );
-          const targetWidth =
-            typeof mediaGeneration.width === "number"
-              ? (mediaGeneration.width as number)
-              : undefined;
-          const targetHeight =
-            typeof mediaGeneration.height === "number"
-              ? (mediaGeneration.height as number)
-              : undefined;
-          const strength =
-            typeof mediaGeneration.strength === "number"
-              ? (mediaGeneration.strength as number)
-              : undefined;
-          const numInferenceSteps =
-            typeof mediaGeneration.num_inference_steps === "number"
-              ? (mediaGeneration.num_inference_steps as number)
-              : undefined;
+          const targetWidth = isNumber(mediaGeneration.width)
+            ? (mediaGeneration.width as number)
+            : undefined;
+          const targetHeight = isNumber(mediaGeneration.height)
+            ? (mediaGeneration.height as number)
+            : undefined;
+          const strength = isNumber(mediaGeneration.strength)
+            ? (mediaGeneration.strength as number)
+            : undefined;
+          const numInferenceSteps = isNumber(
+            mediaGeneration.num_inference_steps
+          )
+            ? (mediaGeneration.num_inference_steps as number)
+            : undefined;
           const editModel: ProviderImageModel = {
             id: modelId,
             name: modelId,
@@ -7312,22 +7288,18 @@ export class UnifiedWebSocketRunner {
         }
 
         // image_to_video
-        const aspectRatio =
-          typeof mediaGeneration.aspect_ratio === "string"
-            ? (mediaGeneration.aspect_ratio as string)
-            : null;
-        const resolution =
-          typeof mediaGeneration.resolution === "string"
-            ? (mediaGeneration.resolution as string)
-            : null;
-        const duration =
-          typeof mediaGeneration.duration === "number"
-            ? (mediaGeneration.duration as number)
-            : null;
-        const numInferenceSteps =
-          typeof mediaGeneration.num_inference_steps === "number"
-            ? (mediaGeneration.num_inference_steps as number)
-            : null;
+        const aspectRatio = isString(mediaGeneration.aspect_ratio)
+          ? (mediaGeneration.aspect_ratio as string)
+          : null;
+        const resolution = isString(mediaGeneration.resolution)
+          ? (mediaGeneration.resolution as string)
+          : null;
+        const duration = isNumber(mediaGeneration.duration)
+          ? (mediaGeneration.duration as number)
+          : null;
+        const numInferenceSteps = isNumber(mediaGeneration.num_inference_steps)
+          ? (mediaGeneration.num_inference_steps as number)
+          : null;
         const i2vModel: ProviderVideoModel = {
           id: modelId,
           name: modelId,
@@ -7431,10 +7403,9 @@ export class UnifiedWebSocketRunner {
       }
     };
 
-    const explicitId =
-      typeof mediaGeneration.source_asset_id === "string"
-        ? (mediaGeneration.source_asset_id as string)
-        : null;
+    const explicitId = isString(mediaGeneration.source_asset_id)
+      ? (mediaGeneration.source_asset_id as string)
+      : null;
     if (explicitId) {
       const fromAsset = await tryLoadAsset(explicitId);
       if (fromAsset && fromAsset.length > 0) return fromAsset;
@@ -7443,20 +7414,18 @@ export class UnifiedWebSocketRunner {
     const content = data.content;
     if (Array.isArray(content)) {
       for (const c of content) {
-        if (!c || typeof c !== "object") continue;
+        if (!isObjectLike(c)) continue;
         const block = c as Record<string, unknown>;
         if (block.type !== "image_url") continue;
         const image = (block.image ?? {}) as Record<string, unknown>;
-        const assetId =
-          typeof image.asset_id === "string"
-            ? (image.asset_id as string)
-            : null;
+        const assetId = isString(image.asset_id)
+          ? (image.asset_id as string)
+          : null;
         if (assetId) {
           const bytes = await tryLoadAsset(assetId);
           if (bytes && bytes.length > 0) return bytes;
         }
-        const uri =
-          typeof image.uri === "string" ? (image.uri as string) : null;
+        const uri = isString(image.uri) ? (image.uri as string) : null;
         if (uri) {
           if (uri.startsWith("asset://")) {
             // `@`-mentioned or library-dragged asset: `asset://<id>.<ext>`.
@@ -7497,8 +7466,7 @@ export class UnifiedWebSocketRunner {
             }
           }
         }
-        const data64 =
-          typeof image.data === "string" ? (image.data as string) : null;
+        const data64 = isString(image.data) ? (image.data as string) : null;
         if (data64) {
           try {
             return new Uint8Array(Buffer.from(data64, "base64"));
@@ -7516,13 +7484,12 @@ export class UnifiedWebSocketRunner {
     requestSeq?: number,
     signal?: AbortSignal
   ): Promise<void> {
-    const threadId = typeof data.thread_id === "string" ? data.thread_id : "";
-    const workflowId =
-      typeof data.workflow_id === "string" ? data.workflow_id : null;
-    const providerId =
-      typeof data.provider === "string" ? data.provider : this.defaultProvider;
-    const model =
-      typeof data.model === "string" ? data.model : this.defaultModel;
+    const threadId = isString(data.thread_id) ? data.thread_id : "";
+    const workflowId = isString(data.workflow_id) ? data.workflow_id : null;
+    const providerId = isString(data.provider)
+      ? data.provider
+      : this.defaultProvider;
+    const model = isString(data.model) ? data.model : this.defaultModel;
     const userId = this.userId ?? "1";
     const jobId = randomUUID();
 
@@ -7558,13 +7525,13 @@ export class UnifiedWebSocketRunner {
         await this.beforeRunJob(graph);
       }
       const messageInputName =
-        (typeof data.workflow_message_input_name === "string"
+        (isString(data.workflow_message_input_name)
           ? data.workflow_message_input_name
           : null) ??
         messageName ??
         "message";
       const messagesInputName =
-        (typeof data.workflow_messages_input_name === "string"
+        (isString(data.workflow_messages_input_name)
           ? data.workflow_messages_input_name
           : null) ??
         messagesName ??
@@ -7581,7 +7548,7 @@ export class UnifiedWebSocketRunner {
 
       // Serialize current message
       const currentMessage = {
-        role: typeof data.role === "string" ? data.role : "user",
+        role: isString(data.role) ? data.role : "user",
         content: data.content,
         thread_id: threadId,
         workflow_id: workflowId,
@@ -7594,7 +7561,7 @@ export class UnifiedWebSocketRunner {
         [messageInputName]: currentMessage,
         [messagesInputName]: [...chatHistorySerialized, currentMessage]
       };
-      if (typeof data.params === "object" && data.params !== null) {
+      if (isObjectLike(data.params)) {
         Object.assign(params, data.params as Record<string, unknown>);
       }
 
@@ -7626,10 +7593,9 @@ export class UnifiedWebSocketRunner {
       // Expose executor/node-type resolution for sub-workflow nodes
       context.setResolveExecutor((node) => this.resolveExecutor(node));
       if (this.resolveNodeType) {
-        const resolverObj =
-          typeof this.resolveNodeType === "function"
-            ? { resolveNodeType: this.resolveNodeType }
-            : this.resolveNodeType;
+        const resolverObj = isFunctionValue(this.resolveNodeType)
+          ? { resolveNodeType: this.resolveNodeType }
+          : this.resolveNodeType;
         context.setResolveNodeType(
           (nodeType) =>
             resolverObj.resolveNodeType(nodeType) as Promise<{
@@ -7732,7 +7698,7 @@ export class UnifiedWebSocketRunner {
       const graphNodes = graph.nodes ?? [];
       for (const n of graphNodes) {
         if (n.id) {
-          nodeTypes.set(String(n.id), typeof n.type === "string" ? n.type : "");
+          nodeTypes.set(String(n.id), isString(n.type) ? n.type : "");
         }
       }
 
@@ -7799,10 +7765,9 @@ export class UnifiedWebSocketRunner {
             // Capture output_update values for the response message
             if (outbound.type === "output_update") {
               if (nodeType.includes("Output")) {
-                const nodeName =
-                  typeof outbound.node_name === "string"
-                    ? outbound.node_name
-                    : nodeType;
+                const nodeName = isString(outbound.node_name)
+                  ? outbound.node_name
+                  : nodeType;
                 result[nodeName] = outbound.value;
               } else {
                 continue; // Skip non-output node output_updates
@@ -7970,10 +7935,10 @@ export class UnifiedWebSocketRunner {
     requestSeq: number,
     signal?: AbortSignal
   ): Promise<void> {
-    const providerId =
-      typeof data.provider === "string" ? data.provider : this.defaultProvider;
-    const model =
-      typeof data.model === "string" ? data.model : this.defaultModel;
+    const providerId = isString(data.provider)
+      ? data.provider
+      : this.defaultProvider;
+    const model = isString(data.model) ? data.model : this.defaultModel;
     const rawMessages = Array.isArray(data.messages) ? data.messages : [];
     log.debug("Inference request", {
       model,
@@ -7984,16 +7949,15 @@ export class UnifiedWebSocketRunner {
     const messages: ProviderMessage[] = rawMessages.map((m) => {
       const msg = m as Record<string, unknown>;
       return {
-        role: (typeof msg.role === "string"
+        role: (isString(msg.role)
           ? msg.role
           : "user") as ProviderMessage["role"],
-        content:
-          typeof msg.content === "string"
-            ? msg.content
-            : Array.isArray(msg.content)
-              ? (msg.content as MessageContent[])
-              : "",
-        toolCallId: typeof msg.toolCallId === "string" ? msg.toolCallId : null,
+        content: isString(msg.content)
+          ? msg.content
+          : Array.isArray(msg.content)
+            ? (msg.content as MessageContent[])
+            : "",
+        toolCallId: isString(msg.toolCallId) ? msg.toolCallId : null,
         toolCalls: Array.isArray(msg.toolCalls)
           ? (msg.toolCalls as Array<{
               id: string;
@@ -8018,9 +7982,10 @@ export class UnifiedWebSocketRunner {
       .map((t) => {
         const tool = t as Record<string, unknown>;
         return {
-          name: typeof tool.name === "string" ? tool.name : "",
-          description:
-            typeof tool.description === "string" ? tool.description : undefined,
+          name: isString(tool.name) ? tool.name : "",
+          description: isString(tool.description)
+            ? tool.description
+            : undefined,
           inputSchema:
             typeof tool.inputSchema === "object"
               ? (tool.inputSchema as Record<string, unknown>)
@@ -8510,7 +8475,7 @@ export class UnifiedWebSocketRunner {
     fn: () => Promise<TResult>
   ): Promise<Record<string, unknown> | null> {
     const requestId = command.request_id;
-    if (typeof requestId !== "string" || requestId.length === 0) {
+    if (!isNonEmptyString(requestId)) {
       return { error: "request_id is required for RPC commands" };
     }
     try {
@@ -8584,9 +8549,10 @@ export class UnifiedWebSocketRunner {
     command: WebSocketCommandEnvelope
   ): Promise<Record<string, unknown> | null> {
     const data = command.data ?? {};
-    const jobId = typeof data.job_id === "string" ? data.job_id : undefined;
-    const workflowId =
-      typeof data.workflow_id === "string" ? data.workflow_id : undefined;
+    const jobId = isString(data.job_id) ? data.job_id : undefined;
+    const workflowId = isString(data.workflow_id)
+      ? data.workflow_id
+      : undefined;
     log.debug("Command", { command: command.command });
 
     switch (command.command as UnifiedCommandType) {
@@ -8638,11 +8604,10 @@ export class UnifiedWebSocketRunner {
             activeJobIds: [...this.activeJobs.keys()]
           });
           if (!target) return { error: "No active job/context" };
-          const inputName = typeof data.input === "string" ? data.input : "";
+          const inputName = isString(data.input) ? data.input : "";
           if (!inputName.trim()) return { error: "Invalid input name" };
           const value = data.value;
-          const handle =
-            typeof data.handle === "string" ? data.handle : undefined;
+          const handle = isString(data.handle) ? data.handle : undefined;
           try {
             await target.hooks.pushInput(inputName, value, handle);
             return {
@@ -8666,10 +8631,9 @@ export class UnifiedWebSocketRunner {
         {
           const target = this.resolveJobControl(jobId);
           if (!target) return { error: "No active job/context" };
-          const inputName = typeof data.input === "string" ? data.input : "";
+          const inputName = isString(data.input) ? data.input : "";
           if (!inputName.trim()) return { error: "Invalid input name" };
-          const handle =
-            typeof data.handle === "string" ? data.handle : undefined;
+          const handle = isString(data.handle) ? data.handle : undefined;
           try {
             target.hooks.finishInputStream(inputName, handle);
             return {
@@ -8695,10 +8659,10 @@ export class UnifiedWebSocketRunner {
         if (!jobId) return { error: "job_id is required" };
         const nodeId = data.node_id;
         const properties = data.properties;
-        if (typeof nodeId !== "string" || nodeId.length === 0) {
+        if (!isNonEmptyString(nodeId)) {
           return { error: "node_id is required" };
         }
-        if (properties === null || typeof properties !== "object") {
+        if (!isObjectLike(properties)) {
           return { error: "properties must be an object" };
         }
         const target = this.resolveJobControl(jobId);
@@ -8721,7 +8685,7 @@ export class UnifiedWebSocketRunner {
       }
       case "chat_message": {
         const threadId = data.thread_id;
-        if (typeof threadId !== "string" || threadId.length === 0) {
+        if (!isNonEmptyString(threadId)) {
           return { error: "thread_id is required for chat_message command" };
         }
         const { seq, signal, controller } = this.beginChatTurn();
@@ -8778,15 +8742,11 @@ export class UnifiedWebSocketRunner {
         return { message: "Chat turns listed", count: sessions.length };
       }
       case "resume_chat": {
-        const threadId =
-          typeof data.thread_id === "string" ? data.thread_id : "";
+        const threadId = isString(data.thread_id) ? data.thread_id : "";
         if (!threadId) {
           return { error: "thread_id is required for resume_chat command" };
         }
-        const lastSeq =
-          typeof data.last_seq === "number" && Number.isFinite(data.last_seq)
-            ? data.last_seq
-            : 0;
+        const lastSeq = isFiniteNumber(data.last_seq) ? data.last_seq : 0;
         const session = chatTurnRegistry.get(this.userId ?? "1", threadId);
         if (!session) {
           // Nothing to replay: no turn ran here, or retention elapsed. The
@@ -8848,8 +8808,7 @@ export class UnifiedWebSocketRunner {
         return { message: "Inference started" };
       }
       case "stop": {
-        const threadId =
-          typeof data.thread_id === "string" ? data.thread_id : undefined;
+        const threadId = isString(data.thread_id) ? data.thread_id : undefined;
         // Always increment seq to cancel any in-progress chat or inference
         this.chatRequestSeq += 1;
         // …and abort it for real. The seq bump alone only discards output at
@@ -8987,46 +8946,36 @@ export class UnifiedWebSocketRunner {
         const provider = String(data.provider ?? this.defaultProvider);
         const model = String(data.model ?? this.defaultModel);
         const prompt = String(data.prompt ?? "");
-        const sourceAssetId =
-          typeof data.source_asset_id === "string"
-            ? (data.source_asset_id as string)
-            : undefined;
-        const maskAssetId =
-          typeof data.mask_asset_id === "string"
-            ? (data.mask_asset_id as string)
-            : undefined;
-        const width =
-          typeof data.width === "number" ? (data.width as number) : undefined;
-        const height =
-          typeof data.height === "number" ? (data.height as number) : undefined;
-        const aspectRatio =
-          typeof data.aspect_ratio === "string"
-            ? (data.aspect_ratio as string)
-            : undefined;
-        const resolution =
-          typeof data.resolution === "string"
-            ? (data.resolution as string)
-            : undefined;
-        const strength =
-          typeof data.strength === "number"
-            ? (data.strength as number)
-            : undefined;
-        const numInferenceSteps =
-          typeof data.num_inference_steps === "number"
-            ? (data.num_inference_steps as number)
-            : undefined;
-        const variations =
-          typeof data.variations === "number"
-            ? (data.variations as number)
-            : undefined;
-        const voice =
-          typeof data.voice === "string" ? (data.voice as string) : undefined;
-        const speed =
-          typeof data.speed === "number" ? (data.speed as number) : undefined;
-        const audioFormat =
-          typeof data.audio_format === "string"
-            ? (data.audio_format as string)
-            : undefined;
+        const sourceAssetId = isString(data.source_asset_id)
+          ? (data.source_asset_id as string)
+          : undefined;
+        const maskAssetId = isString(data.mask_asset_id)
+          ? (data.mask_asset_id as string)
+          : undefined;
+        const width = isNumber(data.width) ? (data.width as number) : undefined;
+        const height = isNumber(data.height)
+          ? (data.height as number)
+          : undefined;
+        const aspectRatio = isString(data.aspect_ratio)
+          ? (data.aspect_ratio as string)
+          : undefined;
+        const resolution = isString(data.resolution)
+          ? (data.resolution as string)
+          : undefined;
+        const strength = isNumber(data.strength)
+          ? (data.strength as number)
+          : undefined;
+        const numInferenceSteps = isNumber(data.num_inference_steps)
+          ? (data.num_inference_steps as number)
+          : undefined;
+        const variations = isNumber(data.variations)
+          ? (data.variations as number)
+          : undefined;
+        const voice = isString(data.voice) ? (data.voice as string) : undefined;
+        const speed = isNumber(data.speed) ? (data.speed as number) : undefined;
+        const audioFormat = isString(data.audio_format)
+          ? (data.audio_format as string)
+          : undefined;
         return this.runRpc(command, () =>
           this.runDirectMediaGeneration({
             mode,
@@ -9051,12 +9000,12 @@ export class UnifiedWebSocketRunner {
       case "transcribe_audio": {
         const provider = String(data.provider ?? this.defaultProvider);
         const model = String(data.model ?? this.defaultModel);
-        const assetId =
-          typeof data.asset_id === "string" ? (data.asset_id as string) : "";
-        const language =
-          typeof data.language === "string"
-            ? (data.language as string)
-            : undefined;
+        const assetId = isString(data.asset_id)
+          ? (data.asset_id as string)
+          : "";
+        const language = isString(data.language)
+          ? (data.language as string)
+          : undefined;
         return this.runRpc(command, () =>
           this.runDirectTranscription({ provider, model, assetId, language })
         );
@@ -9147,7 +9096,7 @@ export class UnifiedWebSocketRunner {
       "updated_at"
     ] as const) {
       const value = data[field];
-      if (typeof value === "string" && value.length > 0) {
+      if (isNonEmptyString(value)) {
         resource[field] = value;
       }
     }
@@ -9212,7 +9161,7 @@ export class UnifiedWebSocketRunner {
       }
       if (data === null) break;
 
-      const msgType = typeof data.type === "string" ? data.type : null;
+      const msgType = isString(data.type) ? data.type : null;
       if (msgType !== null && msgType in controlMessageInSchemas) {
         const schema = controlMessageInSchemas[msgType as ControlMessageInType];
         const parsed = schema.safeParse(data);
@@ -9243,9 +9192,8 @@ export class UnifiedWebSocketRunner {
         this.clientToolsManifest = {};
         for (const tool of tools) {
           if (
-            tool &&
-            typeof tool === "object" &&
-            typeof (tool as Record<string, unknown>).name === "string"
+            isObjectLike(tool) &&
+            isString((tool as Record<string, unknown>).name)
           ) {
             const name = (tool as Record<string, unknown>).name as string;
             this.clientToolsManifest[name] = tool as Record<string, unknown>;
@@ -9259,10 +9207,10 @@ export class UnifiedWebSocketRunner {
       }
 
       if (msgType === "renderer_tool_result") {
-        const rendererId =
-          typeof data.renderer_id === "string" ? data.renderer_id : null;
-        const toolCallId =
-          typeof data.tool_call_id === "string" ? data.tool_call_id : null;
+        const rendererId = isString(data.renderer_id) ? data.renderer_id : null;
+        const toolCallId = isString(data.tool_call_id)
+          ? data.tool_call_id
+          : null;
         if (
           rendererId &&
           toolCallId &&
@@ -9275,8 +9223,9 @@ export class UnifiedWebSocketRunner {
       }
 
       if (msgType === "tool_result") {
-        const toolCallId =
-          typeof data.tool_call_id === "string" ? data.tool_call_id : null;
+        const toolCallId = isString(data.tool_call_id)
+          ? data.tool_call_id
+          : null;
         if (toolCallId) {
           this.toolBridge.resolveResult(toolCallId, data);
           // The waiter may live on the runner executing an adopted turn.
@@ -9289,8 +9238,7 @@ export class UnifiedWebSocketRunner {
       }
 
       if (msgType === "tool_approval_response") {
-        const approvalId =
-          typeof data.approval_id === "string" ? data.approval_id : null;
+        const approvalId = isString(data.approval_id) ? data.approval_id : null;
         if (approvalId) {
           this.approvalBridge.resolveResult(approvalId, data);
           for (const session of this.adoptedSessions.values()) {
@@ -9301,8 +9249,7 @@ export class UnifiedWebSocketRunner {
       }
 
       if (msgType === "plan_approval_response") {
-        const approvalId =
-          typeof data.approval_id === "string" ? data.approval_id : null;
+        const approvalId = isString(data.approval_id) ? data.approval_id : null;
         if (approvalId) {
           this.approvalBridge.resolveResult(approvalId, data);
           for (const session of this.adoptedSessions.values()) {
@@ -9321,7 +9268,7 @@ export class UnifiedWebSocketRunner {
         continue;
       }
 
-      if (typeof data.command === "string") {
+      if (isString(data.command)) {
         const envelopeParsed = webSocketCommandEnvelopeSchema.safeParse(data);
         if (!envelopeParsed.success) {
           await this.sendMessage({

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -882,7 +882,7 @@ async function autoSaveAssets(
       parent_id: null
     });
     const mediaMeta: Record<string, unknown> = { ...promptMeta };
-    if (typeof opts.generationIndex === "number") {
+    if (opts.generationIndex != null) {
       mediaMeta.generation_index = opts.generationIndex;
     }
     if (Object.keys(mediaMeta).length > 0) {
@@ -943,7 +943,7 @@ async function autoSaveAssets(
         parent_id: null
       });
       asset.metadata =
-        typeof opts.generationIndex === "number"
+        opts.generationIndex != null
           ? { text: previewText, generation_index: opts.generationIndex }
           : { text: previewText };
       const fileName = `${asset.id}.txt`;
@@ -1009,7 +1009,7 @@ async function autoSaveAssets(
         if (inline !== undefined) {
           metadata.json = inline;
         }
-        if (typeof opts.generationIndex === "number") {
+        if (opts.generationIndex != null) {
           metadata.generation_index = opts.generationIndex;
         }
         asset.metadata = metadata;

--- a/web/src/components/node/OutputRenderer.tsx
+++ b/web/src/components/node/OutputRenderer.tsx
@@ -46,8 +46,16 @@ import {
   getSketchId,
   resolveSketchDocument,
   getTimelineId,
-  resolveTimelineSequence
+  resolveTimelineSequence,
+  isRecord,
+  isStoredUri
 } from "./outputValueResolvers";
+import {
+  isBoolean,
+  isNonEmptyString,
+  isNumber,
+  isString
+} from "../../utils/typePredicates";
 import SketchRenderer from "../sketch/SketchRenderer";
 
 /** In-flight raw straight-alpha RGBA image format (see protocol RAW_RGBA_MIME). */
@@ -199,10 +207,10 @@ const stableKeyForOutputValue = (v: unknown): string => {
   if (v === undefined) {
     return "undefined";
   }
-  if (typeof v === "string") {
+  if (isString(v)) {
     return `str:${hashStringBounded(v)}`;
   }
-  if (typeof v === "number" || typeof v === "boolean" || typeof v === "bigint") {
+  if (isNumber(v) || isBoolean(v) || typeof v === "bigint") {
     return `${typeof v}:${String(v)}`;
   }
   if (v instanceof Uint8Array) {
@@ -211,22 +219,22 @@ const stableKeyForOutputValue = (v: unknown): string => {
   if (Array.isArray(v)) {
     return `arr:${hashBytesBounded(v)}`;
   }
-  if (typeof v === "object") {
-    const obj = v as Record<string, unknown>;
+  if (isRecord(v)) {
+    const obj = v;
     const id = obj.id;
-    if (typeof id === "string" || typeof id === "number") {
+    if (isString(id) || isNumber(id)) {
       return `id:${String(id)}`;
     }
     const uri = obj.uri;
-    if (typeof uri === "string" && uri) {
+    if (isNonEmptyString(uri)) {
       return `uri:${uri}`;
     }
     const type = obj.type;
     const name = obj.name;
-    if (typeof type === "string" && typeof name === "string") {
+    if (isString(type) && isString(name)) {
       return `type-name:${type}:${name}`;
     }
-    if (typeof type === "string") {
+    if (isString(type)) {
       return `type:${type}:${hashStringBounded(
         JSON.stringify(Object.keys(obj).slice(0, 50))
       )}`;
@@ -251,7 +259,7 @@ const concatTextChunksSafely = (
     if (!c) {
       continue;
     }
-    const piece = typeof c.content === "string" ? c.content : "";
+    const piece = isString(c.content) ? c.content : "";
     if (!piece) {
       used++;
       continue;
@@ -382,9 +390,9 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
   const shouldRender = !(
     value === undefined ||
     value === null ||
-    (typeof value === "string" && value.trim() === "") ||
+    (isString(value) && value.trim() === "") ||
     (Array.isArray(value) && value.length === 0) ||
-    (typeof value === "object" &&
+    (isRecord(value) &&
       !Array.isArray(value) &&
       Object.keys(value).length === 0)
   );
@@ -453,9 +461,9 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
       bytes = data;
     } else if (Array.isArray(data)) {
       bytes = new Uint8Array(data);
-    } else if (data && typeof data === "object") {
+    } else if (isRecord(data)) {
       const numericEntries = Object.entries(data)
-        .filter(([k, v]) => /^\d+$/.test(k) && typeof v === "number")
+        .filter(([k, v]) => /^\d+$/.test(k) && isNumber(v))
         .sort((a, b) => Number(a[0]) - Number(b[0]));
       if (numericEntries.length > 0) {
         bytes = new Uint8Array(numericEntries.map(([, v]) => Number(v)));
@@ -512,9 +520,9 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
   // Extract the primary URI from the current value for signing.
   // memory:// URIs are excluded — they're in-memory only and never stored.
   const valueUri = useMemo(() => {
-    if (!value || typeof value !== "object") return undefined;
-    const v = value as Record<string, unknown>;
-    if (typeof v.uri === "string" && v.uri && !v.uri.startsWith("memory://")) return v.uri;
+    if (!isRecord(value)) return undefined;
+    const v = value;
+    if (isStoredUri(v.uri)) return v.uri;
     return undefined;
   }, [value]);
   const signedValueUrl = useSignedUrl(valueUri);
@@ -548,8 +556,8 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
           if (
             v.mimeType === RAW_RGBA_MIME &&
             v.data instanceof Uint8Array &&
-            typeof v.width === "number" &&
-            typeof v.height === "number"
+            isNumber(v.width) &&
+            isNumber(v.height)
           ) {
             // Raw RGBA can't be decoded by <img>; encode to a PNG data URL.
             imageSource = rawRgbaToPngDataUrl(
@@ -557,13 +565,13 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
               v.width,
               v.height
             );
-          } else if (typeof v.uri === "string" && v.uri !== "" && !v.uri.startsWith("memory://")) {
+          } else if (isStoredUri(v.uri)) {
             imageSource = signedValueUrl;
           } else if (v.data instanceof Uint8Array) {
             imageSource = v.data;
           } else if (Array.isArray(v.data)) {
             imageSource = new Uint8Array(v.data as number[]);
-          } else if (typeof v.data === "string") {
+          } else if (isString(v.data)) {
             imageSource = v.data;
           } else {
             imageSource = "";
@@ -573,13 +581,13 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
       case "audio": {
         let audioSource: string | Uint8Array;
 
-        if (typeof v.uri === "string" && v.uri !== "" && !v.uri.startsWith("memory://")) {
+        if (isStoredUri(v.uri)) {
           audioSource = signedValueUrl;
         } else if (Array.isArray(v.data)) {
           audioSource = new Uint8Array(v.data as number[]);
         } else if (v.data instanceof Uint8Array) {
           audioSource = v.data;
-        } else if (typeof v.data === "string") {
+        } else if (isString(v.data)) {
           audioSource = v.data;
         } else {
           audioSource = "";
@@ -605,10 +613,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
         );
       }
       case "html": {
-        const uri =
-          typeof v.uri === "string" && v.uri && !v.uri.startsWith("memory://")
-            ? signedValueUrl
-            : "";
+        const uri = isStoredUri(v.uri) ? signedValueUrl : "";
         if (uri) {
           return (
             <iframe
@@ -621,7 +626,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
         }
 
         let html = "";
-        if (typeof v.data === "string") {
+        if (isString(v.data)) {
           html = v.data;
         } else if (v.data instanceof Uint8Array) {
           html = new TextDecoder("utf-8").decode(v.data);
@@ -643,8 +648,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
         );
       }
       case "document": {
-        const rawUri =
-          typeof v.uri === "string" ? v.uri : "";
+        const rawUri = isString(v.uri) ? v.uri : "";
         const uriFromRef =
           rawUri && !rawUri.startsWith("memory://") ? signedValueUrl : "";
         const uri = uriFromRef || documentDataPreview.url;
@@ -690,15 +694,14 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
           />
         );
       case "model_3d": {
-        const rawUri: string =
-          typeof v.uri === "string" ? v.uri : "";
+        const rawUri: string = isString(v.uri) ? v.uri : "";
 
         if (!rawUri) {
           return <JSONRenderer value={v} showActions={showTextActions} />;
         }
 
         const url = signedValueUrl;
-        const format = typeof v.format === "string" ? v.format : undefined;
+        const format = isString(v.format) ? v.format : undefined;
         const contentType = getMimeTypeFromUri(url) ||
           (format === "gltf" ? "model/gltf+json" : "model/gltf-binary");
 
@@ -792,12 +795,12 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
 
         if (keys.length === 1) {
           const singleValue = vals[0];
-          if (typeof singleValue === "string") {
+          if (isString(singleValue)) {
             return (
               <TextRenderer text={singleValue} showActions={showTextActions} />
             );
           }
-          if (typeof singleValue === "number") {
+          if (isNumber(singleValue)) {
             return (
               <TextRenderer
                 text={String(singleValue)}
@@ -805,7 +808,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
               />
             );
           }
-          if (typeof singleValue === "boolean") {
+          if (isBoolean(singleValue)) {
             return <BooleanRenderer value={singleValue} />;
           }
           return (
@@ -835,7 +838,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
           if (arr[0] === undefined || arr[0] === null) {
             return null;
           }
-          if (typeof arr[0] === "string" && arr.every((item: unknown) => typeof item === "string")) {
+          if (isString(arr[0]) && arr.every(isString)) {
             const seen = new Map<string, number>();
             return (
               <div
@@ -865,12 +868,12 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
               </div>
             );
           }
-          if (typeof arr[0] === "number") {
+          if (isNumber(arr[0])) {
             return (
               <ListTable data={arr as number[]} data_type="float" editable={false} />
             );
           }
-          if (typeof arr[0] === "object") {
+          if (isRecord(arr[0])) {
             if (arr.every(isAudioChunkLike)) {
               const seen = new Map<string, number>();
               return (
@@ -972,7 +975,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
                         key={withOccurrenceSuffix(
                           `chunk:${c.content_type ?? ""}:${c.done ? 1 : 0
                           }:${hashStringBounded(
-                            typeof c.content === "string" ? c.content : ""
+                            isString(c.content) ? c.content : ""
                           )}`,
                           seen
                         )}
@@ -996,7 +999,7 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
               );
             }
             if (
-              typeof first.type === "string" &&
+              isString(first.type) &&
               ["audio", "video", "html", "sketch"].includes(first.type)
             ) {
               const seen = new Map<string, number>();
@@ -1018,10 +1021,10 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
             const columnType = (
               cell: unknown
             ): "string" | "float" | "int" | "datetime" | "object" => {
-              if (typeof cell === "string") {
+              if (isString(cell)) {
                 return "string";
               }
-              if (typeof cell === "number") {
+              if (isNumber(cell)) {
                 return "float";
               }
               return "object";
@@ -1090,12 +1093,12 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
       case "json":
         return <JSONRenderer value={v} showActions={showTextActions} />;
       default:
-        if (value !== null && typeof value === "object") {
+        if (isRecord(value)) {
           return <JSONRenderer value={value} showActions={showTextActions} />;
         }
         return (
           <TextRenderer
-            text={typeof value === "string" ? value : String(value ?? "")}
+            text={isString(value) ? value : String(value ?? "")}
             showActions={showTextActions}
           />
         );

--- a/web/src/components/node/outputValueResolvers.ts
+++ b/web/src/components/node/outputValueResolvers.ts
@@ -10,8 +10,18 @@ import { fromPersistedSketchEditorState } from "../../stores/sketch/persistence"
 import type { SketchDocument } from "../sketch/types";
 import type { TimelineSequence } from "@nodetool-ai/timeline";
 
-export const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null;
+import { isRecord } from "../../utils/typePredicates";
+
+export { isRecord };
+
+/**
+ * A URI that resolves to stored bytes. `memory://` refs are in-memory only and
+ * can never be fetched, so they do not count.
+ */
+export const isStoredUri = (value: unknown): value is string =>
+  typeof value === "string" &&
+  value !== "" &&
+  !value.startsWith("memory://");
 
 export const getSketchId = (value: unknown): string | null => {
   if (!isRecord(value)) {

--- a/web/src/components/panels/__tests__/StatusMessage.test.tsx
+++ b/web/src/components/panels/__tests__/StatusMessage.test.tsx
@@ -23,6 +23,11 @@ import mockTheme from "../../../__mocks__/themeMock";
 const mockStatusMessage = "Running workflow...";
 const mockRunnerState = "running";
 
+/** Zustand hands the hook a selector, or nothing when the whole state is read. */
+type RunnerSelector = (state: unknown) => unknown;
+const mockIsSelector = (value: unknown): value is RunnerSelector =>
+  typeof value === "function";
+
 jest.mock("../../../stores/WorkflowRunner", () => ({
   useWebsocketRunner: jest.fn((selector) => {
     // Mock the selector function to return different values based on what's being selected
@@ -32,7 +37,7 @@ jest.mock("../../../stores/WorkflowRunner", () => ({
     };
 
     // Simulate Zustand's selector behavior
-    if (typeof selector === "function") {
+    if (mockIsSelector(selector)) {
       return selector(state);
     }
     return state;
@@ -61,7 +66,7 @@ describe("StatusMessage", () => {
       // Mock the hook to return running state
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Processing nodes..." };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -74,7 +79,7 @@ describe("StatusMessage", () => {
       // Mock the hook to return idle state
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "idle", statusMessage: "Ready" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -87,7 +92,7 @@ describe("StatusMessage", () => {
       // Mock the hook to return error state
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "error", statusMessage: "Error occurred" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -100,7 +105,7 @@ describe("StatusMessage", () => {
       // Mock the hook to return connected state
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "connected", statusMessage: "Connected to server" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -113,7 +118,7 @@ describe("StatusMessage", () => {
       // Mock the hook to return paused state
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "paused", statusMessage: "Workflow paused" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -126,7 +131,7 @@ describe("StatusMessage", () => {
       // Mock the hook to return cancelled state
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "cancelled", statusMessage: "Workflow cancelled" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -140,7 +145,7 @@ describe("StatusMessage", () => {
     it("displays the status message text when running", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Executing node 1 of 5" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -151,7 +156,7 @@ describe("StatusMessage", () => {
     it("displays empty string when statusMessage is null", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: null };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       const { container } = renderWithTheme();
@@ -164,7 +169,7 @@ describe("StatusMessage", () => {
     it("displays empty string when statusMessage is undefined", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: undefined };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       const { container } = renderWithTheme();
@@ -179,7 +184,7 @@ describe("StatusMessage", () => {
 
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: longMessage };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -192,7 +197,7 @@ describe("StatusMessage", () => {
 
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: specialMessage };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -203,7 +208,7 @@ describe("StatusMessage", () => {
     it("handles numeric status message converted to string", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "50%" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -216,7 +221,7 @@ describe("StatusMessage", () => {
     it("subscribes to state property only", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Test" };
-        const result = typeof selector === "function" ? selector(state) : state;
+        const result = mockIsSelector(selector) ? selector(state) : state;
         return result;
       });
 
@@ -232,7 +237,7 @@ describe("StatusMessage", () => {
     it("subscribes to statusMessage property only", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Test message" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -244,7 +249,7 @@ describe("StatusMessage", () => {
     it("uses two separate selective subscriptions for performance", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Test" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -258,7 +263,7 @@ describe("StatusMessage", () => {
     it("renders with caption variant", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Test" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       const { container } = renderWithTheme();
@@ -270,7 +275,7 @@ describe("StatusMessage", () => {
     it("renders with inherit color", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Test" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       const { container } = renderWithTheme();
@@ -285,7 +290,7 @@ describe("StatusMessage", () => {
     it("has status-message class", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Test" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       const { container } = renderWithTheme();
@@ -297,7 +302,7 @@ describe("StatusMessage", () => {
     it("has animating class for CSS animations", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Test" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       const { container } = renderWithTheme();
@@ -309,7 +314,7 @@ describe("StatusMessage", () => {
     it("has both status-message and animating classes", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Test" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       const { container } = renderWithTheme();
@@ -323,7 +328,7 @@ describe("StatusMessage", () => {
     it("is memoized to prevent unnecessary re-renders", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Test" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       const { rerender } = renderWithTheme();
@@ -345,7 +350,7 @@ describe("StatusMessage", () => {
       // Start with running
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Step 1" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       const { unmount } = renderWithTheme();
@@ -355,7 +360,7 @@ describe("StatusMessage", () => {
       unmount();
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "idle", statusMessage: "Step 1" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -365,7 +370,7 @@ describe("StatusMessage", () => {
     it("handles status message with emoji", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Running with emoji" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       renderWithTheme();
@@ -376,7 +381,7 @@ describe("StatusMessage", () => {
     it("handles status message with newlines", () => {
       (useWebsocketRunner as jest.Mock).mockImplementation((selector) => {
         const state = { state: "running", statusMessage: "Line 1\nLine 2" };
-        return typeof selector === "function" ? selector(state) : state;
+        return mockIsSelector(selector) ? selector(state) : state;
       });
 
       const { container } = renderWithTheme();

--- a/web/src/components/sketch/types/document.ts
+++ b/web/src/components/sketch/types/document.ts
@@ -38,6 +38,12 @@ import {
   matrixToAffine,
   type AffineMatrix
 } from "../transform/geometry/affineMatrix";
+import {
+  isFiniteNumber,
+  isNumber,
+  isRecord,
+  isString
+} from "../../../utils/typePredicates";
 import { normalizeLayerTransform } from "../transform/normalize";
 import {
   cloneDefaultToolSettings,
@@ -513,19 +519,21 @@ function normalizeLayerEffects(raw: unknown): LayerEffect[] {
   }
   const result: LayerEffect[] = [];
   for (const item of raw) {
-    if (!item || typeof item !== "object" || typeof item.type !== "string") {
+    if (!isRecord(item) || !isString(item.type)) {
       continue;
     }
     const enabled = item.enabled === true;
-    const params = item.params && typeof item.params === "object" ? item.params : {};
+    const params: Record<string, unknown> = isRecord(item.params)
+      ? item.params
+      : {};
     switch (item.type) {
       case "brightness_contrast":
         result.push({
           type: "brightness_contrast",
           enabled,
           params: {
-            brightness: typeof params.brightness === "number" ? params.brightness : 0,
-            contrast: typeof params.contrast === "number" ? params.contrast : 0
+            brightness: isNumber(params.brightness) ? params.brightness : 0,
+            contrast: isNumber(params.contrast) ? params.contrast : 0
           }
         });
         break;
@@ -535,11 +543,11 @@ function normalizeLayerEffects(raw: unknown): LayerEffect[] {
           enabled,
           params: {
             // Migrate legacy "hue" → "hueDegrees"
-            hueDegrees: typeof params.hueDegrees === "number"
+            hueDegrees: isNumber(params.hueDegrees)
               ? params.hueDegrees
-              : typeof params.hue === "number" ? params.hue : 0,
-            saturation: typeof params.saturation === "number" ? params.saturation : 0,
-            lightness: typeof params.lightness === "number" ? params.lightness : 0
+              : isNumber(params.hue) ? params.hue : 0,
+            saturation: isNumber(params.saturation) ? params.saturation : 0,
+            lightness: isNumber(params.lightness) ? params.lightness : 0
           }
         });
         break;
@@ -549,9 +557,9 @@ function normalizeLayerEffects(raw: unknown): LayerEffect[] {
           enabled,
           params: {
             // Migrate legacy "exposure" → "exposureStops"
-            exposureStops: typeof params.exposureStops === "number"
+            exposureStops: isNumber(params.exposureStops)
               ? params.exposureStops
-              : typeof params.exposure === "number" ? params.exposure : 0
+              : isNumber(params.exposure) ? params.exposure : 0
           }
         });
         break;
@@ -574,8 +582,8 @@ function normalizeLayerEffects(raw: unknown): LayerEffect[] {
           params: {
             operator: params.operator === "aces" || params.operator === "reinhard" || params.operator === "filmic"
               ? params.operator : "aces",
-            exposureStops: typeof params.exposureStops === "number" ? params.exposureStops : 0,
-            whitePoint: typeof params.whitePoint === "number" ? params.whitePoint : undefined
+            exposureStops: isNumber(params.exposureStops) ? params.exposureStops : 0,
+            whitePoint: isNumber(params.whitePoint) ? params.whitePoint : undefined
           }
         });
         break;
@@ -584,9 +592,9 @@ function normalizeLayerEffects(raw: unknown): LayerEffect[] {
           type: "bloom",
           enabled,
           params: {
-            threshold: typeof params.threshold === "number" ? params.threshold : 0.8,
-            radius: typeof params.radius === "number" ? params.radius : 10,
-            intensity: typeof params.intensity === "number" ? params.intensity : 0.5
+            threshold: isNumber(params.threshold) ? params.threshold : 0.8,
+            radius: isNumber(params.radius) ? params.radius : 10,
+            intensity: isNumber(params.intensity) ? params.intensity : 0.5
           }
         });
         break;
@@ -603,7 +611,7 @@ const SKETCH_LARGE_TOOL_SIZE_MAX = 200;
 const SKETCH_PENCIL_SIZE_MAX = 10;
 
 function normalizedLargeToolSize(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
+  if (!isFiniteNumber(value)) {
     return fallback;
   }
   const rounded = Math.round(value);
@@ -614,7 +622,7 @@ function normalizedLargeToolSize(value: unknown, fallback: number): number {
 }
 
 function normalizedPencilSize(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
+  if (!isFiniteNumber(value)) {
     return fallback;
   }
   const rounded = Math.round(value);
@@ -625,28 +633,28 @@ function normalizedPencilSize(value: unknown, fallback: number): number {
 }
 
 function normalizedUnitScalar(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
+  if (!isFiniteNumber(value)) {
     return fallback;
   }
   return Math.min(1, Math.max(0, value));
 }
 
 function normalizedBrushRoundness(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
+  if (!isFiniteNumber(value)) {
     return fallback;
   }
   return Math.min(1, Math.max(0.1, value));
 }
 
 function normalizedBrushAngle(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
+  if (!isFiniteNumber(value)) {
     return fallback;
   }
   return ((Math.round(value) % 360) + 360) % 360;
 }
 
 function normalizedBlurStrength(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
+  if (!isFiniteNumber(value)) {
     return fallback;
   }
   const rounded = Math.round(value);

--- a/web/src/e2e_runner/harness.ts
+++ b/web/src/e2e_runner/harness.ts
@@ -9,6 +9,12 @@
  * driver controls execution and harvests results through `window.__E2E__`.
  */
 import { HarnessWsClient } from "./wsClient";
+import {
+  isNonEmptyString,
+  isNumber,
+  isRecord,
+  isString
+} from "../utils/typePredicates";
 import type {
   AdHocRunOptions,
   CapturedArtifact,
@@ -75,7 +81,7 @@ function emptyRecord(ref: WorkflowRef): RunRecord {
 }
 
 function asString(value: unknown): string {
-  if (typeof value === "string") return value;
+  if (isString(value)) return value;
   try {
     return JSON.stringify(value);
   } catch {
@@ -90,13 +96,12 @@ function extractArtifact(output: {
   value: unknown;
 }): CapturedArtifact | null {
   const v = output.value;
-  if (v && typeof v === "object") {
-    const obj = v as Record<string, unknown>;
-    const uri = typeof obj.uri === "string" ? obj.uri : undefined;
-    const data = typeof obj.data === "string" ? obj.data : undefined;
-    const type = typeof obj.type === "string" ? obj.type : output.output_type;
-    const mimeType =
-      typeof obj.mimeType === "string" ? obj.mimeType : undefined;
+  if (isRecord(v)) {
+    const obj = v;
+    const uri = isString(obj.uri) ? obj.uri : undefined;
+    const data = isString(obj.data) ? obj.data : undefined;
+    const type = isString(obj.type) ? obj.type : output.output_type;
+    const mimeType = isString(obj.mimeType) ? obj.mimeType : undefined;
     if (uri || data) {
       // The value's own mimeType is authoritative; the type-based guess is a fallback.
       const contentType =
@@ -146,30 +151,29 @@ function reduceRecordEvent(
   // The backend's invalid_command / invalid_message envelope carries no `type`
   // field, only { error, details?/message? }. Catch it before the type switch;
   // it's terminal and would otherwise fall through and hang to timeout.
-  if (typeof msg.type !== "string") {
+  if (!isString(msg.type)) {
     const errCode = (msg as { error?: unknown }).error;
-    if (typeof errCode === "string" && errCode) {
+    if (isNonEmptyString(errCode)) {
       const details = (msg as { details?: unknown; message?: unknown }).details;
       const message = (msg as { message?: unknown }).message;
-      const text =
-        typeof details === "string" && details
-          ? `${errCode}: ${details}`
-          : typeof message === "string" && message
-            ? `${errCode}: ${message}`
-            : errCode;
+      const text = isNonEmptyString(details)
+        ? `${errCode}: ${details}`
+        : isNonEmptyString(message)
+          ? `${errCode}: ${message}`
+          : errCode;
       if (!rec.error) rec.error = text;
       return { status: "error", error: text };
     }
   }
   switch (msg.type) {
     case "job_update": {
-      if (typeof msg.job_id === "string" && msg.job_id) rec.jobId = msg.job_id;
+      if (isNonEmptyString(msg.job_id)) rec.jobId = msg.job_id;
       const status = String(msg.status ?? "");
-      if (typeof msg.error === "string" && msg.error) rec.error = msg.error;
+      if (isNonEmptyString(msg.error)) rec.error = msg.error;
       if (TERMINAL_STATUSES.has(status)) {
         return {
           status: status as RunStatus,
-          error: typeof msg.error === "string" ? msg.error : undefined
+          error: isString(msg.error) ? msg.error : undefined
         };
       }
       break;
@@ -180,15 +184,11 @@ function reduceRecordEvent(
         const status = String(msg.status ?? "");
         nodeStatus[nodeId] = status;
         const isError = status === "error" || status === "failed";
-        const message =
-          typeof msg.error === "string" && msg.error.length > 0
-            ? msg.error
-            : null;
+        const message = isNonEmptyString(msg.error) ? msg.error : null;
         rec.nodeIO[nodeId] = {
-          node_type:
-            typeof msg.node_type === "string"
-              ? msg.node_type
-              : rec.nodeIO[nodeId]?.node_type,
+          node_type: isString(msg.node_type)
+            ? msg.node_type
+            : rec.nodeIO[nodeId]?.node_type,
           status,
           result:
             (msg as { result?: unknown }).result ?? rec.nodeIO[nodeId]?.result,
@@ -201,13 +201,10 @@ function reduceRecordEvent(
     }
     case "output_update": {
       const output = {
-        node_id: typeof msg.node_id === "string" ? msg.node_id : undefined,
-        node_name:
-          typeof msg.node_name === "string" ? msg.node_name : undefined,
-        output_name:
-          typeof msg.output_name === "string" ? msg.output_name : undefined,
-        output_type:
-          typeof msg.output_type === "string" ? msg.output_type : undefined,
+        node_id: isString(msg.node_id) ? msg.node_id : undefined,
+        node_name: isString(msg.node_name) ? msg.node_name : undefined,
+        output_name: isString(msg.output_name) ? msg.output_name : undefined,
+        output_type: isString(msg.output_type) ? msg.output_type : undefined,
         value: (msg as { value?: unknown }).value
       };
       rec.outputs.push(output);
@@ -218,16 +215,15 @@ function reduceRecordEvent(
     case "log_update": {
       rec.logs.push({
         ts: Date.now(),
-        level: typeof msg.severity === "string" ? msg.severity : undefined,
+        level: isString(msg.severity) ? msg.severity : undefined,
         content: asString((msg as { content?: unknown }).content ?? msg),
-        node_id: typeof msg.node_id === "string" ? msg.node_id : undefined
+        node_id: isString(msg.node_id) ? msg.node_id : undefined
       });
       break;
     }
     case "error": {
       // A backend { type:"error", message } frame is terminal.
-      const text =
-        typeof msg.message === "string" && msg.message ? msg.message : "error";
+      const text = isNonEmptyString(msg.message) ? msg.message : "error";
       if (!rec.error) rec.error = text;
       return { status: "error", error: text };
     }
@@ -525,10 +521,7 @@ export class Harness {
     if (expect.status && rec.status !== expect.status) {
       failures.push(`expected status ${expect.status}, got ${rec.status}`);
     }
-    if (
-      typeof expect.minOutputs === "number" &&
-      rec.outputs.length < expect.minOutputs
-    ) {
+    if (isNumber(expect.minOutputs) && rec.outputs.length < expect.minOutputs) {
       failures.push(
         `expected at least ${expect.minOutputs} outputs, got ${rec.outputs.length}`
       );
@@ -537,7 +530,7 @@ export class Harness {
       // Concatenate raw values (strings verbatim) so an expected substring with
       // quotes/backslashes/newlines isn't defeated by JSON escaping.
       const haystack = rec.outputs
-        .map((o) => (typeof o.value === "string" ? o.value : asString(o.value)))
+        .map((o) => (isString(o.value) ? o.value : asString(o.value)))
         .join("\n");
       if (!haystack.includes(expect.outputContains)) {
         failures.push(`outputs did not contain "${expect.outputContains}"`);

--- a/web/src/utils/createAssetFile.ts
+++ b/web/src/utils/createAssetFile.ts
@@ -3,6 +3,7 @@ import type { Chunk } from "../stores/ApiTypes";
 import { trpcClient } from "../trpc/client";
 import { isTRPCErrorWithCode, ApiErrorCode } from "@nodetool-ai/protocol/api-schemas";
 import { resolveMediaUri } from "./resolveMediaUri";
+import { isFunction, isNumber, isRecord, isString } from "./typePredicates";
 
 interface AssetFileResult {
   file: File;
@@ -89,7 +90,7 @@ const convertDataFrameToCSV = (dataframe: DataFrame): string => {
 
 const decodeBase64 = (value: string): Uint8Array => {
   const cleaned = value.includes(",") ? value.split(",").pop() ?? "" : value;
-  if (typeof globalThis.atob === "function") {
+  if (isFunction(globalThis.atob)) {
     try {
       const binary = globalThis.atob(cleaned);
       const bytes = new Uint8Array(binary.length);
@@ -138,8 +139,8 @@ const isUsableBinary = (val: unknown): boolean => {
   if (val instanceof ArrayBuffer) return val.byteLength > 0;
   if (ArrayBuffer.isView(val)) return val.byteLength > 0;
   if (Array.isArray(val))
-    return val.length > 0 && val.every((v) => typeof v === "number");
-  if (typeof val === "string") return val.trim() !== "";
+    return val.length > 0 && val.every(isNumber);
+  if (isString(val)) return val.trim() !== "";
   return false;
 };
 
@@ -156,7 +157,7 @@ const toUint8Array = (input: unknown): Uint8Array => {
       input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength)
     );
   }
-  if (typeof input === "string") {
+  if (isString(input)) {
     const base64Like =
       input.startsWith("data:") ||
       /^[A-Za-z0-9+/=]+$/.test(input.replace(/[\r\n]+/g, ""));
@@ -172,7 +173,7 @@ const toUint8Array = (input: unknown): Uint8Array => {
   if (Array.isArray(input)) {
     return new Uint8Array(input);
   }
-  if (typeof input === "object") {
+  if (isRecord(input)) {
     if ("data" in input) {
       if (input.data instanceof Uint8Array) return input.data;
       if (input.data instanceof ArrayBuffer) return new Uint8Array(input.data);
@@ -188,8 +189,8 @@ const toUint8Array = (input: unknown): Uint8Array => {
     // Fallback: treat as a sparse byte map. Only safe when all values are
     // numbers; otherwise we'd silently produce garbage (e.g. for `ExtData`
     // wrappers that hold a non-binary `.data`).
-    const values = Object.values(input as Record<string, unknown>);
-    if (values.length > 0 && values.every((v): v is number => typeof v === "number")) {
+    const values = Object.values(input);
+    if (values.length > 0 && values.every(isNumber)) {
       return new Uint8Array(values);
     }
     return new Uint8Array();
@@ -203,7 +204,7 @@ const toArrayBuffer = (view: Uint8Array): ArrayBuffer => {
   const candidate = buffer as ArrayBuffer & {
     slice?: (_start: number, _end: number) => ArrayBuffer;
   };
-  if (typeof candidate.slice === "function") {
+  if (isFunction(candidate.slice)) {
     return candidate.slice(byteOffset, byteOffset + byteLength);
   }
 
@@ -249,13 +250,12 @@ const resolveDownloadUri = (uri: string): string => {
 const chunkToOutput = (chunk: Chunk) => {
   console.debug("[createAssetFile] chunkToOutput", {
     type: chunk.content_type,
-    hasContent: typeof chunk.content !== "undefined",
-    contentLength:
-      typeof chunk.content === "string" ? chunk.content.length : undefined
+    hasContent: chunk.content !== undefined,
+    contentLength: isString(chunk.content) ? chunk.content.length : undefined
   });
   // Native Float32Array audio payloads aren't a saveable string; the asset
   // path only handles encoded (string) content.
-  const content = typeof chunk.content === "string" ? chunk.content : "";
+  const content = isString(chunk.content) ? chunk.content : "";
   switch (chunk.content_type) {
     case "text":
       return { type: "text", data: content };
@@ -276,7 +276,7 @@ const concatTextChunksSafely = (
   let currentLen = 0;
 
   for (const chunk of chunks) {
-    const piece = typeof chunk.content === "string" ? chunk.content : "";
+    const piece = isString(chunk.content) ? chunk.content : "";
     if (!piece) {
       continue;
     }
@@ -374,7 +374,7 @@ const getMimeType = (
   }
 
   const asString = (value: unknown): value is string =>
-    typeof value === "string" && value.includes("/");
+    isString(value) && value.includes("/");
 
   const nestedData = isTypedOutput(output.data) ? output.data : undefined;
   return (
@@ -403,7 +403,7 @@ const buildFilename = (
     return `preview_${id}${suffix}${extension ? `.${extension}` : ""}`;
   }
 
-  if (!suffix || (typeof index === "number" && index === 0)) {
+  if (!suffix || (isNumber(index) && index === 0)) {
     return desired;
   }
 
@@ -463,12 +463,12 @@ const createSingleAssetFile = async (
   const isDataEmpty = !isUsableBinary(data);
 
   const stringLooksLikeUrl =
-    typeof data === "string" &&
+    isString(data) &&
     (data.startsWith("http://") || data.startsWith("https://"));
 
   const typedOutput = isTypedOutput(output) ? output : null;
-  const outputUri = typeof typedOutput?.uri === "string" ? typedOutput.uri : undefined;
-  const isAssetUri = typeof outputUri === "string" && outputUri.startsWith("asset://");
+  const outputUri = isString(typedOutput?.uri) ? typedOutput.uri : undefined;
+  const isAssetUri = isString(outputUri) && outputUri.startsWith("asset://");
   let desiredFilename = typedOutput?.filename;
   // Content type reported by the server when the bytes are fetched via
   // `asset_id`. Used as the MIME/extension fallback so a JPEG/WEBP asset with
@@ -479,10 +479,10 @@ const createSingleAssetFile = async (
   // This covers asset://, /api/storage/, http(s)://, and also the ExtData
   // case where the wrapper exists but doesn't contain real bytes.
   const shouldFetchFromUri =
-    typeof outputUri === "string" &&
+    isString(outputUri) &&
     (isDataEmpty || stringLooksLikeUrl || data === output);
   const shouldDownloadAsset =
-    typeof typedOutput?.asset_id === "string" &&
+    isString(typedOutput?.asset_id) &&
     (isDataEmpty || data === output || isAssetUri);
 
   if (shouldDownloadAsset) {
@@ -492,7 +492,7 @@ const createSingleAssetFile = async (
       });
       const downloadUrl = assetResponse.get_url;
       desiredFilename = assetResponse.name || desiredFilename;
-      if (typeof assetResponse.content_type === "string" && assetResponse.content_type.includes("/")) {
+      if (isString(assetResponse.content_type) && assetResponse.content_type.includes("/")) {
         serverContentType = assetResponse.content_type;
       }
       if (downloadUrl) {
@@ -571,7 +571,7 @@ const createSingleAssetFile = async (
       filename = buildFilename(desiredFilename, id, suffix, "json", index);
       break;
     case "text":
-      content = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+      content = isString(data) ? data : JSON.stringify(data, null, 2);
       mimeType = getMimeType(output, "text/plain");
       filename = buildFilename(
         desiredFilename,
@@ -583,9 +583,9 @@ const createSingleAssetFile = async (
       break;
     default:
       content =
-        typeof output === "string"
+        isString(output)
           ? output
-          : typeof data === "string" || data instanceof Blob
+          : isString(data) || data instanceof Blob
           ? data
           : JSON.stringify(output, null, 2);
       mimeType = getMimeType(output, "text/plain");
@@ -610,7 +610,7 @@ const createSingleAssetFile = async (
  * we expand it into an array so each output gets its own asset file.
  */
 const unwrapNamedOutputs = (output: AssetOutput): AssetOutput | AssetOutput[] => {
-  if (!output || typeof output !== "object" || Array.isArray(output)) {
+  if (!isRecord(output) || Array.isArray(output)) {
     return output;
   }
   if ("type" in output) {

--- a/web/src/utils/typePredicates.ts
+++ b/web/src/utils/typePredicates.ts
@@ -1,0 +1,28 @@
+/**
+ * Named type predicates for the representation checks the web app makes on
+ * values that arrive from a workflow run, an asset payload, or a stored
+ * document.
+ */
+
+export const isString = (value: unknown): value is string =>
+  typeof value === "string";
+
+export const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value !== "";
+
+export const isNumber = (value: unknown): value is number =>
+  typeof value === "number";
+
+export const isBoolean = (value: unknown): value is boolean =>
+  typeof value === "boolean";
+
+/** A number that can be used in arithmetic — excludes NaN and the infinities. */
+export const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+export const isFunction = (
+  value: unknown
+): value is (...args: never[]) => unknown => typeof value === "function";


### PR DESCRIPTION
Follow-up to #4953, implementing its recommendation in two phases. `no-runtime-typeof` 4,277 → **3,107** on the merged tree (−1,180 from this branch; the count and the AGENTS.md table were re-measured after merging `main`, which moved other rules via #4955's dictionary pass — backlog now **19,730**). Side effects of this branch: `require-safety-comment` −69 and `no-unsafe-dictionary-type` −42 fell as narrowing made casts redundant; `no-unknown-parameters` +58 and `no-unknown-returns` +7 rose because predicates take `value: unknown` — the tradeoff is recorded in AGENTS.md.

## Phase 1 — finish the presence bucket in `packages/` (−40)

All 2,514 `packages/` sites classified by asking the compiler for the operand's static type (same method as #4953): 1,590 untyped operands, 351 tautologies, 160 union dispatches, 246 structural presence candidates. Each candidate was reviewed against #4953's provenance criterion; **40 fixed** (operand type is our own in-process contract → `x != null` / ternary collapse), **206 deliberately kept** — `{}`-typed operands where `typeof` genuinely narrows, declared types laid over unvalidated network/file/wire data, and the optional-callback bucket #4953 left by design.

## Phase 2 — the rule's sanctioned form, consolidation, and a real gate (−1,140)

- **`allowInTypeGuards: true`** on the backlog config — the vendored rule's own escape hatch: a `typeof` directly inside a function returning `v is T` is the check's sanctioned home. −385 findings for zero code change; the anti-slop project itself says vendored rules are yours to shape.
- **Named predicates over the densest files.** Per-tree predicate modules (`packages/protocol/src/predicates.ts`, `web/src/utils/typePredicates.ts`, mobile's self-contained twin, per-package siblings in agents/runtime/llm-nodes/websocket/kernel/app-runtime/cli), every body the **verbatim** original check — provider-response and wire-frame validation is load-bearing and none of it moved. Where two leniencies coexist (`isRecord` vs array-permissive `isObjectLike`) they stay separate names so boundaries that accept arrays keep accepting them. Domain predicates where the code was asking a real question: `isStoredUri`, `hasProviderAccess`, `isTypeName`, `isControlEventValue`. Headline files: `unified-websocket-runner.ts` 161 → 3, `packages/agents` top seven 182 → 6, providers+llm-nodes 169 → 10, web/mobile/kernel/cli 238 → 5.
- **What was deliberately left, with reasons:** bare `typeof x === "object"` where `null` currently passes through (a predicate would silently change wire behavior), global-existence probes (`typeof window`, `typeof Buffer` — a predicate would throw `ReferenceError`), value-producing `typeof` in diagnostics and cache keys, one-off `bigint` branches, and a `JSON.parse("null")` path a record predicate would break. No throwaway single-site predicates were created.
- **Scoped enforcement.** `packages/protocol` is now at zero (its five module predicates absorb every site; the decoder `typecheck.ts` keeps five diagnostic `typeof`s in failure messages) and the **enforced** config turns the rule on for `packages/protocol/src` via an override, decoder exempt — in the package that owns the schemas, an inline `typeof` means someone bypassed the parse. The gate was proven able to fail: an injected violation went red before the green was trusted.

## Checks (re-run on the tree merged with `main` after #4955/#4956)

- `npm run build:packages` → exit 0. `npm run typecheck` (web, electron, mobile) → exit 0.
- `npm run lint` → exit 0, including the new protocol enforcement override.
- `npm run test:packages` → exit 0. `npm run test` (web, electron, mobile) → exit 0. (One earlier pre-merge run had a single 30s barrel-import timeout in `packages/agents tests/index.test.ts` under full-tree parallel load; green in isolation, in a clean full-suite re-run, and in the post-merge run.)
- Phase-1 per-rule differential over its 28 changed files vs `origin/main` at the time: only `no-runtime-typeof` moved (−40), every other rule byte-identical. Phase-2 whole-tree deltas measured before/after in the same environment.