### PR TITLE
fix(chat): resolve asset:// attachments through the asset store

### DIFF
--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -1285,6 +1285,14 @@ export class ProcessingContext {
   /** Storage adapter (optional, for asset handling). */
   readonly storage: StorageAdapter | null;
   /**
+   * Asset storage adapter — where user assets (`asset://<id>.<ext>`) live.
+   * Separate from {@link storage}, which servers point at the *temp* store:
+   * without this, an `asset://` reference could only be resolved over HTTP
+   * through `/api/storage`, which authorizes by `x-user-id` and 404s for
+   * anyone but user `1`. Null falls back to {@link storage}.
+   */
+  readonly assetStorage: StorageAdapter | null;
+  /**
    * Workspace storage adapter — the agent's working directory abstracted
    * behind {@link StorageAdapter}. Tools that read/write/list files use
    * this adapter so the same code paths work locally (FS-backed) and in
@@ -1381,6 +1389,7 @@ export class ProcessingContext {
     persistOutputAssets?: boolean;
     cache?: CacheAdapter;
     storage?: StorageAdapter | null;
+    assetStorage?: StorageAdapter | null;
     workspaceStorage?: StorageAdapter | null;
     onMessage?: (msg: ProcessingMessage) => void;
     variables?: Record<string, unknown>;
@@ -1424,6 +1433,7 @@ export class ProcessingContext {
     this.persistOutputAssets = opts.persistOutputAssets ?? true;
     this.cache = opts.cache ?? new MemoryCache();
     this.storage = opts.storage ?? null;
+    this.assetStorage = opts.assetStorage ?? null;
     this.workspaceStorage = opts.workspaceStorage ?? null;
     if (opts.onMessage) {
       this._messageListeners.add(opts.onMessage);
@@ -1482,6 +1492,7 @@ export class ProcessingContext {
       persistOutputAssets: this.persistOutputAssets,
       cache: this.cache,
       storage: this.storage,
+      assetStorage: this.assetStorage,
       workspaceStorage: this.workspaceStorage,
       variables: { ...this._variables },
       environment: { ...this.environment },
@@ -2524,12 +2535,20 @@ export class ProcessingContext {
     const trimmed = assetId.trim();
     const attempts: string[] = [];
 
-    const tryStorageUri = async (uri: string): Promise<Uint8Array | null> => {
-      if (!this.storage) {
-        return null;
-      }
+    // Assets live in the asset store; `this.storage` is the *temp* store on
+    // server paths. Probe the asset adapter first and keep the temp adapter as
+    // the fallback so runtime-materialized refs still resolve.
+    const adapters = [this.assetStorage, this.storage].filter(
+      (adapter, index, all): adapter is StorageAdapter =>
+        adapter !== null && all.indexOf(adapter) === index
+    );
+
+    const tryStorageUri = async (
+      adapter: StorageAdapter,
+      uri: string
+    ): Promise<Uint8Array | null> => {
       try {
-        const retrieved = await this.storage.retrieve(uri);
+        const retrieved = await adapter.retrieve(uri);
         if (retrieved) {
           return retrieved;
         }
@@ -2598,9 +2617,11 @@ export class ProcessingContext {
 
     // A concrete storage URI / http URL handed in directly.
     if (trimmed.includes("://") && !trimmed.startsWith("asset://")) {
-      const direct = await tryStorageUri(trimmed);
-      if (direct) {
-        return { bytes: direct, attempts };
+      for (const adapter of adapters) {
+        const direct = await tryStorageUri(adapter, trimmed);
+        if (direct) {
+          return { bytes: direct, attempts };
+        }
       }
       if (/^https?:\/\//.test(trimmed)) {
         try {
@@ -2617,7 +2638,7 @@ export class ProcessingContext {
       }
     }
 
-    if (this.storage) {
+    for (const adapter of adapters) {
       // Keys assets are written under: `<userId>/<id>.<ext>` (uploads — the
       // current owner-prefixed layout), `<id>.<ext>` (the flat legacy layout)
       // and `assets/<id>` (runtime-materialized refs). The owner-prefixed key
@@ -2631,7 +2652,7 @@ export class ProcessingContext {
           keys.unshift(`${this.userId}/${candidate}`);
         }
         for (const key of keys) {
-          const bytes = await tryStorageUri(this.storage.uriForKey(key));
+          const bytes = await tryStorageUri(adapter, adapter.uriForKey(key));
           if (bytes) {
             return { bytes, attempts };
           }
@@ -2652,7 +2673,7 @@ export class ProcessingContext {
           prefix: string
         ): Promise<Uint8Array | null> => {
           try {
-            const listing = await this.storage!.list(prefix);
+            const listing = await adapter.list(prefix);
             const bareEndsWithThumb = bareId.endsWith("_thumb");
             const match = listing.entries.find((entry) => {
               const key = entry.key;
@@ -2672,7 +2693,7 @@ export class ProcessingContext {
               return !isThumb || bareEndsWithThumb;
             });
             if (match) {
-              return await tryStorageUri(match.uri);
+              return await tryStorageUri(adapter, match.uri);
             }
           } catch (error) {
             attempts.push(
@@ -2738,9 +2759,11 @@ export class ProcessingContext {
         }
         const uri = metadata.uri;
         if (isString(uri)) {
-          const bytes = await tryStorageUri(uri);
-          if (bytes) {
-            return { bytes, attempts };
+          for (const adapter of adapters) {
+            const bytes = await tryStorageUri(adapter, uri);
+            if (bytes) {
+              return { bytes, attempts };
+            }
           }
         }
       } catch (error) {
@@ -2914,7 +2937,12 @@ export class ProcessingContext {
       const { bytes } = await this.resolveAssetBytes(uri);
       return bytes;
     }
-    return this.storage ? await this.storage.retrieve(uri) : null;
+    for (const adapter of [this.assetStorage, this.storage]) {
+      if (!adapter) continue;
+      const bytes = await adapter.retrieve(uri);
+      if (bytes) return bytes;
+    }
+    return null;
   }
 
   /**
@@ -2966,6 +2994,17 @@ export class ProcessingContext {
     const isResolvableUri = (uri: string): boolean =>
       RESOLVABLE_URI_RE.test(uri);
 
+    // An `asset://` reference that cannot be dereferenced must not reach the
+    // provider: providers `fetch` a non-data URI, and the SSRF guard then
+    // rejects `asset://…` with "Refusing to fetch unsafe URL", which fails the
+    // whole turn on a message the user cannot fix. Replace the block with a
+    // note the model can act on instead — a stale attachment in the history
+    // must not break every later turn in the thread.
+    const unresolvedNote = (kind: string, uri: string): MessageContent => ({
+      type: "text",
+      text: `[attached ${kind} could not be loaded: ${uri}]`
+    });
+
     const resolvePart = async (
       part: MessageContent
     ): Promise<MessageContent[]> => {
@@ -2987,7 +3026,7 @@ export class ProcessingContext {
             }
           ];
         }
-        return [part];
+        return [unresolvedNote("image", part.image.uri)];
       }
       if (
         part.type === "audio" &&
@@ -3007,7 +3046,7 @@ export class ProcessingContext {
             }
           ];
         }
-        return [part];
+        return [unresolvedNote("audio", part.audio.uri)];
       }
       if (
         part.type === "video" &&
@@ -3027,7 +3066,7 @@ export class ProcessingContext {
             }
           ];
         }
-        return [part];
+        return [unresolvedNote("video", part.video.uri)];
       }
       if (part.type === "text" && part.text.includes("asset://")) {
         // First split out image / audio mentions into their own blocks; what

--- a/packages/runtime/src/providers/base-provider.ts
+++ b/packages/runtime/src/providers/base-provider.ts
@@ -1595,6 +1595,18 @@ export abstract class BaseProvider {
       }
     }
 
+    // A reference scheme reaching a provider means the caller never
+    // dereferenced it (see `ProcessingContext.resolveMessageMediaUris`). Say
+    // that, instead of handing `asset://…` to `fetch` and reporting the SSRF
+    // guard's "Refusing to fetch unsafe URL" — which names neither the asset
+    // nor the real cause.
+    if (uri.startsWith("asset://") || uri.startsWith("package://")) {
+      throw new Error(
+        `Unresolved asset reference reached the model provider: ${uri}. ` +
+          `The asset bytes could not be loaded from storage.`
+      );
+    }
+
     return uri;
   }
 }

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -1398,6 +1398,73 @@ describe("ProcessingContext – asset helper methods", () => {
     }
   });
 
+  it("resolveMessageMediaUris resolves an asset:// image through assetStorage when storage holds the temp store", async () => {
+    // The server points `storage` at the temp store and assets live elsewhere.
+    // Before `assetStorage` existed the reference could only be chased over
+    // HTTP through `/api/storage`, which 404s for anyone but user `1`.
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const assetStorage = new InMemoryStorageAdapter();
+    await assetStorage.store("u1/abc.png", pngBytes, "image/png");
+
+    const ctx = new ProcessingContext({
+      jobId: "j1",
+      userId: "u1",
+      storage: new InMemoryStorageAdapter(),
+      assetStorage,
+      fetchFn: async () => new Response("not found", { status: 404 })
+    });
+
+    const resolved = await ctx.resolveMessageMediaUris([
+      {
+        role: "user",
+        content: [
+          {
+            type: "image_url",
+            image: { uri: "asset://abc.png", mimeType: "image/png" }
+          }
+        ]
+      }
+    ]);
+
+    const parts = resolved[0].content as Array<Record<string, any>>;
+    expect(parts[0].image.uri).toBe(
+      `data:image/png;base64,${Buffer.from(pngBytes).toString("base64")}`
+    );
+  });
+
+  it("resolveMessageMediaUris replaces an unresolvable asset:// image with a note", async () => {
+    // Handing `asset://…` to a provider makes it `fetch` the reference, which
+    // the SSRF guard rejects and the whole turn fails.
+    const ctx = new ProcessingContext({
+      jobId: "j1",
+      userId: "u1",
+      storage: new InMemoryStorageAdapter(),
+      fetchFn: async () => new Response("not found", { status: 404 })
+    });
+
+    const resolved = await ctx.resolveMessageMediaUris([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "recreate this image" },
+          {
+            type: "image_url",
+            image: { uri: "asset://missing.png", mimeType: "image/png" }
+          }
+        ]
+      }
+    ]);
+
+    const parts = resolved[0].content as Array<Record<string, any>>;
+    expect(parts).toEqual([
+      { type: "text", text: "recreate this image" },
+      {
+        type: "text",
+        text: "[attached image could not be loaded: asset://missing.png]"
+      }
+    ]);
+  });
+
   it("resolveMessageMediaUris dereferences asset:// video URIs to data URIs", async () => {
     const root = await mkdtemp(join(tmpdir(), "nodetool-resolve-asset-video-"));
     try {

--- a/packages/runtime/tests/providers/provider-bugfix-regressions.test.ts
+++ b/packages/runtime/tests/providers/provider-bugfix-regressions.test.ts
@@ -180,6 +180,19 @@ describe("Gemini – media URI handling", () => {
     expect(part.inlineData).toEqual({ mimeType: "image/png", data: "QUJD" });
   });
 
+  it("names the unresolved asset instead of reporting an unsafe fetch", async () => {
+    const fetchFn = vi.fn();
+    const provider = geminiWithFetch(fetchFn);
+
+    await expect(
+      (provider as any).messageContentToGeminiPart({
+        type: "image_url",
+        image: { type: "image", uri: "asset://abc.png" }
+      })
+    ).rejects.toThrow(/Unresolved asset reference.*asset:\/\/abc\.png/);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
   it("resolves file:// audio URIs through resolveUri", async () => {
     const fetchFn = vi.fn();
     const provider = geminiWithFetch(fetchFn);

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1213,6 +1213,12 @@ function createRuntimeContext(opts: {
     ...opts,
     secretResolver: getSecret,
     storage: tempAdapter,
+    // `asset://<id>.<ext>` references (chat attachments, @-mentions, prior
+    // turns) resolve through the asset store, not the temp store. Without it
+    // the only path left is an HTTP hop to `/api/storage`, which authorizes by
+    // `x-user-id` and 404s for every user but `1` — the reference then reached
+    // the provider verbatim and died in the SSRF guard.
+    assetStorage: getAssetAdapter(),
     workspaceStorage: workspaceAdapter,
     authToken: opts.authToken,
     tempUrlResolver: createTempUrlResolver(tempAdapter, storagePath)


### PR DESCRIPTION
## The failure

A chat message carrying an attachment failed the whole turn:

```
I encountered an error: Refusing to fetch unsafe URL (must be https to a public host): asset://134817da974844fbbcc9226c6b552238.png
```

The `asset://` reference was never dereferenced, reached the Gemini provider verbatim, and died in the SSRF guard (`packages/runtime/src/providers/safe-url.ts`) — an error that names neither the asset nor the real cause.

## Why it happened

`createRuntimeContext` wires `ProcessingContext.storage` to the **temp** adapter (`getTempAdapter()`), not the asset adapter. So `resolveAssetBytes` missed every exact-key probe (`<userId>/<id>.png`, `<id>.png`, `assets/<id>`) and every listing, then fell through to its HTTP fallback on `/api/storage/<key>`. That route authorizes by the `x-user-id` header, which the in-process download never sends, so it 404s for every user but `1` — the failure is invisible in single-user local mode and reproducible on a real deployment.

With no bytes, `resolveMessageMediaUris` passed the part through unchanged, and the provider tried to `fetch("asset://…")`.

## Changes

- `ProcessingContext` takes an `assetStorage` adapter. `resolveAssetBytes` probes it before the temp adapter (deduped, so a context that passes one adapter for both is unchanged), and `retrieveMediaBytes` does the same for opaque storage URIs. The websocket runner passes `getAssetAdapter()`.
- `resolveMessageMediaUris` replaces media it cannot dereference with `[attached image could not be loaded: <uri>]` instead of leaking the reference to the provider. Chat history is re-sent every turn, so one stale attachment would otherwise break every later turn in the thread permanently.
- `BaseProvider.resolveUri` throws `Unresolved asset reference reached the model provider: <uri>` for `asset://` / `package://` rather than handing it to `fetch`.

## Tests

Three regression tests, each verified to fail without the corresponding fix:

- `resolveMessageMediaUris` resolves an `asset://` image through `assetStorage` while `storage` holds the temp store and HTTP 404s.
- An unresolvable `asset://` image becomes a text note.
- The Gemini media path rejects `asset://abc.png` by name and never calls `fetch`.

`packages/runtime` (2787), `packages/websocket` (2238), `packages/kernel` (1010), `packages/agents` (2924) all pass. `oxlint` clean on both touched trees; `tsc --noEmit` clean for `packages/runtime`. `npm run lint` cannot run in this sandbox — the anti-slop plugin's `@oxlint/plugins` dependency is not installed here (pre-existing, unrelated to this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAcTJ7m2tgdgWm98kQrEXt

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAcTJ7m2tgdgWm98kQrEXt)_