### PR TITLE
docs(marketing): pin the narrative and lead the hero with ownership

### DIFF
--- a/marketing/NARRATIVE.md
+++ b/marketing/NARRATIVE.md
@@ -1,0 +1,89 @@
+# Narrative
+
+What the site says, in what order, and why. `PRODUCT.md` covers brand, users, and
+design principles; this file covers the message. When homepage copy and this file
+disagree, one of them is wrong — fix both in the same change.
+
+## Positioning line
+
+**Describe the piece. Keep the workflow.**
+
+The hero claim is not the feature list and not the category label. It is the
+trade every competitor loses: a closed tool generates behind glass and hands you
+a file; NodeTool's agent generates *and* hands you the graph that made it —
+a normal, inspectable file you can open, rewire, and run again.
+
+"The agent-first creative workspace" stays as the category descriptor in
+`<title>`, meta descriptions, and schema. It is accurate and it is what people
+search for. It is not the H1: it names a category instead of a benefit.
+
+## Message hierarchy
+
+Everything below the hero earns its place by advancing one of three claims, in
+this order of importance:
+
+1. **The agent builds something you own.** Not chat that tells you what to do,
+   and not a black box that returns a render. Show the graph appearing, the node
+   being edited, the run resuming from the middle.
+2. **One canvas, generation through finish.** Image, video, audio, text, plus
+   the editors — storyboard, timeline, sketch, script — so a piece never leaves
+   the workspace to be finished.
+3. **Independence.** Your keys, your files, your models, AGPL-3.0, local option.
+   Stated as fact, never as a pitch.
+
+Provider lists, node counts, tool counts, and architecture belong under those
+claims, not next to them.
+
+## Order of the page
+
+Hero → the status quo (the pain, once, briefly) → the demo → use cases with real
+output → the three claims above → proof → comparisons → download.
+
+The pain section comes before any feature because the features only mean
+something against it. Comparisons come late: a reader who is convinced does not
+need them, and a reader who is not will scroll to them.
+
+## Audience
+
+The front door speaks to **creatives and small teams** — filmmakers, designers,
+marketers, content studios — who want production output without becoming ML
+engineers or paying a credit tax.
+
+Technical depth is the back door, not the doorway: `/developers`, `/agents`, the
+CLI and SDK pages. Keeping it off the homepage is what stops the site reading as
+neither-for-artists-nor-for-engineers.
+
+## Cost and status, stated early
+
+Two things a reader must not have to hunt for, because vagueness here reads as a
+trap:
+
+- **Cost.** "Studio is free. You pay providers directly, at their published
+  prices. Local models are free after the download." Never imply a NodeTool
+  credit exists.
+- **Cloud.** Studio is the full product; Cloud is the zero-install preview and is
+  in alpha. Say "alpha" wherever Cloud is offered as an entry point. A "start in
+  seconds" claim that lands a reader in an alpha is a claim we lose.
+
+## Proof
+
+The weakest part of the story, and not a copy problem. What closes the gap:
+end-to-end project pages with the finished piece, its workflow file, and its
+real cost; community workflows and mini-apps surfaced on the homepage; short
+user quotes about time saved or control regained.
+
+Until those exist, do not compensate with adjectives. A missing testimonial is
+better than a manufactured superlative.
+
+## Phrasing rules
+
+Beyond [docs/WRITING_STYLE.md](../docs/WRITING_STYLE.md), which applies here too:
+
+- "Workspace" or "studio", not "workflow builder" — the latter undersells the
+  editors and puts us in the n8n bracket.
+- "Every major model, your keys" instead of a fourteen-name provider list. Name
+  providers where a reader is checking for a specific one (pricing, model pages).
+- Concrete over categorical: "a Seedance run that costs $0.18 on KIE costs $0.18
+  here" beats "no markup".
+- No "seamless", "powerful", "unlock", "empower". If a sentence survives its own
+  deletion, delete it.

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -26,10 +26,10 @@ export default function NodeToolHero() {
             id="hero-title"
             className="mt-6 text-5xl font-bold leading-[1.05] tracking-tight text-white md:text-6xl"
           >
-            The agent-first
+            Describe the piece.
             <br />
             <span className="bg-gradient-to-r from-rose-400 via-fuchsia-400 to-amber-300 bg-clip-text text-transparent">
-              creative workspace.
+              Keep the workflow.
             </span>
           </h1>
 
@@ -41,11 +41,10 @@ export default function NodeToolHero() {
             >
               node-based
             </a>{" "}
-            canvas for image, video, audio, and text, where every editor is a
-            tool an agent can drive. Describe what you want to make; the agent
-            builds the workflow and runs it with the right models and tools —
-            and the whole process stays open for you to inspect, edit, and
-            reuse. Every major model, your own keys, provider prices.
+            canvas for image, video, audio, and text. Say what you want to make
+            and the agent builds the graph, picks the models, and runs it — then
+            leaves a normal file you can open, rewire, and run again. Free to
+            download; every major model on your own keys, at provider prices.
           </p>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/marketing/src/components/StatusQuoSection.tsx
+++ b/marketing/src/components/StatusQuoSection.tsx
@@ -50,7 +50,8 @@ export default function StatusQuoSection() {
                 shouldn&apos;t take five tools.
               </h2>
               <p className="mt-4 text-slate-400 leading-relaxed">
-                Stop exporting. Start finishing.
+                Stop exporting. Start finishing. One canvas, your keys, and a
+                workflow file that is yours to keep when the piece is done.
               </p>
               <a
                 href="#differences"


### PR DESCRIPTION
Acts on the narrative review of nodetool.ai. The site copy was already differentiated and truthful; the gap was that the hero led with a category label and the decisions behind the copy lived nowhere.

## Changes

**`marketing/NARRATIVE.md` (new)** — the message, as `PRODUCT.md` is the brand. Records the positioning line, the three claims every section must advance and their order, why the pain section precedes any feature, that the front door speaks to creatives while technical depth stays on `/developers` and `/agents`, how cost and Cloud's alpha status get stated, the proof gap, and the phrasing rules that follow from all of it.

**Hero (`NodeToolHero.tsx`)** — H1 goes from "The agent-first creative workspace" to "Describe the piece. Keep the workflow.", the trade a closed canvas loses: the agent hands back the graph, not just the render. The subhead keeps the category descriptor, adds what the agent leaves behind ("a normal file you can open, rewire, and run again"), and states cost up front — free to download, provider prices, your keys.

"The agent-first creative workspace" is unchanged in `<title>`, meta descriptions, schema, and the other entry pages. It is what people search for; it just is not a benefit, so it is not the H1.

**`StatusQuoSection.tsx`** — the pain section named the problem and stopped at "Stop exporting. Start finishing." One sentence now completes the turn to the promise.

## Not in this PR

The review's largest item is proof — end-to-end project pages with the finished piece, its workflow file, and its real cost, plus community workflows and user quotes. That is content to produce, not copy to edit. `NARRATIVE.md` names it as the open gap and says not to substitute adjectives for it.

## Verification

`marketing/` is not a root workspace and its `node_modules` is not installed in this environment, so `tsc -p marketing/tsconfig.json` fails on unresolved imports across the whole tree, unrelated to this diff. Both edited files parse clean through esbuild's tsx loader. The changes are copy inside existing JSX — no props, imports, or structure touched. No test or SEO check asserts the hero string (grepped `tests/` and `seo/`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGJSZvvscvrHCvqUAyR2Mf)_