### PR TITLE
fix(dashboard): decide the page before rendering it

### DIFF
--- a/web/src/components/portal/Portal.tsx
+++ b/web/src/components/portal/Portal.tsx
@@ -27,12 +27,7 @@ import DashboardFooter from "./DashboardFooter";
 import { useStartTrackChat } from "../../hooks/useStartTrackChat";
 import { openSettingsTab } from "../workspace/openPageTab";
 import { WELCOME_TRACKS, type WelcomeTrackId } from "./welcomeTracks";
-import {
-  Box,
-  BORDER_RADIUS,
-  SPACING,
-  getSpacingPx
-} from "../ui_primitives";
+import { Box, BORDER_RADIUS, SPACING, getSpacingPx } from "../ui_primitives";
 
 const styles = (theme: Theme) =>
   css({
@@ -189,75 +184,83 @@ const Portal: React.FC = () => {
       <div className="dashboard-scroll">
         <main>
           <DashboardDownloads />
-          <DashboardHero
-            mode={mode}
-            onStart={handleStart}
-            onOpenEmptyCanvas={handleCreateNewWorkflow}
-            onOpenSettings={handleOpenSettings}
-          />
-          {/* A returning user's own work leads — agent sessions first, then
+          {/* Which page this is depends on the workflow list. Rendering one
+              order and then swapping to the other showed the same sections
+              twice over, so the page below the downloads banner waits for the
+              answer instead. */}
+          {mode === "pending" ? null : (
+            <>
+              <DashboardHero
+                mode={mode}
+                onStart={handleStart}
+                onOpenEmptyCanvas={handleCreateNewWorkflow}
+                onOpenSettings={handleOpenSettings}
+              />
+              {/* A returning user's own work leads — agent sessions first, then
               workflows — with the checklist and task activity in a rail
               beside it. A first-run user has no work yet, so the material
               that teaches them leads instead. */}
-          {mode === "returning" ? (
-            <div css={[wrapStyles(theme), columnStyles(theme)]}>
-              <div className="dash-main">
-                <DashboardColumn>
-                  <DashboardAgentSessions
-                    onNewSession={handleNewAgentSession}
+              {mode === "returning" ? (
+                <div css={[wrapStyles(theme), columnStyles(theme)]}>
+                  <div className="dash-main">
+                    <DashboardColumn>
+                      <DashboardAgentSessions
+                        onNewSession={handleNewAgentSession}
+                      />
+                      <DashboardWorkflows
+                        workflows={sortedWorkflows}
+                        isLoading={isLoadingWorkflows}
+                        onOpenWorkflow={handleOpenWorkflow}
+                        onCreateNew={handleCreateNewWorkflow}
+                      />
+                      <DashboardDocuments />
+                      <DashboardTemplates />
+                      <DashboardTutorials variant="compact" />
+                    </DashboardColumn>
+                  </div>
+                  <aside className="dash-rail">
+                    <div className="dash-rail-panel">
+                      <GettingStartedChecklist
+                        variant="inline"
+                        hasConfiguredProvider={hasConfiguredProvider}
+                        onConnectProvider={handleConnectProvider}
+                        onOpenTemplates={handleOpenTemplates}
+                        onCreateWorkflow={handleCreateNewWorkflow}
+                      />
+                    </div>
+                    <DashboardActivity
+                      workflows={sortedWorkflows}
+                      onOpenWorkflow={handleOpenWorkflow}
+                    />
+                  </aside>
+                </div>
+              ) : (
+                <>
+                  <GettingStartedChecklist
+                    hasConfiguredProvider={hasConfiguredProvider}
+                    onConnectProvider={handleConnectProvider}
+                    onOpenTemplates={handleOpenTemplates}
+                    onCreateWorkflow={handleCreateNewWorkflow}
                   />
+                  <DashboardTutorials />
+                  <DashboardTemplates />
                   <DashboardWorkflows
                     workflows={sortedWorkflows}
                     isLoading={isLoadingWorkflows}
                     onOpenWorkflow={handleOpenWorkflow}
                     onCreateNew={handleCreateNewWorkflow}
                   />
-                  <DashboardDocuments />
-                  <DashboardTemplates />
-                  <DashboardTutorials variant="compact" />
-                </DashboardColumn>
-              </div>
-              <aside className="dash-rail">
-                <div className="dash-rail-panel">
-                  <GettingStartedChecklist
-                    variant="inline"
-                    hasConfiguredProvider={hasConfiguredProvider}
-                    onConnectProvider={handleConnectProvider}
-                    onOpenTemplates={handleOpenTemplates}
-                    onCreateWorkflow={handleCreateNewWorkflow}
-                  />
-                </div>
-                <DashboardActivity
-                  workflows={sortedWorkflows}
-                  onOpenWorkflow={handleOpenWorkflow}
-                />
-              </aside>
-            </div>
-          ) : (
-            <>
-              <GettingStartedChecklist
-                hasConfiguredProvider={hasConfiguredProvider}
-                onConnectProvider={handleConnectProvider}
-                onOpenTemplates={handleOpenTemplates}
-                onCreateWorkflow={handleCreateNewWorkflow}
-              />
-              <DashboardTutorials />
-              <DashboardTemplates />
-              <DashboardWorkflows
-                workflows={sortedWorkflows}
-                isLoading={isLoadingWorkflows}
-                onOpenWorkflow={handleOpenWorkflow}
-                onCreateNew={handleCreateNewWorkflow}
-              />
-              {/* Empty for a genuinely new user, but a user who started with a
+                  {/* Empty for a genuinely new user, but a user who started with a
                   sketch or a video has no workflows and still has work here. */}
-              <DashboardDocuments />
+                  <DashboardDocuments />
+                </>
+              )}
+              <DashboardFooter
+                workflowCount={sortedWorkflows.length}
+                onGettingStarted={handleOpenTemplates}
+              />
             </>
           )}
-          <DashboardFooter
-            workflowCount={sortedWorkflows.length}
-            onGettingStarted={handleOpenTemplates}
-          />
         </main>
       </div>
     </Box>

--- a/web/src/hooks/__tests__/useDashboardMode.test.tsx
+++ b/web/src/hooks/__tests__/useDashboardMode.test.tsx
@@ -30,17 +30,29 @@ describe("useDashboardMode", () => {
     expect(result.current).toBe("returning");
   });
 
-  it("answers from onboarding alone while the workflow list loads", () => {
+  it("holds the answer back while the workflow list loads", () => {
     const { result: newUser } = renderHook(() =>
       useDashboardMode({ workflowCount: 0, isLoadingWorkflows: true })
     );
-    expect(newUser.current).toBe("first-run");
+    expect(newUser.current).toBe("pending");
 
     act(() => useOnboardingStore.setState({ dismissed: true }));
     const { result: knownUser } = renderHook(() =>
       useDashboardMode({ workflowCount: 0, isLoadingWorkflows: true })
     );
     expect(knownUser.current).toBe("returning");
+  });
+
+  it("never answers first-run and then returning for one user", () => {
+    const { result, rerender } = renderHook(
+      (props: { workflowCount: number; isLoadingWorkflows: boolean }) =>
+        useDashboardMode(props),
+      { initialProps: { workflowCount: 0, isLoadingWorkflows: true } }
+    );
+    expect(result.current).toBe("pending");
+
+    rerender({ workflowCount: 7, isLoadingWorkflows: false });
+    expect(result.current).toBe("returning");
   });
 
   it("treats every step completed as finished, without a dismissal", () => {

--- a/web/src/hooks/useDashboardMode.ts
+++ b/web/src/hooks/useDashboardMode.ts
@@ -4,6 +4,9 @@ import useOnboardingStore, {
 
 export type DashboardMode = "first-run" | "returning";
 
+/** The answer is not knowable yet — nothing mode-dependent may render. */
+export type DashboardModeState = DashboardMode | "pending";
+
 interface UseDashboardModeArgs {
   workflowCount: number;
   isLoadingWorkflows: boolean;
@@ -16,22 +19,24 @@ interface UseDashboardModeArgs {
  * start something: the page leads with the hero and the learning material.
  * Everyone else came back for work they already have, so that leads instead.
  *
- * The workflow count arrives over the network, so until it does the answer
- * comes from onboarding alone (which is persisted, and therefore synchronous).
- * A user who has both unfinished onboarding and a full library sees the
- * first-run order for as long as the list takes to load, once per cold cache.
+ * Onboarding is persisted, so a finished user is answered synchronously. An
+ * unfinished one depends on the workflow count, which arrives over the network:
+ * until it does the answer is "pending" rather than a guess. Guessing put the
+ * first-run page on screen and then replaced it with the returning one — the
+ * same sections re-appearing in a different order, which reads as duplicated
+ * content rather than as loading.
  */
 export const useDashboardMode = ({
   workflowCount,
   isLoadingWorkflows
-}: UseDashboardModeArgs): DashboardMode => {
+}: UseDashboardModeArgs): DashboardModeState => {
   const onboardingFinished = useOnboardingStore(isOnboardingFinished);
 
   if (onboardingFinished) {
     return "returning";
   }
   if (isLoadingWorkflows) {
-    return "first-run";
+    return "pending";
   }
   return workflowCount > 0 ? "returning" : "first-run";
 };


### PR DESCRIPTION
## What

The dashboard picks between two layouts — the first-run page (welcome hero, tutorials, templates) and the returning page (compact command bar, two columns of the user's own work). `useDashboardMode` answered `"first-run"` while the workflow count was still loading.

For a user with unfinished onboarding and a workflow library, that means the first-run page paints, then the returning page replaces it. Both orders carry the same sections — templates, workflows, documents, tutorials — so the swap reads as duplicated or uncleaned content rather than as loading.

## Change

- `useDashboardMode` returns `"pending"` while the answer is unknowable, instead of guessing. New type `DashboardModeState = DashboardMode | "pending"`.
- `Portal` renders nothing below the downloads banner until the mode is decided. `DashboardHero` still takes a decided `DashboardMode`; TypeScript narrows it at the call site.

Onboarding is persisted (synchronous), so a user who has finished it is answered on the first render and waits for nothing. The wait only applies to the cold-cache case that used to flash, and only until the workflow list arrives — a warm TanStack cache makes `isLoading` false, so navigating back to the dashboard in-session renders once.

## Tests

- `useDashboardMode` test updated for the new `"pending"` answer, plus one that rerenders through the load and asserts the sequence is `pending → returning`, never `first-run → returning`.
- `npx jest src/components/portal src/hooks/__tests__/useDashboard` — 10 suites, 64 tests, green.
- `oxlint` clean on both changed files. Web typecheck reports only the pre-existing `@nodetool-ai/audio-nodes` / `image-nodes` module-resolution errors from unbuilt packages; nothing in the touched files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYXQsfeKEqti1igWR1FsdC)_