### PR TITLE
feat: custom nodes — save Code-node scripts to the library, drop them from the node menu

### DIFF
--- a/docs/custom-node-library-design.md
+++ b/docs/custom-node-library-design.md
@@ -1,0 +1,285 @@
+# Custom Nodes: user-saved node types in the library
+
+Status: design. Owner: web / code-nodes / agents. 2026-08-18.
+
+## Problem
+
+A user who has shaped a Code node into something useful — a scraper for one
+API's response shape, a formatter for their invoice numbers, a validator for
+their CSV layout — has no way to keep it as a *node*. The shipped snippets
+(`web/src/config/codeSnippets.ts`) show the right interaction: open the node
+menu, find "Extract URLs", drop it, and a pre-filled Code node appears. But
+snippets are hardcoded into the build. A user's own work has exactly one
+durable home today, the JS script document
+([js-script-document-design.md](js-script-document-design.md)) — and a script
+is reachable only through the Code node's **Link script** picker, three clicks
+deep inside a node that already exists. Nothing a user saves ever shows up
+where they look for nodes: the node menu.
+
+This design closes that gap. A **custom node** is a JS script document the
+user has chosen to expose in the node menu. It appears under a **My Nodes**
+section of the palette with its declared inputs and outputs, drops onto the
+canvas like any node, and the graph it lands in stays portable: the placed
+node is a plain `nodetool.code.Code` node with the script materialized onto
+it and a provenance link back to the library.
+
+No new document type, no new storage, no new execution path. The feature is
+a palette flag on the script document plus the wiring that makes flagged
+scripts show up and drop correctly.
+
+## What already exists
+
+The three mechanisms this design composes, none of them modified in kind:
+
+1. **JS script documents** are the library. `js_scripts` rows own a versioned
+   document with `code`, declared `inputs`/`outputs` ports, `secrets`,
+   `timeoutSeconds`, and saved tests (`packages/models/src/js-script.ts`,
+   tRPC router `packages/websocket/src/trpc/routers/js-scripts.ts`).
+2. **The snippet palette path** already puts virtual node types in the menu.
+   `generateSnippetMetadata()` (`web/src/config/snippetMetadata.ts`) fabricates
+   `NodeMetadata` records that `useMetadata.ts` merges into the store, and
+   `instantiatePaletteNode` (`web/src/utils/instantiatePaletteNode.ts`)
+   expands a virtual type into a real `nodetool.code.Code` node on drop. The
+   registry never hears about these types, and the saved graph never contains
+   them.
+3. **The Code node script link** already defines what a placed custom node is.
+   `useCodeNodeScriptLink.materialize()`
+   (`web/src/hooks/nodes/useCodeNodeScriptLink.ts`) copies a script's code,
+   packages, secrets and timeout onto the node, derives `dynamic_inputs` /
+   `dynamic_outputs` from the declared ports, and records
+   `properties.script = { id, version }` as provenance. Graph validation
+   checks link freshness through `jsScriptPortMismatches` and
+   `collectJsScriptLinks` (`packages/node-sdk/src/js-script-link.ts`,
+   `graph-validation.ts`), and the editor already offers **update to latest**
+   and **detach**.
+
+A custom node is these three composed: a script (1) surfaced like a snippet
+(2) that drops as a linked Code node (3).
+
+## Document shape
+
+One optional field on `JsScriptDocument`
+(`packages/protocol/src/api-schemas/js-scripts.ts`):
+
+```ts
+interface JsScriptDocument {
+  // ...existing fields unchanged...
+  palette?: {
+    category: string;   // menu grouping, e.g. "Text", "My API" — free text
+  };
+}
+```
+
+- **Absence means not exposed.** Every existing script stays a plain library
+  script until its owner opts it in; `schemaVersion` stays 1 and old saves
+  parse unchanged.
+- **`category` is the only knob.** The node's title is the script's `name`,
+  its description is the document's `description`, its ports are the declared
+  `inputs`/`outputs` — all of which the script already maintains for its
+  other consumers. Duplicating any of them into `palette` would create a
+  second copy to drift.
+- Validation (`validate_js_script` and the document-level rules in
+  `packages/node-sdk`): a `palette` on a script with zero declared outputs is
+  a warning (the node would have no handles to connect), and an empty or
+  whitespace `category` is an error.
+
+## Palette surfacing
+
+Client-side synthetic metadata, the snippet path — not registry registration.
+The registry (`NodeRegistry.global`,
+`packages/node-sdk/src/registry.ts`) is process-wide with no per-user
+scoping, and it does not need any: the virtual node type exists only between
+the menu and the drop, and the saved graph never references it. Registering
+per-user types server-side is deferred (see Out of scope) until something
+server-side actually consumes them.
+
+New module `web/src/config/customNodeMetadata.ts`:
+
+```ts
+export const CUSTOM_NODE_PREFIX = "user.";
+
+export function customNodeType(scriptId: string): string {
+  return `${CUSTOM_NODE_PREFIX}${categorySlug}.${scriptId}`;
+}
+
+export function generateCustomNodeMetadata(
+  scripts: JsScriptSummary[]
+): Record<string, NodeMetadata> { /* ... */ }
+```
+
+- **Node type is keyed on the script id**, not the name: ids are stable and
+  unique, names collide and get renamed. The type string is transient (menu →
+  drop), so its looks cost nothing. Title and search text come from `name`
+  and `description`, which is what the menu's search index actually ranks
+  (`NodeSearchIndex` weights title 6, description 1).
+- **Namespace is `user.<categorySlug>`**, slugified the way
+  `snippetMetadata.ts` slugifies snippet categories. `useNamespaceTree`
+  builds the tree from namespace strings alone, so **My Nodes** appears as a
+  `user` top-level group with the user's categories under it, no tree changes
+  needed. `NamespaceIcon.tsx` gets one entry for the `user` root.
+- **Ports map directly.** A declared input becomes a `Property` with its
+  `TypeMetadata` and the type's default value; a declared output becomes an
+  output entry. No AST inference — scripts declare their ports, which is the
+  precision the snippet generator never had. `supports_dynamic_inputs` /
+  `supports_dynamic_outputs` stay true, since the placed node is a Code node.
+- A script whose body streams its inputs (`usesStreamInputContract`) gets
+  `is_streaming_input: true`, so the menu and the drop both say what the node
+  will do.
+
+### Loading and refresh
+
+Custom-node metadata is user data, so it cannot ride the unauthenticated
+`GET /api/nodes/metadata` fetch. A hook beside `useMetadata.ts` —
+`useCustomNodeMetadata` — queries `jsScripts.list` over tRPC (TanStack Query,
+key `['jsScripts', 'palette']`), generates the records, and merges them into
+`MetadataStore` after the base metadata load. Refresh rides the existing
+cross-client sync: `js_scripts` changes already broadcast `resource_change`
+(`registerDocumentSync`), which invalidates the query; saving a script,
+toggling its palette flag, or deleting it updates the menu without a reload.
+Signed-out and error states merge nothing — the menu degrades to the shipped
+catalog.
+
+## Drop semantics: materialize, with provenance
+
+`instantiatePaletteNode` gains a third branch, before the snippet branch:
+
+```ts
+const script = findCustomNodeScript(metadata.node_type); // from the query cache
+if (script) { /* materialize */ }
+```
+
+The branch does what `useCodeNodeScriptLink.materialize()` does today — the
+port→slot mapping (`portsToSlots` / `portsToOutputs`) and property copying
+move into a shared helper both call sites use, so drop and link cannot
+drift:
+
+- `properties`: `code`, `packages`, `secrets`, `timeout` from the document,
+  and `script: { id, version }` pinning the version that was dropped.
+- `data.title`: the script's name. `data.codeNodeMode = "custom"` — a third
+  mode beside `"snippet"`, so `codeNodeUi.ts` renders the custom title and
+  keeps it editable, and the property panel can show the link affordances
+  (update to latest, detach, open script) without the user hunting for them.
+- `afterAdd`: `dynamic_inputs` / `dynamic_properties` / `dynamic_outputs`
+  from the declared ports, merged once the node exists in the store — the
+  snippet pattern.
+
+Everything after the drop is the already-shipped link behavior:
+
+- **The graph is self-contained.** Execution reads only the node's own
+  properties (`CodeNode.envelope()` never resolves the link), so the workflow
+  runs on the server, in the packaged app, and after export exactly as a
+  hand-written Code node does. A deleted or moved script costs freshness
+  warnings, never the run.
+- **Staleness is visible, not silent.** `validateGraph` with a
+  `jsScriptLookup` reports `js_script_missing` and port mismatches through
+  `jsScriptPortMismatches`; the editor's **update to latest** re-materializes
+  and re-pins. Editing the library script does not mutate placed nodes — the
+  same pin-and-update contract the link feature already made, now stated as
+  the custom-node contract too: *your graphs keep the version you dropped
+  until you update them.*
+- **Detach** turns the node back into an anonymous Code node; the code is
+  already inline.
+
+## Save path: where "save my customized stuff" happens
+
+Two entry points, both writing through the existing script machinery:
+
+1. **From a Code node — "Save to My Nodes".** The Code node's context menu
+   and property panel gain the action next to the existing **Extract to
+   script**; it *is* `extractToScript` (which already lifts body, ports,
+   packages, secrets into a new script and links the node) plus a small
+   dialog for name and category that sets `palette` on the created document.
+   One action, and the node the user customized is now in the menu.
+   A node already linked to a script offers **Add to My Nodes** instead,
+   which just sets `palette` on the linked script.
+2. **From the script editor.** The `jsscript` surface's header gains a
+   **Show in node menu** toggle plus the category field — the same
+   `palette` write over the existing autosave/CAS sync. `ui_jsscript_set_meta`
+   gains the field, so the script assistant can do it too.
+
+Snippets stay as they are: a shipped snippet the user modifies is an
+anonymous Code node until they save it, at which point path 1 makes it
+theirs. No migration of `codeNodeMode: "snippet"` nodes.
+
+## Agents and headless surfaces
+
+Nothing headless ever sees a `user.*` node type — graphs carry
+`nodetool.code.Code` — so `validate`, `debug`, the kernel, mini apps, and
+mobile need no changes. What agents need is authoring parity with the user:
+
+- **Discovery** is `list_js_scripts`, which already returns id, name,
+  description, and ports. Its result gains the `palette` field so an agent
+  can distinguish "the user's nodes" from utility scripts, and the graph
+  tools' system prompt tells the agent to check it before writing a Code
+  node body from scratch.
+- **Placement**: the `ui_add_node` path in the web graph tools accepts the
+  virtual `user.*` type like any palette type (it goes through
+  `instantiatePaletteNode` already). Headless graph authoring
+  (`create_workflow`, the DSL) materializes the same way a drop does; a
+  shared helper in `@nodetool-ai/node-sdk` (`materializeJsScriptNode(document,
+  link)` → properties + dynamic slots) keeps the web drop, the link hook,
+  and headless authoring on one code path.
+
+## Validation and safety
+
+- The materialized body is validated exactly like any Code node body — the
+  link adds freshness checks, it never relaxes anything.
+- Secrets: the placed node carries the script's declared `secrets` list, and
+  the Code node's existing secret gating applies. Dropping a custom node
+  grants nothing the same node hand-written would not have.
+- Scripts are per-user (`loadOwned` in the tRPC router); the palette is too.
+  Sharing a custom node with another user is sharing the workflow (the code
+  travels materialized) or exporting the script — a marketplace is out of
+  scope.
+
+## Phases
+
+1. **Schema + save path.** `palette` on the document (Zod, validation rules),
+   `ui_jsscript_set_meta` support, the script-editor toggle, and the Code
+   node's **Save to My Nodes** action on top of `extractToScript`.
+2. **Palette.** `customNodeMetadata.ts`, `useCustomNodeMetadata`, the
+   `instantiatePaletteNode` branch, `codeNodeMode: "custom"`, the shared
+   materialize helper refactor of `useCodeNodeScriptLink`, `NamespaceIcon`
+   entry. A user can save a node and drop it from the menu.
+3. **Agent parity.** `palette` in `list_js_scripts`, headless
+   materialization through the shared helper, prompt guidance, and an eval
+   case in `jsscript-tools` covering "save this Code node as a custom node,
+   then use it in a second workflow".
+
+Each phase lands green alone; phase 2 reads what phase 1 wrote and nothing
+else.
+
+## Testing
+
+- Schema (`packages/protocol` / `packages/node-sdk`): `palette` parses and
+  round-trips; the no-outputs warning and empty-category error each go red on
+  a fixture built to violate them.
+- Web (Jest/RTL): `generateCustomNodeMetadata` maps ports to
+  properties/outputs (typed, defaults, streaming flag); the
+  `instantiatePaletteNode` branch produces a node whose properties and
+  dynamic slots equal what `materialize()` produces for the same script —
+  asserted by comparing the two outputs, so the shared helper is proven
+  shared; menu refresh on `resource_change`.
+- Link freshness: dropping version N, bumping the script to N+1 with a
+  changed port, and validating reports the mismatch — the existing
+  `jsScriptPortMismatches` suite gains the drop-created fixture.
+- Harness: `nodetool jsscript validate` on a fixture with `palette` passes;
+  the eval case in phase 3 gates on the agent using the saved script rather
+  than re-writing the body.
+
+## Out of scope
+
+- **Server-side registry entries for custom nodes.** Metadata-only
+  registration exists (`loadMetadata`), but the global registry has no
+  per-user scoping and nothing server-side consumes the virtual types today.
+  If `search_nodes` should someday return them, that needs a per-request
+  registry view — its own design.
+- **Sharing and marketplace.** Custom nodes travel inside workflows
+  (materialized) and as exported scripts; a catalog of other users' nodes is
+  a distribution problem this design does not touch.
+- **Custom icons and colors.** Metadata has no icon field; the `user`
+  namespace gets one icon. Per-node art waits until metadata grows it for
+  shipped nodes too.
+- **Non-Code custom nodes** (saving a configured LLM node, a subgraph). A
+  subgraph-as-node is a different feature with its own execution semantics;
+  this design deliberately stops at what the Code node can express.

--- a/packages/agents/src/capabilities/js-scripts.specs.ts
+++ b/packages/agents/src/capabilities/js-scripts.specs.ts
@@ -32,11 +32,13 @@ const SCRIPT_REF_PROPERTIES = {
 
 const DOCUMENT_DESCRIPTION =
   "A JsScriptDocument: {schemaVersion: 1, description, code, inputs, " +
-  "outputs, packages, secrets, timeoutSeconds, tests}. Ports are " +
+  "outputs, packages, secrets, timeoutSeconds, tests, palette?}. Ports are " +
   "{name, type}; a test is {name, inputs, expect?, expectedStreamed?}. " +
   "The body is top-level statements (no `export`, no `function run`). " +
   "Outputs leave through `await emit(name, value)` and " +
-  "`await output(name, value)` — never through `return`.";
+  "`await output(name, value)` — never through `return`. " +
+  "`palette: {category}` exposes the script in the user's node menu as a " +
+  "custom node under that category; omit it for a plain library script.";
 
 const DOCUMENT_FIELD: JsonSchema = {
   type: "object",
@@ -140,9 +142,10 @@ export const listJsScriptsSpec: CapabilitySpec = {
   name: "list_js_scripts",
   description:
     "List the caller's JS scripts, most recently updated first: id, name, " +
-    "description, and declared input/output ports. The description says what " +
-    "a script does — this is how you pick one to run. Start here when the " +
-    "user names a script but not its id.",
+    "description, declared input/output ports, and `palette` — set when the " +
+    "user saved the script as one of their custom nodes. The description " +
+    "says what a script does — this is how you pick one to run. Start here " +
+    "when the user names a script but not its id.",
   inputSchema: LIST_JS_SCRIPTS_SCHEMA,
   category: "read",
   userMessage: () => "Listing JS scripts"

--- a/packages/agents/src/capabilities/js-scripts.ts
+++ b/packages/agents/src/capabilities/js-scripts.ts
@@ -8,7 +8,7 @@
  * — or a Code node body, or a CodeAct action, through the same belt — finds
  * one, reads it, saves it, checks it, runs it, and regression-tests it:
  *
- *   list_js_scripts    — id, name, description, ports (the discovery surface)
+ *   list_js_scripts    — id, name, description, ports, palette (discovery)
  *   get_js_script      — the full document
  *   save_js_script     — create or update, validated first, CAS on update
  *   validate_js_script — the static check, inline or by id
@@ -317,6 +317,7 @@ const listJsScripts: CapabilityExport = {
         description: doc.description,
         inputs: doc.inputs,
         outputs: doc.outputs,
+        palette: doc.palette ?? null,
         updated_at: row.updated_at
       };
     });

--- a/packages/agents/src/evals/surfaces/js-script.ts
+++ b/packages/agents/src/evals/surfaces/js-script.ts
@@ -67,6 +67,8 @@ export interface JsScriptBridgeFinalState {
   secrets: string[];
   timeoutSeconds: number;
   tests: string[];
+  /** The node-menu category, when the script is exposed as a custom node. */
+  paletteCategory: string | null;
   /** Whether the document passes the static check as it stands. */
   valid: boolean;
   validationErrorCodes: string[];
@@ -272,12 +274,13 @@ export function createJsScriptToolBridge(
 
     tool(
       "ui_jsscript_set_meta",
-      "Set the script's name, description, declared secrets, or timeout. Only the fields you pass change. The description is what an agent reads to decide whether this script does what it needs, so make it say what the script does.",
+      "Set the script's name, description, declared secrets, timeout, or node-menu placement. Only the fields you pass change. The description is what an agent reads to decide whether this script does what it needs, so make it say what the script does. `palette` shows the script in the node menu as one of the user's custom nodes under the category it names; null takes it back out.",
       z.object({
         name: z.string().optional(),
         description: z.string().optional(),
         secrets: z.array(z.string()).optional(),
-        timeoutSeconds: z.number().optional()
+        timeoutSeconds: z.number().optional(),
+        palette: z.object({ category: z.string() }).nullable().optional()
       }),
       async (args) => {
         if (args["name"] !== undefined) name = args["name"] as string;
@@ -293,6 +296,11 @@ export function createJsScriptToolBridge(
             JS_SCRIPT_MAX_TIMEOUT_SECONDS
           );
         }
+        if (args["palette"] !== undefined) {
+          const palette = args["palette"] as { category: string } | null;
+          if (palette === null) delete document.palette;
+          else document.palette = palette;
+        }
         const validation = await validate();
         return {
           ok: true,
@@ -300,6 +308,7 @@ export function createJsScriptToolBridge(
           description: document.description,
           secrets: document.secrets,
           timeoutSeconds: document.timeoutSeconds,
+          palette: document.palette ?? null,
           validation
         };
       }
@@ -374,6 +383,7 @@ export function createJsScriptToolBridge(
       secrets: [...document.secrets],
       timeoutSeconds: document.timeoutSeconds,
       tests: document.tests.map((testCase) => testCase.name),
+      paletteCategory: document.palette?.category ?? null,
       valid: lastValidation?.ok ?? false,
       validationErrorCodes: (lastValidation?.errors ?? []).map(
         (issue) => issue.code
@@ -470,6 +480,51 @@ export const JS_SCRIPT_TOOL_LOOP_CASES: readonly ToolLoopEvalCase<JsScriptBridge
             name: "testsPass",
             detail: "the saved cases were never run green",
             test: (s) => s.lastTest?.ok === true && s.lastTest.passed >= 2
+          }
+        ]
+      }
+    },
+    {
+      id: "expose-as-custom-node",
+      description:
+        "Expose a working script in the node menu as one of the user's custom nodes",
+      objective:
+        "Save this script to my node menu under the category \"Text\" so I can drop it onto a graph, and give it a description that says what it does. Do not change its body or its ports.",
+      systemPrompt: JS_SCRIPT_SYSTEM_PROMPT,
+      createBridge: () =>
+        createJsScriptToolBridge({
+          name: "Slugify",
+          document: {
+            code: 'await output("slug", String(inputs.title).toLowerCase().replace(/[^a-z0-9]+/g, "-"));',
+            inputs: [{ name: "title", type: "str" }],
+            outputs: [{ name: "slug", type: "str" }]
+          }
+        }),
+      expect: {
+        requiredTools: ["ui_jsscript_set_meta"],
+        minToolCalls: 1,
+        maxToolCalls: 12,
+        finalState: [
+          {
+            name: "exposedUnderText",
+            detail: "the script is not exposed in the node menu under Text",
+            test: (s) => s.paletteCategory === "Text"
+          },
+          {
+            name: "described",
+            detail: "the script still has no description",
+            test: (s) => s.description.trim().length > 0
+          },
+          {
+            name: "portsUntouched",
+            detail: "the declared ports changed",
+            test: (s) =>
+              s.inputs.join() === "title" && s.outputs.join() === "slug"
+          },
+          {
+            name: "documentValid",
+            detail: "the document does not pass the static check",
+            test: (s) => s.valid
           }
         ]
       }

--- a/packages/agents/src/prompts/workflow-authoring-knowledge.ts
+++ b/packages/agents/src/prompts/workflow-authoring-knowledge.ts
@@ -274,6 +274,9 @@ Code node when the step is data shaping, parsing, formatting, arithmetic or
 string work — it replaces a chain of small nodes. Use a specialized node when
 the step wraps a model, a device, or an external service.
 
+- Before writing a body from scratch, call \`list_js_scripts\`: a saved script
+  already does the job when one matches, and a script carrying \`palette\` is
+  one of the user's own custom nodes.
 - **Inputs** are dynamic: any property you pass that is not \`code\` or
   \`packages\` becomes an input handle, and the body reads it off the
   \`inputs\` object.

--- a/packages/agents/tests/js-script-tool-loop.test.ts
+++ b/packages/agents/tests/js-script-tool-loop.test.ts
@@ -211,10 +211,11 @@ describe("JS_SCRIPT_TOOL_LOOP_CASES", () => {
     return report.cases[0];
   };
 
-  it("has three cases with the expected ids", () => {
+  it("has four cases with the expected ids", () => {
     expect(JS_SCRIPT_TOOL_LOOP_CASES.map((c) => c.id)).toEqual([
       "author-sum-script",
       "add-saved-tests",
+      "expose-as-custom-node",
       "repair-failing-test"
     ]);
   });
@@ -257,6 +258,39 @@ describe("JS_SCRIPT_TOOL_LOOP_CASES", () => {
     ]);
     expect(result.checks.filter((c) => !c.pass)).toEqual([]);
     expect(result.score).toBe(1);
+  });
+
+  it("expose-as-custom-node is solved by one set_meta call", async () => {
+    const result = await solve("expose-as-custom-node", [
+      { name: "ui_jsscript_get_state", args: {} },
+      {
+        name: "ui_jsscript_set_meta",
+        args: {
+          description: "Turns a title into a URL slug.",
+          palette: { category: "Text" }
+        }
+      }
+    ]);
+    expect(result.checks.filter((c) => !c.pass)).toEqual([]);
+    expect(result.score).toBe(1);
+  });
+
+  it("scores a model that renames the ports while exposing the script as a miss", async () => {
+    const result = await solve("expose-as-custom-node", [
+      {
+        name: "ui_jsscript_set_meta",
+        args: {
+          description: "Turns a title into a URL slug.",
+          palette: { category: "Text" }
+        }
+      },
+      {
+        name: "ui_jsscript_set_ports",
+        args: { inputs: [{ name: "text", type: "str" }] }
+      }
+    ]);
+    expect(result.checks.some((c) => !c.pass)).toBe(true);
+    expect(result.score).toBeLessThan(1);
   });
 
   it("repair-failing-test is solved by fixing the body, not the case", async () => {

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -45,6 +45,12 @@
       "import": "./dist/code-body.js",
       "default": "./dist/code-body.js"
     },
+    "./js-script-materialize": {
+      "nodetool-dev": "./src/js-script-materialize.ts",
+      "types": "./dist/js-script-materialize.d.ts",
+      "import": "./dist/js-script-materialize.js",
+      "default": "./dist/js-script-materialize.js"
+    },
     "./cost-estimate": {
       "types": "./dist/cost-estimate.d.ts",
       "import": "./dist/cost-estimate.js",

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -18,6 +18,7 @@ export * from "./code-analysis.js";
 export * from "./code-body.js";
 export * from "./code-node-validation.js";
 export * from "./js-script-link.js";
+export * from "./js-script-materialize.js";
 export * from "./graph-validation.js";
 export * from "./workflow-interface.js";
 export * from "./workflow-document-tools.js";

--- a/packages/node-sdk/src/js-script-materialize.ts
+++ b/packages/node-sdk/src/js-script-materialize.ts
@@ -1,0 +1,97 @@
+/**
+ * Materializing a JS script onto a `nodetool.code.Code` node.
+ *
+ * A placed custom node is a plain Code node carrying a copy of one pinned
+ * script version: its body, packages, secrets and timeout as properties, its
+ * declared ports as dynamic slots, and `{id, version}` as provenance. The web
+ * editor does this when a script is linked and when a custom node is dropped
+ * from the menu, and headless authoring does it when it places one — one
+ * mapping, so a dropped node and a linked node cannot differ.
+ *
+ * Pure: no registry, no store, no I/O.
+ */
+import type {
+  JsScriptLink,
+  JsScriptPort
+} from "@nodetool-ai/protocol/api-schemas/js-scripts.js";
+
+/** The `TypeMetadata` JSON a Code node's dynamic slots carry. */
+export interface JsScriptSlotType {
+  type: string;
+  optional: boolean;
+  type_args: [];
+}
+
+/** A sandbox pack declaration as the node stores it. */
+export interface JsScriptPackageRef {
+  specifier: string;
+}
+
+/**
+ * The part of a script document a Code node copies. Structural rather than the
+ * schema type, because callers hold it in several shapes — the tRPC client's
+ * output type, the protocol's inferred type, a version snapshot — differing
+ * only in optionality nothing here reads.
+ */
+export interface MaterializableJsScript {
+  code: string;
+  inputs: readonly JsScriptPort[];
+  outputs: readonly JsScriptPort[];
+  packages: readonly JsScriptPackageRef[];
+  secrets: readonly string[];
+  timeoutSeconds: number;
+}
+
+/** The Code node properties a materialized script writes. */
+export interface MaterializedJsScriptProperties {
+  script: JsScriptLink;
+  code: string;
+  packages: readonly JsScriptPackageRef[];
+  secrets: readonly string[];
+  timeout: number;
+}
+
+export interface MaterializedJsScriptNode {
+  properties: MaterializedJsScriptProperties;
+  dynamic_inputs: Record<string, { type: JsScriptSlotType }>;
+  dynamic_outputs: Record<string, JsScriptSlotType>;
+}
+
+const slotType = (type: string): JsScriptSlotType => ({
+  type,
+  optional: false,
+  type_args: []
+});
+
+export function jsScriptPortsToSlots(
+  ports: readonly JsScriptPort[]
+): Record<string, { type: JsScriptSlotType }> {
+  return Object.fromEntries(
+    ports.map((port) => [port.name, { type: slotType(port.type) }])
+  );
+}
+
+export function jsScriptPortsToOutputs(
+  ports: readonly JsScriptPort[]
+): Record<string, JsScriptSlotType> {
+  return Object.fromEntries(
+    ports.map((port) => [port.name, slotType(port.type)])
+  );
+}
+
+export function materializeJsScriptNode(
+  document: MaterializableJsScript,
+  link: JsScriptLink
+): MaterializedJsScriptNode {
+  return {
+    properties: {
+      script: { id: link.id, version: link.version },
+      code: document.code,
+      packages: document.packages,
+      secrets: document.secrets,
+      timeout: document.timeoutSeconds
+    },
+    dynamic_inputs: jsScriptPortsToSlots(document.inputs),
+    dynamic_outputs: jsScriptPortsToOutputs(document.outputs)
+  };
+}

--- a/packages/node-sdk/tests/js-script-materialize.test.ts
+++ b/packages/node-sdk/tests/js-script-materialize.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { materializeJsScriptNode } from "../src/js-script-materialize.js";
+
+const document = {
+  code: 'await output("formatted", inputs.raw);',
+  inputs: [
+    { name: "raw", type: "str" },
+    { name: "retries", type: "int" }
+  ],
+  outputs: [{ name: "formatted", type: "str" }],
+  packages: [{ specifier: "@nodetool-ai/sandbox-yaml" }],
+  secrets: ["MY_KEY"],
+  timeoutSeconds: 45
+};
+
+describe("materializeJsScriptNode", () => {
+  it("copies the envelope onto Code node properties and pins the version", () => {
+    const { properties } = materializeJsScriptNode(document, {
+      id: "abc",
+      version: 7
+    });
+
+    expect(properties).toEqual({
+      script: { id: "abc", version: 7 },
+      code: document.code,
+      packages: document.packages,
+      secrets: document.secrets,
+      timeout: 45
+    });
+  });
+
+  it("turns declared ports into dynamic slots", () => {
+    const { dynamic_inputs, dynamic_outputs } = materializeJsScriptNode(
+      document,
+      { id: "abc", version: 1 }
+    );
+
+    expect(dynamic_inputs).toEqual({
+      raw: { type: { type: "str", optional: false, type_args: [] } },
+      retries: { type: { type: "int", optional: false, type_args: [] } }
+    });
+    expect(dynamic_outputs).toEqual({
+      formatted: { type: "str", optional: false, type_args: [] }
+    });
+  });
+
+  it("materializes a script with no ports as a node with no slots", () => {
+    const bare = { ...document, inputs: [], outputs: [] };
+    const result = materializeJsScriptNode(bare, { id: "abc", version: 2 });
+    expect(result.dynamic_inputs).toEqual({});
+    expect(result.dynamic_outputs).toEqual({});
+  });
+});

--- a/packages/protocol/src/api-schemas/js-scripts.ts
+++ b/packages/protocol/src/api-schemas/js-scripts.ts
@@ -57,6 +57,17 @@ export const jsScriptTestCase = z.object({
 });
 export type JsScriptTestCase = z.infer<typeof jsScriptTestCase>;
 
+/**
+ * Menu placement for a script its owner exposed as a custom node. Absent means
+ * the script stays a library script; the node's title, description and ports
+ * come from the document itself, so `category` is the only knob here.
+ */
+export const jsScriptPalette = z.object({
+  /** Free-text grouping under the `user` namespace, e.g. "Text", "My API". */
+  category: z.string()
+});
+export type JsScriptPalette = z.infer<typeof jsScriptPalette>;
+
 export const jsScriptDocument = z.object({
   schemaVersion: z.literal(JS_SCRIPT_SCHEMA_VERSION),
   /** What the script does — how an agent picks one out of a list. */
@@ -74,7 +85,9 @@ export const jsScriptDocument = z.object({
     .positive()
     .max(JS_SCRIPT_MAX_TIMEOUT_SECONDS)
     .default(JS_SCRIPT_DEFAULT_TIMEOUT_SECONDS),
-  tests: z.array(jsScriptTestCase).default([])
+  tests: z.array(jsScriptTestCase).default([]),
+  /** Set to expose the script in the node menu as a custom node. */
+  palette: jsScriptPalette.optional()
 });
 export type JsScriptDocument = z.infer<typeof jsScriptDocument>;
 
@@ -205,6 +218,25 @@ export function validateJsScriptDocument(
           message: `test "${testCase.name}" expects a stream from undeclared output "${entry.name}"`
         });
       }
+    }
+  }
+
+  if (doc.palette) {
+    if (doc.palette.category.trim() === "") {
+      issues.push({
+        severity: "error",
+        code: "js_script_palette_category",
+        message: "the palette category is empty"
+      });
+    }
+    if (doc.outputs.length === 0) {
+      issues.push({
+        severity: "warning",
+        code: "js_script_palette_no_outputs",
+        message:
+          "the script is exposed in the node menu but declares no outputs, " +
+          "so the node has no handles to connect"
+      });
     }
   }
 

--- a/packages/protocol/tests/api-schemas-js-scripts.test.ts
+++ b/packages/protocol/tests/api-schemas-js-scripts.test.ts
@@ -178,6 +178,65 @@ describe("validateJsScriptDocument", () => {
   });
 });
 
+describe("palette", () => {
+  it("parses and round-trips, and stays absent on an old document", () => {
+    const parsed = jsScriptDocument.parse({
+      schemaVersion: 1,
+      palette: { category: "My API" }
+    });
+    expect(parsed.palette).toEqual({ category: "My API" });
+    expect(jsScriptDocument.parse({ schemaVersion: 1 }).palette).toBeUndefined();
+  });
+
+  it("errors on a blank category", () => {
+    const issues = validateJsScriptDocument(
+      doc({
+        outputs: [{ name: "out", type: "str" }],
+        palette: { category: "   " }
+      })
+    );
+    expect(
+      issues.some(
+        (issue) =>
+          issue.code === "js_script_palette_category" &&
+          issue.severity === "error"
+      )
+    ).toBe(true);
+  });
+
+  it("accepts a category with content", () => {
+    const issues = validateJsScriptDocument(
+      doc({
+        outputs: [{ name: "out", type: "str" }],
+        palette: { category: "Text" }
+      })
+    );
+    expect(
+      issues.some((issue) => issue.code === "js_script_palette_category")
+    ).toBe(false);
+  });
+
+  it("warns when an exposed script declares no outputs", () => {
+    const issues = validateJsScriptDocument(
+      doc({ outputs: [], palette: { category: "Text" } })
+    );
+    expect(
+      issues.some(
+        (issue) =>
+          issue.code === "js_script_palette_no_outputs" &&
+          issue.severity === "warning"
+      )
+    ).toBe(true);
+  });
+
+  it("says nothing about the menu for a script that is not exposed", () => {
+    const issues = validateJsScriptDocument(doc({ outputs: [] }));
+    expect(
+      issues.some((issue) => issue.code.startsWith("js_script_palette"))
+    ).toBe(false);
+  });
+});
+
 describe("assertValidJsScriptDocument", () => {
   it("throws naming the error, and stays quiet on warnings", () => {
     expect(() =>

--- a/packages/websocket/src/trpc/routers/js-scripts.ts
+++ b/packages/websocket/src/trpc/routers/js-scripts.ts
@@ -7,6 +7,9 @@
  *
  * Procedures:
  *   list             (query)    — JsScriptListItem[]
+ *   palette          (query)    — the caller's custom nodes, each with the
+ *                                  version pinned for it (writes a snapshot
+ *                                  when the newest one no longer matches)
  *   get              (query)    — JsScriptResponse
  *   create           (mutation) — JsScriptResponse
  *   update           (mutation) — JsScriptResponse (CAS via baseUpdatedAt)
@@ -70,6 +73,11 @@ const updateInput = patchJsScriptInput.and(
 
 const okOutput = z.object({ ok: z.literal(true) });
 
+/** One custom node: the script's response shape plus the version pinned for it. */
+const jsScriptPaletteItem = jsScriptResponse.extend({
+  version: z.number().int()
+});
+
 function toListItem(script: JsScript) {
   const doc = script.toDocument();
   return {
@@ -111,6 +119,28 @@ function parseVersionDocument(raw: unknown): JsonValue {
   }
 }
 
+/** A stored document, comparable across the SQLite (text) and Postgres (json) columns. */
+function documentText(raw: unknown): string {
+  return isString(raw) ? raw : JSON.stringify(raw);
+}
+
+/**
+ * The version number that pins a script's current content: the newest snapshot
+ * when it already matches, else a fresh one. Mirrors what the Code node's link
+ * hook does before it materializes a script onto a node.
+ */
+async function pinCurrentVersion(script: JsScript): Promise<number> {
+  const [newest] = await JsScriptVersion.listForScript(script.id, { limit: 1 });
+  if (newest && documentText(newest.document) === documentText(script.document)) {
+    return newest.version;
+  }
+  const created = await JsScriptVersion.snapshot(script, {
+    saveType: "autosave",
+    name: "Pinned for the node menu"
+  });
+  return created.version;
+}
+
 async function loadOwned(
   ctxUserId: string | null,
   id: string
@@ -132,6 +162,34 @@ export const jsScriptsRouter = router({
         ? await JsScript.listByProject(input.projectId, ctx.userId)
         : await JsScript.listByUser(ctx.userId);
       return items.map(toListItem);
+    }),
+
+  /**
+   * The caller's custom nodes: every script whose document carries `palette`,
+   * each with the whole document and the version that pins it. The node menu
+   * needs the ports to build metadata, the body to materialize a dropped node
+   * without a second round trip, and the version number to record on the
+   * placed node as provenance.
+   *
+   * Pinning is why this query writes: a placed node keeps the version it was
+   * dropped at, so the menu can only hand out a version whose document is what
+   * the user is looking at. It snapshots at most once per content change of an
+   * exposed script — a script whose newest snapshot already matches gets that
+   * number back.
+   */
+  palette: protectedProcedure
+    .output(z.array(jsScriptPaletteItem))
+    .query(async ({ ctx }) => {
+      const items = await JsScript.listByUser(ctx.userId);
+      const exposed = items.filter(
+        (script) => script.toDocument().palette !== undefined
+      );
+      return Promise.all(
+        exposed.map(async (script) => ({
+          ...jsScriptResponse.parse(script.toResponse()),
+          version: await pinCurrentVersion(script)
+        }))
+      );
     }),
 
   get: protectedProcedure

--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -34,6 +34,8 @@ export default {
     // pull the heavy barrel (pack-loader, registry) into jsdom.
     "^@nodetool-ai/node-sdk/code-body$":
       "<rootDir>/../packages/node-sdk/src/code-body.ts",
+    "^@nodetool-ai/node-sdk/js-script-materialize$":
+      "<rootDir>/../packages/node-sdk/src/js-script-materialize.ts",
     "^@nodetool-ai/node-sdk/cost-estimate$":
       "<rootDir>/../packages/node-sdk/src/cost-estimate.ts",
     "^@nodetool-ai/node-sdk/pricing-params$":

--- a/web/src/components/jsScript/JsScriptSettingsPanel.tsx
+++ b/web/src/components/jsScript/JsScriptSettingsPanel.tsx
@@ -1,7 +1,7 @@
 /**
  * The JS script's execution envelope, side by side in one panel: what the
- * script says it does, the ports it declares, the secrets it may read, and
- * the timeout it runs under. Every installed sandbox pack and every platform
+ * script says it does, the ports it declares, the secrets it may read, the
+ * timeout it runs under, and whether it shows up in the node menu. Every installed sandbox pack and every platform
  * module resolves by import — there is no packages setting. Every field
  * writes straight into the document, which autosaves.
  */
@@ -10,6 +10,7 @@ import { memo, useCallback } from "react";
 import {
   Divider,
   FlexColumn,
+  LabeledSwitch,
   ScrollArea,
   Text,
   TextInput,
@@ -23,6 +24,9 @@ import {
 } from "../../stores/jsScript/JsScriptStore";
 import JsScriptPortsEditor from "./JsScriptPortsEditor";
 import JsScriptSecretsEditor from "./JsScriptSecretsEditor";
+
+/** What a newly exposed script lands under until its owner names a category. */
+const DEFAULT_CATEGORY = "My Nodes";
 
 interface JsScriptSettingsPanelProps {
   scriptId: string;
@@ -40,6 +44,7 @@ const JsScriptSettingsPanel = ({
   const setTimeoutSeconds = useJsScriptStore(
     (state) => state.setTimeoutSeconds
   );
+  const setPalette = useJsScriptStore((state) => state.setPalette);
 
   const handleInputs = useCallback(
     (inputs: JsScriptPort[]) => setPorts(scriptId, { inputs }),
@@ -52,6 +57,11 @@ const JsScriptSettingsPanel = ({
   const handleSecrets = useCallback(
     (secrets: string[]) => setSecrets(scriptId, secrets),
     [scriptId, setSecrets]
+  );
+  const handleShowInMenu = useCallback(
+    (checked: boolean) =>
+      setPalette(scriptId, checked ? { category: DEFAULT_CATEGORY } : null),
+    [scriptId, setPalette]
   );
 
   return (
@@ -95,6 +105,30 @@ const JsScriptSettingsPanel = ({
           readOnly={readOnly}
           onChange={handleSecrets}
         />
+
+        <Divider />
+        <FlexColumn gap={SPACING.xs}>
+          <LabeledSwitch
+            label="Show in node menu"
+            size="small"
+            checked={document.palette !== undefined}
+            disabled={readOnly}
+            onChange={handleShowInMenu}
+            description="Adds this script to My Nodes, so it drops onto a graph like any node."
+          />
+          {document.palette !== undefined ? (
+            <TextInput
+              label="Category"
+              size="small"
+              value={document.palette.category}
+              placeholder={DEFAULT_CATEGORY}
+              disabled={readOnly}
+              onChange={(event) =>
+                setPalette(scriptId, { category: event.target.value })
+              }
+            />
+          ) : null}
+        </FlexColumn>
 
         <Divider />
         <TextInput

--- a/web/src/components/jsScript/jsScriptAgentBridge.ts
+++ b/web/src/components/jsScript/jsScriptAgentBridge.ts
@@ -15,6 +15,7 @@
 import type { SandboxModuleDeclaration } from "@nodetool-ai/protocol";
 import type {
   JsScriptDocument,
+  JsScriptPalette,
   JsScriptPort,
   JsScriptRunOutcome,
   JsScriptTestCase,
@@ -47,6 +48,8 @@ export interface JsScriptMetaInput {
   description?: string;
   secrets?: string[];
   timeoutSeconds?: number;
+  /** Menu placement; `null` takes the script back out of the node menu. */
+  palette?: JsScriptPalette | null;
 }
 
 /** Operations the live JsScriptSurface exposes to the agent tooling layer. */

--- a/web/src/components/node/__tests__/codeNodeUi.test.ts
+++ b/web/src/components/node/__tests__/codeNodeUi.test.ts
@@ -2,6 +2,7 @@ import {
   CODE_NODE_TYPE,
   isCodeNode,
   isSnippetCodeNode,
+  isCustomCodeNode,
   resolveCodeNodeTitle,
   isCodeNodeTitleEditable,
   getCodeNodeLanguage,
@@ -57,6 +58,37 @@ describe("codeNodeUi", () => {
       expect(
         isSnippetCodeNode("nodetool.text.Concat", { codeNodeMode: "snippet" })
       ).toBe(false);
+    });
+  });
+
+  describe("isCustomCodeNode", () => {
+    it("returns true for a code node materialized from a saved script", () => {
+      expect(isCustomCodeNode(CODE_NODE_TYPE, { codeNodeMode: "custom" })).toBe(
+        true
+      );
+    });
+
+    it("returns false for snippet and plain code nodes", () => {
+      expect(
+        isCustomCodeNode(CODE_NODE_TYPE, { codeNodeMode: "snippet" })
+      ).toBe(false);
+      expect(isCustomCodeNode(CODE_NODE_TYPE, { codeNodeMode: undefined })).toBe(
+        false
+      );
+      expect(
+        isCustomCodeNode("nodetool.text.Concat", { codeNodeMode: "custom" })
+      ).toBe(false);
+    });
+  });
+
+  describe("custom nodes keep the affordances snippets lose", () => {
+    it("shows the code body and keeps the title editable", () => {
+      const data = { codeNodeMode: "custom" as const };
+      expect(isCodeBodyNode(makeMetadata(), data)).toBe(true);
+      expect(isCodeNodeTitleEditable(CODE_NODE_TYPE, data)).toBe(true);
+      expect(resolveCodeNodeTitle(CODE_NODE_TYPE, "Invoice number", "Code")).toBe(
+        "Invoice number"
+      );
     });
   });
 

--- a/web/src/components/node/codeNodeUi.ts
+++ b/web/src/components/node/codeNodeUi.ts
@@ -16,6 +16,18 @@ export function isSnippetCodeNode(
 }
 
 /**
+ * A Code node materialized from one of the user's saved scripts. It is a
+ * regular Code node — its body is visible and its title is its own — so this
+ * only tells the UI where the node came from.
+ */
+export function isCustomCodeNode(
+  nodeType: string,
+  data: Pick<NodeData, "codeNodeMode">
+): boolean {
+  return isCodeNode(nodeType) && data.codeNodeMode === "custom";
+}
+
+/**
  * Monaco language id for a code node's `code` property, derived from its
  * node_type. The Code node runs JavaScript in a sandbox; any other node with an
  * inline `code` property falls back to plain text.

--- a/web/src/components/node_menu/NamespaceIcon.tsx
+++ b/web/src/components/node_menu/NamespaceIcon.tsx
@@ -15,6 +15,7 @@ import ChatIcon from "@mui/icons-material/Chat";
 import BoltIcon from "@mui/icons-material/Bolt";
 import MovieFilterIcon from "@mui/icons-material/MovieFilter";
 import ApiIcon from "@mui/icons-material/Api";
+import StarIcon from "@mui/icons-material/Star";
 
 import openaiIcon from "../../icons/providers/openai.svg";
 import anthropicIcon from "../../icons/providers/anthropic.svg";
@@ -56,6 +57,8 @@ const NAMESPACE_ICONS: Record<string, IconEntry> = {
   nodetool: { kind: "mui", Component: HubIcon },
   search: { kind: "mui", Component: SearchIcon },
   transformers: { kind: "mui", Component: AutoAwesomeIcon },
+  // The user's own saved nodes (JS scripts flagged for the menu).
+  user: { kind: "mui", Component: StarIcon },
   vector: { kind: "mui", Component: ScatterPlotIcon },
 
   // Providers

--- a/web/src/components/node_types/CodeBody.tsx
+++ b/web/src/components/node_types/CodeBody.tsx
@@ -407,7 +407,9 @@ const CodeBodyInner: React.FC<CodeBodyProps> = ({
       <div css={cssStyles} className="code-body" data-bespoke-body="Code">
         <HandleColumn id={id} properties={inputProperties} />
 
-        {supportsCodeGen && <CodeNodeScriptLink id={id} data={data} />}
+        {supportsCodeGen && (
+          <CodeNodeScriptLink id={id} data={data} nodeType={nodeType} />
+        )}
 
         <div className="code-toolbar">
           <span className="code-language">{languageLabel}</span>

--- a/web/src/components/node_types/CodeNodeScriptLink.tsx
+++ b/web/src/components/node_types/CodeNodeScriptLink.tsx
@@ -1,11 +1,12 @@
 /**
  * The Code node's script-link header.
  *
- * Unlinked, it offers the two ways into a script: pick one, or lift this node's
- * body into a new one. Linked, it says what is pinned and offers the two ways
- * out: re-pin to the script's current content, or keep the body inline and drop
- * the link. The editor for the script itself is its own tab; nothing here edits
- * a document.
+ * Unlinked, it offers the ways into a script: pick one, lift this node's body
+ * into a new one, or save that new script straight into the node menu. Linked,
+ * it says what is pinned and offers the two ways out — re-pin to the script's
+ * current content, or keep the body inline and drop the link — plus adding the
+ * linked script to the node menu. The editor for the script itself is its own
+ * tab; nothing here edits a document.
  */
 import { memo, useCallback, useState } from "react";
 
@@ -15,22 +16,35 @@ import type { NodeData } from "../../stores/NodeData";
 import { notifyMutationError } from "../../utils/notifyMutationError";
 import { EditorButton, NodeSelect, NodeMenuItem } from "../editor_ui";
 import { Caption, FlexRow, GAP, SPACING } from "../ui_primitives";
+import SaveToMyNodesDialog from "./SaveToMyNodesDialog";
+import { isCustomCodeNode } from "../node/codeNodeUi";
 
 interface CodeNodeScriptLinkProps {
   id: string;
   data: NodeData;
+  nodeType: string;
 }
 
 const NEW_SCRIPT_NAME = "Extracted from a Code node";
+const DEFAULT_CATEGORY = "My Nodes";
 
 const CodeNodeScriptLinkInner: React.FC<CodeNodeScriptLinkProps> = ({
   id,
-  data
+  data,
+  nodeType
 }) => {
-  const { link, linkedName, linkScript, updateToLatest, extractToScript, detach } =
-    useCodeNodeScriptLink(id, data);
+  const {
+    link,
+    linkedName,
+    linkScript,
+    updateToLatest,
+    extractToScript,
+    addToPalette,
+    detach
+  } = useCodeNodeScriptLink(id, data);
   const scripts = useJsScripts();
   const [busy, setBusy] = useState(false);
+  const [saveOpen, setSaveOpen] = useState(false);
 
   const guard = useCallback(
     async <T,>(label: string, action: () => Promise<T>) => {
@@ -54,6 +68,26 @@ const CodeNodeScriptLinkInner: React.FC<CodeNodeScriptLinkProps> = ({
     [guard, linkScript]
   );
 
+  const saveDialog = (
+    <SaveToMyNodesDialog
+      open={saveOpen}
+      initialName={link ? undefined : data.title || NEW_SCRIPT_NAME}
+      initialCategory={DEFAULT_CATEGORY}
+      busy={busy}
+      onCancel={() => setSaveOpen(false)}
+      onConfirm={({ name, category }) => {
+        setSaveOpen(false);
+        void guard("save the node", async () => {
+          if (link) {
+            await addToPalette(category);
+          } else {
+            await extractToScript(name, category);
+          }
+        });
+      }}
+    />
+  );
+
   if (link) {
     return (
       <FlexRow
@@ -63,7 +97,9 @@ const CodeNodeScriptLinkInner: React.FC<CodeNodeScriptLinkProps> = ({
         sx={{ px: SPACING.xs }}
       >
         <Caption>
-          {`Linked to ${linkedName ?? link.id} v${link.version}`}
+          {`${isCustomCodeNode(nodeType, data) ? "My node" : "Linked to"} ${
+            linkedName ?? link.id
+          } v${link.version}`}
         </Caption>
         <FlexRow gap={GAP.tight}>
           <EditorButton
@@ -73,10 +109,18 @@ const CodeNodeScriptLinkInner: React.FC<CodeNodeScriptLinkProps> = ({
           >
             Update to latest
           </EditorButton>
+          <EditorButton
+            density="compact"
+            disabled={busy}
+            onClick={() => setSaveOpen(true)}
+          >
+            Add to My Nodes
+          </EditorButton>
           <EditorButton density="compact" disabled={busy} onClick={detach}>
             Detach
           </EditorButton>
         </FlexRow>
+        {saveDialog}
       </FlexRow>
     );
   }
@@ -107,6 +151,14 @@ const CodeNodeScriptLinkInner: React.FC<CodeNodeScriptLinkProps> = ({
       >
         Extract to script
       </EditorButton>
+      <EditorButton
+        density="compact"
+        disabled={busy}
+        onClick={() => setSaveOpen(true)}
+      >
+        Save to My Nodes
+      </EditorButton>
+      {saveDialog}
     </FlexRow>
   );
 };

--- a/web/src/components/node_types/SaveToMyNodesDialog.tsx
+++ b/web/src/components/node_types/SaveToMyNodesDialog.tsx
@@ -1,0 +1,81 @@
+/**
+ * Name-and-category prompt behind the Code node's "Save to My Nodes" action.
+ *
+ * A node already linked to a script needs only the category — its name is the
+ * script's — so `name` is omitted for that case.
+ */
+import { memo, useEffect, useState } from "react";
+
+import { Dialog, FlexColumn, SPACING, TextInput } from "../ui_primitives";
+
+interface SaveToMyNodesDialogProps {
+  open: boolean;
+  /** Prefilled node name; omit to ask for the category only. */
+  initialName?: string;
+  initialCategory: string;
+  busy?: boolean;
+  onCancel: () => void;
+  onConfirm: (values: { name: string; category: string }) => void;
+}
+
+const SaveToMyNodesDialogInner: React.FC<SaveToMyNodesDialogProps> = ({
+  open,
+  initialName,
+  initialCategory,
+  busy = false,
+  onCancel,
+  onConfirm
+}) => {
+  const [name, setName] = useState(initialName ?? "");
+  const [category, setCategory] = useState(initialCategory);
+
+  useEffect(() => {
+    if (open) {
+      setName(initialName ?? "");
+      setCategory(initialCategory);
+    }
+  }, [open, initialName, initialCategory]);
+
+  const askName = initialName !== undefined;
+  const valid = category.trim() !== "" && (!askName || name.trim() !== "");
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onCancel}
+      title="Save to My Nodes"
+      confirmText="Save"
+      isLoading={busy}
+      confirmDisabled={!valid}
+      onCancel={onCancel}
+      onConfirm={() =>
+        onConfirm({ name: name.trim(), category: category.trim() })
+      }
+    >
+      <FlexColumn gap={SPACING.md}>
+        {askName ? (
+          <TextInput
+            label="Node name"
+            size="small"
+            autoFocus
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+        ) : null}
+        <TextInput
+          label="Category"
+          size="small"
+          autoFocus={!askName}
+          value={category}
+          onChange={(event) => setCategory(event.target.value)}
+          helperText="Where the node appears under My Nodes."
+        />
+      </FlexColumn>
+    </Dialog>
+  );
+};
+
+export const SaveToMyNodesDialog = memo(SaveToMyNodesDialogInner);
+SaveToMyNodesDialog.displayName = "SaveToMyNodesDialog";
+
+export default SaveToMyNodesDialog;

--- a/web/src/config/__tests__/customNodeMetadata.test.ts
+++ b/web/src/config/__tests__/customNodeMetadata.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment node
+ */
+import {
+  CUSTOM_NODE_PREFIX,
+  customNodeType,
+  findCustomNodeScript,
+  generateCustomNodeMetadata,
+  setCustomNodeScripts,
+  type CustomNodeScript
+} from "../customNodeMetadata";
+
+function script(
+  overrides: Partial<CustomNodeScript> = {},
+  document: Partial<CustomNodeScript["document"]> = {}
+): CustomNodeScript {
+  return {
+    id: "abc-123",
+    name: "Invoice number",
+    version: 4,
+    document: {
+      description: "Formats our invoice numbers",
+      code: 'await output("formatted", inputs.raw);',
+      inputs: [{ name: "raw", type: "str" }],
+      outputs: [{ name: "formatted", type: "str" }],
+      packages: [],
+      secrets: [],
+      timeoutSeconds: 30,
+      palette: { category: "My API" },
+      ...document
+    },
+    ...overrides
+  };
+}
+
+describe("customNodeType", () => {
+  it("keys on the script id under the slugged category", () => {
+    expect(customNodeType(script())).toBe(`${CUSTOM_NODE_PREFIX}my_api.abc_123`);
+  });
+
+  it("falls back to a category when the slug is empty", () => {
+    expect(customNodeType(script({}, { palette: { category: "!!" } }))).toBe(
+      `${CUSTOM_NODE_PREFIX}my_nodes.abc_123`
+    );
+  });
+});
+
+describe("generateCustomNodeMetadata", () => {
+  it("maps declared ports to typed properties and outputs", () => {
+    const metadata = generateCustomNodeMetadata([
+      script({}, {
+        inputs: [
+          { name: "raw", type: "str" },
+          { name: "retries", type: "int" },
+          { name: "strict", type: "bool" }
+        ],
+        outputs: [
+          { name: "formatted", type: "str" },
+          { name: "rows", type: "list" }
+        ]
+      })
+    ]);
+
+    const entry = metadata[`${CUSTOM_NODE_PREFIX}my_api.abc_123`];
+    expect(entry.title).toBe("Invoice number");
+    expect(entry.description).toBe("Formats our invoice numbers");
+    expect(entry.namespace).toBe(`${CUSTOM_NODE_PREFIX}my_api`);
+    expect(entry.supports_dynamic_inputs).toBe(true);
+    expect(entry.supports_dynamic_outputs).toBe(true);
+    expect(entry.properties).toEqual([
+      {
+        name: "raw",
+        type: { type: "str", type_args: [], optional: false },
+        default: "",
+        required: false
+      },
+      {
+        name: "retries",
+        type: { type: "int", type_args: [], optional: false },
+        default: 0,
+        required: false
+      },
+      {
+        name: "strict",
+        type: { type: "bool", type_args: [], optional: false },
+        default: false,
+        required: false
+      }
+    ]);
+    expect(entry.outputs).toEqual([
+      {
+        name: "formatted",
+        type: { type: "str", type_args: [], optional: false },
+        stream: false
+      },
+      {
+        name: "rows",
+        type: { type: "list", type_args: [], optional: false },
+        stream: false
+      }
+    ]);
+  });
+
+  it("skips a script its owner has not exposed", () => {
+    const metadata = generateCustomNodeMetadata([
+      script({}, { palette: undefined })
+    ]);
+    expect(Object.keys(metadata)).toEqual([]);
+  });
+});
+
+describe("the drop registry", () => {
+  afterEach(() => setCustomNodeScripts([]));
+
+  it("finds an exposed script by its virtual type and nothing else", () => {
+    const exposed = script();
+    setCustomNodeScripts([exposed, script({ id: "hidden" }, { palette: undefined })]);
+
+    expect(findCustomNodeScript(customNodeType(exposed))).toBe(exposed);
+    expect(findCustomNodeScript("nodetool.text.Concat")).toBeUndefined();
+    expect(findCustomNodeScript(`${CUSTOM_NODE_PREFIX}my_api.hidden`)).toBeUndefined();
+  });
+
+  it("forgets a script that is no longer exposed", () => {
+    const exposed = script();
+    setCustomNodeScripts([exposed]);
+    setCustomNodeScripts([]);
+    expect(findCustomNodeScript(customNodeType(exposed))).toBeUndefined();
+  });
+});

--- a/web/src/config/customNodeMetadata.ts
+++ b/web/src/config/customNodeMetadata.ts
@@ -1,0 +1,167 @@
+/**
+ * Node-menu metadata for the user's custom nodes.
+ *
+ * A custom node is a JS script document whose owner set `palette` on it. The
+ * records here are virtual the way snippet records are: they exist between the
+ * menu and the drop, the registry never hears about them, and the saved graph
+ * carries a plain `nodetool.code.Code` node instead
+ * (see `instantiatePaletteNode`).
+ *
+ * Ports map straight across — a script declares them, so nothing is inferred.
+ * There is no menu-side streaming-input flag: `NodeMetadata` has no such field,
+ * and the placed Code node derives it from its own body
+ * (`usesStreamInputContract`) when the graph is hydrated.
+ */
+import type { jsScripts } from "@nodetool-ai/protocol/api-schemas";
+
+import type {
+  NodeMetadata,
+  Property,
+  PropertyTypeMetadata
+} from "../stores/ApiTypes";
+
+export const CUSTOM_NODE_PREFIX = "user.";
+
+/**
+ * One saved script exposed in the menu, as the palette query hands it back.
+ * The document is structural rather than the schema type: the tRPC client's
+ * output type differs from the protocol's inferred type in optionality nothing
+ * here reads.
+ */
+export interface CustomNodeScript {
+  id: string;
+  name: string;
+  /** The version the menu pins; a dropped node records it as provenance. */
+  version: number;
+  document: {
+    description: string;
+    code: string;
+    inputs: readonly jsScripts.JsScriptPort[];
+    outputs: readonly jsScripts.JsScriptPort[];
+    packages: readonly { specifier: string }[];
+    secrets: readonly string[];
+    timeoutSeconds: number;
+    palette?: { category: string };
+  };
+}
+
+/** "My API" → "my_api". Same slugging the snippet palette uses. */
+export function categoryToSlug(category: string): string {
+  return (
+    category
+      .toLowerCase()
+      .replace(/&/g, "")
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/^_|_$/g, "") || "my_nodes"
+  );
+}
+
+/**
+ * The virtual type for one custom node. Keyed on the script id, not its name:
+ * ids are stable and unique, names collide and get renamed, and the string is
+ * never saved anywhere.
+ */
+export function customNodeType(script: CustomNodeScript): string {
+  const slug = categoryToSlug(script.document.palette?.category ?? "");
+  return `${CUSTOM_NODE_PREFIX}${slug}.${script.id.replace(/-/g, "_")}`;
+}
+
+/** Value a slot of `type` starts with when the script declares no default. */
+function defaultValueForType(
+  type: string
+): string | number | boolean | unknown[] | object | null {
+  switch (type) {
+    case "bool":
+      return false;
+    case "int":
+    case "float":
+      return 0;
+    case "list":
+      return [];
+    case "dict":
+      return {};
+    case "str":
+    case "any":
+      return "";
+    default:
+      // Media and object refs have no meaningful empty literal; the node
+      // renders an empty slot until something is connected or picked.
+      return null;
+  }
+}
+
+const typeMetadata = (type: string): PropertyTypeMetadata => ({
+  type,
+  type_args: [],
+  optional: false
+});
+
+export function generateCustomNodeMetadata(
+  scripts: readonly CustomNodeScript[]
+): Record<string, NodeMetadata> {
+  const result: Record<string, NodeMetadata> = {};
+
+  for (const script of scripts) {
+    const palette = script.document.palette;
+    if (!palette) continue;
+
+    const nodeType = customNodeType(script);
+    const namespace = `${CUSTOM_NODE_PREFIX}${categoryToSlug(palette.category)}`;
+
+    const properties: Property[] = script.document.inputs.map((port) => ({
+      name: port.name,
+      type: typeMetadata(port.type),
+      default: defaultValueForType(port.type),
+      required: false
+    }));
+
+    const outputs = script.document.outputs.map((port) => ({
+      name: port.name,
+      type: typeMetadata(port.type),
+      stream: false
+    }));
+
+    result[nodeType] = {
+      title: script.name,
+      description: script.document.description,
+      namespace,
+      node_type: nodeType,
+      layout: "default",
+      supports_dynamic_inputs: true,
+      supports_dynamic_outputs: true,
+      properties,
+      outputs,
+      recommended_models: [],
+      is_streaming_output: false,
+      required_settings: []
+    };
+  }
+
+  return result;
+}
+
+/**
+ * The scripts the menu is currently showing, keyed by their virtual type.
+ * `instantiatePaletteNode` runs synchronously, so the drop reads the document
+ * from here rather than awaiting a fetch; `useCustomNodeMetadata` publishes it
+ * from the same query that generated the metadata.
+ */
+let customNodeScripts: Record<string, CustomNodeScript> = {};
+
+export function setCustomNodeScripts(
+  scripts: readonly CustomNodeScript[]
+): void {
+  customNodeScripts = Object.fromEntries(
+    scripts
+      .filter((script) => script.document.palette !== undefined)
+      .map((script) => [customNodeType(script), script])
+  );
+}
+
+export function findCustomNodeScript(
+  nodeType: string
+): CustomNodeScript | undefined {
+  return nodeType.startsWith(CUSTOM_NODE_PREFIX)
+    ? customNodeScripts[nodeType]
+    : undefined;
+}

--- a/web/src/hooks/handlers/__tests__/usePaneEvents.test.ts
+++ b/web/src/hooks/handlers/__tests__/usePaneEvents.test.ts
@@ -186,7 +186,7 @@ describe("usePaneEvents", () => {
 
   describe("handlePaneClick", () => {
     it("creates and adds node when pendingNodeType is set", () => {
-      mockGetMetadata.mockReturnValue({ type: "test-node" });
+      mockGetMetadata.mockReturnValue({ node_type: "nodetool.test.Node" });
       const { result } = renderHook(() =>
         usePaneEvents({
           pendingNodeType: "nodetool.test.Node",

--- a/web/src/hooks/jsScript/useJsScriptAgentBridge.ts
+++ b/web/src/hooks/jsScript/useJsScriptAgentBridge.ts
@@ -119,6 +119,9 @@ export const useJsScriptAgentBridge = (scriptId: string): void => {
         if (meta.timeoutSeconds !== undefined) {
           store().setTimeoutSeconds(scriptId, meta.timeoutSeconds);
         }
+        if (meta.palette !== undefined) {
+          store().setPalette(scriptId, meta.palette);
+        }
         return snapshot();
       },
       setTests: (tests) => {

--- a/web/src/hooks/nodes/__tests__/useCodeNodeScriptLink.test.ts
+++ b/web/src/hooks/nodes/__tests__/useCodeNodeScriptLink.test.ts
@@ -15,6 +15,7 @@ jest.mock("../../../trpc/client", () => ({
     jsScripts: {
       get: { useQuery: jest.fn() },
       create: { useMutation: jest.fn() },
+      update: { useMutation: jest.fn() },
       documentVersions: { create: { useMutation: jest.fn() } }
     }
   }
@@ -39,7 +40,7 @@ const mockFindNode = jest.fn(() => ({ id: "node-1", data: nodeData }));
 const createVersion = jest.fn(async () => ({ version: 7 }));
 interface CreateScriptInput {
   name: string;
-  document: typeof scriptDocument;
+  document: typeof scriptDocument & { palette?: { category: string } };
 }
 const createScript = jest.fn(async (input: CreateScriptInput) => ({
   id: "new-script",
@@ -51,8 +52,10 @@ const versionsGet = jest.fn(async () => ({ document: scriptDocument }));
 const scriptGet = jest.fn(async () => ({
   id: "s1",
   name: "Shout",
-  document: scriptDocument
+  document: scriptDocument,
+  updatedAt: "2026-08-18T00:00:00Z"
 }));
+const updateScript = jest.fn(async () => ({ id: "s1" }));
 
 const data = (properties: Record<string, unknown> = {}): NodeData =>
   ({ properties }) as NodeData;
@@ -70,8 +73,9 @@ describe("useCodeNodeScriptLink", () => {
     nodeData = { properties: {} };
     asMock(trpc.useUtils).mockReturnValue({
       jsScripts: {
-        get: { fetch: scriptGet },
+        get: { fetch: scriptGet, invalidate: jest.fn() },
         list: { invalidate: jest.fn() },
+        palette: { invalidate: jest.fn() },
         documentVersions: {
           list: { fetch: versionsList },
           get: { fetch: versionsGet }
@@ -83,6 +87,9 @@ describe("useCodeNodeScriptLink", () => {
     });
     asMock(trpc.jsScripts.create.useMutation).mockReturnValue({
       mutateAsync: createScript
+    });
+    asMock(trpc.jsScripts.update.useMutation).mockReturnValue({
+      mutateAsync: updateScript
     });
     asMock(trpc.jsScripts.documentVersions.create.useMutation).mockReturnValue({ mutateAsync: createVersion });
   });
@@ -201,6 +208,65 @@ describe("useCodeNodeScriptLink", () => {
       id: "new-script",
       version: 7
     });
+  });
+
+  it("saves an extracted script into the node menu when given a category", async () => {
+    nodeData = stub<Partial<NodeData>>({
+      properties: { code: "await output('out', 1);" },
+      dynamic_outputs: { out: { type: "int" } }
+    });
+    const { result } = renderHook(() =>
+      useCodeNodeScriptLink("node-1", data())
+    );
+
+    await act(async () => {
+      await result.current.extractToScript("Invoice number", "My API");
+    });
+
+    expect(createScript.mock.calls[0][0].document.palette).toEqual({
+      category: "My API"
+    });
+  });
+
+  it("leaves an extracted script out of the menu when no category is given", async () => {
+    const { result } = renderHook(() =>
+      useCodeNodeScriptLink("node-1", data())
+    );
+
+    await act(async () => {
+      await result.current.extractToScript("Extracted");
+    });
+
+    expect(createScript.mock.calls[0][0].document.palette).toBeUndefined();
+  });
+
+  it("adds the linked script to the menu without touching the node", async () => {
+    const { result } = renderHook(() =>
+      useCodeNodeScriptLink("node-1", data({ script: { id: "s1", version: 2 } }))
+    );
+
+    await act(async () => {
+      await result.current.addToPalette("My API");
+    });
+
+    expect(updateScript).toHaveBeenCalledWith({
+      id: "s1",
+      document: { ...scriptDocument, palette: { category: "My API" } },
+      baseUpdatedAt: "2026-08-18T00:00:00Z"
+    });
+    expect(mockUpdateNodeData).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when an unlinked node is asked to add its script", async () => {
+    const { result } = renderHook(() =>
+      useCodeNodeScriptLink("node-1", data())
+    );
+
+    await act(async () => {
+      await result.current.addToPalette("My API");
+    });
+
+    expect(updateScript).not.toHaveBeenCalled();
   });
 
   it("detaches by dropping the link and keeping the body", () => {

--- a/web/src/hooks/nodes/useCodeNodeScriptLink.ts
+++ b/web/src/hooks/nodes/useCodeNodeScriptLink.ts
@@ -15,6 +15,10 @@ import { useCallback, useMemo } from "react";
 import { shallow } from "zustand/shallow";
 
 import type { jsScripts } from "@nodetool-ai/protocol/api-schemas";
+import {
+  materializeJsScriptNode,
+  type MaterializableJsScript
+} from "@nodetool-ai/node-sdk/js-script-materialize";
 
 import { useNodes } from "../../contexts/NodeContext";
 import { trpc, type RouterOutputs } from "../../trpc/client";
@@ -46,8 +50,13 @@ interface CodeNodeScriptLinkState {
   linkScript: (scriptId: string) => Promise<void>;
   /** Re-pin to the script's current content and re-copy it onto the node. */
   updateToLatest: () => Promise<void>;
-  /** Lift the node's body, ports, packages and secrets into a new script. */
-  extractToScript: (name: string) => Promise<string>;
+  /**
+   * Lift the node's body, ports, packages and secrets into a new script.
+   * With a `category`, the script also lands in the node menu as a custom node.
+   */
+  extractToScript: (name: string, category?: string) => Promise<string>;
+  /** Expose the linked script in the node menu under `category`. */
+  addToPalette: (category: string) => Promise<void>;
   /** Keep the pinned body inline and drop the link. */
   detach: () => void;
 }
@@ -64,24 +73,6 @@ const readLink = (value: unknown): JsScriptLink | null => {
     : null;
 };
 
-const portType = (type: string): TypeMetadata => ({
-  type,
-  optional: false,
-  type_args: []
-});
-
-const portsToSlots = (
-  ports: readonly JsScriptPort[]
-): Record<string, DynamicSlotDeclaration> =>
-  Object.fromEntries(
-    ports.map((port) => [port.name, { type: portType(port.type) }])
-  );
-
-const portsToOutputs = (
-  ports: readonly JsScriptPort[]
-): Record<string, TypeMetadata> =>
-  Object.fromEntries(ports.map((port) => [port.name, portType(port.type)]));
-
 const slotsToPorts = (
   slots: Record<string, DynamicSlotDeclaration> | undefined
 ): JsScriptPort[] =>
@@ -97,20 +88,6 @@ const outputsToPorts = (
     name,
     type: type?.type ?? "any"
   }));
-
-/**
- * The part of a script document the node copies. Structural because the tRPC
- * client's document type is the schema's *output* type, which differs from the
- * protocol's inferred type in optionality no consumer here cares about.
- */
-interface MaterializedScript {
-  code: string;
-  inputs: readonly JsScriptPort[];
-  outputs: readonly JsScriptPort[];
-  packages: readonly { specifier: string }[];
-  secrets: readonly string[];
-  timeoutSeconds: number;
-}
 
 const stringList = (value: unknown): string[] =>
   Array.isArray(value)
@@ -130,6 +107,7 @@ export function useCodeNodeScriptLink(
   );
   const utils = trpc.useUtils();
   const createScript = trpc.jsScripts.create.useMutation();
+  const updateScript = trpc.jsScripts.update.useMutation();
   const createVersion = trpc.jsScripts.documentVersions.create.useMutation();
 
   const link = useMemo(() => readLink(data.properties?.script), [
@@ -175,18 +153,18 @@ export function useCodeNodeScriptLink(
   );
 
   const materialize = useCallback(
-    (scriptId: string, version: number, document: MaterializedScript) => {
+    (scriptId: string, version: number, document: MaterializableJsScript) => {
+      const materialized = materializeJsScriptNode(document, {
+        id: scriptId,
+        version
+      });
       updateNodeData(nodeId, {
         properties: {
           ...(findNode(nodeId)?.data?.properties ?? {}),
-          script: { id: scriptId, version },
-          code: document.code,
-          packages: document.packages,
-          secrets: document.secrets,
-          timeout: document.timeoutSeconds
+          ...materialized.properties
         },
-        dynamic_inputs: portsToSlots(document.inputs),
-        dynamic_outputs: portsToOutputs(document.outputs)
+        dynamic_inputs: materialized.dynamic_inputs,
+        dynamic_outputs: materialized.dynamic_outputs
       });
     },
     [findNode, nodeId, updateNodeData]
@@ -209,7 +187,7 @@ export function useCodeNodeScriptLink(
   }, [link, materialize, pinCurrentVersion, utils]);
 
   const extractToScript = useCallback(
-    async (name: string): Promise<string> => {
+    async (name: string, category?: string): Promise<string> => {
       const node = findNode(nodeId);
       const properties = node?.data?.properties ?? {};
       const document = {
@@ -224,15 +202,38 @@ export function useCodeNodeScriptLink(
         secrets: stringList(properties.secrets),
         timeoutSeconds:
           isNumber(properties.timeout) ? properties.timeout : 30,
-        tests: []
+        tests: [],
+        palette: category === undefined ? undefined : { category }
       };
       const created = await createScript.mutateAsync({ name, document });
       const version = await pinCurrentVersion(created.id, created.document);
       materialize(created.id, version, created.document);
       void utils.jsScripts.list.invalidate();
+      void utils.jsScripts.palette.invalidate();
       return created.id;
     },
     [createScript, findNode, materialize, nodeId, pinCurrentVersion, utils]
+  );
+
+  const addToPalette = useCallback(
+    async (category: string): Promise<void> => {
+      if (!link) return;
+      const script = await utils.jsScripts.get.fetch({ id: link.id });
+      await updateScript.mutateAsync({
+        id: link.id,
+        // SAFETY: the router's output document and its input document differ
+        // only in which `unknown` fields zod marks optional; the value is the
+        // document the server just sent back.
+        document: {
+          ...script.document,
+          palette: { category }
+        } as jsScripts.JsScriptDocument,
+        baseUpdatedAt: script.updatedAt
+      });
+      void utils.jsScripts.get.invalidate({ id: link.id });
+      void utils.jsScripts.palette.invalidate();
+    },
+    [link, updateScript, utils]
   );
 
   const detach = useCallback(() => {
@@ -247,6 +248,7 @@ export function useCodeNodeScriptLink(
     linkScript,
     updateToLatest,
     extractToScript,
+    addToPalette,
     detach
   };
 }

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -58,6 +58,7 @@ import useOnboardingStore, { startRouteFor } from "./stores/OnboardingStore";
 import { useSettingsStore } from "./stores/SettingsStore";
 import useRemoteSettingsStore from "./stores/RemoteSettingStore";
 import { loadMetadata, prefetchMetadata } from "./serverState/useMetadata";
+import { useCustomNodeMetadata } from "./serverState/useCustomNodeMetadata";
 import { WorkflowManagerProvider } from "./contexts/WorkflowManagerContext";
 import KeyboardProvider from "./components/KeyboardProvider";
 import { MenuProvider } from "./providers/MenuProvider";
@@ -544,6 +545,16 @@ const root = ReactDOM.createRoot(rootElement);
  * route. "Snap to Grid" toggles the editor setting, and the setting is mirrored
  * back so the View menu checkbox matches whichever surface changed it.
  */
+/**
+ * Merges the user's custom nodes (JS scripts flagged for the node menu) into
+ * the metadata store. It lives here because the hook needs the tRPC provider,
+ * which the app root renders.
+ */
+const CustomNodeMetadataBridge = () => {
+  useCustomNodeMetadata();
+  return null;
+};
+
 const MenuNavigationBridge = () => {
   const snapToGrid = useSettingsStore((state) => state.settings.snapToGrid);
   const setSnapToGrid = useSettingsStore((state) => state.setSnapToGrid);
@@ -638,6 +649,7 @@ const AppWrapper = ({ configReady }: { configReady: Promise<unknown> }) => {
           <MobileClassProvider>
             <MenuProvider>
               <MenuNavigationBridge />
+              <CustomNodeMetadataBridge />
               <WorkflowManagerProvider queryClient={queryClient}>
                 <KeyboardProvider active={true}>
                   {status === "pending" && !isDevTestRoute && (

--- a/web/src/lib/tools/builtin/jsscript.ts
+++ b/web/src/lib/tools/builtin/jsscript.ts
@@ -137,7 +137,7 @@ FrontendToolRegistry.register({
 FrontendToolRegistry.register({
   name: "ui_jsscript_set_meta",
   description:
-    "Set the script's name, description, declared secret names, and/or timeout in seconds. Omitted fields are left alone. The description is how a later agent picks this script out of a list, so make it say what the script does. Secrets are the only ones the body may read; the timeout is capped at 120 seconds.",
+    "Set the script's name, description, declared secret names, timeout in seconds, and/or its node-menu placement. Omitted fields are left alone. The description is how a later agent picks this script out of a list, so make it say what the script does. Secrets are the only ones the body may read; the timeout is capped at 120 seconds. Setting `palette` exposes the script in the node menu as one of the user's custom nodes, under the category it names; `null` takes it back out.",
   parameters: z.object({
     script_id: scriptIdParam,
     name: z.string().optional(),
@@ -146,14 +146,33 @@ FrontendToolRegistry.register({
       .array(z.string())
       .optional()
       .describe("Secret names the body may read; [] for none."),
-    timeoutSeconds: z.number().optional()
+    timeoutSeconds: z.number().optional(),
+    palette: z
+      .object({
+        category: z
+          .string()
+          .describe("Menu grouping, e.g. 'Text' or 'My API'. Free text.")
+      })
+      .nullable()
+      .optional()
+      .describe(
+        "Show the script in the node menu under this category, or null to hide it."
+      )
   }),
-  async execute({ script_id, name, description, secrets, timeoutSeconds }) {
+  async execute({
+    script_id,
+    name,
+    description,
+    secrets,
+    timeoutSeconds,
+    palette
+  }) {
     const snapshot = getJsScriptAgentHandler(script_id).setMeta({
       name,
       description,
       secrets,
-      timeoutSeconds
+      timeoutSeconds,
+      palette
     });
     return {
       ok: true,
@@ -161,6 +180,7 @@ FrontendToolRegistry.register({
       description: snapshot.document.description,
       secrets: snapshot.document.secrets,
       timeoutSeconds: snapshot.document.timeoutSeconds,
+      palette: snapshot.document.palette ?? null,
       issues: snapshot.issues
     };
   }

--- a/web/src/serverState/useCustomNodeMetadata.ts
+++ b/web/src/serverState/useCustomNodeMetadata.ts
@@ -1,0 +1,77 @@
+/**
+ * Merge the user's custom nodes into the node menu.
+ *
+ * Custom-node metadata is user data, so it cannot ride the unauthenticated
+ * `/api/nodes/metadata` fetch `useMetadata` performs. This hook queries the
+ * scripts their owner exposed (`jsScripts.palette`), turns them into virtual
+ * `user.*` records, and merges them into `MetadataStore` once the base catalog
+ * has loaded. A `resource_change` on a js_scripts row invalidates the query, so
+ * saving, exposing or deleting a script updates the menu without a reload.
+ *
+ * Signed out or on error the query yields nothing and the menu is the shipped
+ * catalog — the merge only ever adds `user.*` keys, and rewrites all of them
+ * each pass so a script that lost its palette flag leaves.
+ */
+import { useEffect, useRef } from "react";
+
+import { trpc } from "../trpc/client";
+import useMetadataStore from "../stores/MetadataStore";
+import type { NodeMetadata } from "../stores/ApiTypes";
+import {
+  CUSTOM_NODE_PREFIX,
+  generateCustomNodeMetadata,
+  setCustomNodeScripts,
+  type CustomNodeScript
+} from "../config/customNodeMetadata";
+
+const EMPTY: readonly CustomNodeScript[] = [];
+
+export const useCustomNodeMetadata = (enabled = true): void => {
+  const query = trpc.jsScripts.palette.useQuery(undefined, {
+    enabled,
+    staleTime: 30_000
+  });
+  const metadata = useMetadataStore((state) => state.metadata);
+  const setMetadata = useMetadataStore((state) => state.setMetadata);
+  const data = query.data;
+
+  /**
+   * What the last merge saw. Without it the effect would re-merge the map it
+   * just wrote and loop; a fresh `loadMetadata` gives the map a new identity,
+   * which is exactly when the custom records have to be put back.
+   */
+  const merged = useRef<{
+    scripts: readonly CustomNodeScript[] | undefined;
+    metadata: Record<string, NodeMetadata>;
+  } | null>(null);
+
+  useEffect(() => {
+    // Before the base catalog lands there is nothing to merge into: the load
+    // replaces the map wholesale and would drop these records.
+    if (Object.keys(metadata).length === 0) return;
+    if (
+      merged.current?.scripts === data &&
+      merged.current?.metadata === metadata
+    ) {
+      return;
+    }
+
+    const scripts: readonly CustomNodeScript[] = data ?? EMPTY;
+    setCustomNodeScripts(scripts);
+    const custom = generateCustomNodeMetadata(scripts);
+
+    const base = Object.entries(metadata).filter(
+      ([nodeType]) => !nodeType.startsWith(CUSTOM_NODE_PREFIX)
+    );
+    const hadCustom = base.length !== Object.keys(metadata).length;
+    if (Object.keys(custom).length === 0 && !hadCustom) {
+      merged.current = { scripts: data, metadata };
+      return;
+    }
+    const next = { ...Object.fromEntries(base), ...custom };
+    merged.current = { scripts: data, metadata: next };
+    setMetadata(next);
+  }, [data, metadata, setMetadata]);
+};
+
+export default useCustomNodeMetadata;

--- a/web/src/stores/NodeData.ts
+++ b/web/src/stores/NodeData.ts
@@ -39,8 +39,12 @@ export type NodeData = {
   selected_generations?: string[];
   workflow_id: string;
   title?: string;
-  /** Marks snippet-backed Code nodes so the UI can lock title editing and hide code by default. */
-  codeNodeMode?: "snippet";
+  /**
+   * How a Code node came to be. `"snippet"` locks title editing and hides the
+   * code by default; `"custom"` marks one materialized from the user's own
+   * saved script, which keeps both.
+   */
+  codeNodeMode?: "snippet" | "custom";
   color?: string;
   collapsed?: boolean;
   /** Last expanded body height (px) before header-only collapse — restore on expand; not in `properties` */

--- a/web/src/stores/__tests__/resourceChangeHandler.test.ts
+++ b/web/src/stores/__tests__/resourceChangeHandler.test.ts
@@ -403,6 +403,30 @@ describe("handleResourceChange", () => {
     expect(predicate({ queryKey: ["workflows"] })).toBe(false);
   });
 
+  it("refetches both the js script list and the node menu's palette", () => {
+    handleResourceChange({
+      type: "resource_change",
+      event: "updated",
+      resource_type: "jsscript",
+      resource: { id: "script-1", updated_at: "2026-08-18T00:00:00Z" }
+    });
+
+    const predicates = (queryClient.invalidateQueries as jest.Mock).mock.calls
+      .filter((call) => isFunction(call[0]?.predicate))
+      .map(
+        (call) =>
+          call[0].predicate as (q: { queryKey: readonly unknown[] }) => boolean
+      );
+
+    const matches = (key: readonly unknown[]) =>
+      predicates.some((predicate) => predicate({ queryKey: key }));
+
+    expect(matches([["jsScripts", "list"], {}])).toBe(true);
+    expect(matches([["jsScripts", "palette"], {}])).toBe(true);
+    expect(matches([["jsScripts", "get"], {}])).toBe(false);
+    expect(matches([["scripts", "palette"], {}])).toBe(false);
+  });
+
   it("includes additional resource properties in the update", () => {
     const update: ResourceChangeUpdate = {
       type: "resource_change",

--- a/web/src/stores/jsScript/JsScriptStore.ts
+++ b/web/src/stores/jsScript/JsScriptStore.ts
@@ -30,6 +30,7 @@ import {
 export type JsScriptDocument = jsScripts.JsScriptDocument;
 export type JsScriptPort = jsScripts.JsScriptPort;
 export type JsScriptTestCase = jsScripts.JsScriptTestCase;
+export type JsScriptPalette = jsScripts.JsScriptPalette;
 
 /** Default and ceiling mirrored from the protocol schema. */
 export const JS_SCRIPT_DEFAULT_TIMEOUT_SECONDS = 30;
@@ -116,6 +117,8 @@ interface JsScriptStoreState {
   setSecrets: (scriptId: string, secrets: string[]) => void;
   setTimeoutSeconds: (scriptId: string, timeoutSeconds: number) => void;
   setTests: (scriptId: string, tests: JsScriptTestCase[]) => void;
+  /** Expose the script in the node menu, or (with null) stop exposing it. */
+  setPalette: (scriptId: string, palette: JsScriptPalette | null) => void;
 
   setLastRun: (scriptId: string, outcome: JsScriptRunOutcome | null) => void;
   setLastTest: (scriptId: string, report: JsScriptTestReport | null) => void;
@@ -359,6 +362,26 @@ export const useJsScriptStore = create<JsScriptStoreState>((set, get) => ({
   setTests: (scriptId, tests) =>
     set((state) =>
       withScript(state, scriptId, (entry) => withDocument(entry, { tests }))
+    ),
+
+  setPalette: (scriptId, palette) =>
+    set((state) =>
+      withScript(
+        state,
+        scriptId,
+        (entry) => {
+          if (palette === null) {
+            if (entry.document.palette === undefined) return entry;
+            const document = { ...entry.document };
+            delete document.palette;
+            return { ...entry, document };
+          }
+          return entry.document.palette?.category === palette.category
+            ? entry
+            : { ...entry, document: { ...entry.document, palette } };
+        },
+        { coalesceKey: "palette" }
+      )
     ),
 
   setLastRun: (scriptId, outcome) =>

--- a/web/src/stores/jsScript/__tests__/JsScriptStore.test.ts
+++ b/web/src/stores/jsScript/__tests__/JsScriptStore.test.ts
@@ -88,6 +88,24 @@ describe("JsScriptStore", () => {
     expect(store().getScript(ID)).toBe(before);
   });
 
+  it("exposes the script in the node menu and takes it back out", () => {
+    store().ensureScript(ID);
+    store().setPalette(ID, { category: "My API" });
+    expect(store().getScript(ID)?.document.palette).toEqual({
+      category: "My API"
+    });
+
+    const before = store().getScript(ID);
+    store().setPalette(ID, { category: "My API" });
+    expect(store().getScript(ID)).toBe(before);
+
+    store().setPalette(ID, null);
+    expect(store().getScript(ID)?.document).not.toHaveProperty("palette");
+    const hidden = store().getScript(ID);
+    store().setPalette(ID, null);
+    expect(store().getScript(ID)).toBe(hidden);
+  });
+
   it("undo restores the previous document and redo reapplies it", () => {
     store().ensureScript(ID);
     store().setCode(ID, "first");

--- a/web/src/stores/resourceChangeHandler.ts
+++ b/web/src/stores/resourceChangeHandler.ts
@@ -70,6 +70,16 @@ const DOCUMENT_TRPC_ROUTER = {
   application: "applications"
 } satisfies Record<SyncedDocumentType, string>;
 
+/**
+ * List-shaped procedures beyond `list` a document change must refetch. The
+ * node menu's custom nodes come from `jsScripts.palette`, so saving a script
+ * has to reach it too.
+ */
+const DOCUMENT_EXTRA_PROCEDURES: Partial<Record<SyncedDocumentType, string[]>> =
+  {
+    jsscript: ["palette"]
+  };
+
 const isSyncedDocumentType = (value: string): value is SyncedDocumentType =>
   value in DOCUMENT_TRPC_ROUTER;
 
@@ -160,7 +170,11 @@ export function handleResourceChange(update: ResourceChangeUpdate): void {
   }
 
   if (isSyncedDocumentType(resource_type)) {
-    invalidateTrpcProcedure(DOCUMENT_TRPC_ROUTER[resource_type], "list");
+    const trpcRouter = DOCUMENT_TRPC_ROUTER[resource_type];
+    invalidateTrpcProcedure(trpcRouter, "list");
+    for (const procedure of DOCUMENT_EXTRA_PROCEDURES[resource_type] ?? []) {
+      invalidateTrpcProcedure(trpcRouter, procedure);
+    }
     handleDocumentResourceChange(resource_type, {
       event,
       id: resource.id,

--- a/web/src/utils/__tests__/instantiatePaletteNode.test.ts
+++ b/web/src/utils/__tests__/instantiatePaletteNode.test.ts
@@ -29,6 +29,12 @@ jest.mock("../../components/node/codeNodeUi", () => ({
 }));
 
 import { findSnippetByNodeType } from "../../config/snippetMetadata";
+import { materializeJsScriptNode } from "@nodetool-ai/node-sdk/js-script-materialize";
+import {
+  customNodeType,
+  setCustomNodeScripts,
+  type CustomNodeScript
+} from "../../config/customNodeMetadata";
 import { CODE_GEN_PALETTE_NODE_TYPE } from "../../config/codeGenPaletteMetadata";
 import useMetadataStore from "../../stores/MetadataStore";
 import useCodeGenDialogStore from "../../stores/CodeGenDialogStore";
@@ -341,5 +347,70 @@ describe("instantiatePaletteNode", () => {
 
     expect(createNode).toHaveBeenCalledWith(metadata, { x: 5, y: 5 });
     expect(result.afterAdd).toBeUndefined();
+  });
+});
+
+describe("custom nodes", () => {
+  const script: CustomNodeScript = {
+    id: "abc-123",
+    name: "Invoice number",
+    version: 7,
+    document: {
+      description: "Formats our invoice numbers",
+      code: 'await output("formatted", inputs.raw);',
+      inputs: [{ name: "raw", type: "str" }],
+      outputs: [{ name: "formatted", type: "str" }],
+      packages: [{ specifier: "@nodetool-ai/sandbox-yaml" }],
+      secrets: ["MY_KEY"],
+      timeoutSeconds: 45,
+      palette: { category: "My API" }
+    }
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindSnippet.mockReturnValue(undefined);
+    setCustomNodeScripts([script]);
+    (useMetadataStore.getState as jest.Mock).mockReturnValue({
+      getMetadata: jest.fn().mockReturnValue(makeMetadata("nodetool.code.Code"))
+    });
+  });
+
+  afterEach(() => setCustomNodeScripts([]));
+
+  it("materializes the script the way the link hook does", () => {
+    const createNode = makeCreateNode();
+    const result = instantiatePaletteNode(
+      makeMetadata(customNodeType(script)),
+      { x: 1, y: 2 },
+      createNode
+    );
+
+    // The link hook calls the same helper, so equality here is what keeps a
+    // dropped node and a linked node identical.
+    const expected = materializeJsScriptNode(script.document, {
+      id: script.id,
+      version: script.version
+    });
+
+    expect(result.node.type).toBe("nodetool.code.Code");
+    expect(result.node.data.properties).toEqual(expected.properties);
+    expect(result.node.data.title).toBe("Invoice number");
+    expect(result.node.data.codeNodeMode).toBe("custom");
+    expect(result.afterAdd!.dynamic_inputs).toEqual(expected.dynamic_inputs);
+    expect(result.afterAdd!.dynamic_outputs).toEqual(expected.dynamic_outputs);
+    expect(result.afterAdd!.dynamic_properties).toEqual({ raw: "" });
+  });
+
+  it("pins the version the menu offered", () => {
+    const result = instantiatePaletteNode(
+      makeMetadata(customNodeType(script)),
+      { x: 0, y: 0 },
+      makeCreateNode()
+    );
+    expect(result.node.data.properties?.script).toEqual({
+      id: "abc-123",
+      version: 7
+    });
   });
 });

--- a/web/src/utils/instantiatePaletteNode.ts
+++ b/web/src/utils/instantiatePaletteNode.ts
@@ -4,6 +4,7 @@ import type { NodeMetadata, TypeMetadata } from "../stores/ApiTypes";
 import type { DynamicSlotDeclaration, NodeData } from "../stores/NodeData";
 import { defaultValueForType } from "./dynamicSlots";
 import { findSnippetByNodeType } from "../config/snippetMetadata";
+import { findCustomNodeScript } from "../config/customNodeMetadata";
 import { CODE_GEN_PALETTE_NODE_TYPE } from "../config/codeGenPaletteMetadata";
 import useMetadataStore from "../stores/MetadataStore";
 import useCodeGenDialogStore from "../stores/CodeGenDialogStore";
@@ -12,6 +13,7 @@ import {
   inferInputKeysFromCode
 } from "./codeOutputInference";
 import { CODE_NODE_TYPE } from "../components/node/codeNodeUi";
+import { materializeJsScriptNode } from "@nodetool-ai/node-sdk/js-script-materialize";
 
 /**
  * The JSON form the graph converters round-trip: `{type, type_args, optional}`.
@@ -39,10 +41,12 @@ interface PaletteNodeInstance {
 }
 
 /**
- * Turn node-menu metadata into a concrete ReactFlow node. Code snippets and
- * the "Write Code with AI" entry use a virtual `node_type` in the palette;
- * both become real `nodetool.code.Code` nodes — the snippet with its body, the
- * AI entry empty and with the generation dialog opened against it.
+ * Turn node-menu metadata into a concrete ReactFlow node. Code snippets, the
+ * user's own custom nodes (`user.*`) and the "Write Code with AI" entry use a
+ * virtual `node_type` in the palette; all three become real
+ * `nodetool.code.Code` nodes — the snippet with its body, the custom node with
+ * its script materialized and pinned, the AI entry empty and with the
+ * generation dialog opened against it.
  *
  * For snippets, call `updateNodeData(node.id, afterAdd)` after `addNode(node)` —
  * dynamic IO is merged only once the node exists in the store.
@@ -73,6 +77,38 @@ export function instantiatePaletteNode(
           });
         }
       };
+    }
+  }
+
+  const custom = findCustomNodeScript(metadata.node_type);
+  if (custom) {
+    const codeMetadata = useMetadataStore
+      .getState()
+      .getMetadata(CODE_NODE_TYPE);
+    if (codeMetadata) {
+      // The drop pins the version the user saw in the menu; editing the
+      // library script later does not touch this node until they update it.
+      const materialized = materializeJsScriptNode(custom.document, {
+        id: custom.id,
+        version: custom.version
+      });
+      const node = createNode(codeMetadata, position, {
+        ...materialized.properties
+      });
+      node.data.title = custom.name;
+      node.data.codeNodeMode = "custom";
+
+      const afterAdd: Partial<NodeData> = {
+        dynamic_inputs: materialized.dynamic_inputs,
+        dynamic_outputs: materialized.dynamic_outputs,
+        dynamic_properties: Object.fromEntries(
+          custom.document.inputs.map((port) => [
+            port.name,
+            defaultValueForType(typeMetadata(port.type))
+          ])
+        )
+      };
+      return { node, afterAdd };
     }
   }
 


### PR DESCRIPTION
## What

**Custom nodes**: user-saved node types that appear in the node menu, backed by Code nodes — "snippets, but yours". Design doc (`docs/custom-node-library-design.md`) plus the full implementation of its three phases.

A custom node is a JS script document the user opts into the palette via one optional `palette: { category }` field. The web palette surfaces flagged scripts as synthetic `user.*` node types the same way shipped snippets are surfaced, and dropping one materializes the script onto a `nodetool.code.Code` node with the existing `script: { id, version }` provenance link — so saved graphs contain only plain Code nodes and stay portable, and staleness surfaces through the already-shipped `jsScriptPortMismatches` freshness checks.

## Implementation

**Phase 1 — schema + save path** (`f77db048`)
- Optional `palette: { category }` on `JsScriptDocument` (`schemaVersion` stays 1; old saves parse unchanged). Validation: blank category is an error, exposed script with zero outputs is a warning — both proven failable by fixture tests.
- New `jsScripts.palette` tRPC query: the caller's exposed scripts with full document **and a pinned version** (snapshots at most once per content change, mirroring the link hook's `pinCurrentVersion` rule, so the menu never hands out a version whose document differs from what the user sees).
- Script editor: "Show in node menu" toggle + category field; `ui_jsscript_set_meta` and the agent bridge accept `palette`.

**Phase 2 — palette** (`72de5463`)
- `web/src/config/customNodeMetadata.ts`: `user.<categorySlug>.<scriptId>` node types, declared ports mapped to typed properties/outputs.
- `useCustomNodeMetadata`: merges the records into `MetadataStore` after base metadata load, refreshes via the existing `resource_change` invalidation, merges nothing signed-out or on error.
- `materializeJsScriptNode` in `@nodetool-ai/node-sdk` — the single port→slot mapping shared by the palette drop (`instantiatePaletteNode`) and the Code node's link hook, so drop and link cannot drift (asserted by test).
- `codeNodeMode: "custom"`, Code node "Save to My Nodes" / "Add to My Nodes" actions with a name/category dialog (ui_primitives), `user` namespace icon.

**Phase 3 — agent parity** (`6655ac4f`)
- `list_js_scripts` returns `palette`; one line of Code-node prompt guidance to check the user's saved nodes before writing a body from scratch; `expose-as-custom-node` eval case (plus a negative case) in `jsscript-tools`.

## Deviations from the design doc

- Palette data comes from a dedicated `jsScripts.palette` query rather than `list` — the drop is synchronous and needs the body, and the query pins the version.
- No `is_streaming_input` on generated metadata: `NodeMetadata` has no such field; the placed Code node derives streaming from its own body at hydration.
- Eval case is "expose a working script as a custom node" rather than the cross-surface variant — the `jsscript-tools` bridge has no graph tools and wiring them would be new harness machinery.

## Verification

- `npm run build:packages` — pass
- `npm run test:packages` — pass (image-nodes needed the documented lavapipe/WebGPU env fix; 231/231 after)
- Package tests for protocol, node-sdk, agents, websocket — pass (900 / 1154 / 3082 / 2247)
- `npm run typecheck` — web + electron pass; mobile fails only on uninstalled Expo deps in the sandbox (untouched)
- `npm run lint` — one pre-existing `@oxlint/plugins` resolution failure on the anti-slop-enforced leg, identical on the base branch; file-level findings diff vs base is empty
- `cd web && npm test` — pass (1142 suites, 13210 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnMPCPFZgxDxixsRTcaFKe