### PR TITLE
feat(models): move hero and hardware cards to sidebar, make format chips a real filter

### DIFF
--- a/web/src/components/hugging_face/model_list/FormatFilterChips.tsx
+++ b/web/src/components/hugging_face/model_list/FormatFilterChips.tsx
@@ -1,0 +1,43 @@
+import React, { useCallback } from "react";
+import { Chip, FlexRow, Text } from "../../ui_primitives";
+import { useModelManagerStore } from "../../../stores/ModelManagerStore";
+import { MODEL_FORMATS } from "./modelFormat";
+
+/**
+ * Weight-format filter row: one chip per format, narrowing the model list to
+ * models that carry it. Clicking the active chip clears the filter.
+ */
+const FormatFilterChips: React.FC = () => {
+  const selectedFormat = useModelManagerStore((state) => state.selectedFormat);
+  const setSelectedFormat = useModelManagerStore(
+    (state) => state.setSelectedFormat
+  );
+
+  const handleToggle = useCallback(
+    (formatId: string) => {
+      setSelectedFormat(selectedFormat === formatId ? null : formatId);
+    },
+    [selectedFormat, setSelectedFormat]
+  );
+
+  return (
+    <FlexRow gap={1} align="center" sx={{ flexWrap: "wrap", mb: 2 }}>
+      <Text size="small" color="secondary" sx={{ whiteSpace: "nowrap" }}>
+        Format
+      </Text>
+      {MODEL_FORMATS.map((format) => (
+        <Chip
+          key={format.id}
+          label={format.label}
+          size="small"
+          active={selectedFormat === format.id}
+          color={selectedFormat === format.id ? "primary" : "default"}
+          variant={selectedFormat === format.id ? "filled" : "outlined"}
+          onClick={() => handleToggle(format.id)}
+        />
+      ))}
+    </FlexRow>
+  );
+};
+
+export default React.memo(FormatFilterChips);

--- a/web/src/components/hugging_face/model_list/GoalFilterChips.tsx
+++ b/web/src/components/hugging_face/model_list/GoalFilterChips.tsx
@@ -21,7 +21,7 @@ const GoalFilterChips: React.FC = () => {
   );
 
   return (
-    <FlexRow gap={1} align="center" sx={{ flexWrap: "wrap", mb: 2 }}>
+    <FlexRow gap={1} align="center" sx={{ flexWrap: "wrap", mb: 1 }}>
       <Text size="small" color="secondary" sx={{ whiteSpace: "nowrap" }}>
         I want to
       </Text>

--- a/web/src/components/hugging_face/model_list/LocalModelsHero.tsx
+++ b/web/src/components/hugging_face/model_list/LocalModelsHero.tsx
@@ -55,8 +55,7 @@ const LocalModelsHero: React.FC<LocalModelsHeroProps> = ({ models }) => {
       sx={{
         borderRadius: BORDER_RADIUS.lg,
         border: `1px solid ${theme.vars.palette.divider}`,
-        backgroundColor: theme.vars.palette.background.paper,
-        marginBottom: "1.25rem"
+        backgroundColor: theme.vars.palette.background.paper
       }}
     >
       <FlexRow gap={2} align="center" sx={{ flexWrap: "wrap" }}>

--- a/web/src/components/hugging_face/model_list/ModelListIndex.tsx
+++ b/web/src/components/hugging_face/model_list/ModelListIndex.tsx
@@ -19,10 +19,9 @@ import { IconForType } from "../../../config/IconForType";
 import { useModelManagerStore } from "../../../stores/ModelManagerStore";
 import ModelListItem from "./ModelListItem";
 import ModelsRightSidebar from "./ModelsRightSidebar";
-import LocalModelsHero from "./LocalModelsHero";
 import GoalFilterChips from "./GoalFilterChips";
+import FormatFilterChips from "./FormatFilterChips";
 import ModelOnboarding from "../onboarding/ModelOnboarding";
-import HardwareCard from "../onboarding/HardwareCard";
 import { useHardwareProfile } from "../onboarding/useHardwareProfile";
 import { useModelDownloadStore } from "../../../stores/ModelDownloadStore";
 import type { UnifiedModel } from "../../../stores/ApiTypes";
@@ -177,7 +176,8 @@ const ModelListIndex: React.FC = () => {
     scope, setScope,
     source, setSource,
     sourceInitialized, setSourceInitialized,
-    setSelectedGoal
+    setSelectedGoal,
+    setSelectedFormat
   } = useModelManagerStore(
     useShallow((state) => ({
       selectedModelType: state.selectedModelType,
@@ -190,7 +190,8 @@ const ModelListIndex: React.FC = () => {
       setSource: state.setSource,
       sourceInitialized: state.sourceInitialized,
       setSourceInitialized: state.setSourceInitialized,
-      setSelectedGoal: state.setSelectedGoal
+      setSelectedGoal: state.setSelectedGoal,
+      setSelectedFormat: state.setSelectedFormat
     }))
   );
   const hardwareProfile = useHardwareProfile();
@@ -262,8 +263,16 @@ const ModelListIndex: React.FC = () => {
       setModelSearchTerm("");
       setSelectedModelType("All");
       setSelectedGoal(null);
+      setSelectedFormat(null);
     },
-    [scope, setScope, setModelSearchTerm, setSelectedModelType, setSelectedGoal]
+    [
+      scope,
+      setScope,
+      setModelSearchTerm,
+      setSelectedModelType,
+      setSelectedGoal,
+      setSelectedFormat
+    ]
   );
 
   const handleSourceChange = useCallback(
@@ -280,6 +289,7 @@ const ModelListIndex: React.FC = () => {
       setModelSearchTerm("");
       setSelectedModelType("All");
       setSelectedGoal(null);
+      setSelectedFormat(null);
     },
     [
       source,
@@ -287,7 +297,8 @@ const ModelListIndex: React.FC = () => {
       setSourceInitialized,
       setModelSearchTerm,
       setSelectedModelType,
-      setSelectedGoal
+      setSelectedGoal,
+      setSelectedFormat
     ]
   );
 
@@ -517,13 +528,8 @@ const ModelListIndex: React.FC = () => {
         </Box>
 
         <Box className="content">
-          <LocalModelsHero models={allModels ?? []} />
-          {source === "recommended" && (
-            <Box sx={{ mb: 2 }}>
-              <HardwareCard profile={hardwareProfile} />
-            </Box>
-          )}
           <GoalFilterChips />
+          <FormatFilterChips />
           {isFetching && (
             <Box sx={{ position: "absolute", top: "1em", right: "1em", zIndex: Z_INDEX.raised }}>
               <LoadingSpinner size="small" />
@@ -744,7 +750,10 @@ const ModelListIndex: React.FC = () => {
         </Box>
 
         <Box className="right-sidebar">
-          <ModelsRightSidebar />
+          <ModelsRightSidebar
+            models={allModels ?? []}
+            hardwareProfile={hardwareProfile}
+          />
         </Box>
           </>
         )}

--- a/web/src/components/hugging_face/model_list/ModelsRightSidebar.tsx
+++ b/web/src/components/hugging_face/model_list/ModelsRightSidebar.tsx
@@ -6,22 +6,24 @@ import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import {
   Card,
   Caption,
-  Chip,
   EditorButton,
   FlexColumn,
   FlexRow,
   Text, BORDER_RADIUS } from "../../ui_primitives";
+import type { UnifiedModel } from "../../../stores/ApiTypes";
+import type { HardwareProfile } from "../onboarding/useHardwareProfile";
+import HardwareCard from "../onboarding/HardwareCard";
+import LocalModelsHero from "./LocalModelsHero";
 
-const SUPPORTED_FORMATS = [
-  { label: "GGUF", primary: true },
-  { label: "ONNX" },
-  { label: "Safetensors" },
-  { label: "PyTorch" },
-  { label: "TensorRT" },
-  { label: "MLX" }
-];
+interface ModelsRightSidebarProps {
+  models: UnifiedModel[];
+  hardwareProfile: HardwareProfile;
+}
 
-const ModelsRightSidebar: React.FC = () => {
+const ModelsRightSidebar: React.FC<ModelsRightSidebarProps> = ({
+  models,
+  hardwareProfile
+}) => {
   const theme = useTheme();
 
   return (
@@ -35,44 +37,9 @@ const ModelsRightSidebar: React.FC = () => {
         overflowX: "hidden"
       }}
     >
-      <Card
-        variant="outlined"
-        padding="normal"
-        sx={{
-          borderRadius: BORDER_RADIUS.lg,
-          border: `1px solid ${theme.vars.palette.divider}`
-        }}
-      >
-        <Text size="small" weight={600} sx={{ marginBottom: "0.75rem" }}>
-          Supported Formats
-        </Text>
-        <FlexRow gap={0.5} sx={{ flexWrap: "wrap" }}>
-          {SUPPORTED_FORMATS.map((fmt) => (
-            <Chip
-              key={fmt.label}
-              label={fmt.label}
-              compact
-              variant={fmt.primary ? "filled" : "outlined"}
-              color={fmt.primary ? "success" : "default"}
-              sx={{
-                fontSize: theme.fontSizeSmaller,
-                fontWeight: 500,
-                height: 22,
-                ...(fmt.primary
-                  ? {
-                      backgroundColor: `rgba(${theme.vars.palette.success.mainChannel} / 0.16)`,
-                      color: theme.vars.palette.success.main,
-                      borderColor: `rgba(${theme.vars.palette.success.mainChannel} / 0.4)`
-                    }
-                  : {
-                      borderColor: theme.vars.palette.divider,
-                      color: theme.vars.palette.text.secondary
-                    })
-              }}
-            />
-          ))}
-        </FlexRow>
-      </Card>
+      <LocalModelsHero models={models} />
+
+      <HardwareCard profile={hardwareProfile} />
 
       <Card
         variant="outlined"

--- a/web/src/components/hugging_face/model_list/__tests__/modelFormat.test.ts
+++ b/web/src/components/hugging_face/model_list/__tests__/modelFormat.test.ts
@@ -1,0 +1,64 @@
+import { formatsForModel, MODEL_FORMATS } from "../modelFormat";
+import type { UnifiedModel } from "../../../../stores/ApiTypes";
+
+const model = (overrides: Partial<UnifiedModel>): UnifiedModel => ({
+  id: "test/model",
+  name: "model",
+  ...overrides
+});
+
+describe("formatsForModel", () => {
+  it("classifies Ollama models as GGUF", () => {
+    expect(formatsForModel(model({ type: "llama_model" }))).toContain("gguf");
+  });
+
+  it("classifies transformers.js models as ONNX", () => {
+    expect(
+      formatsForModel(model({ type: "tjs.text_generation" }))
+    ).toContain("onnx");
+  });
+
+  it("reads formats from Hub tags", () => {
+    const formats = formatsForModel(
+      model({ tags: ["GGUF", "safetensors", "text-generation"] })
+    );
+    expect(formats).toContain("gguf");
+    expect(formats).toContain("safetensors");
+    expect(formats).not.toContain("pytorch");
+  });
+
+  it("reads formats from file extensions in path", () => {
+    expect(
+      formatsForModel(model({ path: "unet/flux-dev.safetensors" }))
+    ).toContain("safetensors");
+    expect(formatsForModel(model({ path: "model.onnx" }))).toContain("onnx");
+    expect(formatsForModel(model({ path: "weights.gguf" }))).toContain("gguf");
+    expect(formatsForModel(model({ path: "model.bin" }))).toContain("pytorch");
+  });
+
+  it("reads format markers from the repo id", () => {
+    expect(
+      formatsForModel(model({ repo_id: "TheBloke/Mistral-7B-GGUF" }))
+    ).toContain("gguf");
+    expect(
+      formatsForModel(model({ repo_id: "mlx-community/Qwen3-4B-4bit" }))
+    ).toContain("mlx");
+  });
+
+  it("does not match markers inside larger words", () => {
+    // "mlx" inside "html-xtra" must not count as an MLX marker.
+    expect(formatsForModel(model({ name: "htmlxtra" }))).not.toContain("mlx");
+  });
+
+  it("returns an empty set when nothing identifies a format", () => {
+    expect(formatsForModel(model({ type: "hf.text_generation" })).size).toBe(0);
+  });
+
+  it("every catalog format id is lowercase and unique", () => {
+    const ids = MODEL_FORMATS.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) {
+      expect(id).toBe(id.toLowerCase());
+    }
+  });
+});

--- a/web/src/components/hugging_face/model_list/modelFormat.ts
+++ b/web/src/components/hugging_face/model_list/modelFormat.ts
@@ -1,0 +1,82 @@
+import type { UnifiedModel } from "../../../stores/ApiTypes";
+
+/**
+ * Weight-format classification for the model manager's format filter.
+ *
+ * The list has no explicit format field, so the format is read from what the
+ * model does carry: its runtime type (`llama_model` runs GGUF, `tjs.*` runs
+ * ONNX), Hub tags, file extensions in `path`/`cache_path`, and format markers
+ * in the repo id or name (e.g. `mlx-community/...`, `...-GGUF`).
+ */
+
+export interface ModelFormat {
+  id: string;
+  label: string;
+}
+
+export const MODEL_FORMATS: readonly ModelFormat[] = [
+  { id: "gguf", label: "GGUF" },
+  { id: "onnx", label: "ONNX" },
+  { id: "safetensors", label: "Safetensors" },
+  { id: "pytorch", label: "PyTorch" },
+  { id: "tensorrt", label: "TensorRT" },
+  { id: "mlx", label: "MLX" }
+];
+
+const EXTENSION_FORMATS: Record<string, string> = {
+  gguf: "gguf",
+  onnx: "onnx",
+  safetensors: "safetensors",
+  pt: "pytorch",
+  pth: "pytorch",
+  bin: "pytorch"
+};
+
+/** Format markers matched as whole words in the repo id / name / path. */
+const NAME_MARKERS: Record<string, RegExp> = {
+  gguf: /(^|[^a-z0-9])gguf([^a-z0-9]|$)/,
+  onnx: /(^|[^a-z0-9])onnx([^a-z0-9]|$)/,
+  mlx: /(^|[^a-z0-9])mlx([^a-z0-9]|$)/,
+  tensorrt: /(^|[^a-z0-9])(tensorrt|trt)([^a-z0-9]|$)/
+};
+
+/** Which weight formats a model carries, by id from `MODEL_FORMATS`. */
+export const formatsForModel = (model: UnifiedModel): Set<string> => {
+  const result = new Set<string>();
+
+  const type = model.type ?? "";
+  if (type === "llama_model") {
+    result.add("gguf");
+  }
+  // transformers.js runs ONNX exports.
+  if (type.startsWith("tjs")) {
+    result.add("onnx");
+  }
+
+  for (const tag of model.tags ?? []) {
+    const normalized = tag.toLowerCase();
+    if (MODEL_FORMATS.some((f) => f.id === normalized)) {
+      result.add(normalized);
+    }
+  }
+
+  for (const path of [model.path, model.cache_path]) {
+    const ext = path?.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1];
+    const format = ext ? EXTENSION_FORMATS[ext] : undefined;
+    if (format) {
+      result.add(format);
+    }
+  }
+
+  const haystack = [model.repo_id, model.name, model.id, model.path]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  for (const [format, marker] of Object.entries(NAME_MARKERS)) {
+    if (marker.test(haystack)) {
+      result.add(format);
+    }
+  }
+
+  return result;
+};

--- a/web/src/components/hugging_face/model_list/useModels.ts
+++ b/web/src/components/hugging_face/model_list/useModels.ts
@@ -18,6 +18,7 @@ import { isHfModel } from "../../../utils/hfCache";
 import { isLocalProvider } from "../../../utils/providerDisplay";
 import useMetadataStore from "../../../stores/MetadataStore";
 import { compareModelsByFit, goalsForModel } from "./modelFit";
+import { formatsForModel } from "./modelFormat";
 import { useHardwareProfile } from "../onboarding/useHardwareProfile";
 
 /**
@@ -144,6 +145,7 @@ export const useModels = (scope: ModelScope = "local"): UseModelsResult => {
   );
   const source = useModelManagerStore((state) => state.source);
   const selectedGoal = useModelManagerStore((state) => state.selectedGoal);
+  const selectedFormat = useModelManagerStore((state) => state.selectedFormat);
   const recommendedCatalog = useMetadataStore((state) => state.recommendedModels);
   const { budgetGb } = useHardwareProfile();
 
@@ -236,6 +238,9 @@ export const useModels = (scope: ModelScope = "local"): UseModelsResult => {
       if (selectedGoal && !goalsForModel(model).has(selectedGoal)) {
         return false;
       }
+      if (selectedFormat && !formatsForModel(model).has(selectedFormat)) {
+        return false;
+      }
       if (
         maxModelSizeGB &&
         model.size_on_disk &&
@@ -253,6 +258,7 @@ export const useModels = (scope: ModelScope = "local"): UseModelsResult => {
     modelSearchTerm,
     selectedModelType,
     selectedGoal,
+    selectedFormat,
     maxModelSizeGB,
     sortField,
     sortDirection,
@@ -307,6 +313,9 @@ export const useModels = (scope: ModelScope = "local"): UseModelsResult => {
         if (selectedGoal && !goalsForModel(model).has(selectedGoal)) {
           return false;
         }
+        if (selectedFormat && !formatsForModel(model).has(selectedFormat)) {
+          return false;
+        }
         if (
           maxModelSizeGB &&
           model.size_on_disk &&
@@ -324,7 +333,14 @@ export const useModels = (scope: ModelScope = "local"): UseModelsResult => {
     });
 
     return types;
-  }, [allModels, source, modelSearchTerm, selectedGoal, maxModelSizeGB]);
+  }, [
+    allModels,
+    source,
+    modelSearchTerm,
+    selectedGoal,
+    selectedFormat,
+    maxModelSizeGB
+  ]);
 
   const modelCountsByType = useMemo(() => {
     const counts: Record<string, number> = {};

--- a/web/src/stores/ModelManagerStore.ts
+++ b/web/src/stores/ModelManagerStore.ts
@@ -43,6 +43,11 @@ interface ModelManagerState {
    * list to models that serve it. `null` means "all goals".
    */
   selectedGoal: string | null;
+  /**
+   * Active weight-format filter (`MODEL_FORMATS` id from `modelFormat.ts`),
+   * narrowing the list to models carrying it. `null` means "all formats".
+   */
+  selectedFormat: string | null;
   setIsOpen: (isOpen: boolean) => void;
   setModelSearchTerm: (term: string) => void;
   setSelectedModelType: (type: string) => void;
@@ -55,6 +60,7 @@ interface ModelManagerState {
   setSourceInitialized: (initialized: boolean) => void;
   setVramOverrideGb: (gb: number | null) => void;
   setSelectedGoal: (goal: string | null) => void;
+  setSelectedFormat: (format: string | null) => void;
 }
 
 export const useModelManagerStore = create<ModelManagerState>()(
@@ -71,6 +77,7 @@ export const useModelManagerStore = create<ModelManagerState>()(
       sourceInitialized: false,
       vramOverrideGb: null,
       selectedGoal: null,
+      selectedFormat: null,
       setIsOpen: (isOpen) => set({ isOpen }),
       setModelSearchTerm: (term) => set({ modelSearchTerm: term }),
       setSelectedModelType: (type) => set({ selectedModelType: type }),
@@ -86,7 +93,8 @@ export const useModelManagerStore = create<ModelManagerState>()(
       setSourceInitialized: (initialized) =>
         set({ sourceInitialized: initialized }),
       setVramOverrideGb: (gb) => set({ vramOverrideGb: gb }),
-      setSelectedGoal: (goal) => set({ selectedGoal: goal })
+      setSelectedGoal: (goal) => set({ selectedGoal: goal }),
+      setSelectedFormat: (format) => set({ selectedFormat: format })
     }),
     {
       name: "model-manager",


### PR DESCRIPTION
## What

Reworks the Model Manager layout per feedback on the screenshot:

- **Local Models hero and the "Your machine" hardware card move into the right sidebar.** They no longer sit above the model list; the list gets the vertical space back. The hardware card (with the GPU-memory override select) is now always visible in the sidebar, not only on the Recommended tab.
- **The static "Supported Formats" card is gone.** In its place, a **Format** chip row sits in the top filter area next to the goal chips, and it actually filters the list: GGUF, ONNX, Safetensors, PyTorch, TensorRT, MLX. Clicking the active chip clears the filter.

## How

- New `modelFormat.ts` classifies a model's weight formats from what the list carries: runtime type (`llama_model` → GGUF, `tjs.*` → ONNX), Hub tags, file extensions in `path`/`cache_path`, and whole-word markers in the repo id/name (`...-GGUF`, `mlx-community/...`).
- `ModelManagerStore` gains a session-scoped `selectedFormat`; `useModels` applies it in the list filter and the sidebar type-availability filter. Scope and source switches reset it like the other filters.
- `ModelsRightSidebar` now takes the model list and hardware profile and renders `LocalModelsHero` + `HardwareCard` above the help card.

## Tests

- New `modelFormat.test.ts` covers type/tag/extension/marker detection, the no-marker-inside-words boundary, and the empty case.
- Full web suite green: 12 model-list/onboarding suites plus the whole `npm test` run (exit 0). `npm run typecheck` and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FqCcrCpVUW8rsRzq3zDp1

---
_Generated by [Claude Code](https://claude.ai/code/session_014FqCcrCpVUW8rsRzq3zDp1)_