### PR TITLE
fix(agents): keep network-guard out of the browser bundle's way

### DIFF
--- a/packages/agents/src/network-guard.ts
+++ b/packages/agents/src/network-guard.ts
@@ -18,7 +18,15 @@
  * uses when it can afford a DNS round trip.
  */
 
-import { lookup as dnsLookup } from "node:dns/promises";
+import { importNodeBuiltin } from "@nodetool-ai/config";
+
+/** The slice of `node:dns/promises` the default resolver uses. */
+interface DnsPromises {
+  lookup: (
+    host: string,
+    options: { all: true }
+  ) => Promise<Array<{ address: string }>>;
+}
 
 /** True if the first two octets of an IPv4 address fall in a blocked range. */
 function isBlockedV4(a: number, b: number): boolean {
@@ -176,5 +184,19 @@ export async function assertResolvedHostAllowed(
 /** How {@link assertResolvedHostAllowed} turns a hostname into addresses. */
 export type HostResolver = (host: string) => Promise<string[]>;
 
-const defaultResolver: HostResolver = async (host) =>
-  (await dnsLookup(host, { all: true })).map((entry) => entry.address);
+/**
+ * `node:dns` is loaded through `importNodeBuiltin`, never imported at the top
+ * level: this module is reachable from `js-sandbox.ts`, which the browser
+ * workflow-runner bundles. A static `node:dns/promises` import broke that
+ * bundle outright — the harness aliases `node:dns` to an empty stub, and
+ * `node:dns/promises` then resolved to a path inside that file.
+ *
+ * Off Node there is no resolver, and a caller that cannot resolve treats the
+ * name the way an unresolvable one is treated: the literal check has already
+ * run, and whoever opens the socket reports the rest.
+ */
+const defaultResolver: HostResolver = async (host) => {
+  const dns = await importNodeBuiltin<DnsPromises>("node:dns/promises");
+  if (!dns) return [];
+  return (await dns.lookup(host, { all: true })).map((entry) => entry.address);
+};

--- a/packages/agents/tests/network-guard-browser-safety.test.ts
+++ b/packages/agents/tests/network-guard-browser-safety.test.ts
@@ -1,0 +1,35 @@
+/**
+ * `network-guard.ts` must stay importable in a browser bundle.
+ *
+ * It is reachable from `js-sandbox.ts`, which the workflow-runner harness and
+ * the in-browser runner bundle with Vite. A static `node:*` import there does
+ * not fail a typecheck, a lint, or any Node test — it fails the *bundle*, and
+ * the whole harness page then never boots. That is how it shipped: the browser
+ * E2E leg caught it, after the merge queue had already let it through.
+ *
+ * The Node-only half loads through `importNodeBuiltin`, which answers null off
+ * Node. This test pins that, cheaply, where every suite runs.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SRC = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "src",
+  "network-guard.ts"
+);
+
+describe("network-guard stays bundleable for the browser", () => {
+  it("imports no node builtin at the top level", async () => {
+    const source = await readFile(SRC, "utf8");
+    const statik = [...source.matchAll(/^import[^;]*?from\s+"([^"]+)";/gm)].map(
+      (match) => match[1]
+    );
+    expect(statik.filter((specifier) => specifier.startsWith("node:"))).toEqual(
+      []
+    );
+  });
+});


### PR DESCRIPTION
**Fixes a regression I shipped in #5047, currently on main.** The browser E2E leg went red on that PR and auto-merge landed it anyway, because that leg is not a required check.

## What broke

`network-guard.ts` (new in #5047) imported `node:dns/promises` at the top level, and `js-sandbox.ts` imports it. That module is bundled for the browser by the workflow-runner harness and the in-browser runner. The harness aliases `node:dns` to an empty stub file, so `node:dns/promises` resolved to a path *inside* that file:

```
[vite:load-fallback] Could not load e2e/stubs/empty.js/promises
  (imported by ../agents/dist/network-guard.js): ENOTDIR
```

The bundle never built, the page never set `workflowRunnerReady`, and all 27 browser tests timed out.

## The fix

The lookup goes through `importNodeBuiltin` — the same helper `js-sandbox.ts` already uses one import above for Node-only modules. Off Node it answers null and the resolver returns no addresses, which callers already handle: the literal SSRF check has run, and whoever opens the socket reports the rest.

## Verification

- Reproduced the exact CI failure locally with `vite build` on the harness config, then confirmed it goes away with the fix.
- Ran the harness suite itself: **26 of 27 pass**, including every `sandbox-modules` and `browser-workflow` test that was failing. The remaining failure is a WebCodecs video decode — this container only has an older `chromium_headless_shell` build, which I symlinked into place to run the suite at all. CI has the right browser.
- `network-guard.test.ts`, `capabilities-media`, `js-sandbox`, `yt-dlp-hardening`: 195 tests green. Build, lint, typecheck clean.

## The new test

A static `node:*` import in this file fails no typecheck, no lint, and no Node test — only the bundle, on a leg that does not gate merge. `network-guard-browser-safety.test.ts` asserts the file has no top-level `node:` import; I put the bad import back to watch it fail, then removed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Vf8qWoRyghL3iAnxb9Bmp

---
_Generated by [Claude Code](https://claude.ai/code/session_011Vf8qWoRyghL3iAnxb9Bmp)_