### PR TITLE
test(web): unbreak the web suite after the custom-provider PR

### DIFF
--- a/web/src/components/menus/__tests__/APIKeysTabContent.test.tsx
+++ b/web/src/components/menus/__tests__/APIKeysTabContent.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { ThemeProvider } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import mockTheme from "../../../__mocks__/themeMock";
 
 import { useOAuthConnection } from "../../../hooks/useOAuthConnection";
@@ -20,6 +21,18 @@ jest.mock("../../../hooks/useProviders", () => ({
   })
 }));
 jest.mock("../GoogleWorkspaceCard", () => () => null);
+// The custom-provider section lists the user's endpoints over tRPC; this suite
+// has no server, and an empty catalog is the state it renders here.
+jest.mock("../../../trpc/client", () => ({
+  trpcClient: {
+    customProviders: {
+      list: { query: jest.fn().mockResolvedValue([]) },
+      save: { mutate: jest.fn() },
+      delete: { mutate: jest.fn() },
+      test: { mutate: jest.fn() }
+    }
+  }
+}));
 jest.mock("../../../stores/SecretsStore", () => ({
   __esModule: true,
   default: <T,>(
@@ -58,10 +71,15 @@ describe("APIKeysTabContent on a hosted deployment", () => {
   });
 
   it("hides the Claude subscription card, whose sign-in needs a local server", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } }
+    });
     render(
-      <ThemeProvider theme={mockTheme}>
-        <APIKeysTabContent />
-      </ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={mockTheme}>
+          <APIKeysTabContent />
+        </ThemeProvider>
+      </QueryClientProvider>
     );
 
     expect(


### PR DESCRIPTION
The last red leg on `main` from #5010. `CustomProvidersSection`, added to `APIKeysTab`, calls `useQueryClient` and lists the user's endpoints over tRPC, so `APIKeysTabContent.test.tsx` renders the tab bare and throws:

```
No QueryClient set, use QueryClientProvider to set one
  at CustomProvidersSection (src/components/menus/CustomProvidersSection.tsx:191:37)
```

## What changed

The render is wrapped in a `QueryClientProvider` (retries off), and `trpc/client` is mocked to answer the catalog query with an empty list — the state this hosted-deployment test renders anyway, and it keeps the suite off the network.

## Verification

- Reproduced the failure on `main` first, then confirmed the fix: `TZ=UTC npx jest --forceExit` in `web/` — 1140 suites, 13180 tests pass (was 1 failing).

This is the follow-up to #5013, which fixed the `tsc --build` break and three websocket tests from the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBYJQ9QAAnXoTtR2SKPked

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBYJQ9QAAnXoTtR2SKPked)_