### PR TITLE
test(web): mock the gutter's storyboard query in the assemble-button suite

### DIFF
--- a/web/src/components/script/__tests__/ScriptDocumentPane.assembleButton.test.tsx
+++ b/web/src/components/script/__tests__/ScriptDocumentPane.assembleButton.test.tsx
@@ -6,6 +6,15 @@ import {
   type ScriptTake
 } from "../../../stores/script/ScriptStore";
 
+// The gutter's storyboard link reads the board through trpc when it is not
+// open; this suite renders no query client and only reads the header button.
+jest.mock("../../../trpc/client", () => ({
+  trpc: {
+    storyboards: { get: { useQuery: jest.fn(() => ({ data: undefined })) } }
+  },
+  trpcClient: {}
+}));
+
 // The link control owns its own suite and its own trpc query.
 jest.mock("../StoryboardLinkControl", () => ({
   __esModule: true,


### PR DESCRIPTION
`main` is red. Fixes it.

## What happened

#4964 added `ScriptDocumentPane.assembleButton.test.tsx`, which renders the pane with no query client. #4969 added the script gutter's shot chip, so `SectionLine` now calls `useScriptLineShotLink`, which reads `trpc.storyboards.get.useQuery`. Each PR was green on its own branch; neither ran against the other's merge commit, and auto-merge landed both without rebasing.

The result on `main` today:

```
● ScriptDocumentPane assemble button › reads "Send to timeline" for an unlinked, never-assembled script
    TypeError: Cannot read properties of undefined (reading 'get')
      at useScriptLineShotLink (src/hooks/script/useScriptShotLinks.ts:65:37)
      at SectionLine (src/components/script/ScriptDocumentPane.tsx:225:55)

Test Suites: 1 failed, 1 total
Tests:       4 failed, 4 total
```

## The fix

The same `trpc/client` mock `ScriptDocumentPane.perf.test.tsx` already carries, added for exactly this reason. Test-only; no production code changes.

## Verification

Run against `main` at `d8280097` (the #4964 merge commit):

- Before: `Tests: 4 failed, 4 total`.
- After: `cd web && npx jest src` — **1125 suites, 12992 tests passing**, 3 skipped, 1 todo. So this is the only place the two PRs collided.
- `npx oxlint web/src` — exit 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_012nRg3PsMbzt4fHSAU7dp4b)_