### PR TITLE
fix(editor): add Snap to Grid toggle to the View menu

### DIFF
--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -51,7 +51,7 @@ Shortcuts, hidden features, and workflow efficiency tips.
 | **Fit to screen** | Press `F` |
 | **Focus on selection** | Select nodes, then press `F` |
 | **Reset zoom** | `Ctrl/⌘ + 0` |
-| **Snap to grid** | Enable in View menu |
+| **Snap to grid** | Enable in the View menu, the command menu, or Settings |
 
 ---
 

--- a/docs/workflow-editor.md
+++ b/docs/workflow-editor.md
@@ -45,7 +45,9 @@ Your infinite workspace.
 | Fit everything | `F` |
 | Reset zoom (to 50%) | `Ctrl/⌘ + 0` |
 
-**The grid** helps align nodes. Turn on **Snap to Grid** in View menu.
+**The grid** helps align nodes. Turn on **Snap to Grid** in the View menu of the
+desktop app, from the command menu (`Ctrl/⌘ + K`), or in Settings → General.
+The grid size is the **Grid Snap Precision** setting.
 
 ---
 

--- a/electron/src/__tests__/menu.test.ts
+++ b/electron/src/__tests__/menu.test.ts
@@ -111,6 +111,69 @@ describe('buildMenu', () => {
     expect(setApplicationMenuMock).toHaveBeenCalledWith({ template });
   });
 
+  it('offers Snap to Grid in View and mirrors the renderer state onto its checkbox', async () => {
+    mockIpcChannels();
+
+    const sendMock = jest.fn();
+    const buildFromTemplateMock = jest
+      .fn()
+      .mockImplementation((template) => ({ template }));
+
+    jest.doMock('electron', () => ({
+      app: {
+        isPackaged: false,
+        getPath: jest.fn().mockReturnValue('/mock/userData'),
+      },
+      Menu: {
+        buildFromTemplate: buildFromTemplateMock,
+        setApplicationMenu: jest.fn(),
+      },
+      shell: { openExternal: jest.fn() },
+    }));
+
+    jest.doMock('../state', () => ({
+      getMainWindow: jest.fn().mockReturnValue({
+        webContents: { send: sendMock },
+      }),
+    }));
+
+    jest.doMock('../window', () => ({
+      createLogViewerWindow: jest.fn(),
+      openSettingsInMainWindow: jest.fn(),
+    }));
+
+    const menuModule = await import('../menu');
+    menuModule.buildMenu();
+
+    const findSnapItem = (call: number) => {
+      const template = buildFromTemplateMock.mock.calls[call][0] as Array<
+        Record<string, any>
+      >;
+      const viewMenu = template.find((item) => item.label === 'View');
+      return viewMenu?.submenu?.find(
+        (item: { label?: string }) => item.label === 'Snap to Grid'
+      );
+    };
+
+    const snapItem = findSnapItem(0);
+    expect(snapItem?.type).toBe('checkbox');
+    expect(snapItem?.checked).toBe(false);
+
+    snapItem?.click();
+    expect(sendMock).toHaveBeenCalledWith('menu-event', {
+      type: 'toggleSnapToGrid',
+    });
+
+    // The renderer owns the setting; pushing it back re-checks the item.
+    menuModule.setMenuSnapToGrid(true);
+    expect(buildFromTemplateMock).toHaveBeenCalledTimes(2);
+    expect(findSnapItem(1)?.checked).toBe(true);
+
+    // An unchanged value does not rebuild the menu.
+    menuModule.setMenuSnapToGrid(true);
+    expect(buildFromTemplateMock).toHaveBeenCalledTimes(2);
+  });
+
   it('builds a Vaults submenu, checks the active vault, and switches on click', async () => {
     mockIpcChannels();
 

--- a/electron/src/__tests__/preload.contract.test.ts
+++ b/electron/src/__tests__/preload.contract.test.ts
@@ -36,6 +36,7 @@ const IpcChannels = {
   WINDOW_MINIMIZE: "window-minimize",
   WINDOW_MAXIMIZE: "window-maximize",
   MENU_EVENT: "menu-event",
+  MENU_SET_SNAP_TO_GRID: "menu-set-snap-to-grid",
   ON_CREATE_WORKFLOW: "on-create-workflow",
   ON_UPDATE_WORKFLOW: "on-update-workflow",
   ON_DELETE_WORKFLOW: "on-delete-workflow",

--- a/electron/src/ipc.ts
+++ b/electron/src/ipc.ts
@@ -75,7 +75,7 @@ import {
   openPathInExplorer,
   openSystemDirectory,
 } from "./fileExplorer";
-import { isNonEmptyString, isString } from "./typePredicates";
+import { isBoolean, isNonEmptyString, isString } from "./typePredicates";
 
 const nodePackInstallRequestSchema = z.object({ spec: z.string() }).strict();
 const nodePackUninstallRequestSchema = z.object({ name: z.string() }).strict();
@@ -776,7 +776,7 @@ export function initializeIpcHandlers(): void {
   });
 
   ipcMain.on(IpcChannels.MENU_SET_SNAP_TO_GRID, (_event, enabled: unknown) => {
-    if (typeof enabled !== "boolean") {
+    if (!isBoolean(enabled)) {
       return;
     }
     try {

--- a/electron/src/ipc.ts
+++ b/electron/src/ipc.ts
@@ -42,6 +42,7 @@ import {
   getVaultList,
 } from "./vaults";
 import { applyVaultSwitch } from "./vaultSwitch";
+import { setMenuSnapToGrid } from "./menu";
 import { installMcpBundle } from "./mcpBundle";
 import { IpcRequest } from "./types.d";
 import { registerWorkflowShortcut, setupWorkflowShortcuts } from "./shortcuts";
@@ -771,6 +772,17 @@ export function initializeIpcHandlers(): void {
       }
     } catch (error) {
       logMessage(`Error in window maximize: ${error}`, "error");
+    }
+  });
+
+  ipcMain.on(IpcChannels.MENU_SET_SNAP_TO_GRID, (_event, enabled: unknown) => {
+    if (typeof enabled !== "boolean") {
+      return;
+    }
+    try {
+      setMenuSnapToGrid(enabled);
+    } catch (error) {
+      logMessage(`Error syncing snap-to-grid menu state: ${error}`, "error");
     }
   });
 

--- a/electron/src/menu.ts
+++ b/electron/src/menu.ts
@@ -60,6 +60,19 @@ const buildVaultSubmenu = (): MenuItemConstructorOptions[] => {
   ];
 };
 
+// The renderer owns the "Snap to Grid" setting (it is persisted with the rest
+// of the editor settings). The menu keeps a mirror so its checkbox shows the
+// real state; `setMenuSnapToGrid` is how the renderer pushes changes back.
+let snapToGridChecked = false;
+
+const setMenuSnapToGrid = (enabled: boolean) => {
+  if (snapToGridChecked === enabled) {
+    return;
+  }
+  snapToGridChecked = enabled;
+  buildMenu();
+};
+
 const buildMenu = () => {
   const mainWindow = getMainWindow();
   if (!mainWindow) {
@@ -269,6 +282,17 @@ const buildMenu = () => {
           },
         },
         { type: "separator" },
+        {
+          label: "Snap to Grid",
+          type: "checkbox",
+          checked: snapToGridChecked,
+          click: () => {
+            mainWindow.webContents.send(IpcChannels.MENU_EVENT, {
+              type: "toggleSnapToGrid",
+            });
+          },
+        },
+        { type: "separator" },
         { role: "togglefullscreen" },
       ],
     },
@@ -374,4 +398,4 @@ Features & Versions
   }
 }
 
-export { buildMenu };
+export { buildMenu, setMenuSnapToGrid };

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -235,6 +235,10 @@ const api = {
     menuEventUnsubscribers.delete(callback);
   },
 
+  /** Mirror the renderer's snap-to-grid setting onto the View menu checkbox. */
+  setMenuSnapToGrid: (enabled: boolean) =>
+    ipcRenderer.send(IpcChannels.MENU_SET_SNAP_TO_GRID, enabled),
+
   // ============================================================================
   // server: Server lifecycle, logs, and status
   // ============================================================================
@@ -591,6 +595,10 @@ const api = {
   menu: {
     /** Subscribe to menu events (cut, copy, paste, etc.) */
     onEvent: createEventSubscription(IpcChannels.MENU_EVENT),
+
+    /** Mirror the renderer's snap-to-grid setting onto the View menu checkbox. */
+    setSnapToGrid: (enabled: boolean) =>
+      ipcRenderer.send(IpcChannels.MENU_SET_SNAP_TO_GRID, enabled),
   },
 
   // ============================================================================

--- a/electron/src/typePredicates.ts
+++ b/electron/src/typePredicates.ts
@@ -17,6 +17,10 @@ export function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value !== "";
 }
 
+export function isBoolean(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
 /** Anything `typeof` calls an object, `null` aside — an array passes. */
 export function isObjectLike(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object";

--- a/electron/src/types.d.ts
+++ b/electron/src/types.d.ts
@@ -414,6 +414,7 @@ export interface MenuEventData {
     | "redo"
     | "close"
     | "fitView"
+    | "toggleSnapToGrid"
     | "openSettings";
 }
 
@@ -553,6 +554,7 @@ export enum IpcChannels {
   CLIPBOARD_CLEAR = "clipboard-clear",
   CLIPBOARD_AVAILABLE_FORMATS = "clipboard-available-formats",
   MENU_EVENT = "menu-event",
+  MENU_SET_SNAP_TO_GRID = "menu-set-snap-to-grid",
   ON_CREATE_WORKFLOW = "on-create-workflow",
   ON_UPDATE_WORKFLOW = "on-update-workflow",
   ON_DELETE_WORKFLOW = "on-delete-workflow",
@@ -706,6 +708,7 @@ export interface IpcRequest {
   [IpcChannels.WINDOW_CLOSE]: void;
   [IpcChannels.WINDOW_MINIMIZE]: void;
   [IpcChannels.WINDOW_MAXIMIZE]: void;
+  [IpcChannels.MENU_SET_SNAP_TO_GRID]: boolean;
   [IpcChannels.CLIPBOARD_WRITE_TEXT]: { text: string; type?: ClipboardType };
   [IpcChannels.CLIPBOARD_READ_TEXT]: ClipboardType | undefined;
   [IpcChannels.CLIPBOARD_WRITE_IMAGE]: {
@@ -825,6 +828,7 @@ export interface IpcResponse {
   [IpcChannels.WINDOW_CLOSE]: void;
   [IpcChannels.WINDOW_MINIMIZE]: void;
   [IpcChannels.WINDOW_MAXIMIZE]: void;
+  [IpcChannels.MENU_SET_SNAP_TO_GRID]: void;
   [IpcChannels.CLIPBOARD_WRITE_TEXT]: void;
   [IpcChannels.CLIPBOARD_READ_TEXT]: string;
   [IpcChannels.CLIPBOARD_WRITE_IMAGE]: void;

--- a/web/src/components/menus/CommandMenu.tsx
+++ b/web/src/components/menus/CommandMenu.tsx
@@ -33,6 +33,7 @@ import { useNodes } from "../../contexts/NodeContext";
 import { create } from "zustand";
 import { shallow } from "zustand/shallow";
 import { useMiniMapStore } from "../../stores/MiniMapStore";
+import { useSettingsStore } from "../../stores/SettingsStore";
 import { useCopyPaste } from "../../hooks/handlers/useCopyPaste";
 import { useDuplicateNodes } from "../../hooks/useDuplicate";
 import { useSurroundWithGroup } from "../../hooks/nodes/useSurroundWithGroup";
@@ -91,6 +92,8 @@ import FitScreenRoundedIcon from "@mui/icons-material/FitScreenRounded";
 import ZoomInRoundedIcon from "@mui/icons-material/ZoomInRounded";
 import ZoomOutRoundedIcon from "@mui/icons-material/ZoomOutRounded";
 import RestartAltRoundedIcon from "@mui/icons-material/RestartAltRounded";
+import GridOnRoundedIcon from "@mui/icons-material/GridOnRounded";
+import GridOffRoundedIcon from "@mui/icons-material/GridOffRounded";
 
 // Icons — Panels
 import ChatRoundedIcon from "@mui/icons-material/ChatRounded";
@@ -553,6 +556,8 @@ const ViewCommands = memo(function ViewCommands() {
   const toggleVisible = useMiniMapStore((state) => state.toggleVisible);
   const handleFitView = useFitView();
   const reactFlow = useReactFlow();
+  const snapToGrid = useSettingsStore((state) => state.settings.snapToGrid);
+  const setSnapToGrid = useSettingsStore((state) => state.setSnapToGrid);
 
   return (
     <Command.Group heading="View">
@@ -561,6 +566,12 @@ const ViewCommands = memo(function ViewCommands() {
       >
         {visible ? <MapOutlinedIcon /> : <MapRoundedIcon />}
         {visible ? "Hide Mini Map" : "Show Mini Map"}
+      </Command.Item>
+      <Command.Item
+        onSelect={() => executeAndClose(() => setSnapToGrid(!snapToGrid))}
+      >
+        {snapToGrid ? <GridOffRoundedIcon /> : <GridOnRoundedIcon />}
+        {snapToGrid ? "Turn Off Snap to Grid" : "Snap to Grid"}
       </Command.Item>
       <Command.Item
         onSelect={() => executeAndClose(() => handleFitView({ padding: 0.5 }))}

--- a/web/src/components/menus/SettingsMenu.tsx
+++ b/web/src/components/menus/SettingsMenu.tsx
@@ -200,6 +200,7 @@ function SettingsPage() {
 
   const settingsTab = SECTION_TO_TAB[section];
 
+  const setSnapToGrid = useSettingsStore((state) => state.setSnapToGrid);
   const setGridSnap = useSettingsStore((state) => state.setGridSnap);
   const setConnectionSnap = useSettingsStore(
     (state) => state.setConnectionSnap
@@ -382,6 +383,13 @@ function SettingsPage() {
       setSoundNotifications(checked);
     },
     [setSoundNotifications]
+  );
+
+  const handleSnapToGridChange = useCallback(
+    (checked: boolean) => {
+      setSnapToGrid(checked);
+    },
+    [setSnapToGrid]
   );
 
   const handleGridSnapChange = useCallback(
@@ -910,6 +918,18 @@ function SettingsPage() {
 
                       <SearchItem
                         search={generalSearch}
+                        keywords="canvas navigation grid snap align nodes"
+                      >
+                        <LabeledSwitch
+                          label="Snap to Grid"
+                          checked={!!settings.snapToGrid}
+                          onChange={handleSnapToGridChange}
+                          description="Align nodes to the canvas grid while dragging. Also in the View menu of the desktop app."
+                        />
+                      </SearchItem>
+
+                      <SearchItem
+                        search={generalSearch}
                         keywords="canvas navigation grid snap precision"
                       >
                         <TextInput
@@ -920,11 +940,13 @@ function SettingsPage() {
                           label="Grid Snap Precision"
                           value={settings.gridSnap}
                           onChange={handleGridSnapChange}
+                          disabled={!settings.snapToGrid}
                           variant="standard"
                           size="small"
                         />
                         <Text className="description">
-                          Snap precision for moving nodes on the canvas.
+                          Grid size used when Snap to Grid is on. The canvas grid
+                          is drawn every 25 units.
                         </Text>
                       </SearchItem>
 

--- a/web/src/components/node/ReactFlowWrapper.tsx
+++ b/web/src/components/node/ReactFlowWrapper.tsx
@@ -496,6 +496,7 @@ const ReactFlowWrapper = ({
   const edgeTypes = EDGE_TYPES;
 
   const {
+    snapToGrid,
     gridSnap,
     connectionSnap,
     panControls,
@@ -504,6 +505,7 @@ const ReactFlowWrapper = ({
     instantUpdate
   } = useSettingsStore(
     useShallow((state) => ({
+      snapToGrid: state.settings.snapToGrid,
       gridSnap: state.settings.gridSnap,
       connectionSnap: state.settings.connectionSnap,
       panControls: state.settings.panControls,
@@ -937,7 +939,7 @@ const ReactFlowWrapper = ({
         edges={processedEdges}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
-        snapToGrid={true}
+        snapToGrid={snapToGrid}
         snapGrid={snapGrid}
         defaultViewport={storedViewport || undefined}
         onMoveEnd={handleMoveEnd}

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -536,18 +536,35 @@ if (!rootElement) throw new Error("Root element #root not found");
 const root = ReactDOM.createRoot(rootElement);
 
 /**
- * Routes Electron menu/tray "Settings" actions to the in-app settings tab.
- * The desktop shell sends an `openSettings` menu event (instead of opening a
- * separate window); the tab opens and the router singleton focuses the
- * workspace, which works from any route.
+ * Routes Electron menu/tray actions into the app.
+ *
+ * "Settings" opens the in-app settings tab (the desktop shell sends an
+ * `openSettings` menu event instead of opening a separate window); the tab
+ * opens and the router singleton focuses the workspace, which works from any
+ * route. "Snap to Grid" toggles the editor setting, and the setting is mirrored
+ * back so the View menu checkbox matches whichever surface changed it.
  */
 const MenuNavigationBridge = () => {
-  const handleMenuEvent = useCallback((data: MenuEventData) => {
-    if (data.type === "openSettings") {
-      openSettingsTab();
-    }
-  }, []);
+  const snapToGrid = useSettingsStore((state) => state.settings.snapToGrid);
+  const setSnapToGrid = useSettingsStore((state) => state.setSnapToGrid);
+
+  const handleMenuEvent = useCallback(
+    (data: MenuEventData) => {
+      if (data.type === "openSettings") {
+        openSettingsTab();
+      }
+      if (data.type === "toggleSnapToGrid") {
+        setSnapToGrid(!useSettingsStore.getState().settings.snapToGrid);
+      }
+    },
+    [setSnapToGrid]
+  );
   useMenuHandler(handleMenuEvent);
+
+  useEffect(() => {
+    window.api?.setMenuSnapToGrid?.(snapToGrid);
+  }, [snapToGrid]);
+
   return null;
 };
 

--- a/web/src/stores/SettingsStore.ts
+++ b/web/src/stores/SettingsStore.ts
@@ -23,6 +23,9 @@ export const defaultAutosaveSettings: AutosaveSettings = {
 };
 
 export interface Settings {
+  /** Snap nodes to the canvas grid while dragging. Toggled from the View menu. */
+  snapToGrid: boolean;
+  /** Grid size in canvas units used when {@link snapToGrid} is on. */
   gridSnap: number;
   connectionSnap: number;
   panControls: string;
@@ -70,6 +73,7 @@ export interface Settings {
 
 interface SettingsStore {
   settings: Settings;
+  setSnapToGrid: (value: boolean) => void;
   setGridSnap: (value: number) => void;
   setConnectionSnap: (value: number) => void;
   setPanControls: (value: string) => void;
@@ -91,7 +95,10 @@ interface SettingsStore {
 }
 
 export const defaultSettings: Settings = {
-  gridSnap: 1,
+  snapToGrid: false,
+  // Matches the canvas background grid gap, so a snapped node lands on a
+  // visible grid crossing.
+  gridSnap: 25,
   connectionSnap: 20,
   // On Mac the trackpad already pans (two-finger scroll) and zooms (pinch), so
   // left-drag is free to rubber-band select — the Figma/Sketch convention Mac
@@ -120,6 +127,11 @@ export const useSettingsStore = create<SettingsStore>()(
   persist(
     (set) => ({
       settings: { ...defaultSettings },
+      setSnapToGrid: (value: boolean) =>
+        set((state) => ({
+          settings: { ...state.settings, snapToGrid: value }
+        })),
+
       setGridSnap: (value: number) =>
         set((state) => ({
           settings: {
@@ -256,11 +268,21 @@ export const useSettingsStore = create<SettingsStore>()(
       // Merge persisted state with defaults so newly-added settings get their defaults.
       merge: (persistedState, currentState) => {
         const persisted = persistedState as Partial<SettingsStore> | undefined;
+        const persistedSettings = persisted?.settings;
+        // Before the "Snap to Grid" toggle existed, snapping was always on and
+        // the grid defaulted to 1 — a value that snaps to nothing. Installs
+        // carrying that leftover get the new grid size, not a toggle that does
+        // nothing when switched on.
+        const legacyGridSnap =
+          persistedSettings !== undefined &&
+          persistedSettings.snapToGrid === undefined &&
+          persistedSettings.gridSnap === 1;
         return {
           ...currentState,
           settings: {
             ...defaultSettings,
-            ...persisted?.settings,
+            ...persistedSettings,
+            ...(legacyGridSnap ? { gridSnap: defaultSettings.gridSnap } : {}),
             // Deep merge autosave settings to ensure new defaults are included
             autosave: {
               ...defaultAutosaveSettings,

--- a/web/src/stores/SettingsStore.ts
+++ b/web/src/stores/SettingsStore.ts
@@ -277,19 +277,19 @@ export const useSettingsStore = create<SettingsStore>()(
           persistedSettings !== undefined &&
           persistedSettings.snapToGrid === undefined &&
           persistedSettings.gridSnap === 1;
-        return {
-          ...currentState,
-          settings: {
-            ...defaultSettings,
-            ...persistedSettings,
-            ...(legacyGridSnap ? { gridSnap: defaultSettings.gridSnap } : {}),
-            // Deep merge autosave settings to ensure new defaults are included
-            autosave: {
-              ...defaultAutosaveSettings,
-              ...persisted?.settings?.autosave
-            }
+        const settings: Settings = {
+          ...defaultSettings,
+          ...persistedSettings,
+          // Deep merge autosave settings to ensure new defaults are included
+          autosave: {
+            ...defaultAutosaveSettings,
+            ...persistedSettings?.autosave
           }
         };
+        if (legacyGridSnap) {
+          settings.gridSnap = defaultSettings.gridSnap;
+        }
+        return { ...currentState, settings };
       }
     }
   )

--- a/web/src/stores/__tests__/SettingsStore.test.ts
+++ b/web/src/stores/__tests__/SettingsStore.test.ts
@@ -15,7 +15,8 @@ describe("SettingsStore", () => {
   describe("Initial State", () => {
     test("has correct default settings", () => {
       const settings = useSettingsStore.getState().settings;
-      expect(settings.gridSnap).toBe(1);
+      expect(settings.snapToGrid).toBe(false);
+      expect(settings.gridSnap).toBe(25);
       expect(settings.connectionSnap).toBe(20);
       expect(settings.panControls).toBe("LMB");
       expect(settings.selectionMode).toBe("partial");
@@ -38,9 +39,18 @@ describe("SettingsStore", () => {
       expect(useSettingsStore.getState().settings.gridSnap).toBe(5);
     });
 
-    test("setGridSnap defaults to 1 when falsy value passed", () => {
+    test("setGridSnap falls back to the default when falsy value passed", () => {
       useSettingsStore.getState().setGridSnap(0);
-      expect(useSettingsStore.getState().settings.gridSnap).toBe(1);
+      expect(useSettingsStore.getState().settings.gridSnap).toBe(
+        defaultSettings.gridSnap
+      );
+    });
+
+    test("setSnapToGrid toggles snapping", () => {
+      useSettingsStore.getState().setSnapToGrid(true);
+      expect(useSettingsStore.getState().settings.snapToGrid).toBe(true);
+      useSettingsStore.getState().setSnapToGrid(false);
+      expect(useSettingsStore.getState().settings.snapToGrid).toBe(false);
     });
 
     test("setConnectionSnap updates value", () => {
@@ -303,7 +313,37 @@ describe("SettingsStore", () => {
       expect(defaultSettings.showWelcomeOnStartup).toBeDefined();
       expect(defaultSettings.soundNotifications).toBeDefined();
       expect(defaultSettings.instantUpdate).toBeDefined();
+      expect(defaultSettings.snapToGrid).toBeDefined();
       expect(defaultSettings.autosave).toBeDefined();
+    });
+
+    test("legacy persisted gridSnap of 1 migrates to the new grid size", async () => {
+      localStorage.setItem(
+        "settings-storage",
+        JSON.stringify({ state: { settings: { gridSnap: 1 } }, version: 0 })
+      );
+      let migrated = 0;
+      await jest.isolateModulesAsync(async () => {
+        const fresh = await import("../SettingsStore");
+        migrated = fresh.useSettingsStore.getState().settings.gridSnap;
+      });
+      expect(migrated).toBe(defaultSettings.gridSnap);
+    });
+
+    test("a persisted gridSnap chosen after the toggle shipped is kept", async () => {
+      localStorage.setItem(
+        "settings-storage",
+        JSON.stringify({
+          state: { settings: { gridSnap: 1, snapToGrid: true } },
+          version: 0
+        })
+      );
+      let kept = 0;
+      await jest.isolateModulesAsync(async () => {
+        const fresh = await import("../SettingsStore");
+        kept = fresh.useSettingsStore.getState().settings.gridSnap;
+      });
+      expect(kept).toBe(1);
     });
 
     test("defaultAutosaveSettings has correct structure", () => {

--- a/web/src/window.d.ts
+++ b/web/src/window.d.ts
@@ -122,6 +122,7 @@ export type MenuEventType =
   | "resetZoom"
   | "zoomIn"
   | "zoomOut"
+  | "toggleSnapToGrid"
   | "prevTab"
   | "nextTab"
   | "switchToTab"
@@ -226,6 +227,8 @@ declare global {
       ) => Promise<FileExplorerResult | void>;
       onMenuEvent: (callback: (data: MenuEventData) => void) => void;
       unregisterMenuEvent: (callback: (data: MenuEventData) => void) => void;
+      /** Mirror the snap-to-grid setting onto the desktop View menu checkbox. */
+      setMenuSnapToGrid?: (enabled: boolean) => void;
       onCreateWorkflow: (workflow: Workflow) => Promise<void>;
       onUpdateWorkflow: (workflow: Workflow) => Promise<void>;
       onDeleteWorkflow: (workflow: Workflow) => Promise<void>;


### PR DESCRIPTION
Fixes #5001.

## The bug

`ReactFlowWrapper` passed `snapToGrid={true}` unconditionally with a default `gridSnap` of `1`, so snapping was permanently on and snapped to nothing. No toggle existed on any surface, while `docs/workflow-editor.md` and `docs/tips-and-tricks.md` both told users to enable it in the View menu.

## The change

- **`SettingsStore`** — new persisted `snapToGrid` (default off) with `setSnapToGrid`. `gridSnap` default moves from `1` to `25`, matching the canvas background grid gap so a snapped node lands on a visible crossing. Installs carrying the old `1` (a leftover of the always-on era, not a choice) migrate once in `merge`; a `gridSnap` persisted alongside a `snapToGrid` key is kept as-is.
- **`ReactFlowWrapper`** — reads the setting instead of hardcoding `true`.
- **Electron View menu** — a `Snap to Grid` checkbox that sends a `toggleSnapToGrid` menu event. The renderer owns the setting, so it mirrors the value back over a new `menu-set-snap-to-grid` IPC channel and the checkbox tracks changes made from any surface.
- **Command menu** (`Ctrl/⌘+K`, View group) and **Settings → General** — same toggle. "Grid Snap Precision" is disabled while snapping is off, and its description now says what the number does.
- **Docs** — both lines corrected to name all three surfaces.

## Testing

- `web/src/stores/__tests__/SettingsStore.test.ts` — default and toggle assertions, plus two migration cases. Confirmed the migration test goes red when the migration condition is broken, so it is not passing by accident.
- `electron/src/__tests__/menu.test.ts` — the View submenu carries the checkbox, clicking it sends `toggleSnapToGrid`, `setMenuSnapToGrid` re-checks it, and an unchanged value does not rebuild the menu.
- `npm run typecheck` and `npm run lint` pass at the repo root. The full `npm run test` sweep was not run in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZBJFo5gCvjHZ46RHn2QE8

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZBJFo5gCvjHZ46RHn2QE8)_