### PR TITLE
feat(agents): score the linked script-to-video pipeline

### DIFF
--- a/packages/agents/src/evals/surfaces/creative-pipeline.ts
+++ b/packages/agents/src/evals/surfaces/creative-pipeline.ts
@@ -8,20 +8,36 @@
  * still lose the client's aspect ratio somewhere between them, or assemble a
  * cut that runs twice the length it was commissioned at and call it done.
  *
- * The three creative surfaces are *composed*, not reimplemented: this bridge
- * builds the real {@link createSketchToolBridge}, {@link createStoryboardToolBridge}
- * and {@link createTimelineToolBridge} and merges their tool arrays, so the
- * model drives the same `ui_sketch_*` / `ui_storyboard_*` / `ui_timeline_*`
- * contract those suites already cover, and this file cannot drift from them.
+ * The four creative surfaces are *composed*, not reimplemented: this bridge
+ * builds the real {@link createScriptToolBridge}, {@link createSketchToolBridge},
+ * {@link createStoryboardToolBridge} and {@link createTimelineToolBridge} and
+ * merges their tool arrays, so the model drives the same `ui_script_*` /
+ * `ui_sketch_*` / `ui_storyboard_*` / `ui_timeline_*` contract those suites
+ * already cover, and this file cannot drift from them.
  *
- * Two things are added on top.
+ * Three things are added on top.
  *
  * `ui_storyboard_assemble_timeline` is replaced. The storyboard bridge's own
  * version returns a plausible `sequenceId` and touches nothing, which is fine
  * when only the board is under test and useless here — the handoff *is* the
  * thing being measured. The replacement drives the timeline bridge's own tools
  * to lay one clip per rendered shot, so a later timeline edit acts on the
- * storyboard's output rather than on an unrelated blank sequence.
+ * storyboard's output rather than on an unrelated blank sequence. When the
+ * board was derived from the script it takes the *linked* path instead: the
+ * pure `buildLinkedTimeline` cuts board and script into one sequence — shots
+ * as long as the takes they cover, a voiceover clip per voiced line carrying
+ * both linkage families — and the timeline bridge is reseeded with it, so the
+ * cut the model goes on to edit is the jointly-assembled one.
+ *
+ * `ui_script_derive_storyboard` is replaced for the same reason. The script
+ * bridge's own version scaffolds shots into a board only it can see; the
+ * replacement lays those shots onto the shared storyboard bridge and records
+ * which script lines each covers, which is the link the joint assemble reads.
+ *
+ * `validate_timeline` is the agent-side tool, not a `ui_*` one, and runs the
+ * shipped `validateTimelineSequence` over whatever the timeline now holds. A
+ * cut that assembles is not a cut that validates, and this is the only tool
+ * here that can tell the two apart.
  *
  * The brief and review phases have no shipped `ui_*` surface, so their tools
  * are defined here and named `ui_brief_*` / `ui_review_*`. They are eval
@@ -40,11 +56,21 @@
 
 import { z } from "zod";
 import { parseWithTypeCoercion } from "@nodetool-ai/runtime";
+import type { Shot } from "@nodetool-ai/protocol";
+import { buildLinkedTimeline } from "@nodetool-ai/timeline";
+import {
+  validateTimelineSequence,
+  type TimelineValidation
+} from "@nodetool-ai/execution/timeline-debug";
 import type { HeadlessTool } from "../tool-loop-bridge.js";
 import type {
   HeadlessSurfaceBridge,
   ToolLoopEvalCase
 } from "../tool-loop-eval.js";
+import {
+  createScriptToolBridge,
+  type ScriptBridgeFinalState
+} from "./script.js";
 import {
   createSketchToolBridge,
   type SketchBridgeFinalState
@@ -106,11 +132,22 @@ export interface CreativePipelineFinalState {
   briefReadBeforeWork: boolean;
   concepts: CreativeConcept[];
   chosenConceptId: string | null;
+  script: ScriptBridgeFinalState;
   sketch: SketchBridgeFinalState;
   storyboard: StoryboardBridgeFinalState;
   timeline: TimelineBridgeFinalState;
   /** The replaced assemble tool ran and laid clips into the timeline. */
   timelineAssembled: boolean;
+  /** The board was derived from the script, so the two documents are linked. */
+  scriptLinked: boolean;
+  /** Script lines each board shot covers, keyed by shot id. */
+  scriptLineIdsByShotId: Record<string, string[]>;
+  /** Assembly took the joint path: one cut built from board and script together. */
+  assembledLinked: boolean;
+  /** Lines the joint assemble gave no clip — unvoiced, or on a skipped shot. */
+  skippedLineIds: string[];
+  /** What `validate_timeline` last said about the cut, or null when never run. */
+  timelineValidation: TimelineValidation | null;
   /** Total runtime of the assembled cut, in seconds. */
   cutDurationSeconds: number;
   reviewNotes: ReviewNote[];
@@ -194,7 +231,12 @@ const TIMELINE_MUTATORS = new Set([
 ]);
 
 /** Surface tools that count as "work" for the brief-read-first check. */
-const WORK_PREFIXES = ["ui_sketch_", "ui_storyboard_", "ui_timeline_"];
+const WORK_PREFIXES = [
+  "ui_script_",
+  "ui_sketch_",
+  "ui_storyboard_",
+  "ui_timeline_"
+];
 
 /** One piece of media a live backend actually produced. */
 export interface GeneratedArtifact {
@@ -257,6 +299,7 @@ export function createCreativePipelineBridge(
   const media = initial.media;
   const artifacts: GeneratedArtifact[] = [];
 
+  const script = createScriptToolBridge({ title: brief.product });
   const sketch = createSketchToolBridge({
     name: `${brief.product} — style frame`,
     layers: [{ name: "Background" }]
@@ -266,7 +309,12 @@ export function createCreativePipelineBridge(
     brief: brief.objective,
     aspectRatio: brief.aspectRatio
   });
-  const timeline = createTimelineToolBridge({});
+  // Reassigned by the linked assemble, which reseeds the editor with the cut
+  // `buildLinkedTimeline` produced rather than replaying it through the tools
+  // (a replay would drop the script/board ids every clip carries). Every
+  // timeline tool below dispatches through the current instance, so the swap
+  // is invisible to the model.
+  let timeline = createTimelineToolBridge({});
 
   let briefRead = false;
   let briefReadBeforeWork = false;
@@ -279,6 +327,13 @@ export function createCreativePipelineBridge(
   let toolSeq = 0;
   let editsAfterAssembly = 0;
   let conceptSeq = 0;
+  let scriptLinked = false;
+  let assembledLinked = false;
+  let skippedLineIds: string[] = [];
+  let timelineValidation: TimelineValidation | null = null;
+
+  /** Script lines each board shot covers — the link the joint assemble reads. */
+  const scriptLineIdsByShotId = new Map<string, string[]>();
 
   /** Requested duration per shot id, since the board's snapshot omits it. */
   const shotSeconds = new Map<string, number>();
@@ -289,17 +344,80 @@ export function createCreativePipelineBridge(
     return found;
   };
 
+  interface AssembleResult {
+    sequenceId: string;
+    clipCount: number;
+    skippedShotIds: string[];
+    durationSeconds: number;
+    linked: boolean;
+    skippedLineIds?: string[];
+  }
+
+  /**
+   * The board as the pure assemblers want it: wire `Shot` objects carrying the
+   * rendered clip and the script lines each shot covers. The storyboard bridge
+   * projects its shots for its own answers, so this rebuilds the fields joint
+   * assembly reads from that projection.
+   */
+  function linkedShots(): Shot[] {
+    return storyboard.finalState().shots.map((s) => ({
+      type: "shot",
+      id: s.id,
+      index: s.index,
+      action: s.action,
+      status: s.status,
+      duration_seconds: s.durationSeconds,
+      clip: s.hasClip
+        ? { type: "video" as const, asset_id: `asset_clip_${s.id}` }
+        : undefined,
+      script_line_ids: scriptLineIdsByShotId.get(s.id)
+    }));
+  }
+
+  /**
+   * Cut board and script into one sequence with the shipped
+   * `buildLinkedTimeline`, then reseed the timeline editor with the result.
+   *
+   * Shot length here is the length of the takes the shot covers, so the
+   * {@link RENDER_OVERSHOOT} the unlinked path models does not apply: on a
+   * linked board the audio decides, which is the whole point of the link.
+   */
+  function assembleLinked(): AssembleResult {
+    const shots = linkedShots();
+    const assembled = buildLinkedTimeline({
+      boardId: "board_1",
+      shots,
+      script: script.finalState().assembly
+    });
+    const { fps, width, height } = timeline.finalState();
+    timeline = createTimelineToolBridge({
+      sequence: {
+        fps,
+        width,
+        height,
+        tracks: assembled.tracks,
+        clips: assembled.clips
+      }
+    });
+    timelineAssembled = true;
+    assembledLinked = true;
+    skippedLineIds = assembled.skippedLineIds;
+    return {
+      sequenceId: "seq_1",
+      clipCount: assembled.clips.length,
+      skippedShotIds: assembled.skippedShotIds,
+      skippedLineIds: assembled.skippedLineIds,
+      durationSeconds: assembled.durationMs / 1000,
+      linked: true
+    };
+  }
+
   /**
    * Lay one timeline clip per rendered shot, end to end, by driving the
    * timeline bridge's own tools — so the assembled cut is real state a later
    * trim or delete operates on.
    */
-  async function assembleTimeline(): Promise<{
-    sequenceId: string;
-    clipCount: number;
-    skippedShotIds: string[];
-    durationSeconds: number;
-  }> {
+  async function assembleTimeline(): Promise<AssembleResult> {
     const board = storyboard.finalState();
     const rendered = board.shots.filter((s) => s.hasClip);
     if (rendered.length === 0) {
@@ -307,6 +425,7 @@ export function createCreativePipelineBridge(
         "No shot has a rendered clip yet. Generate at least one clip before assembling the timeline."
       );
     }
+    if (scriptLinked) return assembleLinked();
 
     const addTrack = byName(timeline, "ui_timeline_add_track");
     const generate = byName(timeline, "ui_timeline_generate_clip");
@@ -337,7 +456,8 @@ export function createCreativePipelineBridge(
       sequenceId: "seq_1",
       clipCount: rendered.length,
       skippedShotIds: board.shots.filter((s) => !s.hasClip).map((s) => s.id),
-      durationSeconds: startMs / 1000
+      durationSeconds: startMs / 1000,
+      linked: false
     };
   }
 
@@ -462,19 +582,103 @@ export function createCreativePipelineBridge(
     )
   ];
 
-  // Compose: real surface tools, minus the assemble stub the storyboard bridge
-  // ships (replaced below so the handoff actually moves state).
+  /**
+   * Derive the board from the script and record the link.
+   *
+   * The script bridge's own derive scaffolds shots onto a board only it can
+   * see. This runs that scaffold — so the line→shot mapping is still the pure
+   * `deriveShotScaffold` every surface uses — and then lays each scaffolded
+   * shot onto the shared storyboard bridge, keeping the line ids it covers.
+   * That map is what {@link assembleLinked} reads.
+   */
+  async function deriveStoryboard(args: Record<string, unknown>): Promise<{
+    ok: true;
+    storyboardId: string;
+    shots: { id: string; scriptLineIds: string[]; action: string }[];
+  }> {
+    const derived = (await byName(
+      script,
+      "ui_script_derive_storyboard"
+    ).execute(args)) as {
+      storyboardId: string;
+      shots: { scriptLineIds: string[]; text: string }[];
+    };
+    const addShot = byName(storyboard, "ui_storyboard_add_shot");
+    const placed: { id: string; scriptLineIds: string[]; action: string }[] = [];
+    for (const scaffold of derived.shots) {
+      // The design's headless fallback: with no director pass the shot's
+      // action is the line text it covers, status planned.
+      const action = scaffold.text;
+      const result = (await addShot.execute({ action })) as {
+        shot: { id: string };
+      };
+      scriptLineIdsByShotId.set(result.shot.id, scaffold.scriptLineIds);
+      placed.push({
+        id: result.shot.id,
+        scriptLineIds: scaffold.scriptLineIds,
+        action
+      });
+    }
+    scriptLinked = true;
+    return { ok: true, storyboardId: derived.storyboardId, shots: placed };
+  }
+
+  const deriveTool = tool(
+    "ui_script_derive_storyboard",
+    "Create a storyboard whose shots cover this script's lines and open it: one shot per line in reading order, each carrying the ids of the lines it covers and an action projected from them. The board is linked to the script from here on, so assembling it cuts words and pictures together. Direct or render the shots from the storyboard surface.",
+    z.object({
+      name: z
+        .string()
+        .optional()
+        .describe("Name for the created storyboard. Defaults to the script's.")
+    }),
+    deriveStoryboard
+  );
+
+  const validateTool = tool(
+    "validate_timeline",
+    "Check the assembled sequence without rendering it: tracks and clips a render would refuse, timings that cannot lay out, animation presets that do not exist. Returns errors and warnings. Call it on the delivered cut — a sequence that assembled is not necessarily a sequence that validates.",
+    z.object({}),
+    async () => {
+      const { fps, width, height, documentTracks, documentClips } =
+        timeline.finalState();
+      timelineValidation = validateTimelineSequence(
+        { tracks: documentTracks, clips: documentClips, markers: [] },
+        { fps, width, height }
+      );
+      // `ok` here is the validator's verdict, not "the call succeeded" — a cut
+      // that fails validation is a successful call with a negative answer.
+      return { ...timelineValidation };
+    }
+  );
+
+  // Compose: real surface tools, minus the two the surfaces can only fake in
+  // isolation (assemble and derive, replaced below so the handoffs actually
+  // move state) and the script's own send-to-timeline, which would open a
+  // second sequence nothing else in this bridge can see.
   const surfaceTools: HeadlessTool[] = [
+    ...script.tools.filter(
+      (t) =>
+        t.name !== "ui_script_derive_storyboard" &&
+        t.name !== "ui_script_send_to_timeline"
+    ),
     ...sketch.tools,
     ...storyboard.tools.filter(
       (t) => t.name !== "ui_storyboard_assemble_timeline"
     ),
-    ...timeline.tools
+    // Dispatch by name at call time: the linked assemble swaps the timeline
+    // bridge underneath, and a captured `execute` would keep editing the cut
+    // that was replaced.
+    ...timeline.tools.map((t) => ({
+      ...t,
+      execute: (args: Record<string, unknown>) =>
+        byName(timeline, t.name).execute(args)
+    }))
   ];
 
   const assembleTool = tool(
     "ui_storyboard_assemble_timeline",
-    "Assemble the storyboard's rendered shots into a timeline sequence and open it in the timeline editor. Shot clips are laid end to end in order. Shots without a rendered clip are skipped (returned in skippedShotIds). The delivered clip lengths are what the renderer produced, which is not necessarily what each shot requested.",
+    "Assemble the storyboard's rendered shots into a timeline sequence and open it in the timeline editor. Shot clips are laid end to end in order. Shots without a rendered clip are skipped (returned in skippedShotIds). The delivered clip lengths are what the renderer produced, which is not necessarily what each shot requested. When the board was derived from a script, the cut is assembled jointly instead: each shot runs as long as the takes it covers, every voiced line gets its own voiceover clip, and lines that got none are returned in skippedLineIds.",
     z.object({}),
     async () => {
       const result = await assembleTimeline();
@@ -587,6 +791,8 @@ export function createCreativePipelineBridge(
     ...briefTools,
     ...surfaceTools.map(instrument),
     instrument(assembleTool),
+    instrument(deriveTool),
+    validateTool,
     ...reviewTools
   ];
 
@@ -597,10 +803,16 @@ export function createCreativePipelineBridge(
       briefReadBeforeWork: briefRead && briefReadBeforeWork,
       concepts: [...concepts],
       chosenConceptId,
+      script: script.finalState(),
       sketch: sketch.finalState(),
       storyboard: storyboard.finalState(),
       timeline: timeline.finalState(),
       timelineAssembled,
+      scriptLinked,
+      scriptLineIdsByShotId: Object.fromEntries(scriptLineIdsByShotId),
+      assembledLinked,
+      skippedLineIds: [...skippedLineIds],
+      timelineValidation,
       cutDurationSeconds: cutDurationSeconds(),
       reviewNotes: [...reviewNotes],
       inspectedCut,
@@ -611,6 +823,8 @@ export function createCreativePipelineBridge(
 }
 
 const CREATIVE_PIPELINE_SYSTEM_PROMPT = `You are a creative director running a commissioned video job end to end through UI tools.
+
+A narrated job starts from the words: write the script with the ui_script_* tools, give the cast a voice and voice every line, then call ui_script_derive_storyboard to turn it into a linked board — one shot per line. Rendering and assembly are the same tools as any other job, except that an assembled linked board cuts the words in with the pictures, and validate_timeline checks the sequence that comes out.
 
 Work the job in phases, and finish each before starting the next:
 
@@ -648,6 +862,24 @@ export const ATLAS_BRIEF: CreativeBrief = {
   mustFeature: ["mud"],
   forbid: ["treadmill"],
   deliverable: "One landscape cut for pre-roll, under 8 seconds."
+};
+
+/**
+ * A narrated commission, used by the linked case.
+ *
+ * Its runtime ceiling is generous on purpose: a linked cut is as long as the
+ * voiced takes make it, so a runtime predicate here would score how many words
+ * the model wrote rather than whether it carried the link through.
+ */
+export const TIDEWATCH_BRIEF: CreativeBrief = {
+  client: "Tidewatch Trust",
+  product: "Estuary Restoration",
+  objective: "A narrated piece about a river mouth coming back to life.",
+  aspectRatio: "16:9",
+  maxDurationSeconds: 60,
+  mustFeature: [],
+  forbid: [],
+  deliverable: "One narrated cut, words and pictures assembled together."
 };
 
 const actionsOf = (s: CreativePipelineFinalState) =>
@@ -881,6 +1113,123 @@ The storyboard phase is already done for this job: add the shots that were plann
             test: (s) =>
               s.cutDurationSeconds > 0 &&
               s.cutDurationSeconds <= s.brief.maxDurationSeconds
+          }
+        ]
+      }
+    },
+
+    {
+      // The link is the thing under test, and it is only observable at the
+      // end: a run can call every tool in the right order and still deliver a
+      // cut whose voiceover clips point at nothing, or a board whose shots
+      // lost the lines they cover. So the predicates read the assembled
+      // document — both linkage families on every voiceover clip — rather
+      // than the calls that produced it, and the last one asks the shipped
+      // validator whether the cut would survive a render at all.
+      id: "script-to-linked-cut",
+      description:
+        "Write and voice a script, derive a linked board from it, render it, assemble words and pictures together, and validate the cut",
+      objective:
+        "This is a narrated piece. Write a short narration of at least three lines, give the narrator a voice and voice every line, then derive a storyboard from the script. Render a keyframe and a clip for every shot, assemble the cut, and validate the assembled sequence.",
+      createBridge: () =>
+        createCreativePipelineBridge({ brief: TIDEWATCH_BRIEF }),
+      systemPrompt: CREATIVE_PIPELINE_SYSTEM_PROMPT,
+      expect: {
+        requiredTools: [
+          "ui_script_add_speaker",
+          "ui_script_add_line",
+          "ui_script_derive_storyboard",
+          "ui_storyboard_generate_keyframe",
+          "ui_storyboard_generate_clip",
+          "ui_storyboard_assemble_timeline",
+          "validate_timeline"
+        ],
+        forbiddenTools: ["ui_sketch_generate"],
+        ordering: [
+          ["ui_script_add_line", "ui_script_derive_storyboard"],
+          ["ui_script_derive_storyboard", "ui_storyboard_generate_keyframe"],
+          ["ui_storyboard_generate_keyframe", "ui_storyboard_generate_clip"],
+          ["ui_storyboard_generate_clip", "ui_storyboard_assemble_timeline"],
+          ["ui_storyboard_assemble_timeline", "validate_timeline"]
+        ],
+        noErrorResults: true,
+        // The scripted optimum in the harness test is 15 calls. The ceiling
+        // matches the sibling cases' allowance for state polling.
+        minToolCalls: 10,
+        maxToolCalls: 130,
+        finalState: [
+          {
+            name: "scriptWritten",
+            detail: "fewer than 3 lines of narration were written",
+            test: (s) => s.script.lines.length >= 3
+          },
+          {
+            name: "everyLineVoiced",
+            detail:
+              "a line reached assembly unvoiced, so its words are not in the cut",
+            test: (s) =>
+              s.script.lines.length > 0 &&
+              s.script.lines.every((l) => l.status === "voiced")
+          },
+          {
+            name: "boardDerivedFromScript",
+            detail: "the board was built by hand instead of derived, so the two documents are not linked",
+            test: (s) => s.scriptLinked
+          },
+          {
+            name: "everyShotKeepsItsLines",
+            detail: "a shot covers no script line",
+            test: (s) =>
+              s.storyboard.shots.length > 0 &&
+              s.storyboard.shots.every(
+                (sh) => (s.scriptLineIdsByShotId[sh.id] ?? []).length > 0
+              )
+          },
+          {
+            name: "everyShotRendered",
+            detail: "a shot reached assembly without a rendered clip",
+            test: (s) =>
+              s.storyboard.shots.length > 0 &&
+              s.storyboard.shots.every((sh) => sh.hasClip)
+          },
+          {
+            name: "assembledJointly",
+            detail:
+              "the cut was assembled from the board alone — the words never reached the timeline",
+            test: (s) => s.assembledLinked && s.skippedLineIds.length === 0
+          },
+          {
+            name: "voiceoverClipPerLine",
+            detail: "the cut holds fewer voiceover clips than the script has lines",
+            test: (s) =>
+              s.timeline.documentClips.filter((c) => c.scriptLineId).length >=
+              s.script.lines.length
+          },
+          {
+            name: "clipsCarryBothLinks",
+            detail:
+              "a voiceover clip reached the cut without its script or storyboard ids, so neither editor can sync it back",
+            test: (s) => {
+              const voice = s.timeline.documentClips.filter(
+                (c) => c.scriptLineId
+              );
+              return (
+                voice.length > 0 &&
+                voice.every(
+                  (c) =>
+                    !!c.scriptId && !!c.storyboardBoardId && !!c.storyboardShotId
+                )
+              );
+            }
+          },
+          {
+            name: "cutValidates",
+            detail:
+              "validate_timeline never ran, or the assembled cut does not validate",
+            test: (s) =>
+              s.timelineValidation !== null &&
+              s.timelineValidation.ok &&
+              s.timelineValidation.errors.length === 0
           }
         ]
       }

--- a/packages/agents/src/evals/surfaces/script.ts
+++ b/packages/agents/src/evals/surfaces/script.ts
@@ -28,6 +28,7 @@ import { deriveShotScaffold, joinLineTexts } from "@nodetool-ai/protocol";
 import {
   assembleSubtitleCues,
   formatSubtitles,
+  type ScriptAssemblyInput,
   type SubtitleEntry,
   type SubtitleFormat,
   type SubtitleGranularity
@@ -58,6 +59,9 @@ interface ScriptTakeWord {
 
 /** A recorded voicing of a line. */
 interface ScriptTake {
+  id: string;
+  /** Stands in for the stored audio asset; assembly refuses a take without one. */
+  assetId: string;
   durationMs: number;
   words: ScriptTakeWord[];
 }
@@ -111,10 +115,23 @@ export interface ScriptBridgeFinalState {
     status: "draft" | "voiced" | "stale";
     takeCount: number;
   }[];
+  /**
+   * The script in the shape the pure assemblers take, so a host can hand this
+   * bridge's state straight to `buildScriptTimeline` / `buildLinkedTimeline`.
+   * The reduced `lines` above are what predicates read; this carries the takes
+   * and word timings they drop. The creative-pipeline bridge assembles from it.
+   */
+  assembly: ScriptAssemblyInput;
 }
 
 const MIN_TAKE_DURATION_MS = 500;
 const MS_PER_WORD = 350;
+
+/**
+ * Timestamp stamped on every simulated take. Fixed rather than `now()` so two
+ * runs of the same script produce byte-identical assembly input.
+ */
+const TAKE_CREATED_AT = "2026-01-01T00:00:00.000Z";
 
 function tool<TResult>(
   name: string,
@@ -268,10 +285,15 @@ export function createScriptToolBridge(
       startMs: Math.round(i * perWordMs),
       endMs: Math.round((i + 1) * perWordMs)
     }));
-    line.currentTake = { durationMs, words: timedWords };
+    takeSeq += 1;
+    line.currentTake = {
+      id: `take_${takeSeq}`,
+      assetId: `asset_${takeSeq}`,
+      durationMs,
+      words: timedWords
+    };
     line.status = "voiced";
     line.takeCount += 1;
-    takeSeq += 1;
   };
 
   const canVoice = (line: InternalLine): boolean =>
@@ -569,7 +591,42 @@ export function createScriptToolBridge(
         text: l.text,
         status: l.status,
         takeCount: l.takeCount
-      }))
+      })),
+      assembly: {
+        scriptId: "script_1",
+        cast: cast.map((s) => ({
+          id: s.id,
+          name: s.name,
+          voice: s.voice
+        })),
+        sections: [
+          {
+            id: "section_1",
+            title,
+            lines: lines.map((l) => ({
+              id: l.id,
+              speakerId: l.speakerId,
+              text: l.text,
+              direction: l.direction,
+              pauseAfterMs: l.pauseAfterMs,
+              currentTakeId: l.currentTake?.id ?? null,
+              takes: l.currentTake
+                ? [
+                    {
+                      id: l.currentTake.id,
+                      assetId: l.currentTake.assetId,
+                      durationMs: l.currentTake.durationMs,
+                      words: l.currentTake.words,
+                      textSnapshot: l.text,
+                      voiceSnapshot: effectiveVoice(l),
+                      createdAt: TAKE_CREATED_AT
+                    }
+                  ]
+                : []
+            }))
+          }
+        ]
+      }
     })
   };
 }

--- a/packages/agents/tests/creative-pipeline-tool-loop.test.ts
+++ b/packages/agents/tests/creative-pipeline-tool-loop.test.ts
@@ -22,7 +22,8 @@ import { runToolLoopEval } from "../src/evals/tool-loop-eval.js";
 import {
   createCreativePipelineBridge,
   CREATIVE_PIPELINE_TOOL_LOOP_CASES,
-  LANTERN_BRIEF
+  LANTERN_BRIEF,
+  TIDEWATCH_BRIEF
 } from "../src/evals/surfaces/creative-pipeline.js";
 
 interface ScriptedCall {
@@ -66,9 +67,31 @@ async function call(
   return tool.execute(args);
 }
 
+const linkedBridge = () =>
+  createCreativePipelineBridge({ brief: TIDEWATCH_BRIEF });
+
+/** Write a voiced 2-line narration on a bridge, returning nothing. */
+async function writeNarration(bridge: ReturnType<typeof bridgeOf>) {
+  await call(bridge, "ui_script_add_speaker", {
+    name: "Narrator",
+    voice: { provider: "elevenlabs", model: "eleven_v3", voice: "rachel" }
+  });
+  await call(bridge, "ui_script_add_line", {
+    text: "The river mouth was closed for thirty years.",
+    speakerId: "spk_1"
+  });
+  await call(bridge, "ui_script_add_line", {
+    text: "It reopened in a single winter.",
+    speakerId: "spk_1"
+  });
+  await call(bridge, "ui_script_voice_all");
+}
+
 describe("createCreativePipelineBridge", () => {
-  it("composes all three creative surfaces plus brief and review tools", () => {
+  it("composes all four creative surfaces plus brief and review tools", () => {
     const names = bridgeOf().tools.map((t) => t.name);
+    expect(names.filter((n) => n.startsWith("ui_script_")).length).toBeGreaterThan(5);
+    expect(names).toContain("validate_timeline");
     expect(names.filter((n) => n.startsWith("ui_sketch_")).length).toBeGreaterThan(5);
     expect(names.filter((n) => n.startsWith("ui_storyboard_")).length).toBeGreaterThan(5);
     expect(names.filter((n) => n.startsWith("ui_timeline_")).length).toBeGreaterThan(5);
@@ -187,6 +210,126 @@ describe("createCreativePipelineBridge", () => {
     ]);
   });
 
+  it("lays one shot per script line when the board is derived, keeping the linkage", async () => {
+    const bridge = linkedBridge();
+    await writeNarration(bridge);
+    await call(bridge, "ui_script_derive_storyboard");
+
+    const state = bridge.finalState();
+    expect(state.scriptLinked).toBe(true);
+    expect(state.storyboard.shots).toHaveLength(2);
+    expect(state.scriptLineIdsByShotId).toEqual({
+      shot_1: ["line_1"],
+      shot_2: ["line_2"]
+    });
+  });
+
+  it("assembles words and pictures into one cut once the board is linked", async () => {
+    const bridge = linkedBridge();
+    await writeNarration(bridge);
+    await call(bridge, "ui_script_derive_storyboard");
+    for (const target of ["0", "1"]) {
+      await call(bridge, "ui_storyboard_generate_keyframe", { target });
+      await call(bridge, "ui_storyboard_generate_clip", { target });
+    }
+    const assembled = (await call(
+      bridge,
+      "ui_storyboard_assemble_timeline"
+    )) as { linked: boolean; skippedLineIds: string[] };
+    expect(assembled.linked).toBe(true);
+    expect(assembled.skippedLineIds).toEqual([]);
+
+    const state = bridge.finalState();
+    expect(state.assembledLinked).toBe(true);
+    // Two shot clips plus one voiceover clip per voiced line.
+    expect(state.timeline.clips).toHaveLength(4);
+    const voice = state.timeline.documentClips.filter((c) => c.scriptLineId);
+    expect(voice).toHaveLength(2);
+    for (const clip of voice) {
+      expect(clip.scriptId).toBeTruthy();
+      expect(clip.storyboardBoardId).toBeTruthy();
+      expect(clip.storyboardShotId).toBeTruthy();
+    }
+    // Shot length comes from the takes, not from the render overshoot: 8 words
+    // in the first line and 6 in the second, at 350ms each.
+    expect(state.cutDurationSeconds).toBeCloseTo(14 * 0.35, 3);
+  });
+
+  it("keeps editing the cut the linked assemble produced, not the one it replaced", async () => {
+    const bridge = linkedBridge();
+    await writeNarration(bridge);
+    await call(bridge, "ui_script_derive_storyboard");
+    for (const target of ["0", "1"]) {
+      await call(bridge, "ui_storyboard_generate_keyframe", { target });
+      await call(bridge, "ui_storyboard_generate_clip", { target });
+    }
+    await call(bridge, "ui_storyboard_assemble_timeline");
+
+    const firstClipId = bridge.finalState().timeline.clips[0].id;
+    await call(bridge, "ui_timeline_trim_clip", {
+      target: firstClipId,
+      durationMs: 1000
+    });
+    const trimmed = bridge
+      .finalState()
+      .timeline.clips.find((c) => c.id === firstClipId);
+    expect(trimmed?.durationMs).toBe(1000);
+    expect(bridge.finalState().editsAfterAssembly).toBe(1);
+  });
+
+  it("validates the jointly-assembled cut with the shipped timeline validator", async () => {
+    const bridge = linkedBridge();
+    await writeNarration(bridge);
+    await call(bridge, "ui_script_derive_storyboard");
+    for (const target of ["0", "1"]) {
+      await call(bridge, "ui_storyboard_generate_keyframe", { target });
+      await call(bridge, "ui_storyboard_generate_clip", { target });
+    }
+    await call(bridge, "ui_storyboard_assemble_timeline");
+    const validated = (await call(bridge, "validate_timeline")) as {
+      ok: boolean;
+      errors: unknown[];
+    };
+    expect(validated.errors).toEqual([]);
+    expect(validated.ok).toBe(true);
+    expect(bridge.finalState().timelineValidation?.ok).toBe(true);
+  });
+
+  it("reports a cut the validator refuses rather than calling it green", async () => {
+    // The check has to be able to fail: a clip dragged past the sequence into
+    // negative time is exactly what the validator exists to catch.
+    const bridge = linkedBridge();
+    await writeNarration(bridge);
+    await call(bridge, "ui_script_derive_storyboard");
+    await call(bridge, "ui_storyboard_generate_keyframe", { target: "0" });
+    await call(bridge, "ui_storyboard_generate_clip", { target: "0" });
+    await call(bridge, "ui_storyboard_assemble_timeline");
+    const clipId = bridge.finalState().timeline.clips[0].id;
+    await call(bridge, "ui_timeline_trim_clip", {
+      target: clipId,
+      durationMs: 0
+    });
+    await call(bridge, "validate_timeline");
+    expect(bridge.finalState().timelineValidation?.ok).toBe(false);
+  });
+
+  it("still assembles one clip per rendered shot when no script is linked", async () => {
+    const bridge = bridgeOf();
+    await call(bridge, "ui_storyboard_add_shot", {
+      action: "hands at sunrise",
+      durationSeconds: 4
+    });
+    await call(bridge, "ui_storyboard_generate_keyframe", { target: "0" });
+    await call(bridge, "ui_storyboard_generate_clip", { target: "0" });
+    const assembled = (await call(
+      bridge,
+      "ui_storyboard_assemble_timeline"
+    )) as { linked: boolean };
+    expect(assembled.linked).toBe(false);
+    expect(bridge.finalState().assembledLinked).toBe(false);
+    expect(bridge.finalState().cutDurationSeconds).toBeCloseTo(5.4, 3);
+  });
+
   it("rejects committing to a concept that was never proposed", async () => {
     const bridge = bridgeOf();
     await expect(
@@ -265,9 +408,49 @@ function fullPipelineScript(): ScriptedCall[] {
   return script;
 }
 
+/** A scripted run of the linked case: script → derive → render → cut → check. */
+function linkedPipelineScript(): ScriptedCall[] {
+  const lines = [
+    "The river mouth was closed for thirty years.",
+    "One winter storm opened it again.",
+    "The fish came back before the surveyors did."
+  ];
+  const script: ScriptedCall[] = [
+    { name: "ui_brief_get", args: {} },
+    {
+      name: "ui_script_add_speaker",
+      args: {
+        name: "Narrator",
+        voice: { provider: "elevenlabs", model: "eleven_v3", voice: "rachel" }
+      }
+    }
+  ];
+  for (const text of lines) {
+    script.push({
+      name: "ui_script_add_line",
+      args: { text, speakerId: "spk_1" }
+    });
+  }
+  script.push({ name: "ui_script_voice_all", args: {} });
+  script.push({ name: "ui_script_derive_storyboard", args: {} });
+  lines.forEach((_, i) => {
+    script.push({
+      name: "ui_storyboard_generate_keyframe",
+      args: { target: String(i) }
+    });
+    script.push({
+      name: "ui_storyboard_generate_clip",
+      args: { target: String(i) }
+    });
+  });
+  script.push({ name: "ui_storyboard_assemble_timeline", args: {} });
+  script.push({ name: "validate_timeline", args: {} });
+  return script;
+}
+
 describe("CREATIVE_PIPELINE_TOOL_LOOP_CASES", () => {
-  it("registers three cases, each solvable without configured providers", () => {
-    expect(CREATIVE_PIPELINE_TOOL_LOOP_CASES).toHaveLength(3);
+  it("registers four cases, each solvable without configured providers", () => {
+    expect(CREATIVE_PIPELINE_TOOL_LOOP_CASES).toHaveLength(4);
     for (const c of CREATIVE_PIPELINE_TOOL_LOOP_CASES) {
       // The bridge fakes every generate/render job, so no case depends on a
       // real provider being configured — marking them otherwise would silently
@@ -309,6 +492,58 @@ describe("CREATIVE_PIPELINE_TOOL_LOOP_CASES", () => {
     expect(failedNames).toContain("state:cutRevisedAfterAssembly");
     expect(failedNames).toContain("state:withinBriefRuntime");
     expect(result.score).toBeLessThan(1);
+  });
+
+  it("scores a complete scripted run at 1 on the linked case", async () => {
+    const report = await runToolLoopEval({
+      provider: createScriptedProvider(linkedPipelineScript()),
+      model: "scripted",
+      cases: CREATIVE_PIPELINE_TOOL_LOOP_CASES.filter(
+        (c) => c.id === "script-to-linked-cut"
+      )
+    });
+    const [result] = report.cases;
+    const failed = result.checks.filter((c) => !c.pass);
+    expect(failed.map((f) => `${f.name}: ${f.detail ?? ""}`)).toEqual([]);
+    expect(result.score).toBe(1);
+  });
+
+  it("fails the linked case when the board is built by hand instead of derived", async () => {
+    // Same job, same tools, no link: the shots render and the cut assembles,
+    // but the words never reach the timeline — the failure this case exists
+    // to separate from a run that looks identical in its call list.
+    const script = linkedPipelineScript().flatMap<ScriptedCall>((c) =>
+      c.name === "ui_script_derive_storyboard"
+        ? [
+            {
+              name: "ui_storyboard_add_shot",
+              args: { action: "the river mouth, closed" }
+            },
+            {
+              name: "ui_storyboard_add_shot",
+              args: { action: "a winter storm at the bar" }
+            },
+            {
+              name: "ui_storyboard_add_shot",
+              args: { action: "fish moving through the new channel" }
+            }
+          ]
+        : [c]
+    );
+    const report = await runToolLoopEval({
+      provider: createScriptedProvider(script),
+      model: "scripted",
+      cases: CREATIVE_PIPELINE_TOOL_LOOP_CASES.filter(
+        (c) => c.id === "script-to-linked-cut"
+      )
+    });
+    const failedNames = report.cases[0].checks
+      .filter((c) => !c.pass)
+      .map((c) => c.name);
+    expect(failedNames).toContain("state:boardDerivedFromScript");
+    expect(failedNames).toContain("state:assembledJointly");
+    expect(failedNames).toContain("state:clipsCarryBothLinks");
+    expect(report.cases[0].score).toBeLessThan(1);
   });
 
   it("fails the brief checks when a forbidden element reaches the board", async () => {


### PR DESCRIPTION
Phase 3 "Creative-pipeline eval" from `docs/script-storyboard-link/tasks.md`.

The creative-pipeline suite composed sketch, storyboard and timeline, so a run could go from brief to cut but never from words to cut — nothing scored the link the whole design turns on (design §2.4, §3.3, §6).

## Changes

- Composes the script surface into the bridge (`ui_script_*` alongside the rest). `ui_script_send_to_timeline` is dropped: it would open a second sequence nothing else in the bridge can see.
- Replaces `ui_script_derive_storyboard` — it runs the script bridge's own `deriveShotScaffold` pass, lays those shots onto the shared storyboard bridge, and records which script lines each covers.
- Teaches `ui_storyboard_assemble_timeline` the linked path: when the board was derived from the script it assembles through `buildLinkedTimeline` (shots as long as the takes they cover, one voiceover clip per voiced line carrying both `scriptId`/`scriptLineId` and `storyboardBoardId`/`storyboardShotId`), then reseeds the timeline editor with that cut so later edits act on it. The unlinked one-clip-per-shot path and its render overshoot are unchanged, with a test pinning that.
- Adds `validate_timeline`, running the shipped `validateTimelineSequence` over whatever the cut holds.
- New case `script-to-linked-cut`: write and voice a script → derive → render stubbed keyframes and clips → joint assemble → validate. Scored the way `full-pipeline` is (requiredTools, ordering, `noErrorResults`, call bounds, final-state predicates), with predicates reading the delivered document rather than the call list.
- The script bridge gains an `assembly` snapshot (cast, lines, takes, word timings) so a host can hand its state to the pure assemblers; simulated takes now carry an id and asset id, which assembly requires.

## Runs keyless

The new case has no `needsModelProviders` — every generate and render is faked — and the suite test asserting each case is solvable without configured providers now covers four cases.

Two new tests drive it end to end through `runToolLoopEval` with a scripted provider: one green run, and one that skips the derive and fails exactly `boardDerivedFromScript` / `assembledJointly` / `clipsCarryBothLinks`. So the new checks are proven able to fail. A third trims a clip to zero and shows `validate_timeline` reporting `ok: false`.

## Tests

- `npm run test --workspace=packages/agents` — 193 files, 2885 tests passing, 1 skipped.
- Suite listing shows `full-pipeline`, `brief-constraints-hold`, `review-catches-overrun`, `script-to-linked-cut`.
- `npx oxlint packages/agents/src` — clean; the three warnings are pre-existing and in untouched files.

`npm run build:packages` is a precondition for the workspace test run in a fresh worktree; without dists it cannot resolve `@nodetool-ai/runtime`, confirmed on the unmodified tree first.

## Caveats

- The CLI's suite description (`packages/cli/src/commands/eval.ts:628`) still lists only the sketch/storyboard/timeline surfaces. Left alone to keep this diff inside `packages/agents`; worth a one-line follow-up.
- The linked case deliberately has no runtime-ceiling predicate: a linked cut is as long as its voiced takes, so a ceiling would score how many words the model wrote.
- The harness-registry selfchecks from design §6 are #4963, not this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_012nRg3PsMbzt4fHSAU7dp4b)_