### PR TITLE
refactor: declare what these dictionaries hold (no-unsafe-dictionary-type 4839 → 4498)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ The vendored [anti-slop](https://github.com/dmmulroy/anti-slop) Oxlint plugin
 (`tools/oxlint/anti-slop/`) runs through two configs, and every rule sits in
 exactly one of them:
 
-- `.oxlintrc.anti-slop.json` — the **backlog**, 21,257 findings. Run it with
+- `.oxlintrc.anti-slop.json` — the **backlog**, 20,930 findings. Run it with
   `npm run lint:anti-slop`. Not on the CI path; it would be red for months.
 - `.oxlintrc.anti-slop-enforced.json` — the rules already at **zero**. Run
   inside `npm run lint`, so they cannot come back.
@@ -253,14 +253,14 @@ skips those trees. Remaining backlog, largest first:
 
 | rule | findings |
 |---|---:|
-| `require-safety-comment-for-type-assertion` | 8099 |
-| `no-unsafe-dictionary-type` | 4839 |
+| `require-safety-comment-for-type-assertion` | 8107 |
+| `no-unsafe-dictionary-type` | 4498 |
 | `no-runtime-typeof` | 4277 |
 | `no-unknown-parameters` | 1763 |
-| `no-module-mocking` | 1403 |
-| `no-known-value-widening` | 672 |
+| `no-module-mocking` | 1410 |
+| `no-known-value-widening` | 670 |
 | `no-unknown-returns` | 163 |
-| `no-chained-type-assertions` | 41 |
+| `no-chained-type-assertions` | 42 |
 
 A rule can also stall short of zero. `no-unknown-returns` went 604 → 182; what
 is left is one thing said many ways — a node output, an app-state slot, a

--- a/mobile/src/documents/__tests__/documentStore.test.ts
+++ b/mobile/src/documents/__tests__/documentStore.test.ts
@@ -16,7 +16,16 @@ interface Doc {
   shots: string[];
 }
 
-const detail = (overrides: Record<string, unknown> = {}) => ({
+interface DetailOverrides {
+  ref?: { kind: string; id: string; revision: number };
+  name?: string;
+  projectId?: string;
+  contentType?: string | null;
+  updatedAt?: string;
+  document?: Doc;
+}
+
+const detail = (overrides: DetailOverrides = {}) => ({
   ref: { kind: 'storyboard', id: 'sb1', revision: 3 },
   name: 'Chase scene',
   projectId: 'default',

--- a/packages/audio-nodes/src/nodes/audio.ts
+++ b/packages/audio-nodes/src/nodes/audio.ts
@@ -2,7 +2,8 @@ import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type {
   InputMode,
   OutputCorrelation,
-  Platform
+  Platform,
+  AudioRef
 } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { tagAsServer } from "@nodetool-ai/nodes-utils";
@@ -210,6 +211,11 @@ export class LoadAudioAssetsNode extends BaseNode {
   }
 }
 
+/** Output handles LoadAudioFileNode.process() emits. */
+type LoadAudioFileNodeOutputs = {
+  output: AudioRef;
+};
+
 export class LoadAudioFileNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.LoadAudioFile";
   static readonly platforms = NODE_ONLY;
@@ -230,7 +236,7 @@ export class LoadAudioFileNode extends BaseNode {
   })
   declare path: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<LoadAudioFileNodeOutputs> {
     const p = uriToPath(String(this.path ?? ""));
     const fs = await loadNodeFsPromises();
     const data = new Uint8Array(await fs.readFile(p));
@@ -329,6 +335,11 @@ export class LoadAudioFolderNode extends BaseNode {
   }
 }
 
+/** Output handles SaveAudioNode.process() emits. */
+type SaveAudioNodeOutputs = {
+  output: AudioRef;
+};
+
 export class SaveAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.SaveAudio";
   static readonly platforms = NODE_ONLY;
@@ -377,7 +388,7 @@ export class SaveAudioNode extends BaseNode {
   })
   declare name: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SaveAudioNodeOutputs> {
     const audio = this.audio;
     const folder = resolveFolderPath(this.folder) || ".";
     const name = dateName(String(this.name || "audio.wav"));
@@ -389,6 +400,11 @@ export class SaveAudioNode extends BaseNode {
     return { output: audioRefFromBytes(audioBytes(audio), `file://${full}`) };
   }
 }
+
+/** Output handles SaveAudioFileNode.process() emits. */
+type SaveAudioFileNodeOutputs = {
+  output: string;
+};
 
 export class SaveAudioFileNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.SaveAudioFile";
@@ -447,7 +463,7 @@ export class SaveAudioFileNode extends BaseNode {
   })
   declare FORMAT_MAP: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SaveAudioFileNodeOutputs> {
     const audio = this.audio;
     const folder = String(this.folder || ".");
     const fname = dateName(String(this.filename || "audio.wav"));
@@ -459,6 +475,11 @@ export class SaveAudioFileNode extends BaseNode {
     return { output: p };
   }
 }
+
+/** Output handles NormalizeAudioNode.process() emits. */
+type NormalizeAudioNodeOutputs = {
+  output: AudioRef;
+};
 
 export class NormalizeAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.Normalize";
@@ -485,7 +506,7 @@ export class NormalizeAudioNode extends BaseNode {
   })
   declare audio: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<NormalizeAudioNodeOutputs> {
     const bytes = await requireAudioBytes(this.audio, context);
     const wav = await decodeAudioToWav(bytes);
     if (wav.samples.length === 0) {
@@ -518,6 +539,11 @@ export class NormalizeAudioNode extends BaseNode {
     };
   }
 }
+
+/** Output handles OverlayAudioNode.process() emits. */
+type OverlayAudioNodeOutputs = {
+  output: AudioRef;
+};
 
 export class OverlayAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.OverlayAudio";
@@ -558,7 +584,7 @@ export class OverlayAudioNode extends BaseNode {
   })
   declare b: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<OverlayAudioNodeOutputs> {
     const aBytes = await audioBytesAsync(this.a, context);
     const bBytes = await audioBytesAsync(this.b, context);
     const aw = parseWavBytes(aBytes);
@@ -593,6 +619,11 @@ export class OverlayAudioNode extends BaseNode {
     return { output: audioRefFromBytes(out) };
   }
 }
+
+/** Output handles RemoveSilenceNode.process() emits. */
+type RemoveSilenceNodeOutputs = {
+  output: AudioRef;
+};
 
 export class RemoveSilenceNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.RemoveSilence";
@@ -673,7 +704,7 @@ export class RemoveSilenceNode extends BaseNode {
   })
   declare min_silence_between_parts: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<RemoveSilenceNodeOutputs> {
     const bytes = await audioBytesAsync(this.audio, context);
     const wav = parseWavBytes(bytes);
     if (!wav || wav.samples.length === 0) {
@@ -770,6 +801,11 @@ export class RemoveSilenceNode extends BaseNode {
   }
 }
 
+/** Output handles SliceAudioNode.process() emits. */
+type SliceAudioNodeOutputs = {
+  output: AudioRef;
+};
+
 export class SliceAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.SliceAudio";
   static readonly title = "Slice Audio";
@@ -813,7 +849,7 @@ export class SliceAudioNode extends BaseNode {
   })
   declare end: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<SliceAudioNodeOutputs> {
     const bytes = await requireAudioBytes(this.audio, context);
     const start = Math.max(0, Number(this.start ?? 0));
     const end = Number(this.end ?? 0);
@@ -832,6 +868,11 @@ export class SliceAudioNode extends BaseNode {
     };
   }
 }
+
+/** Output handles MonoToStereoNode.process() emits. */
+type MonoToStereoNodeOutputs = {
+  output: AudioRef;
+};
 
 export class MonoToStereoNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.MonoToStereo";
@@ -858,7 +899,7 @@ export class MonoToStereoNode extends BaseNode {
   })
   declare audio: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<MonoToStereoNodeOutputs> {
     const bytes = await audioBytesAsync(this.audio, context);
     const wav = parseWavBytes(bytes);
     if (!wav) {
@@ -887,6 +928,11 @@ export class MonoToStereoNode extends BaseNode {
     return { output: audioRefFromWav(encodeWav(out, wav.sampleRate, 2)) };
   }
 }
+
+/** Output handles StereoToMonoNode.process() emits. */
+type StereoToMonoNodeOutputs = {
+  output: AudioRef;
+};
 
 export class StereoToMonoNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.StereoToMono";
@@ -921,7 +967,7 @@ export class StereoToMonoNode extends BaseNode {
   })
   declare method: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<StereoToMonoNodeOutputs> {
     const bytes = await audioBytesAsync(this.audio, context);
     const method = String(this.method ?? "average");
     const wav = parseWavBytes(bytes);
@@ -958,6 +1004,11 @@ export class StereoToMonoNode extends BaseNode {
   }
 }
 
+/** Output handles ReverseAudioNode.process() emits. */
+type ReverseAudioNodeOutputs = {
+  output: AudioRef;
+};
+
 export class ReverseAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.Reverse";
   static readonly title = "Reverse";
@@ -983,7 +1034,7 @@ export class ReverseAudioNode extends BaseNode {
   })
   declare audio: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ReverseAudioNodeOutputs> {
     const bytes = await audioBytesAsync(this.audio, context);
     const wav = parseWavBytes(bytes);
     if (!wav) {
@@ -1004,6 +1055,11 @@ export class ReverseAudioNode extends BaseNode {
     };
   }
 }
+
+/** Output handles FadeInAudioNode.process() emits. */
+type FadeInAudioNodeOutputs = {
+  output: AudioRef;
+};
 
 export class FadeInAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.FadeIn";
@@ -1039,7 +1095,7 @@ export class FadeInAudioNode extends BaseNode {
   })
   declare duration: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<FadeInAudioNodeOutputs> {
     const bytes = await requireAudioBytes(this.audio, context);
     const duration = Math.max(0, Number(this.duration ?? 1));
     const wav = await decodeAudioToWav(bytes);
@@ -1058,6 +1114,11 @@ export class FadeInAudioNode extends BaseNode {
     };
   }
 }
+
+/** Output handles FadeOutAudioNode.process() emits. */
+type FadeOutAudioNodeOutputs = {
+  output: AudioRef;
+};
 
 export class FadeOutAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.FadeOut";
@@ -1093,7 +1154,7 @@ export class FadeOutAudioNode extends BaseNode {
   })
   declare duration: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<FadeOutAudioNodeOutputs> {
     const bytes = await requireAudioBytes(this.audio, context);
     const duration = Math.max(0, Number(this.duration ?? 1));
     const wav = await decodeAudioToWav(bytes);
@@ -1113,6 +1174,11 @@ export class FadeOutAudioNode extends BaseNode {
     };
   }
 }
+
+/** Output handles RepeatAudioNode.process() emits. */
+type RepeatAudioNodeOutputs = {
+  output: AudioRef;
+};
 
 export class RepeatAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.Repeat";
@@ -1150,7 +1216,7 @@ export class RepeatAudioNode extends BaseNode {
   })
   declare loops: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<RepeatAudioNodeOutputs> {
     const bytes = await audioBytesAsync(this.audio, context);
     const count = Math.max(1, Math.floor(Number(this.loops ?? 2)));
     const wav = parseWavBytes(bytes);
@@ -1174,6 +1240,11 @@ export class RepeatAudioNode extends BaseNode {
   }
 }
 
+/** Output handles AudioMixerNode.process() emits. */
+type AudioMixerNodeOutputs = {
+  output: AudioRef;
+};
+
 export class AudioMixerNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.AudioMixer";
   static readonly body = "content_card";
@@ -1187,7 +1258,7 @@ export class AudioMixerNode extends BaseNode {
   static readonly inputFields: string[] = [];
   static readonly supportsDynamicInputs = true;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<AudioMixerNodeOutputs> {
     const inputs = Array.from(this.dynamicProps.values()).filter(
       (t) => t && typeof t === "object"
     );
@@ -1237,6 +1308,11 @@ export class AudioMixerNode extends BaseNode {
   }
 }
 
+/** Output handles TrimAudioNode.process() emits. */
+type TrimAudioNodeOutputs = {
+  output: AudioRef;
+};
+
 export class TrimAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.Trim";
   static readonly title = "Trim";
@@ -1280,7 +1356,7 @@ export class TrimAudioNode extends BaseNode {
   })
   declare end: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<TrimAudioNodeOutputs> {
     const bytes = await requireAudioBytes(this.audio, context);
     const start = Math.max(0, Number(this.start ?? 0));
     const end = Math.max(0, Number(this.end ?? 0));
@@ -1300,6 +1376,11 @@ export class TrimAudioNode extends BaseNode {
     };
   }
 }
+
+/** Output handles CreateSilenceNode.process() emits. */
+type CreateSilenceNodeOutputs = {
+  output: AudioRef;
+};
 
 export class CreateSilenceNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.CreateSilence";
@@ -1330,7 +1411,7 @@ export class CreateSilenceNode extends BaseNode {
   })
   declare sample_rate: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<CreateSilenceNodeOutputs> {
     const duration = Math.max(0, Number(this.duration ?? 1));
     const sampleRate = Math.max(1, Math.floor(Number(this.sample_rate ?? 44100)));
     const frames = Math.round(duration * sampleRate);
@@ -1341,6 +1422,11 @@ export class CreateSilenceNode extends BaseNode {
     };
   }
 }
+
+/** Output handles ConcatAudioNode.process() emits. */
+type ConcatAudioNodeOutputs = {
+  output: AudioRef;
+};
 
 export class ConcatAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.Concat";
@@ -1355,7 +1441,7 @@ export class ConcatAudioNode extends BaseNode {
   static readonly inputFields: string[] = [];
   static readonly supportsDynamicInputs = true;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ConcatAudioNodeOutputs> {
     // Each dynamic input may be a single audio ref or a list<audio> from an
     // upstream loop/list node — flatten so list elements concatenate in order.
     const values = Array.from(this.dynamicProps.values()).flatMap((v) =>
@@ -1404,6 +1490,11 @@ async function concatAudio(parts: Uint8Array[]): Promise<AudioRefResult> {
   );
 }
 
+/** Output handles ConcatAudioListNode.process() emits. */
+type ConcatAudioListNodeOutputs = {
+  output: AudioRef;
+};
+
 export class ConcatAudioListNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.ConcatList";
   static readonly title = "Concatenate Audio List";
@@ -1423,7 +1514,7 @@ export class ConcatAudioListNode extends BaseNode {
   })
   declare audio_files: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ConcatAudioListNodeOutputs> {
     const audios = Array.isArray(this.audio_files)
       ? (this.audio_files as unknown[])
       : [];
@@ -1433,6 +1524,11 @@ export class ConcatAudioListNode extends BaseNode {
     return { output: await concatAudio(parts) };
   }
 }
+
+/** Output handles TextToSpeechNode.process() emits. */
+type TextToSpeechNodeOutputs = {
+  audio: AudioRef;
+};
 
 export class TextToSpeechNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.TextToSpeech";
@@ -1492,7 +1588,7 @@ export class TextToSpeechNode extends BaseNode {
   })
   declare speed: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<TextToSpeechNodeOutputs> {
     const text = String(this.text ?? "");
     const { providerId, modelId } = getModelConfig(this.serialize());
     const modelObj = (this.model ?? {}) as Record<string, unknown>;
@@ -1575,6 +1671,11 @@ function hasMusicProviderSupport(
   );
 }
 
+/** Output handles TextToMusicNode.process() emits. */
+type TextToMusicNodeOutputs = {
+  audio: AudioRef;
+};
+
 export class TextToMusicNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.TextToMusic";
   static readonly body = "content_card";
@@ -1634,7 +1735,7 @@ export class TextToMusicNode extends BaseNode {
   })
   declare duration: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<TextToMusicNodeOutputs> {
     const prompt = String(this.prompt ?? "");
     const lyrics = String(this.lyrics ?? "");
     const { providerId, modelId } = getModelConfig(this.serialize());
@@ -1663,6 +1764,11 @@ export class TextToMusicNode extends BaseNode {
     );
   }
 }
+
+/** Output handles ChunkToAudioNode.process() emits. */
+type ChunkToAudioNodeOutputs = {
+  audio: AudioRef | { type: string; uri: string; data: string };
+};
 
 export class ChunkToAudioNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.ChunkToAudio";
@@ -1693,7 +1799,7 @@ export class ChunkToAudioNode extends BaseNode {
   })
   declare chunk: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ChunkToAudioNodeOutputs> {
     const chunk = this.chunk;
     if (chunk && typeof chunk === "object") {
       const c = chunk as {
@@ -1721,6 +1827,15 @@ export class ChunkToAudioNode extends BaseNode {
     return { audio: audioRefFromBytes(new Uint8Array()) };
   }
 }
+
+/** Output handles GetAudioInfoNode.process() emits. */
+type GetAudioInfoNodeOutputs = {
+  duration: number;
+  sample_rate: number;
+  channels: number;
+  format: string;
+  size_bytes: number;
+};
 
 export class GetAudioInfoNode extends BaseNode {
   static readonly nodeType = "nodetool.audio.GetAudioInfo";
@@ -1751,7 +1866,7 @@ export class GetAudioInfoNode extends BaseNode {
   })
   declare audio: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<GetAudioInfoNodeOutputs> {
     const bytes = await audioBytesAsync(this.audio, context);
     if (bytes.length === 0) {
       return { duration: 0, sample_rate: 0, channels: 0, format: "unknown", size_bytes: 0 };

--- a/packages/audio-nodes/src/nodes/lib-audio-dsp.ts
+++ b/packages/audio-nodes/src/nodes/lib-audio-dsp.ts
@@ -99,6 +99,11 @@ export async function applyFilter(
   );
 }
 
+/** Output handles GainNode_.process() emits. */
+type GainNode_Outputs = {
+  output: AudioRef;
+};
+
 export class GainNode_ extends BaseNode {
   static readonly nodeType = "lib.audio.Gain";
   static readonly title = "Gain";
@@ -135,7 +140,7 @@ export class GainNode_ extends BaseNode {
   })
   declare gain_db: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<GainNode_Outputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const gainDb = Number(this.gain_db ?? 0);
 
@@ -156,6 +161,11 @@ export class GainNode_ extends BaseNode {
     };
   }
 }
+
+/** Output handles DelayNode_.process() emits. */
+type DelayNode_Outputs = {
+  output: AudioRef;
+};
 
 export class DelayNode_ extends BaseNode {
   static readonly nodeType = "lib.audio.Delay";
@@ -212,7 +222,7 @@ export class DelayNode_ extends BaseNode {
   })
   declare mix: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<DelayNode_Outputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const delaySec = Number(this.delay_seconds ?? 0.5);
     const feedback = Number(this.feedback ?? 0.3);
@@ -258,6 +268,11 @@ export class DelayNode_ extends BaseNode {
   }
 }
 
+/** Output handles HighPassFilterNode.process() emits. */
+type HighPassFilterNodeOutputs = {
+  output: AudioRef;
+};
+
 export class HighPassFilterNode extends BaseNode {
   static readonly nodeType = "lib.audio.HighPassFilter";
   static readonly title = "High Pass Filter";
@@ -293,7 +308,7 @@ export class HighPassFilterNode extends BaseNode {
   })
   declare cutoff_frequency_hz: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<HighPassFilterNodeOutputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const cutoff = Number(this.cutoff_frequency_hz ?? 80);
 
@@ -307,6 +322,11 @@ export class HighPassFilterNode extends BaseNode {
     return { output };
   }
 }
+
+/** Output handles LowPassFilterNode.process() emits. */
+type LowPassFilterNodeOutputs = {
+  output: AudioRef;
+};
 
 export class LowPassFilterNode extends BaseNode {
   static readonly nodeType = "lib.audio.LowPassFilter";
@@ -343,7 +363,7 @@ export class LowPassFilterNode extends BaseNode {
   })
   declare cutoff_frequency_hz: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<LowPassFilterNodeOutputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const cutoff = Number(this.cutoff_frequency_hz ?? 5000);
 
@@ -357,6 +377,11 @@ export class LowPassFilterNode extends BaseNode {
     return { output };
   }
 }
+
+/** Output handles HighShelfFilterNode.process() emits. */
+type HighShelfFilterNodeOutputs = {
+  output: AudioRef;
+};
 
 export class HighShelfFilterNode extends BaseNode {
   static readonly nodeType = "lib.audio.HighShelfFilter";
@@ -404,7 +429,7 @@ export class HighShelfFilterNode extends BaseNode {
   })
   declare gain_db: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<HighShelfFilterNodeOutputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const cutoff = Number(this.cutoff_frequency_hz ?? 5000);
     const gainDb = Number(this.gain_db ?? 0);
@@ -420,6 +445,11 @@ export class HighShelfFilterNode extends BaseNode {
     return { output };
   }
 }
+
+/** Output handles LowShelfFilterNode.process() emits. */
+type LowShelfFilterNodeOutputs = {
+  output: AudioRef;
+};
 
 export class LowShelfFilterNode extends BaseNode {
   static readonly nodeType = "lib.audio.LowShelfFilter";
@@ -467,7 +497,7 @@ export class LowShelfFilterNode extends BaseNode {
   })
   declare gain_db: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<LowShelfFilterNodeOutputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const cutoff = Number(this.cutoff_frequency_hz ?? 200);
     const gainDb = Number(this.gain_db ?? 0);
@@ -483,6 +513,11 @@ export class LowShelfFilterNode extends BaseNode {
     return { output };
   }
 }
+
+/** Output handles PeakFilterNode.process() emits. */
+type PeakFilterNodeOutputs = {
+  output: AudioRef;
+};
 
 export class PeakFilterNode extends BaseNode {
   static readonly nodeType = "lib.audio.PeakFilter";
@@ -541,7 +576,7 @@ export class PeakFilterNode extends BaseNode {
   })
   declare gain_db: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<PeakFilterNodeOutputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const cutoff = Number(this.cutoff_frequency_hz ?? 1000);
     const q = Number(this.q_factor ?? 1.0);

--- a/packages/audio-nodes/src/nodes/lib-audio-effects.ts
+++ b/packages/audio-nodes/src/nodes/lib-audio-effects.ts
@@ -1,3 +1,4 @@
+import type { AudioRef } from "@nodetool-ai/protocol";
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { tagAsServer } from "@nodetool-ai/nodes-utils";
@@ -40,6 +41,11 @@ function processPerChannel(
 }
 
 // ── Bitcrush ──────────────────────────────────────────────────────
+
+/** Output handles BitcrushNode.process() emits. */
+type BitcrushNodeOutputs = {
+  output: AudioRef;
+};
 
 export class BitcrushNode extends BaseNode {
   static readonly nodeType = "lib.audio.Bitcrush";
@@ -88,7 +94,7 @@ export class BitcrushNode extends BaseNode {
   })
   declare sample_rate_reduction: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<BitcrushNodeOutputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const bitDepth = Number(this.bit_depth ?? 8);
     const srrFactor = Number(this.sample_rate_reduction ?? 1);
@@ -119,6 +125,11 @@ export class BitcrushNode extends BaseNode {
 }
 
 // ── Compress ──────────────────────────────────────────────────────
+
+/** Output handles CompressNode.process() emits. */
+type CompressNodeOutputs = {
+  output: AudioRef;
+};
 
 export class CompressNode extends BaseNode {
   static readonly nodeType = "lib.audio.Compress";
@@ -194,7 +205,7 @@ export class CompressNode extends BaseNode {
   })
   declare auto_gain: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<CompressNodeOutputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const thresholdDb = Number(this.threshold ?? -20);
     const ratio = Number(this.ratio ?? 4);
@@ -249,6 +260,11 @@ export class CompressNode extends BaseNode {
 
 // ── Distortion ────────────────────────────────────────────────────
 
+/** Output handles DistortionNode.process() emits. */
+type DistortionNodeOutputs = {
+  output: AudioRef;
+};
+
 export class DistortionNode extends BaseNode {
   static readonly nodeType = "lib.audio.Distortion";
   static readonly title = "Distortion";
@@ -284,7 +300,7 @@ export class DistortionNode extends BaseNode {
   })
   declare drive_db: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<DistortionNodeOutputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const driveDb = Number(this.drive_db ?? 25);
 
@@ -310,6 +326,11 @@ export class DistortionNode extends BaseNode {
 }
 
 // ── Limiter ───────────────────────────────────────────────────────
+
+/** Output handles LimiterNode.process() emits. */
+type LimiterNodeOutputs = {
+  output: AudioRef;
+};
 
 export class LimiterNode extends BaseNode {
   static readonly nodeType = "lib.audio.Limiter";
@@ -365,7 +386,7 @@ export class LimiterNode extends BaseNode {
   })
   declare auto_gain: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<LimiterNodeOutputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const thresholdDb = Number(this.threshold_db ?? -2);
     const releaseMs = Number(this.release_ms ?? 250);
@@ -409,6 +430,11 @@ export class LimiterNode extends BaseNode {
 }
 
 // ── Reverb (Schroeder) ───────────────────────────────────────────
+
+/** Output handles ReverbNode.process() emits. */
+type ReverbNodeOutputs = {
+  output: AudioRef;
+};
 
 export class ReverbNode extends BaseNode {
   static readonly nodeType = "lib.audio.Reverb";
@@ -477,7 +503,7 @@ export class ReverbNode extends BaseNode {
   })
   declare dry_level: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ReverbNodeOutputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const roomScale = Number(this.room_scale ?? 0.5);
     const damping = Number(this.damping ?? 0.5);
@@ -856,6 +882,11 @@ export class TimeStretchNode extends BaseNode {
 
 // ── NoiseGate ─────────────────────────────────────────────────────
 
+/** Output handles NoiseGateNode.process() emits. */
+type NoiseGateNodeOutputs = {
+  output: AudioRef;
+};
+
 export class NoiseGateNode extends BaseNode {
   static readonly nodeType = "lib.audio.NoiseGate";
   static readonly title = "Noise Gate";
@@ -911,7 +942,7 @@ export class NoiseGateNode extends BaseNode {
   })
   declare release_ms: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<NoiseGateNodeOutputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const thresholdDb = Number(this.threshold_db ?? -50);
     const attackMs = Math.max(0.1, Number(this.attack_ms ?? 1));
@@ -957,6 +988,11 @@ export class NoiseGateNode extends BaseNode {
 }
 
 // ── Phaser ────────────────────────────────────────────────────────
+
+/** Output handles PhaserNode.process() emits. */
+type PhaserNodeOutputs = {
+  output: AudioRef;
+};
 
 export class PhaserNode extends BaseNode {
   static readonly nodeType = "lib.audio.Phaser";
@@ -1034,7 +1070,7 @@ export class PhaserNode extends BaseNode {
   })
   declare mix: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<PhaserNodeOutputs> {
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const rateHz = Number(this.rate_hz ?? 1);
     const depth = Number(this.depth ?? 0.5);

--- a/packages/automation-nodes/src/nodes/lib-apple.ts
+++ b/packages/automation-nodes/src/nodes/lib-apple.ts
@@ -163,6 +163,11 @@ function parseRecords(stdout: string): string[][] {
 // Calendar
 // ---------------------------------------------------------------------------
 
+/** Output handles CreateCalendarEventAppleNode.process() emits. */
+type CreateCalendarEventAppleNodeOutputs = {
+  output: boolean;
+};
+
 export class CreateCalendarEventAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.CreateCalendarEvent";
   static readonly title = "Create Calendar Event";
@@ -196,7 +201,7 @@ export class CreateCalendarEventAppleNode extends BaseNode {
   @prop({ type: "str", default: "", title: "Description", description: "Notes for the event" })
   declare description_text: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<CreateCalendarEventAppleNodeOutputs> {
     const title = String(this.event_title ?? "");
     if (!title) throw new Error("title cannot be empty");
     const start = parseDateInput(this.start_date);
@@ -224,6 +229,11 @@ return "ok"
   }
 }
 
+/** Output handles ListCalendarEventsAppleNode.process() emits. */
+type ListCalendarEventsAppleNodeOutputs = {
+  events: { title: string; start_date: string; end_date: string; location: string; notes: string; calendar: string }[];
+};
+
 export class ListCalendarEventsAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.ListCalendarEvents";
   static readonly title = "List Calendar Events";
@@ -243,7 +253,7 @@ export class ListCalendarEventsAppleNode extends BaseNode {
   @prop({ type: "str", default: "Calendar", title: "Calendar Name", description: "Calendar to query" })
   declare calendar_name: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ListCalendarEventsAppleNodeOutputs> {
     const back = Math.max(0, Number(this.days_back ?? 0));
     const fwd = Math.max(0, Number(this.days_forward ?? 7));
     const calName = String(this.calendar_name ?? "Calendar");
@@ -299,6 +309,11 @@ return output
 // Notes
 // ---------------------------------------------------------------------------
 
+/** Output handles CreateNoteAppleNode.process() emits. */
+type CreateNoteAppleNodeOutputs = {
+  output: boolean;
+};
+
 export class CreateNoteAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.CreateNote";
   static readonly title = "Create Note";
@@ -318,7 +333,7 @@ export class CreateNoteAppleNode extends BaseNode {
   @prop({ type: "str", default: "Notes", title: "Folder", description: "Folder to save the note in" })
   declare folder: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<CreateNoteAppleNodeOutputs> {
     const title = String(this.title ?? "");
     const body = String(this.body ?? "");
     const folder = String(this.folder ?? "Notes");
@@ -345,6 +360,11 @@ return "ok"
   }
 }
 
+/** Output handles ListNotesAppleNode.process() emits. */
+type ListNotesAppleNodeOutputs = {
+  notes: { title: string; content: string; folder: string }[];
+};
+
 export class ListNotesAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.ListNotes";
   static readonly title = "List Notes";
@@ -360,7 +380,7 @@ export class ListNotesAppleNode extends BaseNode {
   @prop({ type: "str", default: "", title: "Folder", description: "Optional folder name; empty = all folders" })
   declare folder: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ListNotesAppleNodeOutputs> {
     const limit = Math.max(1, Number(this.limit ?? 25));
     const folder = String(this.folder ?? "");
 
@@ -402,6 +422,11 @@ return output
 // Reminders
 // ---------------------------------------------------------------------------
 
+/** Output handles CreateReminderAppleNode.process() emits. */
+type CreateReminderAppleNodeOutputs = {
+  output: boolean;
+};
+
 export class CreateReminderAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.CreateReminder";
   static readonly title = "Create Reminder";
@@ -424,7 +449,7 @@ export class CreateReminderAppleNode extends BaseNode {
   @prop({ type: "str", default: "", title: "Notes", description: "Additional notes" })
   declare notes: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<CreateReminderAppleNodeOutputs> {
     const title = String(this.title ?? "");
     if (!title) throw new Error("title cannot be empty");
     const listName = String(this.list_name ?? "Reminders");
@@ -459,6 +484,11 @@ return "ok"
   }
 }
 
+/** Output handles ListRemindersAppleNode.process() emits. */
+type ListRemindersAppleNodeOutputs = {
+  reminders: { title: string; notes: string; completed: boolean; due_date: string; list: string }[];
+};
+
 export class ListRemindersAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.ListReminders";
   static readonly title = "List Reminders";
@@ -474,7 +504,7 @@ export class ListRemindersAppleNode extends BaseNode {
   @prop({ type: "bool", default: false, title: "Include Completed", description: "Include completed reminders" })
   declare include_completed: boolean;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ListRemindersAppleNodeOutputs> {
     const listName = String(this.list_name ?? "Reminders");
     const includeCompleted = Boolean(this.include_completed ?? false);
 
@@ -519,6 +549,11 @@ return output
 // Messages
 // ---------------------------------------------------------------------------
 
+/** Output handles SendMessageAppleNode.process() emits. */
+type SendMessageAppleNodeOutputs = {
+  output: boolean;
+};
+
 export class SendMessageAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.SendMessage";
   static readonly title = "Send iMessage";
@@ -535,7 +570,7 @@ export class SendMessageAppleNode extends BaseNode {
   @prop({ type: "str", default: "", title: "Text", description: "Message body" })
   declare text: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SendMessageAppleNodeOutputs> {
     const recipient = String(this.recipient ?? "");
     const text = String(this.text ?? "");
     if (!recipient) throw new Error("recipient cannot be empty");
@@ -557,6 +592,11 @@ return "ok"
 // ---------------------------------------------------------------------------
 // Mail
 // ---------------------------------------------------------------------------
+
+/** Output handles SendMailAppleNode.process() emits. */
+type SendMailAppleNodeOutputs = {
+  output: boolean;
+};
 
 export class SendMailAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.SendMail";
@@ -583,7 +623,7 @@ export class SendMailAppleNode extends BaseNode {
   @prop({ type: "bool", default: false, title: "Visible", description: "Show the message in the UI rather than sending silently" })
   declare visible: boolean;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SendMailAppleNodeOutputs> {
     const to = String(this.to_address ?? "");
     if (!to) throw new Error("to_address cannot be empty");
     const cc = String(this.cc_address ?? "");
@@ -621,6 +661,11 @@ return "ok"
 // Contacts
 // ---------------------------------------------------------------------------
 
+/** Output handles SearchContactsAppleNode.process() emits. */
+type SearchContactsAppleNodeOutputs = {
+  contacts: { identifier: string; full_name: string; given_name: string; family_name: string; emails: string[]; phones: string[] }[];
+};
+
 export class SearchContactsAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.SearchContacts";
   static readonly title = "Search Contacts";
@@ -637,7 +682,7 @@ export class SearchContactsAppleNode extends BaseNode {
   @prop({ type: "int", default: 10, min: 1, max: 200, title: "Limit", description: "Maximum results" })
   declare limit: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SearchContactsAppleNodeOutputs> {
     const query = String(this.query ?? "");
     const limit = Math.max(1, Number(this.limit ?? 10));
 
@@ -702,6 +747,12 @@ return output
 // Safari
 // ---------------------------------------------------------------------------
 
+/** Output handles GetFrontSafariTabAppleNode.process() emits. */
+type GetFrontSafariTabAppleNodeOutputs = {
+  url: string;
+  title: string;
+};
+
 export class GetFrontSafariTabAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.GetFrontSafariTab";
   static readonly title = "Get Front Safari Tab";
@@ -712,7 +763,7 @@ export class GetFrontSafariTabAppleNode extends BaseNode {
     title: "str"
   };
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<GetFrontSafariTabAppleNodeOutputs> {
     const script = `
 tell application "Safari"
     set u to URL of current tab of front window
@@ -725,6 +776,11 @@ return u & "${FIELD_SEP}" & t
     return { url, title };
   }
 }
+
+/** Output handles OpenSafariURLAppleNode.process() emits. */
+type OpenSafariURLAppleNodeOutputs = {
+  output: boolean;
+};
 
 export class OpenSafariURLAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.OpenSafariURL";
@@ -742,7 +798,7 @@ export class OpenSafariURLAppleNode extends BaseNode {
   @prop({ type: "bool", default: true, title: "Activate", description: "Bring Safari to the foreground" })
   declare activate: boolean;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<OpenSafariURLAppleNodeOutputs> {
     const url = String(this.url ?? "");
     if (!url) throw new Error("url cannot be empty");
     const activate = Boolean(this.activate ?? true);
@@ -759,6 +815,11 @@ return "ok"
   }
 }
 
+/** Output handles SafariSelectionTextAppleNode.process() emits. */
+type SafariSelectionTextAppleNodeOutputs = {
+  output: string;
+};
+
 export class SafariSelectionTextAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.SafariSelectionText";
   static readonly title = "Safari Selection Text";
@@ -768,7 +829,7 @@ export class SafariSelectionTextAppleNode extends BaseNode {
     output: "str"
   };
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SafariSelectionTextAppleNodeOutputs> {
     const script = `
 tell application "Safari"
     set selText to do JavaScript "window.getSelection().toString()" in front document
@@ -779,6 +840,11 @@ return selText
     return { output: out.replace(/\n+$/g, "") };
   }
 }
+
+/** Output handles SafariPageTextAppleNode.process() emits. */
+type SafariPageTextAppleNodeOutputs = {
+  output: string;
+};
 
 export class SafariPageTextAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.SafariPageText";
@@ -795,7 +861,7 @@ export class SafariPageTextAppleNode extends BaseNode {
   @prop({ type: "bool", default: true, title: "Prefer Article", description: "Use <article> innerText when present" })
   declare prefer_article: boolean;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SafariPageTextAppleNodeOutputs> {
     const maxChars = Math.max(100, Number(this.max_chars ?? 50_000));
     const preferArticle = Boolean(this.prefer_article ?? true);
 
@@ -818,6 +884,11 @@ return pageText
 // Clipboard
 // ---------------------------------------------------------------------------
 
+/** Output handles GetClipboardTextAppleNode.process() emits. */
+type GetClipboardTextAppleNodeOutputs = {
+  output: string;
+};
+
 export class GetClipboardTextAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.GetClipboardText";
   static readonly title = "Get Clipboard Text";
@@ -827,11 +898,16 @@ export class GetClipboardTextAppleNode extends BaseNode {
     output: "str"
   };
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<GetClipboardTextAppleNodeOutputs> {
     const out = await runOsascript(`return (the clipboard as text)`);
     return { output: out.replace(/\n+$/g, "") };
   }
 }
+
+/** Output handles SetClipboardTextAppleNode.process() emits. */
+type SetClipboardTextAppleNodeOutputs = {
+  output: boolean;
+};
 
 export class SetClipboardTextAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.SetClipboardText";
@@ -845,7 +921,7 @@ export class SetClipboardTextAppleNode extends BaseNode {
   @prop({ type: "str", default: "", title: "Text", description: "Text to put on the clipboard" })
   declare text: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SetClipboardTextAppleNodeOutputs> {
     const text = String(this.text ?? "");
     await runOsascript(`set the clipboard to "${escAS(text)}"\nreturn "ok"`);
     return { output: true };
@@ -855,6 +931,11 @@ export class SetClipboardTextAppleNode extends BaseNode {
 // ---------------------------------------------------------------------------
 // Speech
 // ---------------------------------------------------------------------------
+
+/** Output handles SayTextAppleNode.process() emits. */
+type SayTextAppleNodeOutputs = {
+  output: boolean;
+};
 
 export class SayTextAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.SayText";
@@ -878,7 +959,7 @@ export class SayTextAppleNode extends BaseNode {
   @prop({ type: "bool", default: true, title: "Wait", description: "Wait for speech to finish before returning" })
   declare wait: boolean;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SayTextAppleNodeOutputs> {
     const text = String(this.text ?? "");
     if (!text) throw new Error("text cannot be empty");
     const voice = String(this.voice ?? "");
@@ -900,6 +981,11 @@ export class SayTextAppleNode extends BaseNode {
 // ---------------------------------------------------------------------------
 // Notifications
 // ---------------------------------------------------------------------------
+
+/** Output handles PostNotificationAppleNode.process() emits. */
+type PostNotificationAppleNodeOutputs = {
+  output: boolean;
+};
 
 export class PostNotificationAppleNode extends BaseNode {
   static readonly nodeType = "lib.apple.PostNotification";
@@ -923,7 +1009,7 @@ export class PostNotificationAppleNode extends BaseNode {
   @prop({ type: "str", default: "", title: "Sound", description: "Optional sound name (e.g. 'Glass'); empty = silent" })
   declare sound_name: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<PostNotificationAppleNodeOutputs> {
     const title = String(this.title ?? "Nodetool");
     const subtitle = String(this.subtitle ?? "");
     const message = String(this.message ?? "");

--- a/packages/automation-nodes/src/nodes/lib-sqlite.ts
+++ b/packages/automation-nodes/src/nodes/lib-sqlite.ts
@@ -14,6 +14,11 @@ function resolveDbPath(
   return join(workspaceDir, databaseName);
 }
 
+/** Output handles GetDatabasePathLibNode.process() emits. */
+type GetDatabasePathLibNodeOutputs = {
+  output: string;
+};
+
 export class GetDatabasePathLibNode extends BaseNode {
   static readonly nodeType = "lib.sqlite.GetDatabasePath";
   static readonly title = "Get Database Path";
@@ -33,7 +38,7 @@ export class GetDatabasePathLibNode extends BaseNode {
   })
   declare database_name: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<GetDatabasePathLibNodeOutputs> {
     const databaseName = String(this.database_name ?? "memory.db");
     const dbPath = resolveDbPath(context, databaseName);
     return { output: dbPath };

--- a/packages/code-nodes/src/nodes/claude-code-tmux.ts
+++ b/packages/code-nodes/src/nodes/claude-code-tmux.ts
@@ -459,6 +459,14 @@ const POLL_MS = 750;
 const DIALOG_RETRY_MS = 2000;
 const READY_TIMEOUT_MS = 90_000;
 
+/** Output handles ClaudeCodeAgentNode.genProcess() emits. */
+type ClaudeCodeAgentNodeStreamOutputs = {
+  chunk: { type: string; content: string; content_type: string; done: boolean };
+  text: null | string;
+  transcript?: string;
+  session_id?: string;
+};
+
 export class ClaudeCodeAgentNode extends BaseNode {
   static readonly nodeType = "nodetool.agents.ClaudeCodeAgent";
   static readonly title = "Claude Code Agent";
@@ -587,7 +595,7 @@ export class ClaudeCodeAgentNode extends BaseNode {
 
   async *genProcess(
     context?: ProcessingContext
-  ): AsyncGenerator<Record<string, unknown>> {
+  ): AsyncGenerator<ClaudeCodeAgentNodeStreamOutputs> {
     const promptText = combinePrompt(
       String(this.prompt ?? ""),
       String(this.input ?? "")

--- a/packages/core-nodes/src/nodes/constant.ts
+++ b/packages/core-nodes/src/nodes/constant.ts
@@ -35,6 +35,11 @@ interface ImageSizeValue {
   height?: number;
 }
 
+/** Output handles ConstantBaseNode.process() emits. */
+type ConstantBaseNodeOutputs = {
+  output: null;
+};
+
 export class ConstantBaseNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Constant";
   static readonly retrySafe = true;
@@ -42,10 +47,15 @@ export class ConstantBaseNode extends BaseNode {
   static readonly description =
     "Base class for fixed-value nodes.\n    constant, parameter, default\n\n    Use cases:\n    - Provide static inputs to a workflow\n    - Hold configuration values\n    - Simplify testing with deterministic outputs";
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantBaseNodeOutputs> {
     return { output: null };
   }
 }
+
+/** Output handles ConstantBoolNode.process() emits. */
+type ConstantBoolNodeOutputs = {
+  output: boolean;
+};
 
 export class ConstantBoolNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Bool";
@@ -62,10 +72,15 @@ export class ConstantBoolNode extends BaseNode {
   @prop({ type: "bool", default: false, title: "Value" })
   declare value: boolean;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantBoolNodeOutputs> {
     return { output: this.value ?? false };
   }
 }
+
+/** Output handles ConstantIntegerNode.process() emits. */
+type ConstantIntegerNodeOutputs = {
+  output: number;
+};
 
 export class ConstantIntegerNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Integer";
@@ -82,10 +97,15 @@ export class ConstantIntegerNode extends BaseNode {
   @prop({ type: "int", default: 0, title: "Value" })
   declare value: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantIntegerNodeOutputs> {
     return { output: this.value ?? 0 };
   }
 }
+
+/** Output handles ConstantFloatNode.process() emits. */
+type ConstantFloatNodeOutputs = {
+  output: number;
+};
 
 export class ConstantFloatNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Float";
@@ -102,10 +122,15 @@ export class ConstantFloatNode extends BaseNode {
   @prop({ type: "float", default: 0, title: "Value" })
   declare value: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantFloatNodeOutputs> {
     return { output: this.value ?? 0.0 };
   }
 }
+
+/** Output handles ConstantStringNode.process() emits. */
+type ConstantStringNodeOutputs = {
+  output: string;
+};
 
 export class ConstantStringNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.String";
@@ -122,7 +147,7 @@ export class ConstantStringNode extends BaseNode {
   @prop({ type: "str", default: "", title: "Value" })
   declare value: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantStringNodeOutputs> {
     return { output: this.value ?? "" };
   }
 }
@@ -147,6 +172,11 @@ export class ConstantListNode extends BaseNode {
   }
 }
 
+/** Output handles ConstantTextListNode.process() emits. */
+type ConstantTextListNodeOutputs = {
+  output: string[];
+};
+
 export class ConstantTextListNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.TextList";
   static readonly retrySafe = true;
@@ -168,7 +198,7 @@ export class ConstantTextListNode extends BaseNode {
   })
   declare value: string[] | null;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantTextListNodeOutputs> {
     return { output: this.value ?? [] };
   }
 }
@@ -361,6 +391,11 @@ export class ConstantSketchNode extends BaseNode {
   }
 }
 
+/** Output handles ConstantTimelineNode.process() emits. */
+type ConstantTimelineNodeOutputs = {
+  output: TimelineRef;
+};
+
 export class ConstantTimelineNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Timeline";
   static readonly retrySafe = true;
@@ -380,10 +415,15 @@ export class ConstantTimelineNode extends BaseNode {
   })
   declare value: TimelineRef;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantTimelineNodeOutputs> {
     return { output: this.value ?? {} };
   }
 }
+
+/** Output handles ConstantScriptNode.process() emits. */
+type ConstantScriptNodeOutputs = {
+  output: ScriptRef;
+};
 
 export class ConstantScriptNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Script";
@@ -404,7 +444,7 @@ export class ConstantScriptNode extends BaseNode {
   })
   declare value: ScriptRef;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantScriptNodeOutputs> {
     return { output: this.value ?? {} };
   }
 }
@@ -481,6 +521,11 @@ export class ConstantDataFrameNode extends BaseNode {
   }
 }
 
+/** Output handles ConstantAudioListNode.process() emits. */
+type ConstantAudioListNodeOutputs = {
+  output: AudioRef[];
+};
+
 export class ConstantAudioListNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.AudioList";
   static readonly retrySafe = true;
@@ -502,10 +547,15 @@ export class ConstantAudioListNode extends BaseNode {
   })
   declare value: AudioRef[] | null;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantAudioListNodeOutputs> {
     return { output: this.value ?? [] };
   }
 }
+
+/** Output handles ConstantImageListNode.process() emits. */
+type ConstantImageListNodeOutputs = {
+  output: ImageRef[];
+};
 
 export class ConstantImageListNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.ImageList";
@@ -528,10 +578,15 @@ export class ConstantImageListNode extends BaseNode {
   })
   declare value: ImageRef[] | null;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantImageListNodeOutputs> {
     return { output: this.value ?? [] };
   }
 }
+
+/** Output handles ConstantVideoListNode.process() emits. */
+type ConstantVideoListNodeOutputs = {
+  output: VideoRef[];
+};
 
 export class ConstantVideoListNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.VideoList";
@@ -554,10 +609,15 @@ export class ConstantVideoListNode extends BaseNode {
   })
   declare value: VideoRef[] | null;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantVideoListNodeOutputs> {
     return { output: this.value ?? [] };
   }
 }
+
+/** Output handles ConstantSelectNode.process() emits. */
+type ConstantSelectNodeOutputs = {
+  output: string;
+};
 
 export class ConstantSelectNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Select";
@@ -599,7 +659,7 @@ export class ConstantSelectNode extends BaseNode {
   })
   declare enum_type_name: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantSelectNodeOutputs> {
     const value = this.value ?? "";
     const options = Array.isArray(this.options) ? this.options : [];
     if (value !== "" && options.length > 0 && !options.includes(value)) {
@@ -610,6 +670,13 @@ export class ConstantSelectNode extends BaseNode {
     return { output: value };
   }
 }
+
+/** Output handles ConstantImageSizeNode.process() emits. */
+type ConstantImageSizeNodeOutputs = {
+  image_size: { width?: number; height?: number };
+  width: number;
+  height: number;
+};
 
 export class ConstantImageSizeNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.ImageSize";
@@ -628,7 +695,7 @@ export class ConstantImageSizeNode extends BaseNode {
   @prop({ type: "image_size", default: null, title: "Value", required: true })
   declare value: ImageSizeValue | null;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantImageSizeNodeOutputs> {
     const value = (this.value ?? { width: 1024, height: 1024 }) as {
       width?: number;
       height?: number;
@@ -638,6 +705,11 @@ export class ConstantImageSizeNode extends BaseNode {
     return { image_size: value, width, height };
   }
 }
+
+/** Output handles ConstantDateNode.process() emits. */
+type ConstantDateNodeOutputs = {
+  output: { year: number; month: number; day: number };
+};
 
 export class ConstantDateNode extends BaseNode {
   static readonly nodeType = "nodetool.constant.Date";
@@ -681,7 +753,7 @@ export class ConstantDateNode extends BaseNode {
   })
   declare day: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConstantDateNodeOutputs> {
     const year = Number(this.year ?? 1900);
     const month = Number(this.month ?? 1);
     const day = Number(this.day ?? 1);

--- a/packages/core-nodes/src/nodes/control.ts
+++ b/packages/core-nodes/src/nodes/control.ts
@@ -150,6 +150,12 @@ export class AssetCollectionNode extends BaseNode {
   }
 }
 
+/** Output handles RepeatCountNode.genProcess() emits. */
+type RepeatCountNodeStreamOutputs = {
+  output: number;
+  index: number;
+};
+
 export class RepeatCountNode extends BaseNode {
   static readonly nodeType = "nodetool.control.RepeatCount";
   static readonly retrySafe = true;
@@ -182,7 +188,7 @@ export class RepeatCountNode extends BaseNode {
     return {};
   }
 
-  async *genProcess(): AsyncGenerator<Record<string, unknown>> {
+  async *genProcess(): AsyncGenerator<RepeatCountNodeStreamOutputs> {
     const total = Math.max(0, Math.floor(Number(this.count ?? 0)));
     for (let index = 0; index < total; index++) {
       yield { output: index, index };
@@ -778,6 +784,11 @@ export class LastNode extends BaseNode {
   }
 }
 
+/** Output handles CountStreamNode.process() emits. */
+type CountStreamNodeOutputs = {
+  output: number;
+};
+
 export class CountStreamNode extends BaseNode {
   static readonly nodeType = "nodetool.control.Count";
   static readonly retrySafe = true;
@@ -804,7 +815,7 @@ export class CountStreamNode extends BaseNode {
   })
   declare input_item: unknown;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<CountStreamNodeOutputs> {
     return { output: 0 };
   }
 

--- a/packages/core-nodes/src/nodes/fake-media.ts
+++ b/packages/core-nodes/src/nodes/fake-media.ts
@@ -116,6 +116,11 @@ const renderGradientPng = async (
   return `data:image/png;base64,${bytesToBase64(bytes)}`;
 };
 
+/** Output handles FakeGenerateImageNode.process() emits. */
+type FakeGenerateImageNodeOutputs = {
+  output: ImageRef;
+};
+
 export class FakeGenerateImageNode extends BaseNode {
   static readonly nodeType = "nodetool.fake.GenerateImage";
   static readonly retrySafe = true;
@@ -144,7 +149,7 @@ export class FakeGenerateImageNode extends BaseNode {
   @prop({ type: "int", default: 512, title: "Height", min: 16, max: 2048 })
   declare height: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FakeGenerateImageNodeOutputs> {
     const width = clampDim(this.width, 512);
     const height = clampDim(this.height, 512);
     const prompt = String(this.prompt ?? "");

--- a/packages/core-nodes/src/nodes/input.ts
+++ b/packages/core-nodes/src/nodes/input.ts
@@ -50,6 +50,11 @@ interface ImageSizeValue {
   height?: number;
 }
 
+/** Output handles FloatInputNode.process() emits. */
+type FloatInputNodeOutputs = {
+  output: number;
+};
+
 export class FloatInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.FloatInput";
   static readonly retrySafe = true;
@@ -77,13 +82,18 @@ export class FloatInputNode extends BaseNode {
   @prop({ type: "float", default: 99999, title: "Max" })
   declare max: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FloatInputNodeOutputs> {
     const value = this.value ?? 0.0;
     const min = this.min ?? 0;
     const max = this.max ?? 99999;
     return { output: Math.min(Math.max(value, min), max) };
   }
 }
+
+/** Output handles BooleanInputNode.process() emits. */
+type BooleanInputNodeOutputs = {
+  output: boolean;
+};
 
 export class BooleanInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.BooleanInput";
@@ -106,10 +116,15 @@ export class BooleanInputNode extends BaseNode {
   @prop(INPUT_DESCRIPTION_PROP)
   declare description: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<BooleanInputNodeOutputs> {
     return { output: this.value ?? false };
   }
 }
+
+/** Output handles IntegerInputNode.process() emits. */
+type IntegerInputNodeOutputs = {
+  output: number;
+};
 
 export class IntegerInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.IntegerInput";
@@ -138,13 +153,18 @@ export class IntegerInputNode extends BaseNode {
   @prop({ type: "int", default: 99999, title: "Max" })
   declare max: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<IntegerInputNodeOutputs> {
     const value = this.value ?? 0;
     const min = this.min ?? 0;
     const max = this.max ?? 99999;
     return { output: Math.trunc(Math.min(Math.max(value, min), max)) };
   }
 }
+
+/** Output handles SelectInputNode.process() emits. */
+type SelectInputNodeOutputs = {
+  output: string;
+};
 
 export class SelectInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.SelectInput";
@@ -192,7 +212,7 @@ export class SelectInputNode extends BaseNode {
   })
   declare enum_type_name: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SelectInputNodeOutputs> {
     const value = this.value ?? "";
     const options = Array.isArray(this.options) ? this.options : [];
     if (value !== "" && options.length > 0 && !options.includes(value)) {
@@ -203,6 +223,11 @@ export class SelectInputNode extends BaseNode {
     return { output: value };
   }
 }
+
+/** Output handles StringListInputNode.process() emits. */
+type StringListInputNodeOutputs = {
+  output: string[];
+};
 
 export class StringListInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.StringListInput";
@@ -230,10 +255,15 @@ export class StringListInputNode extends BaseNode {
   @prop(INPUT_DESCRIPTION_PROP)
   declare description: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<StringListInputNodeOutputs> {
     return { output: this.value ?? [] };
   }
 }
+
+/** Output handles FolderPathInputNode.process() emits. */
+type FolderPathInputNodeOutputs = {
+  output: string;
+};
 
 export class FolderPathInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.FolderPathInput";
@@ -264,7 +294,7 @@ export class FolderPathInputNode extends BaseNode {
   @prop(INPUT_DESCRIPTION_PROP)
   declare description: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FolderPathInputNodeOutputs> {
     return { output: this.value ?? "" };
   }
 }
@@ -331,6 +361,11 @@ export class ColorInputNode extends BaseNode {
   }
 }
 
+/** Output handles ImageSizeInputNode.process() emits. */
+type ImageSizeInputNodeOutputs = {
+  output: ImageSizeValue;
+};
+
 export class ImageSizeInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.ImageSizeInput";
   static readonly retrySafe = true;
@@ -358,7 +393,7 @@ export class ImageSizeInputNode extends BaseNode {
   @prop(INPUT_DESCRIPTION_PROP)
   declare description: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ImageSizeInputNodeOutputs> {
     return { output: this.value ?? {} };
   }
 }
@@ -642,6 +677,11 @@ export class ImageInputNode extends BaseNode {
   }
 }
 
+/** Output handles ImageListInputNode.process() emits. */
+type ImageListInputNodeOutputs = {
+  output: ImageRef[];
+};
+
 export class ImageListInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.ImageListInput";
   static readonly retrySafe = true;
@@ -668,10 +708,15 @@ export class ImageListInputNode extends BaseNode {
   @prop(INPUT_DESCRIPTION_PROP)
   declare description: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ImageListInputNodeOutputs> {
     return { output: this.value ?? [] };
   }
 }
+
+/** Output handles VideoListInputNode.process() emits. */
+type VideoListInputNodeOutputs = {
+  output: VideoRef[];
+};
 
 export class VideoListInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.VideoListInput";
@@ -699,10 +744,15 @@ export class VideoListInputNode extends BaseNode {
   @prop(INPUT_DESCRIPTION_PROP)
   declare description: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<VideoListInputNodeOutputs> {
     return { output: this.value ?? [] };
   }
 }
+
+/** Output handles AudioListInputNode.process() emits. */
+type AudioListInputNodeOutputs = {
+  output: AudioRef[];
+};
 
 export class AudioListInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.AudioListInput";
@@ -730,10 +780,15 @@ export class AudioListInputNode extends BaseNode {
   @prop(INPUT_DESCRIPTION_PROP)
   declare description: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<AudioListInputNodeOutputs> {
     return { output: this.value ?? [] };
   }
 }
+
+/** Output handles TextListInputNode.process() emits. */
+type TextListInputNodeOutputs = {
+  output: string[];
+};
 
 export class TextListInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.TextListInput";
@@ -761,7 +816,7 @@ export class TextListInputNode extends BaseNode {
   @prop(INPUT_DESCRIPTION_PROP)
   declare description: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TextListInputNodeOutputs> {
     return { output: this.value ?? [] };
   }
 }
@@ -921,6 +976,11 @@ export class MessageInputNode extends BaseNode {
   }
 }
 
+/** Output handles MessageListInputNode.process() emits. */
+type MessageListInputNodeOutputs = {
+  output: Message[];
+};
+
 export class MessageListInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.MessageListInput";
   static readonly retrySafe = true;
@@ -947,10 +1007,15 @@ export class MessageListInputNode extends BaseNode {
   @prop(INPUT_DESCRIPTION_PROP)
   declare description: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<MessageListInputNodeOutputs> {
     return { output: this.value ?? [] };
   }
 }
+
+/** Output handles StringInputNode.process() emits. */
+type StringInputNodeOutputs = {
+  output: string;
+};
 
 export class StringInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.StringInput";
@@ -996,7 +1061,7 @@ export class StringInputNode extends BaseNode {
   })
   declare line_mode: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<StringInputNodeOutputs> {
     const raw = String(this.value ?? "");
     const max = Number(this.max_length ?? 0);
     if (max > 0 && raw.length > max) {
@@ -1005,6 +1070,11 @@ export class StringInputNode extends BaseNode {
     return { output: raw };
   }
 }
+
+/** Output handles RealtimeAudioInputNode.process() emits. */
+type RealtimeAudioInputNodeOutputs = {
+  chunk: AudioRef | null;
+};
 
 export class RealtimeAudioInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.RealtimeAudioInput";
@@ -1045,10 +1115,16 @@ export class RealtimeAudioInputNode extends BaseNode {
   @prop(INPUT_DESCRIPTION_PROP)
   declare description: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<RealtimeAudioInputNodeOutputs> {
     return { chunk: this.value ?? null };
   }
 }
+
+/** Output handles DocumentFileInputNode.process() emits. */
+type DocumentFileInputNodeOutputs = {
+  document: { type: string; uri: string };
+  path: string;
+};
 
 export class DocumentFileInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.DocumentFileInput";
@@ -1080,7 +1156,7 @@ export class DocumentFileInputNode extends BaseNode {
   @prop(INPUT_DESCRIPTION_PROP)
   declare description: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<DocumentFileInputNodeOutputs> {
     const p = String(this.value ?? "");
     return {
       document: { type: "document", uri: p ? `file://${p}` : "" },
@@ -1088,6 +1164,11 @@ export class DocumentFileInputNode extends BaseNode {
     };
   }
 }
+
+/** Output handles FilePathInputNode.process() emits. */
+type FilePathInputNodeOutputs = {
+  output: string;
+};
 
 export class FilePathInputNode extends BaseNode {
   static readonly nodeType = "nodetool.input.FilePathInput";
@@ -1118,7 +1199,7 @@ export class FilePathInputNode extends BaseNode {
   @prop(INPUT_DESCRIPTION_PROP)
   declare description: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FilePathInputNodeOutputs> {
     return { output: this.value ?? "" };
   }
 }

--- a/packages/core-nodes/src/nodes/vector.ts
+++ b/packages/core-nodes/src/nodes/vector.ts
@@ -82,6 +82,11 @@ function keywordFilter(
   return { $document: { $contains: queryTokens[0] } };
 }
 
+/** Output handles CollectionNode.process() emits. */
+type CollectionNodeOutputs = {
+  output: { type: string; name: string };
+};
+
 export class CollectionNode extends BaseNode {
   static readonly nodeType = "vector.Collection";
   static readonly title = "Collection";
@@ -118,7 +123,7 @@ export class CollectionNode extends BaseNode {
   })
   declare embedding_model: unknown;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<CollectionNodeOutputs> {
     const name = String(this.name ?? "");
     const embeddingModel = (this.embedding_model ?? { repo_id: "" }) as {
       repo_id: string;
@@ -137,6 +142,11 @@ export class CollectionNode extends BaseNode {
     return { output: { type: "collection", name } };
   }
 }
+
+/** Output handles CountNode.process() emits. */
+type CountNodeOutputs = {
+  output: number;
+};
 
 export class CountNode extends BaseNode {
   static readonly nodeType = "vector.Count";
@@ -160,7 +170,7 @@ export class CountNode extends BaseNode {
   })
   declare collection: unknown;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<CountNodeOutputs> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
     const name = collectionInput.name ?? "";
     if (!name.trim()) throw new Error("Collection name cannot be empty");
@@ -170,6 +180,11 @@ export class CountNode extends BaseNode {
     return { output: count };
   }
 }
+
+/** Output handles GetDocumentsNode.process() emits. */
+type GetDocumentsNodeOutputs = {
+  output: (string | null)[];
+};
 
 export class GetDocumentsNode extends BaseNode {
   static readonly nodeType = "vector.GetDocuments";
@@ -214,7 +229,7 @@ export class GetDocumentsNode extends BaseNode {
   })
   declare offset: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<GetDocumentsNodeOutputs> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
     const name = collectionInput.name ?? "";
     if (!name.trim()) throw new Error("Collection name cannot be empty");
@@ -235,6 +250,11 @@ export class GetDocumentsNode extends BaseNode {
     return { output: records.map((r: VectorRecord) => r.document ?? null) };
   }
 }
+
+/** Output handles PeekNode.process() emits. */
+type PeekNodeOutputs = {
+  output: (string | null)[];
+};
 
 export class PeekNode extends BaseNode {
   static readonly nodeType = "vector.Peek";
@@ -263,7 +283,7 @@ export class PeekNode extends BaseNode {
   })
   declare limit: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<PeekNodeOutputs> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
     const name = collectionInput.name ?? "";
     if (!name.trim()) throw new Error("Collection name cannot be empty");
@@ -275,6 +295,11 @@ export class PeekNode extends BaseNode {
     return { output: records.map((r: VectorRecord) => r.document ?? null) };
   }
 }
+
+/** Output handles IndexImageNode.process() emits. */
+type IndexImageNodeOutputs = {
+  output: null;
+};
 
 export class IndexImageNode extends BaseNode {
   static readonly nodeType = "vector.IndexImage";
@@ -331,7 +356,7 @@ export class IndexImageNode extends BaseNode {
   })
   declare upsert: boolean;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<IndexImageNodeOutputs> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
     const name = collectionInput.name ?? "";
     if (!name.trim()) throw new Error("Collection name cannot be empty");
@@ -367,6 +392,11 @@ export class IndexImageNode extends BaseNode {
     return { output: null };
   }
 }
+
+/** Output handles IndexEmbeddingNode.process() emits. */
+type IndexEmbeddingNodeOutputs = {
+  output: null;
+};
 
 export class IndexEmbeddingNode extends BaseNode {
   static readonly nodeType = "vector.IndexEmbedding";
@@ -408,7 +438,7 @@ export class IndexEmbeddingNode extends BaseNode {
   })
   declare metadata: Record<string, unknown> | Record<string, unknown>[];
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<IndexEmbeddingNodeOutputs> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
     const name = collectionInput.name ?? "";
     if (!name.trim()) throw new Error("Collection name cannot be empty");
@@ -492,6 +522,11 @@ export class IndexEmbeddingNode extends BaseNode {
   }
 }
 
+/** Output handles IndexTextChunkNode.process() emits. */
+type IndexTextChunkNodeOutputs = {
+  output: null;
+};
+
 export class IndexTextChunkNode extends BaseNode {
   static readonly nodeType = "vector.IndexTextChunk";
   static readonly title = "Index Text Chunk";
@@ -532,7 +567,7 @@ export class IndexTextChunkNode extends BaseNode {
   })
   declare metadata: Record<string, unknown>;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<IndexTextChunkNodeOutputs> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
     const name = collectionInput.name ?? "";
     if (!name.trim()) throw new Error("Collection name cannot be empty");
@@ -553,6 +588,11 @@ export class IndexTextChunkNode extends BaseNode {
 }
 
 type AggregationMethod = "mean" | "max" | "min" | "sum";
+
+/** Output handles IndexAggregatedTextNode.process() emits. */
+type IndexAggregatedTextNodeOutputs = {
+  output: null;
+};
 
 export class IndexAggregatedTextNode extends BaseNode {
   static readonly nodeType = "vector.IndexAggregatedText";
@@ -611,7 +651,7 @@ export class IndexAggregatedTextNode extends BaseNode {
   })
   declare aggregation: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<IndexAggregatedTextNodeOutputs> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
     const name = collectionInput.name ?? "";
     if (!name.trim()) throw new Error("Collection name cannot be empty");
@@ -689,6 +729,11 @@ export class IndexAggregatedTextNode extends BaseNode {
   }
 }
 
+/** Output handles IndexStringNode.process() emits. */
+type IndexStringNodeOutputs = {
+  output: null;
+};
+
 export class IndexStringNode extends BaseNode {
   static readonly nodeType = "vector.IndexString";
   static readonly title = "Index String";
@@ -729,7 +774,7 @@ export class IndexStringNode extends BaseNode {
   })
   declare metadata: Record<string, unknown>;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<IndexStringNodeOutputs> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
     const name = collectionInput.name ?? "";
     if (!name.trim()) throw new Error("Collection name cannot be empty");
@@ -745,6 +790,14 @@ export class IndexStringNode extends BaseNode {
     return { output: null };
   }
 }
+
+/** Output handles QueryImageNode.process() emits. */
+type QueryImageNodeOutputs = {
+  ids: string[];
+  documents: string[];
+  metadatas: RecordMetadata[];
+  distances: number[];
+};
 
 export class QueryImageNode extends BaseNode {
   static readonly nodeType = "vector.QueryImage";
@@ -790,7 +843,7 @@ export class QueryImageNode extends BaseNode {
   })
   declare n_results: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<QueryImageNodeOutputs> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
     const name = collectionInput.name ?? "";
     if (!name.trim()) throw new Error("Collection name cannot be empty");
@@ -814,6 +867,14 @@ export class QueryImageNode extends BaseNode {
     };
   }
 }
+
+/** Output handles QueryTextNode.process() emits. */
+type QueryTextNodeOutputs = {
+  ids: string[];
+  documents: string[];
+  metadatas: RecordMetadata[];
+  distances: number[];
+};
 
 export class QueryTextNode extends BaseNode {
   static readonly nodeType = "vector.QueryText";
@@ -853,7 +914,7 @@ export class QueryTextNode extends BaseNode {
   })
   declare n_results: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<QueryTextNodeOutputs> {
     const collectionInput = (this.collection ?? { name: "" }) as { name: string };
     const name = collectionInput.name ?? "";
     if (!name.trim()) throw new Error("Collection name cannot be empty");
@@ -874,6 +935,11 @@ export class QueryTextNode extends BaseNode {
     };
   }
 }
+
+/** Output handles RemoveOverlapNode.process() emits. */
+type RemoveOverlapNodeOutputs = {
+  documents: string[];
+};
 
 export class RemoveOverlapNode extends BaseNode {
   static readonly nodeType = "vector.RemoveOverlap";
@@ -902,7 +968,7 @@ export class RemoveOverlapNode extends BaseNode {
   })
   declare min_overlap_words: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<RemoveOverlapNodeOutputs> {
     const documents = (this.documents ?? []) as string[];
     const minOverlapWords = Number(this.min_overlap_words ?? 2);
 

--- a/packages/data-nodes/src/nodes/data.ts
+++ b/packages/data-nodes/src/nodes/data.ts
@@ -78,6 +78,12 @@ function parseCsv(csv: string): Row[] {
   );
 }
 
+/** Output handles ForEachRowNode.genProcess() emits. */
+type ForEachRowNodeStreamOutputs = {
+  row: Row;
+  index: number;
+};
+
 export class ForEachRowNode extends BaseNode {
   static readonly nodeType = "nodetool.data.ForEachRow";
   static readonly retrySafe = true;
@@ -116,7 +122,7 @@ export class ForEachRowNode extends BaseNode {
     return {};
   }
 
-  async *genProcess(): AsyncGenerator<Record<string, unknown>> {
+  async *genProcess(): AsyncGenerator<ForEachRowNodeStreamOutputs> {
     const rows = asRows(this.dataframe);
     for (const [index, row] of rows.entries()) {
       yield { row, index };

--- a/packages/data-nodes/src/nodes/lib-charts.ts
+++ b/packages/data-nodes/src/nodes/lib-charts.ts
@@ -1,6 +1,11 @@
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import { asRows } from "./data.js";
 
+/** Output handles ChartRendererLibNode.process() emits. */
+type ChartRendererLibNodeOutputs = {
+  output: { type: string; data: string };
+};
+
 export class ChartRendererLibNode extends BaseNode {
   static readonly nodeType = "lib.charts.ChartRenderer";
   static readonly retrySafe = true;
@@ -117,7 +122,7 @@ export class ChartRendererLibNode extends BaseNode {
   })
   declare trim_margins: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ChartRendererLibNodeOutputs> {
     const config = (this.chart_config ?? {}) as Record<string, unknown>;
     const width = Number(this.width ?? 640);
     const height = Number(this.height ?? 480);

--- a/packages/document-nodes/src/nodes/document.ts
+++ b/packages/document-nodes/src/nodes/document.ts
@@ -36,6 +36,11 @@ function wildcardToRegExp(pattern: string): RegExp {
   return new RegExp(`^${escaped.replaceAll("*", ".*")}$`);
 }
 
+/** Output handles LoadDocumentFileNode.process() emits. */
+type LoadDocumentFileNodeOutputs = {
+  output: { uri: string; data: string };
+};
+
 export class LoadDocumentFileNode extends BaseNode {
   static readonly nodeType = "nodetool.document.LoadDocumentFile";
   static readonly platforms = NODE_ONLY;
@@ -56,7 +61,7 @@ export class LoadDocumentFileNode extends BaseNode {
   })
   declare path: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<LoadDocumentFileNodeOutputs> {
     const p = String(this.path ?? this.path ?? "");
     const full = toFilePath(p);
     const fs = await loadNodeFsPromises();
@@ -69,6 +74,11 @@ export class LoadDocumentFileNode extends BaseNode {
     };
   }
 }
+
+/** Output handles SaveDocumentFileNode.process() emits. */
+type SaveDocumentFileNodeOutputs = {
+  output: string;
+};
 
 export class SaveDocumentFileNode extends BaseNode {
   static readonly nodeType = "nodetool.document.SaveDocumentFile";
@@ -109,7 +119,7 @@ export class SaveDocumentFileNode extends BaseNode {
   })
   declare filename: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SaveDocumentFileNodeOutputs> {
     const document = (this.document ?? this.document ?? {}) as DocumentRefLike;
     const p = String((this as any).path ?? "");
     const full = toFilePath(p);

--- a/packages/document-nodes/src/nodes/lib-pdf.ts
+++ b/packages/document-nodes/src/nodes/lib-pdf.ts
@@ -55,6 +55,11 @@ const PDF_INPUT = {
   description: "The PDF document to process"
 };
 
+/** Output handles PdfExtractTextNode.process() emits. */
+type PdfExtractTextNodeOutputs = {
+  output: string;
+};
+
 export class PdfExtractTextNode extends BaseNode {
   static readonly nodeType = "lib.pdf.ExtractText";
   static readonly title = "PDF Extract Text";
@@ -83,7 +88,7 @@ export class PdfExtractTextNode extends BaseNode {
   })
   declare end_page: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<PdfExtractTextNodeOutputs> {
     const result = await parsePdf(
       (this.pdf ?? {}) as DocumentRefLike,
       context
@@ -102,6 +107,11 @@ export class PdfExtractTextNode extends BaseNode {
     return { output: parts.join("\n\n").trim() };
   }
 }
+
+/** Output handles PdfExtractMarkdownNode.process() emits. */
+type PdfExtractMarkdownNodeOutputs = {
+  output: string;
+};
 
 export class PdfExtractMarkdownNode extends BaseNode {
   static readonly nodeType = "lib.pdf.ExtractMarkdown";
@@ -131,7 +141,7 @@ export class PdfExtractMarkdownNode extends BaseNode {
   })
   declare end_page: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<PdfExtractMarkdownNodeOutputs> {
     const result = await parsePdf(
       (this.pdf ?? {}) as DocumentRefLike,
       context
@@ -536,6 +546,11 @@ export class PdfExtractStyledTextNode extends BaseNode {
   }
 }
 
+/** Output handles PdfScreenshotNode.process() emits. */
+type PdfScreenshotNodeOutputs = {
+  output: { type: string; data: string }[];
+};
+
 export class PdfScreenshotNode extends BaseNode {
   static readonly nodeType = "lib.pdf.Screenshot";
   static readonly title = "PDF Page Screenshot";
@@ -574,7 +589,7 @@ export class PdfScreenshotNode extends BaseNode {
   })
   declare dpi: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<PdfScreenshotNodeOutputs> {
     // Bypass liteparse's parser.screenshot(): it loads the same buffer into
     // pdf.js *and* PDFium, but pdf.js detaches the underlying ArrayBuffer
     // during its load, leaving PDFium with a detached buffer (→ "File not in
@@ -630,6 +645,11 @@ export class PdfScreenshotNode extends BaseNode {
     return { output: images };
   }
 }
+
+/** Output handles PdfToppmNode.process() emits. */
+type PdfToppmNodeOutputs = {
+  output: { type: string; data: string }[];
+};
 
 export class PdfToppmNode extends BaseNode {
   static readonly nodeType = "lib.pdf.Pdftoppm";
@@ -690,7 +710,7 @@ export class PdfToppmNode extends BaseNode {
   })
   declare scale_to: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<PdfToppmNodeOutputs> {
     const { execFile } = await import("node:child_process");
     const { promisify } = await import("node:util");
     const { promises: fs } = await import("node:fs");
@@ -770,6 +790,11 @@ async function countPdfPages(pdf: Buffer): Promise<number> {
   }
 }
 
+/** Output handles PdfExtractOcrNode.process() emits. */
+type PdfExtractOcrNodeOutputs = {
+  output: string;
+};
+
 export class PdfExtractOcrNode extends BaseNode {
   static readonly nodeType = "lib.pdf.ExtractOcr";
   static readonly title = "PDF Extract Text (OCR)";
@@ -816,7 +841,7 @@ export class PdfExtractOcrNode extends BaseNode {
   })
   declare dpi: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<PdfExtractOcrNodeOutputs> {
     const { LiteParse } = await import("@llamaindex/liteparse");
     const pdfBuffer = await resolvePdfBuffer(
       (this.pdf ?? {}) as DocumentRefLike,

--- a/packages/elevenlabs-nodes/src/nodes/standard-voice.ts
+++ b/packages/elevenlabs-nodes/src/nodes/standard-voice.ts
@@ -2,6 +2,11 @@ import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
 import { VOICE_ID_MAP, VOICE_NAMES } from "../elevenlabs-base.js";
 
+/** Output handles StandardVoiceNode.process() emits. */
+type StandardVoiceNodeOutputs = {
+  voice_id: string;
+};
+
 export class StandardVoiceNode extends BaseNode {
   static readonly nodeType = "elevenlabs.StandardVoice";
   static readonly body = "small";
@@ -26,7 +31,7 @@ export class StandardVoiceNode extends BaseNode {
   })
   declare voice: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<StandardVoiceNodeOutputs> {
     const voice = String(this.voice ?? "Aria");
     const voiceId = VOICE_ID_MAP[voice];
     if (!voiceId) throw new Error(`Unknown voice: ${voice}`);

--- a/packages/elevenlabs-nodes/src/nodes/text-to-speech.ts
+++ b/packages/elevenlabs-nodes/src/nodes/text-to-speech.ts
@@ -2,6 +2,11 @@ import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
 import { getElevenLabsApiKey, VOICE_ID_MAP } from "../elevenlabs-base.js";
 
+/** Output handles TextToSpeechNode.process() emits. */
+type TextToSpeechNodeOutputs = {
+  output: { type: string; data: string };
+};
+
 export class TextToSpeechNode extends BaseNode {
   static readonly nodeType = "elevenlabs.TextToSpeech";
   static readonly body = "content_card";
@@ -168,7 +173,7 @@ export class TextToSpeechNode extends BaseNode {
   })
   declare text_normalization: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TextToSpeechNodeOutputs> {
     const apiKey = getElevenLabsApiKey(this._secrets);
 
     const voiceId = String(this.voice_id ?? VOICE_ID_MAP.Aria);

--- a/packages/huggingface-nodes/src/nodes/audio.ts
+++ b/packages/huggingface-nodes/src/nodes/audio.ts
@@ -29,6 +29,12 @@ function asrBody(inputs: string, returnTimestamps: boolean): AsrBody {
   return body;
 }
 
+/** Output handles AutomaticSpeechRecognitionNode.process() emits. */
+type AutomaticSpeechRecognitionNodeOutputs = {
+  output: string;
+  chunks: { text?: string; timestamp?: number[] }[];
+};
+
 export class AutomaticSpeechRecognitionNode extends BaseNode {
   static readonly nodeType = "huggingface.AutomaticSpeechRecognition";
   static readonly title = "Automatic Speech Recognition";
@@ -69,7 +75,7 @@ export class AutomaticSpeechRecognitionNode extends BaseNode {
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]
-  ): Promise<Record<string, unknown>> {
+  ): Promise<AutomaticSpeechRecognitionNodeOutputs> {
     const token = getHfToken(this._secrets);
     const audio = this.audio as MediaRef | undefined;
     if (!audio || (!audio.uri && !audio.data)) {
@@ -94,6 +100,12 @@ export class AutomaticSpeechRecognitionNode extends BaseNode {
     };
   }
 }
+
+/** Output handles AudioClassificationNode.process() emits. */
+type AudioClassificationNodeOutputs = {
+  output: string;
+  scores: { label?: string; score?: number }[];
+};
 
 export class AudioClassificationNode extends BaseNode {
   static readonly nodeType = "huggingface.AudioClassification";
@@ -137,7 +149,7 @@ export class AudioClassificationNode extends BaseNode {
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]
-  ): Promise<Record<string, unknown>> {
+  ): Promise<AudioClassificationNodeOutputs> {
     const token = getHfToken(this._secrets);
     const audio = this.audio as MediaRef | undefined;
     if (!audio || (!audio.uri && !audio.data)) {

--- a/packages/huggingface-nodes/src/nodes/image.ts
+++ b/packages/huggingface-nodes/src/nodes/image.ts
@@ -20,6 +20,11 @@ const EMPTY_IMAGE = {
   metadata: null
 };
 
+/** Output handles TextToImageNode.process() emits. */
+type TextToImageNodeOutputs = {
+  output: { type: string; data: string; content_type: string };
+};
+
 export class TextToImageNode extends BaseNode {
   static readonly nodeType = "huggingface.TextToImage";
   static readonly body = "content_card";
@@ -111,7 +116,7 @@ export class TextToImageNode extends BaseNode {
   })
   declare seed: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TextToImageNodeOutputs> {
     const token = getHfToken(this._secrets);
     const prompt = String(this.prompt ?? "");
     if (!prompt) throw new Error("Prompt cannot be empty");
@@ -143,6 +148,11 @@ export class TextToImageNode extends BaseNode {
     };
   }
 }
+
+/** Output handles ImageToImageNode.process() emits. */
+type ImageToImageNodeOutputs = {
+  output: { type: string; data: string; content_type: string };
+};
 
 export class ImageToImageNode extends BaseNode {
   static readonly nodeType = "huggingface.ImageToImage";
@@ -215,7 +225,7 @@ export class ImageToImageNode extends BaseNode {
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]
-  ): Promise<Record<string, unknown>> {
+  ): Promise<ImageToImageNodeOutputs> {
     const token = getHfToken(this._secrets);
     const image = this.image as MediaRef | undefined;
     if (!image || (!image.uri && !image.data)) {
@@ -245,6 +255,12 @@ export class ImageToImageNode extends BaseNode {
     };
   }
 }
+
+/** Output handles ImageClassificationNode.process() emits. */
+type ImageClassificationNodeOutputs = {
+  output: string;
+  scores: { label?: string; score?: number }[];
+};
 
 export class ImageClassificationNode extends BaseNode {
   static readonly nodeType = "huggingface.ImageClassification";
@@ -288,7 +304,7 @@ export class ImageClassificationNode extends BaseNode {
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]
-  ): Promise<Record<string, unknown>> {
+  ): Promise<ImageClassificationNodeOutputs> {
     const token = getHfToken(this._secrets);
     const image = this.image as MediaRef | undefined;
     if (!image || (!image.uri && !image.data)) {
@@ -307,6 +323,11 @@ export class ImageClassificationNode extends BaseNode {
     return { output: String(scores[0]?.label ?? ""), scores };
   }
 }
+
+/** Output handles ImageSegmentationNode.process() emits. */
+type ImageSegmentationNodeOutputs = {
+  output: { label: string; score: number | null; mask: { type: string; data: string; content_type: string } | null }[];
+};
 
 export class ImageSegmentationNode extends BaseNode {
   static readonly nodeType = "huggingface.ImageSegmentation";
@@ -340,7 +361,7 @@ export class ImageSegmentationNode extends BaseNode {
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]
-  ): Promise<Record<string, unknown>> {
+  ): Promise<ImageSegmentationNodeOutputs> {
     const token = getHfToken(this._secrets);
     const image = this.image as MediaRef | undefined;
     if (!image || (!image.uri && !image.data)) {
@@ -364,6 +385,11 @@ export class ImageSegmentationNode extends BaseNode {
     return { output: segments };
   }
 }
+
+/** Output handles ObjectDetectionNode.process() emits. */
+type ObjectDetectionNodeOutputs = {
+  output: { label?: string; score?: number; box?: { xmin: number; ymin: number; xmax: number; ymax: number } }[];
+};
 
 export class ObjectDetectionNode extends BaseNode {
   static readonly nodeType = "huggingface.ObjectDetection";
@@ -407,7 +433,7 @@ export class ObjectDetectionNode extends BaseNode {
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]
-  ): Promise<Record<string, unknown>> {
+  ): Promise<ObjectDetectionNodeOutputs> {
     const token = getHfToken(this._secrets);
     const image = this.image as MediaRef | undefined;
     if (!image || (!image.uri && !image.data)) {

--- a/packages/huggingface-nodes/src/nodes/text.ts
+++ b/packages/huggingface-nodes/src/nodes/text.ts
@@ -31,6 +31,11 @@ function nerBody(inputs: string, strategy: string): NerBody {
   return body;
 }
 
+/** Output handles ChatCompletionNode.process() emits. */
+type ChatCompletionNodeOutputs = {
+  output: string;
+};
+
 export class ChatCompletionNode extends BaseNode {
   static readonly nodeType = "huggingface.ChatCompletion";
   static readonly title = "Chat Completion";
@@ -100,7 +105,7 @@ export class ChatCompletionNode extends BaseNode {
   })
   declare top_p: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ChatCompletionNodeOutputs> {
     const token = getHfToken(this._secrets);
     const prompt = String(this.prompt ?? "");
     if (!prompt) throw new Error("Prompt cannot be empty");
@@ -121,6 +126,11 @@ export class ChatCompletionNode extends BaseNode {
     return { output: result.content };
   }
 }
+
+/** Output handles TextGenerationNode.process() emits. */
+type TextGenerationNodeOutputs = {
+  output: string;
+};
 
 export class TextGenerationNode extends BaseNode {
   static readonly nodeType = "huggingface.TextGeneration";
@@ -180,7 +190,7 @@ export class TextGenerationNode extends BaseNode {
   })
   declare return_full_text: boolean;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TextGenerationNodeOutputs> {
     const token = getHfToken(this._secrets);
     const prompt = String(this.prompt ?? "");
     if (!prompt) throw new Error("Prompt cannot be empty");
@@ -200,6 +210,11 @@ export class TextGenerationNode extends BaseNode {
     return { output: String(first?.generated_text ?? "") };
   }
 }
+
+/** Output handles SummarizationNode.process() emits. */
+type SummarizationNodeOutputs = {
+  output: string;
+};
 
 export class SummarizationNode extends BaseNode {
   static readonly nodeType = "huggingface.Summarization";
@@ -251,7 +266,7 @@ export class SummarizationNode extends BaseNode {
   })
   declare min_length: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SummarizationNodeOutputs> {
     const token = getHfToken(this._secrets);
     const text = String(this.inputs ?? "");
     if (!text) throw new Error("Text cannot be empty");
@@ -273,6 +288,11 @@ export class SummarizationNode extends BaseNode {
     return { output: String(first?.summary_text ?? "") };
   }
 }
+
+/** Output handles TranslationNode.process() emits. */
+type TranslationNodeOutputs = {
+  output: string;
+};
 
 export class TranslationNode extends BaseNode {
   static readonly nodeType = "huggingface.Translation";
@@ -323,7 +343,7 @@ export class TranslationNode extends BaseNode {
   })
   declare tgt_lang: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TranslationNodeOutputs> {
     const token = getHfToken(this._secrets);
     const text = String(this.inputs ?? "");
     if (!text) throw new Error("Text cannot be empty");
@@ -342,6 +362,12 @@ export class TranslationNode extends BaseNode {
     return { output: String(first?.translation_text ?? "") };
   }
 }
+
+/** Output handles FillMaskNode.process() emits. */
+type FillMaskNodeOutputs = {
+  output: string;
+  predictions: { sequence?: string; score?: number; token_str?: string }[];
+};
 
 export class FillMaskNode extends BaseNode {
   static readonly nodeType = "huggingface.FillMask";
@@ -374,7 +400,7 @@ export class FillMaskNode extends BaseNode {
   })
   declare inputs: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FillMaskNodeOutputs> {
     const token = getHfToken(this._secrets);
     const text = String(this.inputs ?? "");
     if (!text) throw new Error("Text cannot be empty");
@@ -390,6 +416,12 @@ export class FillMaskNode extends BaseNode {
     };
   }
 }
+
+/** Output handles QuestionAnsweringNode.process() emits. */
+type QuestionAnsweringNodeOutputs = {
+  output: string;
+  score: number;
+};
 
 export class QuestionAnsweringNode extends BaseNode {
   static readonly nodeType = "huggingface.QuestionAnswering";
@@ -430,7 +462,7 @@ export class QuestionAnsweringNode extends BaseNode {
   })
   declare context: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<QuestionAnsweringNodeOutputs> {
     const token = getHfToken(this._secrets);
     const question = String(this.question ?? "");
     const context = String(this.context ?? "");
@@ -452,6 +484,13 @@ export class QuestionAnsweringNode extends BaseNode {
     };
   }
 }
+
+/** Output handles TableQuestionAnsweringNode.process() emits. */
+type TableQuestionAnsweringNodeOutputs = {
+  output: string;
+  cells: string[];
+  aggregator: string;
+};
 
 export class TableQuestionAnsweringNode extends BaseNode {
   static readonly nodeType = "huggingface.TableQuestionAnswering";
@@ -497,7 +536,7 @@ export class TableQuestionAnsweringNode extends BaseNode {
   })
   declare table: Record<string, unknown>;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TableQuestionAnsweringNodeOutputs> {
     const token = getHfToken(this._secrets);
     const question = String(this.question ?? "");
     if (!question) throw new Error("Question cannot be empty");
@@ -530,6 +569,11 @@ export class TableQuestionAnsweringNode extends BaseNode {
     };
   }
 }
+
+/** Output handles FeatureExtractionNode.process() emits. */
+type FeatureExtractionNodeOutputs = {
+  output: number[] | number[][];
+};
 
 export class FeatureExtractionNode extends BaseNode {
   static readonly nodeType = "huggingface.FeatureExtraction";
@@ -569,7 +613,7 @@ export class FeatureExtractionNode extends BaseNode {
   })
   declare normalize: boolean;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FeatureExtractionNodeOutputs> {
     const token = getHfToken(this._secrets);
     const text = String(this.inputs ?? "");
     if (!text) throw new Error("Text cannot be empty");
@@ -583,6 +627,12 @@ export class FeatureExtractionNode extends BaseNode {
     return { output: result };
   }
 }
+
+/** Output handles TextClassificationNode.process() emits. */
+type TextClassificationNodeOutputs = {
+  output: string;
+  scores: { label?: string; score?: number }[];
+};
 
 export class TextClassificationNode extends BaseNode {
   static readonly nodeType = "huggingface.TextClassification";
@@ -614,7 +664,7 @@ export class TextClassificationNode extends BaseNode {
   })
   declare inputs: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TextClassificationNodeOutputs> {
     const token = getHfToken(this._secrets);
     const text = String(this.inputs ?? "");
     if (!text) throw new Error("Text cannot be empty");
@@ -694,6 +744,12 @@ export class TokenClassificationNode extends BaseNode {
   }
 }
 
+/** Output handles ZeroShotClassificationNode.process() emits. */
+type ZeroShotClassificationNodeOutputs = {
+  output: string;
+  scores: { label: string; score: number }[];
+};
+
 export class ZeroShotClassificationNode extends BaseNode {
   static readonly nodeType = "huggingface.ZeroShotClassification";
   static readonly title = "Zero Shot Classification";
@@ -740,7 +796,7 @@ export class ZeroShotClassificationNode extends BaseNode {
   })
   declare multi_label: boolean;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ZeroShotClassificationNodeOutputs> {
     const token = getHfToken(this._secrets);
     const text = String(this.inputs ?? "");
     if (!text) throw new Error("Text cannot be empty");

--- a/packages/huggingface-nodes/src/nodes/video.ts
+++ b/packages/huggingface-nodes/src/nodes/video.ts
@@ -7,6 +7,11 @@ import {
   videoRefFromBytes
 } from "../huggingface-base.js";
 
+/** Output handles TextToVideoNode.process() emits. */
+type TextToVideoNodeOutputs = {
+  output: { type: string; data: string; content_type: string; format: string };
+};
+
 export class TextToVideoNode extends BaseNode {
   static readonly nodeType = "huggingface.TextToVideo";
   static readonly body = "content_card";
@@ -87,7 +92,7 @@ export class TextToVideoNode extends BaseNode {
   })
   declare seed: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TextToVideoNodeOutputs> {
     const token = getHfToken(this._secrets);
     const prompt = String(this.prompt ?? "");
     if (!prompt) throw new Error("Prompt cannot be empty");

--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -256,6 +256,11 @@ async function metadataFor(
   }
 }
 
+/** Output handles LoadImageFileNode.process() emits. */
+type LoadImageFileNodeOutputs = {
+  output: ImageRef;
+};
+
 export class LoadImageFileNode extends BaseNode {
   static readonly nodeType = "nodetool.image.LoadImageFile";
   static readonly title = "Load Image File";
@@ -276,7 +281,7 @@ export class LoadImageFileNode extends BaseNode {
   })
   declare path: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<LoadImageFileNodeOutputs> {
     const fs = await loadNodeFsPromises();
     const p = await filePath(String(this.path ?? ""));
     const data = new Uint8Array(await fs.readFile(p));
@@ -435,6 +440,12 @@ export class LoadImageFolderNode extends BaseNode {
   }
 }
 
+/** Output handles SaveImageFileImageNode.process() emits. */
+type SaveImageFileImageNodeOutputs = {
+  output: ImageRef;
+  path: string;
+};
+
 export class SaveImageFileImageNode extends BaseNode {
   static readonly nodeType = "nodetool.image.SaveImageFile";
   static readonly title = "Save Image File";
@@ -488,7 +499,7 @@ export class SaveImageFileImageNode extends BaseNode {
   })
   declare overwrite: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SaveImageFileImageNodeOutputs> {
     const fs = await loadNodeFsPromises();
     const path = await loadNodePath();
     const folder = String(this.folder ?? ".");
@@ -577,6 +588,11 @@ export class LoadImageAssetsNode extends BaseNode {
   }
 }
 
+/** Output handles SaveImageNode.process() emits. */
+type SaveImageNodeOutputs = {
+  output: ImageRef;
+};
+
 export class SaveImageNode extends BaseNode {
   static readonly nodeType = "nodetool.image.SaveImage";
   static readonly title = "Save Image Asset";
@@ -626,7 +642,7 @@ export class SaveImageNode extends BaseNode {
   })
   declare name: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<SaveImageNodeOutputs> {
     const bytes = await imageBytesAsync(this.image, context);
     if (bytes.length === 0) throw new Error("The input image is not connected.");
 
@@ -679,6 +695,15 @@ export class SaveImageNode extends BaseNode {
   }
 }
 
+/** Output handles GetMetadataNode.process() emits. */
+type GetMetadataNodeOutputs = {
+  format: string;
+  mode: string;
+  width: number;
+  height: number;
+  channels: number;
+};
+
 export class GetMetadataNode extends BaseNode {
   static readonly nodeType = "nodetool.image.GetMetadata";
   static readonly title = "Get Metadata";
@@ -709,7 +734,7 @@ export class GetMetadataNode extends BaseNode {
   })
   declare image: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<GetMetadataNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const bytes = await imageBytesAsync(image, context);
     try {
@@ -839,6 +864,11 @@ abstract class TransformImageNode extends BaseNode {
   }
 }
 
+/** Output handles PasteNode.process() emits. */
+type PasteNodeOutputs = {
+  output: ImageRefLike | ImageRef;
+};
+
 export class PasteNode extends TransformImageNode {
   static readonly nodeType = "nodetool.image.Paste";
   static readonly title = "Paste";
@@ -898,7 +928,7 @@ export class PasteNode extends TransformImageNode {
   })
   declare top: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<PasteNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const paste = (this.paste ?? {}) as ImageRefLike;
     const left = Math.max(0, Number(this.left ?? 0));
@@ -944,6 +974,11 @@ const RESIZE_IMAGE_NODE_TYPE = "nodetool.image.ResizeImage";
 function deprecatedResizeDescription(body: string): string {
   return `Deprecated — use Resize Image (${RESIZE_IMAGE_NODE_TYPE}) instead.\n${body}`;
 }
+
+/** Output handles ResizeImageNode.process() emits. */
+type ResizeImageNodeOutputs = {
+  output: ImageRefLike | ImageRef;
+};
 
 export class ResizeImageNode extends TransformImageNode {
   static readonly nodeType = RESIZE_IMAGE_NODE_TYPE;
@@ -1012,7 +1047,7 @@ export class ResizeImageNode extends TransformImageNode {
   })
   declare height: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ResizeImageNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const { width: srcW, height: srcH } = await decodeRgba(image, context);
     if (!srcW || !srcH) return { output: image };
@@ -1061,6 +1096,11 @@ export class ResizeImageNode extends TransformImageNode {
   }
 }
 
+/** Output handles ScaleNode.process() emits. */
+type ScaleNodeOutputs = {
+  output: ImageRefLike | ImageRef;
+};
+
 export class ScaleNode extends TransformImageNode {
   static readonly nodeType = "nodetool.image.Scale";
   static readonly title = "Scale";
@@ -1099,7 +1139,7 @@ export class ScaleNode extends TransformImageNode {
   })
   declare scale: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ScaleNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const requestedScale = Number(this.scale ?? 0);
     const scale = requestedScale > 0 ? requestedScale : 1;
@@ -1118,6 +1158,11 @@ export class ScaleNode extends TransformImageNode {
     return { output };
   }
 }
+
+/** Output handles ResizeNode.process() emits. */
+type ResizeNodeOutputs = {
+  output: ImageRefLike | ImageRef;
+};
 
 export class ResizeNode extends TransformImageNode {
   static readonly nodeType = "nodetool.image.Resize";
@@ -1167,7 +1212,7 @@ export class ResizeNode extends TransformImageNode {
   })
   declare height: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ResizeNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const { width: srcW, height: srcH } = await decodeRgba(image, context);
     if (!srcW || !srcH) return { output: image };
@@ -1211,6 +1256,11 @@ function anchorOffset(
   else y = Math.floor((canvasH - srcH) / 2);
   return [x, y];
 }
+
+/** Output handles CanvasResizeNode.process() emits. */
+type CanvasResizeNodeOutputs = {
+  output: ImageRefLike | ImageRef;
+};
 
 export class CanvasResizeNode extends TransformImageNode {
   static readonly nodeType = "nodetool.image.CanvasResize";
@@ -1365,7 +1415,7 @@ export class CanvasResizeNode extends TransformImageNode {
   })
   declare color: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<CanvasResizeNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const { width: srcW, height: srcH } = await decodeRgba(image, context);
     if (!srcW || !srcH) return { output: image };
@@ -1471,6 +1521,11 @@ export class CanvasResizeNode extends TransformImageNode {
   }
 }
 
+/** Output handles CropNode.process() emits. */
+type CropNodeOutputs = {
+  output: ImageRefLike | ImageRef;
+};
+
 export class CropNode extends TransformImageNode {
   static readonly nodeType = "nodetool.image.Crop";
   static readonly title = "Crop";
@@ -1536,7 +1591,7 @@ export class CropNode extends TransformImageNode {
   })
   declare bottom: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<CropNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     // Crop is defined in pixels; the GPU crop shader samples a normalized-UV
     // sub-rectangle, so resolve source dims first to convert px → UV.
@@ -1563,6 +1618,11 @@ export class CropNode extends TransformImageNode {
     return { output };
   }
 }
+
+/** Output handles FitNode.process() emits. */
+type FitNodeOutputs = {
+  output: ImageRefLike | ImageRef;
+};
 
 export class FitNode extends TransformImageNode {
   static readonly nodeType = "nodetool.image.Fit";
@@ -1612,7 +1672,7 @@ export class FitNode extends TransformImageNode {
   })
   declare height: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<FitNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const targetW = Math.max(1, Number(this.width ?? 512));
     const targetH = Math.max(1, Number(this.height ?? 512));
@@ -1634,6 +1694,11 @@ export class FitNode extends TransformImageNode {
     return { output };
   }
 }
+
+/** Output handles TextToImageNode.process() emits. */
+type TextToImageNodeOutputs = {
+  output: ImageRef;
+};
 
 export class TextToImageNode extends BaseNode {
   static readonly nodeType = "nodetool.image.TextToImage";
@@ -1708,7 +1773,7 @@ export class TextToImageNode extends BaseNode {
   })
   declare resolution: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<TextToImageNodeOutputs> {
     const prompt = String(this.prompt ?? "");
     const aspectRatio = String(this.aspect_ratio ?? "1:1");
     const resolution = String(this.resolution ?? "1K");
@@ -1741,6 +1806,11 @@ export class TextToImageNode extends BaseNode {
     };
   }
 }
+
+/** Output handles ImageToImageNode.process() emits. */
+type ImageToImageNodeOutputs = {
+  output: ImageRef;
+};
 
 export class ImageToImageNode extends BaseNode {
   static readonly nodeType = "nodetool.image.ImageToImage";
@@ -1843,7 +1913,7 @@ export class ImageToImageNode extends BaseNode {
   })
   declare scheduler: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ImageToImageNodeOutputs> {
     let images = normalizeImageList(this.image);
     let prompt = String(this.prompt ?? "");
 
@@ -2044,6 +2114,11 @@ export class RotateAndFlipNode extends TransformImageNode {
   }
 }
 
+/** Output handles ChannelsNode.process() emits. */
+type ChannelsNodeOutputs = {
+  output: ImageRef | ImageRef | ImageRefLike;
+};
+
 export class ChannelsNode extends TransformImageNode {
   static readonly nodeType = "nodetool.image.Channels";
   static readonly title = "Channels";
@@ -2080,7 +2155,7 @@ export class ChannelsNode extends TransformImageNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<ChannelsNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const channel = String(this.channel ?? "luminance");
 
@@ -2112,6 +2187,11 @@ export class ChannelsNode extends TransformImageNode {
     return { output };
   }
 }
+
+/** Output handles BlurNode.process() emits. */
+type BlurNodeOutputs = {
+  output: ImageRef | ImageRefLike | ImageRef;
+};
 
 export class BlurNode extends TransformImageNode {
   static readonly nodeType = "nodetool.image.Blur";
@@ -2159,7 +2239,7 @@ export class BlurNode extends TransformImageNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<BlurNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const size = Math.max(0, Math.min(100, Math.round(Number(this.size ?? 0))));
     const blurType = String(this.blur_type ?? "gaussian");
@@ -2197,6 +2277,11 @@ export class BlurNode extends TransformImageNode {
     return { output };
   }
 }
+
+/** Output handles LevelsNode.process() emits. */
+type LevelsNodeOutputs = {
+  output: ImageRefLike | ImageRef;
+};
 
 export class LevelsNode extends TransformImageNode {
   static readonly nodeType = "nodetool.image.Levels";
@@ -2315,7 +2400,7 @@ export class LevelsNode extends TransformImageNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<LevelsNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const clamp255 = (n: number): number =>
       Math.max(0, Math.min(255, Math.round(n)));
@@ -2420,6 +2505,11 @@ function compositorLayerState(raw: unknown): CompositorLayerState {
  * to straight-alpha RGBA on the way in, encode the composite to PNG on the
  * way out.
  */
+/** Output handles CompositorNode.process() emits. */
+type CompositorNodeOutputs = {
+  output: ImageRef;
+};
+
 export class CompositorNode extends BaseNode {
   static readonly nodeType = "nodetool.image.Compositor";
   static readonly title = "Compositor";
@@ -2461,7 +2551,7 @@ export class CompositorNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<CompositorNodeOutputs> {
     type LayerInput = {
       index: number;
       image: ImageRefLike;
@@ -2589,6 +2679,12 @@ export class CompositorNode extends BaseNode {
  * Plan §9.E9 / §12. Standalone (not an extension of the sketch node) so
  * the bespoke body stays focused on the paint-on-image workflow.
  */
+/** Output handles PainterNode.process() emits. */
+type PainterNodeOutputs = {
+  mask: ImageRef;
+  image: ImageRef | { uri?: string; data?: Uint8Array | string; mimeType?: string; width?: number; height?: number };
+};
+
 export class PainterNode extends BaseNode {
   static readonly nodeType = "nodetool.image.Painter";
   static readonly title = "Painter";
@@ -2646,7 +2742,7 @@ export class PainterNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<PainterNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
 
     // Pass the source image through (resolved bytes if available) so
@@ -2735,6 +2831,11 @@ export class PainterNode extends BaseNode {
   }
 }
 
+/** Output handles UpscaleImageNode.process() emits. */
+type UpscaleImageNodeOutputs = {
+  output: ImageRef;
+};
+
 export class UpscaleImageNode extends BaseNode {
   static readonly nodeType = "nodetool.image.Upscale";
   static readonly body = "content_card";
@@ -2786,7 +2887,7 @@ export class UpscaleImageNode extends BaseNode {
   })
   declare prompt: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<UpscaleImageNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const bytes = await imageBytesAsync(image, context);
     if (bytes.length === 0) throw new Error("The input image is empty.");
@@ -2814,6 +2915,11 @@ export class UpscaleImageNode extends BaseNode {
     };
   }
 }
+
+/** Output handles RemoveBackgroundNode.process() emits. */
+type RemoveBackgroundNodeOutputs = {
+  output: ImageRef;
+};
 
 export class RemoveBackgroundNode extends BaseNode {
   static readonly nodeType = "nodetool.image.RemoveBackground";
@@ -2849,7 +2955,7 @@ export class RemoveBackgroundNode extends BaseNode {
   })
   declare image: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<RemoveBackgroundNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const bytes = await imageBytesAsync(image, context);
     if (bytes.length === 0) throw new Error("The input image is empty.");
@@ -2873,6 +2979,11 @@ export class RemoveBackgroundNode extends BaseNode {
     };
   }
 }
+
+/** Output handles RelightImageNode.process() emits. */
+type RelightImageNodeOutputs = {
+  output: ImageRef;
+};
 
 export class RelightImageNode extends BaseNode {
   static readonly nodeType = "nodetool.image.Relight";
@@ -2924,7 +3035,7 @@ export class RelightImageNode extends BaseNode {
   })
   declare negative_prompt: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<RelightImageNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const bytes = await imageBytesAsync(image, context);
     if (bytes.length === 0) throw new Error("The input image is empty.");
@@ -2952,6 +3063,11 @@ export class RelightImageNode extends BaseNode {
     };
   }
 }
+
+/** Output handles VectorizeImageNode.process() emits. */
+type VectorizeImageNodeOutputs = {
+  output: { content: string };
+};
 
 export class VectorizeImageNode extends BaseNode {
   static readonly nodeType = "nodetool.image.Vectorize";
@@ -2986,7 +3102,7 @@ export class VectorizeImageNode extends BaseNode {
   })
   declare image: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<VectorizeImageNodeOutputs> {
     const image = (this.image ?? {}) as ImageRefLike;
     const bytes = await imageBytesAsync(image, context);
     if (bytes.length === 0) throw new Error("The input image is empty.");

--- a/packages/image-nodes/src/nodes/lib-grid.ts
+++ b/packages/image-nodes/src/nodes/lib-grid.ts
@@ -201,6 +201,11 @@ export class SliceImageGridLibNode extends BaseNode {
   }
 }
 
+/** Output handles CombineImageGridLibNode.process() emits. */
+type CombineImageGridLibNodeOutputs = {
+  output: { type: string; data: Uint8Array<ArrayBuffer>; mimeType: string; metadata: { grid: TilePlacement } | null };
+};
+
 export class CombineImageGridLibNode extends BaseNode {
   static readonly nodeType = "lib.grid.CombineImageGrid";
   static readonly title = "Combine Image Grid";
@@ -230,7 +235,7 @@ export class CombineImageGridLibNode extends BaseNode {
   })
   declare columns: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<CombineImageGridLibNodeOutputs> {
     const sharp = await requireSharp();
     const tileInputs = (this.tiles ?? []) as unknown[];
     if (!Array.isArray(tileInputs) || tileInputs.length === 0) {

--- a/packages/image-nodes/src/nodes/sketch.ts
+++ b/packages/image-nodes/src/nodes/sketch.ts
@@ -334,6 +334,11 @@ export class SketchLayersNode extends BaseNode {
   }
 }
 
+/** Output handles CreateSketchNode.process() emits. */
+type CreateSketchNodeOutputs = {
+  output: { type: string; id: string };
+};
+
 export class CreateSketchNode extends BaseNode {
   static readonly nodeType = "nodetool.sketch.CreateSketch";
   static readonly title = "Create Sketch";
@@ -363,7 +368,7 @@ export class CreateSketchNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<CreateSketchNodeOutputs> {
     if (!context) {
       throw new Error("CreateSketch requires a processing context");
     }

--- a/packages/integration-nodes/src/nodes/lib-google.ts
+++ b/packages/integration-nodes/src/nodes/lib-google.ts
@@ -9,7 +9,12 @@
 
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { InputMode, OutputCorrelation } from "@nodetool-ai/protocol";
-import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type {
+  ProcessingContext,
+  DriveFile,
+  GmailMessage,
+  CalendarEvent
+} from "@nodetool-ai/runtime";
 import {
   requireGoogleAccessToken,
   driveSearchFiles,
@@ -69,6 +74,12 @@ function splitList(value: unknown): string[] {
 
 // ── Drive ────────────────────────────────────────────────────────────
 
+/** Output handles GoogleDriveSearchLibNode.process() emits. */
+type GoogleDriveSearchLibNodeOutputs = {
+  output: DriveFile;
+  outputs: DriveFile[];
+};
+
 export class GoogleDriveSearchLibNode extends BaseNode {
   static readonly nodeType = "lib.google.DriveSearch";
   static readonly title = "Google Drive Search";
@@ -100,7 +111,9 @@ export class GoogleDriveSearchLibNode extends BaseNode {
   })
   declare max_results: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleDriveSearchLibNodeOutputs> {
     const token = await requireGoogleAccessToken(context);
     const files = await driveSearchFiles(token, {
       q: str(this.query),
@@ -109,6 +122,13 @@ export class GoogleDriveSearchLibNode extends BaseNode {
     return { output: files[0] ?? null, outputs: files };
   }
 }
+
+/** Output handles GoogleDriveReadFileLibNode.process() emits. */
+type GoogleDriveReadFileLibNodeOutputs = {
+  output: string;
+  name: string;
+  mime_type: string;
+};
 
 export class GoogleDriveReadFileLibNode extends BaseNode {
   static readonly nodeType = "lib.google.DriveReadFile";
@@ -131,7 +151,9 @@ export class GoogleDriveReadFileLibNode extends BaseNode {
   })
   declare file_id: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleDriveReadFileLibNodeOutputs> {
     const fileId = str(this.file_id);
     if (!fileId) throw new Error("file_id is required");
     const token = await requireGoogleAccessToken(context);
@@ -143,6 +165,11 @@ export class GoogleDriveReadFileLibNode extends BaseNode {
     };
   }
 }
+
+/** Output handles GoogleDriveCreateFileLibNode.process() emits. */
+type GoogleDriveCreateFileLibNodeOutputs = {
+  output: DriveFile;
+};
 
 export class GoogleDriveCreateFileLibNode extends BaseNode {
   static readonly nodeType = "lib.google.DriveCreateFile";
@@ -187,7 +214,9 @@ export class GoogleDriveCreateFileLibNode extends BaseNode {
   })
   declare folder_id: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleDriveCreateFileLibNodeOutputs> {
     const name = str(this.name);
     if (!name) throw new Error("name is required");
     const token = await requireGoogleAccessToken(context);
@@ -203,6 +232,12 @@ export class GoogleDriveCreateFileLibNode extends BaseNode {
 }
 
 // ── Gmail ────────────────────────────────────────────────────────────
+
+/** Output handles GoogleGmailSearchLibNode.process() emits. */
+type GoogleGmailSearchLibNodeOutputs = {
+  output: GmailMessage;
+  outputs: GmailMessage[];
+};
 
 export class GoogleGmailSearchLibNode extends BaseNode {
   static readonly nodeType = "lib.google.GmailSearch";
@@ -234,7 +269,9 @@ export class GoogleGmailSearchLibNode extends BaseNode {
   })
   declare max_results: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleGmailSearchLibNodeOutputs> {
     const token = await requireGoogleAccessToken(context);
     const messages = await gmailSearchMessages(token, {
       q: str(this.query),
@@ -243,6 +280,11 @@ export class GoogleGmailSearchLibNode extends BaseNode {
     return { output: messages[0] ?? null, outputs: messages };
   }
 }
+
+/** Output handles GoogleGmailSendLibNode.process() emits. */
+type GoogleGmailSendLibNodeOutputs = {
+  output: { id: string; threadId: string };
+};
 
 export class GoogleGmailSendLibNode extends BaseNode {
   static readonly nodeType = "lib.google.GmailSend";
@@ -287,7 +329,9 @@ export class GoogleGmailSendLibNode extends BaseNode {
   })
   declare cc: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleGmailSendLibNodeOutputs> {
     const to = str(this.to);
     if (!to) throw new Error("to is required");
     const token = await requireGoogleAccessToken(context);
@@ -301,6 +345,11 @@ export class GoogleGmailSendLibNode extends BaseNode {
     };
   }
 }
+
+/** Output handles GoogleGmailModifyLabelsLibNode.process() emits. */
+type GoogleGmailModifyLabelsLibNodeOutputs = {
+  output: { id: string; labelIds: string[] };
+};
 
 export class GoogleGmailModifyLabelsLibNode extends BaseNode {
   static readonly nodeType = "lib.google.GmailModifyLabels";
@@ -337,7 +386,9 @@ export class GoogleGmailModifyLabelsLibNode extends BaseNode {
   })
   declare remove_labels: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleGmailModifyLabelsLibNodeOutputs> {
     const messageId = str(this.message_id);
     if (!messageId) throw new Error("message_id is required");
     const token = await requireGoogleAccessToken(context);
@@ -352,6 +403,12 @@ export class GoogleGmailModifyLabelsLibNode extends BaseNode {
 }
 
 // ── Docs ─────────────────────────────────────────────────────────────
+
+/** Output handles GoogleDocsReadLibNode.process() emits. */
+type GoogleDocsReadLibNodeOutputs = {
+  output: string;
+  title: string;
+};
 
 export class GoogleDocsReadLibNode extends BaseNode {
   static readonly nodeType = "lib.google.DocsRead";
@@ -373,7 +430,9 @@ export class GoogleDocsReadLibNode extends BaseNode {
   })
   declare document_id: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleDocsReadLibNodeOutputs> {
     const documentId = str(this.document_id);
     if (!documentId) throw new Error("document_id is required");
     const token = await requireGoogleAccessToken(context);
@@ -381,6 +440,11 @@ export class GoogleDocsReadLibNode extends BaseNode {
     return { output: doc.text, title: doc.title };
   }
 }
+
+/** Output handles GoogleDocsCreateLibNode.process() emits. */
+type GoogleDocsCreateLibNodeOutputs = {
+  output: { documentId: string; title: string; url: string };
+};
 
 export class GoogleDocsCreateLibNode extends BaseNode {
   static readonly nodeType = "lib.google.DocsCreate";
@@ -409,7 +473,9 @@ export class GoogleDocsCreateLibNode extends BaseNode {
   })
   declare text: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleDocsCreateLibNodeOutputs> {
     const title = str(this.title);
     if (!title) throw new Error("title is required");
     const token = await requireGoogleAccessToken(context);
@@ -421,6 +487,11 @@ export class GoogleDocsCreateLibNode extends BaseNode {
     };
   }
 }
+
+/** Output handles GoogleDocsAppendLibNode.process() emits. */
+type GoogleDocsAppendLibNodeOutputs = {
+  output: string;
+};
 
 export class GoogleDocsAppendLibNode extends BaseNode {
   static readonly nodeType = "lib.google.DocsAppend";
@@ -449,7 +520,9 @@ export class GoogleDocsAppendLibNode extends BaseNode {
   })
   declare text: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleDocsAppendLibNodeOutputs> {
     const documentId = str(this.document_id);
     if (!documentId) throw new Error("document_id is required");
     const token = await requireGoogleAccessToken(context);
@@ -459,6 +532,11 @@ export class GoogleDocsAppendLibNode extends BaseNode {
 }
 
 // ── Sheets ───────────────────────────────────────────────────────────
+
+/** Output handles GoogleSheetsReadLibNode.process() emits. */
+type GoogleSheetsReadLibNodeOutputs = {
+  output: string[][];
+};
 
 export class GoogleSheetsReadLibNode extends BaseNode {
   static readonly nodeType = "lib.google.SheetsRead";
@@ -487,7 +565,9 @@ export class GoogleSheetsReadLibNode extends BaseNode {
   })
   declare range: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleSheetsReadLibNodeOutputs> {
     const spreadsheetId = str(this.spreadsheet_id);
     if (!spreadsheetId) throw new Error("spreadsheet_id is required");
     const token = await requireGoogleAccessToken(context);
@@ -499,6 +579,11 @@ export class GoogleSheetsReadLibNode extends BaseNode {
     };
   }
 }
+
+/** Output handles GoogleSheetsAppendLibNode.process() emits. */
+type GoogleSheetsAppendLibNodeOutputs = {
+  output: { updatedRange: string; updatedRows: number };
+};
 
 export class GoogleSheetsAppendLibNode extends BaseNode {
   static readonly nodeType = "lib.google.SheetsAppend";
@@ -535,7 +620,9 @@ export class GoogleSheetsAppendLibNode extends BaseNode {
   })
   declare values: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleSheetsAppendLibNodeOutputs> {
     const spreadsheetId = str(this.spreadsheet_id);
     if (!spreadsheetId) throw new Error("spreadsheet_id is required");
     const token = await requireGoogleAccessToken(context);
@@ -548,6 +635,11 @@ export class GoogleSheetsAppendLibNode extends BaseNode {
     };
   }
 }
+
+/** Output handles GoogleSheetsUpdateLibNode.process() emits. */
+type GoogleSheetsUpdateLibNodeOutputs = {
+  output: { updatedRange: string; updatedCells: number };
+};
 
 export class GoogleSheetsUpdateLibNode extends BaseNode {
   static readonly nodeType = "lib.google.SheetsUpdate";
@@ -584,7 +676,9 @@ export class GoogleSheetsUpdateLibNode extends BaseNode {
   })
   declare values: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleSheetsUpdateLibNodeOutputs> {
     const spreadsheetId = str(this.spreadsheet_id);
     if (!spreadsheetId) throw new Error("spreadsheet_id is required");
     const token = await requireGoogleAccessToken(context);
@@ -599,6 +693,12 @@ export class GoogleSheetsUpdateLibNode extends BaseNode {
 }
 
 // ── Calendar ─────────────────────────────────────────────────────────
+
+/** Output handles GoogleCalendarListEventsLibNode.process() emits. */
+type GoogleCalendarListEventsLibNodeOutputs = {
+  output: CalendarEvent;
+  outputs: CalendarEvent[];
+};
 
 export class GoogleCalendarListEventsLibNode extends BaseNode {
   static readonly nodeType = "lib.google.CalendarListEvents";
@@ -646,7 +746,9 @@ export class GoogleCalendarListEventsLibNode extends BaseNode {
   })
   declare max_results: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleCalendarListEventsLibNodeOutputs> {
     const token = await requireGoogleAccessToken(context);
     const events = await calendarListEvents(token, {
       calendarId: str(this.calendar_id, "primary"),
@@ -657,6 +759,11 @@ export class GoogleCalendarListEventsLibNode extends BaseNode {
     return { output: events[0] ?? null, outputs: events };
   }
 }
+
+/** Output handles GoogleCalendarCreateEventLibNode.process() emits. */
+type GoogleCalendarCreateEventLibNodeOutputs = {
+  output: CalendarEvent;
+};
 
 export class GoogleCalendarCreateEventLibNode extends BaseNode {
   static readonly nodeType = "lib.google.CalendarCreateEvent";
@@ -717,7 +824,9 @@ export class GoogleCalendarCreateEventLibNode extends BaseNode {
   })
   declare attendees: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<GoogleCalendarCreateEventLibNodeOutputs> {
     const summary = str(this.summary);
     const start = str(this.start);
     const end = str(this.end);

--- a/packages/integration-nodes/src/nodes/lib-mail.ts
+++ b/packages/integration-nodes/src/nodes/lib-mail.ts
@@ -278,6 +278,11 @@ export class GmailSearchLibNode extends BaseNode {
   }
 }
 
+/** Output handles AddLabelLibNode.process() emits. */
+type AddLabelLibNodeOutputs = {
+  output: boolean;
+};
+
 export class AddLabelLibNode extends BaseNode {
   static readonly nodeType = "lib.mail.AddLabel";
   static readonly title = "Add Label";
@@ -309,7 +314,7 @@ export class AddLabelLibNode extends BaseNode {
   })
   declare label: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<AddLabelLibNodeOutputs> {
     const user = this._secrets["GOOGLE_MAIL_USER"];
     const pass = this._secrets["GOOGLE_APP_PASSWORD"];
     if (!user || !pass) {
@@ -346,6 +351,11 @@ export class AddLabelLibNode extends BaseNode {
   }
 }
 
+/** Output handles MoveToArchiveLibNode.process() emits. */
+type MoveToArchiveLibNodeOutputs = {
+  output: boolean;
+};
+
 export class MoveToArchiveLibNode extends BaseNode {
   static readonly nodeType = "lib.mail.MoveToArchive";
   static readonly title = "Move To Archive";
@@ -369,7 +379,7 @@ export class MoveToArchiveLibNode extends BaseNode {
   })
   declare message_id: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<MoveToArchiveLibNodeOutputs> {
     const user = this._secrets["GOOGLE_MAIL_USER"];
     const pass = this._secrets["GOOGLE_APP_PASSWORD"];
     if (!user || !pass) {

--- a/packages/integration-nodes/src/nodes/lib-secret.ts
+++ b/packages/integration-nodes/src/nodes/lib-secret.ts
@@ -2,6 +2,11 @@ import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { tagAsServer } from "@nodetool-ai/nodes-utils";
 
+/** Output handles GetSecretLibNode.process() emits. */
+type GetSecretLibNodeOutputs = {
+  output: string;
+};
+
 export class GetSecretLibNode extends BaseNode {
   static readonly nodeType = "lib.secret.GetSecret";
   static readonly title = "Get Secret";
@@ -29,7 +34,7 @@ export class GetSecretLibNode extends BaseNode {
   })
   declare default: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<GetSecretLibNodeOutputs> {
     const name = String(this.name ?? "");
     const defaultValue = String(this.default ?? "");
     if (!name) {

--- a/packages/llm-nodes/src/nodes/agents.ts
+++ b/packages/llm-nodes/src/nodes/agents.ts
@@ -115,6 +115,12 @@ const ENHANCE_PROMPT_GUIDANCE: Record<string, string> = {
 };
 const ENHANCE_PROMPT_MAX_TOKENS = 1024;
 
+/** Output handles SummarizerNode.process() emits. */
+type SummarizerNodeOutputs = {
+  text: string;
+  output: string;
+};
+
 export class SummarizerNode extends BaseNode {
   static readonly nodeType = "nodetool.agents.Summarizer";
   static readonly body = "content_card";
@@ -281,7 +287,7 @@ export class SummarizerNode extends BaseNode {
     yield { chunk: null, text: summary, output: summary };
   }
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<SummarizerNodeOutputs> {
     let text = "";
     for await (const item of this.genProcess(context)) {
       if (typeof item.text === "string") text = item.text;
@@ -289,6 +295,12 @@ export class SummarizerNode extends BaseNode {
     return { text, output: text };
   }
 }
+
+/** Output handles EnhancePromptNode.process() emits. */
+type EnhancePromptNodeOutputs = {
+  text: string;
+  output: string;
+};
 
 export class EnhancePromptNode extends BaseNode {
   static readonly nodeType = "nodetool.agents.EnhancePrompt";
@@ -434,7 +446,7 @@ export class EnhancePromptNode extends BaseNode {
     yield { chunk: null, text: enhanced, output: enhanced };
   }
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<EnhancePromptNodeOutputs> {
     let text = "";
     for await (const item of this.genProcess(context)) {
       if (typeof item.text === "string") text = item.text;
@@ -442,6 +454,11 @@ export class EnhancePromptNode extends BaseNode {
     return { text, output: text };
   }
 }
+
+/** Output handles CreateThreadNode.process() emits. */
+type CreateThreadNodeOutputs = {
+  thread_id: string;
+};
 
 export class CreateThreadNode extends BaseNode {
   static readonly nodeType = "nodetool.agents.CreateThread";
@@ -471,7 +488,7 @@ export class CreateThreadNode extends BaseNode {
   })
   declare thread_id: string;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<CreateThreadNodeOutputs> {
     const requested = String(this.thread_id ?? "").trim();
     const title = String(this.title ?? "Agent Conversation");
     const id = requested || makeThreadId();
@@ -608,6 +625,12 @@ export class ExtractorNode extends BaseNode {
   }
 }
 
+/** Output handles ClassifierNode.process() emits. */
+type ClassifierNodeOutputs = {
+  output: string;
+  category: string;
+};
+
 export class ClassifierNode extends BaseNode {
   static readonly nodeType = "nodetool.agents.Classifier";
   static readonly body = "content_card";
@@ -703,7 +726,7 @@ export class ClassifierNode extends BaseNode {
   })
   declare max_tokens: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ClassifierNodeOutputs> {
     const text = asText(this.text ?? "");
     const categories = getCategories(this.categories);
     if (categories.length < 2) {

--- a/packages/llm-nodes/src/nodes/director.ts
+++ b/packages/llm-nodes/src/nodes/director.ts
@@ -369,6 +369,14 @@ function buildDirectorPrompt(
 // Nodes
 // ---------------------------------------------------------------------------
 
+/** Output handles DirectorNode.process() emits. */
+type DirectorNodeOutputs = {
+  screenplay: Screenplay;
+  narration: string;
+  music_prompt: string;
+  title: string;
+};
+
 export class DirectorNode extends BaseNode {
   static readonly nodeType = "nodetool.creative.Director";
   static readonly title = "Director";
@@ -439,7 +447,7 @@ export class DirectorNode extends BaseNode {
   })
   declare max_tokens: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<DirectorNodeOutputs> {
     const brief = asText(this.brief ?? "");
     const style = asText(this.style ?? "");
     const shotCount = clampShotCount(this.shot_count);
@@ -491,6 +499,19 @@ export class DirectorNode extends BaseNode {
   }
 }
 
+/** Output handles ScreenplayShotsNode.genProcess() emits. */
+type ScreenplayShotsNodeStreamOutputs = {
+  shot: Shot | null;
+  shot_prompt: string | null;
+  index: number | null;
+  output?: string[];
+};
+
+/** Output handles ScreenplayShotsNode.process() emits. */
+type ScreenplayShotsNodeOutputs = {
+  output: string[];
+};
+
 export class ScreenplayShotsNode extends BaseNode {
   static readonly nodeType = "nodetool.creative.ScreenplayShots";
   static readonly title = "Screenplay Shots";
@@ -525,7 +546,7 @@ export class ScreenplayShotsNode extends BaseNode {
   })
   declare screenplay: Record<string, unknown>;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ScreenplayShotsNodeOutputs> {
     const prompts: string[] = [];
     for await (const chunk of this.genProcess(context)) {
       const prompt = (chunk as { shot_prompt?: unknown }).shot_prompt;
@@ -536,7 +557,7 @@ export class ScreenplayShotsNode extends BaseNode {
 
   async *genProcess(
     _context?: ProcessingContext
-  ): AsyncGenerator<Record<string, unknown>> {
+  ): AsyncGenerator<ScreenplayShotsNodeStreamOutputs> {
     const screenplay = toScreenplay(this.screenplay);
     const prompts: string[] = [];
     for (const shot of screenplay.shots) {

--- a/packages/llm-nodes/src/nodes/gemini.ts
+++ b/packages/llm-nodes/src/nodes/gemini.ts
@@ -38,6 +38,13 @@ function isRefSet(ref: unknown): boolean {
 
 // ── Text nodes ──────────────────────────────────────────────────────────────
 
+/** Output handles GroundedSearchNode.process() emits. */
+type GroundedSearchNodeOutputs = {
+  results: string[];
+  sources: { title: string; url: string }[];
+  text: string;
+};
+
 export class GroundedSearchNode extends BaseNode {
   static readonly nodeType = "gemini.text.GroundedSearch";
   static readonly title = "Grounded Search";
@@ -76,7 +83,7 @@ export class GroundedSearchNode extends BaseNode {
   })
   declare model: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<GroundedSearchNodeOutputs> {
     const apiKey = getGeminiApiKey(this._secrets);
     const query = String(this.query ?? "");
     const model = String(this.model ?? "gemini-3.5-flash");
@@ -219,6 +226,11 @@ export class EmbeddingNode extends BaseNode {
 
 // ── Image nodes ─────────────────────────────────────────────────────────────
 
+/** Output handles ImageGenerationNode.process() emits. */
+type ImageGenerationNodeOutputs = {
+  output: { type: string; data: string };
+};
+
 export class ImageGenerationNode extends BaseNode {
   static readonly nodeType = "gemini.image.ImageGeneration";
   static readonly body = "content_card";
@@ -302,7 +314,7 @@ export class ImageGenerationNode extends BaseNode {
   })
   declare resolution: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ImageGenerationNodeOutputs> {
     const apiKey = getGeminiApiKey(this._secrets);
     const prompt = String(this.prompt ?? "");
     const model = String(this.model ?? "gemini-3.1-flash-image");
@@ -431,6 +443,11 @@ export class ImageGenerationNode extends BaseNode {
 
 // ── Video nodes ─────────────────────────────────────────────────────────────
 
+/** Output handles TextToVideoGeminiNode.process() emits. */
+type TextToVideoGeminiNodeOutputs = {
+  output: { type: string; data: string };
+};
+
 export class TextToVideoGeminiNode extends BaseNode {
   static readonly nodeType = "gemini.video.TextToVideo";
   static readonly body = "content_card";
@@ -492,7 +509,7 @@ export class TextToVideoGeminiNode extends BaseNode {
   })
   declare resolution: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TextToVideoGeminiNodeOutputs> {
     const apiKey = getGeminiApiKey(this._secrets);
     const prompt = String(this.prompt ?? "");
     const model = String(this.model ?? "veo-3.1-generate-preview");
@@ -529,6 +546,11 @@ export class TextToVideoGeminiNode extends BaseNode {
     return { output: { type: "video", data: videoData } };
   }
 }
+
+/** Output handles ImageToVideoGeminiNode.process() emits. */
+type ImageToVideoGeminiNodeOutputs = {
+  output: { type: string; data: string };
+};
 
 export class ImageToVideoGeminiNode extends BaseNode {
   static readonly nodeType = "gemini.video.ImageToVideo";
@@ -605,7 +627,7 @@ export class ImageToVideoGeminiNode extends BaseNode {
   })
   declare resolution: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ImageToVideoGeminiNodeOutputs> {
     const apiKey = getGeminiApiKey(this._secrets);
     const image = (this.image ?? {}) as Record<string, unknown>;
     const prompt = String(this.prompt ?? "Animate this image");
@@ -743,6 +765,11 @@ async function extractVideoFromResponse(
 
 // ── Audio nodes ─────────────────────────────────────────────────────────────
 
+/** Output handles TextToSpeechGeminiNode.process() emits. */
+type TextToSpeechGeminiNodeOutputs = {
+  output: { type: string; uri: string; data: string };
+};
+
 export class TextToSpeechGeminiNode extends BaseNode {
   static readonly nodeType = "gemini.audio.TextToSpeech";
   static readonly body = "content_card";
@@ -827,7 +854,7 @@ export class TextToSpeechGeminiNode extends BaseNode {
   })
   declare style_prompt: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TextToSpeechGeminiNodeOutputs> {
     const apiKey = getGeminiApiKey(this._secrets);
     const text = String(this.text ?? "");
     const model = String(this.model ?? "gemini-3.1-flash-tts-preview");
@@ -917,6 +944,11 @@ export class TextToSpeechGeminiNode extends BaseNode {
   }
 }
 
+/** Output handles TranscribeGeminiNode.process() emits. */
+type TranscribeGeminiNodeOutputs = {
+  output: string;
+};
+
 export class TranscribeGeminiNode extends BaseNode {
   static readonly nodeType = "gemini.audio.Transcribe";
   static readonly body = "content_card";
@@ -963,7 +995,7 @@ export class TranscribeGeminiNode extends BaseNode {
   })
   declare prompt: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TranscribeGeminiNodeOutputs> {
     const apiKey = getGeminiApiKey(this._secrets);
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     const model = String(this.model ?? "gemini-3.5-flash");

--- a/packages/llm-nodes/src/nodes/generators.ts
+++ b/packages/llm-nodes/src/nodes/generators.ts
@@ -656,6 +656,18 @@ export class DataGeneratorNode extends BaseNode {
   }
 }
 
+/** Output handles ListGeneratorNode.genProcess() emits. */
+type ListGeneratorNodeStreamOutputs = {
+  item?: string;
+  index?: number;
+  output?: string[];
+};
+
+/** Output handles ListGeneratorNode.process() emits. */
+type ListGeneratorNodeOutputs = {
+  output: string[];
+};
+
 export class ListGeneratorNode extends BaseNode {
   static readonly nodeType = "nodetool.generators.ListGenerator";
   static readonly title = "List Generator";
@@ -729,7 +741,7 @@ export class ListGeneratorNode extends BaseNode {
   })
   declare max_tokens: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ListGeneratorNodeOutputs> {
     const items: string[] = [];
     for await (const chunk of this.genProcess(context)) {
       const item = (chunk as { item?: unknown }).item;
@@ -740,7 +752,7 @@ export class ListGeneratorNode extends BaseNode {
 
   async *genProcess(
     context?: ProcessingContext
-  ): AsyncGenerator<Record<string, unknown>> {
+  ): AsyncGenerator<ListGeneratorNodeStreamOutputs> {
     const prompt = asText(this.prompt ?? "");
     const inputText = asText(this.input_text ?? "");
     const userMessage = [prompt, inputText].filter(Boolean).join("\n\n");
@@ -1037,6 +1049,11 @@ Set a descriptive title, axis labels, and legend settings.`;
   }
 }
 
+/** Output handles SVGGeneratorNode.process() emits. */
+type SVGGeneratorNodeOutputs = {
+  output: { content: string }[];
+};
+
 export class SVGGeneratorNode extends BaseNode {
   static readonly nodeType = "nodetool.generators.SVGGenerator";
   static readonly title = "SVGGenerator";
@@ -1103,7 +1120,7 @@ export class SVGGeneratorNode extends BaseNode {
   })
   declare max_tokens: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<SVGGeneratorNodeOutputs> {
     const prompt = asText(this.prompt ?? "");
     const width = Number((this as any).width ?? 512) || 512;
     const height = Number((this as any).height ?? 512) || 512;

--- a/packages/llm-nodes/src/nodes/mistral.ts
+++ b/packages/llm-nodes/src/nodes/mistral.ts
@@ -42,6 +42,11 @@ async function mistralPost(
 
 // ── Chat Completion ─────────────────────────────────────────────────────────
 
+/** Output handles ChatComplete.process() emits. */
+type ChatCompleteOutputs = {
+  output: string;
+};
+
 export class ChatComplete extends BaseNode {
   static readonly nodeType = "mistral.text.ChatComplete";
   static readonly body = "content_card";
@@ -108,7 +113,7 @@ export class ChatComplete extends BaseNode {
   })
   declare max_tokens: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ChatCompleteOutputs> {
     const apiKey = getApiKey(this._secrets);
     const prompt = String(this.prompt ?? "");
     if (!prompt) throw new Error("Prompt cannot be empty");
@@ -140,6 +145,11 @@ export class ChatComplete extends BaseNode {
 }
 
 // ── Code Completion ─────────────────────────────────────────────────────────
+
+/** Output handles CodeComplete.process() emits. */
+type CodeCompleteOutputs = {
+  output: string;
+};
 
 export class CodeComplete extends BaseNode {
   static readonly nodeType = "mistral.text.CodeComplete";
@@ -189,7 +199,7 @@ export class CodeComplete extends BaseNode {
   })
   declare max_tokens: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<CodeCompleteOutputs> {
     const apiKey = getApiKey(this._secrets);
     const prompt = String(this.prompt ?? "");
     if (!prompt) throw new Error("Prompt cannot be empty");
@@ -230,6 +240,11 @@ export class CodeComplete extends BaseNode {
 
 // ── Embeddings ──────────────────────────────────────────────────────────────
 
+/** Output handles Embedding.process() emits. */
+type EmbeddingOutputs = {
+  output: { data: number[]; shape: number[]; dtype: string };
+};
+
 export class Embedding extends BaseNode {
   static readonly nodeType = "mistral.embeddings.Embedding";
   static readonly title = "Embedding";
@@ -269,7 +284,7 @@ export class Embedding extends BaseNode {
   })
   declare chunk_size: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<EmbeddingOutputs> {
     const apiKey = getApiKey(this._secrets);
     const input = String(this.input ?? "");
     if (!input) throw new Error("Input text cannot be empty");
@@ -310,6 +325,11 @@ export class Embedding extends BaseNode {
 }
 
 // ── Image to Text ───────────────────────────────────────────────────────────
+
+/** Output handles ImageToText.process() emits. */
+type ImageToTextOutputs = {
+  output: string;
+};
 
 export class ImageToText extends BaseNode {
   static readonly nodeType = "mistral.vision.ImageToText";
@@ -374,7 +394,7 @@ export class ImageToText extends BaseNode {
   })
   declare max_tokens: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ImageToTextOutputs> {
     const apiKey = getApiKey(this._secrets);
     const image = (this.image ?? {}) as ImageRefLike;
     if (!image.data && !image.uri) throw new Error("Image is required");
@@ -415,6 +435,11 @@ export class ImageToText extends BaseNode {
 
 // ── OCR ─────────────────────────────────────────────────────────────────────
 
+/** Output handles OCR.process() emits. */
+type OCROutputs = {
+  output: string;
+};
+
 export class OCR extends BaseNode {
   static readonly nodeType = "mistral.vision.OCR";
   static readonly title = "OCR";
@@ -450,7 +475,7 @@ export class OCR extends BaseNode {
   })
   declare model: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<OCROutputs> {
     const apiKey = getApiKey(this._secrets);
     const image = (this.image ?? {}) as ImageRefLike;
     if (!image.data && !image.uri) throw new Error("Image is required");

--- a/packages/llm-nodes/src/nodes/openai.ts
+++ b/packages/llm-nodes/src/nodes/openai.ts
@@ -91,6 +91,11 @@ export class EmbeddingNode extends BaseNode {
 // ---------------------------------------------------------------------------
 // 2. WebSearch
 // ---------------------------------------------------------------------------
+/** Output handles WebSearchNode.process() emits. */
+type WebSearchNodeOutputs = {
+  output: string;
+};
+
 export class WebSearchNode extends BaseNode {
   static readonly nodeType = "openai.text.WebSearch";
   static readonly title = "Web Search";
@@ -111,7 +116,7 @@ export class WebSearchNode extends BaseNode {
   })
   declare query: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<WebSearchNodeOutputs> {
     const apiKey = getApiKey(this._secrets);
     const query = String(this.query ?? "");
     if (!query) throw new Error("Search query cannot be empty");
@@ -217,6 +222,11 @@ export class ModerationNode extends BaseNode {
 // ---------------------------------------------------------------------------
 // 4. CreateImage
 // ---------------------------------------------------------------------------
+/** Output handles CreateImageNode.process() emits. */
+type CreateImageNodeOutputs = {
+  output: { type: string; data: string; content_type: string } | { type: string; uri: string };
+};
+
 export class CreateImageNode extends BaseNode {
   static readonly nodeType = "openai.image.CreateImage";
   static readonly body = "content_card";
@@ -275,7 +285,7 @@ export class CreateImageNode extends BaseNode {
   })
   declare quality: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<CreateImageNodeOutputs> {
     const apiKey = getApiKey(this._secrets);
     const prompt = String(this.prompt ?? "");
     if (!prompt) throw new Error("Prompt cannot be empty");
@@ -319,6 +329,11 @@ export class CreateImageNode extends BaseNode {
 // ---------------------------------------------------------------------------
 // 5. EditImage
 // ---------------------------------------------------------------------------
+/** Output handles EditImageNode.process() emits. */
+type EditImageNodeOutputs = {
+  output: { type: string; data: string; content_type: string } | { type: string; uri: string };
+};
+
 export class EditImageNode extends BaseNode {
   static readonly nodeType = "openai.image.EditImage";
   static readonly body = "content_card";
@@ -397,7 +412,7 @@ export class EditImageNode extends BaseNode {
   })
   declare quality: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<EditImageNodeOutputs> {
     const apiKey = getApiKey(this._secrets);
     const prompt = String(this.prompt ?? "");
     if (!prompt) throw new Error("Edit prompt cannot be empty");
@@ -457,6 +472,11 @@ export class EditImageNode extends BaseNode {
 // ---------------------------------------------------------------------------
 // 5b. ImageVariation
 // ---------------------------------------------------------------------------
+/** Output handles ImageVariationNode.process() emits. */
+type ImageVariationNodeOutputs = {
+  output: { type: string; data: string; content_type: string } | { type: string; uri: string };
+};
+
 export class ImageVariationNode extends BaseNode {
   static readonly nodeType = "openai.image.ImageVariation";
   static readonly body = "content_card";
@@ -494,7 +514,7 @@ export class ImageVariationNode extends BaseNode {
   })
   declare size: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ImageVariationNodeOutputs> {
     const apiKey = getApiKey(this._secrets);
     const image = this.image as Record<string, unknown> | undefined;
     if (!image || (!image.data && !image.uri)) {
@@ -576,6 +596,11 @@ async function refToBlob(ref: Record<string, unknown>): Promise<Blob> {
 // ---------------------------------------------------------------------------
 // 6. TextToSpeech
 // ---------------------------------------------------------------------------
+/** Output handles TextToSpeechNode.process() emits. */
+type TextToSpeechNodeOutputs = {
+  output: { type: string; data: string; content_type: string };
+};
+
 export class TextToSpeechNode extends BaseNode {
   static readonly nodeType = "openai.audio.TextToSpeech";
   static readonly body = "content_card";
@@ -633,7 +658,7 @@ export class TextToSpeechNode extends BaseNode {
   })
   declare instructions: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TextToSpeechNodeOutputs> {
     const apiKey = getApiKey(this._secrets);
     const text = String(this.input ?? "");
     if (!text) throw new Error("Input text cannot be empty");
@@ -677,6 +702,11 @@ export class TextToSpeechNode extends BaseNode {
 // ---------------------------------------------------------------------------
 // 7. Translate
 // ---------------------------------------------------------------------------
+/** Output handles TranslateNode.process() emits. */
+type TranslateNodeOutputs = {
+  output: string;
+};
+
 export class TranslateNode extends BaseNode {
   static readonly nodeType = "openai.audio.Translate";
   static readonly body = "content_card";
@@ -712,7 +742,7 @@ export class TranslateNode extends BaseNode {
   })
   declare temperature: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TranslateNodeOutputs> {
     const apiKey = getApiKey(this._secrets);
     const audio = this.audio as Record<string, unknown> | undefined;
     if (!audio || (!audio.data && !audio.uri)) {
@@ -743,6 +773,13 @@ export class TranslateNode extends BaseNode {
 // ---------------------------------------------------------------------------
 // 8. Transcribe
 // ---------------------------------------------------------------------------
+/** Output handles TranscribeNode.process() emits. */
+type TranscribeNodeOutputs = {
+  text: string;
+  words: { timestamp: [number, number]; text: string }[];
+  segments: { timestamp: [number, number]; text: string }[];
+};
+
 export class TranscribeNode extends BaseNode {
   static readonly nodeType = "openai.audio.Transcribe";
   static readonly body = "content_card";
@@ -881,7 +918,7 @@ export class TranscribeNode extends BaseNode {
   })
   declare temperature: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TranscribeNodeOutputs> {
     const apiKey = getApiKey(this._secrets);
     const audio = this.audio as Record<string, unknown> | undefined;
     if (!audio || (!audio.data && !audio.uri)) {

--- a/packages/llm-nodes/src/nodes/shots.ts
+++ b/packages/llm-nodes/src/nodes/shots.ts
@@ -181,6 +181,11 @@ export function planShotChain(specs: ShotSpec[]): ChainStep[] {
 // Nodes
 // ---------------------------------------------------------------------------
 
+/** Output handles ShotBatchNode.process() emits. */
+type ShotBatchNodeOutputs = {
+  shots: ShotSpec[];
+};
+
 export class ShotBatchNode extends BaseNode {
   static readonly nodeType = "nodetool.creative.ShotBatch";
   static readonly title = "Shot Batch";
@@ -219,7 +224,7 @@ export class ShotBatchNode extends BaseNode {
   })
   declare default_duration: number;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ShotBatchNodeOutputs> {
     const shots = toShotSpecs(this.screenplay, {
       aspectRatio: str(this.aspect_ratio ?? "").trim() || "16:9",
       defaultDuration: Number(this.default_duration ?? 4)
@@ -227,6 +232,11 @@ export class ShotBatchNode extends BaseNode {
     return { shots };
   }
 }
+
+/** Output handles ShotChainNode.process() emits. */
+type ShotChainNodeOutputs = {
+  videos: VideoRef[];
+};
 
 export class ShotChainNode extends BaseNode {
   static readonly nodeType = "nodetool.creative.ShotChain";
@@ -282,7 +292,7 @@ export class ShotChainNode extends BaseNode {
   })
   declare resolution: string;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ShotChainNodeOutputs> {
     const specs = (Array.isArray(this.shots) ? this.shots : []).map((raw, i) =>
       coerceSpec(raw, i)
     );

--- a/packages/llm-nodes/src/nodes/xai.ts
+++ b/packages/llm-nodes/src/nodes/xai.ts
@@ -55,6 +55,11 @@ function firstMessageContent(data: Record<string, unknown>): string {
 
 // ── Chat Completion ─────────────────────────────────────────────────────────
 
+/** Output handles ChatComplete.process() emits. */
+type ChatCompleteOutputs = {
+  output: string;
+};
+
 export class ChatComplete extends BaseNode {
   static readonly nodeType = "xai.text.ChatComplete";
   static readonly body = "content_card";
@@ -113,7 +118,7 @@ export class ChatComplete extends BaseNode {
   })
   declare max_tokens: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ChatCompleteOutputs> {
     const apiKey = getApiKey(this._secrets);
     const prompt = String(this.prompt ?? "");
     if (!prompt) throw new Error("Prompt cannot be empty");
@@ -139,6 +144,12 @@ export class ChatComplete extends BaseNode {
 }
 
 // ── Web Search (Live Search) ────────────────────────────────────────────────
+
+/** Output handles WebSearch.process() emits. */
+type WebSearchOutputs = {
+  output: string;
+  citations: string[];
+};
 
 export class WebSearch extends BaseNode {
   static readonly nodeType = "xai.text.WebSearch";
@@ -190,7 +201,7 @@ export class WebSearch extends BaseNode {
   })
   declare max_results: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<WebSearchOutputs> {
     const apiKey = getApiKey(this._secrets);
     const query = String(this.query ?? "");
     if (!query) throw new Error("Search query cannot be empty");
@@ -219,6 +230,11 @@ export class WebSearch extends BaseNode {
 }
 
 // ── Image To Text (Vision) ──────────────────────────────────────────────────
+
+/** Output handles ImageToText.process() emits. */
+type ImageToTextOutputs = {
+  output: string;
+};
 
 export class ImageToText extends BaseNode {
   static readonly nodeType = "xai.vision.ImageToText";
@@ -283,7 +299,7 @@ export class ImageToText extends BaseNode {
   })
   declare max_tokens: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ImageToTextOutputs> {
     const apiKey = getApiKey(this._secrets);
     const image = (this.image ?? {}) as ImageRefLike;
     if (!image.data && !image.uri) throw new Error("Image is required");
@@ -318,6 +334,12 @@ export class ImageToText extends BaseNode {
 
 // ── Image Generation ────────────────────────────────────────────────────────
 
+/** Output handles GenerateImage.process() emits. */
+type GenerateImageOutputs = {
+  output: { type: string; data: string } | { type: string; uri: string };
+  revised_prompt: string;
+};
+
 export class GenerateImage extends BaseNode {
   static readonly nodeType = "xai.image.GenerateImage";
   static readonly body = "content_card";
@@ -350,7 +372,7 @@ export class GenerateImage extends BaseNode {
   })
   declare model: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<GenerateImageOutputs> {
     const apiKey = getApiKey(this._secrets);
     const prompt = String(this.prompt ?? "");
     if (!prompt) throw new Error("Prompt cannot be empty");

--- a/packages/minimax-nodes/src/nodes/image-to-video.ts
+++ b/packages/minimax-nodes/src/nodes/image-to-video.ts
@@ -14,6 +14,11 @@ import {
   videoRenderSettings
 } from "../minimax-base.js";
 
+/** Output handles MinimaxImageToVideoNode.process() emits. */
+type MinimaxImageToVideoNodeOutputs = {
+  output: { type: string; data: string };
+};
+
 export class MinimaxImageToVideoNode extends BaseNode {
   static readonly nodeType = "minimax.ImageToVideo";
   static readonly body = "content_card";
@@ -80,7 +85,9 @@ export class MinimaxImageToVideoNode extends BaseNode {
   })
   declare resolution: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(
+    context?: ProcessingContext
+  ): Promise<MinimaxImageToVideoNodeOutputs> {
     const apiKey = getMinimaxApiKey(this._secrets);
 
     const imageBytes = await loadMediaRefBytes(this.image, context);

--- a/packages/minimax-nodes/src/nodes/music.ts
+++ b/packages/minimax-nodes/src/nodes/music.ts
@@ -12,6 +12,11 @@ import {
 
 const MUSIC_FORMATS = ["mp3", "wav"];
 
+/** Output handles MinimaxMusicNode.process() emits. */
+type MinimaxMusicNodeOutputs = {
+  output: { type: string; data: string; content_type: string };
+};
+
 export class MinimaxMusicNode extends BaseNode {
   static readonly nodeType = "minimax.MusicGeneration";
   static readonly body = "content_card";
@@ -69,7 +74,7 @@ export class MinimaxMusicNode extends BaseNode {
   })
   declare format: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<MinimaxMusicNodeOutputs> {
     const apiKey = getMinimaxApiKey(this._secrets);
 
     const prompt = String(this.prompt ?? "");

--- a/packages/minimax-nodes/src/nodes/text-to-image.ts
+++ b/packages/minimax-nodes/src/nodes/text-to-image.ts
@@ -9,6 +9,11 @@ import {
   minimaxHeaders
 } from "../minimax-base.js";
 
+/** Output handles MinimaxTextToImageNode.process() emits. */
+type MinimaxTextToImageNodeOutputs = {
+  output: { type: string; data: string; mimeType: string };
+};
+
 export class MinimaxTextToImageNode extends BaseNode {
   static readonly nodeType = "minimax.TextToImage";
   static readonly body = "content_card";
@@ -68,7 +73,7 @@ export class MinimaxTextToImageNode extends BaseNode {
   })
   declare prompt_optimizer: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<MinimaxTextToImageNodeOutputs> {
     const apiKey = getMinimaxApiKey(this._secrets);
 
     const basePrompt = String(this.prompt ?? "");

--- a/packages/minimax-nodes/src/nodes/text-to-speech.ts
+++ b/packages/minimax-nodes/src/nodes/text-to-speech.ts
@@ -16,6 +16,11 @@ import {
 
 const TTS_FORMATS = ["mp3", "wav", "flac"];
 
+/** Output handles MinimaxTextToSpeechNode.process() emits. */
+type MinimaxTextToSpeechNodeOutputs = {
+  output: { type: string; data: string; content_type: string };
+};
+
 export class MinimaxTextToSpeechNode extends BaseNode {
   static readonly nodeType = "minimax.TextToSpeech";
   static readonly body = "content_card";
@@ -122,7 +127,7 @@ export class MinimaxTextToSpeechNode extends BaseNode {
   })
   declare format: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<MinimaxTextToSpeechNodeOutputs> {
     const apiKey = getMinimaxApiKey(this._secrets);
 
     const text = String(this.text ?? "");

--- a/packages/minimax-nodes/src/nodes/text-to-video.ts
+++ b/packages/minimax-nodes/src/nodes/text-to-video.ts
@@ -10,6 +10,11 @@ import {
   videoRenderSettings
 } from "../minimax-base.js";
 
+/** Output handles MinimaxTextToVideoNode.process() emits. */
+type MinimaxTextToVideoNodeOutputs = {
+  output: { type: string; data: string };
+};
+
 export class MinimaxTextToVideoNode extends BaseNode {
   static readonly nodeType = "minimax.TextToVideo";
   static readonly body = "content_card";
@@ -65,7 +70,7 @@ export class MinimaxTextToVideoNode extends BaseNode {
   })
   declare resolution: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<MinimaxTextToVideoNodeOutputs> {
     const apiKey = getMinimaxApiKey(this._secrets);
 
     const prompt = String(this.prompt ?? "");

--- a/packages/minimax-nodes/src/nodes/voice.ts
+++ b/packages/minimax-nodes/src/nodes/voice.ts
@@ -2,6 +2,11 @@ import { BaseNode, prop } from "@nodetool-ai/node-sdk";
 import type { NodeClass } from "@nodetool-ai/node-sdk";
 import { DEFAULT_VOICE, MINIMAX_VOICES } from "../minimax-base.js";
 
+/** Output handles MinimaxVoiceNode.process() emits. */
+type MinimaxVoiceNodeOutputs = {
+  voice_id: string;
+};
+
 export class MinimaxVoiceNode extends BaseNode {
   static readonly nodeType = "minimax.Voice";
   static readonly body = "small";
@@ -26,7 +31,7 @@ export class MinimaxVoiceNode extends BaseNode {
   })
   declare voice: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<MinimaxVoiceNodeOutputs> {
     const voice = String(this.voice ?? DEFAULT_VOICE);
     return { voice_id: voice };
   }

--- a/packages/node-sdk/src/nodes/test-nodes.ts
+++ b/packages/node-sdk/src/nodes/test-nodes.ts
@@ -14,6 +14,11 @@ export class Passthrough extends BaseNode {
   }
 }
 
+/** Output handles Add.process() emits. */
+type AddOutputs = {
+  result: number;
+};
+
 export class Add extends BaseNode {
   static readonly nodeType = "nodetool.test.Add";
   static readonly title = "Add";
@@ -25,7 +30,7 @@ export class Add extends BaseNode {
   @prop({ type: "int", default: 0 })
   declare b: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<AddOutputs> {
     const values = [this.a, this.b, ...Array.from(this.dynamicProps.values())];
     const sum = values.reduce((acc: number, value: unknown) => {
       return acc + Number(value ?? 0);
@@ -33,6 +38,11 @@ export class Add extends BaseNode {
     return { result: sum };
   }
 }
+
+/** Output handles Multiply.process() emits. */
+type MultiplyOutputs = {
+  result: number;
+};
 
 export class Multiply extends BaseNode {
   static readonly nodeType = "nodetool.test.Multiply";
@@ -44,7 +54,7 @@ export class Multiply extends BaseNode {
   @prop({ type: "int", default: 1 })
   declare b: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<MultiplyOutputs> {
     const a = (this.a ?? 1) as number;
     const b = (this.b ?? 1) as number;
     return { result: a * b };
@@ -63,6 +73,11 @@ export class Constant extends BaseNode {
   }
 }
 
+/** Output handles StringConcat.process() emits. */
+type StringConcatOutputs = {
+  result: string;
+};
+
 export class StringConcat extends BaseNode {
   static readonly nodeType = "nodetool.test.StringConcat";
   static readonly title = "String Concat";
@@ -77,7 +92,7 @@ export class StringConcat extends BaseNode {
   @prop({ type: "str", default: "" })
   declare separator: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<StringConcatOutputs> {
     const sep = String(this.separator ?? "");
     const values = [this.a, this.b, ...Array.from(this.dynamicProps.values())].map(
       (value) => String(value ?? "")
@@ -85,6 +100,11 @@ export class StringConcat extends BaseNode {
     return { result: values.join(sep) };
   }
 }
+
+/** Output handles FormatText.process() emits. */
+type FormatTextOutputs = {
+  result: string;
+};
 
 export class FormatText extends BaseNode {
   static readonly nodeType = "nodetool.test.FormatText";
@@ -97,12 +117,17 @@ export class FormatText extends BaseNode {
   @prop({ type: "str", default: "" })
   declare text: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FormatTextOutputs> {
     const template = String(this.template ?? "{{ text }}");
     const text = String(this.text ?? "");
     return { result: template.replace(/\{\{\s*text\s*\}\}/g, text) };
   }
 }
+
+/** Output handles ThresholdProcessor.process() emits. */
+type ThresholdProcessorOutputs = {
+  result: string;
+};
 
 export class ThresholdProcessor extends BaseNode {
   static readonly nodeType = "nodetool.test.ThresholdProcessor";
@@ -118,7 +143,7 @@ export class ThresholdProcessor extends BaseNode {
   @prop({ type: "str", default: "normal" })
   declare mode: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ThresholdProcessorOutputs> {
     const value = (this.value ?? 0) as number;
     const threshold = (this.threshold ?? 0.5) as number;
     const mode = String(this.mode ?? "normal");
@@ -141,6 +166,11 @@ export class ErrorNode extends BaseNode {
   }
 }
 
+/** Output handles SlowNode.process() emits. */
+type SlowNodeOutputs = {
+  result: string;
+};
+
 export class SlowNode extends BaseNode {
   static readonly nodeType = "nodetool.test.SlowNode";
   static readonly title = "Slow Node";
@@ -148,11 +178,16 @@ export class SlowNode extends BaseNode {
   @prop({ type: "int", default: 100 })
   declare delayMs: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SlowNodeOutputs> {
     await new Promise((r) => setTimeout(r, (this.delayMs as number) ?? 100));
     return { result: "completed" };
   }
 }
+
+/** Output handles StreamingCounter.genProcess() emits. */
+type StreamingCounterStreamOutputs = {
+  value: number;
+};
 
 export class StreamingCounter extends BaseNode {
   static readonly nodeType = "nodetool.test.StreamingCounter";
@@ -168,7 +203,7 @@ export class StreamingCounter extends BaseNode {
     return {};
   }
 
-  async *genProcess(): AsyncGenerator<Record<string, unknown>> {
+  async *genProcess(): AsyncGenerator<StreamingCounterStreamOutputs> {
     const count = (this.count as number) ?? 3;
     const start = (this.start as number) ?? 0;
     for (let i = 0; i < count; i++) {
@@ -176,6 +211,13 @@ export class StreamingCounter extends BaseNode {
     }
   }
 }
+
+/** Output handles IntAccumulator.process() emits. */
+type IntAccumulatorOutputs = {
+  count: number;
+  value: number;
+  values: number[];
+};
 
 export class IntAccumulator extends BaseNode {
   static readonly nodeType = "nodetool.test.IntAccumulator";
@@ -188,7 +230,7 @@ export class IntAccumulator extends BaseNode {
   @prop({ type: "int", default: 0 })
   declare value: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<IntAccumulatorOutputs> {
     this._execCount++;
     const value = (this.value ?? 0) as number;
     this._accumulated.push(value);
@@ -272,6 +314,11 @@ export class MultiTriggerController extends BaseNode {
  * Source node that emits a StopEvent on its __control__ handle,
  * causing the controlled node to stop immediately.
  */
+/** Output handles StopEventController.genProcess() emits. */
+type StopEventControllerStreamOutputs = {
+  __control__: { event_type: string };
+};
+
 export class StopEventController extends BaseNode {
   static readonly nodeType = "nodetool.test.StopEventController";
   static readonly title = "Stop Event Controller";
@@ -281,7 +328,7 @@ export class StopEventController extends BaseNode {
     return {};
   }
 
-  async *genProcess(): AsyncGenerator<Record<string, unknown>> {
+  async *genProcess(): AsyncGenerator<StopEventControllerStreamOutputs> {
     yield { __control__: { event_type: "stop" } };
   }
 }
@@ -294,6 +341,11 @@ export class StopEventController extends BaseNode {
  * Node with is_streaming_input: true.
  * Called once with empty inputs by the actor.
  */
+/** Output handles StreamingInputProcessor.process() emits. */
+type StreamingInputProcessorOutputs = {
+  result: string;
+};
+
 export class StreamingInputProcessor extends BaseNode {
   static readonly nodeType = "nodetool.test.StreamingInputProcessor";
   static readonly title = "Streaming Input Processor";
@@ -301,7 +353,7 @@ export class StreamingInputProcessor extends BaseNode {
     "Streaming input node – called once with empty inputs";
   static readonly isStreamingInput = true;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<StreamingInputProcessorOutputs> {
     return { result: "processed" };
   }
 }
@@ -310,6 +362,16 @@ export class StreamingInputProcessor extends BaseNode {
  * Node with both is_streaming_input and is_streaming_output set.
  * Called once with empty inputs (streaming input takes priority in actor).
  */
+/** Output handles FullStreamingNode.genProcess() emits. */
+type FullStreamingNodeStreamOutputs = {
+  value: number;
+};
+
+/** Output handles FullStreamingNode.process() emits. */
+type FullStreamingNodeOutputs = {
+  result: string;
+};
+
 export class FullStreamingNode extends BaseNode {
   static readonly nodeType = "nodetool.test.FullStreamingNode";
   static readonly title = "Full Streaming Node";
@@ -318,11 +380,11 @@ export class FullStreamingNode extends BaseNode {
   @prop({ type: "int", default: 2 })
   declare count: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FullStreamingNodeOutputs> {
     return { result: "full-streaming" };
   }
 
-  async *genProcess(): AsyncGenerator<Record<string, unknown>> {
+  async *genProcess(): AsyncGenerator<FullStreamingNodeStreamOutputs> {
     const count = (this.count as number) ?? 2;
     for (let i = 0; i < count; i++) {
       yield { value: i };
@@ -334,6 +396,11 @@ export class FullStreamingNode extends BaseNode {
 // Data processing nodes
 // ---------------------------------------------------------------------------
 
+/** Output handles ListSumProcessor.process() emits. */
+type ListSumProcessorOutputs = {
+  sum: number;
+};
+
 export class ListSumProcessor extends BaseNode {
   static readonly nodeType = "nodetool.test.ListSumProcessor";
   static readonly title = "List Sum Processor";
@@ -342,7 +409,7 @@ export class ListSumProcessor extends BaseNode {
   @prop({ type: "list[int]", default: [] })
   declare values: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ListSumProcessorOutputs> {
     const values = (this.values ?? []) as number[];
     const sum = Array.isArray(values)
       ? values.reduce((a: number, b) => a + (b as number), 0)
@@ -350,6 +417,11 @@ export class ListSumProcessor extends BaseNode {
     return { sum };
   }
 }
+
+/** Output handles ConditionalErrorProcessor.process() emits. */
+type ConditionalErrorProcessorOutputs = {
+  result: string;
+};
 
 export class ConditionalErrorProcessor extends BaseNode {
   static readonly nodeType = "nodetool.test.ConditionalErrorProcessor";
@@ -361,7 +433,7 @@ export class ConditionalErrorProcessor extends BaseNode {
   @prop({ type: "str", default: "conditional error" })
   declare message: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConditionalErrorProcessorOutputs> {
     const shouldFail = (this.shouldFail ?? false) as boolean;
     if (shouldFail) {
       throw new Error(String(this.message ?? "conditional error"));

--- a/packages/text-nodes/src/nodes/lib-nlp.ts
+++ b/packages/text-nodes/src/nodes/lib-nlp.ts
@@ -16,6 +16,14 @@ import {
   DoubleMetaphone
 } from "./nlp/index.js";
 
+/** Output handles SentimentAnalysisLibNode.process() emits. */
+type SentimentAnalysisLibNodeOutputs = {
+  score: number;
+  comparative: number;
+  positive_words: string[];
+  negative_words: string[];
+};
+
 export class SentimentAnalysisLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.SentimentAnalysis";
   static readonly retrySafe = true;
@@ -48,7 +56,7 @@ export class SentimentAnalysisLibNode extends BaseNode {
   })
   declare language: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SentimentAnalysisLibNodeOutputs> {
     const text = String(this.text ?? "");
     const language = String(this.language ?? "English");
 
@@ -102,6 +110,12 @@ export class SentimentAnalysisLibNode extends BaseNode {
   }
 }
 
+/** Output handles TokenizeLibNode.process() emits. */
+type TokenizeLibNodeOutputs = {
+  output: string[];
+  count: number;
+};
+
 export class TokenizeLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.Tokenize";
   static readonly retrySafe = true;
@@ -132,7 +146,7 @@ export class TokenizeLibNode extends BaseNode {
   })
   declare mode: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TokenizeLibNodeOutputs> {
     const text = String(this.text ?? "");
     const mode = String(this.mode ?? "word");
 
@@ -152,6 +166,12 @@ export class TokenizeLibNode extends BaseNode {
     return { output: tokens, count: tokens.length };
   }
 }
+
+/** Output handles StemLibNode.process() emits. */
+type StemLibNodeOutputs = {
+  output: string;
+  tokens: string[];
+};
 
 export class StemLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.Stem";
@@ -183,7 +203,7 @@ export class StemLibNode extends BaseNode {
   })
   declare algorithm: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<StemLibNodeOutputs> {
     const text = String(this.text ?? "");
     const algorithm = String(this.algorithm ?? "porter");
 
@@ -202,6 +222,11 @@ export class StemLibNode extends BaseNode {
     return { output, tokens: stemmedTokens };
   }
 }
+
+/** Output handles TfIdfLibNode.process() emits. */
+type TfIdfLibNodeOutputs = {
+  output: { document_index: number; score: number }[];
+};
 
 export class TfIdfLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.TfIdf";
@@ -231,7 +256,7 @@ export class TfIdfLibNode extends BaseNode {
   })
   declare query: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TfIdfLibNodeOutputs> {
     const documents = Array.isArray(this.documents) ? this.documents : [];
     const query = String(this.query ?? "");
 
@@ -252,6 +277,12 @@ export class TfIdfLibNode extends BaseNode {
     return { output: results };
   }
 }
+
+/** Output handles ClassifyTextLibNode.process() emits. */
+type ClassifyTextLibNodeOutputs = {
+  output: string;
+  classifications: { label: string; value: number }[];
+};
 
 export class ClassifyTextLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.ClassifyText";
@@ -282,7 +313,7 @@ export class ClassifyTextLibNode extends BaseNode {
   })
   declare training_data: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ClassifyTextLibNodeOutputs> {
     const text = String(this.text ?? "");
     const trainingData = Array.isArray(this.training_data)
       ? this.training_data
@@ -318,6 +349,16 @@ export class ClassifyTextLibNode extends BaseNode {
   }
 }
 
+/** Output handles ExtractEntitiesLibNode.process() emits. */
+type ExtractEntitiesLibNodeOutputs = {
+  people: string[];
+  places: string[];
+  organizations: string[];
+  numbers: string[];
+  nouns: string[];
+  verbs: string[];
+};
+
 export class ExtractEntitiesLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.ExtractEntities";
   static readonly retrySafe = true;
@@ -343,7 +384,7 @@ export class ExtractEntitiesLibNode extends BaseNode {
   })
   declare text: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ExtractEntitiesLibNodeOutputs> {
     const nlp = (await import("compromise")).default;
     const text = String(this.text ?? "");
 
@@ -378,6 +419,12 @@ export class ExtractEntitiesLibNode extends BaseNode {
   }
 }
 
+/** Output handles PhoneticMatchLibNode.process() emits. */
+type PhoneticMatchLibNodeOutputs = {
+  output: string;
+  tokens: { word: string; code: string | string[] }[];
+};
+
 export class PhoneticMatchLibNode extends BaseNode {
   static readonly nodeType = "lib.nlp.PhoneticMatch";
   static readonly retrySafe = true;
@@ -408,7 +455,7 @@ export class PhoneticMatchLibNode extends BaseNode {
   })
   declare algorithm: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<PhoneticMatchLibNodeOutputs> {
     const text = String(this.text ?? "");
     const algorithm = String(this.algorithm ?? "metaphone");
 

--- a/packages/text-nodes/src/nodes/lib-svg.ts
+++ b/packages/text-nodes/src/nodes/lib-svg.ts
@@ -173,6 +173,21 @@ export class RectLibNode extends BaseNode {
   }
 }
 
+/** Output handles CircleLibNode.process() emits. */
+type CircleLibNodeOutputs = {
+  output: {
+    name: string;
+    attributes: {
+      cx: string;
+      cy: string;
+      r: string;
+      fill: string;
+      stroke: string;
+      "stroke-width": string;
+    };
+  };
+};
+
 export class CircleLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Circle";
   static readonly retrySafe = true;
@@ -234,7 +249,7 @@ export class CircleLibNode extends BaseNode {
   })
   declare stroke_width: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<CircleLibNodeOutputs> {
     return {
       output: {
         name: "circle",
@@ -250,6 +265,22 @@ export class CircleLibNode extends BaseNode {
     };
   }
 }
+
+/** Output handles EllipseLibNode.process() emits. */
+type EllipseLibNodeOutputs = {
+  output: {
+    name: string;
+    attributes: {
+      cx: string;
+      cy: string;
+      rx: string;
+      ry: string;
+      fill: string;
+      stroke: string;
+      "stroke-width": string;
+    };
+  };
+};
 
 export class EllipseLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Ellipse";
@@ -315,7 +346,7 @@ export class EllipseLibNode extends BaseNode {
   })
   declare stroke_width: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<EllipseLibNodeOutputs> {
     return {
       output: {
         name: "ellipse",
@@ -332,6 +363,21 @@ export class EllipseLibNode extends BaseNode {
     };
   }
 }
+
+/** Output handles LineLibNode.process() emits. */
+type LineLibNodeOutputs = {
+  output: {
+    name: string;
+    attributes: {
+      x1: string;
+      y1: string;
+      x2: string;
+      y2: string;
+      stroke: string;
+      "stroke-width": string;
+    };
+  };
+};
 
 export class LineLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Line";
@@ -396,7 +442,7 @@ export class LineLibNode extends BaseNode {
   })
   declare stroke_width: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<LineLibNodeOutputs> {
     return {
       output: {
         name: "line",
@@ -412,6 +458,19 @@ export class LineLibNode extends BaseNode {
     };
   }
 }
+
+/** Output handles PolygonLibNode.process() emits. */
+type PolygonLibNodeOutputs = {
+  output: {
+    name: string;
+    attributes: {
+      points: string;
+      fill: string;
+      stroke: string;
+      "stroke-width": string;
+    };
+  };
+};
 
 export class PolygonLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Polygon";
@@ -463,7 +522,7 @@ export class PolygonLibNode extends BaseNode {
   })
   declare stroke_width: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<PolygonLibNodeOutputs> {
     return {
       output: {
         name: "polygon",
@@ -477,6 +536,19 @@ export class PolygonLibNode extends BaseNode {
     };
   }
 }
+
+/** Output handles PathLibNode.process() emits. */
+type PathLibNodeOutputs = {
+  output: {
+    name: string;
+    attributes: {
+      d: string;
+      fill: string;
+      stroke: string;
+      "stroke-width": string;
+    };
+  };
+};
 
 export class PathLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Path";
@@ -528,7 +600,7 @@ export class PathLibNode extends BaseNode {
   })
   declare stroke_width: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<PathLibNodeOutputs> {
     return {
       output: {
         name: "path",
@@ -623,6 +695,15 @@ export class TextLibNode extends BaseNode {
   }
 }
 
+/** Output handles GaussianBlurLibNode.process() emits. */
+type GaussianBlurLibNodeOutputs = {
+  output: {
+    name: string;
+    attributes: { id: string };
+    children: { name: string; attributes: { stdDeviation: string } }[];
+  };
+};
+
 export class GaussianBlurLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.GaussianBlur";
   static readonly retrySafe = true;
@@ -643,7 +724,7 @@ export class GaussianBlurLibNode extends BaseNode {
   })
   declare std_deviation: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<GaussianBlurLibNodeOutputs> {
     return {
       output: {
         name: "filter",
@@ -744,6 +825,11 @@ export class DropShadowLibNode extends BaseNode {
   }
 }
 
+/** Output handles DocumentLibNode.process() emits. */
+type DocumentLibNodeOutputs = {
+  output: { data: string };
+};
+
 export class DocumentLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Document";
   static readonly retrySafe = true;
@@ -792,7 +878,7 @@ export class DocumentLibNode extends BaseNode {
   })
   declare viewBox: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<DocumentLibNodeOutputs> {
     const content = normalizeContent(this.elements ?? []);
     const width = Number(this.width ?? 800);
     const height = Number(this.height ?? 600);
@@ -801,6 +887,17 @@ export class DocumentLibNode extends BaseNode {
     return { output: { data: Buffer.from(doc, "utf-8").toString("base64") } };
   }
 }
+
+/** Output handles SVGToImageLibNode.process() emits. */
+type SVGToImageLibNodeOutputs = {
+  output: {
+    type: string;
+    data: string;
+    mimeType: string;
+    width: number;
+    height: number;
+  };
+};
 
 export class SVGToImageLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.SVGToImage";
@@ -863,7 +960,7 @@ export class SVGToImageLibNode extends BaseNode {
   })
   declare scale: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SVGToImageLibNodeOutputs> {
     const sharp = await loadSharp();
     if (!sharp) throw new Error(SHARP_UNAVAILABLE_MESSAGE);
     const content = normalizeContent(this.elements ?? []);
@@ -888,6 +985,15 @@ export class SVGToImageLibNode extends BaseNode {
     };
   }
 }
+
+/** Output handles GradientLibNode.process() emits. */
+type GradientLibNodeOutputs = {
+  output: {
+    name: string;
+    attributes: Record<string, string>;
+    children: { name: string; attributes: { offset: string; style: string } }[];
+  };
+};
 
 export class GradientLibNode extends BaseNode {
   static readonly nodeType = "lib.svg.Gradient";
@@ -964,7 +1070,7 @@ export class GradientLibNode extends BaseNode {
   })
   declare color2: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<GradientLibNodeOutputs> {
     const gradientType = String(this.gradient_type ?? "linearGradient");
     const attrs: Record<string, string> = {
       id: nextSvgId(`gradient_${gradientType}`)

--- a/packages/text-nodes/src/nodes/text-extra.ts
+++ b/packages/text-nodes/src/nodes/text-extra.ts
@@ -76,6 +76,11 @@ function embeddingParams(text: string, dimensions: number): EmbeddingParams {
   return params;
 }
 
+/** Output handles CountTokensNode.process() emits. */
+type CountTokensNodeOutputs = {
+  output: number;
+};
+
 export class CountTokensNode extends BaseNode {
   static readonly nodeType = "nodetool.text.CountTokens";
   static readonly retrySafe = true;
@@ -100,7 +105,7 @@ export class CountTokensNode extends BaseNode {
   })
   declare encoding: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<CountTokensNodeOutputs> {
     const text = String(this.text ?? "");
     if (!text) {
       return { output: 0 };
@@ -114,6 +119,12 @@ export class CountTokensNode extends BaseNode {
     return { output: encoder.encode(text).length };
   }
 }
+
+/** Output handles AutomaticSpeechRecognitionNode.process() emits. */
+type AutomaticSpeechRecognitionNodeOutputs = {
+  text: string;
+  output: string;
+};
 
 export class AutomaticSpeechRecognitionNode extends BaseNode {
   static readonly nodeType = "nodetool.text.AutomaticSpeechRecognition";
@@ -180,7 +191,7 @@ export class AutomaticSpeechRecognitionNode extends BaseNode {
   })
   declare temperature: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<AutomaticSpeechRecognitionNodeOutputs> {
     const { providerId, modelId } = modelConfig(this.serialize());
     const audio = (this.audio ?? {}) as Record<string, unknown>;
     let bytes: Uint8Array = new Uint8Array();
@@ -228,6 +239,11 @@ export class AutomaticSpeechRecognitionNode extends BaseNode {
   }
 }
 
+/** Output handles EmbeddingTextNode.process() emits. */
+type EmbeddingTextNodeOutputs = {
+  output: number[];
+};
+
 export class EmbeddingTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Embedding";
   static readonly title = "Embedding";
@@ -272,7 +288,7 @@ export class EmbeddingTextNode extends BaseNode {
   })
   declare chunk_size: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<EmbeddingTextNodeOutputs> {
     const text = String(this.input ?? "");
     if (!text) {
       throw new Error("input text must not be empty");
@@ -299,6 +315,11 @@ export class EmbeddingTextNode extends BaseNode {
     return { output: vectors[0] ?? [] };
   }
 }
+
+/** Output handles SaveTextFileNode.process() emits. */
+type SaveTextFileNodeOutputs = {
+  output: { uri: string; data: string };
+};
 
 export class SaveTextFileNode extends BaseNode {
   static readonly nodeType = "nodetool.text.SaveTextFile";
@@ -331,7 +352,7 @@ export class SaveTextFileNode extends BaseNode {
   })
   declare name: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SaveTextFileNodeOutputs> {
     const text = String(this.text ?? "");
     const folder = String(this.folder ?? "");
     const name = formatFilename(String(this.name ?? "output.txt"));
@@ -349,6 +370,11 @@ export class SaveTextFileNode extends BaseNode {
     return { output: { uri, data: text } };
   }
 }
+
+/** Output handles SaveTextNode.process() emits. */
+type SaveTextNodeOutputs = {
+  output: { uri: string; data: string };
+};
 
 export class SaveTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.SaveText";
@@ -387,7 +413,7 @@ export class SaveTextNode extends BaseNode {
   })
   declare name: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SaveTextNodeOutputs> {
     const text = String(this.text ?? "");
     const name = formatFilename(String(this.name ?? "output.txt"));
     const folder = folderPath(this.folder ?? "");
@@ -402,6 +428,22 @@ export class SaveTextNode extends BaseNode {
     return { output: { uri, data: text } };
   }
 }
+
+/** Output handles LoadTextFolderNode.genProcess() emits. */
+type LoadTextFolderNodeStreamOutputs = {
+  path?: string;
+  text?: string;
+  texts?: string[];
+  paths?: string[];
+};
+
+/** Output handles LoadTextFolderNode.process() emits. */
+type LoadTextFolderNodeOutputs = {
+  text: string;
+  path: string;
+  texts: string[];
+  paths: string[];
+};
 
 export class LoadTextFolderNode extends BaseNode {
   static readonly nodeType = "nodetool.text.LoadTextFolder";
@@ -448,7 +490,7 @@ export class LoadTextFolderNode extends BaseNode {
   })
   declare pattern: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<LoadTextFolderNodeOutputs> {
     const allTexts: string[] = [];
     const allPaths: string[] = [];
     for await (const item of this._walkFiles()) {
@@ -502,7 +544,7 @@ export class LoadTextFolderNode extends BaseNode {
     }
   }
 
-  async *genProcess(): AsyncGenerator<Record<string, unknown>> {
+  async *genProcess(): AsyncGenerator<LoadTextFolderNodeStreamOutputs> {
     const allTexts: string[] = [];
     const allPaths: string[] = [];
     for await (const item of this._walkFiles()) {
@@ -588,6 +630,11 @@ type FilterStringType =
   | "length_less"
   | "exact_length";
 
+/** Output handles FilterStringNode.process() emits. */
+type FilterStringNodeOutputs = {
+  output?: string;
+};
+
 export class FilterStringNode extends BaseNode {
   static readonly nodeType = "nodetool.text.FilterString";
   static readonly retrySafe = true;
@@ -642,7 +689,7 @@ export class FilterStringNode extends BaseNode {
     this._criteria = String(this.criteria ?? "");
   }
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FilterStringNodeOutputs> {
     this._filterType = String(
       this.filter_type ?? "contains"
     ) as FilterStringType;
@@ -687,6 +734,11 @@ export class FilterStringNode extends BaseNode {
     return { output: value };
   }
 }
+
+/** Output handles FilterRegexStringNode.process() emits. */
+type FilterRegexStringNodeOutputs = {
+  output?: string;
+};
 
 export class FilterRegexStringNode extends BaseNode {
   static readonly nodeType = "nodetool.text.FilterRegexString";
@@ -733,7 +785,7 @@ export class FilterRegexStringNode extends BaseNode {
     this._fullMatch = Boolean(this.full_match ?? false);
   }
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FilterRegexStringNodeOutputs> {
     this._pattern = String(this.pattern ?? "");
     this._fullMatch = Boolean(this.full_match ?? false);
 
@@ -760,6 +812,11 @@ export class FilterRegexStringNode extends BaseNode {
   }
 }
 
+/** Output handles ConcatTextNode.process() emits. */
+type ConcatTextNodeOutputs = {
+  output: string;
+};
+
 export class ConcatTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Concat";
   static readonly retrySafe = true;
@@ -775,7 +832,7 @@ export class ConcatTextNode extends BaseNode {
   static readonly inputFields: string[] = [];
   static readonly supportsDynamicInputs = true;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ConcatTextNodeOutputs> {
     // A dynamic input may carry a single value or a list<str> from an upstream
     // loop/list node — flatten so list elements concatenate in order instead of
     // stringifying the whole array as "a,b,c".
@@ -787,6 +844,11 @@ export class ConcatTextNode extends BaseNode {
     };
   }
 }
+
+/** Output handles JoinTextNode.process() emits. */
+type JoinTextNodeOutputs = {
+  output: string;
+};
 
 export class JoinTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Join";
@@ -815,12 +877,17 @@ export class JoinTextNode extends BaseNode {
   })
   declare separator: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<JoinTextNodeOutputs> {
     const list = Array.isArray(this.strings) ? this.strings : [];
     const sep = String(this.separator ?? "");
     return { output: list.map((s: unknown) => String(s ?? "")).join(sep) };
   }
 }
+
+/** Output handles CollectTextNode.process() emits. */
+type CollectTextNodeOutputs = {
+  output: string;
+};
 
 export class CollectTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Collect";
@@ -853,7 +920,7 @@ export class CollectTextNode extends BaseNode {
     this._items = [];
   }
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<CollectTextNodeOutputs> {
     this._items.push(String(this.input_item ?? ""));
     const sep = String(this.separator ?? "");
     return { output: this._items.join(sep) };
@@ -924,6 +991,11 @@ export class PromptNode extends BaseNode {
   }
 }
 
+/** Output handles TemplateTextNode.process() emits. */
+type TemplateTextNodeOutputs = {
+  output: string;
+};
+
 export class TemplateTextNode extends BaseNode {
   static readonly nodeType = "nodetool.text.Template";
   static readonly retrySafe = true;
@@ -946,7 +1018,7 @@ export class TemplateTextNode extends BaseNode {
   })
   declare string: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TemplateTextNodeOutputs> {
     let result = String(this.string ?? "");
     const props = tokenizeAssetVars(Object.fromEntries(this.dynamicProps));
 

--- a/packages/transformers-js-nodes/src/nodes/audio-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/audio-classification.ts
@@ -21,6 +21,13 @@ type AudioClassificationResult = { label: string; score: number };
 
 const DEFAULT_SAMPLING_RATE = 16000;
 
+/** Output handles AudioClassificationNode.process() emits. */
+type AudioClassificationNodeOutputs = {
+  label: string;
+  score: number;
+  results: AudioClassificationResult[];
+};
+
 export class AudioClassificationNode extends BaseNode {
   static readonly nodeType = "transformers.AudioClassification";
   static readonly inlineFields: string[] = [];
@@ -95,7 +102,7 @@ export class AudioClassificationNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<AudioClassificationNodeOutputs> {
     const samplingRate = asNumber(this.sampling_rate, DEFAULT_SAMPLING_RATE);
     const samples = await loadAudioSamples(this.audio, samplingRate, context);
 

--- a/packages/transformers-js-nodes/src/nodes/automatic-speech-recognition.ts
+++ b/packages/transformers-js-nodes/src/nodes/automatic-speech-recognition.ts
@@ -22,6 +22,12 @@ type AsrResult = {
 
 const WHISPER_SAMPLING_RATE = 16000;
 
+/** Output handles AutomaticSpeechRecognitionNode.process() emits. */
+type AutomaticSpeechRecognitionNodeOutputs = {
+  text: string;
+  chunks: { text?: string; timestamp?: [number, number] }[];
+};
+
 export class AutomaticSpeechRecognitionNode extends BaseNode {
   static readonly nodeType = "transformers.AutomaticSpeechRecognition";
   static readonly inlineFields: string[] = [];
@@ -101,7 +107,7 @@ export class AutomaticSpeechRecognitionNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<AutomaticSpeechRecognitionNodeOutputs> {
     const samples = await loadAudioSamples(
       this.audio,
       WHISPER_SAMPLING_RATE,

--- a/packages/transformers-js-nodes/src/nodes/feature-extraction.ts
+++ b/packages/transformers-js-nodes/src/nodes/feature-extraction.ts
@@ -80,6 +80,12 @@ function tensorToVector(tensor: unknown): number[] {
   return [];
 }
 
+/** Output handles FeatureExtractionNode.process() emits. */
+type FeatureExtractionNodeOutputs = {
+  embedding: number[];
+  dim: number;
+};
+
 export class FeatureExtractionNode extends BaseNode {
   static readonly nodeType = "transformers.FeatureExtraction";
   static readonly inlineFields = ["text"];
@@ -148,7 +154,7 @@ export class FeatureExtractionNode extends BaseNode {
   })
   declare device: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FeatureExtractionNodeOutputs> {
     const text = asString(this.text);
     if (!text) throw new Error("Text is required");
 

--- a/packages/transformers-js-nodes/src/nodes/fill-mask.ts
+++ b/packages/transformers-js-nodes/src/nodes/fill-mask.ts
@@ -22,6 +22,12 @@ type FillMaskResult = {
   token_str?: string;
 };
 
+/** Output handles FillMaskNode.process() emits. */
+type FillMaskNodeOutputs = {
+  top: string;
+  results: FillMaskResult[];
+};
+
 export class FillMaskNode extends BaseNode {
   static readonly nodeType = "transformers.FillMask";
   static readonly inlineFields = ["text"];
@@ -83,7 +89,7 @@ export class FillMaskNode extends BaseNode {
   })
   declare device: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FillMaskNodeOutputs> {
     const text = asString(this.text);
     if (!text) throw new Error("Text is required");
 

--- a/packages/transformers-js-nodes/src/nodes/image-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/image-classification.ts
@@ -19,6 +19,13 @@ const TJS_TYPE = "tjs.image_classification";
 
 type ImageClassificationResult = { label: string; score: number };
 
+/** Output handles ImageClassificationNode.process() emits. */
+type ImageClassificationNodeOutputs = {
+  label: string;
+  score: number;
+  results: ImageClassificationResult[];
+};
+
 export class ImageClassificationNode extends BaseNode {
   static readonly nodeType = "transformers.ImageClassification";
   static readonly inlineFields: string[] = [];
@@ -83,7 +90,7 @@ export class ImageClassificationNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<ImageClassificationNodeOutputs> {
     const rawImage = await loadRawImage(this.image, context);
 
     const pipeline = await getPipeline<

--- a/packages/transformers-js-nodes/src/nodes/image-to-text.ts
+++ b/packages/transformers-js-nodes/src/nodes/image-to-text.ts
@@ -19,6 +19,11 @@ const TJS_TYPE = "tjs.image_to_text";
 
 type CaptionResult = { generated_text: string };
 
+/** Output handles ImageToTextNode.process() emits. */
+type ImageToTextNodeOutputs = {
+  text: string;
+};
+
 export class ImageToTextNode extends BaseNode {
   static readonly nodeType = "transformers.ImageToText";
   static readonly inlineFields: string[] = [];
@@ -79,7 +84,7 @@ export class ImageToTextNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<ImageToTextNodeOutputs> {
     const rawImage = await loadRawImage(this.image, context);
 
     const pipeline = await getPipeline<

--- a/packages/transformers-js-nodes/src/nodes/object-detection.ts
+++ b/packages/transformers-js-nodes/src/nodes/object-detection.ts
@@ -28,6 +28,11 @@ type ObjectBox = {
   };
 };
 
+/** Output handles ObjectDetectionNode.process() emits. */
+type ObjectDetectionNodeOutputs = {
+  detections: ObjectBox[];
+};
+
 export class ObjectDetectionNode extends BaseNode {
   static readonly nodeType = "transformers.ObjectDetection";
   static readonly inlineFields: string[] = [];
@@ -98,7 +103,7 @@ export class ObjectDetectionNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<ObjectDetectionNodeOutputs> {
     const rawImage = await loadRawImage(this.image, context);
 
     const pipeline = await getPipeline<

--- a/packages/transformers-js-nodes/src/nodes/question-answering.ts
+++ b/packages/transformers-js-nodes/src/nodes/question-answering.ts
@@ -22,6 +22,15 @@ type QAResult = {
   end?: number;
 };
 
+/** Output handles QuestionAnsweringNode.process() emits. */
+type QuestionAnsweringNodeOutputs = {
+  answer: string;
+  score: number;
+  start: number;
+  end: number;
+  results: QAResult[];
+};
+
 export class QuestionAnsweringNode extends BaseNode {
   static readonly nodeType = "transformers.QuestionAnswering";
   static readonly inlineFields = ["question", "context"];
@@ -94,7 +103,7 @@ export class QuestionAnsweringNode extends BaseNode {
   })
   declare device: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<QuestionAnsweringNodeOutputs> {
     const question = asString(this.question);
     const context = asString(this.context);
     if (!question) throw new Error("Question is required");

--- a/packages/transformers-js-nodes/src/nodes/summarization.ts
+++ b/packages/transformers-js-nodes/src/nodes/summarization.ts
@@ -17,6 +17,11 @@ const TJS_TYPE = "tjs.summarization";
 
 type SummaryResult = { summary_text: string };
 
+/** Output handles SummarizationNode.process() emits. */
+type SummarizationNodeOutputs = {
+  summary: string;
+};
+
 export class SummarizationNode extends BaseNode {
   static readonly nodeType = "transformers.Summarization";
   static readonly inlineFields = ["text"];
@@ -93,7 +98,7 @@ export class SummarizationNode extends BaseNode {
   })
   declare device: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<SummarizationNodeOutputs> {
     const text = asString(this.text);
     if (!text) throw new Error("Text is required");
 

--- a/packages/transformers-js-nodes/src/nodes/text-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/text-classification.ts
@@ -17,6 +17,13 @@ const TJS_TYPE = "tjs.text_classification";
 
 type ClassificationResult = { label: string; score: number };
 
+/** Output handles TextClassificationNode.process() emits. */
+type TextClassificationNodeOutputs = {
+  label: string;
+  score: number;
+  results: ClassificationResult[];
+};
+
 export class TextClassificationNode extends BaseNode {
   static readonly nodeType = "transformers.TextClassification";
   static readonly inlineFields = ["text"];
@@ -79,7 +86,7 @@ export class TextClassificationNode extends BaseNode {
   })
   declare device: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TextClassificationNodeOutputs> {
     const text = asString(this.text);
     if (!text) throw new Error("Text is required");
     const topK = asNumber(this.top_k, 1);

--- a/packages/transformers-js-nodes/src/nodes/text-generation.ts
+++ b/packages/transformers-js-nodes/src/nodes/text-generation.ts
@@ -26,6 +26,11 @@ function extractText(value: unknown): string {
   return "";
 }
 
+/** Output handles TextGenerationNode.process() emits. */
+type TextGenerationNodeOutputs = {
+  text: string;
+};
+
 export class TextGenerationNode extends BaseNode {
   static readonly nodeType = "transformers.TextGeneration";
   static readonly inlineFields = ["prompt"];
@@ -132,7 +137,7 @@ export class TextGenerationNode extends BaseNode {
   })
   declare device: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TextGenerationNodeOutputs> {
     const prompt = asString(this.prompt);
     if (!prompt) throw new Error("Prompt is required");
 

--- a/packages/transformers-js-nodes/src/nodes/text-to-speech.ts
+++ b/packages/transformers-js-nodes/src/nodes/text-to-speech.ts
@@ -25,6 +25,11 @@ type TtsResult = {
   sampling_rate?: number;
 };
 
+/** Output handles TextToSpeechNode.process() emits. */
+type TextToSpeechNodeOutputs = {
+  output: { type: string; data: string; content_type: string };
+};
+
 export class TextToSpeechNode extends BaseNode {
   static readonly nodeType = "transformers.TextToSpeech";
   static readonly inlineFields = ["text"];
@@ -95,7 +100,7 @@ export class TextToSpeechNode extends BaseNode {
   })
   declare device: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TextToSpeechNodeOutputs> {
     const text = asString(this.text);
     if (!text) throw new Error("Text is required");
 

--- a/packages/transformers-js-nodes/src/nodes/token-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/token-classification.ts
@@ -23,6 +23,11 @@ type TokenEntity = {
   end?: number;
 };
 
+/** Output handles TokenClassificationNode.process() emits. */
+type TokenClassificationNodeOutputs = {
+  entities: TokenEntity[];
+};
+
 export class TokenClassificationNode extends BaseNode {
   static readonly nodeType = "transformers.TokenClassification";
   static readonly inlineFields = ["text"];
@@ -82,7 +87,7 @@ export class TokenClassificationNode extends BaseNode {
   })
   declare device: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TokenClassificationNodeOutputs> {
     const text = asString(this.text);
     if (!text) throw new Error("Text is required");
 

--- a/packages/transformers-js-nodes/src/nodes/translation.ts
+++ b/packages/transformers-js-nodes/src/nodes/translation.ts
@@ -17,6 +17,11 @@ const TJS_TYPE = "tjs.translation";
 
 type TranslationResult = { translation_text: string };
 
+/** Output handles TranslationNode.process() emits. */
+type TranslationNodeOutputs = {
+  translation: string;
+};
+
 export class TranslationNode extends BaseNode {
   static readonly nodeType = "transformers.Translation";
   static readonly inlineFields = ["text", "src_lang", "tgt_lang"];
@@ -92,7 +97,7 @@ export class TranslationNode extends BaseNode {
   })
   declare device: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<TranslationNodeOutputs> {
     const text = asString(this.text);
     if (!text) throw new Error("Text is required");
 

--- a/packages/transformers-js-nodes/src/nodes/zero-shot-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/zero-shot-classification.ts
@@ -29,6 +29,14 @@ function parseLabels(value: unknown): string[] {
     .filter(Boolean);
 }
 
+/** Output handles ZeroShotClassificationNode.process() emits. */
+type ZeroShotClassificationNodeOutputs = {
+  label: string;
+  score: number;
+  labels: string[];
+  scores: number[];
+};
+
 export class ZeroShotClassificationNode extends BaseNode {
   static readonly nodeType = "transformers.ZeroShotClassification";
   static readonly inlineFields = ["text", "candidate_labels"];
@@ -106,7 +114,7 @@ export class ZeroShotClassificationNode extends BaseNode {
   })
   declare device: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<ZeroShotClassificationNodeOutputs> {
     const text = asString(this.text);
     if (!text) throw new Error("Text is required");
     const labels = parseLabels(this.candidate_labels);

--- a/packages/transformers-js-nodes/src/nodes/zero-shot-image-classification.ts
+++ b/packages/transformers-js-nodes/src/nodes/zero-shot-image-classification.ts
@@ -27,6 +27,13 @@ function parseLabels(value: unknown): string[] {
     .filter(Boolean);
 }
 
+/** Output handles ZeroShotImageClassificationNode.process() emits. */
+type ZeroShotImageClassificationNodeOutputs = {
+  label: string;
+  score: number;
+  results: ClassificationResult[];
+};
+
 export class ZeroShotImageClassificationNode extends BaseNode {
   static readonly nodeType = "transformers.ZeroShotImageClassification";
   static readonly inlineFields = ["candidate_labels"];
@@ -89,7 +96,7 @@ export class ZeroShotImageClassificationNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<ZeroShotImageClassificationNodeOutputs> {
     const rawImage = await loadRawImage(this.image, context);
     const labels = parseLabels(this.candidate_labels);
     if (labels.length === 0) {

--- a/packages/video-nodes/src/nodes/model3d/base.ts
+++ b/packages/video-nodes/src/nodes/model3d/base.ts
@@ -3,6 +3,11 @@ import type { ProcessingContext } from "@nodetool-ai/runtime";
 import type { Model3DRefLike } from "./types.js";
 import { modelRef, modelRefToBytes } from "./utils.js";
 
+/** Output handles GlbTransformNode.process() emits. */
+type GlbTransformNodeOutputs = {
+  output: { type: string; asset_id: null; metadata: null; data: string };
+};
+
 export abstract class GlbTransformNode extends BaseNode {
   declare model: any;
 
@@ -15,7 +20,7 @@ export abstract class GlbTransformNode extends BaseNode {
     bytes: Uint8Array
   ): Uint8Array | null | Promise<Uint8Array | null>;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<GlbTransformNodeOutputs> {
     const model = this.getModel();
     const bytes = await modelRefToBytes(model, context);
     const out = await this.transform(bytes);

--- a/packages/video-nodes/src/nodes/model3d/convert.ts
+++ b/packages/video-nodes/src/nodes/model3d/convert.ts
@@ -5,6 +5,11 @@ import { DEFAULT_MODEL_3D } from "./defaults.js";
 import { convertGlbToGltf } from "./document-ops.js";
 import { modelBytes, modelFormat, modelRef, replaceExtension } from "./utils.js";
 
+/** Output handles FormatConverterNode.process() emits. */
+type FormatConverterNodeOutputs = {
+  output: { type: string; asset_id: null; metadata: null; data: string };
+};
+
 export class FormatConverterNode extends GlbTransformNode {
   static readonly nodeType = "nodetool.model3d.FormatConverter";
   static readonly title = "Format Converter";
@@ -37,7 +42,7 @@ export class FormatConverterNode extends GlbTransformNode {
     return null;
   }
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FormatConverterNodeOutputs> {
     const model = this.getModel();
     const bytes = modelBytes(model);
     const inputFormat = modelFormat(model);

--- a/packages/video-nodes/src/nodes/model3d/io.ts
+++ b/packages/video-nodes/src/nodes/model3d/io.ts
@@ -37,6 +37,11 @@ async function writeWithSuffixWhenNeeded(
   );
 }
 
+/** Output handles LoadModel3DFileNode.process() emits. */
+type LoadModel3DFileNodeOutputs = {
+  output: { type: string; asset_id: null; metadata: null; data: string };
+};
+
 export class LoadModel3DFileNode extends BaseNode {
   static readonly nodeType = "nodetool.model3d.LoadModel3DFile";
   static readonly title = "Load Model 3D File";
@@ -56,7 +61,7 @@ export class LoadModel3DFileNode extends BaseNode {
   })
   declare path: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<LoadModel3DFileNodeOutputs> {
     const p = filePath(String(this.path ?? ""));
     const data = new Uint8Array(await fs.readFile(p));
     return {
@@ -64,6 +69,11 @@ export class LoadModel3DFileNode extends BaseNode {
     };
   }
 }
+
+/** Output handles SaveModel3DFileNode.process() emits. */
+type SaveModel3DFileNodeOutputs = {
+  output: { type: string; asset_id: null; metadata: null; data: string };
+};
 
 export class SaveModel3DFileNode extends BaseNode {
   static readonly nodeType = "nodetool.model3d.SaveModel3DFile";
@@ -110,7 +120,7 @@ export class SaveModel3DFileNode extends BaseNode {
   })
   declare overwrite: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<SaveModel3DFileNodeOutputs> {
     const folder = String(this.folder ?? ".");
     const filename = dateName(String(this.filename ?? "model.glb"));
     const overwrite = this.overwrite === true;
@@ -132,6 +142,11 @@ export class SaveModel3DFileNode extends BaseNode {
     };
   }
 }
+
+/** Output handles SaveModel3DNode.process() emits. */
+type SaveModel3DNodeOutputs = {
+  output: { type: string; asset_id: null; metadata: null; data: string };
+};
 
 export class SaveModel3DNode extends BaseNode {
   static readonly nodeType = "nodetool.model3d.SaveModel3D";
@@ -169,7 +184,7 @@ export class SaveModel3DNode extends BaseNode {
   })
   declare name: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<SaveModel3DNodeOutputs> {
     const folder = String(this.folder ?? ".");
     const name = dateName(String(this.name ?? "model.glb"));
     const full = path.resolve(folder, name);

--- a/packages/video-nodes/src/nodes/model3d/render.ts
+++ b/packages/video-nodes/src/nodes/model3d/render.ts
@@ -70,6 +70,11 @@ async function resolveModelBytes(
   return new Uint8Array();
 }
 
+/** Output handles RenderToImageNode.process() emits. */
+type RenderToImageNodeOutputs = {
+  output: { type: string; uri: string; asset_id: null; data: string };
+};
+
 export class RenderToImageNode extends BaseNode {
   static readonly nodeType = "nodetool.model3d.RenderToImage";
   static readonly title = "Render 3D To Image";
@@ -126,7 +131,7 @@ export class RenderToImageNode extends BaseNode {
   @prop({ type: "bool", default: false, title: "Transparent", description: "Render on a transparent background (PNG alpha)" })
   declare transparent: any;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<RenderToImageNodeOutputs> {
     const model = (this.model ?? {}) as Model3DRefLike;
     const format = String(model.format ?? "").toLowerCase();
     if (!RENDERABLE_FORMATS.has(format)) {

--- a/packages/video-nodes/src/nodes/script.ts
+++ b/packages/video-nodes/src/nodes/script.ts
@@ -94,6 +94,14 @@ const allLines = (doc: ScriptDocumentLike): ScriptLineLike[] =>
 
 // ── Nodes ────────────────────────────────────────────────────────────────────
 
+/** Output handles LoadScriptNode.process() emits. */
+type LoadScriptNodeOutputs = {
+  text: string;
+  lines: string[];
+  name: string;
+  line_count: number;
+};
+
 export class LoadScriptNode extends BaseNode {
   static readonly nodeType = "nodetool.script.LoadScript";
   static readonly title = "Load Script";
@@ -118,7 +126,7 @@ export class LoadScriptNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<LoadScriptNodeOutputs> {
     const script = await loadScript(this.script, context);
     const lines = allLines(script.document).map((line) => line.text);
     return {
@@ -129,6 +137,12 @@ export class LoadScriptNode extends BaseNode {
     };
   }
 }
+
+/** Output handles VoiceScriptNode.process() emits. */
+type VoiceScriptNodeOutputs = {
+  output: { type: string; id: string };
+  voiced_count: number;
+};
 
 export class VoiceScriptNode extends BaseNode {
   static readonly nodeType = "nodetool.script.VoiceScript";
@@ -163,7 +177,7 @@ export class VoiceScriptNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<VoiceScriptNodeOutputs> {
     if (!context) {
       throw new Error("VoiceScript requires a processing context");
     }
@@ -233,6 +247,11 @@ export class VoiceScriptNode extends BaseNode {
   }
 }
 
+/** Output handles ScriptToTimelineNode.process() emits. */
+type ScriptToTimelineNodeOutputs = {
+  output: { type: string; id: string };
+};
+
 export class ScriptToTimelineNode extends BaseNode {
   static readonly nodeType = "nodetool.script.ScriptToTimeline";
   static readonly title = "Script To Timeline";
@@ -254,7 +273,7 @@ export class ScriptToTimelineNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<ScriptToTimelineNodeOutputs> {
     if (!context) {
       throw new Error("ScriptToTimeline requires a processing context");
     }
@@ -336,6 +355,12 @@ export class ScriptToTimelineNode extends BaseNode {
   }
 }
 
+/** Output handles ScriptToSubtitlesNode.process() emits. */
+type ScriptToSubtitlesNodeOutputs = {
+  subtitles: string;
+  cue_count: number;
+};
+
 export class ScriptToSubtitlesNode extends BaseNode {
   static readonly nodeType = "nodetool.script.ScriptToSubtitles";
   static readonly title = "Script To Subtitles";
@@ -377,7 +402,7 @@ export class ScriptToSubtitlesNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<ScriptToSubtitlesNodeOutputs> {
     const script = await loadScript(this.script, context);
     const doc = script.document;
 

--- a/packages/video-nodes/src/nodes/timeline.ts
+++ b/packages/video-nodes/src/nodes/timeline.ts
@@ -17,7 +17,7 @@
  */
 
 import { BaseNode, prop } from "@nodetool-ai/node-sdk";
-import type { TimelineRef } from "@nodetool-ai/protocol";
+import type { TimelineRef, VideoRef } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { loadMediaRefBytes } from "@nodetool-ai/runtime";
 import {
@@ -546,6 +546,11 @@ async function mixAudioInto(opts: {
   return outPath;
 }
 
+/** Output handles RenderTimelineNode.process() emits. */
+type RenderTimelineNodeOutputs = {
+  output: VideoRef;
+};
+
 export class RenderTimelineNode extends BaseNode {
   static readonly nodeType = "nodetool.timeline.RenderTimeline";
   static readonly title = "Render Timeline";
@@ -576,7 +581,7 @@ export class RenderTimelineNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<RenderTimelineNodeOutputs> {
     const seq = await loadTimelineSequence(this.timeline, context);
     const ctx = context as ProcessingContext;
     const width = seq.width > 0 ? seq.width : 1920;
@@ -672,6 +677,12 @@ export class RenderTimelineNode extends BaseNode {
   }
 }
 
+/** Output handles TimelineTranscriptNode.process() emits. */
+type TimelineTranscriptNodeOutputs = {
+  text: string;
+  lines: string[];
+};
+
 export class TimelineTranscriptNode extends BaseNode {
   static readonly nodeType = "nodetool.timeline.Transcript";
   static readonly title = "Timeline Transcript";
@@ -694,12 +705,17 @@ export class TimelineTranscriptNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<TimelineTranscriptNodeOutputs> {
     const seq = await loadTimelineSequence(this.timeline, context);
     const lines = (seq.transcript ?? []).map((line) => line.text);
     return { text: lines.join("\n"), lines };
   }
 }
+
+/** Output handles AddClipsToTimelineNode.process() emits. */
+type AddClipsToTimelineNodeOutputs = {
+  output: { type: string; id: string };
+};
 
 export class AddClipsToTimelineNode extends BaseNode {
   static readonly nodeType = "nodetool.timeline.AddClips";
@@ -750,7 +766,7 @@ export class AddClipsToTimelineNode extends BaseNode {
 
   async process(
     context?: ProcessingContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<AddClipsToTimelineNodeOutputs> {
     if (!context) {
       throw new Error("AddClipsToTimeline requires a processing context");
     }

--- a/packages/video-nodes/src/nodes/video.ts
+++ b/packages/video-nodes/src/nodes/video.ts
@@ -349,6 +349,11 @@ abstract class VideoTransformNode extends BaseNode {
   static readonly requiredRuntimes = ["ffmpeg"];
 }
 
+/** Output handles TextToVideoNode.process() emits. */
+type TextToVideoNodeOutputs = {
+  output: VideoRef;
+};
+
 export class TextToVideoNode extends BaseNode {
   static readonly nodeType = "nodetool.video.TextToVideo";
   static readonly body = "content_card";
@@ -433,7 +438,7 @@ export class TextToVideoNode extends BaseNode {
   })
   declare timeout_seconds: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<TextToVideoNodeOutputs> {
     const text = String(this.prompt ?? "");
     const { providerId, modelId } = modelConfig(this.serialize());
     if (!canUseProvider(context, providerId, modelId)) {
@@ -458,6 +463,11 @@ export class TextToVideoNode extends BaseNode {
     return { output: videoRef(output) };
   }
 }
+
+/** Output handles ImageToVideoNode.process() emits. */
+type ImageToVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class ImageToVideoNode extends BaseNode {
   static readonly nodeType = "nodetool.video.ImageToVideo";
@@ -561,7 +571,7 @@ export class ImageToVideoNode extends BaseNode {
   })
   declare timeout_seconds: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ImageToVideoNodeOutputs> {
     let images = normalizeImageList(this.image);
     let prompt = String(this.prompt ?? "");
 
@@ -614,6 +624,11 @@ export class ImageToVideoNode extends BaseNode {
   }
 }
 
+/** Output handles LoadVideoFileNode.process() emits. */
+type LoadVideoFileNodeOutputs = {
+  output: VideoRef;
+};
+
 export class LoadVideoFileNode extends BaseNode {
   static readonly nodeType = "nodetool.video.LoadVideoFile";
   static readonly title = "Load Video File";
@@ -633,7 +648,7 @@ export class LoadVideoFileNode extends BaseNode {
   })
   declare path: string;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<LoadVideoFileNodeOutputs> {
     const p = filePath(String(this.path ?? "").trim());
     if (!p) throw new Error("No file path provided to Load Video File.");
     const data = new Uint8Array(await fs.readFile(p));
@@ -649,6 +664,11 @@ export class LoadVideoFileNode extends BaseNode {
 function saveFolder(rawFolder: unknown, context?: ProcessingContext): string {
   return folderPath(rawFolder) || context?.workspaceDir || ".";
 }
+
+/** Output handles SaveVideoFileVideoNode.process() emits. */
+type SaveVideoFileVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class SaveVideoFileVideoNode extends BaseNode {
   static readonly nodeType = "nodetool.video.SaveVideoFile";
@@ -686,7 +706,7 @@ export class SaveVideoFileVideoNode extends BaseNode {
   })
   declare filename: string;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<SaveVideoFileVideoNodeOutputs> {
     const folder = saveFolder(this.folder, context);
     const fname = dateName(String(this.filename || "video.mp4"));
     await fs.mkdir(path.resolve(folder), { recursive: true });
@@ -788,6 +808,11 @@ export class LoadVideoAssetsNode extends BaseNode {
   }
 }
 
+/** Output handles SaveVideoNode.process() emits. */
+type SaveVideoNodeOutputs = {
+  output: VideoRef;
+};
+
 export class SaveVideoNode extends BaseNode {
   static readonly nodeType = "nodetool.video.SaveVideo";
   static readonly title = "Save Video Asset";
@@ -830,7 +855,7 @@ export class SaveVideoNode extends BaseNode {
   })
   declare name: string;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<SaveVideoNodeOutputs> {
     const folder = saveFolder(this.folder, context);
     const filename = dateName(String(this.name || "video.mp4"));
     await fs.mkdir(path.resolve(folder), { recursive: true });
@@ -842,6 +867,13 @@ export class SaveVideoNode extends BaseNode {
     return { output: videoRef(bytes, { uri: `file://${full}` }) };
   }
 }
+
+/** Output handles ForEachFrameNode.genProcess() emits. */
+type ForEachFrameNodeStreamOutputs = {
+  frame: { type: string; data: string };
+  index: number;
+  fps: number;
+};
 
 export class ForEachFrameNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.ForEachFrame";
@@ -895,7 +927,7 @@ export class ForEachFrameNode extends VideoTransformNode {
     return {};
   }
 
-  async *genProcess(context?: ProcessingContext): AsyncGenerator<Record<string, unknown>> {
+  async *genProcess(context?: ProcessingContext): AsyncGenerator<ForEachFrameNodeStreamOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     if (bytes.length === 0) return;
 
@@ -975,6 +1007,11 @@ export class ForEachFrameNode extends VideoTransformNode {
   }
 }
 
+/** Output handles FpsNode.process() emits. */
+type FpsNodeOutputs = {
+  output: number;
+};
+
 export class FpsNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Fps";
   static readonly title = "Fps";
@@ -994,7 +1031,7 @@ export class FpsNode extends VideoTransformNode {
   })
   declare video: VideoRef;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<FpsNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     if (bytes.length === 0) return { output: 0 };
 
@@ -1017,6 +1054,11 @@ export class FpsNode extends VideoTransformNode {
     }
   }
 }
+
+/** Output handles FrameToVideoNode.process() emits. */
+type FrameToVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class FrameToVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.FrameToVideo";
@@ -1089,7 +1131,7 @@ export class FrameToVideoNode extends VideoTransformNode {
     }
   }
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<FrameToVideoNodeOutputs> {
     // Legacy fallback for non-streaming usage (e.g., direct array input)
     const frames = Array.isArray(this.frame) ? (this.frame as unknown[]) : [];
     if (frames.length === 0) return { output: videoRef(new Uint8Array()) };
@@ -1199,6 +1241,11 @@ async function normalizeConcatSegment(
   );
 }
 
+/** Output handles ConcatVideoNode.process() emits. */
+type ConcatVideoNodeOutputs = {
+  output: VideoRef;
+};
+
 export class ConcatVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Concat";
   static readonly body = "content_card";
@@ -1212,7 +1259,7 @@ export class ConcatVideoNode extends VideoTransformNode {
   static readonly inputFields: string[] = [];
   static readonly supportsDynamicInputs = true;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ConcatVideoNodeOutputs> {
     const inputValues = Array.from(this.dynamicProps.values()).flatMap(
       (value) => normalizeVideoList(value)
     );
@@ -1297,6 +1344,11 @@ export class ConcatVideoNode extends VideoTransformNode {
   }
 }
 
+/** Output handles TrimVideoNode.process() emits. */
+type TrimVideoNodeOutputs = {
+  output: VideoRef;
+};
+
 export class TrimVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Trim";
   static readonly title = "Trim";
@@ -1342,7 +1394,7 @@ export class TrimVideoNode extends VideoTransformNode {
   })
   declare accurate: boolean;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<TrimVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     if (bytes.length === 0) return { output: videoRef(bytes) };
 
@@ -1374,6 +1426,11 @@ export class TrimVideoNode extends VideoTransformNode {
     return { output: videoRef(transformed) };
   }
 }
+
+/** Output handles ResizeVideoNode.process() emits. */
+type ResizeVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class ResizeVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Resize";
@@ -1407,7 +1464,7 @@ export class ResizeVideoNode extends VideoTransformNode {
   })
   declare height: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ResizeVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     const width = Number(this.width ?? -1);
     const height = Number(this.height ?? -1);
@@ -1421,6 +1478,11 @@ export class ResizeVideoNode extends VideoTransformNode {
     return { output: videoRef(transformed) };
   }
 }
+
+/** Output handles RotateVideoNode.process() emits. */
+type RotateVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class RotateVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Rotate";
@@ -1448,7 +1510,7 @@ export class RotateVideoNode extends VideoTransformNode {
   })
   declare angle: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<RotateVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     const angle = Number(this.angle ?? 0);
     const radians = (angle * Math.PI) / 180;
@@ -1462,6 +1524,11 @@ export class RotateVideoNode extends VideoTransformNode {
     return { output: videoRef(transformed) };
   }
 }
+
+/** Output handles SetSpeedVideoNode.process() emits. */
+type SetSpeedVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class SetSpeedVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.SetSpeed";
@@ -1488,7 +1555,7 @@ export class SetSpeedVideoNode extends VideoTransformNode {
   })
   declare speed_factor: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<SetSpeedVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     const speed = Math.max(0.1, Number(this.speed_factor ?? 1));
 
@@ -1533,6 +1600,11 @@ export class SetSpeedVideoNode extends VideoTransformNode {
     return { output: videoRef(transformed) };
   }
 }
+
+/** Output handles OverlayVideoNode.process() emits. */
+type OverlayVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class OverlayVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Overlay";
@@ -1592,7 +1664,7 @@ export class OverlayVideoNode extends VideoTransformNode {
   })
   declare overlay_audio_volume: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<OverlayVideoNodeOutputs> {
     const mainVideo = await videoBytesAsync(this.main_video, context);
     const overlayVideo = await videoBytesAsync(this.overlay_video, context);
     if (overlayVideo.length === 0) return { output: videoRef(mainVideo) };
@@ -1635,6 +1707,11 @@ export class OverlayVideoNode extends VideoTransformNode {
     return { output: videoRef(transformed) };
   }
 }
+
+/** Output handles ColorBalanceVideoNode.process() emits. */
+type ColorBalanceVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class ColorBalanceVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.ColorBalance";
@@ -1682,7 +1759,7 @@ export class ColorBalanceVideoNode extends VideoTransformNode {
   })
   declare blue_adjust: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ColorBalanceVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     // Props are 0-2 range where 1.0 = neutral; colorbalance expects -1 to 1
     const rs = Number(this.red_adjust ?? 1) - 1;
@@ -1698,6 +1775,11 @@ export class ColorBalanceVideoNode extends VideoTransformNode {
     return { output: videoRef(transformed) };
   }
 }
+
+/** Output handles DenoiseVideoNode.process() emits. */
+type DenoiseVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class DenoiseVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Denoise";
@@ -1727,7 +1809,7 @@ export class DenoiseVideoNode extends VideoTransformNode {
   })
   declare strength: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<DenoiseVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     const strength = Number(this.strength ?? 5);
     const transformed =
@@ -1740,6 +1822,11 @@ export class DenoiseVideoNode extends VideoTransformNode {
     return { output: videoRef(transformed) };
   }
 }
+
+/** Output handles StabilizeVideoNode.process() emits. */
+type StabilizeVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class StabilizeVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Stabilize";
@@ -1778,7 +1865,7 @@ export class StabilizeVideoNode extends VideoTransformNode {
   })
   declare crop_black: boolean;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<StabilizeVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     if (bytes.length === 0) return { output: videoRef(bytes) };
     const smoothing = Math.max(1, Number(this.smoothing ?? 10));
@@ -1845,6 +1932,11 @@ export class StabilizeVideoNode extends VideoTransformNode {
   }
 }
 
+/** Output handles SharpnessVideoNode.process() emits. */
+type SharpnessVideoNodeOutputs = {
+  output: VideoRef;
+};
+
 export class SharpnessVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Sharpness";
   static readonly title = "Sharpness";
@@ -1882,7 +1974,7 @@ export class SharpnessVideoNode extends VideoTransformNode {
   })
   declare chroma_amount: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<SharpnessVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     const lumaAmount = Number(this.luma_amount ?? 1);
     const chromaAmount = Number(this.chroma_amount ?? 0.5);
@@ -1896,6 +1988,11 @@ export class SharpnessVideoNode extends VideoTransformNode {
     return { output: videoRef(transformed) };
   }
 }
+
+/** Output handles BlurVideoNode.process() emits. */
+type BlurVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class BlurVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Blur";
@@ -1924,7 +2021,7 @@ export class BlurVideoNode extends VideoTransformNode {
   })
   declare strength: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<BlurVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     const radius = Number(this.strength ?? 5);
     if (radius <= 0) return { output: videoRef(bytes) };
@@ -1938,6 +2035,11 @@ export class BlurVideoNode extends VideoTransformNode {
     return { output: videoRef(transformed) };
   }
 }
+
+/** Output handles SaturationVideoNode.process() emits. */
+type SaturationVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class SaturationVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Saturation";
@@ -1966,7 +2068,7 @@ export class SaturationVideoNode extends VideoTransformNode {
   })
   declare saturation: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<SaturationVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     const saturation = Number(this.saturation ?? 1);
     const transformed =
@@ -1979,6 +2081,11 @@ export class SaturationVideoNode extends VideoTransformNode {
     return { output: videoRef(transformed) };
   }
 }
+
+/** Output handles AddSubtitlesVideoNode.process() emits. */
+type AddSubtitlesVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class AddSubtitlesVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.AddSubtitles";
@@ -2048,7 +2155,7 @@ export class AddSubtitlesVideoNode extends VideoTransformNode {
   })
   declare font_color: ColorRef;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<AddSubtitlesVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     const chunks = Array.isArray(this.chunks) ? this.chunks : [];
     if (chunks.length === 0) return { output: videoRef(bytes) };
@@ -2118,6 +2225,11 @@ export class AddSubtitlesVideoNode extends VideoTransformNode {
   }
 }
 
+/** Output handles ReverseVideoNode.process() emits. */
+type ReverseVideoNodeOutputs = {
+  output: VideoRef;
+};
+
 export class ReverseVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Reverse";
   static readonly title = "Reverse";
@@ -2137,7 +2249,7 @@ export class ReverseVideoNode extends VideoTransformNode {
   })
   declare video: VideoRef;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ReverseVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     if (bytes.length === 0) return { output: videoRef(bytes) };
 
@@ -2150,6 +2262,11 @@ export class ReverseVideoNode extends VideoTransformNode {
     return { output: videoRef(transformed) };
   }
 }
+
+/** Output handles TransitionVideoNode.process() emits. */
+type TransitionVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class TransitionVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.Transition";
@@ -2253,7 +2370,7 @@ export class TransitionVideoNode extends VideoTransformNode {
   })
   declare duration: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<TransitionVideoNodeOutputs> {
     const a = await videoBytesAsync(this.video_a, context);
     const b = await videoBytesAsync(this.video_b, context);
     if (b.length === 0) return { output: videoRef(a) };
@@ -2301,6 +2418,11 @@ export class TransitionVideoNode extends VideoTransformNode {
     return { output: videoRef(transformed) };
   }
 }
+
+/** Output handles AddAudioVideoNode.process() emits. */
+type AddAudioVideoNodeOutputs = {
+  output: VideoRef;
+};
 
 export class AddAudioVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.AddAudio";
@@ -2355,7 +2477,7 @@ export class AddAudioVideoNode extends VideoTransformNode {
   })
   declare mix: boolean;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<AddAudioVideoNodeOutputs> {
     const v = await videoBytesAsync(this.video, context);
     const a = await audioBytesAsync(this.audio, context);
     if (v.length === 0) return { output: videoRef(v) };
@@ -2425,6 +2547,11 @@ export class AddAudioVideoNode extends VideoTransformNode {
   }
 }
 
+/** Output handles ChromaKeyVideoNode.process() emits. */
+type ChromaKeyVideoNodeOutputs = {
+  output: VideoRef;
+};
+
 export class ChromaKeyVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.ChromaKey";
   static readonly title = "Chroma Key";
@@ -2472,7 +2599,7 @@ export class ChromaKeyVideoNode extends VideoTransformNode {
   })
   declare blend: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ChromaKeyVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     const keyColorObj = this.key_color as { value?: string } | undefined;
     const color = String(keyColorObj?.value ?? "#00FF00").replace("#", "0x");
@@ -2488,6 +2615,11 @@ export class ChromaKeyVideoNode extends VideoTransformNode {
     return { output: videoRef(transformed) };
   }
 }
+
+/** Output handles ExtractAudioVideoNode.process() emits. */
+type ExtractAudioVideoNodeOutputs = {
+  output: { type: string; data: null; uri: string; asset_id: null; metadata: null } | { type: string; data: string; uri: string; asset_id: null; metadata: null };
+};
 
 export class ExtractAudioVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.ExtractAudio";
@@ -2508,7 +2640,7 @@ export class ExtractAudioVideoNode extends VideoTransformNode {
   })
   declare video: VideoRef;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ExtractAudioVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     if (bytes.length === 0) {
       return {
@@ -2550,6 +2682,11 @@ export class ExtractAudioVideoNode extends VideoTransformNode {
   }
 }
 
+/** Output handles ExtractFrameVideoNode.process() emits. */
+type ExtractFrameVideoNodeOutputs = {
+  output: { type: string; data: null } | { type: string; data: string };
+};
+
 export class ExtractFrameVideoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.ExtractFrame";
   static readonly title = "Extract Video Frame";
@@ -2578,7 +2715,7 @@ export class ExtractFrameVideoNode extends VideoTransformNode {
   })
   declare time: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<ExtractFrameVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     if (bytes.length === 0) {
       return { output: { type: "image", data: null } };
@@ -2621,6 +2758,17 @@ export class ExtractFrameVideoNode extends VideoTransformNode {
   }
 }
 
+/** Output handles GetVideoInfoNode.process() emits. */
+type GetVideoInfoNodeOutputs = {
+  duration: number;
+  width: number;
+  height: number;
+  fps: number;
+  frame_count: number;
+  codec: string;
+  has_audio: boolean;
+};
+
 export class GetVideoInfoNode extends VideoTransformNode {
   static readonly nodeType = "nodetool.video.GetVideoInfo";
   static readonly title = "Get Video Info";
@@ -2646,7 +2794,7 @@ export class GetVideoInfoNode extends VideoTransformNode {
   })
   declare video: VideoRef;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<GetVideoInfoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     if (bytes.length === 0) {
       return {
@@ -2727,6 +2875,11 @@ export class GetVideoInfoNode extends VideoTransformNode {
   }
 }
 
+/** Output handles VideoToVideoNode.process() emits. */
+type VideoToVideoNodeOutputs = {
+  output: VideoRef;
+};
+
 export class VideoToVideoNode extends BaseNode {
   static readonly nodeType = "nodetool.video.VideoToVideo";
   static readonly body = "content_card";
@@ -2787,7 +2940,7 @@ export class VideoToVideoNode extends BaseNode {
   })
   declare strength: number;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<VideoToVideoNodeOutputs> {
     const bytes = await videoBytesAsync(this.video, context);
     if (bytes.length === 0) throw new Error("The input video is empty.");
     const { providerId, modelId } = modelConfig(this.serialize());
@@ -2811,6 +2964,11 @@ export class VideoToVideoNode extends BaseNode {
     return { output: videoRef(output) };
   }
 }
+
+/** Output handles LipSyncNode.process() emits. */
+type LipSyncNodeOutputs = {
+  output: VideoRef;
+};
 
 export class LipSyncNode extends BaseNode {
   static readonly nodeType = "nodetool.video.LipSync";
@@ -2854,7 +3012,7 @@ export class LipSyncNode extends BaseNode {
   })
   declare audio: AudioRef;
 
-  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+  async process(context?: ProcessingContext): Promise<LipSyncNodeOutputs> {
     const video = await videoBytesAsync(this.video, context);
     if (video.length === 0) throw new Error("The input video is empty.");
     const audio = await audioBytesAsync(this.audio, context);

--- a/web/src/__mocks__/xterm.ts
+++ b/web/src/__mocks__/xterm.ts
@@ -3,15 +3,26 @@
  * canvas/DOM in ways jsdom can't support; tests only need to observe the
  * calls NodeTerminal makes.
  */
+/** The `ITerminalOptions` subset NodeTerminal constructs a terminal with. */
+export interface TerminalOptions {
+  cols?: number;
+  rows?: number;
+  disableStdin?: boolean;
+  scrollback?: number;
+  fontSize?: number;
+  fontFamily?: string;
+  theme?: { background?: string };
+}
+
 export class Terminal {
-  options: Record<string, unknown>;
+  options: TerminalOptions;
   written: string[] = [];
   cols: number;
   rows: number;
   disposed = false;
   resetCount = 0;
 
-  constructor(options: Record<string, unknown> = {}) {
+  constructor(options: TerminalOptions = {}) {
     this.options = options;
     this.cols = Number(options.cols ?? 80);
     this.rows = Number(options.rows ?? 24);

--- a/web/src/components/chat/message/markdown_elements/CodeBlock.tsx
+++ b/web/src/components/chat/message/markdown_elements/CodeBlock.tsx
@@ -22,14 +22,12 @@ import {
 } from "./codeBlockColors";
 import isEqual from "../../../../utils/isEqual";
 
-interface CodeBlockProps {
+export interface CodeBlockProps
+  extends React.ComponentPropsWithoutRef<"code"> {
   node?: unknown;
   inline?: boolean;
-  className?: string;
-  children?: React.ReactNode;
   _isFromPre?: boolean;
   onInsert?: (text: string, language?: string) => void;
-  [key: string]: unknown;
 }
 
 const cssStyles = css({

--- a/web/src/components/chat/message/markdown_elements/PreRenderer.tsx
+++ b/web/src/components/chat/message/markdown_elements/PreRenderer.tsx
@@ -1,11 +1,9 @@
 import React, { memo } from "react";
-import { CodeBlock } from "./CodeBlock";
+import { CodeBlock, type CodeBlockProps } from "./CodeBlock";
 
-interface PreRendererProps {
+interface PreRendererProps extends React.ComponentPropsWithoutRef<"pre"> {
   node?: unknown;
-  children?: React.ReactNode;
   onInsert?: (text: string, language?: string) => void;
-  [key: string]: unknown;
 }
 
 export const PreRenderer: React.FC<PreRendererProps> = memo(({
@@ -30,7 +28,7 @@ export const PreRenderer: React.FC<PreRendererProps> = memo(({
     // Forward the original <code> props and flag this as coming from a <pre>.
     return (
       <CodeBlock
-        {...(codeBlockChild.props as Record<string, unknown>)}
+        {...(codeBlockChild.props as CodeBlockProps)}
         _isFromPre={true}
         onInsert={props.onInsert}
       />

--- a/web/src/components/editor_ui/EditorMenu.tsx
+++ b/web/src/components/editor_ui/EditorMenu.tsx
@@ -12,7 +12,11 @@ import { Menu, MenuItem, type MenuItemProps, type MenuProps } from "@mui/materia
 import { editorUiClasses } from "../../constants/editorUiClasses";
 import { cn } from "./editorUtils";
 
-type SlotPropsWithSx = { sx?: SxProps<Theme> } & Record<string, unknown>;
+/** The subset of a MUI slot's props this menu reads back before merging. */
+interface SlotPropsWithSx {
+  sx?: SxProps<Theme>;
+  className?: string;
+}
 
 export interface EditorMenuProps extends Omit<MenuProps, "slotProps"> {
   /**

--- a/web/src/components/hugging_face/model_list/__tests__/ModelListIndex.scope.test.tsx
+++ b/web/src/components/hugging_face/model_list/__tests__/ModelListIndex.scope.test.tsx
@@ -40,6 +40,7 @@ jest.mock("../../onboarding/ModelOnboarding", () => ({
 
 import ModelListIndex from "../ModelListIndex";
 import { useModelManagerStore } from "../../../../stores/ModelManagerStore";
+import type { WorkerInstance } from "../../../../hooks/useWorkers";
 
 const EMPTY_MODELS: UseModelsResult = {
   modelTypes: ["All"],
@@ -54,7 +55,7 @@ const EMPTY_MODELS: UseModelsResult = {
   handleShowInExplorer: async () => undefined
 };
 
-const makeInstance = (overrides: Record<string, unknown> = {}) => ({
+const makeInstance = (overrides: Partial<WorkerInstance> = {}) => ({
   id: "i-1",
   profile_name: "pod-a",
   target: "runpod",

--- a/web/src/components/node/DataTable/DataTableEditors.tsx
+++ b/web/src/components/node/DataTable/DataTableEditors.tsx
@@ -1,5 +1,6 @@
 import {
   Editor,
+  EditorParams,
   CellComponent,
   EmptyCallback,
   ValueBooleanCallback,
@@ -14,7 +15,7 @@ export const integerEditor: Editor = (
   onRendered: EmptyCallback,
   success: ValueBooleanCallback,
   cancel: ValueVoidCallback,
-  _editorParams: Record<string, unknown>
+  _editorParams: EditorParams
 ) => {
   const editor = document.createElement("input");
   editor.setAttribute("type", "text");
@@ -59,7 +60,7 @@ export const floatEditor: Editor = (
   onRendered: EmptyCallback,
   success: ValueBooleanCallback,
   cancel: ValueVoidCallback,
-  _editorParams: Record<string, unknown>
+  _editorParams: EditorParams
 ) => {
   const editor = document.createElement("input");
   editor.setAttribute("type", "text");
@@ -106,7 +107,7 @@ export const datetimeEditor: Editor = (
   onRendered: EmptyCallback,
   success: ValueBooleanCallback,
   cancel: ValueVoidCallback,
-  _editorParams: Record<string, unknown>
+  _editorParams: EditorParams
 ) => {
   const editor = document.createElement("div");
   editor.style.width = "100%";

--- a/web/src/components/node_types/CodeBody.tsx
+++ b/web/src/components/node_types/CodeBody.tsx
@@ -45,7 +45,10 @@ import TextEditorModal from "../properties/TextEditorModal";
 
 import type { NodeMetadata } from "../../stores/ApiTypes";
 import type { NodeData } from "../../stores/NodeData";
-import { useMonacoEditor } from "../../hooks/editor/useMonacoEditor";
+import {
+  useMonacoEditor,
+  type MonacoEditorOptions
+} from "../../hooks/editor/useMonacoEditor";
 import { useBespokePropertyWriter } from "../../hooks/nodes/useBespokePropertyWriter";
 import { useDynamicProperty } from "../../hooks/nodes/useDynamicProperty";
 import { useNodes } from "../../contexts/NodeContext";
@@ -95,7 +98,7 @@ const EDITOR_OPTIONS = {
     verticalScrollbarSize: 8,
     horizontalScrollbarSize: 8
   }
-} satisfies Record<string, unknown>;
+} satisfies MonacoEditorOptions;
 
 const styles = (theme: Theme) =>
   css({

--- a/web/src/components/properties/CodeProperty.tsx
+++ b/web/src/components/properties/CodeProperty.tsx
@@ -27,7 +27,10 @@ import {
   getSpacingPx
 } from "../ui_primitives";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
-import { useMonacoEditor } from "../../hooks/editor/useMonacoEditor";
+import {
+  useMonacoEditor,
+  type MonacoEditorOptions
+} from "../../hooks/editor/useMonacoEditor";
 import { useInspectorHeaderSupplementalRegistration } from "../../hooks/useInspectorHeaderSupplemental";
 import { useIsConnectedSelector } from "../../hooks/nodes/useIsConnected";
 import { useNodes } from "../../contexts/NodeContext";
@@ -50,7 +53,7 @@ const EDITOR_OPTIONS = {
     verticalScrollbarSize: 8,
     horizontalScrollbarSize: 8
   }
-} satisfies Record<string, unknown>;
+} satisfies MonacoEditorOptions;
 
 const CodeProperty = ({
   property,

--- a/web/src/components/sketch/sam/SamServiceFal.ts
+++ b/web/src/components/sketch/sam/SamServiceFal.ts
@@ -64,6 +64,21 @@ interface FalBoxPrompt {
   height: number;
 }
 
+/** Request body posted to the FAL SAM 3.1 endpoint. */
+interface FalSamRequestBody {
+  image_url: string;
+  sync_mode: boolean;
+  output_format: string;
+  return_multiple_masks: boolean;
+  max_masks: number;
+  include_scores: boolean;
+  include_boxes: boolean;
+  apply_mask: boolean;
+  prompt?: string;
+  point_prompts?: FalPointPrompt[];
+  box_prompts?: FalBoxPrompt[];
+}
+
 interface FalQueueResponse {
   request_id: string;
   status: string;
@@ -568,7 +583,7 @@ export class SamServiceFal implements SamService {
       ? [this.buildFalBoxPrompt(request.boxPrompt, promptMapper, scale)]
       : [];
 
-    const falInput: Record<string, unknown> = {
+    const falInput: FalSamRequestBody = {
       image_url: imageUrl,
       sync_mode: true,
       output_format: "png",

--- a/web/src/components/ui_primitives/tokens.ts
+++ b/web/src/components/ui_primitives/tokens.ts
@@ -6,6 +6,7 @@
  */
 
 import { Theme } from "@mui/material/styles";
+import type { CSSObject } from "@emotion/react";
 
 /**
  * Typography System — Single Source of Truth
@@ -185,9 +186,7 @@ export const MOTION = {
  *   ...reducedMotion({ animation: "none", opacity: 0.6 }),
  * })
  */
-export const reducedMotion = (
-  overrides: Record<string, unknown>
-): Record<string, unknown> => ({
+export const reducedMotion = (overrides: CSSObject): CSSObject => ({
   "@media (prefers-reduced-motion: reduce)": overrides,
 });
 

--- a/web/src/components/workers/WorkerProfilesDialog.tsx
+++ b/web/src/components/workers/WorkerProfilesDialog.tsx
@@ -16,6 +16,7 @@ import {
 } from "../ui_primitives";
 import type {
   CreateWorkerProfileInput,
+  WorkerSpec,
   WorkerProfile,
   WorkerTarget,
   TokenPolicy
@@ -210,7 +211,7 @@ const WorkerProfilesDialog: React.FC<WorkerProfilesDialogProps> = ({
       image: image.trim(),
       token_policy: tokenPolicy
     };
-    const spec: Record<string, unknown> = {};
+    const spec: WorkerSpec = {};
     if (resolvedGpu) {
       spec.gpu = resolvedGpu;
     }

--- a/web/src/components/workspaces/WorkspaceTree.tsx
+++ b/web/src/components/workspaces/WorkspaceTree.tsx
@@ -21,13 +21,18 @@ import { useCurrentWorkspace } from "../../hooks/useCurrentWorkspace";
 import WorkspaceSelect from "./WorkspaceSelect";
 import PanelHeadline from "../ui/PanelHeadline";
 
+/** Props forwarded onto a rendered tree row. */
+export interface TreeViewItemSlotProps {
+  className?: string;
+}
+
 export interface TreeViewItem {
   id: string;
   label: string;
   className?: string;
   children?: TreeViewItem[];
-  itemProps?: Record<string, unknown>;
-  treeItemProps?: Record<string, unknown>;
+  itemProps?: TreeViewItemSlotProps;
+  treeItemProps?: TreeViewItemSlotProps;
   style?: Record<string, string>;
 }
 

--- a/web/src/e2e_runner/graphRender.ts
+++ b/web/src/e2e_runner/graphRender.ts
@@ -172,7 +172,7 @@ export async function buildRenderGraph(raw: RawGraph): Promise<RenderGraph> {
   // Only fill in types with no registered component yet — never override one
   // that's already there.
   const currentNodeTypes = useMetadataStore.getState().nodeTypes;
-  const newNodeTypes: Record<string, unknown> = {};
+  const newNodeTypes: Record<string, typeof BaseNode> = {};
   for (const node of graphNodes) {
     const nodeType = node.type;
     if (!currentNodeTypes[nodeType] && !newNodeTypes[nodeType]) {

--- a/web/src/hooks/__tests__/useDashboardData.test.tsx
+++ b/web/src/hooks/__tests__/useDashboardData.test.tsx
@@ -33,12 +33,13 @@ import { trpcClient } from "../../trpc/client";
 import { useSettingsStore } from "../../stores/SettingsStore";
 import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import { useDashboardData } from "../useDashboardData";
+import type { Workflow } from "../../stores/ApiTypes";
 
 const mockListQuery = trpcClient.workflows.list.query as jest.Mock;
 const mockUseSettings = asMock(useSettingsStore);
 const mockUseWorkflowManager = asMock(useWorkflowManager);
 
-const makeWorkflow = (overrides: Record<string, unknown>) => ({
+const makeWorkflow = (overrides: Partial<Workflow>) => ({
   id: "wf-1",
   name: "Test",
   description: "",

--- a/web/src/hooks/__tests__/useWorkers.test.tsx
+++ b/web/src/hooks/__tests__/useWorkers.test.tsx
@@ -28,6 +28,7 @@ jest.mock("../../trpc/client", () => ({
 
 import { trpcClient } from "../../trpc/client";
 import { useWorkers } from "../useWorkers";
+import type { WorkerInstance, WorkerProfile } from "../useWorkers";
 
 const mockProfilesList = trpcClient.worker.profiles.list.query as jest.Mock;
 const mockProfilesCreate = trpcClient.worker.profiles.create.mutate as jest.Mock;
@@ -38,7 +39,7 @@ const mockStop = trpcClient.worker.stop.mutate as jest.Mock;
 const mockAttach = trpcClient.worker.attach.mutate as jest.Mock;
 const mockDetach = trpcClient.worker.detach.mutate as jest.Mock;
 
-const makeProfile = (overrides: Record<string, unknown> = {}) => ({
+const makeProfile = (overrides: Partial<WorkerProfile> = {}) => ({
   id: "p-1",
   name: "hf-a40",
   target: "runpod",
@@ -52,7 +53,7 @@ const makeProfile = (overrides: Record<string, unknown> = {}) => ({
   ...overrides
 });
 
-const makeInstance = (overrides: Record<string, unknown> = {}) => ({
+const makeInstance = (overrides: Partial<WorkerInstance> = {}) => ({
   id: "i-1",
   profile_name: "hf-a40",
   target: "runpod",

--- a/web/src/hooks/editor/useMonacoEditor.ts
+++ b/web/src/hooks/editor/useMonacoEditor.ts
@@ -20,12 +20,15 @@ async function configureMonacoLoader() {
   loaderConfigured = true;
 }
 
+/** Construction options accepted by the lazily-loaded Monaco editor. */
+export type MonacoEditorOptions = monaco.editor.IStandaloneEditorConstructionOptions;
+
 type MonacoComponent = (props: {
   value: string;
   onChange?: (val?: string) => void;
   language?: string;
   theme?: string;
-  options?: Record<string, unknown>;
+  options?: MonacoEditorOptions;
   width?: string | number;
   height?: string | number;
   onMount?: (editor: monaco.editor.IStandaloneCodeEditor, monaco: typeof import("monaco-editor")) => void;

--- a/web/src/hooks/nodes/__tests__/useNodeResultHistory.test.ts
+++ b/web/src/hooks/nodes/__tests__/useNodeResultHistory.test.ts
@@ -6,8 +6,9 @@ import {
   assetsToPreviewValue,
   nodeAssetsQueryKey
 } from "../useNodeResultHistory";
+import type { Asset } from "../../../stores/ApiTypes";
 
-const makeAsset = (overrides: Record<string, unknown> = {}) =>
+const makeAsset = (overrides: Partial<Asset> = {}) =>
   ({
     id: "asset-1",
     name: "test-asset.png",

--- a/web/src/hooks/nodes/useNodeExecState.ts
+++ b/web/src/hooks/nodes/useNodeExecState.ts
@@ -16,7 +16,7 @@
 
 import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
-import useStatusStore from "../../stores/StatusStore";
+import useStatusStore, { type StatusValue } from "../../stores/StatusStore";
 import useErrorStore, { hasNodeError } from "../../stores/ErrorStore";
 import type { NodeError } from "../../stores/ErrorStore";
 import useResultsStore, {
@@ -33,8 +33,6 @@ import type { PlanningUpdate, ProviderCost, Task, ToolCallUpdate } from "../../s
 
 // ── Type re-exports (keep consumers from reaching into individual stores) ────
 
-/** Status value as stored by StatusStore. */
-type StatusValue = string | Record<string, unknown> | null | undefined;
 
 
 /**

--- a/web/src/hooks/useOllamaModels.ts
+++ b/web/src/hooks/useOllamaModels.ts
@@ -1,6 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { trpc } from "../lib/trpc";
 
+/** `details` block of an Ollama `/api/tags` entry. */
+interface OllamaModelDetails {
+  parent_model?: string;
+  format?: string;
+  family?: string;
+  families?: string[] | null;
+  parameter_size?: string;
+  quantization_level?: string;
+}
+
 interface OllamaModel {
   type: string;
   name: string;
@@ -8,7 +18,7 @@ interface OllamaModel {
   modified_at: string;
   size: number;
   digest: string;
-  details: Record<string, unknown>;
+  details: OllamaModelDetails;
 }
 
 interface UseOllamaModelsResult {

--- a/web/src/hooks/useProcessedEdges.ts
+++ b/web/src/hooks/useProcessedEdges.ts
@@ -4,6 +4,7 @@ import { DataType } from "../config/data_types";
 import { NodeMetadata } from "../stores/ApiTypes";
 import { findOutputHandle, findInputHandle } from "../utils/handleUtils";
 import { NodeData } from "../stores/NodeData";
+import type { StatusValue } from "../stores/StatusStore";
 import { forwardInputHandle, isForwardInput } from "../utils/forwardOutputs";
 import { nodeKey, edgeKey } from "../stores/nodeKey";
 import { MOTION } from "../components/ui_primitives";
@@ -21,7 +22,7 @@ interface ProcessedEdgesOptions {
    */
   focusedJobId?: string;
   edgeStatuses?: Record<string, { status: string; counter?: number }>;
-  nodeStatuses?: Record<string, string | Record<string, unknown> | null | undefined>;
+  nodeStatuses?: Record<string, StatusValue>;
   isSelecting?: boolean;
 }
 

--- a/web/src/hooks/useWorkers.ts
+++ b/web/src/hooks/useWorkers.ts
@@ -47,11 +47,21 @@ export interface WorkerInstance
   status: WorkerStatus;
 }
 
+/** Machine sizing a worker profile asks its target for. */
+export type WorkerSpec = {
+  /** Provider GPU id (RunPod), when the profile asks for a GPU machine. */
+  gpu?: string;
+  /** vCPU count, for a CPU-only machine. */
+  vcpu?: number;
+  /** Container disk size in GB. */
+  disk?: number;
+};
+
 export interface CreateWorkerProfileInput {
   name: string;
   target: WorkerTarget;
   image: string;
-  spec?: Record<string, unknown>;
+  spec?: WorkerSpec;
   token_policy: TokenPolicy;
   idle_timeout_minutes?: number | null;
   max_lifetime_minutes?: number | null;

--- a/web/src/lib/tools/builtin/searchNodes.ts
+++ b/web/src/lib/tools/builtin/searchNodes.ts
@@ -19,6 +19,33 @@ const booleanLikeOptional = z.preprocess((value) => {
   return value;
 }, z.boolean().optional());
 
+/** Handle descriptor as reported for a matched node. */
+interface NodeHandleSummary {
+  name: string;
+  type: unknown;
+}
+
+/** Property descriptor as reported for a matched node. */
+interface NodePropertySummary extends NodeHandleSummary {
+  required?: boolean;
+}
+
+/** Output descriptor as reported for a matched node. */
+interface NodeOutputSummary extends NodeHandleSummary {
+  stream?: boolean;
+}
+
+/** One entry of the `search_nodes` result list. */
+interface NodeSearchResult {
+  node_type: string;
+  title?: string;
+  namespace?: string;
+  properties?: NodePropertySummary[];
+  input_handles?: NodeHandleSummary[];
+  outputs?: NodeOutputSummary[];
+  output_handles?: NodeHandleSummary[];
+}
+
 type SearchNodesArgs = {
   query: string;
   input_type?: string;
@@ -76,7 +103,7 @@ FrontendToolRegistry.register({
       .map((entry) => entry.node);
 
     const results = preferred.slice(0, limit).map((node) => {
-      const base: Record<string, unknown> = {
+      const base: NodeSearchResult = {
         node_type: node.node_type,
         title: node.title,
         namespace: node.namespace,

--- a/web/src/stores/StatusStore.ts
+++ b/web/src/stores/StatusStore.ts
@@ -9,7 +9,7 @@
 import { create } from "zustand";
 import { nodeKey, type NodeKey } from "./nodeKey";
 
-type StatusValue = string | Record<string, unknown> | null | undefined;
+export type StatusValue = string | Record<string, unknown> | null | undefined;
 
 type StatusStore = {
   statuses: Record<NodeKey, StatusValue>;

--- a/web/src/utils/__tests__/nodeRanking.test.ts
+++ b/web/src/utils/__tests__/nodeRanking.test.ts
@@ -8,7 +8,7 @@ import {
 import { stub } from "../../test-utils/doubles";
 import type { NodeMetadata } from "../../stores/ApiTypes";
 
-const makeNode = (overrides: Record<string, unknown>): NodeMetadata =>
+const makeNode = (overrides: Partial<NodeMetadata>): NodeMetadata =>
   stub<NodeMetadata>({
     description: "",
     properties: [],


### PR DESCRIPTION
Stack 14/15. 4,839 → **4,498** (−341), 93 files. Backlog 21,257 → **20,930**.

## The one pattern that was a real defect

`BaseNode`'s own docstring prescribes `async process(): Promise<{ output: ImageRef }>`. **312 node methods across 68 files had widened that back to `Record<string, unknown>`** — `ConcatAudioNode.process()` returns an `AudioRef` and declared an untyped map, purely because nobody re-stated what the base class already says.

Each output handle set is statically known: it is what the class's `return`/`yield` literals produce. Each now carries a named type beside the class, inferred with the TypeScript compiler API from those literals, so the compiler checks handle names for the first time.

Two mechanics worth recording:
- It must be `type X = { … }`, not `interface X`. An interface has no implicit index signature, so it doesn't satisfy the base class's declared return and every override fails TS2416. The first pass hit that and switched.
- Anonymous class expressions, non-literal returns, and anything inferring `never`/`unknown`/`any` were **skipped automatically, never forced** — an early attempt emitted `type ?Outputs` in the fal/atlascloud factory files and was reverted.

Also fixed, in `web`/`mobile`: 31 sites where a real type existed or a fixed key set deserved an interface — Monaco options, tabulator editor params, Emotion `CSSObject`, the FAL SAM request body, `search_nodes` result rows, MUI slot props, react-markdown's code/pre props, xterm options, and seven test factories now taking `Partial<T>`. The Monaco one was doing harm: `satisfies Record<string, unknown>` had been widening `lineNumbers: "off"` to `string`.

## Why it stops at ~4,500, and a warning about the metric

Both agents classified every site. Roughly four fifths of the remainder is the rule mistaking NodeTool's architecture for sloppiness:

| bucket | count | why it can't be annotated away |
|---|---:|---|
| local `as Record<string, unknown>` assertions | 749 | narrowing an already-`unknown` value one step before reading it; fixing means parsing, a behavior change |
| wire frames (Python bridge, provider payloads, msgpack) | 523 | honest fix is a Zod parse per boundary, which changes error behavior |
| workflow-value domain (`properties`, node outputs, graph nodes/edges) | 339 | `@nodetool-ai/protocol`'s `Node`/`Edge` carry `[key: string]: unknown` deliberately |
| tool argument bags | 255 | JSON-schema-shaped at runtime; a static type would be a second, unenforced copy |
| generated `mobile/src/api.ts` | 237 | openapi-typescript output |
| `value is Record<string, unknown>` guard predicates | 35 | the return type *is* the point — the rule flags the parse boundary it asks you to build |

**The count is gameable, so it should not be used as a progress metric.** `isPlainAliasConsumerUse` in the plugin's own `shared/dictionary-types.ts` exempts every use of a locally-declared alias, so `type RawMessage = Record<string, unknown>` collapses N findings to 1 with **zero** change in type safety — ~1,500 findings could be erased that way. Two files in the repo already do it accidentally. Both agents identified the dodge and explicitly declined it. The enforced `no-unknown-type-aliases` rule blocks the worst version of it, which is the right design.

And the largest honest holdout is the same wall that stalled `no-unknown-returns` at 163: NodeTool has no name for its workflow-value domain, and its honest name (`type NodeValue = unknown`) is banned by an enforced rule. The two rules are in tension until someone models it.

## Checks

- `npm run lint` → exit 0; enforced config **0** across all four trees.
- All 16 touched packages: `tsc --noEmit` 0 errors (tsbuildinfo deleted first) and tests green. `web`: `tsc` clean, 1,112 suites / 12,879 tests. `mobile`: typecheck 0, 1,038 tests.
- Per-rule differentials on all 93 changed files: **no rule rose** in either half.
- **Downstream**: these are narrowed *overrides*, so `BaseNode`'s abstract signature is unchanged. Every `.process(`/`.genProcess(` caller outside the node packages was enumerated (kernel's `NodeExecutor`, agents' unrelated `Tool.process`) — zero hits in `web/src`, `electron/src`, `mobile/src` — and `packages/base-nodes`, which re-exports every node class, was typechecked against these sources via a temporary root tsconfig rather than stale `dist` declarations: 0 errors.
- Diff hygiene: a `prettier --write` pass reformatted 41 files that were already non-conformant at `HEAD`, adding ~2,400 lines of unrelated churn. It was reverted wholesale and redone without prettier, with per-file conformance checked against `HEAD`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPXapRVTWZDbebtC3xaL8z)_