### PR TITLE
feat(marketing): resolve remaining narrative breaks after review

### DIFF
--- a/marketing/src/app/cloud/page.tsx
+++ b/marketing/src/app/cloud/page.tsx
@@ -56,7 +56,7 @@ const proPoints = [
   {
     icon: Zap,
     title: "Start in 30 seconds",
-    body: "Sign in, open a workflow, and press run. No installer, no drivers, nothing to set up beyond a browser tab.",
+    body: "Sign in and describe what you want to make. Start from the agent, an existing workflow, or a blank canvas — no installer, no drivers, nothing beyond a browser tab.",
   },
   {
     icon: Globe,
@@ -65,8 +65,8 @@ const proPoints = [
   },
   {
     icon: Users,
-    title: "Built for teams",
-    body: "Share workflows, hand over prompts, and work on agents together in one shared workspace.",
+    title: "Share what you build",
+    body: "Export a workflow as a single portable bundle — the graph plus its assets — and anyone can import and run it. Deeper team features are part of the alpha roadmap.",
   },
   {
     icon: KeyRound,

--- a/marketing/src/app/layout.tsx
+++ b/marketing/src/app/layout.tsx
@@ -65,7 +65,7 @@ export const metadata: Metadata = {
     images: [
       {
         url: "/preview.png",
-        alt: "NodeTool — the open creative AI workspace",
+        alt: "NodeTool — the open, agent-first creative workspace",
       },
     ],
     locale: "en_US",

--- a/marketing/src/app/marketing/page.tsx
+++ b/marketing/src/app/marketing/page.tsx
@@ -37,9 +37,9 @@ const marketingBenefits = [
     icon: Zap,
   },
   {
-    title: "Brand consistency, built in",
+    title: "Brand constraints, built into the workflow",
     description:
-      "Set a palette, a tone of voice, or a product shot once, and every asset the workflow produces follows it. There is no need to re-brief for each output.",
+      "Encode your palette, tone, references, and product shots into the workflow once, so every generation starts from the same brand constraints instead of a fresh brief.",
     icon: Palette,
   },
 ];

--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -263,6 +263,10 @@ export default function Home() {
         {/* Name the pain before showing the fix — the demo answers this block */}
         <StatusQuoSection />
 
+        {/* The core differentiator, right after the problem: the agent leaves
+            an executable, editable process behind — not a transcript */}
+        <ChatUISection />
+
         {/* Demo video — surface the product immediately after the hero */}
         <section id="demo-video" aria-label="NodeTool Demo" className="rhythm-section relative scroll-mt-24">
           <div className={`${sectionContainer}`}>
@@ -308,9 +312,6 @@ export default function Home() {
 
         {/* Concrete proof right after the mental model: a complete, runnable workflow */}
         <UseCasesShowcase />
-
-        {/* Why the agent here is more than a chatbot — the toolbelt */}
-        <ChatUISection />
 
         {/* Route by intent once the core story has landed */}
         <WaysInSection />

--- a/marketing/src/app/studio/page.tsx
+++ b/marketing/src/app/studio/page.tsx
@@ -25,10 +25,6 @@ const ModelManagerSection = dynamic(
   () => import("../../components/ModelManagerSection"),
   { ssr: true }
 );
-const FeaturesSection = dynamic(
-  () => import("../../components/FeaturesSection"),
-  { ssr: true }
-);
 const EditionsCompareSection = dynamic(
   () => import("../../components/EditionsCompareSection"),
   { ssr: true }
@@ -364,8 +360,36 @@ export default function StudioPage() {
         {/* Model manager */}
         <ModelManagerSection />
 
-        {/* Generic features (still relevant for Studio) */}
-        <FeaturesSection />
+        {/* Everything else NodeTool does lives on the main and agents pages —
+            this page stays on its one question: why run it locally? */}
+        <section className="rhythm-section py-16">
+          <div className={sectionContainer}>
+            <div className="mx-auto max-w-3xl rounded-2xl border border-slate-800/80 bg-slate-950/60 p-8 text-center">
+              <h2 className="text-2xl md:text-3xl font-bold text-white">
+                The full workspace, running locally.
+              </h2>
+              <p className="mt-4 text-slate-400 leading-relaxed">
+                Studio is not a lite edition. The canvas, the agent, and the
+                built-in editors — storyboard, script, timeline, sketch, and
+                mini apps — all ship in the desktop app.
+              </p>
+              <div className="mt-6 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm font-medium">
+                <a
+                  href="/#how-title"
+                  className="text-amber-300 hover:text-amber-200 underline underline-offset-2"
+                >
+                  See how NodeTool works →
+                </a>
+                <a
+                  href="/agents"
+                  className="text-amber-300 hover:text-amber-200 underline underline-offset-2"
+                >
+                  How the agent uses it →
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
 
         {/* Editions compare — Studio highlighted */}
         <EditionsCompareSection

--- a/marketing/src/components/BuildRunDeploy.tsx
+++ b/marketing/src/components/BuildRunDeploy.tsx
@@ -48,27 +48,27 @@ export default function BuildRunDeploy() {
           title="Describe the outcome"
           icon={<Workflow className="h-6 w-6" />}
           accent="blue"
-          description="A campaign, a trailer, a set of product shots — say what you want and the agent plans the steps and builds the workflow from real models, editors, and tools. You can also build it by hand: it's the same canvas."
+          description="Tell the agent what you want to make — a campaign, a trailer, a set of product shots. That's the whole first step. (Prefer to wire it yourself? It's the same canvas.)"
         >
           <BuildVisual />
         </Card>
 
         <Card
           step="02"
-          title="Watch it run to a finished piece"
+          title="Watch it build and run"
           icon={<PlayCircle className="h-6 w-6" />}
           accent="fuchsia"
-          description="The workflow doesn't stop at a model answer. It chains generation, editing, and assembly — image, video, audio, and text — on your own provider keys, at provider prices, and streams results in as it goes."
+          description="The agent chooses the models, tools, and steps, builds the workflow on your canvas, and runs it in front of you — generation, editing, and assembly chained into a finished piece, on your own keys at provider prices."
         >
           <RunVisual />
         </Card>
 
         <Card
           step="03"
-          title="Inspect, edit, run again"
+          title="Take control"
           icon={<Wand2 className="h-6 w-6" />}
           accent="amber"
-          description="No black box: the process is on the canvas. See every step, swap the model, change one parameter, and run from there. Refine the result in the built-in editors, then save the workflow and reuse it for the next piece."
+          description="Inspect any step, swap a model, change an input, and run again from there. Refine the result in the built-in editors, then save the workflow and reuse it for the next job."
         >
           <EditVisual />
         </Card>

--- a/marketing/src/components/ChatUISection.tsx
+++ b/marketing/src/components/ChatUISection.tsx
@@ -34,9 +34,9 @@ export default function ChatUISection() {
             transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            An agent with <br />
+            The agent doesn&apos;t just answer. <br />
             <span className="text-white">
-              a real toolbelt
+              It leaves the work behind.
             </span>
           </motion.h2>
 
@@ -47,14 +47,23 @@ export default function ChatUISection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            A chatbot answers in text. This agent works with the studio&apos;s
-            own capabilities: it builds and runs workflows, invokes models,
-            edits on the timeline and the sketch canvas, and works with your
-            assets — anything you can click in any editor, it can do. It
-            isn&apos;t agent <em>or</em> workflow: the agent plans and
-            orchestrates, and the workflow it leaves behind makes the process
-            visible, editable, and yours to run again.
+            A chatbot leaves you a transcript. This agent has the whole studio
+            as its toolbelt — it builds the actual workflow on your canvas,
+            runs it in front of you, and every decision becomes part of the
+            canvas. Inspect it, change it, rerun it, or reuse it for the next
+            job.
           </motion.p>
+
+          <motion.a
+            href="/agents"
+            initial={false}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.25, delay: 0.08 }}
+            className="mt-6 inline-flex items-center gap-1.5 text-sm font-semibold text-emerald-300 transition-colors hover:text-emerald-200 focus-ring"
+          >
+            How agents and workflows work together →
+          </motion.a>
         </div>
 
         <motion.div

--- a/marketing/src/components/SiteFooter.tsx
+++ b/marketing/src/components/SiteFooter.tsx
@@ -81,8 +81,8 @@ export default function SiteFooter() {
               </span>
             </a>
             <p className="mt-3 max-w-xs text-sm text-slate-300">
-              The open creative AI workspace. Every model, your keys, your
-              canvas.
+              The open, agent-first creative workspace. Describe the work. The
+              agent builds the process. You keep the workflow.
             </p>
           </div>
 

--- a/marketing/src/lib/siteSchema.ts
+++ b/marketing/src/lib/siteSchema.ts
@@ -75,7 +75,7 @@ export const organizationSchema: JsonLdObject = {
 export const demoVideoSchema: JsonLdObject = {
   "@context": "https://schema.org",
   "@type": "VideoObject",
-  name: "NodeTool — the open creative AI workspace (demo)",
+  name: "NodeTool — the open, agent-first creative workspace (demo)",
   description:
     "A walkthrough of NodeTool: connecting image, video, audio, and text models from every major provider on one visual canvas, using your own keys.",
   thumbnailUrl: "https://nodetool.ai/preview.png",


### PR DESCRIPTION
Follow-up to #5037, acting on the site review. Fixes the last places where the page contradicts the agent-first hero, and aligns the whole site to one anchor sentence: *describe the work → the agent builds the process → you keep the workflow*.

## Main landing page
- The three "how it works" steps now match the reviewed wording exactly: **Describe the outcome** / **Watch it build and run** (the agent chooses models, tools, and steps and builds the workflow on your canvas) / **Take control**.
- The core differentiator moved directly after the problem block and is now titled **"The agent doesn't just answer. It leaves the work behind."** — a transcript vs. an executable, editable process — with a link to `/agents` for the full argument.

## Entry pages
- **Studio**: dropped the generic `FeaturesSection` (the page was re-explaining the whole product); replaced with a compact "The full workspace, running locally" block linking to the main and agents pages. The page now stays on its one question: why run it locally?
- **Cloud**: "Start in 30 seconds" no longer says "open a workflow and press run" (the pre-agent story) — it now leads with describe-first. "Built for teams" softened to the verified portable-bundle sharing story ("Share what you build"), with deeper team features named as alpha roadmap.
- **Marketing**: the absolute brand-consistency claim ("every asset … follows it") replaced with **"Brand constraints, built into the workflow"** — constraints encoded once, every run starts from them.

## Footer / SEO
- Footer tagline and OG alt/schema updated from "Every model, your keys, your canvas" to the agent-first anchor sentence.

## Verification
- `tsc --noEmit`, `next lint` (no errors), and `next build` (613 static pages) all pass in `marketing/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5vwrysXGRiz2Bh7EmR1t4

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5vwrysXGRiz2Bh7EmR1t4)_