### PR TITLE
feat(agents): gate auto mode on the risk a code action declares

### DIFF
--- a/docs/codeact-design.md
+++ b/docs/codeact-design.md
@@ -201,6 +201,31 @@ through the prompt and killed the program mid-wait — the dialog was still on
 screen, and answering it resolved nothing. Tests:
 `packages/websocket/tests/chat-codeact-approval.test.ts`.
 
+### Auto mode reads the action's declared risk
+
+Auto mode used to mean "every call runs, no prompts", which made a code action
+the one place a user could lose work they never agreed to lose: the per-call
+ladder answers `allow` for every category, so a program that deletes a
+workflow ran exactly like one that counted rows.
+
+So `execute_code` carries one more required option, `risk` (`"low"` | `"high"`),
+next to `title` and `code`. The model declares it; the host reads it before a
+line of the program runs
+(`admitCodeAction`, `packages/agents/src/codeact/execute-code-contract.ts`).
+In auto mode a `low` action runs unattended and a `high` one asks once — for
+the whole action, because the action, not the bridged call, is what the user is
+being shown. A denied action never runs, and the refusal is the observation.
+"Allow for this chat" is keyed on `execute_code` itself, so it stops the asking
+for the rest of the thread.
+
+It fails closed: a call with no `risk`, or one carrying anything outside the
+enum, reads as `high`. Plan and default modes are untouched — their per-call
+ladder already blocks or asks, and a second question per action would only
+double the prompts. Hosts with no one to ask (the MCP mount, the security
+monitor's pass in `Agent`) carry an always-allow `requestApproval`, so nothing
+there can deadlock. Tests:
+`packages/agents/tests/codeact-action-risk.test.ts`.
+
 ## Workflow graph editing: the JS object model
 
 When the belt carries the `ui_*` workflow document tools, code actions get an

--- a/docs/global-chat.md
+++ b/docs/global-chat.md
@@ -121,7 +121,9 @@ The permission chip sets how far the agent may act on its own. It's per-thread, 
 |------|----------|
 | **Plan** | Read and propose only. No actions taken. |
 | **Default** | Reads run automatically; actions ask first. |
-| **Auto** | Everything runs, no prompts. |
+| **Auto** | Routine work runs unattended; the agent asks once before an action it declares risky. |
+
+In Auto the agent labels every code action it writes `low` or `high` risk. A `low` action — reading, computing, work you asked for and can undo — runs with no prompt. A `high` one — deleting or overwriting something, publishing or sending anything outside the account, spending real money — asks you first, once, showing the program it wants to run. Unlabeled counts as high. "Allow for this chat" stops the asking for the rest of the thread.
 
 ### Agent Capabilities
 

--- a/packages/agents/src/codeact/chat-codeact.ts
+++ b/packages/agents/src/codeact/chat-codeact.ts
@@ -73,10 +73,13 @@ import {
 import {
   CODEACT_DEFER_THRESHOLD,
   CODEACT_RESIDENT_TOOL_NAMES,
-  DEFAULT_CODEACT_ACTION_TIMEOUT_MS,
+  DEFAULT_CODEACT_ACTION_TIMEOUT_MS
+} from "./codeact-executor.js";
+import {
+  admitCodeAction,
   EXECUTE_CODE_INPUT_SCHEMA,
   EXECUTE_CODE_TOOL_NAME
-} from "./codeact-executor.js";
+} from "./execute-code-contract.js";
 import {
   GRAPH_MODEL_PRELUDE,
   GRAPH_MODEL_PROMPT_SECTION,
@@ -218,8 +221,7 @@ function normalizeToolResult(raw: unknown): unknown {
     raw.length > 0 &&
     raw.every(
       (block) =>
-        isObjectLike(block) &&
-        isString((block as { type?: unknown }).type)
+        isObjectLike(block) && isString((block as { type?: unknown }).type)
     )
   ) {
     const texts = raw
@@ -360,9 +362,7 @@ export function createChatCodeActSession(
       if (isNonEmptyString(argsJson)) {
         try {
           const parsed = JSON.parse(argsJson) as unknown;
-          if (
-            isRecord(parsed)
-          ) {
+          if (isRecord(parsed)) {
             args = parsed as Record<string, unknown>;
           } else if (parsed !== null) {
             return {
@@ -424,10 +424,9 @@ export function createChatCodeActSession(
     { ok: true; result: ToolSearchHit[] } | { ok: false; error: string }
   > => {
     try {
-      const limit =
-        isFiniteNumber(maxResults)
-          ? Math.max(1, Math.min(25, Math.floor(maxResults)))
-          : 5;
+      const limit = isFiniteNumber(maxResults)
+        ? Math.max(1, Math.min(25, Math.floor(maxResults)))
+        : 5;
       const hits = searchTools(searchCatalog, String(query ?? ""), limit).map(
         (entry): ToolSearchHit =>
           toolSearchHit(
@@ -517,6 +516,15 @@ export function createChatCodeActSession(
         toolCalls: 0
       } satisfies ActionObservation);
     }
+    // Auto mode's one question, asked before the program runs.
+    const admission = await admitCodeAction(options.capabilityRun?.gate, args);
+    if (!admission.allowed) {
+      return JSON.stringify({
+        ok: false,
+        error: admission.error,
+        toolCalls: 0
+      } satisfies ActionObservation);
+    }
     const mountOptions: MountCapabilityModulesOptions = {};
     if (options.signal !== undefined) mountOptions.signal = options.signal;
     if (sessionModules.length > 0) mountOptions.session = sessionModules;
@@ -570,12 +578,11 @@ export function createChatCodeActSession(
                 : type === "audio"
                   ? "audio/wav"
                   : "video/mp4";
-          const filename =
-            isString(opts?.filename)
-              ? opts.filename
-              : isString(opts?.name)
-                ? opts.name
-                : undefined;
+          const filename = isString(opts?.filename)
+            ? opts.filename
+            : isString(opts?.name)
+              ? opts.name
+              : undefined;
           const persistOptions: Parameters<typeof persistOutput>[2] = {
             namePrefix: type,
             mime

--- a/packages/agents/src/codeact/codeact-executor.ts
+++ b/packages/agents/src/codeact/codeact-executor.ts
@@ -67,6 +67,12 @@ import {
   type ToolCallRecord,
   type ToolSearchHit
 } from "./tool-api.js";
+import {
+  admitCodeAction,
+  EXECUTE_CODE_INPUT_SCHEMA,
+  EXECUTE_CODE_TOOL_NAME,
+  executeCodeMessage
+} from "./execute-code-contract.js";
 import { searchTools } from "../tools/tool-search.js";
 import { buildCodeActSystemPrompt } from "./prompt.js";
 import {
@@ -126,32 +132,19 @@ export const DEFAULT_CODEACT_MAX_ITERATIONS = 20;
  */
 export const DEFAULT_CODEACT_ACTION_TIMEOUT_MS = 600_000;
 
-/**
- * Input schema for the one provider tool codeact mode exposes. `title` is the
- * user-facing label the UI shows for the action card while the code runs —
- * the code itself is a detail view, so without a title the user sees only
- * "Execute Code". Required: a strict schema (additionalProperties: false)
- * must list every property under `required` for OpenAI structured outputs.
- */
-export const EXECUTE_CODE_INPUT_SCHEMA = {
-  type: "object",
-  properties: {
-    title: {
-      type: "string",
-      description:
-        "3-8 word user-facing summary of what this action does, shown in " +
-        'the UI while it runs (e.g. "Rendering product images from CSV").'
-    },
-    code: {
-      type: "string",
-      description: "The JavaScript program to run."
-    }
-  },
-  required: ["title", "code"],
-  additionalProperties: false
-} as const;
+// The `execute_code` contract lives beside the auto-mode admission that reads
+// it (execute-code-contract.ts); re-exported here so every importer keeps its
+// path.
+export {
+  EXECUTE_CODE_INPUT_SCHEMA,
+  EXECUTE_CODE_TOOL_NAME,
+  executeCodeMessage,
+  declaredActionRisk,
+  admitCodeAction,
+  ACTION_RISK_VALUES
+} from "./execute-code-contract.js";
+export type { ActionRisk, ActionAdmission } from "./execute-code-contract.js";
 
-/** The display label for a code action: its title, else a generic fallback. */
 /**
  * A string leaf that is a JSON-serialized tool envelope rather than the value
  * itself: it parses to an object carrying an envelope key (status/outputs/
@@ -216,13 +209,6 @@ export function coercionArtifactPaths(
   }
   return [];
 }
-
-export function executeCodeMessage(args: Record<string, unknown>): string {
-  const title = isString(args?.["title"]) ? args["title"].trim() : "";
-  return title || "Executing code action";
-}
-
-export const EXECUTE_CODE_TOOL_NAME = "execute_code";
 
 /**
  * Tools documented in full in the prompt regardless of toolbelt size — the
@@ -531,14 +517,11 @@ export class CodeActExecutor {
     this.sessionModuleExports = new Map();
     this.graftedSpecifiers = new Map();
     for (const tool of this.tools) {
-      const module =
-        capabilityModuleOf(tool.name) ?? SESSION_CAPABILITY_MODULE;
-      this.graftedSpecifiers.set(
-        tool.name,
-        sandboxCapabilitySpecifier(module)
-      );
+      const module = capabilityModuleOf(tool.name) ?? SESSION_CAPABILITY_MODULE;
+      this.graftedSpecifiers.set(tool.name, sandboxCapabilitySpecifier(module));
       const names = this.sessionModuleExports.get(module);
-      if (names === undefined) this.sessionModuleExports.set(module, [tool.name]);
+      if (names === undefined)
+        this.sessionModuleExports.set(module, [tool.name]);
       else names.push(tool.name);
     }
 
@@ -695,10 +678,9 @@ export class CodeActExecutor {
       { ok: true; result: ToolSearchHit[] } | { ok: false; error: string }
     > => {
       try {
-        const limit =
-          isFiniteNumber(maxResults)
-            ? Math.max(1, Math.min(25, Math.floor(maxResults)))
-            : 5;
+        const limit = isFiniteNumber(maxResults)
+          ? Math.max(1, Math.min(25, Math.floor(maxResults)))
+          : 5;
         const byName = new Map(this.tools.map((t) => [t.name, t]));
         const hits = searchTools(searchCatalog, String(query ?? ""), limit).map(
           (entry): ToolSearchHit =>
@@ -733,6 +715,15 @@ export class CodeActExecutor {
         return JSON.stringify({
           ok: false,
           error: "execute_code: `code` must be a non-empty string",
+          toolCalls: 0
+        } satisfies ActionObservation);
+      }
+      // Auto mode's one question, asked before the program runs.
+      const admission = await admitCodeAction(this.capabilityRun?.gate, args);
+      if (!admission.allowed) {
+        return JSON.stringify({
+          ok: false,
+          error: admission.error,
           toolCalls: 0
         } satisfies ActionObservation);
       }
@@ -811,9 +802,7 @@ export class CodeActExecutor {
       // Pixels a tool returned during the action ride beside the observation
       // as a provider image message; the observation itself stays light.
       const images = bridge.drainImages();
-      return images.length > 0
-        ? [{ type: "text", text }, ...images]
-        : text;
+      return images.length > 0 ? [{ type: "text", text }, ...images] : text;
     };
 
     const providerTools = [
@@ -887,10 +876,9 @@ export class CodeActExecutor {
         if ("type" in item && item.type === "message") {
           const m = (item as { message?: Message }).message;
           if (m && m.role === "assistant") {
-            lastAssistant =
-              isString(m.content)
-                ? { ...m, content: removeThinkTags(m.content) }
-                : m;
+            lastAssistant = isString(m.content)
+              ? { ...m, content: removeThinkTags(m.content) }
+              : m;
           }
         }
         yield* drainUi();
@@ -953,9 +941,7 @@ export class CodeActExecutor {
     if (!this.step.outputSchema) return null;
     try {
       const parsed = JSON.parse(this.step.outputSchema) as unknown;
-      if (
-        isRecord(parsed)
-      ) {
+      if (isRecord(parsed)) {
         return parsed as Record<string, unknown>;
       }
       return null;
@@ -1033,9 +1019,5 @@ function isChunk(item: ProviderStreamItem): item is Chunk {
 }
 
 function isToolCall(item: ProviderStreamItem): item is ToolCall {
-  return (
-    "name" in item &&
-    typeof item.name === "string" &&
-    "id" in item
-  );
+  return "name" in item && typeof item.name === "string" && "id" in item;
 }

--- a/packages/agents/src/codeact/execute-code-contract.ts
+++ b/packages/agents/src/codeact/execute-code-contract.ts
@@ -1,0 +1,131 @@
+/**
+ * The `execute_code` tool contract, and the one question auto mode asks about
+ * a code action before running it.
+ *
+ * Auto mode used to mean "everything runs, no prompts": `decidePermission`
+ * answers `allow` for every category, so a code action could delete a
+ * workflow, publish one, or spend on media without the user seeing anything.
+ * That is not what a user grants by picking Auto — they grant *not being
+ * interrupted for routine work*, not a blank cheque.
+ *
+ * So the call carries one more option: `risk`. The model declares whether the
+ * program it is about to run is `low` risk (reads, local compute, work the
+ * user already asked for and can undo) or `high` (deletes, publishes,
+ * third-party side effects, real spend). In auto mode a `low` action runs
+ * unattended and a `high` one asks once — for the whole action, not per
+ * bridged call, because the action is the unit the user is being asked about.
+ * Plan and default modes are untouched: their per-call ladder in
+ * `capabilities/invoke.ts` already blocks or asks.
+ *
+ * It fails closed. A call with no `risk`, or one carrying a value that is not
+ * in the enum, is read as `high`.
+ */
+
+import type { CapabilityGate } from "../capabilities/types.js";
+import { isString } from "../utils/type-guards.js";
+
+export const EXECUTE_CODE_TOOL_NAME = "execute_code";
+
+/** How much a code action claims it can cost the user if it goes wrong. */
+export type ActionRisk = "low" | "high";
+
+export const ACTION_RISK_VALUES = ["low", "high"] as const;
+
+/**
+ * Input schema for the one provider tool codeact mode exposes. `title` is the
+ * user-facing label the UI shows for the action card while the code runs —
+ * the code itself is a detail view, so without a title the user sees only
+ * "Execute Code". `risk` is what auto mode reads (see the module comment).
+ * Required: a strict schema (additionalProperties: false) must list every
+ * property under `required` for OpenAI structured outputs.
+ */
+export const EXECUTE_CODE_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    title: {
+      type: "string",
+      description:
+        "3-8 word user-facing summary of what this action does, shown in " +
+        'the UI while it runs (e.g. "Rendering product images from CSV").'
+    },
+    risk: {
+      type: "string",
+      enum: ACTION_RISK_VALUES,
+      description:
+        '"low" when the program only reads, computes, or does work the user ' +
+        'asked for and can undo; "high" when it deletes or overwrites ' +
+        "something, publishes or sends anything outside this account, or " +
+        "spends real money. In auto mode a low-risk action runs unattended " +
+        "and a high-risk one asks the user once. Say high when unsure."
+    },
+    code: {
+      type: "string",
+      description: "The JavaScript program to run."
+    }
+  },
+  required: ["title", "risk", "code"],
+  additionalProperties: false
+} as const;
+
+/** The display label for a code action: its title, else a generic fallback. */
+export function executeCodeMessage(args: Record<string, unknown>): string {
+  const title = isString(args?.["title"]) ? args["title"].trim() : "";
+  return title || "Executing code action";
+}
+
+/** The risk a call declared, reading anything unrecognized as `high`. */
+export function declaredActionRisk(
+  args: Record<string, unknown> | null | undefined
+): ActionRisk {
+  return args?.["risk"] === "low" ? "low" : "high";
+}
+
+/** Refusal carries the observation text the model sees instead of a result. */
+export type ActionAdmission =
+  | { allowed: true }
+  | { allowed: false; error: string };
+
+const ALLOWED: ActionAdmission = { allowed: true };
+
+/**
+ * Whether this code action may run, before a line of it executes.
+ *
+ * Only auto mode asks: without a gate (a headless step loop) or in plan /
+ * default mode the per-call ladder inside the action is the gate, unchanged.
+ * "Allow for this chat" is keyed on `execute_code` itself, so granting it once
+ * makes every later high-risk action in the thread run unattended — which is
+ * the user saying "stop asking", the same meaning it has for any other tool.
+ */
+export async function admitCodeAction(
+  gate: CapabilityGate | undefined,
+  args: Record<string, unknown>
+): Promise<ActionAdmission> {
+  if (!gate || gate.mode !== "auto") return ALLOWED;
+  if (declaredActionRisk(args) === "low") return ALLOWED;
+  if (gate.sessionAllow.has(EXECUTE_CODE_TOOL_NAME)) return ALLOWED;
+
+  const answer = await gate.requestApproval({
+    toolName: EXECUTE_CODE_TOOL_NAME,
+    category: "execute",
+    args: {
+      title: isString(args["title"]) ? args["title"] : "",
+      risk: declaredActionRisk(args),
+      code: isString(args["code"]) ? args["code"] : ""
+    },
+    message: executeCodeMessage(args)
+  });
+
+  if (answer === "deny") {
+    return {
+      allowed: false,
+      error:
+        "The user declined to run this code action. Do not re-submit the " +
+        "same program; explain what it would have done, or propose a " +
+        "narrower action that avoids the destructive or costly part."
+    };
+  }
+  if (answer === "allow_for_chat") {
+    gate.sessionAllow.add(EXECUTE_CODE_TOOL_NAME);
+  }
+  return ALLOWED;
+}

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -56,6 +56,15 @@ Rules:
 - Every \`execute_code\` call carries a \`title\`: 3-8 words, user-facing,
   naming what THIS action does ("Rendering product images from CSV") — it is
   the only thing the user sees while your code runs.
+- Every \`execute_code\` call also carries a \`risk\`: \`"low"\` when the program
+  only reads, computes, or does work the user asked for and can undo;
+  \`"high"\` when it deletes or overwrites something, publishes or sends
+  anything outside this account, or spends real money. Say \`"high"\` when you
+  are unsure. It is what decides whether the action runs unattended or asks
+  the user first, so declaring \`"low"\` for a destructive program is how a
+  user loses work they never agreed to lose. Keep the destructive or costly
+  part in its own action: the routine work around it then still runs
+  unattended.
 - Chain the WHOLE pipeline into one action: call several tools, loop over
   items, branch on intermediate results, retry inside try/catch, and
   post-process in the same program. Assign each expensive intermediate to

--- a/packages/agents/tests/codeact-action-risk.test.ts
+++ b/packages/agents/tests/codeact-action-risk.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Auto mode reads the risk a code action declares about itself: a `low` action
+ * runs unattended, a `high` one asks the user once before any of it runs.
+ * These drive the admission directly and through a real chat session.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  admitCodeAction,
+  declaredActionRisk,
+  EXECUTE_CODE_INPUT_SCHEMA,
+  EXECUTE_CODE_TOOL_NAME
+} from "../src/codeact/execute-code-contract.js";
+import type {
+  ApprovalDecision,
+  ApprovalRequest,
+  PermissionMode
+} from "../src/tools/tool-permissions.js";
+import type { CapabilityGate } from "../src/capabilities/types.js";
+import { createCapabilityRun } from "../src/capabilities/invoke.js";
+import {
+  createChatCodeActSession,
+  type ChatCodeActToolCall
+} from "../src/codeact/chat-codeact.js";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+function makeGate(
+  mode: PermissionMode,
+  answer: ApprovalDecision = "allow"
+): { gate: CapabilityGate; asked: ApprovalRequest[] } {
+  const asked: ApprovalRequest[] = [];
+  const gate: CapabilityGate = {
+    mode,
+    sessionAllow: new Set<string>(),
+    requestApproval: async (request: ApprovalRequest) => {
+      asked.push(request);
+      return answer;
+    }
+  };
+  return { gate, asked };
+}
+
+const lowAction = { title: "Counting rows", risk: "low", code: "return 1;" };
+const highAction = {
+  title: "Deleting the old workflows",
+  risk: "high",
+  code: "return 1;"
+};
+
+describe("the execute_code contract", () => {
+  it("carries risk as a required enum", () => {
+    const schema = EXECUTE_CODE_INPUT_SCHEMA;
+    expect(schema.properties.risk.enum).toEqual(["low", "high"]);
+    expect(schema.required).toEqual(["title", "risk", "code"]);
+    // OpenAI structured outputs reject a strict schema that leaves a property
+    // out of `required`.
+    expect(Object.keys(schema.properties).sort()).toEqual(
+      [...schema.required].sort()
+    );
+  });
+});
+
+describe("declaredActionRisk", () => {
+  it("reads a declared low", () => {
+    expect(declaredActionRisk(lowAction)).toBe("low");
+  });
+
+  it("fails closed on anything else", () => {
+    expect(declaredActionRisk(highAction)).toBe("high");
+    expect(declaredActionRisk({})).toBe("high");
+    expect(declaredActionRisk(null)).toBe("high");
+    expect(declaredActionRisk({ risk: "LOW" })).toBe("high");
+    expect(declaredActionRisk({ risk: "medium" })).toBe("high");
+    expect(declaredActionRisk({ risk: true })).toBe("high");
+  });
+});
+
+describe("admitCodeAction", () => {
+  it("admits everything without a gate", async () => {
+    await expect(admitCodeAction(undefined, highAction)).resolves.toEqual({
+      allowed: true
+    });
+  });
+
+  it("asks nothing in plan or default mode — the per-call ladder is the gate", async () => {
+    for (const mode of ["plan", "default"] as PermissionMode[]) {
+      const { gate, asked } = makeGate(mode);
+      await expect(admitCodeAction(gate, highAction)).resolves.toEqual({
+        allowed: true
+      });
+      expect(asked).toEqual([]);
+    }
+  });
+
+  it("runs a low-risk action unattended in auto mode", async () => {
+    const { gate, asked } = makeGate("auto");
+    await expect(admitCodeAction(gate, lowAction)).resolves.toEqual({
+      allowed: true
+    });
+    expect(asked).toEqual([]);
+  });
+
+  it("asks once for a high-risk action in auto mode", async () => {
+    const { gate, asked } = makeGate("auto", "allow");
+    await expect(admitCodeAction(gate, highAction)).resolves.toEqual({
+      allowed: true
+    });
+    expect(asked).toHaveLength(1);
+    expect(asked[0]).toMatchObject({
+      toolName: EXECUTE_CODE_TOOL_NAME,
+      category: "execute",
+      message: "Deleting the old workflows"
+    });
+    // The user sees the program they are approving.
+    expect(asked[0].args).toEqual({
+      title: "Deleting the old workflows",
+      risk: "high",
+      code: "return 1;"
+    });
+    // Approving one call grants nothing beyond it.
+    await admitCodeAction(gate, highAction);
+    expect(asked).toHaveLength(2);
+  });
+
+  it("refuses a denied action with repair instructions", async () => {
+    const { gate } = makeGate("auto", "deny");
+    const admission = await admitCodeAction(gate, highAction);
+    expect(admission.allowed).toBe(false);
+    expect(admission.allowed === false && admission.error).toMatch(
+      /declined to run this code action/
+    );
+  });
+
+  it("stops asking after allow_for_chat", async () => {
+    const { gate, asked } = makeGate("auto", "allow_for_chat");
+    await admitCodeAction(gate, highAction);
+    await admitCodeAction(gate, highAction);
+    expect(asked).toHaveLength(1);
+    expect(gate.sessionAllow.has(EXECUTE_CODE_TOOL_NAME)).toBe(true);
+  });
+
+  it("reads an unlabeled action as high risk", async () => {
+    const { gate, asked } = makeGate("auto", "deny");
+    const admission = await admitCodeAction(gate, {
+      title: "Tidying up",
+      code: "return 1;"
+    });
+    expect(admission.allowed).toBe(false);
+    expect(asked).toHaveLength(1);
+  });
+});
+
+describe("a chat session in auto mode", () => {
+  const tools = [
+    {
+      name: "ui_add",
+      description: "Add two numbers.",
+      inputSchema: {
+        type: "object",
+        properties: { a: { type: "number" }, b: { type: "number" } }
+      }
+    }
+  ];
+  const code =
+    `import { ui_add } from "@nodetool-ai/sandbox-nodetool/ui";\n` +
+    `return (await ui_add({ a: 2, b: 3 })).sum;`;
+
+  function makeSession(gate: CapabilityGate, executeTool: typeof noopTool) {
+    const context = createMockContext() as unknown as ProcessingContext;
+    return createChatCodeActSession({
+      tools,
+      executeTool,
+      context,
+      capabilityRun: createCapabilityRun({ context, gate })
+    });
+  }
+
+  const noopTool = async (_call: ChatCodeActToolCall): Promise<unknown> =>
+    JSON.stringify({ sum: 5 });
+
+  it("never runs the program the user denied", async () => {
+    const executeTool = vi.fn(noopTool);
+    const { gate } = makeGate("auto", "deny");
+    const session = makeSession(gate, executeTool);
+
+    const observation = JSON.parse(
+      await session.executeAction({ title: "Adding", risk: "high", code })
+    ) as { ok: boolean; error?: string; toolCalls: number };
+
+    expect(observation.ok).toBe(false);
+    expect(observation.error).toMatch(/declined/);
+    expect(observation.toolCalls).toBe(0);
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("runs a low-risk program with no prompt", async () => {
+    const executeTool = vi.fn(noopTool);
+    const { gate, asked } = makeGate("auto", "deny");
+    const session = makeSession(gate, executeTool);
+
+    const observation = JSON.parse(
+      await session.executeAction({ title: "Adding", risk: "low", code })
+    ) as { ok: boolean; result?: unknown };
+
+    expect(observation.ok).toBe(true);
+    expect(observation.result).toBe(5);
+    expect(asked).toEqual([]);
+  });
+});

--- a/packages/websocket/src/mcp-agent-tools.ts
+++ b/packages/websocket/src/mcp-agent-tools.ts
@@ -803,13 +803,19 @@ export function registerAgentMcpTools(
   // model skipped a field this server does not use had its whole action
   // rejected on validation. It stays in the schema — described, and the
   // contract in the description still asks for one — but is optional here.
+  //
+  // `risk` is optional here for the same reason, and one more: this session's
+  // gate runs in `auto` with an always-allow approval (there is no MCP client
+  // to prompt), so the declared risk decides nothing on this surface. A
+  // missing one still reads as `high` — it just resolves to allow.
+  const optionalOnMcp = new Set(["title", "risk"]);
   const actionSchema = session.providerTool.inputSchema;
   const actionShape = jsonSchemaToZodShape({
     ...actionSchema,
     required: (Array.isArray(actionSchema["required"])
       ? (actionSchema["required"] as string[])
       : []
-    ).filter((name) => name !== "title")
+    ).filter((name) => !optionalOnMcp.has(name))
   });
 
   server.tool(

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1461,8 +1461,14 @@ const PERMISSION_MODE_PROMPTS = {
     "retry it — explain or propose an alternative.\n",
   auto:
     "\n# Permission mode: AUTO\n" +
-    "All tools run automatically without prompting. Be deliberate with actions " +
-    "that write, run, or have external side effects.\n"
+    "Tool calls inside a code action run without prompting, so the `risk` you " +
+    "declare on each `execute_code` call is what protects the user: a `low` " +
+    "action runs unattended, a `high` one asks them once before any of it " +
+    "runs. Declare `high` whenever the program deletes or overwrites " +
+    "something, publishes or sends anything outside this account, or spends " +
+    "real money — and whenever you are unsure. Keep the destructive or costly " +
+    "part in its own action so the routine work around it still runs " +
+    "unattended.\n"
 } satisfies Record<PermissionMode, string>;
 
 /**

--- a/packages/websocket/tests/chat-codeact-approval.test.ts
+++ b/packages/websocket/tests/chat-codeact-approval.test.ts
@@ -57,7 +57,7 @@ const sentMsgs = (ws: MockWS): Record<string, unknown>[] =>
   ws.sentBytes.map((b) => unpack(b) as Record<string, unknown>);
 
 /** Yields one `execute_code` call on the first round, then plain text. */
-function codeActProvider(code: string) {
+function codeActProvider(code: string, risk: "low" | "high" = "low") {
   let round = 0;
   return async () =>
     ({
@@ -65,7 +65,11 @@ function codeActProvider(code: string) {
       async *generateMessages() {},
       async *generateMessagesTraced() {
         if (round++ === 0) {
-          yield { id: "tc1", name: "execute_code", args: { title: "t", code } };
+          yield {
+            id: "tc1",
+            name: "execute_code",
+            args: { title: "t", risk, code }
+          };
         } else {
           yield { type: "chunk", content: "done", done: true };
         }
@@ -108,7 +112,7 @@ describe("codeact permission prompts", () => {
       resolveExecutor: noop,
       resolveProvider: codeActProvider(
         'import { write_file } from "@nodetool-ai/sandbox-nodetool/files";\n' +
-        `const r = await write_file({ file_path: "note.txt", content: "hi" });\n` +
+          `const r = await write_file({ file_path: "note.txt", content: "hi" });\n` +
           `return { wrote: String(r) };`
       )
     });
@@ -201,6 +205,98 @@ describe("codeact permission prompts", () => {
       sentMsgs(ws).find((m) => m.type === "message" && m.role === "tool")
     );
     expect(String(observation.content)).toContain("denied");
+
+    await runner.disconnect();
+  }, 60_000);
+  it("asks once for a high-risk action in auto mode, and runs nothing when denied", async () => {
+    initTestDb();
+    const ws = new MockWS();
+    const runner = new UnifiedWebSocketRunner({
+      resolveExecutor: noop,
+      resolveProvider: codeActProvider(
+        'import { write_file } from "@nodetool-ai/sandbox-nodetool/files";\n' +
+          `await write_file({ file_path: "note.txt", content: "hi" });\n` +
+          `return { wrote: true };`,
+        "high"
+      )
+    });
+    await runner.connect(ws);
+    void runner.receiveMessages();
+    void runner.handleCommand({
+      command: "chat_message",
+      data: {
+        thread_id: "t-auto-high",
+        content: "clean up the notes",
+        provider: "mock",
+        model: "m",
+        permission_mode: "auto"
+      }
+    });
+
+    // The action itself is what the user is asked about — not the write inside
+    // it, which auto mode would wave through.
+    const request = await waitFor(() =>
+      sentMsgs(ws).find((m) => m.type === "tool_approval_request")
+    );
+    expect(request).toMatchObject({
+      tool_name: "execute_code",
+      category: "execute"
+    });
+
+    ws.push({
+      type: "websocket.receive",
+      bytes: pack({
+        type: "tool_approval_response",
+        approval_id: request.approval_id,
+        decision: "deny"
+      })
+    } as WebSocketReceiveFrame);
+
+    const observation = await waitFor(() =>
+      sentMsgs(ws).find((m) => m.type === "message" && m.role === "tool")
+    );
+    expect(String(observation.content)).toContain("declined");
+    expect(String(observation.content)).not.toContain("wrote");
+    // The program never ran, so nothing inside it was ever asked about.
+    expect(
+      sentMsgs(ws).filter((m) => m.type === "tool_approval_request")
+    ).toHaveLength(1);
+
+    await runner.disconnect();
+  }, 60_000);
+
+  it("runs a low-risk action in auto mode with no prompt", async () => {
+    initTestDb();
+    const ws = new MockWS();
+    const runner = new UnifiedWebSocketRunner({
+      resolveExecutor: noop,
+      resolveProvider: codeActProvider(
+        'import { write_file } from "@nodetool-ai/sandbox-nodetool/files";\n' +
+          `const r = await write_file({ file_path: "note.txt", content: "hi" });\n` +
+          `return { wrote: String(r) };`,
+        "low"
+      )
+    });
+    await runner.connect(ws);
+    void runner.receiveMessages();
+    void runner.handleCommand({
+      command: "chat_message",
+      data: {
+        thread_id: "t-auto-low",
+        content: "write a note",
+        provider: "mock",
+        model: "m",
+        permission_mode: "auto"
+      }
+    });
+
+    const observation = await waitFor(() =>
+      sentMsgs(ws).find((m) => m.type === "message" && m.role === "tool")
+    );
+    expect(String(observation.content)).toContain('"wrote"');
+    expect(sentMsgs(ws).some((m) => m.type === "tool_approval_request")).toBe(
+      false
+    );
 
     await runner.disconnect();
   }, 60_000);


### PR DESCRIPTION
## What

Auto mode meant "everything runs, no prompts": `decidePermission` answers `allow` for every category, so inside a code action a program that deletes a workflow ran exactly like one that counted rows. That is the one place a user could lose work they never agreed to lose — picking Auto grants *not being interrupted for routine work*, not a blank cheque.

`execute_code` now carries one more required option, **`risk`** (`"low" | "high"`), next to `title` and `code`. The model declares it; the host reads it before a line of the program runs.

- **auto + low** → runs unattended, no prompt.
- **auto + high** → asks once, for the *whole action* (the action, not each bridged call, is what the user is shown — the approval card carries the title, the risk, and the program).
- **denied** → the program never runs; the refusal is the observation, with instructions to propose a narrower action.
- **"Allow for this chat"** is keyed on `execute_code`, so it stops the asking for the rest of the thread.

Fails closed: a call with no `risk`, or anything outside the enum, reads as `high`. Plan and default modes are untouched — their per-call ladder in `capabilities/invoke.ts` already blocks or asks, and a second question per action would only double the prompts. Hosts with nobody to ask (the MCP mount, the security monitor's pass in `Agent`) already carry always-allow approvals, so nothing there can deadlock.

## Changes

- `packages/agents/src/codeact/execute-code-contract.ts` (new) — the `execute_code` schema, `declaredActionRisk`, and `admitCodeAction`. The schema and `EXECUTE_CODE_TOOL_NAME` moved here from `codeact-executor.ts` and are re-exported from it, so every importer keeps its path.
- `codeact-executor.ts` / `chat-codeact.ts` — both surfaces run the admission before mounting or running the program.
- `prompt.ts` — the action contract explains what `low`/`high` mean and tells the model to keep the destructive or costly part in its own action, so the routine work around it still runs unattended.
- `unified-websocket-runner.ts` — the AUTO permission-mode prompt says the declared risk is what protects the user.
- Docs: `docs/codeact-design.md` (new section under the chat-turn part), `docs/global-chat.md` (mode table).

## Testing

- `packages/agents/tests/codeact-action-risk.test.ts` (new, 12 cases) — schema shape, `declaredActionRisk` failing closed on `{}`/`null`/`"LOW"`/`"medium"`/`true`, and the admission across plan/default/auto × low/high, including deny, `allow_for_chat` persistence, and a real chat session whose denied program never reaches the router.
- `packages/websocket/tests/chat-codeact-approval.test.ts` — two end-to-end cases over the real runner: a high-risk action in auto mode raises one `tool_approval_request` for `execute_code`, and denying it leaves the inner `write_file` never asked about and never run; a low-risk action runs with no prompt at all.
- Proven to bite: with `admitCodeAction` short-circuited to always allow and the package rebuilt, the high-risk end-to-end case fails; restored, it passes.
- `npx tsc --noEmit` clean for `packages/agents` and `packages/websocket`; `npx oxlint packages/*/src` reports nothing new on the changed files. Full-suite runs for both packages were still in flight when this PR was opened — CI is the check of record.
- `npm run lint` cannot complete in this environment: `web/.oxlintrc.json` loads a JS plugin needing `@oxlint/plugins`, which is not installed here. It fails identically on a clean tree (verified with the change stashed), and no `web/` file is touched by this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzrESQG42RcghNh4bcSYSs)_