### PR TITLE
fix(agents): escape the NUL separator instead of embedding the byte

### DIFF
--- a/packages/agents/src/capabilities/scripts.ts
+++ b/packages/agents/src/capabilities/scripts.ts
@@ -1225,7 +1225,7 @@ function normalizeDirectedShots(
     };
   }
 
-  const key = (ids: readonly string[]): string => ids.join(" ");
+  const key = (ids: readonly string[]): string => ids.join("\u0000");
   const byKey = new Map(
     scaffoldShots.map((shot) => [key(shot.script_line_ids ?? []), shot])
   );


### PR DESCRIPTION
## Problem

`packages/agents/src/capabilities/scripts.ts:1228` joins shot ids with a **literal NUL character** rather than an escape, so the source file carries a raw control byte:

```
const key = (ids: readonly string[]): string => ids.join("<U+0000>");
```

The file had zero NUL bytes before #4952 and one after it, so the byte came in with that change.

This is the trap AGENTS.md names under "Claims, Checks, and Measurements" — a `` written as the byte it denotes previously got a `.ts` file staged as **binary**.

## Why it hasn't bitten yet

Measured rather than assumed: the byte is at offset 40559, past git's 8000-byte binary-sniff window, so git still diffs the file as text and both GNU `grep` and ripgrep still search it. That is the only thing keeping it benign — any edit that moves the byte earlier in the file flips it to binary and takes the diff and code review with it.

## Change

One character: the literal byte becomes the `` escape. Runtime behavior is identical — the joined separator is still U+0000, so existing dedup keys are unchanged.

## Testing

- `npm run build:packages` → 56/56 successful
- `npx vitest run --root packages/agents tests/script-storyboard-link-tools.test.ts` → 10 passed (the suite covering the code that builds this key)
- Byte count on the file after the edit → 0 NUL bytes

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qg4JML6CFGtajqVticjmEt)_