### PR TITLE
fix(providers): unbreak main after the custom-provider PR

### DIFF
--- a/packages/runtime/src/providers/custom-openai-provider.ts
+++ b/packages/runtime/src/providers/custom-openai-provider.ts
@@ -21,18 +21,19 @@ import type { LanguageModel } from "./types.js";
 const MODEL_LIST_TIMEOUT_MS = 5000;
 
 /**
- * Kwargs the registry hands the constructor. The `_`-prefixed keys are runtime
- * injections the registry excludes from its credential check; the two secret
- * names it also resolves are read back off this same object.
+ * Kwargs the registry hands the constructor. The registry constructs every
+ * provider from a plain `Record<string, unknown>`, so the shape is documented
+ * rather than declared, and each key is narrowed as it is read:
+ *
+ * - `_providerId` — the wire id this instance reports.
+ * - `_baseUrlKey` / `_apiKeyKey` — names of the two resolved secrets; their
+ *   values arrive on this same object under those names.
+ * - `_models` — model ids to report instead of calling `GET <base>/models`.
+ *
+ * The `_`-prefixed keys are runtime injections the registry excludes from its
+ * credential check.
  */
-export interface CustomOpenAIProviderConfig {
-  _providerId: string;
-  _baseUrlKey: string;
-  _apiKeyKey: string;
-  /** Model ids to report instead of calling `GET <base>/models`. */
-  _models?: string[];
-  [key: string]: unknown;
-}
+export type CustomOpenAIProviderConfig = Record<string, unknown>;
 
 /** Placeholder key for endpoints that accept anonymous requests. */
 const NO_KEY = "no-key";
@@ -40,6 +41,11 @@ const NO_KEY = "no-key";
 function readString(config: CustomOpenAIProviderConfig, key: string): string {
   const value = config[key];
   return isString(value) ? value.trim() : "";
+}
+
+function readModels(config: CustomOpenAIProviderConfig): string[] {
+  const value = config._models;
+  return Array.isArray(value) ? value.filter(isString) : [];
 }
 
 export class CustomOpenAIProvider extends OpenAICompatProvider {
@@ -57,24 +63,32 @@ export class CustomOpenAIProvider extends OpenAICompatProvider {
     config: CustomOpenAIProviderConfig,
     options: OpenAICompatProviderOptions = {}
   ) {
-    const providerId = config._providerId;
+    const providerId = readString(config, "_providerId");
     if (!providerId) {
       throw new Error("_providerId is required for a custom provider");
     }
-    const baseURL = normalizeBaseUrl(readString(config, config._baseUrlKey));
-    if (!baseURL) {
-      throw new Error(`${config._baseUrlKey} is required`);
+    const baseUrlKey = readString(config, "_baseUrlKey");
+    if (!baseUrlKey) {
+      throw new Error("_baseUrlKey is required for a custom provider");
     }
-    const apiKey = readString(config, config._apiKeyKey) || NO_KEY;
+    const apiKeyKey = readString(config, "_apiKeyKey");
+    if (!apiKeyKey) {
+      throw new Error("_apiKeyKey is required for a custom provider");
+    }
+    const baseURL = normalizeBaseUrl(readString(config, baseUrlKey));
+    if (!baseURL) {
+      throw new Error(`${baseUrlKey} is required`);
+    }
+    const apiKey = readString(config, apiKeyKey) || NO_KEY;
     const fetchFn = options.fetchFn ?? globalThis.fetch.bind(globalThis);
 
     super({ providerId, apiKey, baseURL }, { ...options, fetchFn });
 
     this._customFetch = fetchFn;
     this._customBaseURL = baseURL;
-    this._customModels = config._models ?? [];
-    this._baseUrlKey = config._baseUrlKey;
-    this._apiKeyKey = config._apiKeyKey;
+    this._customModels = readModels(config);
+    this._baseUrlKey = baseUrlKey;
+    this._apiKeyKey = apiKeyKey;
   }
 
   override getContainerEnv(): Record<string, string> {

--- a/packages/websocket/tests/trpc-http.test.ts
+++ b/packages/websocket/tests/trpc-http.test.ts
@@ -10,6 +10,7 @@ import {
   fastifyTRPCPlugin,
   type FastifyTRPCPluginOptions
 } from "@trpc/server/adapters/fastify";
+import { initTestDb } from "@nodetool-ai/models";
 import { appRouter, type AppRouter } from "../src/trpc/router.js";
 import { createContextFactory } from "../src/trpc/context.js";
 import type { Context } from "../src/trpc/context.js";
@@ -60,6 +61,10 @@ let baseUrl: string;
 const AUTH_USER_ID = "test-user-http";
 
 beforeAll(async () => {
+  // models.providers reads the caller's custom-provider catalog from the
+  // settings table, so the router needs a database to answer at all.
+  initTestDb();
+
   app = Fastify();
 
   // Add userId to every request from the x-user-id header (mimics auth middleware)

--- a/packages/websocket/tests/trpc-models.test.ts
+++ b/packages/websocket/tests/trpc-models.test.ts
@@ -4,7 +4,16 @@
  * Heavy external dependencies (provider instances, HF cache I/O) are mocked so
  * the tests remain fast and hermetic.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi
+} from "vitest";
+import { initTestDb } from "@nodetool-ai/models";
 import { appRouter } from "../src/trpc/router.js";
 import { createCallerFactory } from "../src/trpc/index.js";
 import type { Context } from "../src/trpc/context.js";
@@ -129,6 +138,12 @@ function makeProvider(
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe("models router", () => {
+  // models.providers reads the caller's custom-provider catalog from the
+  // settings table, so the router needs a database to answer at all.
+  beforeAll(() => {
+    initTestDb();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     // Default: no providers, no HF cache, no disk I/O errors


### PR DESCRIPTION
#5010 landed with a type error that fails `tsc --build` for `@nodetool-ai/runtime`, which takes down every CI leg that builds the packages (build, docker, workflow integration, browser E2E):

```
src/providers/custom-provider-registry.ts(33,5): error TS2345:
  Argument of type 'typeof CustomOpenAIProvider' is not assignable to parameter of type 'ProviderConstructor'.
    Type 'Record<string, unknown>' is missing the following properties from type
    'CustomOpenAIProviderConfig': _providerId, _baseUrlKey, _apiKeyKey
```

## What changed

- `CustomOpenAIProvider`'s constructor takes the registry's `Record<string, unknown>` and narrows each key as it reads it, which is what `ProviderConstructor` requires. The expected shape moved from a declared interface to the doc comment, and `_baseUrlKey` / `_apiKeyKey` now throw by name when absent instead of building an error message around `undefined`.
- `models.providers` reads the caller's custom-provider catalog from the settings table before enumerating, so `trpc-models` and `trpc-http` failed with `Database not initialized`. Both suites now call `initTestDb()`, the in-memory database the rest of the websocket tests use.

## Verification

- `npm run build:packages` — green (56/56).
- `packages/runtime`: 1787 tests pass, including the 11 custom-provider ones.
- `packages/websocket`: 2238 tests pass (was 3 failing).
- `packages/protocol`: 894 pass. `web` typecheck clean.
- Not run here: `image-nodes` (no Vulkan ICD in this container) and the `mobile` typecheck (Expo deps not installed) — both documented environment gaps, unrelated to this diff.

The design-lint failure on that CI run (`SubgraphNode.tsx` raw px) was fixed separately by #5012 and is already clean on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBYJQ9QAAnXoTtR2SKPked

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBYJQ9QAAnXoTtR2SKPked)_