### PR TITLE
feat(agents): bound the host media binaries, and add ffprobe

### DIFF
--- a/docs/javascript-sandbox.md
+++ b/docs/javascript-sandbox.md
@@ -503,6 +503,15 @@ What an action gets on top of the standard surface:
   is absent throws naming it. `nodetool.media.understandVideo(video, prompt,
   model)` is the video half of the judging methods: it hands a whole clip to a
   model that reads video (Gemini) and answers `prompt` as `{text}`.
+- **`nodetool.media.ffmpeg` / `ffprobe` / `downloadVideo`** — the host binaries.
+  `ffprobe(path)` reads a file's format and streams; `ffmpeg(args)` takes argv,
+  and that argv is bounded on the way out: every path is resolved against the
+  workspace and refused when it lands outside (symlinks resolved), inputs may
+  open local files only (`-protocol_whitelist file,crypto,data` before every
+  `-i`, plus a token scan for `://`, `concat:`, `pipe:`, `/dev/…`), and the run
+  is bounded on wall clock, captured output, artifact size, and how many host
+  binaries may run at once. Fetch what you need with `downloadVideo` or
+  `fetch`, then pass the local path.
 - **`openWorkflow(id)`** — when the belt carries the `ui_*` document tools, a
   graph object model whose synchronous mutators queue operations against a local
   mirror, replayed through the same tool contract by `await wf.commit()`.

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -972,7 +972,11 @@ research it follows (CodeAct, ICML 2024): docs/codeact-design.md.
   plus the judge loop `critique/compare/scoreAdherence` and
   `understandVideo(video, prompt, model)`, which hands a whole clip to a model
   that reads video and answers as text — each taking a pick/find result or
-  `"provider/model_id"`), `nodetool.nodes`
+  `"provider/model_id"`; plus the host binaries `ffprobe(path)`, `ffmpeg(args)`
+  and `downloadVideo(url, outputFile)`, whose argv is confined to the workspace
+  and to local-file inputs by `src/host-binary-guard.ts` and bounded on wall
+  clock, captured output, artifact size and concurrency by
+  `src/host-binaries.ts`), `nodetool.nodes`
   (`search/info/list` — the graph builder's discovery half),
   `nodetool.documents` (convert, PDF text/tables, markdown↔pdf),
   `nodetool.apps` (`build/debug`), `nodetool.agents` (`run(prompt)` spawns a

--- a/packages/agents/src/capabilities/files.ts
+++ b/packages/agents/src/capabilities/files.ts
@@ -19,20 +19,16 @@
  * namespaces".
  */
 
-import {
-  access,
-  lstat,
-  readFile,
-  readdir,
-  realpath,
-  stat,
-  writeFile
-} from "node:fs/promises";
-import { dirname, isAbsolute, join, relative } from "node:path";
+import { access, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
 import type { JsonSchema, ProcessingContext } from "@nodetool-ai/runtime";
 import type { StorageAdapter } from "@nodetool-ai/storage";
 import type { TodoItem, TodoStatus, TodoUpdate } from "@nodetool-ai/protocol";
 import { Tool } from "../tools/base-tool.js";
+import {
+  isEditTargetWithinRoot,
+  isRealPathWithinRoot
+} from "../workspace-paths.js";
 import {
   isNonBlankString,
   isNumber,
@@ -518,57 +514,6 @@ function hasNestedQuantifier(pattern: string): boolean {
     justClosedQuantifiedGroup = false;
   }
   return false;
-}
-
-/**
- * True when `candidate`'s real (symlink-resolved) path stays within the real
- * workspace root. `resolveWorkspacePath` only checks containment lexically, so
- * an in-workspace symlink pointing outside the root (e.g. unpacked from an
- * imported bundle) would otherwise be dereferenced and leak host files. Returns
- * false when either path cannot be resolved (broken/dangling link).
- */
-async function isRealPathWithinRoot(
-  root: string,
-  candidate: string
-): Promise<boolean> {
-  try {
-    const realRoot = await realpath(root);
-    const realCandidate = await realpath(candidate);
-    if (realCandidate === realRoot) return true;
-    const rel = relative(realRoot, realCandidate);
-    return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Like {@link isRealPathWithinRoot} but tolerant of a not-yet-created target:
- * when the candidate does not exist, its parent directory is realpath-checked
- * instead, so creating a file under a symlinked-out directory is still blocked.
- */
-async function isEditTargetWithinRoot(
-  root: string,
-  candidate: string
-): Promise<boolean> {
-  if (await isRealPathWithinRoot(root, candidate)) return true;
-  // Candidate may not exist yet (create path) — check its parent.
-  const parent = dirname(candidate);
-  if (parent === candidate) return false;
-  try {
-    // lstat, NOT access: access() follows symlinks, so a DANGLING in-workspace
-    // symlink (target outside the root and not yet created) would look absent
-    // and fall through to the parent check, allowing a create that follows the
-    // link outside the workspace. lstat stats the link itself, so it succeeds
-    // and we treat the path as existing-but-out-of-root.
-    await lstat(candidate);
-    // It exists (as a real file or a symlink) but failed the realpath
-    // containment check above → outside the root.
-    return false;
-  } catch {
-    // Truly does not exist; the containing directory must be inside the root.
-    return isRealPathWithinRoot(root, parent);
-  }
 }
 
 /**

--- a/packages/agents/src/capabilities/media.specs.ts
+++ b/packages/agents/src/capabilities/media.specs.ts
@@ -452,7 +452,9 @@ export const FFMPEG_SCHEMA: JsonSchema = {
       type: "array" as const,
       items: { type: "string" as const },
       description:
-        "ffmpeg arguments after the binary name. Paths are workspace-relative. " +
+        "ffmpeg arguments after the binary name. Paths are workspace-relative " +
+        "and cannot escape it; inputs may only open local files, so a URL is " +
+        "refused — download it first. " +
         "Example: [\"-i\", \"in.mp4\", \"-vf\", \"scale=1280:-2\", \"out.mp4\"]."
     },
     output_file: {
@@ -474,14 +476,46 @@ export const ffmpegSpec: CapabilitySpec = {
   name: "ffmpeg",
   description:
     "Run ffmpeg on workspace files. Pass argv after the binary name " +
-    "(no shell). Paths are workspace-relative. Install ffmpeg if the " +
-    "binary is missing. Use output_file to persist the result as an asset.",
+    "(no shell). Paths are workspace-relative and confined to the " +
+    "workspace; inputs open local files only (no URLs, pipes, or device " +
+    "files). Install ffmpeg if the binary is missing. Use output_file to " +
+    "persist the result as an asset.",
   inputSchema: FFMPEG_SCHEMA,
   category: "execute",
   userMessage: (params) => {
     const out =
       isString(params["output_file"]) ? params["output_file"] : "";
     return out ? `Running ffmpeg → ${out}` : "Running ffmpeg";
+  }
+};
+
+export const FFPROBE_SCHEMA: JsonSchema = {
+  type: "object" as const,
+  properties: {
+    path: {
+      type: "string" as const,
+      description:
+        "Workspace-relative media file to inspect. Cannot escape the workspace."
+    },
+    timeout_seconds: {
+      type: "number" as const,
+      description: "Wall-clock timeout. Default 30, max 120."
+    }
+  },
+  required: ["path"]
+};
+
+export const ffprobeSpec: CapabilitySpec = {
+  name: "ffprobe",
+  description:
+    "Read a media file's format and streams with ffprobe: duration, size, " +
+    "bit rate, and per-stream codec/resolution/frame rate/channels. Takes a " +
+    "workspace path, not argv. Use it before ffmpeg to decide what to do.",
+  inputSchema: FFPROBE_SCHEMA,
+  category: "execute",
+  userMessage: (params) => {
+    const target = isString(params["path"]) ? params["path"] : "a file";
+    return `Inspecting ${target}`;
   }
 };
 
@@ -540,5 +574,6 @@ export const mediaSpecs: readonly CapabilitySpec[] = [
   scoreImageAdherenceSpec,
   understandVideoSpec,
   ffmpegSpec,
+  ffprobeSpec,
   ytDlpSpec
 ];

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -32,6 +32,10 @@ import {
   mimeFromFilename,
   runHostBinary
 } from "../host-binaries.js";
+import {
+  confineArgvToWorkspace,
+  hardenFfmpegArgv
+} from "../host-binary-guard.js";
 import { encodeBase64 as encodeMediaBase64 } from "../sandbox-bytes.js";
 import {
   DEFAULT_MIME,
@@ -64,6 +68,7 @@ import {
   scoreImageAdherenceSpec,
   understandVideoSpec,
   ffmpegSpec,
+  ffprobeSpec,
   ytDlpSpec,
   DEFAULT_UNDERSTAND_VIDEO_TOKENS,
   DEFAULT_VIDEO_PROMPT,
@@ -1199,17 +1204,23 @@ const ffmpeg: CapabilityExport = {
       argv.push(outputFile);
     }
 
+    const refusal = await confineArgvToWorkspace(argv, workspace);
+    if (refusal) return refusal;
+    const hardened = hardenFfmpegArgv(argv);
+    if ("error" in hardened) return hardened;
+
+    const persistTarget =
+      outputFile ||
+      [...argv].reverse().find((item) => item && !item.startsWith("-")) ||
+      "";
     const timeoutMs =
       clampTimeoutSeconds(params["timeout_seconds"], 180, 600) * 1000;
     try {
-      const result = await runHostBinary("ffmpeg", argv, {
+      const result = await runHostBinary("ffmpeg", hardened.argv, {
         cwd: workspace,
-        timeoutMs
+        timeoutMs,
+        ...(persistTarget ? { artifactPath: persistTarget } : {})
       });
-      const persistTarget =
-        outputFile ||
-        [...argv].reverse().find((item) => item && !item.startsWith("-")) ||
-        "";
       const persisted =
         result.exitCode === 0 && persistTarget
           ? await persistWorkspaceFile(run.context, persistTarget)
@@ -1227,6 +1238,62 @@ const ffmpeg: CapabilityExport = {
       }
       return {
         error: `ffmpeg failed: ${e instanceof Error ? e.message : String(e)}`
+      };
+    }
+  }
+};
+
+/**
+ * ffprobe with an argv NodeTool writes, not the caller.
+ *
+ * Everything a caller can say is one workspace path, so the whole boundary is
+ * the confinement check — there is no flag surface to guard, and no way to ask
+ * ffprobe to open a socket.
+ */
+const ffprobe: CapabilityExport = {
+  spec: ffprobeSpec,
+  impl: async (run, params) => {
+    const workspace = requireWorkspaceDir(run.context);
+    if (!isString(workspace)) return workspace;
+    const target = params["path"];
+    if (!isNonBlankString(target)) {
+      return { error: "path is required" };
+    }
+    const refusal = await confineArgvToWorkspace([target.trim()], workspace);
+    if (refusal) return refusal;
+
+    const timeoutMs =
+      clampTimeoutSeconds(params["timeout_seconds"], 30, 120) * 1000;
+    try {
+      const result = await runHostBinary(
+        "ffprobe",
+        [
+          "-v",
+          "error",
+          "-print_format",
+          "json",
+          "-show_format",
+          "-show_streams",
+          target.trim()
+        ],
+        { cwd: workspace, timeoutMs }
+      );
+      if (result.exitCode !== 0) {
+        return {
+          error: `ffprobe failed: ${result.stderr.trim() || `exit ${result.exitCode}`}`
+        };
+      }
+      const parsed: unknown = JSON.parse(result.stdout);
+      if (!isObjectLike(parsed)) {
+        return { error: "ffprobe returned no readable JSON" };
+      }
+      return { path: target.trim(), ...parsed };
+    } catch (e) {
+      if (e instanceof HostBinaryMissingError) {
+        return { error: e.message };
+      }
+      return {
+        error: `ffprobe failed: ${e instanceof Error ? e.message : String(e)}`
       };
     }
   }
@@ -1260,6 +1327,11 @@ const ytDlp: CapabilityExport = {
       : "";
     const timeoutMs =
       clampTimeoutSeconds(params["timeout_seconds"], 300, 900) * 1000;
+
+    // The template is the caller's, so it escapes the workspace as easily as
+    // an ffmpeg path does. `format` reaches yt-dlp as a selector, never a path.
+    const refusal = await confineArgvToWorkspace([outputFile], workspace);
+    if (refusal) return refusal;
 
     const outDir = path.dirname(outputFile);
     if (outDir && outDir !== ".") {
@@ -1342,6 +1414,7 @@ export const MEDIA_CAPABILITIES: readonly CapabilityExport[] = [
   scoreImageAdherence,
   understandVideo,
   ffmpeg,
+  ffprobe,
   ytDlp
 ];
 

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -30,7 +30,8 @@ import {
   HostBinaryMissingError,
   clampTimeoutSeconds,
   mimeFromFilename,
-  runHostBinary
+  runHostBinary,
+  type RunHostBinaryOptions
 } from "../host-binaries.js";
 import {
   confineArgvToWorkspace,
@@ -1215,12 +1216,14 @@ const ffmpeg: CapabilityExport = {
       "";
     const timeoutMs =
       clampTimeoutSeconds(params["timeout_seconds"], 180, 600) * 1000;
+    const runOptions: RunHostBinaryOptions = { cwd: workspace, timeoutMs };
+    // Only a known output path can be watched for size; without one the
+    // wall clock and the capture cap are the run's bounds.
+    if (persistTarget) {
+      runOptions.artifactPath = persistTarget;
+    }
     try {
-      const result = await runHostBinary("ffmpeg", hardened.argv, {
-        cwd: workspace,
-        timeoutMs,
-        ...(persistTarget ? { artifactPath: persistTarget } : {})
-      });
+      const result = await runHostBinary("ffmpeg", hardened.argv, runOptions);
       const persisted =
         result.exitCode === 0 && persistTarget
           ? await persistWorkspaceFile(run.context, persistTarget)

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -54,6 +54,7 @@ export const NODETOOL_API_NAMESPACE_TOOLS: Record<string, readonly string[]> = {
     "score_image_adherence",
     "understand_video",
     "ffmpeg",
+    "ffprobe",
     "yt_dlp"
   ],
   documents: [
@@ -712,6 +713,8 @@ const nodetool = (() => {
         ),
       /** Run ffmpeg on workspace files. \`args\` is argv after the binary name. */
       ffmpeg: (args, opts) => __need("ffmpeg")(__merge(opts, { args: args })),
+      /** Read a media file's format and streams with ffprobe. */
+      ffprobe: (path, opts) => __need("ffprobe")(__merge(opts, { path: path })),
       /** Download a video with yt-dlp. */
       downloadVideo: (url, outputFile, opts) =>
         __need("yt_dlp")(__merge(opts, { url: url, output_file: outputFile }))
@@ -1115,7 +1118,9 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   with a model that takes video (Gemini) and answers \`prompt\` as \`{text}\` —
   describe it, summarize it, or pull the on-screen text out.
   Host binaries: \`ffmpeg(args, {output_file, timeout_seconds})\` runs ffmpeg
-  in the workspace (no shell); \`downloadVideo(url, outputFile, {format,
+  in the workspace (no shell, workspace paths only, no URL inputs);
+  \`ffprobe(path)\` reads a file's format and streams before you decide what to
+  run; \`downloadVideo(url, outputFile, {format,
   timeout_seconds})\` downloads with yt-dlp. Browse pages with
   \`nodetool.web.browse(url)\`.`
   },

--- a/packages/agents/src/evals/codeact-api-core.ts
+++ b/packages/agents/src/evals/codeact-api-core.ts
@@ -1163,6 +1163,33 @@ export function createCoreApiTools(recorder: CodeActToolRecorder): Tool[] {
       }
     ),
     tool(
+      "ffprobe",
+      "Read a media file's format and streams with ffprobe.",
+      { path: s, timeout_seconds: { type: "number" } },
+      (params) => {
+        const target = str(params["path"]);
+        return {
+          path: target,
+          format: {
+            filename: target,
+            format_name: "mov,mp4,m4a",
+            duration: "12.500000",
+            size: "1048576"
+          },
+          streams: [
+            {
+              codec_type: "video",
+              codec_name: "h264",
+              width: 1920,
+              height: 1080,
+              r_frame_rate: "30/1"
+            },
+            { codec_type: "audio", codec_name: "aac", channels: 2 }
+          ]
+        };
+      }
+    ),
+    tool(
       "yt_dlp",
       "Download a video with yt-dlp.",
       {

--- a/packages/agents/src/host-binaries.ts
+++ b/packages/agents/src/host-binaries.ts
@@ -3,9 +3,25 @@
  *
  * Used by the ffmpeg and yt-dlp capabilities. A missing binary is a named
  * error, not an ENOENT stack.
+ *
+ * What the caller gets is bounded on every axis a media tool can exhaust,
+ * because the argv behind it comes from a model:
+ *
+ * - **Wall clock** — `timeoutMs`, SIGTERM then SIGKILL five seconds later.
+ * - **Memory** — captured stdout/stderr stop at {@link MAX_CAPTURED_BYTES}
+ *   each. `-loglevel debug` over a long clip used to accumulate the whole
+ *   stream into one string in the server's heap.
+ * - **Disk** — `maxArtifactBytes` watches the file being written and kills the
+ *   child when it passes the cap. ffmpeg's own `-fs` does not hold: measured
+ *   against ffmpeg 6.1, `-fs 50000` still produced a 164 KB mp4.
+ * - **CPU** — {@link maxConcurrentHostBinaries} spawns run at once; the rest
+ *   queue. One run cannot take every core from the request handlers.
+ *
+ * The filesystem/network half of the boundary lives in `host-binary-guard.ts`.
  */
 
 import { spawn } from "node:child_process";
+import { stat } from "node:fs/promises";
 import path from "node:path";
 import { isNumber, isObjectLike } from "./utils/type-guards.js";
 
@@ -13,7 +29,58 @@ export type HostBinaryResult = {
   stdout: string;
   stderr: string;
   exitCode: number;
+  /** True when output was cut at the capture cap; the child still ran on. */
+  truncated?: boolean;
 };
+
+/** Captured bytes kept per stream. Beyond this the tail is dropped. */
+export const MAX_CAPTURED_BYTES = 256 * 1024;
+
+/** Default ceiling on a single artifact a host binary writes (2 GiB). */
+export const MAX_ARTIFACT_BYTES = 2 * 1024 * 1024 * 1024;
+
+/** How often the artifact watchdog stats the file it is watching. */
+const ARTIFACT_POLL_MS = 500;
+
+/**
+ * Concurrent host-binary spawns. `NODETOOL_HOST_BINARY_CONCURRENCY` overrides
+ * it; anything unparseable or non-positive keeps the default.
+ */
+export function maxConcurrentHostBinaries(): number {
+  const raw = Number(process.env["NODETOOL_HOST_BINARY_CONCURRENCY"]);
+  return Number.isFinite(raw) && raw >= 1 ? Math.floor(raw) : 2;
+}
+
+let running = 0;
+const waiting: Array<() => void> = [];
+
+/** Take a slot, waiting behind the queue when every slot is busy. */
+async function acquireSlot(): Promise<void> {
+  if (running < maxConcurrentHostBinaries()) {
+    running++;
+    return;
+  }
+  await new Promise<void>((resolve) => waiting.push(resolve));
+  running++;
+}
+
+function releaseSlot(): void {
+  running--;
+  waiting.shift()?.();
+}
+
+/** Append to a captured stream, stopping at the cap. */
+function capture(
+  buffer: string,
+  chunk: string
+): { text: string; truncated: boolean } {
+  if (buffer.length >= MAX_CAPTURED_BYTES) {
+    return { text: buffer, truncated: true };
+  }
+  const room = MAX_CAPTURED_BYTES - buffer.length;
+  if (chunk.length <= room) return { text: buffer + chunk, truncated: false };
+  return { text: buffer + chunk.slice(0, room), truncated: true };
+}
 
 export class HostBinaryMissingError extends Error {
   readonly binary: string;
@@ -27,33 +94,92 @@ export class HostBinaryMissingError extends Error {
   }
 }
 
+export interface RunHostBinaryOptions {
+  cwd: string;
+  timeoutMs: number;
+  /**
+   * Workspace-relative file the run is writing. When set, the watchdog kills
+   * the child once that file passes `maxArtifactBytes`.
+   */
+  artifactPath?: string;
+  /** Ceiling for `artifactPath`. Defaults to {@link MAX_ARTIFACT_BYTES}. */
+  maxArtifactBytes?: number;
+}
+
 export async function runHostBinary(
   cmd: string,
   args: string[],
-  opts: { cwd: string; timeoutMs: number }
+  opts: RunHostBinaryOptions
+): Promise<HostBinaryResult> {
+  await acquireSlot();
+  try {
+    return await spawnBounded(cmd, args, opts);
+  } finally {
+    releaseSlot();
+  }
+}
+
+function spawnBounded(
+  cmd: string,
+  args: string[],
+  opts: RunHostBinaryOptions
 ): Promise<HostBinaryResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(cmd, args, { cwd: opts.cwd, stdio: "pipe" });
     let stdout = "";
     let stderr = "";
+    let truncated = false;
     let timedOut = false;
+    let overran = false;
     let killTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const kill = (): void => {
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => child.kill("SIGKILL"), 5000);
+    };
 
     const timer = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGTERM");
-      killTimer = setTimeout(() => child.kill("SIGKILL"), 5000);
+      kill();
     }, opts.timeoutMs);
 
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-    child.on("error", (err) => {
+    const artifactCap = opts.maxArtifactBytes ?? MAX_ARTIFACT_BYTES;
+    const artifact =
+      opts.artifactPath !== undefined && opts.artifactPath !== ""
+        ? path.resolve(opts.cwd, opts.artifactPath)
+        : undefined;
+    const watchdog =
+      artifact === undefined
+        ? undefined
+        : setInterval(() => {
+            void stat(artifact)
+              .then((info) => {
+                if (info.size <= artifactCap || overran) return;
+                overran = true;
+                kill();
+              })
+              // Not written yet, or already gone: nothing to bound.
+              .catch(() => undefined);
+          }, ARTIFACT_POLL_MS);
+
+    const done = (): void => {
       clearTimeout(timer);
       if (killTimer) clearTimeout(killTimer);
+      if (watchdog) clearInterval(watchdog);
+    };
+
+    child.stdout.on("data", (chunk) => {
+      const next = capture(stdout, String(chunk));
+      stdout = next.text;
+      truncated = truncated || next.truncated;
+    });
+    child.stderr.on("data", (chunk) => {
+      const next = capture(stderr, String(chunk));
+      stderr = next.text;
+      truncated = truncated || next.truncated;
+    });
+    child.on("error", (err) => {
+      done();
       const code =
         isObjectLike(err) && "code" in err
           ? String(err.code)
@@ -65,17 +191,28 @@ export async function runHostBinary(
       reject(err);
     });
     child.on("close", (code) => {
-      clearTimeout(timer);
-      if (killTimer) clearTimeout(killTimer);
+      done();
       if (timedOut) {
         resolve({
           stdout,
           stderr: `${stderr}\nProcess timed out after ${opts.timeoutMs}ms`,
-          exitCode: 124
+          exitCode: 124,
+          truncated
         });
         return;
       }
-      resolve({ stdout, stderr, exitCode: code ?? 0 });
+      if (overran) {
+        resolve({
+          stdout,
+          stderr:
+            `${stderr}\nStopped: ${opts.artifactPath} passed the ` +
+            `${artifactCap}-byte output limit`,
+          exitCode: 124,
+          truncated
+        });
+        return;
+      }
+      resolve({ stdout, stderr, exitCode: code ?? 0, truncated });
     });
   });
 }

--- a/packages/agents/src/host-binary-guard.ts
+++ b/packages/agents/src/host-binary-guard.ts
@@ -1,0 +1,137 @@
+/**
+ * The boundary around `ffmpeg` and `yt-dlp` — the two capabilities that hand a
+ * model's own strings to a process on the host.
+ *
+ * The argv arrives from guest JavaScript or from an LLM tool call, and the
+ * child runs with the server's identity. In the managed cloud that server also
+ * holds every other tenant's database handle and secret store, so an unbounded
+ * `ffmpeg` is an arbitrary-file reader (`-i /etc/passwd`), an arbitrary-file
+ * writer (`-y ../../app/backend/server.mjs`), and an SSRF client — measured,
+ * not assumed: `ffmpeg -i http://169.254.169.254/…` opens the socket and
+ * reports what came back.
+ *
+ * Three rules, in the order they are cheapest to check:
+ *
+ * 1. **No opener but the filesystem.** Anything naming a protocol or a
+ *    pseudo-file — `://`, `concat:`, `pipe:`, `/dev/…` — is refused, and
+ *    `-protocol_whitelist file,crypto,data` is injected before *every* input
+ *    so a playlist inside the workspace cannot reach the network either.
+ *    ffmpeg applies that option per input, so one copy at the front covers
+ *    only the first `-i` (verified against ffmpeg 6.1).
+ * 2. **Nothing outside the workspace.** Every non-flag argument is resolved
+ *    against the workspace root and refused when it lands outside, symlinks
+ *    resolved. A filter value carries its path inside the token
+ *    (`subtitles=../../etc/x`), and resolving the whole token catches that
+ *    without parsing filter syntax.
+ * 3. **No stdin.** `-nostdin` keeps a child from inheriting and blocking on
+ *    the server's stdin, which outlives any single run.
+ *
+ * The CPU/memory/disk half of the boundary lives in `host-binaries.ts`:
+ * bounded output capture, a concurrency cap, the wall-clock timeout, and the
+ * artifact-size watchdog.
+ */
+
+import path from "node:path";
+
+import { isEditTargetWithinRoot } from "./workspace-paths.js";
+
+/** What every `-i` gets: local files, plus the two openers that read bytes we already hold. */
+export const FFMPEG_PROTOCOL_WHITELIST = "file,crypto,data";
+
+/**
+ * Substrings that name an opener other than a plain path. `://` covers every
+ * network protocol at once; the rest are ffmpeg's own pseudo-files and the
+ * filter sources that read a file without looking like a path.
+ */
+const DENIED_TOKENS: readonly string[] = [
+  "://",
+  "concat:",
+  "subfile:",
+  "async:",
+  "cache:",
+  "pipe:",
+  "fd:",
+  "movie=",
+  "amovie=",
+  "/dev/",
+  "/proc/",
+  "/sys/"
+];
+
+/** An argument the caller must not set: it would widen rule 1. */
+const RESERVED_FLAGS: readonly string[] = ["-protocol_whitelist"];
+
+export interface ArgvRefusal {
+  error: string;
+}
+
+/** The token that made an argument unacceptable, or undefined when it is fine. */
+function deniedToken(arg: string): string | undefined {
+  const lowered = arg.toLowerCase();
+  return DENIED_TOKENS.find((token) => lowered.includes(token));
+}
+
+/**
+ * Refuse argv that reaches past the workspace, or `undefined` when every
+ * argument stays inside it.
+ *
+ * Flags are skipped: a leading `-` is ffmpeg's option marker, so such an
+ * argument is never a path, and a file named `-x` is unusable by ffmpeg
+ * anyway. Everything else is resolved against the workspace root — an absolute
+ * path, a `..` chain, and a path buried in a filter token all land outside it
+ * the same way.
+ */
+export async function confineArgvToWorkspace(
+  argv: readonly string[],
+  workspace: string
+): Promise<ArgvRefusal | undefined> {
+  for (const arg of argv) {
+    const token = deniedToken(arg);
+    if (token !== undefined) {
+      return {
+        error:
+          `"${token}" is not allowed in a host media argument (in "${arg}"). ` +
+          `Only workspace files are readable; download first, then pass the ` +
+          `local path.`
+      };
+    }
+    if (arg === "" || arg.startsWith("-")) continue;
+    const resolved = path.resolve(workspace, arg);
+    if (!(await isEditTargetWithinRoot(workspace, resolved))) {
+      return {
+        error:
+          `"${arg}" resolves outside the workspace. Paths are ` +
+          `workspace-relative and cannot escape it.`
+      };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The argv actually spawned: `-nostdin`, then the caller's arguments with
+ * `-protocol_whitelist` in front of every input.
+ *
+ * Refuses a caller who sets `-protocol_whitelist` themselves rather than
+ * silently dropping it — the refusal says which flag the host owns.
+ */
+export function hardenFfmpegArgv(
+  argv: readonly string[]
+): { argv: string[] } | ArgvRefusal {
+  const reserved = argv.find((arg) => RESERVED_FLAGS.includes(arg));
+  if (reserved !== undefined) {
+    return {
+      error:
+        `${reserved} is set by NodeTool and cannot be passed. Inputs may ` +
+        `only open workspace files (${FFMPEG_PROTOCOL_WHITELIST}).`
+    };
+  }
+  const hardened: string[] = ["-nostdin"];
+  for (const arg of argv) {
+    if (arg === "-i") {
+      hardened.push("-protocol_whitelist", FFMPEG_PROTOCOL_WHITELIST);
+    }
+    hardened.push(arg);
+  }
+  return { argv: hardened };
+}

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -129,6 +129,7 @@ export const BUILTIN_TOOL_NAMES: readonly string[] = [
 
   // Host media binaries
   "ffmpeg",
+  "ffprobe",
   "yt_dlp",
 
   // Email

--- a/packages/agents/src/tools/tool-permissions.ts
+++ b/packages/agents/src/tools/tool-permissions.ts
@@ -202,6 +202,7 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   debug_app: "execute",
   start_background_job: "execute",
   ffmpeg: "execute",
+  ffprobe: "execute",
 
   // --- external: third-party side effects ---
   browser: "external",

--- a/packages/agents/src/workspace-paths.ts
+++ b/packages/agents/src/workspace-paths.ts
@@ -1,0 +1,64 @@
+/**
+ * Whether a path stays inside the workspace, symlinks included.
+ *
+ * `resolveWorkspacePath` checks containment lexically, which a symlink defeats:
+ * a link inside the workspace (unpacked from an imported bundle, or written by
+ * an earlier run) can point anywhere on the host, and dereferencing it hands
+ * out files the workspace was supposed to bound. Both predicates below resolve
+ * the real path first and answer against the real root.
+ *
+ * Shared by the file capabilities and the host-binary guard, so "inside the
+ * workspace" means one thing no matter which surface asks.
+ */
+
+import { lstat, realpath } from "node:fs/promises";
+import { dirname, isAbsolute, relative } from "node:path";
+
+/**
+ * True when `candidate`'s real (symlink-resolved) path stays within the real
+ * workspace root. Returns false when either path cannot be resolved
+ * (broken/dangling link).
+ */
+export async function isRealPathWithinRoot(
+  root: string,
+  candidate: string
+): Promise<boolean> {
+  try {
+    const realRoot = await realpath(root);
+    const realCandidate = await realpath(candidate);
+    if (realCandidate === realRoot) return true;
+    const rel = relative(realRoot, realCandidate);
+    return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Like {@link isRealPathWithinRoot} but tolerant of a not-yet-created target:
+ * when the candidate does not exist, its parent directory is realpath-checked
+ * instead, so creating a file under a symlinked-out directory is still blocked.
+ */
+export async function isEditTargetWithinRoot(
+  root: string,
+  candidate: string
+): Promise<boolean> {
+  if (await isRealPathWithinRoot(root, candidate)) return true;
+  // Candidate may not exist yet (create path) — check its parent.
+  const parent = dirname(candidate);
+  if (parent === candidate) return false;
+  try {
+    // lstat, NOT access: access() follows symlinks, so a DANGLING in-workspace
+    // symlink (target outside the root and not yet created) would look absent
+    // and fall through to the parent check, allowing a create that follows the
+    // link outside the workspace. lstat stats the link itself, so it succeeds
+    // and we treat the path as existing-but-out-of-root.
+    await lstat(candidate);
+    // It exists (as a real file or a symlink) but failed the realpath
+    // containment check above → outside the root.
+    return false;
+  } catch {
+    // Truly does not exist; the containing directory must be inside the root.
+    return isRealPathWithinRoot(root, parent);
+  }
+}

--- a/packages/agents/tests/capabilities-media.test.ts
+++ b/packages/agents/tests/capabilities-media.test.ts
@@ -83,6 +83,7 @@ describe("media and style capability modules", () => {
       "score_image_adherence",
       "understand_video",
       "ffmpeg",
+      "ffprobe",
       "yt_dlp"
     ]);
     const style = await loadCapabilityModule("style");
@@ -400,5 +401,42 @@ describe("ffmpeg and yt_dlp capabilities", () => {
       { url: "file:///etc/passwd" }
     )) as Record<string, unknown>;
     expect(String(result["error"])).toMatch(/http\(s\)/);
+  });
+
+  // The guard is unit-tested in host-binary-guard.test.ts; these pin that the
+  // capability actually calls it, and refuses before anything is spawned.
+  it("ffmpeg refuses a path outside the workspace", async () => {
+    const result = (await asTool(ffmpeg).process(
+      { workspaceDir: "/tmp" } as unknown as ProcessingContext,
+      { args: ["-i", "/etc/passwd", "out.wav"] }
+    )) as Record<string, unknown>;
+    expect(String(result["error"])).toMatch(/outside the workspace/);
+  });
+
+  it("ffmpeg refuses a network input", async () => {
+    const result = (await asTool(ffmpeg).process(
+      { workspaceDir: "/tmp" } as unknown as ProcessingContext,
+      { args: ["-i", "http://169.254.169.254/latest/meta-data/", "out.txt"] }
+    )) as Record<string, unknown>;
+    expect(String(result["error"])).toMatch(/Only workspace files are readable/);
+  });
+
+  it("ffmpeg refuses an output_file that escapes the workspace", async () => {
+    const result = (await asTool(ffmpeg).process(
+      { workspaceDir: "/tmp" } as unknown as ProcessingContext,
+      { args: ["-i", "in.mp4"], output_file: "../../etc/cron.d/x" }
+    )) as Record<string, unknown>;
+    expect(String(result["error"])).toMatch(/outside the workspace/);
+  });
+
+  it("yt_dlp refuses an output template that escapes the workspace", async () => {
+    const result = (await asTool(ytDlp).process(
+      { workspaceDir: "/tmp" } as unknown as ProcessingContext,
+      {
+        url: "https://example.com/v",
+        output_file: "../../root/.ssh/authorized_keys"
+      }
+    )) as Record<string, unknown>;
+    expect(String(result["error"])).toMatch(/outside the workspace/);
   });
 });

--- a/packages/agents/tests/capabilities-registry.test.ts
+++ b/packages/agents/tests/capabilities-registry.test.ts
@@ -109,6 +109,7 @@ const CAPABILITY_CATEGORY_SNAPSHOT: Record<string, PermissionCategory> = {
   start_background_job: "execute",
   transcribe_audio: "write",
   ffmpeg: "execute",
+  ffprobe: "execute",
   yt_dlp: "external",
   validate_workflow: "read",
   vector_batch_index: "write",

--- a/packages/agents/tests/host-binaries.test.ts
+++ b/packages/agents/tests/host-binaries.test.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   HostBinaryMissingError,
+  MAX_CAPTURED_BYTES,
   clampTimeoutSeconds,
+  maxConcurrentHostBinaries,
   mimeFromFilename,
   runHostBinary
 } from "../src/host-binaries.js";
@@ -22,6 +24,89 @@ describe("runHostBinary", () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("stops capturing output at the cap instead of buying the whole stream", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "nt-host-bin-"));
+    try {
+      // Two megabytes of stderr — an ffmpeg -loglevel debug run, in miniature.
+      const result = await runHostBinary(
+        process.execPath,
+        [
+          "-e",
+          "const line='x'.repeat(1024)+'\\n';" +
+            "for (let i=0;i<2048;i++) process.stderr.write(line);"
+        ],
+        { cwd, timeoutMs: 30_000 }
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr.length).toBe(MAX_CAPTURED_BYTES);
+      expect(result.truncated).toBe(true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("kills a run whose artifact passes the size cap", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "nt-host-bin-"));
+    try {
+      const result = await runHostBinary(
+        process.execPath,
+        [
+          "-e",
+          "const fs=require('fs');const b=Buffer.alloc(64*1024,1);" +
+            "const s=fs.createWriteStream('big.bin');" +
+            "const t=setInterval(()=>s.write(b),5);" +
+            "setTimeout(()=>{clearInterval(t);s.end();},30000);"
+        ],
+        {
+          cwd,
+          timeoutMs: 30_000,
+          artifactPath: "big.bin",
+          maxArtifactBytes: 256 * 1024
+        }
+      );
+      expect(result.exitCode).toBe(124);
+      expect(result.stderr).toContain("passed the");
+      expect(result.stderr).toContain("output limit");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("runs no more host binaries at once than the concurrency cap", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "nt-host-bin-"));
+    const cap = maxConcurrentHostBinaries();
+    try {
+      // Each child reports the window it occupied; overlapping windows beyond
+      // the cap would mean the semaphore let extra spawns through.
+      const runs = await Promise.all(
+        Array.from({ length: cap + 3 }, () =>
+          runHostBinary(
+            process.execPath,
+            [
+              "-e",
+              "const s=Date.now();setTimeout(()=>" +
+                "process.stdout.write(s+' '+Date.now()),200);"
+            ],
+            { cwd, timeoutMs: 30_000 }
+          )
+        )
+      );
+      const windows = runs.map((r) => {
+        const [start, end] = r.stdout.trim().split(" ").map(Number);
+        return { start: start as number, end: end as number };
+      });
+      const peak = Math.max(
+        ...windows.map(
+          (w) =>
+            windows.filter((o) => o.start < w.end && w.start < o.end).length
+        )
+      );
+      expect(peak).toBeLessThanOrEqual(cap);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  }, 60_000);
 
   it("names a missing binary", async () => {
     const cwd = await mkdtemp(path.join(tmpdir(), "nt-host-bin-"));

--- a/packages/agents/tests/host-binary-guard.test.ts
+++ b/packages/agents/tests/host-binary-guard.test.ts
@@ -1,0 +1,179 @@
+/**
+ * The argv boundary around the host media binaries.
+ *
+ * Each case is an escape a model can write today: an absolute path, a `..`
+ * chain, a path hidden inside a filter token, a symlink planted in the
+ * workspace, and a URL input — which ffmpeg really does open (an unguarded
+ * `-i http://…` reaches the socket, so in the cloud it reaches the instance
+ * metadata service).
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runHostBinary } from "../src/host-binaries.js";
+import {
+  FFMPEG_PROTOCOL_WHITELIST,
+  confineArgvToWorkspace,
+  hardenFfmpegArgv
+} from "../src/host-binary-guard.js";
+
+let workspace = "";
+let outside = "";
+
+beforeEach(async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "nt-guard-"));
+  workspace = path.join(root, "ws");
+  outside = path.join(root, "outside");
+  await mkdir(workspace, { recursive: true });
+  await mkdir(outside, { recursive: true });
+  await writeFile(path.join(outside, "secret.txt"), "s3cret");
+});
+
+afterEach(async () => {
+  await rm(path.dirname(workspace), { recursive: true, force: true });
+});
+
+async function refusal(argv: string[]): Promise<string> {
+  const result = await confineArgvToWorkspace(argv, workspace);
+  return result?.error ?? "";
+}
+
+describe("confineArgvToWorkspace", () => {
+  it("passes argv that stays inside the workspace", async () => {
+    await writeFile(path.join(workspace, "in.mp4"), "x");
+    expect(
+      await refusal(["-i", "in.mp4", "-vf", "scale=1280:-2", "out.mp4"])
+    ).toBe("");
+  });
+
+  it("refuses an absolute path outside the workspace", async () => {
+    expect(await refusal(["-i", "/etc/passwd"])).toContain(
+      "resolves outside the workspace"
+    );
+  });
+
+  it("refuses a `..` chain", async () => {
+    expect(await refusal(["-i", "../outside/secret.txt"])).toContain(
+      "resolves outside the workspace"
+    );
+  });
+
+  it("refuses a path buried in a filter token", async () => {
+    // The whole token resolves, so no filter-syntax parsing is needed.
+    expect(await refusal(["-vf", "subtitles=../outside/secret.txt"])).toContain(
+      "resolves outside the workspace"
+    );
+  });
+
+  it("refuses an in-workspace symlink that points out", async () => {
+    await symlink(path.join(outside, "secret.txt"), path.join(workspace, "link"));
+    expect(await refusal(["-i", "link"])).toContain(
+      "resolves outside the workspace"
+    );
+  });
+
+  it("refuses writing through a symlinked directory", async () => {
+    await symlink(outside, path.join(workspace, "out"));
+    expect(await refusal(["out/new.mp4"])).toContain(
+      "resolves outside the workspace"
+    );
+  });
+
+  it.each([
+    ["http://169.254.169.254/latest/meta-data/", "://"],
+    ["rtmp://example.com/live", "://"],
+    ["concat:a.ts|b.ts", "concat:"],
+    ["pipe:0", "pipe:"],
+    ["/dev/urandom", "/dev/"],
+    ["movie=../outside/secret.txt", "movie="]
+  ])("refuses %s as a non-file opener", async (arg, token) => {
+    const message = await refusal(["-i", arg]);
+    expect(message).toContain(token);
+    expect(message).toContain("Only workspace files are readable");
+  });
+
+  it("allows a file that does not exist yet under a real directory", async () => {
+    await mkdir(path.join(workspace, "clips"));
+    expect(await refusal(["clips/out.mp4"])).toBe("");
+  });
+});
+
+describe("hardenFfmpegArgv", () => {
+  it("puts the protocol whitelist in front of every input", () => {
+    const hardened = hardenFfmpegArgv(["-i", "a.mp4", "-i", "b.mp4", "out.mp4"]);
+    expect(hardened).toEqual({
+      argv: [
+        "-nostdin",
+        "-protocol_whitelist",
+        FFMPEG_PROTOCOL_WHITELIST,
+        "-i",
+        "a.mp4",
+        "-protocol_whitelist",
+        FFMPEG_PROTOCOL_WHITELIST,
+        "-i",
+        "b.mp4",
+        "out.mp4"
+      ]
+    });
+  });
+
+  it("refuses a caller who sets the whitelist itself", () => {
+    const hardened = hardenFfmpegArgv([
+      "-protocol_whitelist",
+      "file,http",
+      "-i",
+      "a.mp4"
+    ]);
+    expect(hardened).toEqual({
+      error: expect.stringContaining("-protocol_whitelist is set by NodeTool")
+    });
+  });
+});
+
+/** ffmpeg ships on the CI images and on most dev boxes; skip where it does not. */
+const hasFfmpeg = spawnSync("ffmpeg", ["-version"]).status === 0;
+
+describe.skipIf(!hasFfmpeg)("the hardened argv against real ffmpeg", () => {
+  it("still transcodes a workspace file", async () => {
+    const source = hardenFfmpegArgv([
+      "-f",
+      "lavfi",
+      "-i",
+      "testsrc=size=160x120:rate=5",
+      "-t",
+      "1",
+      "-y",
+      "out.mp4"
+    ]);
+    expect("argv" in source).toBe(true);
+    if (!("argv" in source)) return;
+    const result = await runHostBinary("ffmpeg", source.argv, {
+      cwd: workspace,
+      timeoutMs: 60_000
+    });
+    expect(result.exitCode).toBe(0);
+    expect((await stat(path.join(workspace, "out.mp4"))).size).toBeGreaterThan(0);
+  }, 90_000);
+
+  it("refuses a URL input that got past the token scan", async () => {
+    // Defense in depth: the scan above rejects `://` before ffmpeg sees it, so
+    // this drives ffmpeg directly to show what the whitelist itself does — an
+    // unwhitelisted run opens the socket instead (that is the SSRF this bounds).
+    const hardened = hardenFfmpegArgv([
+      "-i",
+      "http://169.254.169.254/latest/meta-data/",
+      "-y",
+      "out.txt"
+    ]);
+    expect("argv" in hardened).toBe(true);
+    if (!("argv" in hardened)) return;
+    const result = await runHostBinary("ffmpeg", hardened.argv, {
+      cwd: workspace,
+      timeoutMs: 60_000
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("not on whitelist");
+  }, 90_000);
+});


### PR DESCRIPTION
Follow-up to #5043. That PR made the capability surface reachable from the QuickJS sandbox in production; this one makes the ffmpeg half of it safe to reach, and completes the toolchain with `ffprobe`.

## Why

`ffmpeg` takes argv straight from guest JavaScript or an LLM tool call and runs it as the server. In the managed cloud that server also holds every other tenant's database handle and secret store, so the capability as it stood was:

- an arbitrary-file reader — `-i /etc/passwd`, or `-i ../../app/backend/server.mjs`
- an arbitrary-file writer — `-y ../../etc/cron.d/x`
- an SSRF client — **measured, not inferred**: an unguarded `ffmpeg -i http://169.254.169.254/latest/meta-data/` opens the socket and reports what came back. On Fly that is the instance metadata service.

## Filesystem and network — `host-binary-guard.ts`

Every non-flag argument is resolved against the workspace root and refused when it lands outside, symlinks resolved. Resolving the *whole token* also catches a path buried in filter syntax (`subtitles=../../etc/x`) without parsing filter grammar.

Inputs may open local files only: `-protocol_whitelist file,crypto,data` is injected before **every** `-i`, plus a token scan for `://`, `concat:`, `subfile:`, `pipe:`, `fd:`, `movie=`, `/dev/`, `/proc/`, `/sys/`. Per-input placement is not a guess — ffmpeg applies that option to the next input only, so one copy at the front leaves input 2 open; verified against ffmpeg 6.1 in both configurations. A caller who passes `-protocol_whitelist` themselves is refused rather than silently overridden. `-nostdin` keeps a child off the server's stdin.

yt-dlp's `output_file` template goes through the same confinement — it was equally escapable.

## System resources — `host-binaries.ts`

| Axis | Bound |
|---|---|
| Wall clock | existing `timeoutMs`, SIGTERM → SIGKILL |
| Memory | captured stdout/stderr stop at 256 KiB each (a `-loglevel debug` run used to accumulate the whole stream into one string in the server's heap) |
| Disk | watchdog stats the artifact and kills the run past its cap |
| CPU | semaphore over concurrent spawns (`NODETOOL_HOST_BINARY_CONCURRENCY`, default 2) |

The disk bound is a watchdog rather than ffmpeg's own `-fs` because `-fs` does not hold: measured on ffmpeg 6.1, `-fs 50000` still produced a 164 KB mp4.

## `ffprobe`

New capability, deliberately argv-free: one workspace path, a fixed command, parsed JSON back. Reading a file's format and streams was the half of the ffmpeg toolchain the sandbox never had — a guest could transcode but not look first. Registered on the belt, in the permission map, and as `nodetool.media.ffprobe(path)`.

`isRealPathWithinRoot` / `isEditTargetWithinRoot` move out of `files.ts` into `workspace-paths.ts`, so "inside the workspace" means one thing on both surfaces.

## Verification

- 14 boundary cases (absolute path, `..` chain, filter-token path, in-workspace symlink, symlinked output directory, six non-file openers, the three resource bounds) — all fail when the boundary is removed, checked by inverting each one.
- Two tests drive **real ffmpeg**: the hardened argv still transcodes a workspace file, and the whitelist refuses a URL input. `describe.skipIf` on binary presence.
- Four capability-level tests pin that `ffmpeg` and `yt_dlp` actually call the guard and refuse before spawning.
- `npm run build:packages`, all package + reliability suites, web (13,184), electron (678), `nodetool harness gate`, web/electron typecheck: green. Lint adds zero findings (same count before and after).
- Two "exports all public API" import tests (`chat`, `deploy`) timed out under parallel load on different runs and pass in isolation — a 5s/60s import budget under CPU contention, not this diff. Pre-existing container gaps unrelated to the diff: mobile typecheck (no `mobile/node_modules`), `lint:anti-slop:enforced` and `test:oxlint-rules` (no `@oxlint/plugins`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Vf8qWoRyghL3iAnxb9Bmp

---
_Generated by [Claude Code](https://claude.ai/code/session_011Vf8qWoRyghL3iAnxb9Bmp)_