### PR TITLE
docs: correct command menu shortcut to Ctrl+K

### DIFF
--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -17,7 +17,7 @@ Shortcuts, hidden features, and workflow efficiency tips.
 | `Ctrl/⌘ + S` | Save |
 | `F` | Fit view |
 | `Ctrl/⌘ + Z` | Undo |
-| `Alt/⌘ + K` | Command menu |
+| `Ctrl/⌘ + K` | Command menu |
 
 ---
 
@@ -126,7 +126,7 @@ Shortcuts, hidden features, and workflow efficiency tips.
 
 ### Command Menu
 
-Press `Alt/⌘ + K` to open the command menu – the fastest way to:
+Press `Ctrl/⌘ + K` to open the command menu – the fastest way to:
 - Open any workflow by name
 - Switch views and panels
 - Access settings
@@ -230,7 +230,7 @@ Press `Alt/⌘ + K` to open the command menu – the fastest way to:
 | `Ctrl + D` | `⌘ + D` | Duplicate |
 | `F` | `F` | Fit to screen |
 | `A` | `A` | Align nodes |
-| `Alt + K` | `⌘ + K` | Command menu |
+| `Ctrl + K` | `⌘ + K` | Command menu |
 | `i` | `i` | Toggle Inspector |
 
 ---


### PR DESCRIPTION
Fixes #5002.

`docs/tips-and-tricks.md` listed `Alt + K` as the Windows/Linux shortcut for the command menu in three places. The editor binds `Meta+K` on Mac and `Control+K` everywhere else:

```ts
// web/src/components/node_editor/NodeEditor.tsx:127
const commandMenuCombo = isMac() ? ["meta", "k"] : ["control", "k"];
```

`Alt+K` was never bound, so it had no effect. All three mentions now read `Ctrl/⌘ + K`, matching `docs/user-interface.md` and `docs/troubleshooting.md`, which were already correct.

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AASduyfECPbB9Fpps2oFNE

---
_Generated by [Claude Code](https://claude.ai/code/session_01AASduyfECPbB9Fpps2oFNE)_