### PR TITLE
fix(script-storyboard): use the persisted storyboard back-pointer

### DIFF
--- a/packages/agents/src/capabilities/script-link.ts
+++ b/packages/agents/src/capabilities/script-link.ts
@@ -1,0 +1,42 @@
+/**
+ * The script side of the script ↔ storyboard link: the `scripts.storyboard_id`
+ * back-pointer (design §1.2).
+ *
+ * The board owns the link — `Screenplay.script_id` is what validation reads —
+ * and this column is the navigation pointer back. Both tools that create a
+ * linked pair stamp it, and they stamp it last: the pointer is only written
+ * once the row it names exists and the board carries the forward link, so a
+ * write that fails leaves a consistent unlinked-but-valid script rather than a
+ * pointer at something no board confirms (design §7).
+ */
+
+const CAS_ATTEMPTS = 5;
+
+/**
+ * Point `scriptId` at `storyboardId` (or clear it with `null`), CAS on the
+ * script's `updated_at`. Returns the failure as a message rather than throwing:
+ * the callers report it beside the resource they did create.
+ */
+export async function stampScriptStoryboardId(
+  scriptId: string,
+  storyboardId: string | null,
+  userId: string | undefined
+): Promise<{ ok: true } | { error: string }> {
+  const { Script } = await import("@nodetool-ai/models");
+  for (let attempt = 0; attempt < CAS_ATTEMPTS; attempt++) {
+    const row = await Script.findById(scriptId);
+    if (!row || (userId && row.user_id !== userId)) {
+      return { error: `Script ${scriptId} was not found.` };
+    }
+    if ((row.storyboard_id ?? null) === storyboardId) return { ok: true };
+    const saved = await Script.updateFieldsIfUnchanged(
+      scriptId,
+      row.updated_at,
+      { storyboard_id: storyboardId }
+    );
+    if (saved) return { ok: true };
+  }
+  return {
+    error: `Script ${scriptId} is being modified concurrently, so its storyboard back-pointer could not be written.`
+  };
+}

--- a/packages/agents/src/capabilities/scripts.ts
+++ b/packages/agents/src/capabilities/scripts.ts
@@ -38,6 +38,7 @@ import type {
 } from "@nodetool-ai/protocol";
 import type { CaptionWord } from "@nodetool-ai/timeline";
 import { UNGATED, createCapabilityRun } from "./invoke.js";
+import { stampScriptStoryboardId } from "./script-link.js";
 import type {
   CapabilityExport,
   CapabilityModule,
@@ -324,58 +325,73 @@ const EMPTY_LINK: StoryboardLinkSummary = {
 };
 
 /**
- * The board that links this script, and what its link looks like now.
+ * The board this script points at, and what its link looks like now.
  *
- * The link lives on the board (design §1.1), so finding it from this side is a
- * scan of the caller's boards. It is bounded by the same list the tools use;
- * the `scripts.storyboard_id` back-pointer replaces the scan once it lands.
+ * The board owns the link (design §1.1) and `scripts.storyboard_id` is the
+ * back-pointer (design §1.2), so this is one read by id. A pointer at a board
+ * that is gone, or at one that no longer names this script, is reported as an
+ * issue rather than silently dropped — the script still works, only the link
+ * affordances do not.
  */
 async function storyboardLinkFor(
   userId: string | undefined,
+  storyboardId: string | null,
   scriptId: string,
   doc: ScriptDocument
 ): Promise<StoryboardLinkSummary> {
-  if (!userId) return EMPTY_LINK;
+  if (!userId || !storyboardId) return EMPTY_LINK;
   const { Storyboard } = await import("@nodetool-ai/models");
   const { orphanedLineIds, shotDialogueDrifted, validateScriptLink } =
     await import("@nodetool-ai/protocol");
 
-  const boards = await Storyboard.listByUser(userId, 100);
-  for (const board of boards) {
-    const boardDoc = board.toDocument();
-    if (boardDoc.screenplay?.script_id !== scriptId) continue;
+  const stale = (message: string): StoryboardLinkSummary => ({
+    ...EMPTY_LINK,
+    storyboard_id: storyboardId,
+    issues: [message]
+  });
 
-    const screenplay: Screenplay = {
-      ...boardDoc.screenplay,
-      shots: boardDoc.shots
-    };
-    const scriptDoc: ScriptLinkDocument = { sections: doc.sections };
-    const linesById = new Map(
-      doc.sections.flatMap((section) =>
-        section.lines.map((line) => [line.id, line] as const)
-      )
+  const board = await Storyboard.findById(storyboardId);
+  if (!board || board.user_id !== userId) {
+    return stale(
+      `Storyboard ${storyboardId} is no longer available, so the script's back-pointer is stale.`
     );
-    const shotIdByLineId: Record<string, string> = {};
-    for (const shot of screenplay.shots) {
-      for (const lineId of shot.script_line_ids ?? []) {
-        shotIdByLineId[lineId] = shot.id;
-      }
-    }
-    const validation = validateScriptLink(screenplay, scriptDoc);
-    return {
-      linked: true,
-      storyboard_id: board.id,
-      orphan_line_ids: orphanedLineIds(screenplay, scriptDoc),
-      drifted_shot_ids: screenplay.shots
-        .filter((shot) => shotDialogueDrifted(shot, linesById))
-        .map((shot) => shot.id),
-      shot_id_by_line_id: shotIdByLineId,
-      issues: [...validation.errors, ...validation.warnings].map(
-        (issue) => issue.message
-      )
-    };
   }
-  return EMPTY_LINK;
+  const boardDoc = board.toDocument();
+  if (boardDoc.screenplay?.script_id !== scriptId) {
+    return stale(
+      `Storyboard ${storyboardId} does not link this script back, so the back-pointer is stale.`
+    );
+  }
+
+  const screenplay: Screenplay = {
+    ...boardDoc.screenplay,
+    shots: boardDoc.shots
+  };
+  const scriptDoc: ScriptLinkDocument = { sections: doc.sections };
+  const linesById = new Map(
+    doc.sections.flatMap((section) =>
+      section.lines.map((line) => [line.id, line] as const)
+    )
+  );
+  const shotIdByLineId: Record<string, string> = {};
+  for (const shot of screenplay.shots) {
+    for (const lineId of shot.script_line_ids ?? []) {
+      shotIdByLineId[lineId] = shot.id;
+    }
+  }
+  const validation = validateScriptLink(screenplay, scriptDoc);
+  return {
+    linked: true,
+    storyboard_id: board.id,
+    orphan_line_ids: orphanedLineIds(screenplay, scriptDoc),
+    drifted_shot_ids: screenplay.shots
+      .filter((shot) => shotDialogueDrifted(shot, linesById))
+      .map((shot) => shot.id),
+    shot_id_by_line_id: shotIdByLineId,
+    issues: [...validation.errors, ...validation.warnings].map(
+      (issue) => issue.message
+    )
+  };
 }
 
 const listScripts: CapabilityExport = {
@@ -420,7 +436,12 @@ const getScript: CapabilityExport = {
     const { row, doc } = handle;
     const { currentTake, effectiveVoice, needsVoicing, scriptLines } =
       await import("@nodetool-ai/timeline");
-    const link = await storyboardLinkFor(run.context.userId, row.id, doc);
+    const link = await storyboardLinkFor(
+      run.context.userId,
+      row.storyboard_id ?? null,
+      row.id,
+      doc
+    );
     const orphans = new Set(link.orphan_line_ids);
     return {
       id: row.id,
@@ -1413,8 +1434,11 @@ const deriveStoryboardFromScript: CapabilityExport = {
       };
     }
 
-    // One write, so there is no half-linked state to recover from: the board is
-    // created already carrying `script_id` and every shot's line references.
+    // The board is created already carrying `script_id` and every shot's line
+    // references, so the forward link needs no second write. The script's
+    // back-pointer does, and it is stamped after — a board that exists without
+    // the pointer is consistent and navigable from the board side, while a
+    // pointer written first could name a board that was never created.
     // Bound as a namespace so the `Storyboard` row type imported at the top of
     // this file stays visible here.
     const models = await import("@nodetool-ai/models");
@@ -1440,6 +1464,19 @@ const deriveStoryboardFromScript: CapabilityExport = {
         videoModel: null
       })
     });
+
+    const stamped = await stampScriptStoryboardId(
+      row.id,
+      board.id,
+      context.userId
+    );
+    if (isError(stamped)) {
+      return {
+        error: `Storyboard ${board.id} was created and links script ${row.id}, but the script's back-pointer could not be written: ${stamped.error} The board is valid; the script reads as unlinked until this is retried.`,
+        storyboard_id: board.id,
+        script_id: row.id
+      };
+    }
 
     return {
       ok: true,

--- a/packages/agents/src/capabilities/storyboards.ts
+++ b/packages/agents/src/capabilities/storyboards.ts
@@ -38,6 +38,7 @@ import type {
   CapabilityModule,
   CapabilityRun
 } from "./types.js";
+import { stampScriptStoryboardId } from "./script-link.js";
 import {
   listStoryboardsSpec,
   getStoryboardSpec,
@@ -1301,6 +1302,22 @@ const extractScriptFromStoryboard: CapabilityExport = {
         }
       );
       if (!saved) continue;
+
+      // Last write, and only now that the board carries the forward link: the
+      // back-pointer never names a board that failed to link (design §7).
+      const stamped = await stampScriptStoryboardId(
+        scriptId,
+        current.id,
+        context.userId
+      );
+      if (isError(stamped)) {
+        return {
+          error: `Storyboard ${current.id} links script ${scriptId}, but the script's back-pointer could not be written: ${stamped.error} The board is valid; the script reads as unlinked until this is retried with relink: true.`,
+          storyboard_id: current.id,
+          script_id: scriptId
+        };
+      }
+
       return {
         ok: true,
         storyboard_id: current.id,

--- a/packages/agents/tests/script-storyboard-link-tools.test.ts
+++ b/packages/agents/tests/script-storyboard-link-tools.test.ts
@@ -422,4 +422,113 @@ describe("derive_storyboard_from_script", () => {
     expect(result.error).toContain("nothing to storyboard");
     expect(await Storyboard.listByUser("u1")).toHaveLength(0);
   });
+
+  it("stamps the script's storyboard_id back-pointer", async () => {
+    const script = await writtenScript();
+    const result = (await run(plainContext()).invoke(
+      "derive_storyboard_from_script",
+      { script_id: script.id }
+    )) as { ok: boolean; storyboard_id: string };
+
+    expect(result.ok).toBe(true);
+    expect((await Script.findById(script.id))!.storyboard_id).toBe(
+      result.storyboard_id
+    );
+  });
+
+  it("reports a failed back-pointer write and leaves the script unlinked", async () => {
+    const script = await writtenScript();
+    // The board is created first; the second write is the one that fails.
+    const stamp = vi
+      .spyOn(Script, "updateFieldsIfUnchanged")
+      .mockResolvedValue(null);
+
+    const result = (await run(plainContext()).invoke(
+      "derive_storyboard_from_script",
+      { script_id: script.id }
+    )) as { error: string; storyboard_id: string };
+
+    expect(stamp).toHaveBeenCalled();
+    stamp.mockRestore();
+    expect(result.error).toContain("back-pointer");
+    // Consistent, not half-linked: the board carries the forward link and the
+    // script simply reads as unlinked.
+    const board = await Storyboard.findById(result.storyboard_id);
+    expect(board!.toDocument().screenplay?.script_id).toBe(script.id);
+    expect((await Script.findById(script.id))!.storyboard_id).toBeNull();
+  });
+});
+
+describe("the script's storyboard back-pointer", () => {
+  beforeEach(() => initTestDb());
+  afterEach(() => ModelObserver.clear());
+
+  const spokenBoard = () =>
+    makeBoard([
+      shot({ id: "s1", index: 0, dialogue: "The light goes out tonight." })
+    ]);
+
+  it("is written by extract and read by get_script without scanning boards", async () => {
+    const board = await spokenBoard();
+    const context = plainContext();
+    const extracted = (await run(context).invoke(
+      "extract_script_from_storyboard",
+      { storyboard_id: board.id }
+    )) as { ok: boolean; script_id: string };
+    expect(extracted.ok).toBe(true);
+    expect((await Script.findById(extracted.script_id))!.storyboard_id).toBe(
+      board.id
+    );
+
+    const listByUser = vi.spyOn(Storyboard, "listByUser");
+    const read = (await run(context).invoke("get_script", {
+      script_id: extracted.script_id
+    })) as { storyboard_id: string | null; storyboard_link: { linked: boolean } };
+
+    expect(read.storyboard_id).toBe(board.id);
+    expect(read.storyboard_link.linked).toBe(true);
+    expect(listByUser).not.toHaveBeenCalled();
+    listByUser.mockRestore();
+  });
+
+  it("leaves the board unlinked when extract cannot write it", async () => {
+    const board = await spokenBoard();
+    const context = plainContext();
+    // The script row is created with `create`, so only the back-pointer write
+    // goes through `updateFieldsIfUnchanged` on a first extraction.
+    const stamp = vi
+      .spyOn(Script, "updateFieldsIfUnchanged")
+      .mockResolvedValue(null);
+
+    const result = (await run(context).invoke(
+      "extract_script_from_storyboard",
+      { storyboard_id: board.id }
+    )) as { error: string; script_id: string };
+
+    stamp.mockRestore();
+    expect(result.error).toContain("back-pointer");
+    expect((await Script.findById(result.script_id))!.storyboard_id).toBeNull();
+    const saved = await Storyboard.findById(board.id);
+    expect(saved!.toDocument().screenplay?.script_id).toBe(result.script_id);
+  });
+
+  it("reports a pointer at a board that is gone instead of claiming a link", async () => {
+    const board = await spokenBoard();
+    const context = plainContext();
+    const extracted = (await run(context).invoke(
+      "extract_script_from_storyboard",
+      { storyboard_id: board.id }
+    )) as { script_id: string };
+    await (await Storyboard.findById(board.id))!.delete();
+
+    const read = (await run(context).invoke("get_script", {
+      script_id: extracted.script_id
+    })) as {
+      storyboard_id: string | null;
+      storyboard_link: { linked: boolean; issues: string[] };
+    };
+    expect(read.storyboard_link.linked).toBe(false);
+    expect(read.storyboard_id).toBe(board.id);
+    expect(read.storyboard_link.issues[0]).toContain("no longer available");
+  });
 });

--- a/web/src/components/script/StoryboardLinkControl.tsx
+++ b/web/src/components/script/StoryboardLinkControl.tsx
@@ -7,8 +7,8 @@
  * Link problems on that board are shown here too, so the script side sees a
  * broken link without opening the board.
  *
- * The back-pointer is session-scoped until the `scripts.storyboard_id` column
- * lands — see {@link useScriptStoryboardLink}.
+ * The back-pointer is the persisted `scripts.storyboard_id`, so a reload still
+ * shows *Open storyboard* — see {@link useScriptStoryboardLink}.
  */
 
 import { memo, useCallback } from "react";

--- a/web/src/components/script/__tests__/ScriptDocumentPane.perf.test.tsx
+++ b/web/src/components/script/__tests__/ScriptDocumentPane.perf.test.tsx
@@ -62,7 +62,8 @@ beforeEach(() => {
     title: "Perf",
     cast: [],
     sections: [makeSection("a", 6), makeSection("b", 6)],
-    timelineId: null
+    timelineId: null,
+    storyboardId: null
   });
   rowRenders.length = 0;
 });

--- a/web/src/components/script/__tests__/StoryboardLinkControl.test.tsx
+++ b/web/src/components/script/__tests__/StoryboardLinkControl.test.tsx
@@ -32,7 +32,7 @@ const renderControl = () =>
 
 describe("StoryboardLinkControl", () => {
   beforeEach(() => {
-    useScriptStore.setState({ storyboardLinks: {} });
+    useScriptStore.setState({ scripts: {}, serverRevisions: {} });
     useScriptStore.getState().ensureScript(SCRIPT);
   });
 
@@ -57,5 +57,40 @@ describe("StoryboardLinkControl", () => {
     expect(
       screen.queryByRole("button", { name: /create storyboard/i })
     ).toBeNull();
+  });
+
+  it("still offers Open storyboard after a reload of a linked script", () => {
+    // What useScriptServerSync does on mount: the server copy replaces the
+    // local one, carrying the persisted `scripts.storyboard_id`.
+    useScriptStore.getState().loadScript(SCRIPT, {
+      title: "Reloaded",
+      cast: [],
+      sections: [],
+      timelineId: null,
+      storyboardId: "board-3"
+    });
+    renderControl();
+
+    expect(
+      screen.getByRole("button", { name: /open storyboard/i })
+    ).toBeEnabled();
+    expect(
+      screen.queryByRole("button", { name: /create storyboard/i })
+    ).toBeNull();
+  });
+
+  it("falls back to Create storyboard when the reloaded script links none", () => {
+    useScriptStore.getState().loadScript(SCRIPT, {
+      title: "Reloaded",
+      cast: [],
+      sections: [],
+      timelineId: null,
+      storyboardId: null
+    });
+    renderControl();
+
+    expect(
+      screen.getByRole("button", { name: /create storyboard/i })
+    ).toBeEnabled();
   });
 });

--- a/web/src/components/script/__tests__/assembleScriptTimeline.test.ts
+++ b/web/src/components/script/__tests__/assembleScriptTimeline.test.ts
@@ -45,6 +45,7 @@ const script = (overrides: Partial<ScriptDraft> = {}): ScriptDraft => ({
   cast: [],
   sections: [],
   timelineId: null,
+  storyboardId: null,
   updatedAt: 0,
   ...overrides
 });

--- a/web/src/components/storyboard/StoryboardListPanel.tsx
+++ b/web/src/components/storyboard/StoryboardListPanel.tsx
@@ -396,9 +396,14 @@ const StoryboardListPanel = () => {
     }
     const { id } = itemToDelete;
     deleteStoryboard.mutate({ id });
-    // The script keeps its words; only its pointer at this board goes.
-    downgradeScriptsLinkedToBoard(id);
-  }, [itemToDelete, deleteStoryboard]);
+    // The script keeps its words; only its pointer at this board goes. Never
+    // blocks the delete (design §4).
+    void downgradeScriptsLinkedToBoard(id).then((scriptIds) => {
+      if (scriptIds.length > 0) {
+        void utils.scripts.list.invalidate();
+      }
+    });
+  }, [itemToDelete, deleteStoryboard, utils]);
 
   useEffect(() => {
     setActions({

--- a/web/src/hooks/script/__tests__/useAssembleScriptTimeline.test.ts
+++ b/web/src/hooks/script/__tests__/useAssembleScriptTimeline.test.ts
@@ -39,7 +39,8 @@ const seedVoicedScript = (id: string, timelineId: string | null): void => {
     sections: [
       { id: "s1", lines: [{ id: "line-a", text: "hi", takes: [t], currentTakeId: t.id }] }
     ],
-    timelineId
+    timelineId,
+    storyboardId: null
   });
 };
 
@@ -82,7 +83,8 @@ describe("useAssembleScriptTimeline", () => {
       title: "Empty",
       cast: [],
       sections: [{ id: "s1", lines: [{ id: "l", text: "hi", takes: [] }] }],
-      timelineId: null
+      timelineId: null,
+      storyboardId: null
     });
     const { result } = renderHook(() => useAssembleScriptTimeline());
     await act(async () => {

--- a/web/src/hooks/script/__tests__/useScriptServerSync.test.tsx
+++ b/web/src/hooks/script/__tests__/useScriptServerSync.test.tsx
@@ -65,6 +65,34 @@ describe("useScriptServerSync", () => {
     );
   });
 
+  it("loads the persisted storyboard back-pointer and saves it back", async () => {
+    getQuery.mockResolvedValue({
+      id: "script-1",
+      name: "Saved script",
+      document: { cast: [], sections: [] },
+      storyboardId: "board-7",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "rev-1"
+    });
+    const { unmount } = renderHook(() => useScriptServerSync("script-1"));
+
+    await waitFor(() =>
+      expect(useScriptStore.getState().serverRevisions["script-1"]).toBe("rev-1")
+    );
+    // The reload case: the link is on the loaded script, not on session state.
+    expect(useScriptStore.getState().scripts["script-1"]?.storyboardId).toBe(
+      "board-7"
+    );
+
+    act(() => useScriptStore.getState().setTitle("script-1", "Unsaved title"));
+    unmount();
+
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    expect(updateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ storyboardId: "board-7" })
+    );
+  });
+
   it("marks the script saved after an autosave lands", async () => {
     renderHook(() => useScriptServerSync("script-1"));
 

--- a/web/src/hooks/script/useDeriveStoryboard.ts
+++ b/web/src/hooks/script/useDeriveStoryboard.ts
@@ -19,6 +19,7 @@ import { useScriptStore } from "../../stores/script/ScriptStore";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import { newDocumentId } from "../../lib/newDocumentId";
+import { writeScriptStoryboardId } from "../../lib/scriptStoryboardBackpointer";
 import {
   boardLinkIssues,
   scaffoldShots,
@@ -57,7 +58,7 @@ export const useDeriveStoryboard = (): UseDeriveStoryboardResult => {
       if (!script) {
         throw new Error(`No script "${scriptId}".`);
       }
-      const existing = useScriptStore.getState().storyboardLinks[scriptId];
+      const existing = script.storyboardId;
       if (existing) {
         throw new Error(
           `This script already has storyboard ${existing}. Open it instead of deriving a second one.`
@@ -128,7 +129,19 @@ export const useDeriveStoryboard = (): UseDeriveStoryboardResult => {
         });
 
         useStoryboardStore.getState().loadBoard(boardId, board);
-        useScriptStore.getState().setStoryboardLink(scriptId, boardId);
+        // Stamped only now that the board row exists, so a failed second write
+        // leaves an unlinked-but-valid pair rather than a pointer at nothing.
+        try {
+          await writeScriptStoryboardId(scriptId, boardId);
+        } catch (writeError) {
+          throw new Error(
+            `Storyboard ${boardId} was created, but the script's back-pointer failed: ${
+              writeError instanceof Error
+                ? writeError.message
+                : String(writeError)
+            }`
+          );
+        }
         if (options.open !== false) {
           useWorkspaceTabsStore.getState().openTab({
             type: "storyboard",

--- a/web/src/hooks/script/useExtractScript.ts
+++ b/web/src/hooks/script/useExtractScript.ts
@@ -68,7 +68,8 @@ export const useExtractScript = (): UseExtractScriptResult => {
           title: name,
           cast: extracted.cast,
           sections: extracted.sections,
-          timelineId: null
+          timelineId: null,
+          storyboardId: null
         });
         useScriptStore.getState().setServerRevision(created.id, created.updatedAt);
         useWorkspaceTabsStore.getState().openTab({

--- a/web/src/hooks/script/useScriptAgentBridge.ts
+++ b/web/src/hooks/script/useScriptAgentBridge.ts
@@ -139,7 +139,7 @@ export const useScriptAgentBridge = (scriptId: string): void => {
         ),
         hasTimeline: script.timelineId !== null,
         timelineId: script.timelineId,
-        storyboardId: store().storyboardLinks[scriptId] ?? null
+        storyboardId: script.storyboardId
       };
     };
 

--- a/web/src/hooks/script/useScriptServerSync.ts
+++ b/web/src/hooks/script/useScriptServerSync.ts
@@ -44,7 +44,8 @@ const responseToScript = (
     title: res.name === "Untitled script" ? "" : res.name,
     cast: doc.cast,
     sections: doc.sections,
-    timelineId: res.timelineId ?? null
+    timelineId: res.timelineId ?? null,
+    storyboardId: res.storyboardId ?? null
   };
 };
 
@@ -140,7 +141,8 @@ export const useScriptServerSync = (scriptId: string): void => {
           baseUpdatedAt: revision,
           name: script.title || "Untitled script",
           document: scriptToDocument(script),
-          timelineId: script.timelineId
+          timelineId: script.timelineId,
+          storyboardId: script.storyboardId
         });
         store.getState().setServerRevision(scriptId, updated.updatedAt);
         syncedRef.current = script;

--- a/web/src/hooks/storyboard/useExtractScriptFromBoard.ts
+++ b/web/src/hooks/storyboard/useExtractScriptFromBoard.ts
@@ -18,9 +18,9 @@ import type { Entity } from "@nodetool-ai/protocol";
 import { trpcClient } from "../../trpc/client";
 import { useEntities } from "../../serverState/useEntities";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
-import { useScriptStore } from "../../stores/script/ScriptStore";
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
 import { newDocumentId } from "../../lib/newDocumentId";
+import { writeScriptStoryboardId } from "../../lib/scriptStoryboardBackpointer";
 import {
   boardLinkIssues,
   extractScriptFromBoard,
@@ -136,7 +136,19 @@ export const useExtractScriptFromBoard = (): UseExtractScriptResult => {
             extracted.lineIdsByShotId,
             texts
           );
-        useScriptStore.getState().setStoryboardLink(scriptId, boardId);
+        // Last write, once the board carries the forward link: a back-pointer
+        // that fails here leaves a valid unlinked script, never a half-link.
+        try {
+          await writeScriptStoryboardId(scriptId, boardId);
+        } catch (writeError) {
+          throw new Error(
+            `Script ${scriptId} was written and the board links it, but the script's back-pointer failed: ${
+              writeError instanceof Error
+                ? writeError.message
+                : String(writeError)
+            }`
+          );
+        }
 
         if (options.open !== false) {
           useWorkspaceTabsStore.getState().openTab({

--- a/web/src/lib/__tests__/scriptStoryboardDowngrade.test.ts
+++ b/web/src/lib/__tests__/scriptStoryboardDowngrade.test.ts
@@ -8,6 +8,11 @@ jest.mock("../../trpc/client", () => ({
       list: { query: jest.fn() },
       get: { query: jest.fn() },
       update: { mutate: jest.fn() }
+    },
+    scripts: {
+      list: { query: jest.fn() },
+      get: { query: jest.fn() },
+      update: { mutate: jest.fn() }
     }
   }
 }));
@@ -23,6 +28,9 @@ import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
 const list = trpcClient.storyboards.list.query as jest.Mock;
 const get = trpcClient.storyboards.get.query as jest.Mock;
 const update = trpcClient.storyboards.update.mutate as jest.Mock;
+const scriptList = trpcClient.scripts.list.query as jest.Mock;
+const scriptGet = trpcClient.scripts.get.query as jest.Mock;
+const scriptUpdate = trpcClient.scripts.update.mutate as jest.Mock;
 
 const screenplayFor = (id: string, scriptId: string | null) => {
   const screenplay: Record<string, unknown> = {
@@ -120,19 +128,62 @@ describe("downgradeBoardsLinkedToScript", () => {
 });
 
 describe("downgradeScriptsLinkedToBoard", () => {
-  beforeEach(() => {
-    useScriptStore.setState({ storyboardLinks: {} });
+  const scriptResponse = (id: string, storyboardId: string | null) => ({
+    id,
+    name: id,
+    document: { cast: [], sections: [] },
+    storyboardId: storyboardId ?? undefined,
+    createdAt: "2026-08-16T00:00:00.000Z",
+    updatedAt: `rev-${id}`
   });
 
-  it("drops the back-pointer of every script naming the deleted board", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    useScriptStore.setState({ scripts: {}, serverRevisions: {}, history: {} });
+    scriptUpdate.mockImplementation(async ({ id }: { id: string }) => ({
+      ...scriptResponse(id, null),
+      updatedAt: `rev-${id}-next`
+    }));
+  });
+
+  it("clears the back-pointer of every script naming the deleted board", async () => {
     const store = useScriptStore.getState();
+    store.ensureScript("script-1");
+    store.ensureScript("script-2");
     store.setStoryboardLink("script-1", "board-1");
     store.setStoryboardLink("script-2", "board-2");
+    scriptList.mockResolvedValue([{ id: "script-1" }, { id: "script-2" }]);
+    scriptGet.mockImplementation(async ({ id }: { id: string }) =>
+      scriptResponse(id, id === "script-1" ? "board-1" : "board-2")
+    );
 
-    downgradeScriptsLinkedToBoard("board-1");
+    expect(await downgradeScriptsLinkedToBoard("board-1")).toEqual(["script-1"]);
 
-    const links = useScriptStore.getState().storyboardLinks;
-    expect(links["script-1"]).toBeUndefined();
-    expect(links["script-2"]).toBe("board-2");
+    const scripts = useScriptStore.getState().scripts;
+    expect(scripts["script-1"]?.storyboardId).toBeNull();
+    expect(scripts["script-2"]?.storyboardId).toBe("board-2");
+    // Persisted, so a reload does not resurrect the pointer.
+    expect(scriptUpdate).toHaveBeenCalledTimes(1);
+    expect(scriptUpdate).toHaveBeenCalledWith({
+      id: "script-1",
+      baseUpdatedAt: "rev-script-1",
+      storyboardId: null
+    });
+  });
+
+  it("never throws when a script cannot be cleared", async () => {
+    scriptList.mockResolvedValue([{ id: "script-1" }]);
+    scriptGet.mockResolvedValue(scriptResponse("script-1", "board-1"));
+    scriptUpdate.mockRejectedValue(new Error("409 revision conflict"));
+
+    await expect(downgradeScriptsLinkedToBoard("board-1")).resolves.toEqual([]);
+  });
+
+  it("never throws when the scripts cannot be listed", async () => {
+    scriptList.mockRejectedValue(new Error("offline"));
+
+    await expect(downgradeScriptsLinkedToBoard("board-1")).resolves.toEqual([]);
+    expect(scriptGet).not.toHaveBeenCalled();
   });
 });

--- a/web/src/lib/scriptStoryboardBackpointer.ts
+++ b/web/src/lib/scriptStoryboardBackpointer.ts
@@ -1,0 +1,35 @@
+/**
+ * The script side of the script ↔ storyboard link: the persisted
+ * `scripts.storyboard_id` back-pointer (design §1.2).
+ *
+ * The board owns the link — `Screenplay.script_id` is what validation reads —
+ * and this column is what the script header navigates by, so it has to survive
+ * a reload. Every write goes through the scripts CAS patch here rather than
+ * relying on the editor's autosave: the script whose pointer changes often has
+ * no tab open (a board extracted from the storyboard side, a board deleted from
+ * the sidebar), and autosave only runs for a mounted tab.
+ */
+
+import { trpcClient } from "../trpc/client";
+import { useScriptStore } from "../stores/script/ScriptStore";
+
+/**
+ * Point `scriptId` at `storyboardId` (or clear it with `null`), CAS on the
+ * script's `updatedAt`, then mirror it into the store. Throws what tRPC throws,
+ * so a caller that created a resource can report the failed second write.
+ */
+export async function writeScriptStoryboardId(
+  scriptId: string,
+  storyboardId: string | null
+): Promise<void> {
+  const current = await trpcClient.scripts.get.query({ id: scriptId });
+  const updated = await trpcClient.scripts.update.mutate({
+    id: scriptId,
+    baseUpdatedAt: current.updatedAt,
+    storyboardId
+  });
+  // The open tab's autosave holds the old CAS token; hand it the new one so its
+  // next save is not a spurious conflict that reloads over the user's edits.
+  useScriptStore.getState().setServerRevision(scriptId, updated.updatedAt);
+  useScriptStore.getState().setStoryboardLink(scriptId, storyboardId);
+}

--- a/web/src/lib/scriptStoryboardDowngrade.ts
+++ b/web/src/lib/scriptStoryboardDowngrade.ts
@@ -15,6 +15,7 @@ import { trpcClient } from "../trpc/client";
 import { useScriptStore } from "../stores/script/ScriptStore";
 import { useStoryboardStore } from "../stores/storyboard/StoryboardStore";
 import { unlinkedScreenplay, unlinkedShots } from "./scriptStoryboardLink";
+import { writeScriptStoryboardId } from "./scriptStoryboardBackpointer";
 
 type StoryboardDocument = Awaited<
   ReturnType<typeof trpcClient.storyboards.get.query>
@@ -68,10 +69,39 @@ export async function downgradeBoardsLinkedToScript(
 }
 
 /**
- * Forget the deleted board on the script side. The persisted back-pointer
- * (`scripts.storyboard_id`) is a separate change, so today this clears the
- * session-scoped link the script editor navigates by.
+ * Clear the deleted board from every script that points at it, in the store and
+ * on the server. Returns the ids cleared. Never throws: a script whose pointer
+ * survives the delete reads as linked to a board that is gone, which the header
+ * reports rather than breaking on.
  */
-export function downgradeScriptsLinkedToBoard(storyboardId: string): void {
+export async function downgradeScriptsLinkedToBoard(
+  storyboardId: string
+): Promise<string[]> {
   useScriptStore.getState().clearStoryboardLink(storyboardId);
+
+  const cleared: string[] = [];
+  let scripts: Array<{ id: string }> = [];
+  try {
+    scripts = await trpcClient.scripts.list.query({});
+  } catch (error) {
+    console.error("Could not list scripts to clear the deleted board", error);
+    return cleared;
+  }
+
+  for (const item of scripts) {
+    try {
+      const script = await trpcClient.scripts.get.query({ id: item.id });
+      if (script.storyboardId !== storyboardId) {
+        continue;
+      }
+      await writeScriptStoryboardId(item.id, null);
+      cleared.push(item.id);
+    } catch (error) {
+      console.error(
+        `Could not clear the deleted board from script ${item.id}`,
+        error
+      );
+    }
+  }
+  return cleared;
 }

--- a/web/src/stores/script/ScriptStore.ts
+++ b/web/src/stores/script/ScriptStore.ts
@@ -86,6 +86,12 @@ export interface ScriptDraft {
   sections: ScriptSection[];
   /** Persisted timeline sequence this script was assembled into, if any. */
   timelineId: string | null;
+  /**
+   * Persisted storyboard this script is linked to (`scripts.storyboard_id`).
+   * The board owns the link (`Screenplay.script_id`); this is the back-pointer
+   * the script editor navigates by, so it survives a reload.
+   */
+  storyboardId: string | null;
   /** Epoch ms of the last mutation; drives the sidebar's recency sort. */
   updatedAt: number;
 }
@@ -115,13 +121,6 @@ interface ScriptStoreState {
   saveStatus: Record<string, ScriptSaveStatus>;
   /** Line ids currently generating a take — transient, not persisted. */
   voicingLineIds: Record<string, true>;
-  /**
-   * Storyboard this script is linked to, per script id. The board owns the
-   * link (`Screenplay.script_id`); this is the back-pointer the script editor
-   * navigates by. It is **not** persisted — the `scripts.storyboard_id` column
-   * is a separate change — so it holds for the session that made the link.
-   */
-  storyboardLinks: Record<string, string>;
   /** Per-script undo/redo checkpoints of the {@link ScriptDraft} document. */
   history: HistoryMap<ScriptDraft>;
 
@@ -229,6 +228,7 @@ const emptyScript = (id: string): ScriptDraft => ({
   cast: [],
   sections: [],
   timelineId: null,
+  storyboardId: null,
   updatedAt: Date.now()
 });
 
@@ -300,7 +300,6 @@ export const useScriptStore = create<ScriptStoreState>((set, get) => ({
   serverRevisions: {},
   saveStatus: {},
   voicingLineIds: {},
-  storyboardLinks: {},
   history: {},
 
   undo: (scriptId) =>
@@ -412,32 +411,33 @@ export const useScriptStore = create<ScriptStoreState>((set, get) => ({
     ),
 
   setStoryboardLink: (scriptId, storyboardId) =>
-    set((state) => {
-      if ((state.storyboardLinks[scriptId] ?? null) === storyboardId) {
-        return state;
-      }
-      const storyboardLinks = { ...state.storyboardLinks };
-      if (storyboardId === null) {
-        delete storyboardLinks[scriptId];
-      } else {
-        storyboardLinks[scriptId] = storyboardId;
-      }
-      return { storyboardLinks };
-    }),
+    set((state) =>
+      withScript(
+        state,
+        scriptId,
+        (s) => (s.storyboardId === storyboardId ? s : { ...s, storyboardId }),
+        // A link handoff isn't an authoring edit — keep it out of undo.
+        false
+      )
+    ),
 
   clearStoryboardLink: (storyboardId) =>
     set((state) => {
-      const linked = Object.entries(state.storyboardLinks).filter(
-        ([, boardId]) => boardId === storyboardId
+      const linked = Object.values(state.scripts).filter(
+        (script) => script.storyboardId === storyboardId
       );
       if (linked.length === 0) {
         return state;
       }
-      const storyboardLinks = { ...state.storyboardLinks };
-      for (const [scriptId] of linked) {
-        delete storyboardLinks[scriptId];
+      const scripts = { ...state.scripts };
+      for (const script of linked) {
+        scripts[script.id] = {
+          ...script,
+          storyboardId: null,
+          updatedAt: Date.now()
+        };
       }
-      return { storyboardLinks };
+      return { scripts };
     }),
 
   addSpeaker: (scriptId, speaker) =>
@@ -774,13 +774,9 @@ export const useScript = (
 export const useScriptCast = (scriptId: string): ScriptSpeaker[] =>
   useScriptStore((state) => state.scripts[scriptId]?.cast ?? EMPTY_CAST);
 
-/**
- * Reactive storyboard back-pointer for a script, or null when none was linked
- * in this session. See {@link ScriptStoreState.storyboardLinks} on why it does
- * not survive a reload.
- */
+/** Reactive storyboard back-pointer for a script, or null when unlinked. */
 export const useScriptStoryboardLink = (scriptId: string): string | null =>
-  useScriptStore((state) => state.storyboardLinks[scriptId] ?? null);
+  useScriptStore((state) => state.scripts[scriptId]?.storyboardId ?? null);
 
 /** Reactive title for a script — see {@link useScriptCast} on why it's narrow. */
 export const useScriptTitle = (scriptId: string): string =>

--- a/web/src/stores/script/__tests__/scriptSubtitles.test.ts
+++ b/web/src/stores/script/__tests__/scriptSubtitles.test.ts
@@ -46,6 +46,7 @@ const draft = (lines: ScriptLine[]): ScriptDraft => ({
   cast: [],
   sections: [{ id: "sec-1", lines }],
   timelineId: null,
+  storyboardId: null,
   updatedAt: 0
 });
 

--- a/web/src/stores/script/__tests__/timelineSync.test.ts
+++ b/web/src/stores/script/__tests__/timelineSync.test.ts
@@ -57,7 +57,8 @@ const seedScript = (timelineId: string | null): void => {
     title: "S",
     cast: [],
     sections: [],
-    timelineId
+    timelineId,
+    storyboardId: null
   });
 };
 
@@ -80,7 +81,8 @@ describe("syncLineClipToTimeline", () => {
           { id: "line-2", text: "Two", takes: [], currentTakeId: null }
         ] }
       ],
-      timelineId: "tl-1"
+      timelineId: "tl-1",
+      storyboardId: null
     });
     getQuery.mockResolvedValue({
       id: "tl-1",


### PR DESCRIPTION
## What

Removes the two workarounds the script ↔ storyboard link shipped with. #4948 added the nullable `scripts.storyboard_id` column plus `storyboardId` in `scriptResponse`/`patchScriptInput` and the CAS patch in the scripts router, but #4950 (web) and #4952 (agents) were developed off a base without it and each worked around it.

**Web.** The script → board pointer lived in a session-scoped `storyboardLinks` map on `ScriptStore`, never persisted, so after a page reload the script header offered *Create storyboard* for a script whose board exists. The pointer is now a field on `ScriptDraft`, loaded from `scriptResponse.storyboardId` and saved back through the same `scripts.update` call that carries `timelineId`. Extract, derive and board deletion each write it explicitly through the CAS patch (`web/src/lib/scriptStoryboardBackpointer.ts`) rather than leaning on autosave — the script whose pointer changes usually has no tab open (a board extracted from the storyboard side, a board deleted from the sidebar), and autosave only runs for a mounted tab. The write hands the open tab the new CAS token so its next save is not a spurious conflict. The map is gone.

**Agents.** `get_script` found the linked board by scanning up to 100 of the caller's storyboards; it now reads `storyboard_id` and loads that one row. A pointer at a board that is gone, or at one that no longer names this script, is reported as an issue instead of silently reading as unlinked. `extract_script_from_storyboard` and `derive_storyboard_from_script` now write the back-pointer, which #4952 deliberately skipped.

Design §7's two-write posture is kept: the pointer is stamped **last**, only once the created row exists and the board carries the forward link, so a failed write leaves a valid unlinked-but-consistent pair and a named error — never a half-link.

Out of scope, deliberately untouched: the assemble switch, `ui_storyboard_set_duration_source`, drift badges, Studio, docs.

## Files

- `packages/agents/src/capabilities/script-link.ts` (new) — the CAS back-pointer write, shared by both tools
- `packages/agents/src/capabilities/scripts.ts` — direct read in `storyboardLinkFor`; derive stamps the pointer
- `packages/agents/src/capabilities/storyboards.ts` — extract stamps the pointer after the board write lands
- `web/src/lib/scriptStoryboardBackpointer.ts` (new) — `writeScriptStoryboardId`
- `web/src/stores/script/ScriptStore.ts`, `web/src/hooks/script/useScriptServerSync.ts` — persisted field replaces the map
- `web/src/hooks/script/useDeriveStoryboard.ts`, `web/src/hooks/storyboard/useExtractScriptFromBoard.ts`, `web/src/lib/scriptStoryboardDowngrade.ts`, `web/src/components/storyboard/StoryboardListPanel.tsx` — write / clear the pointer

## Tests

- `StoryboardLinkControl.test.tsx` — the reload case: a script loaded with a persisted `storyboardId` shows *Open storyboard*, and one without it shows *Create storyboard*. Verified failing when the selector is stubbed to `null` (2 of 4 red), then restored.
- `useScriptServerSync.test.tsx` — the loaded back-pointer lands in the store and rides the next save.
- `scriptStoryboardDowngrade.test.ts` — board deletion clears the pointer in the store and on the server, and never throws when the list or the write fails.
- `script-storyboard-link-tools.test.ts` — extract writes the pointer and `get_script` resolves the board with `Storyboard.listByUser` never called (verified failing when a scan is reinstated, then restored); derive writes it; both report a failed second write and leave the script unlinked with the board's forward link intact; a pointer at a deleted board reports "no longer available".

## Verification

| Command | Result |
|---|---|
| `npm run build:packages` | 56/56 successful |
| `npm run test --workspace=packages/agents` | 193 files, 2877 passed, 1 skipped |
| `cd web && npx tsc --noEmit -p tsconfig.json` | clean apart from pre-existing `TS2307`/`TS7006` from unresolvable deps in this sandbox |
| `cd web && npx jest` | 1116 files, 12910 passed |
| `npm run typecheck` | web and electron clean; mobile fails only on its own missing dependency tree (no `mobile/node_modules` here) |
| `npm run lint` | exit 0, warnings only |

The known false green was avoided: `@oxlint/plugins` is not installed in this sandbox, so `.oxlintrc.anti-slop-enforced.json` silently fails to load. The package was fetched and extracted locally and `npm run lint:anti-slop:enforced` then ran for real — 0 errors. The diff also contains no `...(cond ? {…} : {})`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qg4JML6CFGtajqVticjmEt)_