### PR TITLE
chore(tests): remove unused React imports

### DIFF
--- a/mobile/src/components/app_runtime/__tests__/ApplicationAppView.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/ApplicationAppView.test.tsx
@@ -3,7 +3,6 @@
  * as native widgets, a Run button turns widget values into run params, and the
  * streamed messages of that run fold into the bound display widget.
  */
-import React from "react";
 import { fireEvent, render, screen, act } from "@testing-library/react-native";
 import { v4 as uuidv4 } from "uuid";
 import {

--- a/mobile/src/components/app_runtime/__tests__/catalogWidgets.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/catalogWidgets.test.tsx
@@ -3,7 +3,6 @@
  * web builder can place but this renderer does not know falls through to the
  * unknown-widget hint, so each one is checked against a real document.
  */
-import React from "react";
 import { render, screen } from "@testing-library/react-native";
 
 import {

--- a/mobile/src/components/app_runtime/__tests__/newWidgets.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/newWidgets.test.tsx
@@ -6,7 +6,6 @@
  * charting library and no PDF viewer — so what is asserted there is that the
  * card names the value and offers to open it, not that it draws it.
  */
-import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 
 import {

--- a/mobile/src/components/app_runtime/__tests__/resourceWidgets.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/resourceWidgets.test.tsx
@@ -3,7 +3,6 @@
  * screen its kind already has, a binding that resolves to nothing says so, and
  * an `openResource` action navigates rather than no-opping.
  */
-import React from "react";
 import { fireEvent, render, screen, act } from "@testing-library/react-native";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 

--- a/mobile/src/components/app_runtime/__tests__/sketchWidget.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/sketchWidget.test.tsx
@@ -5,7 +5,6 @@
  * `SketchRef` carrying only an id — and both must end up composited. The
  * document backend is mocked so the ref path is exercised without a server.
  */
-import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 

--- a/mobile/src/components/app_runtime/__tests__/tableWidget.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/tableWidget.test.tsx
@@ -3,7 +3,6 @@
  * array of primitives becomes one column, and an empty value says so instead of
  * rendering an empty frame.
  */
-import React from "react";
 import { render, screen } from "@testing-library/react-native";
 
 import {

--- a/mobile/src/components/app_runtime/__tests__/widgetLayout.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/widgetLayout.test.tsx
@@ -4,7 +4,6 @@
  * fixed-size control, and nested scrolling on the inner scrollers that sit
  * inside the app's own ScrollView (Android needs the prop to deliver the pan).
  */
-import React from "react";
 import { ScrollView, StyleSheet } from "react-native";
 import { render, screen } from "@testing-library/react-native";
 

--- a/mobile/src/components/app_runtime/__tests__/workflowInputKinds.test.tsx
+++ b/mobile/src/components/app_runtime/__tests__/workflowInputKinds.test.tsx
@@ -4,7 +4,6 @@
  * a kind that falls through to a plain text box would silently break the app
  * (a model reference is not something anybody types).
  */
-import React from "react";
 import { render, screen } from "@testing-library/react-native";
 
 import {

--- a/mobile/src/components/chat/ChatMarkdown.test.tsx
+++ b/mobile/src/components/chat/ChatMarkdown.test.tsx
@@ -2,7 +2,6 @@
  * Tests for ChatMarkdown component
  */
 
-import React from 'react';
 import { render } from '@testing-library/react-native';
 import { ChatMarkdown } from './ChatMarkdown';
 

--- a/mobile/src/components/chat/ChatMessageList.test.tsx
+++ b/mobile/src/components/chat/ChatMessageList.test.tsx
@@ -2,7 +2,6 @@
  * Tests for ChatMessageList component
  */
 
-import React from 'react';
 import { render, screen } from '@testing-library/react-native';
 import { ChatMessageList } from './ChatMessageList';
 import { Message } from '../../types';

--- a/mobile/src/components/chat/ChatView.test.tsx
+++ b/mobile/src/components/chat/ChatView.test.tsx
@@ -2,7 +2,6 @@
  * Tests for ChatView component
  */
 
-import React from 'react';
 import { StyleSheet } from 'react-native';
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import { ChatView } from './ChatView';

--- a/mobile/src/components/chat/FilePreview.test.tsx
+++ b/mobile/src/components/chat/FilePreview.test.tsx
@@ -2,7 +2,6 @@
  * Tests for FilePreview component
  */
 
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import { FilePreview } from './FilePreview';
 import { DroppedFile } from '../../types/chat.types';

--- a/mobile/src/components/chat/MessageContentRenderer.test.tsx
+++ b/mobile/src/components/chat/MessageContentRenderer.test.tsx
@@ -2,7 +2,6 @@
  * Tests for MessageContentRenderer component
  */
 
-import React from 'react';
 import { Dimensions, StyleSheet } from 'react-native';
 import { render, screen, act } from '@testing-library/react-native';
 import { MessageContentRenderer } from './MessageContentRenderer';

--- a/mobile/src/components/chat/MessageView.test.tsx
+++ b/mobile/src/components/chat/MessageView.test.tsx
@@ -2,7 +2,6 @@
  * Tests for MessageView component
  */
 
-import React from 'react';
 import { render, screen } from '@testing-library/react-native';
 import { MessageView } from './MessageView';
 import { Message } from '../../types';

--- a/mobile/src/screens/AssetViewerScreen.test.tsx
+++ b/mobile/src/screens/AssetViewerScreen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Alert } from 'react-native';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';

--- a/mobile/src/screens/AssetViewerScreen.zoom.test.tsx
+++ b/mobile/src/screens/AssetViewerScreen.zoom.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, render, screen, fireEvent } from '@testing-library/react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';

--- a/mobile/src/screens/ChatScreen.test.tsx
+++ b/mobile/src/screens/ChatScreen.test.tsx
@@ -2,7 +2,6 @@
  * Tests for ChatScreen
  */
 
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import ChatScreen from './ChatScreen';

--- a/mobile/src/screens/__tests__/DocumentViewerScreen.test.tsx
+++ b/mobile/src/screens/__tests__/DocumentViewerScreen.test.tsx
@@ -5,7 +5,6 @@
  * (loading, loaded summary, failure) can be driven directly.
  */
 
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react-native';
 
 import DocumentViewerScreen from '../DocumentViewerScreen';

--- a/mobile/src/screens/__tests__/DocumentsScreen.test.tsx
+++ b/mobile/src/screens/__tests__/DocumentsScreen.test.tsx
@@ -5,7 +5,6 @@
  * registry-driven navigation can be exercised without a server.
  */
 
-import React from 'react';
 import { Alert, type AlertButton } from 'react-native';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react-native';
 

--- a/mobile/src/screens/__tests__/JobDetailScreen.test.tsx
+++ b/mobile/src/screens/__tests__/JobDetailScreen.test.tsx
@@ -6,7 +6,6 @@
  * that has no stored output to show.
  */
 
-import React from 'react';
 import { Alert } from 'react-native';
 import { act, render, screen, fireEvent } from '@testing-library/react-native';
 

--- a/mobile/src/screens/__tests__/JobsScreen.test.tsx
+++ b/mobile/src/screens/__tests__/JobsScreen.test.tsx
@@ -3,7 +3,6 @@
  * button inside a row must not double as a row tap.
  */
 
-import React from 'react';
 import { Alert } from 'react-native';
 import { render, screen, fireEvent } from '@testing-library/react-native';
 

--- a/mobile/src/screens/__tests__/SketchViewerScreen.test.tsx
+++ b/mobile/src/screens/__tests__/SketchViewerScreen.test.tsx
@@ -8,7 +8,6 @@
  * the screen around it — loading, retry, and the layer list.
  */
 
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 
 import SketchViewerScreen from '../SketchViewerScreen';

--- a/mobile/src/screens/__tests__/TriggersScreen.test.tsx
+++ b/mobile/src/screens/__tests__/TriggersScreen.test.tsx
@@ -4,7 +4,6 @@
  * registration id.
  */
 
-import React from 'react';
 import { Alert } from 'react-native';
 import { render, screen, fireEvent } from '@testing-library/react-native';
 

--- a/web/src/__tests__/ErrorBoundary.test.tsx
+++ b/web/src/__tests__/ErrorBoundary.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/__tests__/components/assets/AssetExplorer.test.tsx
+++ b/web/src/__tests__/components/assets/AssetExplorer.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/__tests__/performance/LogStoreReRender.test.tsx
+++ b/web/src/__tests__/performance/LogStoreReRender.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, act } from '@testing-library/react';
 import useLogsStore, { nodeLogKey } from '../../stores/LogStore';
 

--- a/web/src/components/__tests__/KeyboardProvider.test.tsx
+++ b/web/src/components/__tests__/KeyboardProvider.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import { KeyboardProvider } from '../KeyboardProvider';
 

--- a/web/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/web/src/components/__tests__/ProtectedRoute.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { asMock } from "../../test-utils/doubles";
 import { render, screen, waitFor } from '@testing-library/react';
 import ProtectedRoute from '../ProtectedRoute';

--- a/web/src/components/appbuilder/__tests__/AppBuilderShell.test.tsx
+++ b/web/src/components/appbuilder/__tests__/AppBuilderShell.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { stub } from "../../../test-utils/doubles";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/web/src/components/appbuilder/__tests__/AppDataPanel.test.tsx
+++ b/web/src/components/appbuilder/__tests__/AppDataPanel.test.tsx
@@ -2,7 +2,6 @@
  * The panel that makes operations, variables, and resources editable by hand
  * rather than only through the agent's `ui_app_*` tools.
  */
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/appbuilder/__tests__/AppRuntimeView.test.tsx
+++ b/web/src/components/appbuilder/__tests__/AppRuntimeView.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { stub } from "../../../test-utils/doubles";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/web/src/components/appbuilder/__tests__/ApplicationRunView.test.tsx
+++ b/web/src/components/appbuilder/__tests__/ApplicationRunView.test.tsx
@@ -2,7 +2,6 @@
  * Running an app renders its release, not the canvas — and falls back to the
  * draft only while nothing is published.
  */
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/appbuilder/puck/__tests__/fixedKindInputWidget.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/fixedKindInputWidget.test.tsx
@@ -3,7 +3,6 @@
  * and routes it through the editor's property resolver, so the check that
  * matters is that a kind lands on its real editor rather than on a text box.
  */
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 

--- a/web/src/components/appbuilder/puck/__tests__/modelSelectWidget.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/modelSelectWidget.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/appbuilder/puck/__tests__/resourceGalleryWidget.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/resourceGalleryWidget.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/appbuilder/puck/__tests__/storyboardSceneListWidget.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/storyboardSceneListWidget.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/appbuilder/puck/__tests__/workflowInputWidget.test.tsx
+++ b/web/src/components/appbuilder/puck/__tests__/workflowInputWidget.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 

--- a/web/src/components/applications/__tests__/ApplicationGovernancePanel.test.tsx
+++ b/web/src/components/applications/__tests__/ApplicationGovernancePanel.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/applications/__tests__/LegacyAppRedirect.test.tsx
+++ b/web/src/components/applications/__tests__/LegacyAppRedirect.test.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Route, Routes } from "react-router-dom";

--- a/web/src/components/chat/containers/__tests__/WelcomePlaceholder.test.tsx
+++ b/web/src/components/chat/containers/__tests__/WelcomePlaceholder.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import "@testing-library/jest-dom";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/chat/message/__tests__/MediaOutputGroup.test.tsx
+++ b/web/src/components/chat/message/__tests__/MediaOutputGroup.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { stub } from "../../../../test-utils/doubles";
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";

--- a/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
+++ b/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { asMock } from "../../../../test-utils/doubles";
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";

--- a/web/src/components/chat/message/__tests__/ResourceChip.test.tsx
+++ b/web/src/components/chat/message/__tests__/ResourceChip.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/web/src/components/common/__tests__/ReasoningToggle.test.tsx
+++ b/web/src/components/common/__tests__/ReasoningToggle.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { ReasoningToggle, ReasoningToggleProps } from "../ReasoningToggle";

--- a/web/src/components/content/Help/__tests__/OnScreenKeyboard.test.tsx
+++ b/web/src/components/content/Help/__tests__/OnScreenKeyboard.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { fireEvent } from "@testing-library/dom";
 

--- a/web/src/components/context_menus/__tests__/OutputContextMenu.test.tsx
+++ b/web/src/components/context_menus/__tests__/OutputContextMenu.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/hugging_face/model_list/__tests__/DeleteModelDialog.scope.test.tsx
+++ b/web/src/components/hugging_face/model_list/__tests__/DeleteModelDialog.scope.test.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import React from "react";
 import { stub } from "../../../../test-utils/doubles";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/web/src/components/hugging_face/model_list/__tests__/ModelListIndex.scope.test.tsx
+++ b/web/src/components/hugging_face/model_list/__tests__/ModelListIndex.scope.test.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/hugging_face/model_list/__tests__/ScopeToggle.test.tsx
+++ b/web/src/components/hugging_face/model_list/__tests__/ScopeToggle.test.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ScopeToggle } from "../ScopeToggle";

--- a/web/src/components/hugging_face/onboarding/__tests__/ModelOnboarding.test.tsx
+++ b/web/src/components/hugging_face/onboarding/__tests__/ModelOnboarding.test.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/inputs/__tests__/DatePicker.test.tsx
+++ b/web/src/components/inputs/__tests__/DatePicker.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/menus/__tests__/APIKeysTabContent.test.tsx
+++ b/web/src/components/menus/__tests__/APIKeysTabContent.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/menus/__tests__/DefaultModelsMenu.test.tsx
+++ b/web/src/components/menus/__tests__/DefaultModelsMenu.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/menus/__tests__/ProviderCard.test.tsx
+++ b/web/src/components/menus/__tests__/ProviderCard.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { stub } from "../../../test-utils/doubles";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/web/src/components/model_menu/__tests__/ModelMenuDialogBase.mobile.test.tsx
+++ b/web/src/components/model_menu/__tests__/ModelMenuDialogBase.mobile.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { stub } from "../../../test-utils/doubles";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/node/__tests__/AddDynamicOutputButton.test.tsx
+++ b/web/src/components/node/__tests__/AddDynamicOutputButton.test.tsx
@@ -1,5 +1,4 @@
 import { makeNodeStore, nodeStoreRenderers } from "../../../test-utils/nodeStore";
-import React from "react";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/node/__tests__/BitmapCanvas.test.tsx
+++ b/web/src/components/node/__tests__/BitmapCanvas.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { stub } from "../../../test-utils/doubles";
 import { render, screen } from "@testing-library/react";
 import BitmapCanvas from "../BitmapCanvas";

--- a/web/src/components/node/__tests__/NodeInputs.fieldMemo.test.tsx
+++ b/web/src/components/node/__tests__/NodeInputs.fieldMemo.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import React, { FC } from "react";
+import { FC } from "react";
 import { NodeInputs } from "../NodeInputs";
 import { NodeProvider } from "../../../contexts/NodeContext";
 import { createNodeStore } from "../../../stores/NodeStore";

--- a/web/src/components/node/__tests__/NodeInputs.performance.test.tsx
+++ b/web/src/components/node/__tests__/NodeInputs.performance.test.tsx
@@ -1,5 +1,5 @@
 import { render, act } from "@testing-library/react";
-import React, { FC } from "react";
+import { FC } from "react";
 import { NodeInputs } from "../NodeInputs";
 import { NodeProvider } from "../../../contexts/NodeContext";
 import { createNodeStore } from "../../../stores/NodeStore";

--- a/web/src/components/node/__tests__/NodeTerminal.test.tsx
+++ b/web/src/components/node/__tests__/NodeTerminal.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import NodeTerminal from "../NodeTerminal";
 import { Terminal } from "@xterm/xterm";

--- a/web/src/components/node/output/__tests__/PlotlyChart.test.tsx
+++ b/web/src/components/node/output/__tests__/PlotlyChart.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, waitFor, cleanup } from "@testing-library/react";
 import type { Data, Frame } from "plotly.js";
 

--- a/web/src/components/node_editor/__tests__/Alert.test.tsx
+++ b/web/src/components/node_editor/__tests__/Alert.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { asMock } from "../../../test-utils/doubles";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/node_editor/__tests__/ConnectionLine.test.tsx
+++ b/web/src/components/node_editor/__tests__/ConnectionLine.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { asMock } from "../../../test-utils/doubles";
 import { render } from '@testing-library/react';
 import ConnectionLine from '../ConnectionLine';

--- a/web/src/components/node_types/editing/__tests__/AdjustmentBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/AdjustmentBody.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { AdjustmentBody } from "../AdjustmentBody";
 import { ADJUSTMENT_NODE_TYPES } from "../AdjustmentBody.constants";

--- a/web/src/components/node_types/editing/__tests__/ListGeneratorBody.test.tsx
+++ b/web/src/components/node_types/editing/__tests__/ListGeneratorBody.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { stub } from "../../../../test-utils/doubles";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/web/src/components/packages/__tests__/SandboxPackDisclosure.test.tsx
+++ b/web/src/components/packages/__tests__/SandboxPackDisclosure.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { asMock } from "../../../test-utils/doubles";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/web/src/components/panels/__tests__/MobileRailLauncher.test.tsx
+++ b/web/src/components/panels/__tests__/MobileRailLauncher.test.tsx
@@ -6,7 +6,6 @@
  * buttons are present and that the toggle flips the shared panel visibility.
  */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
+++ b/web/src/components/panels/__tests__/PanelLeftMobile.test.tsx
@@ -6,7 +6,6 @@
  * ones that only make sense while a workflow is open for editing.
  */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/panels/__tests__/QueueOverlay.focus.test.tsx
+++ b/web/src/components/panels/__tests__/QueueOverlay.focus.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { asMock } from "../../../test-utils/doubles";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/panels/__tests__/QueueOverlay.test.tsx
+++ b/web/src/components/panels/__tests__/QueueOverlay.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { asMock } from "../../../test-utils/doubles";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/panels/__tests__/RailAppMenu.test.tsx
+++ b/web/src/components/panels/__tests__/RailAppMenu.test.tsx
@@ -7,7 +7,6 @@
  * and the workspace is focused.
  */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/panels/__tests__/StatusMessage.test.tsx
+++ b/web/src/components/panels/__tests__/StatusMessage.test.tsx
@@ -13,7 +13,6 @@
  * - Has correct CSS classes and MUI Typography props
  */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import StatusMessage from "../StatusMessage";

--- a/web/src/components/panels/jobs/__tests__/QueuePanel.test.tsx
+++ b/web/src/components/panels/jobs/__tests__/QueuePanel.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { asMock } from "../../../../test-utils/doubles";
 import { render, screen, within } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/properties/__tests__/AudioListProperty.test.tsx
+++ b/web/src/components/properties/__tests__/AudioListProperty.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/properties/__tests__/BoolProperty.test.tsx
+++ b/web/src/components/properties/__tests__/BoolProperty.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/properties/__tests__/CodeProperty.test.tsx
+++ b/web/src/components/properties/__tests__/CodeProperty.test.tsx
@@ -1,5 +1,4 @@
 import { makeNodeStore, nodeStoreRenderers } from "../../../test-utils/nodeStore";
-import React from "react";
 import { screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/properties/__tests__/DataframeProperty.test.tsx
+++ b/web/src/components/properties/__tests__/DataframeProperty.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 
 // Mocks

--- a/web/src/components/properties/__tests__/ImageListProperty.test.tsx
+++ b/web/src/components/properties/__tests__/ImageListProperty.test.tsx
@@ -1,5 +1,4 @@
 import { makeNodeStore, nodeStoreRenderers } from "../../../test-utils/nodeStore";
-import React from "react";
 import { screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/properties/__tests__/ImageSizePresetsMenu.test.tsx
+++ b/web/src/components/properties/__tests__/ImageSizePresetsMenu.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { stub } from "../../../test-utils/doubles";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/properties/__tests__/Model3DProperty.test.tsx
+++ b/web/src/components/properties/__tests__/Model3DProperty.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 
 // Mocks

--- a/web/src/components/properties/__tests__/SandboxPackagesProperty.test.tsx
+++ b/web/src/components/properties/__tests__/SandboxPackagesProperty.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { asMock } from "../../../test-utils/doubles";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/web/src/components/properties/__tests__/TextListProperty.test.tsx
+++ b/web/src/components/properties/__tests__/TextListProperty.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/properties/__tests__/VideoListProperty.test.tsx
+++ b/web/src/components/properties/__tests__/VideoListProperty.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
+++ b/web/src/components/provider_onboarding/__tests__/ProviderOnboardingDialog.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { asMock, stub } from "../../../test-utils/doubles";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/web/src/components/script/__tests__/StoryboardLinkControl.test.tsx
+++ b/web/src/components/script/__tests__/StoryboardLinkControl.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/sketch/__tests__/ConnectedGeneratePopover.test.tsx
+++ b/web/src/components/sketch/__tests__/ConnectedGeneratePopover.test.tsx
@@ -7,7 +7,6 @@
  * full-frame generation.
  */
 
-import React from "react";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/sketch/__tests__/ConnectedStatusBar.test.tsx
+++ b/web/src/components/sketch/__tests__/ConnectedStatusBar.test.tsx
@@ -7,7 +7,6 @@
  * selection size render from real store state.
  */
 
-import React from "react";
 import { render } from "@testing-library/react";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 

--- a/web/src/components/sketch/__tests__/SketchLayersPanel.test.tsx
+++ b/web/src/components/sketch/__tests__/SketchLayersPanel.test.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import React from "react";
 import { render, screen, createEvent, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider, createTheme } from "@mui/material/styles";

--- a/web/src/components/sketch/__tests__/SketchToolbar.test.tsx
+++ b/web/src/components/sketch/__tests__/SketchToolbar.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { ThemeProvider, createTheme } from "@mui/material/styles";

--- a/web/src/components/sketch/__tests__/activeLayerTransform.test.ts
+++ b/web/src/components/sketch/__tests__/activeLayerTransform.test.ts
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import React from "react";
 import { act, renderHook } from "@testing-library/react";
 import { useSketchStore } from "../state/useSketchStore";
 import { createDefaultDocument, makeAffineTransform, type LayerTransform } from "../types";

--- a/web/src/components/sketch/__tests__/agentPaintStrokes.test.tsx
+++ b/web/src/components/sketch/__tests__/agentPaintStrokes.test.tsx
@@ -17,7 +17,6 @@
  * brush stamp included), so no headless canvas shim is needed.
  */
 
-import React from "react";
 import { act, render } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 

--- a/web/src/components/sketch/__tests__/toolTopBarCollapse.test.tsx
+++ b/web/src/components/sketch/__tests__/toolTopBarCollapse.test.tsx
@@ -7,7 +7,6 @@
  * canvas on a phone.
  */
 
-import React from "react";
 import { stub } from "../../../test-utils/doubles";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/web/src/components/sketch/__tests__/useCompositing.test.tsx
+++ b/web/src/components/sketch/__tests__/useCompositing.test.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import React from "react";
 import { act, renderHook } from "@testing-library/react";
 import { createDefaultDocument } from "../types";
 import { useCompositing } from "../sketchCanvasHooks/useCompositing";

--- a/web/src/components/sketch/__tests__/useSketchStoreSelectors.test.tsx
+++ b/web/src/components/sketch/__tests__/useSketchStoreSelectors.test.tsx
@@ -5,7 +5,6 @@
  * The old useSketchStoreSelectors() aggregator has been removed; these tests
  * verify the replacement provides correct isolation.
  */
-import React from "react";
 import { act, renderHook } from "@testing-library/react";
 import { useSketchStore } from "../state/useSketchStore";
 import {

--- a/web/src/components/storyboard/__tests__/ScriptLinkControl.test.tsx
+++ b/web/src/components/storyboard/__tests__/ScriptLinkControl.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/storyboard/__tests__/ShotScriptPanel.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotScriptPanel.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/storyboard/__tests__/ShotTakesGallery.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotTakesGallery.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/storyboard/__tests__/StoryboardQueueOverlay.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardQueueOverlay.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/timeline/Inspector/__tests__/TimelineInspector.sections.test.tsx
+++ b/web/src/components/timeline/Inspector/__tests__/TimelineInspector.sections.test.tsx
@@ -4,7 +4,6 @@
  * an effect without folding the section, and the hover-revealed reset action.
  */
 
-import React from "react";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/timeline/Tracks/__tests__/ScriptLane.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/ScriptLane.test.tsx
@@ -4,7 +4,6 @@
  * playhead and selects the clip (bidirectional with the tracks).
  */
 
-import React from "react";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { makeClip } from "@nodetool-ai/timeline";

--- a/web/src/components/timeline/Tracks/__tests__/ScriptToggleButton.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/ScriptToggleButton.test.tsx
@@ -5,7 +5,6 @@
  * false. Flipping false is non-destructive (it only changes the flag).
  */
 
-import React from "react";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 

--- a/web/src/components/timeline/Tracks/__tests__/TimeRuler.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TimeRuler.test.tsx
@@ -6,7 +6,6 @@
  * the playhead, and the delete button removes it from the store.
  */
 
-import React from "react";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 

--- a/web/src/components/timeline/Tracks/__tests__/TrackHeaderReorder.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TrackHeaderReorder.test.tsx
@@ -8,7 +8,6 @@
  * mount and pushes it active, so static getState() only reaches that instance
  * once the provider is rendered.
  */
-import React from "react";
 import { stub } from "../../../../test-utils/doubles";
 import { describe, it, expect } from "@jest/globals";
 import { act, fireEvent, render, screen } from "@testing-library/react";

--- a/web/src/components/timeline/Tracks/__tests__/TracksRegionEmptyAreaDrop.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TracksRegionEmptyAreaDrop.test.tsx
@@ -7,7 +7,6 @@
  * Regression: the empty-area path used to call addImportedClip directly, so
  * dropping a video to create a new track skipped audio extraction.
  */
-import React from "react";
 import { stub } from "../../../../test-utils/doubles";
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import { act, fireEvent, render, screen } from "@testing-library/react";

--- a/web/src/components/timeline/Tracks/__tests__/TracksRegionScriptGating.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TracksRegionScriptGating.test.tsx
@@ -4,7 +4,6 @@
  * flag off hides both without touching tracks/clips.
  */
 
-import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 

--- a/web/src/components/timeline/Tracks/__tests__/TracksRegionShortcuts.test.tsx
+++ b/web/src/components/timeline/Tracks/__tests__/TracksRegionShortcuts.test.tsx
@@ -8,7 +8,6 @@
  * `window` rather than a specific element. Store state is seeded AFTER render
  * so `getState()` routes to the mounted provider's instance (not the default).
  */
-import React from "react";
 import { describe, it, expect, jest } from "@jest/globals";
 import { act, fireEvent, render } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/timeline/__tests__/ProjectSettingsDialog.test.tsx
+++ b/web/src/components/timeline/__tests__/ProjectSettingsDialog.test.tsx
@@ -7,7 +7,6 @@
  * values.
  */
 
-import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/timeline/__tests__/TimelineVersionHistoryPanel.test.tsx
+++ b/web/src/components/timeline/__tests__/TimelineVersionHistoryPanel.test.tsx
@@ -6,7 +6,6 @@
  * pre-restore document back), and the destructive delete confirm.
  */
 
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/timeline/__tests__/TrackLaneScrollMath.test.tsx
+++ b/web/src/components/timeline/__tests__/TrackLaneScrollMath.test.tsx
@@ -8,7 +8,6 @@
  * positions or px→ms conversions (seek, rubber-band).
  */
 
-import React from "react";
 import { installGlobal } from "../../../test-utils/doubles";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/timeline/preview/__tests__/TransformGizmoOverlay.test.tsx
+++ b/web/src/components/timeline/preview/__tests__/TransformGizmoOverlay.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import type { ClipTransform } from "@nodetool-ai/timeline";

--- a/web/src/components/tutorials/__tests__/TutorialsPage.test.tsx
+++ b/web/src/components/tutorials/__tests__/TutorialsPage.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { stub } from "../../../test-utils/doubles";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/web/src/components/ui_primitives/__tests__/ActionButtonGroup.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/ActionButtonGroup.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { ActionButtonGroup } from "../ActionButtonGroup";

--- a/web/src/components/ui_primitives/__tests__/AlertBanner.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/AlertBanner.test.tsx
@@ -1,4 +1,4 @@
-import React, { createRef } from "react";
+import { createRef } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AlertBanner } from "../AlertBanner";

--- a/web/src/components/ui_primitives/__tests__/CircularActionButton.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/CircularActionButton.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { CircularActionButton } from "../CircularActionButton";

--- a/web/src/components/ui_primitives/__tests__/CloseButton.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/CloseButton.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { CloseButton } from "../CloseButton";

--- a/web/src/components/ui_primitives/__tests__/Container.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/Container.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { Container } from "../Container";

--- a/web/src/components/ui_primitives/__tests__/Dialog.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/Dialog.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { Dialog } from "../Dialog";

--- a/web/src/components/ui_primitives/__tests__/DialogActionButtons.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/DialogActionButtons.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { DialogActionButtons } from "../DialogActionButtons";

--- a/web/src/components/ui_primitives/__tests__/ExpandCollapseButton.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/ExpandCollapseButton.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { ExpandCollapseButton } from "../ExpandCollapseButton";

--- a/web/src/components/ui_primitives/__tests__/LabeledToggle.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/LabeledToggle.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { LabeledToggle } from "../LabeledToggle";

--- a/web/src/components/ui_primitives/__tests__/NavButton.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/NavButton.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { NavButton } from "../NavButton";

--- a/web/src/components/ui_primitives/__tests__/PlaybackButton.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/PlaybackButton.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { PlaybackButton } from "../PlaybackButton";

--- a/web/src/components/ui_primitives/__tests__/RefreshButton.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/RefreshButton.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { RefreshButton } from "../RefreshButton";

--- a/web/src/components/ui_primitives/__tests__/SelectionControls.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/SelectionControls.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { SelectionControls } from "../SelectionControls";

--- a/web/src/components/ui_primitives/__tests__/SettingsButton.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/SettingsButton.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { SettingsButton } from "../SettingsButton";

--- a/web/src/components/ui_primitives/__tests__/ShortcutHint.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/ShortcutHint.test.tsx
@@ -1,5 +1,4 @@
 /** @jsxImportSource @emotion/react */
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "@jest/globals";
 import { ShortcutHint } from "../ShortcutHint";

--- a/web/src/components/ui_primitives/__tests__/StateIconButton.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/StateIconButton.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { StateIconButton } from "../StateIconButton";

--- a/web/src/components/ui_primitives/__tests__/Toast.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/Toast.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Toast } from "../Toast";

--- a/web/src/components/ui_primitives/__tests__/ToolbarIconButton.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/ToolbarIconButton.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { ToolbarIconButton } from "../ToolbarIconButton";

--- a/web/src/components/ui_primitives/__tests__/UploadButton.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/UploadButton.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { UploadButton } from "../UploadButton";

--- a/web/src/components/ui_primitives/__tests__/ZoomControls.test.tsx
+++ b/web/src/components/ui_primitives/__tests__/ZoomControls.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import { ZoomControls } from "../ZoomControls";

--- a/web/src/components/workers/__tests__/WorkerProfilesDialog.test.tsx
+++ b/web/src/components/workers/__tests__/WorkerProfilesDialog.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/workers/__tests__/WorkerStatusIndicator.test.tsx
+++ b/web/src/components/workers/__tests__/WorkerStatusIndicator.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { stub } from "../../../test-utils/doubles";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/web/src/components/workers/__tests__/WorkersPanel.test.tsx
+++ b/web/src/components/workers/__tests__/WorkersPanel.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/workflows/__tests__/WorkflowTriggerIndicator.test.tsx
+++ b/web/src/components/workflows/__tests__/WorkflowTriggerIndicator.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "@mui/material/styles";
 import mockTheme from "../../../__mocks__/themeMock";

--- a/web/src/components/workspace/__tests__/JsScriptSurfaceMobile.test.tsx
+++ b/web/src/components/workspace/__tests__/JsScriptSurfaceMobile.test.tsx
@@ -6,7 +6,6 @@
  * model and the console output survive a switch; only one is displayed.
  */
 
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/workspace/__tests__/LinkedWorkflowsMenu.test.tsx
+++ b/web/src/components/workspace/__tests__/LinkedWorkflowsMenu.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@mui/material/styles";

--- a/web/src/components/workspace/__tests__/PageSurface.test.tsx
+++ b/web/src/components/workspace/__tests__/PageSurface.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import PageSurface from "../PageSurface";
 

--- a/web/src/components/workspace/__tests__/SettingsRedirect.test.tsx
+++ b/web/src/components/workspace/__tests__/SettingsRedirect.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 

--- a/web/src/components/workspace/__tests__/TextDocumentEditor.test.tsx
+++ b/web/src/components/workspace/__tests__/TextDocumentEditor.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { installGlobal, stub } from "../../../test-utils/doubles";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/web/src/contexts/__tests__/NodeContext.test.tsx
+++ b/web/src/contexts/__tests__/NodeContext.test.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { render, screen, act } from '@testing-library/react';
 import { create } from 'zustand';
 import { NodeProvider, useNodes, useTemporalNodes, NodeContext } from '../NodeContext';

--- a/web/src/hooks/assets/__tests__/useAssetDisplay.test.tsx
+++ b/web/src/hooks/assets/__tests__/useAssetDisplay.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import { useAssetDisplay } from "../useAssetDisplay";
 

--- a/web/src/providers/__tests__/ConnectableNodesProvider.test.tsx
+++ b/web/src/providers/__tests__/ConnectableNodesProvider.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, act } from "@testing-library/react";
 import { ConnectableNodesProvider } from "../ConnectableNodesProvider";
 import useConnectableNodes from "../../stores/ConnectableNodesStore";

--- a/web/src/providers/__tests__/ContextMenuProvider.test.tsx
+++ b/web/src/providers/__tests__/ContextMenuProvider.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, act } from "@testing-library/react";
 import { ContextMenuProvider } from "../ContextMenuProvider";
 import useContextMenu from "../../stores/ContextMenuStore";

--- a/web/src/providers/__tests__/MenuProvider.test.tsx
+++ b/web/src/providers/__tests__/MenuProvider.test.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import { useContext } from "react";
 import { render, act } from "@testing-library/react";
 import { MenuProvider, MenuContext } from "../MenuProvider";
 

--- a/web/src/utils/__tests__/modelFormatting.test.tsx
+++ b/web/src/utils/__tests__/modelFormatting.test.tsx
@@ -5,7 +5,6 @@ import "@testing-library/jest-dom/jest-globals";
 import { stub } from "../../test-utils/doubles";
 import { describe, it, expect } from "@jest/globals";
 import { render, screen } from "@testing-library/react";
-import React from "react";
 import {
   formatBytes,
   groupModelsByType,


### PR DESCRIPTION
Web and electron compile JSX with `"jsx": "react-jsx"`; mobile goes through `babel-preset-expo`, which uses the automatic runtime too. In all three a bare `import React` in a test file binds a name nothing reads.

147 test files edited. Nothing but the import line changed:

- `import React from "react";` — line deleted (142 files)
- `import React, { useState } from "react";` — narrowed to the named imports (5 files)

Any file that still references `React` anywhere — `React.FC`, `React.ReactNode`, `React.createElement`, `<React.Fragment>` — was left alone. The edit was made by a script that reads the whole file minus the import line and skips on a `\bReact\b` match, so the 174 files it passed over were skipped on evidence rather than on a guess.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` (web) | clean |
| `tsc --noEmit` (electron) | clean |
| `tsc --noEmit` (mobile) | clean |
| `jest` (web) | 1128 suites, 13020 passed |
| `jest` (electron) | 63 suites, 674 passed |
| `jest` (mobile) | 75 suites, 1038 passed |
| `npm run lint` | no new findings |

Two pre-existing environment gaps, both unrelated to this diff: `lint:anti-slop:enforced` cannot load its plugin (`@oxlint/plugins` is not installed here), and `mobile/` needed its own `npm install` before it would typecheck at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmRh3fSqXUnBC6z6JRU1f5)_