### PR TITLE
feat(cloud): ship yt-dlp in production and keep it reachable from QuickJS

### DIFF
--- a/docs/CLOUD_NODE_CURATION.md
+++ b/docs/CLOUD_NODE_CURATION.md
@@ -11,9 +11,11 @@ office-doc tooling, local model runtimes) that is powerful but "nerdy" — it
 dilutes the creative mission and balloons the support surface. The cloud profile
 drops it.
 
-> **One exception:** the **sandboxed Code node** (`nodetool.code.Code`, QuickJS
-> WASM JavaScript) is kept. It is the intentional power-user escape hatch, and
-> it is admitted by name rather than by namespace.
+> **Two exceptions,** both admitted by name rather than by namespace: the
+> **sandboxed Code node** (`nodetool.code.Code`, QuickJS WASM JavaScript), the
+> intentional power-user escape hatch; and the **yt-dlp downloader**
+> (`lib.video.download.YtDlpDownload`), because bringing a clip in from a URL
+> starts most video work and the cloud image ships `yt-dlp` on PATH.
 
 ## How it's enabled
 
@@ -148,7 +150,8 @@ Admitting it by name rather than whole-listing the namespace keeps any future
 - **Data/docs:** `nodetool.data` (dataframes), `nodetool.document`, `lib.pdf`,
   `lib.markdown`, `lib.html`, `lib.charts`
 - **System/automation:** `lib.os`, `nodetool.workspace`,
-  `nodetool.triggers`, `lib.browser`, `lib.video.download`
+  `nodetool.triggers`, `lib.browser`, `lib.video.download` (except
+  `YtDlpDownload`, kept by name)
 - **Databases/cloud/integrations:** `lib.sqlite`, `lib.http`, `lib.graphql`,
   `lib.mail`, `lib.secret`, `lib.comfy`
 - **Messaging:** `messaging.discord`, `messaging.telegram`
@@ -163,7 +166,9 @@ The namespace is kept. The product surface is the standard Agent plus
 Classifier, Extractor, Summarizer, CreateThread, and EnhancePrompt.
 Specialist tool-agent nodes were removed. ffmpeg, yt-dlp, and browser
 are CodeAct capabilities (`nodetool.media.ffmpeg`,
-`nodetool.media.downloadVideo`, `nodetool.web.browse`).
+`nodetool.media.downloadVideo`, `nodetool.web.browse`) — the same binaries the
+image installs, reached from chat and from the Code node instead of from an
+agent node.
 
 ## Maintenance
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -366,7 +366,7 @@ the run is a separate concern; see
 
 These configure the build, not the server. The packaged Electron backend is one
 bundled `server.mjs` plus a flat `_modules/` directory staged by
-[`scripts/bundle-backend.mjs`](../scripts/bundle-backend.mjs). Some staged
+[`scripts/bundle-backend.mjs`](https://github.com/nodetool-ai/nodetool/blob/main/scripts/bundle-backend.mjs). Some staged
 dependencies ship prebuilt binaries for every OS and architecture in a single
 package; staging all of them wastes disk in a single-target artifact, so the
 staging step prunes them to one target.
@@ -383,7 +383,7 @@ A build for the host needs neither.
 NODETOOL_BUNDLE_PLATFORM=win32 NODETOOL_BUNDLE_ARCH=x64 node scripts/bundle-backend.mjs
 ```
 
-[`scripts/verify-backend-bundle.mjs`](../scripts/verify-backend-bundle.mjs)
+[`scripts/verify-backend-bundle.mjs`](https://github.com/nodetool-ai/nodetool/blob/main/scripts/verify-backend-bundle.mjs)
 reads the same two variables and resolves the `@seydx/node-av-<platform>-<arch>`
 binary it expects to find staged (`node-av-win32-<arch>-msvc` on Windows), so a
 verification run must be given the target the staging run used. When no prebuild

--- a/docs/javascript-sandbox.md
+++ b/docs/javascript-sandbox.md
@@ -558,6 +558,7 @@ it around every tool- and plan-approval round trip.
 | `setTimeout is not defined` | Deleted deliberately. Use `sleep`, `Promise.all` or `parallelMap` |
 | A bare identifier is a `ReferenceError` in a Code node | Node inputs live on `inputs`, not in the global scope |
 | `nodetool.*` throws naming a tool | The host has no toolbelt (browser runner, no context) or that tool is not on the belt |
+| A Code node has an empty `nodetool.capabilities()` and cannot import `@nodetool-ai/sandbox-nodetool/*` | The host never called `setCodeNodeAgentsModule`. The node resolves `@nodetool-ai/agents` by bare specifier, which resolves in a checkout and nowhere in the bundled backend (esbuild inlines the workspace packages into `server.mjs`); `packages/websocket/src/server.ts` hands over the inlined copy at bootstrap |
 | A CPU-bound loop outlives its cancellation | The signal ends `runInSandbox`, but the guest loop still runs to the execution timeout |
 
 ## Extending it

--- a/packages/base-nodes/src/index.ts
+++ b/packages/base-nodes/src/index.ts
@@ -127,7 +127,10 @@ export {
   LoadCSVAssetsNode,
   DATA_NODES
 } from "@nodetool-ai/data-nodes/nodes/data";
-export { CodeNode } from "@nodetool-ai/code-nodes/nodes/code-node";
+export {
+  CodeNode,
+  setCodeNodeAgentsModule
+} from "@nodetool-ai/code-nodes/nodes/code-node";
 export {
   LoadAudioAssetsNode,
   LoadAudioFileNode,

--- a/packages/code-nodes/src/nodes/code-node.ts
+++ b/packages/code-nodes/src/nodes/code-node.ts
@@ -168,16 +168,38 @@ const NO_TOOLS_GLOBALS = {
 } satisfies Record<string, unknown>;
 
 let agentsModulePromise: Promise<AgentsModule | null> | null = null;
+let injectedAgentsModule: AgentsModule | null = null;
 
 /**
- * The agents package index, loaded lazily and hidden from bundlers.
- * `importHidden` answers `null` off Node, so a browser bundle never resolves
- * the toolbelt's server-only dependencies. Hosts where the bare specifier is
- * not resolvable at runtime (the packaged Electron backend inlines workspace
- * packages instead of staging them in `_modules/`) degrade the same way the
- * browser does unless they inject a belt via {@link setCodeNodeTools}.
+ * Hand the Code node the agents package a host already holds.
+ *
+ * The bare specifier below resolves in a workspace checkout and in the CLI,
+ * and resolves nowhere in the bundled backend: `bundle-backend.mjs` inlines
+ * every workspace package into `server.mjs` and stages only third-party
+ * externals, so `node_modules/@nodetool-ai/agents` does not exist in the
+ * packaged desktop app or in the Docker/Fly image. Without this, a Code node
+ * body in production runs with no toolbelt (`nodetool.capabilities()` is `{}`,
+ * `tools.yt_dlp` is missing) and cannot import
+ * `@nodetool-ai/sandbox-nodetool/*` at all.
+ *
+ * The server calls this at bootstrap with the copy esbuild already inlined,
+ * which also keeps the run on one module instance — a staged second copy would
+ * carry its own capability registry.
+ */
+export function setCodeNodeAgentsModule(mod: AgentsModule | null): void {
+  injectedAgentsModule = mod;
+  agentsModulePromise = null;
+}
+
+/**
+ * The agents package index: the injected one, else loaded lazily and hidden
+ * from bundlers. `importHidden` answers `null` off Node, so a browser bundle
+ * never resolves the toolbelt's server-only dependencies, and a host that
+ * neither injects nor can resolve the specifier degrades the same way —
+ * no belt, no capability modules.
  */
 function loadAgentsModule(): Promise<AgentsModule | null> {
+  if (injectedAgentsModule) return Promise.resolve(injectedAgentsModule);
   if (!agentsModulePromise) {
     agentsModulePromise = importHidden<AgentsModule>(
       "@nodetool-ai/agents"

--- a/packages/code-nodes/tests/code-node-agents-module.test.ts
+++ b/packages/code-nodes/tests/code-node-agents-module.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Where `nodetool.code.Code` gets the agents package from.
+ *
+ * The node resolves `@nodetool-ai/agents` by bare specifier, which works in a
+ * checkout and fails in the bundled backend (esbuild inlines every workspace
+ * package into `server.mjs`, so nothing is left on disk to resolve). A host
+ * that already holds the module hands it over with
+ * `setCodeNodeAgentsModule`, and that is what keeps the toolbelt and the
+ * `@nodetool-ai/sandbox-nodetool/*` imports — `yt_dlp` among them — alive in
+ * the desktop app and the Docker image.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  CodeNode,
+  setCodeNodeAgentsModule,
+  setCodeNodeTools
+} from "@nodetool-ai/code-nodes";
+import * as agents from "@nodetool-ai/agents";
+import { Tool } from "@nodetool-ai/agents";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+
+type AgentsModule = Parameters<typeof setCodeNodeAgentsModule>[0];
+
+/** Minimal context: nothing below reads it. */
+const fakeContext = {} as unknown as ProcessingContext;
+
+class MarkerTool extends Tool {
+  readonly name = "list_workflows";
+  readonly description = "Marker tool served only by the injected module.";
+  async process(): Promise<unknown> {
+    return [{ id: "wf_injected", name: "Injected" }];
+  }
+}
+
+function runNode(
+  code: string,
+  context?: ProcessingContext
+): Promise<Record<string, unknown>> {
+  return new CodeNode({ code }).process(context);
+}
+
+afterEach(() => {
+  setCodeNodeAgentsModule(null);
+  setCodeNodeTools(null);
+});
+
+describe("CodeNode — injected agents module", () => {
+  it("builds the toolbelt from the injected module, not the resolved one", async () => {
+    const marker = new MarkerTool();
+    const injected = {
+      ...agents,
+      getAgentToolbelt: () => [marker],
+      getAllMcpTools: () => []
+    } as unknown as AgentsModule;
+    setCodeNodeAgentsModule(injected);
+
+    const result = await runNode(
+      `
+      const names = __toolNames.slice().sort();
+      const wfs = await nodetool.workflows.list({});
+      return { names, ids: wfs.map((w) => w.id) };
+      `,
+      fakeContext
+    );
+    // The real belt carries dozens of tools; the injected one carries exactly
+    // this marker, so the belt could only have come from the injection.
+    expect(result["names"]).toEqual(["list_workflows"]);
+    expect(result["ids"]).toEqual(["wf_injected"]);
+  }, 60_000);
+
+  it("mounts capability modules through the injected module", async () => {
+    const mounted: string[] = [];
+    const injected = {
+      ...agents,
+      mountCapabilityModules: async (code: string, run: unknown) => {
+        mounted.push(code);
+        return agents.mountCapabilityModules(
+          code,
+          run as Parameters<typeof agents.mountCapabilityModules>[1]
+        );
+      }
+    } as unknown as AgentsModule;
+    setCodeNodeAgentsModule(injected);
+
+    const result = await runNode(
+      `
+      import { yt_dlp } from "@nodetool-ai/sandbox-nodetool/media";
+      return { kind: typeof yt_dlp };
+      `,
+      fakeContext
+    );
+    expect(result).toEqual({ kind: "function" });
+    expect(mounted).toHaveLength(1);
+  }, 60_000);
+
+  it("goes back to resolving the specifier once the injection is cleared", async () => {
+    setCodeNodeAgentsModule({
+      ...agents,
+      getAgentToolbelt: () => [],
+      getAllMcpTools: () => []
+    } as unknown as AgentsModule);
+    setCodeNodeAgentsModule(null);
+
+    const result = await runNode(
+      `return { hasYtDlp: __toolNames.includes("yt_dlp") };`,
+      fakeContext
+    );
+    expect(result).toEqual({ hasYtDlp: true });
+  }, 60_000);
+});

--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -111,10 +111,19 @@ export const CLOUD_NODE_NAMESPACES: readonly string[] = [
  * - `nodetool.code.Code` — the sandboxed (QuickJS WASM) JavaScript node only.
  *   Admitting it by name rather than whole-listing `nodetool.code` keeps any
  *   future node in that namespace out of the cloud until it is reviewed.
+ * - `lib.video.download.YtDlpDownload` — the one node of the otherwise-trimmed
+ *   `lib.video.download` namespace. Bringing a clip in from a URL is the first
+ *   step of most video work, and the cloud image ships `yt-dlp` on PATH
+ *   (Dockerfile, /opt/venv), so the node runs there as it does locally. The
+ *   same binary already backs the `yt_dlp` capability, which cloud users reach
+ *   from chat and from the Code node — the node is the graph-shaped surface on
+ *   the same thing.
  */
 export const CLOUD_NODE_ALLOWLIST: readonly string[] = [
   // Sandboxed code only.
-  "nodetool.code.Code"
+  "nodetool.code.Code",
+  // Media in from a URL; the binary ships in the cloud image.
+  "lib.video.download.YtDlpDownload"
 ];
 
 /**

--- a/packages/protocol/tests/cloud-profile.test.ts
+++ b/packages/protocol/tests/cloud-profile.test.ts
@@ -155,6 +155,14 @@ describe("code is node-level trimmed; text is whole-listed minus file I/O", () =
     }
   });
 
+  it("keeps the yt-dlp downloader without its namespace", () => {
+    // The cloud image ships yt-dlp on PATH, so the node runs there. Admitting
+    // it by name must not drag the rest of the automation surface in with it.
+    expect(isCloudNodeType("lib.video.download.YtDlpDownload")).toBe(true);
+    expect(isCloudNodeType("lib.video.download.SomethingElse")).toBe(false);
+    expect(isCloudNodeType("lib.browser.WebFetch")).toBe(false);
+  });
+
   it("admits every explicit allowlist entry", () => {
     for (const nodeType of CLOUD_NODE_ALLOWLIST) {
       expect(isCloudNodeType(nodeType)).toBe(true);

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -21,6 +21,8 @@ import {
   loadEnvironment
 } from "@nodetool-ai/config";
 import { registerTransformersJsProvider } from "@nodetool-ai/transformers-js-provider";
+import { setCodeNodeAgentsModule } from "@nodetool-ai/base-nodes";
+import * as agentsModule from "@nodetool-ai/agents";
 import {
   bootstrapNodeRegistry,
   mergePythonBridgeMetadata
@@ -443,6 +445,14 @@ const registry = await bootstrapNodeRegistry({
   log
 });
 log.info(`Node registry ready [${startupMs()}]`);
+
+// The Code node reaches the toolbelt and its `@nodetool-ai/sandbox-nodetool/*`
+// imports through the agents package, which it resolves by bare specifier.
+// That specifier resolves in a checkout and nowhere in the bundled backend —
+// esbuild inlines the workspace packages into server.mjs — so hand it the copy
+// this module already holds. Without it, a Code node body in the desktop app
+// and in the Docker image runs with an empty `nodetool.capabilities()`.
+setCodeNodeAgentsModule(agentsModule);
 if (process.env["NODETOOL_ENV"] !== "production") {
   registerTransformersJsProvider();
 }


### PR DESCRIPTION
The production image already installs `yt-dlp` on PATH (`Dockerfile`, `/opt/venv`), but both surfaces that would use it were dark there.

## The node

`lib.video.download.YtDlpDownload` sits in a namespace the cloud profile trims whole, so `applyCloudNodePolicy` unregistered it at bootstrap. It is now admitted by name in `CLOUD_NODE_ALLOWLIST`, the way `nodetool.code.Code` is — the rest of `lib.video.download` and the other automation namespaces stay out.

## The sandbox

A Code node reaches `tools.yt_dlp`, `nodetool.media.yt_dlp`, and `import { yt_dlp } from "@nodetool-ai/sandbox-nodetool/media"` through `@nodetool-ai/agents`, which it resolves by bare specifier via `importHidden`. That resolves in a checkout and in the CLI, and nowhere in the bundled backend: `scripts/bundle-backend.mjs` inlines every workspace package into `server.mjs` and stages only third-party externals, so neither the packaged desktop app nor the Docker/Fly image has `node_modules/@nodetool-ai/agents`. The import failed, the failure was swallowed by design, and the guest ran with an empty `nodetool.capabilities()` and no capability modules at all — `@nodetool-ai/sandbox-nodetool/*` imports were refused outright.

`setCodeNodeAgentsModule` lets a host hand the node the copy it already holds; `packages/websocket/src/server.ts` calls it at bootstrap with the copy esbuild inlined. Injecting rather than staging a second copy keeps the run on one module instance — a staged copy would carry its own capability registry.

## Verification

- `packages/protocol/tests/cloud-profile.test.ts` — new case fails when the allowlist entry is removed (checked).
- `packages/code-nodes/tests/code-node-agents-module.test.ts` — new file; the belt case and the capability-mount case both fail when the injection is removed from `loadAgentsModule` and the package is rebuilt (checked).
- `npm run build:packages`, `npm run test:packages` (105/105 tasks), web (13,184) and electron (678) suites, `nodetool harness gate` (3/3) all pass.
- Web and electron typecheck clean. Three pre-existing environment gaps in this container are unrelated to the diff: mobile typecheck (no `mobile/node_modules`), and `lint:anti-slop:enforced` / `test:oxlint-rules` (no `@oxlint/plugins`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Vf8qWoRyghL3iAnxb9Bmp

---
_Generated by [Claude Code](https://claude.ai/code/session_011Vf8qWoRyghL3iAnxb9Bmp)_