### PR TITLE
feat(agents): assemble a linked board through the joint timeline

### DIFF
--- a/packages/agents/src/capabilities/scripts.ts
+++ b/packages/agents/src/capabilities/scripts.ts
@@ -704,7 +704,8 @@ const assembleScriptTimeline: CapabilityExport = {
     const { row, doc } = handle;
 
     const { Script, TimelineSequence } = await import("@nodetool-ai/models");
-    const { buildScriptTimeline } = await import("@nodetool-ai/timeline");
+    const { buildScriptTimeline, foreignTimelineParts } =
+      await import("@nodetool-ai/timeline");
 
     const assembled = buildScriptTimeline({
       scriptId: row.id,
@@ -738,19 +739,12 @@ const assembleScriptTimeline: CapabilityExport = {
     if (reuse) {
       // Re-assembling replaces this script's voiceover track and clips, and
       // leaves everything another surface put in the sequence alone.
-      const previous = reuse.toDocument();
-      const foreignClips = previous.clips.filter((c) => c.scriptId !== row.id);
-      const scriptTrackIds = new Set(
-        previous.clips
-          .filter((c) => c.scriptId === row.id)
-          .map((c) => c.trackId)
+      const foreign = foreignTimelineParts(
+        reuse.toDocument(),
+        (clip) => clip.scriptId === row.id
       );
-      const foreignTrackIds = new Set(foreignClips.map((c) => c.trackId));
-      const foreignTracks = previous.tracks.filter(
-        (t) => foreignTrackIds.has(t.id) || !scriptTrackIds.has(t.id)
-      );
-      tracks = [...assembled.tracks, ...foreignTracks];
-      clips = [...assembled.clips, ...foreignClips];
+      tracks = [...assembled.tracks, ...foreign.tracks];
+      clips = [...assembled.clips, ...foreign.clips];
       durationMs = clips.reduce(
         (end, c) => Math.max(end, c.startMs + c.durationMs),
         0

--- a/packages/agents/src/capabilities/storyboards.specs.ts
+++ b/packages/agents/src/capabilities/storyboards.specs.ts
@@ -243,9 +243,12 @@ export const assembleStoryboardTimelineSpec: CapabilitySpec = {
     "Lay a storyboard's rendered clips end to end into a timeline sequence and " +
     "save it, without building a workflow. Clips keep their link to the shot " +
     "they came from, and the screenplay's narration and music become draft " +
-    "audio clips the timeline can generate on demand. Shots with no rendered " +
-    "clip are skipped and listed. Re-running rebuilds the same sequence in " +
-    "place. Validate the result with validate_timeline before rendering.",
+    "audio clips the timeline can generate on demand. When the board links a " +
+    "script, each shot is instead as long as the takes it covers and every " +
+    "voiced line gets its own voiceover clip. Shots with no rendered clip, " +
+    "and lines with no take, are skipped and listed. Re-running rebuilds the " +
+    "same sequence in place, keeping tracks the board does not own. Validate " +
+    "the result with validate_timeline before rendering.",
   inputSchema: ASSEMBLE_STORYBOARD_TIMELINE_SCHEMA,
   category: "write",
   userMessage: (params) =>

--- a/packages/agents/src/capabilities/storyboards.ts
+++ b/packages/agents/src/capabilities/storyboards.ts
@@ -33,6 +33,7 @@ import type {
   Shot,
   VideoRef
 } from "@nodetool-ai/protocol";
+import type { ScriptAssemblyInput } from "@nodetool-ai/timeline";
 import type {
   CapabilityExport,
   CapabilityModule,
@@ -145,6 +146,27 @@ async function loadLinkedScript(
   const row = await Script.findById(scriptId);
   if (!row || row.user_id !== userId) return null;
   return row.toDocument();
+}
+
+/**
+ * The linked script as the joint assembler wants it, or `null` when nothing
+ * links, the script is gone, or reading it failed. Never throws: a broken link
+ * downgrades the assemble to the unlinked path with a warning (design §1.3).
+ */
+async function loadLinkedAssemblyScript(
+  scriptId: string,
+  userId: string | undefined
+): Promise<ScriptAssemblyInput | null> {
+  try {
+    const { Script } = await import("@nodetool-ai/models");
+    const row = await Script.findById(scriptId);
+    if (!row || row.user_id !== userId) return null;
+    const doc = row.toDocument();
+    return { scriptId, cast: doc.cast, sections: doc.sections };
+  } catch {
+    // A link that cannot be read is a link that is not there.
+    return null;
+  }
 }
 
 /**
@@ -847,27 +869,51 @@ const assembleStoryboardTimeline: CapabilityExport = {
 
     const { Storyboard, TimelineSequence } =
       await import("@nodetool-ai/models");
-    const { buildStoryboardTimeline } = await import("@nodetool-ai/timeline");
+    const {
+      buildLinkedTimeline,
+      buildStoryboardTimeline,
+      foreignTimelineParts
+    } = await import("@nodetool-ai/timeline");
 
-    const assembled = buildStoryboardTimeline({
-      boardId: row.id,
-      shots: doc.shots,
-      narration: doc.screenplay?.narration,
-      musicPrompt: doc.screenplay?.music_prompt
-    });
+    // A board that links a script is cut against the words: shot lengths come
+    // from the takes and every voiced line gets its own clip. A link pointing
+    // at a script that is gone is a warning, not a failure — the board still
+    // assembles on its own (design §1.3).
+    const scriptId = doc.screenplay?.script_id ?? null;
+    const script = scriptId
+      ? await loadLinkedAssemblyScript(scriptId, context.userId)
+      : null;
+    const warnings: string[] = [];
+    if (scriptId && !script) {
+      warnings.push(
+        `Script ${scriptId} is linked but could not be loaded, so the board was assembled on its own.`
+      );
+    }
+
+    const assembled = script
+      ? buildLinkedTimeline({
+          boardId: row.id,
+          shots: doc.shots,
+          musicPrompt: doc.screenplay?.music_prompt,
+          script
+        })
+      : buildStoryboardTimeline({
+          boardId: row.id,
+          shots: doc.shots,
+          narration: doc.screenplay?.narration,
+          musicPrompt: doc.screenplay?.music_prompt
+        });
+    const skippedLineIds =
+      "skippedLineIds" in assembled ? assembled.skippedLineIds : [];
     if (assembled.clips.length === 0) {
       return {
         error:
           "No shot has a rendered clip, so there is nothing to assemble. Run render_storyboard_stills, then render_storyboard_clips.",
-        skipped_shot_ids: assembled.skippedShotIds
+        skipped_shot_ids: assembled.skippedShotIds,
+        skipped_line_ids: skippedLineIds
       };
     }
 
-    const document = {
-      tracks: assembled.tracks,
-      clips: assembled.clips,
-      markers: []
-    };
     const { width, height } = frameSize(doc.aspectRatio || "16:9");
     const fps = Math.max(1, Math.min(Number(params["fps"]) || 30, 120));
     const name =
@@ -876,24 +922,51 @@ const assembleStoryboardTimeline: CapabilityExport = {
         : row.name;
 
     // Re-assembling replaces the board's existing cut rather than leaving a
-    // trail of orphan sequences behind it.
+    // trail of orphan sequences behind it — and rewrites only what this board
+    // (and, when linked, this script) owns.
     const existing = row.timeline_id
       ? await TimelineSequence.findById(row.timeline_id)
       : null;
+    const reuse =
+      existing && existing.user_id === context.userId ? existing : null;
+
+    let tracks = assembled.tracks;
+    let clips = assembled.clips;
+    let durationMs = assembled.durationMs;
+    const previous = reuse?.toDocument();
+    if (previous) {
+      const foreign = foreignTimelineParts(
+        previous,
+        (clip) =>
+          clip.storyboardBoardId === row.id ||
+          (!!scriptId && clip.scriptId === scriptId)
+      );
+      tracks = [...assembled.tracks, ...foreign.tracks];
+      clips = [...assembled.clips, ...foreign.clips];
+      durationMs = clips.reduce(
+        (end, clip) => Math.max(end, clip.startMs + clip.durationMs),
+        0
+      );
+    }
+
     const sequence =
-      existing && existing.user_id === context.userId
-        ? existing
-        : new TimelineSequence({
-            user_id: context.userId,
-            project_id: row.project_id,
-            name
-          });
+      reuse ??
+      new TimelineSequence({
+        user_id: context.userId,
+        project_id: row.project_id,
+        name
+      });
     sequence.name = name;
     sequence.fps = fps;
     sequence.width = width;
     sequence.height = height;
-    sequence.duration_ms = assembled.durationMs;
-    sequence.fromDocument(document);
+    sequence.duration_ms = durationMs;
+    sequence.fromDocument({
+      ...previous,
+      tracks,
+      clips,
+      markers: previous ? previous.markers : []
+    });
     await sequence.save();
 
     if (row.timeline_id !== sequence.id) {
@@ -909,10 +982,13 @@ const assembleStoryboardTimeline: CapabilityExport = {
       fps,
       width,
       height,
-      duration_ms: assembled.durationMs,
-      clip_count: assembled.clips.length,
-      track_count: assembled.tracks.length,
-      skipped_shot_ids: assembled.skippedShotIds
+      duration_ms: durationMs,
+      clip_count: clips.length,
+      track_count: tracks.length,
+      script_id: script ? scriptId : null,
+      skipped_shot_ids: assembled.skippedShotIds,
+      skipped_line_ids: skippedLineIds,
+      ...(warnings.length ? { warnings } : {})
     };
   }
 };

--- a/packages/agents/src/capabilities/storyboards.ts
+++ b/packages/agents/src/capabilities/storyboards.ts
@@ -975,7 +975,7 @@ const assembleStoryboardTimeline: CapabilityExport = {
       });
     }
 
-    return {
+    const result: Record<string, unknown> = {
       ok: true,
       timeline_id: sequence.id,
       name: sequence.name,
@@ -987,9 +987,12 @@ const assembleStoryboardTimeline: CapabilityExport = {
       track_count: tracks.length,
       script_id: script ? scriptId : null,
       skipped_shot_ids: assembled.skippedShotIds,
-      skipped_line_ids: skippedLineIds,
-      ...(warnings.length ? { warnings } : {})
+      skipped_line_ids: skippedLineIds
     };
+    if (warnings.length) {
+      result.warnings = warnings;
+    }
+    return result;
   }
 };
 

--- a/packages/agents/tests/capabilities-storyboards.test.ts
+++ b/packages/agents/tests/capabilities-storyboards.test.ts
@@ -13,7 +13,9 @@ import type { ProcessingContext } from "@nodetool-ai/runtime";
 import {
   Asset,
   ModelObserver,
+  Script,
   Storyboard,
+  TimelineSequence,
   initTestDb
 } from "@nodetool-ai/models";
 import type { Shot } from "@nodetool-ai/protocol";
@@ -96,6 +98,67 @@ async function makeBoard(
     })
   });
 }
+
+/** A shot that assembles: rendered, with a persisted clip asset. */
+const renderedShot = (
+  id: string,
+  index: number,
+  scriptLineIds?: string[]
+): Shot =>
+  shot({
+    id,
+    index,
+    status: "rendered",
+    clip: { type: "video", asset_id: `clip-${id}` },
+    ...(scriptLineIds ? { script_line_ids: scriptLineIds } : {})
+  });
+
+/** Two voiced lines, 1200ms and 800ms of audio. */
+async function makeVoicedScript(): Promise<Script> {
+  const take = (lineId: string, durationMs: number) => ({
+    id: `take-${lineId}`,
+    assetId: `asset-${lineId}`,
+    durationMs,
+    words: [{ word: lineId, startMs: 0, endMs: durationMs }],
+    textSnapshot: `text of ${lineId}`,
+    voiceSnapshot: null,
+    createdAt: "2026-01-01T00:00:00.000Z"
+  });
+  const line = (lineId: string, durationMs: number) => ({
+    id: lineId,
+    speakerId: "sp1",
+    text: `text of ${lineId}`,
+    currentTakeId: `take-${lineId}`,
+    takes: [take(lineId, durationMs)]
+  });
+  return Script.create<Script>({
+    user_id: "u1",
+    project_id: "default",
+    name: "Script",
+    document: JSON.stringify({
+      cast: [
+        {
+          id: "sp1",
+          name: "Narrator",
+          voice: { provider: "openai", model: "tts-1", voice: "alloy" }
+        }
+      ],
+      sections: [
+        {
+          id: "sec1",
+          title: "Main",
+          lines: [line("l1", 1200), line("l2", 800)]
+        }
+      ]
+    })
+  });
+}
+
+const sequenceOf = async (id: string): Promise<TimelineSequence> => {
+  const row = await TimelineSequence.findById(id);
+  if (!row) throw new Error(`No sequence ${id}`);
+  return row;
+};
 
 /** Every capability paired with the `Tool` the belt builds for it. */
 const PAIRS: Array<[string, () => Tool]> = [
@@ -282,6 +345,142 @@ describe("storyboards capability behaviour", () => {
       width: 1920,
       height: 1080
     });
+  });
+
+  it("cuts a linked board against the script's takes", async () => {
+    const script = await makeVoicedScript();
+    const board = await makeBoard(
+      [renderedShot("s1", 0, ["l1"]), renderedShot("s2", 1, ["l2"])],
+      { screenplay: { script_id: script.id } }
+    );
+    const context = ctx();
+
+    const assembled = (await run(context).invoke(
+      "assemble_storyboard_timeline",
+      { storyboard_id: board.id }
+    )) as {
+      ok: boolean;
+      timeline_id: string;
+      script_id: string | null;
+      duration_ms: number;
+      skipped_line_ids: string[];
+    };
+    expect(assembled).toMatchObject({
+      ok: true,
+      script_id: script.id,
+      skipped_line_ids: []
+    });
+    // Shot lengths come from the takes (1200 + 800), not DEFAULT_SHOT_MS.
+    expect(assembled.duration_ms).toBe(2000);
+
+    const document = (await sequenceOf(assembled.timeline_id)).toDocument();
+    expect(document.tracks.map((t) => t.name)).toEqual(["Shots", "Voiceover"]);
+    const voiceover = document.clips.filter((c) => c.mediaType === "audio");
+    expect(voiceover.map((c) => [c.scriptLineId, c.storyboardShotId])).toEqual([
+      ["l1", "s1"],
+      ["l2", "s2"]
+    ]);
+    expect(voiceover.every((c) => c.scriptId === script.id)).toBe(true);
+  });
+
+  it("leaves an unlinked board on the storyboard-only cut", async () => {
+    const board = await makeBoard([renderedShot("s1", 0)], {
+      screenplay: { narration: "A quiet town at dusk." }
+    });
+    const context = ctx();
+
+    const assembled = (await run(context).invoke(
+      "assemble_storyboard_timeline",
+      { storyboard_id: board.id }
+    )) as { timeline_id: string; script_id: string | null };
+    expect(assembled.script_id).toBeNull();
+
+    const document = (await sequenceOf(assembled.timeline_id)).toDocument();
+    expect(document.tracks.map((t) => t.name)).toEqual(["Shots", "Narration"]);
+    expect(
+      document.clips.some((c) => c.prompt === "A quiet town at dusk.")
+    ).toBe(true);
+  });
+
+  it("falls back to the unlinked cut when the linked script is gone", async () => {
+    const board = await makeBoard([renderedShot("s1", 0, ["l1"])], {
+      screenplay: { script_id: "sc-deleted" }
+    });
+
+    const assembled = (await run(ctx()).invoke("assemble_storyboard_timeline", {
+      storyboard_id: board.id
+    })) as {
+      ok: boolean;
+      script_id: string | null;
+      warnings?: string[];
+      timeline_id: string;
+    };
+    expect(assembled.ok).toBe(true);
+    expect(assembled.script_id).toBeNull();
+    expect(assembled.warnings?.[0]).toContain("sc-deleted");
+
+    const document = (await sequenceOf(assembled.timeline_id)).toDocument();
+    expect(document.tracks.map((t) => t.name)).toEqual(["Shots"]);
+  });
+
+  it("keeps tracks the board does not own when re-assembling", async () => {
+    const script = await makeVoicedScript();
+    const board = await makeBoard([renderedShot("s1", 0, ["l1"])], {
+      screenplay: { script_id: script.id }
+    });
+    const context = ctx();
+
+    const first = (await run(context).invoke("assemble_storyboard_timeline", {
+      storyboard_id: board.id
+    })) as { timeline_id: string };
+
+    // Something else — the editor, another document — adds a track.
+    const sequence = await sequenceOf(first.timeline_id);
+    const previous = sequence.toDocument();
+    const foreignTrack = {
+      id: "t-foreign",
+      name: "Sound design",
+      type: "audio" as const,
+      index: 9,
+      visible: true,
+      locked: false
+    };
+    sequence.fromDocument({
+      ...previous,
+      tracks: [...previous.tracks, foreignTrack],
+      clips: [
+        ...previous.clips,
+        {
+          ...previous.clips[0],
+          id: "c-foreign",
+          trackId: "t-foreign",
+          name: "Wind",
+          scriptId: undefined,
+          storyboardBoardId: undefined,
+          storyboardShotId: undefined
+        }
+      ]
+    });
+    await sequence.save();
+
+    const second = (await run(context).invoke("assemble_storyboard_timeline", {
+      storyboard_id: board.id
+    })) as { timeline_id: string };
+    expect(second.timeline_id).toBe(first.timeline_id);
+
+    const document = (await sequenceOf(first.timeline_id)).toDocument();
+    expect(document.tracks.map((t) => t.name)).toContain("Sound design");
+    expect(document.clips.filter((c) => c.name === "Wind")).toHaveLength(1);
+    // The board's own clips were rewritten, not doubled: one shot clip and
+    // one voiceover clip for the single linked line.
+    expect(
+      document.clips.filter((c) => c.storyboardShotId === "s1").length
+    ).toBe(2);
+    expect(document.tracks.map((t) => t.name)).toEqual([
+      "Shots",
+      "Voiceover",
+      "Sound design"
+    ]);
   });
 
   it("adds and reorders shots, and records an op naming a shot the board lacks", async () => {

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -11,6 +11,7 @@ export * from "./script.js";
 export * from "./storyboard.js";
 export * from "./script-link.js";
 export * from "./linked.js";
+export * from "./reassemble.js";
 export * from "./splitClip.js";
 export * from "./trimClip.js";
 export * from "./sourceRate.js";

--- a/packages/timeline/src/reassemble.ts
+++ b/packages/timeline/src/reassemble.ts
@@ -1,0 +1,44 @@
+/**
+ * What a re-assemble must not throw away.
+ *
+ * Assembling a script or a board into a sequence that already exists rewrites
+ * only what that document owns. Anything another surface put in the sequence —
+ * a second script's voiceover, a music bed the editor dropped in, an empty
+ * track someone made room with — survives, because the sequence is a shared
+ * place and only the owner's clips are being regenerated.
+ *
+ * The rule is one predicate plus one track question, and both the script
+ * assemble and the storyboard assemble ask it identically, so it lives here
+ * rather than twice in `packages/agents`.
+ */
+
+import type { TimelineClip, TimelineTrack } from "./types.js";
+
+export interface TimelineParts {
+  tracks: TimelineTrack[];
+  clips: TimelineClip[];
+}
+
+/**
+ * The part of `previous` a re-assemble keeps, given which clips the assembling
+ * document owns.
+ *
+ * Clips: every clip the caller does not own. Tracks: every track that still
+ * holds one of those clips, plus every track that never held an owned clip —
+ * so an empty track the editor added stays, while the track the last assemble
+ * wrote its own clips onto is dropped and rebuilt.
+ */
+export function foreignTimelineParts(
+  previous: TimelineParts,
+  owns: (clip: TimelineClip) => boolean
+): TimelineParts {
+  const clips = previous.clips.filter((clip) => !owns(clip));
+  const ownedTrackIds = new Set(
+    previous.clips.filter(owns).map((clip) => clip.trackId)
+  );
+  const foreignTrackIds = new Set(clips.map((clip) => clip.trackId));
+  const tracks = previous.tracks.filter(
+    (track) => foreignTrackIds.has(track.id) || !ownedTrackIds.has(track.id)
+  );
+  return { tracks, clips };
+}

--- a/packages/timeline/tests/reassemble.test.ts
+++ b/packages/timeline/tests/reassemble.test.ts
@@ -1,0 +1,90 @@
+/**
+ * What a re-assemble keeps: everything the assembling document does not own.
+ */
+
+import { describe, it, expect } from "vitest";
+import { makeClip, makeTrack } from "../src/defaults.js";
+import { foreignTimelineParts } from "../src/reassemble.js";
+import type { TimelineClip } from "../src/types.js";
+
+const track = (name: string, index: number) =>
+  makeTrack({ type: "audio", name, index });
+
+const clip = (trackId: string, overrides: Partial<TimelineClip> = {}) =>
+  makeClip({
+    trackId,
+    name: "clip",
+    startMs: 0,
+    durationMs: 1000,
+    mediaType: "audio",
+    sourceType: "imported",
+    versions: [],
+    ...overrides
+  });
+
+describe("foreignTimelineParts", () => {
+  it("drops the owner's clips and the tracks that only held them", () => {
+    const mine = track("Voiceover", 0);
+    const theirs = track("Music", 1);
+    const previous = {
+      tracks: [mine, theirs],
+      clips: [
+        clip(mine.id, { scriptId: "sc-1" }),
+        clip(theirs.id, { scriptId: "sc-2" })
+      ]
+    };
+
+    const foreign = foreignTimelineParts(
+      previous,
+      (c) => c.scriptId === "sc-1"
+    );
+
+    expect(foreign.tracks.map((t) => t.name)).toEqual(["Music"]);
+    expect(foreign.clips.map((c) => c.scriptId)).toEqual(["sc-2"]);
+  });
+
+  it("keeps a track that carries both an owned and a foreign clip", () => {
+    const shared = track("Shared", 0);
+    const previous = {
+      tracks: [shared],
+      clips: [
+        clip(shared.id, { scriptId: "sc-1" }),
+        clip(shared.id, { scriptId: "sc-2" })
+      ]
+    };
+
+    const foreign = foreignTimelineParts(
+      previous,
+      (c) => c.scriptId === "sc-1"
+    );
+
+    expect(foreign.tracks).toHaveLength(1);
+    expect(foreign.clips).toHaveLength(1);
+  });
+
+  it("keeps an empty track the editor added", () => {
+    const mine = track("Voiceover", 0);
+    const empty = track("Room tone", 1);
+    const previous = {
+      tracks: [mine, empty],
+      clips: [clip(mine.id, { scriptId: "sc-1" })]
+    };
+
+    const foreign = foreignTimelineParts(
+      previous,
+      (c) => c.scriptId === "sc-1"
+    );
+
+    expect(foreign.tracks.map((t) => t.name)).toEqual(["Room tone"]);
+    expect(foreign.clips).toEqual([]);
+  });
+
+  it("keeps everything when the owner has nothing in the sequence", () => {
+    const other = track("Music", 0);
+    const previous = { tracks: [other], clips: [clip(other.id)] };
+
+    const foreign = foreignTimelineParts(previous, () => false);
+
+    expect(foreign).toEqual(previous);
+  });
+});


### PR DESCRIPTION
Phase 3 "Assemble switch" from `docs/script-storyboard-link/tasks.md`, headless half. The web half is a separate PR.

`buildLinkedTimeline` has existed and been tested since #4947 with nothing calling it. This wires it into the one tool that assembles a board.

## Changes

- `assemble_storyboard_timeline` reads the board's `script_id` (design §3.2). When one is set and the script loads, the cut comes from `buildLinkedTimeline` — shots as long as the takes they cover, one clip per voiced line. The result reports `skipped_line_ids` beside the existing `skipped_shot_ids`, plus `script_id`.
- An unlinked board takes the same `buildStoryboardTimeline` path as before. A link pointing at a deleted or unreadable script degrades to the unlinked path with a warning rather than throwing (design §1.3).
- Re-assembling in place now keeps every clip this board — and, when linked, this script — does not own, the tracks holding them, and any empty track the editor added. It previously replaced the whole document, clobbering foreign tracks. The partition rule `assemble_script_timeline` had written out by hand moves to `@nodetool-ai/timeline` as `foreignTimelineParts`, and both callers use it.
- No web changes. `buildStoryboardTimeline` and `buildScriptTimeline` are untouched.

## Tests

New cases in `packages/agents/tests/capabilities-storyboards.test.ts`: linked cut (take-derived 2000ms duration, both linkage key families on the voiceover clips), unlinked cut unchanged, missing-script fallback with warning, foreign-track survival across a re-assemble. The partition rule itself is covered in `packages/timeline/tests/reassemble.test.ts`.

- `npm run test --workspace=packages/timeline` — 23 files, 252 tests, passing.
- `npm run test --workspace=packages/agents` — 191/193 files passing. The two failures are 60s/30s timeouts in `tests/codeact-prompt-drift.test.ts` and `tests/dsl-workflow-authoring.test.ts`, hit while a package build ran concurrently in the same worktree; re-run alone they pass (2 files, 44 tests). Neither touches anything in this diff.
- `npx oxlint packages/agents/src packages/timeline/src` — clean, three pre-existing warnings in untouched files.
- Falsifiability: replacing the ownership predicate with `() => true` turns the foreign-track test red; restored after.

## Caveats

- `packages/agents/src/capabilities/{storyboards,scripts}.ts` already fail `prettier --check` on `main`; not reformatted wholesale here. The new test file is prettier-clean.
- The `tasks.md` checkbox stays unticked until the web half lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_012nRg3PsMbzt4fHSAU7dp4b)_