### PR TITLE
refactor(lint): drive seven more trees to zero on all eight anti-slop rules

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -45,6 +45,7 @@ see below.
 | `example-smoke-debug.yml` | Nightly + manual real-provider smoke via `nodetool debug` | 2 | Nightly (spend-capped), also dispatch-only |
 | `abstraction-improver.yaml` | Scheduled agent flattens single-implementation interfaces, forwarding wrappers, re-export-only barrels | none/maintenance | Advisory (`continue-on-error`) |
 | `abstraction-police.yaml` | Scheduled agent fixes layering violations found by `check:*` plus the import greps no script covers | none/maintenance | Advisory (`continue-on-error`) |
+| `anti-slop-ratchet.yaml` | Daily agent drives anti-slop (rule, tree) pairs to zero, regenerates the enforced overrides, and proves the new ratchet can fail | none/maintenance | Advisory |
 | `app-build-eval.yml` | Nightly `app-build` eval suite; reports the one-shot rate, gates nothing | none/maintenance | Advisory (report only) |
 | `aur-publish.yml` | Publish the AUR package on a GitHub release | none/maintenance | Required for its own job |
 | `claude-code-review.yml` | Claude reviews new/updated PRs | none/maintenance | Advisory |
@@ -173,6 +174,7 @@ gh workflow run shipped-feature-inliner.yaml
 gh workflow run flaky-test-fixer.yaml
 gh workflow run abstraction-improver.yaml
 gh workflow run abstraction-police.yaml
+gh workflow run anti-slop-ratchet.yaml
 gh workflow run example-smoke-debug.yml
 gh workflow run user-journeys.yml
 ```

--- a/.github/workflows/anti-slop-ratchet.yaml
+++ b/.github/workflows/anti-slop-ratchet.yaml
@@ -1,0 +1,234 @@
+name: Anti-Slop Ratchet
+
+# Drives (rule, tree) pairs of the anti-slop backlog to zero and ratchets what
+# it wins. See AGENTS.md § anti-slop for the backlog/enforced config split.
+#
+# The measurement is the slow part: one oxlint invocation per tree, run three
+# times over a full pass (scan, `:write`, `:check`). Budget for that, not for
+# the edits.
+
+on:
+  schedule:
+    - cron: "30 9 * * *" # Daily at 09:30 UTC
+  workflow_dispatch:
+
+jobs:
+  anti-slop-ratchet:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install all workspace dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      - name: Install mobile dependencies
+        run: cd mobile && npm ci
+
+      - name: Measure the backlog and pick targets
+        id: targets
+        run: |
+          npm run lint:anti-slop:targets > /tmp/anti-slop-targets.md
+          cat /tmp/anti-slop-targets.md >> $GITHUB_STEP_SUMMARY
+
+          # Read the count rather than infer it. An unreadable measurement must
+          # fail here: parsed as "0 pairs left" it would skip the agent and
+          # report a clean nightly, which is the one wrong answer available.
+          REMAINING=$(sed -n 's/^\([0-9]\{1,\}\) non-zero pairs remain.*/\1/p' /tmp/anti-slop-targets.md)
+          if [ -z "$REMAINING" ]; then
+            echo "Could not read the pair count from the measurement." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+          echo "REMAINING_PAIRS=$REMAINING" >> $GITHUB_ENV
+          echo "$REMAINING non-zero (rule, tree) pairs remain." >> $GITHUB_STEP_SUMMARY
+
+      - name: Run quality checks baseline
+        id: pre-check
+        continue-on-error: true
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0; PKG_TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+          npm run test:packages 2>&1 || PKG_TEST_EXIT=1
+          echo "TYPECHECK_PRE_EXIT=$TYPECHECK_EXIT" >> $GITHUB_ENV
+          echo "LINT_PRE_EXIT=$LINT_EXIT" >> $GITHUB_ENV
+          echo "TEST_PRE_EXIT=$TEST_EXIT" >> $GITHUB_ENV
+          echo "PKG_TEST_PRE_EXIT=$PKG_TEST_EXIT" >> $GITHUB_ENV
+
+      - name: Run Claude Code
+        if: env.REMAINING_PAIRS != '0'
+        uses: anthropics/claude-code-action@v1.0.189
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash,Edit,Read,Replace,CreatePullRequest"
+            --append-system-prompt "Before finalizing any code change or PR, invoke the unslop skill (.claude/skills/unslop/SKILL.md) and apply its checklist to your diff."
+          prompt: |
+            # Drive anti-slop (rule, tree) pairs to zero
+
+            The vendored anti-slop Oxlint plugin runs through two configs: a
+            backlog (`.oxlintrc.anti-slop.json`) and an enforced config
+            (`.oxlintrc.anti-slop-enforced.json`) carrying every (rule, tree)
+            pair already at zero. Read AGENTS.md § anti-slop first — it explains
+            the split, the generated overrides, and which rules are holdouts.
+
+            Your job: take pairs from backlog to enforced, by fixing the code.
+
+            ## Today's measurement
+
+            `npm run lint:anti-slop:targets` has already run. Read
+            `/tmp/anti-slop-targets.md` — it holds the per-rule table, the trees
+            closest to zero, and the cheapest remaining pairs. **Use it. Do not
+            re-derive these numbers**: counting findings off a raw `oxlint` run
+            silently mixes in oxlint's own default-rule diagnostics, which
+            report through the same channel and are not backlog findings.
+
+            To see the findings for one tree:
+            ```bash
+            npx oxlint --config .oxlintrc.anti-slop.json --format json packages/<name>/src \
+              | jq '.diagnostics[] | select(.code | startswith("anti-slop"))'
+            ```
+
+            ## Picking scope
+
+            Prefer **finishing one whole tree** over scattering single fixes:
+            one typecheck and one test run then cover several pairs at once, and
+            a tree at zero on all eight rules cannot regress on any of them.
+            Take the top tree from the "closest to zero" table that you can
+            finish. If none is finishable, take cheap pairs from one package.
+
+            Keep it to one package (plus any caller you must update) per PR.
+
+            ## What a real fix looks like
+
+            Fix the typing, do not annotate around the finding. Four shapes
+            cover nearly everything:
+
+            1. **Name the value crossing a boundary.** A function taking
+               `Record<string, unknown>` or `unknown` usually has a real
+               contract nobody wrote down. Write it, and make the caller meet it
+               at its own boundary.
+            2. **Give a `typeof` narrowing a predicate that takes a domain
+               type.** `no-runtime-typeof` allows `typeof` inside a function
+               returning `v is T`. But a predicate taking bare `unknown` just
+               moves the finding into `no-unknown-parameters` — take `T`, a
+               named union, or an indexed access like `Foo["bar"]` instead.
+            3. **Delete guards that check what the type already declares.** A
+               `typeof params.seconds === "number"` against a declared
+               `seconds?: number` is a defensive check on a trusted path and
+               usually collapses into `??`.
+            4. **Point a type at its owner.** `params?: RunWorkflowOptions["params"]`
+               beats a second `Record<string, unknown>` that can drift from it.
+
+            A genuine assertion that cannot go away keeps a `SAFETY:` comment
+            stating the invariant TypeScript cannot express. Note the rule's
+            comment walk stops at the `VariableDeclaration`, so for an exported
+            const the comment goes inside, before the asserted expression.
+
+            ## Rules
+
+            - **Never** weaken the plugin, the backlog config, or a rule's
+              options to make findings disappear. Do not add
+              `oxlint-disable` comments. The only legitimate way a finding goes
+              away is the code getting better.
+            - Do not change runtime behavior. Where a check looks dead, confirm
+              it against tests before removing it — some are load-bearing for
+              injected stubs.
+            - Do not touch CI workflow files.
+            - Respect the documented holdouts in AGENTS.md; if a pair is a
+              holdout, say so in the PR and pick another.
+
+            ## Before starting
+
+            Run `gh pr list --state open --limit 30` and skip the run entirely
+            if an anti-slop ratchet PR is already open.
+
+            ## Ratchet what you win
+
+            After the code is fixed, regenerate the enforced overrides from a
+            fresh measurement and commit the result:
+            ```bash
+            npm run lint:anti-slop:write
+            ```
+            Then update the backlog table, the pair count, and the
+            list of trees at zero on all eight rules in AGENTS.md to match what
+            it printed. Those numbers are checked, so they must not be guessed.
+
+            ## Prove the new ratchet can fail
+
+            A check that has only ever been green is indistinguishable from one
+            that examines nothing. For one pair you just ratcheted,
+            re-introduce the violation, confirm `npm run lint:anti-slop:enforced`
+            reports it and exits non-zero, then revert and confirm it is green
+            again. Put both observations in the PR body. If the enforced lint
+            stays green with the violation present, the ratchet did not take —
+            stop and report that instead of opening the PR.
+
+            ## Verification
+
+            All of these must pass, and `:check` must agree with the config you
+            committed:
+            ```bash
+            npm run typecheck && npm run lint && npm run test && npm run test:packages
+            npm run lint:anti-slop:check
+            ```
+            Some suites fail on a runner for reasons that predate your change.
+            If one does, confirm it against a clean tree before calling it
+            unrelated, and say which in the PR.
+
+            ## Submit
+
+            Open a PR titled "refactor(lint): drive <tree> to zero on <n> anti-slop rules".
+            In the body give the before/after pair count and backlog total, what
+            each fix named rather than annotated, the failure you induced to
+            prove the ratchet works, and anything you deliberately left as a
+            holdout.
+
+      - name: Post-change verification
+        if: always() && env.REMAINING_PAIRS != '0'
+        run: |
+          TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0; PKG_TEST_EXIT=0
+          npm run typecheck 2>&1 || TYPECHECK_EXIT=1
+          npm run lint 2>&1 || LINT_EXIT=1
+          npm run test 2>&1 || TEST_EXIT=1
+          npm run test:packages 2>&1 || PKG_TEST_EXIT=1
+
+          if [ "$TYPECHECK_PRE_EXIT" -eq 0 ] && [ $TYPECHECK_EXIT -ne 0 ]; then
+            echo "New TypeScript errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$LINT_PRE_EXIT" -eq 0 ] && [ $LINT_EXIT -ne 0 ]; then
+            echo "New lint errors introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$TEST_PRE_EXIT" -eq 0 ] && [ $TEST_EXIT -ne 0 ]; then
+            echo "New test failures introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+          if [ "$PKG_TEST_PRE_EXIT" -eq 0 ] && [ $PKG_TEST_EXIT -ne 0 ]; then
+            echo "New package test failures introduced" >> $GITHUB_STEP_SUMMARY; exit 1
+          fi
+
+          # The enforced config is generated from a measurement. A pair driven
+          # to zero without `:write` being run leaves it unratcheted, and a
+          # regression leaves it claiming a zero that is gone — both are drift,
+          # and both look like success without this.
+          npm run lint:anti-slop:check

--- a/.oxlintrc.anti-slop-enforced.json
+++ b/.oxlintrc.anti-slop-enforced.json
@@ -67,17 +67,22 @@
     {
       "files": [
         "packages/atlascloud-nodes/src/**",
+        "packages/auth/src/**",
         "packages/base-nodes/src/**",
         "packages/chat/src/**",
         "packages/code-nodes/src/**",
+        "packages/config/src/**",
         "packages/document-nodes/src/**",
         "packages/dsl/src/**",
         "packages/execution/src/**",
         "packages/huggingface-nodes/src/**",
+        "packages/model-pricing/src/**",
         "packages/nodes-utils/src/**",
         "packages/replicate-nodes/src/**",
+        "packages/reve-nodes/src/**",
         "packages/sdk/src/**",
-        "packages/security/src/**"
+        "packages/security/src/**",
+        "packages/workflow-runner/src/**"
       ],
       "rules": {
         "anti-slop/no-known-value-widening": "error"
@@ -150,16 +155,22 @@
         "electron/src/**",
         "packages/app-runtime/src/**",
         "packages/audio-nodes/src/**",
+        "packages/auth/src/**",
         "packages/base-nodes/src/**",
+        "packages/chat/src/**",
         "packages/cli/src/**",
+        "packages/config/src/**",
         "packages/image-nodes/src/**",
         "packages/llm-nodes/src/**",
         "packages/minimax-nodes/src/**",
+        "packages/model-pricing/src/**",
         "packages/node-sdk/src/**",
         "packages/nodes-utils/src/**",
         "packages/protocol/src/**",
+        "packages/reve-nodes/src/**",
         "packages/security/src/**",
-        "packages/text-nodes/src/**"
+        "packages/text-nodes/src/**",
+        "packages/workflow-runner/src/**"
       ],
       "rules": {
         "anti-slop/no-runtime-typeof": [
@@ -172,14 +183,19 @@
     },
     {
       "files": [
+        "packages/auth/src/**",
         "packages/base-nodes/src/**",
+        "packages/chat/src/**",
         "packages/config/src/**",
         "packages/document-nodes/src/**",
         "packages/elevenlabs-nodes/src/**",
         "packages/minimax-nodes/src/**",
+        "packages/model-pricing/src/**",
         "packages/nodes-utils/src/**",
+        "packages/reve-nodes/src/**",
         "packages/security/src/**",
-        "packages/transformers-js-provider/src/**"
+        "packages/transformers-js-provider/src/**",
+        "packages/workflow-runner/src/**"
       ],
       "rules": {
         "anti-slop/no-unknown-parameters": "error"
@@ -236,11 +252,15 @@
     },
     {
       "files": [
+        "packages/auth/src/**",
         "packages/base-nodes/src/**",
         "packages/chat/src/**",
         "packages/config/src/**",
         "packages/model-pricing/src/**",
-        "packages/security/src/**"
+        "packages/nodes-utils/src/**",
+        "packages/reve-nodes/src/**",
+        "packages/security/src/**",
+        "packages/workflow-runner/src/**"
       ],
       "rules": {
         "anti-slop/no-unsafe-dictionary-type": "error"
@@ -248,9 +268,15 @@
     },
     {
       "files": [
+        "packages/auth/src/**",
         "packages/base-nodes/src/**",
+        "packages/chat/src/**",
+        "packages/config/src/**",
+        "packages/model-pricing/src/**",
         "packages/nodes-utils/src/**",
-        "packages/security/src/**"
+        "packages/reve-nodes/src/**",
+        "packages/security/src/**",
+        "packages/workflow-runner/src/**"
       ],
       "rules": {
         "anti-slop/require-safety-comment-for-type-assertion": "error"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,13 +236,13 @@ The vendored [anti-slop](https://github.com/dmmulroy/anti-slop) Oxlint plugin
 (`tools/oxlint/anti-slop/`) runs through two configs, and every rule sits in
 exactly one of them:
 
-- `.oxlintrc.anti-slop.json` — the **backlog**, 15,994 findings. Run it with
+- `.oxlintrc.anti-slop.json` — the **backlog**, 15,918 findings. Run it with
   `npm run lint:anti-slop`. Not on the CI path; it would be red for months.
 - `.oxlintrc.anti-slop-enforced.json` — everything already at **zero**. Run
   inside `npm run lint`, so it cannot come back.
 
 The unit of enforcement is a **(rule, tree) pair**, not a rule. Eight rules over
-58 trees is 464 pairs, and 184 of them are already at zero — so a rule still
+58 trees is 464 pairs, and 210 of them are already at zero — so a rule still
 thousands of findings deep across the repo is nonetheless finished in forty
 packages, and those forty are ratcheted today rather than after the last one
 lands. Six rules are at zero everywhere and sit in the enforced config's top-level
@@ -292,12 +292,12 @@ Remaining backlog, largest first — regenerate with `npm run lint:anti-slop:cou
 
 | rule | findings | trees at zero |
 |---|---:|---:|
-| `require-safety-comment-for-type-assertion` | 7001 | 3 / 58 |
-| `no-unsafe-dictionary-type` | 4241 | 5 / 58 |
-| `no-unknown-parameters` | 1890 | 8 / 58 |
+| `require-safety-comment-for-type-assertion` | 6982 | 9 / 58 |
+| `no-unsafe-dictionary-type` | 4227 | 9 / 58 |
+| `no-unknown-parameters` | 1882 | 13 / 58 |
 | `no-module-mocking` | 1427 | 55 / 58 |
-| `no-known-value-widening` | 663 | 12 / 58 |
-| `no-runtime-typeof` | 537 | 13 / 58 |
+| `no-known-value-widening` | 657 | 17 / 58 |
+| `no-runtime-typeof` | 508 | 19 / 58 |
 | `no-unknown-returns` | 191 | 42 / 58 |
 | `no-chained-type-assertions` | 44 | 46 / 58 |
 
@@ -307,8 +307,17 @@ concentrated in the frontend test suites and is a test-seam problem, not a
 typing one — enforced everywhere else already, and worth its own change rather
 than a slot in the typing work. `require-safety-comment-for-type-assertion` is
 the opposite, present nearly everywhere, and moves only when the values crossing
-a boundary get named. `packages/base-nodes` and `packages/security` are at zero
-on all eight.
+a boundary get named. Nine trees are at zero on all eight: `packages/auth`,
+`packages/base-nodes`, `packages/chat`, `packages/config`,
+`packages/model-pricing`, `packages/nodes-utils`, `packages/reve-nodes`,
+`packages/security` and `packages/workflow-runner`.
+
+Driving a whole small tree to zero is the cheapest way to move the pair count,
+and the fixes that get there rhyme: name the value crossing a boundary
+(`TemplateVars`, `ExecutedToolCall`, `JsonObject`, `ReveRequestBody`), give a
+`typeof` narrowing a predicate that takes a domain type rather than `unknown`
+so the finding does not just change rules, and delete the guards that were
+only ever checking a field the type already declared.
 
 A rule can also stall short of zero. `no-unknown-returns` went 604 → 191 (the
 predicate consolidation above put twenty back); what

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,10 +249,18 @@ lands. Six rules are at zero everywhere and sit in the enforced config's top-lev
 `rules`; the rest are enforced per-path, one override block per rule listing the
 trees at zero for it.
 
+`.github/workflows/anti-slop-ratchet.yaml` runs this loop daily: measure, fix
+one tree, regenerate the overrides, and induce a failure to prove the new ones
+bite. It opens a PR; it merges nothing.
+
 Those override blocks are generated, never hand-edited:
-`npm run lint:anti-slop:count` prints the table below, `:write` regenerates the
-overrides from a fresh measurement, and `:check` fails when the config and the
-measurement disagree. Hand-maintaining them is how the numbers here drifted
+`npm run lint:anti-slop:count` prints the table below, `:targets` adds the
+trees closest to zero and the cheapest remaining pairs, `:write` regenerates
+the overrides from a fresh measurement, and `:check` fails when the config and
+the measurement disagree. Read the counts off `:targets` rather than off a raw
+`oxlint` run — oxlint's own default rules report through the same channel, so
+counting diagnostics instead of `anti-slop(...)` codes overstates a tree by
+several times. Hand-maintaining them is how the numbers here drifted
 before (6,991/18,453 recorded against an actual 7,016/18,504). The generator
 lints one tree per oxlint invocation and rejects any tree whose scan touched
 zero files: oxlint does not expand `packages/*/src` itself, and a glob that

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "lint:anti-slop": "oxlint --config .oxlintrc.anti-slop.json packages/*/src web/src electron/src mobile/src",
     "lint:anti-slop:enforced": "oxlint --config .oxlintrc.anti-slop-enforced.json packages/*/src web/src electron/src mobile/src",
     "lint:anti-slop:count": "node ./scripts/anti-slop-ratchet.mjs",
+    "lint:anti-slop:targets": "node ./scripts/anti-slop-ratchet.mjs --targets",
     "lint:anti-slop:write": "node ./scripts/anti-slop-ratchet.mjs --write",
     "lint:anti-slop:check": "node ./scripts/anti-slop-ratchet.mjs --check",
     "lint:eslint": "eslint packages/*/src",

--- a/packages/auth/src/file-user-manager.ts
+++ b/packages/auth/src/file-user-manager.ts
@@ -74,6 +74,9 @@ export class FileUserManager {
       // Buffer, which JSON.parse coerces via the default utf8 decoding, so "utf8"
       // and "" are byte-identical here (equivalent mutant).
       const data = await readFile(this.usersFile, "utf8");
+      // SAFETY: this file has one writer — `save()` below, which serializes a
+      // `UsersFile`. A hand-edited or truncated file throws in `JSON.parse`
+      // and is caught as "no users", so a bad shape never reaches a caller.
       return JSON.parse(data) as UsersFile;
     } catch {
       return { version: "1.0", users: {} };

--- a/packages/auth/src/json-wire.ts
+++ b/packages/auth/src/json-wire.ts
@@ -1,0 +1,64 @@
+/**
+ * The shape of decoded JSON, before any field of it is trusted.
+ *
+ * Auth providers read bodies that arrive from an identity service over the
+ * network. Typing those bodies as `unknown` (or as an open `Record<string,
+ * unknown>`) pushes the question of what is in them to every read site; naming
+ * the wire shape once answers it here, and the field-level readers below are
+ * the only place a wire value turns into a domain value.
+ */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/** A decoded JSON object — the only wire shape with readable fields. */
+export type JsonObject = { [key: string]: JsonValue };
+
+/**
+ * Whether a decoded body is a JSON object. Generic in the caller's type so it
+ * narrows whatever the caller holds, rather than taking bare `unknown`.
+ */
+export function isJsonObject<T>(value: T): value is T & JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Whether a wire value arrived as text with something in it. Generic in the
+ * caller's type so it narrows a JWT claim or an `unknown` just as well as a
+ * `JsonValue`.
+ */
+export function isNonEmptyString<T>(value: T): value is T & string {
+  return typeof value === "string" && value !== "";
+}
+
+/** Whether a wire value arrived as a real number. */
+function isFiniteNumber<T>(value: T): value is T & number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/**
+ * A wire field read as an identifier: text, or a number rendered as text.
+ * Anything else — `null`, an object, a missing field — reads as `undefined`
+ * rather than as the string `"null"`.
+ */
+export function readIdentifier(
+  body: JsonObject,
+  field: string
+): string | undefined {
+  const value = body[field];
+  if (isNonEmptyString(value)) return value;
+  return isFiniteNumber(value) ? String(value) : undefined;
+}
+
+/** A wire field read as a non-empty string, or `undefined` if it is anything else. */
+export function readString(
+  body: JsonObject,
+  field: string
+): string | undefined {
+  const value = body[field];
+  return isNonEmptyString(value) ? value : undefined;
+}

--- a/packages/auth/src/providers/multi-user-provider.ts
+++ b/packages/auth/src/providers/multi-user-provider.ts
@@ -5,6 +5,7 @@
  */
 import * as jose from "jose";
 import { AuthProvider, AuthResult, TokenType } from "../auth-provider.js";
+import { isNonEmptyString } from "../json-wire.js";
 
 export interface MultiUserAuthProviderOptions {
   /** JWT signing secret (symmetric HS256). */
@@ -28,14 +29,14 @@ export class MultiUserAuthProvider extends AuthProvider {
       const { payload } = await jose.jwtVerify(token, this.secret);
 
       const userId = payload[this.userIdClaim];
-      if (typeof userId !== "string" || !userId) {
+      if (!isNonEmptyString(userId)) {
         return {
           ok: false,
           error: `Missing user ID claim: ${this.userIdClaim}`
         };
       }
 
-      const role = typeof payload.role === "string" ? payload.role : undefined;
+      const role = isNonEmptyString(payload.role) ? payload.role : undefined;
 
       return {
         ok: true,

--- a/packages/auth/src/providers/static-token-provider.ts
+++ b/packages/auth/src/providers/static-token-provider.ts
@@ -11,6 +11,11 @@
 import { timingSafeEqual } from "node:crypto";
 
 import { AuthProvider, AuthResult, TokenType } from "../auth-provider.js";
+import {
+  isJsonObject,
+  isNonEmptyString,
+  type JsonValue
+} from "../json-wire.js";
 
 /**
  * Minimum length (in bytes) for a presented token to be considered.
@@ -50,9 +55,14 @@ export class StaticTokenProvider extends AuthProvider {
     // forcing the branch true registers no tokens either way (equivalent).
     if (multiTokens) {
       try {
-        const parsed = JSON.parse(multiTokens) as Record<string, string>;
-        for (const [token, userId] of Object.entries(parsed)) {
-          this.tokens.set(token, userId);
+        // `STATIC_AUTH_TOKENS` is operator-supplied JSON, so each entry is
+        // checked rather than asserted into a `Record<string, string>` — a
+        // non-string value used to be stored as a user id verbatim.
+        const parsed: JsonValue = JSON.parse(multiTokens);
+        for (const [token, userId] of isJsonObject(parsed)
+          ? Object.entries(parsed)
+          : []) {
+          if (isNonEmptyString(userId)) this.tokens.set(token, userId);
         }
       } catch {
         // Ignore malformed JSON – treat as no tokens configured.
@@ -61,7 +71,7 @@ export class StaticTokenProvider extends AuthProvider {
   }
 
   async verifyToken(token: string): Promise<AuthResult> {
-    if (typeof token !== "string") {
+    if (!isNonEmptyString(token)) {
       return { ok: false, error: "Invalid token" };
     }
 

--- a/packages/auth/src/providers/supabase-provider.ts
+++ b/packages/auth/src/providers/supabase-provider.ts
@@ -10,6 +10,13 @@
 
 import { createHash } from "node:crypto";
 import { AuthProvider, AuthResult, TokenType } from "../auth-provider.js";
+import {
+  isJsonObject,
+  readIdentifier,
+  readString,
+  type JsonObject,
+  type JsonValue
+} from "../json-wire.js";
 
 /** The slice of the GoTrue user object we consume. */
 interface GoTrueUser {
@@ -32,13 +39,18 @@ interface SupabaseAuthClient {
   };
 }
 
-/** Extract a human-readable message from a GoTrue error body. */
-function readGoTrueErrorMessage(body: unknown, status: number): string {
-  if (body && typeof body === "object") {
-    const obj = body as Record<string, unknown>;
-    for (const field of ["msg", "message", "error_description", "error"]) {
-      const val = obj[field];
-      if (typeof val === "string" && val) return val;
+/** The spellings GoTrue uses for an error message, most specific first. */
+const GOTRUE_ERROR_FIELDS = ["msg", "message", "error_description", "error"];
+
+/** Extract a human-readable message from a decoded GoTrue error body. */
+function readGoTrueErrorMessage(
+  body: JsonObject | null,
+  status: number
+): string {
+  if (body !== null) {
+    for (const field of GOTRUE_ERROR_FIELDS) {
+      const message = readString(body, field);
+      if (message !== undefined) return message;
     }
   }
   return `Supabase auth request failed with status ${status}`;
@@ -65,9 +77,12 @@ function createGoTrueClient(
           }
         });
 
-        let body: unknown = null;
+        // The body is untrusted network JSON. Decode it to the wire shape
+        // here, at the boundary, so no read below works on `unknown`.
+        let body: JsonObject | null = null;
         try {
-          body = await response.json();
+          const decoded: JsonValue = await response.json();
+          body = isJsonObject(decoded) ? decoded : null;
         } catch {
           // Non-JSON body (e.g. empty 5xx) — handled below via status.
         }
@@ -81,10 +96,8 @@ function createGoTrueClient(
           };
         }
 
-        const user =
-          body && typeof body === "object" && "id" in body
-            ? { id: String(body.id) }
-            : null;
+        const id = body === null ? undefined : readIdentifier(body, "id");
+        const user = id === undefined ? null : { id };
         return { data: { user }, error: null };
       }
     }
@@ -200,12 +213,14 @@ export class SupabaseAuthProvider extends AuthProvider {
       const { data, error } = await client.auth.getUser(token);
 
       if (error) {
-        // `error` is truthy here, so it cannot be null — no null guard needed.
-        const errMsg =
-          typeof error === "object" && "message" in error
-            ? String(error.message)
-            : String(error);
-        return { ok: false, error: errMsg };
+        // `error` is truthy here, so it cannot be null. Its declared shape is
+        // `{ message }`, but this client is injectable and the tests feed it
+        // strings, numbers and message-less objects, so render whatever
+        // arrived rather than trusting the declaration.
+        const message = isJsonObject(error)
+          ? readIdentifier(error, "message")
+          : undefined;
+        return { ok: false, error: message ?? String(error) };
       }
 
       const user = data?.user;

--- a/packages/chat/src/message-processor.ts
+++ b/packages/chat/src/message-processor.ts
@@ -39,13 +39,23 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * A tool call together with what running it produced. The provider-facing
+ * `ToolCall` describes a call the model asked for and has no room for an
+ * answer, so the executed form is its own type rather than an intersection
+ * asserted onto the call at each use.
+ */
+export interface ExecutedToolCall extends ToolCall {
+  result: unknown;
+}
+
 export interface ChatCallbacks {
   /** Called for each text chunk streamed from the provider. */
   onChunk?: (text: string) => void;
   /** Called when a tool call is received from the provider. */
   onToolCall?: (toolCall: ToolCall) => void;
-  /** Called after a tool has been executed. */
-  onToolResult?: (toolCall: ToolCall, result: unknown) => void;
+  /** Called after a tool has been executed, with that call's result. */
+  onToolResult?: (toolCall: ToolCall, result: ExecutedToolCall["result"]) => void;
   /**
    * Called when the provider emits a session-continuity update. The caller
    * persists the token onto the assistant message so the next turn can resume.
@@ -64,7 +74,7 @@ export async function runTool(
   context: ProcessingContext,
   toolCall: ToolCall,
   tools: Tool[]
-): Promise<ToolCall> {
+): Promise<ExecutedToolCall> {
   const tool = tools.find((t) => t.name === toolCall.name);
   if (!tool) {
     throw new Error(`Tool "${toolCall.name}" not found`);
@@ -77,7 +87,7 @@ export async function runTool(
     name: toolCall.name,
     args: toolCall.args,
     result
-  } as ToolCall & { result: unknown };
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -85,11 +95,16 @@ export async function runTool(
 // ---------------------------------------------------------------------------
 
 function isChunk(item: ProviderStreamItem): item is Chunk {
-  return "type" in item && (item as Chunk).type === "chunk";
+  return "type" in item && item.type === "chunk";
 }
 
 function isToolCall(item: ProviderStreamItem): item is ToolCall {
   return "name" in item && "id" in item && !("type" in item);
+}
+
+/** A tool result that is already plain text, so it needs no JSON encoding. */
+function isTextResult(result: ExecutedToolCall["result"]): result is string {
+  return typeof result === "string";
 }
 
 /**
@@ -105,13 +120,17 @@ type JsonValue =
   | JsonValue[]
   | { [key: string]: JsonValue };
 
+/**
+ * Whether a value implements the `JSON.stringify` hook. By that protocol's
+ * contract `toJSON` returns something JSON-representable, which is what lets
+ * the serializer hand the result straight back.
+ */
+function hasToJson<T>(value: T): value is T & { toJSON: () => JsonValue } {
+  return value !== null && typeof value === "object" && "toJSON" in value;
+}
+
 export function defaultSerializer<T>(_key: string, value: T): T | JsonValue {
-  if (value !== null && typeof value === "object" && "toJSON" in value) {
-    // SAFETY: `toJSON` is the JSON.stringify protocol hook — it exists on the
-    // value and, by that contract, produces a JSON-representable result.
-    return (value as { toJSON: () => JsonValue }).toJSON();
-  }
-  return value;
+  return hasToJson(value) ? value.toJSON() : value;
 }
 
 /**
@@ -219,9 +238,7 @@ export async function processChat(opts: {
   const executeTool = async (
     toolCall: ToolCall
   ): Promise<string | MessageContent[]> => {
-    const executed = (await runTool(context, toolCall, tools)) as ToolCall & {
-      result: unknown;
-    };
+    const executed = await runTool(context, toolCall, tools);
     callbacks?.onToolResult?.(toolCall, executed.result);
 
     // A view-image-style result carries pixels the model asked for. Forward
@@ -232,7 +249,7 @@ export async function processChat(opts: {
       ? stripImagePayload(executed.result)
       : executed.result;
     const text = truncateToolResult(
-      typeof value === "string"
+      isTextResult(value)
         ? value
         : (JSON.stringify(value, defaultSerializer) ?? "")
     );
@@ -271,7 +288,9 @@ export async function processChat(opts: {
     }
     if (isChunk(item)) {
       if (item.thinking) continue;
-      if (typeof item.content !== "string") continue;
+      // A chunk's content is either text or raw audio samples; only text is
+      // streamed to the caller.
+      if (item.content instanceof Float32Array) continue;
       callbacks?.onChunk?.(item.content);
     }
   }

--- a/packages/chat/src/token-counter.ts
+++ b/packages/chat/src/token-counter.ts
@@ -37,6 +37,11 @@ function countToolCallsTokens(
   return count;
 }
 
+/** A message body that is plain text rather than an array of content parts. */
+function isTextBody(content: Message["content"]): content is string {
+  return typeof content === "string";
+}
+
 /**
  * Count tokens for a single Message.
  *
@@ -48,7 +53,7 @@ export function countMessageTokens(message: Message): number {
 
   const content = message.content;
   if (content) {
-    if (typeof content === "string") {
+    if (isTextBody(content)) {
       tokenCount += countTextTokens(content);
     } else if (Array.isArray(content)) {
       for (const part of content) {

--- a/packages/config/src/logging.ts
+++ b/packages/config/src/logging.ts
@@ -42,15 +42,18 @@ const LEVEL_NUM = {
 } satisfies Record<LogLevel, number>;
 
 /** Maps Python-style log level names to their JS equivalents. */
-const LEVEL_ALIASES: Record<string, LogLevel> = {
-  warning: "warn",
-  critical: "error"
-};
+const LEVEL_ALIASES = new Map<string, LogLevel>([
+  ["warning", "warn"],
+  ["critical", "error"]
+]);
 
 function normalizeLevel(raw: string): LogLevel | null {
   const lower = raw.toLowerCase();
-  if ((VALID_LEVELS as string[]).includes(lower)) return lower as LogLevel;
-  return LEVEL_ALIASES[lower] ?? null;
+  return (
+    VALID_LEVELS.find((level) => level === lower) ??
+    LEVEL_ALIASES.get(lower) ??
+    null
+  );
 }
 
 // Initialize eagerly from env so configureLogging() is optional for entry
@@ -152,6 +155,11 @@ function jsonReplacer<T>(_key: string, value: T): T | SerializedError {
   return value;
 }
 
+/** A log argument worth rendering as JSON instead of stringifying. */
+function isStructured<T>(value: T): value is T & object {
+  return typeof value === "object" && value !== null;
+}
+
 function formatArgs(args: unknown[]): string {
   if (args.length === 0) return "";
   return (
@@ -159,7 +167,7 @@ function formatArgs(args: unknown[]): string {
     args
       .map((a) => {
         if (a instanceof Error) return a.stack ?? a.message;
-        if (typeof a === "object" && a !== null) {
+        if (isStructured(a)) {
           try {
             return JSON.stringify(a, jsonReplacer);
           } catch {

--- a/packages/config/src/node-import.ts
+++ b/packages/config/src/node-import.ts
@@ -19,8 +19,7 @@
 type ModuleNamespace = object;
 
 export const IS_NODE =
-  typeof process !== "undefined" &&
-  typeof process.versions?.node === "string";
+  typeof process !== "undefined" && process.versions?.node != null;
 
 /**
  * `process` is undefined in browser/edge runtimes, where a bare `process.env`
@@ -34,9 +33,7 @@ export const safeProcessEnv = (): Record<string, string | undefined> =>
 
 /** `process.platform`, or `""` where there is no `process`. */
 export const safeProcessPlatform = (): string =>
-  typeof process !== "undefined" && typeof process.platform === "string"
-    ? process.platform
-    : "";
+  typeof process !== "undefined" ? (process.platform ?? "") : "";
 
 /**
  * Dynamic import that bundlers can't statically resolve.
@@ -105,6 +102,20 @@ interface GlobalWithRequire {
   require?: BuiltinRequire;
 }
 
+/** Whether this Node build exposes the `process.getBuiltinModule` accessor. */
+function hasGetBuiltinModule(
+  proc: NodeProcessGlobal | undefined
+): proc is { getBuiltinModule: BuiltinRequire } {
+  return typeof proc?.getBuiltinModule === "function";
+}
+
+/** Whether this module was loaded from a CJS bundle, which carries `require`. */
+function hasCjsRequire(
+  global: GlobalWithRequire
+): global is { require: BuiltinRequire } {
+  return typeof global.require === "function";
+}
+
 export function getNodeBuiltinSync<T>(name: string): T | null {
   if (!IS_NODE) return null;
   try {
@@ -112,16 +123,16 @@ export function getNodeBuiltinSync<T>(name: string): T | null {
     // `@types/node` `Process` this repo compiles against; the guard below is
     // what decides whether it is really there.
     const proc = globalThis.process as NodeProcessGlobal | undefined;
-    if (typeof proc?.getBuiltinModule === "function") {
+    if (hasGetBuiltinModule(proc)) {
       // SAFETY: `T` is the namespace shape the caller names for `name`.
       return proc.getBuiltinModule(name) as T;
     }
     // SAFETY: `require` exists only when this module is loaded from a CJS
     // bundle, so it is not on the ESM `globalThis` type; the guard decides.
-    const cjsRequire = (globalThis as GlobalWithRequire).require;
-    if (typeof cjsRequire === "function") {
+    const globalScope = globalThis as GlobalWithRequire;
+    if (hasCjsRequire(globalScope)) {
       // SAFETY: `T` is the export shape the caller names for `name`.
-      return cjsRequire(name) as T;
+      return globalScope.require(name) as T;
     }
   } catch {
     // fall through to null

--- a/packages/config/src/package-assets.ts
+++ b/packages/config/src/package-assets.ts
@@ -138,5 +138,8 @@ export function loadPackageAssetJson<T>(
 ): T {
   const resolved = resolvePackageAssetPath(ref, importerUrl, registry);
   const req = nodeModule!.createRequire(importerUrl);
+  // SAFETY: `T` is the shape the caller names for this registered asset;
+  // `resolvePackageAssetPath` has already checked the ref against the registry,
+  // so what `require` returns is that asset's JSON and nothing else.
   return req(resolved) as T;
 }

--- a/packages/model-pricing/src/genspend-calc.ts
+++ b/packages/model-pricing/src/genspend-calc.ts
@@ -59,7 +59,7 @@ export interface ModelParamPrice extends ModelUnitPricingLike {
  * and the stored row are pushed through this, so the two always compare in one
  * vocabulary.
  */
-const RESOLUTION_TIERS: Record<string, string> = {
+const RESOLUTION_TIERS = new Map<string, string>(Object.entries({
   "360p": "360p",
   "480p": "480p",
   "540p": "480p",
@@ -86,11 +86,11 @@ const RESOLUTION_TIERS: Record<string, string> = {
   "2048": "2K",
   "2048x2048": "2K",
   "4096": "4K"
-};
+}));
 
 /** Normalize a resolution to a tier, or null when it names none we know. */
-export function normalizeResolution(value: unknown): string | null {
-  if (typeof value !== "string") return null;
+export function normalizeResolution(value: string | undefined): string | null {
+  if (value === undefined) return null;
   // Collapse whitespace runs before touching the separators: an unbounded
   // `\s*` on both sides of the class backtracks polynomially (CodeQL).
   const key = value
@@ -99,7 +99,7 @@ export function normalizeResolution(value: unknown): string | null {
     .replace(/\s+/g, " ")
     .replace(/ ?[x*×] ?/g, "x");
   if (!key) return null;
-  return RESOLUTION_TIERS[key] ?? null;
+  return RESOLUTION_TIERS.get(key) ?? null;
 }
 
 const PER_SECOND_CLASSES = new Set(["per-video-second", "per-audio-second"]);
@@ -200,10 +200,7 @@ function selectRow(
 
   // Audio is a billing axis worth up to 2×. Unset, the honest default is
   // whatever the base spec delivers — not the cheaper of the two.
-  const wantAudio =
-    typeof params.withAudio === "boolean"
-      ? params.withAudio
-      : (baseRow?.with_audio ?? null);
+  const wantAudio = params.withAudio ?? baseRow?.with_audio ?? null;
   if (wantAudio !== null) {
     const audio = candidates.filter((row) => row.with_audio === wantAudio);
     if (audio.length > 0) candidates = audio;
@@ -245,12 +242,9 @@ export function priceGenspendEntry(
     );
   }
 
+  const askedSeconds = params.seconds ?? 0;
   const statedSeconds =
-    typeof params.seconds === "number" &&
-    Number.isFinite(params.seconds) &&
-    params.seconds > 0
-      ? params.seconds
-      : null;
+    Number.isFinite(askedSeconds) && askedSeconds > 0 ? askedSeconds : null;
 
   const clip = "clip_seconds" in entry ? entry.clip_seconds : undefined;
   if (statedSeconds !== null && clip !== undefined) {
@@ -306,11 +300,10 @@ export function priceGenspendEntry(
   // A re-rate replaces the generation cost rather than adding to it, and is
   // scoped by resolution. No row for the requested resolution declines the
   // re-rate — never another rung — leaving the generation cost as a floor.
-  const refVideoSeconds =
-    typeof params.referenceVideoSeconds === "number" &&
-    Number.isFinite(params.referenceVideoSeconds)
-      ? params.referenceVideoSeconds
-      : 0;
+  const statedRefVideoSeconds = params.referenceVideoSeconds ?? 0;
+  const refVideoSeconds = Number.isFinite(statedRefVideoSeconds)
+    ? statedRefVideoSeconds
+    : 0;
   if (refVideoSeconds > 0) {
     const rates = surcharges.filter((s) => s.kind === "input_video_second");
     const rate =
@@ -332,11 +325,8 @@ export function priceGenspendEntry(
     }
   }
 
-  const refImages =
-    typeof params.referenceImages === "number" &&
-    Number.isFinite(params.referenceImages)
-      ? params.referenceImages
-      : 0;
+  const statedRefImages = params.referenceImages ?? 0;
+  const refImages = Number.isFinite(statedRefImages) ? statedRefImages : 0;
   if (refImages > 0) {
     const surcharge = surcharges.find((s) => s.kind === "input_image");
     if (surcharge) {

--- a/packages/model-pricing/src/genspend-catalog.ts
+++ b/packages/model-pricing/src/genspend-catalog.ts
@@ -136,6 +136,10 @@ export interface GenspendPricingCatalog {
 }
 
 export const genspendPricingCatalog =
+  // SAFETY: `catalog` is the generated `genspend-pricing.json` shipped in this
+  // package, written by `npm run sync:genspend` to exactly this shape and kept
+  // there by `sync:genspend:check`. TypeScript infers the JSON's literal
+  // types, which do not match the declared interface structurally.
   catalog as GenspendPricingCatalog;
 
 /** The catalog price for a provider-native model id, or null when untracked. */

--- a/packages/model-pricing/src/index.ts
+++ b/packages/model-pricing/src/index.ts
@@ -38,38 +38,49 @@ interface CatalogPrice {
   usd_price?: unknown;
 }
 
-function readNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+/**
+ * Whether a catalog field arrived as a real number. Generic in the caller's
+ * type so it narrows the row's `unknown` fields in place, rather than taking
+ * bare `unknown` and handing back a value that lost its origin.
+ */
+function isFiniteNumber<T>(value: T): value is T & number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/** Whether a catalog field arrived as text. */
+function isText<T>(value: T): value is T & string {
+  return typeof value === "string";
 }
 
 function falPrice(modelId: string): ModelUnitPricingLike | null {
   const prices = falUnitPricingCatalog.prices;
+  // SAFETY: the FAL catalog is generated JSON shipped with the package, so its
+  // rows have no declared field types here; every field is checked below
+  // before it becomes a price.
   const entry = prices?.[modelId] as CatalogPrice | undefined;
   if (!entry) return null;
-  const unitPrice = readNumber(entry.unit_price);
-  if (unitPrice === undefined) return null;
+  if (!isFiniteNumber(entry.unit_price)) return null;
   return {
-    unit_price: unitPrice,
-    billing_unit:
-      typeof entry.billing_unit === "string" ? entry.billing_unit : "",
-    currency: typeof entry.currency === "string" ? entry.currency : "USD",
+    unit_price: entry.unit_price,
+    billing_unit: isText(entry.billing_unit) ? entry.billing_unit : "",
+    currency: isText(entry.currency) ? entry.currency : "USD",
     source: "bundle"
   };
 }
 
 function kiePrice(modelId: string): ModelUnitPricingLike | null {
+  // SAFETY: as in `falPrice` — generated JSON with no declared field types,
+  // checked field by field below.
   const entry = kieUnitPricingCatalog.prices?.[modelId] as
     | CatalogPrice
     | undefined;
   if (!entry) return null;
   // Only the USD conversion is a real price; a raw credit figure has no fixed
   // USD value, so skip the model when it's absent.
-  const usd = readNumber(entry.usd_price);
-  if (usd === undefined) return null;
+  if (!isFiniteNumber(entry.usd_price)) return null;
   return {
-    unit_price: usd,
-    billing_unit:
-      typeof entry.billing_unit === "string" ? entry.billing_unit : "",
+    unit_price: entry.usd_price,
+    billing_unit: isText(entry.billing_unit) ? entry.billing_unit : "",
     currency: "USD",
     source: "bundle"
   };

--- a/packages/nodes-utils/src/index.ts
+++ b/packages/nodes-utils/src/index.ts
@@ -34,5 +34,6 @@ export {
 } from "./node-only-modules.js";
 
 export { renderTemplate, referencedVariables } from "./template.js";
+export type { TemplateValue, TemplateVars } from "./template.js";
 
 export { base64ToBytes, bytesToBase64 } from "./base64.js";

--- a/packages/nodes-utils/src/template.ts
+++ b/packages/nodes-utils/src/template.ts
@@ -66,13 +66,23 @@ export function referencedVariables(template: string): string[] {
 }
 
 /**
+ * One template variable's value. The renderer substitutes `String(value ?? "")`
+ * and then runs string filters over the result, so the contract is "a scalar
+ * with a meaningful string form"; `null` and `undefined` render as the empty
+ * string. Callers holding a richer value stringify it at their own boundary,
+ * where they know what its string form should be — the renderer's
+ * `[object Object]` is never that.
+ */
+export type TemplateValue = string | number | boolean | null | undefined;
+
+/** The variable bag `renderTemplate` substitutes from. */
+export type TemplateVars = Record<string, TemplateValue>;
+
+/**
  * Substitute `{{ variable }}` / `{variable}` placeholders in `template` with
  * values from `vars`. Unknown placeholders are left intact.
  */
-export function renderTemplate(
-  template: string,
-  vars: Record<string, unknown>
-): string {
+export function renderTemplate(template: string, vars: TemplateVars): string {
   let result = template;
 
   // {{ var|filter1|filter2 }}. The content class excludes both braces so the

--- a/packages/reve-nodes/src/nodes/create-image.ts
+++ b/packages/reve-nodes/src/nodes/create-image.ts
@@ -6,8 +6,14 @@ import {
   reveGenerate,
   reveImageToRef,
   REVE_ASPECT_RATIOS,
-  REVE_POSTPROCESSING
+  REVE_POSTPROCESSING,
+  type ReveImageRef
 } from "../reve-base.js";
+
+/** Output handles CreateImageNode.process() emits. */
+type CreateImageNodeOutputs = {
+  output: ReveImageRef;
+};
 
 export class CreateImageNode extends BaseNode {
   static readonly nodeType = "reve.CreateImage";
@@ -70,7 +76,7 @@ export class CreateImageNode extends BaseNode {
   })
   declare test_time_scaling: any;
 
-  async process(): Promise<Record<string, unknown>> {
+  async process(): Promise<CreateImageNodeOutputs> {
     const apiKey = getReveApiKey(this._secrets);
 
     const prompt = String(this.prompt ?? "");

--- a/packages/reve-nodes/src/nodes/edit-image.ts
+++ b/packages/reve-nodes/src/nodes/edit-image.ts
@@ -7,8 +7,14 @@ import {
   reveGenerate,
   reveImageToRef,
   REVE_ASPECT_RATIOS,
-  REVE_POSTPROCESSING
+  REVE_POSTPROCESSING,
+  type ReveImageRef
 } from "../reve-base.js";
+
+/** Output handles EditImageNode.process() emits. */
+type EditImageNodeOutputs = {
+  output: ReveImageRef;
+};
 
 export class EditImageNode extends BaseNode {
   static readonly nodeType = "reve.EditImage";
@@ -94,7 +100,7 @@ export class EditImageNode extends BaseNode {
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]
-  ): Promise<Record<string, unknown>> {
+  ): Promise<EditImageNodeOutputs> {
     const apiKey = getReveApiKey(this._secrets);
 
     const instruction = String(this.edit_instruction ?? "");

--- a/packages/reve-nodes/src/nodes/remix-image.ts
+++ b/packages/reve-nodes/src/nodes/remix-image.ts
@@ -7,8 +7,14 @@ import {
   reveGenerate,
   reveImageToRef,
   REVE_ASPECT_RATIOS,
-  REVE_POSTPROCESSING
+  REVE_POSTPROCESSING,
+  type ReveImageRef
 } from "../reve-base.js";
+
+/** Output handles RemixImageNode.process() emits. */
+type RemixImageNodeOutputs = {
+  output: ReveImageRef;
+};
 
 export class RemixImageNode extends BaseNode {
   static readonly nodeType = "reve.RemixImage";
@@ -92,7 +98,7 @@ export class RemixImageNode extends BaseNode {
 
   async process(
     context?: Parameters<BaseNode["process"]>[0]
-  ): Promise<Record<string, unknown>> {
+  ): Promise<RemixImageNodeOutputs> {
     const apiKey = getReveApiKey(this._secrets);
 
     const prompt = String(this.prompt ?? "");

--- a/packages/reve-nodes/src/reve-base.ts
+++ b/packages/reve-nodes/src/reve-base.ts
@@ -92,18 +92,33 @@ function localFilePath(uri: string): string {
   }
 }
 
+/**
+ * The `ImageRef` fields this pack resolves bytes from. Node props arrive
+ * untyped from the graph, so the contract is stated here rather than at each
+ * read: bytes inline, base64 (bare or as a data URI), or a URI to fetch.
+ */
+export interface ReveImageInput {
+  uri?: string;
+  data?: Uint8Array | string;
+}
+
+/** Whether an image payload arrived base64-encoded rather than as bytes. */
+function isEncodedData(data: Uint8Array | string): data is string {
+  return typeof data === "string";
+}
+
 /** Resolve an ImageRef-like value to raw bytes. */
 export async function refToBytes(
-  ref: unknown,
+  ref: ReveImageInput | null | undefined,
   context?: AssetContext
 ): Promise<Uint8Array> {
-  if (!ref || typeof ref !== "object") {
+  if (!ref) {
     throw new Error("Image is required");
   }
-  const r = ref as { uri?: string; data?: Uint8Array | string };
+  const r = ref;
 
   if (r.data) {
-    if (typeof r.data === "string") {
+    if (isEncodedData(r.data)) {
       const inline = r.data.match(/^data:[^;]*;base64,(.+)$/s);
       const b64 = inline ? inline[1] : r.data;
       return new Uint8Array(Buffer.from(b64, "base64"));
@@ -147,7 +162,7 @@ export async function refToBytes(
 
 /** Resolve an ImageRef-like value to a base64 string (no data: prefix). */
 export async function refToBase64(
-  ref: unknown,
+  ref: ReveImageInput | null | undefined,
   context?: AssetContext
 ): Promise<string> {
   const bytes = await refToBytes(ref, context);
@@ -158,11 +173,19 @@ export async function refToBase64(
 // Response → ImageRef
 // ---------------------------------------------------------------------------
 
+/** The `ImageRef` this pack emits: a base64 PNG, sized when sharp is present. */
+export interface ReveImageRef {
+  type: "image";
+  uri: string;
+  data: string;
+  mimeType: string;
+  width?: number;
+  height?: number;
+}
+
 /** Build an ImageRef from a base64 PNG, attaching dimensions when sharp is available. */
-export async function reveImageToRef(
-  base64: string
-): Promise<Record<string, unknown>> {
-  const ref: Record<string, unknown> = {
+export async function reveImageToRef(base64: string): Promise<ReveImageRef> {
+  const ref: ReveImageRef = {
     type: "image",
     uri: "",
     data: base64,
@@ -184,9 +207,31 @@ export async function reveImageToRef(
 // Request
 // ---------------------------------------------------------------------------
 
+/**
+ * The fields the three Reve image endpoints accept. Each node fills the subset
+ * its endpoint uses, and `cleanBody` drops whatever it left unset.
+ */
+export interface ReveRequestBody {
+  /** `create` and `remix`. */
+  prompt?: string;
+  /** `edit`. */
+  edit_instruction?: string;
+  /** `edit`: one base64 image, no data: prefix. */
+  reference_image?: string;
+  /** `remix`: 1–6 base64 images, no data: prefix. */
+  reference_images?: string[];
+  aspect_ratio?: string;
+  version?: string;
+  postprocessing?: string[];
+  test_time_scaling?: number;
+}
+
+/** One request field's value, before the empty ones are dropped. */
+type ReveRequestField = ReveRequestBody[keyof ReveRequestBody];
+
 /** Drop null/undefined/empty fields and an all-"none" postprocessing array. */
-function cleanBody(body: Record<string, unknown>) {
-  const out: Record<string, unknown> = {};
+function cleanBody(body: ReveRequestBody): ReveRequestBody {
+  const out: Record<string, ReveRequestField> = {};
   for (const [k, v] of Object.entries(body)) {
     if (v === null || v === undefined || v === "") continue;
     if (Array.isArray(v) && v.length === 0) continue;
@@ -195,8 +240,11 @@ function cleanBody(body: Record<string, unknown>) {
   return out;
 }
 
-/** Normalize a postprocessing enum selection into the API's array form. */
-export function postprocessingArray(value: unknown): string[] {
+/**
+ * Normalize a postprocessing enum selection into the API's array form. The
+ * selection is a node prop, so it arrives as whatever the graph stored.
+ */
+export function postprocessingArray(value: string | null | undefined): string[] {
   const v = String(value ?? "none");
   return v === "none" ? [] : [v];
 }
@@ -209,7 +257,7 @@ export function postprocessingArray(value: unknown): string[] {
 export async function reveGenerate(
   apiKey: string,
   endpoint: ReveEndpoint,
-  body: Record<string, unknown>
+  body: ReveRequestBody
 ): Promise<ReveImageResponse> {
   const response = await fetch(`${REVE_API_BASE}/v1/image/${endpoint}`, {
     method: "POST",
@@ -226,6 +274,9 @@ export async function reveGenerate(
     throw new Error(`Reve API error (${response.status}): ${errorText}`);
   }
 
+  // SAFETY: a 2xx from the documented Reve endpoints carries this JSON shape;
+  // the two fields read below (`content_violation`, `image`) are checked
+  // immediately, and a missing `image` throws rather than reaching a node.
   const result = (await response.json()) as ReveImageResponse;
   if (result.content_violation) {
     throw new Error("Reve flagged this request as a content policy violation");

--- a/packages/text-nodes/src/nodes/text-extra.ts
+++ b/packages/text-nodes/src/nodes/text-extra.ts
@@ -9,6 +9,7 @@ import {
   referencedVariables,
   base64ToBytes
 } from "@nodetool-ai/nodes-utils";
+import type { TemplateVars } from "@nodetool-ai/nodes-utils";
 import { loadNodeFsPromises, loadNodePath } from "@nodetool-ai/nodes-utils";
 import {
   isFunction,
@@ -23,15 +24,14 @@ const NODE_ONLY: readonly Platform[] = ["node"];
  * Turn any asset-ref values in a template's variable bag into their
  * `asset://<id>.<ext>` token so a wired image / audio / video / document
  * expands like an inline `@`-mention instead of rendering as `"[object
- * Object]"`. Non-asset values (strings, numbers, other refs) pass through
- * untouched for the normal `String(value)` substitution.
+ * Object]"`. Non-asset values take the string form the renderer would have
+ * given them anyway; `null`/`undefined` stay absent so they render as "".
  */
-function tokenizeAssetVars(
-  vars: Record<string, unknown>
-) {
-  const out: Record<string, unknown> = {};
+function tokenizeAssetVars(vars: Record<string, unknown>): TemplateVars {
+  const out: TemplateVars = {};
   for (const [key, value] of Object.entries(vars)) {
-    out[key] = assetRefToPromptToken(value) ?? value;
+    out[key] =
+      assetRefToPromptToken(value) ?? (value == null ? undefined : String(value));
   }
   return out;
 }

--- a/packages/workflow-runner/src/browser.ts
+++ b/packages/workflow-runner/src/browser.ts
@@ -48,15 +48,21 @@ export function createBrowserRegistry(
  * A graph that passes can run entirely client-side; one that doesn't must be
  * sent to the server (it references nodes the browser can't execute).
  */
+/**
+ * Whether a node from an untrusted graph actually names a type. Generic in the
+ * caller's type so it narrows the declared `string` and a wire value alike.
+ */
+function isNodeType<T>(value: T): value is T & string {
+  return typeof value === "string" && value !== "";
+}
+
 export function graphRunsInRegistry(
   graph: GraphData,
   registry: Pick<NodeRegistry, "has">
 ): boolean {
   const nodes = graph?.nodes ?? [];
   if (nodes.length === 0) return false;
-  return nodes.every(
-    (node) => typeof node.type === "string" && registry.has(node.type)
-  );
+  return nodes.every((node) => isNodeType(node.type) && registry.has(node.type));
 }
 
 export interface RunBrowserWorkflowOptions
@@ -110,16 +116,25 @@ export async function* runBrowserWorkflow(
  * Stamp `job_id`/`workflow_id` onto a message without clobbering values the
  * runner already set (mirrors the server's `streamJobMessages` fallback).
  */
+/** The routing fields the transport stamps on every outgoing message. */
+type MessageRouting = { job_id?: string | null; workflow_id?: string | null };
+
 function stamp(
   message: ProcessingMessage,
   jobId: string,
   workflowId: string | null
 ): ProcessingMessage {
-  const record = message as Record<string, unknown>;
+  // SAFETY: `job_id`/`workflow_id` are routing fields the transport stamps on
+  // every message, but a few union variants (`save_update`, for one) do not
+  // declare them — so both the read and the stamped result go through the
+  // routing shape instead of re-declaring the fields on each variant.
+  const routing = message as MessageRouting;
+  // SAFETY: the spread preserves `message`'s own discriminant and fields, so
+  // the result is the same variant it went in as, plus the two routing fields.
   return {
-    ...record,
-    job_id: record.job_id ?? jobId,
-    workflow_id: record.workflow_id ?? workflowId
+    ...message,
+    job_id: routing.job_id ?? jobId,
+    workflow_id: routing.workflow_id ?? workflowId
   } as ProcessingMessage;
 }
 
@@ -130,13 +145,14 @@ function stampResult(
 ): RunResult {
   return {
     ...result,
-    messages: result.messages.map((m) =>
-      stamp(m as ProcessingMessage, jobId, workflowId)
-    )
+    messages: result.messages.map((m) => stamp(m, jobId, workflowId))
   };
 }
 
 function generateJobId(): string {
+  // SAFETY: `crypto.randomUUID` is absent from older browsers and from
+  // non-secure contexts, and the DOM lib types it as always present — so the
+  // optional shape here is what the guard below actually checks.
   const g = globalThis as { crypto?: { randomUUID?: () => string } };
   if (g.crypto?.randomUUID) return g.crypto.randomUUID();
   return `job_${Date.now().toString(36)}_${Math.random()

--- a/packages/workflow-runner/src/handler.ts
+++ b/packages/workflow-runner/src/handler.ts
@@ -25,6 +25,7 @@
  */
 
 import type { Platform, ProcessingMessage } from "@nodetool-ai/protocol";
+import type { RunResult } from "@nodetool-ai/kernel";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
 import { ProcessingContext } from "@nodetool-ai/runtime/context";
 import { runWorkflow, type GraphData, type RunWorkflowOptions } from "./run.js";
@@ -66,7 +67,8 @@ export interface CreateWorkflowHandlerOptions {
 
 export interface WorkflowRequestBody {
   graph: GraphData;
-  params?: Record<string, unknown>;
+  /** The run's params, exactly as `runWorkflow` takes them. */
+  params?: RunWorkflowOptions["params"];
   workflow_id?: string;
   job_id?: string;
 }
@@ -81,12 +83,15 @@ export function createWorkflowHandler(
 
     let body: WorkflowRequestBody;
     try {
+      // SAFETY: an untrusted HTTP body. Nothing is read from it before the
+      // object/`graph` check below, and the graph itself is validated against
+      // the node registry by `runWorkflow`, which rejects an unknown node type.
       body = (await req.json()) as WorkflowRequestBody;
     } catch {
       return jsonError(400, "invalid_json");
     }
 
-    if (!body || typeof body !== "object" || !body.graph) {
+    if (!isObjectBody(body) || !body.graph) {
       return jsonError(400, "missing_graph");
     }
 
@@ -151,24 +156,32 @@ export function createWorkflowHandler(
   };
 }
 
-function formatSse(event: string | null, data: unknown): string {
+/** Whether a decoded JSON body arrived as an object at all. */
+function isObjectBody<T>(body: T): body is T & object {
+  return typeof body === "object" && body !== null;
+}
+
+/** Everything this handler streams: run messages, the final result, an error. */
+type SseData = ProcessingMessage | RunResult | { message: string };
+
+function formatSse(event: string | null, data: SseData): string {
   const payload = JSON.stringify(data);
   const prefix = event ? `event: ${event}\n` : "";
   return `${prefix}data: ${payload}\n\n`;
 }
 
-const ERROR_MESSAGES: Record<string, string> = {
-  method_not_allowed: "POST required",
-  invalid_json: "Body must be valid JSON",
-  missing_graph: "Body must include a `graph`",
-  before_run_failed: "beforeRun hook failed"
-};
+const ERROR_MESSAGES = new Map<string, string>([
+  ["method_not_allowed", "POST required"],
+  ["invalid_json", "Body must be valid JSON"],
+  ["missing_graph", "Body must include a `graph`"],
+  ["before_run_failed", "beforeRun hook failed"]
+]);
 
 function jsonError(status: number, code: string): Response {
   return new Response(
     JSON.stringify({
       error: code,
-      message: ERROR_MESSAGES[code] ?? "Request failed"
+      message: ERROR_MESSAGES.get(code) ?? "Request failed"
     }),
     {
       status,

--- a/packages/workflow-runner/src/run.ts
+++ b/packages/workflow-runner/src/run.ts
@@ -40,7 +40,8 @@ export type GraphData = {
 export interface RunWorkflowOptions {
   graph: GraphData;
   registry: NodeRegistry;
-  params?: Record<string, unknown>;
+  /** The run's params, exactly as the job request carries them. */
+  params?: RunJobRequest["params"];
   jobId?: string;
   workflowId?: string;
 
@@ -169,7 +170,7 @@ export async function* runWorkflow(
   };
 
   let finished = false;
-  let runError: unknown = null;
+  let runError: unknown;
   let result: RunResult | null = null;
 
   const runPromise = runner

--- a/scripts/anti-slop-ratchet.mjs
+++ b/scripts/anti-slop-ratchet.mjs
@@ -15,6 +15,7 @@
 //   node scripts/anti-slop-ratchet.mjs            # report: per-rule + per-tree
 //   node scripts/anti-slop-ratchet.mjs --write    # regenerate the enforced overrides
 //   node scripts/anti-slop-ratchet.mjs --check    # exit 1 if the overrides drifted
+//   node scripts/anti-slop-ratchet.mjs --targets  # report + what to finish next
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -172,6 +173,58 @@ function report(counts, total, files, clean, rules, trees) {
   console.log(`Trees at zero on all ${rules.length} rules: ${spotless.join(", ") || "none"}.`);
 }
 
+/**
+ * The cheapest pairs to finish next, smallest first.
+ *
+ * The per-rule table ranks by how much work is left; this ranks by how little.
+ * A pair sitting at one or two findings is a ratchet win for an afternoon,
+ * and a tree whose every remaining pair is small can be finished outright —
+ * which is worth more than the finding count suggests, because one typecheck
+ * and one test run then cover several pairs.
+ *
+ * Printed rather than derived by whoever is doing the work: counting these by
+ * hand off a raw `oxlint` run silently mixes in oxlint's own default-rule
+ * diagnostics, which report through the same channel and are not backlog
+ * findings at all.
+ */
+function targets(counts, rules, trees, limit = 40) {
+  const pairs = [];
+  for (const tree of trees) {
+    for (const rule of rules) {
+      const count = counts.get(`${tree}|${rule}`) ?? 0;
+      if (count > 0) pairs.push({ count, rule, tree });
+    }
+  }
+  pairs.sort((a, b) => a.count - b.count || a.tree.localeCompare(b.tree));
+
+  const treeTotals = new Map(
+    trees.map((tree) => [
+      tree,
+      rules.reduce((sum, rule) => sum + (counts.get(`${tree}|${rule}`) ?? 0), 0)
+    ])
+  );
+  const nearlyDone = trees
+    .filter((tree) => (treeTotals.get(tree) ?? 0) > 0)
+    .sort((a, b) => (treeTotals.get(a) ?? 0) - (treeTotals.get(b) ?? 0))
+    .slice(0, 10);
+
+  console.log(`### Whole trees closest to zero on all ${rules.length} rules\n`);
+  console.log(`| tree | findings left | rules left |`);
+  console.log(`|---|---:|---:|`);
+  for (const tree of nearlyDone) {
+    const rulesLeft = rules.filter((rule) => (counts.get(`${tree}|${rule}`) ?? 0) > 0).length;
+    console.log(`| \`${tree}\` | ${treeTotals.get(tree)} | ${rulesLeft} |`);
+  }
+
+  console.log(`\n### Cheapest (rule, tree) pairs\n`);
+  console.log(`| findings | rule | tree |`);
+  console.log(`|---:|---|---|`);
+  for (const pair of pairs.slice(0, limit)) {
+    console.log(`| ${pair.count} | \`${pair.rule}\` | \`${pair.tree}\` |`);
+  }
+  console.log(`\n${pairs.length} non-zero pairs remain.`);
+}
+
 const mode = process.argv[2] ?? "--report";
 const rules = backlogRules();
 const trees = lintableTrees();
@@ -198,6 +251,10 @@ if (mode === "--write") {
     );
     process.exit(1);
   }
+} else if (mode === "--targets") {
+  report(counts, total, files, clean, rules, trees);
+  console.log("");
+  targets(counts, rules, trees);
 } else {
   report(counts, total, files, clean, rules, trees);
 }


### PR DESCRIPTION
Continues #4972, which ratcheted the 184 (rule, tree) pairs that were already at zero. This one wins 26 more.

| | before | after |
|---|---:|---:|
| pairs at zero | 184 / 464 (39.7%) | **210 / 464 (45.3%)** |
| backlog findings | 15,994 | **15,918** |
| trees at zero on all eight rules | 2 | **9** |

Newly spotless: `nodes-utils`, `chat`, `config`, `auth`, `workflow-runner`, `model-pricing`, `reve-nodes` — joining `base-nodes` and `security`.

## Picking the targets

AGENTS.md notes that the two columns of the backlog table rank differently, and that this is the scheduling signal. Measuring the full 8×58 matrix rather than the per-rule totals shows the other half of it: 29 pairs sat at exactly one finding, and several whole trees were small enough to finish outright. Finishing a tree concentrates the verification (one typecheck, one test run) and moves several pairs at once, so that is what this change does.

## What the fixes look like

They are not annotations added around the findings. Four shapes recur:

**Name the value crossing a boundary.** `renderTemplate` took `Record<string, unknown>` and stringified whatever landed in it — its real contract is "a scalar with a meaningful string form", now `TemplateVars`, with the one production caller stringifying at its own boundary where it knows what an asset ref's string form should be. `runTool` returned a `ToolCall` asserted to carry a `result` the provider-facing type has no room for, and every use re-asserted it; that is `ExecutedToolCall` now. auth's GoTrue client read an untrusted response body through `unknown` and an open record at each field; `json-wire.ts` names that shape once and the client decodes at the fetch. reve-nodes had no type for the image input, the request body, or the ImageRef it emits.

**Give a `typeof` a predicate that takes a domain type.** `hasToJson`, `isTextResult`, `isStructured`, `hasGetBuiltinModule`, `isNodeType` and friends take `T` or a named type rather than `unknown`, so the finding does not simply move from `no-runtime-typeof` into `no-unknown-parameters` — which AGENTS.md records as what happened last time.

**Delete guards that check what the type already declares.** `ModelPriceParams` declares `withAudio?: boolean` and `seconds?: number`; the `typeof` checks against them were defensive checks on a trusted path and collapse into `??`.

**Point a type at its owner instead of restating it.** workflow-runner's `params` is now `RunWorkflowOptions["params"]` rather than a second `Record<string, unknown>` that can drift from it.

Two latent bugs fell out: a GoTrue `{"id": null}` body used to yield the user id `"null"`, and a non-string value in `STATIC_AUTH_TOKENS` used to be stored as a user id verbatim.

## Verification

- `npm run lint` — green (this includes `lint:anti-slop:enforced` against the new overrides).
- `npm run lint:anti-slop:check` — `.oxlintrc.anti-slop-enforced.json matches the measured zero set`.
- `npm run typecheck` — web and electron green. mobile fails on missing `node_modules` (mobile is not a root workspace); unrelated to this diff.
- `npm run dev:nodetool -- harness gate --base origin/main` — 0 selfchecks demanded by this diff.
- Every changed package's suite run individually: `nodes-utils` 17, `chat` 32, `config` 146, `text-nodes` 242, `auth` 196, `model-pricing` 91, `reve-nodes` 26 — all passing.

Two pre-existing failures on this checkout, both confirmed against a clean tree: `packages/workflow-runner/tests/browser.test.ts` (missing `@nodetool-ai/base-nodes/platforms/browser` subpath), and `packages/chat/tests/index.test.ts` timing out at 60s only under the 93-way parallel `test:packages` run — it passes standalone.

**The new ratchet was proved able to fail, not only to pass.** Re-introducing a `typeof` narrowing in `packages/config` — newly ratcheted on `no-runtime-typeof` — turns `npm run lint:anti-slop:enforced` red with `error anti-slop(no-runtime-typeof)`; removing it turns it green again.

## Left for next time

`packages/sdk` (16 findings, all in `chat.ts`) is the obvious next tree, but it is the WebSocket client's msgpack/JSON decode path and wants the same wire-type treatment auth just got, which is a change worth its own review. `no-chained-type-assertions` is down to 44 findings across 12 trees and is the closest rule to being enforced everywhere — but every remaining site already carries a hand-written SAFETY comment explaining why it is hard, so it is residue rather than backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpudXt1rUeUwN2wtufMwzT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpudXt1rUeUwN2wtufMwzT)_