### PR TITLE
fix(chat): explain what Auto permission mode actually allows

### DIFF
--- a/packages/protocol/src/api-types.ts
+++ b/packages/protocol/src/api-types.ts
@@ -646,7 +646,8 @@ export interface Message {
    * run automatically, ask for approval, or are blocked:
    * - `"plan"` — read-only; actionable tools are blocked.
    * - `"default"` — read tools auto-run; actions require approval.
-   * - `"auto"` — everything runs without prompting.
+   * - `"auto"` — routine work runs unattended; a code action declared high
+   *   risk (deletes, publishes, spends) asks for approval once.
    * Omitted defaults to `"default"`.
    */
   permission_mode?: "plan" | "default" | "auto" | null;

--- a/web/src/components/chat/composer/PermissionSelector.tsx
+++ b/web/src/components/chat/composer/PermissionSelector.tsx
@@ -33,7 +33,8 @@ const MODES: ModeItem[] = [
   {
     id: "auto",
     label: "Auto",
-    description: "Everything runs, no prompts.",
+    description:
+      "Routine work runs unattended. A step that deletes, publishes, or spends asks once.",
     tone: "success"
   }
 ];
@@ -94,7 +95,7 @@ const dotCss = (color: string) =>
 /**
  * Compact composer-footer dropdown for the per-thread permission mode. The
  * trigger shows the active mode (label + colored status dot) and opens a
- * three-item menu (Plan / Default / Auto), each with a one-line description
+ * three-item menu (Plan / Default / Auto), each with a short description
  * and a check on the active mode. Reads/writes the active thread's
  * `permissionMode` directly from GlobalChatStore.
  */
@@ -132,7 +133,7 @@ const PermissionSelector: React.FC<PermissionSelectorProps> = ({
         ref={buttonRef}
         className="permission-selector-trigger"
         icon={<span css={dotCss(dotColor(theme, activeMode.tone))} />}
-        title={`Permission: ${activeMode.label}`}
+        title={`Permission: ${activeMode.label} — ${activeMode.description}`}
         active={open}
         showChevron
         onClick={() => setOpen(true)}

--- a/web/src/stores/ApiTypes.ts
+++ b/web/src/stores/ApiTypes.ts
@@ -128,7 +128,8 @@ export type { LogUpdate };
  * Chat permission mode (per-thread). Sent on every outgoing chat message.
  * - `plan`: read & propose only; actionable tools are blocked.
  * - `default`: reads run; actionable tools ask for approval first.
- * - `auto`: everything runs, no prompts.
+ * - `auto`: routine work runs unattended; a code action the agent declares
+ *   high risk (deletes, publishes, spends) asks once before it runs.
  */
 export type PermissionMode = "plan" | "default" | "auto";
 


### PR DESCRIPTION
The composer's permission selector described Auto as "Everything runs, no prompts." That stopped being true when `execute_code` gained a declared `risk` (`packages/agents/src/codeact/execute-code-contract.ts`): in Auto a `low` action runs unattended, a `high` one — deletes, publishes, real spend — asks once for the whole action. A user picking Auto read the old label as a blank cheque and then met an approval prompt the label said would not come.

Changes, all user-facing text:

- `web/src/components/chat/composer/PermissionSelector.tsx` — Auto now reads "Routine work runs unattended. A step that deletes, publishes, or spends asks once." The trigger tooltip carries the active mode's description as well, so the explanation is reachable without opening the menu.
- `web/src/stores/ApiTypes.ts`, `packages/protocol/src/api-types.ts` — the `PermissionMode` / `permission_mode` doc comments said the same wrong thing; both now match the gate.

No behavior change — the gate (`decidePermission` plus `admitCodeAction`) is untouched.

Verification: `web` typecheck reports only the pre-existing `Cannot find module '@nodetool-ai/*-nodes/...'` errors from unbuilt packages in this container, none in the touched files. `oxlint` cannot run here — its JS plugin config fails to load (`Cannot find package '@oxlint/plugins'`), a container gap unrelated to this diff. The change is string literals and comments inside existing declarations.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvpfpDqCUnKjdFXzFd32hM)_