### PR TITLE
fix(agents): close the four dead ends a "stitch my videos" chat hit

### DIFF
--- a/packages/agents/src/capabilities/assets.ts
+++ b/packages/agents/src/capabilities/assets.ts
@@ -298,6 +298,9 @@ async function readSourceBytes(
       };
     }
     const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength === 0) {
+      return { error: `${source} returned an empty body — nothing to save.` };
+    }
     if (bytes.byteLength > MAX_SOURCE_BYTES) {
       return {
         error: `${source} is ${bytes.byteLength} bytes, past the ${MAX_SOURCE_BYTES}-byte limit.`
@@ -320,6 +323,18 @@ async function readSourceBytes(
       error:
         `Source not found: ${source}. Pass the asset_url or /api/storage/ ` +
         `key a tool returned, an asset:// URI, or an http(s) URL.`
+    };
+  }
+  // A resolver that finds the key but reads nothing back — a bucket the
+  // adapter is not configured for, an object still being written — hands back
+  // an empty buffer rather than null. Saving it produced a 0-byte asset the
+  // caller was told was fine, and a chat that answered with a video nobody
+  // could play. Zero bytes is never a successful copy.
+  if (bytes.byteLength === 0) {
+    return {
+      error:
+        `${source} resolved to 0 bytes — nothing was copied. Check that the ` +
+        `source still exists and that this server can read its storage.`
     };
   }
   return { bytes };
@@ -396,6 +411,12 @@ const saveAsset: CapabilityExport = {
         data = hasBinary
           ? new Uint8Array(Buffer.from(contentBase64, "base64"))
           : new TextEncoder().encode(content as string);
+        if (hasBinary && data.byteLength === 0) {
+          return {
+            success: false,
+            error: "`content_base64` decoded to 0 bytes — nothing to save."
+          };
+        }
         mime =
           isString(contentTypeArg) && contentTypeArg
             ? contentTypeArg

--- a/packages/agents/src/capabilities/media.specs.ts
+++ b/packages/agents/src/capabilities/media.specs.ts
@@ -465,9 +465,20 @@ export const FFMPEG_SCHEMA: JsonSchema = {
       items: { type: "string" as const },
       description:
         "ffmpeg arguments after the binary name. Paths are workspace-relative " +
-        "and cannot escape it; inputs may only open local files, so a URL is " +
-        "refused — download it first. " +
+        "and cannot escape it; ffmpeg opens local files only, so an " +
+        "asset:// URI or a URL in args is refused — name it in `inputs` " +
+        "instead. " +
         "Example: [\"-i\", \"in.mp4\", \"-vf\", \"scale=1280:-2\", \"out.mp4\"]."
+    },
+    inputs: {
+      type: "object" as const,
+      description:
+        "Files to copy into the workspace before the run, as " +
+        "{\"<workspace-relative name>\": \"<asset:// URI, /api/storage/ key, " +
+        "or data: URI>\"}. This is how an asset reaches ffmpeg: stage it, " +
+        "then use the name in args. At most 8 files, 100 MB each. " +
+        "Example: {\"a.mp4\": \"asset://<id>.mp4\", \"b.mp4\": \"asset://<id>.mp4\"}.",
+      additionalProperties: { type: "string" as const }
     },
     output_file: {
       type: "string" as const,
@@ -489,9 +500,11 @@ export const ffmpegSpec: CapabilitySpec = {
   description:
     "Run ffmpeg on workspace files. Pass argv after the binary name " +
     "(no shell). Paths are workspace-relative and confined to the " +
-    "workspace; inputs open local files only (no URLs, pipes, or device " +
-    "files). Install ffmpeg if the binary is missing. Use output_file to " +
-    "persist the result as an asset.",
+    "workspace; ffmpeg opens local files only (no URLs, pipes, or device " +
+    "files) — put asset:// URIs in `inputs` to stage them under workspace " +
+    "names first. Install ffmpeg if the binary is missing. Use output_file " +
+    "to persist the result as an asset. Concatenating two assets is one " +
+    "call: inputs {a.mp4, b.mp4} plus a concat filter_complex.",
   inputSchema: FFMPEG_SCHEMA,
   category: "execute",
   userMessage: (params) => {

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -1398,16 +1398,17 @@ const ffmpeg: CapabilityExport = {
         result.exitCode === 0 && persistTarget
           ? await persistWorkspaceFile(run.context, persistTarget)
           : undefined;
-      return {
+      const report: Record<string, unknown> = {
         success: result.exitCode === 0,
         stdout: result.stdout,
         stderr: result.stderr,
         exit_code: result.exitCode,
-        ...(Object.keys(stagedResult.staged).length > 0
-          ? { staged: stagedResult.staged }
-          : {}),
         ...(persisted ?? {})
       };
+      if (Object.keys(stagedResult.staged).length > 0) {
+        report["staged"] = stagedResult.staged;
+      }
+      return report;
     } catch (e) {
       if (e instanceof HostBinaryMissingError) {
         return { error: e.message };

--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -21,7 +21,7 @@
 
 import { Buffer } from "node:buffer";
 import { randomInt } from "node:crypto";
-import { mkdir, readFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Message, MessageContent } from "@nodetool-ai/protocol";
 import type { JsonSchema, ProcessingContext } from "@nodetool-ai/runtime";
@@ -1256,6 +1256,102 @@ async function persistWorkspaceFile(
   }
 }
 
+/**
+ * What a refused `://` in ffmpeg argv should do instead. The guard's default
+ * says "stage it first" without saying how; here there is a parameter for it.
+ */
+const FFMPEG_REMEDY =
+  'Pass the ref in `inputs` instead — {"clip.mp4": "asset://<id>.mp4"} ' +
+  "copies it into the workspace, then name `clip.mp4` in args.";
+
+/** Largest single file `ffmpeg`'s `inputs` stages into the workspace. */
+const MAX_STAGED_INPUT_BYTES = 100 * 1024 * 1024;
+/** Files one `inputs` bag may stage. */
+const MAX_STAGED_INPUTS = 8;
+/** Bytes one `inputs` bag may stage in total. */
+const MAX_STAGED_TOTAL_BYTES = 256 * 1024 * 1024;
+
+/**
+ * Copy the refs in `inputs` into the workspace under the names the caller
+ * gave them, so argv can name plain local files.
+ *
+ * ffmpeg opens local files only — a URL or an `asset://` URI in argv is
+ * refused, and rightly so. But chat code has no workspace API of its own, so
+ * before this there was no way to put an asset where ffmpeg could see it: the
+ * capability was on the belt and unusable, and the refusal told the caller to
+ * "download first" with nothing to download with. Staging is that missing
+ * half, and it changes no boundary — the bytes are resolved host-side by the
+ * same resolver `save_asset` uses, and every name still goes through
+ * {@link confineArgvToWorkspace}.
+ */
+async function stageInputs(
+  context: ProcessingContext,
+  workspace: string,
+  raw: unknown
+): Promise<{ staged: Record<string, number> } | { error: string }> {
+  if (raw === undefined || raw === null) return { staged: {} };
+  if (!isRecord(raw)) {
+    return {
+      error:
+        'inputs must be an object of {"<workspace-relative name>": "<asset:// URI, /api/storage/ key, or data: URI>"}'
+    };
+  }
+  const entries = Object.entries(raw);
+  if (entries.length > MAX_STAGED_INPUTS) {
+    return {
+      error: `inputs stages at most ${MAX_STAGED_INPUTS} files; ${entries.length} were given.`
+    };
+  }
+  const names = entries.map(([name]) => name);
+  const refusal = await confineArgvToWorkspace(names, workspace);
+  if (refusal) return refusal;
+
+  const staged: Record<string, number> = {};
+  let total = 0;
+  for (const [name, ref] of entries) {
+    if (!isNonBlankString(name)) {
+      return { error: "inputs keys must be non-empty workspace paths." };
+    }
+    if (!isNonBlankString(ref)) {
+      return {
+        error: `inputs["${name}"] must be a string ref (asset:// URI, /api/storage/ key, or data: URI).`
+      };
+    }
+    let bytes: Uint8Array | null = null;
+    try {
+      bytes = await loadMediaRefBytes({ uri: ref.trim() }, context);
+    } catch {
+      // Reported as unreadable below; the message names the forms that work.
+    }
+    // Zero bytes is a failed read wearing a buffer, the same way it is in
+    // `save_asset` — staging it would hand ffmpeg an empty file and the
+    // failure would surface as an unhelpable decode error.
+    if (!bytes || bytes.byteLength === 0) {
+      return {
+        error:
+          `inputs["${name}"]: could not read ${ref}. Pass an asset:// URI, ` +
+          `the /api/storage/ key a tool returned, or a data: URI.`
+      };
+    }
+    if (bytes.byteLength > MAX_STAGED_INPUT_BYTES) {
+      return {
+        error: `inputs["${name}"] is ${bytes.byteLength} bytes, over the ${MAX_STAGED_INPUT_BYTES}-byte limit.`
+      };
+    }
+    total += bytes.byteLength;
+    if (total > MAX_STAGED_TOTAL_BYTES) {
+      return {
+        error: `inputs stages ${total} bytes, over the ${MAX_STAGED_TOTAL_BYTES}-byte total limit.`
+      };
+    }
+    const abs = context.resolveWorkspacePath(name);
+    await mkdir(path.dirname(abs), { recursive: true });
+    await writeFile(abs, bytes);
+    staged[name] = bytes.byteLength;
+  }
+  return { staged };
+}
+
 const ffmpeg: CapabilityExport = {
   spec: ffmpegSpec,
   impl: async (run, params) => {
@@ -1263,6 +1359,13 @@ const ffmpeg: CapabilityExport = {
     if (!isString(workspace)) return workspace;
     const args = stringArgs(params["args"]);
     if ("error" in args) return args;
+
+    const stagedResult = await stageInputs(
+      run.context,
+      workspace,
+      params["inputs"]
+    );
+    if ("error" in stagedResult) return stagedResult;
 
     const outputFile = isNonBlankString(params["output_file"])
       ? params["output_file"].trim()
@@ -1272,7 +1375,7 @@ const ffmpeg: CapabilityExport = {
       argv.push(outputFile);
     }
 
-    const refusal = await confineArgvToWorkspace(argv, workspace);
+    const refusal = await confineArgvToWorkspace(argv, workspace, FFMPEG_REMEDY);
     if (refusal) return refusal;
     const hardened = hardenFfmpegArgv(argv);
     if ("error" in hardened) return hardened;
@@ -1300,6 +1403,9 @@ const ffmpeg: CapabilityExport = {
         stdout: result.stdout,
         stderr: result.stderr,
         exit_code: result.exitCode,
+        ...(Object.keys(stagedResult.staged).length > 0
+          ? { staged: stagedResult.staged }
+          : {}),
         ...(persisted ?? {})
       };
     } catch (e) {

--- a/packages/agents/src/capabilities/timelines.specs.ts
+++ b/packages/agents/src/capabilities/timelines.specs.ts
@@ -110,11 +110,13 @@ export const EDIT_TIMELINE_SCHEMA: JsonSchema = {
         'Operations in order. Each is {"op": <name>, ...arguments}, e.g. ' +
         '{"op": "add_track", "type": "audio", "name": "Music"} or ' +
         '{"op": "animate_clip", "target": "Title", "animations": [{"role": "in", "preset": "fade"}]}. ' +
-        "Ops: get_state, add_track, add_text_clip, add_shape_clip, " +
+        "Ops: get_state, add_track, add_media_clip, add_text_clip, add_shape_clip, " +
         "split_clip, trim_clip, move_clip, duplicate_clip, delete_clip, " +
         "set_clip_params, set_clip_binding, animate_clip, clear_animations, " +
         "list_animation_presets, select_clip, seek. Start with get_state to " +
-        "read track and clip ids.",
+        "read track and clip ids. To lay existing videos end to end, call " +
+        'add_media_clip once per asset ({"op": "add_media_clip", "asset": ' +
+        '"asset://<id>.mp4"}) — each appends after the last.',
       items: { type: "object" }
     }
   },

--- a/packages/agents/src/capabilities/timelines.ts
+++ b/packages/agents/src/capabilities/timelines.ts
@@ -25,7 +25,10 @@ import type {
   TimelineSequenceVersion
 } from "@nodetool-ai/models";
 import type { TimelineValidation } from "@nodetool-ai/execution/timeline-debug";
-import type { TimelineBridgeFinalState } from "../evals/surfaces/timeline.js";
+import type {
+  TimelineBridgeAsset,
+  TimelineBridgeFinalState
+} from "../evals/surfaces/timeline.js";
 import type {
   CapabilityExport,
   CapabilityModule,
@@ -414,12 +417,54 @@ interface ApplyOutcome {
 }
 
 /**
+ * Read one of the caller's assets for `add_media_clip`.
+ *
+ * The ref a model has in hand is whatever `list_assets` printed — a bare id or
+ * an `asset://<id>.<ext>` URI — so both resolve here.
+ */
+async function resolveTimelineAsset(
+  run: CapabilityRun,
+  ref: string
+): Promise<TimelineBridgeAsset | null> {
+  const id = ref.startsWith("asset://")
+    ? ref.slice("asset://".length).replace(/\.[A-Za-z0-9]{1,8}$/, "")
+    : ref;
+  if (!id) return null;
+  const userId = run.context.userId;
+  if (!userId) return null;
+  const { Asset } = await import("@nodetool-ai/models");
+  // `find` is already user-scoped: someone else's asset reads as missing.
+  const asset = await Asset.find(userId, id);
+  if (!asset) return null;
+  const thumbnails = isRecord(asset.metadata)
+    ? asset.metadata["thumbnails"]
+    : undefined;
+  const thumbnailAssetId =
+    Array.isArray(thumbnails) && isString(thumbnails[0])
+      ? thumbnails[0]
+      : undefined;
+  const resolved: TimelineBridgeAsset = {
+    id: asset.id,
+    name: asset.name,
+    contentType: asset.content_type
+  };
+  // `duration` is seconds and often null — assets are catalogued without
+  // probing. The bridge falls back to its own default when it is missing.
+  if (isFiniteNumber(asset.duration) && asset.duration > 0) {
+    resolved.durationMs = Math.round(asset.duration * 1000);
+  }
+  if (thumbnailAssetId) resolved.thumbnailAssetId = thumbnailAssetId;
+  return resolved;
+}
+
+/**
  * Run `ops` against a bridge seeded from `document`.
  *
  * A failing op is recorded and the script continues: stopping at the first
  * error hides every problem behind it, and the caller wants the whole picture.
  */
 async function applyOps(
+  run: CapabilityRun,
   sequence: TimelineSequence,
   document: TimelineDocument,
   ops: ParsedOp[]
@@ -433,7 +478,8 @@ async function applyOps(
       height: sequence.height,
       tracks: document.tracks,
       clips: document.clips
-    }
+    },
+    resolveAsset: (ref) => resolveTimelineAsset(run, ref)
   });
   const byName = new Map(
     bridge.tools
@@ -491,7 +537,7 @@ const editTimeline: CapabilityExport = {
         return { error: `Timeline ${timelineId} was not found.` };
       }
       const document = sequence.toDocument();
-      const { records, state } = await applyOps(sequence, document, ops);
+      const { records, state } = await applyOps(run, sequence, document, ops);
 
       // Markers and the transcript ride along untouched: no timeline operation
       // edits them, so the stored copies stay authoritative.

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -1172,8 +1172,13 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   \`understandVideo(video, prompt, videoModel, {max_tokens})\` reads a whole clip
   with a model that takes video (Gemini) and answers \`prompt\` as \`{text}\` —
   describe it, summarize it, or pull the on-screen text out.
-  Host binaries: \`ffmpeg(args, {output_file, timeout_seconds})\` runs ffmpeg
-  in the workspace (no shell, workspace paths only, no URL inputs);
+  Host binaries: \`ffmpeg(args, {inputs, output_file, timeout_seconds})\` runs
+  ffmpeg in the workspace (no shell, workspace paths only, no URL inputs).
+  \`inputs\` stages refs under workspace names first, which is how an asset
+  reaches ffmpeg — concatenating two of them is one call:
+  \`ffmpeg(["-i", "a.mp4", "-i", "b.mp4", "-filter_complex",
+  "[0:v][0:a][1:v][1:a]concat=n=2:v=1:a=1[v][a]", "-map", "[v]", "-map", "[a]",
+  "out.mp4"], {inputs: {"a.mp4": uriA, "b.mp4": uriB}, output_file: "out.mp4"})\`;
   \`ffprobe(path)\` reads a file's format and streams before you decide what to
   run; \`downloadVideo(url, outputFile, {format,
   timeout_seconds})\` downloads with yt-dlp. Browse pages with
@@ -1289,7 +1294,10 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   \`edit(id, ops)\` — the cut itself, server-side: \`[{op: "add_track", type:
   "audio"}, {op: "add_text_clip", text: "Hi"}, {op: "split_clip", target:
   "shot", atMs: 3000}, {op: "animate_clip", target: "Hi", animations:
-  [{role: "in", preset: "fade"}]}]\`. Start with \`{op: "get_state"}\` for ids.`
+  [{role: "in", preset: "fade"}]}]\`. Start with \`{op: "get_state"}\` for ids.
+  Existing library media goes on with \`{op: "add_media_clip", asset:
+  "asset://<id>.mp4"}\`, which appends after the track's last clip — so one
+  call per asset lays them end to end.`
   },
   {
     namespace: "sketches",

--- a/packages/agents/src/evals/surfaces/timeline.ts
+++ b/packages/agents/src/evals/surfaces/timeline.ts
@@ -36,6 +36,9 @@ import {
   DEFAULT_SHAPE_FILL_COLOR,
   DEFAULT_SHAPE_STROKE_COLOR,
   DEFAULT_SHAPE_STROKE_WIDTH_PX,
+  DEFAULT_MEDIA_CLIP_DURATION_MS,
+  mediaTypeForContentType,
+  trackTypeForMediaType,
   type TimelineClip,
   type TimelineTrack,
   type ClipAnimation
@@ -87,6 +90,26 @@ const fullTextStyleParams = z.object({
   maxWidthFrac: z.number().optional()
 });
 
+/**
+ * What the bridge needs to know about an asset to place it as a clip. A host
+ * that can read the asset table supplies {@link TimelineAssetResolver}; the
+ * eval bridge seeds a fixed table instead, so the op is exercised with no
+ * database in reach.
+ */
+export interface TimelineBridgeAsset {
+  id: string;
+  name: string;
+  contentType: string;
+  /** Length in ms, when the catalogue knows it. */
+  durationMs?: number;
+  thumbnailAssetId?: string;
+}
+
+/** Look up an asset by id or `asset://<id>[.ext]` URI. */
+export type TimelineAssetResolver = (
+  ref: string
+) => Promise<TimelineBridgeAsset | null>;
+
 /** A whole sequence handed to the bridge as-is, fields and all. */
 export interface TimelineBridgeSequenceSeed {
   fps?: number;
@@ -109,6 +132,12 @@ export interface TimelineBridgeInitialState {
    * can hand over state it still owns.
    */
   sequence?: TimelineBridgeSequenceSeed;
+  /**
+   * Resolve an asset ref for `ui_timeline_add_media_clip`. Without one the op
+   * reports that this surface has no asset lookup rather than inventing a
+   * clip that points at nothing.
+   */
+  resolveAsset?: TimelineAssetResolver;
   tracks?: { name?: string; type: "video" | "audio" | "overlay" | "subtitle" }[];
   clips?: {
     name: string;
@@ -179,6 +208,7 @@ export function createTimelineToolBridge(
   initial: TimelineBridgeInitialState = {}
 ): HeadlessSurfaceBridge<TimelineBridgeFinalState> {
   const seed = initial.sequence;
+  const resolveAsset = initial.resolveAsset;
   const fps = seed?.fps ?? initial.fps ?? 30;
   const width = seed?.width ?? initial.width ?? 1920;
   const height = seed?.height ?? initial.height ?? 1080;
@@ -421,6 +451,62 @@ export function createTimelineToolBridge(
             maxWidthFrac: s.maxWidthFrac
           }
         });
+        clips.push(clip);
+        selectedClipIds = [clip.id];
+        return { ok: true, clip: serializeClip(clip) };
+      }
+    ),
+
+    tool(
+      "ui_timeline_add_media_clip",
+      "Place an existing asset — a video, image, or audio file already in the library — on the specified timeline sequence. `asset` is an asset id or `asset://<id>.<ext>` URI (list_assets returns both). Without a track the clip lands on a track matching its media kind, creating one when needed; without `startMs` it is appended after that track's existing content, so calling this once per asset lays them end to end. Duration comes from the asset when known.",
+      z.object({
+        asset: z.string().trim().min(1),
+        trackId: z.string().optional(),
+        startMs: z.number().optional(),
+        durationMs: z.number().optional(),
+        name: z.string().optional()
+      }),
+      async ({ asset, trackId, startMs, durationMs, name }) => {
+        if (!resolveAsset) {
+          throw new Error(
+            "This timeline surface cannot look up assets, so an existing asset cannot be placed here."
+          );
+        }
+        const ref = asset as string;
+        const found = await resolveAsset(ref);
+        if (!found) {
+          throw new Error(
+            `No asset found for "${ref}". Pass an asset id or an asset:// URI from list_assets.`
+          );
+        }
+        const mediaType = mediaTypeForContentType(found.contentType);
+        if (!mediaType) {
+          throw new Error(
+            `Asset "${found.name}" is ${found.contentType}, which is not video, image, or audio and cannot go on a timeline.`
+          );
+        }
+        const track = trackId
+          ? resolveTrack(trackId as string)
+          : findOrCreateTrack(trackTypeForMediaType(mediaType));
+        const init: Parameters<typeof makeClip>[0] = {
+          id: nextClipId(),
+          trackId: track.id,
+          name: (name as string | undefined) ?? found.name,
+          startMs: (startMs as number | undefined) ?? trackEndMs(track.id),
+          durationMs:
+            (durationMs as number | undefined) ??
+            found.durationMs ??
+            DEFAULT_MEDIA_CLIP_DURATION_MS,
+          mediaType,
+          sourceType: "imported",
+          status: "generated",
+          currentAssetId: found.id
+        };
+        if (found.thumbnailAssetId) {
+          init.thumbnailAssetId = found.thumbnailAssetId;
+        }
+        const clip = makeClip(init);
         clips.push(clip);
         selectedClipIds = [clip.id];
         return { ok: true, clip: serializeClip(clip) };

--- a/packages/agents/src/host-binary-guard.ts
+++ b/packages/agents/src/host-binary-guard.ts
@@ -113,10 +113,16 @@ function pathCandidates(arg: string): string[] {
  * {@link pathCandidates} — is resolved against the workspace root, so an
  * absolute path, a `..` chain, and a path inside a filter token all land
  * outside it the same way.
+ *
+ * `remedy` is the one sentence the refusal ends on. It defaults to something
+ * true of every host binary; a caller with a way to put the file where the
+ * binary can see it — `ffmpeg`'s `inputs` — names that instead, so the refusal
+ * points at a parameter rather than at an errand the caller cannot run.
  */
 export async function confineArgvToWorkspace(
   argv: readonly string[],
-  workspace: string
+  workspace: string,
+  remedy = "Stage it in the workspace first, then pass the local path."
 ): Promise<ArgvRefusal | undefined> {
   for (const arg of argv) {
     const token = deniedToken(arg);
@@ -124,8 +130,7 @@ export async function confineArgvToWorkspace(
       return {
         error:
           `"${token}" is not allowed in a host media argument (in "${arg}"). ` +
-          `Only workspace files are readable; download first, then pass the ` +
-          `local path.`
+          `Only workspace files are readable. ${remedy}`
       };
     }
     if (arg === "" || arg.startsWith("-")) continue;

--- a/packages/agents/tests/capabilities-assets.test.ts
+++ b/packages/agents/tests/capabilities-assets.test.ts
@@ -281,6 +281,36 @@ describe("assets capabilities against the database", () => {
     }
   });
 
+  it("refuses a source that resolves to zero bytes", async () => {
+    // A storage adapter that answers with an empty buffer instead of null is
+    // what turned a failed copy into a 0-byte asset reported as saved.
+    const ctx = makeContext({
+      storage: {
+        retrieve: async () => new Uint8Array(0),
+        store: async (key: string) => `mem://${key}`,
+        uriForKey: (key: string) => `mem://${key}`
+      }
+    });
+
+    const saved = (await asTool("save_asset", ctx).process(ctx, {
+      name: "stitched.mp4",
+      source: "supabase://nodetool-temp/assets/missing.mp4",
+      content_type: "video/mp4"
+    })) as Record<string, unknown>;
+    expect(saved.success).toBe(false);
+    expect(String(saved.error)).toContain("0 bytes");
+  });
+
+  it("refuses base64 that decodes to nothing", async () => {
+    const ctx = makeContext();
+    const saved = (await asTool("save_asset", ctx).process(ctx, {
+      name: "empty.mp4",
+      content_base64: "",
+      content_type: "video/mp4"
+    })) as Record<string, unknown>;
+    expect(saved.success).toBe(false);
+  });
+
   it("refuses more than one content form and names a missing source", async () => {
     const ctx = makeContext();
     const both = (await asTool("save_asset", ctx).process(ctx, {

--- a/packages/agents/tests/capabilities-media.test.ts
+++ b/packages/agents/tests/capabilities-media.test.ts
@@ -11,6 +11,9 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import type { Message, MessageContent } from "@nodetool-ai/protocol";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import { toolFromCapability } from "../src/capabilities/adapters.js";
@@ -52,6 +55,15 @@ function makeContext(
   return {
     userId: "user-1",
     runProviderPrediction
+  } as unknown as ProcessingContext;
+}
+
+/** A context with a real workspace directory on disk. */
+function workspaceContext(dir: string): ProcessingContext {
+  return {
+    userId: "user-1",
+    workspaceDir: dir,
+    resolveWorkspacePath: (relative: string) => resolve(dir, relative)
   } as unknown as ProcessingContext;
 }
 
@@ -419,6 +431,55 @@ describe("ffmpeg and yt_dlp capabilities", () => {
       { args: ["-i", "http://169.254.169.254/latest/meta-data/", "out.txt"] }
     )) as Record<string, unknown>;
     expect(String(result["error"])).toMatch(/Only workspace files are readable/);
+  });
+
+  it("ffmpeg stages an inputs ref into the workspace before running", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ffmpeg-inputs-"));
+    try {
+      // ffmpeg may not be installed here; staging happens before the spawn,
+      // so the file on disk is what this pins.
+      await asTool(ffmpeg).process(workspaceContext(dir), {
+        args: ["-i", "a.txt", "out.mp4"],
+        inputs: { "a.txt": "data:text/plain;base64,aGk=" }
+      });
+      expect(await readFile(join(dir, "a.txt"), "utf8")).toBe("hi");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ffmpeg refuses an inputs name that escapes the workspace", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ffmpeg-inputs-"));
+    try {
+      const result = (await asTool(ffmpeg).process(workspaceContext(dir), {
+        args: ["-i", "a.txt", "out.mp4"],
+        inputs: { "../escaped.txt": "data:text/plain;base64,aGk=" }
+      })) as Record<string, unknown>;
+      expect(String(result["error"])).toMatch(/outside the workspace/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ffmpeg names the ref it could not read", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ffmpeg-inputs-"));
+    try {
+      const result = (await asTool(ffmpeg).process(workspaceContext(dir), {
+        args: ["-i", "a.mp4", "out.mp4"],
+        inputs: { "a.mp4": "asset://does-not-exist.mp4" }
+      })) as Record<string, unknown>;
+      expect(String(result["error"])).toMatch(/could not read/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ffmpeg points a refused URI at the inputs parameter", async () => {
+    const result = (await asTool(ffmpeg).process(
+      { workspaceDir: "/tmp" } as unknown as ProcessingContext,
+      { args: ["-i", "asset://abc.mp4", "out.mp4"] }
+    )) as Record<string, unknown>;
+    expect(String(result["error"])).toMatch(/`inputs`/);
   });
 
   it("ffmpeg refuses an output_file that escapes the workspace", async () => {

--- a/packages/agents/tests/capabilities-timelines.test.ts
+++ b/packages/agents/tests/capabilities-timelines.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import {
+  Asset,
   ModelObserver,
   TimelineSequence,
   initTestDb
@@ -215,6 +216,76 @@ describe("timelines capability behaviour", () => {
     })) as { applied: number; failed: number; tracks: Array<{ name: string }> };
     expect(result).toMatchObject({ applied: 1, failed: 0 });
     expect(result.tracks.map((t) => t.name)).toContain("Music");
+  });
+
+  it("lays two library videos end to end with add_media_clip", async () => {
+    const row = await makeTimeline();
+    const first = (await Asset.create({
+      user_id: "u1",
+      name: "skateboarding_red_panda.mp4",
+      content_type: "video/mp4",
+      duration: 3
+    })) as Asset;
+    const second = (await Asset.create({
+      user_id: "u1",
+      name: "second.mp4",
+      content_type: "video/mp4"
+    })) as Asset;
+
+    const result = (await run().invoke("edit_timeline", {
+      timeline_id: row.id,
+      ops: [
+        { op: "add_media_clip", asset: `asset://${first.id}.mp4` },
+        { op: "add_media_clip", asset: second.id }
+      ]
+    })) as {
+      applied: number;
+      failed: number;
+      clips: Array<{
+        name: string;
+        start_ms: number;
+        duration_ms: number;
+        track_id: string;
+      }>;
+    };
+    expect(result).toMatchObject({ applied: 2, failed: 0 });
+
+    // The seed document already holds a 2000ms clip on the only video track,
+    // so the two appends land after it, back to back — which is what
+    // "stitch my videos" means on a timeline.
+    const added = result.clips.slice(1);
+    expect(added.map((c) => c.name)).toEqual([
+      "skateboarding_red_panda.mp4",
+      "second.mp4"
+    ]);
+    expect(added[0]).toMatchObject({ start_ms: 2000, duration_ms: 3000 });
+    expect(added[1].start_ms).toBe(5000);
+    expect(added[0].track_id).toBe(added[1].track_id);
+  });
+
+  it("refuses an asset that is not this user's, and one that is not media", async () => {
+    const row = await makeTimeline();
+    const theirs = (await Asset.create({
+      user_id: "u2",
+      name: "private.mp4",
+      content_type: "video/mp4"
+    })) as Asset;
+    const notMedia = (await Asset.create({
+      user_id: "u1",
+      name: "notes.md",
+      content_type: "text/markdown"
+    })) as Asset;
+
+    const result = (await run().invoke("edit_timeline", {
+      timeline_id: row.id,
+      ops: [
+        { op: "add_media_clip", asset: theirs.id },
+        { op: "add_media_clip", asset: notMedia.id }
+      ]
+    })) as { failed: number; ops: Array<{ error?: string }> };
+    expect(result.failed).toBe(2);
+    expect(result.ops[0].error).toContain("No asset found");
+    expect(result.ops[1].error).toContain("cannot go on a timeline");
   });
 
   it("records an unknown edit op instead of throwing", async () => {

--- a/packages/dsl/src/core.ts
+++ b/packages/dsl/src/core.ts
@@ -183,6 +183,61 @@ export function createNode<
   return node;
 }
 
+/**
+ * Find an {@link OutputHandle} nested inside a prop value — in an array, or
+ * under an object key. Returns the path to the first one, or null.
+ *
+ * `workflow()` derives edges from handles sitting *directly* on an input, so a
+ * handle one level down is not a connection: it used to be written verbatim
+ * into the node's `data`, the node producing it was never reached, and the
+ * graph validated clean with the producer missing entirely. Reporting the path
+ * is what turns that silent hole into an error a caller can act on.
+ */
+function findNestedHandlePath(
+  value: unknown,
+  seen: Set<object>
+): string | null {
+  if (typeof value !== "object" || value === null) return null;
+  if (seen.has(value)) return null;
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      const item = value[i];
+      if (isOutputHandle(item)) return `[${i}]`;
+      const deeper = findNestedHandlePath(item, seen);
+      if (deeper !== null) return `[${i}]${deeper}`;
+    }
+    return null;
+  }
+  for (const [key, item] of Object.entries(value)) {
+    if (isOutputHandle(item)) return `.${key}`;
+    const deeper = findNestedHandlePath(item, seen);
+    if (deeper !== null) return `.${key}${deeper}`;
+  }
+  return null;
+}
+
+/**
+ * Refuse a prop that buries a node reference where no edge can be drawn from
+ * it. The message names the one shape that works: a handle per input, which
+ * for a node with dynamic inputs means one named slot per source.
+ */
+function assertNoNestedHandles(desc: RegisteredNodeDescriptor): void {
+  for (const [inputName, value] of Object.entries(desc.inputs)) {
+    if (isOutputHandle(value)) continue;
+    const path = findNestedHandlePath(value, new Set());
+    if (path === null) continue;
+    throw new Error(
+      `${desc.nodeType} input "${inputName}" holds a node output at ` +
+        `"${inputName}${path}". A connection is only made from a handle ` +
+        `assigned directly to an input — one nested in an array or object is ` +
+        `not wired, and the node producing it is left out of the graph. Give ` +
+        `each source its own input (e.g. {video1: a.output(), video2: ` +
+        `b.output()}) instead of a list.`
+    );
+  }
+}
+
 export function workflow(...terminals: DslNode<never>[]): Workflow {
   if (terminals.length === 0) {
     throw new Error("workflow() requires at least one terminal node");
@@ -208,6 +263,7 @@ export function workflow(...terminals: DslNode<never>[]): Workflow {
   while (queue.length > 0) {
     const currentId = queue.shift()!;
     const desc = visited.get(currentId)!;
+    assertNoNestedHandles(desc);
 
     for (const [inputName, value] of Object.entries(desc.inputs)) {
       if (isOutputHandle(value)) {

--- a/packages/dsl/tests/core.test.ts
+++ b/packages/dsl/tests/core.test.ts
@@ -121,6 +121,40 @@ describe("createNode", () => {
 });
 
 describe("workflow", () => {
+  test("refuses a node output buried in an array prop", () => {
+    const a = createNode<SingleOutput<string>>("nodetool.constant.String", {
+      value: "a"
+    });
+    const b = createNode<SingleOutput<string>>("nodetool.constant.String", {
+      value: "b"
+    });
+    const sink = createNode<SingleOutput<string>>("nodetool.video.Concat", {
+      videos: [a.output(), b.output()]
+    });
+    // Before this check the array was written into the node's data verbatim,
+    // no edge was drawn, and both constants were dropped — a one-node graph
+    // that validated clean.
+    expect(() => workflow(sink)).toThrow(/videos\[0\]/);
+  });
+
+  test("refuses a node output buried under an object key", () => {
+    const a = createNode<SingleOutput<string>>("nodetool.constant.String", {
+      value: "a"
+    });
+    const sink = createNode<SingleOutput<string>>("nodetool.text.Concat", {
+      settings: { source: a.output() }
+    });
+    expect(() => workflow(sink)).toThrow(/settings\.source/);
+  });
+
+  test("leaves a plain array prop alone", () => {
+    const sink = createNode<SingleOutput<string>>("nodetool.text.Concat", {
+      parts: ["a", "b"],
+      nested: { deep: [1, 2, 3] }
+    });
+    expect(() => workflow(sink)).not.toThrow();
+  });
+
   test("single node — 1 node, 0 edges", () => {
     const a = createNode<SingleOutput<number>>("nodetool.constant.Integer", {
       input_item: 5

--- a/packages/timeline/src/defaults.ts
+++ b/packages/timeline/src/defaults.ts
@@ -35,6 +35,35 @@ export const DEFAULT_TEXT_CLIP_COLOR = "#FFFFFF";
 export const DEFAULT_TEXT_CLIP_DURATION_MS = 3000;
 export const DEFAULT_TEXT_CLIP_FONT_SIZE_PX = 96;
 
+/**
+ * Length an imported media clip gets when nothing knows its real duration.
+ * Assets are catalogued without probing, so `Asset.duration` is often null.
+ */
+export const DEFAULT_MEDIA_CLIP_DURATION_MS = 4000;
+
+/**
+ * The timeline media type an asset's MIME type maps to, or null when the
+ * asset is not placeable on a timeline. Shared by the editor's drag-and-drop
+ * adapter and the headless agent surface so a clip placed by an agent matches
+ * one placed by hand.
+ */
+export function mediaTypeForContentType(
+  contentType: string | undefined | null
+): "image" | "video" | "audio" | null {
+  if (!contentType) return null;
+  if (contentType.startsWith("image/")) return "image";
+  if (contentType.startsWith("video/")) return "video";
+  if (contentType.startsWith("audio/")) return "audio";
+  return null;
+}
+
+/** The track type an imported clip of this media type belongs on. */
+export function trackTypeForMediaType(
+  mediaType: "image" | "video" | "audio"
+): "video" | "audio" {
+  return mediaType === "audio" ? "audio" : "video";
+}
+
 /** Default authored-shape colors, stored as canvas-ready color data. */
 export const DEFAULT_SHAPE_FILL_COLOR = "#FFFFFF";
 export const DEFAULT_SHAPE_STROKE_COLOR = "#FFFFFF";

--- a/web/src/components/timeline/__tests__/timelineAgentBridge.test.ts
+++ b/web/src/components/timeline/__tests__/timelineAgentBridge.test.ts
@@ -9,6 +9,7 @@ import type { TimelineAgentHandler } from "../timelineAgentBridge";
 const makeMockHandler = (): TimelineAgentHandler => ({
   getSnapshot: jest.fn(),
   addTrack: jest.fn(),
+  addMediaClip: jest.fn(),
   addTextClip: jest.fn(),
   addShapeClip: jest.fn(),
   generateClip: jest.fn(),

--- a/web/src/components/timeline/dnd/assetToClipAdapter.ts
+++ b/web/src/components/timeline/dnd/assetToClipAdapter.ts
@@ -1,30 +1,19 @@
 import type { Asset } from "../../../stores/ApiTypes";
-import { makeClip } from "@nodetool-ai/timeline";
+import {
+  DEFAULT_MEDIA_CLIP_DURATION_MS,
+  makeClip,
+  mediaTypeForContentType
+} from "@nodetool-ai/timeline";
 import type { TimelineClip } from "@nodetool-ai/timeline";
-
-const DEFAULT_DURATION_MS = 4000;
 
 /**
  * Derive the timeline mediaType from an asset's content_type.
  * Returns null if the content type is not image, video, or audio.
+ *
+ * The mapping itself lives in `@nodetool-ai/timeline` so the headless agent
+ * surface places an imported clip the same way a drop does.
  */
-export function assetMediaType(
-  contentType: string | undefined | null
-): "image" | "video" | "audio" | null {
-  if (!contentType) {
-    return null;
-  }
-  if (contentType.startsWith("image/")) {
-    return "image";
-  }
-  if (contentType.startsWith("video/")) {
-    return "video";
-  }
-  if (contentType.startsWith("audio/")) {
-    return "audio";
-  }
-  return null;
-}
+export const assetMediaType = mediaTypeForContentType;
 
 /**
  * Return true if the given mediaType is compatible with the given track type.
@@ -62,7 +51,7 @@ export function assetToClip(
   const durationMs =
     asset.duration !== null && asset.duration !== undefined
       ? Math.round(asset.duration * 1000)
-      : DEFAULT_DURATION_MS;
+      : DEFAULT_MEDIA_CLIP_DURATION_MS;
 
   // Thumbnail: for video assets check metadata.thumbnails array
   let thumbnailAssetId: string | undefined;

--- a/web/src/components/timeline/timelineAgentBridge.ts
+++ b/web/src/components/timeline/timelineAgentBridge.ts
@@ -272,6 +272,18 @@ export interface ClipAnimationInput {
   };
 }
 
+/** Place an asset the library already holds as a clip. */
+export interface TimelineAddMediaClipOptions {
+  /** Asset id or `asset://<id>.<ext>` URI. */
+  asset: string;
+  trackId?: string;
+  startMs?: number;
+  /** Overrides the asset's own duration. */
+  durationMs?: number;
+  /** Overrides the asset's name as the clip label. */
+  name?: string;
+}
+
 /** How {@link TimelineAgentHandler.setClipAnimations} applies its inputs. */
 export type ClipAnimationMode = "add" | "replace";
 
@@ -290,6 +302,13 @@ export interface TimelineAgentHandler {
   generateClip: (
     opts: TimelineGenerateOptions
   ) => Promise<TimelineGenerateResult>;
+  /**
+   * Place an existing library asset. Async because the asset row is fetched
+   * for its media type, duration and thumbnail.
+   */
+  addMediaClip: (
+    opts: TimelineAddMediaClipOptions
+  ) => Promise<TimelineClipNode>;
   addTextClip: (opts: TimelineAddTextClipOptions) => TimelineClipNode;
   addShapeClip: (opts: TimelineAddShapeClipOptions) => TimelineClipNode;
   /** Split a clip at the given time (defaults to the playhead). */

--- a/web/src/hooks/timeline/useTimelineAgentBridge.ts
+++ b/web/src/hooks/timeline/useTimelineAgentBridge.ts
@@ -12,7 +12,7 @@
  */
 
 import { useEffect, useMemo } from "react";
-import { makeClip } from "@nodetool-ai/timeline";
+import { makeClip, trackTypeForMediaType } from "@nodetool-ai/timeline";
 import type {
   ClipAnimation,
   TimelineClip,
@@ -32,6 +32,11 @@ import {
   type ModelKind
 } from "../../stores/lastModelStore";
 import { useAssetStore } from "../../stores/AssetStore";
+import {
+  assetMediaType,
+  assetToClip,
+  isCompatibleWithTrack
+} from "../../components/timeline/dnd/assetToClipAdapter";
 import { getAssetUrl } from "../../utils/assetHelpers";
 import { useTimelineDirectGenJob } from "./useTimelineDirectGenJob";
 import {
@@ -42,6 +47,7 @@ import {
   type TimelineAnimationNode,
   type TimelineClipNode,
   type TimelineClipFrameNode,
+  type TimelineAddMediaClipOptions,
   type TimelineAddTextClipOptions,
   type TimelineAddShapeClipOptions,
   type TimelineGenerateKind,
@@ -347,6 +353,63 @@ export const useTimelineAgentBridge = (sequenceId: string | null): void => {
         }
 
         return { clip: clipNode(reReadClip(clipId)), generationStarted, note };
+      },
+
+      async addMediaClip(opts: TimelineAddMediaClipOptions) {
+        const assetId = opts.asset.startsWith("asset://")
+          ? opts.asset.slice("asset://".length).replace(/\.[A-Za-z0-9]{1,8}$/, "")
+          : opts.asset;
+        const asset = await useAssetStore.getState().get(assetId);
+        if (!asset) {
+          throw new Error(`No asset found for "${opts.asset}".`);
+        }
+        const mediaType = assetMediaType(asset.content_type);
+        if (!mediaType) {
+          throw new Error(
+            `Asset "${asset.name}" is ${asset.content_type ?? "of unknown type"}, which cannot go on a timeline.`
+          );
+        }
+        const store = doc.getState();
+        let trackId: string;
+        if (opts.trackId) {
+          const track = requireTrack(opts.trackId);
+          if (!isCompatibleWithTrack(mediaType, track.type)) {
+            throw new Error(
+              `A ${mediaType} clip cannot go on "${track.name}", which is a ${track.type} track.`
+            );
+          }
+          trackId = track.id;
+        } else {
+          const wanted = trackTypeForMediaType(mediaType);
+          const existing = store.tracks.find((track) => track.type === wanted);
+          if (existing) {
+            trackId = existing.id;
+          } else {
+            store.addTrack(wanted);
+            const created = doc.getState().tracks.at(-1);
+            if (!created) {
+              throw new Error(`Could not create a ${wanted} track.`);
+            }
+            trackId = created.id;
+          }
+        }
+        // Appending after the track's last clip is what lays several assets
+        // end to end, one call each.
+        const base = assetToClip(
+          asset,
+          trackId,
+          Math.max(0, opts.startMs ?? trackEndMs(trackId))
+        );
+        const clip: TimelineClip = {
+          ...base,
+          ...(opts.durationMs !== undefined
+            ? { durationMs: Math.max(1, opts.durationMs) }
+            : {}),
+          ...(opts.name ? { name: opts.name } : {})
+        };
+        doc.getState().addClip(clip);
+        ui.getState().selectClip(clip.id);
+        return clipNode(reReadClip(clip.id));
       },
 
       addTextClip(opts: TimelineAddTextClipOptions) {

--- a/web/src/hooks/timeline/useTimelineAgentBridge.ts
+++ b/web/src/hooks/timeline/useTimelineAgentBridge.ts
@@ -400,13 +400,11 @@ export const useTimelineAgentBridge = (sequenceId: string | null): void => {
           trackId,
           Math.max(0, opts.startMs ?? trackEndMs(trackId))
         );
-        const clip: TimelineClip = {
-          ...base,
-          ...(opts.durationMs !== undefined
-            ? { durationMs: Math.max(1, opts.durationMs) }
-            : {}),
-          ...(opts.name ? { name: opts.name } : {})
-        };
+        const clip: TimelineClip = { ...base };
+        if (opts.durationMs !== undefined) {
+          clip.durationMs = Math.max(1, opts.durationMs);
+        }
+        if (opts.name) clip.name = opts.name;
         doc.getState().addClip(clip);
         ui.getState().selectClip(clip.id);
         return clipNode(reReadClip(clip.id));

--- a/web/src/lib/tools/__tests__/timelineTools.test.ts
+++ b/web/src/lib/tools/__tests__/timelineTools.test.ts
@@ -65,6 +65,7 @@ const snapshot = (): TimelineSnapshot => ({
 const createMockHandler = (): jest.Mocked<TimelineAgentHandler> => ({
   getSnapshot: jest.fn(),
   addTrack: jest.fn(),
+  addMediaClip: jest.fn(),
   addTextClip: jest.fn(),
   addShapeClip: jest.fn(),
   generateClip: jest.fn(),
@@ -202,6 +203,27 @@ describe("ui_timeline_* tools", () => {
     expect(result.ok).toBe(true);
     expect(result.generationStarted).toBe(true);
     expect(result.clip.name).toBe("city at night");
+  });
+
+  it("places an existing asset as a clip", async () => {
+    const handler = createMockHandler();
+    handler.addMediaClip.mockResolvedValue(
+      clipNode({ mediaType: "video", name: "panda.mp4" })
+    );
+    setTimelineAgentHandler(SEQ_ID, handler);
+
+    const result = (await FrontendToolRegistry.call(
+      "ui_timeline_add_media_clip",
+      { timeline_id: SEQ_ID, asset: "asset://abc123.mp4" },
+      "tc-media",
+      ctx
+    )) as { ok: boolean; clip: { name: string } };
+
+    expect(handler.addMediaClip).toHaveBeenCalledWith({
+      asset: "asset://abc123.mp4"
+    });
+    expect(result.ok).toBe(true);
+    expect(result.clip.name).toBe("panda.mp4");
   });
 
   it("adds authored text with optional styling", async () => {

--- a/web/src/lib/tools/builtin/timeline.ts
+++ b/web/src/lib/tools/builtin/timeline.ts
@@ -64,6 +64,28 @@ FrontendToolRegistry.register({
 });
 
 FrontendToolRegistry.register({
+  name: "ui_timeline_add_media_clip",
+  description:
+    "Place an existing asset — a video, image, or audio file already in the library — on the specified timeline sequence. `asset` is an asset id or `asset://<id>.<ext>` URI. Without a track the clip lands on a track matching its media kind, creating one when needed; without `startMs` it is appended after that track's existing content, so calling this once per asset lays them end to end. Duration comes from the asset unless `durationMs` overrides it.",
+  parameters: z.object({
+    timeline_id: timelineIdParam,
+    asset: z.string().trim().min(1),
+    trackId: z.string().optional(),
+    startMs: z.number().optional(),
+    durationMs: z.number().optional(),
+    name: z.string().optional()
+  }),
+  async execute({ timeline_id, ...args }) {
+    const clip = await getTimelineAgentHandler(timeline_id).addMediaClip(args);
+    return {
+      ok: true,
+      clip,
+      url: docUrl("timeline", timeline_id, { key: "clip", value: clip.id })
+    };
+  }
+});
+
+FrontendToolRegistry.register({
   name: "ui_timeline_add_text_clip",
   description:
     "Add authored text to the specified timeline sequence. It goes on an overlay track, creating one when needed, lasts 3000ms by default, and accepts the same motion presets as media clips.",


### PR DESCRIPTION
A chat asked to stitch two videos from the library. Every route it tried was blocked or silently wrong, and it finished by telling the user the video was ready — pointing at a 0-byte asset. Four separate defects, each fixed here with a test that fails without the fix.

## Timeline had no way to place an existing asset

The surface offers `add_text_clip` and `add_shape_clip` but nothing for imported media, so the model guessed `add_video_clip` and the timeline route dead-ended (leaving an orphan empty track behind). The data model has supported imported clips all along — `sourceType: "imported"` + `currentAssetId` is what drag-and-drop writes.

`add_media_clip` takes an asset id or `asset://` URI, defaults to a track matching the media kind (creating one when needed), and defaults `startMs` to after that track's last clip — so one call per asset lays them end to end, which is what stitching means on a timeline. Added to:

- the headless bridge (`evals/surfaces/timeline.ts`), which is what `edit_timeline` runs on, via an optional asset resolver on the bridge
- the frontend `ui_timeline_add_media_clip` tool + `TimelineAgentHandler.addMediaClip`, so the contract the bridge mirrors does not fork

The MIME→media-type mapping and the fallback clip length move from `web/src/components/timeline/dnd/assetToClipAdapter.ts` into `@nodetool-ai/timeline`, so an agent-placed clip matches a hand-placed one by construction. Asset lookup goes through `Asset.find`, which is already user-scoped.

## ffmpeg was on the chat belt and unusable there

`ffmpeg` opens local files only — correct, and the containment guard should stay. But chat code deliberately gets no `ProcessingContext`, so `workspace.*` throws, and the refusal said *"download first, then pass the local path"* naming nothing that could do the downloading. The capability was offered and impossible to use.

`inputs` is the missing half: `{"a.mp4": "asset://<id>.mp4", "b.mp4": "asset://<id>.mp4"}` is resolved host-side (same resolver `save_asset` uses) and written into the workspace before the run, so argv names plain files. Concatenating two assets is now one call.

No boundary moves: the staged names go through the same `confineArgvToWorkspace` check, and no URI ever reaches ffmpeg. Caps are 8 files, 100 MB each, 256 MB total. `confineArgvToWorkspace` grew a `remedy` argument so the refusal points at the parameter instead of at an errand the caller cannot run.

## save_asset reported success for zero bytes

`readSourceBytes` checked `!bytes`, and a storage adapter that finds the key but reads nothing back returns an **empty buffer**, not null — so the check passed and a 0-byte asset came back as `{success: true, size: 0}`. That is the asset the chat's final answer linked to. Zero bytes is now an error on every byte-copy path (`source`, an empty HTTP body, `content_base64`), with a message saying what to check. Empty *text* content is still allowed — an empty note is a legitimate file.

## The DSL dropped node outputs nested in arrays, in silence

`workflow()` derives edges from handles sitting *directly* on an input. `concat({videos: [a.output(), b.output()]})` therefore drew no edge, left both producers out of the graph entirely, and wrote the raw `OutputHandle` objects into the node's `data` — and `validate` reported a clean one-node graph. Reproduced before fixing:

```
{"nodes":[{"type":"nodetool.video.Concat","data":{"videos":[{"__brand":"OutputHandle",...}]}}],"edges":[]}
```

It now throws, naming the path (`videos[0]`) and the shape that works (one handle per input, which for a dynamic-input node means one named slot per source). Plain arrays and plain nested objects are untouched.

## Considered and not done

`edit_timeline` persists the ops that succeeded when part of a batch fails — which is how the orphan track in the transcript got saved. That is a deliberate contract, pinned by `document-edit-tools.test.ts:88` ("records a failing op and still applies the rest"), and making it atomic trades one failure mode for another (one bad target name discards nine good edits). Left alone; flagging it as a real question rather than changing it here.

## Verification

- `packages/agents` — 3232 tests pass (211 files)
- `packages/dsl`, `packages/timeline` — pass (256 in timeline)
- web — full Jest suite passes, 13232 tests / 1148 files
- electron — 682 tests pass
- `typecheck:web`, `typecheck:electron` — clean
- `npm run lint` — clean, 0 errors
- `nodetool harness gate` — 1/1 selfcheck, 219/219 example graphs validate
- each new check confirmed red before its fix (the zero-byte save and the DSL drop were both run against the unfixed source)

The second commit fixes three `no-conditional-empty-object-spread` errors CI caught in the first. `@oxlint/plugins` was missing from `node_modules` in the dev environment, so every JS-plugin oxlint config failed to load and `npm run lint` died before reaching any rule — installing it reproduced all three errors locally, and the full gate now passes there.

Also pre-existing in that environment and unrelated to this change: the `packages/cli` build fails on a missing `@nodetool-ai/telegram` module, and mobile typecheck fails on uninstalled deps. Both reproduce on a clean `main` checkout.