### PR TITLE
feat(studio): group a linked script and board into one project

### DIFF
--- a/web/src/studio/StudioHome.tsx
+++ b/web/src/studio/StudioHome.tsx
@@ -1,12 +1,13 @@
 /** @jsxImportSource @emotion/react */
 /**
- * Studio home: two creation paths and the recent projects that came out of
- * them. A storyboard project starts visual (shots → stills → clips); a script
- * project starts spoken (lines → voices → takes). Both end in the timeline
- * editor, which is the one finishing surface the product has.
+ * Studio home: one prompt that lands on a linked script + storyboard, the two
+ * blank starting points for people who would rather write first, and the
+ * projects that came out of them. Linked documents share a card — the script,
+ * the board it links, and the timeline either produced are one project, not
+ * three rows (see {@link groupLinkedProjects}).
  */
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTheme } from "@mui/material/styles";
 import TheatersRoundedIcon from "@mui/icons-material/TheatersRounded";
@@ -15,120 +16,143 @@ import MovieRoundedIcon from "@mui/icons-material/MovieRounded";
 import {
   BORDER_RADIUS,
   Card,
-  Chip,
   EditorButton,
   FlexColumn,
   FlexRow,
   SPACING,
-  Text
+  Text,
+  TextInput
 } from "../components/ui_primitives";
-import { useCreateStoryboard, useStoryboards } from "../hooks/storyboard/useStoryboards";
-import { useCreateScript, useScripts } from "../hooks/script/useScripts";
-import { useTimelines } from "../hooks/useTimelineSequence";
+import { useCreateStoryboard } from "../hooks/storyboard/useStoryboards";
+import { useCreateScript } from "../hooks/script/useScripts";
 import StudioShell from "./StudioShell";
-
-type ProjectKind = "storyboard" | "script" | "timeline";
-
-interface RecentProject {
-  kind: ProjectKind;
-  id: string;
-  name: string;
-  updatedAt: string;
-}
+import { useStudioProjects } from "./useStudioProjects";
+import { useStudioPromptStart } from "./useStudioPromptStart";
+import type {
+  StudioDocument,
+  StudioDocumentKind,
+  StudioProject
+} from "./groupLinkedProjects";
 
 const KIND_LABEL = {
   storyboard: "Storyboard",
   script: "Script",
   timeline: "Video"
-} satisfies Record<ProjectKind, string>;
+} satisfies Record<StudioDocumentKind, string>;
 
 const KIND_ICON = {
   storyboard: <TheatersRoundedIcon fontSize="small" />,
   script: <RecordVoiceOverRoundedIcon fontSize="small" />,
   timeline: <MovieRoundedIcon fontSize="small" />
-} satisfies Record<ProjectKind, React.ReactNode>;
+} satisfies Record<StudioDocumentKind, React.ReactNode>;
 
-const projectRoute = (p: RecentProject) => `/studio/${p.kind}/${p.id}`;
+const documentRoute = (document: StudioDocument) =>
+  `/studio/${document.kind}/${document.id}`;
 
-const PathCard = ({
+const PROMPT_STAGE_LABEL = {
+  idle: "Make it",
+  directing: "Directing…",
+  writing: "Writing the script…"
+} as const;
+
+const ProjectCard = ({
+  project,
+  onOpen
+}: {
+  project: StudioProject;
+  onOpen: (document: StudioDocument) => void;
+}) => {
+  const theme = useTheme();
+  return (
+    <FlexColumn
+      gap={SPACING.sm}
+      data-testid="studio-project-card"
+      sx={{
+        width: "100%",
+        border: `1px solid ${theme.vars.palette.divider}`,
+        borderRadius: BORDER_RADIUS.md,
+        px: SPACING.md,
+        py: SPACING.sm
+      }}
+    >
+      <FlexRow align="center" gap={SPACING.md}>
+        <Text size="normal" truncate sx={{ flex: 1 }}>
+          {project.name}
+        </Text>
+        <Text size="smaller" color="secondary">
+          {new Date(project.updatedAt).toLocaleDateString()}
+        </Text>
+      </FlexRow>
+      <FlexRow align="center" gap={SPACING.sm} wrap>
+        {project.documents.map((document) => (
+          <FlexRow
+            key={`${document.kind}:${document.id}`}
+            component="button"
+            align="center"
+            gap={SPACING.xs}
+            onClick={() => onOpen(document)}
+            sx={{
+              cursor: "pointer",
+              background: "none",
+              border: `1px solid ${theme.vars.palette.divider}`,
+              borderRadius: BORDER_RADIUS.pill,
+              px: SPACING.sm,
+              py: SPACING.xs,
+              color: "inherit",
+              "&:hover": {
+                backgroundColor: theme.vars.palette.action.hover
+              }
+            }}
+          >
+            {KIND_ICON[document.kind]}
+            <Text size="smaller">{KIND_LABEL[document.kind]}</Text>
+          </FlexRow>
+        ))}
+      </FlexRow>
+    </FlexColumn>
+  );
+};
+
+const BlankStart = ({
   icon,
-  title,
-  description,
-  cta,
+  label,
   busy,
   disabled,
   onStart
 }: {
   icon: React.ReactNode;
-  title: string;
-  description: string;
-  cta: string;
+  label: string;
   busy: boolean;
   disabled: boolean;
   onStart: () => void;
 }) => (
-  <Card
-    variant="outlined"
-    padding="comfortable"
-    sx={{ flex: 1, minWidth: 260, maxWidth: 420 }}
-  >
-    <FlexColumn gap={SPACING.md} align="flex-start">
-      {icon}
-      <Text size="big" weight={600}>
-        {title}
-      </Text>
-      <Text size="small" color="secondary">
-        {description}
-      </Text>
-      <EditorButton variant="contained" onClick={onStart} disabled={disabled}>
-        {busy ? "Creating…" : cta}
-      </EditorButton>
-    </FlexColumn>
-  </Card>
+  <EditorButton variant="text" startIcon={icon} onClick={onStart} disabled={disabled}>
+    {busy ? "Creating…" : label}
+  </EditorButton>
 );
 
 const StudioHome = () => {
-  const theme = useTheme();
   const navigate = useNavigate();
   const createStoryboard = useCreateStoryboard();
   const createScript = useCreateScript();
-  const [creating, setCreating] = useState<ProjectKind | null>(null);
+  const [creating, setCreating] = useState<StudioDocumentKind | null>(null);
+  const [prompt, setPrompt] = useState("");
 
-  const storyboards = useStoryboards();
-  const scripts = useScripts();
-  // No project filter: storyboards and scripts list all the user's documents,
-  // so the merged recent list scopes timelines the same way.
-  const timelines = useTimelines();
+  const { projects } = useStudioProjects();
+  const { start, stage, busy, error: promptError } = useStudioPromptStart();
 
-  const recent = useMemo<RecentProject[]>(() => {
-    const rows: RecentProject[] = [
-      ...(storyboards.data ?? []).map((s) => ({
-        kind: "storyboard" as const,
-        id: s.id,
-        name: s.name,
-        updatedAt: s.updatedAt
-      })),
-      ...(scripts.data ?? []).map((s) => ({
-        kind: "script" as const,
-        id: s.id,
-        name: s.name,
-        updatedAt: s.updatedAt
-      })),
-      ...(timelines.data ?? []).map((t) => ({
-        kind: "timeline" as const,
-        id: t.id,
-        name: t.name,
-        updatedAt: t.updatedAt
-      }))
-    ];
-    return rows
-      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
-      .slice(0, 12);
-  }, [storyboards.data, scripts.data, timelines.data]);
+  const makeIt = useCallback(() => {
+    if (busy) return;
+    void start(prompt)
+      .then(({ boardId }) => navigate(`/studio/storyboard/${boardId}`))
+      .catch(() => {
+        // Surfaced through promptError; the prompt stays for a second try.
+      });
+  }, [busy, navigate, prompt, start]);
 
-  // One creation at a time: both cards disable while either runs, and the
-  // handlers guard on a ref as well so a double-activation can't create two
-  // projects or race the navigation.
+  // One creation at a time: the blank starts disable while either runs, and
+  // the handlers guard on a ref as well so a double-activation can't create
+  // two projects or race the navigation.
   const creatingRef = useRef(false);
   const startStoryboard = useCallback(() => {
     if (creatingRef.current) return;
@@ -156,6 +180,11 @@ const StudioHome = () => {
       });
   }, [createScript, navigate]);
 
+  const openDocument = useCallback(
+    (document: StudioDocument) => navigate(documentRoute(document)),
+    [navigate]
+  );
+
   return (
     <StudioShell showBack={false}>
       <FlexColumn
@@ -168,67 +197,71 @@ const StudioHome = () => {
             Make a video
           </Text>
           <Text size="normal" color="secondary">
-            Pick a starting point — the agent handles the models, you direct.
+            Describe it once — the agent directs the shots and writes the
+            script, linked to each other.
           </Text>
         </FlexColumn>
 
-        <FlexRow gap={SPACING.lg} wrap justify="center" fullWidth>
-          <PathCard
-            icon={<TheatersRoundedIcon />}
-            title="Start with a storyboard"
-            description="Describe your idea. The director agent breaks it into shots, renders stills, animates them into clips, and cuts them together."
-            cta="New storyboard"
-            busy={creating === "storyboard"}
-            disabled={creating !== null}
-            onStart={startStoryboard}
-          />
-          <PathCard
-            icon={<RecordVoiceOverRoundedIcon />}
-            title="Start with a script"
-            description="Write or generate a script, cast a voice for every speaker, and turn the voiced lines into a video with captions."
-            cta="New script"
-            busy={creating === "script"}
-            disabled={creating !== null}
-            onStart={startScript}
-          />
-        </FlexRow>
+        <Card
+          variant="outlined"
+          padding="comfortable"
+          sx={{ width: "100%", maxWidth: 720 }}
+        >
+          <FlexColumn gap={SPACING.md} align="stretch">
+            <TextInput
+              label="What is the video about?"
+              placeholder="A 30-second explainer about how tides work, calm narration over close-up ocean shots."
+              multiline
+              rows={3}
+              value={prompt}
+              disabled={busy}
+              onChange={(event) => setPrompt(event.target.value)}
+            />
+            {promptError && (
+              <Text size="small" color="error">
+                {promptError}
+              </Text>
+            )}
+            <FlexRow align="center" gap={SPACING.sm} wrap>
+              <EditorButton
+                variant="contained"
+                onClick={makeIt}
+                disabled={busy || prompt.trim().length === 0}
+              >
+                {PROMPT_STAGE_LABEL[stage]}
+              </EditorButton>
+              <Text size="smaller" color="secondary" sx={{ flex: 1 }}>
+                or start blank:
+              </Text>
+              <BlankStart
+                icon={<TheatersRoundedIcon />}
+                label="New storyboard"
+                busy={creating === "storyboard"}
+                disabled={busy || creating !== null}
+                onStart={startStoryboard}
+              />
+              <BlankStart
+                icon={<RecordVoiceOverRoundedIcon />}
+                label="New script"
+                busy={creating === "script"}
+                disabled={busy || creating !== null}
+                onStart={startScript}
+              />
+            </FlexRow>
+          </FlexColumn>
+        </Card>
 
-        {recent.length > 0 && (
+        {projects.length > 0 && (
           <FlexColumn gap={SPACING.sm} sx={{ width: "100%", maxWidth: 880 }}>
             <Text size="small" weight={600} color="secondary">
               Recent projects
             </Text>
-            {recent.map((p) => (
-              <FlexRow
-                key={`${p.kind}:${p.id}`}
-                component="button"
-                align="center"
-                gap={SPACING.md}
-                onClick={() => navigate(projectRoute(p))}
-                sx={{
-                  width: "100%",
-                  textAlign: "left",
-                  cursor: "pointer",
-                  background: "none",
-                  border: `1px solid ${theme.vars.palette.divider}`,
-                  borderRadius: BORDER_RADIUS.md,
-                  px: SPACING.md,
-                  py: SPACING.sm,
-                  color: "inherit",
-                  "&:hover": {
-                    backgroundColor: theme.vars.palette.action.hover
-                  }
-                }}
-              >
-                {KIND_ICON[p.kind]}
-                <Text size="normal" truncate sx={{ flex: 1 }}>
-                  {p.name}
-                </Text>
-                <Chip compact label={KIND_LABEL[p.kind]} />
-                <Text size="smaller" color="secondary">
-                  {new Date(p.updatedAt).toLocaleDateString()}
-                </Text>
-              </FlexRow>
+            {projects.slice(0, 12).map((project) => (
+              <ProjectCard
+                key={project.key}
+                project={project}
+                onOpen={openDocument}
+              />
             ))}
           </FlexColumn>
         )}

--- a/web/src/studio/__tests__/StudioHome.test.tsx
+++ b/web/src/studio/__tests__/StudioHome.test.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import mockTheme from "../../__mocks__/themeMock";
+
+const navigate = jest.fn();
+const start = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  __esModule: true,
+  useNavigate: () => navigate
+}));
+
+jest.mock("../StudioShell", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}));
+
+jest.mock("../useStudioPromptStart", () => ({
+  __esModule: true,
+  useStudioPromptStart: () => ({
+    start,
+    stage: "idle" as const,
+    busy: false,
+    error: null
+  })
+}));
+
+jest.mock("../../hooks/storyboard/useStoryboards", () => ({
+  __esModule: true,
+  useStoryboards: () => ({
+    data: [
+      {
+        id: "b1",
+        name: "Tides",
+        updatedAt: "2026-01-03T00:00:00.000Z",
+        projectId: "default",
+        shotCount: 6
+      }
+    ],
+    isLoading: false
+  }),
+  useCreateStoryboard: () => ({ mutateAsync: jest.fn() })
+}));
+
+jest.mock("../../hooks/script/useScripts", () => ({
+  __esModule: true,
+  useScripts: () => ({
+    data: [
+      {
+        id: "s1",
+        name: "Tides script",
+        updatedAt: "2026-01-04T00:00:00.000Z",
+        projectId: "default",
+        lineCount: 4
+      }
+    ],
+    isLoading: false
+  }),
+  useCreateScript: () => ({ mutateAsync: jest.fn() })
+}));
+
+jest.mock("../../hooks/useTimelineSequence", () => ({
+  __esModule: true,
+  useTimelines: () => ({
+    data: [
+      {
+        id: "t1",
+        name: "Tides cut",
+        updatedAt: "2026-01-05T00:00:00.000Z",
+        projectId: "default"
+      }
+    ],
+    isLoading: false
+  })
+}));
+
+jest.mock("../../trpc/client", () => ({
+  __esModule: true,
+  trpcClient: {
+    scripts: {
+      get: {
+        query: jest.fn().mockResolvedValue({
+          id: "s1",
+          storyboardId: "b1",
+          timelineId: "t1"
+        })
+      }
+    },
+    storyboards: {
+      get: {
+        query: jest.fn().mockResolvedValue({
+          id: "b1",
+          document: { screenplay: { script_id: "s1" } },
+          timelineId: "t1"
+        })
+      }
+    }
+  }
+}));
+
+import StudioHome from "../StudioHome";
+
+const renderHome = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={mockTheme}>
+        <StudioHome />
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe("StudioHome", () => {
+  beforeEach(() => {
+    navigate.mockReset();
+    start.mockReset();
+    start.mockResolvedValue({ boardId: "b9", scriptId: "s9" });
+  });
+
+  it("shows one card for the linked script, board and timeline", async () => {
+    renderHome();
+
+    // Before the link queries settle every document stands alone.
+    await waitFor(() =>
+      expect(screen.getAllByTestId("studio-project-card")).toHaveLength(1)
+    );
+    const card = screen.getByTestId("studio-project-card");
+    expect(card).toHaveTextContent("Tides");
+    expect(
+      within(card).getAllByRole("button").map((b) => b.textContent)
+    ).toEqual(["Storyboard", "Script", "Video"]);
+  });
+
+  it("opens the document whose chip was clicked", async () => {
+    const user = userEvent.setup();
+    renderHome();
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId("studio-project-card")).toHaveLength(1)
+    );
+    await user.click(
+      within(screen.getByTestId("studio-project-card")).getByText("Video")
+    );
+    expect(navigate).toHaveBeenCalledWith("/studio/timeline/t1");
+  });
+
+  it("starts a linked project from a prompt and lands on the board", async () => {
+    const user = userEvent.setup();
+    renderHome();
+
+    await user.type(
+      screen.getByLabelText("What is the video about?"),
+      "a short film about tides"
+    );
+    await user.click(screen.getByRole("button", { name: "Make it" }));
+
+    await waitFor(() =>
+      expect(start).toHaveBeenCalledWith("a short film about tides")
+    );
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith("/studio/storyboard/b9")
+    );
+  });
+});

--- a/web/src/studio/__tests__/groupLinkedProjects.test.ts
+++ b/web/src/studio/__tests__/groupLinkedProjects.test.ts
@@ -1,0 +1,135 @@
+import {
+  groupLinkedProjects,
+  studioDocumentKey,
+  type StudioDocument,
+  type StudioDocumentLinks
+} from "../groupLinkedProjects";
+
+const board: StudioDocument = {
+  kind: "storyboard",
+  id: "b1",
+  name: "Tides",
+  updatedAt: "2026-01-03T00:00:00.000Z"
+};
+const script: StudioDocument = {
+  kind: "script",
+  id: "s1",
+  name: "Tides script",
+  updatedAt: "2026-01-04T00:00:00.000Z"
+};
+const timeline: StudioDocument = {
+  kind: "timeline",
+  id: "t1",
+  name: "Tides cut",
+  updatedAt: "2026-01-05T00:00:00.000Z"
+};
+
+const links = (
+  entries: Array<[StudioDocument, StudioDocumentLinks]>
+): Record<string, StudioDocumentLinks> =>
+  Object.fromEntries(
+    entries.map(([document, link]) => [studioDocumentKey(document), link])
+  );
+
+describe("groupLinkedProjects", () => {
+  it("folds a linked script, board and timeline into one project", () => {
+    const projects = groupLinkedProjects(
+      [board, script, timeline],
+      links([
+        [script, { storyboardId: "b1", timelineId: "t1" }],
+        [board, { scriptId: "s1" }]
+      ])
+    );
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0].documents.map((d) => d.kind)).toEqual([
+      "storyboard",
+      "script",
+      "timeline"
+    ]);
+    // The board leads the card; the newest document is where it opens.
+    expect(projects[0].name).toBe("Tides");
+    expect(projects[0].key).toBe("storyboard:b1");
+    expect(projects[0].primary).toEqual(timeline);
+    expect(projects[0].updatedAt).toBe(timeline.updatedAt);
+  });
+
+  it("groups a linked pair reached from either side", () => {
+    const fromScript = groupLinkedProjects(
+      [board, script],
+      links([[script, { storyboardId: "b1" }]])
+    );
+    const fromBoard = groupLinkedProjects(
+      [board, script],
+      links([[board, { scriptId: "s1" }]])
+    );
+
+    expect(fromScript).toHaveLength(1);
+    expect(fromBoard).toHaveLength(1);
+    expect(fromScript[0].documents).toEqual(fromBoard[0].documents);
+  });
+
+  it("keeps unlinked documents as projects of their own", () => {
+    const projects = groupLinkedProjects([board, script, timeline]);
+
+    expect(projects).toHaveLength(3);
+    expect(projects.every((p) => p.documents.length === 1)).toBe(true);
+  });
+
+  it("ignores a pointer at a document that is gone", () => {
+    // The board was deleted; the downgrade could not reach the script, so its
+    // back-pointer still names a row nobody lists.
+    const projects = groupLinkedProjects(
+      [script, timeline],
+      links([[script, { storyboardId: "b1", timelineId: "t1" }]])
+    );
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0].documents.map((d) => d.kind)).toEqual([
+      "script",
+      "timeline"
+    ]);
+  });
+
+  it("leaves a document alone when its only pointer dangles", () => {
+    const projects = groupLinkedProjects(
+      [script],
+      links([[script, { storyboardId: "b1" }]])
+    );
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0].documents).toEqual([script]);
+    expect(projects[0].primary).toEqual(script);
+  });
+
+  it("sorts projects by the newest document in each group", () => {
+    const older: StudioDocument = {
+      kind: "storyboard",
+      id: "b0",
+      name: "Older board",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    };
+    const projects = groupLinkedProjects(
+      [older, board, script, timeline],
+      links([
+        [script, { storyboardId: "b1", timelineId: "t1" }],
+        [board, { scriptId: "s1" }]
+      ])
+    );
+
+    expect(projects.map((p) => p.key)).toEqual([
+      "storyboard:b1",
+      "storyboard:b0"
+    ]);
+  });
+
+  it("groups a board and the timeline it was assembled into", () => {
+    const projects = groupLinkedProjects(
+      [board, timeline],
+      links([[board, { timelineId: "t1" }]])
+    );
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0].documents.map((d) => d.id)).toEqual(["b1", "t1"]);
+  });
+});

--- a/web/src/studio/__tests__/studioPromptName.test.ts
+++ b/web/src/studio/__tests__/studioPromptName.test.ts
@@ -1,0 +1,19 @@
+import { projectNameFromPrompt } from "../useStudioPromptStart";
+
+describe("projectNameFromPrompt", () => {
+  it("names the project after the prompt's first clause", () => {
+    expect(
+      projectNameFromPrompt("A short film about tides. Calm narration.")
+    ).toBe("A short film about tides");
+  });
+
+  it("truncates a long clause", () => {
+    const name = projectNameFromPrompt("x".repeat(200));
+    expect(name).toHaveLength(58);
+    expect(name.endsWith("…")).toBe(true);
+  });
+
+  it("falls back when the prompt has no words", () => {
+    expect(projectNameFromPrompt("  ")).toBe("Untitled project");
+  });
+});

--- a/web/src/studio/groupLinkedProjects.ts
+++ b/web/src/studio/groupLinkedProjects.ts
@@ -1,0 +1,155 @@
+/**
+ * Studio home grouping (design §4).
+ *
+ * A script, the storyboard it links, and the timeline either produced are one
+ * project, not three documents. This folds the three flat lists into one card
+ * per project by walking the link pointers, and keeps every unlinked document
+ * as a project of its own.
+ *
+ * A pointer at a document that is not in the lists is ignored, so a group
+ * whose counterpart was deleted collapses to the survivors instead of naming
+ * something that is gone — the same read the deletion downgrades leave behind
+ * when they cannot reach the far side (`lib/scriptStoryboardDowngrade.ts`).
+ */
+
+export type StudioDocumentKind = "storyboard" | "script" | "timeline";
+
+export interface StudioDocument {
+  kind: StudioDocumentKind;
+  id: string;
+  name: string;
+  /** ISO timestamp, as every list item reports it. */
+  updatedAt: string;
+}
+
+/** What one document points at. Unknown or absent fields mean "no link". */
+export interface StudioDocumentLinks {
+  /** Set on a storyboard: the script its words come from. */
+  scriptId?: string | null;
+  /** Set on a script: the board derived from it. */
+  storyboardId?: string | null;
+  /** Set on either: the sequence it was assembled into. */
+  timelineId?: string | null;
+}
+
+export interface StudioProject {
+  /** Stable React key: the leading document's `kind:id`. */
+  key: string;
+  /** The project's name — the leading document's. */
+  name: string;
+  /** Newest `updatedAt` in the group. */
+  updatedAt: string;
+  /** Every document in the group, storyboard → script → timeline. */
+  documents: StudioDocument[];
+  /** Where the card opens: the document touched most recently. */
+  primary: StudioDocument;
+}
+
+export const studioDocumentKey = (document: {
+  kind: StudioDocumentKind;
+  id: string;
+}): string => `${document.kind}:${document.id}`;
+
+/**
+ * Which document leads a project: the board is the visual spine, the script
+ * the words behind it, the timeline the cut that came out.
+ */
+const KIND_ORDER: Record<StudioDocumentKind, number> = {
+  storyboard: 0,
+  script: 1,
+  timeline: 2
+};
+
+const byKindThenRecency = (a: StudioDocument, b: StudioDocument): number =>
+  KIND_ORDER[a.kind] - KIND_ORDER[b.kind] ||
+  b.updatedAt.localeCompare(a.updatedAt) ||
+  a.id.localeCompare(b.id);
+
+const byRecencyThenKind = (a: StudioDocument, b: StudioDocument): number =>
+  b.updatedAt.localeCompare(a.updatedAt) ||
+  KIND_ORDER[a.kind] - KIND_ORDER[b.kind] ||
+  a.id.localeCompare(b.id);
+
+class DisjointSet {
+  private readonly parent = new Map<string, string>();
+
+  find(key: string): string {
+    const seen = this.parent.get(key);
+    if (seen === undefined) {
+      this.parent.set(key, key);
+      return key;
+    }
+    if (seen === key) return key;
+    const root = this.find(seen);
+    this.parent.set(key, root);
+    return root;
+  }
+
+  union(a: string, b: string): void {
+    const rootA = this.find(a);
+    const rootB = this.find(b);
+    if (rootA !== rootB) this.parent.set(rootB, rootA);
+  }
+}
+
+/**
+ * Fold `documents` into project groups using `links`, keyed by
+ * {@link studioDocumentKey}. Pure: the same inputs always give the same
+ * grouping and the same order (newest project first).
+ */
+export function groupLinkedProjects(
+  documents: readonly StudioDocument[],
+  links: Readonly<Record<string, StudioDocumentLinks>> = {}
+): StudioProject[] {
+  const byKey = new Map<string, StudioDocument>();
+  for (const document of documents) {
+    byKey.set(studioDocumentKey(document), document);
+  }
+
+  const sets = new DisjointSet();
+  for (const [key, document] of byKey) {
+    const link = links[key];
+    if (!link) continue;
+    const counterparts = [
+      document.kind === "script" && link.storyboardId
+        ? `storyboard:${link.storyboardId}`
+        : null,
+      document.kind === "storyboard" && link.scriptId
+        ? `script:${link.scriptId}`
+        : null,
+      link.timelineId ? `timeline:${link.timelineId}` : null
+    ];
+    for (const counterpart of counterparts) {
+      // A pointer at a document nobody listed is dangling: the survivors keep
+      // their own card rather than the group naming a deleted document.
+      if (counterpart && byKey.has(counterpart)) sets.union(key, counterpart);
+    }
+  }
+
+  const groups = new Map<string, StudioDocument[]>();
+  for (const [key, document] of byKey) {
+    const root = sets.find(key);
+    const group = groups.get(root);
+    if (group) {
+      group.push(document);
+    } else {
+      groups.set(root, [document]);
+    }
+  }
+
+  return [...groups.values()]
+    .map((group) => {
+      const ordered = [...group].sort(byKindThenRecency);
+      const primary = [...ordered].sort(byRecencyThenKind)[0];
+      return {
+        key: studioDocumentKey(ordered[0]),
+        name: ordered[0].name,
+        updatedAt: primary.updatedAt,
+        documents: ordered,
+        primary
+      };
+    })
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt) || a.key.localeCompare(b.key));
+}
+
+export default groupLinkedProjects;

--- a/web/src/studio/useStudioProjects.ts
+++ b/web/src/studio/useStudioProjects.ts
@@ -1,0 +1,131 @@
+/**
+ * The Studio home feed: the user's storyboards, scripts and timelines, folded
+ * into one card per project by {@link groupLinkedProjects}.
+ *
+ * The list endpoints carry no link fields, so the pointers come from the
+ * detail queries of the most recent scripts and boards — batched by the tRPC
+ * http link, cached per document revision, and never blocking: until they
+ * settle every document stands alone, which is exactly what the grouping does
+ * with an empty link map.
+ */
+
+import { useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
+
+import { trpcClient } from "../trpc/client";
+import { useStoryboards } from "../hooks/storyboard/useStoryboards";
+import { useScripts } from "../hooks/script/useScripts";
+import { useTimelines } from "../hooks/useTimelineSequence";
+import {
+  groupLinkedProjects,
+  studioDocumentKey,
+  type StudioDocument,
+  type StudioDocumentLinks,
+  type StudioProject
+} from "./groupLinkedProjects";
+
+/** How many documents deep the home feed resolves links for. */
+const LINK_LOOKUP_LIMIT = 24;
+
+const fetchLinks = async (
+  document: StudioDocument
+): Promise<StudioDocumentLinks> => {
+  if (document.kind === "script") {
+    const script = await trpcClient.scripts.get.query({ id: document.id });
+    return {
+      storyboardId: script.storyboardId ?? null,
+      timelineId: script.timelineId ?? null
+    };
+  }
+  const board = await trpcClient.storyboards.get.query({ id: document.id });
+  // The screenplay is a passthrough zod object, so its `script_id` arrives
+  // as widely as the schema allows; only a string is a link.
+  const scriptId = board.document.screenplay?.script_id;
+  return {
+    scriptId: typeof scriptId === "string" ? scriptId : null,
+    timelineId: board.timelineId ?? null
+  };
+};
+
+export interface UseStudioProjectsResult {
+  projects: StudioProject[];
+  loading: boolean;
+}
+
+export const useStudioProjects = (): UseStudioProjectsResult => {
+  const storyboards = useStoryboards();
+  const scripts = useScripts();
+  // No project filter: storyboards and scripts list all the user's documents,
+  // so the merged feed scopes timelines the same way.
+  const timelines = useTimelines();
+
+  const documents = useMemo<StudioDocument[]>(
+    () => [
+      ...(storyboards.data ?? []).map((s) => ({
+        kind: "storyboard" as const,
+        id: s.id,
+        name: s.name,
+        updatedAt: s.updatedAt
+      })),
+      ...(scripts.data ?? []).map((s) => ({
+        kind: "script" as const,
+        id: s.id,
+        name: s.name,
+        updatedAt: s.updatedAt
+      })),
+      ...(timelines.data ?? []).map((t) => ({
+        kind: "timeline" as const,
+        id: t.id,
+        name: t.name,
+        updatedAt: t.updatedAt
+      }))
+    ],
+    [storyboards.data, scripts.data, timelines.data]
+  );
+
+  // Only scripts and boards carry pointers; a timeline is always pointed at.
+  const linked = useMemo(
+    () =>
+      documents
+        .filter((document) => document.kind !== "timeline")
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+        .slice(0, LINK_LOOKUP_LIMIT),
+    [documents]
+  );
+
+  const linkQueries = useQueries({
+    queries: linked.map((document) => ({
+      // The revision is part of the key: a saved link invalidates itself.
+      queryKey: [
+        "studio-links",
+        document.kind,
+        document.id,
+        document.updatedAt
+      ],
+      queryFn: () => fetchLinks(document),
+      staleTime: 30_000,
+      retry: false
+    }))
+  });
+
+  const links = useMemo(() => {
+    const map: Record<string, StudioDocumentLinks> = {};
+    linked.forEach((document, index) => {
+      const data = linkQueries[index]?.data;
+      if (data) map[studioDocumentKey(document)] = data;
+    });
+    return map;
+  }, [linked, linkQueries]);
+
+  const projects = useMemo(
+    () => groupLinkedProjects(documents, links),
+    [documents, links]
+  );
+
+  return {
+    projects,
+    loading: storyboards.isLoading || scripts.isLoading || timelines.isLoading
+  };
+};
+
+export default useStudioProjects;

--- a/web/src/studio/useStudioPromptStart.ts
+++ b/web/src/studio/useStudioPromptStart.ts
@@ -1,0 +1,138 @@
+/**
+ * The Studio prompt-first start (design §4).
+ *
+ * One prompt, one pass, and the user lands on a linked pair instead of an
+ * empty document: the prompt becomes a board's brief, the Director drafts the
+ * shots, and the words are projected straight back out into a linked script.
+ * Every step is an existing surface — `useDirectScreenplay` and
+ * `useExtractScriptFromBoard` — so the pair is stamped by the same code the
+ * editors use, and the curated Studio models are stamped at creation so
+ * nothing waits for a dropdown.
+ */
+
+import { useCallback, useRef, useState } from "react";
+
+import { trpcClient } from "../trpc/client";
+import { newDocumentId } from "../lib/newDocumentId";
+import { useStoryboardStore } from "../stores/storyboard/StoryboardStore";
+import { useDirectScreenplay } from "../hooks/storyboard/useDirectScreenplay";
+import { useExtractScriptFromBoard } from "../hooks/storyboard/useExtractScriptFromBoard";
+import {
+  STUDIO_CLIP_MODEL,
+  STUDIO_DIRECTOR_MODEL,
+  STUDIO_STILL_MODEL
+} from "./curatedModels";
+
+type StoryboardWireDocument = Awaited<
+  ReturnType<typeof trpcClient.storyboards.get.query>
+>["document"];
+
+/** Shots the first pass drafts — the storyboard editor's own default. */
+const DEFAULT_SHOT_COUNT = 6;
+const ASPECT_RATIO = "16:9";
+
+export type StudioPromptStage = "idle" | "directing" | "writing";
+
+export interface StudioPromptStartResult {
+  boardId: string;
+  scriptId: string;
+}
+
+export interface UseStudioPromptStartResult {
+  start: (prompt: string) => Promise<StudioPromptStartResult>;
+  stage: StudioPromptStage;
+  busy: boolean;
+  error: string | null;
+}
+
+/** A card title out of the prompt: its first clause, kept short. */
+export const projectNameFromPrompt = (prompt: string): string => {
+  const firstLine = prompt.trim().split("\n")[0].trim();
+  const clause = firstLine.split(/[.!?]/)[0].trim() || firstLine;
+  if (clause.length <= 60) return clause || "Untitled project";
+  return `${clause.slice(0, 57).trimEnd()}…`;
+};
+
+export const useStudioPromptStart = (): UseStudioPromptStartResult => {
+  const { direct } = useDirectScreenplay();
+  const { extract } = useExtractScriptFromBoard();
+  const [stage, setStage] = useState<StudioPromptStage>("idle");
+  const [error, setError] = useState<string | null>(null);
+  // One start at a time: the caller's button disables too, but a double
+  // activation must not create two projects or race the navigation.
+  const running = useRef(false);
+
+  const start = useCallback(
+    async (prompt: string): Promise<StudioPromptStartResult> => {
+      const brief = prompt.trim();
+      if (brief.length === 0) {
+        throw new Error("Describe the video before starting.");
+      }
+      if (running.current) {
+        throw new Error("A project is already being created.");
+      }
+      running.current = true;
+      setError(null);
+      setStage("directing");
+      try {
+        const boardId = newDocumentId();
+        const name = projectNameFromPrompt(brief);
+        const document = {
+          screenplay: null,
+          shots: [],
+          brief,
+          style: "",
+          entityIds: [],
+          aspectRatio: ASPECT_RATIO,
+          directorModel: STUDIO_DIRECTOR_MODEL,
+          imageModel: STUDIO_STILL_MODEL,
+          videoModel: STUDIO_CLIP_MODEL
+        } as unknown as StoryboardWireDocument;
+        await trpcClient.storyboards.create.mutate({
+          id: boardId,
+          name,
+          document
+        });
+        useStoryboardStore.getState().loadBoard(boardId, {
+          screenplay: null,
+          shots: [],
+          title: name,
+          brief,
+          style: "",
+          entityIds: [],
+          aspectRatio: ASPECT_RATIO,
+          directorModel: STUDIO_DIRECTOR_MODEL,
+          imageModel: STUDIO_STILL_MODEL,
+          videoModel: STUDIO_CLIP_MODEL,
+          activeShotId: null,
+          timelineId: null
+        });
+
+        await direct(boardId, DEFAULT_SHOT_COUNT);
+        // `direct` reports its failures through its own state and resolves
+        // either way, so the board itself is the verdict.
+        const drafted = useStoryboardStore.getState().getBoard(boardId);
+        if (!drafted || drafted.shots.length === 0) {
+          throw new Error(
+            "The director did not draft any shots. Open the storyboard and try again."
+          );
+        }
+
+        setStage("writing");
+        const { scriptId } = await extract(boardId, { open: false });
+        return { boardId, scriptId };
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        throw err;
+      } finally {
+        running.current = false;
+        setStage("idle");
+      }
+    },
+    [direct, extract]
+  );
+
+  return { start, stage, busy: stage !== "idle", error };
+};
+
+export default useStudioPromptStart;


### PR DESCRIPTION
Phase 4 "Studio" from `docs/script-storyboard-link/tasks.md`.

Studio home listed every storyboard, script and timeline as its own row, so a derived pair read as three unrelated documents.

## Changes

- `web/src/studio/groupLinkedProjects.ts` folds documents by their link pointers (script → storyboard, either → timeline) into one project card. Pure and unit-tested apart from the component.
- `useStudioProjects.ts` resolves those pointers from the detail queries — the list endpoints carry no link fields — and feeds the grouper. A pointer at a document nobody lists is ignored, so a deleted counterpart leaves the survivors on their own card, matching the log-and-continue downgrades in `web/src/lib/scriptStoryboardDowngrade.ts`.
- `useStudioPromptStart.ts` makes the start path prompt-first: the prompt becomes a board's brief, the existing `useDirectScreenplay` pass runs, then `useExtractScriptFromBoard` lands the user on a linked board + script. The two blank starts remain as secondary buttons.

## On the direction of the prompt-first flow

The task text implies script → board. That is not reachable from the web client today: there is no headless "draft a script from a prompt" path in `web/`. Scripts are authored by hand or through the chat assistant (`ScriptAgentPanel` / `useScriptAgentBridge`), which needs a user turn, and the one-shot drafting that exists is agent-side (`derive_storyboard_from_script`), with no route the client can call.

So this uses the equivalent existing pair in the other direction — board with the prompt as brief → the real Director run the storyboard editor already uses → extract script. Same outcome (one prompt, one pass, a linked script + board) with no new backend surface. If script-first is required, the missing piece is a web-callable "draft script from prompt": either a `nodetool.script.*` node the client can run like the Director node, or a route over the agent capability.

## Tests

Grouping (linked triple, pair from either side, unlinked singles, dangling pointer, ordering, board+timeline); StudioHome render (one card, chip row, per-document navigation, prompt start); prompt naming.

- `cd web && npx jest src/studio` — 4 suites, 17 tests passing.
- `npx oxlint src/studio` — clean.
- `npx tsc --noEmit | grep -E "^src/" | grep -v TS2307` — two errors, both pre-existing in `src/hooks/useWorkflowCostEstimate.ts`; nothing under `src/studio`.
- Falsifiability: disabling the union step in `groupLinkedProjects` turned 7 of 14 tests red, including 2 of the 3 StudioHome cases; restored after.

## Caveats

- Link resolution costs one detail query per script and storyboard, capped at the 24 most recent, batched by the tRPC http link and cached per document revision. Adding `storyboardId` / `script_id` / `timelineId` to the list items in `packages/protocol` would remove those round trips — out of scope here, `packages/` is untouched.
- `useStudioPromptStart` is covered by its naming helper and a module-import smoke; the Director run itself is not Jest-covered, since it needs the workflow runner and WebSocket manager.

---
_Generated by [Claude Code](https://claude.ai/code/session_012nRg3PsMbzt4fHSAU7dp4b)_