### PR TITLE
feat(cloud): drop yt-dlp from the production profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ ENV NODE_ENV=production \
 # Beyond ca-certificates/curl (health check, downloads), this bakes in the
 # CLIs that agent skill nodes (execute_bash) and document/video nodes shell
 # out to at runtime, so containers don't fail or install tools on every run:
-#   ffmpeg            — FFmpeg + yt-dlp downloader agents, video nodes
+#   ffmpeg            — FFmpeg agents/capabilities, video nodes
 #   git               — Git agent
 #   poppler-utils     — PDF agents, pdf-to-image nodes (pdftoppm/pdftotext)
 #   qpdf              — PDF agents (split/merge/optimize/check)
@@ -134,8 +134,10 @@ RUN echo 'deb http://deb.debian.org/debian bookworm-backports main' \
 # chrome-launcher (browser_* agent tools) locates the system Chromium.
 ENV CHROME_PATH=/usr/bin/chromium
 
-# Python tool venv on PATH for every execute_bash call: yt-dlp for the
-# downloader agent plus the PDF stack the PDF agent's prompt references.
+# Python tool venv on PATH for every execute_bash call: the PDF stack the PDF
+# agent's prompt references, plus yt-dlp. The cloud profile drops the yt-dlp
+# node and capability (docs/CLOUD_NODE_CURATION.md), but a self-hosted install
+# runs this same image with NODETOOL_NODE_PROFILE=full and keeps both.
 RUN python3 -m venv /opt/venv \
     && /opt/venv/bin/pip install --no-cache-dir \
        yt-dlp pypdf pdfplumber pypdfium2 reportlab \

--- a/docs/CLOUD_NODE_CURATION.md
+++ b/docs/CLOUD_NODE_CURATION.md
@@ -11,11 +11,9 @@ office-doc tooling, local model runtimes) that is powerful but "nerdy" — it
 dilutes the creative mission and balloons the support surface. The cloud profile
 drops it.
 
-> **Two exceptions,** both admitted by name rather than by namespace: the
+> **One exception,** admitted by name rather than by namespace: the
 > **sandboxed Code node** (`nodetool.code.Code`, QuickJS WASM JavaScript), the
-> intentional power-user escape hatch; and the **yt-dlp downloader**
-> (`lib.video.download.YtDlpDownload`), because bringing a clip in from a URL
-> starts most video work and the cloud image ships `yt-dlp` on PATH.
+> intentional power-user escape hatch.
 
 ## How it's enabled
 
@@ -150,8 +148,7 @@ Admitting it by name rather than whole-listing the namespace keeps any future
 - **Data/docs:** `nodetool.data` (dataframes), `nodetool.document`, `lib.pdf`,
   `lib.markdown`, `lib.html`, `lib.charts`
 - **System/automation:** `lib.os`, `nodetool.workspace`,
-  `nodetool.triggers`, `lib.browser`, `lib.video.download` (except
-  `YtDlpDownload`, kept by name)
+  `nodetool.triggers`, `lib.browser`, `lib.video.download`
 - **Databases/cloud/integrations:** `lib.sqlite`, `lib.http`, `lib.graphql`,
   `lib.mail`, `lib.secret`, `lib.comfy`
 - **Messaging:** `messaging.discord`, `messaging.telegram`
@@ -164,11 +161,32 @@ Admitting it by name rather than whole-listing the namespace keeps any future
 
 The namespace is kept. The product surface is the standard Agent plus
 Classifier, Extractor, Summarizer, CreateThread, and EnhancePrompt.
-Specialist tool-agent nodes were removed. ffmpeg, yt-dlp, and browser
-are CodeAct capabilities (`nodetool.media.ffmpeg`,
-`nodetool.media.downloadVideo`, `nodetool.web.browse`) — the same binaries the
-image installs, reached from chat and from the Code node instead of from an
-agent node.
+Specialist tool-agent nodes were removed. ffmpeg and browser are CodeAct
+capabilities (`nodetool.media.ffmpeg`, `nodetool.web.browse`) — the same
+binaries the image installs, reached from chat and from the Code node instead
+of from an agent node. yt-dlp is not: see below.
+
+## yt-dlp
+
+`lib.video.download.YtDlpDownload` was allowlisted by name, and the `yt_dlp`
+capability behind `nodetool.media.downloadVideo()` was on every belt. Both are
+off under the cloud profile.
+
+A managed multi-tenant server pulling media from arbitrary sites on a user's
+behalf is a different product from a downloader running on that user's own
+machine, and datacenter egress is what those sites block first — so the node
+offered cloud users a button that mostly returns an extractor error.
+
+The node goes through the same registry prune as everything else. The
+capability is dropped from the belt by `isYtDlpEnabled()`
+([`packages/agents/src/yt-dlp-gate.ts`](../packages/agents/src/yt-dlp-gate.ts)),
+which reads the same two env vars `isCloudProfileActive` reads, so chat and the
+Code node cannot route around the node's absence:
+`nodetool.media.downloadVideo()` throws the prelude's "not in this toolbelt"
+error. The capability itself refuses too, for a host that resolves it by name.
+
+The binary stays in the image: `docker-compose.yml` self-hosting runs the same
+image with `NODETOOL_NODE_PROFILE=full`, and that install keeps both surfaces.
 
 ## Maintenance
 

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -54,6 +54,7 @@ import {
 import { inferImageMime, persistOutput } from "../tools/asset-persist.js";
 import { persistBinaryOutput } from "../tools/binary-output.js";
 import { extractJSON } from "../utils/json-parser.js";
+import { isYtDlpEnabled } from "../yt-dlp-gate.js";
 import {
   isNonBlankString,
   isNonEmptyString,
@@ -1314,6 +1315,11 @@ const DEFAULT_YT_DLP_OUTPUT = "downloads/yt-dlp/%(id)s.%(ext)s";
 const ytDlp: CapabilityExport = {
   spec: ytDlpSpec,
   impl: async (run, params) => {
+    // The cloud profile leaves this off every belt, so a model never sees it.
+    // A host that resolves the capability by name still lands here.
+    if (!isYtDlpEnabled()) {
+      return { error: "yt_dlp is not available on this deployment" };
+    }
     const workspace = requireWorkspaceDir(run.context);
     if (!isString(workspace)) return workspace;
     const url = params["url"];

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -142,11 +142,13 @@ export {
 } from "./tools/tool-registry.js";
 export {
   BUILTIN_TOOL_NAMES,
+  availableBuiltinToolNames,
   getBuiltinTools,
   getAgentToolbelt,
   registerBuiltinTools,
   resetBuiltinToolsRegistration
 } from "./tools/builtin-tools.js";
+export { isYtDlpEnabled } from "./yt-dlp-gate.js";
 export {
   GOOGLE_WORKSPACE_TOOL_NAMES,
   getGoogleWorkspaceTools,

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -27,6 +27,7 @@
 import type { Tool } from "./base-tool.js";
 import { registerTool } from "./tool-registry.js";
 import { toolForCapabilityName } from "../capabilities/lazy-tool.js";
+import { isYtDlpEnabled } from "../yt-dlp-gate.js";
 
 export const BUILTIN_TOOL_NAMES: readonly string[] = [
   // Filesystem (workspace-relative)
@@ -128,6 +129,7 @@ export const BUILTIN_TOOL_NAMES: readonly string[] = [
   // Host media binaries
   "ffmpeg",
   "ffprobe",
+  // Dropped under the cloud profile — see `availableBuiltinToolNames`.
   "yt_dlp",
 
   // Email
@@ -148,15 +150,28 @@ export const BUILTIN_TOOL_NAMES: readonly string[] = [
  * Useful when constructing a tool list for an agent.
  */
 export function getBuiltinTools(): Tool[] {
-  return BUILTIN_TOOL_NAMES.map((name) => toolForCapabilityName(name));
+  return availableBuiltinToolNames().map((name) => toolForCapabilityName(name));
+}
+
+/**
+ * {@link BUILTIN_TOOL_NAMES} minus the ones this deployment does not offer.
+ *
+ * Only `yt_dlp` is conditional today: the cloud profile drops it (see
+ * {@link isYtDlpEnabled}), so an agent, a Code node and a JS script all see the
+ * same belt as the node catalog — one gate rather than a per-host filter.
+ */
+export function availableBuiltinToolNames(): readonly string[] {
+  if (isYtDlpEnabled()) return BUILTIN_TOOL_NAMES;
+  return BUILTIN_TOOL_NAMES.filter((name) => name !== "yt_dlp");
 }
 
 /**
  * The built-ins an agent gets. The nine provider-specific duplicates this set
  * used to subtract are gone: the media four were deleted, and the five search
  * backends became plain functions that the single `web_search` capability
- * routes to host-side. Every host therefore assembles the same belt, and
- * there is nothing left to exclude.
+ * routes to host-side. Every host therefore assembles the same belt, and the
+ * only thing subtracted from it is what the deployment does not offer
+ * ({@link availableBuiltinToolNames}).
  */
 export function getAgentToolbelt(): Tool[] {
   return getBuiltinTools();

--- a/packages/agents/src/yt-dlp-gate.ts
+++ b/packages/agents/src/yt-dlp-gate.ts
@@ -1,0 +1,30 @@
+/**
+ * Availability gate for the `yt_dlp` capability.
+ *
+ * A managed multi-tenant server pulling media from arbitrary sites on a user's
+ * behalf is a different product from a downloader running on that user's own
+ * machine, and datacenter egress is what those sites block first — so in the
+ * cloud the capability mostly spends a spawn to return an extractor error.
+ * Under the cloud profile it is left off the toolbelt entirely, which makes
+ * `nodetool.media.downloadVideo()` throw the prelude's "not in this toolbelt"
+ * error rather than fail deep inside yt-dlp.
+ *
+ * Same switch that prunes the node catalog: `NODETOOL_NODE_PROFILE=cloud`, or
+ * `NODETOOL_ENV=production` with the profile unset. A self-hosted install of
+ * the same image sets `NODETOOL_NODE_PROFILE=full` and keeps the capability,
+ * as does every local install.
+ */
+
+import {
+  CLOUD_PROFILE_ENV,
+  NODE_ENV_VAR,
+  isCloudProfileActive
+} from "@nodetool-ai/protocol";
+
+/** Whether the `yt_dlp` capability should be offered on this deployment. */
+export function isYtDlpEnabled(): boolean {
+  return !isCloudProfileActive(
+    process.env[CLOUD_PROFILE_ENV],
+    process.env[NODE_ENV_VAR]
+  );
+}

--- a/packages/agents/tests/yt-dlp-gate.test.ts
+++ b/packages/agents/tests/yt-dlp-gate.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The cloud profile drops `yt_dlp`.
+ *
+ * Two surfaces have to agree: the belt every host assembles
+ * (`availableBuiltinToolNames`), so a model never sees the tool, and the
+ * capability itself, so a host that resolves it by name still refuses.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  BUILTIN_TOOL_NAMES,
+  availableBuiltinToolNames,
+  getBuiltinTools
+} from "../src/tools/builtin-tools.js";
+import { isYtDlpEnabled } from "../src/yt-dlp-gate.js";
+import { ytDlp } from "../src/capabilities/media.js";
+import { toolFromCapability } from "../src/capabilities/adapters.js";
+import { UNGATED, createCapabilityRun } from "../src/capabilities/invoke.js";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+
+const KEYS = ["NODETOOL_NODE_PROFILE", "NODETOOL_ENV"] as const;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe("isYtDlpEnabled", () => {
+  it("is on for a local install", () => {
+    expect(isYtDlpEnabled()).toBe(true);
+  });
+
+  it("is off under the cloud profile and in production", () => {
+    process.env["NODETOOL_NODE_PROFILE"] = "cloud";
+    expect(isYtDlpEnabled()).toBe(false);
+    delete process.env["NODETOOL_NODE_PROFILE"];
+    process.env["NODETOOL_ENV"] = "production";
+    expect(isYtDlpEnabled()).toBe(false);
+  });
+
+  it("is on for a self-hosted production install", () => {
+    process.env["NODETOOL_ENV"] = "production";
+    process.env["NODETOOL_NODE_PROFILE"] = "full";
+    expect(isYtDlpEnabled()).toBe(true);
+  });
+});
+
+describe("the belt", () => {
+  it("carries yt_dlp by default", () => {
+    expect(availableBuiltinToolNames()).toContain("yt_dlp");
+    expect(getBuiltinTools().map((tool) => tool.name)).toContain("yt_dlp");
+  });
+
+  it("drops only yt_dlp under the cloud profile", () => {
+    process.env["NODETOOL_NODE_PROFILE"] = "cloud";
+    const names = availableBuiltinToolNames();
+    expect(names).not.toContain("yt_dlp");
+    expect(names).toContain("ffmpeg");
+    expect(names).toHaveLength(BUILTIN_TOOL_NAMES.length - 1);
+    expect(getBuiltinTools().map((tool) => tool.name)).not.toContain("yt_dlp");
+  });
+});
+
+describe("the capability", () => {
+  it("refuses when the profile is cloud, before touching the workspace", async () => {
+    process.env["NODETOOL_NODE_PROFILE"] = "cloud";
+    const tool = toolFromCapability(ytDlp.spec, ytDlp.impl, (context) =>
+      createCapabilityRun({ context, gate: UNGATED })
+    );
+    const result = await tool.process(
+      { workspaceDir: "/tmp" } as unknown as ProcessingContext,
+      { url: "https://example.com/clip" }
+    );
+    expect(result).toEqual({
+      error: "yt_dlp is not available on this deployment"
+    });
+  });
+});

--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -111,19 +111,20 @@ export const CLOUD_NODE_NAMESPACES: readonly string[] = [
  * - `nodetool.code.Code` — the sandboxed (QuickJS WASM) JavaScript node only.
  *   Admitting it by name rather than whole-listing `nodetool.code` keeps any
  *   future node in that namespace out of the cloud until it is reviewed.
- * - `lib.video.download.YtDlpDownload` — the one node of the otherwise-trimmed
- *   `lib.video.download` namespace. Bringing a clip in from a URL is the first
- *   step of most video work, and the cloud image ships `yt-dlp` on PATH
- *   (Dockerfile, /opt/venv), so the node runs there as it does locally. The
- *   same binary already backs the `yt_dlp` capability, which cloud users reach
- *   from chat and from the Code node — the node is the graph-shaped surface on
- *   the same thing.
+ *
+ * `lib.video.download.YtDlpDownload` used to sit here. It is out: a managed
+ * multi-tenant server pulling media from arbitrary sites on a user's behalf is
+ * a different product from a downloader running on that user's own machine,
+ * and datacenter egress is what the sites it targets block first — so the node
+ * offered cloud users a button that mostly returns an extractor error. The
+ * `yt_dlp` capability is gated on the same profile (see `isYtDlpEnabled` in
+ * `@nodetool-ai/agents`), so chat and the Code node do not route around the
+ * node's absence. Both come back under `NODETOOL_NODE_PROFILE=full`, which is
+ * what a self-hosted install of the same image runs.
  */
 export const CLOUD_NODE_ALLOWLIST: readonly string[] = [
   // Sandboxed code only.
-  "nodetool.code.Code",
-  // Media in from a URL; the binary ships in the cloud image.
-  "lib.video.download.YtDlpDownload"
+  "nodetool.code.Code"
 ];
 
 /**

--- a/packages/protocol/tests/cloud-profile.test.ts
+++ b/packages/protocol/tests/cloud-profile.test.ts
@@ -155,10 +155,10 @@ describe("code is node-level trimmed; text is whole-listed minus file I/O", () =
     }
   });
 
-  it("keeps the yt-dlp downloader without its namespace", () => {
-    // The cloud image ships yt-dlp on PATH, so the node runs there. Admitting
-    // it by name must not drag the rest of the automation surface in with it.
-    expect(isCloudNodeType("lib.video.download.YtDlpDownload")).toBe(true);
+  it("drops the yt-dlp downloader along with its namespace", () => {
+    // It was allowlisted by name once; pulling media from arbitrary sites is
+    // not something a managed multi-tenant server does on a user's behalf.
+    expect(isCloudNodeType("lib.video.download.YtDlpDownload")).toBe(false);
     expect(isCloudNodeType("lib.video.download.SomethingElse")).toBe(false);
     expect(isCloudNodeType("lib.browser.WebFetch")).toBe(false);
   });


### PR DESCRIPTION
## What

`lib.video.download.YtDlpDownload` was allowlisted by name in the cloud profile, and the `yt_dlp` capability behind `nodetool.media.downloadVideo()` sat on every belt. Both are off under that profile now.

## Why

A managed multi-tenant server pulling media from arbitrary sites on a user's behalf is a different product from a downloader running on that user's own machine, and datacenter egress is what those sites block first — so the node offered cloud users a button that mostly returns an extractor error.

## How

- `CLOUD_NODE_ALLOWLIST` loses its yt-dlp entry, so the node goes through the same registry prune as the rest of `lib.video.download`. The only entry left is the sandboxed Code node.
- New `isYtDlpEnabled()` (`packages/agents/src/yt-dlp-gate.ts`) reads the same two env vars `isCloudProfileActive` reads — `NODETOOL_NODE_PROFILE`, `NODETOOL_ENV` — so one switch governs the node catalog and the capability.
- Applied once in `availableBuiltinToolNames()`, which `getBuiltinTools()` now maps over. That is the single choke point every host assembles through (`getAgentToolbelt` → agent loop, `assembleSandboxToolbelt` → JS scripts, the Code node's own `assembleToolbelt`), so all of them see the same belt. `nodetool.media.downloadVideo()` then throws the prelude's "not in this toolbelt" error instead of failing deep inside yt-dlp.
- The capability impl refuses before touching the workspace, for a host that resolves it by name.

The binary stays in the image: self-hosting runs the same image with `NODETOOL_NODE_PROFILE=full` and keeps both surfaces. Dockerfile comments say so now.

## Tests

New `packages/agents/tests/yt-dlp-gate.test.ts` covers the three profile states (local, cloud/production, self-hosted production with `full`), asserts the belt drops `yt_dlp` and nothing else, and asserts the capability's refusal. Verified it can fail: stubbing `isYtDlpEnabled()` to `true` turns 3 of its 6 tests red.

Updated `packages/protocol/tests/cloud-profile.test.ts` — the case that pinned the node as kept now pins it as dropped.

Ran: `packages/agents` (3086 passed), `protocol`, `websocket`, `code-nodes`, `video-nodes`, web typecheck, electron typecheck, oxlint on the touched files, and `nodetool harness gate` (3/3 selfchecks).

Two pre-existing environment gaps in this sandbox, unrelated to the diff: `packages/base-nodes` image tests fail on "No WebGPU adapter available" (no Vulkan ICD installed — AGENTS.md documents this), and mobile typecheck fails on missing `node_modules` (`mobile/` is not a workspace and was not installed).

## Docs

`docs/CLOUD_NODE_CURATION.md` gains a yt-dlp section explaining the removal and where the gate lives; the "two exceptions" callout is now one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAoMLjeqTwABKYguv3C3vy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAoMLjeqTwABKYguv3C3vy)_