### PR TITLE
feat(agents): Gemini video understanding as sandbox capability

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -189,7 +189,7 @@ lazy implementation table disagree.
 | `apps` | `debug_app` |
 | `code` | `validate_code`, `run_code`, `test_code` |
 | `js-scripts` | `list_js_scripts`, `get_js_script`, `save_js_script`, `validate_js_script`, `run_js_script`, `test_js_script` |
-| `media` | `generate_image`, `edit_image`, `generate_video`, `animate_image`, `generate_speech`, `transcribe_audio`, `embed_text`, `critique_image`, `compare_images`, `score_image_adherence` |
+| `media` | `generate_image`, `edit_image`, `generate_video`, `animate_image`, `generate_speech`, `transcribe_audio`, `embed_text`, `critique_image`, `compare_images`, `score_image_adherence`, `understand_video` |
 | `timelines` | `list_timelines`, `list_timeline_versions`, `get_timeline_version`, `create_timeline_version`, `restore_timeline_version`, `edit_timeline`, `validate_timeline` |
 | `sketches` | `list_sketches`, `list_sketch_versions`, `get_sketch_version`, `create_sketch_version`, `restore_sketch_version`, `edit_sketch`, `validate_sketch` |
 | `storyboards` | `list_storyboards`, `get_storyboard`, `render_storyboard_stills`, `render_storyboard_clips`, `revise_storyboard_clip`, `assemble_storyboard_timeline`, `edit_storyboard` |

--- a/docs/javascript-sandbox.md
+++ b/docs/javascript-sandbox.md
@@ -500,7 +500,9 @@ What an action gets on top of the standard surface:
 - **`nodetool.*`** — the platform as objects (`workflows`, `graph()`, `nodes`,
   `agents`, `models`, `media`, `assets`, `jobs`, `collections`, `web`, `memory`,
   and the rest), each method wrapping a belt tool. A method whose backing tool
-  is absent throws naming it.
+  is absent throws naming it. `nodetool.media.understandVideo(video, prompt,
+  model)` is the video half of the judging methods: it hands a whole clip to a
+  model that reads video (Gemini) and answers `prompt` as `{text}`.
 - **`openWorkflow(id)`** — when the belt carries the `ui_*` document tools, a
   graph object model whose synchronous mutators queue operations against a local
   mirror, replayed through the same tool contract by `await wf.commit()`.

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -969,8 +969,10 @@ research it follows (CodeAct, ICML 2024): docs/codeact-design.md.
   one ranked model; `find`/`list` for the long form; `forProvider(provider)`
   for one provider's own catalog), and `nodetool.media`
   (`generateImage/editImage/generateVideo/animateImage/speak/transcribe/embed`
-  plus the judge loop `critique/compare/scoreAdherence`, each taking a
-  pick/find result or `"provider/model_id"`), `nodetool.nodes`
+  plus the judge loop `critique/compare/scoreAdherence` and
+  `understandVideo(video, prompt, model)`, which hands a whole clip to a model
+  that reads video and answers as text — each taking a pick/find result or
+  `"provider/model_id"`), `nodetool.nodes`
   (`search/info/list` — the graph builder's discovery half),
   `nodetool.documents` (convert, PDF text/tables, markdown↔pdf),
   `nodetool.apps` (`build/debug`), `nodetool.agents` (`run(prompt)` spawns a

--- a/packages/agents/src/capabilities/media.specs.ts
+++ b/packages/agents/src/capabilities/media.specs.ts
@@ -14,6 +14,10 @@ import { isString } from "../utils/type-guards.js";
 
 export const MAX_COMPARE_IMAGES = 8;
 
+export const DEFAULT_VIDEO_PROMPT = "Describe this video in detail.";
+export const DEFAULT_UNDERSTAND_VIDEO_TOKENS = 1500;
+export const MAX_UNDERSTAND_VIDEO_TOKENS = 8192;
+
 export const GENERATE_IMAGE_SCHEMA: JsonSchema = {
   type: "object" as const,
   properties: {
@@ -260,6 +264,50 @@ export const SCORE_ADHERENCE_SCHEMA: JsonSchema = {
   required: ["provider", "model", "image", "brief"]
 };
 
+export const UNDERSTAND_VIDEO_SCHEMA: JsonSchema = {
+  type: "object" as const,
+  properties: {
+    provider: {
+      type: "string" as const,
+      description:
+        "Provider id of a chat model that reads video, e.g. gemini (find_model)."
+    },
+    model: { type: "string" as const, description: "Model id." },
+    video: {
+      type: "string" as const,
+      description: "Video to read: asset id, asset:// URI, URL, or data URI."
+    },
+    prompt: {
+      type: "string" as const,
+      description: `What to ask about the video. Default: "${DEFAULT_VIDEO_PROMPT}"`
+    },
+    max_tokens: {
+      type: "integer" as const,
+      minimum: 1,
+      maximum: MAX_UNDERSTAND_VIDEO_TOKENS,
+      description:
+        `Answer length cap. Default ${DEFAULT_UNDERSTAND_VIDEO_TOKENS}, ` +
+        `max ${MAX_UNDERSTAND_VIDEO_TOKENS}.`
+    }
+  },
+  required: ["provider", "model", "video"]
+};
+
+export const understandVideoSpec: CapabilitySpec = {
+  name: "understand_video",
+  description:
+    "Send a video plus an instruction to a multimodal chat model (Gemini " +
+    "reads video natively) and return the model's answer as text. Use it to " +
+    "describe or summarize a clip, answer questions about what happens in " +
+    "it, or extract on-screen text. Takes the whole video, not sampled " +
+    "frames — for a single still use critique_image instead.",
+  inputSchema: UNDERSTAND_VIDEO_SCHEMA,
+  // Unlisted in `TOOL_PERMISSION_CATEGORIES`, so the gate classes it
+  // `external` — the same category the vision judges carry.
+  category: "external",
+  userMessage: () => "Reading a video with a multimodal model"
+};
+
 export const generateImageSpec: CapabilitySpec = {
   name: "generate_image",
   description:
@@ -490,6 +538,7 @@ export const mediaSpecs: readonly CapabilitySpec[] = [
   critiqueImageSpec,
   compareImagesSpec,
   scoreImageAdherenceSpec,
+  understandVideoSpec,
   ffmpegSpec,
   ytDlpSpec
 ];

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -62,9 +62,13 @@ import {
   critiqueImageSpec,
   compareImagesSpec,
   scoreImageAdherenceSpec,
+  understandVideoSpec,
   ffmpegSpec,
   ytDlpSpec,
+  DEFAULT_UNDERSTAND_VIDEO_TOKENS,
+  DEFAULT_VIDEO_PROMPT,
   MAX_COMPARE_IMAGES,
+  MAX_UNDERSTAND_VIDEO_TOKENS,
   GENERATE_IMAGE_SCHEMA,
   EDIT_IMAGE_SCHEMA,
   GENERATE_VIDEO_SCHEMA,
@@ -75,7 +79,8 @@ import {
   READ_MEDIA_BYTES_SCHEMA,
   CRITIQUE_IMAGE_SCHEMA,
   COMPARE_IMAGES_SCHEMA,
-  SCORE_ADHERENCE_SCHEMA
+  SCORE_ADHERENCE_SCHEMA,
+  UNDERSTAND_VIDEO_SCHEMA
 } from "./media.specs.js";
 
 export {
@@ -90,7 +95,8 @@ export {
   READ_MEDIA_BYTES_SCHEMA,
   CRITIQUE_IMAGE_SCHEMA,
   COMPARE_IMAGES_SCHEMA,
-  SCORE_ADHERENCE_SCHEMA
+  SCORE_ADHERENCE_SCHEMA,
+  UNDERSTAND_VIDEO_SCHEMA
 } from "./media.specs.js";
 
 const MAX_INLINE_TEXT_PREVIEW = 500;
@@ -636,8 +642,8 @@ function parseJudgeModelArgs(
   return { provider, model };
 }
 
-/** Normalize an image source so the context media resolver can inline it. */
-function normalizeImageSource(source: string): string {
+/** Normalize a media source so the context media resolver can inline it. */
+function normalizeMediaSource(source: string): string {
   const trimmed = source.trim();
   if (
     trimmed.startsWith("data:") ||
@@ -654,7 +660,14 @@ function normalizeImageSource(source: string): string {
 function imagePart(source: string): MessageContent {
   return {
     type: "image_url",
-    image: { type: "image", uri: normalizeImageSource(source) }
+    image: { type: "image", uri: normalizeMediaSource(source) }
+  };
+}
+
+function videoPart(source: string): MessageContent {
+  return {
+    type: "video",
+    video: { type: "video", uri: normalizeMediaSource(source) }
   };
 }
 
@@ -678,7 +691,8 @@ function messageText(message: Message): string {
 async function judgeCall(
   context: ProcessingContext,
   m: JudgeModelArgs,
-  content: MessageContent[]
+  content: MessageContent[],
+  maxTokens: number = JUDGE_MAX_TOKENS
 ): Promise<string> {
   const result = (await context.runProviderPrediction({
     provider: m.provider,
@@ -686,7 +700,7 @@ async function judgeCall(
     model: m.model,
     params: {
       messages: [{ role: "user", content }] satisfies Message[],
-      max_tokens: JUDGE_MAX_TOKENS,
+      max_tokens: maxTokens,
       temperature: 0
     }
   })) as Message;
@@ -1022,6 +1036,52 @@ const scoreImageAdherence: CapabilityExport = {
   }
 };
 
+// ---------------------------------------------------------------------------
+// understand_video
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a video with a multimodal chat model.
+ *
+ * The video rides as a `video` content part next to the instruction; the
+ * context's media resolver inlines an `asset://` URI and the provider decides
+ * whether the bytes go inline or through its files API.
+ */
+const understandVideo: CapabilityExport = {
+  spec: understandVideoSpec,
+  impl: async (run, params) => {
+    const m = parseJudgeModelArgs(params);
+    if ("error" in m) return m;
+    const video = params["video"];
+    if (!isNonEmptyString(video)) {
+      return { error: "video is required" };
+    }
+    const promptParam = params["prompt"];
+    const prompt = isNonBlankString(promptParam)
+      ? promptParam
+      : DEFAULT_VIDEO_PROMPT;
+    const requested = Number(params["max_tokens"]);
+    const maxTokens =
+      Number.isFinite(requested) && requested > 0
+        ? Math.min(Math.floor(requested), MAX_UNDERSTAND_VIDEO_TOKENS)
+        : DEFAULT_UNDERSTAND_VIDEO_TOKENS;
+
+    try {
+      const text = await judgeCall(
+        run.context,
+        m,
+        [textPart(prompt), videoPart(video)],
+        maxTokens
+      );
+      return { text, provider: m.provider, model: m.model };
+    } catch (e) {
+      return {
+        error: `understand_video failed: ${e instanceof Error ? e.message : String(e)}`
+      };
+    }
+  }
+};
+
 /**
  * The gated read behind a media reference.
  *
@@ -1280,6 +1340,7 @@ export const MEDIA_CAPABILITIES: readonly CapabilityExport[] = [
   critiqueImage,
   compareImages,
   scoreImageAdherence,
+  understandVideo,
   ffmpeg,
   ytDlp
 ];
@@ -1301,6 +1362,7 @@ export {
   critiqueImage,
   compareImages,
   scoreImageAdherence,
+  understandVideo,
   ffmpeg,
   ytDlp
 };

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -48,6 +48,7 @@ export const NODETOOL_API_NAMESPACE_TOOLS: Record<string, readonly string[]> = {
     "critique_image",
     "compare_images",
     "score_image_adherence",
+    "understand_video",
     "ffmpeg",
     "yt_dlp"
   ],
@@ -694,6 +695,17 @@ const nodetool = (() => {
             __merge(__model(model), { image: image, brief: brief })
           )
         ),
+      /**
+       * Read a video with a multimodal chat model (Gemini reads video
+       * natively). Returns \`{text}\` — the model's answer to \`prompt\`.
+       */
+      understandVideo: (video, prompt, model, opts) =>
+        __need("understand_video")(
+          __merge(
+            opts,
+            __merge(__model(model), { video: video, prompt: prompt })
+          )
+        ),
       /** Run ffmpeg on workspace files. \`args\` is argv after the binary name. */
       ffmpeg: (args, opts) => __need("ffmpeg")(__merge(opts, { args: args })),
       /** Download a video with yt-dlp. */
@@ -1095,6 +1107,9 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   \`scoreAdherence(image, brief, visionModel, {questions})\`. The judge takes a
   VISION chat model — \`pick("generate_message")\` on a vision-capable one, not
   the image model that generated the picture.
+  \`understandVideo(video, prompt, videoModel, {max_tokens})\` reads a whole clip
+  with a model that takes video (Gemini) and answers \`prompt\` as \`{text}\` —
+  describe it, summarize it, or pull the on-screen text out.
   Host binaries: \`ffmpeg(args, {output_file, timeout_seconds})\` runs ffmpeg
   in the workspace (no shell); \`downloadVideo(url, outputFile, {format,
   timeout_seconds})\` downloads with yt-dlp. Browse pages with

--- a/packages/agents/src/evals/codeact-api-core.ts
+++ b/packages/agents/src/evals/codeact-api-core.ts
@@ -1130,6 +1130,22 @@ export function createCoreApiTools(recorder: CodeActToolRecorder): Tool[] {
       }
     ),
     tool(
+      "understand_video",
+      "Read a video with a multimodal chat model.",
+      { provider: s, model: s, video: s, prompt: s },
+      (params) => {
+        world.model(params["provider"], params["model"], "vision");
+        const asset = world.asset(params["video"]);
+        const prompt =
+          str(params["prompt"]) || "Describe this video in detail.";
+        return {
+          text: `${prompt} — ${asset.name} shows ${asset.prompt ?? asset.content}`,
+          provider: str(params["provider"]),
+          model: str(params["model"])
+        };
+      }
+    ),
+    tool(
       "ffmpeg",
       "Run ffmpeg on workspace files.",
       {

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -118,6 +118,9 @@ export const BUILTIN_TOOL_NAMES: readonly string[] = [
   "record_style_preference",
   "get_style_profile",
 
+  // Video understanding (a multimodal chat model reads a whole clip)
+  "understand_video",
+
   // Web
   "browser",
   "take_screenshot",

--- a/packages/agents/tests/capabilities-media.test.ts
+++ b/packages/agents/tests/capabilities-media.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import type { Message } from "@nodetool-ai/protocol";
+import type { Message, MessageContent } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { toolFromCapability } from "../src/capabilities/adapters.js";
 import { UNGATED, createCapabilityRun } from "../src/capabilities/invoke.js";
@@ -31,6 +31,7 @@ import {
   generateVideo,
   scoreImageAdherence,
   transcribeAudio,
+  understandVideo,
   ffmpeg,
   ytDlp
 } from "../src/capabilities/media.js";
@@ -80,6 +81,7 @@ describe("media and style capability modules", () => {
       "critique_image",
       "compare_images",
       "score_image_adherence",
+      "understand_video",
       "ffmpeg",
       "yt_dlp"
     ]);
@@ -109,6 +111,7 @@ describe("wire identity: a Tool built from the spec", () => {
     [critiqueImage, toolForCapabilityName("critique_image")],
     [compareImages, toolForCapabilityName("compare_images")],
     [scoreImageAdherence, toolForCapabilityName("score_image_adherence")],
+    [understandVideo, toolForCapabilityName("understand_video")],
     [ffmpeg, toolForCapabilityName("ffmpeg")],
     [ytDlp, toolForCapabilityName("yt_dlp")],
     [recordStylePreference, toolForCapabilityName("record_style_preference")],
@@ -204,6 +207,116 @@ describe("critique_image through the adapter", () => {
       brief: "a portrait"
     })) as Record<string, unknown>;
     expect(String(result["error"])).toMatch(/did not return parseable JSON/);
+  });
+});
+
+describe("understand_video through the adapter", () => {
+  function partsOf(predict: ReturnType<typeof vi.fn>): MessageContent[] {
+    const call = predict.mock.calls[0]?.[0] as {
+      params: { messages: Message[]; max_tokens: number };
+      provider: string;
+      model: string;
+      capability: string;
+    };
+    const content = call.params.messages[0].content;
+    if (!Array.isArray(content)) throw new Error("expected content parts");
+    return content;
+  }
+
+  it("sends the prompt and a video part, and returns the answer text", async () => {
+    const predict = vi.fn(async () => ({
+      role: "assistant",
+      content: "A fox crosses a snowfield."
+    }));
+    const result = (await asTool(understandVideo).process(
+      makeContext(predict),
+      {
+        provider: "gemini",
+        model: "gemini-3-pro",
+        video: "asset://clip-1.mp4",
+        prompt: "What happens?"
+      }
+    )) as Record<string, unknown>;
+
+    expect(result).toEqual({
+      text: "A fox crosses a snowfield.",
+      provider: "gemini",
+      model: "gemini-3-pro"
+    });
+    expect(partsOf(predict)).toEqual([
+      { type: "text", text: "What happens?" },
+      { type: "video", video: { type: "video", uri: "asset://clip-1.mp4" } }
+    ]);
+  });
+
+  it("normalizes a bare asset id and defaults the prompt", async () => {
+    const predict = vi.fn(async () => ({
+      role: "assistant",
+      content: "ok"
+    }));
+    await asTool(understandVideo).process(makeContext(predict), {
+      provider: "gemini",
+      model: "gemini-3-pro",
+      video: " clip-1 "
+    });
+    expect(partsOf(predict)).toEqual([
+      { type: "text", text: "Describe this video in detail." },
+      { type: "video", video: { type: "video", uri: "asset://clip-1" } }
+    ]);
+  });
+
+  it("caps max_tokens and defaults it when absent", async () => {
+    const maxTokensOf = async (params: Record<string, unknown>) => {
+      const predict = vi.fn(async () => ({ role: "assistant", content: "ok" }));
+      await asTool(understandVideo).process(makeContext(predict), {
+        provider: "gemini",
+        model: "gemini-3-pro",
+        video: "clip-1",
+        ...params
+      });
+      const call = predict.mock.calls[0][0] as {
+        params: { max_tokens: number };
+      };
+      return call.params.max_tokens;
+    };
+    expect(await maxTokensOf({})).toBe(1500);
+    expect(await maxTokensOf({ max_tokens: 400 })).toBe(400);
+    expect(await maxTokensOf({ max_tokens: 100000 })).toBe(8192);
+  });
+
+  it("requires provider, model and video, pointing at find_model", async () => {
+    const predict = vi.fn();
+    const noModel = (await asTool(understandVideo).process(
+      makeContext(predict),
+      { provider: "gemini", video: "clip-1" }
+    )) as Record<string, unknown>;
+    expect(String(noModel["error"])).toMatch(/find_model/);
+
+    const noProvider = (await asTool(understandVideo).process(
+      makeContext(predict),
+      { model: "gemini-3-pro", video: "clip-1" }
+    )) as Record<string, unknown>;
+    expect(String(noProvider["error"])).toMatch(/find_model/);
+
+    const noVideo = (await asTool(understandVideo).process(
+      makeContext(predict),
+      { provider: "gemini", model: "gemini-3-pro" }
+    )) as Record<string, unknown>;
+    expect(noVideo).toEqual({ error: "video is required" });
+    expect(predict).not.toHaveBeenCalled();
+  });
+
+  it("reports a provider failure as an error", async () => {
+    const predict = vi.fn(async () => {
+      throw new Error("no video support");
+    });
+    const result = (await asTool(understandVideo).process(
+      makeContext(predict),
+      { provider: "gemini", model: "gemini-3-pro", video: "clip-1" }
+    )) as Record<string, unknown>;
+    expect(String(result["error"])).toBe(
+      "understand_video failed: no video support"
+    );
   });
 });
 

--- a/packages/agents/tests/capabilities-registry.test.ts
+++ b/packages/agents/tests/capabilities-registry.test.ts
@@ -49,6 +49,7 @@ const CAPABILITY_CATEGORY_SNAPSHOT: Record<string, PermissionCategory> = {
   run_search: "read",
   run_subtask: "read",
   todo_write: "read",
+  understand_video: "external",
   write_file: "write",
   // Google Workspace: none is listed in `TOOL_PERMISSION_CATEGORIES`, so the
   // map's conservative default classes them `external`. Carried over as-is.

--- a/packages/agents/tests/nodetool-api-media-docs.test.ts
+++ b/packages/agents/tests/nodetool-api-media-docs.test.ts
@@ -24,7 +24,8 @@ const CRITIQUE_TOOLS = [
   "generate_image",
   "critique_image",
   "compare_images",
-  "score_image_adherence"
+  "score_image_adherence",
+  "understand_video"
 ].map(toolDef);
 
 const PIPELINE_TOOLS = ["generate_image"].map(toolDef);
@@ -99,6 +100,12 @@ function createFakeRouter(opts: { imageBytes?: "tiny" | "png" } = {}) {
           type: "comparison",
           winner: args["images"] ? (args["images"] as string[])[1] : null,
           matches: []
+        });
+      case "understand_video":
+        return JSON.stringify({
+          text: "A fox crosses a snowfield.",
+          provider: args["provider"],
+          model: args["model"]
         });
       case "score_image_adherence":
         return JSON.stringify({
@@ -204,6 +211,29 @@ describe("nodetool.media judging", () => {
         model: "gpt-5.4-mini",
         images: ["a.png", "b.png"],
         brief: "a fox"
+      }
+    });
+  });
+
+  it("reads a video with a multimodal model", async () => {
+    const { executeTool, calls } = createFakeRouter();
+    const session = makeSession(CRITIQUE_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `const r = await nodetool.media.understandVideo("asset://clip1.mp4",
+         "What happens?", "gemini/gemini-3-pro", { max_tokens: 400 });
+       return r.text;`
+    );
+    expect(obs.ok).toBe(true);
+    expect(obs.result).toBe("A fox crosses a snowfield.");
+    expect(calls[0]).toMatchObject({
+      name: "understand_video",
+      args: {
+        provider: "gemini",
+        model: "gemini-3-pro",
+        video: "asset://clip1.mp4",
+        prompt: "What happens?",
+        max_tokens: 400
       }
     });
   });
@@ -364,6 +394,7 @@ describe("nodetool.documents", () => {
     expect(section).toContain("nodetool.media");
     expect(section).toContain("nodetool.documents");
     expect(section).toContain("scoreAdherence(");
+    expect(section).toContain("understandVideo(");
     expect(section).toContain("pdfToMarkdown(");
     expect(buildNodetoolApiPromptSection(["web_search"])).not.toContain(
       "nodetool.documents"

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -2944,6 +2944,13 @@ export class ProcessingContext {
       m4a: "audio/mp4",
       flac: "audio/flac"
     };
+    const VIDEO_MIME: Record<string, string> = {
+      mp4: "video/mp4",
+      m4v: "video/mp4",
+      webm: "video/webm",
+      mov: "video/quicktime",
+      avi: "video/x-msvideo"
+    };
 
     // Strict, anchored sanitizer for the URIs that may flow into the asset /
     // storage retrieval path. Two schemes are recognized — `asset://<id>.<ext>`
@@ -2997,6 +3004,26 @@ export class ProcessingContext {
             {
               type: "audio",
               audio: { uri: `data:${mimeType};base64,${b64}`, mimeType }
+            }
+          ];
+        }
+        return [part];
+      }
+      if (
+        part.type === "video" &&
+        part.video.uri &&
+        isResolvableUri(part.video.uri)
+      ) {
+        const bytes = await this.retrieveMediaBytes(part.video.uri);
+        if (bytes) {
+          const ext = part.video.uri.split(".").pop()?.toLowerCase() ?? "mp4";
+          const mimeType =
+            VIDEO_MIME[ext] ?? part.video.mimeType ?? "video/mp4";
+          const b64 = Buffer.from(bytes).toString("base64");
+          return [
+            {
+              type: "video",
+              video: { uri: `data:${mimeType};base64,${b64}`, mimeType }
             }
           ];
         }

--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -2,6 +2,7 @@ import type { Chunk } from "@nodetool-ai/protocol";
 import { createLogger } from "@nodetool-ai/config";
 import { BaseProvider } from "./base-provider.js";
 import { sniffAudioMime } from "./audio-mime.js";
+import { sniffVideoMime } from "./video-mime.js";
 import { safeFetch } from "./safe-url.js";
 import {
   isBoolean,
@@ -23,6 +24,7 @@ import type {
   MessageAudioContent,
   MessageImageContent,
   MessageTextContent,
+  MessageVideoContent,
   ProviderStreamItem,
   ProviderTool,
   StreamingAudioChunk,
@@ -35,6 +37,21 @@ import type {
 import { WEB_SEARCH_TOOL_NAME } from "./types.js";
 
 const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
+const GEMINI_UPLOAD_BASE = `${GEMINI_API_BASE.replace(
+  "/v1beta",
+  ""
+)}/upload/v1beta/files`;
+
+/**
+ * Largest payload sent as `inlineData`. Gemini caps a generateContent request
+ * at 20 MB total; anything above this goes through the Files API instead, which
+ * leaves room for the rest of the request.
+ */
+export const GEMINI_INLINE_VIDEO_MAX_BYTES = 19 * 1024 * 1024;
+
+/** Polls of `files/{name}` before an uploaded file is declared stuck. */
+const GEMINI_FILE_MAX_POLLS = 60;
+const GEMINI_FILE_POLL_INTERVAL_MS = 2_000;
 
 /** Drop `; charset=…`/`; codecs=…` parameters from a Content-Type header. */
 function stripMimeParams(value: string | null): string | undefined {
@@ -56,6 +73,17 @@ function geminiAudioMime(mime: string | undefined): string {
 
 interface GeminiProviderOptions {
   fetchFn?: typeof fetch;
+  /** Delay between Files API polls — overridden in tests to run them back to back. */
+  sleepFn?: (ms: number) => Promise<void>;
+}
+
+/** A file record returned by the Gemini Files API. */
+interface GeminiFile {
+  name?: string;
+  uri?: string;
+  mimeType?: string;
+  state?: string;
+  error?: { message?: string };
 }
 
 /** A Gemini content part. */
@@ -63,6 +91,7 @@ interface GeminiPart {
   text?: string;
   thought?: boolean;
   inlineData?: { mimeType: string; data: string };
+  fileData?: { mimeType: string; fileUri: string };
   functionCall?: {
     id?: string;
     name: string;
@@ -546,6 +575,7 @@ export class GeminiProvider extends BaseProvider {
 
   readonly apiKey: string;
   private _fetch: typeof fetch;
+  private _sleep: (ms: number) => Promise<void>;
 
   constructor(
     secrets: { GEMINI_API_KEY?: string },
@@ -560,6 +590,9 @@ export class GeminiProvider extends BaseProvider {
 
     this.apiKey = apiKey;
     this._fetch = options.fetchFn ?? globalThis.fetch.bind(globalThis);
+    this._sleep =
+      options.sleepFn ??
+      ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   }
 
   getContainerEnv() {
@@ -738,7 +771,155 @@ export class GeminiProvider extends BaseProvider {
       };
     }
 
+    if (content.type === "video") {
+      return await this.videoContentToGeminiPart(
+        (content as MessageVideoContent).video
+      );
+    }
+
     return { text: "[unsupported content type]" };
+  }
+
+  /**
+   * Source a video's bytes the way the image and audio branches do, then send
+   * them inline when small enough and through the Files API when not.
+   */
+  private async videoContentToGeminiPart(
+    video: MessageVideoContent["video"]
+  ): Promise<GeminiPart> {
+    let bytes: Buffer;
+    let mimeType = video.mimeType;
+
+    const parseVideoDataUri = (uri: string): Buffer => {
+      const idx = uri.indexOf(",");
+      if (idx < 0) throw new Error("Invalid video data URI");
+      const header = uri.slice(5, idx);
+      mimeType = mimeType ?? stripMimeParams(header.split(";base64")[0]);
+      return Buffer.from(uri.slice(idx + 1), "base64");
+    };
+
+    if (
+      isNonEmptyString(video.data) ||
+      (video.data instanceof Uint8Array && video.data.length > 0)
+    ) {
+      if (isString(video.data)) {
+        bytes = video.data.startsWith("data:")
+          ? parseVideoDataUri(video.data)
+          : Buffer.from(video.data, "base64");
+      } else {
+        bytes = Buffer.from(video.data);
+      }
+    } else if (video.uri) {
+      const resolvedUri = video.uri.startsWith("data:")
+        ? video.uri
+        : await this.resolveUri(video.uri);
+      if (resolvedUri.startsWith("data:")) {
+        bytes = parseVideoDataUri(resolvedUri);
+      } else {
+        const resp = await safeFetch(resolvedUri, undefined, 5, this._fetch);
+        if (!resp.ok) throw new Error(`Failed to fetch video: ${resp.status}`);
+        mimeType =
+          stripMimeParams(resp.headers.get("content-type")) ?? mimeType;
+        bytes = Buffer.from(await resp.arrayBuffer());
+      }
+    } else {
+      bytes = Buffer.alloc(0);
+    }
+
+    const resolvedMime = mimeType ?? sniffVideoMime(bytes);
+
+    if (bytes.length > GEMINI_INLINE_VIDEO_MAX_BYTES) {
+      const fileUri = await this.uploadFileToGemini(bytes, resolvedMime);
+      return { fileData: { mimeType: resolvedMime, fileUri } };
+    }
+
+    return {
+      inlineData: { mimeType: resolvedMime, data: bytes.toString("base64") }
+    };
+  }
+
+  /**
+   * Upload bytes with the Files API resumable protocol and wait until the file
+   * is ACTIVE — Gemini rejects a `fileData` part that references a file still
+   * being processed. Returns the file's uri.
+   */
+  private async uploadFileToGemini(
+    bytes: Uint8Array,
+    mimeType: string
+  ): Promise<string> {
+    const startResp = await this._fetch(
+      `${GEMINI_UPLOAD_BASE}?key=${this.apiKey}`,
+      {
+        method: "POST",
+        headers: {
+          "X-Goog-Upload-Protocol": "resumable",
+          "X-Goog-Upload-Command": "start",
+          "X-Goog-Upload-Header-Content-Length": String(bytes.length),
+          "X-Goog-Upload-Header-Content-Type": mimeType,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          file: { display_name: `nodetool-upload.${mimeType.split("/")[1]}` }
+        })
+      }
+    );
+    if (!startResp.ok) {
+      const errText = await startResp.text();
+      throw new Error(
+        `Gemini file upload failed to start ${startResp.status}: ${errText}`
+      );
+    }
+    const uploadUrl = startResp.headers.get("x-goog-upload-url");
+    if (!uploadUrl) {
+      throw new Error("Gemini file upload returned no X-Goog-Upload-URL");
+    }
+
+    const uploadResp = await this._fetch(uploadUrl, {
+      method: "POST",
+      headers: {
+        "Content-Length": String(bytes.length),
+        "X-Goog-Upload-Offset": "0",
+        "X-Goog-Upload-Command": "upload, finalize"
+      },
+      body: new Blob([new Uint8Array(bytes) as Uint8Array<ArrayBuffer>], {
+        type: mimeType
+      })
+    });
+    if (!uploadResp.ok) {
+      const errText = await uploadResp.text();
+      throw new Error(
+        `Gemini file upload failed ${uploadResp.status}: ${errText}`
+      );
+    }
+
+    const uploaded = (await uploadResp.json()) as { file?: GeminiFile };
+    let file = uploaded.file;
+    if (!file?.name || !file.uri) {
+      throw new Error("Gemini file upload returned no file record");
+    }
+    const fileUri = file.uri;
+    const fileName = file.name;
+
+    for (let poll = 0; poll < GEMINI_FILE_MAX_POLLS; poll++) {
+      if (file?.state === "ACTIVE") return fileUri;
+      if (file?.state === "FAILED") {
+        throw new Error(
+          `Gemini file processing failed: ${file.error?.message ?? "unknown error"}`
+        );
+      }
+      await this._sleep(GEMINI_FILE_POLL_INTERVAL_MS);
+      const pollResp = await this._fetch(`${GEMINI_API_BASE}/${fileName}`, {
+        headers: { "x-goog-api-key": this.apiKey }
+      });
+      if (!pollResp.ok) {
+        const errText = await pollResp.text();
+        throw new Error(`Gemini file poll failed ${pollResp.status}: ${errText}`);
+      }
+      file = (await pollResp.json()) as GeminiFile;
+    }
+
+    if (file?.state === "ACTIVE") return fileUri;
+    throw new Error(`Gemini file ${fileName} did not become ACTIVE in time`);
   }
 
   /**

--- a/packages/runtime/src/providers/openai-provider.ts
+++ b/packages/runtime/src/providers/openai-provider.ts
@@ -896,6 +896,10 @@ export class OpenAIProvider extends BaseProvider {
       };
     }
 
+    if (content.type === "video") {
+      throw new Error("video input is not supported by openai");
+    }
+
     const c = content as MessageImageContent;
     const imageUrl = c.image.uri
       ? await this.uriToBase64(c.image.uri)

--- a/packages/runtime/src/providers/types.ts
+++ b/packages/runtime/src/providers/types.ts
@@ -203,6 +203,15 @@ export interface MessageAudioContent {
   };
 }
 
+export interface MessageVideoContent {
+  type: "video";
+  video: {
+    uri?: string;
+    data?: Uint8Array | string;
+    mimeType?: string;
+  };
+}
+
 export interface MessageDocumentContent {
   type: "document";
   document: {
@@ -269,6 +278,7 @@ export type MessageContent =
   | MessageTextContent
   | MessageImageContent
   | MessageAudioContent
+  | MessageVideoContent
   | MessageDocumentContent;
 
 export interface ProviderToolErrorResult {

--- a/packages/runtime/src/providers/video-mime.ts
+++ b/packages/runtime/src/providers/video-mime.ts
@@ -1,0 +1,47 @@
+/**
+ * Detect a video container from its leading magic bytes.
+ *
+ * Used when a video reaches a provider without a reliable Content-Type — e.g.
+ * asset bytes read from storage. Defaults to `video/mp4`, the container every
+ * multimodal provider accepts.
+ */
+export function sniffVideoMime(bytes: Uint8Array): string {
+  // ISO base media file format: <4-byte size> "ftyp" — mp4, m4v and mov all
+  // use it; the brand that follows separates QuickTime from mp4.
+  if (
+    bytes[4] === 0x66 &&
+    bytes[5] === 0x74 &&
+    bytes[6] === 0x79 &&
+    bytes[7] === 0x70
+  ) {
+    const brand = String.fromCharCode(
+      bytes[8] ?? 0,
+      bytes[9] ?? 0,
+      bytes[10] ?? 0,
+      bytes[11] ?? 0
+    );
+    return brand === "qt  " ? "video/quicktime" : "video/mp4";
+  }
+  // EBML header — Matroska and WebM share it; WebM is the only one Gemini takes.
+  if (
+    bytes[0] === 0x1a &&
+    bytes[1] === 0x45 &&
+    bytes[2] === 0xdf &&
+    bytes[3] === 0xa3
+  ) {
+    return "video/webm";
+  }
+  // "RIFF" ... "AVI "
+  if (
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x41 &&
+    bytes[9] === 0x56 &&
+    bytes[10] === 0x49
+  ) {
+    return "video/x-msvideo";
+  }
+  return "video/mp4";
+}

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -1398,6 +1398,50 @@ describe("ProcessingContext – asset helper methods", () => {
     }
   });
 
+  it("resolveMessageMediaUris dereferences asset:// video URIs to data URIs", async () => {
+    const root = await mkdtemp(join(tmpdir(), "nodetool-resolve-asset-video-"));
+    try {
+      const mp4Bytes = new Uint8Array([0, 0, 0, 0x18, 0x66, 0x74, 0x79, 0x70]);
+      const ctx = new ProcessingContext({
+        jobId: "j1",
+        userId: "u1",
+        workspaceDir: root,
+        fetchFn: async (input: string | URL | Request) => {
+          const url = String(input);
+          if (url.endsWith("/api/assets/clip.mp4")) {
+            return new Response(
+              JSON.stringify({ id: "clip", get_url: "/api/storage/clip.mp4" }),
+              { status: 200, headers: { "content-type": "application/json" } }
+            );
+          }
+          if (url.endsWith("/api/storage/clip.mp4")) {
+            return new Response(mp4Bytes, {
+              status: 200,
+              headers: { "content-type": "video/mp4" }
+            });
+          }
+          return new Response("not found", { status: 404 });
+        }
+      });
+
+      const resolved = await ctx.resolveMessageMediaUris([
+        {
+          role: "user",
+          content: [{ type: "video", video: { uri: "asset://clip.mp4" } }]
+        }
+      ]);
+
+      const parts = resolved[0].content as Array<Record<string, any>>;
+      expect(parts[0].type).toBe("video");
+      expect(parts[0].video.mimeType).toBe("video/mp4");
+      expect(parts[0].video.uri).toBe(
+        `data:video/mp4;base64,${Buffer.from(mp4Bytes).toString("base64")}`
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("resolveMessageMediaUris splits a text-embedded image mention into its own resolved block", async () => {
     const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
     const ctx = new ProcessingContext({

--- a/packages/runtime/tests/providers/gemini-video-content.test.ts
+++ b/packages/runtime/tests/providers/gemini-video-content.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  GeminiProvider,
+  GEMINI_INLINE_VIDEO_MAX_BYTES
+} from "../../src/providers/gemini-provider.js";
+
+function jsonResponse(
+  body: unknown,
+  headers: Record<string, string> = {}
+): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers(headers),
+    json: async () => body,
+    text: async () => JSON.stringify(body)
+  } as unknown as Response;
+}
+
+describe("GeminiProvider video content", () => {
+  it("sends a small video inline with a sniffed mime type", async () => {
+    const provider = new GeminiProvider({ GEMINI_API_KEY: "k" });
+    // ISO base media header: <size> "ftyp" "isom" — sniffs as video/mp4.
+    const bytes = new Uint8Array([
+      0, 0, 0, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 1, 2, 3
+    ]);
+
+    const result = await provider.convertMessages([
+      { role: "user", content: [{ type: "video", video: { data: bytes } }] }
+    ]);
+
+    const part = result.contents[0].parts[0];
+    expect(part.inlineData).toBeDefined();
+    expect(part.inlineData!.mimeType).toBe("video/mp4");
+    expect(part.inlineData!.data).toBe(Buffer.from(bytes).toString("base64"));
+  });
+
+  it("takes the mime type from a video data URI", async () => {
+    const provider = new GeminiProvider({ GEMINI_API_KEY: "k" });
+    const base64 = Buffer.from("webmdata").toString("base64");
+
+    const result = await provider.convertMessages([
+      {
+        role: "user",
+        content: [
+          { type: "video", video: { uri: `data:video/webm;base64,${base64}` } }
+        ]
+      }
+    ]);
+
+    const part = result.contents[0].parts[0];
+    expect(part.inlineData!.mimeType).toBe("video/webm");
+    expect(part.inlineData!.data).toBe(base64);
+  });
+
+  it("uploads a large video through the Files API and emits fileData", async () => {
+    const bytes = new Uint8Array(GEMINI_INLINE_VIDEO_MAX_BYTES + 1024);
+    bytes.set([0, 0, 0, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d]);
+
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchFn = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        calls.push({ url, init });
+        if (url.includes("/upload/v1beta/files")) {
+          return jsonResponse(
+            {},
+            { "x-goog-upload-url": "https://upload.example/session/1" }
+          );
+        }
+        if (url.startsWith("https://upload.example/")) {
+          return jsonResponse({
+            file: {
+              name: "files/abc",
+              uri: "https://generativelanguage.googleapis.com/v1beta/files/abc",
+              state: "PROCESSING"
+            }
+          });
+        }
+        return jsonResponse({ name: "files/abc", state: "ACTIVE" });
+      }
+    ) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider(
+      { GEMINI_API_KEY: "k" },
+      { fetchFn, sleepFn: async () => {} }
+    );
+
+    const result = await provider.convertMessages([
+      { role: "user", content: [{ type: "video", video: { data: bytes } }] }
+    ]);
+
+    const part = result.contents[0].parts[0];
+    expect(part.inlineData).toBeUndefined();
+    expect(part.fileData).toEqual({
+      mimeType: "video/mp4",
+      fileUri: "https://generativelanguage.googleapis.com/v1beta/files/abc"
+    });
+
+    const startHeaders = calls[0].init?.headers as Record<string, string>;
+    expect(calls[0].url).toContain("/upload/v1beta/files");
+    expect(startHeaders["X-Goog-Upload-Protocol"]).toBe("resumable");
+    expect(startHeaders["X-Goog-Upload-Command"]).toBe("start");
+    expect(startHeaders["X-Goog-Upload-Header-Content-Length"]).toBe(
+      String(bytes.length)
+    );
+    expect(startHeaders["X-Goog-Upload-Header-Content-Type"]).toBe("video/mp4");
+
+    const uploadHeaders = calls[1].init?.headers as Record<string, string>;
+    expect(calls[1].url).toBe("https://upload.example/session/1");
+    expect(uploadHeaders["X-Goog-Upload-Command"]).toBe("upload, finalize");
+    expect(uploadHeaders["X-Goog-Upload-Offset"]).toBe("0");
+
+    // One poll, and it stops as soon as the file reports ACTIVE.
+    expect(calls).toHaveLength(3);
+    expect(calls[2].url).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/files/abc"
+    );
+  });
+
+  it("fails when the uploaded file reports FAILED", async () => {
+    const bytes = new Uint8Array(GEMINI_INLINE_VIDEO_MAX_BYTES + 1);
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/upload/v1beta/files")) {
+        return jsonResponse(
+          {},
+          { "x-goog-upload-url": "https://upload.example/session/1" }
+        );
+      }
+      if (url.startsWith("https://upload.example/")) {
+        return jsonResponse({
+          file: { name: "files/bad", uri: "u", state: "PROCESSING" }
+        });
+      }
+      return jsonResponse({
+        name: "files/bad",
+        state: "FAILED",
+        error: { message: "transcode error" }
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = new GeminiProvider(
+      { GEMINI_API_KEY: "k" },
+      { fetchFn, sleepFn: async () => {} }
+    );
+
+    await expect(
+      provider.convertMessages([
+        { role: "user", content: [{ type: "video", video: { data: bytes } }] }
+      ])
+    ).rejects.toThrow("transcode error");
+  });
+
+  it("still degrades unsupported content to a text placeholder", async () => {
+    const provider = new GeminiProvider({ GEMINI_API_KEY: "k" });
+
+    const result = await provider.convertMessages([
+      {
+        role: "user",
+        content: [
+          {
+            type: "document",
+            document: { data: "x", mimeType: "application/pdf" }
+          }
+        ]
+      }
+    ]);
+
+    expect(result.contents[0].parts[0]).toEqual({
+      text: "[unsupported content type]"
+    });
+  });
+});


### PR DESCRIPTION
Adds video understanding to the sandbox tool surface, backed by Gemini. An agent (or a Code node body) can now send a video plus an instruction to a multimodal model and get the model's text back — describe, summarize, answer questions about, or read on-screen text from a video.

## Runtime provider layer (`packages/runtime`)

- `MessageVideoContent` variant in the provider-facing `MessageContent` union (previously video input was structurally impossible at the provider layer).
- Gemini provider: a `video` branch in `messageContentToGeminiPart`. Videos up to `GEMINI_INLINE_VIDEO_MAX_BYTES` (19 MB) go inline as `inlineData`; larger ones are uploaded through the Gemini Files API (resumable upload, poll `files/{name}` until `ACTIVE`, bounded polls) and referenced with a new `fileData` part. Poll delay and fetch are injectable for tests.
- New `video-mime.ts` sniffer (ISO-BMFF mp4/quicktime, EBML/webm, RIFF/AVI; default `video/mp4`).
- `resolveMessageMediaUris`: a `type: "video"` branch so `asset://` / `/api/storage/` video parts are inlined to data URIs before the provider sees them.
- OpenAI provider now rejects video parts explicitly instead of mis-reading them as images; other providers already degrade the way they do for any unsupported part.

## Sandbox capability layer (`packages/agents`)

- New `understand_video` capability in `capabilities/media.*`, same shape as the `critique_image` vision judge: explicit `provider` + `model` (error text points at `find_model`), `video` (asset id, `asset://` URI, URL, or data URI — normalized through the shared `normalizeMediaSource`), optional `prompt` (default "Describe this video in detail.") and `max_tokens` (default 1500, capped 8192). Returns `{ text, provider, model }`. Category `external`, like the other judges.
- Guest API: `nodetool.media.understandVideo(video, prompt, model, opts)` in the CodeAct / Code-node prelude, wire name on the builtin belt and in `NODETOOL_API_NAMESPACE_TOOLS.media`, prompt-doc entry.
- Docs updated: `docs/AGENTS.md`, `docs/javascript-sandbox.md`, `packages/agents/AGENTS.md`.

## Tests

- `gemini-video-content.test.ts` (new): inline path with sniffed mime, mime from data URI, mocked resumable upload (asserts start/upload headers, `fileData` emission, stops on `ACTIVE`), `FAILED` state rejects, unsupported content still degrades.
- `context.test.ts`: `asset://clip.mp4` inlined to a `data:video/mp4;base64,…` part.
- `capabilities-media.test.ts`: scripted-provider round trip asserting the video part and prompt reach the provider, source normalization, find_model errors; registry category snapshot and nodetool-api media-docs tests extended.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run test:packages` — 105/105 tasks green (plus the oxlint-rules suite)
- `packages/runtime`: 2784 tests passing; `packages/agents`: 2899 passing / 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ki1YenqLPpqKkwecNHX1v