### PR TITLE
feat(fal): offer every Topaz model, not just fal's default

### DIFF
--- a/packages/model-pricing/src/index.ts
+++ b/packages/model-pricing/src/index.ts
@@ -52,12 +52,33 @@ function isText<T>(value: T): value is T & string {
   return typeof value === "string";
 }
 
+/**
+ * Endpoints whose catalog id is a prefix of the ids NodeTool offers: the FAL
+ * provider expands Topaz's `model` enum into one selectable model per variant
+ * (`fal-ai/topaz/upscale/image/Redefine`), while the generated catalog is keyed
+ * by the endpoint FAL bills — which prices every variant the same. Without this
+ * the variants would come back unpriced, so a run of one would skip the budget
+ * gate the single entry used to be gated by.
+ */
+const FAL_VARIANT_ENDPOINTS = [
+  "fal-ai/topaz/upscale/image",
+  "fal-ai/topaz/upscale/video"
+];
+
+/** The catalog key for a model id, folding a variant back onto its endpoint. */
+function falPricingKey(modelId: string): string {
+  return (
+    FAL_VARIANT_ENDPOINTS.find((e) => modelId.startsWith(`${e}/`)) ?? modelId
+  );
+}
+
 function falPrice(modelId: string): ModelUnitPricingLike | null {
   const prices = falUnitPricingCatalog.prices;
   // SAFETY: the FAL catalog is generated JSON shipped with the package, so its
   // rows have no declared field types here; every field is checked below
   // before it becomes a price.
-  const entry = prices?.[modelId] as CatalogPrice | undefined;
+  const entry = (prices?.[modelId] ??
+    prices?.[falPricingKey(modelId)]) as CatalogPrice | undefined;
   if (!entry) return null;
   if (!isFiniteNumber(entry.unit_price)) return null;
   return {

--- a/packages/model-pricing/tests/model-pricing.test.ts
+++ b/packages/model-pricing/tests/model-pricing.test.ts
@@ -31,6 +31,21 @@ describe("getModelUnitPrice", () => {
     });
   });
 
+  it("prices a Topaz variant at its endpoint's rate", () => {
+    const endpoint = "fal-ai/topaz/upscale/image";
+    const base = getModelUnitPrice({ id: endpoint, provider: "fal_ai" });
+    expect(base?.unit_price).toBeGreaterThan(0);
+    expect(
+      getModelUnitPrice({ id: `${endpoint}/Redefine`, provider: "fal_ai" })
+    ).toEqual(base);
+  });
+
+  it("does not price an unrelated id that merely extends a FAL endpoint", () => {
+    expect(
+      getModelUnitPrice({ id: "fal-ai/flux/schnell/nope", provider: "fal_ai" })
+    ).toBeNull();
+  });
+
   it("prices a kie model from its USD conversion, not its credit figure", () => {
     const { id, price } = firstEntry(kieUnitPricingCatalog, "usd_price");
     const found = getModelUnitPrice({ id, provider: "kie" });

--- a/packages/runtime/src/providers/fal-provider.ts
+++ b/packages/runtime/src/providers/fal-provider.ts
@@ -99,6 +99,7 @@ interface FalManifestField {
   name: string;
   apiParamName?: string;
   propType: string;
+  enumValues?: string[];
 }
 interface FalManifestEntry {
   endpointId?: string;
@@ -121,6 +122,97 @@ function getFalManifestEntry(modelId: string): FalManifestEntry | undefined {
     }
   }
   return _falManifestByEndpoint.get(modelId);
+}
+
+// ---------------------------------------------------------------------------
+// Topaz model variants
+// ---------------------------------------------------------------------------
+
+/**
+ * fal ships Topaz as one endpoint per media kind and selects the actual Topaz
+ * model — Standard V2, Redefine, Wonder 3 for images; Proteus, Artemis, Gaia,
+ * Nyx, Starlight for video — through a `model` enum on that endpoint. A single
+ * catalog entry per endpoint therefore offers no way to pick one, and every
+ * run silently gets fal's default (Standard V2 / Proteus), which is the wrong
+ * model for compressed sources, CGI, animation, or generative restoration.
+ *
+ * So each endpoint is expanded into one catalog entry per variant, id
+ * `<endpointId>/<variant>`, and the variant is split back off and sent as
+ * `model` when the request is built — the same shape TopazProvider uses for
+ * Topaz's own API.
+ */
+const TOPAZ_UPSCALE_IMAGE = "fal-ai/topaz/upscale/image";
+const TOPAZ_UPSCALE_VIDEO = "fal-ai/topaz/upscale/video";
+const TOPAZ_VARIANT_ENDPOINTS = [TOPAZ_UPSCALE_IMAGE, TOPAZ_UPSCALE_VIDEO];
+
+/** The `model` enum a Topaz endpoint declares, or [] when it isn't shipped. */
+function topazVariants(endpointId: string): string[] {
+  const field = getFalManifestEntry(endpointId)?.inputFields?.find(
+    (f) => (f.apiParamName ?? f.name) === "model"
+  );
+  return field?.enumValues ?? [];
+}
+
+/**
+ * Replace each Topaz entry with one entry per model variant. Entries whose
+ * endpoint declares no `model` enum are left as they are, so a manifest that
+ * drops the field degrades to today's single entry rather than to none.
+ */
+function expandTopazVariants<T extends { id: string; name: string }>(
+  models: T[]
+): T[] {
+  const out: T[] = [];
+  for (const m of models) {
+    const variants = TOPAZ_VARIANT_ENDPOINTS.includes(m.id)
+      ? topazVariants(m.id)
+      : [];
+    if (variants.length === 0) {
+      out.push(m);
+      continue;
+    }
+    for (const variant of variants) {
+      out.push({
+        ...m,
+        id: `${m.id}/${variant}`,
+        name: `${m.name} — ${variant}`
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Split a catalog id back into the fal endpoint and the Topaz `model` value.
+ * Bare endpoint ids (saved before variants existed, or typed by hand) resolve
+ * to no variant, which leaves fal's own default in place.
+ */
+function splitTopazVariant(modelId: string): {
+  endpointId: string;
+  variant?: string;
+} {
+  for (const endpointId of TOPAZ_VARIANT_ENDPOINTS) {
+    const prefix = `${endpointId}/`;
+    if (modelId.startsWith(prefix)) {
+      return { endpointId, variant: modelId.slice(prefix.length) };
+    }
+  }
+  return { endpointId: modelId };
+}
+
+/**
+ * `UpscaleImageParams.creativity` is 0–1; the Topaz image endpoint takes a
+ * 1–6 level (Redefine only) and rejects anything else, so it is rescaled for
+ * that endpoint and passed through untouched everywhere else.
+ */
+function topazCreativity(
+  endpointId: string,
+  creativity: number | null | undefined
+): number | string | null | undefined {
+  if (endpointId !== TOPAZ_UPSCALE_IMAGE || creativity == null) {
+    return creativity;
+  }
+  const level = Math.round(Math.min(1, Math.max(0, creativity)) * 5) + 1;
+  return String(level);
 }
 
 /**
@@ -316,8 +408,7 @@ class FalArgsBuilder {
     const field = this.accepted.get(apiName);
     if (!field) return undefined;
     if (field.propType.toLowerCase() !== "enum") return value;
-    const enumValues = (field as FalManifestField & { enumValues?: string[] })
-      .enumValues;
+    const enumValues = field.enumValues;
     if (!enumValues || enumValues.length === 0) return value;
     return enumValues.includes(value) ? value : undefined;
   }
@@ -326,7 +417,7 @@ class FalArgsBuilder {
   private enumValuesOf(apiName: string): string[] | undefined {
     const field = this.accepted.get(apiName);
     if (!field || field.propType.toLowerCase() !== "enum") return undefined;
-    return (field as FalManifestField & { enumValues?: string[] }).enumValues;
+    return field.enumValues;
   }
 
   /**
@@ -483,11 +574,15 @@ export class FalProvider extends BaseProvider {
   }
 
   override async getAvailableImageModels(): Promise<ImageModel[]> {
-    return loadImageModels(FAL_MANIFEST_PKG, FAL_MANIFEST_PATH, "fal_ai");
+    return expandTopazVariants(
+      loadImageModels(FAL_MANIFEST_PKG, FAL_MANIFEST_PATH, "fal_ai")
+    );
   }
 
   override async getAvailableVideoModels(): Promise<VideoModel[]> {
-    return loadVideoModels(FAL_MANIFEST_PKG, FAL_MANIFEST_PATH, "fal_ai");
+    return expandTopazVariants(
+      loadVideoModels(FAL_MANIFEST_PKG, FAL_MANIFEST_PATH, "fal_ai")
+    );
   }
 
   override async getAvailableTTSModels(): Promise<TTSModel[]> {
@@ -1007,17 +1102,18 @@ export class FalProvider extends BaseProvider {
     image: Uint8Array,
     params: UpscaleImageParams
   ): Promise<Uint8Array> {
-    const modelId = params.model.id;
+    const { endpointId, variant } = splitTopazVariant(params.model.id);
     const url = await this.upload(image, "image/png");
-    const b = new FalArgsBuilder(modelId);
+    const b = new FalArgsBuilder(endpointId);
     b.attachAsset("image", url)
+      .set("model", variant)
       .set("prompt", params.prompt)
       .set("upscale_factor", params.scale)
       .set("scale", params.scale)
-      .set("creativity", params.creativity);
+      .set("creativity", topazCreativity(endpointId, params.creativity));
     if (params.seed != null && params.seed !== -1) b.set("seed", params.seed);
-    log.debug("FAL upscaleImage", { model: modelId });
-    return this.runImageEndpoint(modelId, b.args);
+    log.debug("FAL upscaleImage", { model: endpointId, variant });
+    return this.runImageEndpoint(endpointId, b.args);
   }
 
   override async removeBackground(
@@ -1064,18 +1160,19 @@ export class FalProvider extends BaseProvider {
     video: Uint8Array,
     params: VideoToVideoParams
   ): Promise<Uint8Array> {
-    const modelId = params.model.id;
+    const { endpointId, variant } = splitTopazVariant(params.model.id);
     const url = await this.upload(video, "video/mp4");
-    const b = new FalArgsBuilder(modelId);
+    const b = new FalArgsBuilder(endpointId);
     b.attachAsset("video", url)
+      .set("model", variant)
       .set("prompt", params.prompt)
       .set("negative_prompt", params.negativePrompt)
       .set("strength", params.strength)
       .set("duration", params.durationSeconds)
       .setSize(null, params.resolution);
     if (params.seed != null && params.seed !== -1) b.set("seed", params.seed);
-    log.debug("FAL videoToVideo", { model: modelId });
-    return this.runVideoEndpoint(modelId, b.args);
+    log.debug("FAL videoToVideo", { model: endpointId, variant });
+    return this.runVideoEndpoint(endpointId, b.args);
   }
 
   override async lipSync(

--- a/packages/runtime/src/providers/manifest-models.ts
+++ b/packages/runtime/src/providers/manifest-models.ts
@@ -195,6 +195,24 @@ export function inferVideoTasks(name: string, id: string): string[] {
   ) {
     return ["video_to_video"];
   }
+  // Video upscalers/enhancers (Topaz, SeedVR, FlashVSR, …) transform a source
+  // clip, but their ids never spell out "video-to-video", so without this they
+  // fall through to the generator branch and show up in the text/image-to-video
+  // pickers with no video input.
+  if (
+    matchesAny(
+      hay,
+      "upscal",
+      "super-resolution",
+      "super resolution",
+      "superres",
+      "seedvr",
+      "vsr",
+      "enhancer"
+    )
+  ) {
+    return ["video_to_video"];
+  }
   if (matchesAny(hay, "text-to-video", "text to video", "texttovideo")) {
     tasks.push("text_to_video");
   }

--- a/packages/runtime/tests/providers/fal-provider-coverage.test.ts
+++ b/packages/runtime/tests/providers/fal-provider-coverage.test.ts
@@ -635,3 +635,131 @@ describe("FalProvider — TTS arg shaping fallbacks", () => {
     expect(captured.seed).toBe(5);
   });
 });
+
+describe("FalProvider — Topaz model variants", () => {
+  const IMAGE_ENDPOINT = "fal-ai/topaz/upscale/image";
+  const VIDEO_ENDPOINT = "fal-ai/topaz/upscale/video";
+
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** Client that records both the endpoint id and the request body. */
+  function recordingClient(response: any) {
+    const uploadMock = vi.fn().mockResolvedValue("https://fal.media/u.bin");
+    let endpoint: string | null = null;
+    let input: any = null;
+    const subscribeMock = vi.fn(async (id: string, opts: any) => {
+      endpoint = id;
+      input = opts.input;
+      return { data: response };
+    });
+    return {
+      client: { subscribe: subscribeMock, storage: { upload: uploadMock } },
+      get endpoint() {
+        return endpoint;
+      },
+      get input() {
+        return input;
+      }
+    };
+  }
+
+  it("lists one image model per Topaz variant instead of one endpoint", async () => {
+    const models = await createProvider().getAvailableImageModels();
+    const ids = models.map((m) => m.id);
+
+    expect(ids).not.toContain(IMAGE_ENDPOINT);
+    expect(ids).toContain(`${IMAGE_ENDPOINT}/Standard V2`);
+    expect(ids).toContain(`${IMAGE_ENDPOINT}/Redefine`);
+    expect(ids).toContain(`${IMAGE_ENDPOINT}/Wonder 3`);
+    const redefine = models.find(
+      (m) => m.id === `${IMAGE_ENDPOINT}/Redefine`
+    )!;
+    expect(redefine.name).toContain("Redefine");
+    expect(redefine.supportedTasks).toEqual(["upscale"]);
+  });
+
+  it("lists one video model per Topaz variant, tagged video-to-video", async () => {
+    const models = await createProvider().getAvailableVideoModels();
+    const ids = models.map((m) => m.id);
+
+    expect(ids).not.toContain(VIDEO_ENDPOINT);
+    expect(ids).toContain(`${VIDEO_ENDPOINT}/Proteus`);
+    expect(ids).toContain(`${VIDEO_ENDPOINT}/Starlight Precise 2.5`);
+    const proteus = models.find((m) => m.id === `${VIDEO_ENDPOINT}/Proteus`)!;
+    expect(proteus.supportedTasks).toEqual(["video_to_video"]);
+  });
+
+  it("sends the selected variant as `model` to the bare endpoint", async () => {
+    const ctx = recordingClient({ image: { url: "https://fal.ai/up.png" } });
+    vi.stubGlobal("fetch", okFetch());
+    const p = createProvider();
+    (p as any)._client = ctx.client;
+
+    await p.upscaleImage(new Uint8Array([1, 2]), {
+      model: {
+        id: `${IMAGE_ENDPOINT}/Redefine`,
+        name: "Topaz Redefine",
+        provider: "fal_ai"
+      },
+      scale: 4
+    } satisfies UpscaleImageParams);
+
+    expect(ctx.endpoint).toBe(IMAGE_ENDPOINT);
+    expect(ctx.input.model).toBe("Redefine");
+    expect(ctx.input.image_url).toBe("https://fal.media/u.bin");
+    expect(ctx.input.upscale_factor).toBe(4);
+  });
+
+  it("rescales 0–1 creativity onto Topaz's 1–6 level", async () => {
+    const ctx = recordingClient({ image: { url: "https://fal.ai/up.png" } });
+    vi.stubGlobal("fetch", okFetch());
+    const p = createProvider();
+    (p as any)._client = ctx.client;
+
+    await p.upscaleImage(new Uint8Array([1, 2]), {
+      model: {
+        id: `${IMAGE_ENDPOINT}/Redefine`,
+        name: "Topaz Redefine",
+        provider: "fal_ai"
+      },
+      creativity: 1
+    } satisfies UpscaleImageParams);
+
+    expect(ctx.input.creativity).toBe("6");
+  });
+
+  it("runs a bare Topaz endpoint id without a variant", async () => {
+    const ctx = recordingClient({ image: { url: "https://fal.ai/up.png" } });
+    vi.stubGlobal("fetch", okFetch());
+    const p = createProvider();
+    (p as any)._client = ctx.client;
+
+    await p.upscaleImage(new Uint8Array([1, 2]), {
+      model: { id: IMAGE_ENDPOINT, name: "Topaz", provider: "fal_ai" },
+      scale: 2
+    } satisfies UpscaleImageParams);
+
+    expect(ctx.endpoint).toBe(IMAGE_ENDPOINT);
+    expect(ctx.input.model).toBeUndefined();
+  });
+
+  it("sends the selected variant on the video endpoint", async () => {
+    const ctx = recordingClient({ video: { url: "https://fal.ai/up.mp4" } });
+    vi.stubGlobal("fetch", okFetch());
+    const p = createProvider();
+    (p as any)._client = ctx.client;
+
+    await p.videoToVideo(new Uint8Array([1, 2]), {
+      model: {
+        id: `${VIDEO_ENDPOINT}/Starlight Precise 2.5`,
+        name: "Topaz Starlight",
+        provider: "fal_ai"
+      }
+    } satisfies VideoToVideoParams);
+
+    expect(ctx.endpoint).toBe(VIDEO_ENDPOINT);
+    expect(ctx.input.model).toBe("Starlight Precise 2.5");
+    expect(ctx.input.video_url).toBe("https://fal.media/u.bin");
+  });
+});

--- a/packages/runtime/tests/providers/manifest-models-hardening.test.ts
+++ b/packages/runtime/tests/providers/manifest-models-hardening.test.ts
@@ -344,7 +344,12 @@ describe("inferVideoTasks", () => {
     ["texttovideo", ["text_to_video"]],
     ["image-to-video", ["image_to_video"]],
     ["image to video", ["image_to_video"]],
-    ["imagetovideo", ["image_to_video"]]
+    ["imagetovideo", ["image_to_video"]],
+    ["fal-ai/topaz/upscale/video", ["video_to_video"]],
+    ["super-resolution", ["video_to_video"]],
+    ["seedvr", ["video_to_video"]],
+    ["flashvsr", ["video_to_video"]],
+    ["wan-vision-enhancer", ["video_to_video"]]
   ];
   for (const [frag, expected] of cases) {
     it(`"${frag}" → ${expected.join("+")}`, () => {


### PR DESCRIPTION
fal ships Topaz as two endpoints — `fal-ai/topaz/upscale/image` and `fal-ai/topaz/upscale/video` — and picks the actual Topaz model through a `model` enum on each. One catalog entry per endpoint gave no way to choose one, so every run got fal's default (Standard V2 / Proteus) even when the source needed Redefine, CGI, Nyx or Starlight.

Each endpoint now expands into one selectable model per variant — 11 image models, 19 video models — with id `<endpointId>/<variant>`. The variant is split back off and sent as `model` when the request is built, so the endpoint fal receives is unchanged. Bare endpoint ids (saved before this, or typed by hand) still run and leave fal's default in place.

Three things this dragged in:

- **`creativity` was being rejected.** `UpscaleImageParams.creativity` is 0–1; the Topaz image endpoint takes a 1–6 level (Redefine only). The fraction is now rescaled for that endpoint and passed through untouched everywhere else.
- **Video upscalers were in the wrong pickers.** `inferVideoTasks` matches on the id, and none of these ids spell out "video-to-video", so Topaz, SeedVR, FlashVSR, ByteDance, Clarity and two more fell through to the generator branch and showed up in the text/image-to-video pickers with no video input. All seven are `video_to_video`, which their manifest `moduleName` already said.
- **A variant id would have been unpriced.** The generated FAL catalog is keyed by the endpoint fal bills, so a variant would have missed the lookup and skipped the pre-run budget gate the single entry used to be gated by. The lookup folds a variant back onto its endpoint — which is the rate fal charges for every variant anyway.

## Testing

- `packages/runtime` — 2778 tests pass, including 6 new cases covering variant expansion for both catalogs, the `model` value reaching the request, the creativity rescale, and a bare endpoint id still running. Each new assertion was watched fail with the change reverted.
- `packages/model-pricing` — 93 pass, with a new case pinning a variant to its endpoint's rate and one asserting an unrelated id that merely extends an endpoint stays unpriced.
- `npm run test:packages`, `npm run typecheck` (web + electron), `npm run lint`, and the web cost-preview suites.

Two failures in this sandbox are environment gaps, not this change: `packages/text-nodes`' `nlp-parity` hits a 10 s hook timeout importing `natural` under parallel load (passes on its own, 198/198), mobile typecheck has no `node_modules`, and the anti-slop lint leg cannot load `@oxlint/plugins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JAiWn3k2aCt4jWJEqaLZx

---
_Generated by [Claude Code](https://claude.ai/code/session_012JAiWn3k2aCt4jWJEqaLZx)_