### PR TITLE
feat(prompts): route do-the-work asks to native flow

### DIFF
--- a/packages/agents/src/codeact/flow-package.ts
+++ b/packages/agents/src/codeact/flow-package.ts
@@ -53,20 +53,32 @@ export const FLOW_PROMPT_SECTION = `# Calling nodes directly (native flow)
 
 Run a node as a typed async function with \`${FLOW_PACKAGE}\`: one generated
 function per node type, taking that node's real inputs and resolving to its
-outputs record. Use it when you want the node's value in this action —
-branches, loops, retries, and fan-out are plain JavaScript. When the result
-must be a saved, editable workflow, author a graph instead.
+outputs record. This is how a turn *does* node work. "Generate an image, then
+remove its background" is two calls in one action — branches, loops, retries
+and fan-out are plain JavaScript.
 
 \`\`\`js
 import "@nodetool-ai/sandbox-nodetool/flow"; // mounts the bridge — required
-import { concat } from "${FLOW_PACKAGE}/nodetool.text";
+import { textToImage, removeBackground } from "${FLOW_PACKAGE}/nodetool.image";
 
-const joined = await concat({ a: "hi ", b: "there" });   // {output: "hi there"}
-const many = await Promise.all(items.map((b) => concat({ a: "» ", b })));
+const model = await nodetool.models.pick("text_to_image");
+const shot = await textToImage({ prompt: "a red fox in snow", model: model.ref });
+state.cutout = (await removeBackground({ image: shot.output })).output;
+return { generated: true };
 \`\`\`
 
 - The bare capability import must appear in the body — without it every flow
   call fails saying the bridge is not mounted.
+- The export name is the node class in camelCase:
+  \`nodetool.image.RemoveBackground\` is \`removeBackground\`,
+  \`nodetool.constant.Integer\` is \`integer\`, and a reserved word takes a
+  trailing underscore (\`if_\`).
+- An input you leave out runs the node's own default. A \`*_model\` input is
+  the one worth always setting: pass \`(await nodetool.models.pick(task)).ref\`
+  so the node runs on a model this install has.
+- Outputs come back keyed by slot — \`r.output\` is the default one. Feed one
+  node's output straight into the next call. A media output is a ref that can
+  carry inline bytes: keep it in \`state\`, never return it as the observation.
 - A streaming-output node also carries \`.stream(inputs)\`, an async iterable
   of partial outputs; early \`break\` closes the stream and runs node cleanup.
 - Errors reject the call — \`try\`/\`catch\` is the supervisor. Stream-typed

--- a/packages/agents/src/codeact/graph-dsl-package.ts
+++ b/packages/agents/src/codeact/graph-dsl-package.ts
@@ -100,5 +100,11 @@ capability modules. Both forms reach one implementation past one gate.
 - A node type the catalog does not have has no export, so the import fails
   before the action runs. Find the real one with \`nodetool.nodes.search()\`,
   then import its namespace.
+- A \`*_model\` property left unset fails validation: assign
+  \`(await nodetool.models.pick(task)).ref\` — the typed
+  \`{type, provider, id, name}\` value, not a bare model id.
+- Authoring and saving a graph does not run it. A user who asked for results
+  gets them from \`nodetool.workflows.run(saved.id, params)\`; a workflow id on
+  its own answers a question they did not ask.
 - \`nodetool.workflows.debug(id, params)\` reports per-node status when a run
   fails and the graph looks right.`;

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -15,8 +15,11 @@
  */
 
 import { GRAPH_JSON_PRELUDE } from "../graph-dsl-core.js";
-import { GRAPH_DSL_PROMPT_SECTION } from "./graph-dsl-package.js";
-import { FLOW_PROMPT_SECTION } from "./flow-package.js";
+import {
+  GRAPH_DSL_PACKAGE,
+  GRAPH_DSL_PROMPT_SECTION
+} from "./graph-dsl-package.js";
+import { FLOW_PACKAGE, FLOW_PROMPT_SECTION } from "./flow-package.js";
 
 /** Namespace → the belt tools that light it up (any one is enough). */
 export const NODETOOL_API_NAMESPACE_TOOLS: Record<string, readonly string[]> = {
@@ -1336,6 +1339,57 @@ interface NodetoolApiPromptOptions {
   nativeFlow?: boolean;
 }
 
+/**
+ * The rule for choosing between the three ways a turn makes node work happen.
+ * Rendered only for the surfaces this session actually has, so it never sends
+ * the model at a pack that is not installed.
+ *
+ * It exists because the surfaces answer different questions and a model that
+ * knows all three still picks by habit: a chat turn asked to "run a pipeline
+ * that generates an image and removes its background" authored a graph, saved
+ * it, never ran it, and then — asked to do it "without a graph" — bent
+ * `media.editImage` into a background remover instead of calling the
+ * `RemoveBackground` node it had already found.
+ */
+function surfaceChoiceSection(
+  options: NodetoolApiPromptOptions,
+  names: ReadonlySet<string>
+): string {
+  if (!options.nativeFlow && !options.graphDsl) return "";
+  const bullets: string[] = [];
+  if (names.has("generate_image")) {
+    bullets.push(`- \`nodetool.media.*\` — ONE generation with a picked model: an image, a
+  video, speech, a transcript. The short path when a verb there does exactly
+  what was asked. It has no verb for most node work, and stretching one to
+  cover a node — an edit prompt in place of a background remover, an
+  upscaler, a converter — produces something other than the node the user
+  meant.`);
+  }
+  if (options.nativeFlow) {
+    bullets.push(`- **Native flow** (\`${FLOW_PACKAGE}\`) — the user wants the RESULT:
+  "run", "generate", "then", "for each". Any node in the registry, several in
+  a row, in this action. Nothing is saved and nothing opens in the editor.`);
+  }
+  if (options.graphDsl) {
+    bullets.push(`- **Graph DSL** (\`${GRAPH_DSL_PACKAGE}\`) — the user wants the WORKFLOW:
+  something saved, opened in the editor, re-run later, or handed to someone
+  else. Authoring it does not run it — \`nodetool.workflows.run(id, params)\`
+  does.`);
+  }
+  const closer = options.nativeFlow
+    ? `
+
+When the ask is to do the work and the user never mentioned a workflow, run
+the nodes and report what came out. Reaching for a graph there leaves the
+user with an artifact they did not ask for and the work still undone.`
+    : "";
+  return `# Which surface runs the work
+
+Pick by what the user asked for, not by what the last turn used.
+
+${bullets.join("\n")}${closer}`;
+}
+
 export function buildNodetoolApiPromptSection(
   toolNames: Iterable<string>,
   options: NodetoolApiPromptOptions = {}
@@ -1364,6 +1418,8 @@ available, and the two cannot disagree. A module this session does not mount
 fails the action by name, before any code runs.`,
     active.map((entry) => entry.doc).join("\n")
   ];
+  const choice = surfaceChoiceSection(options, names);
+  if (choice) sections.push(choice);
   if (options.graphDsl) sections.push(GRAPH_DSL_PROMPT_SECTION);
   if (options.nativeFlow) sections.push(FLOW_PROMPT_SECTION);
   if (names.has("find_model") && names.has("generate_image")) {

--- a/packages/agents/tests/codeact-flow-package.test.ts
+++ b/packages/agents/tests/codeact-flow-package.test.ts
@@ -12,6 +12,7 @@ import {
   catalogServesFlow,
   withFlowPackage
 } from "../src/codeact/flow-package.js";
+import { buildNodetoolApiPromptSection } from "../src/codeact/nodetool-api.js";
 import { createChatCodeActSession } from "../src/codeact/chat-codeact.js";
 import type { ChatCodeActToolCall } from "../src/codeact/chat-codeact.js";
 import { shippedPackCatalog } from "../src/evals/codeact-sandbox-pack-cases.js";
@@ -81,5 +82,79 @@ describe("a chat session with the flow pack", () => {
       sandboxModuleCatalog: emptyCatalog
     }).systemPromptSection;
     expect(prompt).not.toContain(FLOW_PACKAGE);
+  });
+});
+
+describe("choosing between the surfaces", () => {
+  const BELT = [
+    "create_workflow",
+    "validate_workflow",
+    "run_workflow",
+    "find_model",
+    "generate_image",
+    "search_nodes"
+  ];
+
+  it("routes a do-the-work ask to flow and a save-it ask to the graph", () => {
+    // A turn asked to "run a pipeline: generate an image, then remove its
+    // background" authored a graph, saved it, and never ran it.
+    const section = buildNodetoolApiPromptSection(BELT, {
+      graphDsl: true,
+      nativeFlow: true
+    });
+    expect(section).toContain("# Which surface runs the work");
+    expect(section).toContain("the user wants the RESULT");
+    expect(section).toContain("the user wants the WORKFLOW");
+    expect(section).toContain("Authoring it does not run it");
+    // The section decides before either pack's own instructions are read.
+    expect(section.indexOf("# Which surface runs the work")).toBeLessThan(
+      section.indexOf("# Calling nodes directly")
+    );
+  });
+
+  it("says a media verb is not a stand-in for a node", () => {
+    // Asked to do it "without a graph", the same turn called
+    // `media.editImage(img, "remove the background")` rather than the
+    // RemoveBackground node it had already found with search_nodes.
+    const section = buildNodetoolApiPromptSection(BELT, {
+      graphDsl: true,
+      nativeFlow: true
+    });
+    expect(section).toContain("`nodetool.media.*` — ONE generation");
+    expect(section).toContain("background remover");
+  });
+
+  it("names no surface this session lacks", () => {
+    const flowOnly = buildNodetoolApiPromptSection(["search_nodes"], {
+      nativeFlow: true
+    });
+    expect(flowOnly).toContain("# Which surface runs the work");
+    expect(flowOnly).not.toContain("Graph DSL");
+    expect(flowOnly).not.toContain("nodetool.media.*` — ONE generation");
+
+    const neither = buildNodetoolApiPromptSection(BELT);
+    expect(neither).not.toContain("# Which surface runs the work");
+  });
+});
+
+describe("what the flow section teaches", () => {
+  const section = buildNodetoolApiPromptSection(["search_nodes"], {
+    nativeFlow: true
+  });
+
+  it("maps a node type to its export name", () => {
+    expect(section).toContain("`nodetool.image.RemoveBackground` is");
+    expect(section).toContain("removeBackground");
+  });
+
+  it("tells the caller to pick a model instead of taking the default", () => {
+    // A graph run failed validation twice on unset `image_model` properties;
+    // a flow call takes the node's default silently instead.
+    expect(section).toContain("`*_model` input");
+    expect(section).toContain("nodetool.models.pick(task)).ref");
+  });
+
+  it("keeps media refs out of the observation", () => {
+    expect(section).toContain("never return it as the observation");
   });
 });

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1328,6 +1328,20 @@ has no way to create a storyboard, script, timeline, sketch, or 3D scene from
 nothing: when none is open, name the one you need and ask the user to open or
 create it, instead of falling back to a workflow that approximates it.
 
+# Doing node work without a workflow
+A workflow is an artifact the user keeps. When they asked for the RESULT —
+"generate an image", "run a pipeline that does X then Y" — call the nodes
+directly: import the namespaces you need from \`@nodetool-ai/sandbox-flow\`
+and \`await\` each node in one action. \`await\` is the edge, a variable is the
+wire, and the user gets what they asked for in the turn they asked for it.
+Nothing is saved and nothing opens in the editor.
+- \`nodetool.media.*\` stays the shortest path for a single generation it has a
+  verb for. A node it has no verb for — background removal, upscaling, a
+  format conversion — is a flow call, never a media verb bent to fit.
+- Build a workflow instead when the user wants the WORKFLOW: something to open
+  in the editor, re-run later, or hand to someone else. Authoring one does not
+  run it, and answering "do this" with a saved id leaves the work undone.
+
 # Building workflows
 You author the graph yourself, in an \`execute_code\` action. Drive this loop:
 1. \`await nodetool.nodes.search(["what the step does"])\` for every step you

--- a/packages/websocket/tests/resident-tools.test.ts
+++ b/packages/websocket/tests/resident-tools.test.ts
@@ -55,6 +55,24 @@ describe("resident toolbelt", () => {
     expect(CHAT_AGENT_SYSTEM_PROMPT).toContain("tools.debug_app({document})");
   });
 
+  it("sends do-the-work asks to the flow pack, not to a saved graph", () => {
+    // A turn asked to "run a pipeline: generate an image, then remove its
+    // background" authored a workflow, saved it, and never ran it; asked to
+    // do it without a graph, it bent `media.editImage` into a background
+    // remover instead of calling the node.
+    const section = CHAT_AGENT_SYSTEM_PROMPT.split(
+      "# Doing node work without a workflow"
+    )[1];
+    expect(section).toBeDefined();
+    expect(section).toContain("@nodetool-ai/sandbox-flow");
+    expect(section).toContain("background removal");
+    expect(section).toContain("Authoring one does not");
+    // The routing rule is stated before the authoring loop it routes away from.
+    expect(
+      CHAT_AGENT_SYSTEM_PROMPT.indexOf("# Doing node work without a workflow")
+    ).toBeLessThan(CHAT_AGENT_SYSTEM_PROMPT.indexOf("# Building workflows"));
+  });
+
   it("describes every resource kind, not just workflows", () => {
     const section = CHAT_AGENT_SYSTEM_PROMPT.split("# NodeTool resources")[1];
     expect(section).toBeDefined();


### PR DESCRIPTION
## What

The prompts name `@nodetool-ai/sandbox-flow` but never say when it is the answer, so a chat turn reaches for whatever it used last.

From a real transcript (gemini-3.5-flash-lite): asked to "run a pipeline generate image and then remove background", the turn searched nodes, found `nodetool.image.RemoveBackground`, then **authored a graph, saved it, and never ran it**. Asked to "run it without graph", it called `nodetool.media.editImage(img, "Remove the background completely")` — bending a media verb into a node it had already located. Along the way it also spent two round trips learning that a `*_model` property left unset fails validation.

## Changes

- **`packages/agents/src/codeact/nodetool-api.ts`** — a `# Which surface runs the work` section, rendered before the two pack sections and only for the surfaces a session actually has: `nodetool.media.*` for one generation it has a verb for, native flow for the result, the graph DSL for the workflow. A media-less or flow-less session never sees the bullet it cannot use.
- **`packages/agents/src/codeact/flow-package.ts`** — the section now leads with "this is how a turn *does* node work", and the example is the failing case (generate → remove background). Three new rules: the class-name → export mapping (`nodetool.image.RemoveBackground` → `removeBackground`), that a `*_model` input should carry `(await nodetool.models.pick(task)).ref` rather than the node's default, and what the outputs record is — including keeping media refs out of the observation.
- **`packages/agents/src/codeact/graph-dsl-package.ts`** — an unset `*_model` property fails validation; authoring and saving a graph does not run it.
- **`packages/websocket/src/unified-websocket-runner.ts`** — the same routing rule in the chat system prompt, immediately before "Building workflows".

## Tests

Four new checks in `packages/agents/tests/codeact-flow-package.test.ts` and `packages/websocket/tests/resident-tools.test.ts`, each carrying the transcript failure it pins. Every one was inverted and watched go red before being restored (routing section suppressed → 3 red; flow rules reworded → 3 red; chat heading renamed → 1 red).

- `packages/agents`: 195 files, 2958 passed / 1 skipped
- `packages/websocket`: 207 files, 2242 passed
- `npm run lint` clean; `npm run typecheck` clean (electron's two `TS2307`s were unbuilt `dist/` for `@nodetool-ai/websocket` and `@nodetool-ai/sandbox-compiler` — green after building them)

No behavior outside prompt text changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_018scvzrGLxmexwgJqSRHzku)_