### PR TITLE
fix(editor): use the spacing token for the SubgraphNode header inset

### DIFF
--- a/web/src/components/node/SubgraphNode/SubgraphNode.tsx
+++ b/web/src/components/node/SubgraphNode/SubgraphNode.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useMemo } from "react";
 import { Node, NodeProps } from "@xyflow/react";
-import { Box, FlexColumn } from "../../ui_primitives";
+import { Box, FlexColumn, SPACING } from "../../ui_primitives";
 import { useTheme } from "@mui/material/styles";
 import { NodeData } from "../../../stores/NodeData";
 import { NodeHeader } from "../NodeHeader";
@@ -78,7 +78,7 @@ const SubgraphNode: React.FC<NodeProps<Node<NodeData>>> = (props) => {
       {/* This node draws its own body (no `.node-body.base-node`), so it also
           has to supply the 8px inset that class gives every other node's
           header — without it the icon sits flush against the border. */}
-      <Box sx={{ px: "8px", pt: "8px", flexShrink: 0 }}>
+      <Box sx={{ px: SPACING.md, pt: SPACING.md, flexShrink: 0 }}>
         <NodeHeader
           id={id}
           selected={selected}


### PR DESCRIPTION
## The problem

The Quality Gate `lint` leg is red on `main`. `lint:design` reports two errors:

```
web/src/components/node/SubgraphNode/SubgraphNode.tsx
  81:22  error  Use a spacing token instead of a raw px value for padding/margin/gap
  81:33  error  Use a spacing token instead of a raw px value for padding/margin/gap
```

The header inset was written as `sx={{ px: "8px", pt: "8px" }}` in 16cbba41. `docs/DESIGN.md` §2 requires a `SPACING` token for any padding/margin/gap.

## The change

`px`/`pt` use `SPACING.md`. Theme spacing is `4` (`ThemeNodetool.ts:97`) and `SPACING.md` is `2`, so it resolves to the same 8px — the pixels do not move, and the comment above the element still describes the inset accurately.

## Testing

`npm run lint:design` in `web/` passes: eslint clean, and all five CSS token checks green. Before the change the same command reported the two errors above, so the gate is verified to bite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZBJFo5gCvjHZ46RHn2QE8

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZBJFo5gCvjHZ46RHn2QE8)_