### PR TITLE
fix(gemini): keep tool-call thought signatures across turns

### DIFF
--- a/packages/llm-nodes/src/nodes/agent-utils.ts
+++ b/packages/llm-nodes/src/nodes/agent-utils.ts
@@ -390,7 +390,12 @@ export function normalizeToolCalls(value: unknown): ToolCall[] | null {
       name: isString(item.name) ? item.name : "",
       args: isObjectLike(item.args)
         ? (item.args as Record<string, unknown>)
-        : {}
+        : {},
+      // Gemini 3 rejects a replayed function call whose signature is gone, so
+      // it has to survive the round trip through stored history.
+      ...(isNonEmptyString(item.thought_signature)
+        ? { thought_signature: item.thought_signature }
+        : {})
     }))
     .filter((item) => item.name.length > 0);
   return toolCalls.length > 0 ? toolCalls : null;

--- a/packages/llm-nodes/src/nodes/agent-utils.ts
+++ b/packages/llm-nodes/src/nodes/agent-utils.ts
@@ -385,18 +385,21 @@ export function normalizeToolCalls(value: unknown): ToolCall[] | null {
       (item): item is Record<string, unknown> =>
         !!item && typeof item === "object"
     )
-    .map((item, index) => ({
-      id: isNonEmptyString(item.id) ? item.id : `tool_${index + 1}`,
-      name: isString(item.name) ? item.name : "",
-      args: isObjectLike(item.args)
-        ? (item.args as Record<string, unknown>)
-        : {},
+    .map((item, index) => {
+      const call: ToolCall = {
+        id: isNonEmptyString(item.id) ? item.id : `tool_${index + 1}`,
+        name: isString(item.name) ? item.name : "",
+        args: isObjectLike(item.args)
+          ? (item.args as Record<string, unknown>)
+          : {}
+      };
       // Gemini 3 rejects a replayed function call whose signature is gone, so
       // it has to survive the round trip through stored history.
-      ...(isNonEmptyString(item.thought_signature)
-        ? { thought_signature: item.thought_signature }
-        : {})
-    }))
+      if (isNonEmptyString(item.thought_signature)) {
+        call.thought_signature = item.thought_signature;
+      }
+      return call;
+    })
     .filter((item) => item.name.length > 0);
   return toolCalls.length > 0 ? toolCalls : null;
 }

--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -560,6 +560,12 @@ export interface ToolCall {
   result?: unknown;
   step_id?: string | null;
   message?: string | null;
+  /**
+   * Gemini's encrypted reasoning state for the call. Gemini 3 rejects a
+   * request whose history replays a function call without it, so the value
+   * has to survive the trip through the database.
+   */
+  thought_signature?: string | null;
 }
 
 /**

--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -470,6 +470,32 @@ function appendGeminiContent(
   }
 }
 
+/**
+ * Sentinel Gemini accepts in place of a real thought signature. Gemini 3
+ * rejects a request whose history replays a function call with no signature —
+ * which is every turn recorded before signatures were persisted, and every
+ * call a caller injected by hand. The documented escape hatch is this literal:
+ * https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures
+ * Reasoning continuity is lost for that call, so it is only ever a fallback
+ * for a signature we do not have.
+ */
+const GEMINI_UNSIGNED_CALL_SENTINEL = "skip_thought_signature_validator";
+
+/**
+ * Gemini validates that the *first* functionCall part of each model turn
+ * carries a signature. Stamp the sentinel on any that reaches us without one
+ * so an unsigned history fails soft (degraded reasoning) instead of 400.
+ */
+function signUnsignedFunctionCalls(contents: GeminiContent[]): void {
+  for (const content of contents) {
+    if (content.role !== "model") continue;
+    const first = content.parts.find((p) => p.functionCall !== undefined);
+    if (first && !first.thoughtSignature) {
+      first.thoughtSignature = GEMINI_UNSIGNED_CALL_SENTINEL;
+    }
+  }
+}
+
 function geminiResponseError(data: GeminiResponse): Error | null {
   if (data.error?.message)
     return new Error(`Gemini API error: ${data.error.message}`);
@@ -1003,9 +1029,13 @@ export class GeminiProvider extends BaseProvider {
       if (msg.role === "assistant") {
         // If we have raw Gemini parts (with thought content), replay them exactly
         if (msg._rawGeminiParts && Array.isArray(msg._rawGeminiParts)) {
+          // Copy: the contents we build get merged and stamped below, and the
+          // message's own parts must survive that untouched for the next turn.
           appendGeminiContent(contents, {
             role: "model",
-            parts: msg._rawGeminiParts as GeminiPart[]
+            parts: (msg._rawGeminiParts as GeminiPart[]).map((part) => ({
+              ...part
+            }))
           });
           continue;
         }
@@ -1054,6 +1084,8 @@ export class GeminiProvider extends BaseProvider {
         appendGeminiContent(contents, { role: "user", parts });
       }
     }
+
+    signUnsignedFunctionCalls(contents);
 
     return { contents, systemInstruction };
   }

--- a/packages/runtime/tests/providers/gemini-provider.test.ts
+++ b/packages/runtime/tests/providers/gemini-provider.test.ts
@@ -102,7 +102,10 @@ describe("GeminiProvider", () => {
     expect(result.contents[0]).toEqual({
       role: "model",
       parts: [
-        { functionCall: { id: "tc1", name: "search", args: { q: "test" } } }
+        {
+          functionCall: { id: "tc1", name: "search", args: { q: "test" } },
+          thoughtSignature: "skip_thought_signature_validator"
+        }
       ]
     });
     expect(result.contents[1]).toEqual({
@@ -764,7 +767,8 @@ describe("GeminiProvider", () => {
       { role: "tool", toolCallId: "vendor-call-1", content: "ok" }
     ]);
     expect(converted.contents[0].parts[0]).toEqual({
-      functionCall: { id: "vendor-call-1", name: "lookup", args: { q: "x" } }
+      functionCall: { id: "vendor-call-1", name: "lookup", args: { q: "x" } },
+      thoughtSignature: "skip_thought_signature_validator"
     });
     expect(converted.contents[1].parts[0]).toEqual({
       functionResponse: {
@@ -981,6 +985,65 @@ describe("GeminiProvider", () => {
       { role: "user", parts: [{ text: "a" }, { text: "b" }] },
       { role: "model", parts: [{ text: "c" }, { text: "d" }] }
     ]);
+  });
+
+  it("replays a persisted tool call with its thought signature", async () => {
+    const provider = new GeminiProvider({ GEMINI_API_KEY: "k" });
+    const converted = await provider.convertMessages([
+      { role: "user", content: "hi" },
+      {
+        role: "assistant",
+        content: null,
+        toolCalls: [
+          { id: "c1", name: "search", args: { q: "x" }, thought_signature: "sig" },
+          { id: "c2", name: "search", args: { q: "y" } }
+        ]
+      }
+    ]);
+    const parts = converted.contents[1].parts;
+    expect(parts[0].thoughtSignature).toBe("sig");
+    // Gemini signs only the first call of a parallel batch — leave the rest bare.
+    expect(parts[1].thoughtSignature).toBeUndefined();
+  });
+
+  it("stamps the skip sentinel on an unsigned tool call in history", async () => {
+    const provider = new GeminiProvider({ GEMINI_API_KEY: "k" });
+    const converted = await provider.convertMessages([
+      { role: "user", content: "hi" },
+      {
+        role: "assistant",
+        content: null,
+        toolCalls: [{ id: "c1", name: "search", args: {} }]
+      },
+      { role: "tool", content: "result", toolCallId: "c1" },
+      { role: "user", content: "again" }
+    ]);
+    expect(converted.contents[1].parts[0].thoughtSignature).toBe(
+      "skip_thought_signature_validator"
+    );
+  });
+
+  it("leaves the message's own raw parts untouched when replaying them", async () => {
+    const provider = new GeminiProvider({ GEMINI_API_KEY: "k" });
+    const rawParts = [
+      { functionCall: { id: "c1", name: "search", args: {} } }
+    ];
+    const message: Message = {
+      role: "assistant",
+      content: null,
+      toolCalls: [{ id: "c1", name: "search", args: {} }],
+      _rawGeminiParts: rawParts
+    };
+    const converted = await provider.convertMessages([
+      { role: "user", content: "hi" },
+      message
+    ]);
+    expect(converted.contents[1].parts[0].thoughtSignature).toBe(
+      "skip_thought_signature_validator"
+    );
+    expect(rawParts[0]).toEqual({
+      functionCall: { id: "c1", name: "search", args: {} }
+    });
   });
 
   it("preserves text-part thought signatures in non-streaming history", async () => {

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -4742,14 +4742,17 @@ export class UnifiedWebSocketRunner {
       content: rawContent ?? "",
       toolCallId: isString(m.tool_call_id) ? m.tool_call_id : null,
       toolCalls: Array.isArray(m.tool_calls)
-        ? (m.tool_calls as Array<ProviderToolCall>).map((tc) => ({
-            id: tc.id,
-            name: tc.name,
-            args: tc.args,
-            ...(isString(tc.thought_signature)
-              ? { thought_signature: tc.thought_signature }
-              : {})
-          }))
+        ? (m.tool_calls as Array<ProviderToolCall>).map((tc) => {
+            const call: ProviderToolCall = {
+              id: tc.id,
+              name: tc.name,
+              args: tc.args
+            };
+            if (isString(tc.thought_signature)) {
+              call.thought_signature = tc.thought_signature;
+            }
+            return call;
+          })
         : null,
       threadId: m.thread_id
     };

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -4742,11 +4742,14 @@ export class UnifiedWebSocketRunner {
       content: rawContent ?? "",
       toolCallId: isString(m.tool_call_id) ? m.tool_call_id : null,
       toolCalls: Array.isArray(m.tool_calls)
-        ? (m.tool_calls as Array<{
-            id: string;
-            name: string;
-            args: Record<string, unknown>;
-          }>)
+        ? (m.tool_calls as Array<ProviderToolCall>).map((tc) => ({
+            id: tc.id,
+            name: tc.name,
+            args: tc.args,
+            ...(isString(tc.thought_signature)
+              ? { thought_signature: tc.thought_signature }
+              : {})
+          }))
         : null,
       threadId: m.thread_id
     };
@@ -6189,7 +6192,10 @@ export class UnifiedWebSocketRunner {
               id: tc.id,
               name: tc.name,
               args: tc.args,
-              result: null
+              result: null,
+              // Gemini 3 rejects a history that replays a function call
+              // without the signature it issued, so it rides into the DB.
+              thought_signature: tc.thought_signature ?? null
             }))
           : null;
         for (const tc of toolCalls ?? []) {

--- a/packages/websocket/tests/chat-agent-parity.test.ts
+++ b/packages/websocket/tests/chat-agent-parity.test.ts
@@ -534,6 +534,86 @@ describe("dbMessageToProviderMessage filtering", () => {
 });
 
 
+// ── Gemini thought signatures ───────────────────────────────────────
+
+describe("tool-call thought signatures survive the database", () => {
+  let ws: MockWS;
+
+  beforeEach(() => {
+    setupModels();
+    ws = new MockWS();
+  });
+
+  it("persists a signature and replays it in the next turn's history", async () => {
+    const threadId = "t-sig";
+    await Thread.create({ id: threadId, user_id: "1", title: "" });
+    await Message.create({
+      thread_id: threadId,
+      user_id: "1",
+      role: "assistant",
+      content: null,
+      tool_calls: [
+        {
+          id: "c1",
+          name: "search",
+          args: {},
+          result: null,
+          thought_signature: "sig-from-gemini"
+        }
+      ]
+    });
+
+    let capturedMessages: unknown[] = [];
+    const provider = async () =>
+      ({
+        provider: "mock",
+        async *generateMessagesTraced(opts: any) {
+          capturedMessages = opts.messages;
+          yield { type: "chunk" as const, content: "hi" };
+        },
+        async generateMessageTraced() {
+          return {};
+        },
+        generateMessage: vi.fn(),
+        hasToolSupport: async () => false,
+        getAvailableLanguageModels: async () => [],
+        getAvailableImageModels: async () => [],
+        getAvailableVideoModels: async () => [],
+        getAvailableTTSModels: async () => [],
+        getAvailableASRModels: async () => [],
+        getAvailableEmbeddingModels: async () => [],
+        getContainerEnv: () => ({}),
+        generateLoop: BaseProvider.prototype.generateLoop
+      }) as any;
+
+    const runner = new UnifiedWebSocketRunner({
+      resolveExecutor: noop,
+      resolveProvider: provider
+    });
+    await runner.connect(ws);
+    await runner.handleCommand({
+      command: "chat_message",
+      data: {
+        thread_id: threadId,
+        content: "again",
+        provider: "mock",
+        model: "m"
+      }
+    });
+    await new Promise((r) => setTimeout(r, 150));
+
+    const replayed = (
+      capturedMessages as Array<{
+        role: string;
+        toolCalls?: Array<{ thought_signature?: string }> | null;
+      }>
+    ).find((m) => m.role === "assistant" && m.toolCalls?.length);
+    expect(replayed?.toolCalls?.[0].thought_signature).toBe("sig-from-gemini");
+
+    await runner.disconnect();
+  });
+});
+
 // ── saveMessageToDb ─────────────────────────────────────────────────
 
 describe("saveMessageToDb", () => {


### PR DESCRIPTION
## The bug

A Gemini chat thread that had called a tool failed on its next turn:

```
Gemini API error 400: Function call is missing a thought_signature in
functionCall parts. ... position 36.
```

Gemini 3 issues an encrypted `thoughtSignature` with each function call and rejects a request whose history replays that call without it. The provider already read the signature off the response and sent it back **within** a live turn. What it did not survive was the database: the chat runner wrote the assistant message's tool calls as `{id, name, args, result}` and rebuilt them from history the same way, so the signature was gone by the time the thread was resumed — and every resumed thread with a tool call was permanently broken.

## The fix

- **Persist it.** `ToolCall` (protocol) carries `thought_signature`; the websocket runner writes it with the tool call and reads it back in `dbMessageToProviderMessage`. The agent nodes' history normalizer (`normalizeToolCalls`) keeps it too.
- **Fail soft on unsigned history.** Every turn recorded before this change has no signature, and no amount of persistence recovers it. `convertMessages` now stamps Gemini's documented `skip_thought_signature_validator` sentinel on the first function call of each model turn that arrives without one, so those threads lose reasoning continuity for that call instead of 400-ing. A real signature is never overwritten. ([docs](https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures))
- **Stop aliasing raw parts.** A message's `_rawGeminiParts` were pushed into the request by reference, so the merge-and-stamp step edited the message's own parts. They are copied now.

## Verification

- `packages/runtime` — new cases: a persisted signature is replayed and a parallel sibling stays bare; an unsigned call gets the sentinel; a replayed message's raw parts are left untouched. Two existing assertions updated for the sentinel. 2792 passed.
- `packages/websocket` — new round-trip case: a signature stored on a thread's assistant message reaches the provider on the next turn. Reverting the runner mapping makes it fail, so it bites. 2309 passed.
- `npm run typecheck` clean; `packages/protocol`, `packages/llm-nodes` green; `npm run test` (web + electron) 682 passed.
- Not run here: `oxlint` over `web/` and the mobile jest suite — both fail in this container on missing installed packages (`@oxlint/plugins`, `@react-native/jest-preset`), unrelated to this diff, which touches no web or mobile file. `oxlint` over the four changed package trees is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4AGXq3qBvFtivRM6TMFNo)_