### PR TITLE
chore(ci): narrow type-safety workflow to what the ratchet does not hold

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -81,7 +81,7 @@ see below.
 | `seo-seed.yml` | Seed SEO showcase assets via generation providers | none/maintenance | Manual |
 | `shipped-feature-inliner.yaml` | Scheduled agent inlines flags whose feature has fully shipped | none/maintenance | Advisory (`continue-on-error`) |
 | `test-coverage.yaml` | Scheduled agent adds tests for uncovered code | none/maintenance | Advisory (`continue-on-error`) |
-| `type-safety.yaml` | Scheduled agent removes `any`, tightens types | none/maintenance | Advisory (`continue-on-error`) |
+| `type-safety.yaml` | Scheduled agent removes `as any` and adds missing return types in `web`/`electron`/`mobile` — what the anti-slop ratchet does not hold | none/maintenance | Advisory (`continue-on-error`) |
 | `ui-primitives-compliance.yaml` | Scheduled agent migrates raw MUI imports to `ui_primitives/`, fixes hardcoded design tokens | none/maintenance | Advisory (`continue-on-error`) |
 | `useless-test-pruner.yaml` | Scheduled agent deletes or strengthens tests proven unable to fail under mutation | none/maintenance | Advisory (`continue-on-error`) |
 | `workflow-example-validation.yaml` | Weekly `nodetool validate` + repair of shipped example workflows | none/maintenance | Advisory (`continue-on-error`) |

--- a/.github/workflows/type-safety.yaml
+++ b/.github/workflows/type-safety.yaml
@@ -41,13 +41,17 @@ jobs:
           echo "## Type Safety Scan" >> $GITHUB_STEP_SUMMARY
           ISSUES=0
 
-          ANY_COUNT=$(grep -r ": any" web/src electron/src mobile/src --include="*.ts" --include="*.tsx" -l 2>/dev/null | wc -l || echo 0)
-          echo "Files with explicit 'any' types: $ANY_COUNT" >> $GITHUB_STEP_SUMMARY
-          if [ "$ANY_COUNT" -gt 0 ]; then ISSUES=1; fi
-
-          AS_ANY_COUNT=$(grep -r "as any" web/src electron/src mobile/src --include="*.ts" --include="*.tsx" -l 2>/dev/null | wc -l || echo 0)
-          echo "Files with 'as any' casts: $AS_ANY_COUNT" >> $GITHUB_STEP_SUMMARY
-          if [ "$AS_ANY_COUNT" -gt 0 ]; then ISSUES=1; fi
+          # `: any` is deliberately not scanned. anti-slop/no-hand-written-any
+          # holds it at zero in all three of these trees and `npm run lint`
+          # enforces it on every PR, so there is nothing here left to find. A
+          # grep for it now matches only prose and identifiers like `anyType`
+          # (20 such lines in web/src, 0 real annotations), which would pin
+          # this gate open for reasons no agent can fix.
+          AS_ANY=$(grep -rn "as any" web/src electron/src mobile/src \
+            --include="*.ts" --include="*.tsx" 2>/dev/null \
+            | grep -cvE ':[0-9]+:[[:space:]]*(//|\*|/\*)' || true)
+          echo "\`as any\` assertions: $AS_ANY" >> $GITHUB_STEP_SUMMARY
+          if [ "$AS_ANY" -gt 0 ]; then ISSUES=1; fi
 
           echo "TYPE_ISSUES=$ISSUES" >> $GITHUB_ENV
 
@@ -64,7 +68,7 @@ jobs:
           echo "TEST_PRE_EXIT=$TEST_EXIT" >> $GITHUB_ENV
 
       - name: Run Claude Code
-        if: env.TYPE_ISSUES == '1'
+        if: env.TYPE_ISSUES == '1' || github.event_name == 'workflow_dispatch'
         uses: anthropics/claude-code-action@v1.0.189
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -77,7 +81,9 @@ jobs:
           prompt: |
             # Improve Type Safety
 
-            Find and fix weak TypeScript types in the NodeTool codebase.
+            Fix the two weak-type problems in `web/`, `electron/` and `mobile/`
+            that no lint rule holds today. Everything else in this area is
+            already ratcheted — do not re-do the ratchet's work.
 
             ## Scope
             - `/web/src` — React frontend
@@ -86,37 +92,67 @@ jobs:
 
             ## What to fix
 
-            **Replace `any` types**: Search for `: any`, `as any`, `any[]`, `Record<string, any>`, and `Promise<any>`. Replace with proper types by reading the surrounding code to understand what the actual type should be.
+            **`as any` assertions.** `anti-slop/require-safety-comment-for-type-assertion`
+            is at zero in only 9 of 58 trees, and these three are not among
+            them, so nothing stops an `as any` landing here. All 478 of them
+            sit in test files; production code in these trees has none. So this
+            is about typing the doubles, not the code under test:
 
-            **Add missing return types**: Functions and methods that are missing explicit return type annotations. Focus on exported functions and public methods.
+            - A mocked zustand hook takes `selectorOver(state)` from
+              `web/src/test-utils/doubles.ts`, not `(s: any) => s(state)`.
+            - A partial fixture (`{} as any`, `{title: "x"} as any`) gets the
+              real type with the fields the component reads, or a factory in
+              `doubles.ts` when the shape repeats.
+            - `(global as any).fetch = …` and friends: declare the member
+              instead of asserting over it.
+            - An assertion that is genuinely load-bearing — a test deliberately
+              passing an invalid value to assert the runtime handles it — stays,
+              with a one-line comment saying why. That is the form the rule will
+              ask for when it reaches these trees.
 
-            **Replace type assertions with type guards**: Where `as SomeType` is used, consider if a type guard (`if ('prop' in obj)` or `instanceof`) would be safer.
+            **Missing return type annotations** on exported functions and public
+            methods. `anti-slop/no-unknown-returns` reports a return typed
+            `unknown`, not one typed nothing, so this is uncovered too.
 
-            **Fix loose generic types**: Replace `Array<any>` with properly typed arrays. Replace `Record<string, any>` with specific interfaces.
+            Replacing `as SomeType` with a type guard (`'prop' in obj`,
+            `instanceof`) counts as fixing it, when the guard is honest.
+
+            ## Do not fix here
+            - `: any`, `any[]`, `Promise<any>`, `Record<string, any>` —
+              `anti-slop/no-hand-written-any` holds these at zero in every tree
+              and `npm run lint` enforces it on every PR. If you find one, the
+              rule has a hole; report it in the PR body instead of patching the
+              site.
 
             ## Rules
             - Only fix types you can verify are correct. Do not guess types — read the usage sites.
             - Do not touch `@ts-expect-error` / `@ts-ignore` directives — these exist for cross-library compatibility.
             - Do not change runtime behavior. Type changes should be compile-time only.
+            - Do not weaken a test to make it type-check. If typing a double makes
+              an assertion fail, the assertion was testing a payload the app
+              cannot produce — fix the fixture and say so in the PR body.
             - Do not touch CI workflow files.
             - Keep changes focused — maximum 10 files per PR.
-            - Prioritize: exported APIs > internal functions > local variables.
 
             ## Before starting
             - Run `gh pr list --state open --limit 20` — skip if a type safety PR is already open.
-            - Pick the 5-10 worst offenders (most `any` usage or most impactful files).
+            - Pick the 5-10 files with the most `as any` lines.
 
             ## Verification
             After changes, all checks must still pass:
             ```bash
             npm run typecheck && npm run lint && npm run test
             ```
+            `electron/tsconfig.json` does not cover `src/__tests__`, so
+            `npm run typecheck` reads none of the electron test files you edit —
+            only `npm run test` (through ts-jest) does. A green typecheck there
+            proves nothing about them.
 
             ## Submit
             Create a PR titled "types: improve type safety in <area>" listing each file changed and what types were improved.
 
       - name: Post-change verification
-        if: always() && env.TYPE_ISSUES == '1'
+        if: always() && (env.TYPE_ISSUES == '1' || github.event_name == 'workflow_dispatch')
         run: |
           TYPECHECK_EXIT=0; LINT_EXIT=0; TEST_EXIT=0
           npm run typecheck 2>&1 || TYPECHECK_EXIT=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,13 +367,28 @@ type-alias body or a type-parameter default, neither of which is an annotation.
 exact and pinned by test — `Record<string, any[]>` has an array value type, so
 the dictionary rule classifies nothing and the `any` is this rule's to report.
 
-`type-safety.yaml` is untouched here, and the case for narrowing it is now
-concrete rather than a matter of taste: its `: any` half is redundant, since the
-ratchet holds that at zero in all three trees it targets. What it still covers
-that nothing else does is missing return annotations — `no-unknown-returns`
-reports a return typed `unknown`, not one typed nothing — and `as any`, which is
-`require-safety-comment-for-type-assertion`'s and sits at 9 of 58 trees. That is
-a separate change.
+`.github/workflows/type-safety.yaml` is now narrowed to what the ratchet does
+**not** hold. Its `: any` half was redundant the moment the rule reached zero in
+all three trees it targets, and worse than redundant as a gate: a grep for
+`: any` in `web/src` matches twenty lines and every one of them is prose or an
+identifier named `anyType`, so the scan could never reach zero and the job ran
+on a signal no agent could clear. That half is gone, with the reason written at
+the scan step so nobody adds it back.
+
+What is left is the two things nothing else reports. **Missing return
+annotations** — `no-unknown-returns` reports a return typed `unknown`, not one
+typed nothing. And **`as any`**, which belongs to
+`require-safety-comment-for-type-assertion`, still at 9 of 58 trees with
+`web/`, `electron/` and `mobile/` outside that set. There are 478 of them
+across the three, and — exactly as with `no-hand-written-any` — **every one is
+in a test file**; the single production hit is a comment containing the words
+"has any". So the prompt now says what the fix is: type the double in
+`web/src/test-utils/doubles.ts`, keep a deliberately-invalid fixture with a
+comment saying why, and never weaken an assertion to make it compile.
+
+The gate flips both directions now, which the old one could not: run the scan
+step against a tree with no assertion and it reports `TYPE_ISSUES=0`; add one
+`as any` and it reports 1.
 
 A rule can also stall short of zero. `no-unknown-returns` went 604 → 191 (the
 predicate consolidation above put twenty back); what

--- a/docs/DEVELOPMENT_STANDARDS.md
+++ b/docs/DEVELOPMENT_STANDARDS.md
@@ -562,7 +562,7 @@ The mechanisms that make the above stick:
 | Tests required | CI workflow `test.yml` |
 | Coverage targets | `npm run test:coverage` + **target** Codecov gate |
 | Security advisories | `npm audit` in `security-audit.yaml` |
-| Type safety | `type-safety.yaml` workflow |
+| Type safety | `anti-slop/no-hand-written-any` in `npm run lint`; `type-safety.yaml` for `as any` and missing return types |
 | Quality | `quality-checks.yml`, `quality-guard.yml`, `quality-assurance.yaml` |
 | Dead code | `dead-code-cleanup.yaml` |
 | Bundle size | **target** size-limit CI step |


### PR DESCRIPTION
Follow-up to #4995, which drove `no-hand-written-any` to zero in all 58 trees and closed by naming this as the separate change: `type-safety.yaml`'s `: any` half is now redundant, and what it still covers alone is `as any` and missing return annotations.

## The `: any` half was worse than redundant

It could not report zero. A grep for `: any` in `web/src` matches 20 lines today, and every one of them is prose or an identifier:

```
web/src/stores/PanelStore.ts:275:  // Migrate legacy flat-list views: any node-category id now lives
web/src/components/node/RerouteNode.tsx:177:      slug: anyType?.slug || "any",
web/src/utils/__tests__/nodeGenerations.test.ts:440:    it("rolls up status: any running → running", () => {
```

Zero real annotations — `no-hand-written-any` holds that at zero and `npm run lint` enforces it on every PR. So `TYPE_ISSUES` was pinned to `1` on a signal no agent could ever clear, and the job ran nightly on it. That half is gone, with the reason written at the scan step so it does not come back.

## What is left is two things nothing else reports

**`as any`** belongs to `require-safety-comment-for-type-assertion`, which is at zero in 9 of 58 trees — `packages/{auth,base-nodes,chat,config,model-pricing,nodes-utils,reve-nodes,security,workflow-runner}`. `web/`, `electron/` and `mobile/` are not among them, so nothing stops one landing here.

**Missing return annotations** are covered by nothing: `no-unknown-returns` reports a return typed `unknown`, not one typed nothing.

## Counting first, again

The same measurement that shaped `no-hand-written-any` shapes the prompt here. Of 478 `as any` assertions across the three trees (483 grep hits, 5 of them comments):

| tree | assertions | in test files | in production |
|---|---:|---:|---:|
| `web/src` | 432 | 432 | 0 |
| `electron/src` | 33 | 33 | 0 |
| `mobile/src` | 13 | 13 | 0 |

Production is clean. The one non-test file that matches is a comment reading `Check if the mask has any active pixels`.

So the prompt no longer says "replace `as any` with a proper type" and leaves the agent to guess where. It says the fix is typing the double — `selectorOver(state)` for a mocked zustand hook, a real type or a `doubles.ts` factory for a partial fixture, a declared member instead of `(global as any).fetch = …` — and that a deliberately-invalid fixture stays, with a one-line comment saying why, which is the form the rule will demand when it reaches these trees. It also forbids the failure mode that costs the most: weakening an assertion to make it compile. #4995 found `ChatView` asserting against `PlanningUpdate` payloads the app cannot produce, hidden behind exactly this kind of assertion.

Removed from the prompt: the `: any` / `any[]` / `Promise<any>` / `Record<string, any>` bullet and the loose-generics bullet, replaced by a **Do not fix here** section naming the rule that owns them — and asking for a report in the PR body if the agent ever finds one, since that means the rule has a hole.

Added to Verification: `electron/tsconfig.json` excludes `src/__tests__` and `**/*.test.ts`, so `npm run typecheck` reads none of the electron test files this job now edits. Only `npm run test`, through ts-jest, does. #4995 hit this — a pass green under `tsc` and red under `jest`.

## Proving the gate can fail

The old gate could not flip. The new one does, checked by extracting the `type-scan` step's `run:` from the YAML and executing it verbatim:

| target | reported | `TYPE_ISSUES` |
|---|---:|---|
| `web/src electron/src mobile/src` | 478 | `1` |
| a tree with one `.ts` file, no assertion | 0 | **`0`** |
| same tree, `const y = 1 as any;` appended | 1 | `1` |

The scan counts assertions rather than files now, and skips lines whose code starts with a comment marker.

## `workflow_dispatch` escape hatch

With the gate down to one signal, the job would stop firing entirely once `as any` reaches zero — and the return-annotation half would never be worked, since no cheap grep finds a missing annotation. So `workflow_dispatch` runs the agent (and the post-change verification) regardless of the count. The nightly schedule still gates on `as any`.

## Verification

The diff is one workflow file and three Markdown files — no TypeScript, so `typecheck`/`lint`/`test` are untouched by it. What was checked instead:

| check | result |
|---|---|
| `type-safety.yaml` parses; step conditions read back as intended | pass |
| `type-scan` step run verbatim against the real trees | 478, `TYPE_ISSUES=1` |
| same step against a clean tree, then a dirtied one | `0` → `1` |
| `electron/tsconfig.json` excludes its tests | confirmed from the file, not the claim |
| `selectorOver` / `mustFind` exist in `web/src/test-utils/doubles.ts` | confirmed at lines 73 and 85 |

Docs updated alongside: the AGENTS.md paragraph that ended "That is a separate change" now describes the narrowing, the `.github/workflows/README.md` row, and the enforcement row in `docs/DEVELOPMENT_STANDARDS.md` (which credited only this workflow for type safety, not the rule that now does most of the work).

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4t9Xv41Y3VLzxEZ8Zkj3N)_