### PR TITLE
feat(dashboard): order the page by user state, lead with the command bar

### DIFF
--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -87,6 +87,12 @@ import { useDragAndDrop } from "../hooks/useDragAndDrop";
 import { usePromptHistory } from "../hooks/usePromptHistory";
 import { useMessageQueue } from "../../../hooks/useMessageQueue";
 import { createMediaComposerStyles } from "./MediaChatComposer.styles";
+import {
+  audioModelPatch,
+  imageModelPatch,
+  recentModelEntry,
+  videoModelPatch
+} from "./modelSelection";
 import useModelPreferencesStore from "../../../stores/ModelPreferencesStore";
 import { useChatDraftStore } from "../../../stores/ChatDraftStore";
 import { StopGenerationButton } from "./StopGenerationButton";
@@ -720,64 +726,20 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
 
   const handlePickImageModel = useCallback(
     (model: ImageModel) => {
-      const constraints = imageModelConstraints(model);
-      setImageParams({
-        model: {
-          type: "image_model",
-          id: model.id,
-          provider: model.provider,
-          name: model.name || "",
-          path: model.path || "",
-          ...constraints
-        },
-        resolution: clampToAllowed(
-          imageParams.resolution,
-          constraints.resolutions
-        ),
-        aspectRatio: clampToAllowed(
-          imageParams.aspectRatio,
-          constraints.aspectRatios
-        )
-      });
-      addRecentModel({
-        provider: model.provider || "",
-        id: model.id || "",
-        name: model.name || ""
-      });
+      setImageParams(imageModelPatch(model, imageParams));
+      addRecentModel(recentModelEntry(model));
       setImageModelOpen(false);
     },
-    [setImageParams, addRecentModel, imageParams.resolution, imageParams.aspectRatio]
+    [setImageParams, addRecentModel, imageParams]
   );
 
   const handlePickVideoModel = useCallback(
     (model: VideoModel) => {
-      const constraints = videoModelConstraints(model);
-      setVideoParams({
-        model: {
-          type: "video_model",
-          id: model.id,
-          provider: model.provider,
-          name: model.name || "",
-          ...constraints
-        },
-        duration: clampToAllowed(videoParams.duration, constraints.durations),
-        resolution: clampToAllowed(
-          videoParams.resolution,
-          constraints.resolutions
-        ),
-        aspectRatio: clampToAllowed(
-          videoParams.aspectRatio,
-          constraints.aspectRatios
-        )
-      });
-      addRecentModel({
-        provider: model.provider || "",
-        id: model.id || "",
-        name: model.name || ""
-      });
+      setVideoParams(videoModelPatch(model, videoParams));
+      addRecentModel(recentModelEntry(model));
       setVideoModelOpen(false);
     },
-    [setVideoParams, addRecentModel, videoParams.duration, videoParams.resolution, videoParams.aspectRatio]
+    [setVideoParams, addRecentModel, videoParams]
   );
 
   const handlePickImageEditModel = useCallback(
@@ -847,23 +809,8 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
 
   const handlePickTtsModel = useCallback(
     (model: TTSModel) => {
-      const voices = Array.isArray(model.voices) ? model.voices : [];
-      setAudioParams({
-        model: {
-          type: "tts_model",
-          id: model.id,
-          provider: model.provider,
-          name: model.name || "",
-          voices,
-          selected_voice: voices[0] ?? audioParams.voice
-        },
-        voice: voices[0] ?? audioParams.voice
-      });
-      addRecentModel({
-        provider: model.provider || "",
-        id: model.id || "",
-        name: model.name || ""
-      });
+      setAudioParams(audioModelPatch(model, audioParams.voice));
+      addRecentModel(recentModelEntry(model));
       setTtsModelOpen(false);
     },
     [setAudioParams, addRecentModel, audioParams.voice]

--- a/web/src/components/chat/composer/modelSelection.ts
+++ b/web/src/components/chat/composer/modelSelection.ts
@@ -1,0 +1,122 @@
+/**
+ * modelSelection — turning a model the user picked in a menu dialog into the
+ * params patch its store expects.
+ *
+ * A model carries constraints (which resolutions, aspect ratios and durations
+ * it supports), so picking one has to clamp the current settings to what the
+ * new model allows. That rule belongs in one place: the chat composer and the
+ * dashboard command bar both write these same stores, and a second copy of the
+ * clamping would drift from the first.
+ */
+import type { ImageModel, TTSModel, VideoModel } from "../../../stores/ApiTypes";
+import type {
+  ImageModelValue,
+  TTSModelValue
+} from "../../../stores/ApiTypes";
+import type {
+  VideoModelSelection,
+  ImageResolution,
+  VideoResolution
+} from "../../../stores/MediaGenerationStore";
+import { imageModelConstraints } from "./imageModelOptions";
+import { clampToAllowed, videoModelConstraints } from "./videoModelOptions";
+
+interface ImageSettings {
+  resolution: ImageResolution;
+  aspectRatio: string;
+}
+
+interface VideoSettings {
+  resolution: VideoResolution;
+  aspectRatio: string;
+  duration: number;
+}
+
+export interface ImageModelPatch extends ImageSettings {
+  model: ImageModelValue;
+}
+
+export interface VideoModelPatch extends VideoSettings {
+  model: VideoModelSelection;
+}
+
+export interface AudioModelPatch {
+  model: TTSModelValue;
+  voice: string;
+}
+
+/** The image params to write when `model` is picked over `current` settings. */
+export function imageModelPatch(
+  model: ImageModel,
+  current: ImageSettings
+): ImageModelPatch {
+  const constraints = imageModelConstraints(model);
+  return {
+    model: {
+      type: "image_model",
+      id: model.id,
+      provider: model.provider,
+      name: model.name || "",
+      path: model.path || "",
+      ...constraints
+    },
+    resolution: clampToAllowed(current.resolution, constraints.resolutions),
+    aspectRatio: clampToAllowed(current.aspectRatio, constraints.aspectRatios)
+  };
+}
+
+/** The video params to write when `model` is picked over `current` settings. */
+export function videoModelPatch(
+  model: VideoModel,
+  current: VideoSettings
+): VideoModelPatch {
+  const constraints = videoModelConstraints(model);
+  return {
+    model: {
+      type: "video_model",
+      id: model.id,
+      provider: model.provider,
+      name: model.name || "",
+      ...constraints
+    },
+    duration: clampToAllowed(current.duration, constraints.durations),
+    resolution: clampToAllowed(current.resolution, constraints.resolutions),
+    aspectRatio: clampToAllowed(current.aspectRatio, constraints.aspectRatios)
+  };
+}
+
+/**
+ * The audio params to write when `model` is picked. A TTS model carries its
+ * own voices, so the current voice is replaced by the new model's first one
+ * rather than clamped — a voice from another model does not exist here.
+ */
+export function audioModelPatch(
+  model: TTSModel,
+  currentVoice: string
+): AudioModelPatch {
+  const voices = Array.isArray(model.voices) ? model.voices : [];
+  return {
+    model: {
+      type: "tts_model",
+      id: model.id,
+      provider: model.provider,
+      name: model.name || "",
+      voices,
+      selected_voice: voices[0] ?? currentVoice
+    },
+    voice: voices[0] ?? currentVoice
+  };
+}
+
+/** The `{provider, id, name}` a picked model contributes to recents. */
+export function recentModelEntry(model: {
+  provider?: string | null;
+  id?: string | null;
+  name?: string | null;
+}): { provider: string; id: string; name: string } {
+  return {
+    provider: model.provider || "",
+    id: model.id || "",
+    name: model.name || ""
+  };
+}

--- a/web/src/components/portal/CommandBarModelChip.tsx
+++ b/web/src/components/portal/CommandBarModelChip.tsx
@@ -1,0 +1,158 @@
+import { memo, useCallback, useRef, useState } from "react";
+import TuneIcon from "@mui/icons-material/Tune";
+import { isModelSelected } from "@nodetool-ai/protocol";
+import type {
+  ImageModel,
+  LanguageModel,
+  TTSModel,
+  VideoModel
+} from "../../stores/ApiTypes";
+import useGlobalChatStore from "../../stores/GlobalChatStore";
+import useMediaGenerationStore from "../../stores/MediaGenerationStore";
+import useModelPreferencesStore from "../../stores/ModelPreferencesStore";
+import MediaControlChip from "../chat/composer/MediaControlChip";
+import {
+  audioModelPatch,
+  imageModelPatch,
+  recentModelEntry,
+  videoModelPatch
+} from "../chat/composer/modelSelection";
+import ImageModelMenuDialog from "../model_menu/ImageModelMenuDialog";
+import LanguageModelMenuDialog from "../model_menu/LanguageModelMenuDialog";
+import TTSModelMenuDialog from "../model_menu/TTSModelMenuDialog";
+import VideoModelMenuDialog from "../model_menu/VideoModelMenuDialog";
+import type { WelcomeTrackId } from "./welcomeTracks";
+
+const UNSET_LABEL = "Select model";
+
+interface CommandBarModelChipProps {
+  /** Which track's model this chip selects. */
+  track: WelcomeTrackId;
+}
+
+/**
+ * The model for the track the command bar is set to.
+ *
+ * Each track's model lives in the store its composer reads — chat in
+ * GlobalChatStore, the rest in MediaGenerationStore — so a model chosen here
+ * is already chosen when the chat opens, with no handoff of its own.
+ */
+const CommandBarModelChip: React.FC<CommandBarModelChipProps> = ({ track }) => {
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+
+  const languageModel = useGlobalChatStore((s) => s.selectedModel);
+  const setLanguageModel = useGlobalChatStore((s) => s.setSelectedModel);
+
+  const imageParams = useMediaGenerationStore((s) => s.image);
+  const videoParams = useMediaGenerationStore((s) => s.video);
+  const audioParams = useMediaGenerationStore((s) => s.audio);
+  const setImageParams = useMediaGenerationStore((s) => s.setImageParams);
+  const setVideoParams = useMediaGenerationStore((s) => s.setVideoParams);
+  const setAudioParams = useMediaGenerationStore((s) => s.setAudioParams);
+
+  const addRecentModel = useModelPreferencesStore((s) => s.addRecent);
+
+  const selected =
+    track === "agent"
+      ? languageModel
+      : track === "image"
+        ? imageParams.model
+        : track === "video"
+          ? videoParams.model
+          : audioParams.model;
+
+  const label =
+    selected && isModelSelected(selected)
+      ? selected.name || selected.id || UNSET_LABEL
+      : UNSET_LABEL;
+
+  const close = useCallback(() => setOpen(false), []);
+
+  const pickLanguage = useCallback(
+    (model: LanguageModel) => {
+      setLanguageModel(model);
+      addRecentModel(recentModelEntry(model));
+      close();
+    },
+    [setLanguageModel, addRecentModel, close]
+  );
+
+  const pickImage = useCallback(
+    (model: ImageModel) => {
+      setImageParams(imageModelPatch(model, imageParams));
+      addRecentModel(recentModelEntry(model));
+      close();
+    },
+    [setImageParams, imageParams, addRecentModel, close]
+  );
+
+  const pickVideo = useCallback(
+    (model: VideoModel) => {
+      setVideoParams(videoModelPatch(model, videoParams));
+      addRecentModel(recentModelEntry(model));
+      close();
+    },
+    [setVideoParams, videoParams, addRecentModel, close]
+  );
+
+  const pickAudio = useCallback(
+    (model: TTSModel) => {
+      setAudioParams(audioModelPatch(model, audioParams.voice));
+      addRecentModel(recentModelEntry(model));
+      close();
+    },
+    [setAudioParams, audioParams.voice, addRecentModel, close]
+  );
+
+  return (
+    <>
+      <MediaControlChip
+        ref={anchorRef}
+        icon={<TuneIcon fontSize="small" />}
+        label={label}
+        title={`Model for ${track}`}
+        active={open}
+        size="sm"
+        showChevron
+        onClick={() => setOpen(true)}
+      />
+      {open && track === "agent" && (
+        <LanguageModelMenuDialog
+          open={open}
+          anchorEl={anchorRef.current}
+          onClose={close}
+          onModelChange={pickLanguage}
+        />
+      )}
+      {open && track === "image" && (
+        <ImageModelMenuDialog
+          open={open}
+          anchorEl={anchorRef.current}
+          onClose={close}
+          onModelChange={pickImage}
+          task="text_to_image"
+        />
+      )}
+      {open && track === "video" && (
+        <VideoModelMenuDialog
+          open={open}
+          anchorEl={anchorRef.current}
+          onClose={close}
+          onModelChange={pickVideo}
+          task="text_to_video"
+        />
+      )}
+      {open && track === "audio" && (
+        <TTSModelMenuDialog
+          open={open}
+          anchorEl={anchorRef.current}
+          onClose={close}
+          onModelChange={pickAudio}
+        />
+      )}
+    </>
+  );
+};
+
+export default memo(CommandBarModelChip);

--- a/web/src/components/portal/DashboardActivity.tsx
+++ b/web/src/components/portal/DashboardActivity.tsx
@@ -1,0 +1,168 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import type { Theme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
+import { memo, useMemo } from "react";
+import { Job, Workflow } from "../../stores/ApiTypes";
+import { useRunningJobs } from "../../hooks/useRunningJobs";
+import { BORDER_RADIUS, MOTION, SPACING, getSpacingPx } from "../ui_primitives";
+import { shortAgo, toneFor } from "./runStatus";
+
+const MAX_RUNS = 6;
+
+const styles = (theme: Theme) =>
+  css({
+    border: `1px solid ${theme.vars.palette.divider}`,
+    borderRadius: BORDER_RADIUS.lg,
+    background: theme.vars.palette.c_node_bg,
+    padding: getSpacingPx(SPACING.lg),
+
+    ".act-head": {
+      display: "flex",
+      alignItems: "baseline",
+      justifyContent: "space-between",
+      gap: getSpacingPx(SPACING.sm),
+      marginBottom: getSpacingPx(SPACING.md)
+    },
+    ".act-title": {
+      fontSize: "var(--fontSizeNormal)",
+      fontWeight: 500,
+      color: theme.vars.palette.text.primary
+    },
+    ".act-count": {
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.disabled
+    },
+    ".act-list": {
+      display: "flex",
+      flexDirection: "column",
+      gap: getSpacingPx(SPACING.micro)
+    },
+    ".act-run": {
+      display: "flex",
+      alignItems: "center",
+      gap: getSpacingPx(SPACING.md),
+      width: "100%",
+      textAlign: "left",
+      padding: `${getSpacingPx(SPACING.sm)} ${getSpacingPx(SPACING.sm)}`,
+      background: "transparent",
+      border: "none",
+      borderRadius: BORDER_RADIUS.sm,
+      cursor: "pointer",
+      transition: `background ${MOTION.fast}`,
+      "&:hover": { background: theme.vars.palette.action.hover }
+    },
+    ".act-dot": {
+      width: 7,
+      height: 7,
+      flexShrink: 0,
+      borderRadius: BORDER_RADIUS.circle,
+      background: theme.vars.palette.text.disabled,
+      "&.running": { background: theme.vars.palette.primary.main },
+      "&.failed": { background: theme.vars.palette.error.main },
+      "&.done": { background: theme.vars.palette.success.main }
+    },
+    ".act-name": {
+      flex: 1,
+      minWidth: 0,
+      fontSize: "var(--fontSizeSmall)",
+      color: theme.vars.palette.text.primary,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap"
+    },
+    ".act-when": {
+      flexShrink: 0,
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.disabled
+    },
+    ".act-empty": {
+      fontSize: "var(--fontSizeSmall)",
+      color: theme.vars.palette.text.disabled,
+      lineHeight: 1.5
+    }
+  });
+
+interface DashboardActivityProps {
+  workflows: Workflow[];
+  onOpenWorkflow: (workflowId: string) => void;
+}
+
+/**
+ * Recent runs, in the dashboard's right rail. A workflow tool whose dashboard
+ * says nothing about what ran, or what broke, is missing the one thing only it
+ * can show.
+ */
+const DashboardActivity: React.FC<DashboardActivityProps> = ({
+  workflows,
+  onOpenWorkflow
+}) => {
+  const theme = useTheme();
+  const { data: jobs } = useRunningJobs();
+
+  const namesById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const workflow of workflows) {
+      map.set(workflow.id, workflow.name);
+    }
+    return map;
+  }, [workflows]);
+
+  const runs = useMemo(() => {
+    const all: Job[] = jobs ?? [];
+    return [...all]
+      .sort((a, b) =>
+        (b.started_at ?? "").localeCompare(a.started_at ?? "")
+      )
+      .slice(0, MAX_RUNS);
+  }, [jobs]);
+
+  const runningCount = runs.filter(
+    (job) => toneFor(job.status) === "running"
+  ).length;
+
+  return (
+    <section css={styles(theme)} aria-label="Recent runs">
+      <div className="act-head">
+        <span className="act-title">Recent runs</span>
+        {runningCount > 0 && (
+          <span className="act-count">{runningCount} running</span>
+        )}
+      </div>
+
+      {runs.length === 0 ? (
+        <p className="act-empty">
+          Nothing has run yet. Open a workflow and press run — what it does will
+          show up here.
+        </p>
+      ) : (
+        <div className="act-list">
+          {runs.map((job) => {
+            const tone = toneFor(job.status);
+            const name =
+              job.name || namesById.get(job.workflow_id) || "Workflow";
+            return (
+              <button
+                key={job.id}
+                type="button"
+                className="act-run"
+                onClick={() => onOpenWorkflow(job.workflow_id)}
+                title={job.error ?? undefined}
+              >
+                <span className={`act-dot ${tone}`} />
+                <span className="act-name">{name}</span>
+                <span className="act-when">
+                  {shortAgo(job.finished_at ?? job.started_at)}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default memo(DashboardActivity);

--- a/web/src/components/portal/DashboardCommandBar.tsx
+++ b/web/src/components/portal/DashboardCommandBar.tsx
@@ -1,0 +1,226 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import type { Theme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
+import { memo, useCallback, useState, type CSSProperties } from "react";
+import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
+import VideocamOutlinedIcon from "@mui/icons-material/VideocamOutlined";
+import GraphicEqIcon from "@mui/icons-material/GraphicEq";
+import SmartToyOutlinedIcon from "@mui/icons-material/SmartToyOutlined";
+import type { SvgIconComponent } from "@mui/icons-material";
+import { BORDER_RADIUS, MOTION, SPACING, getSpacingPx } from "../ui_primitives";
+import { WELCOME_TRACKS, type WelcomeTrackId } from "./welcomeTracks";
+
+const TRACK_ICONS = {
+  image: ImageOutlinedIcon,
+  video: VideocamOutlinedIcon,
+  audio: GraphicEqIcon,
+  agent: SmartToyOutlinedIcon
+} satisfies Record<WelcomeTrackId, SvgIconComponent>;
+
+/** What a bare "send" means: a written answer, not a generated picture. */
+const DEFAULT_TRACK: WelcomeTrackId = "agent";
+
+const styles = (theme: Theme) =>
+  css({
+    ".cmd-field": {
+      display: "flex",
+      alignItems: "center",
+      gap: getSpacingPx(SPACING.md),
+      padding: `0 ${getSpacingPx(SPACING.md)}`,
+      height: 48,
+      background: theme.vars.palette.background.paper,
+      border: `1px solid ${theme.vars.palette.divider}`,
+      borderRadius: BORDER_RADIUS.lg,
+      transition: `border-color ${MOTION.fast}`,
+      "&:focus-within": {
+        borderColor: theme.vars.palette.primary.main
+      }
+    },
+    ".cmd-field input": {
+      flex: 1,
+      minWidth: 0,
+      background: "transparent",
+      border: "none",
+      outline: "none",
+      font: "inherit",
+      fontSize: "var(--fontSizeNormal)",
+      color: theme.vars.palette.text.primary,
+      "&::placeholder": { color: theme.vars.palette.text.disabled }
+    },
+    ".cmd-send": {
+      display: "inline-flex",
+      alignItems: "center",
+      gap: getSpacingPx(SPACING.sm),
+      height: 32,
+      flexShrink: 0,
+      padding: `0 ${getSpacingPx(SPACING.lg)}`,
+      borderRadius: BORDER_RADIUS.md,
+      border: "none",
+      background: theme.vars.palette.primary.main,
+      color: theme.vars.palette.primary.contrastText,
+      fontSize: "var(--fontSizeSmall)",
+      cursor: "pointer",
+      transition: `opacity ${MOTION.fast}`,
+      "&:disabled": {
+        opacity: 0.4,
+        cursor: "default"
+      }
+    },
+    ".cmd-modes": {
+      display: "flex",
+      alignItems: "center",
+      gap: getSpacingPx(SPACING.sm),
+      flexWrap: "wrap",
+      marginTop: getSpacingPx(SPACING.md)
+    },
+    ".cmd-mode": {
+      display: "inline-flex",
+      alignItems: "center",
+      gap: getSpacingPx(SPACING.sm),
+      height: 30,
+      padding: `0 ${getSpacingPx(SPACING.lg)}`,
+      borderRadius: BORDER_RADIUS.pill,
+      border: `1px solid ${theme.vars.palette.divider}`,
+      background: "transparent",
+      color: theme.vars.palette.text.secondary,
+      fontSize: "var(--fontSizeSmall)",
+      cursor: "pointer",
+      transition: `border-color ${MOTION.fast}, color ${MOTION.fast}, background ${MOTION.fast}`,
+      "&:hover": {
+        borderColor: "var(--track-accent)",
+        color: theme.vars.palette.text.primary
+      },
+      "&.on": {
+        borderColor: "var(--track-accent)",
+        color: "var(--track-accent)",
+        background: "color-mix(in srgb, var(--track-accent) 12%, transparent)"
+      },
+      "& svg": { fontSize: "var(--fontSizeNormal)" }
+    },
+    ".cmd-hint": {
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.disabled,
+      marginLeft: "auto",
+      [theme.breakpoints.down("sm")]: { marginLeft: 0 }
+    }
+  });
+
+interface DashboardCommandBarProps {
+  /**
+   * Runs the prompt in a track's composer mode. An empty prompt falls back to
+   * that track's own example, so a bare chip click still opens something.
+   */
+  onSubmit: (trackId: WelcomeTrackId, prompt: string) => void;
+  /**
+   * The mode chips. Hidden where the host already shows the four starter
+   * cards (the first-run hero), which say the same thing at more length.
+   */
+  showModes?: boolean;
+}
+
+/**
+ * One door into the product: describe what you want, pick the kind of output,
+ * press send. Replaces four starter cards that all led to the same chat.
+ */
+const DashboardCommandBar: React.FC<DashboardCommandBarProps> = ({
+  onSubmit,
+  showModes = true
+}) => {
+  const theme = useTheme();
+  const [prompt, setPrompt] = useState("");
+  const [track, setTrack] = useState<WelcomeTrackId>(DEFAULT_TRACK);
+
+  const submit = useCallback(() => {
+    onSubmit(track, prompt);
+  }, [onSubmit, prompt, track]);
+
+  const hasPrompt = prompt.trim().length > 0;
+
+  return (
+    <div css={styles(theme)}>
+      <div className="cmd-field">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          aria-hidden
+        >
+          <path d="M8 2.5 9.4 6.6 13.5 8l-4.1 1.4L8 13.5 6.6 9.4 2.5 8l4.1-1.4z" />
+        </svg>
+        <input
+          value={prompt}
+          placeholder="Describe what you want to make…"
+          aria-label="Describe what you want to make"
+          onChange={(e) => setPrompt(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              submit();
+            }
+          }}
+        />
+        <button
+          type="button"
+          className="cmd-send"
+          onClick={submit}
+          disabled={!hasPrompt}
+        >
+          Send
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            aria-hidden
+          >
+            <path d="m6 4 4 4-4 4" />
+          </svg>
+        </button>
+      </div>
+
+      {showModes && (
+        <div className="cmd-modes" role="group" aria-label="Output kind">
+          {WELCOME_TRACKS.map((t) => {
+            const active = t.id === track;
+            const Icon = TRACK_ICONS[t.id];
+            return (
+              <button
+                key={t.id}
+                type="button"
+                className={`cmd-mode${active ? " on" : ""}`}
+                aria-pressed={active}
+                style={{ "--track-accent": t.accent } as CSSProperties}
+                onClick={() => {
+                  setTrack(t.id);
+                  // A chip on an empty box is the old starter-card gesture:
+                  // open that track with its own example prompt. With
+                  // something typed it only chooses what the send makes.
+                  if (!hasPrompt) {
+                    onSubmit(t.id, "");
+                  }
+                }}
+              >
+                <Icon />
+                {t.label}
+              </button>
+            );
+          })}
+          <span className="cmd-hint">
+            {hasPrompt
+              ? "enter to open a chat with this prompt"
+              : "pick one for an example prompt"}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default memo(DashboardCommandBar);

--- a/web/src/components/portal/DashboardCommandBar.tsx
+++ b/web/src/components/portal/DashboardCommandBar.tsx
@@ -9,6 +9,7 @@ import GraphicEqIcon from "@mui/icons-material/GraphicEq";
 import SmartToyOutlinedIcon from "@mui/icons-material/SmartToyOutlined";
 import type { SvgIconComponent } from "@mui/icons-material";
 import { BORDER_RADIUS, MOTION, SPACING, getSpacingPx } from "../ui_primitives";
+import CommandBarModelChip from "./CommandBarModelChip";
 import { WELCOME_TRACKS, type WelcomeTrackId } from "./welcomeTracks";
 
 const TRACK_ICONS = {
@@ -98,6 +99,15 @@ const styles = (theme: Theme) =>
       },
       "& svg": { fontSize: "var(--fontSizeNormal)" }
     },
+    // A vertical rule sets the model apart: the chips before it choose what
+    // gets made, this chooses what makes it.
+    ".cmd-model": {
+      display: "inline-flex",
+      alignItems: "center",
+      marginLeft: getSpacingPx(SPACING.sm),
+      paddingLeft: getSpacingPx(SPACING.md),
+      borderLeft: `1px solid ${theme.vars.palette.divider}`
+    },
     ".cmd-hint": {
       fontFamily: theme.fontFamily2,
       fontSize: "var(--fontSizeSmaller)",
@@ -185,9 +195,12 @@ const DashboardCommandBar: React.FC<DashboardCommandBarProps> = ({
         </button>
       </div>
 
-      {showModes && (
-        <div className="cmd-modes" role="group" aria-label="Output kind">
-          {WELCOME_TRACKS.map((t) => {
+      {/* The row carries the model chip in both modes: the first-run hero
+          hides the kind chips because its starter cards say the same thing,
+          but which model runs is not something the cards cover. */}
+      <div className="cmd-modes" role="group" aria-label="Output kind">
+        {showModes &&
+          WELCOME_TRACKS.map((t) => {
             const active = t.id === track;
             const Icon = TRACK_ICONS[t.id];
             return (
@@ -199,11 +212,12 @@ const DashboardCommandBar: React.FC<DashboardCommandBarProps> = ({
                 style={{ "--track-accent": t.accent } as CSSProperties}
                 onClick={() => {
                   setTrack(t.id);
-                  // A chip on an empty box is the old starter-card gesture:
-                  // open that track with its own example prompt. With
-                  // something typed it only chooses what the send makes.
+                  // A chip on an empty box writes that track's example into
+                  // the box rather than opening a chat outright. Choosing a
+                  // kind is also how you reach its model, so the click has to
+                  // leave the user here.
                   if (!hasPrompt) {
-                    onSubmit(t.id, "");
+                    setPrompt(t.samplePrompt);
                   }
                 }}
               >
@@ -212,13 +226,17 @@ const DashboardCommandBar: React.FC<DashboardCommandBarProps> = ({
               </button>
             );
           })}
-          <span className="cmd-hint">
-            {hasPrompt
-              ? "enter to open a chat with this prompt"
-              : "pick one for an example prompt"}
-          </span>
-        </div>
-      )}
+        <span className={showModes ? "cmd-model" : undefined}>
+          <CommandBarModelChip track={track} />
+        </span>
+        <span className="cmd-hint">
+          {hasPrompt
+            ? "enter to open a chat with this prompt"
+            : showModes
+              ? "pick a kind for an example prompt"
+              : "pick a starter below, or describe your own"}
+        </span>
+      </div>
     </div>
   );
 };

--- a/web/src/components/portal/DashboardHero.tsx
+++ b/web/src/components/portal/DashboardHero.tsx
@@ -4,25 +4,26 @@ import type { Theme } from "@mui/material/styles";
 import { useTheme } from "@mui/material/styles";
 import { memo } from "react";
 import { MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
-import useOnboardingStore, {
-  isOnboardingFinished
-} from "../../stores/OnboardingStore";
+import type { DashboardMode } from "../../hooks/useDashboardMode";
+import DashboardCommandBar from "./DashboardCommandBar";
 import WelcomeFlow from "./WelcomeFlow";
 import { wrapStyles } from "./dashboardChrome";
 import type { WelcomeTrackId } from "./welcomeTracks";
 
-const heroStyles = (theme: Theme) =>
+const heroStyles = (theme: Theme, compact: boolean) =>
   css({
     position: "relative",
     overflow: "hidden",
     borderBottom: `1px solid ${theme.vars.palette.divider}`,
-    background: `radial-gradient(120% 140% at 0% 0%, rgba(102,144,212,0.05), transparent 46%), ${theme.vars.palette.c_app_header}`,
+    background: compact
+      ? theme.vars.palette.c_app_header
+      : `radial-gradient(120% 140% at 0% 0%, rgba(102,144,212,0.05), transparent 46%), ${theme.vars.palette.c_app_header}`,
     // Faint node-canvas dot grid, fading out toward the bottom.
     "&::before": {
       content: '""',
       position: "absolute",
       inset: 0,
-      opacity: 0.5,
+      opacity: compact ? 0 : 0.5,
       pointerEvents: "none",
       backgroundImage: `radial-gradient(${theme.vars.palette.c_editor_grid_color} 1px, transparent 1px)`,
       backgroundSize: "26px 26px",
@@ -85,61 +86,72 @@ const heroStyles = (theme: Theme) =>
   });
 
 interface DashboardHeroProps {
-  onPickTrack: (trackId: WelcomeTrackId) => void;
+  mode: DashboardMode;
+  onStart: (trackId: WelcomeTrackId, prompt: string) => void;
   onOpenEmptyCanvas: () => void;
   onOpenSettings: () => void;
 }
 
 /**
- * First-run hero: the "what do you want to make today?" track picker. It
- * retires itself once the user finishes or dismisses onboarding, leaving the
- * dashboard to open on its own content.
+ * The dashboard's one starting point. Both modes carry the same command bar —
+ * describe a thing, pick its kind, send. First-run keeps the welcome copy and
+ * the starter cards around it; a returning user gets the bar alone, so their
+ * own work stays near the top of the page.
  */
 const DashboardHero: React.FC<DashboardHeroProps> = ({
-  onPickTrack,
+  mode,
+  onStart,
   onOpenEmptyCanvas,
   onOpenSettings
 }) => {
   const theme = useTheme();
-  const onboardingFinished = useOnboardingStore(isOnboardingFinished);
-
-  if (onboardingFinished) {
-    return null;
-  }
+  const compact = mode === "returning";
 
   return (
-    <section css={heroStyles(theme)}>
+    <section css={heroStyles(theme, compact)}>
       <div css={wrapStyles(theme)} className="hero-wrap">
-        <WelcomeFlow
-          onPick={onPickTrack}
-          onSkip={onOpenEmptyCanvas}
-          statusDot
-          fullWidth
-          hideFooter
-        />
+        {compact ? (
+          <DashboardCommandBar onSubmit={onStart} />
+        ) : (
+          <>
+            <WelcomeFlow
+              onPick={(trackId) => onStart(trackId, "")}
+              onSkip={onOpenEmptyCanvas}
+              statusDot
+              fullWidth
+              hideFooter
+              commandBar={
+                <DashboardCommandBar onSubmit={onStart} showModes={false} />
+              }
+            />
 
-        <div className="hero-foot">
-          <button
-            type="button"
-            className="hero-skip"
-            onClick={onOpenEmptyCanvas}
-          >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 16 16"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-            >
-              <path d="M8 3v10M3 8h10" />
-            </svg>
-            Skip, open an empty canvas
-          </button>
-          <span className="hero-hint">
-            local model? <button type="button" onClick={onOpenSettings}>open settings</button>
-          </span>
-        </div>
+            <div className="hero-foot">
+              <button
+                type="button"
+                className="hero-skip"
+                onClick={onOpenEmptyCanvas}
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                >
+                  <path d="M8 3v10M3 8h10" />
+                </svg>
+                Skip, open an empty canvas
+              </button>
+              <span className="hero-hint">
+                local model?{" "}
+                <button type="button" onClick={onOpenSettings}>
+                  open settings
+                </button>
+              </span>
+            </div>
+          </>
+        )}
       </div>
     </section>
   );

--- a/web/src/components/portal/DashboardHero.tsx
+++ b/web/src/components/portal/DashboardHero.tsx
@@ -33,8 +33,8 @@ const heroStyles = (theme: Theme, compact: boolean) =>
     },
     ".hero-wrap": {
       position: "relative",
-      paddingTop: getSpacingPx(SPACING.md),
-      paddingBottom: getSpacingPx(SPACING.md),
+      paddingTop: getSpacingPx(compact ? SPACING.xxl : SPACING.md),
+      paddingBottom: getSpacingPx(compact ? SPACING.xxl : SPACING.md),
       [theme.breakpoints.down("sm")]: {
         paddingTop: getSpacingPx(SPACING.md),
         paddingBottom: getSpacingPx(SPACING.md)

--- a/web/src/components/portal/DashboardTemplates.tsx
+++ b/web/src/components/portal/DashboardTemplates.tsx
@@ -23,7 +23,7 @@ import {
   getSpacingPx
 } from "../ui_primitives";
 import {
-  wrapStyles,
+  useSectionWrap,
   SectionHeader,
   DashboardSearchBox,
   SectionLink
@@ -118,6 +118,7 @@ const DashboardTemplates: React.FC<DashboardTemplatesProps> = ({
   fullPage = false
 }) => {
   const theme = useTheme();
+  const sectionWrap = useSectionWrap();
   const loadTemplates = useWorkflowManager((state) => state.loadTemplates);
   const { handleExampleClick, handleViewAllTemplates, loadingExampleId } =
     useWorkflowActions();
@@ -194,7 +195,7 @@ const DashboardTemplates: React.FC<DashboardTemplatesProps> = ({
       id={DASHBOARD_TEMPLATES_SECTION_ID}
       css={fullPage ? [styles(theme), fullPageStyles] : styles(theme)}
     >
-      <div css={wrapStyles(theme)}>
+      <div css={sectionWrap}>
         <SectionHeader title="Start from a template" count={countLabel}>
           <DashboardSearchBox
             ref={searchRef}

--- a/web/src/components/portal/DashboardTutorials.tsx
+++ b/web/src/components/portal/DashboardTutorials.tsx
@@ -6,8 +6,13 @@ import { memo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { TutorialCard } from "../tutorials/TutorialCard";
 import { TUTORIALS } from "../tutorials/tutorialsData";
-import { SPACING, getSpacingPx } from "../ui_primitives";
-import { wrapStyles, SectionHeader, SectionLink } from "./dashboardChrome";
+import {
+  BORDER_RADIUS,
+  MOTION,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+import { useSectionWrap, SectionHeader, SectionLink } from "./dashboardChrome";
 
 const gridStyles = (theme: Theme) =>
   css({
@@ -25,9 +30,54 @@ const gridStyles = (theme: Theme) =>
     }
   });
 
+const compactStyles = (theme: Theme) =>
+  css({
+    paddingTop: getSpacingPx(SPACING.md),
+    ".tut-row": {
+      display: "flex",
+      flexWrap: "wrap",
+      gap: getSpacingPx(SPACING.sm)
+    },
+    ".tut-chip": {
+      display: "inline-flex",
+      alignItems: "center",
+      gap: getSpacingPx(SPACING.sm),
+      height: 30,
+      padding: `0 ${getSpacingPx(SPACING.lg)}`,
+      borderRadius: BORDER_RADIUS.pill,
+      border: `1px solid ${theme.vars.palette.divider}`,
+      background: "transparent",
+      color: theme.vars.palette.text.secondary,
+      fontSize: "var(--fontSizeSmall)",
+      cursor: "pointer",
+      transition: `border-color ${MOTION.fast}, color ${MOTION.fast}`,
+      "&:hover": {
+        borderColor: theme.vars.palette.action.focus,
+        color: theme.vars.palette.text.primary
+      }
+    },
+    ".tut-chip-time": {
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.disabled
+    }
+  });
+
+interface DashboardTutorialsProps {
+  /**
+   * "grid" shows the full tutorial cards — the first-run dashboard, where
+   * learning is the point. "compact" reduces them to a chip row, so a user
+   * who already has workflows does not scroll past a wall of beginner art.
+   */
+  variant?: "grid" | "compact";
+}
+
 /** Dashboard section: the beginner tutorials, opening the Tutorials page. */
-const DashboardTutorials: React.FC = () => {
+const DashboardTutorials: React.FC<DashboardTutorialsProps> = ({
+  variant = "grid"
+}) => {
   const theme = useTheme();
+  const sectionWrap = useSectionWrap();
   const navigate = useNavigate();
 
   const open = useCallback(
@@ -35,9 +85,36 @@ const DashboardTutorials: React.FC = () => {
     [navigate]
   );
 
+  if (variant === "compact") {
+    return (
+      <section css={compactStyles(theme)}>
+        <div css={sectionWrap}>
+          <SectionHeader title="Learn" count={`${TUTORIALS.length} short walkthroughs`}>
+            <SectionLink onClick={() => navigate("/tutorials")}>
+              All tutorials
+            </SectionLink>
+          </SectionHeader>
+          <div className="tut-row">
+            {TUTORIALS.map((tutorial) => (
+              <button
+                key={tutorial.id}
+                type="button"
+                className="tut-chip"
+                onClick={() => open(tutorial.id)}
+              >
+                {tutorial.title}
+                <span className="tut-chip-time">{tutorial.durationLabel}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section css={gridStyles(theme)}>
-      <div css={wrapStyles(theme)}>
+      <div css={sectionWrap}>
         <SectionHeader title="Learn the basics" count="new to NodeTool? start here">
           <SectionLink onClick={() => navigate("/tutorials")}>
             All tutorials

--- a/web/src/components/portal/DashboardWorkflows.tsx
+++ b/web/src/components/portal/DashboardWorkflows.tsx
@@ -19,10 +19,16 @@ import {
   SPACING,
   getSpacingPx
 } from "../ui_primitives";
+import { useRunningJobs } from "../../hooks/useRunningJobs";
+import { lastRunByWorkflow } from "./runStatus";
 import RecentWorkflowCard from "./RecentWorkflowCard";
 import WorkflowListView from "../workflows/WorkflowListView";
 import WorkflowDeleteDialog from "../workflows/WorkflowDeleteDialog";
-import { wrapStyles, SectionHeader, DashboardSearchBox } from "./dashboardChrome";
+import {
+  useSectionWrap,
+  SectionHeader,
+  DashboardSearchBox
+} from "./dashboardChrome";
 
 type ViewMode = "grid" | "list";
 
@@ -132,6 +138,7 @@ const DashboardWorkflows: React.FC<DashboardWorkflowsProps> = ({
   onCreateNew
 }) => {
   const theme = useTheme();
+  const sectionWrap = useSectionWrap();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const copyWorkflow = useWorkflowManager((state) => state.copy);
@@ -149,6 +156,9 @@ const DashboardWorkflows: React.FC<DashboardWorkflowsProps> = ({
   const [query, setQuery] = useState("");
   const [workflowsToDelete, setWorkflowsToDelete] = useState<Workflow[]>([]);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
+  const { data: jobs } = useRunningJobs();
+  const lastRuns = useMemo(() => lastRunByWorkflow(jobs), [jobs]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -236,7 +246,7 @@ const DashboardWorkflows: React.FC<DashboardWorkflowsProps> = ({
         onClose={() => setIsDeleteOpen(false)}
         workflowsToDelete={workflowsToDelete}
       />
-      <div css={wrapStyles(theme)}>
+      <div css={sectionWrap}>
         <SectionHeader title="Recent workflows" count={countLabel}>
           <DashboardSearchBox
             value={query}
@@ -294,6 +304,7 @@ const DashboardWorkflows: React.FC<DashboardWorkflowsProps> = ({
                   key={workflow.id}
                   workflow={workflow}
                   onClick={handleOpen}
+                  lastRun={lastRuns.get(workflow.id)}
                 />
               ))}
             </div>

--- a/web/src/components/portal/Portal.tsx
+++ b/web/src/components/portal/Portal.tsx
@@ -25,7 +25,12 @@ import DashboardFooter from "./DashboardFooter";
 import { useStartTrackChat } from "../../hooks/useStartTrackChat";
 import { openSettingsTab } from "../workspace/openPageTab";
 import { WELCOME_TRACKS, type WelcomeTrackId } from "./welcomeTracks";
-import { Box, SPACING, getSpacingPx } from "../ui_primitives";
+import {
+  Box,
+  BORDER_RADIUS,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
 
 const styles = (theme: Theme) =>
   css({
@@ -73,6 +78,15 @@ const columnStyles = (theme: Theme) =>
       [theme.breakpoints.down("lg")]: {
         position: "static"
       }
+    },
+    ".dash-rail-panel": {
+      border: `1px solid ${theme.vars.palette.divider}`,
+      borderRadius: BORDER_RADIUS.lg,
+      background: theme.vars.palette.c_node_bg,
+      padding: `0 ${getSpacingPx(SPACING.lg)}`,
+      // The checklist retires itself once complete; without this the panel
+      // would stay behind as an empty box.
+      "&:empty": { display: "none" }
     }
   });
 
@@ -191,13 +205,15 @@ const Portal: React.FC = () => {
                 </DashboardColumn>
               </div>
               <aside className="dash-rail">
-                <GettingStartedChecklist
-                  variant="inline"
-                  hasConfiguredProvider={hasConfiguredProvider}
-                  onConnectProvider={handleConnectProvider}
-                  onOpenTemplates={handleOpenTemplates}
-                  onCreateWorkflow={handleCreateNewWorkflow}
-                />
+                <div className="dash-rail-panel">
+                  <GettingStartedChecklist
+                    variant="inline"
+                    hasConfiguredProvider={hasConfiguredProvider}
+                    onConnectProvider={handleConnectProvider}
+                    onOpenTemplates={handleOpenTemplates}
+                    onCreateWorkflow={handleCreateNewWorkflow}
+                  />
+                </div>
                 <DashboardActivity
                   workflows={sortedWorkflows}
                   onOpenWorkflow={handleOpenWorkflow}

--- a/web/src/components/portal/Portal.tsx
+++ b/web/src/components/portal/Portal.tsx
@@ -6,12 +6,15 @@ import { useTheme } from "@mui/material/styles";
 import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useDashboardData } from "../../hooks/useDashboardData";
+import { useDashboardMode } from "../../hooks/useDashboardMode";
 import { useWorkflowActions } from "../../hooks/useWorkflowActions";
 import { useHasConfiguredProvider } from "../../hooks/useHasConfiguredProvider";
 import { usePanelStore } from "../../stores/PanelStore";
 import { openProviderOnboarding } from "../../stores/ProviderOnboardingStore";
 import DashboardHero from "./DashboardHero";
+import DashboardActivity from "./DashboardActivity";
 import DashboardDownloads from "./DashboardDownloads";
+import { DashboardColumn, wrapStyles } from "./dashboardChrome";
 import GettingStartedChecklist from "./GettingStartedChecklist";
 import DashboardTemplates, {
   DASHBOARD_TEMPLATES_SECTION_ID
@@ -44,10 +47,45 @@ const styles = (theme: Theme) =>
     }
   });
 
+/** Two columns for the returning dashboard: the user's work, and a rail. */
+const columnStyles = (theme: Theme) =>
+  css({
+    display: "grid",
+    gridTemplateColumns: "minmax(0, 1fr) 320px",
+    gap: getSpacingPx(SPACING.xxl),
+    alignItems: "start",
+    paddingTop: getSpacingPx(SPACING.md),
+    [theme.breakpoints.down("lg")]: {
+      gridTemplateColumns: "minmax(0, 1fr)"
+    },
+    ".dash-main": {
+      minWidth: 0,
+      display: "flex",
+      flexDirection: "column",
+      gap: getSpacingPx(SPACING.md)
+    },
+    ".dash-rail": {
+      display: "flex",
+      flexDirection: "column",
+      gap: getSpacingPx(SPACING.lg),
+      position: "sticky",
+      top: getSpacingPx(SPACING.md),
+      [theme.breakpoints.down("lg")]: {
+        position: "static"
+      }
+    }
+  });
+
+/** A start the user asked for before a provider was configured. */
+interface PendingStart {
+  trackId: WelcomeTrackId;
+  prompt: string;
+}
+
 const Portal: React.FC = () => {
   const theme = useTheme();
   const navigate = useNavigate();
-  const [pendingTrack, setPendingTrack] = useState<WelcomeTrackId | null>(null);
+  const [pendingStart, setPendingStart] = useState<PendingStart | null>(null);
 
   // The dashboard wants the full width; collapse the left panel on entry.
   useEffect(() => {
@@ -56,16 +94,20 @@ const Portal: React.FC = () => {
 
   const { sortedWorkflows, isLoadingWorkflows } = useDashboardData();
   const { handleCreateNewWorkflow } = useWorkflowActions();
+  const mode = useDashboardMode({
+    workflowCount: sortedWorkflows.length,
+    isLoadingWorkflows
+  });
 
   const startTrackChat = useStartTrackChat();
   const hasConfiguredProvider = useHasConfiguredProvider();
 
-  const handlePickTrack = useCallback(
-    (trackId: WelcomeTrackId) => {
+  const handleStart = useCallback(
+    (trackId: WelcomeTrackId, prompt: string) => {
       // The first send needs a model; route key-less users through the shared
       // provider onboarding first so that send doesn't fail.
       if (!hasConfiguredProvider) {
-        setPendingTrack(trackId);
+        setPendingStart({ trackId, prompt });
         const track = WELCOME_TRACKS.find((t) => t.id === trackId);
         const onboarding: Parameters<typeof openProviderOnboarding>[0] = {};
         if (track) {
@@ -75,24 +117,24 @@ const Portal: React.FC = () => {
         openProviderOnboarding(onboarding);
         return;
       }
-      void startTrackChat(trackId);
+      void startTrackChat(trackId, prompt);
     },
     [hasConfiguredProvider, startTrackChat]
   );
 
-  // Picking a track without a provider parks it here; once one is connected the
-  // chat opens on its own, so the user finishes the thing they asked for
+  // Starting without a provider parks the request here; once one is connected
+  // the chat opens on its own, so the user finishes the thing they asked for
   // rather than landing back on the dashboard.
   const startChat = useRef(startTrackChat);
   startChat.current = startTrackChat;
   useEffect(() => {
-    if (!pendingTrack || !hasConfiguredProvider) {
+    if (!pendingStart || !hasConfiguredProvider) {
       return;
     }
-    const trackId = pendingTrack;
-    setPendingTrack(null);
-    void startChat.current(trackId);
-  }, [pendingTrack, hasConfiguredProvider]);
+    const { trackId, prompt } = pendingStart;
+    setPendingStart(null);
+    void startChat.current(trackId, prompt);
+  }, [pendingStart, hasConfiguredProvider]);
 
   const handleOpenWorkflow = useCallback(
     (workflowId: string) => {
@@ -126,24 +168,60 @@ const Portal: React.FC = () => {
         <main>
           <DashboardDownloads />
           <DashboardHero
-            onPickTrack={handlePickTrack}
+            mode={mode}
+            onStart={handleStart}
             onOpenEmptyCanvas={handleCreateNewWorkflow}
             onOpenSettings={handleOpenSettings}
           />
-          <GettingStartedChecklist
-            hasConfiguredProvider={hasConfiguredProvider}
-            onConnectProvider={handleConnectProvider}
-            onOpenTemplates={handleOpenTemplates}
-            onCreateWorkflow={handleCreateNewWorkflow}
-          />
-          <DashboardTutorials />
-          <DashboardTemplates />
-          <DashboardWorkflows
-            workflows={sortedWorkflows}
-            isLoading={isLoadingWorkflows}
-            onOpenWorkflow={handleOpenWorkflow}
-            onCreateNew={handleCreateNewWorkflow}
-          />
+          {/* A returning user's own work leads, with the checklist and run
+              activity moved into a rail beside it. A first-run user has no
+              work yet, so the material that teaches them leads instead. */}
+          {mode === "returning" ? (
+            <div css={[wrapStyles(theme), columnStyles(theme)]}>
+              <div className="dash-main">
+                <DashboardColumn>
+                  <DashboardWorkflows
+                    workflows={sortedWorkflows}
+                    isLoading={isLoadingWorkflows}
+                    onOpenWorkflow={handleOpenWorkflow}
+                    onCreateNew={handleCreateNewWorkflow}
+                  />
+                  <DashboardTemplates />
+                  <DashboardTutorials variant="compact" />
+                </DashboardColumn>
+              </div>
+              <aside className="dash-rail">
+                <GettingStartedChecklist
+                  variant="inline"
+                  hasConfiguredProvider={hasConfiguredProvider}
+                  onConnectProvider={handleConnectProvider}
+                  onOpenTemplates={handleOpenTemplates}
+                  onCreateWorkflow={handleCreateNewWorkflow}
+                />
+                <DashboardActivity
+                  workflows={sortedWorkflows}
+                  onOpenWorkflow={handleOpenWorkflow}
+                />
+              </aside>
+            </div>
+          ) : (
+            <>
+              <GettingStartedChecklist
+                hasConfiguredProvider={hasConfiguredProvider}
+                onConnectProvider={handleConnectProvider}
+                onOpenTemplates={handleOpenTemplates}
+                onCreateWorkflow={handleCreateNewWorkflow}
+              />
+              <DashboardTutorials />
+              <DashboardTemplates />
+              <DashboardWorkflows
+                workflows={sortedWorkflows}
+                isLoading={isLoadingWorkflows}
+                onOpenWorkflow={handleOpenWorkflow}
+                onCreateNew={handleCreateNewWorkflow}
+              />
+            </>
+          )}
           <DashboardFooter
             workflowCount={sortedWorkflows.length}
             onGettingStarted={handleOpenTemplates}

--- a/web/src/components/portal/RecentWorkflowCard.tsx
+++ b/web/src/components/portal/RecentWorkflowCard.tsx
@@ -7,6 +7,7 @@ import { MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 import { Workflow } from "../../stores/ApiTypes";
 import { BASE_URL } from "../../stores/BASE_URL";
 import { WorkflowMiniPreview } from "../version/WorkflowMiniPreview";
+import type { WorkflowLastRun } from "./runStatus";
 
 const styles = (theme: Theme) =>
   css({
@@ -62,10 +63,28 @@ const styles = (theme: Theme) =>
       whiteSpace: "nowrap"
     },
     ".redit": {
+      display: "flex",
+      alignItems: "center",
+      gap: `${theme.spacing(SPACING.xs)}`,
       fontSize: "var(--fontSizeSmaller)",
       color: theme.vars.palette.text.disabled,
       marginTop: `${theme.spacing(SPACING.micro)}`
-    }
+    },
+    ".rrun": {
+      display: "inline-flex",
+      alignItems: "center",
+      gap: `${theme.spacing(SPACING.xs)}`
+    },
+    ".rrun-dot": {
+      width: 6,
+      height: 6,
+      borderRadius: BORDER_RADIUS.circle,
+      background: theme.vars.palette.text.disabled,
+      "&.running": { background: theme.vars.palette.primary.main },
+      "&.failed": { background: theme.vars.palette.error.main },
+      "&.done": { background: theme.vars.palette.success.main }
+    },
+    ".rsep": { color: theme.vars.palette.divider }
   });
 
 function lastEdited(dateStr: string | undefined): string {
@@ -85,6 +104,7 @@ function lastEdited(dateStr: string | undefined): string {
 interface RecentWorkflowCardProps {
   workflow: Workflow;
   onClick: (workflow: Workflow) => void;
+  lastRun?: WorkflowLastRun;
 }
 
 const boltGlyph = (
@@ -95,7 +115,8 @@ const boltGlyph = (
 
 const RecentWorkflowCard: React.FC<RecentWorkflowCardProps> = ({
   workflow,
-  onClick
+  onClick,
+  lastRun
 }) => {
   const theme = useTheme();
   const [imgFailed, setImgFailed] = useState(false);
@@ -131,7 +152,9 @@ const RecentWorkflowCard: React.FC<RecentWorkflowCardProps> = ({
             />
           </div>
         )}
-        {nodeCount > 0 && (
+        {/* WorkflowMiniPreview draws its own node count, so the badge is only
+            ours to add when a generated thumbnail covers it. */}
+        {showGeneration && nodeCount > 0 && (
           <span className="nodes">
             {boltGlyph}
             {nodeCount} {nodeCount === 1 ? "node" : "nodes"}
@@ -140,7 +163,18 @@ const RecentWorkflowCard: React.FC<RecentWorkflowCardProps> = ({
       </div>
       <div className="rmeta">
         <div className="rname">{workflow.name}</div>
-        <div className="redit">{lastEdited(workflow.updated_at)}</div>
+        <div className="redit">
+          <span>{lastEdited(workflow.updated_at)}</span>
+          {lastRun && (
+            <>
+              <span className="rsep">·</span>
+              <span className="rrun">
+                <span className={`rrun-dot ${lastRun.tone}`} />
+                {lastRun.label}
+              </span>
+            </>
+          )}
+        </div>
       </div>
     </button>
   );

--- a/web/src/components/portal/WelcomeFlow.tsx
+++ b/web/src/components/portal/WelcomeFlow.tsx
@@ -2,7 +2,7 @@
 import { css, keyframes } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
 import { useTheme } from "@mui/material/styles";
-import { memo, type CSSProperties } from "react";
+import { memo, type CSSProperties, type ReactNode } from "react";
 import { MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
 import VideocamOutlinedIcon from "@mui/icons-material/VideocamOutlined";
@@ -69,6 +69,11 @@ const styles = (theme: Theme, fullWidth: boolean) =>
       fontSize: "var(--fontSizeNormal)",
       lineHeight: 1.45,
       animation: `${rise} ${MOTION.slow} ${240}ms backwards`
+    },
+
+    ".welcome-command": {
+      marginBottom: getSpacingPx(SPACING.xxl),
+      animation: `${rise} ${MOTION.slow} ${280}ms backwards`
     },
 
     ".welcome-grid": {
@@ -179,6 +184,11 @@ interface WelcomeFlowProps {
    *  dashboard hero, which places a composer and an "open empty canvas" action
    *  below the cards). */
   hideFooter?: boolean;
+  /**
+   * The command bar, rendered between the intro copy and the starter cards.
+   * The host owns it so the same bar can appear alone on the compact hero.
+   */
+  commandBar?: ReactNode;
 }
 
 const WelcomeFlow: React.FC<WelcomeFlowProps> = ({
@@ -186,7 +196,8 @@ const WelcomeFlow: React.FC<WelcomeFlowProps> = ({
   onSkip,
   statusDot = false,
   fullWidth = false,
-  hideFooter = false
+  hideFooter = false,
+  commandBar
 }) => {
   const theme = useTheme();
 
@@ -202,6 +213,8 @@ const WelcomeFlow: React.FC<WelcomeFlowProps> = ({
         to go — press send, or write your own. You can always change your mind,
         or skip and explore.
       </p>
+
+      {commandBar && <div className="welcome-command">{commandBar}</div>}
 
       <div className="welcome-grid">
         {WELCOME_TRACKS.map((track) => {

--- a/web/src/components/portal/WelcomeFlow.tsx
+++ b/web/src/components/portal/WelcomeFlow.tsx
@@ -209,9 +209,9 @@ const WelcomeFlow: React.FC<WelcomeFlowProps> = ({
       </div>
       <h1 className="welcome-heading">What do you want to make today?</h1>
       <p className="welcome-sub">
-        Pick one. We&apos;ll open a chat in that mode with an example prompt ready
-        to go — press send, or write your own. You can always change your mind,
-        or skip and explore.
+        {commandBar
+          ? "Describe it, or pick a starting point below. Either opens a chat with the prompt already written — press send, or edit it first."
+          : "Pick one. We'll open a chat in that mode with an example prompt ready to go — press send, or write your own. You can always change your mind, or skip and explore."}
       </p>
 
       {commandBar && <div className="welcome-command">{commandBar}</div>}

--- a/web/src/components/portal/__tests__/DashboardCommandBar.test.tsx
+++ b/web/src/components/portal/__tests__/DashboardCommandBar.test.tsx
@@ -2,17 +2,26 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import mockTheme from "../../../__mocks__/themeMock";
 import DashboardCommandBar from "../DashboardCommandBar";
+import { WELCOME_TRACKS } from "../welcomeTracks";
+import useGlobalChatStore from "../../../stores/GlobalChatStore";
+import useMediaGenerationStore from "../../../stores/MediaGenerationStore";
 
 const renderBar = (
   props: Partial<React.ComponentProps<typeof DashboardCommandBar>> = {}
 ) => {
   const onSubmit = jest.fn();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
   render(
-    <ThemeProvider theme={mockTheme}>
-      <DashboardCommandBar onSubmit={onSubmit} {...props} />
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={mockTheme}>
+        <DashboardCommandBar onSubmit={onSubmit} {...props} />
+      </ThemeProvider>
+    </QueryClientProvider>
   );
   return { onSubmit };
 };
@@ -64,17 +73,96 @@ describe("DashboardCommandBar", () => {
     expect(onSubmit).toHaveBeenCalledWith("image", "a fox in snow");
   });
 
-  it("opens a track's own example when the box is empty", async () => {
+  // Choosing a kind is also how you reach that kind's model, so the click has
+  // to leave the user on the dashboard rather than opening a chat.
+  it("writes a track's own example into the box when it is empty", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderBar();
 
     await user.click(screen.getByRole("button", { name: "Video" }));
 
-    expect(onSubmit).toHaveBeenCalledWith("video", "");
+    const video = WELCOME_TRACKS.find((t) => t.id === "video");
+    expect(screen.getByLabelText("Describe what you want to make")).toHaveValue(
+      video?.samplePrompt
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("leaves a typed prompt alone when a kind is chosen", async () => {
+    const user = userEvent.setup();
+    renderBar();
+    const input = screen.getByLabelText("Describe what you want to make");
+
+    await user.type(input, "my own idea");
+    await user.click(screen.getByRole("button", { name: "Video" }));
+
+    expect(input).toHaveValue("my own idea");
   });
 
   it("hides the track chips where the host already shows starter cards", () => {
     renderBar({ showModes: false });
     expect(screen.queryByRole("button", { name: "Image" })).toBeNull();
+  });
+
+  describe("model chip", () => {
+    it("says so when the track has no model chosen", () => {
+      useMediaGenerationStore.getState().setImageParams({ model: null });
+      renderBar();
+      expect(screen.getByTitle("Model for agent")).toBeInTheDocument();
+    });
+
+    it("names the chat model for the agent track", () => {
+      useGlobalChatStore.setState({
+        selectedModel: {
+          type: "language_model",
+          provider: "anthropic",
+          id: "claude-sonnet-5",
+          name: "Claude Sonnet 5"
+        }
+      });
+      renderBar();
+      expect(screen.getByTitle("Model for agent")).toHaveTextContent(
+        "Claude Sonnet 5"
+      );
+    });
+
+    // Each track reads its own store, so switching kind switches the model
+    // shown — that is the whole point of the chip sitting next to the chips.
+    it("follows the chosen track to that track's own model", async () => {
+      const user = userEvent.setup();
+      useGlobalChatStore.setState({
+        selectedModel: {
+          type: "language_model",
+          provider: "anthropic",
+          id: "claude-sonnet-5",
+          name: "Claude Sonnet 5"
+        }
+      });
+      useMediaGenerationStore.getState().setImageParams({
+        model: {
+          type: "image_model",
+          provider: "fal_ai",
+          id: "fal-ai/flux/schnell",
+          name: "FLUX schnell",
+          path: ""
+        }
+      });
+      renderBar();
+
+      expect(screen.getByTitle("Model for agent")).toHaveTextContent(
+        "Claude Sonnet 5"
+      );
+
+      await user.click(screen.getByRole("button", { name: "Image" }));
+
+      expect(screen.getByTitle("Model for image")).toHaveTextContent(
+        "FLUX schnell"
+      );
+    });
+
+    it("is offered even where the track chips are hidden", () => {
+      renderBar({ showModes: false });
+      expect(screen.getByTitle("Model for agent")).toBeInTheDocument();
+    });
   });
 });

--- a/web/src/components/portal/__tests__/DashboardCommandBar.test.tsx
+++ b/web/src/components/portal/__tests__/DashboardCommandBar.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import DashboardCommandBar from "../DashboardCommandBar";
+
+const renderBar = (
+  props: Partial<React.ComponentProps<typeof DashboardCommandBar>> = {}
+) => {
+  const onSubmit = jest.fn();
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <DashboardCommandBar onSubmit={onSubmit} {...props} />
+    </ThemeProvider>
+  );
+  return { onSubmit };
+};
+
+describe("DashboardCommandBar", () => {
+  it("cannot send an empty prompt", () => {
+    renderBar();
+    expect(screen.getByRole("button", { name: /send/i })).toBeDisabled();
+  });
+
+  it("sends what the user typed, in the default track", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderBar();
+
+    await user.type(
+      screen.getByLabelText("Describe what you want to make"),
+      "a poster for a jazz night"
+    );
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith("agent", "a poster for a jazz night");
+  });
+
+  it("sends on Enter", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderBar();
+
+    await user.type(
+      screen.getByLabelText("Describe what you want to make"),
+      "hello{Enter}"
+    );
+
+    expect(onSubmit).toHaveBeenCalledWith("agent", "hello");
+  });
+
+  it("routes a typed prompt to the chosen track", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderBar();
+
+    await user.type(
+      screen.getByLabelText("Describe what you want to make"),
+      "a fox in snow"
+    );
+    await user.click(screen.getByRole("button", { name: "Image" }));
+    // Choosing a track with a prompt typed selects, it does not send.
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    expect(onSubmit).toHaveBeenCalledWith("image", "a fox in snow");
+  });
+
+  it("opens a track's own example when the box is empty", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderBar();
+
+    await user.click(screen.getByRole("button", { name: "Video" }));
+
+    expect(onSubmit).toHaveBeenCalledWith("video", "");
+  });
+
+  it("hides the track chips where the host already shows starter cards", () => {
+    renderBar({ showModes: false });
+    expect(screen.queryByRole("button", { name: "Image" })).toBeNull();
+  });
+});

--- a/web/src/components/portal/__tests__/runStatus.test.ts
+++ b/web/src/components/portal/__tests__/runStatus.test.ts
@@ -1,0 +1,109 @@
+import type { Job } from "../../../stores/ApiTypes";
+import { lastRunByWorkflow, shortAgo, toneFor } from "../runStatus";
+
+const job = (overrides: Partial<Job>): Job => ({
+  id: "job-1",
+  user_id: "user-1",
+  job_type: "workflow",
+  status: "completed",
+  name: null,
+  workflow_id: "wf-1",
+  started_at: "2026-08-16T10:00:00.000Z",
+  finished_at: "2026-08-16T10:01:00.000Z",
+  error: null,
+  cost: null,
+  ...overrides
+});
+
+const ago = (minutes: number): string =>
+  new Date(Date.now() - minutes * 60_000).toISOString();
+
+describe("toneFor", () => {
+  it("reads in-flight statuses as running", () => {
+    for (const status of ["running", "starting", "queued", "pending"]) {
+      expect(toneFor(status)).toBe("running");
+    }
+  });
+
+  it("reads failures and cancellations as failed", () => {
+    for (const status of ["failed", "error", "cancelled"]) {
+      expect(toneFor(status)).toBe("failed");
+    }
+  });
+
+  it("treats anything else as done, ignoring case", () => {
+    expect(toneFor("completed")).toBe("done");
+    expect(toneFor("COMPLETED")).toBe("done");
+    expect(toneFor("RUNNING")).toBe("running");
+  });
+});
+
+describe("shortAgo", () => {
+  it("returns nothing for a missing or unparseable timestamp", () => {
+    expect(shortAgo(null)).toBe("");
+    expect(shortAgo(undefined)).toBe("");
+    expect(shortAgo("not a date")).toBe("");
+  });
+
+  it("steps through minutes, hours and days", () => {
+    expect(shortAgo(ago(0))).toBe("now");
+    expect(shortAgo(ago(12))).toBe("12m");
+    expect(shortAgo(ago(180))).toBe("3h");
+    expect(shortAgo(ago(60 * 24 * 5))).toBe("5d");
+  });
+});
+
+describe("lastRunByWorkflow", () => {
+  it("returns an empty map when there are no jobs", () => {
+    expect(lastRunByWorkflow(undefined).size).toBe(0);
+    expect(lastRunByWorkflow([]).size).toBe(0);
+  });
+
+  it("keeps the most recent run per workflow", () => {
+    const runs = lastRunByWorkflow([
+      job({ id: "a", workflow_id: "wf-1", started_at: ago(300), finished_at: ago(300) }),
+      job({ id: "b", workflow_id: "wf-1", started_at: ago(12), finished_at: ago(12) }),
+      job({ id: "c", workflow_id: "wf-2", started_at: ago(60), finished_at: ago(60) })
+    ]);
+    expect(runs.get("wf-1")).toEqual({ tone: "done", label: "ran 12m ago" });
+    expect(runs.get("wf-2")).toEqual({ tone: "done", label: "ran 1h ago" });
+  });
+
+  // Both orderings, because the running job winning is handled by a different
+  // branch depending on whether it is seen before or after the settled one.
+  it.each([
+    ["running job first", ["running", "completed"]],
+    ["running job second", ["completed", "running"]]
+  ])("prefers a running job over a newer settled one (%s)", (_label, order) => {
+    const [first, second] = order;
+    const runs = lastRunByWorkflow([
+      job({
+        id: "a",
+        status: first,
+        started_at: first === "running" ? ago(30) : ago(2),
+        finished_at: first === "running" ? null : ago(1)
+      }),
+      job({
+        id: "b",
+        status: second,
+        started_at: second === "running" ? ago(30) : ago(2),
+        finished_at: second === "running" ? null : ago(1)
+      })
+    ]);
+    expect(runs.get("wf-1")).toEqual({ tone: "running", label: "running" });
+  });
+
+  it("labels a failure as failed", () => {
+    const runs = lastRunByWorkflow([
+      job({ status: "failed", started_at: ago(120), finished_at: ago(119) })
+    ]);
+    expect(runs.get("wf-1")).toEqual({ tone: "failed", label: "failed 1h ago" });
+  });
+
+  it("still labels a run whose timestamps are missing", () => {
+    const runs = lastRunByWorkflow([
+      job({ status: "completed", started_at: null, finished_at: null })
+    ]);
+    expect(runs.get("wf-1")).toEqual({ tone: "done", label: "ran" });
+  });
+});

--- a/web/src/components/portal/__tests__/runStatus.test.ts
+++ b/web/src/components/portal/__tests__/runStatus.test.ts
@@ -100,6 +100,13 @@ describe("lastRunByWorkflow", () => {
     expect(runs.get("wf-1")).toEqual({ tone: "failed", label: "failed 1h ago" });
   });
 
+  it("says 'just now' rather than 'now ago' for a fresh run", () => {
+    const runs = lastRunByWorkflow([
+      job({ status: "completed", started_at: ago(0), finished_at: ago(0) })
+    ]);
+    expect(runs.get("wf-1")).toEqual({ tone: "done", label: "ran just now" });
+  });
+
   it("still labels a run whose timestamps are missing", () => {
     const runs = lastRunByWorkflow([
       job({ status: "completed", started_at: null, finished_at: null })

--- a/web/src/components/portal/dashboardChrome.tsx
+++ b/web/src/components/portal/dashboardChrome.tsx
@@ -2,7 +2,14 @@
 import { css } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
 import { useTheme } from "@mui/material/styles";
-import { memo, type ReactNode, type Ref } from "react";
+import {
+  createContext,
+  memo,
+  useContext,
+  type ReactNode,
+  type Ref
+} from "react";
+import type { SerializedStyles } from "@emotion/react";
 import { MOTION, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 
 /** Shared horizontal rhythm for the dashboard: a centered column that the hero
@@ -16,6 +23,24 @@ export const wrapStyles = (theme: Theme) =>
       padding: `0 ${getSpacingPx(SPACING.xl)}` // was 18px
     }
   });
+
+/**
+ * True inside the two-column layout, where the columns already carry the
+ * centering and gutters. Sections keep their own `wrapStyles` everywhere else,
+ * so each one still works as a full-bleed band.
+ */
+const InColumnContext = createContext(false);
+
+export const DashboardColumn = ({ children }: { children: ReactNode }) => (
+  <InColumnContext.Provider value={true}>{children}</InColumnContext.Provider>
+);
+
+/** The wrap a section should apply, or nothing when a column owns it. */
+export const useSectionWrap = (): SerializedStyles | undefined => {
+  const theme = useTheme();
+  const inColumn = useContext(InColumnContext);
+  return inColumn ? undefined : wrapStyles(theme);
+};
 
 const headerStyles = (theme: Theme) =>
   css({

--- a/web/src/components/portal/runStatus.ts
+++ b/web/src/components/portal/runStatus.ts
@@ -76,15 +76,19 @@ export function lastRunByWorkflow(
   const result = new Map<string, WorkflowLastRun>();
   for (const [workflowId, job] of latest) {
     const tone = toneFor(job.status);
+    if (tone === "running") {
+      result.set(workflowId, { tone, label: "running" });
+      continue;
+    }
+    const verb = tone === "failed" ? "failed" : "ran";
     const when = shortAgo(job.finished_at ?? job.started_at);
-    const label =
-      tone === "running"
-        ? "running"
-        : when
-          ? `${tone === "failed" ? "failed" : "ran"} ${when} ago`
-          : tone === "failed"
-            ? "failed"
-            : "ran";
+    // shortAgo says "now" for anything under a minute, which does not take
+    // an "ago".
+    const label = !when
+      ? verb
+      : when === "now"
+        ? `${verb} just now`
+        : `${verb} ${when} ago`;
     result.set(workflowId, { tone, label });
   }
   return result;

--- a/web/src/components/portal/runStatus.ts
+++ b/web/src/components/portal/runStatus.ts
@@ -1,0 +1,91 @@
+import type { Job } from "../../stores/ApiTypes";
+
+export type RunTone = "running" | "failed" | "done";
+
+/** Jobs the backend has not settled yet. */
+const RUNNING_STATUSES = new Set(["running", "starting", "queued", "pending"]);
+const FAILED_STATUSES = new Set(["failed", "error", "cancelled"]);
+
+export const toneFor = (status: string | null | undefined): RunTone => {
+  const normalized = (status ?? "").toLowerCase();
+  if (RUNNING_STATUSES.has(normalized)) {
+    return "running";
+  }
+  if (FAILED_STATUSES.has(normalized)) {
+    return "failed";
+  }
+  return "done";
+};
+
+/** Compact relative time: "now", "12m", "3h", "5d". */
+export function shortAgo(iso: string | null | undefined): string {
+  if (!iso) {
+    return "";
+  }
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) {
+    return "";
+  }
+  const mins = Math.floor((Date.now() - then) / 60_000);
+  if (mins < 1) {
+    return "now";
+  }
+  if (mins < 60) {
+    return `${mins}m`;
+  }
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+  return `${Math.floor(hours / 24)}d`;
+}
+
+export interface WorkflowLastRun {
+  tone: RunTone;
+  label: string;
+}
+
+const runTime = (job: Job): string => job.started_at ?? job.finished_at ?? "";
+
+/**
+ * The most recent run per workflow. A running job always wins over a settled
+ * one, so a card shows "running" while a run is in flight even if the job list
+ * still carries a newer finished record for a different attempt.
+ */
+export function lastRunByWorkflow(
+  jobs: Job[] | undefined
+): Map<string, WorkflowLastRun> {
+  const latest = new Map<string, Job>();
+  for (const job of jobs ?? []) {
+    const current = latest.get(job.workflow_id);
+    if (!current) {
+      latest.set(job.workflow_id, job);
+      continue;
+    }
+    const jobRunning = toneFor(job.status) === "running";
+    const currentRunning = toneFor(current.status) === "running";
+    if (jobRunning && !currentRunning) {
+      latest.set(job.workflow_id, job);
+      continue;
+    }
+    if (jobRunning === currentRunning && runTime(job) > runTime(current)) {
+      latest.set(job.workflow_id, job);
+    }
+  }
+
+  const result = new Map<string, WorkflowLastRun>();
+  for (const [workflowId, job] of latest) {
+    const tone = toneFor(job.status);
+    const when = shortAgo(job.finished_at ?? job.started_at);
+    const label =
+      tone === "running"
+        ? "running"
+        : when
+          ? `${tone === "failed" ? "failed" : "ran"} ${when} ago`
+          : tone === "failed"
+            ? "failed"
+            : "ran";
+    result.set(workflowId, { tone, label });
+  }
+  return result;
+}

--- a/web/src/hooks/__tests__/useDashboardMode.test.tsx
+++ b/web/src/hooks/__tests__/useDashboardMode.test.tsx
@@ -1,0 +1,55 @@
+import { act, renderHook } from "@testing-library/react";
+import { useDashboardMode } from "../useDashboardMode";
+import useOnboardingStore from "../../stores/OnboardingStore";
+
+const resetOnboarding = () =>
+  useOnboardingStore.setState({ completedSteps: [], dismissed: false });
+
+describe("useDashboardMode", () => {
+  beforeEach(resetOnboarding);
+
+  it("leads with the first-run material for a new user with no workflows", () => {
+    const { result } = renderHook(() =>
+      useDashboardMode({ workflowCount: 0, isLoadingWorkflows: false })
+    );
+    expect(result.current).toBe("first-run");
+  });
+
+  it("leads with the user's own work once they have a workflow", () => {
+    const { result } = renderHook(() =>
+      useDashboardMode({ workflowCount: 20, isLoadingWorkflows: false })
+    );
+    expect(result.current).toBe("returning");
+  });
+
+  it("leads with the user's own work once onboarding is finished", () => {
+    useOnboardingStore.setState({ dismissed: true });
+    const { result } = renderHook(() =>
+      useDashboardMode({ workflowCount: 0, isLoadingWorkflows: false })
+    );
+    expect(result.current).toBe("returning");
+  });
+
+  it("answers from onboarding alone while the workflow list loads", () => {
+    const { result: newUser } = renderHook(() =>
+      useDashboardMode({ workflowCount: 0, isLoadingWorkflows: true })
+    );
+    expect(newUser.current).toBe("first-run");
+
+    act(() => useOnboardingStore.setState({ dismissed: true }));
+    const { result: knownUser } = renderHook(() =>
+      useDashboardMode({ workflowCount: 0, isLoadingWorkflows: true })
+    );
+    expect(knownUser.current).toBe("returning");
+  });
+
+  it("treats every step completed as finished, without a dismissal", () => {
+    useOnboardingStore.setState({
+      completedSteps: ["open-template", "run-workflow", "create-workflow"]
+    });
+    const { result } = renderHook(() =>
+      useDashboardMode({ workflowCount: 0, isLoadingWorkflows: false })
+    );
+    expect(result.current).toBe("returning");
+  });
+});

--- a/web/src/hooks/useDashboardMode.ts
+++ b/web/src/hooks/useDashboardMode.ts
@@ -1,0 +1,39 @@
+import useOnboardingStore, {
+  isOnboardingFinished
+} from "../stores/OnboardingStore";
+
+export type DashboardMode = "first-run" | "returning";
+
+interface UseDashboardModeArgs {
+  workflowCount: number;
+  isLoadingWorkflows: boolean;
+}
+
+/**
+ * Which dashboard a user gets.
+ *
+ * A user with no workflows of their own and unfinished onboarding came here to
+ * start something: the page leads with the hero and the learning material.
+ * Everyone else came back for work they already have, so that leads instead.
+ *
+ * The workflow count arrives over the network, so until it does the answer
+ * comes from onboarding alone (which is persisted, and therefore synchronous).
+ * A user who has both unfinished onboarding and a full library sees the
+ * first-run order for as long as the list takes to load, once per cold cache.
+ */
+export const useDashboardMode = ({
+  workflowCount,
+  isLoadingWorkflows
+}: UseDashboardModeArgs): DashboardMode => {
+  const onboardingFinished = useOnboardingStore(isOnboardingFinished);
+
+  if (onboardingFinished) {
+    return "returning";
+  }
+  if (isLoadingWorkflows) {
+    return "first-run";
+  }
+  return workflowCount > 0 ? "returning" : "first-run";
+};
+
+export default useDashboardMode;

--- a/web/src/hooks/useStartTrackChat.ts
+++ b/web/src/hooks/useStartTrackChat.ts
@@ -13,17 +13,21 @@ import {
 
 /**
  * Opens a welcome-flow track as a chat tab: a fresh thread in the track's
- * composer mode, with the track's example prompt already in the box. Nothing
- * is sent — the user reads the prompt, edits it if they like, and presses
- * send.
+ * composer mode, with a prompt already in the box. Nothing is sent — the user
+ * reads the prompt, edits it if they like, and presses send.
+ *
+ * With no `prompt` the track's own example is used, which is what the starter
+ * cards want. The dashboard command bar passes what the user typed instead,
+ * so the track only decides the composer mode.
  */
 export const useStartTrackChat = (): ((
-  trackId: WelcomeTrackId
+  trackId: WelcomeTrackId,
+  prompt?: string
 ) => Promise<void>) => {
   const navigate = useNavigate();
 
   return useCallback(
-    async (trackId: WelcomeTrackId) => {
+    async (trackId: WelcomeTrackId, prompt?: string) => {
       const track = WELCOME_TRACKS.find((t) => t.id === trackId);
       if (!track) {
         return;
@@ -39,7 +43,9 @@ export const useStartTrackChat = (): ((
           // Explicit null: a dashboard starter is a plain conversation, not
           // one bound to whatever workflow happens to be open.
           .createNewThread(track.threadTitle, null);
-        useChatDraftStore.getState().setDraft(threadId, track.samplePrompt);
+        useChatDraftStore
+          .getState()
+          .setDraft(threadId, prompt?.trim() || track.samplePrompt);
         useWorkspaceTabsStore.getState().openTab({
           type: "chat",
           ref: threadId,


### PR DESCRIPTION
The dashboard served one page to two different people. A user with twenty
workflows scrolled past a full-screen hero, a getting-started checklist, a
tutorial grid and a template grid before reaching their own work — and three of
those sections were doing the same job: start something new.

## Order by state

`useDashboardMode` decides whether a visitor is here to start something (no
workflows of their own, onboarding unfinished) or came back for work they
already have.

| Mode | Order |
|---|---|
| first-run | hero → checklist → tutorials → templates → workflows |
| returning | **workflows** → templates → tutorials (chip row) |

The workflow count arrives over the network, so until it does the answer comes
from onboarding alone, which is persisted and therefore synchronous. A user with
both unfinished onboarding and a full library sees the first-run order for as
long as the list takes to load, once per cold cache.

## One door instead of four

`DashboardCommandBar` takes a typed prompt and a kind of output, and opens the
chat with both — the four starter cards all led to that same chat. The first-run
hero keeps the cards for their blurbs and hides the bar's redundant chips; a
returning user gets the bar alone, which is what lets their work sit near the
top of the page.

`useStartTrackChat` now accepts an optional prompt; with none it falls back to
the track's own example, so the starter-card gesture is unchanged.

## Two columns and a run rail

The returning dashboard becomes two columns, with the checklist and a new
`DashboardActivity` rail beside the main content. A workflow tool whose
dashboard said nothing about what ran, or what broke, was missing the one thing
only it could show. The rail reads `jobs.list`; the same records give each
workflow card a last-run dot. No backend change — `JobResponse` already carries
status, timestamps and error.

Sections drop their own centering inside a column through `useSectionWrap`, so
each one still works as a full-bleed band everywhere else.

## Card fixes

- The node count was printed twice: `WorkflowMiniPreview` draws its own, and the
  card added another. The card's badge now only appears over a generated
  thumbnail, which covers the preview's.
- Cards carried no run state at all; they now show a status dot and label.

## Verification

Typecheck, lint and the full web suite pass (1128 suites, 13015 tests).

I also drove the real page — backend on :7777, Vite on :3000, Playwright against
both modes — which caught four things the types could not, fixed in the second
commit: the compact hero sat flush against the top edge, the first-run copy
still said "pick one" when there is now a box to type in, a run under a minute
old read "ran now ago", and the rail's checklist floated while the runs panel
had a border.

One test lesson worth recording: the first version of the `lastRunByWorkflow`
test passed with the running-preference branch disabled, because it only
exercised one job ordering. It now covers both orderings and goes red when that
branch is broken.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhysTbcj6WM3zeNVCbryP4)_