### PR TITLE
fix(web): open assets on tap instead of deleting them on touch

### DIFF
--- a/web/src/components/assets/AssetItem.tsx
+++ b/web/src/components/assets/AssetItem.tsx
@@ -16,6 +16,7 @@ import { formatFileSize } from "../../utils/formatUtils";
 import { useSettingsStore } from "../../stores/SettingsStore";
 import { useAssetActions } from "./useAssetActions";
 import { useActivateOnKey } from "../../hooks/useActivateOnKey";
+import { isCoarsePointer } from "../../utils/isCoarsePointer";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 
@@ -32,6 +33,9 @@ const styles = (theme: Theme) =>
       height: "100%",
       cursor: "grab",
       minHeight: "30px",
+      // Without this a phone waits for a second tap before dispatching the
+      // first click, and double-tap zooms the panel instead of opening.
+      touchAction: "manipulation",
       boxSizing: "border-box",
       WebkitBoxSizing: "border-box",
       MozBoxSizing: "border-box"
@@ -239,6 +243,14 @@ const styles = (theme: Theme) =>
       pointerEvents: "all",
       opacity: 1
     },
+    // A phone keeps :hover on the tile it last tapped, which would leave this
+    // button live over the thumbnail — the next tap deletes instead of opens.
+    // Touch deletes through the long-press context menu.
+    "@media (pointer: coarse)": {
+      ".asset-delete-overlay": {
+        display: "none"
+      }
+    },
     "&.image": {
       background: "transparent",
       backgroundRepeat: "no-repeat",
@@ -416,7 +428,11 @@ const AssetItem: React.FC<AssetItemProps> = (props) => {
   // Memoize click handler to prevent unnecessary re-renders
   const handleItemClick = useCallback(() => {
     handleClick(onSelect, onClickParent, isParent);
-  }, [handleClick, onSelect, onClickParent, isParent]);
+    // Touch has no reliable dblclick, so a tap has to both select and open.
+    if (!isParent && isCoarsePointer()) {
+      onDoubleClick?.(asset);
+    }
+  }, [handleClick, onSelect, onClickParent, isParent, onDoubleClick, asset]);
 
   const handleItemKeyDown = useActivateOnKey(handleItemClick);
 
@@ -449,7 +465,7 @@ const AssetItem: React.FC<AssetItemProps> = (props) => {
       onDragOver={handleDragOver}
     >
       {showDeleteButton && (
-        <div css={deleteButtonOverlayStyle}>
+        <div className="asset-delete-overlay" css={deleteButtonOverlayStyle}>
           <DeleteButton
             className="asset-delete"
             onClick={handleDelete}

--- a/web/src/components/assets/AssetListView.tsx
+++ b/web/src/components/assets/AssetListView.tsx
@@ -14,6 +14,7 @@ import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { ExpandCollapseButton, EmptyState, Text, Box, MOTION, BORDER_RADIUS, Z_INDEX } from "../ui_primitives";
 import { useSettingsStore } from "../../stores/SettingsStore";
+import { isCoarsePointer } from "../../utils/isCoarsePointer";
 
 interface AssetListViewProps {
   assets: Asset[];
@@ -449,6 +450,10 @@ const AssetListView: React.FC<AssetListViewProps> = ({
         onClick={(e) => {
           e.stopPropagation();
           handleSelectAsset(asset.id);
+          // Touch has no reliable dblclick, so a tap has to both select and open.
+          if (isCoarsePointer()) {
+            onDoubleClick?.(asset);
+          }
         }}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {

--- a/web/src/components/assets/FolderItem.tsx
+++ b/web/src/components/assets/FolderItem.tsx
@@ -78,13 +78,23 @@ const styles = (theme: Theme) =>
       fontWeight: 600
     },
     "&:hover .delete-button": {
+      pointerEvents: "all",
       opacity: 1
+    },
+    // A phone keeps :hover on the row it last tapped, which would leave this
+    // button live over the folder name. Touch deletes through the context menu.
+    "@media (pointer: coarse)": {
+      ".delete-button": {
+        display: "none"
+      }
     },
     "&.drag-hover": {
       backgroundColor: theme.vars.palette.grey[500]
     },
     ".delete-button": {
       position: "absolute",
+      // Transparent, so it must not swallow clicks meant for the folder.
+      pointerEvents: "none",
       opacity: 0,
       width: "20px",
       minWidth: "20px",

--- a/web/src/components/assets/__tests__/AssetItem.test.tsx
+++ b/web/src/components/assets/__tests__/AssetItem.test.tsx
@@ -54,8 +54,12 @@ const baseImageAsset: Asset = {
 const mockUseSettingsStore = useSettingsStore as jest.MockedFunction<typeof useSettingsStore>;
 
 describe("AssetItem", () => {
+  const originalMatchMedia = window.matchMedia;
   beforeEach(() => {
     mockUseSettingsStore.mockReturnValue(4);  // Return assetItemSize directly
+  });
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
   });
   it("renders name and filetype info", () => {
     renderWithTheme(
@@ -75,6 +79,41 @@ describe("AssetItem", () => {
     );
     fireEvent.click(screen.getAllByLabelText(baseImageAsset.id)[0]);
     expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the asset on a single tap when the pointer is coarse", () => {
+    const onDoubleClick = jest.fn();
+    // jsdom has no matchMedia; a coarse pointer is what a phone reports.
+    window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+      matches: query.includes("pointer: coarse")
+    })) as unknown as typeof window.matchMedia;
+    renderWithTheme(
+      <AssetItem
+        asset={baseImageAsset}
+        onDoubleClick={onDoubleClick}
+        showDeleteButton={false}
+      />
+    );
+    fireEvent.click(screen.getAllByLabelText(baseImageAsset.id)[0]);
+    expect(onDoubleClick).toHaveBeenCalledWith(baseImageAsset);
+  });
+
+  it("leaves opening to the double click when the pointer is fine", () => {
+    const onDoubleClick = jest.fn();
+    window.matchMedia = jest.fn().mockImplementation(() => ({
+      matches: false
+    })) as unknown as typeof window.matchMedia;
+    renderWithTheme(
+      <AssetItem
+        asset={baseImageAsset}
+        onDoubleClick={onDoubleClick}
+        showDeleteButton={false}
+      />
+    );
+    fireEvent.click(screen.getAllByLabelText(baseImageAsset.id)[0]);
+    expect(onDoubleClick).not.toHaveBeenCalled();
+    fireEvent.doubleClick(screen.getAllByLabelText(baseImageAsset.id)[0]);
+    expect(onDoubleClick).toHaveBeenCalledWith(baseImageAsset);
   });
 
   it("paints an SVG from get_url, not a raster thumb", () => {

--- a/web/src/utils/isCoarsePointer.ts
+++ b/web/src/utils/isCoarsePointer.ts
@@ -1,0 +1,10 @@
+/**
+ * True when the primary pointer is touch-like.
+ *
+ * Read at call time instead of through `useMediaQuery`: the answer is only
+ * needed inside an event handler, and a hook would add one media-query
+ * subscription per asset tile. `matchMedia` is absent in jsdom.
+ */
+export const isCoarsePointer = (): boolean =>
+  typeof window.matchMedia === "function" &&
+  window.matchMedia("(pointer: coarse)").matches;


### PR DESCRIPTION
On a phone, tapping an asset in the asset manager opened the delete dialog, and there was no way to open the asset at all.

## What was wrong

Two defects compound:

1. **No open gesture on touch.** `AssetFilesPanel` opens an asset from `onDoubleClick` only. A phone does not deliver `dblclick` reliably — the tile also had no `touch-action`, so the browser held the first click waiting to see whether the tap was a zoom.

2. **The delete button becomes a live tap target after the first tap.** `AssetItem` gates it on `&.selected:hover`:

   ```
   ".asset-delete": { pointerEvents: "none", opacity: 0 },
   "&.selected:hover .asset-delete": { pointerEvents: "all", opacity: 1 }
   ```

   A touch browser keeps `:hover` on the element it last tapped. So the first tap selects the tile, `:hover` sticks, and the 30px trash button lights up in the corner of a ~92px thumbnail — the next tap opens the delete dialog.

`FolderItem` had a third, device-independent variant: its `.delete-button` was `opacity: 0` with no `pointer-events: none`, so an invisible-but-clickable button sat over the right edge of every folder row.

## Changes

- New `web/src/utils/isCoarsePointer.ts` — reads `(pointer: coarse)` at call time rather than through `useMediaQuery`, so it costs no media-query subscription per tile.
- `AssetItem`: a coarse-pointer click calls `onDoubleClick` as well as `onSelect`, so a single tap opens; `touch-action: manipulation` on the tile; the delete overlay is `display: none` under `@media (pointer: coarse)`.
- `AssetListView`: same single-tap-opens rule for list rows.
- `FolderItem`: `pointer-events: none` while the delete button is transparent, `all` on hover, and hidden under `@media (pointer: coarse)`.

Deleting on touch stays available through the long-press context menu, which already carries Delete.

## Tests

Two cases in `AssetItem.test.tsx` pin both directions: a coarse pointer opens on a single click, a fine pointer still requires the double click. Verified the coarse case fails when the branch is removed.

`npm run typecheck`, `npm run lint`, and `npm run test` (web + electron) pass. Mobile's Jest preset is not installed in this sandbox; nothing under `mobile/` changed. Backend packages are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPEkToNpSpcRjSKtUJeMtu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPEkToNpSpcRjSKtUJeMtu)_