### PR TITLE
feat(dashboard): lead with the agent and its tasks

### DIFF
--- a/web/src/components/portal/DashboardActivity.tsx
+++ b/web/src/components/portal/DashboardActivity.tsx
@@ -91,7 +91,7 @@ interface DashboardActivityProps {
 }
 
 /**
- * Recent runs, in the dashboard's right rail. A workflow tool whose dashboard
+ * Recent tasks, in the dashboard's right rail. An agent tool whose dashboard
  * says nothing about what ran, or what broke, is missing the one thing only it
  * can show.
  */
@@ -124,9 +124,9 @@ const DashboardActivity: React.FC<DashboardActivityProps> = ({
   ).length;
 
   return (
-    <section css={styles(theme)} aria-label="Recent runs">
+    <section css={styles(theme)} aria-label="Task activity">
       <div className="act-head">
-        <span className="act-title">Recent runs</span>
+        <span className="act-title">Task activity</span>
         {runningCount > 0 && (
           <span className="act-count">{runningCount} running</span>
         )}
@@ -134,8 +134,8 @@ const DashboardActivity: React.FC<DashboardActivityProps> = ({
 
       {runs.length === 0 ? (
         <p className="act-empty">
-          Nothing has run yet. Open a workflow and press run — what it does will
-          show up here.
+          Nothing has run yet. Ask the agent for something, or run a workflow —
+          every task lands here.
         </p>
       ) : (
         <div className="act-list">

--- a/web/src/components/portal/DashboardAgentSessions.tsx
+++ b/web/src/components/portal/DashboardAgentSessions.tsx
@@ -1,0 +1,178 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import type { Theme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
+import { memo, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import type { Thread } from "../../stores/ApiTypes";
+import { trpcClient } from "../../trpc/client";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import {
+  EmptyState,
+  BORDER_RADIUS,
+  MOTION,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+import { useSectionWrap, SectionHeader, SectionLink } from "./dashboardChrome";
+import { shortAgo } from "./runStatus";
+
+const MAX_SESSIONS = 8;
+
+const styles = (theme: Theme) =>
+  css({
+    paddingTop: getSpacingPx(SPACING.md),
+    ".sess-list": {
+      border: `1px solid ${theme.vars.palette.divider}`,
+      borderRadius: BORDER_RADIUS.lg,
+      background: theme.vars.palette.c_node_bg,
+      padding: getSpacingPx(SPACING.sm),
+      display: "flex",
+      flexDirection: "column",
+      gap: getSpacingPx(SPACING.micro)
+    },
+    ".sess-row": {
+      display: "flex",
+      alignItems: "center",
+      gap: getSpacingPx(SPACING.md),
+      width: "100%",
+      textAlign: "left",
+      padding: `${getSpacingPx(SPACING.sm)} ${getSpacingPx(SPACING.md)}`,
+      background: "transparent",
+      border: "none",
+      borderRadius: BORDER_RADIUS.sm,
+      cursor: "pointer",
+      transition: `background ${MOTION.fast}`,
+      "&:hover": { background: theme.vars.palette.action.hover }
+    },
+    ".sess-icon": {
+      flexShrink: 0,
+      display: "grid",
+      placeItems: "center",
+      width: 24,
+      height: 24,
+      borderRadius: BORDER_RADIUS.sm,
+      background: `rgba(${theme.vars.palette.primary.mainChannel} / 0.12)`,
+      color: theme.vars.palette.primary.main
+    },
+    ".sess-title": {
+      flex: 1,
+      minWidth: 0,
+      fontSize: "var(--fontSizeSmall)",
+      color: theme.vars.palette.text.primary,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap"
+    },
+    ".sess-when": {
+      flexShrink: 0,
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.disabled
+    }
+  });
+
+interface DashboardAgentSessionsProps {
+  /** Open a fresh agent chat, the same way the hero's agent track does. */
+  onNewSession: () => void;
+}
+
+/**
+ * The user's agent conversations, first in the dashboard's main column: an
+ * agent-centric dashboard resumes the work the agent was doing before it
+ * shows anything else.
+ */
+const DashboardAgentSessions: React.FC<DashboardAgentSessionsProps> = ({
+  onNewSession
+}) => {
+  const theme = useTheme();
+  const sectionWrap = useSectionWrap();
+  const navigate = useNavigate();
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["dashboard", "threads"],
+    queryFn: () => trpcClient.threads.list.query({ limit: 50 }),
+    staleTime: 30_000
+  });
+
+  const sessions = useMemo(() => {
+    const all: Thread[] = data?.threads ?? [];
+    return [...all]
+      .sort((a, b) => (b.updated_at ?? "").localeCompare(a.updated_at ?? ""))
+      .slice(0, MAX_SESSIONS);
+  }, [data]);
+
+  const openSession = useCallback(
+    (thread: Thread) => {
+      openTab({
+        type: "chat",
+        ref: thread.id,
+        mode: "view",
+        title: thread.title || "Untitled chat"
+      });
+      navigate("/workspace");
+    },
+    [openTab, navigate]
+  );
+
+  // While loading there is nothing useful to say; the section appears when
+  // the threads do, and the empty state only once we know there are none.
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <section css={styles(theme)} aria-label="Agent sessions">
+      <div css={sectionWrap}>
+        <SectionHeader
+          title="Agent sessions"
+          count={sessions.length > 0 ? `${sessions.length}` : undefined}
+        >
+          <SectionLink onClick={onNewSession}>New session</SectionLink>
+        </SectionHeader>
+
+        {sessions.length === 0 ? (
+          <EmptyState
+            size="small"
+            title="No agent sessions yet"
+            description="Describe a task above, or start a session — the agent plans it, runs it, and the conversation lands here."
+            actionText="Start a session"
+            onAction={onNewSession}
+          />
+        ) : (
+          <div className="sess-list">
+            {sessions.map((thread) => (
+              <button
+                key={thread.id}
+                type="button"
+                className="sess-row"
+                onClick={() => openSession(thread)}
+              >
+                <span className="sess-icon" aria-hidden>
+                  <svg
+                    width="13"
+                    height="13"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                  >
+                    <path d="M3 3h10v7H8l-3 3v-3H3z" />
+                  </svg>
+                </span>
+                <span className="sess-title">
+                  {thread.title || "Untitled chat"}
+                </span>
+                <span className="sess-when">{shortAgo(thread.updated_at)}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default memo(DashboardAgentSessions);

--- a/web/src/components/portal/Portal.tsx
+++ b/web/src/components/portal/Portal.tsx
@@ -13,6 +13,7 @@ import { usePanelStore } from "../../stores/PanelStore";
 import { openProviderOnboarding } from "../../stores/ProviderOnboardingStore";
 import DashboardHero from "./DashboardHero";
 import DashboardActivity from "./DashboardActivity";
+import DashboardAgentSessions from "./DashboardAgentSessions";
 import DashboardDownloads from "./DashboardDownloads";
 import { DashboardColumn, wrapStyles } from "./dashboardChrome";
 import GettingStartedChecklist from "./GettingStartedChecklist";
@@ -176,6 +177,12 @@ const Portal: React.FC = () => {
     openProviderOnboarding();
   }, []);
 
+  // A fresh agent chat, through the same gate the hero's agent track uses —
+  // key-less users get provider onboarding first, then the chat opens.
+  const handleNewAgentSession = useCallback(() => {
+    handleStart("agent", "");
+  }, [handleStart]);
+
   return (
     <Box css={styles(theme)}>
       <div className="dashboard-scroll">
@@ -187,13 +194,17 @@ const Portal: React.FC = () => {
             onOpenEmptyCanvas={handleCreateNewWorkflow}
             onOpenSettings={handleOpenSettings}
           />
-          {/* A returning user's own work leads, with the checklist and run
-              activity moved into a rail beside it. A first-run user has no
-              work yet, so the material that teaches them leads instead. */}
+          {/* A returning user's own work leads — agent sessions first, then
+              workflows — with the checklist and task activity in a rail
+              beside it. A first-run user has no work yet, so the material
+              that teaches them leads instead. */}
           {mode === "returning" ? (
             <div css={[wrapStyles(theme), columnStyles(theme)]}>
               <div className="dash-main">
                 <DashboardColumn>
+                  <DashboardAgentSessions
+                    onNewSession={handleNewAgentSession}
+                  />
                   <DashboardWorkflows
                     workflows={sortedWorkflows}
                     isLoading={isLoadingWorkflows}

--- a/web/src/components/portal/__tests__/DashboardAgentSessions.test.tsx
+++ b/web/src/components/portal/__tests__/DashboardAgentSessions.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { ThemeProvider } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import mockTheme from "../../../__mocks__/themeMock";
+import DashboardAgentSessions from "../DashboardAgentSessions";
+import { useWorkspaceTabsStore } from "../../../stores/WorkspaceTabsStore";
+import { trpcClient } from "../../../trpc/client";
+
+jest.mock("../../../trpc/client", () => ({
+  trpcClient: {
+    threads: {
+      list: { query: jest.fn() }
+    }
+  }
+}));
+
+const listQuery = trpcClient.threads.list.query as jest.Mock;
+
+const thread = (id: string, title: string | null, updatedAt: string) => ({
+  id,
+  user_id: "u1",
+  workflow_id: null,
+  title,
+  created_at: updatedAt,
+  updated_at: updatedAt
+});
+
+const renderSessions = (onNewSession = jest.fn()) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+  render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={mockTheme}>
+          <DashboardAgentSessions onNewSession={onNewSession} />
+        </ThemeProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+  return { onNewSession };
+};
+
+describe("DashboardAgentSessions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("lists sessions newest first and opens one as a chat tab", async () => {
+    const user = userEvent.setup();
+    listQuery.mockResolvedValue({
+      threads: [
+        thread("t-old", "Older session", "2026-08-01T00:00:00Z"),
+        thread("t-new", "Newest session", "2026-08-16T00:00:00Z")
+      ]
+    });
+    renderSessions();
+
+    const newest = await screen.findByRole("button", {
+      name: /newest session/i
+    });
+    const older = screen.getByRole("button", { name: /older session/i });
+    // Newest first: the newest row precedes the older one in the list.
+    expect(
+      newest.compareDocumentPosition(older) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+
+    await user.click(newest);
+    const tabs = useWorkspaceTabsStore.getState().tabs;
+    expect(tabs.some((t) => t.type === "chat" && t.ref === "t-new")).toBe(true);
+  });
+
+  it("falls back to a name for an untitled thread", async () => {
+    listQuery.mockResolvedValue({
+      threads: [thread("t1", null, "2026-08-16T00:00:00Z")]
+    });
+    renderSessions();
+
+    expect(await screen.findByText("Untitled chat")).toBeInTheDocument();
+  });
+
+  it("offers to start a session when there are none", async () => {
+    const user = userEvent.setup();
+    listQuery.mockResolvedValue({ threads: [] });
+    const { onNewSession } = renderSessions();
+
+    await user.click(
+      await screen.findByRole("button", { name: /start a session/i })
+    );
+    expect(onNewSession).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/portal/welcomeTracks.ts
+++ b/web/src/components/portal/welcomeTracks.ts
@@ -35,6 +35,18 @@ export interface WelcomeTrack {
 
 export const WELCOME_TRACKS: WelcomeTrack[] = [
   {
+    id: "agent",
+    label: "Agent",
+    blurb: "A task the agent plans, runs, and reports back on.",
+    modeLabel: "agent",
+    accent: "#60A5FA",
+    threadTitle: "Agent",
+    samplePrompt:
+      "research the three strongest open-source video models and write a short comparison I can paste into a doc",
+    chatMode: "chat",
+    capability: "generate_message"
+  },
+  {
     id: "image",
     label: "Image",
     blurb: "A still frame from a prompt.",
@@ -69,17 +81,5 @@ export const WELCOME_TRACKS: WelcomeTrack[] = [
       "a calm narrator: you are listening to nodetool. every model, your keys, your canvas.",
     chatMode: "audio",
     capability: "text_to_speech"
-  },
-  {
-    id: "agent",
-    label: "Text · Agent",
-    blurb: "A reasoning step or written output.",
-    modeLabel: "chat",
-    accent: "#60A5FA",
-    threadTitle: "Chat",
-    samplePrompt:
-      "draft a 4-line tagline for a creative tool that runs every AI model locally or in the cloud, no hype words",
-    chatMode: "chat",
-    capability: "generate_message"
   }
 ];


### PR DESCRIPTION
## What

Refocuses the dashboard on the agent and agentic tasks.

- **Agent track leads.** The agent entry in `WELCOME_TRACKS` moves to first position, relabeled from "Text · Agent" to "Agent" with a task-oriented blurb and sample prompt ("research … and write a short comparison"). This reorders the first-run welcome cards and the command-bar kind chips; the bar's default track was already `agent`.
- **New "Agent sessions" section** (`DashboardAgentSessions`) leads the returning user's main column: the eight most recent chat threads, newest first, each opening as a chat tab in the workspace. A "New session" action starts a fresh agent chat through the same provider-onboarding gate as the hero. The section renders nothing while threads load and shows an empty state pointing at the command bar when there are none.
- **Activity rail reframed** from "Recent runs" to "Task activity", with empty-state copy that names the agent as a way tasks get run.

## Why

The dashboard was workflow-first: it listed workflows, templates, and tutorials, treated agent chat as the last of four modality tracks, and showed nothing about past agent conversations. A returning user's agent work now resumes from the top of the page.

## Verification

- `cd web && npm run typecheck` — clean
- `npm run lint` — clean (pre-existing warnings elsewhere only)
- `cd web && npm test` — 1129 suites, 13,023 tests passed, including a new behavior suite for `DashboardAgentSessions` (ordering, open-as-chat-tab, untitled fallback, empty state)
- `electron` typecheck — clean; mobile typecheck untouched by this web-only diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RE8LXxmQu27SbvL5tVf94R

---
_Generated by [Claude Code](https://claude.ai/code/session_01RE8LXxmQu27SbvL5tVf94R)_