### PR TITLE
docs(script-storyboard-link): mark the link shipped and record two deviations

### DIFF
--- a/docs/script-storyboard-link/design.md
+++ b/docs/script-storyboard-link/design.md
@@ -1,8 +1,6 @@
 # Script ↔ Storyboard Link — Technical Design
 
-> Status: Phase 1 shipped · Phase 2 shipped except audio-led timing (§2.3) ·
-> Phase 3 has `buildLinkedTimeline` (§2.4), not the assemble switch ·
-> Phase 4 has the drift helpers (§2.5) and the tool summaries (§3.2), no UI.
+> Status: all four phases shipped, with two deviations noted below (§4, §2.4).
 > Companion: [prd.md](prd.md), [tasks.md](tasks.md).
 
 The design links the two documents with keys and derives everything else. No
@@ -166,6 +164,15 @@ buildLinkedTimeline(input: {
 assembly is a third function, so unlinked behavior is provably unchanged
 (regression tests assert identical output on existing fixtures).
 
+**Deviation found in implementation.** The claim above that both back-sync
+paths patch a joint cut "with no changes" held for `stores/script/timelineSync`
+and failed for `stores/storyboard/timelineSync`: it matched on the shot keys
+alone, which the voiceover clips also carry, so re-rendering a shot handed its
+video asset to a line's audio clip. The fix restricts that match to video
+clips. A second gap stands open: a re-voiced line shifts later voiceover clips
+but never the shot clips, so picture and audio drift apart until someone
+re-assembles.
+
 ### 2.5 Drift
 
 Derived helpers next to `needsVoicing` (same "derived, never stored" rule):
@@ -242,6 +249,14 @@ Extend the storyboard/script tool files
   one project card (script + board + timeline); the prompt-first flow runs
   derive right after the director drafts, so the user lands linked. Curated
   models stamp as today.
+  **Deviation found in implementation.** The shipped flow runs the other
+  direction — prompt becomes a board brief, the director drafts, then
+  `extract_script_from_storyboard` — because no script-drafting path is
+  callable from the web client: scripts are authored by hand or through the
+  chat assistant, and the one-shot drafting lives agent-side with no route.
+  Same outcome (one prompt, one pass, a linked pair) with no new backend
+  surface. Script-first needs either a `nodetool.script.*` node the client can
+  run like the Director node, or a route over the agent capability.
 - **Deletion**: deleting a linked script downgrades the board to unlinked
   (link fields cleared, projected text kept — it is ordinary shot text);
   deleting a board clears the script's `storyboard_id`. Both are

--- a/docs/script-storyboard-link/prd.md
+++ b/docs/script-storyboard-link/prd.md
@@ -1,8 +1,6 @@
 # Script ↔ Storyboard Link — PRD
 
-> Status: Phase 1 shipped · Phase 2 shipped except audio-led timing ·
-> Phase 3 has the joint builder, not the assemble switch · Phase 4 has the
-> drift helpers and the tool summaries, no UI · Owner: matti
+> Status: all four phases shipped · Owner: matti
 >
 > Companion documents: [design.md](design.md) (technical design),
 > [tasks.md](tasks.md) (implementation checklist).

--- a/docs/script-storyboard-link/tasks.md
+++ b/docs/script-storyboard-link/tasks.md
@@ -46,7 +46,7 @@
       `packages/agents/src/capabilities/scripts.ts`; no-provider mode emits
       the deterministic scaffold. Eval case in
       `packages/agents/src/evals/surfaces/script.ts`.
-- [ ] **Timing.** `linkedShotDurationMs` in
+- [x] **Timing.** `linkedShotDurationMs` in
       `packages/timeline/src/script-link.ts` (design §2.3); storyboard
       editor and render tools read it when `duration_source !== "manual"`;
       `ui_storyboard_set_duration_source` toggle + inspector control.
@@ -63,28 +63,28 @@
       fixtures proving unlinked `buildStoryboardTimeline` /
       `buildScriptTimeline` output is unchanged. Feed the built document to
       the timeline validator in tests.
-- [ ] **Assemble switch.** `assemble_storyboard_timeline` (headless) and
+- [x] **Assemble switch.** `assemble_storyboard_timeline` (headless) and
       `ui_storyboard_assemble_timeline` / `ui_script_send_to_timeline` (web)
       call `buildLinkedTimeline` when linked; script-side button relabels to
       *Assemble video*. Re-assemble in place preserves foreign tracks (reuse
       the script re-assemble pattern).
-- [ ] **Back-sync verification.** Jest tests that a re-voiced line and a
+- [x] **Back-sync verification.** Jest tests that a re-voiced line and a
       revised shot both patch the same jointly-assembled sequence through
       the existing `timelineSync` modules, unmodified.
-- [ ] **Creative-pipeline eval.** Case: script → derive → render (stubbed
+- [x] **Creative-pipeline eval.** Case: script → derive → render (stubbed
       assets) → joint assemble → `validate_timeline` green, in
       `packages/agents/src/evals/surfaces/creative-pipeline.ts`.
 
 ## Phase 4 — Drift, Studio, polish
 
-- [ ] **Drift helpers.** `shotDialogueDrifted`, `orphanedLineIds` (design
+- [x] **Drift helpers.** `shotDialogueDrifted`, `orphanedLineIds` (design
       §2.5) with tests; *Re-project* action updating snapshot + projected
       text in one CAS save.
-- [ ] **Badges.** Drift badge + Re-project in the shot inspector; orphan
+- [x] **Badges.** Drift badge + Re-project in the shot inspector; orphan
       badge in the script gutter; linked-line panel (speaker chip, voice
       status, play, voice-from-board) in the shot inspector; keyframe
       thumbnail chips in the script gutter.
-- [ ] **Studio.** Prompt-first flow derives script + board linked in one
+- [x] **Studio.** Prompt-first flow derives script + board linked in one
       pass; home groups linked documents into one project card
       (`web/src/studio/`).
 - [x] **Tool/summary surface.** `get_storyboard` / `get_script` report link


### PR DESCRIPTION
Closes out `docs/script-storyboard-link/`. Every task in `tasks.md` is merged as of #4970; the status lines still said otherwise, because #4963 deliberately ticked only what was merged at the time.

## Checkboxes

Ticks the last seven: Phase 2 timing, Phase 3 assemble switch / back-sync verification / creative-pipeline eval, Phase 4 drift helpers / badges / Studio. Each was verified against the code on `main` rather than taken from a PR description — `effectiveShotDuration`, `ui_storyboard_set_duration_source`, `mergeIntoSequence`, the *Assemble video* label, `web/src/stores/storyboard/__tests__/timelineSync.test.ts`, the `script-to-linked-cut` eval case at `creative-pipeline.ts:1129`, `reprojectShots`, `ShotScriptPanel`, `ScriptShotChip`, `groupLinkedProjects`, `useStudioPromptStart`.

## Two deviations recorded in the design

Implementation contradicted the design twice. Both are now written down next to the claims they break, rather than left for the next reader to rediscover.

**§2.4 — back-sync.** The design said both back-sync paths patch a joint cut "with no changes". True for `stores/script/timelineSync`; false for `stores/storyboard/timelineSync`, which matched on the shot keys the voiceover clips also carry, so re-rendering a shot handed its video asset to a line's audio clip (fixed in #4960). A second gap stays open: a re-voiced line shifts later voiceover clips but never the shot clips, so picture and audio drift apart until someone re-assembles.

**§4 — Studio.** The design said the prompt-first flow derives script → board. The shipped flow runs board-first (prompt as board brief → director → `extract_script_from_storyboard`) because no script-drafting path is callable from the web client. Same outcome with no new backend surface; the note names what script-first would need.

Docs only.

---
_Generated by [Claude Code](https://claude.ai/code/session_012nRg3PsMbzt4fHSAU7dp4b)_