### PR TITLE
feat(demo): replay the sketch and timeline editors, not just their canvases

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -150,10 +150,19 @@ straight off the global `GlobalChatStore` instead of props; `seedChatGlobalState
 mirrors the replay state into that store each frame, the same "seed the shared
 store" trick `seedCastMetadata`/`seedDemoAuth` use for the graph editor.
 
-**Timeline** (`web/src/demo/timeline/`): mounts only `PreviewArea` +
-`TracksRegion` inside a `TimelineProvider` — not the full `TimelineEditor` page,
+**Timeline** (`web/src/demo/timeline/`): mounts the editor's own layout inside a
+`TimelineProvider` — `TopBar`, `PreviewArea` beside `TimelineInspector`,
+`TracksRegion`, `BottomStatusBar` — but not the full `TimelineEditor` page,
 which also wires up autosave, generation-job subscriptions, and tRPC-backed
-sequence loading that don't apply to a hand-authored, backend-free cast.
+sequence loading that don't apply to a hand-authored, backend-free cast. The
+chrome reads the same stores the engine seeds: the inspector shows the clip the
+cast's `select` event picked, the status bar the zoom its `zoom` event set. The
+top bar's actions are inert — a tutorial should show where Save and Export live,
+and a replay must not run them. A composition that draws its own chrome (the
+promo, with its recreated prompt bar) passes `chrome={false}` for the bare
+preview + tracks surface. The chrome lives in `timelineChrome.tsx` so it can be
+mounted without the preview compositor, which needs a canvas backend a test
+environment has no way to give it (`__tests__/timelineChrome.test.tsx`).
 `TimelineDemoEngine` seeds a fresh `TimelineInstance` (`createTimelineInstance`,
 exported from `TimelineInstance.tsx` for exactly this purpose) with the cast's
 starting `TimelineSequence`, then folds `TimelineCastEvent[]` (add/patch/remove
@@ -177,6 +186,17 @@ document down. `DocDemoPlayer` mounts the production component per surface —
 `SketchRenderer`, `ScriptDocumentPane`, `StoryboardBoard`, `JsScriptEditorPane`,
 `AppRuntimeView` — read-only, without each editor's page shell (autosave,
 generation subscriptions, tRPC loading).
+
+Sketch is the one surface with chrome of its own: `SketchEditorSurface` puts the
+production toolbar, layers panel, and status bar around `SketchRenderer`, all
+subscribed to a `SketchInstance` the player seeds per frame — so the tool lights
+up in the toolbar because the cast says so, and the panel's opacity and blend
+controls move as the assistant sets them. The canvas stays `SketchRenderer`
+rather than the interactive `SketchCanvasPane`: a replay renders state and never
+accepts input, so the painting, pointer, and history machinery has nothing to
+drive it. That is why a sketch cast's document has two halves — `document` (the
+layer stack) and `editor` (tool, zoom, colors, panel selection), each patchable
+on its own.
 
 Every document cast also carries an **assistant track**: the conversation that
 produced the edits, in the same event shape the chat cast uses. `AssistantDock`

--- a/demo/src/docTutorials.ts
+++ b/demo/src/docTutorials.ts
@@ -44,7 +44,7 @@ export const DOC_TUTORIALS: DocTutorialEntry[] = [
     ],
     captions: [
       { fromMs: 600, toMs: 4800, text: "Say what you want changed — the assistant reads the layer stack you have." },
-      { fromMs: 5400, toMs: 9000, text: "It adds the layer itself: same tools you'd reach for, driven by the chat." },
+      { fromMs: 5400, toMs: 9000, text: "The new layer appears in the panel on the right, selected and ready." },
       { fromMs: 9600, toMs: 14600, text: "Then it dials in blend mode and opacity, and the canvas settles." },
     ],
     outroTitle: "Your canvas, your words",

--- a/demo/src/promo/TimelineScene.tsx
+++ b/demo/src/promo/TimelineScene.tsx
@@ -56,6 +56,9 @@ export const TimelineScene: React.FC = () => {
         resolveAssetUrl={resolvePromoAsset}
         tracksHeightPx={tracksHeightPx}
         onPendingMedia={onPendingMedia}
+        // The promo draws its own prompt bar and headlines over the surface;
+        // the editor's own chrome would collide with them.
+        chrome={false}
       />
 
       <GenerateBar

--- a/demo/src/timelineTutorials.ts
+++ b/demo/src/timelineTutorials.ts
@@ -42,7 +42,7 @@ export const TIMELINE_TUTORIALS: TimelineTutorialEntry[] = [
       { atMs: 7200, label: "Zoom in and play it back" },
     ],
     captions: [
-      { fromMs: 700, toMs: 2000, text: "Select a clip on the timeline to trim or inspect it." },
+      { fromMs: 700, toMs: 2000, text: "Select a clip on the timeline — the inspector fills in with its settings." },
       { fromMs: 3800, toMs: 6200, text: "Drag in the next shot and a caption — both land on their own track." },
       { fromMs: 7400, toMs: 15600, text: "Zoom in, scrub the playhead, and watch the cut play back live." },
     ],

--- a/demo/src/web-demo.d.ts
+++ b/demo/src/web-demo.d.ts
@@ -108,6 +108,8 @@ declare module "@web-demo" {
     resolveAssetUrl?: (file: string) => string;
     /** Pixel height of the tracks region. Default 320. */
     tracksHeightPx?: number;
+    /** Mount the editor chrome (top bar, inspector, status bar). Default true. */
+    chrome?: boolean;
     /** Lets a frame renderer block the capture until videos are paintable. */
     onPendingMedia?: PendingMediaHandler;
     style?: React.CSSProperties;

--- a/web/src/demo/doc/DocDemoPlayer.tsx
+++ b/web/src/demo/doc/DocDemoPlayer.tsx
@@ -5,12 +5,13 @@
  * `../DemoPlayer.tsx` (graph) and `../timeline/TimelineDemoPlayer.tsx`
  * (timeline), and the one that covers the remaining five document types.
  *
- * The document is the production component in every case — `SketchRenderer`,
- * `ScriptDocumentPane`, `StoryboardBoard`, `JsScriptEditorPane`,
- * `AppRuntimeView` — driven as a pure function of elapsed time. It deliberately
- * mounts the document surface only, not each editor's page shell: those wire up
- * autosave, tRPC-backed loading, and generation subscriptions, none of which
- * apply to a backend-free, hand-authored cast.
+ * The document is the production component in every case — the sketch editor's
+ * own toolbar/layers/status chrome around `SketchRenderer`, `ScriptDocumentPane`,
+ * `StoryboardBoard`, `JsScriptEditorPane`, `AppRuntimeView` — driven as a pure
+ * function of elapsed time. It deliberately mounts the document surface only,
+ * not each editor's page shell: those wire up autosave, tRPC-backed loading,
+ * and generation subscriptions, none of which apply to a backend-free,
+ * hand-authored cast.
  *
  * The surfaces are read-only here for the same reason the graph canvas is: a
  * replay renders state, it never accepts input.
@@ -36,8 +37,8 @@ import ThemeNodetool from "../../components/themes/ThemeNodetool";
 import AppRuntimeView from "../../components/appbuilder/AppRuntimeView";
 import JsScriptEditorPane from "../../components/jsScript/JsScriptEditorPane";
 import ScriptDocumentPane from "../../components/script/ScriptDocumentPane";
-import SketchRenderer from "../../components/sketch/SketchRenderer";
 import { StoryboardBoard } from "../../components/storyboard/StoryboardBoard";
+import { SketchEditorSurface } from "./SketchEditorSurface";
 import { WorkflowManagerProvider } from "../../contexts/WorkflowManagerContext";
 import { queryClient } from "../../queryClient";
 import { TRPCProvider } from "../../trpc/Provider";
@@ -66,9 +67,9 @@ function DocSurfaceView({
   switch (cast.surface) {
     case "sketch":
       return (
-        <SketchRenderer
-          document={doc as SketchDocCast["doc"]}
-          showDimensions
+        <SketchEditorSurface
+          documentId={cast.docId}
+          doc={doc as SketchDocCast["doc"]}
           ariaLabel={cast.name}
         />
       );

--- a/web/src/demo/doc/SketchEditorSurface.tsx
+++ b/web/src/demo/doc/SketchEditorSurface.tsx
@@ -1,0 +1,169 @@
+/**
+ * SketchEditorSurface — the sketch editor as a tutorial shows it: the real
+ * toolbar down the left, the layers panel down the right, the status bar along
+ * the bottom, and the canvas in the middle.
+ *
+ * The chrome is the production `editor-shell/` components, unchanged. They
+ * subscribe to a `SketchInstance` this surface owns and seeds from the cast, so
+ * a replayed frame drives the same store reads the app does — a tool lights up
+ * in the toolbar because `activeTool` says so, the layer rows and their opacity
+ * sliders come from the document, the status bar counts the layers it was given.
+ *
+ * The middle is `SketchRenderer`, not the interactive `SketchCanvasPane`: a
+ * replay renders state and never accepts input, and the pane's painting,
+ * pointer, and history machinery has nothing to drive it here. The panel
+ * callbacks are no-ops for the same reason — nothing in a replay clicks them.
+ */
+/** @jsxImportSource @emotion/react */
+import React, { useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { useTheme } from "@mui/material/styles";
+
+import {
+  ConnectedLayersPanel,
+  ConnectedStatusBar,
+  ConnectedToolbar
+} from "../../components/sketch/editor-shell";
+import type { ConnectedLayersPanelProps } from "../../components/sketch/editor-shell";
+import SketchRenderer from "../../components/sketch/SketchRenderer";
+import { hydrateSketchStore } from "../../components/sketch/state/useSketchStore";
+import {
+  createSketchInstance,
+  SketchProvider,
+  type SketchInstance
+} from "../../stores/sketch/SketchInstance";
+import type { SketchCastDoc } from "./docCastTypes";
+
+/**
+ * Every panel action a replay never takes. One frozen bag so the memoised
+ * panel keeps its props identity across frames.
+ */
+const NOOP_PANEL_ACTIONS: ConnectedLayersPanelProps = Object.freeze({
+  onClearLayer: () => {},
+  onFlipHorizontal: () => {},
+  onFlipVertical: () => {},
+  onRotate180: () => {},
+  onMergeDown: () => {},
+  onFlattenVisible: () => {},
+  onTrimLayerToBounds: () => {},
+  onCropCanvasToActiveLayerVisiblePixels: () => {},
+  onCropCanvasToActiveLayerExtents: () => {},
+  onToggleVisibility: () => {},
+  onAddLayer: () => {},
+  onRemoveLayer: () => {},
+  onDuplicateLayer: () => {},
+  onReorderLayers: () => {},
+  onSetMaskLayer: () => {},
+  onToggleAlphaLock: () => {},
+  onToggleExposedInput: () => {},
+  onToggleExposedOutput: () => {},
+  onLayerOpacityChange: () => {},
+  onLayerBlendModeChange: () => {},
+  onRenameLayer: () => {},
+  onAddGroup: () => {},
+  onToggleGroupCollapsed: () => {},
+  onMoveLayerToGroup: () => {},
+  onUngroupLayer: () => {},
+  onGroupSelectedLayers: () => {},
+  onMergeSelectedLayers: () => {},
+  onDeleteSelectedLayers: () => {},
+  onLoadLayerAsSelection: () => {}
+});
+
+/**
+ * Push a cast frame into the editor stores. Called before paint on every seek,
+ * so what the chrome renders is exactly the cast state at that time.
+ */
+export function seedSketchInstance(
+  instance: SketchInstance,
+  documentId: string,
+  doc: SketchCastDoc
+): void {
+  const editor = doc.editor ?? {};
+  hydrateSketchStore(instance.editor, {
+    document: doc.document,
+    activeTool: editor.activeTool,
+    zoom: editor.zoom
+  });
+  instance.editor.setState({
+    foregroundColor: editor.foregroundColor ?? "#ffffff",
+    backgroundColor: editor.backgroundColor ?? "#000000",
+    selectedLayerIds: editor.selectedLayerIds ?? [],
+    cursorDocPos: editor.cursorDocPos ?? null
+  });
+  // The status bar hides itself until a document is open.
+  instance.session.setState({ documentId });
+}
+
+export interface SketchEditorSurfaceProps {
+  /** Row id the editor keys this document by — the status bar reads it. */
+  documentId: string;
+  /** The cast's document and editor state at the frame being rendered. */
+  doc: SketchCastDoc;
+  ariaLabel?: string;
+}
+
+/** The sketch editor for one replayed frame. `doc` may change every frame. */
+export function SketchEditorSurface({
+  documentId,
+  doc,
+  ariaLabel
+}: SketchEditorSurfaceProps): React.JSX.Element {
+  const theme = useTheme();
+  const [instance] = useState(createSketchInstance);
+
+  // Seed before paint, the way the other two players seek.
+  useLayoutEffect(() => {
+    seedSketchInstance(instance, documentId, doc);
+  }, [instance, documentId, doc]);
+
+  useEffect(
+    () => () => {
+      instance.session.setState({ documentId: null });
+    },
+    [instance]
+  );
+
+  const canvasStyle = useMemo(
+    () => ({
+      flex: 1,
+      minWidth: 0,
+      display: "flex",
+      padding: theme.spacing(1),
+      backgroundColor: theme.vars.palette.grey[900]
+    }),
+    [theme]
+  );
+
+  return (
+    // `active={false}`: a replay must never take over the imperative statics
+    // (keyboard shortcuts, save) from a real editor mounted alongside it.
+    <SketchProvider instance={instance} active={false}>
+      <div
+        data-demo-sketch-editor
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          height: "100%",
+          overflow: "hidden",
+          backgroundColor: theme.vars.palette.grey[900]
+        }}
+      >
+        <div style={{ display: "flex", flex: 1, minHeight: 0 }}>
+          <ConnectedToolbar />
+          <div style={canvasStyle}>
+            <SketchRenderer
+              document={doc.document}
+              showDimensions
+              ariaLabel={ariaLabel}
+            />
+          </div>
+          <ConnectedLayersPanel {...NOOP_PANEL_ACTIONS} />
+        </div>
+        <ConnectedStatusBar />
+      </div>
+    </SketchProvider>
+  );
+}
+
+export default SketchEditorSurface;

--- a/web/src/demo/doc/__tests__/docCasts.test.ts
+++ b/web/src/demo/doc/__tests__/docCasts.test.ts
@@ -103,17 +103,34 @@ describe("document casts — the surfaces get their data", () => {
 
   it("sketch: the vignette layer is added, then dialed in", () => {
     const start = docStateAt(sketchAssistantCast, 0);
-    expect(start.layers).toHaveLength(1);
+    expect(start.document.layers).toHaveLength(1);
 
     const added = docStateAt(sketchAssistantCast, 6000);
-    expect(added.layers).toHaveLength(2);
-    expect(added.layers[1].blendMode).toBe("normal");
-    expect(added.activeLayerId).toBe("layer-vignette");
+    expect(added.document.layers).toHaveLength(2);
+    expect(added.document.layers[1].blendMode).toBe("normal");
+    expect(added.document.activeLayerId).toBe("layer-vignette");
 
     const settled = docStateAt(sketchAssistantCast, 12000);
-    expect(settled.layers[1].blendMode).toBe("multiply");
-    expect(settled.layers[1].opacity).toBeCloseTo(0.7);
-    expect(settled.layers[1].data).toContain("data:image/svg+xml");
+    expect(settled.document.layers[1].blendMode).toBe("multiply");
+    expect(settled.document.layers[1].opacity).toBeCloseTo(0.7);
+    expect(settled.document.layers[1].data).toContain("data:image/svg+xml");
+  });
+
+  it("sketch: the editor chrome follows the layer the assistant works on", () => {
+    // The panel highlights the row being edited, and a patch that touches only
+    // the document leaves the chrome where the previous patch put it.
+    expect(docStateAt(sketchAssistantCast, 0).editor?.selectedLayerIds).toEqual([
+      "layer-base"
+    ]);
+    expect(
+      docStateAt(sketchAssistantCast, 6000).editor?.selectedLayerIds
+    ).toEqual(["layer-vignette"]);
+    expect(
+      docStateAt(sketchAssistantCast, 12000).editor?.selectedLayerIds
+    ).toEqual(["layer-vignette"]);
+    expect(docStateAt(sketchAssistantCast, 12000).editor?.activeTool).toBe(
+      "select"
+    );
   });
 
   it("script: the store gets the cast, the lines, then a take on each line", () => {

--- a/web/src/demo/doc/__tests__/sketchEditorSurface.test.tsx
+++ b/web/src/demo/doc/__tests__/sketchEditorSurface.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * The sketch tutorial surface mounts the editor's own chrome and drives it from
+ * the cast: the toolbar's active tool, the layers panel's rows, the status
+ * bar's canvas size and layer count. A cast frame is the only input, so these
+ * assert the frame reaches each piece of chrome.
+ */
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import ThemeNodetool from "../../../components/themes/ThemeNodetool";
+import { createSketchInstance } from "../../../stores/sketch/SketchInstance";
+import { sketchCastDoc, sketchDocument, sketchLayer } from "../docCastHelpers";
+import { SketchEditorSurface, seedSketchInstance } from "../SketchEditorSurface";
+
+const DOC_ID = "demo-sketch-test";
+
+const frame = (opacity: number) =>
+  sketchCastDoc(
+    sketchDocument(
+      800,
+      600,
+      [
+        sketchLayer("layer-base", "Base art"),
+        sketchLayer("layer-vignette", "Vignette", { opacity })
+      ],
+      "layer-vignette"
+    ),
+    { activeTool: "brush", zoom: 0.5, selectedLayerIds: ["layer-vignette"] }
+  );
+
+// Layer thumbnails resolve their asset through react-query; the player supplies
+// the client in production.
+const renderSurface = (opacity = 1) =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <ThemeProvider theme={ThemeNodetool}>
+        <SketchEditorSurface documentId={DOC_ID} doc={frame(opacity)} />
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+
+describe("seedSketchInstance", () => {
+  it("puts the cast frame into the editor stores the chrome reads", () => {
+    const instance = createSketchInstance();
+    seedSketchInstance(instance, DOC_ID, frame(0.7));
+
+    const editor = instance.editor.getState();
+    expect(editor.document.layers).toHaveLength(2);
+    expect(editor.document.activeLayerId).toBe("layer-vignette");
+    expect(editor.activeTool).toBe("brush");
+    expect(editor.zoom).toBeCloseTo(0.5);
+    expect(editor.selectedLayerIds).toEqual(["layer-vignette"]);
+    // The status bar stays hidden until a document is bound.
+    expect(instance.session.getState().documentId).toBe(DOC_ID);
+  });
+
+  it("falls back to the editor defaults for an unset chrome field", () => {
+    const instance = createSketchInstance();
+    seedSketchInstance(instance, DOC_ID, sketchCastDoc(sketchDocument(64, 64, [])));
+
+    const editor = instance.editor.getState();
+    expect(editor.activeTool).toBe("select");
+    expect(editor.zoom).toBe(1);
+    expect(editor.selectedLayerIds).toEqual([]);
+    expect(editor.cursorDocPos).toBeNull();
+  });
+
+  it("re-seeding replaces the previous frame rather than merging it", () => {
+    const instance = createSketchInstance();
+    seedSketchInstance(instance, DOC_ID, frame(1));
+    seedSketchInstance(
+      instance,
+      DOC_ID,
+      sketchCastDoc(sketchDocument(64, 64, [sketchLayer("only", "Only")]))
+    );
+
+    expect(instance.editor.getState().document.layers).toHaveLength(1);
+    expect(instance.editor.getState().selectedLayerIds).toEqual([]);
+  });
+});
+
+describe("<SketchEditorSurface />", () => {
+  it("renders the toolbar with the cast's tool selected", () => {
+    renderSurface();
+    const brush = screen.getByRole("button", { name: /brush/i });
+    expect(brush).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("renders a layers-panel row per layer in the cast", () => {
+    renderSurface();
+    expect(screen.getByText("Base art")).toBeInTheDocument();
+    expect(screen.getByText("Vignette")).toBeInTheDocument();
+  });
+
+  it("renders the status bar for the bound document", () => {
+    renderSurface();
+    expect(screen.getByTestId("sketch-status-bar")).toHaveTextContent(
+      "800 × 600"
+    );
+    expect(screen.getByTestId("sketch-status-bar")).toHaveTextContent(
+      "2 layers"
+    );
+  });
+});

--- a/web/src/demo/doc/docCastHelpers.ts
+++ b/web/src/demo/doc/docCastHelpers.ts
@@ -13,7 +13,11 @@ import {
   type SketchDocument
 } from "../../components/sketch/types";
 import type { ScriptLine, ScriptSection } from "../../stores/script/ScriptStore";
-import type { DocCastEvent } from "./docCastTypes";
+import type {
+  DocCastEvent,
+  SketchCastDoc,
+  SketchEditorCast
+} from "./docCastTypes";
 
 /** A timed shallow patch of the document root. */
 export const patch = <Doc>(t: number, patch: Partial<Doc>): DocCastEvent<Doc> => ({
@@ -47,6 +51,7 @@ export const sketchLayer = (
   ...overrides
 });
 
+/** The document half of a sketch cast frame — the layer stack and canvas. */
 export const sketchDocument = (
   width: number,
   height: number,
@@ -61,6 +66,12 @@ export const sketchDocument = (
   toolSettings: cloneDefaultToolSettings(),
   metadata: { createdAt: EPOCH, updatedAt: EPOCH }
 });
+
+/** One sketch cast frame: the document plus the editor chrome around it. */
+export const sketchCastDoc = (
+  document: SketchDocument,
+  editor: SketchEditorCast = {}
+): SketchCastDoc => ({ document, editor });
 
 // ── Script ──────────────────────────────────────────────────────────────────
 

--- a/web/src/demo/doc/docCastTypes.ts
+++ b/web/src/demo/doc/docCastTypes.ts
@@ -21,7 +21,10 @@
 import type { ApplicationDocument } from "@nodetool-ai/app-runtime";
 
 import type { LanguageModel, Workflow } from "../../stores/ApiTypes";
-import type { SketchDocument } from "../../components/sketch/types";
+import type {
+  SketchDocument,
+  SketchTool
+} from "../../components/sketch/types";
 import type { JsScriptDocument } from "../../stores/jsScript/JsScriptStore";
 import type { ScriptDraft } from "../../stores/script/ScriptStore";
 import type { StoryboardBoard } from "../../stores/storyboard/StoryboardStore";
@@ -73,6 +76,33 @@ interface DocDemoCastBase<Surface extends DocSurface, Doc> {
   assistantTitle: string;
 }
 
+/**
+ * The sketch-editor chrome around the canvas: the toolbar's active tool and
+ * colors, the layers panel's multi-selection, the status bar's zoom and cursor
+ * readout. None of it lives in the document, so a cast that wants the tutorial
+ * to show a tool being picked carries it here.
+ */
+export interface SketchEditorCast {
+  activeTool?: SketchTool;
+  zoom?: number;
+  foregroundColor?: string;
+  backgroundColor?: string;
+  /** Layers highlighted in the panel beyond the document's `activeLayerId`. */
+  selectedLayerIds?: string[];
+  /** Cursor readout in document pixels, or null for "pointer is off-canvas". */
+  cursorDocPos?: { x: number; y: number } | null;
+}
+
+/**
+ * A sketch surface renders the document *and* the editor state around it, so
+ * the cast wraps both — a patch sets either half, the way the JS-script and
+ * app casts patch their own two-part documents.
+ */
+export interface SketchCastDoc {
+  document: SketchDocument;
+  editor?: SketchEditorCast;
+}
+
 /** The script store keys `id`/`updatedAt` itself, so a cast never sets them. */
 export type ScriptCastDoc = Omit<ScriptDraft, "id" | "updatedAt">;
 /** Same for the storyboard store. */
@@ -88,7 +118,7 @@ export interface AppCastDoc {
   workflow: Workflow;
 }
 
-export type SketchDocCast = DocDemoCastBase<"sketch", SketchDocument>;
+export type SketchDocCast = DocDemoCastBase<"sketch", SketchCastDoc>;
 export type ScriptDocCast = DocDemoCastBase<"script", ScriptCastDoc>;
 export type StoryboardDocCast = DocDemoCastBase<"storyboard", StoryboardCastDoc>;
 export type JsScriptDocCast = DocDemoCastBase<"jsscript", JsScriptCastDoc>;

--- a/web/src/demo/doc/sketchAssistantCast.ts
+++ b/web/src/demo/doc/sketchAssistantCast.ts
@@ -3,7 +3,9 @@
  *
  * The Sketch Assistant is asked for a vignette and a warmer look; it calls
  * `ui_sketch_add_layer` and `ui_sketch_set_layer_props`, and the layer stack
- * changes under the real `SketchRenderer` as the calls land.
+ * changes in the real editor — toolbar, layers panel, status bar — as the
+ * calls land. The panel's row for the new layer is selected while the
+ * assistant works on it, the way it would be if you had added it yourself.
  *
  * Backend-free: the generated art is an inline SVG data URI, so replay never
  * paints a stroke or spends a credit.
@@ -18,7 +20,12 @@ import {
   toolRunning,
   userMessage
 } from "../chat/chatCastHelpers";
-import { patch, sketchDocument, sketchLayer } from "./docCastHelpers";
+import {
+  patch,
+  sketchCastDoc,
+  sketchDocument,
+  sketchLayer
+} from "./docCastHelpers";
 import { DOC_CAST_VERSION, type SketchDocCast } from "./docCastTypes";
 
 const WIDTH = 1024;
@@ -77,19 +84,39 @@ export const sketchAssistantCast: SketchDocCast = {
     provider: PROVIDER_IDS.ANTHROPIC
   },
 
-  doc: sketchDocument(WIDTH, HEIGHT, [base], base.id),
+  doc: sketchCastDoc(sketchDocument(WIDTH, HEIGHT, [base], base.id), {
+    activeTool: "select",
+    zoom: 1,
+    foregroundColor: "#f2b28c",
+    selectedLayerIds: [base.id]
+  }),
 
   events: [
     // The assistant's add_layer call lands: a new layer on top, still at full
     // strength and normal blend — deliberately wrong, so the fix reads.
     patch(5200, {
-      layers: [base, { ...vignette, opacity: 1, blendMode: "normal" }],
-      activeLayerId: vignette.id
+      document: sketchDocument(
+        WIDTH,
+        HEIGHT,
+        [base, { ...vignette, opacity: 1, blendMode: "normal" }],
+        vignette.id
+      ),
+      editor: {
+        activeTool: "select",
+        zoom: 1,
+        foregroundColor: "#f2b28c",
+        selectedLayerIds: [vignette.id]
+      }
     }),
-    // set_layer_props dials it in.
+    // set_layer_props dials it in: the panel's opacity and blend controls for
+    // the selected row are what changes.
     patch(9400, {
-      layers: [base, { ...vignette, opacity: 0.7, blendMode: "multiply" }],
-      activeLayerId: vignette.id
+      document: sketchDocument(
+        WIDTH,
+        HEIGHT,
+        [base, { ...vignette, opacity: 0.7, blendMode: "multiply" }],
+        vignette.id
+      )
     })
   ],
 

--- a/web/src/demo/timeline/TimelineDemoPlayer.tsx
+++ b/web/src/demo/timeline/TimelineDemoPlayer.tsx
@@ -1,14 +1,22 @@
 /** @jsxImportSource @emotion/react */
 /**
- * TimelineDemoPlayer — renders the real timeline editor UI (preview + tracks)
- * for a timeline cast at a given time. Sibling to `../DemoPlayer.tsx` (the
- * graph-editor player): a self-contained provider stack driving the
- * production components (`PreviewArea`, `TracksRegion`) as a pure function of
- * elapsed time via `TimelineDemoEngine`.
+ * TimelineDemoPlayer — renders the real timeline editor UI for a timeline cast
+ * at a given time. Sibling to `../DemoPlayer.tsx` (the graph-editor player): a
+ * self-contained provider stack driving the production components as a pure
+ * function of elapsed time via `TimelineDemoEngine`.
  *
- * Deliberately mounts only the preview + tracks surfaces, not the full
- * `TimelineEditor` page shell — that page also wires up autosave, generation
- * subscriptions, and tRPC-backed sequence loading, none of which apply to a
+ * With `chrome` (the default) the layout is the editor's own — `TopBar` above,
+ * `PreviewArea` beside `TimelineInspector`, `TracksRegion`, then
+ * `BottomStatusBar` — so a tutorial shows the editor a viewer will open, not a
+ * preview pane floating on its own. The inspector fills in from the cast's
+ * `select` events: the clip the cast selects is the clip whose trim, adjustments,
+ * and animations the panel shows. A cinematic composition that supplies its own
+ * chrome (the promo) passes `chrome={false}` for the bare surface.
+ *
+ * The chrome is read-only like the rest of a replay: `TopBar`'s actions are
+ * no-ops, present because a tutorial should show where Save and Export live.
+ * The page shell around it is still deliberately absent — autosave, generation
+ * subscriptions, and tRPC-backed sequence loading have nothing to do in a
  * backend-free, hand-authored cast.
  */
 import React, {
@@ -30,6 +38,11 @@ import ThemeNodetool from "../../components/themes/ThemeNodetool";
 import { TimelineProvider } from "../../stores/timeline/TimelineInstance";
 import { PreviewArea } from "../../components/timeline/preview/PreviewArea";
 import { TracksRegion } from "../../components/timeline/Tracks/TracksRegion";
+import {
+  DemoInspectorPane,
+  DemoStatusBar,
+  DemoTopBar
+} from "./timelineChrome";
 import type { TimelineDemoCast } from "./timelineCastTypes";
 import { TimelineDemoEngine } from "./timelineReplay";
 import {
@@ -66,6 +79,8 @@ export interface TimelineDemoPlayerProps {
   resolveAssetUrl?: (file: string) => string;
   /** Pixel height of the tracks region. Default 320. */
   tracksHeightPx?: number;
+  /** Mount the editor chrome (top bar, inspector, status bar). Default true. */
+  chrome?: boolean;
   /** Called with a promise per not-yet-decoded video so a frame renderer can
    *  block the capture until media is paintable (see ../mediaReadiness.ts). */
   onPendingMedia?: PendingMediaHandler;
@@ -76,10 +91,12 @@ function TimelineDemoSurface({
   engine,
   timeMs,
   tracksHeightPx,
+  chrome,
 }: {
   engine: TimelineDemoEngine;
   timeMs: number;
   tracksHeightPx: number;
+  chrome: boolean;
 }): React.JSX.Element {
   // Drive the replay synchronously before paint so each frame's DOM reflects
   // exactly the cast state at `timeMs`.
@@ -99,14 +116,19 @@ function TimelineDemoSurface({
         overflow: "hidden",
       }}
     >
-      <div style={{ flex: 1, minHeight: 0 }}>
-        <PreviewArea
-          fps={engine.fps}
-          sequenceWidth={sequence.width}
-          sequenceHeight={sequence.height}
-        />
+      {chrome && <DemoTopBar />}
+      <div style={{ flex: 1, minHeight: 0, display: "flex" }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <PreviewArea
+            fps={engine.fps}
+            sequenceWidth={sequence.width}
+            sequenceHeight={sequence.height}
+          />
+        </div>
+        {chrome && <DemoInspectorPane />}
       </div>
       <TracksRegion heightPx={tracksHeightPx} />
+      {chrome && <DemoStatusBar />}
     </div>
   );
 }
@@ -117,6 +139,7 @@ export function TimelineDemoPlayer({
   timeMs,
   resolveAssetUrl,
   tracksHeightPx = TRACKS_HEIGHT_PX,
+  chrome = true,
   onPendingMedia,
   style,
 }: TimelineDemoPlayerProps): React.JSX.Element {
@@ -158,6 +181,7 @@ export function TimelineDemoPlayer({
                 engine={engine}
                 timeMs={timeMs}
                 tracksHeightPx={tracksHeightPx}
+                chrome={chrome}
               />
             </TimelineProvider>
           </div>

--- a/web/src/demo/timeline/__tests__/timelineChrome.test.tsx
+++ b/web/src/demo/timeline/__tests__/timelineChrome.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * The timeline tutorial surface mounts the editor's own chrome around the
+ * preview: the top bar's actions, the inspector for the clip the cast selects,
+ * and the status bar reading the cast's zoom.
+ *
+ * The chrome is mounted here without the preview compositor — it needs a canvas
+ * backend jsdom cannot give it — which is why `timelineChrome.tsx` is a module
+ * of its own. Everything below is driven by the same engine the player drives.
+ */
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import ThemeNodetool from "../../../components/themes/ThemeNodetool";
+import { TimelineProvider } from "../../../stores/timeline/TimelineInstance";
+import {
+  DemoInspectorPane,
+  DemoStatusBar,
+  DemoTopBar
+} from "../timelineChrome";
+import { TimelineDemoEngine } from "../timelineReplay";
+import { timelineEditingCast } from "../timelineEditingCast";
+
+/** Seek the cast, then mount the chrome against the stores that seek wrote. */
+function renderChrome(timeMs: number) {
+  const engine = new TimelineDemoEngine(timelineEditingCast);
+  engine.seekToTime(timeMs);
+  const view = render(
+    <MemoryRouter>
+      <QueryClientProvider client={new QueryClient()}>
+        <ThemeProvider theme={ThemeNodetool}>
+          <TimelineProvider instance={engine.instance}>
+            <DemoTopBar />
+            <DemoInspectorPane />
+            <DemoStatusBar />
+          </TimelineProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+  return { engine, view };
+}
+
+describe("timeline demo chrome", () => {
+  it("shows the editor's actions, inert", () => {
+    renderChrome(0);
+    for (const name of [/project settings/i, /^save$/i, /^export$/i]) {
+      expect(screen.getByRole("button", { name })).toBeInTheDocument();
+    }
+  });
+
+  it("reports the cast's zoom in the status bar", () => {
+    const zoomEvent = timelineEditingCast.events.find(
+      (e) => e.payload.kind === "zoom"
+    );
+    expect(zoomEvent).toBeDefined();
+
+    // Past the cast's zoom-in, the bar reads that zoom — not the 10 ms/px
+    // baseline it starts at.
+    const { engine } = renderChrome(zoomEvent!.t);
+    const msPerPx = engine.instance.ui.getState().msPerPx;
+    expect(msPerPx).not.toBe(10);
+    expect(screen.getByLabelText("Zoom controls")).toHaveTextContent(
+      `${Math.round((10 / msPerPx) * 100)}%`
+    );
+  });
+
+  it("fills the inspector from the clip the cast selected", () => {
+    const selectEvent = timelineEditingCast.events.find(
+      (e) => e.payload.kind === "select" && e.payload.clipIds.length === 1
+    );
+    expect(selectEvent).toBeDefined();
+
+    const { engine } = renderChrome(selectEvent!.t);
+    expect(engine.instance.ui.getState().selectedClipIds.size).toBe(1);
+    // With one clip selected the inspector shows that clip, not its empty state.
+    expect(screen.queryByText(/no clip selected/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/timing/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/demo/timeline/timelineChrome.tsx
+++ b/web/src/demo/timeline/timelineChrome.tsx
@@ -1,0 +1,78 @@
+/** @jsxImportSource @emotion/react */
+/**
+ * The timeline editor's chrome, as a replay mounts it: the production `TopBar`,
+ * `TimelineInspector`, and `BottomStatusBar`, wired to the stores the replay
+ * engine seeds instead of to a live sequence.
+ *
+ * Kept apart from `TimelineDemoPlayer` so the chrome can be mounted — and
+ * asserted on — without the preview compositor, which needs a canvas backend a
+ * test environment has no way to give it.
+ */
+import React from "react";
+
+import { BottomStatusBar } from "../../components/timeline/BottomStatusBar";
+import { TimelineInspector } from "../../components/timeline/Inspector/TimelineInspector";
+import { TopBar } from "../../components/timeline/TopBar";
+import {
+  useFailedCount,
+  useGeneratingCount
+} from "../../stores/timeline/TimelineGenerationStore";
+import { useTimelineUIStore } from "../../stores/timeline/TimelineUIStore";
+
+/** Share of the middle row the inspector takes, matching the editor's split. */
+export const INSPECTOR_WIDTH_PCT = 30;
+
+/** The editor's zoom baseline: `zoom = DEFAULT_MS_PER_PX / msPerPx`. */
+const DEFAULT_MS_PER_PX = 10;
+
+/** Nothing in a replay clicks a top-bar action; they render to be seen. */
+const noop = (): void => {};
+
+/**
+ * The editor's top bar with every action present and inert — a tutorial should
+ * show where Save and Export live, and a replay must not run them.
+ */
+export function DemoTopBar(): React.JSX.Element {
+  return (
+    <TopBar
+      onSave={noop}
+      onExportVideo={noop}
+      onSaveToAssets={noop}
+      onOpenSettings={noop}
+    />
+  );
+}
+
+/** The inspector column beside the preview. Fills in from the cast's selection. */
+export function DemoInspectorPane(): React.JSX.Element {
+  return (
+    <div
+      style={{
+        width: `${INSPECTOR_WIDTH_PCT}%`,
+        flexShrink: 0,
+        minWidth: 0,
+        overflow: "hidden"
+      }}
+    >
+      <TimelineInspector />
+    </div>
+  );
+}
+
+/**
+ * The status bar, reading the stores the editor reads — the cast's zoom through
+ * `msPerPx`, and any generation the cast put in flight.
+ */
+export function DemoStatusBar(): React.JSX.Element {
+  const msPerPx = useTimelineUIStore((s) => s.msPerPx);
+  const generatingCount = useGeneratingCount();
+  const failedCount = useFailedCount();
+  return (
+    <BottomStatusBar
+      mode="local"
+      zoom={DEFAULT_MS_PER_PX / msPerPx}
+      generatingCount={generatingCount}
+      failedCount={failedCount}
+    />
+  );
+}

--- a/web/src/stores/sketch/SketchInstance.tsx
+++ b/web/src/stores/sketch/SketchInstance.tsx
@@ -60,7 +60,13 @@ export interface SketchInstance {
   saveInFlight: { current: boolean };
 }
 
-const createSketchInstance = (): SketchInstance => ({
+/**
+ * Build a fresh, isolated bundle of sketch stores. `SketchProvider` calls this
+ * for the surfaces a user edits in; the demo harness calls it directly so a
+ * replay engine can seed the stores it will provide (the timeline's
+ * `createTimelineInstance` exists for the same reason).
+ */
+export const createSketchInstance = (): SketchInstance => ({
   editor: createSketchStore(),
   session: createSketchSessionStore(),
   canvasRef: createSketchCanvasRefStore(),
@@ -129,14 +135,21 @@ interface SketchProviderProps {
    * button). Defaults to `true` for always-focused surfaces (page, modal).
    */
   active?: boolean;
+  /**
+   * Stores to provide instead of a fresh bundle. The demo harness passes the
+   * instance its replay engine already seeded; editor surfaces omit it.
+   */
+  instance?: SketchInstance;
   children: React.ReactNode;
 }
 
 export const SketchProvider = ({
   active = true,
+  instance: provided,
   children
 }: SketchProviderProps) => {
-  const instance = useMemo(() => createSketchInstance(), []);
+  const created = useMemo(() => createSketchInstance(), []);
+  const instance = provided ?? created;
 
   useEffect(() => {
     if (!active) return;


### PR DESCRIPTION
The harness could show a sketch *document* and a timeline *preview*; it could not show either **editor**.

A sketch cast rendered `SketchRenderer` alone — no toolbar, no layers panel, no status bar — so the tutorial where the assistant sets a layer's blend mode had nowhere to show the control it set. The timeline player mounted `PreviewArea` + `TracksRegion`, so a `select` event changed nothing a viewer could see, and the promo had to hand-draw a prompt bar over the surface because the real top bar was not there.

Both now mount the production chrome.

## Sketch

`SketchEditorSurface` (`web/src/demo/doc/`) puts `ConnectedToolbar`, `ConnectedLayersPanel`, and `ConnectedStatusBar` around the canvas, subscribed to a `SketchInstance` the player seeds per frame. The active tool lights up in the toolbar because the cast says so; the panel's opacity and blend controls move as the assistant sets them; the status bar counts the layers it was given.

The canvas stays `SketchRenderer` rather than the interactive `SketchCanvasPane` — a replay renders state and never accepts input, so the painting, pointer, and history machinery has nothing to drive it. Panel callbacks are no-ops for the same reason.

None of that chrome state lives in a `SketchDocument`, so a sketch cast's doc gains a second half — `{ document, editor }` — each patchable on its own by the existing shallow-patch fold, the way the JS-script and app casts already carry two-part documents.

## Timeline

`TimelineDemoPlayer` gains the editor's own layout: `TopBar`, `PreviewArea` beside `TimelineInspector`, `TracksRegion`, `BottomStatusBar`. It reads the stores the engine already seeds — the inspector shows the clip a `select` event picked, the status bar the zoom a `zoom` event set. Top-bar actions are inert: a tutorial should show where Save and Export live, and a replay must not run them. The promo passes `chrome={false}` and keeps its own overlays.

## Seams

Two, both mirroring the timeline's existing `createTimelineInstance`:

- `createSketchInstance` is exported and `SketchProvider` accepts an `instance`, so the harness can seed the stores it provides.
- The timeline chrome lives in `timelineChrome.tsx` so it can be mounted without the preview compositor, which needs a canvas backend jsdom cannot give it.

## Verification

`npm run typecheck` (web + demo), `oxlint`, and the full web Jest suite (1135 suites, 13131 tests) pass; the two pre-existing `DataframeProperty`/`RecordTypeProperty` type errors are unchanged by this diff.

New tests: `sketchEditorSurface.test.tsx` (seeding, then toolbar/layers/status render from a cast frame) and `timelineChrome.test.tsx` (actions present, cast zoom in the status bar, inspector filled from the cast's selection). Both were verified to fail when the chrome is broken — seeding stubbed out, the status bar removed, the zoom hardcoded, the inspector replaced — and to pass again on restore.

Not in this change: rendering the MP4s. The existing `timeline-trim-arrange.mp4` and the sketch tutorial's video predate the chrome and need a re-render (`npm run render:tutorial:timeline-trim-arrange`, `npm run render:tutorial:sketch`) to show it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKAkfwTpX1LNLd6mNKd78X)_