### PR TITLE
fix(agents,web): make generated media pickable, reusable, and visible

### DIFF
--- a/packages/agents/src/capabilities/assets.ts
+++ b/packages/agents/src/capabilities/assets.ts
@@ -34,6 +34,7 @@ import {
 import type { Asset as AssetRow } from "@nodetool-ai/models";
 import { loadMediaRefBytes, safeFetch } from "@nodetool-ai/runtime";
 import { mimeForPath } from "../sandbox-media-ref.js";
+import { MIME_TO_EXT } from "../tools/asset-persist.js";
 import { userIdOf } from "../tools/mcp-tool-support.js";
 import type {
   CapabilityExport,
@@ -324,6 +325,18 @@ async function readSourceBytes(
   return { bytes };
 }
 
+/**
+ * The `.<ext>` an `asset://` URI carries, from the saved name or its MIME
+ * type. Empty when neither names one — a suffix guessed wrong is worse than
+ * none, since it is what a renderer types the media by.
+ */
+function assetUriSuffix(name: string, mime: string): string {
+  const fromName = /\.([A-Za-z0-9]{1,8})$/.exec(name);
+  if (fromName) return `.${fromName[1].toLowerCase()}`;
+  const ext = MIME_TO_EXT[mime];
+  return ext ? `.${ext}` : "";
+}
+
 const saveAsset: CapabilityExport = {
   spec: saveAssetSpec,
   impl: async (run, params) => {
@@ -419,7 +432,11 @@ const saveAsset: CapabilityExport = {
             success: true,
             name,
             asset_id: asset.id,
-            asset_uri: `asset://${asset.id}`,
+            // With the extension: a chat embed of `asset://<id>` alone has no
+            // way to tell a video from an image and renders it as one, which
+            // is how a saved mp4 came back as a broken image. `generate_*`
+            // already returns the suffixed form.
+            asset_uri: `asset://${asset.id}${assetUriSuffix(name, mime)}`,
             content_type: mime,
             size: data.byteLength
           };

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -122,6 +122,29 @@ interface MediaModelArgs {
   model: string;
 }
 
+/**
+ * A provider rejection, with the model that was called in it.
+ *
+ * "text_to_video failed: Unprocessable Entity" told a live session nothing:
+ * the model it had picked was an image-to-video endpoint, and the message
+ * named neither the model nor the way out. `find_model` now filters by
+ * direction, and when a provider still refuses, the error says which model to
+ * re-pick.
+ */
+function predictionError(
+  capability: string,
+  m: MediaModelArgs,
+  e: unknown
+): { error: string } {
+  const detail = e instanceof Error ? e.message : String(e);
+  return {
+    error:
+      `${capability} failed for ${m.provider}:${m.model} — ${detail}. ` +
+      `If the model does not do ${capability}, pick another with ` +
+      `find_model({capability: "${capability}"}).`
+  };
+}
+
 function parseModelArgs(
   params: Record<string, unknown>
 ): MediaModelArgs | { error: string } {
@@ -203,9 +226,7 @@ const generateImage: CapabilityExport = {
         ...persisted
       };
     } catch (e) {
-      return {
-        error: `text_to_image failed: ${e instanceof Error ? e.message : String(e)}`
-      };
+      return predictionError("text_to_image", m, e);
     }
   }
 };
@@ -252,9 +273,7 @@ const editImage: CapabilityExport = {
         ...persisted
       };
     } catch (e) {
-      return {
-        error: `image_to_image failed: ${e instanceof Error ? e.message : String(e)}`
-      };
+      return predictionError("image_to_image", m, e);
     }
   }
 };
@@ -296,9 +315,7 @@ const generateVideo: CapabilityExport = {
         ...persisted
       };
     } catch (e) {
-      return {
-        error: `text_to_video failed: ${e instanceof Error ? e.message : String(e)}`
-      };
+      return predictionError("text_to_video", m, e);
     }
   }
 };
@@ -341,9 +358,7 @@ const animateImage: CapabilityExport = {
         ...persisted
       };
     } catch (e) {
-      return {
-        error: `image_to_video failed: ${e instanceof Error ? e.message : String(e)}`
-      };
+      return predictionError("image_to_video", m, e);
     }
   }
 };
@@ -541,9 +556,7 @@ const generateSpeech: CapabilityExport = {
         ...persisted
       };
     } catch (e) {
-      return {
-        error: `text_to_speech failed: ${e instanceof Error ? e.message : String(e)}`
-      };
+      return predictionError("text_to_speech", m, e);
     }
   }
 };

--- a/packages/agents/src/capabilities/models.ts
+++ b/packages/agents/src/capabilities/models.ts
@@ -228,6 +228,44 @@ async function fetchModelsForCapability(
   }
 }
 
+/**
+ * The task a capability asks a model to perform, where one model list serves
+ * two directions. `getAvailableVideoModels` answers with every video endpoint
+ * the provider has — text-to-video, image-to-video, lip-sync, upscalers — so
+ * without this a `text_to_video` search ranked `.../image-to-video` first and
+ * the generation call that followed failed with a 422 from the provider. The
+ * same holds for image models (`text_to_image` vs `image_to_image`).
+ *
+ * Capabilities whose model list is already single-purpose (tts, asr,
+ * embeddings, language) map to `null` and filter nothing.
+ */
+function capabilityTask(capability: SupportedCapability): string | null {
+  switch (capability) {
+    case "text_to_image":
+    case "image_to_image":
+    case "text_to_video":
+    case "image_to_video":
+      return capability;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Models that declare they can do this capability's task. A model that
+ * declares no tasks at all is kept — the alternative is hiding every model
+ * from a provider whose manifest carries no task information.
+ */
+function forCapabilityTask<T extends { model: AnyModel }>(
+  candidates: T[],
+  capability: SupportedCapability
+): { kept: T[]; dropped: number } {
+  const task = capabilityTask(capability);
+  if (!task) return { kept: candidates, dropped: 0 };
+  const kept = candidates.filter(({ model }) => taskMatch(model, task));
+  return { kept, dropped: candidates.length - kept.length };
+}
+
 function taskMatch(model: AnyModel, task: string | undefined): boolean {
   if (!task) return true;
   if (!model.supportedTasks || model.supportedTasks.length === 0) return true;
@@ -350,10 +388,21 @@ const findModel: CapabilityExport = {
       }
     }
 
+    // Drop the models that cannot do what the capability asks before anything
+    // ranks or filters them: an `image_to_video` endpoint is not an answer to
+    // a `text_to_video` search, however well its name matches the query.
+    const forTask = forCapabilityTask(candidates, capability);
+    const capabilityCandidates = forTask.kept;
+
     const notes: string[] = [];
     if (unavailable.length > 0) {
       notes.push(
         `Skipped providers that cannot run here: ${unavailable.join(", ")}.`
+      );
+    }
+    if (forTask.dropped > 0 && capabilityCandidates.length === 0) {
+      notes.push(
+        `${forTask.dropped} model(s) were found but none declares ${capability}.`
       );
     }
     let words = queryWords(query ?? "");
@@ -363,18 +412,18 @@ const findModel: CapabilityExport = {
     // all, the unfiltered default ranking — and no way to tell why. A task no
     // model declares is read as a name search instead.
     const declaredTasks = new Set<string>();
-    for (const { model } of candidates) {
+    for (const { model } of capabilityCandidates) {
       for (const t of model.supportedTasks ?? []) declaredTasks.add(t);
     }
-    let pool: typeof candidates;
+    let pool: typeof capabilityCandidates;
     if (task && !declaredTasks.has(task)) {
-      pool = candidates;
+      pool = capabilityCandidates;
       words = [...words, ...queryWords(task)];
       notes.push(
         `No model declares task '${task}'; searched model names for it instead. Use \`query\` to search by name.`
       );
     } else {
-      pool = candidates.filter(({ model }) => taskMatch(model, task));
+      pool = capabilityCandidates.filter(({ model }) => taskMatch(model, task));
     }
 
     let queryMatched: boolean | undefined;

--- a/packages/agents/src/codeact/chat-codeact.ts
+++ b/packages/agents/src/codeact/chat-codeact.ts
@@ -156,6 +156,15 @@ export interface ChatCodeActSessionOptions {
    * Without one nothing is mounted and such an import is refused by name.
    */
   capabilityRun?: CapabilityRun;
+  /**
+   * The `state` object actions read and write. A host that passes the same
+   * object on the next turn carries the turn's work forward: a chat session is
+   * one session per turn, so without this a model that stored a generated
+   * video in `state` found it `undefined` in the next turn and paid to
+   * generate it again. Mutations land in this object, so the host needs no
+   * write-back of its own. Defaults to a fresh object.
+   */
+  state?: Record<string, unknown>;
   /** Observability hook — fires before each bridged tool executes. */
   onToolCall?: (record: {
     name: string;
@@ -319,8 +328,9 @@ export function createChatCodeActSession(
   const withGraphModel = hasGraphModelTools(toolNames);
   const toolCallIdPrefix = globalThis.crypto.randomUUID();
 
-  // Persists across the turn's actions (CaveAgent-style runtime state).
-  const state: Record<string, unknown> = {};
+  // Persists across the turn's actions (CaveAgent-style runtime state), and
+  // across turns when the host supplies the object (see `state` above).
+  const state: Record<string, unknown> = options.state ?? {};
   let totalCalls = 0;
   let actionCalls = 0;
 

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -78,8 +78,11 @@ Rules:
   does not persist. Assign each expensive result to \`state\` immediately
   (\`state.video = state.video ?? await nodetool.media.generateVideo(prompt, model)\`),
   then continue. The next action must reuse what \`state\` already holds —
-  never re-run generate, speak, or fetch. Write a large literal into \`state\`
-  in the action that builds it. If that action fails, patch the copy in
+  never re-run generate, speak, or fetch. A chat turn keeps its thread's
+  \`state\`, so an earlier turn's results may still be there; read it
+  defensively (\`state.video?.asset_uri\`) instead of assuming a key exists,
+  and re-derive what is missing rather than throwing on \`undefined\`.
+  Write a large literal into \`state\` in the action that builds it. If that action fails, patch the copy in
   \`state\` (\`state.doc.type = "screenplay"\`) and retry — do not emit the
   literal a second time.
 - Keep observations small. \`return\` a compact summary (counts, ids, the few

--- a/packages/agents/src/tools/asset-persist.ts
+++ b/packages/agents/src/tools/asset-persist.ts
@@ -8,7 +8,6 @@
  * tests), it falls back to writing the bytes to a workspace file.
  */
 
-import { formatResourceUri } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { isString } from "../utils/type-guards.js";
 
@@ -76,7 +75,7 @@ export function inferImageMime(bytes: Uint8Array): string {
 export interface SavedOutput {
   asset_id?: string;
   asset_uri?: string;
-  /** `asset://<id>` — ready-made link for the agent's prose. */
+  /** `asset://<id>.<ext>` — ready-made link for the agent's prose. */
   url?: string;
   path?: string;
   bytes: number;
@@ -108,7 +107,10 @@ export async function persistOutput(
       if (asset && isString(asset.id)) {
         result.asset_id = asset.id;
         result.asset_uri = `asset://${asset.id}.${ext}`;
-        result.url = formatResourceUri({ kind: "asset", id: asset.id });
+        // The same URI, extension and all: a renderer types the media by the
+        // suffix, and the bare `asset://<id>` this used to hand the model's
+        // prose embedded a video as an image.
+        result.url = result.asset_uri;
       }
     } catch {
       // Fall through to filesystem fallback.

--- a/packages/agents/tests/capabilities-assets.test.ts
+++ b/packages/agents/tests/capabilities-assets.test.ts
@@ -183,6 +183,40 @@ describe("assets capabilities against the database", () => {
     expect(read.content).toBe("# hello");
   });
 
+  it("returns an asset_uri that carries the file extension", async () => {
+    let created = 1;
+    // `asset://<id>` alone types nothing: a chat embed of a saved mp4 rendered
+    // as an image and showed a blank tile.
+    // The library path: a context that persists through `createAsset`.
+    const ctx = makeContext({
+      hasModelInterface: (name: string) => name === "createAsset",
+      createAsset: async () => ({ id: `as_${created++}` })
+    });
+    const saved = (await asTool("save_asset", ctx).process(ctx, {
+      name: "panda.mp4",
+      content_base64: Buffer.from([0, 1, 2, 3]).toString("base64"),
+      content_type: "video/mp4"
+    })) as Record<string, unknown>;
+    expect(saved.success).toBe(true);
+    expect(saved.asset_uri).toBe(`asset://${String(saved.asset_id)}.mp4`);
+
+    // No extension on the name — the content type still names one.
+    const unnamed = (await asTool("save_asset", ctx).process(ctx, {
+      name: "panda clip",
+      content_base64: Buffer.from([0, 1, 2, 3]).toString("base64"),
+      content_type: "video/mp4"
+    })) as Record<string, unknown>;
+    expect(unnamed.asset_uri).toBe(`asset://${String(unnamed.asset_id)}.mp4`);
+
+    // Neither names one — no suffix is better than a wrong one.
+    const opaque = (await asTool("save_asset", ctx).process(ctx, {
+      name: "blob",
+      content_base64: Buffer.from([0, 1, 2, 3]).toString("base64"),
+      content_type: "application/x-thing"
+    })) as Record<string, unknown>;
+    expect(opaque.asset_uri).toBe(`asset://${String(opaque.asset_id)}`);
+  });
+
   it("copies a stored file into the library from a /api/storage/ source, without base64", async () => {
     // The regression: a tool downloaded a video to storage and returned its
     // asset_url; the model's only way to make it a library asset was

--- a/packages/agents/tests/capabilities-models.test.ts
+++ b/packages/agents/tests/capabilities-models.test.ts
@@ -10,7 +10,8 @@ import type {
   ImageModel,
   LanguageModel,
   ProcessingContext,
-  ProviderId
+  ProviderId,
+  VideoModel
 } from "@nodetool-ai/runtime";
 import { toolFromCapability } from "../src/capabilities/adapters.js";
 import { UNGATED, createCapabilityRun } from "../src/capabilities/invoke.js";
@@ -39,6 +40,18 @@ class FakeImageProvider extends BaseProvider {
     super(id);
   }
   override async getAvailableImageModels(): Promise<ImageModel[]> {
+    return this.models;
+  }
+}
+
+class FakeVideoProvider extends BaseProvider {
+  constructor(
+    id: ProviderId,
+    private readonly models: VideoModel[]
+  ) {
+    super(id);
+  }
+  override async getAvailableVideoModels(): Promise<VideoModel[]> {
     return this.models;
   }
 }
@@ -172,6 +185,81 @@ describe("find_model through the adapter", () => {
       model_hint: ["FLUX.1-dev"]
     })) as { results: { model_id: string }[] };
     expect(byHint.results[0].model_id).toBe("black-forest-labs/FLUX.1-dev");
+  });
+
+  it("does not offer an image-to-video model for text_to_video", async () => {
+    // A live session picked `.../image-to-video` for a text-to-video call and
+    // the provider answered 422. One video list serves both directions, so the
+    // capability has to filter it.
+    const fal = new FakeVideoProvider("fal_ai" as ProviderId, [
+      {
+        id: "alibaba/happy-horse/image-to-video",
+        name: "Happy Horse Image To Video",
+        provider: "fal_ai",
+        supportedTasks: ["image_to_video"]
+      } as VideoModel,
+      {
+        id: "alibaba/happy-horse/text-to-video",
+        name: "Happy Horse Text To Video",
+        provider: "fal_ai",
+        supportedTasks: ["text_to_video"]
+      } as VideoModel
+    ]);
+    const tool = asTool(findModel, { fal_ai: fal });
+
+    const t2v = (await tool.process(ctx, {
+      capability: "text_to_video"
+    })) as { total: number; results: { model_id: string }[] };
+    expect(t2v.results.map((r) => r.model_id)).toEqual([
+      "alibaba/happy-horse/text-to-video"
+    ]);
+
+    // The query used to pull the wrong direction back in: "fast" (or any word
+    // both ids carry) matched the image-to-video endpoint first.
+    const queried = (await tool.process(ctx, {
+      capability: "text_to_video",
+      query: "happy horse"
+    })) as { results: { model_id: string }[] };
+    expect(queried.results.map((r) => r.model_id)).toEqual([
+      "alibaba/happy-horse/text-to-video"
+    ]);
+
+    const i2v = (await tool.process(ctx, {
+      capability: "image_to_video"
+    })) as { results: { model_id: string }[] };
+    expect(i2v.results.map((r) => r.model_id)).toEqual([
+      "alibaba/happy-horse/image-to-video"
+    ]);
+  });
+
+  it("says so when every video model declares another direction", async () => {
+    const tool = asTool(findModel, {
+      fal_ai: new FakeVideoProvider("fal_ai" as ProviderId, [
+        {
+          id: "topaz/upscale",
+          name: "Topaz Upscale",
+          provider: "fal_ai",
+          supportedTasks: ["video_to_video"]
+        } as VideoModel
+      ])
+    });
+    const result = (await tool.process(ctx, {
+      capability: "text_to_video"
+    })) as { total: number; note: string };
+    expect(result.total).toBe(0);
+    expect(result.note).toMatch(/none declares text_to_video/);
+  });
+
+  it("keeps a model that declares no tasks at all", async () => {
+    const tool = asTool(findModel, {
+      fal_ai: new FakeVideoProvider("fal_ai" as ProviderId, [
+        { id: "some/clip", name: "Some Clip", provider: "fal_ai" } as VideoModel
+      ])
+    });
+    const result = (await tool.process(ctx, {
+      capability: "text_to_video"
+    })) as { total: number };
+    expect(result.total).toBe(1);
   });
 
   it("reports a missed search instead of ranking an unrelated model first", async () => {

--- a/packages/agents/tests/chat-codeact.test.ts
+++ b/packages/agents/tests/chat-codeact.test.ts
@@ -277,6 +277,43 @@ return { secret: secret === undefined ? null : secret, fetchError, workspaceErro
     expect(second.result).toBe("asset://abc");
   });
 
+  it("carries a host-supplied state object into the next session", async () => {
+    // A chat session is built per turn. Without the host holding the object,
+    // a video parked in `state` was `undefined` on the follow-up turn and the
+    // model paid to generate it again — twice, in the session this fixes.
+    const { executeTool } = createFakeRouter({ nodes: [], edges: [] });
+    const state: Record<string, unknown> = {};
+    const turnOne = createChatCodeActSession({
+      tools: GENERIC_TOOLS,
+      executeTool,
+      context: createMockContext() as unknown as ProcessingContext,
+      state
+    });
+    const first = await runAction(
+      turnOne,
+      `state.video = { asset_uri: "asset://abc.mp4" };\nreturn "set";`
+    );
+    expect(first.ok).toBe(true);
+    expect(state.video).toEqual({ asset_uri: "asset://abc.mp4" });
+
+    const turnTwo = createChatCodeActSession({
+      tools: GENERIC_TOOLS,
+      executeTool,
+      context: createMockContext() as unknown as ProcessingContext,
+      state
+    });
+    const second = await runAction(turnTwo, `return state.video.asset_uri;`);
+    expect(second.ok).toBe(true);
+    expect(second.result).toBe("asset://abc.mp4");
+  });
+
+  it("starts empty when the host supplies no state", async () => {
+    const { executeTool } = createFakeRouter({ nodes: [], edges: [] });
+    const session = makeSession(GENERIC_TOOLS, executeTool);
+    const obs = await runAction(session, `return Object.keys(state).length;`);
+    expect(obs.result).toBe(0);
+  });
+
   it("rejects finish() with chat guidance", async () => {
     const { executeTool } = createFakeRouter({ nodes: [], edges: [] });
     const session = makeSession(GENERIC_TOOLS, executeTool);

--- a/packages/agents/tests/media-tools.test.ts
+++ b/packages/agents/tests/media-tools.test.ts
@@ -147,7 +147,7 @@ describe("GenerateImageTool", () => {
       model: "m",
       prompt: "p"
     })) as { error?: string };
-    expect(r.error).toBe("text_to_image failed: upstream 500");
+    expect(r.error).toContain("text_to_image failed for openai:m — upstream 500");
   });
 
   it("passes output_file through to workspace storage", async () => {
@@ -300,7 +300,9 @@ describe("GenerateVideoTool", () => {
       model: "m",
       prompt: "p"
     })) as { error?: string };
-    expect(r.error).toBe("text_to_video failed: boom-str");
+    // The message names the model, so a wrong-direction pick is legible.
+    expect(r.error).toContain("text_to_video failed for p:m — boom-str");
+    expect(r.error).toContain('find_model({capability: "text_to_video"})');
   });
 });
 
@@ -531,7 +533,9 @@ describe("GenerateSpeechTool", () => {
       makeContext({ getProvider, streamProviderPrediction }),
       { provider: "openai", model: "tts", text: "hi" }
     )) as { error?: string };
-    expect(r.error).toBe("text_to_speech failed: stream setup failed");
+    expect(r.error).toContain(
+      "text_to_speech failed for openai:tts — stream setup failed"
+    );
   });
 });
 

--- a/packages/agents/tests/tools/asset-tools.test.ts
+++ b/packages/agents/tests/tools/asset-tools.test.ts
@@ -114,7 +114,7 @@ describe("SaveAssetTool", () => {
 
     expect(result.success).toBe(true);
     expect(result.asset_id).toBe("abc123");
-    expect(result.asset_uri).toBe("asset://abc123");
+    expect(result.asset_uri).toBe("asset://abc123.png");
     expect(calls).toHaveLength(1);
     expect(calls[0].contentType).toBe("image/png");
     expect(Array.from(calls[0].content)).toEqual([1, 2, 3, 4]);

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1508,6 +1508,9 @@ export function focusedUiToolNames(
  */
 const GUEST_TOOL_PREFIX = "tools.";
 
+/** Threads whose codeact `state` this connection keeps between turns. */
+const MAX_CODEACT_STATE_THREADS = 8;
+
 /** Recover the plain tool name from a `tools.<name>` slip. */
 export function normalizeToolCallName(name: string): string {
   return name.startsWith(GUEST_TOOL_PREFIX)
@@ -2163,6 +2166,38 @@ export class UnifiedWebSocketRunner {
    * 11 is what switches the guest onto `run.invoke`.
    */
   private chatCapabilityRun: CapabilityRun | null = null;
+  /**
+   * CodeAct `state` per thread, so a turn can reuse what the previous turn
+   * produced. A session is built per turn; without this, a model that parked a
+   * generated video in `state` read `undefined` on the follow-up question and
+   * regenerated it — twice, in the session this fixes. Bounded: the oldest
+   * thread's state is dropped past {@link MAX_CODEACT_STATE_THREADS}, and a
+   * turn with no thread id gets a throwaway object.
+   */
+  private readonly codeactStateByThread = new Map<
+    string,
+    Record<string, unknown>
+  >();
+
+  /** The `state` object this turn's codeact session reads and writes. */
+  private codeactStateFor(threadId: string | null): Record<string, unknown> {
+    if (!threadId) return {};
+    const existing = this.codeactStateByThread.get(threadId);
+    if (existing) {
+      // Re-insert so the eviction below drops the least recently used thread.
+      this.codeactStateByThread.delete(threadId);
+      this.codeactStateByThread.set(threadId, existing);
+      return existing;
+    }
+    const fresh: Record<string, unknown> = {};
+    this.codeactStateByThread.set(threadId, fresh);
+    while (this.codeactStateByThread.size > MAX_CODEACT_STATE_THREADS) {
+      const oldest = this.codeactStateByThread.keys().next().value;
+      if (oldest === undefined) break;
+      this.codeactStateByThread.delete(oldest);
+    }
+    return fresh;
+  }
   /** The run built for the last chat turn — what PR 11 hands to the sandbox. */
   getChatCapabilityRun(): CapabilityRun | null {
     return this.chatCapabilityRun;
@@ -5856,7 +5891,8 @@ export class UnifiedWebSocketRunner {
         context: ctx,
         signal,
         clock: codeactClock,
-        capabilityRun: this.chatCapabilityRun ?? undefined
+        capabilityRun: this.chatCapabilityRun ?? undefined,
+        state: this.codeactStateFor(threadId || null)
       });
       providerToolSchemas.push(codeactSession.providerTool);
       providerToolSchemas.push(...directSchemas);

--- a/web/src/components/chat/message/ChatMarkdown.tsx
+++ b/web/src/components/chat/message/ChatMarkdown.tsx
@@ -16,7 +16,7 @@ import { BORDER_RADIUS } from "../../ui_primitives";
 import { packageAssetHttpPath } from "@nodetool-ai/protocol";
 import { BASE_URL } from "../../../stores/BASE_URL";
 import { trpc } from "../../../trpc/client";
-import { useResolvedMediaUri } from "../../../hooks/useResolvedMediaUri";
+import { useResolvedMedia } from "../../../hooks/useResolvedMediaUri";
 import ResourceChip from "./ResourceChip";
 import { isNumber, isString } from "../../../utils/typePredicates";
 import "../../../styles/markdown/github-markdown.css";
@@ -92,28 +92,36 @@ const extractStorageKey = (uri: string | null | undefined): string | null => {
   return null;
 };
 
-const useChatAssetSrc = (src: string | undefined): string | undefined => {
+interface ChatAssetSrc {
+  url: string | undefined;
+  /** The asset's own MIME type, when the locator needed a lookup. */
+  contentType: string | undefined;
+}
+
+const useChatAssetSrc = (src: string | undefined): ChatAssetSrc => {
   // `asset://<id>` is an id, not a storage key (`<user>/<id>.<ext>`).
   const isAssetUri = Boolean(src?.startsWith("asset://"));
-  const fromAsset = useResolvedMediaUri(isAssetUri ? src : undefined);
+  const fromAsset = useResolvedMedia(isAssetUri ? src : undefined);
   const key = isAssetUri ? null : extractStorageKey(src);
   const { data } = trpc.storage.signUrl.useQuery(
     { key: key ?? "" },
     { enabled: Boolean(key), staleTime: 6 * 24 * 60 * 60 * 1000 }
   );
-  if (!src) return undefined;
+  if (!src) return { url: undefined, contentType: undefined };
   if (isAssetUri) {
     return fromAsset;
   }
   if (key) {
     // Legacy `/api/storage/<key>` markdown — resolve through the signed-URL
     // path so owner-prefixed keys and cloud backends work.
-    return data?.url;
+    return { url: data?.url, contentType: undefined };
   }
   const pkgPath = packageAssetHttpPath(src);
-  if (pkgPath) return `${BASE_URL}${pkgPath}`;
-  if (src.startsWith("/api/")) return `${BASE_URL}${src}`;
-  return src;
+  if (pkgPath) return { url: `${BASE_URL}${pkgPath}`, contentType: undefined };
+  if (src.startsWith("/api/")) {
+    return { url: `${BASE_URL}${src}`, contentType: undefined };
+  }
+  return { url: src, contentType: undefined };
 };
 
 /**
@@ -127,8 +135,20 @@ interface HastNodeLike {
   children?: HastNodeLike[];
 }
 
+/**
+ * An `asset://<id>` with no extension could be anything — its type comes from
+ * the asset row, which is fetched too late for this decision. Treated as a
+ * possible block embed so a video that resolves to one is not nested in a
+ * `<p>`.
+ */
+const isUntypedAssetSrc = (src: string): boolean =>
+  src.startsWith("asset://") && !/\.[A-Za-z0-9]{1,8}$/.test(hrefPath(src));
+
 const isBlockEmbedSrc = (src: string): boolean =>
-  isInlinePreviewUri(src) || isVideoHref(src) || isAudioHref(src);
+  isInlinePreviewUri(src) ||
+  isVideoHref(src) ||
+  isAudioHref(src) ||
+  isUntypedAssetSrc(src);
 
 const containsBlockEmbed = (node: unknown): boolean => {
   const children = (node as HastNodeLike | undefined)?.children;
@@ -149,11 +169,21 @@ const ChatMarkdownImg: React.FC<React.ComponentPropsWithoutRef<"img">> = ({
   ...props
 }) => {
   const href = src != null ? src : "";
-  const resolvedSrc = useChatAssetSrc(href || undefined);
+  const { url: resolvedSrc, contentType } = useChatAssetSrc(href || undefined);
   if (!resolvedSrc) {
     return null;
   }
-  if (href && isVideoHref(href)) {
+  // The extension decides when the URI has one; otherwise the asset's own
+  // content type does. `![clip](asset://<id>)` — what `save_asset` returned —
+  // rendered as an `<img>` with a video behind it, which shows nothing.
+  const isVideo =
+    (href !== "" && isVideoHref(href)) ||
+    Boolean(contentType?.startsWith("video/"));
+  const isAudio =
+    !isVideo &&
+    ((href !== "" && isAudioHref(href)) ||
+      Boolean(contentType?.startsWith("audio/")));
+  if (isVideo) {
     return (
       <video
         src={resolvedSrc}
@@ -165,7 +195,7 @@ const ChatMarkdownImg: React.FC<React.ComponentPropsWithoutRef<"img">> = ({
       />
     );
   }
-  if (href && isAudioHref(href)) {
+  if (isAudio) {
     return (
       <audio
         src={resolvedSrc}
@@ -191,7 +221,7 @@ const ChatMarkdownImageLink: React.FC<{ href: string; children: React.ReactNode 
   href,
   children
 }) => {
-  const resolvedHref = useChatAssetSrc(href);
+  const { url: resolvedHref } = useChatAssetSrc(href);
   return (
     <a href={resolvedHref} target="_blank" rel="noopener noreferrer">
       <img src={resolvedHref} alt={String(children ?? "")} css={imageCss} loading="lazy" />

--- a/web/src/components/chat/message/__tests__/ChatMarkdown.assetVideo.test.tsx
+++ b/web/src/components/chat/message/__tests__/ChatMarkdown.assetVideo.test.tsx
@@ -19,6 +19,13 @@ jest.mock("../../../../trpc/client", () => ({
 jest.mock("../../../../hooks/useResolvedMediaUri");
 import { mockAssetUrl } from "../../../../hooks/__mocks__/useResolvedMediaUri";
 
+// The map the component sees: `jest.mock` above swapped the module the
+// component imports, and reaching the manual mock by its own path hands this
+// suite a second copy of it.
+const { mockAssetContentTypes } = jest.requireMock(
+  "../../../../hooks/useResolvedMediaUri"
+) as typeof import("../../../../hooks/__mocks__/useResolvedMediaUri");
+
 /**
  * react-markdown is ESM-only; this mock handles markdown images `![](src)`
  * and links `[label](href)` and forwards them to `components.img` / `components.a`.
@@ -116,6 +123,7 @@ const renderMarkdown = (content: string) =>
 describe("ChatMarkdown asset video", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAssetContentTypes.clear();
   });
 
   it("renders an asset:// mp4 markdown image as a video player", () => {
@@ -135,6 +143,45 @@ describe("ChatMarkdown asset video", () => {
       { key: "51f0fcd92a05488caf261eb22bbf98df.mp4" },
       expect.anything()
     );
+  });
+
+  it("types an extension-less asset:// by its content type", () => {
+    // `save_asset` returned `asset://<id>` with no suffix, and the embed
+    // rendered as an <img> with an mp4 behind it — a blank tile in chat.
+    mockUseQuery.mockReturnValue({ data: undefined });
+    mockAssetContentTypes.set("9c936089c3d0471a90aa5443f6f46665", "video/mp4");
+
+    const { container } = renderMarkdown(
+      "![Skateboarding Red Panda](asset://9c936089c3d0471a90aa5443f6f46665)"
+    );
+
+    const video = container.querySelector("video") as HTMLVideoElement;
+    expect(video).not.toBeNull();
+    expect(video).toHaveAttribute(
+      "src",
+      mockAssetUrl("9c936089c3d0471a90aa5443f6f46665")
+    );
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("types an extension-less audio asset by its content type", () => {
+    mockUseQuery.mockReturnValue({ data: undefined });
+    mockAssetContentTypes.set("narration1", "audio/mpeg");
+
+    const { container } = renderMarkdown("![Narration](asset://narration1)");
+
+    expect(container.querySelector("audio")).not.toBeNull();
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("still renders an extension-less image asset as an image", () => {
+    mockUseQuery.mockReturnValue({ data: undefined });
+    mockAssetContentTypes.set("pic1", "image/png");
+
+    const { container } = renderMarkdown("![Pic](asset://pic1)");
+
+    expect(container.querySelector("img")).not.toBeNull();
+    expect(container.querySelector("video")).toBeNull();
   });
 
   it("renders an https mp4 markdown image as a video player", () => {

--- a/web/src/hooks/__mocks__/useResolvedMediaUri.ts
+++ b/web/src/hooks/__mocks__/useResolvedMediaUri.ts
@@ -41,6 +41,31 @@ export const resolveStaticMediaUri = realResolveStaticMediaUri;
 
 export const useResolvedMediaUri = resolve;
 
+/**
+ * Content type a test wants an asset id to resolve to, so a suite can exercise
+ * the extension-less `asset://<id>` path. Unset ids resolve to `undefined`,
+ * the way an asset row that has not loaded yet does.
+ */
+export const mockAssetContentTypes = new Map<string, string>();
+
+const assetIdOf = (source: MediaLocator): string | undefined => {
+  const uri = typeof source === "string" ? source : (source?.uri ?? undefined);
+  const declared = typeof source === "object" ? source?.asset_id : undefined;
+  if (declared) return declared;
+  if (!uri?.startsWith("asset://")) return undefined;
+  return uri.slice("asset://".length).replace(/\.[^.]+$/, "");
+};
+
+export const useResolvedMedia = (
+  source: MediaLocator
+): { url: string | undefined; contentType: string | undefined } => {
+  const id = assetIdOf(source);
+  return {
+    url: resolve(source),
+    contentType: id ? mockAssetContentTypes.get(id) : undefined
+  };
+};
+
 export const useResolvedMediaUris = (
   sources: MediaLocator[]
 ): (string | undefined)[] => sources.map(resolve);

--- a/web/src/hooks/useResolvedMediaUri.ts
+++ b/web/src/hooks/useResolvedMediaUri.ts
@@ -47,10 +47,20 @@ const locatorParts = (
   return { uri, assetId: declared ?? assetIdFromLocator(uri) };
 };
 
-export function useResolvedMediaUri(source: MediaLocator): string | undefined {
+/**
+ * The resolved URL plus the asset's own content type. `useResolvedMediaUri`
+ * is this hook's URL half — a caller that only renders needs no MIME type. A locator with no file
+ * extension (`asset://<id>`, what `save_asset` used to return) carries nothing
+ * a renderer can type the media by, so a saved mp4 rendered as a broken image
+ * in chat. The asset row is already fetched for the URL; its `content_type` is
+ * the answer.
+ */
+export function useResolvedMedia(source: MediaLocator): {
+  url: string | undefined;
+  contentType: string | undefined;
+} {
   const getAsset = useAssetStore((state) => state.get);
   const { uri, assetId } = locatorParts(source);
-
   const staticUrl = resolveStaticMediaUri(uri);
   // A locator that resolves without the server still needs the asset id path
   // disabled — hooks cannot be called conditionally, so gate the query instead.
@@ -63,9 +73,16 @@ export function useResolvedMediaUri(source: MediaLocator): string | undefined {
   });
 
   if (staticUrl !== null) {
-    return staticUrl || undefined;
+    return { url: staticUrl || undefined, contentType: undefined };
   }
-  return asset?.get_url ?? undefined;
+  return {
+    url: asset?.get_url ?? undefined,
+    contentType: asset?.content_type ?? undefined
+  };
+}
+
+export function useResolvedMediaUri(source: MediaLocator): string | undefined {
+  return useResolvedMedia(source).url;
 }
 
 /**


### PR DESCRIPTION
One chat session ("generate a short fun video fast") hit four separate failures. Each is fixed here.

## 1. `find_model` offered a model that cannot do the job

`getAvailableVideoModels()` returns every video endpoint a provider has — text-to-video, image-to-video, lip-sync, upscalers — and `find_model` filtered none of them by direction. The session picked `alibaba/happy-horse/image-to-video` for a `text_to_video` call and the provider answered `422 Unprocessable Entity`.

`find_model` now drops candidates whose declared `supportedTasks` exclude the capability's own task, for the four capabilities where one list serves two directions (`text_to_image`/`image_to_image`, `text_to_video`/`image_to_video`). A model that declares no tasks is still kept — a provider whose manifest carries no task info should not vanish. When every candidate is filtered out, the note says so instead of answering with an unexplained empty list.

## 2. The refusal said nothing useful

`text_to_video failed: Unprocessable Entity` named neither the model nor a way out. The five generation capabilities now report `text_to_video failed for fal_ai:<model> — <detail>. If the model does not do text_to_video, pick another with find_model({capability: "text_to_video"}).`

## 3. `state` was empty on the next turn

A chat codeact session is built per turn, so the video the model parked in `state` read `undefined` when the user asked a follow-up — and it regenerated the video twice, at full cost, to recover. `createChatCodeActSession` now takes its `state` object from the host, and the websocket runner keeps one per thread (LRU, 8 threads per connection). The action-contract prompt says the state may carry an earlier turn's results and to read it defensively.

## 4. The saved video did not render in chat

`save_asset` returned `asset://<id>` with no extension; chat types media by the URI suffix, so the embed rendered as an `<img>` with an mp4 behind it. Two changes: `save_asset` returns the suffixed URI that `generate_*` already returned (from the saved name, else the MIME type, else nothing — a wrong suffix is worse than none), and `ChatMarkdown` falls back to the asset's own `content_type` when the locator has no extension. `persistOutput`'s `url` field carries the extension too, since it is what the prompt hands the model for prose.

## Tests

- `capabilities-models.test.ts` — the image-to-video mis-pick (plain and via `query`), the all-filtered note, and a task-less model still being kept.
- `chat-codeact.test.ts` — a `state` object surviving across two sessions, and defaulting to empty without one.
- `capabilities-assets.test.ts` — the suffix from the name, from the MIME type, and absent when neither names one.
- `ChatMarkdown.assetVideo.test.tsx` — extension-less video, audio, and image assets each rendering the right element.

Each new check was inverted once and observed failing before the fix was restored.

## Verification

`npm run typecheck` clean; `packages/agents` (3195), `packages/websocket` (2291) and `web` (13208) suites pass, along with every other package `nodetool affected` names. Two pre-existing environment failures are untouched by this diff and reproduce on a clean checkout: `packages/cli` cannot build (`@nodetool-ai/telegram` is not linked into `node_modules` here), and 14 `packages/base-nodes` image tests fail on the missing Vulkan ICD documented in AGENTS.md.


---
_Generated by [Claude Code](https://claude.ai/code/session_011GZLBiM9eKBS4UgbFHHgHS)_