### PR TITLE
chore(cli): put the script-storyboard link on the harness registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,6 +432,7 @@ reference is the [CLI](#cli) section below, plus [docs/cli.md](docs/cli.md).
 | Run a workflow (id, JSON, or DSL `.ts`) | `nodetool run <file>` / `nodetool workflows run <id> [--params …]` | `run_workflow`, `start_background_job` | varies |
 | Map changed files → minimal workspaces to rebuild/test | `nodetool affected [--base main]` | — | instant |
 | Author/inspect a graph against the live registry | — | `create_workflow`, `search_nodes`, `list_nodes`, `get_node_info`, `get_example_workflow`, `export_workflow_digraph` | — |
+| Check a script↔storyboard link (extract, scaffold, joint assemble) | no command of its own — the pure-function suites the `script-storyboard-link` harness entry names, run by `harness gate` on diffs touching either surface | `get_storyboard`, `get_script` (link state, drift, orphans), `validate_timeline` on the assembled output | seconds |
 | Jobs & assets | `nodetool jobs …` / `nodetool assets …` | `list_jobs`, `get_job`, `get_job_logs`, `list_assets`, `get_asset` | — |
 | Agent/chat REPL (one unified agent loop, no mode to select) | `nodetool-chat` (`npm run dev:chat`) | — | — |
 | Deploy + remote ops (Docker/SSH/RunPod/GCP/Supabase) | `nodetool deploy <init\|plan\|apply\|status\|logs\|destroy>`; `deploy workflows <sync\|run>`, `deploy database`, `deploy collections` | — | — |

--- a/docs/agentic-video-product.md
+++ b/docs/agentic-video-product.md
@@ -36,10 +36,11 @@ reused NodeTool.
 | Timeline editing | `web/src/components/timeline/TimelineEditor`, `ui_timeline_*` tools |
 | Storyboard → timeline | `useAssembleTimeline` → `buildStoryboardTimeline` (`@nodetool-ai/timeline`) |
 | Script → timeline | `useAssembleScriptTimeline` → `buildScriptTimeline` (`@nodetool-ai/timeline`) |
+| Linked board + script → timeline | `buildLinkedTimeline` (`@nodetool-ai/timeline`) — shot-aligned picture, one voiceover clip per line, no narration draft clip |
 | Agent chat in every editor | `ChatView` + per-document agent panels and bridges |
 | Persistence | tRPC `storyboards` / `scripts` / `timeline` routers, autosave hooks |
 | Cost data | prediction ledger (`nodetool_predictions`) via `costs.dashboard` |
-| Headless QA | `nodetool timeline validate`, `storyboard`/`script` render tools, the tool-loop evals |
+| Headless QA | `nodetool timeline validate`, `storyboard`/`script` render tools, the tool-loop evals, and the `script-storyboard-link` harness selfcheck (`packages/cli/src/harness/registry.ts`) the gate runs on diffs touching either surface |
 
 The Studio module itself is five small files in `web/src/studio/` plus four
 routes in `web/src/index.tsx`. Nothing under `web/src/components/` changed.

--- a/docs/script-editor-concept.md
+++ b/docs/script-editor-concept.md
@@ -156,7 +156,13 @@ The storyboard's assemble move, for audio:
   transcript document (`buildTranscriptDoc`) into a new script resource. Cheap
   to build because the projection already exists, and it closes the loop for
   recorded/imported media: transcribe a recording in the timeline, extract the
-  script, re-voice it with a cast.
+  script, re-voice it with a cast. A storyboard is the second source the same
+  action reads from: *Extract script* on a board projects every shot's dialogue
+  and narration into a linked script and keeps the shot→line ids
+  (`extractScriptFromScreenplay`, [script-storyboard-link/design.md](script-storyboard-link/design.md)
+  §2.1). Timeline and board differ in what they carry back — the transcript
+  brings word timings off real media, the board brings the shot the words
+  belong to — so they stay two projections into one script shape.
 
 ### Relation to the in-timeline transcript
 
@@ -208,12 +214,16 @@ existing editor is a rewrite, not a feature.
    gallery, play-through. The document pane is a plain per-line editor rather
    than the Lexical transcript editor — that reuse is deferred to a later pass.
 2. **To timeline** *(implemented)* — assemble the current takes into a
-   voiceover sequence with `scriptId`/`scriptLineId` linkage keys
-   (`assembleScriptTimeline`, `useAssembleScriptTimeline`, "Send to timeline"),
-   per-line back-sync on re-voice / take switch (`stores/script/timelineSync`),
-   re-assemble in place on structural drift (preserving foreign tracks), and
-   extract-as-script from a timeline transcript (`extractScript`,
-   `useExtractScript`, the transcript panel's "Extract as script").
+   voiceover sequence with `scriptId`/`scriptLineId` linkage keys. The mapping
+   is a pure function in `@nodetool-ai/timeline` (`buildScriptTimeline`) with
+   three callers: the editor button ("Send to timeline",
+   `useAssembleScriptTimeline`), the headless `assemble_script_timeline` tool,
+   and the `ScriptToTimeline` node. Plus per-line back-sync on re-voice / take
+   switch (`stores/script/timelineSync`), re-assemble in place on structural
+   drift (preserving foreign tracks), and extract-as-script from a timeline
+   transcript (`extractScript`, `useExtractScript`, the transcript panel's
+   "Extract as script"). A script that links a storyboard assembles through a
+   different builder — phase 5.
 3. **Automation** *(implemented)* — `ui_script_*` agent tools
    (`scriptAgentBridge`, `useScriptAgentBridge`, `builtin/script`:
    `get_state`, `add_speaker`, `set_speaker_voice`, `add_line`, `set_line_text`,
@@ -232,6 +242,35 @@ existing editor is a rewrite, not a feature.
    surface (`exportScriptSubtitles`). Still open: dialogue-mode rendering,
    provider-native timestamps, audio-only mixdown, and `.nodetool` bundle
    support.
+5. **Storyboard link** — one script and one storyboard describing the same
+   video, keyed to each other, per
+   [script-storyboard-link/prd.md](script-storyboard-link/prd.md). Status by
+   sub-phase:
+   - Link schema + extract *(implemented)* — `script_id` on the screenplay,
+     `script_line_ids` / `script_text_snapshot` / `duration_source` on a shot,
+     the `storyboard_id` back-pointer on the script row, the pure projection
+     (`extractScriptFromScreenplay`, `validateScriptLink` in
+     `@nodetool-ai/protocol` `script-link.ts`), the
+     `extract_script_from_storyboard` tool and `ui_storyboard_extract_script`,
+     *Extract script* / *Open script* / *Open storyboard* in both headers, and
+     the deletion downgrade in both directions.
+   - Derive board from script *(implemented)* — `deriveShotScaffold` pins
+     linkage, order and projected text; the director pass fills in shot
+     content and is refused and retried when it drops or reassigns
+     `script_line_ids`. Exposed as `derive_storyboard_from_script`,
+     `ui_script_derive_storyboard`, and *Create storyboard*.
+   - Audio-led shot timing *(in progress)* — `linkedShotDurationMs` is in
+     `@nodetool-ai/timeline`; the editor and render tools do not read it yet
+     and there is no `duration_source` toggle.
+   - Joint assemble *(in progress)* — `buildLinkedTimeline` is in
+     `@nodetool-ai/timeline` `linked.ts` with tests, including fixtures that
+     pin unlinked `buildStoryboardTimeline` / `buildScriptTimeline` output
+     unchanged. The assemble buttons and headless tools still call the
+     unlinked builders.
+   - Drift, badges, Studio *(not started as UI)* — `shotDialogueDrifted` and
+     `orphanedLineIds` exist and `get_storyboard` / `get_script` report link
+     state, drift and orphans; no badges, no re-project action, no linked
+     Studio flow.
 
 Phase 1 is deliberately shippable alone: a script you can write, cast, voice,
 and listen to is already the ElevenLabs-Studio use case, before any timeline

--- a/docs/script-storyboard-link/design.md
+++ b/docs/script-storyboard-link/design.md
@@ -1,6 +1,9 @@
 # Script ↔ Storyboard Link — Technical Design
 
-> Status: Proposed · Companion: [prd.md](prd.md), [tasks.md](tasks.md).
+> Status: Phase 1 shipped · Phase 2 shipped except audio-led timing (§2.3) ·
+> Phase 3 has `buildLinkedTimeline` (§2.4), not the assemble switch ·
+> Phase 4 has the drift helpers (§2.5) and the tool summaries (§3.2), no UI.
+> Companion: [prd.md](prd.md), [tasks.md](tasks.md).
 
 The design links the two documents with keys and derives everything else. No
 document is merged, no ownership moves: the script keeps words and voice, the

--- a/docs/script-storyboard-link/prd.md
+++ b/docs/script-storyboard-link/prd.md
@@ -1,6 +1,8 @@
 # Script ↔ Storyboard Link — PRD
 
-> Status: Proposed · Owner: matti
+> Status: Phase 1 shipped · Phase 2 shipped except audio-led timing ·
+> Phase 3 has the joint builder, not the assemble switch · Phase 4 has the
+> drift helpers and the tool summaries, no UI · Owner: matti
 >
 > Companion documents: [design.md](design.md) (technical design),
 > [tasks.md](tasks.md) (implementation checklist).

--- a/docs/script-storyboard-link/tasks.md
+++ b/docs/script-storyboard-link/tasks.md
@@ -7,42 +7,42 @@
 
 ## Phase 1 — Link schema + extract script from storyboard
 
-- [ ] **Protocol: link fields.** Add `script_id` to `Screenplay` and
+- [x] **Protocol: link fields.** Add `script_id` to `Screenplay` and
       `script_line_ids`, `script_text_snapshot`, `duration_source` to `Shot`
       in `packages/protocol/src/creative.ts`; mirror in the zod shapes and
       key aliases in `packages/protocol/src/api-schemas/storyboards.ts`.
       Tests: normalization round-trips camelCase aliases; old documents
       parse unchanged.
-- [ ] **Protocol: `script-link.ts`.** `extractScriptFromScreenplay` +
+- [x] **Protocol: `script-link.ts`.** `extractScriptFromScreenplay` +
       `validateScriptLink` per design §2.1/§1.3, with unit tests covering
       speaker matching via `entitiesForShot`, `voice_id` seeding, the
       shot→lines map, duplicate/dangling line references.
-- [ ] **Script back-pointer.** Nullable `storyboard_id` on the `scripts`
+- [x] **Script back-pointer.** Nullable `storyboard_id` on the `scripts`
       table (`packages/models/src/schema/scripts.ts` + migration),
       `scriptResponse`/`patchScriptInput` in
       `packages/protocol/src/api-schemas/scripts.ts`, CAS patch in the
       `scripts` tRPC router.
-- [ ] **Headless tool: `extract_script_from_storyboard`.** In
+- [x] **Headless tool: `extract_script_from_storyboard`.** In
       `packages/agents/src/capabilities/storyboards.ts` (creates script row,
       stamps link, sets back-pointer, `relink` re-projects). Tool-loop eval
       case in `packages/agents/src/evals/surfaces/storyboard.ts`.
-- [ ] **Web: extract + navigation.** `ui_storyboard_extract_script` in
+- [x] **Web: extract + navigation.** `ui_storyboard_extract_script` in
       `web/src/lib/tools/builtin/storyboard.ts`; *Extract script* / *Open
       script* in the storyboard header; *Open storyboard* in the script
       header. Deletion downgrade both directions (design §4).
-- [ ] **Link validation on save.** Wire `validateScriptLink` into the
+- [x] **Link validation on save.** Wire `validateScriptLink` into the
       storyboard normalize/save path; surface issues in both editors.
 
 ## Phase 2 — Derive board from script + audio-led timing
 
-- [ ] **Protocol: `deriveShotScaffold`.** In `script-link.ts` per design
+- [x] **Protocol: `deriveShotScaffold`.** In `script-link.ts` per design
       §2.2, unit-tested (order, one-line-per-shot default, narration vs.
       dialogue projection).
-- [ ] **Director variant.** Scaffold-constrained director pass; normalizer
+- [x] **Director variant.** Scaffold-constrained director pass; normalizer
       rejects responses that drop or reassign `script_line_ids` (retry, then
       fall back to scaffold-only shots). Lives with the existing director
       prompt path used by the storyboard agent.
-- [ ] **Headless tool: `derive_storyboard_from_script`.** In
+- [x] **Headless tool: `derive_storyboard_from_script`.** In
       `packages/agents/src/capabilities/scripts.ts`; no-provider mode emits
       the deterministic scaffold. Eval case in
       `packages/agents/src/evals/surfaces/script.ts`.
@@ -50,13 +50,13 @@
       `packages/timeline/src/script-link.ts` (design §2.3); storyboard
       editor and render tools read it when `duration_source !== "manual"`;
       `ui_storyboard_set_duration_source` toggle + inspector control.
-- [ ] **Web: derive.** `ui_script_derive_storyboard` in
+- [x] **Web: derive.** `ui_script_derive_storyboard` in
       `web/src/lib/tools/builtin/script.ts`; *Create storyboard* button in
       the script editor.
 
 ## Phase 3 — Joint assemble
 
-- [ ] **`buildLinkedTimeline`.** `packages/timeline/src/linked.ts` per
+- [x] **`buildLinkedTimeline`.** `packages/timeline/src/linked.ts` per
       design §2.4. Unit tests: shot-aligned take starts, in-shot offsets
       with pauses, both linkage key families on voiceover clips, narration
       draft clip suppressed, `skippedLineIds`/`skippedShotIds`; regression
@@ -87,12 +87,12 @@
 - [ ] **Studio.** Prompt-first flow derives script + board linked in one
       pass; home groups linked documents into one project card
       (`web/src/studio/`).
-- [ ] **Tool/summary surface.** `get_storyboard` / `get_script` report link
+- [x] **Tool/summary surface.** `get_storyboard` / `get_script` report link
       state, drift, and orphans (design §3.2).
-- [ ] **Harness registry.** Extend the storyboard/script surface entries in
+- [x] **Harness registry.** Extend the storyboard/script surface entries in
       `packages/cli/src/harness/registry.ts` with the new deterministic
       selfchecks; `nodetool harness audit` stays clean.
-- [ ] **Docs.** Update `docs/script-editor-concept.md` (phase table) and
+- [x] **Docs.** Update `docs/script-editor-concept.md` (phase table) and
       `docs/agentic-video-product.md` (reuse table, home cards) to reflect
       the link; move this feature's status lines from Proposed to shipped
       per phase.

--- a/packages/cli/src/harness/registry.ts
+++ b/packages/cli/src/harness/registry.ts
@@ -319,6 +319,29 @@ export const HARNESSES: HarnessEntry[] = [
     }
   },
   {
+    id: "script-storyboard-link",
+    title:
+      "Script ↔ storyboard link (extract, scaffold, joint assemble, link validation)",
+    // No CLI command owns the link: it is pure functions in protocol and
+    // timeline plus the tools that call them. The checked-in suites are the
+    // headless surface — they build a linked document and hand the assembled
+    // timeline to the same validator `nodetool timeline validate` runs.
+    command:
+      "npm run test --workspace=packages/protocol -- script-link && " +
+      "npm run test --workspace=packages/timeline -- script-link linked && " +
+      "npm run test --workspace=packages/execution -- linked-timeline-validate",
+    kind: "static",
+    capabilities: ["no-db"],
+    docs: "docs/script-storyboard-link/design.md § 6",
+    selfcheck: {
+      command:
+        "npm run test --workspace=packages/protocol -- script-link && " +
+        "npm run test --workspace=packages/timeline -- script-link linked && " +
+        "npm run test --workspace=packages/execution -- linked-timeline-validate",
+      cost: "cheap"
+    }
+  },
+  {
     id: "harness-audit",
     title: "Harness coverage audit (this registry)",
     command: "nodetool harness audit [--strict]",
@@ -374,6 +397,7 @@ export const SURFACES: SurfaceEntry[] = [
       "eval"
     ],
     paths: [
+      "packages/timeline/",
       "packages/execution/src/timeline-debug/",
       "packages/cli/src/timeline-debug/",
       "packages/cli/src/commands/timeline-versions.ts",
@@ -421,6 +445,51 @@ export const SURFACES: SurfaceEntry[] = [
       "packages/protocol/src/api-schemas/js-scripts.ts",
       "packages/websocket/src/trpc/routers/js-scripts.ts",
       "packages/websocket/src/routes/js-scripts.ts"
+    ]
+  },
+  {
+    id: "storyboard",
+    title:
+      "Storyboards (shots, keyframes, clips, ui_storyboard_* tools, script link)",
+    harnesses: ["script-storyboard-link", "timeline-validate", "eval"],
+    paths: [
+      "packages/protocol/src/script-link.ts",
+      "packages/protocol/src/api-schemas/storyboards.ts",
+      "packages/timeline/src/storyboard.ts",
+      "packages/timeline/src/script-link.ts",
+      "packages/timeline/src/linked.ts",
+      "packages/agents/src/capabilities/storyboards.ts",
+      "packages/agents/src/capabilities/storyboards.specs.ts",
+      "packages/agents/src/tools/storyboard-render-tools.ts",
+      "packages/agents/src/evals/surfaces/storyboard.ts",
+      "packages/agents/src/evals/surfaces/creative-pipeline.ts",
+      "packages/models/src/schema/storyboards.ts",
+      "packages/websocket/src/trpc/routers/storyboards.ts",
+      "web/src/components/storyboard/",
+      "web/src/lib/tools/builtin/storyboard.ts",
+      "web/src/studio/"
+    ]
+  },
+  {
+    id: "script",
+    title: "Scripts (lines, cast, voicing, ui_script_* tools, storyboard link)",
+    harnesses: ["script-storyboard-link", "timeline-validate", "eval"],
+    paths: [
+      "packages/protocol/src/script-link.ts",
+      "packages/protocol/src/api-schemas/scripts.ts",
+      "packages/timeline/src/script.ts",
+      "packages/timeline/src/script-link.ts",
+      "packages/timeline/src/linked.ts",
+      "packages/agents/src/capabilities/scripts.ts",
+      "packages/agents/src/capabilities/scripts.specs.ts",
+      "packages/agents/src/tools/script-voice-tools.ts",
+      "packages/agents/src/evals/surfaces/script.ts",
+      "packages/agents/src/evals/surfaces/creative-pipeline.ts",
+      "packages/models/src/schema/scripts.ts",
+      "packages/websocket/src/trpc/routers/scripts.ts",
+      "web/src/components/script/",
+      "web/src/lib/tools/builtin/script.ts",
+      "web/src/studio/"
     ]
   },
   {

--- a/packages/cli/tests/harness-registry.test.ts
+++ b/packages/cli/tests/harness-registry.test.ts
@@ -117,6 +117,35 @@ describe("harness gate", () => {
     expect(plan.unmappedFiles).toEqual([]);
   });
 
+  it("maps a script↔storyboard link change onto both surfaces and their selfcheck", () => {
+    const plan = planGate([
+      "packages/protocol/src/script-link.ts",
+      "packages/timeline/src/linked.ts",
+      "packages/agents/src/capabilities/storyboards.ts",
+      "web/src/lib/tools/builtin/script.ts"
+    ]);
+    const surfaces = plan.surfaces.map((s) => s.id);
+    expect(surfaces).toContain("storyboard");
+    expect(surfaces).toContain("script");
+    const check = plan.checks.find(
+      (c) => c.harnessId === "script-storyboard-link"
+    );
+    expect(check).toBeDefined();
+    expect(check!.surfaces.sort()).toEqual(["script", "storyboard"]);
+    // timeline-validate and eval need a target or a model, so they are manual.
+    expect(plan.manual.map((m) => m.harnessId)).toContain("timeline-validate");
+    expect(plan.unmappedFiles).toEqual([]);
+  });
+
+  it("claims every packages/timeline file for the timeline surface", () => {
+    const plan = planGate([
+      "packages/timeline/src/script-link.ts",
+      "packages/timeline/src/render/sceneModel.ts"
+    ]);
+    expect(plan.surfaces.map((s) => s.id)).toContain("timeline");
+    expect(plan.unmappedFiles).toEqual([]);
+  });
+
   it("reports files no surface claims", () => {
     const plan = planGate(["README.md"]);
     expect(plan.unmappedFiles).toEqual(["README.md"]);


### PR DESCRIPTION
Phase 4 "Harness registry" and "Docs" from `docs/script-storyboard-link/tasks.md`.

The link's code had no surface of its own: storyboard and script files were covered incidentally by `web-editor` and `workflow-authoring`, and every file under `packages/timeline/` landed in the gate's unmapped list.

## Registry (`packages/cli/src/harness/registry.ts`)

- Two new surfaces, `storyboard` and `script`, claiming the protocol/timeline/agents/models/websocket/web paths of the link, covered by `script-storyboard-link` + `timeline-validate` + `eval`.
- New harness `script-storyboard-link` with a keyless `cheap` selfcheck. There is no `nodetool storyboard`/`script` command, so it follows the `packs-compile` pattern: `npm run test --workspace=packages/protocol -- script-link && npm run test --workspace=packages/timeline -- script-link linked && npm run test --workspace=packages/execution -- linked-timeline-validate` (47 tests; the last hands the jointly assembled document to the same validator `nodetool timeline validate` runs).
- `packages/timeline/` added to the `timeline` surface, closing the unmapped hole.
- Two `planGate` tests: one asserting a link diff selects the new selfcheck for both surfaces, one asserting no `packages/timeline` file goes unmapped.

## Proving the selfcheck can fail

Injected a real defect rather than mutating an assertion: in `packages/timeline/src/linked.ts`, replaced `linkedShotDurationMs(shot, linesById) ?? shotDurationMs(shot)` with `shotDurationMs(shot)`, dropping audio-led shot timing.

- `nodetool harness gate packages/timeline/src/linked.ts` → `Tests 4 failed | 16 passed`, `Gate: 0/1 selfchecks passed`, `FAIL script-storyboard-link`, exit 1 (captured outside a pipe).
- After `git checkout --` of that file, the same command → `Gate: 1/1 selfchecks passed`, exit 0.

And that the mapping selects it rather than passing vacuously: `harness gate --dry-run --json packages/protocol/src/script-link.ts packages/timeline/src/linked.ts` lists `"harnessId": "script-storyboard-link"` with `"surfaces": ["storyboard","script"]` and `"unmappedFiles": []`.

## Docs

- `docs/script-editor-concept.md`: phase 5 (storyboard link) added with honest per-item status; phase 2 "To timeline" rewritten to name the shared `buildScriptTimeline` and its three callers; the "Reverse import" bullet cross-referenced with the board-side extract.
- `docs/agentic-video-product.md`: a `buildLinkedTimeline` row in the reuse table and the new selfcheck named on the Headless QA row.
- `prd.md` / `design.md` Status lines moved off "Proposed".
- One row added to the AGENTS.md harness table (HARNESS_FIRST rule 4).
- `tasks.md` boxes ticked only for work verified merged on `main`: all of Phase 1; Phase 2 except timing; Phase 3's `buildLinkedTimeline` only; Phase 4's tool/summary surface plus these two items. Assemble switch, back-sync tests, creative-pipeline eval, timing, drift Re-project, badges and Studio stay unticked — they are in flight or not started.

## Tests

- `npm run test --workspace=packages/cli` — 53 files, 629 tests, passing.
- `npm run dev:nodetool -- harness audit` — `13/15 covered, 2 gap(s)`; the two are the pre-existing documented `mobile` and `electron-shell`. `storyboard` and `script` both `ok`.
- `npm run dev:nodetool -- harness gate --base origin/main --dry-run` — this diff touches only `chat-agent`, no unmapped source files.
- `npx oxlint packages/cli/src` and `npx tsc --noEmit -p packages/cli/tsconfig.json` — both clean.

`npm run build:packages` is a precondition for the selfcheck, since `packages/execution`'s test imports `@nodetool-ai/gpu`'s dist — the same assumption the existing `validate:examples` and `app debug` selfchecks make.

---
_Generated by [Claude Code](https://claude.ai/code/session_012nRg3PsMbzt4fHSAU7dp4b)_