### PR TITLE
feat(models): suggest models by goal and hardware fit in the model manager

### DIFF
--- a/packages/websocket/src/system-stats.ts
+++ b/packages/websocket/src/system-stats.ts
@@ -1,4 +1,12 @@
 import os from "node:os";
+import { execFile } from "node:child_process";
+
+type GpuStatsSnapshot = {
+  gpu_percent: number;
+  vram_total_gb: number;
+  vram_used_gb: number;
+  vram_percent: number;
+};
 
 type SystemStatsSnapshot = {
   cpu_percent: number;
@@ -7,11 +15,12 @@ type SystemStatsSnapshot = {
   memory_total: number;
   memory_used_gb: number;
   memory_total_gb: number;
-};
+} & Partial<GpuStatsSnapshot>;
 
 type CpuTimes = { total: number; idle: number };
 
 const BYTES_PER_GB = 1024 ** 3;
+const MIB_PER_GB = 1024;
 
 function snapshotCpu(): CpuTimes {
   let total = 0;
@@ -24,14 +33,85 @@ function snapshotCpu(): CpuTimes {
   return { total, idle };
 }
 
+const NVIDIA_SMI_ARGS = [
+  "--query-gpu=utilization.gpu,memory.total,memory.used",
+  "--format=csv,noheader,nounits"
+];
+
+/**
+ * Parse `nvidia-smi --query-gpu=utilization.gpu,memory.total,memory.used
+ * --format=csv,noheader,nounits` output (one CSV line per GPU; utilization in
+ * %, memory in MiB). With several GPUs, report the one with the most memory —
+ * that's where models land, and a summed figure would suggest budgets no
+ * single card has. Returns null when no line parses to a usable total.
+ */
+export function parseNvidiaSmiGpuStats(stdout: string): GpuStatsSnapshot | null {
+  let best: { util: number; totalMib: number; usedMib: number } | null = null;
+  for (const line of stdout.split("\n")) {
+    const parts = line.split(",").map((part) => part.trim());
+    if (parts.length < 3) {
+      continue;
+    }
+    // Unsupported fields print "[N/A]"; Number() turns those into NaN.
+    const util = Number(parts[0]);
+    const totalMib = Number(parts[1]);
+    const usedMib = Number(parts[2]);
+    if (!Number.isFinite(totalMib) || totalMib <= 0) {
+      continue;
+    }
+    if (!best || totalMib > best.totalMib) {
+      best = {
+        util: Number.isFinite(util) ? Math.max(0, Math.min(100, util)) : 0,
+        totalMib,
+        usedMib: Number.isFinite(usedMib) ? Math.max(0, usedMib) : 0
+      };
+    }
+  }
+  if (!best) {
+    return null;
+  }
+  return {
+    gpu_percent: best.util,
+    vram_total_gb: best.totalMib / MIB_PER_GB,
+    vram_used_gb: best.usedMib / MIB_PER_GB,
+    vram_percent: Math.max(0, Math.min(100, (best.usedMib / best.totalMib) * 100))
+  };
+}
+
 /**
  * Build a stateful sampler that returns whole-system stats on each call.
  * CPU% is computed from the delta of `os.cpus()` times since the last call,
  * so the first call after construction returns ~0% (no delta yet).
+ *
+ * GPU stats come from an async `nvidia-smi` probe kicked off by each call and
+ * read from a cache, so the sampler itself stays synchronous; the first call
+ * carries no GPU fields, later ones do. A machine without a working
+ * `nvidia-smi` is marked unavailable after the first failed probe so no
+ * further processes are spawned. (Apple Silicon has no discrete VRAM; the
+ * frontend budgets against unified system memory instead.)
  */
 export function createSystemStatsSampler(): () => SystemStatsSnapshot {
   let previous = snapshotCpu();
+  let gpu: GpuStatsSnapshot | null = null;
+  let gpuProbe: "idle" | "probing" | "unavailable" = "idle";
+
+  const probeGpu = () => {
+    gpuProbe = "probing";
+    execFile("nvidia-smi", NVIDIA_SMI_ARGS, { timeout: 3000 }, (error, stdout) => {
+      if (error) {
+        gpuProbe = "unavailable";
+        gpu = null;
+        return;
+      }
+      gpu = parseNvidiaSmiGpuStats(stdout);
+      gpuProbe = gpu ? "idle" : "unavailable";
+    });
+  };
+
   return () => {
+    if (gpuProbe === "idle") {
+      probeGpu();
+    }
     const current = snapshotCpu();
     const totalDelta = current.total - previous.total;
     const idleDelta = current.idle - previous.idle;
@@ -49,7 +129,8 @@ export function createSystemStatsSampler(): () => SystemStatsSnapshot {
       memory_used: usedMem,
       memory_total: totalMem,
       memory_used_gb: usedMem / BYTES_PER_GB,
-      memory_total_gb: totalMem / BYTES_PER_GB
+      memory_total_gb: totalMem / BYTES_PER_GB,
+      ...(gpu ?? {})
     };
   };
 }

--- a/packages/websocket/tests/system-stats-gpu.test.ts
+++ b/packages/websocket/tests/system-stats-gpu.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The system-stats sampler feeds the Model Manager's hardware-fit
+ * recommendations (`useHardwareProfile` in web). VRAM comes from an
+ * `nvidia-smi` probe; these tests pin the parser so a driver-output quirk
+ * degrades to "no GPU fields" instead of a bogus budget.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  createSystemStatsSampler,
+  parseNvidiaSmiGpuStats
+} from "../src/system-stats.js";
+
+describe("parseNvidiaSmiGpuStats", () => {
+  it("parses a single GPU line (utilization %, memory MiB)", () => {
+    const stats = parseNvidiaSmiGpuStats("37, 24576, 4096\n");
+    expect(stats).toEqual({
+      gpu_percent: 37,
+      vram_total_gb: 24,
+      vram_used_gb: 4,
+      vram_percent: (4096 / 24576) * 100
+    });
+  });
+
+  it("reports the GPU with the most memory, not a sum across GPUs", () => {
+    const stats = parseNvidiaSmiGpuStats("90, 8192, 8000\n10, 49140, 1024\n");
+    expect(stats?.vram_total_gb).toBeCloseTo(48, 1);
+    expect(stats?.gpu_percent).toBe(10);
+  });
+
+  it("tolerates [N/A] utilization but still reports memory", () => {
+    const stats = parseNvidiaSmiGpuStats("[N/A], 16384, 512\n");
+    expect(stats?.vram_total_gb).toBe(16);
+    expect(stats?.gpu_percent).toBe(0);
+  });
+
+  it("returns null for empty or unparseable output", () => {
+    expect(parseNvidiaSmiGpuStats("")).toBeNull();
+    expect(parseNvidiaSmiGpuStats("NVIDIA-SMI has failed\n")).toBeNull();
+    expect(parseNvidiaSmiGpuStats("[N/A], [N/A], [N/A]\n")).toBeNull();
+  });
+});
+
+describe("createSystemStatsSampler", () => {
+  it("returns CPU/RAM stats synchronously even when no GPU probe has resolved", () => {
+    const sample = createSystemStatsSampler()();
+    expect(sample.cpu_percent).toBeGreaterThanOrEqual(0);
+    expect(sample.memory_total_gb).toBeGreaterThan(0);
+    // GPU fields are absent (not null/NaN) until a probe succeeds.
+    expect(sample).not.toHaveProperty("vram_total_gb");
+  });
+});

--- a/web/src/components/hugging_face/model_list/GoalFilterChips.tsx
+++ b/web/src/components/hugging_face/model_list/GoalFilterChips.tsx
@@ -1,0 +1,44 @@
+import React, { useCallback } from "react";
+import { Chip, FlexRow, Text, Tooltip } from "../../ui_primitives";
+import { useModelManagerStore } from "../../../stores/ModelManagerStore";
+import { MODEL_GOALS } from "./modelFit";
+
+/**
+ * "What do you want to do?" filter row: one chip per goal, narrowing the model
+ * list to models that serve it. Clicking the active chip clears the filter.
+ */
+const GoalFilterChips: React.FC = () => {
+  const selectedGoal = useModelManagerStore((state) => state.selectedGoal);
+  const setSelectedGoal = useModelManagerStore(
+    (state) => state.setSelectedGoal
+  );
+
+  const handleToggle = useCallback(
+    (goalId: string) => {
+      setSelectedGoal(selectedGoal === goalId ? null : goalId);
+    },
+    [selectedGoal, setSelectedGoal]
+  );
+
+  return (
+    <FlexRow gap={1} align="center" sx={{ flexWrap: "wrap", mb: 2 }}>
+      <Text size="small" color="secondary" sx={{ whiteSpace: "nowrap" }}>
+        I want to
+      </Text>
+      {MODEL_GOALS.map((goalOption) => (
+        <Tooltip key={goalOption.id} title={goalOption.description} delay={400}>
+          <Chip
+            label={goalOption.label}
+            size="small"
+            active={selectedGoal === goalOption.id}
+            color={selectedGoal === goalOption.id ? "primary" : "default"}
+            variant={selectedGoal === goalOption.id ? "filled" : "outlined"}
+            onClick={() => handleToggle(goalOption.id)}
+          />
+        </Tooltip>
+      ))}
+    </FlexRow>
+  );
+};
+
+export default React.memo(GoalFilterChips);

--- a/web/src/components/hugging_face/model_list/ModelListHeader.tsx
+++ b/web/src/components/hugging_face/model_list/ModelListHeader.tsx
@@ -36,6 +36,7 @@ interface ModelListHeaderProps {
 }
 
 const SORT_OPTIONS: { value: ModelSortField; label: string }[] = [
+  { value: "fit", label: "Best fit" },
   { value: "name", label: "Name" },
   { value: "size", label: "Size" },
   { value: "downloads", label: "Downloads" },

--- a/web/src/components/hugging_face/model_list/ModelListIndex.tsx
+++ b/web/src/components/hugging_face/model_list/ModelListIndex.tsx
@@ -20,7 +20,10 @@ import { useModelManagerStore } from "../../../stores/ModelManagerStore";
 import ModelListItem from "./ModelListItem";
 import ModelsRightSidebar from "./ModelsRightSidebar";
 import LocalModelsHero from "./LocalModelsHero";
+import GoalFilterChips from "./GoalFilterChips";
 import ModelOnboarding from "../onboarding/ModelOnboarding";
+import HardwareCard from "../onboarding/HardwareCard";
+import { useHardwareProfile } from "../onboarding/useHardwareProfile";
 import { useModelDownloadStore } from "../../../stores/ModelDownloadStore";
 import type { UnifiedModel } from "../../../stores/ApiTypes";
 import { useModelCompatibility } from "./useModelCompatibility";
@@ -173,7 +176,8 @@ const ModelListIndex: React.FC = () => {
     modelSearchTerm, setModelSearchTerm,
     scope, setScope,
     source, setSource,
-    sourceInitialized, setSourceInitialized
+    sourceInitialized, setSourceInitialized,
+    setSelectedGoal
   } = useModelManagerStore(
     useShallow((state) => ({
       selectedModelType: state.selectedModelType,
@@ -185,9 +189,11 @@ const ModelListIndex: React.FC = () => {
       source: state.source,
       setSource: state.setSource,
       sourceInitialized: state.sourceInitialized,
-      setSourceInitialized: state.setSourceInitialized
+      setSourceInitialized: state.setSourceInitialized,
+      setSelectedGoal: state.setSelectedGoal
     }))
   );
+  const hardwareProfile = useHardwareProfile();
   const { activeWorker } = useWorkers();
   const workerName = activeWorker?.profile_name ?? activeWorker?.id ?? null;
   const { cacheStatuses, cachePending, cacheVersion, ensureStatuses } =
@@ -255,8 +261,9 @@ const ModelListIndex: React.FC = () => {
       setScope(nextScope);
       setModelSearchTerm("");
       setSelectedModelType("All");
+      setSelectedGoal(null);
     },
-    [scope, setScope, setModelSearchTerm, setSelectedModelType]
+    [scope, setScope, setModelSearchTerm, setSelectedModelType, setSelectedGoal]
   );
 
   const handleSourceChange = useCallback(
@@ -272,13 +279,15 @@ const ModelListIndex: React.FC = () => {
       setSourceInitialized(true);
       setModelSearchTerm("");
       setSelectedModelType("All");
+      setSelectedGoal(null);
     },
     [
       source,
       setSource,
       setSourceInitialized,
       setModelSearchTerm,
-      setSelectedModelType
+      setSelectedModelType,
+      setSelectedGoal
     ]
   );
 
@@ -509,6 +518,12 @@ const ModelListIndex: React.FC = () => {
 
         <Box className="content">
           <LocalModelsHero models={allModels ?? []} />
+          {source === "recommended" && (
+            <Box sx={{ mb: 2 }}>
+              <HardwareCard profile={hardwareProfile} />
+            </Box>
+          )}
+          <GoalFilterChips />
           {isFetching && (
             <Box sx={{ position: "absolute", top: "1em", right: "1em", zIndex: Z_INDEX.raised }}>
               <LoadingSpinner size="small" />
@@ -646,6 +661,7 @@ const ModelListIndex: React.FC = () => {
                         showModelStats={true}
                         compatibility={compatibility}
                         isCheckingCache={isCheckingCache}
+                        fitBudgetGb={hardwareProfile.budgetGb}
                       />
                     </Box>
                   );

--- a/web/src/components/hugging_face/model_list/ModelListItem.tsx
+++ b/web/src/components/hugging_face/model_list/ModelListItem.tsx
@@ -17,8 +17,19 @@ import { formatBytes } from "../../../utils/modelFormatting";
 import { getModelUrl } from "../../../utils/providerDisplay";
 import type { ModelCompatibilityResult } from "./useModelCompatibility";
 import ModelCompatibilityDialog from "./ModelCompatibilityDialog";
+import { classifyModelFit, estimateRequiredGb } from "./modelFit";
+import type { FitLevel } from "../onboarding/onboardingCatalog";
 
 const IMPORTANT_TAGS = new Set(["gguf", "mlx"]);
+
+const FIT_CHIP: Record<
+  Exclude<FitLevel, "unknown">,
+  { color: "success" | "warning" | "error"; label: (requiredGb: number) => string }
+> = {
+  fits: { color: "success", label: () => "Fits your machine" },
+  tight: { color: "warning", label: () => "Tight fit" },
+  over: { color: "error", label: (gb) => `Needs ~${Math.ceil(gb)} GB` }
+};
 
 const ModelListItem: React.FC<
   ModelComponentProps & {
@@ -27,6 +38,11 @@ const ModelListItem: React.FC<
     compatibility?: ModelCompatibilityResult;
     isCheckingCache?: boolean;
     onSelect?: () => void;
+    /**
+     * Memory budget (GB) to grade the model's size against; null/undefined
+     * hides the fit badge.
+     */
+    fitBudgetGb?: number | null;
   }
 > = ({
   model,
@@ -37,7 +53,8 @@ const ModelListItem: React.FC<
   compactView = false,
   showFileExplorerButton = true,
   compatibility,
-  isCheckingCache = false
+  isCheckingCache = false,
+  fitBudgetGb = null
 }) => {
   const baseId = model.repo_id || model.id;
   const downloadId = model.path ? `${baseId}/${model.path}` : baseId;
@@ -49,6 +66,11 @@ const ModelListItem: React.FC<
     [model.tags]
   );
   const [dialogOpen, setDialogOpen] = useState(false);
+
+  const fit = useMemo(
+    () => classifyModelFit(model, fitBudgetGb),
+    [model, fitBudgetGb]
+  );
 
   const handleOpenDialog = useCallback(() => {
     setDialogOpen(true);
@@ -221,6 +243,23 @@ const ModelListItem: React.FC<
                       component="span"
                     />
                   </TextLink>
+                </Tooltip>
+              )}
+              {fit !== "unknown" && (
+                <Tooltip
+                  title={`Estimated from the model's ${formatBytes(
+                    model.size_on_disk ?? 0
+                  )} size against your ${fitBudgetGb} GB memory budget (set it under Get Started).`}
+                  delay={400}
+                >
+                  <Chip
+                    label={FIT_CHIP[fit].label(estimateRequiredGb(model) ?? 0)}
+                    size="small"
+                    component="span"
+                    color={FIT_CHIP[fit].color}
+                    variant="outlined"
+                    sx={{ height: 20, fontSize: theme.vars.fontSizeSmaller, cursor: "help" }}
+                  />
                 </Tooltip>
               )}
               {compatibility && compatibilityCounts.total > 0 && (

--- a/web/src/components/hugging_face/model_list/__tests__/modelFit.test.ts
+++ b/web/src/components/hugging_face/model_list/__tests__/modelFit.test.ts
@@ -1,0 +1,114 @@
+import { UnifiedModel } from "../../../../stores/ApiTypes";
+import {
+  classifyModelFit,
+  compareModelsByFit,
+  estimateRequiredGb,
+  goalsForModel,
+  MODEL_GOALS
+} from "../modelFit";
+
+const GB = 1024 ** 3;
+
+const model = (overrides: Partial<UnifiedModel>): UnifiedModel =>
+  ({
+    id: "m",
+    name: "m",
+    type: "language_model",
+    repo_id: null,
+    path: null,
+    ...overrides
+  }) as UnifiedModel;
+
+describe("estimateRequiredGb", () => {
+  it("converts size_on_disk to GB", () => {
+    expect(estimateRequiredGb(model({ size_on_disk: 8 * GB }))).toBe(8);
+  });
+
+  it("returns null when the size is missing or zero", () => {
+    expect(estimateRequiredGb(model({}))).toBeNull();
+    expect(estimateRequiredGb(model({ size_on_disk: 0 }))).toBeNull();
+  });
+});
+
+describe("classifyModelFit", () => {
+  it("grades a sized model against the budget with headroom", () => {
+    const m = model({ size_on_disk: 8 * GB });
+    expect(classifyModelFit(m, 16)).toBe("fits");
+    expect(classifyModelFit(m, 8)).toBe("tight");
+    expect(classifyModelFit(m, 4)).toBe("over");
+  });
+
+  it("is unknown without a size or without a budget", () => {
+    expect(classifyModelFit(model({}), 16)).toBe("unknown");
+    expect(classifyModelFit(model({ size_on_disk: 8 * GB }), null)).toBe(
+      "unknown"
+    );
+  });
+});
+
+describe("compareModelsByFit", () => {
+  it("orders fits before tight before unknown before over, largest fitting first", () => {
+    const budget = 16;
+    const fitsSmall = model({ id: "fits-small", size_on_disk: 4 * GB });
+    const fitsBig = model({ id: "fits-big", size_on_disk: 12 * GB });
+    const tight = model({ id: "tight", size_on_disk: 15 * GB });
+    const unknown = model({ id: "unknown" });
+    const overClose = model({ id: "over-close", size_on_disk: 20 * GB });
+    const overFar = model({ id: "over-far", size_on_disk: 80 * GB });
+
+    const sorted = [overFar, unknown, fitsSmall, tight, overClose, fitsBig].sort(
+      (a, b) => compareModelsByFit(a, b, budget)
+    );
+    expect(sorted.map((m) => m.id)).toEqual([
+      "fits-big",
+      "fits-small",
+      "tight",
+      "unknown",
+      "over-close",
+      "over-far"
+    ]);
+  });
+});
+
+describe("goalsForModel", () => {
+  it("maps HF types and pipeline tags to goals", () => {
+    expect(
+      goalsForModel(model({ type: "hf.text_to_image" }))
+    ).toEqual(new Set(["image-gen"]));
+    expect(
+      goalsForModel(model({ type: "hf.automatic_speech_recognition" }))
+    ).toEqual(new Set(["transcribe"]));
+    expect(
+      goalsForModel(
+        model({ type: "hf.text_generation", pipeline_tag: "text-generation" })
+      )
+    ).toEqual(new Set(["chat"]));
+    expect(
+      goalsForModel(model({ type: "tjs.feature_extraction" }))
+    ).toEqual(new Set(["embedding"]));
+    expect(
+      goalsForModel(model({ type: "hf.image_text_to_text" }))
+    ).toEqual(new Set(["vision"]));
+  });
+
+  it("splits llama_model into chat vs embedding by name", () => {
+    expect(
+      goalsForModel(model({ type: "llama_model", name: "qwen3.5:9b" }))
+    ).toEqual(new Set(["chat"]));
+    expect(
+      goalsForModel(model({ type: "llama_model", name: "nomic-embed-text" }))
+    ).toEqual(new Set(["embedding"]));
+    expect(
+      goalsForModel(model({ type: "llama_model", name: "bge-m3" }))
+    ).toEqual(new Set(["embedding"]));
+  });
+
+  it("returns no goals for a type nothing covers", () => {
+    expect(goalsForModel(model({ type: "hf.reinforcement_learning" })).size).toBe(0);
+  });
+
+  it("every goal id is unique", () => {
+    const ids = MODEL_GOALS.map((g) => g.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/web/src/components/hugging_face/model_list/modelFit.ts
+++ b/web/src/components/hugging_face/model_list/modelFit.ts
@@ -1,0 +1,160 @@
+import type { UnifiedModel } from "../../../stores/ApiTypes";
+import { classifyFit, type FitLevel } from "../onboarding/onboardingCatalog";
+
+/**
+ * Hardware-fit and goal classification for the model manager list.
+ *
+ * The onboarding catalog carries hand-written memory figures; the general
+ * lists (installed / recommended / hub) only have `size_on_disk`. Model
+ * weights load into GPU or unified memory roughly at their on-disk size, so
+ * that size is the memory estimate here — `classifyFit`'s built-in headroom
+ * (1.15×) covers activations and context on top of it.
+ */
+
+/** Estimated memory (GB) needed to run the model, or null when unknowable. */
+export const estimateRequiredGb = (model: UnifiedModel): number | null => {
+  const bytes = model.size_on_disk;
+  if (!bytes || bytes <= 0) {
+    return null;
+  }
+  return bytes / 1024 ** 3;
+};
+
+/** Classify a model against the machine's memory budget (GB). */
+export const classifyModelFit = (
+  model: UnifiedModel,
+  budgetGb: number | null
+): FitLevel => {
+  const requiredGb = estimateRequiredGb(model);
+  if (requiredGb == null) {
+    return "unknown";
+  }
+  return classifyFit(requiredGb, budgetGb);
+};
+
+const FIT_ORDER = {
+  fits: 0,
+  tight: 1,
+  unknown: 2,
+  over: 3
+} satisfies Record<FitLevel, number>;
+
+/**
+ * Best-fit-first comparator for the "Best fit" sort: models that fit come
+ * first (largest fitting model on top, since bigger usually means better),
+ * then tight, then unknown-size, then over (smallest-over first — closest to
+ * runnable).
+ */
+export const compareModelsByFit = (
+  a: UnifiedModel,
+  b: UnifiedModel,
+  budgetGb: number | null
+): number => {
+  const fa = classifyModelFit(a, budgetGb);
+  const fb = classifyModelFit(b, budgetGb);
+  if (fa !== fb) {
+    return FIT_ORDER[fa] - FIT_ORDER[fb];
+  }
+  const sa = a.size_on_disk || 0;
+  const sb = b.size_on_disk || 0;
+  // Within "over", smaller (closer to fitting) first; otherwise larger first.
+  return fa === "over" ? sa - sb : sb - sa;
+};
+
+/** A user goal the manager can filter/suggest models for. */
+export interface ModelGoal {
+  id: string;
+  label: string;
+  description: string;
+  /** Normalized task tokens (dash-cased, no `hf.`/`tjs.` prefix) this goal covers. */
+  tasks: ReadonlySet<string>;
+}
+
+const goal = (
+  id: string,
+  label: string,
+  description: string,
+  tasks: string[]
+): ModelGoal => ({ id, label, description, tasks: new Set(tasks) });
+
+/**
+ * The goal catalog. Matching runs over a model's `type` and `pipeline_tag`,
+ * both normalized to the Hub's dash-cased task names.
+ */
+export const MODEL_GOALS: readonly ModelGoal[] = [
+  goal("chat", "Chat & agents", "Write, reason, and use tools with a language model", [
+    "text-generation",
+    "text2text-generation",
+    "audio-text-to-text",
+    "any-to-any"
+  ]),
+  goal("image-gen", "Create images", "Generate or restyle images from prompts", [
+    "text-to-image",
+    "image-to-image",
+    "inpainting"
+  ]),
+  goal("vision", "Understand images", "Describe, classify, or analyze images and documents", [
+    "image-text-to-text",
+    "image-to-text",
+    "image-classification",
+    "object-detection",
+    "image-segmentation",
+    "visual-question-answering",
+    "document-question-answering",
+    "zero-shot-image-classification",
+    "depth-estimation",
+    "mask-generation"
+  ]),
+  goal("transcribe", "Transcribe speech", "Turn audio recordings into text", [
+    "automatic-speech-recognition"
+  ]),
+  goal("speech", "Generate speech & audio", "Voice lines, narration, and sound from text", [
+    "text-to-speech",
+    "text-to-audio",
+    "audio-to-audio"
+  ]),
+  goal("video", "Create video", "Generate video from prompts or still images", [
+    "text-to-video",
+    "image-to-video"
+  ]),
+  goal("embedding", "Search & RAG", "Embeddings for semantic search over your documents", [
+    "feature-extraction",
+    "sentence-similarity"
+  ])
+];
+
+/**
+ * GGUF chat and embedding models share the one `llama_model` type, so the
+ * type alone can't split them; the model families all carry these markers in
+ * their names.
+ */
+const LLAMA_EMBED_NAME = /embed|bge|minilm|e5|arctic/i;
+
+const normalizeTask = (raw: string): string =>
+  raw
+    .replace(/^[a-z0-9_]+\./i, "")
+    .replace(/_/g, "-")
+    .toLowerCase();
+
+/** Which goals a model serves, from its type and pipeline tag. */
+export const goalsForModel = (model: UnifiedModel): Set<string> => {
+  const tokens = new Set<string>();
+  for (const raw of [model.type, model.pipeline_tag]) {
+    if (raw) {
+      tokens.add(normalizeTask(raw));
+    }
+  }
+  const result = new Set<string>();
+  for (const candidate of MODEL_GOALS) {
+    for (const token of tokens) {
+      if (candidate.tasks.has(token)) {
+        result.add(candidate.id);
+      }
+    }
+  }
+  if (model.type === "llama_model") {
+    const name = model.name || model.id || "";
+    result.add(LLAMA_EMBED_NAME.test(name) ? "embedding" : "chat");
+  }
+  return result;
+};

--- a/web/src/components/hugging_face/model_list/useModels.ts
+++ b/web/src/components/hugging_face/model_list/useModels.ts
@@ -17,6 +17,8 @@ import { openInExplorer, openOllamaPath } from "../../../utils/fileExplorer";
 import { isHfModel } from "../../../utils/hfCache";
 import { isLocalProvider } from "../../../utils/providerDisplay";
 import useMetadataStore from "../../../stores/MetadataStore";
+import { compareModelsByFit, goalsForModel } from "./modelFit";
+import { useHardwareProfile } from "../onboarding/useHardwareProfile";
 
 /**
  * HuggingFace Hub pipeline tags, shown as the fixed category list when browsing
@@ -91,10 +93,15 @@ export const isManageableModel = (model: UnifiedModel): boolean => {
 const sortModels = (
   models: UnifiedModel[],
   field: ModelSortField,
-  direction: ModelSortDirection
+  direction: ModelSortDirection,
+  budgetGb: number | null = null
 ): UnifiedModel[] => {
   const sorted = [...models].sort((a, b) => {
     switch (field) {
+      case "fit":
+        // Best-fit-first is already the "ascending" order; the direction
+        // toggle below flips it like any other field.
+        return compareModelsByFit(a, b, budgetGb);
       case "name": {
         const nameA = (a.name || a.id || "").toLowerCase();
         const nameB = (b.name || b.id || "").toLowerCase();
@@ -136,7 +143,9 @@ export const useModels = (scope: ModelScope = "local"): UseModelsResult => {
     (state) => state.addNotification
   );
   const source = useModelManagerStore((state) => state.source);
+  const selectedGoal = useModelManagerStore((state) => state.selectedGoal);
   const recommendedCatalog = useMetadataStore((state) => state.recommendedModels);
+  const { budgetGb } = useHardwareProfile();
 
   const {
     data: rawModels,
@@ -224,6 +233,9 @@ export const useModels = (scope: ModelScope = "local"): UseModelsResult => {
 
       if (!matchesText) {return false;}
       if (!typeMatches) {return false;}
+      if (selectedGoal && !goalsForModel(model).has(selectedGoal)) {
+        return false;
+      }
       if (
         maxModelSizeGB &&
         model.size_on_disk &&
@@ -234,15 +246,17 @@ export const useModels = (scope: ModelScope = "local"): UseModelsResult => {
       return true;
     };
     const filtered = allModels?.filter(filterModel) || [];
-    return sortModels(filtered, sortField, sortDirection);
+    return sortModels(filtered, sortField, sortDirection, budgetGb);
   }, [
     allModels,
     source,
     modelSearchTerm,
     selectedModelType,
+    selectedGoal,
     maxModelSizeGB,
     sortField,
-    sortDirection
+    sortDirection,
+    budgetGb
   ]);
 
   const modelTypes = useMemo(() => {
@@ -290,6 +304,9 @@ export const useModels = (scope: ModelScope = "local"): UseModelsResult => {
           model.repo_id?.toLowerCase().includes(searchTerm);
 
         if (!matchesText) {return false;}
+        if (selectedGoal && !goalsForModel(model).has(selectedGoal)) {
+          return false;
+        }
         if (
           maxModelSizeGB &&
           model.size_on_disk &&
@@ -307,7 +324,7 @@ export const useModels = (scope: ModelScope = "local"): UseModelsResult => {
     });
 
     return types;
-  }, [allModels, source, modelSearchTerm, maxModelSizeGB]);
+  }, [allModels, source, modelSearchTerm, selectedGoal, maxModelSizeGB]);
 
   const modelCountsByType = useMemo(() => {
     const counts: Record<string, number> = {};

--- a/web/src/components/hugging_face/onboarding/useHardwareProfile.ts
+++ b/web/src/components/hugging_face/onboarding/useHardwareProfile.ts
@@ -67,18 +67,19 @@ export const TIER_LABELS = {
  * explicit VRAM value that takes precedence.
  */
 export const useHardwareProfile = (): HardwareProfile => {
-  const stats = useSystemStatsStore((state) => state.stats);
+  // Scalar selectors: total VRAM/RAM are stable across the 5s stats ticks, so
+  // subscribers (including the whole model list) don't re-render per tick.
+  const vramTotalGb = useSystemStatsStore(
+    (state) => state.stats?.vram_total_gb ?? null
+  );
+  const ramTotalGb = useSystemStatsStore(
+    (state) => state.stats?.memory_total_gb ?? null
+  );
   const override = useModelManagerStore((state) => state.vramOverrideGb);
 
   return useMemo(() => {
-    const vramGb =
-      stats?.vram_total_gb != null && stats.vram_total_gb > 0
-        ? stats.vram_total_gb
-        : null;
-    const ramGb =
-      stats?.memory_total_gb != null && stats.memory_total_gb > 0
-        ? stats.memory_total_gb
-        : null;
+    const vramGb = vramTotalGb != null && vramTotalGb > 0 ? vramTotalGb : null;
+    const ramGb = ramTotalGb != null && ramTotalGb > 0 ? ramTotalGb : null;
 
     let budgetGb: number | null;
     let budgetSource: BudgetSource;
@@ -105,5 +106,5 @@ export const useHardwareProfile = (): HardwareProfile => {
       isManual: budgetSource === "manual",
       classify: (minVramGb: number) => classifyFit(minVramGb, budgetGb)
     };
-  }, [stats, override]);
+  }, [vramTotalGb, ramTotalGb, override]);
 };

--- a/web/src/stores/ModelManagerStore.ts
+++ b/web/src/stores/ModelManagerStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-export type ModelSortField = "name" | "size" | "downloads" | "likes";
+export type ModelSortField = "name" | "size" | "downloads" | "likes" | "fit";
 export type ModelSortDirection = "asc" | "desc";
 /** Which model cache the manager is browsing: the local FS or an attached worker. */
 export type ModelScope = "local" | "worker";
@@ -38,6 +38,11 @@ interface ModelManagerState {
    * `null` means "use whatever was detected".
    */
   vramOverrideGb: number | null;
+  /**
+   * Active goal filter (`MODEL_GOALS` id from `modelFit.ts`), narrowing the
+   * list to models that serve it. `null` means "all goals".
+   */
+  selectedGoal: string | null;
   setIsOpen: (isOpen: boolean) => void;
   setModelSearchTerm: (term: string) => void;
   setSelectedModelType: (type: string) => void;
@@ -49,6 +54,7 @@ interface ModelManagerState {
   setSource: (source: ModelSource) => void;
   setSourceInitialized: (initialized: boolean) => void;
   setVramOverrideGb: (gb: number | null) => void;
+  setSelectedGoal: (goal: string | null) => void;
 }
 
 export const useModelManagerStore = create<ModelManagerState>()(
@@ -64,6 +70,7 @@ export const useModelManagerStore = create<ModelManagerState>()(
       source: "installed",
       sourceInitialized: false,
       vramOverrideGb: null,
+      selectedGoal: null,
       setIsOpen: (isOpen) => set({ isOpen }),
       setModelSearchTerm: (term) => set({ modelSearchTerm: term }),
       setSelectedModelType: (type) => set({ selectedModelType: type }),
@@ -78,7 +85,8 @@ export const useModelManagerStore = create<ModelManagerState>()(
       setSource: (source) => set({ source }),
       setSourceInitialized: (initialized) =>
         set({ sourceInitialized: initialized }),
-      setVramOverrideGb: (gb) => set({ vramOverrideGb: gb })
+      setVramOverrideGb: (gb) => set({ vramOverrideGb: gb }),
+      setSelectedGoal: (goal) => set({ selectedGoal: goal })
     }),
     {
       name: "model-manager",


### PR DESCRIPTION
The model manager knew nothing about the user's machine or intent outside the onboarding tab: the main list showed raw sizes with no indication of what actually runs on this hardware, and finding "a model for transcription" meant knowing HF pipeline-tag jargon. The backend never reported VRAM at all, so even onboarding's fit logic budgeted against a RAM guess.

This makes the whole manager suggest models for the user's goals and hardware:

**Real VRAM detection.** The system-stats sampler (`packages/websocket/src/system-stats.ts`) now probes `nvidia-smi` asynchronously and populates the `vram_total_gb` / `vram_used_gb` / `vram_percent` / `gpu_percent` fields that `SystemStats` has declared all along but nothing filled. The probe is cached, keeps the sampler synchronous, and one failed probe marks the GPU unavailable so no further processes are spawned. With several GPUs it reports the largest card, not a summed figure no single card has. `useHardwareProfile`'s budget now comes from the actual GPU on NVIDIA machines instead of the RAM×0.7 fallback.

**Fit badges on every model row.** Each listed model (installed / recommended / hub) is graded against the machine's memory budget — "Fits your machine" / "Tight fit" / "Needs ~X GB" — estimated from `size_on_disk`, with a tooltip explaining the estimate and where to adjust the budget. New shared logic in `web/src/components/hugging_face/model_list/modelFit.ts`, reusing onboarding's `classifyFit` headroom rules.

**Goal filter.** An "I want to…" chip row (chat & agents, create images, understand images, transcribe speech, generate speech & audio, create video, search & RAG) narrows every list source. Goals are matched from model `type` and `pipeline_tag`; GGUF chat vs embedding models share one `llama_model` type, so those are split by model-family name markers.

**Best-fit sort.** A new "Best fit" sort option orders fits-first with the largest fitting model on top (bigger usually means better), then tight, unknown, and over (closest-to-runnable first).

**Hardware card on the Recommended tab.** The detected GPU/RAM readout with the manual GPU-memory-budget override, previously buried in Get Started, now sits above the recommended list where the suggestions it drives are shown.

**Perf.** `useHardwareProfile` reads scalar selectors from the stats store, so the model list (and onboarding) no longer re-render on every 5-second stats broadcast.

Tests: parser + sampler tests for the `nvidia-smi` probe (`packages/websocket/tests/system-stats-gpu.test.ts`), and unit tests for fit estimation, fit ordering, and goal matching (`web/.../model_list/__tests__/modelFit.test.ts`).

Verified: web + electron typecheck, `npm run lint`, full web suite (1141 suites / 13,193 tests), electron suite, and the affected package suites (websocket 2247, cli 629, deploy 861). `harness gate` demands no selfchecks for this diff. Mobile typecheck fails in this sandbox on missing Expo deps for untouched files (environment gap, mobile untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBgrjKqbtukGixqpFMWCzf

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBgrjKqbtukGixqpFMWCzf)_