### PR TITLE
revert(marketing): restore the previous hero headline and subhead

### DIFF
--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -26,10 +26,10 @@ export default function NodeToolHero() {
             id="hero-title"
             className="mt-6 text-5xl font-bold leading-[1.05] tracking-tight text-white md:text-6xl"
           >
-            Describe the piece.
+            The agent-first
             <br />
             <span className="bg-gradient-to-r from-rose-400 via-fuchsia-400 to-amber-300 bg-clip-text text-transparent">
-              Keep the workflow.
+              creative workspace.
             </span>
           </h1>
 
@@ -41,10 +41,11 @@ export default function NodeToolHero() {
             >
               node-based
             </a>{" "}
-            canvas for image, video, audio, and text. Say what you want to make
-            and the agent builds the graph, picks the models, and runs it — then
-            leaves a normal file you can open, rewire, and run again. Free to
-            download; every major model on your own keys, at provider prices.
+            canvas for image, video, audio, and text, where every editor is a
+            tool an agent can drive. Describe what you want to make; the agent
+            builds the workflow and runs it with the right models and tools —
+            and the whole process stays open for you to inspect, edit, and
+            reuse. Every major model, your own keys, provider prices.
           </p>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">


### PR DESCRIPTION
Puts `NodeToolHero.tsx` back to the copy it had before #5046 — H1 returns to "The agent-first creative workspace" and the subhead to its previous wording.

Hero only. `marketing/NARRATIVE.md` and `StatusQuoSection.tsx` from #5046 are untouched.

## One thing left inconsistent, deliberately

`NARRATIVE.md` records "Describe the piece. Keep the workflow." as the positioning line and states that the category descriptor is not the H1. With this revert, the site does not match that. I did not edit the doc, because which of the two is right is the call to make, not the mismatch:

- keep the doc as the target and the hero as it stands today, or
- change the doc's positioning line back to the category descriptor.

Say which and I will follow up.

## Verification

Diff is 7 insertions / 6 deletions inside one JSX block — no props, imports, or structure touched; the file parses clean through esbuild's tsx loader. As before, `marketing/` has no installed `node_modules` in this environment, so its `tsc` fails repo-wide on unresolved imports regardless of this diff. No test asserts the hero string; the Playwright smoke test only counts h1 elements, and the count is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGJSZvvscvrHCvqUAyR2Mf)_