### PR TITLE
feat(storyboard): time linked shots from their takes

### DIFF
--- a/packages/agents/src/capabilities/storyboards.ts
+++ b/packages/agents/src/capabilities/storyboards.ts
@@ -642,7 +642,19 @@ const renderStoryboardClips: CapabilityExport = {
 
     const { loadMediaRefBytes } = await import("@nodetool-ai/runtime");
     const { entitiesForShot } = await import("@nodetool-ai/protocol");
+    const { effectiveShotDuration, scriptLinesById } = await import(
+      "@nodetool-ai/timeline"
+    );
     const entities = await loadBoardEntities(context, doc);
+    // A linked board times its shots from the words they cover, so a clip is
+    // rendered long enough to hold its voiceover (design §2.3). A shot pinned
+    // to `manual`, an unvoiced line, or an unlinked board keeps
+    // `duration_seconds`.
+    const scriptDoc = await loadLinkedScript(
+      boardScreenplay(row, doc),
+      context.userId
+    );
+    const linesById = scriptLinesById(scriptDoc?.sections ?? []);
     const aspectRatio = doc.aspectRatio || "16:9";
     const resolution =
       typeof params["resolution"] === "string"
@@ -684,7 +696,7 @@ const renderStoryboardClips: CapabilityExport = {
               entities: entitiesForShot(shot, entities).map(wireEntity),
               aspect_ratio: aspectRatio,
               resolution,
-              duration_seconds: shot.duration_seconds
+              duration_seconds: effectiveShotDuration(shot, linesById).seconds
             }
           })) as Uint8Array;
           const saved = await saveMedia(

--- a/packages/agents/src/evals/surfaces/storyboard.ts
+++ b/packages/agents/src/evals/surfaces/storyboard.ts
@@ -116,6 +116,7 @@ interface ShotNode {
   camera?: CameraDirection;
   motion?: string;
   durationSeconds?: number;
+  durationSource?: "audio" | "manual";
   status: ShotStatus;
   hasKeyframe: boolean;
   hasClip: boolean;
@@ -130,6 +131,7 @@ const toShotNode = (shot: Shot): ShotNode => ({
   camera: shot.camera,
   motion: shot.motion,
   durationSeconds: shot.duration_seconds,
+  durationSource: shot.duration_source,
   status: shot.status,
   hasKeyframe: !!shot.keyframe,
   hasClip: !!shot.clip,
@@ -520,6 +522,26 @@ export function createStoryboardToolBridge(
     ),
 
     tool(
+      "ui_storyboard_set_duration_source",
+      'Choose where the named shots get their length. "audio" times each shot from the takes of the script lines it covers, so the clip is long enough to hold its voiceover (a shot with an unvoiced line keeps its own duration until the line is voiced). "manual" pins the shot to its own durationSeconds and audio never touches it. Only meaningful on a board linked to a script.',
+      z.object({
+        targets: z.union([targetParam, z.array(targetParam).min(1)]),
+        source: z.enum(["audio", "manual"])
+      }),
+      async ({ targets, source }) => {
+        const list = (
+          Array.isArray(targets) ? targets : [targets]
+        ) as string[];
+        const touched = list.map((target) => {
+          const shot = resolveTarget(target);
+          shot.duration_source = source as "audio" | "manual";
+          return serialize(shot);
+        });
+        return { ok: true, source, shots: touched };
+      }
+    ),
+
+    tool(
       "ui_storyboard_select_shot",
       "Select a shot on the specified storyboard (driving the surface's focus). Pass null to clear the selection.",
       z.object({ target: targetParam.nullable() }),
@@ -572,6 +594,7 @@ Use the ui_storyboard_* tools to inspect and drive the board:
 - Generate a keyframe still before generating a clip; a clip must exist before revising it.
 - ui_storyboard_assemble_timeline cuts every shot with a rendered clip into a sequence.
 - ui_storyboard_extract_script moves the board's dialogue and narration into a linked script, one line per shot's words.
+- ui_storyboard_set_duration_source picks whether a shot's length comes from its script takes ("audio") or from its own durationSeconds ("manual").
 
 Call one tool at a time and use the result before the next call. When the objective is fully satisfied, STOP calling tools and give a one-line summary.`;
 

--- a/packages/agents/tests/capabilities-storyboards.test.ts
+++ b/packages/agents/tests/capabilities-storyboards.test.ts
@@ -13,6 +13,7 @@ import type { ProcessingContext } from "@nodetool-ai/runtime";
 import {
   Asset,
   ModelObserver,
+  Script,
   Storyboard,
   initTestDb
 } from "@nodetool-ai/models";
@@ -255,6 +256,106 @@ describe("storyboards capability behaviour", () => {
       instruction: "make it darker"
     })) as { error: string };
     expect(result.error).toContain("Run render_storyboard_clips first");
+  });
+
+  describe("clip length on a script-linked board", () => {
+    /** A script whose one line has a 3.4 s take, plus 250 ms of silence. */
+    const makeScript = async (voiced: boolean): Promise<Script> =>
+      Script.create<Script>({
+        user_id: "u1",
+        project_id: "default",
+        name: "Script",
+        document: JSON.stringify({
+          cast: [{ id: "sp1", name: "Keeper", voice: null }],
+          sections: [
+            {
+              id: "sec1",
+              lines: [
+                {
+                  id: "line-1",
+                  speakerId: "sp1",
+                  text: "We are closed.",
+                  pauseAfterMs: 250,
+                  currentTakeId: voiced ? "take-1" : null,
+                  takes: voiced
+                    ? [
+                        {
+                          id: "take-1",
+                          assetId: "audio-1",
+                          durationMs: 3400,
+                          words: [],
+                          textSnapshot: "We are closed.",
+                          voiceSnapshot: null,
+                          createdAt: "2026-01-01T00:00:00.000Z"
+                        }
+                      ]
+                    : []
+                }
+              ]
+            }
+          ]
+        })
+      });
+
+    const linkedBoard = async (
+      scriptId: string,
+      shotOverrides: Partial<Shot> = {}
+    ): Promise<Storyboard> =>
+      makeBoard(
+        [
+          shot({
+            id: "s1",
+            index: 0,
+            duration_seconds: 8,
+            script_line_ids: ["line-1"],
+            ...shotOverrides
+          })
+        ],
+        { screenplay: { type: "screenplay", id: "sp", script_id: scriptId } }
+      );
+
+    /** The `duration_seconds` the image_to_video prediction asked for. */
+    const renderedDuration = async (
+      board: Storyboard,
+      context: ReturnType<typeof ctx>
+    ): Promise<unknown> => {
+      await run(context).invoke("render_storyboard_stills", {
+        storyboard_id: board.id
+      });
+      await run(context).invoke("render_storyboard_clips", {
+        storyboard_id: board.id
+      });
+      const call = context.runProviderPrediction.mock.calls
+        .map((c) => c[0] as { capability: string; params: Record<string, unknown> })
+        .find((c) => c.capability === "image_to_video");
+      return call?.params["duration_seconds"];
+    };
+
+    it("renders a linked shot as long as the takes it covers", async () => {
+      const script = await makeScript(true);
+      const board = await linkedBoard(script.id);
+      // 3400 ms + 250 ms of silence, rounded up to whole seconds.
+      expect(await renderedDuration(board, ctx())).toBe(4);
+    });
+
+    it("keeps the shot's own length when it is pinned to manual", async () => {
+      const script = await makeScript(true);
+      const board = await linkedBoard(script.id, { duration_source: "manual" });
+      expect(await renderedDuration(board, ctx())).toBe(8);
+    });
+
+    it("keeps the shot's own length when the linked line is unvoiced", async () => {
+      const script = await makeScript(false);
+      const board = await linkedBoard(script.id);
+      expect(await renderedDuration(board, ctx())).toBe(8);
+    });
+
+    it("leaves an unlinked board's shots alone", async () => {
+      const board = await makeBoard([
+        shot({ id: "s1", index: 0, duration_seconds: 8 })
+      ]);
+      expect(await renderedDuration(board, ctx())).toBe(8);
+    });
   });
 
   it("assembles the rendered clips into a timeline", async () => {

--- a/packages/agents/tests/storyboard-tool-loop.test.ts
+++ b/packages/agents/tests/storyboard-tool-loop.test.ts
@@ -56,7 +56,7 @@ function createScriptedProvider(script: ScriptedCall[]): BaseProvider {
 // --- createStoryboardToolBridge ----------------------------------------------
 
 describe("createStoryboardToolBridge", () => {
-  it("exposes exactly the 10 ui_storyboard_* tools", () => {
+  it("exposes exactly the 11 ui_storyboard_* tools", () => {
     const bridge = createStoryboardToolBridge();
     const names = bridge.tools.map((t) => t.name).sort();
     expect(names).toEqual(
@@ -70,10 +70,11 @@ describe("createStoryboardToolBridge", () => {
         "ui_storyboard_revise_shot",
         "ui_storyboard_assemble_timeline",
         "ui_storyboard_extract_script",
+        "ui_storyboard_set_duration_source",
         "ui_storyboard_select_shot"
       ].sort()
     );
-    expect(names).toHaveLength(10);
+    expect(names).toHaveLength(11);
   });
 
   it("rejects a set_screenplay call with an invalid object", async () => {

--- a/packages/timeline/src/script-link.ts
+++ b/packages/timeline/src/script-link.ts
@@ -74,3 +74,33 @@ export function linkedShotDurationMs(
   }
   return totalMs;
 }
+
+/** Where a shot's effective length came from. */
+export type EffectiveDurationSource = "audio" | "manual";
+
+export interface EffectiveShotDuration {
+  /** Seconds to render, or `undefined` to let the model's default decide. */
+  seconds: number | undefined;
+  source: EffectiveDurationSource;
+}
+
+/**
+ * The length a render should ask a video model for, and where it came from.
+ * Audio wins whenever {@link linkedShotDurationMs} has an answer; otherwise the
+ * shot's own `duration_seconds` does, which is also what an unlinked board and
+ * a `duration_source: "manual"` shot get.
+ *
+ * Seconds are rounded **up**: a clip that runs a fraction short of its takes
+ * leaves black under the voiceover, while an overlong one is trimmed by the
+ * timeline slot `buildLinkedTimeline` gives it.
+ */
+export function effectiveShotDuration(
+  shot: Shot,
+  linesById: Map<string, ScriptLine>
+): EffectiveShotDuration {
+  const audioMs = linkedShotDurationMs(shot, linesById);
+  if (audioMs !== null && audioMs > 0) {
+    return { seconds: Math.ceil(audioMs / 1000), source: "audio" };
+  }
+  return { seconds: shot.duration_seconds, source: "manual" };
+}

--- a/packages/timeline/tests/script-link.test.ts
+++ b/packages/timeline/tests/script-link.test.ts
@@ -7,6 +7,7 @@ import type { Shot } from "@nodetool-ai/protocol";
 import type { ScriptLine } from "@nodetool-ai/protocol/api-schemas/scripts.js";
 import { PLACEHOLDER_LINE_MS } from "../src/script.js";
 import {
+  effectiveShotDuration,
   linkedLineDurationMs,
   linkedShotDurationMs,
   scriptLinesById
@@ -119,5 +120,52 @@ describe("linkedShotDurationMs", () => {
         linesById
       )
     ).toBe(3250);
+  });
+});
+
+describe("effectiveShotDuration", () => {
+  const linesById = scriptLinesById([
+    {
+      id: "section-1",
+      lines: [
+        voicedLine("a", 1000, { pauseAfterMs: 250 }),
+        voicedLine("b", 2000),
+        draftLine("c")
+      ]
+    }
+  ]);
+
+  it("rounds the audio-derived length up to whole seconds", () => {
+    expect(
+      effectiveShotDuration(
+        linkedShot(["a", "b"], { duration_seconds: 5 }),
+        linesById
+      )
+    ).toEqual({ seconds: 4, source: "audio" });
+  });
+
+  it("keeps the shot's own length when it is pinned to manual", () => {
+    expect(
+      effectiveShotDuration(
+        linkedShot(["a", "b"], { duration_seconds: 5, duration_source: "manual" }),
+        linesById
+      )
+    ).toEqual({ seconds: 5, source: "manual" });
+  });
+
+  it("falls back to the shot's own length when a linked line is unvoiced", () => {
+    expect(
+      effectiveShotDuration(
+        linkedShot(["a", "c"], { duration_seconds: 6 }),
+        linesById
+      )
+    ).toEqual({ seconds: 6, source: "manual" });
+  });
+
+  it("reports no seconds for an unlinked shot that sets none", () => {
+    expect(effectiveShotDuration(linkedShot([]), linesById)).toEqual({
+      seconds: undefined,
+      source: "manual"
+    });
   });
 });

--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -39,6 +39,7 @@ import ShotTakesGallery from "./ShotTakesGallery";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
 import { entitiesForShot } from "../../stores/storyboard/shotEntities";
 import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
+import { useShotDuration } from "../../hooks/storyboard/useShotDuration";
 import { useEntities } from "../../serverState/useEntities";
 import { ENTITY_KIND_COLOR } from "../entities/entityKind";
 import { useResolvedMediaUri } from "../../hooks/useResolvedMediaUri";
@@ -114,6 +115,7 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   isLast
 }) => {
   const toggleShotEntity = useStoryboardStore((state) => state.toggleShotEntity);
+  const updateShot = useStoryboardStore((state) => state.updateShot);
   const moveShot = useStoryboardStore((state) => state.moveShot);
   const removeShot = useStoryboardStore((state) => state.removeShot);
   const boardEntityIds = useStoryboardStore(
@@ -169,6 +171,20 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   const handleMoveDown = useCallback(() => {
     moveShot(boardId, shot.id, "down");
   }, [moveShot, boardId, shot.id]);
+
+  // A shot covering script lines is timed by the takes under it unless the
+  // user pins it; the chip says which, and clicking it switches.
+  const duration = useShotDuration(boardId, shot);
+  const linksLines = (shot.script_line_ids?.length ?? 0) > 0;
+  const durationLabel =
+    duration.seconds != null
+      ? `${duration.seconds}s · ${duration.source === "audio" ? "from takes" : "manual"}`
+      : "model default";
+  const handleToggleDurationSource = useCallback(() => {
+    updateShot(boardId, shot.id, {
+      duration_source: shot.duration_source === "manual" ? "audio" : "manual"
+    });
+  }, [updateShot, boardId, shot.id, shot.duration_source]);
 
   const handleDelete = useCallback(() => {
     removeShot(boardId, shot.id);
@@ -234,6 +250,21 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
                 compact
                 color="info"
                 label={`~$${shot.cost_estimate.toFixed(2)}`}
+              />
+            )}
+            {linksLines && (
+              <Chip
+                compact
+                color={duration.source === "audio" ? "info" : "default"}
+                variant={duration.source === "audio" ? "filled" : "outlined"}
+                label={durationLabel}
+                sx={{ borderRadius: BORDER_RADIUS.sm }}
+                title={
+                  duration.source === "audio"
+                    ? "Length comes from the takes of the lines this shot covers. Click to pin it to the shot's own duration."
+                    : "Length is pinned to the shot's own duration. Click to take it from the lines this shot covers."
+                }
+                onClick={readOnly ? undefined : handleToggleDurationSource}
               />
             )}
             <StatusIndicator

--- a/web/src/components/storyboard/__tests__/ShotCard.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotCard.test.tsx
@@ -23,6 +23,9 @@ jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
 
 const moveShotMock = jest.fn();
 const removeShotMock = jest.fn();
+const updateShotMock = jest.fn();
+/** Script the board links, if any — set per test before rendering. */
+let linkedScriptId: string | null = null;
 jest.mock("../../../stores/storyboard/StoryboardStore", () => {
   const actual = jest.requireActual(
     "../../../stores/storyboard/StoryboardStore"
@@ -36,12 +39,65 @@ jest.mock("../../../stores/storyboard/StoryboardStore", () => {
         toggleShotEntity: jest.fn(),
         moveShot: moveShotMock,
         removeShot: removeShotMock,
+        updateShot: updateShotMock,
         selectKeyframeVersion: jest.fn(),
         selectClipVersion: jest.fn(),
-        boards: {}
+        boards: {
+          "board-1": {
+            screenplay: linkedScriptId ? { script_id: linkedScriptId } : null
+          }
+        }
       })
   };
 });
+
+/** The linked script: one line, voiced with a 3.4 s take plus 250 ms silence. */
+let lineIsVoiced = true;
+jest.mock("../../../trpc/client", () => ({
+  trpc: {
+    scripts: {
+      get: {
+        useQuery: (_input: { id: string }, options?: { enabled?: boolean }) =>
+          options?.enabled
+            ? {
+                data: {
+                  document: {
+                    cast: [],
+                    sections: [
+                      {
+                        id: "sec1",
+                        lines: [
+                          {
+                            id: "line-1",
+                            text: "We are closed.",
+                            pauseAfterMs: 250,
+                            currentTakeId: lineIsVoiced ? "take-1" : null,
+                            takes: lineIsVoiced
+                              ? [
+                                  {
+                                    id: "take-1",
+                                    assetId: "audio-1",
+                                    durationMs: 3400,
+                                    words: [],
+                                    textSnapshot: "We are closed.",
+                                    voiceSnapshot: null,
+                                    createdAt: "2026-01-01T00:00:00.000Z"
+                                  }
+                                ]
+                              : []
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            : { data: undefined }
+      }
+    }
+  },
+  trpcClient: {}
+}));
 
 jest.mock("../../node/ImageRefPreview", () => ({
   __esModule: true,
@@ -79,6 +135,9 @@ describe("ShotCard", () => {
   beforeEach(() => {
     moveShotMock.mockClear();
     removeShotMock.mockClear();
+    updateShotMock.mockClear();
+    linkedScriptId = null;
+    lineIsVoiced = true;
   });
 
   it("renders the shot action and status label", () => {
@@ -202,5 +261,52 @@ describe("ShotCard", () => {
       ).toBeDisabled();
       unmount();
     }
+  });
+});
+
+describe("ShotCard duration source", () => {
+  const linkedShot = (overrides: Partial<Shot> = {}): Shot =>
+    makeShot({ duration_seconds: 8, script_line_ids: ["line-1"], ...overrides });
+
+  beforeEach(() => {
+    updateShotMock.mockClear();
+    linkedScriptId = "script-1";
+    lineIsVoiced = true;
+  });
+
+  it("shows the audio-derived length for a linked, voiced shot", () => {
+    renderCard(linkedShot());
+    // 3400 ms + 250 ms of silence, rounded up to whole seconds.
+    expect(screen.getByText("4s · from takes")).toBeInTheDocument();
+  });
+
+  it("shows the shot's own length when it is pinned to manual", () => {
+    renderCard(linkedShot({ duration_source: "manual" }));
+    expect(screen.getByText("8s · manual")).toBeInTheDocument();
+  });
+
+  it("falls back to the shot's own length while the line is unvoiced", () => {
+    lineIsVoiced = false;
+    renderCard(linkedShot());
+    expect(screen.getByText("8s · manual")).toBeInTheDocument();
+  });
+
+  it("shows nothing for a shot that covers no script lines", () => {
+    renderCard(makeShot({ duration_seconds: 8 }));
+    expect(screen.queryByText(/from takes|manual/)).not.toBeInTheDocument();
+  });
+
+  it("toggles the source through the store", async () => {
+    renderCard(linkedShot());
+    await userEvent.click(screen.getByText("4s · from takes"));
+    expect(updateShotMock).toHaveBeenCalledWith("board-1", "shot-1", {
+      duration_source: "manual"
+    });
+  });
+
+  it("does not toggle in read-only mode", async () => {
+    renderCard(linkedShot(), { readOnly: true });
+    await userEvent.click(screen.getByText("4s · from takes"));
+    expect(updateShotMock).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/storyboard/storyboardAgentBridge.ts
+++ b/web/src/components/storyboard/storyboardAgentBridge.ts
@@ -17,6 +17,7 @@
 import type {
   CameraDirection,
   Screenplay,
+  ShotDurationSource,
   ShotStatus
 } from "@nodetool-ai/protocol";
 
@@ -29,6 +30,8 @@ export interface StoryboardShotNode {
   camera?: CameraDirection;
   motion?: string;
   durationSeconds?: number;
+  /** Where `durationSeconds` comes from; absent on an unlinked board. */
+  durationSource?: ShotDurationSource;
   status: ShotStatus;
   /** Whether the shot has a rendered keyframe still. */
   hasKeyframe: boolean;
@@ -79,6 +82,11 @@ export interface StoryboardUpdateShotPatch {
   camera?: CameraDirection;
   motion?: string;
   status?: ShotStatus;
+  /**
+   * Where the shot's length comes from: `"audio"` derives it from the takes of
+   * the script lines the shot covers, `"manual"` pins `durationSeconds`.
+   */
+  durationSource?: ShotDurationSource;
 }
 
 /**

--- a/web/src/hooks/storyboard/__tests__/useGenerateShot.test.tsx
+++ b/web/src/hooks/storyboard/__tests__/useGenerateShot.test.tsx
@@ -26,6 +26,13 @@ jest.mock("../../../serverState/useEntities", () => ({
 jest.mock("../../useModelsByProvider", () => ({
   useImageModelsByProvider: () => ({ models: [] })
 }));
+// The clip render reads the linked script to time the shot; this stands in for
+// the tRPC round trip.
+const scriptQuery = jest.fn();
+jest.mock("../../../trpc/client", () => ({
+  trpc: {},
+  trpcClient: { scripts: { get: { query: (input: { id: string }) => scriptQuery(input) } } }
+}));
 
 import { useGenerateShot, __resetStartingShotsForTests } from "../useGenerateShot";
 import { useStoryboardStore } from "../../../stores/storyboard/StoryboardStore";
@@ -82,4 +89,120 @@ it("allows a new start after the previous one settles", async () => {
     await result.current.generateKeyframe(BOARD, shot);
   });
   expect(run).toHaveBeenCalledTimes(1);
+});
+
+describe("clip length on a script-linked board", () => {
+  // A fresh board per test: `ensureBoard` keeps whatever screenplay a previous
+  // test put on the id.
+  let boardSeq = 0;
+  let LINKED = "";
+  const linkedShot: Shot = {
+    type: "shot",
+    id: "shot-linked",
+    index: 0,
+    action: "a lighthouse",
+    status: "keyframe_ready",
+    keyframe: { type: "image", uri: "http://example.com/still.png" },
+    duration_seconds: 8,
+    script_line_ids: ["line-1"]
+  };
+
+  /** A script whose one line has a 3.4 s take plus 250 ms of silence. */
+  const script = (voiced: boolean) => ({
+    document: {
+      cast: [],
+      sections: [
+        {
+          id: "sec1",
+          lines: [
+            {
+              id: "line-1",
+              text: "We are closed.",
+              pauseAfterMs: 250,
+              currentTakeId: voiced ? "take-1" : null,
+              takes: voiced
+                ? [
+                    {
+                      id: "take-1",
+                      assetId: "audio-1",
+                      durationMs: 3400,
+                      words: [],
+                      textSnapshot: "We are closed.",
+                      voiceSnapshot: null,
+                      createdAt: "2026-01-01T00:00:00.000Z"
+                    }
+                  ]
+                : []
+            }
+          ]
+        }
+      ]
+    }
+  });
+
+  /** The `duration` the ImageToVideo node was given. */
+  const renderedDuration = async (shotToRender: Shot): Promise<unknown> => {
+    const { result } = renderHook(() => useGenerateShot());
+    await act(async () => {
+      await result.current.generateClip(LINKED, shotToRender);
+    });
+    const nodes = run.mock.calls[0][2] as Array<{
+      id: string;
+      data: { properties: Record<string, unknown> };
+    }>;
+    return nodes.find((n) => n.id === "gen")?.data.properties["duration"];
+  };
+
+  const seedBoard = (scriptId: string | null): void => {
+    boardSeq += 1;
+    LINKED = `board-linked-${boardSeq}`;
+    useStoryboardStore.getState().ensureBoard(LINKED);
+    if (scriptId) {
+      useStoryboardStore.getState().setScreenplay(LINKED, {
+        type: "screenplay",
+        id: "sp-1",
+        title: "Film",
+        script_id: scriptId,
+        shots: []
+      });
+    }
+    useStoryboardStore.getState().upsertShot(LINKED, linkedShot);
+  };
+
+  beforeEach(() => {
+    run.mockReset();
+    run.mockResolvedValue("job-clip");
+    scriptQuery.mockReset();
+    __resetStartingShotsForTests();
+    useStoryboardGenerationStore.getState().clear(linkedShot.id);
+  });
+
+  it("renders a linked shot as long as the takes it covers", async () => {
+    seedBoard("script-1");
+    scriptQuery.mockResolvedValue(script(true));
+    // 3400 ms + 250 ms of silence, rounded up to whole seconds.
+    expect(await renderedDuration(linkedShot)).toBe(4);
+    expect(scriptQuery).toHaveBeenCalledWith({ id: "script-1" });
+  });
+
+  it("keeps the shot's own length when it is pinned to manual", async () => {
+    seedBoard("script-1");
+    scriptQuery.mockResolvedValue(script(true));
+    expect(
+      await renderedDuration({ ...linkedShot, duration_source: "manual" })
+    ).toBe(8);
+    expect(scriptQuery).not.toHaveBeenCalled();
+  });
+
+  it("keeps the shot's own length when the linked line is unvoiced", async () => {
+    seedBoard("script-1");
+    scriptQuery.mockResolvedValue(script(false));
+    expect(await renderedDuration(linkedShot)).toBe(8);
+  });
+
+  it("leaves an unlinked board's shots alone", async () => {
+    seedBoard(null);
+    expect(await renderedDuration(linkedShot)).toBe(8);
+    expect(scriptQuery).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/hooks/storyboard/useGenerateShot.ts
+++ b/web/src/hooks/storyboard/useGenerateShot.ts
@@ -32,6 +32,7 @@ import {
   useStoryboardGenerationStore,
   type ShotJobKind
 } from "../../stores/storyboard/StoryboardGenerationStore";
+import { fetchShotDurationSeconds } from "./useShotDuration";
 
 const GEN_NODE_ID = "gen";
 const OUT_NODE_ID = "out";
@@ -301,6 +302,12 @@ export const useGenerateShot = (): UseGenerateShotResult => {
       }
       const board = useStoryboardStore.getState().getBoard(boardId);
       const aspectRatio = board?.aspectRatio ?? "16:9";
+      // A board linked to a script renders each shot as long as the takes it
+      // covers, so the clip holds its voiceover (design §2.3).
+      const durationSeconds = await fetchShotDurationSeconds(
+        board?.screenplay?.script_id,
+        shot
+      );
       const workflowId = runnerIdForShot(shot.id);
       const nodes: Node<NodeData>[] = [
         makeNode(
@@ -315,7 +322,7 @@ export const useGenerateShot = (): UseGenerateShotResult => {
               boardEntities(board?.entityIds)
             ).map(wireEntity),
             aspect_ratio: aspectRatio,
-            duration: shot.duration_seconds,
+            duration: durationSeconds,
             // Board-level clip model; omitted = the node's default model.
             ...modelProp(board?.videoModel)
           },

--- a/web/src/hooks/storyboard/useShotDuration.ts
+++ b/web/src/hooks/storyboard/useShotDuration.ts
@@ -1,0 +1,81 @@
+/**
+ * useShotDuration
+ *
+ * Where a shot's length comes from on the web side. A board linked to a script
+ * times its shots from the takes they cover (`effectiveShotDuration`, design
+ * §2.3); an unlinked board, an unvoiced line, or a shot pinned to
+ * `duration_source: "manual"` keeps the shot's own `duration_seconds`.
+ *
+ * Two entry points because the two callers differ: the card renders inside
+ * React and reads the linked script through the query cache, while the clip
+ * render starts from a callback with only a board id in hand and fetches once.
+ */
+
+import { useMemo } from "react";
+import type { Shot } from "@nodetool-ai/protocol";
+import type { scripts } from "@nodetool-ai/protocol/api-schemas";
+import {
+  effectiveShotDuration,
+  scriptLinesById,
+  type EffectiveShotDuration
+} from "@nodetool-ai/timeline";
+
+import { trpc, trpcClient } from "../../trpc/client";
+import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
+
+const NO_LINES = new Map<string, scripts.ScriptLine>();
+
+/**
+ * The linked script's lines, keyed by id — empty for an unlinked board and
+ * while the script is still loading.
+ */
+export const useBoardScriptLines = (
+  boardId: string
+): Map<string, scripts.ScriptLine> => {
+  const scriptId = useStoryboardStore(
+    (state) => state.boards[boardId]?.screenplay?.script_id ?? null
+  );
+  const { data: script } = trpc.scripts.get.useQuery(
+    { id: scriptId ?? "" },
+    { enabled: !!scriptId, staleTime: 30_000, retry: false }
+  );
+  return useMemo(
+    () => (script ? scriptLinesById(script.document.sections) : NO_LINES),
+    [script]
+  );
+};
+
+/** A shot's effective length and where it came from, for one open board. */
+export const useShotDuration = (
+  boardId: string,
+  shot: Shot
+): EffectiveShotDuration => {
+  const linesById = useBoardScriptLines(boardId);
+  return useMemo(
+    () => effectiveShotDuration(shot, linesById),
+    [shot, linesById]
+  );
+};
+
+/**
+ * The length a clip render should ask for, fetching the linked script when the
+ * board has one. A script that cannot be read leaves the shot's own duration
+ * in charge rather than failing the render.
+ */
+export const fetchShotDurationSeconds = async (
+  scriptId: string | null | undefined,
+  shot: Shot
+): Promise<number | undefined> => {
+  if (!scriptId || shot.duration_source === "manual") {
+    return shot.duration_seconds;
+  }
+  let linesById = NO_LINES;
+  try {
+    const script = await trpcClient.scripts.get.query({ id: scriptId });
+    linesById = scriptLinesById(script.document.sections);
+  } catch {
+    // Unreadable script: fall through with no lines, which lands on the
+    // shot's own duration below.
+  }
+  return effectiveShotDuration(shot, linesById).seconds;
+};

--- a/web/src/hooks/storyboard/useStoryboardAgentBridge.ts
+++ b/web/src/hooks/storyboard/useStoryboardAgentBridge.ts
@@ -32,6 +32,7 @@ const toShotNode = (shot: Shot): StoryboardShotNode => ({
   camera: shot.camera,
   motion: shot.motion,
   durationSeconds: shot.duration_seconds,
+  durationSource: shot.duration_source,
   status: shot.status,
   hasKeyframe: !!shot.keyframe,
   hasClip: !!shot.clip,
@@ -144,6 +145,9 @@ export const useStoryboardAgentBridge = (boardId: string): void => {
         if (patch.camera !== undefined) next.camera = patch.camera;
         if (patch.motion !== undefined) next.motion = patch.motion;
         if (patch.status !== undefined) next.status = patch.status;
+        if (patch.durationSource !== undefined) {
+          next.duration_source = patch.durationSource;
+        }
         store().updateShot(boardId, shot.id, next);
         return toShotNode(reRead(shot.id));
       },

--- a/web/src/lib/tools/__tests__/storyboardTools.test.ts
+++ b/web/src/lib/tools/__tests__/storyboardTools.test.ts
@@ -79,6 +79,7 @@ describe("ui_storyboard_* tools", () => {
         "ui_storyboard_assemble_timeline",
         "ui_storyboard_extract_script",
         "ui_storyboard_relink_script",
+        "ui_storyboard_set_duration_source",
         "ui_storyboard_select_shot"
       ])
     );
@@ -492,6 +493,46 @@ describe("ui_storyboard_* tools", () => {
 
       expect(handler.extractScript).toHaveBeenCalledWith({ relink: true });
       expect(result.created).toBe(false);
+    });
+
+    it("sets the duration source on every named shot", async () => {
+      const handler = createMockHandler();
+      handler.updateShot.mockImplementation((target) =>
+        shotNode({ id: target, durationSource: "audio" })
+      );
+      setStoryboardAgentHandler(BOARD_ID, handler);
+
+      const result = (await FrontendToolRegistry.call(
+        "ui_storyboard_set_duration_source",
+        { storyboard_id: BOARD_ID, targets: ["shot-1", "1"], source: "audio" },
+        "tc-dur",
+        ctx
+      )) as { ok: boolean; shots: StoryboardShotNode[] };
+
+      expect(handler.updateShot.mock.calls).toEqual([
+        ["shot-1", { durationSource: "audio" }],
+        ["1", { durationSource: "audio" }]
+      ]);
+      expect(result.shots).toHaveLength(2);
+    });
+
+    it("takes a single shot without a list, and pins it to manual", async () => {
+      const handler = createMockHandler();
+      handler.updateShot.mockReturnValue(
+        shotNode({ durationSource: "manual" })
+      );
+      setStoryboardAgentHandler(BOARD_ID, handler);
+
+      await FrontendToolRegistry.call(
+        "ui_storyboard_set_duration_source",
+        { storyboard_id: BOARD_ID, targets: "selected", source: "manual" },
+        "tc-dur-2",
+        ctx
+      );
+
+      expect(handler.updateShot).toHaveBeenCalledWith("selected", {
+        durationSource: "manual"
+      });
     });
 
     it("refuses to relink a board that links no script", async () => {

--- a/web/src/lib/tools/builtin/storyboard.ts
+++ b/web/src/lib/tools/builtin/storyboard.ts
@@ -342,6 +342,28 @@ FrontendToolRegistry.register({
 });
 
 FrontendToolRegistry.register({
+  name: "ui_storyboard_set_duration_source",
+  description:
+    'Choose where the named shots get their length. "audio" times each shot from the takes of the script lines it covers, so the clip is long enough to hold its voiceover (a shot with an unvoiced line keeps its own duration until the line is voiced). "manual" pins the shot to its own durationSeconds and audio never touches it. Only meaningful on a board linked to a script.',
+  parameters: z.object({
+    storyboard_id: storyboardIdParam,
+    targets: z
+      .union([targetParam, z.array(targetParam).min(1)])
+      .describe("One shot, or a list of them."),
+    source: z.enum(["audio", "manual"])
+  }),
+  async execute({ storyboard_id, targets, source }) {
+    const handler = getStoryboardAgentHandler(storyboard_id);
+    const list = Array.isArray(targets) ? targets : [targets];
+    const shots = list.map((target) =>
+      handler.updateShot(target, { durationSource: source })
+    );
+    const persisted = await persistBoard(storyboard_id, "The duration source");
+    return { ok: true, source, shots, ...persisted };
+  }
+});
+
+FrontendToolRegistry.register({
   name: "ui_storyboard_select_shot",
   description:
     "Select a shot on the specified storyboard (driving the surface's focus). Pass null to clear the selection.",


### PR DESCRIPTION
Phase 2 "Timing" from `docs/script-storyboard-link/tasks.md`. `linkedShotDurationMs` shipped in #4946 but nothing outside `buildLinkedTimeline` read it, so a linked board still rendered every shot at its stored `duration_seconds`.

## Changes

- `effectiveShotDuration(shot, linesById)` in `packages/timeline/src/script-link.ts` returns the seconds to render plus where they came from (`"audio"` / `"manual"`), rounding **up** so a clip is never shorter than the voiceover the timeline lays inside it.
- Both render paths read it and load the linked script themselves: `useGenerateShot.generateClip` (web, via the new `web/src/hooks/storyboard/useShotDuration.ts`) and `render_storyboard_clips` in `packages/agents/src/capabilities/storyboards.ts`. A `manual` pin, an unvoiced line, a missing line, and an unlinked board all fall back to `duration_seconds`.
- New `ui_storyboard_set_duration_source` ({storyboard_id, targets: one or many, source}) writing through the existing `updateShot` CAS path, mirrored in the headless eval bridge.
- `ShotCard` shows a chip with the effective length and its source — "4s · from takes" / "8s · manual" — that toggles on click. Hidden for a shot covering no script lines, inert in read-only. ui_primitives and tokens only.

## Tests

Vitest for the helper (`packages/timeline`) and the headless render path (`packages/agents`); Jest for the clip hook, the tool, and the card. Each covers audio-derived / manual / unvoiced / unlinked.

- `packages/timeline` — 22 files, 252 tests passing.
- `packages/agents` storyboard suites — 4 files, 58 tests passing.
- `cd web && npx jest src/hooks/storyboard src/components/storyboard src/lib/tools` — 36 suites, 325 tests passing.
- `npx oxlint web/src packages/agents/src` — clean, nothing in touched files.
- `cd web && npx tsc --noEmit | grep -E "^src/" | grep -v TS2307` — empty.
- Falsifiability: reverting the implementation line once turned the agents test red, then green again after restoring.

## Caveats

- The full `npm run test --workspace=packages/agents` is not green in this sandbox: 31 files fail on unbuilt dists (`Cannot find package '@nodetool-ai/execution/…'`, `Failed to resolve entry for "@nodetool-ai/vectorstore"`). Pre-existing, none in a storyboard file. Only the packages this change needs were built.
- Overlaps with #4962 (`packages/agents/src/capabilities/storyboards.ts`, `capabilities-storyboards.test.ts`) and #4964 (`web/src/lib/tools/builtin/storyboard.ts`, `ShotCard.tsx`, `storyboardTools.test.ts`). The edits are additive — one appended tool registration, one chip inside the existing header row — so the merges should be mechanical. The eval-bridge tool-count assertion in `packages/agents/tests/storyboard-tool-loop.test.ts` moved 10 → 11 and will conflict if another PR adds a tool.
- The `tasks.md` checkbox is left unticked; #4963 owns that file.

---
_Generated by [Claude Code](https://claude.ai/code/session_012nRg3PsMbzt4fHSAU7dp4b)_