### PR TITLE
docs: UGC strategy from Higgsfield and competitor research

### DIFF
--- a/docs/UGC_STRATEGY.md
+++ b/docs/UGC_STRATEGY.md
@@ -1,0 +1,164 @@
+---
+layout: page
+title: "UGC Strategy"
+permalink: /ugc-strategy
+description: "Creator-driven distribution strategy for NodeTool — the Higgsfield playbook, what transfers to an open BYOK tool, and a 90-day plan."
+---
+
+Research basis: external research on Higgsfield, PixVerse, OpenArt, Freepik/Magnific, and Krea
+(sources linked inline), plus an audit of NodeTool's own distribution surfaces — the example
+workflow gallery, the example mini apps and their generated `/apps/*` landing pages, the `demo/`
+Remotion cast harness, and [SEO_STRATEGY.md](SEO_STRATEGY.md). Written 2026-08-18. Numbers about
+competitors decay fast; re-verify before quoting them externally.
+
+**The one-line thesis:** Higgsfield replaced performance marketing with paid creators posting
+template-made videos, and it reached ~$300M ARR in 11 months doing it. NodeTool cannot copy the
+mechanism (we have no credit currency and no engagement budget), but it can copy the structure:
+a high-cadence template engine, a distinctive shareable artifact, and a creator program that pays
+in things an open-source BYOK tool actually has.
+
+## 1. What Higgsfield did
+
+The [Product Growth teardown](https://www.productgrowth.blog/p/higgsfield-growth-teardown),
+[Sacra](https://sacra.com/c/higgsfield/), and
+[Forbes](https://www.forbes.com/sites/rashishrivastava/2026/02/11/racist-videos-and-payment-problems-the-dark-side-of-this-ai-startups-super-fast-growth/)
+agree on the mechanics:
+
+1. **Presets, not prompts.** 100+ cinematic templates (dolly-ins, crash-zooms, FPV drone shots)
+   made "click-to-video" the product. Ten new presets shipped daily; underperformers were cycled
+   out on engagement data. The preset is the unit of virality: a viewer sees an effect, wants that
+   exact effect, and the preset name is the search query that converts.
+2. **Creators as the paid channel.** Higgsfield Earn paid creators on real-time engagement
+   metrics: 50,000+ submissions, ~90% approval, $1M+ paid to 10,000+ creators. Mid-tier and micro
+   creators got polished templates to showcase; the company got 3B+ organic impressions and
+   300,000 paying subscribers in a year — more reach than paid ads would have bought.
+3. **A partner tier above the mercenary tier.** The
+   [Creator Partnership Program](https://higgsfield.ai/blog/creator-partnership-program) pays in
+   plan + monthly credits, early model access, and featuring — audience size explicitly does not
+   matter, only that AI content is central to the creator's work.
+4. **Persistent characters.** Soul ID gave creators consistent AI personas they could run as
+   accounts — turning one-off outputs into ongoing series, which is what platforms reward.
+5. **Move upmarket on the same asset.** Marketing Studio / Hermes and UGC Factory resold the same
+   preset engine to social media marketers, who became
+   [85% of usage](https://sacra.com/c/higgsfield/) and the durable revenue base.
+
+**Where it broke.** Paying on raw engagement with no content review bought shock-value content —
+Forbes documented payment offered for deliberately offensive videos — plus creator payment
+disputes and an X account suspension for inauthentic behavior. The lesson is not "don't pay
+creators"; it is that the approval gate must score content quality, not engagement alone, and
+that paying creators late destroys the channel.
+
+## 2. The rest of the field
+
+- **PixVerse** runs the classic [affiliate motion](https://pixverse.ai/en/affiliate): 30%
+  recurring for 12 months, 90-day cookie, 2-tier payouts, and — notably — distributes playbooks
+  from top affiliates on which hooks and formats convert. The playbook *is* the enablement.
+- **OpenArt** splits the two tiers the way Higgsfield does: a
+  [Creative Partner Program](https://openart.ai/programs/cpp) paying in tools, early access, and
+  collaboration, plus a separate [affiliate program](https://openart.ai/programs/affiliate) for
+  commission-motivated referrers.
+- **Freepik/Magnific** competes on model aggregation (Kling, Veo, Runway, Seedance, PixVerse,
+  Wan, LTX in one subscription) — the closest positioning overlap with NodeTool, but
+  credit-metered.
+- **Krea**'s real-time brush-driven canvas is inherently screen-recordable: the product demo is
+  the content. No preset engine needed when watching the tool *is* the hook.
+
+Pattern across all of them: the shareable unit is small and named (a preset, an effect, a
+real-time session), creators get enablement (templates + format playbooks) rather than just a
+link, and the partner tier pays in access and featuring, not only cash.
+
+## 3. What transfers to NodeTool — and what does not
+
+| Higgsfield mechanism | NodeTool equivalent | Status |
+|---|---|---|
+| Preset (click-to-video) | Example workflow / example mini app, installable in one click | Exists — 61 example workflows, curated app bundles, `/apps/*` landing pages |
+| Preset engine (10/day, cull losers) | Trend-reactive template cadence with kill criteria | Missing — examples ship with releases, not with trends |
+| Paid-per-engagement creator pool | No equivalent: no credit currency, no engagement budget | Do not copy (it is also the part that blew up) |
+| Credits as creator compensation | Template bounties (cash), featuring, early access, roadmap voice | Adapt |
+| Affiliate on subscriptions | Only viable where a paid surface exists (cloud); dormant until then | Defer |
+| Soul ID persistent personas | Workflows that hold a character/identity constant across outputs | Template category, not a feature build |
+| The output video as the artifact | The output **plus the canvas** — the node graph is visually distinctive and no competitor can show one | Our edge |
+
+Two structural differences do the work:
+
+**BYOK cuts both ways.** We cannot hand out credits, but every Higgsfield-style tool meters
+credits — and creator comment sections fill with "how many credits does this cost?" NodeTool's
+answer ("your keys, provider prices, no markup") is a hook in itself, and it means a creator's
+audience can reproduce the result without a paywall between them and the first output.
+
+**The canvas is the format.** A Higgsfield video looks like every other AI video. A screen
+recording that ends by zooming out from the output to the node graph that made it is instantly
+attributable to NodeTool — the watermark is the product. The `demo/` Remotion harness already
+replays recorded graph-UI casts into polished video; pointing it at user-submitted casts turns
+"share your workflow" into "we render your workflow into a post-ready clip."
+
+## 4. The strategy
+
+### 4.1 Template engine (the preset analog)
+
+- Ship **one trend-reactive template per week** as a floor: an example workflow + mini app bundle
+  built around whatever effect is currently moving on TikTok/Reels/Shorts, named after the effect
+  the way Higgsfield names presets ("the search query is the name").
+- Each template ships with: the installable bundle, an `/apps/*` landing page (the generator in
+  `marketing/scripts/generate-miniapp-entries.mjs` already does this), a 15–30s canvas-reveal
+  clip rendered through the `demo/` harness, and a caption block creators can paste.
+- **Kill criteria, stated up front:** a template that produces no measurable installs or social
+  pickup in 30 days is retired from the featured row. Higgsfield's daily cull is the discipline
+  to copy even at weekly cadence.
+
+### 4.2 The signature format: output → canvas reveal
+
+Standardize one recognizable clip shape and use it everywhere (our channels and creator
+enablement kits): hook with the finished output for 3–5 seconds, cut or zoom out to the canvas,
+scrub one or two parameter changes live, end on the template name + "free, open source, your own
+keys." This is Krea's insight (the tool on screen is the content) fused with Higgsfield's
+(the named effect is the search query).
+
+### 4.3 Creator program, adapted
+
+Two tiers, mirroring the OpenArt/Higgsfield split but paying in what we have:
+
+- **Partners** (apply, curated, size-blind like Higgsfield's): early access to releases, featured
+  placement on the site and example gallery with attribution and a link, a direct channel to the
+  team, and their templates shipped as named examples ("the *X* workflow by *creator*"). For an
+  audience of makers, having your workflow ship inside the product is compensation Higgsfield
+  cannot offer.
+- **Template bounties** (open, transactional): a posted list of wanted templates (trend effects,
+  model showcases, persistent-character series), fixed cash per accepted submission, acceptance
+  judged on quality bar + `nodetool validate` passing + a rendered demo clip — never on
+  engagement metrics. Pay within 14 days, publicly stated. Both rules are direct corrections of
+  the two failure modes Forbes documented.
+
+### 4.4 Persistent characters as a template category
+
+Soul ID's lesson: series beat one-offs. Ship a "consistent character" template family (reference
+image + identity-preserving workflow across image and video nodes) and pitch it to creators as
+"run an AI account from a canvas you own" — with the BYOK line as the differentiator against
+subscription-locked persona tools.
+
+### 4.5 What we explicitly do not do
+
+- **No engagement-metered payouts.** That mechanism selected for shock content at Higgsfield.
+- **No affiliate program yet.** Recurring-commission affiliates need a metered subscription to
+  commission; revisit only when a paid cloud surface has stable pricing.
+- **No inauthentic amplification.** One suspended X account costs more reach than a botnet buys.
+
+## 5. Measurement
+
+Per template: installs (example install endpoint already exists —
+`POST /api/applications/examples/:slug/install`), landing-page sessions (`/apps/*` is already in
+Search Console per SEO_STRATEGY §0.10), and tracked social pickups. Per program: accepted
+bounties, partner-attributed templates shipped, and share of new-user sessions that start from a
+template versus a blank canvas. North star: **weekly count of publicly posted
+"made with NodeTool" clips we did not make ourselves.**
+
+## 6. First 90 days
+
+1. **Weeks 1–2:** pick the first four trend templates; wire the demo-cast → clip pipeline into a
+   repeatable checklist; write the creator enablement kit (format spec from §4.2, caption block,
+   asset pack).
+2. **Weeks 3–6:** ship weekly templates; open partner applications with the size-blind criteria;
+   post the first bounty list (5 templates, fixed price, published quality bar).
+3. **Weeks 7–12:** first partner-authored template ships as a named example; publish the
+   PixVerse-style "what converted" playbook to partners from our own template metrics; review
+   kill list; decide whether cadence moves from weekly toward 2–3/week.

--- a/docs/UGC_STRATEGY.md
+++ b/docs/UGC_STRATEGY.md
@@ -17,6 +17,11 @@ mechanism (we have no credit currency and no engagement budget), but it can copy
 a high-cadence template engine, a distinctive shareable artifact, and a creator program that pays
 in things an open-source BYOK tool actually has.
 
+**Constraint: zero cash budget.** Nothing below assumes ad spend, paid creators, or cash
+bounties. Every incentive in this plan is one we can grant at no marginal cost: attribution,
+featuring, early access, and shipping a creator's work inside the product. The spend is team
+time — mostly the weekly template and its demo clip.
+
 ## 1. What Higgsfield did
 
 The [Product Growth teardown](https://www.productgrowth.blog/p/higgsfield-growth-teardown),
@@ -74,7 +79,7 @@ link, and the partner tier pays in access and featuring, not only cash.
 | Preset (click-to-video) | Example workflow / example mini app, installable in one click | Exists — 61 example workflows, curated app bundles, `/apps/*` landing pages |
 | Preset engine (10/day, cull losers) | Trend-reactive template cadence with kill criteria | Missing — examples ship with releases, not with trends |
 | Paid-per-engagement creator pool | No equivalent: no credit currency, no engagement budget | Do not copy (it is also the part that blew up) |
-| Credits as creator compensation | Template bounties (cash), featuring, early access, roadmap voice | Adapt |
+| Credits as creator compensation | Featuring, attribution, early access, roadmap voice — no cash | Adapt |
 | Affiliate on subscriptions | Only viable where a paid surface exists (cloud); dormant until then | Defer |
 | Soul ID persistent personas | Workflows that hold a character/identity constant across outputs | Template category, not a feature build |
 | The output video as the artifact | The output **plus the canvas** — the node graph is visually distinctive and no competitor can show one | Our edge |
@@ -116,18 +121,23 @@ keys." This is Krea's insight (the tool on screen is the content) fused with Hig
 
 ### 4.3 Creator program, adapted
 
-Two tiers, mirroring the OpenArt/Higgsfield split but paying in what we have:
+Two tiers, mirroring the OpenArt/Higgsfield split, paid entirely in non-cash currency:
 
 - **Partners** (apply, curated, size-blind like Higgsfield's): early access to releases, featured
   placement on the site and example gallery with attribution and a link, a direct channel to the
   team, and their templates shipped as named examples ("the *X* workflow by *creator*"). For an
-  audience of makers, having your workflow ship inside the product is compensation Higgsfield
-  cannot offer.
-- **Template bounties** (open, transactional): a posted list of wanted templates (trend effects,
-  model showcases, persistent-character series), fixed cash per accepted submission, acceptance
-  judged on quality bar + `nodetool validate` passing + a rendered demo clip — never on
-  engagement metrics. Pay within 14 days, publicly stated. Both rules are direct corrections of
-  the two failure modes Forbes documented.
+  audience of makers, having your workflow ship inside the product — with a permanent link on its
+  `/apps/*` page — is compensation Higgsfield cannot offer at any price.
+- **Template wanted-list** (open, contribution-based): a public list of templates we want (trend
+  effects, model showcases, persistent-character series), run like open-source issues. An
+  accepted submission — judged on a published quality bar + `nodetool validate` passing + a
+  rendered demo clip, never on engagement metrics — ships as a named example with attribution
+  and gets featured across our channels. This is the OSS contribution loop applied to templates:
+  the same motivation that produces pull requests produces presets, and it costs review time,
+  not money.
+
+The quality-gated acceptance rule is the direct correction of Higgsfield's failure mode:
+engagement-metered rewards selected for shock content. We reward acceptance, not reach.
 
 ### 4.4 Persistent characters as a template category
 
@@ -138,7 +148,9 @@ subscription-locked persona tools.
 
 ### 4.5 What we explicitly do not do
 
-- **No engagement-metered payouts.** That mechanism selected for shock content at Higgsfield.
+- **No paid creators, no cash bounties, no ad spend.** There is no budget, and Higgsfield's
+  trajectory shows the paid version is also the dangerous one: engagement-metered payouts
+  selected for shock content, and late payments burned the channel.
 - **No affiliate program yet.** Recurring-commission affiliates need a metered subscription to
   commission; revisit only when a paid cloud surface has stable pricing.
 - **No inauthentic amplification.** One suspended X account costs more reach than a botnet buys.
@@ -148,8 +160,8 @@ subscription-locked persona tools.
 Per template: installs (example install endpoint already exists —
 `POST /api/applications/examples/:slug/install`), landing-page sessions (`/apps/*` is already in
 Search Console per SEO_STRATEGY §0.10), and tracked social pickups. Per program: accepted
-bounties, partner-attributed templates shipped, and share of new-user sessions that start from a
-template versus a blank canvas. North star: **weekly count of publicly posted
+wanted-list submissions, partner-attributed templates shipped, and share of new-user sessions
+that start from a template versus a blank canvas. North star: **weekly count of publicly posted
 "made with NodeTool" clips we did not make ourselves.**
 
 ## 6. First 90 days
@@ -158,7 +170,7 @@ template versus a blank canvas. North star: **weekly count of publicly posted
    repeatable checklist; write the creator enablement kit (format spec from §4.2, caption block,
    asset pack).
 2. **Weeks 3–6:** ship weekly templates; open partner applications with the size-blind criteria;
-   post the first bounty list (5 templates, fixed price, published quality bar).
+   post the first wanted-list (5 templates, published quality bar, attribution promise).
 3. **Weeks 7–12:** first partner-authored template ships as a named example; publish the
    PixVerse-style "what converted" playbook to partners from our own template metrics; review
    kill list; decide whether cadence moves from weekly toward 2–3/week.


### PR DESCRIPTION
Adds `docs/UGC_STRATEGY.md`: a creator-driven distribution strategy built from a teardown of Higgsfield's growth playbook and a scan of PixVerse, OpenArt, Freepik/Magnific, and Krea.

What it covers:

- **The Higgsfield playbook**, sourced: preset engine (10 templates/day, engagement-based culls), Higgsfield Earn ($1M+ to 10k+ creators, 3B+ impressions), the Creator Partnership Program, Soul ID personas, and the documented failure modes (shock-content payouts, late creator payments, X suspension).
- **A transfer table** mapping each mechanism to NodeTool's existing surfaces — example workflows, example mini apps and their `/apps/*` landing pages, the `demo/` Remotion cast harness — with explicit "do not copy" calls (engagement-metered payouts, affiliate-before-paid-cloud).
- **The strategy**: a weekly trend-reactive template cadence with kill criteria, a signature output→canvas-reveal clip format, a two-tier creator program (curated partners paid in featuring/early access; open template bounties paid fixed cash on a quality bar, never on engagement), and a persistent-character template family.
- **Measurement and a 90-day plan** wired to endpoints and reports that already exist (example install route, Search Console `/apps/*` data from SEO_STRATEGY §0.10).

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXHZXMMnTh8Gd4CLGqY666

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXHZXMMnTh8Gd4CLGqY666)_