### PR TITLE
fix(desktop): preview a dropped image that lives outside home

### DIFF
--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -72,7 +72,11 @@ symlinks that leave the roots are refused too.
 
 - **Keep the roots narrow.** Widen `NODETOOL_LOCAL_FILE_ROOTS` only to the
   directories that actually hold media you preview — an external volume, a
-  scratch dir — never to `/`.
+  scratch dir — never to `/`. The single entry `*` lifts the containment check
+  (the denylist still applies); it belongs to the desktop app, which runs the
+  server as one user's own process on loopback and lets them drag a file onto
+  the canvas from anywhere. Electron sets it, and a launching environment that
+  configured its own roots keeps them.
 - **Set `NODETOOL_ENV=production`** on any deployment more than one person can
   reach, which disables both surfaces outright.
 

--- a/electron/src/__tests__/config.test.ts
+++ b/electron/src/__tests__/config.test.ts
@@ -3,6 +3,7 @@ import {
   getPythonPath,
   getUVPath,
   getProcessEnv,
+  getLocalFileRootsEnv,
   _resetCondaEnvCache,
   srcPath,
   PID_FILE_PATH,
@@ -394,6 +395,25 @@ describe('Config', () => {
       // UV_CACHE_DIR should be inside userData directory
       const userDataPath = app.getPath('userData').replace(/\\/g, '/');
       expect((result.UV_CACHE_DIR ?? '').replace(/\\/g, '/')).toContain(userDataPath);
+    });
+  });
+
+  describe('getLocalFileRootsEnv', () => {
+    // The server's own default is the home directory. That refused the preview
+    // of an image dragged in from a folder outside home while the runner read
+    // it happily — nodetool-ai/nodetool#4999.
+    it('lifts the containment check for the desktop app', () => {
+      expect(getLocalFileRootsEnv({})).toBe('*');
+    });
+
+    it('keeps roots the launching environment configured', () => {
+      expect(
+        getLocalFileRootsEnv({ NODETOOL_LOCAL_FILE_ROOTS: '/srv/media' })
+      ).toBe('/srv/media');
+    });
+
+    it('ignores an empty setting', () => {
+      expect(getLocalFileRootsEnv({ NODETOOL_LOCAL_FILE_ROOTS: '' })).toBe('*');
     });
   });
 });

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -378,6 +378,24 @@ const resolveNpmInvocation = (): NpmInvocation | null => {
 };
 
 /**
+ * The `NODETOOL_LOCAL_FILE_ROOTS` the backend runs with.
+ *
+ * The server defaults to the user's home directory, which is the right
+ * allowlist for a self-hosted deployment several people can reach. The desktop
+ * app is the opposite case: it spawns the server as this user's own process on
+ * loopback, and the user drags files onto the canvas from wherever they keep
+ * them. Restricting only the *preview* left a dropped image from a folder
+ * outside home running fine (the runner reads any absolute `file://` path) but
+ * showing a broken image — nodetool-ai/nodetool#4999. `*` lifts the containment
+ * check; the server's denylist for `.ssh`, `.aws` and friends still applies.
+ *
+ * A launching environment that set its own roots keeps them.
+ */
+const getLocalFileRootsEnv = (
+  env: Record<string, string | undefined> = process.env
+): string => env["NODETOOL_LOCAL_FILE_ROOTS"] || "*";
+
+/**
  * Resets the cached conda env path. Intended for use in tests only so that
  * each test case starts with a clean slate.
  */
@@ -391,6 +409,7 @@ export {
   getPythonPath,
   getUVPath,
   getProcessEnv,
+  getLocalFileRootsEnv,
   resolveNpmInvocation,
   getSystemDataPath,
   getDefaultAssetsPath,

--- a/electron/src/server.ts
+++ b/electron/src/server.ts
@@ -4,6 +4,7 @@ import {
   getOptionalNodeModulesPath,
   getPythonPath,
   getProcessEnv,
+  getLocalFileRootsEnv,
   PID_FILE_PATH,
   webPath,
 } from "./config";
@@ -319,6 +320,8 @@ async function startServer(): Promise<void> {
     // surface where they are the point. Set `NODETOOL_NODE_PROFILE=cloud` in
     // the launching environment to opt into the curated cloud catalog.
     NODETOOL_NODE_PROFILE: getProcessEnv()["NODETOOL_NODE_PROFILE"] ?? "full",
+    // Preview any file the user drags onto the canvas, wherever it lives.
+    NODETOOL_LOCAL_FILE_ROOTS: getLocalFileRootsEnv(),
     NODE_OPTIONS: nodeOptionsParts.filter(Boolean).join(" "),
     NODE_PATH: backendNodePath,
     NODETOOL_OPTIONAL_NODE_MODULES: optionalNodeModules,

--- a/packages/websocket/src/lib/local-file-access.ts
+++ b/packages/websocket/src/lib/local-file-access.ts
@@ -14,6 +14,12 @@
  * (platform path-delimited) replaces that default, which is how a desktop user
  * previews media off an external volume.
  *
+ * The single entry `*` lifts the containment check entirely. That is for the
+ * desktop app, which spawns this server as the user's own process on loopback
+ * and lets them drag a file in from anywhere — the run path already reads any
+ * absolute `file://` URI, so restricting only the *preview* left a dropped file
+ * that runs fine but shows a broken image. The denylist below still applies.
+ *
  * These surfaces are already disabled when `NODETOOL_ENV=production`; this is
  * the second layer, for the dev/desktop/self-hosted deployments where the file
  * browser is live and more than one person can reach the port.
@@ -23,6 +29,14 @@ import * as path from "node:path";
 import * as os from "node:os";
 
 export const LOCAL_FILE_ROOTS_ENV = "NODETOOL_LOCAL_FILE_ROOTS";
+
+/** The `NODETOOL_LOCAL_FILE_ROOTS` entry that lifts the containment check. */
+export const UNRESTRICTED_ROOT = "*";
+
+/** Whether a resolved root list places no containment requirement on a path. */
+export function isUnrestricted(roots: string[]): boolean {
+  return roots.includes(UNRESTRICTED_ROOT);
+}
 
 /**
  * Never part of a legitimate preview or browse flow, even inside a root.
@@ -48,7 +62,11 @@ export function getLocalFileRoots(): string[] {
       .split(path.delimiter)
       .map((entry) => entry.trim())
       .filter(Boolean)
-      .map((entry) => path.resolve(expandTilde(entry)));
+      .map((entry) =>
+        entry === UNRESTRICTED_ROOT
+          ? UNRESTRICTED_ROOT
+          : path.resolve(expandTilde(entry))
+      );
     if (roots.length > 0) return roots;
   }
   return [path.resolve(os.homedir())];
@@ -115,8 +133,9 @@ export function localPathDenialMessage(reason: LocalPathDenial): string {
 /**
  * Resolve a caller-supplied path against the allowed roots.
  *
- * A relative path resolves against the first root, so the file browser's "."
- * still means "home". A leading `~` expands. Containment is checked twice:
+ * A relative path resolves against the first root (against home when the roots
+ * are unrestricted), so the file browser's "." still means "home" out of the
+ * box. A leading `~` expands. Containment is checked twice:
  * lexically on the resolved path, then again on the symlink-resolved path —
  * a link at an allowed location (`~/shortcut -> /etc`) passes the first check
  * but the stat/stream that follows would traverse it. realpath runs against
@@ -131,12 +150,15 @@ export async function resolveLocalPath(
     return { ok: false, reason: "invalid" };
   }
 
+  const unrestricted = isUnrestricted(roots);
+  const relativeBase = unrestricted ? os.homedir() : roots[0];
+
   const expanded = expandTilde(userPath);
   const resolved = path.isAbsolute(expanded)
     ? path.resolve(expanded)
-    : path.resolve(roots[0], expanded);
+    : path.resolve(relativeBase, expanded);
 
-  if (!isWithinAnyRoot(resolved, roots)) {
+  if (!unrestricted && !isWithinAnyRoot(resolved, roots)) {
     return { ok: false, reason: "outside_roots" };
   }
   if (isSensitivePath(resolved)) {
@@ -145,7 +167,7 @@ export async function resolveLocalPath(
 
   // A root can itself sit behind a symlink (macOS `/var` → `/private/var`), so
   // the post-realpath containment check compares against the real roots too.
-  const resolvedRoots = await realRoots(roots);
+  const resolvedRoots = unrestricted ? roots : await realRoots(roots);
 
   let probe = resolved;
   for (;;) {
@@ -154,7 +176,7 @@ export async function resolveLocalPath(
       // Re-anchor the not-yet-resolved tail onto the real ancestor so a link
       // in the middle of the path can't smuggle the leaf out of the roots.
       const realResolved = path.join(real, path.relative(probe, resolved));
-      if (!isWithinAnyRoot(realResolved, resolvedRoots)) {
+      if (!unrestricted && !isWithinAnyRoot(realResolved, resolvedRoots)) {
         return { ok: false, reason: "outside_roots" };
       }
       if (isSensitivePath(realResolved)) {

--- a/packages/websocket/tests/local-file-access.test.ts
+++ b/packages/websocket/tests/local-file-access.test.ts
@@ -9,7 +9,9 @@ import * as path from "node:path";
 import * as os from "node:os";
 import {
   LOCAL_FILE_ROOTS_ENV,
+  UNRESTRICTED_ROOT,
   getLocalFileRoots,
+  isUnrestricted,
   localPathDenialMessage,
   resolveLocalPath
 } from "../src/lib/local-file-access.js";
@@ -166,6 +168,63 @@ describe("resolveLocalPath", () => {
       tmpDir
     ]);
     expect(result).toEqual({ ok: false, reason: "outside_roots" });
+  });
+});
+
+/**
+ * The desktop app runs the server as the user's own process and lets them drag
+ * a file onto the canvas from anywhere. Home-only roots refused the preview of
+ * a file kept outside home while the runner read it happily —
+ * nodetool-ai/nodetool#4999.
+ */
+describe("resolveLocalPath with unrestricted roots", () => {
+  it("refuses a file outside home under the default roots", async () => {
+    const outside = path.join(tmpDir, "projects", "playingTag.png");
+    expect(await resolveLocalPath(outside, [os.homedir()])).toEqual({
+      ok: false,
+      reason: "outside_roots"
+    });
+  });
+
+  it("accepts that same file when the roots are unrestricted", async () => {
+    const outside = path.join(tmpDir, "projects", "playingTag.png");
+    expect(await resolveLocalPath(outside, [UNRESTRICTED_ROOT])).toEqual({
+      ok: true,
+      path: outside
+    });
+  });
+
+  it("still refuses sensitive home entries", async () => {
+    const result = await resolveLocalPath(
+      path.join(os.homedir(), ".ssh", "id_rsa"),
+      [UNRESTRICTED_ROOT]
+    );
+    expect(result).toEqual({ ok: false, reason: "sensitive" });
+  });
+
+  it("still refuses a NUL byte", async () => {
+    expect(await resolveLocalPath("/tmp/a\0b", [UNRESTRICTED_ROOT])).toEqual({
+      ok: false,
+      reason: "invalid"
+    });
+  });
+
+  it("resolves a relative path against home", async () => {
+    const result = await resolveLocalPath("Documents/a.png", [
+      UNRESTRICTED_ROOT
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      path: path.join(os.homedir(), "Documents", "a.png")
+    });
+  });
+
+  it("reads the marker off the environment", () => {
+    process.env[LOCAL_FILE_ROOTS_ENV] = UNRESTRICTED_ROOT;
+    const roots = getLocalFileRoots();
+    expect(roots).toEqual([UNRESTRICTED_ROOT]);
+    expect(isUnrestricted(roots)).toBe(true);
+    expect(isUnrestricted([os.homedir()])).toBe(false);
   });
 });
 

--- a/web/src/components/node/SubgraphNode/SubgraphNode.tsx
+++ b/web/src/components/node/SubgraphNode/SubgraphNode.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useMemo } from "react";
 import { Node, NodeProps } from "@xyflow/react";
-import { Box, FlexColumn } from "../../ui_primitives";
+import { Box, FlexColumn, SPACING } from "../../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import { NodeData } from "../../../stores/NodeData";
 import { NodeHeader } from "../NodeHeader";
@@ -78,7 +78,7 @@ const SubgraphNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
       {/* This node draws its own body (no `.node-body.base-node`), so it also
           has to supply the 8px inset that class gives every other node's
           header — without it the icon sits flush against the border. */}
-      <Box sx={{ px: "8px", pt: "8px", flexShrink: 0 }}>
+      <Box sx={{ px: SPACING.md, pt: SPACING.md, flexShrink: 0 }}>
         <NodeHeader
           id={id}
           selected={selected}

--- a/web/src/components/properties/PropertyDropzone.tsx
+++ b/web/src/components/properties/PropertyDropzone.tsx
@@ -55,6 +55,7 @@ const PropertyDropzone = ({
 
   const [openViewer, setOpenViewer] = useState(false);
   const [imageDimensions, setImageDimensions] = useState<{ width: number; height: number } | null>(null);
+  const [imageError, setImageError] = useState(false);
   const imageRef = useRef<HTMLImageElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const id = `audio-${props.property.name}-${props.propertyIndex}`;
@@ -194,12 +195,24 @@ const PropertyDropzone = ({
   );
 
   const handleImageLoad = useCallback(() => {
+    setImageError(false);
     if (imageRef.current) {
       setImageDimensions({
         width: imageRef.current.naturalWidth,
         height: imageRef.current.naturalHeight
       });
     }
+  }, []);
+
+  // A dropped file the backend refuses to serve (or an asset URL that has gone
+  // stale) otherwise renders as a bare broken-image glyph with nothing said
+  // about it anywhere — the shape of nodetool-ai/nodetool#4999.
+  const handleImageError = useCallback(() => {
+    setImageDimensions(null);
+    setImageError(true);
+    console.error("PropertyDropzone: image failed to load", {
+      src: imageRef.current?.src
+    });
   }, []);
 
   const handleDoubleClick = useCallback(() => {
@@ -344,7 +357,8 @@ const PropertyDropzone = ({
 
   const renderViewer = useMemo(() => {
     switch (contentType.split("/")[0]) {
-      case "image":
+      case "image": {
+        const imageSource = asset?.get_url || uri || "";
         return (
           <>
             <AssetViewer
@@ -356,12 +370,19 @@ const PropertyDropzone = ({
             <div className="image-preview-surface" style={{ position: "relative" }}>
               <img
                 ref={imageRef}
-                src={asset?.get_url || uri || ""}
+                src={imageSource}
                 alt={asset?.name || ""}
                 onLoad={handleImageLoad}
+                onError={handleImageError}
                 onDoubleClick={handleDoubleClick}
                 draggable={false}
+                // Hidden rather than unmounted so a later source still loads
+                // and clears the message through onLoad.
+                style={imageError ? { display: "none" } : undefined}
               />
+              {imageError && (
+                <p className="centered uppercase">Image could not be loaded</p>
+              )}
               {imageDimensions && (
                 <ImageDimensions
                   width={imageDimensions.width}
@@ -371,6 +392,7 @@ const PropertyDropzone = ({
             </div>
           </>
         );
+      }
       case "audio":
         return (
           <>
@@ -462,7 +484,7 @@ const PropertyDropzone = ({
       default:
         return null;
     }
-  }, [contentType, uri, openViewer, asset, id, filename, handleImageLoad, handleDoubleClick, handleCloseViewer, imageDimensions, handleVolumeChange]);
+  }, [contentType, uri, openViewer, asset, id, filename, handleImageLoad, handleImageError, imageError, handleDoubleClick, handleCloseViewer, imageDimensions, handleVolumeChange]);
 
   return (
     <div css={styles(theme)}>

--- a/web/src/components/properties/__tests__/PropertyDropzone.test.tsx
+++ b/web/src/components/properties/__tests__/PropertyDropzone.test.tsx
@@ -29,6 +29,13 @@ jest.mock("../../../utils/browser", () => ({
   },
 }));
 
+// The viewer is a whole asset browser behind a router and a query client;
+// these tests are about the dropzone itself.
+jest.mock("../../assets/AssetViewer", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
 // Import after mocks are set up
 import PropertyDropzone from "../PropertyDropzone";
 
@@ -144,5 +151,32 @@ describe("PropertyDropzone", () => {
       uri: "asset://87c6124bc9684facabb8cb3575dcb8ad",
       asset_id: "87c6124bc9684facabb8cb3575dcb8ad"
     });
+  });
+
+  // A source the backend refuses (a dropped file outside the allowed roots, a
+  // stale asset URL) used to render as a bare broken-image glyph, which is how
+  // nodetool-ai/nodetool#4999 read as "an empty image node".
+  it("says so when the image source fails to load", () => {
+    const { container } = renderWithTheme(
+      <PropertyDropzone
+        asset={undefined}
+        uri="/api/files/local?path=%2Fprojects%2FplayingTag.png"
+        onChange={mockOnChange}
+        contentType="image"
+        props={mockProps as any}
+      />
+    );
+
+    const image = container.querySelector("img") as HTMLImageElement;
+    expect(screen.queryByText("Image could not be loaded")).toBeNull();
+
+    fireEvent.error(image);
+
+    expect(screen.getByText("Image could not be loaded")).toBeInTheDocument();
+    expect(image.style.display).toBe("none");
+
+    fireEvent.load(image);
+
+    expect(screen.queryByText("Image could not be loaded")).toBeNull();
   });
 });

--- a/web/src/hooks/handlers/__tests__/useFileHandlers.test.tsx
+++ b/web/src/hooks/handlers/__tests__/useFileHandlers.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * `handleGenericFile` is what a canvas drop of an image/audio/video/document
+ * lands in. Two shapes matter and neither used to be covered: uploading the
+ * file (browser, or Electron when the drop exposes no disk path) and
+ * referencing it in place via `file://` (Electron local mode).
+ *
+ * The upload branch used to `await` a queue call that returns immediately, so a
+ * failed upload reported a successful drop — no node, no error, nothing in the
+ * log. That is the shape of nodetool-ai/nodetool#4999.
+ */
+import { renderHook } from "@testing-library/react";
+import type { Asset } from "../../../stores/ApiTypes";
+
+type UploadArgs = {
+  file: File;
+  onCompleted?: (asset: Asset) => void;
+  onFailed?: (error: string) => void;
+};
+
+const mockUploadAsset = jest.fn<void, [UploadArgs]>();
+const mockAddNotification = jest.fn();
+const mockAddNode = jest.fn();
+const mockCreateNode = jest.fn(() => ({
+  id: "node-1",
+  data: { properties: {} as Record<string, unknown> }
+}));
+const mockGetLocalFilePath = jest.fn<string | null, [File]>(() => null);
+
+jest.mock("../../../serverState/useAssetUpload", () => ({
+  useAssetUpload: () => ({ uploadAsset: mockUploadAsset })
+}));
+jest.mock("../../../stores/AssetGridStore", () => ({
+  useAssetGridStore: (selector: (state: unknown) => unknown) =>
+    selector({ currentFolderId: null }),
+  useLibraryCurrentFolderId: () => null
+}));
+jest.mock("../../../stores/NotificationStore", () => ({
+  useNotificationStore: (selector: (state: unknown) => unknown) =>
+    selector({ addNotification: mockAddNotification })
+}));
+jest.mock("../../../stores/useAuth", () => ({
+  __esModule: true,
+  default: (selector: (state: unknown) => unknown) =>
+    selector({ user: { id: "user-1" } })
+}));
+jest.mock("../../../stores/MetadataStore", () => ({
+  __esModule: true,
+  default: (selector: (state: unknown) => unknown) =>
+    selector({ getMetadata: () => ({ node_type: "nodetool.constant.Image" }) })
+}));
+jest.mock("../../../contexts/NodeContext", () => ({
+  useNodes: (selector: (state: unknown) => unknown) =>
+    selector({
+      createNode: mockCreateNode,
+      addNode: mockAddNode,
+      workflow: { id: "workflow-1" }
+    })
+}));
+jest.mock("../../../contexts/WorkflowManagerContext", () => ({
+  useWorkflowManager: (selector: (state: unknown) => unknown) =>
+    selector({ create: jest.fn() })
+}));
+jest.mock("../useCreateDataframe", () => ({
+  useCreateDataframe: () => jest.fn(() => [])
+}));
+jest.mock("react-router-dom", () => ({ useNavigate: () => jest.fn() }));
+jest.mock("../../../utils/localFile", () => ({
+  getLocalFilePath: (file: File) => mockGetLocalFilePath(file),
+  pathToFileUri: (p: string) => `file://${p}`
+}));
+
+import { useFileHandlers } from "../dropHandlerUtils";
+
+const png = () => new File(["bytes"], "playingTag.png", { type: "image/png" });
+const position = { x: 0, y: 0 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetLocalFilePath.mockReturnValue(null);
+});
+
+describe("handleGenericFile", () => {
+  it("reports a failed upload instead of a successful drop", async () => {
+    mockUploadAsset.mockImplementation(({ onFailed }) => {
+      onFailed?.("storage is full");
+    });
+
+    const { result } = renderHook(() => useFileHandlers());
+    const outcome = await result.current.handleGenericFile(png(), position);
+
+    expect(outcome.success).toBe(false);
+    expect(outcome.error).toContain("storage is full");
+    expect(mockAddNode).not.toHaveBeenCalled();
+  });
+
+  it("adds a node pointing at the uploaded asset", async () => {
+    mockUploadAsset.mockImplementation(({ onCompleted }) => {
+      onCompleted?.({
+        id: "asset-1",
+        name: "playingTag.png",
+        content_type: "image/png",
+        get_url: "http://localhost:7777/api/storage/user-1/asset-1.png"
+      } as Asset);
+    });
+
+    const { result } = renderHook(() => useFileHandlers());
+    const outcome = await result.current.handleGenericFile(png(), position);
+
+    expect(outcome.success).toBe(true);
+    expect(mockAddNode).toHaveBeenCalledTimes(1);
+    expect(mockCreateNode.mock.results[0].value.data.properties.value).toEqual({
+      type: "image",
+      uri: "http://localhost:7777/api/storage/user-1/asset-1.png",
+      asset_id: "asset-1",
+      temp_id: null
+    });
+  });
+
+  it("references a dropped file in place when it has a disk path", async () => {
+    mockGetLocalFilePath.mockReturnValue("C:\\projects\\playingTag.png");
+
+    const { result } = renderHook(() => useFileHandlers());
+    const outcome = await result.current.handleGenericFile(png(), position);
+
+    expect(outcome.success).toBe(true);
+    expect(mockUploadAsset).not.toHaveBeenCalled();
+    expect(mockCreateNode.mock.results[0].value.data.properties.value).toEqual({
+      type: "image",
+      uri: "file://C:\\projects\\playingTag.png",
+      asset_id: null,
+      temp_id: null
+    });
+  });
+});

--- a/web/src/hooks/handlers/dropHandlerUtils.ts
+++ b/web/src/hooks/handlers/dropHandlerUtils.ts
@@ -116,40 +116,46 @@ export const useFileHandlers = () => {
       }
 
       try {
-        await uploadAsset({
-          file,
-          workflow_id: workflow.id,
-          parent_id: currentFolderId || user?.id,
-          onCompleted: (uploadedAsset: Asset) => {
-            const assetType = contentTypeToNodeType(
-              uploadedAsset.content_type,
-              uploadedAsset.name || file.name
-            );
-            const nodeType = constantForType(assetType || "");
-
-            if (nodeType === null) {
-              addNotification({
-                type: "warning",
-                alert: true,
-                content: "Unsupported file type: " + file.type
-              });
-              return;
-            }
-
-            const nodeMetadata = getMetadata(nodeType);
-            if (!nodeMetadata) {
-              throw new Error("No metadata for node type: " + nodeType);
-            }
-            const newNode = createNode(nodeMetadata, position);
-            newNode.data.properties.value = {
-              type: assetType,
-              uri: uploadedAsset.get_url,
-              asset_id: uploadedAsset.id,
-              temp_id: null
-            };
-            addNode(newNode);
-          }
+        // `uploadAsset` queues the upload and returns immediately, so await the
+        // callbacks rather than the call — otherwise a failed upload resolves as
+        // a successful drop and the user gets no node and no error.
+        const uploadedAsset = await new Promise<Asset>((resolve, reject) => {
+          uploadAsset({
+            file,
+            workflow_id: workflow.id,
+            parent_id: currentFolderId || user?.id,
+            onCompleted: resolve,
+            onFailed: (error: string) => reject(new Error(error))
+          });
         });
+
+        const assetType = contentTypeToNodeType(
+          uploadedAsset.content_type,
+          uploadedAsset.name || file.name
+        );
+        const nodeType = constantForType(assetType || "");
+
+        if (nodeType === null) {
+          addNotification({
+            type: "warning",
+            alert: true,
+            content: "Unsupported file type: " + file.type
+          });
+          return { success: false, error: "Unsupported file type" };
+        }
+
+        const nodeMetadata = getMetadata(nodeType);
+        if (!nodeMetadata) {
+          throw new Error("No metadata for node type: " + nodeType);
+        }
+        const newNode = createNode(nodeMetadata, position);
+        newNode.data.properties.value = {
+          type: assetType,
+          uri: uploadedAsset.get_url,
+          asset_id: uploadedAsset.id,
+          temp_id: null
+        };
+        addNode(newNode);
 
         return { success: true };
       } catch (error) {


### PR DESCRIPTION
Fixes #4999 — dragging a PNG from File Explorer onto the canvas produced an image node with nothing in it.

## What was wrong

The drop itself worked. Electron resolves the file's disk path, the node gets `file:///…`, and a run reads it — `ProcessingContext.resolvePathFromUri` takes any absolute path. Only the **preview** failed.

A preview goes through `GET /api/files/local`, whose allowlist ([added 2026-08-13](https://github.com/nodetool-ai/nodetool/blob/main/packages/websocket/src/lib/local-file-access.ts)) is the user's home directory. A file kept anywhere else — a project folder, another drive, which is where `playingTag.png` in the report would live — answers 403, and the `<img>` falls back to the broken-image glyph. That reads as "an empty image node with a placeholder icon".

Reproduced against the policy itself: `resolveLocalPath("<file outside home>")` returns `{ ok: false, reason: "outside_roots" }`, which the endpoint turns into a 403. The reporter's log matches — it ends at `[drop] Processing file`, with no error after it, because nothing on this path reports one.

## What changed

**`NODETOOL_LOCAL_FILE_ROOTS=*` lifts the containment check** (`packages/websocket/src/lib/local-file-access.ts`), and the desktop app sets it (`electron/src/config.ts`, `electron/src/server.ts`) when the launching environment has not chosen roots of its own. The desktop app spawns the server as one user's own process on loopback; restricting the preview while the runner reads the same file was the inconsistency. The home-directory allowlist stays the default everywhere else, where more than one person can reach the port, and the denylist for `.ssh`, `.aws`, `.npmrc` and friends applies either way.

Two things kept this invisible, both fixed here:

- **A failed upload reported a successful drop.** `handleGenericFile` awaited `uploadAsset`, which queues and returns immediately, and passed no `onFailed` — so a failed upload produced no node, no error, and nothing in the log. It now awaits the callbacks and returns the failure.
- **The image dropzone rendered an unloadable source as a bare broken-image glyph.** It now says the image could not be loaded and logs the source.

## Tests

- `packages/websocket/tests/local-file-access.test.ts` — a file outside home is refused under the default roots and accepted under `*`; sensitive entries, NUL bytes and relative-path resolution still behave. Verified the new cases fail with the fix removed.
- `electron/src/__tests__/config.test.ts` — the desktop default, and that a configured value wins.
- `web/src/hooks/handlers/__tests__/useFileHandlers.test.tsx` (new) — the upload branch reports failure, the success branch wires the node to the asset, and the Electron branch references the file in place. The first case fails against the old handler.
- `web/src/components/properties/__tests__/PropertyDropzone.test.tsx` — the load-error message appears and clears.

`npm run typecheck` (web, electron), `npm run lint`, `npm test` (web 13,167, electron 677), and `npm run test --workspace=packages/websocket` (2,238) all pass. Mobile typecheck fails on missing Expo deps in this sandbox, unrelated to the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeYwjtD1XHVdvnry27qTub

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeYwjtD1XHVdvnry27qTub)_