### PR TITLE
fix(web): keep the create-folder dialog inside the viewport

### DIFF
--- a/web/src/components/assets/AssetCreateFolderConfirmation.tsx
+++ b/web/src/components/assets/AssetCreateFolderConfirmation.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useRef, useState, useMemo } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useMemo
+} from "react";
 import { Text, FlexRow, AlertBanner, Surface, TextInput, BORDER_RADIUS, FONT_WEIGHT, SPACING, getSpacingPx } from "../ui_primitives";
 import { EditorButton } from "../editor_ui";
 import { getMousePosition } from "../../utils/MousePosition";
@@ -8,6 +15,13 @@ import useAssets from "../../serverState/useAssets";
 import { useNotificationStore } from "../../stores/NotificationStore";
 import { Asset } from "../../stores/ApiTypes";
 import { useTheme } from "@mui/material/styles";
+
+const VIEWPORT_MARGIN = 16;
+
+const clampToViewport = (desired: number, size: number, viewport: number) => {
+  const max = Math.max(VIEWPORT_MARGIN, viewport - size - VIEWPORT_MARGIN);
+  return Math.min(Math.max(desired, VIEWPORT_MARGIN), max);
+};
 
 const AssetCreateFolderConfirmation: React.FC = () => {
   const setDialogOpen = useAssetGridStore(
@@ -23,13 +37,19 @@ const AssetCreateFolderConfirmation: React.FC = () => {
     (state) => state.setSelectedAssets
   );
 
-  const [dialogPosition, setDialogPosition] = useState({ x: 0, y: 0 });
+  const [position, setPosition] = useState<{
+    left: number;
+    top: number;
+  } | null>(null);
   const [folderName, setFolderName] = useState("New Folder");
   const [showAlert, setShowAlert] = useState<string | null>(null);
   const handleClose = useCallback(() => {
     setDialogOpen(false);
   }, [setDialogOpen]);
+  const dismissAlert = useCallback(() => setShowAlert(null), []);
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<{ x: number; y: number } | null>(null);
   const theme = useTheme();
   const createFolder = useAssetStore((state) => state.createFolder);
   const updateAsset = useAssetStore((state) => state.update);
@@ -61,8 +81,6 @@ const AssetCreateFolderConfirmation: React.FC = () => {
   useEffect(() => {
     if (dialogOpen) {
       setFolderName("New Folder");
-      const mousePosition = getMousePosition();
-      setDialogPosition({ x: mousePosition.x, y: mousePosition.y });
       setShowAlert(null);
       const timer = setTimeout(() => {
         if (inputRef.current) {
@@ -161,14 +179,24 @@ const AssetCreateFolderConfirmation: React.FC = () => {
     setSelectedAssets
   ]);
 
-  const screenWidth = window.innerWidth;
-  const dialogWidth = 400;
-  const leftPosition = dialogPosition.x - dialogWidth;
-
-  const safeLeft = Math.min(
-    Math.max(leftPosition, 50),
-    screenWidth - dialogWidth - 50
-  );
+  // Place from the measured size, not an assumed one: a fixed upward offset put
+  // the name field above the viewport whenever the New Folder button sat near
+  // the top of the window. Re-runs when an alert or the move notice changes the
+  // height, keeping the anchor the cursor had when the dialog opened.
+  useLayoutEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialogOpen || !dialog) {
+      anchorRef.current = null;
+      return;
+    }
+    const anchor = anchorRef.current ?? getMousePosition();
+    anchorRef.current = anchor;
+    const { width, height } = dialog.getBoundingClientRect();
+    setPosition({
+      left: clampToViewport(anchor.x - width, width, window.innerWidth),
+      top: clampToViewport(anchor.y - height, height, window.innerHeight)
+    });
+  }, [dialogOpen, showAlert, hasSelectedAssets]);
 
   const handleBackdropClick = useCallback(
     (event: React.MouseEvent) => {
@@ -199,17 +227,25 @@ const AssetCreateFolderConfirmation: React.FC = () => {
     >
       <Surface
         className="asset-create-folder-dialog"
+        ref={dialogRef}
         elevation={3}
+        style={{
+          left: `${position?.left ?? 0}px`,
+          top: `${position?.top ?? 0}px`,
+          // Placement happens before the browser paints, so nothing is ever
+          // seen at the fallback origin.
+          visibility: position ? "visible" : "hidden"
+        }}
         sx={{
           position: "absolute",
-          left: `${safeLeft}px`,
-          top: `${dialogPosition.y - 200}px`,
           width: 400,
           maxWidth: "calc(100vw - 32px)",
+          maxHeight: `calc(100vh - ${VIEWPORT_MARGIN * 2}px)`,
           backgroundColor: `rgba(${theme.vars.palette.background.defaultChannel} / 0.9)`,
           backdropFilter: "blur(10px)",
           borderRadius: BORDER_RADIUS.sm,
-          overflow: "hidden"
+          overflowX: "hidden",
+          overflowY: "auto"
         }}
       >
         <Text
@@ -232,7 +268,7 @@ const AssetCreateFolderConfirmation: React.FC = () => {
             <AlertBanner
               className="asset-create-folder-error-alert"
               severity="error"
-              onClose={handleClose}
+              onClose={dismissAlert}
             >
               {showAlert}
             </AlertBanner>

--- a/web/src/components/assets/__tests__/AssetCreateFolderConfirmation.test.tsx
+++ b/web/src/components/assets/__tests__/AssetCreateFolderConfirmation.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * The dialog is anchored to the cursor, and the cursor is on the New Folder
+ * button — which sits near the top of the Library panel. A fixed upward offset
+ * therefore put the name field above the viewport, leaving only Cancel and
+ * Create Folder on screen (#5004).
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../__mocks__/themeMock";
+import { installGlobal } from "../../../test-utils/doubles";
+import AssetCreateFolderConfirmation from "../AssetCreateFolderConfirmation";
+
+const mockGridState = {
+  createFolderDialogOpen: true,
+  setCreateFolderDialogOpen: jest.fn(),
+  selectedAssetIds: [] as string[],
+  currentFolder: null,
+  setSelectedAssetIds: jest.fn(),
+  setSelectedAssets: jest.fn()
+};
+
+const mockAssetState = {
+  createFolder: jest.fn(),
+  update: jest.fn()
+};
+
+jest.mock("../../../stores/AssetGridStore", () => ({
+  useAssetGridStore: <R,>(select: (state: typeof mockGridState) => R): R =>
+    select(mockGridState)
+}));
+
+jest.mock("../../../stores/AssetStore", () => ({
+  useAssetStore: <R,>(select: (state: typeof mockAssetState) => R): R =>
+    select(mockAssetState)
+}));
+
+jest.mock("../../../stores/NotificationStore", () => ({
+  useNotificationStore: <R,>(
+    select: (state: { addNotification: () => void }) => R
+  ): R => select({ addNotification: jest.fn() })
+}));
+
+jest.mock("../../../serverState/useAssets", () => ({
+  __esModule: true,
+  default: () => ({
+    refetchAssetsAndFolders: jest.fn(),
+    folderFilesFiltered: []
+  })
+}));
+
+const DIALOG_WIDTH = 400;
+const DIALOG_HEIGHT = 220;
+const VIEWPORT_WIDTH = 1200;
+const VIEWPORT_HEIGHT = 800;
+
+const openAt = (clientX: number, clientY: number): HTMLElement => {
+  document.dispatchEvent(new MouseEvent("mousemove", { clientX, clientY }));
+
+  // jsdom lays nothing out, so the measurement the placement reads has to be
+  // supplied — reading the real height is the whole point of the fix.
+  jest.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+    width: DIALOG_WIDTH,
+    height: DIALOG_HEIGHT,
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: DIALOG_WIDTH,
+    bottom: DIALOG_HEIGHT,
+    toJSON: () => ({})
+  });
+
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <AssetCreateFolderConfirmation />
+    </ThemeProvider>
+  );
+
+  const dialog = document.querySelector(".asset-create-folder-dialog");
+  if (!(dialog instanceof HTMLElement)) {
+    throw new Error("expected the create-folder dialog to render");
+  }
+  return dialog;
+};
+
+describe("AssetCreateFolderConfirmation placement", () => {
+  beforeEach(() => {
+    installGlobal("innerWidth", VIEWPORT_WIDTH);
+    installGlobal("innerHeight", VIEWPORT_HEIGHT);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("keeps the name field on screen when opened near the top of the window", () => {
+    const dialog = openAt(990, 100);
+
+    expect(parseFloat(dialog.style.top)).toBeGreaterThanOrEqual(0);
+    expect(dialog.style.visibility).toBe("visible");
+    expect(screen.getByDisplayValue("New Folder")).toBeVisible();
+  });
+
+  it("stays on screen when the cursor was never tracked", () => {
+    const dialog = openAt(0, 0);
+
+    expect(parseFloat(dialog.style.top)).toBeGreaterThanOrEqual(0);
+    expect(parseFloat(dialog.style.left)).toBeGreaterThanOrEqual(0);
+  });
+
+  it("keeps the dialog inside the bottom-right corner", () => {
+    const dialog = openAt(1190, 795);
+
+    expect(parseFloat(dialog.style.left) + DIALOG_WIDTH).toBeLessThanOrEqual(
+      VIEWPORT_WIDTH
+    );
+    expect(parseFloat(dialog.style.top) + DIALOG_HEIGHT).toBeLessThanOrEqual(
+      VIEWPORT_HEIGHT
+    );
+  });
+
+  it("sits above and left of the cursor when there is room", () => {
+    const dialog = openAt(900, 600);
+
+    expect(parseFloat(dialog.style.top)).toBe(600 - DIALOG_HEIGHT);
+    expect(parseFloat(dialog.style.left)).toBe(900 - DIALOG_WIDTH);
+  });
+});


### PR DESCRIPTION
The New Folder dialog was placed at the cursor minus a hardcoded 200px, with an assumed 400px width. Opening it from the Library toolbar puts the cursor near the top of the window, so the title and the name field landed above the viewport and only Cancel and Create Folder stayed visible.

Placement now measures the dialog and clamps both axes into the viewport, so a short window, a cursor at either edge, and an untracked cursor keep the whole dialog on screen. The error banner's close button now dismisses the banner instead of the dialog.

Four tests cover the clamping; the top-of-window case fails on the old code.

Note: typecheck/lint/tests could not be run in the agent environment (npm not permitted) — CI is the first run.

Fixes #5004

Generated with [Claude Code](https://claude.ai/code)