### PR TITLE
feat(web): show every document type on the dashboard

### DIFF
--- a/web/src/components/portal/DashboardDocuments.tsx
+++ b/web/src/components/portal/DashboardDocuments.tsx
@@ -1,0 +1,332 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import type { Theme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
+import React, { memo, useCallback, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import BrushOutlinedIcon from "@mui/icons-material/BrushOutlined";
+import MovieOutlinedIcon from "@mui/icons-material/MovieOutlined";
+import DashboardOutlinedIcon from "@mui/icons-material/DashboardOutlined";
+import DashboardCustomizeOutlinedIcon from "@mui/icons-material/DashboardCustomizeOutlined";
+import RecordVoiceOverOutlinedIcon from "@mui/icons-material/RecordVoiceOverOutlined";
+import DataObjectOutlinedIcon from "@mui/icons-material/DataObjectOutlined";
+import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
+import GraphicEqOutlinedIcon from "@mui/icons-material/GraphicEqOutlined";
+import ViewInArOutlinedIcon from "@mui/icons-material/ViewInArOutlined";
+import ArticleOutlinedIcon from "@mui/icons-material/ArticleOutlined";
+
+import {
+  EmptyState,
+  BORDER_RADIUS,
+  MOTION,
+  SPACING,
+  getSpacingPx
+} from "../ui_primitives";
+import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import {
+  useRecentDocuments,
+  DOCUMENT_KINDS,
+  DOCUMENT_KIND_LABEL,
+  type DocumentKind,
+  type RecentDocument
+} from "../../hooks/useRecentDocuments";
+import { useSectionWrap, SectionHeader, DashboardSearchBox } from "./dashboardChrome";
+import { shortAgo } from "./runStatus";
+
+/** How many documents the feed shows before the user filters or searches. */
+const MAX_DOCUMENTS = 24;
+
+const KIND_ICON: Record<DocumentKind, React.ReactNode> = {
+  app: <DashboardCustomizeOutlinedIcon fontSize="inherit" />,
+  sketch: <BrushOutlinedIcon fontSize="inherit" />,
+  timeline: <MovieOutlinedIcon fontSize="inherit" />,
+  storyboard: <DashboardOutlinedIcon fontSize="inherit" />,
+  script: <RecordVoiceOverOutlinedIcon fontSize="inherit" />,
+  jsscript: <DataObjectOutlinedIcon fontSize="inherit" />,
+  image: <ImageOutlinedIcon fontSize="inherit" />,
+  audio: <GraphicEqOutlinedIcon fontSize="inherit" />,
+  model3d: <ViewInArOutlinedIcon fontSize="inherit" />,
+  text: <ArticleOutlinedIcon fontSize="inherit" />
+};
+
+/** Singular label for one row's type badge; the chips use the plural. */
+const KIND_BADGE: Record<DocumentKind, string> = {
+  app: "App",
+  sketch: "Sketch",
+  timeline: "Video",
+  storyboard: "Storyboard",
+  script: "Script",
+  jsscript: "JS script",
+  image: "Image",
+  audio: "Audio",
+  model3d: "3D model",
+  text: "Text"
+};
+
+const styles = (theme: Theme) =>
+  css({
+    paddingTop: getSpacingPx(SPACING.md),
+    ".doc-chips": {
+      display: "flex",
+      flexWrap: "wrap",
+      gap: getSpacingPx(SPACING.micro),
+      paddingBottom: getSpacingPx(SPACING.sm)
+    },
+    ".doc-chip": {
+      display: "inline-flex",
+      alignItems: "center",
+      gap: getSpacingPx(SPACING.xs),
+      height: 26,
+      padding: `0 ${getSpacingPx(SPACING.sm)}`,
+      background: theme.vars.palette.c_node_bg,
+      border: `1px solid ${theme.vars.palette.divider}`,
+      borderRadius: BORDER_RADIUS.pill,
+      color: theme.vars.palette.text.secondary,
+      fontSize: "var(--fontSizeSmaller)",
+      cursor: "pointer",
+      transition: `background ${MOTION.fast}, color ${MOTION.fast}, border-color ${MOTION.fast}`,
+      "&:hover": { color: theme.vars.palette.text.primary },
+      "&.on": {
+        background: theme.vars.palette.c_node_bg_group,
+        borderColor: `rgba(${theme.vars.palette.primary.mainChannel} / 0.5)`,
+        color: theme.vars.palette.text.primary
+      }
+    },
+    ".doc-chip-count": {
+      fontFamily: theme.fontFamily2,
+      color: theme.vars.palette.text.disabled
+    },
+    ".doc-list": {
+      border: `1px solid ${theme.vars.palette.divider}`,
+      borderRadius: BORDER_RADIUS.lg,
+      background: theme.vars.palette.c_node_bg,
+      padding: getSpacingPx(SPACING.sm),
+      display: "flex",
+      flexDirection: "column",
+      gap: getSpacingPx(SPACING.micro)
+    },
+    ".doc-row": {
+      display: "flex",
+      alignItems: "center",
+      gap: getSpacingPx(SPACING.md),
+      width: "100%",
+      textAlign: "left",
+      padding: `${getSpacingPx(SPACING.sm)} ${getSpacingPx(SPACING.md)}`,
+      background: "transparent",
+      border: "none",
+      borderRadius: BORDER_RADIUS.sm,
+      cursor: "pointer",
+      transition: `background ${MOTION.fast}`,
+      "&:hover": { background: theme.vars.palette.action.hover }
+    },
+    ".doc-icon": {
+      flexShrink: 0,
+      display: "grid",
+      placeItems: "center",
+      width: 24,
+      height: 24,
+      fontSize: "var(--fontSizeSmall)",
+      borderRadius: BORDER_RADIUS.sm,
+      background: `rgba(${theme.vars.palette.primary.mainChannel} / 0.12)`,
+      color: theme.vars.palette.primary.main,
+      overflow: "hidden"
+    },
+    ".doc-thumb": {
+      width: "100%",
+      height: "100%",
+      objectFit: "cover"
+    },
+    ".doc-title": {
+      flex: 1,
+      minWidth: 0,
+      fontSize: "var(--fontSizeSmall)",
+      color: theme.vars.palette.text.primary,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap"
+    },
+    ".doc-kind": {
+      flexShrink: 0,
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.secondary
+    },
+    ".doc-when": {
+      flexShrink: 0,
+      width: 34,
+      textAlign: "right",
+      fontFamily: theme.fontFamily2,
+      fontSize: "var(--fontSizeSmaller)",
+      color: theme.vars.palette.text.disabled
+    }
+  });
+
+interface DocumentRowProps {
+  doc: RecentDocument;
+  onOpen: (doc: RecentDocument) => void;
+}
+
+const DocumentRow = memo(function DocumentRow({
+  doc,
+  onOpen
+}: DocumentRowProps) {
+  return (
+    <button
+      type="button"
+      className="doc-row"
+      onClick={() => onOpen(doc)}
+    >
+      <span className="doc-icon" aria-hidden>
+        {doc.thumbUrl ? (
+          <img className="doc-thumb" src={doc.thumbUrl} alt="" />
+        ) : (
+          KIND_ICON[doc.kind]
+        )}
+      </span>
+      <span className="doc-title">{doc.name}</span>
+      <span className="doc-kind">{KIND_BADGE[doc.kind]}</span>
+      <span className="doc-when">{shortAgo(doc.updatedAt)}</span>
+    </button>
+  );
+});
+
+/**
+ * Everything the user has made that is not a workflow or a chat: apps,
+ * sketches, videos, storyboards, scripts, JS scripts, and the assets that open
+ * as documents. One feed ordered by recency, narrowed by the type chips.
+ */
+const DashboardDocuments: React.FC = () => {
+  const theme = useTheme();
+  const sectionWrap = useSectionWrap();
+  const navigate = useNavigate();
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const { documents, isLoading } = useRecentDocuments();
+
+  const [kind, setKind] = useState<DocumentKind | null>(null);
+  const [query, setQuery] = useState("");
+
+  const counts = useMemo(() => {
+    const byKind = new Map<DocumentKind, number>();
+    for (const doc of documents) {
+      byKind.set(doc.kind, (byKind.get(doc.kind) ?? 0) + 1);
+    }
+    return byKind;
+  }, [documents]);
+
+  // Only the types the user actually has: an empty chip is a dead control.
+  const availableKinds = useMemo(
+    () => DOCUMENT_KINDS.filter((k) => (counts.get(k) ?? 0) > 0),
+    [counts]
+  );
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return documents.filter(
+      (doc) =>
+        (kind === null || doc.kind === kind) &&
+        (!needle || doc.name.toLowerCase().includes(needle))
+    );
+  }, [documents, kind, query]);
+
+  const visible = useMemo(
+    () => filtered.slice(0, MAX_DOCUMENTS),
+    [filtered]
+  );
+
+  const handleOpen = useCallback(
+    (doc: RecentDocument) => {
+      openTab({
+        type: doc.tabType,
+        ref: doc.id,
+        mode: "edit",
+        title: doc.name
+      });
+      navigate("/workspace");
+    },
+    [openTab, navigate]
+  );
+
+  // Nothing useful to say while the queries settle, and a user with no
+  // documents beyond workflows is better served by the sections that follow
+  // than by an empty box.
+  if (isLoading || documents.length === 0) {
+    return null;
+  }
+
+  const hasQuery = query.trim().length > 0;
+  // Counts what is on screen, not what matched: the feed is capped, so
+  // "24 of 60" has to mean the user is seeing 24.
+  const countLabel =
+    visible.length === documents.length
+      ? `${documents.length}`
+      : `${visible.length} of ${documents.length}`;
+
+  return (
+    <section css={styles(theme)} aria-label="Documents">
+      <div css={sectionWrap}>
+        <SectionHeader title="Recent documents" count={countLabel}>
+          <DashboardSearchBox
+            value={query}
+            onChange={setQuery}
+            placeholder="Search documents…"
+            aria-label="Search documents"
+          />
+        </SectionHeader>
+
+        <div className="doc-chips" role="group" aria-label="Filter by type">
+          <button
+            type="button"
+            className={kind === null ? "doc-chip on" : "doc-chip"}
+            aria-pressed={kind === null}
+            onClick={() => setKind(null)}
+          >
+            All
+            <span className="doc-chip-count">{documents.length}</span>
+          </button>
+          {availableKinds.map((k) => (
+            <button
+              key={k}
+              type="button"
+              className={kind === k ? "doc-chip on" : "doc-chip"}
+              aria-pressed={kind === k}
+              onClick={() => setKind(kind === k ? null : k)}
+            >
+              {DOCUMENT_KIND_LABEL[k]}
+              <span className="doc-chip-count">{counts.get(k)}</span>
+            </button>
+          ))}
+        </div>
+
+        {visible.length === 0 ? (
+          <EmptyState
+            variant="no-results"
+            size="small"
+            title="No matching documents"
+            description={
+              hasQuery
+                ? `No documents match “${query.trim()}”.`
+                : "No documents of this type."
+            }
+            actionText="Clear filters"
+            onAction={() => {
+              setQuery("");
+              setKind(null);
+            }}
+          />
+        ) : (
+          <div className="doc-list">
+            {visible.map((doc) => (
+              <DocumentRow
+                key={doc.key}
+                doc={doc}
+                onOpen={handleOpen}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default memo(DashboardDocuments);

--- a/web/src/components/portal/Portal.tsx
+++ b/web/src/components/portal/Portal.tsx
@@ -14,6 +14,7 @@ import { openProviderOnboarding } from "../../stores/ProviderOnboardingStore";
 import DashboardHero from "./DashboardHero";
 import DashboardActivity from "./DashboardActivity";
 import DashboardAgentSessions from "./DashboardAgentSessions";
+import DashboardDocuments from "./DashboardDocuments";
 import DashboardDownloads from "./DashboardDownloads";
 import { DashboardColumn, wrapStyles } from "./dashboardChrome";
 import GettingStartedChecklist from "./GettingStartedChecklist";
@@ -211,6 +212,7 @@ const Portal: React.FC = () => {
                     onOpenWorkflow={handleOpenWorkflow}
                     onCreateNew={handleCreateNewWorkflow}
                   />
+                  <DashboardDocuments />
                   <DashboardTemplates />
                   <DashboardTutorials variant="compact" />
                 </DashboardColumn>
@@ -247,6 +249,9 @@ const Portal: React.FC = () => {
                 onOpenWorkflow={handleOpenWorkflow}
                 onCreateNew={handleCreateNewWorkflow}
               />
+              {/* Empty for a genuinely new user, but a user who started with a
+                  sketch or a video has no workflows and still has work here. */}
+              <DashboardDocuments />
             </>
           )}
           <DashboardFooter

--- a/web/src/components/portal/__tests__/DashboardDocuments.test.tsx
+++ b/web/src/components/portal/__tests__/DashboardDocuments.test.tsx
@@ -30,7 +30,8 @@ const doc = (
   kind,
   name,
   updatedAt,
-  tabType
+  tabType,
+  thumbUrl: null
 });
 
 const DOCUMENTS: RecentDocument[] = [

--- a/web/src/components/portal/__tests__/DashboardDocuments.test.tsx
+++ b/web/src/components/portal/__tests__/DashboardDocuments.test.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import DashboardDocuments from "../DashboardDocuments";
+import { useWorkspaceTabsStore } from "../../../stores/WorkspaceTabsStore";
+import {
+  useRecentDocuments,
+  type RecentDocument
+} from "../../../hooks/useRecentDocuments";
+
+jest.mock("../../../hooks/useRecentDocuments", () => ({
+  ...jest.requireActual("../../../hooks/useRecentDocuments"),
+  useRecentDocuments: jest.fn()
+}));
+
+const mockedDocuments = useRecentDocuments as jest.Mock;
+
+const doc = (
+  kind: RecentDocument["kind"],
+  id: string,
+  name: string,
+  updatedAt: string,
+  tabType: RecentDocument["tabType"]
+): RecentDocument => ({
+  key: `${kind}:${id}`,
+  id,
+  kind,
+  name,
+  updatedAt,
+  tabType
+});
+
+const DOCUMENTS: RecentDocument[] = [
+  doc("timeline", "t1", "Trailer cut", "2026-08-16T00:00:00Z", "timeline"),
+  doc("image", "i1", "poster.png", "2026-08-15T00:00:00Z", "image"),
+  doc("app", "a1", "Note drafter", "2026-08-14T00:00:00Z", "application"),
+  doc("script", "s1", "Voiceover", "2026-08-13T00:00:00Z", "script")
+];
+
+const renderDocuments = (documents = DOCUMENTS, isLoading = false) => {
+  mockedDocuments.mockReturnValue({ documents, isLoading });
+  return render(
+    <MemoryRouter>
+      <ThemeProvider theme={mockTheme}>
+        <DashboardDocuments />
+      </ThemeProvider>
+    </MemoryRouter>
+  );
+};
+
+describe("DashboardDocuments", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useWorkspaceTabsStore.setState({ tabs: [], activeTabId: null });
+  });
+
+  it("lists every document type in one feed", () => {
+    renderDocuments();
+
+    for (const name of [
+      "Trailer cut",
+      "poster.png",
+      "Note drafter",
+      "Voiceover"
+    ]) {
+      expect(screen.getByText(name)).toBeInTheDocument();
+    }
+  });
+
+  it("opens a document in the workspace tab its type uses", async () => {
+    const user = userEvent.setup();
+    renderDocuments();
+
+    await user.click(screen.getByRole("button", { name: /note drafter/i }));
+
+    const { tabs } = useWorkspaceTabsStore.getState();
+    expect(tabs).toEqual([
+      expect.objectContaining({ type: "application", ref: "a1" })
+    ]);
+  });
+
+  it("narrows the feed to one type when a chip is pressed", async () => {
+    const user = userEvent.setup();
+    renderDocuments();
+
+    await user.click(screen.getByRole("button", { name: /^Images/ }));
+
+    expect(screen.getByText("poster.png")).toBeInTheDocument();
+    expect(screen.queryByText("Trailer cut")).not.toBeInTheDocument();
+  });
+
+  it("offers only the types the user actually has", () => {
+    renderDocuments([doc("script", "s1", "Voiceover", "2026-08-13T00:00:00Z", "script")]);
+
+    expect(screen.getByRole("button", { name: /^Scripts/ })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^Storyboards/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it("filters by name and recovers from a search with no matches", async () => {
+    const user = userEvent.setup();
+    renderDocuments();
+
+    await user.type(screen.getByLabelText("Search documents"), "trailer");
+    expect(screen.getByText("Trailer cut")).toBeInTheDocument();
+    expect(screen.queryByText("Voiceover")).not.toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText("Search documents"));
+    await user.type(screen.getByLabelText("Search documents"), "zzz");
+    expect(screen.getByText(/No matching documents/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /clear filters/i }));
+    expect(screen.getByText("Voiceover")).toBeInTheDocument();
+  });
+
+  it("renders nothing when the user has no documents", () => {
+    const { container } = renderDocuments([]);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing while the lists are still loading", () => {
+    const { container } = renderDocuments(DOCUMENTS, true);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/hooks/__tests__/useRecentDocuments.test.tsx
+++ b/web/src/hooks/__tests__/useRecentDocuments.test.tsx
@@ -1,0 +1,236 @@
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { useRecentDocuments } from "../useRecentDocuments";
+import { useApplications } from "../useApplications";
+import { useTimelines } from "../useTimelineSequence";
+import { useStoryboards } from "../storyboard/useStoryboards";
+import { useScripts } from "../script/useScripts";
+import { useJsScripts } from "../jsScript/useJsScripts";
+import { trpc, trpcClient } from "../../trpc/client";
+
+jest.mock("../useApplications", () => ({ useApplications: jest.fn() }));
+jest.mock("../useTimelineSequence", () => ({ useTimelines: jest.fn() }));
+jest.mock("../storyboard/useStoryboards", () => ({
+  useStoryboards: jest.fn()
+}));
+jest.mock("../script/useScripts", () => ({ useScripts: jest.fn() }));
+jest.mock("../jsScript/useJsScripts", () => ({ useJsScripts: jest.fn() }));
+jest.mock("../../trpc/client", () => ({
+  trpc: { sketch: { list: { useQuery: jest.fn() } } },
+  trpcClient: { assets: { list: { query: jest.fn() } } }
+}));
+
+const mocked = {
+  apps: useApplications as jest.Mock,
+  timelines: useTimelines as jest.Mock,
+  storyboards: useStoryboards as jest.Mock,
+  scripts: useScripts as jest.Mock,
+  jsScripts: useJsScripts as jest.Mock,
+  sketches: trpc.sketch.list.useQuery as jest.Mock,
+  assets: trpcClient.assets.list.query as jest.Mock
+};
+
+/** A typed list item, as every document router returns one. */
+const item = (id: string, name: string, updatedAt: string) => ({
+  id,
+  name,
+  updatedAt
+});
+
+const asset = (
+  id: string,
+  name: string,
+  contentType: string,
+  createdAt: string,
+  extra: Record<string, unknown> = {}
+) => ({
+  id,
+  name,
+  content_type: contentType,
+  created_at: createdAt,
+  sketch_document_id: null,
+  thumb_url: null,
+  ...extra
+});
+
+/** Every list empty; individual tests fill in the ones they care about. */
+const seedEmpty = () => {
+  for (const key of [
+    "apps",
+    "timelines",
+    "storyboards",
+    "scripts",
+    "jsScripts",
+    "sketches"
+  ] as const) {
+    mocked[key].mockReturnValue({ data: [], isLoading: false });
+  }
+  mocked.assets.mockResolvedValue({ assets: [], next: null });
+};
+
+const renderDocuments = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return renderHook(() => useRecentDocuments(), { wrapper });
+};
+
+describe("useRecentDocuments", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    seedEmpty();
+  });
+
+  it("merges every document type into one feed, newest first", async () => {
+    mocked.apps.mockReturnValue({
+      data: [item("a1", "Note drafter", "2026-08-10T00:00:00Z")],
+      isLoading: false
+    });
+    mocked.sketches.mockReturnValue({
+      data: [item("sk1", "Poster", "2026-08-14T00:00:00Z")],
+      isLoading: false
+    });
+    mocked.timelines.mockReturnValue({
+      data: [item("t1", "Trailer", "2026-08-16T00:00:00Z")],
+      isLoading: false
+    });
+    mocked.storyboards.mockReturnValue({
+      data: [item("sb1", "Board", "2026-08-11T00:00:00Z")],
+      isLoading: false
+    });
+    mocked.scripts.mockReturnValue({
+      data: [item("s1", "Voiceover", "2026-08-12T00:00:00Z")],
+      isLoading: false
+    });
+    mocked.jsScripts.mockReturnValue({
+      data: [item("j1", "Sum", "2026-08-13T00:00:00Z")],
+      isLoading: false
+    });
+    mocked.assets.mockResolvedValue({
+      assets: [asset("as1", "photo.png", "image/png", "2026-08-15T00:00:00Z")],
+      next: null
+    });
+
+    const { result } = renderDocuments();
+
+    await waitFor(() => expect(result.current.documents).toHaveLength(7));
+    expect(result.current.documents.map((d) => d.kind)).toEqual([
+      "timeline",
+      "image",
+      "sketch",
+      "jsscript",
+      "script",
+      "storyboard",
+      "app"
+    ]);
+  });
+
+  it("maps each asset content type to the tab that opens it", async () => {
+    mocked.assets.mockResolvedValue({
+      assets: [
+        asset("i1", "photo.png", "image/png", "2026-08-16T00:00:00Z"),
+        asset("a1", "take.wav", "audio/wav", "2026-08-15T00:00:00Z"),
+        asset("m1", "cube.glb", "model/gltf-binary", "2026-08-14T00:00:00Z"),
+        asset("t1", "notes.md", "text/markdown", "2026-08-13T00:00:00Z")
+      ],
+      next: null
+    });
+
+    const { result } = renderDocuments();
+
+    await waitFor(() => expect(result.current.documents).toHaveLength(4));
+    expect(result.current.documents.map((d) => d.tabType)).toEqual([
+      "image",
+      "audio",
+      "model3d",
+      "text"
+    ]);
+  });
+
+  it("drops assets no workspace surface can open", async () => {
+    mocked.assets.mockResolvedValue({
+      assets: [
+        asset("f1", "My folder", "folder", "2026-08-16T00:00:00Z"),
+        asset("v1", "clip.mp4", "video/mp4", "2026-08-15T00:00:00Z"),
+        asset("i1", "photo.png", "image/png", "2026-08-14T00:00:00Z")
+      ],
+      next: null
+    });
+
+    const { result } = renderDocuments();
+
+    await waitFor(() => expect(result.current.documents).toHaveLength(1));
+    expect(result.current.documents[0].id).toBe("i1");
+  });
+
+  it("lists a sketch once, not also as its saved image asset", async () => {
+    mocked.sketches.mockReturnValue({
+      data: [item("sk1", "Poster", "2026-08-16T00:00:00Z")],
+      isLoading: false
+    });
+    mocked.assets.mockResolvedValue({
+      assets: [
+        asset("as1", "Poster.png", "image/png", "2026-08-16T00:00:00Z", {
+          sketch_document_id: "sk1"
+        }),
+        // An unrelated asset, so the wait below cannot settle before the
+        // asset query has landed — otherwise "one document" would pass while
+        // the sketch's own image was still in flight.
+        asset("as2", "photo.png", "image/png", "2026-08-15T00:00:00Z")
+      ],
+      next: null
+    });
+
+    const { result } = renderDocuments();
+
+    await waitFor(() =>
+      expect(result.current.documents.some((d) => d.id === "as2")).toBe(true)
+    );
+    expect(result.current.documents.map((d) => d.key)).toEqual([
+      "sketch:sk1",
+      "image:as2"
+    ]);
+  });
+
+  it("names an untitled document by its type", async () => {
+    mocked.timelines.mockReturnValue({
+      data: [item("t1", "", "2026-08-16T00:00:00Z")],
+      isLoading: false
+    });
+
+    const { result } = renderDocuments();
+
+    await waitFor(() => expect(result.current.documents).toHaveLength(1));
+    expect(result.current.documents[0].name).toBe("Untitled video");
+  });
+
+  it("keys documents by type so two ids can collide", async () => {
+    mocked.scripts.mockReturnValue({
+      data: [item("shared", "A script", "2026-08-16T00:00:00Z")],
+      isLoading: false
+    });
+    mocked.storyboards.mockReturnValue({
+      data: [item("shared", "A board", "2026-08-15T00:00:00Z")],
+      isLoading: false
+    });
+
+    const { result } = renderDocuments();
+
+    await waitFor(() => expect(result.current.documents).toHaveLength(2));
+    const keys = result.current.documents.map((d) => d.key);
+    expect(new Set(keys).size).toBe(2);
+  });
+
+  it("reports loading while any list is still in flight", () => {
+    mocked.scripts.mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderDocuments();
+
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/web/src/hooks/useRecentDocuments.ts
+++ b/web/src/hooks/useRecentDocuments.ts
@@ -91,8 +91,8 @@ export interface RecentDocument {
   updatedAt: string;
   /** The workspace tab that opens this document. */
   tabType: WorkspaceTabType;
-  /** Asset thumbnail, when the document has one. */
-  thumbUrl?: string;
+  /** Asset thumbnail, or null for a document that has none. */
+  thumbUrl: string | null;
 }
 
 /** The fields every typed list item carries, whatever the router. */
@@ -115,7 +115,9 @@ const toDocument = (
   kind,
   name: item.name || fallbackName,
   updatedAt: item.updatedAt,
-  tabType: KIND_TAB_TYPE[kind]
+  tabType: KIND_TAB_TYPE[kind],
+  // Only assets carry a thumbnail; the typed documents render their icon.
+  thumbUrl: null
 });
 
 const listAssets = () =>
@@ -179,7 +181,7 @@ export const useRecentDocuments = (): UseRecentDocumentsResult => {
             // Assets are immutable once written, so creation is their date.
             updatedAt: asset.created_at,
             tabType,
-            ...(asset.thumb_url ? { thumbUrl: asset.thumb_url } : {})
+            thumbUrl: asset.thumb_url ?? null
           }
         ];
       }

--- a/web/src/hooks/useRecentDocuments.ts
+++ b/web/src/hooks/useRecentDocuments.ts
@@ -1,0 +1,212 @@
+/**
+ * Every document the user owns, in one ordered feed.
+ *
+ * The sidebar lists each document type in its own panel; the dashboard needs
+ * them together, so this hook reads the same queries those panels use — the
+ * caches are shared, not duplicated — and folds them into one shape alongside
+ * the assets that open as documents (images, audio, 3D models, text files).
+ *
+ * Workflows and chats are deliberately absent: the dashboard already gives
+ * each of them a section of its own.
+ */
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { trpc, trpcClient } from "../trpc/client";
+import { useApplications } from "./useApplications";
+import { useTimelines } from "./useTimelineSequence";
+import { useStoryboards } from "./storyboard/useStoryboards";
+import { useScripts } from "./script/useScripts";
+import { useJsScripts } from "./jsScript/useJsScripts";
+import { assetTabType } from "../components/workspace/assetTabType";
+import type { WorkspaceTabType } from "../stores/WorkspaceTabsStore";
+
+/** How many assets the dashboard reads from the user's home folder. */
+export const DASHBOARD_ASSET_PAGE_SIZE = 200;
+
+const STALE_TIME = 30_000;
+
+/** The asset content types that have a workspace surface to open them in. */
+const ASSET_KINDS = ["image", "audio", "model3d", "text"] as const;
+type AssetKind = (typeof ASSET_KINDS)[number];
+
+export type DocumentKind =
+  | "app"
+  | "sketch"
+  | "timeline"
+  | "storyboard"
+  | "script"
+  | "jsscript"
+  | AssetKind;
+
+/** Section filter order, which is also the chip order in the UI. */
+export const DOCUMENT_KINDS: readonly DocumentKind[] = [
+  "app",
+  "sketch",
+  "timeline",
+  "storyboard",
+  "script",
+  "jsscript",
+  "image",
+  "audio",
+  "model3d",
+  "text"
+];
+
+export const DOCUMENT_KIND_LABEL: Record<DocumentKind, string> = {
+  app: "Apps",
+  sketch: "Sketches",
+  timeline: "Videos",
+  storyboard: "Storyboards",
+  script: "Scripts",
+  jsscript: "JS scripts",
+  image: "Images",
+  audio: "Audio",
+  model3d: "3D models",
+  text: "Text"
+};
+
+/** The workspace tab that opens a document of each kind. */
+const KIND_TAB_TYPE: Record<DocumentKind, WorkspaceTabType> = {
+  app: "application",
+  sketch: "sketch",
+  timeline: "timeline",
+  storyboard: "storyboard",
+  script: "script",
+  jsscript: "jsscript",
+  image: "image",
+  audio: "audio",
+  model3d: "model3d",
+  text: "text"
+};
+
+export interface RecentDocument {
+  /** `${kind}:${id}` — unique across types, which ids alone are not. */
+  key: string;
+  id: string;
+  kind: DocumentKind;
+  name: string;
+  /** ISO timestamp the feed orders on. */
+  updatedAt: string;
+  /** The workspace tab that opens this document. */
+  tabType: WorkspaceTabType;
+  /** Asset thumbnail, when the document has one. */
+  thumbUrl?: string;
+}
+
+/** The fields every typed list item carries, whatever the router. */
+interface ListItemLike {
+  id: string;
+  name: string;
+  updatedAt: string;
+}
+
+const isAssetKind = (tab: WorkspaceTabType): tab is AssetKind =>
+  ASSET_KINDS.some((kind) => kind === tab);
+
+const toDocument = (
+  kind: DocumentKind,
+  item: ListItemLike,
+  fallbackName: string
+): RecentDocument => ({
+  key: `${kind}:${item.id}`,
+  id: item.id,
+  kind,
+  name: item.name || fallbackName,
+  updatedAt: item.updatedAt,
+  tabType: KIND_TAB_TYPE[kind]
+});
+
+const listAssets = () =>
+  trpcClient.assets.list.query({ page_size: DASHBOARD_ASSET_PAGE_SIZE });
+
+interface UseRecentDocumentsResult {
+  documents: RecentDocument[];
+  isLoading: boolean;
+}
+
+export const useRecentDocuments = (): UseRecentDocumentsResult => {
+  const apps = useApplications();
+  const sketches = trpc.sketch.list.useQuery({}, { staleTime: STALE_TIME });
+  const timelines = useTimelines();
+  const storyboards = useStoryboards();
+  const scripts = useScripts();
+  const jsScripts = useJsScripts();
+  const assets = useQuery({
+    queryKey: ["dashboard", "assets", DASHBOARD_ASSET_PAGE_SIZE],
+    queryFn: listAssets,
+    staleTime: STALE_TIME
+  });
+
+  const documents = useMemo<RecentDocument[]>(() => {
+    const typed: RecentDocument[] = [
+      ...(apps.data ?? []).map((item) => toDocument("app", item, "Untitled app")),
+      ...(sketches.data ?? []).map((item) =>
+        toDocument("sketch", item, "Untitled sketch")
+      ),
+      ...(timelines.data ?? []).map((item) =>
+        toDocument("timeline", item, "Untitled video")
+      ),
+      ...(storyboards.data ?? []).map((item) =>
+        toDocument("storyboard", item, "Untitled storyboard")
+      ),
+      ...(scripts.data ?? []).map((item) =>
+        toDocument("script", item, "Untitled script")
+      ),
+      ...(jsScripts.data ?? []).map((item) =>
+        toDocument("jsscript", item, "Untitled JS script")
+      )
+    ];
+
+    const fromAssets = (assets.data?.assets ?? []).flatMap(
+      (asset): RecentDocument[] => {
+        // A sketch's saved image is already in the feed as its sketch
+        // document; listing the asset too would show the artwork twice.
+        if (asset.sketch_document_id) {
+          return [];
+        }
+        const tabType = assetTabType(asset);
+        if (tabType === null || !isAssetKind(tabType)) {
+          return [];
+        }
+        return [
+          {
+            key: `${tabType}:${asset.id}`,
+            id: asset.id,
+            kind: tabType,
+            name: asset.name || "Untitled",
+            // Assets are immutable once written, so creation is their date.
+            updatedAt: asset.created_at,
+            tabType,
+            ...(asset.thumb_url ? { thumbUrl: asset.thumb_url } : {})
+          }
+        ];
+      }
+    );
+
+    return [...typed, ...fromAssets].sort((a, b) =>
+      b.updatedAt.localeCompare(a.updatedAt)
+    );
+  }, [
+    apps.data,
+    sketches.data,
+    timelines.data,
+    storyboards.data,
+    scripts.data,
+    jsScripts.data,
+    assets.data
+  ]);
+
+  return {
+    documents,
+    isLoading:
+      apps.isLoading ||
+      sketches.isLoading ||
+      timelines.isLoading ||
+      storyboards.isLoading ||
+      scripts.isLoading ||
+      jsScripts.isLoading ||
+      assets.isLoading
+  };
+};


### PR DESCRIPTION
## What

The dashboard listed workflows and agent sessions only. Everything else the user makes — apps, sketches, videos, storyboards, scripts, JS scripts — and every asset that opens as a document was reachable only through the sidebar panels or the workspace `[+]` menu.

This adds a **Recent documents** section that merges all of them into one feed ordered by recency, with a type chip per kind the user actually has and a name search. Clicking a row opens the document in the workspace tab its type uses and navigates to `/workspace`, the same way `DashboardAgentSessions` opens a chat.

## Changes

- **`web/src/hooks/useRecentDocuments.ts`** (new) — folds `applications`, `sketch`, `timeline`, `storyboards`, `scripts` and `jsScripts` list queries plus `assets.list` into one `RecentDocument[]`, sorted by recency. It calls the same wrapper hooks the sidebar panels use, so the dashboard shares their TanStack Query caches instead of refetching. The list routers return camelCase `updatedAt` while assets return snake_case `created_at`; the hook normalizes both.
- **`web/src/components/portal/DashboardDocuments.tsx`** (new) — the section: type chips, search box, and a row list built from the shared `dashboardChrome` primitives so it matches the sections around it. Renders `null` while loading and when the user has no documents.
- **`web/src/components/portal/Portal.tsx`** — renders the section in both the returning and first-run layouts. First-run isn't dead weight: a user who started with a sketch or a video has no workflows but does have work to show.

## Notes on the merge rules

- An asset carrying a `sketch_document_id` is dropped — the sketch document already represents it, and listing both would show one piece of artwork twice.
- Assets no workspace surface can open (folders, video) are dropped via the existing `assetTabType` mapping.
- Workflows and chats stay out of the feed; each already has its own dashboard section, and duplicating them would be noise.
- Assets come from the user's home folder (`assets.list` defaults there) at `page_size: 200`, and the feed shows 24 rows. The header count reports what is on screen rather than what matched, so the cap is never silent.

## Verification

- `npx tsc --noEmit -p web/tsconfig.json` — clean for these files. Two errors remain in `DataframeProperty.tsx` / `RecordTypeProperty.tsx`; both are pre-existing and in files this PR does not touch.
- `oxlint` — clean on all five files.
- `npx jest` in `web/` — 1131 suites, 13100 tests, all pass. Electron: 63 suites, 674 tests, all pass.
- `nodetool affected` reports `web` only, so no backend package suites are in scope.
- 14 new tests across `useRecentDocuments.test.tsx` and `DashboardDocuments.test.tsx`.

Each new test was checked against a deliberate mutation of the code it covers, and every mutation was caught — reversing the recency sort, removing the sketch-asset dedupe, dropping the unopenable-asset filter, opening the wrong tab type, disabling the chip filter, and rendering chips for types the user lacks. One dedupe assertion passed under mutation on the first attempt (a `waitFor` that settled before the asset query landed); it was rewritten to wait on an unrelated asset first, and then failed as it should.

## Not covered

Mobile tests could not run in this environment — `mobile/node_modules` is not installed, so jest cannot resolve `@react-native/jest-preset`. This change is web-only and touches no mobile code. The `lint:anti-slop:enforced` leg also fails here because `@oxlint/plugins` is not installed; verified it fails identically on a clean tree with the change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139CtAFT9NttxCegX8WD6Kw

---
_Generated by [Claude Code](https://claude.ai/code/session_0139CtAFT9NttxCegX8WD6Kw)_