### PR TITLE
feat(marketing): sharpen agent-first narrative and cross-page routing

### DIFF
--- a/marketing/src/app/creatives/page.tsx
+++ b/marketing/src/app/creatives/page.tsx
@@ -510,6 +510,13 @@ export default function CreativesPage() {
                   choose NodeTool
                 </span>
               </h2>
+              <p className="text-lg text-slate-400 max-w-2xl mx-auto leading-relaxed">
+                The agent does the assembling, and what it leaves behind is a
+                process you can open, tweak, and run again. The second
+                variation costs minutes, not another afternoon — and when a
+                step looks wrong, you change that step instead of starting
+                over.
+              </p>
             </motion.div>
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">

--- a/marketing/src/app/marketing/page.tsx
+++ b/marketing/src/app/marketing/page.tsx
@@ -202,7 +202,9 @@ export default function MarketingSegmentPage() {
                 Automation tools compete on integrations and speed. Creative
                 tools compete on the polish of a single asset. Campaigns need
                 both: a workflow that runs at volume and still looks on-brand
-                every time.
+                every time. The agent orchestrates the production; you keep
+                the process on screen, edit any step, and rerun it for the
+                next product or market.
               </p>
             </motion.div>
 

--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -26,6 +26,7 @@ import CommunitySection from "../components/CommunitySection";
 import ContactSection from "../components/ContactSection";
 import ComparisonSection from "../components/ComparisonSection";
 import UseCasesShowcase from "../components/UseCasesShowcase";
+import WaysInSection from "../components/WaysInSection";
 import FaqBlock from "../components/FaqBlock";
 import JsonLd from "../components/JsonLd";
 import { demoVideoSchema } from "../lib/siteSchema";
@@ -298,7 +299,7 @@ export default function Home() {
           </div>
         </section>
 
-        {/* How it works (Build / Run / Edit) — the 3-step mental model */}
+        {/* How it works (Describe / Run / Inspect) — the 3-step mental model */}
         <section aria-labelledby="how-title" className="rhythm-section pt-4">
           <div className={`${sectionContainer}`}>
             <BuildRunDeploy />
@@ -307,6 +308,12 @@ export default function Home() {
 
         {/* Concrete proof right after the mental model: a complete, runnable workflow */}
         <UseCasesShowcase />
+
+        {/* Why the agent here is more than a chatbot — the toolbelt */}
+        <ChatUISection />
+
+        {/* Route by intent once the core story has landed */}
+        <WaysInSection />
 
         {/* Position vs. the alternatives — answers the status-quo block up top */}
         <ComparisonSection reducedMotion={reducedMotion} />
@@ -341,9 +348,6 @@ export default function Home() {
 
         {/* Asset Manager — companion to the canvas story */}
         <AssetManagerSection />
-
-        {/* Alternate interface: drive workflows by chat (payoff after canvas) */}
-        <ChatUISection />
 
         {/* Local model library — supports the "runs on your machine" claim above */}
         <ModelManagerSection />
@@ -417,12 +421,13 @@ export default function Home() {
               id="closing-cta-title"
               className="text-3xl md:text-4xl font-bold tracking-tight text-white"
             >
-              Put every model on one canvas.
+              Describe the next piece. Keep the process.
             </h2>
             <p className="mt-4 text-lg text-slate-300">
-              Start the next piece and finish it in the same place. Free, open
-              source, and yours to run: download Studio, or try Cloud in the
-              browser with nothing to install.
+              Tell the agent what you want, watch the workflow run, and keep a
+              process you can edit and reuse. Free, open source, and yours to
+              run: download Studio, or try Cloud in the browser with nothing
+              to install.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <SmartDownloadButton

--- a/marketing/src/components/BuildRunDeploy.tsx
+++ b/marketing/src/components/BuildRunDeploy.tsx
@@ -45,30 +45,30 @@ export default function BuildRunDeploy() {
       <div className="scroll-fade grid grid-cols-1 gap-6 md:grid-cols-3">
         <Card
           step="01"
-          title="Build your canvas"
+          title="Describe the outcome"
           icon={<Workflow className="h-6 w-6" />}
           accent="blue"
-          description="Drag in models, edits, and files, then connect them. Every model from every provider sits on the same canvas."
+          description="A campaign, a trailer, a set of product shots — say what you want and the agent plans the steps and builds the workflow from real models, editors, and tools. You can also build it by hand: it's the same canvas."
         >
           <BuildVisual />
         </Card>
 
         <Card
           step="02"
-          title="Run it with your own keys"
+          title="Watch it run to a finished piece"
           icon={<PlayCircle className="h-6 w-6" />}
           accent="fuchsia"
-          description="Bring your own keys to FAL, KIE, OpenAI, Anthropic, Gemini, Replicate. Pay providers directly. Watch results stream in."
+          description="The workflow doesn't stop at a model answer. It chains generation, editing, and assembly — image, video, audio, and text — on your own provider keys, at provider prices, and streams results in as it goes."
         >
           <RunVisual />
         </Card>
 
         <Card
           step="03"
-          title="Edit and finish"
+          title="Inspect, edit, run again"
           icon={<Wand2 className="h-6 w-6" />}
           accent="amber"
-          description="Send the image or clip straight into the built-in editors. Crop, mask, cut, and arrange on the timeline. Nothing to export, no second app to open."
+          description="No black box: the process is on the canvas. See every step, swap the model, change one parameter, and run from there. Refine the result in the built-in editors, then save the workflow and reuse it for the next piece."
         >
           <EditVisual />
         </Card>

--- a/marketing/src/components/ChatUISection.tsx
+++ b/marketing/src/components/ChatUISection.tsx
@@ -34,9 +34,9 @@ export default function ChatUISection() {
             transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            An agent that <br />
+            An agent with <br />
             <span className="text-white">
-              does the work
+              a real toolbelt
             </span>
           </motion.h2>
 
@@ -47,10 +47,13 @@ export default function ChatUISection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            The chat isn&apos;t a help panel — it&apos;s an agent with the whole
-            app as its toolbelt: anything you can click in any editor, it can
-            do. Ask in plain English and it builds the workflow, runs it, and
-            leaves behind something you can inspect, edit, and rerun.
+            A chatbot answers in text. This agent works with the studio&apos;s
+            own capabilities: it builds and runs workflows, invokes models,
+            edits on the timeline and the sketch canvas, and works with your
+            assets — anything you can click in any editor, it can do. It
+            isn&apos;t agent <em>or</em> workflow: the agent plans and
+            orchestrates, and the workflow it leaves behind makes the process
+            visible, editable, and yours to run again.
           </motion.p>
         </div>
 

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -42,9 +42,10 @@ export default function NodeToolHero() {
               node-based
             </a>{" "}
             canvas for image, video, audio, and text, where every editor is a
-            tool an agent can drive. Say what you want and the agent builds the
-            workflow and runs it — on every major model, with your own keys, at
-            provider prices.
+            tool an agent can drive. Describe what you want to make; the agent
+            builds the workflow and runs it with the right models and tools —
+            and the whole process stays open for you to inspect, edit, and
+            reuse. Every major model, your own keys, provider prices.
           </p>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/marketing/src/components/WaysInSection.tsx
+++ b/marketing/src/components/WaysInSection.tsx
@@ -1,0 +1,126 @@
+"use client";
+import React from "react";
+import {
+  Monitor,
+  Cloud,
+  Sparkles,
+  Code2,
+  Megaphone,
+  ArrowRight,
+} from "lucide-react";
+
+/**
+ * One workspace, several doors. Routes visitors by intent to the five entry
+ * pages — Studio, Cloud, Creatives, Developers, Marketing — framed as ways
+ * to use the same product, not as separate products.
+ */
+
+const entries = [
+  {
+    intent: "Run it on your machine",
+    name: "Studio",
+    href: "/studio",
+    body: "The desktop app: your files, your local models, your GPU. The most control, fully offline if you want.",
+    icon: Monitor,
+    accent: "text-amber-300",
+    chip: "border-amber-500/30 bg-amber-500/10",
+  },
+  {
+    intent: "Try it in the browser",
+    name: "Cloud",
+    href: "/cloud",
+    body: "Nothing to install. Sign in and start building — currently in alpha, and the fastest way to see what NodeTool is.",
+    icon: Cloud,
+    accent: "text-blue-300",
+    chip: "border-blue-500/30 bg-blue-500/10",
+  },
+  {
+    intent: "Make visual work",
+    name: "Creatives",
+    href: "/creatives",
+    body: "Start from the piece you want — images, video, music — and let the agent handle the models and the plumbing.",
+    icon: Sparkles,
+    accent: "text-rose-300",
+    chip: "border-rose-500/30 bg-rose-500/10",
+  },
+  {
+    intent: "Build and integrate",
+    name: "Developers",
+    href: "/developers",
+    body: "SDK, CLI, custom nodes, and an MCP server: one execution layer under the canvas, the agent, and your code.",
+    icon: Code2,
+    accent: "text-violet-300",
+    chip: "border-violet-500/30 bg-violet-500/10",
+  },
+  {
+    intent: "Produce campaigns",
+    name: "Marketing",
+    href: "/marketing",
+    body: "Turn a brief into a production workflow you run again for every product, market, and variant.",
+    icon: Megaphone,
+    accent: "text-emerald-300",
+    chip: "border-emerald-500/30 bg-emerald-500/10",
+  },
+];
+
+export default function WaysInSection() {
+  return (
+    <section
+      id="ways-in"
+      aria-labelledby="ways-in-title"
+      className="relative py-24 scroll-mt-24"
+    >
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <header className="scroll-fade mb-12 max-w-3xl">
+          <div className="mb-3 flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.18em] text-blue-300/80">
+            <span className="h-px w-8 bg-blue-300/60" />
+            One workspace, several doors
+          </div>
+          <h2
+            id="ways-in-title"
+            className="text-3xl md:text-5xl font-bold tracking-tight text-white"
+          >
+            Pick the way in that fits you.
+          </h2>
+          <p className="mt-4 text-lg text-slate-400 leading-relaxed max-w-2xl">
+            Studio, Cloud, and the pages for creatives, developers, and
+            marketers are not five products. They are five ways to use the
+            same open-source workspace: the same agent, the same workflows,
+            the same models.
+          </p>
+        </header>
+
+        <div className="scroll-fade grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {entries.map((e) => (
+            <a
+              key={e.name}
+              href={e.href}
+              className="group relative flex flex-col rounded-2xl border border-slate-800/70 bg-slate-950/50 p-6 ring-1 ring-white/5 transition-all hover:border-slate-600 hover:bg-slate-900/60 focus-ring"
+            >
+              <div
+                className={`mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg border ${e.chip} ${e.accent}`}
+              >
+                <e.icon className="h-5 w-5" strokeWidth={1.5} />
+              </div>
+              <div className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                {e.intent}
+              </div>
+              <h3 className="mt-1.5 text-lg font-semibold text-white">
+                {e.name}
+              </h3>
+              <p className="mt-2 text-sm leading-relaxed text-slate-400">
+                {e.body}
+              </p>
+              <span
+                className={`mt-4 inline-flex items-center gap-1.5 text-sm font-semibold ${e.accent}`}
+              >
+                Go to {e.name}
+                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+              </span>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/marketing/src/components/developers/DevelopersHero.tsx
+++ b/marketing/src/components/developers/DevelopersHero.tsx
@@ -42,12 +42,13 @@ export default function DevelopersHero() {
           transition={{ duration: 0.25, delay: 0.05 }}
           className="mt-6 text-lg sm:text-xl text-slate-300 max-w-2xl mx-auto leading-relaxed"
         >
-          TypeScript-first, async Node.js under the hood, the same open-source
-          codebase that ships Studio and Cloud. Write a custom node, drive the
-          canvas from a CLI, generate workflows in code — or point Claude Code
-          at the MCP server and let an agent do it: every editor action is
-          also a tool, with validators and debug harnesses built for the agent
-          loop.
+          One execution layer instead of a stack of provider SDKs and
+          hand-rolled orchestration: the same open-source, TypeScript-first
+          runtime powers the visual canvas, the agent, and your code. Write a
+          custom node, drive the canvas from a CLI, generate workflows in
+          code — or point Claude Code at the MCP server and let an agent do
+          it: every editor action is also a tool, with validators and debug
+          harnesses built for the agent loop.
         </motion.p>
 
         {/* Feature Pills */}


### PR DESCRIPTION
Reworks the marketing site's narrative and information architecture around one mental model, threaded through the main landing page and the five entry pages: **describe the outcome → the agent builds and runs the workflow → inspect and edit the process → reuse it**.

## Main landing page
- The "how it works" trio is now goal-first instead of canvas-first: **01 Describe the outcome** (agent plans and builds the workflow), **02 Watch it run to a finished piece** (generation + editing + assembly, not just a model answer), **03 Inspect, edit, run again** ("See every step, swap the model, change one parameter, and run from there").
- The agent section (`ChatUISection`) moved from near the bottom to right after the mental model + use cases, rewritten as "An agent with a real toolbelt": builds/runs workflows, invokes models, drives the timeline and sketch editors — and states explicitly that agent and workflow complement each other rather than compete.
- New `WaysInSection` routes visitors by intent (run locally → Studio, try in browser → Cloud, make visual work → Creatives, build/integrate → Developers, produce campaigns → Marketing), framed as five ways into one workspace, not five products.
- Hero subheadline and closing CTA now close the same loop (closing CTA: "Describe the next piece. Keep the process.").

## Entry pages
- **Developers**: hero now leads with the actual argument — one execution layer under the canvas, the agent, and your code, instead of a stack of provider SDKs plus hand-rolled orchestration.
- **Creatives**: adds the repeatable-process point ("the second variation costs minutes, not another afternoon") without adding node/API language.
- **Marketing**: states the agent-orchestrates / human-edits-and-reruns split.
- **Studio** and **Cloud** were already aligned (agent-first heroes, honest alpha framing, mutual cross-links) and are deliberately unchanged.

## Verification
- `tsc --noEmit`, `next lint` (only pre-existing warnings), and `next build` all pass in `marketing/`.
- Agent-capability claims were checked against the shipped tool surface (`ui_timeline_*`, `ui_sketch_*`, workflow run/build tools, MCP server); "manages your assets" was softened to "works with your assets" to match the read-oriented asset tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5vwrysXGRiz2Bh7EmR1t4

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5vwrysXGRiz2Bh7EmR1t4)_