### PR TITLE
Fix the failure modes a social-media-ad session hit: model discovery, background jobs, job results

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -274,8 +274,10 @@ from inside an agent:
   Puck editor, so a chat agent could debug an app but never build one. There is
   still no `build_app` tool: the batch harness lives on at
   `POST /api/applications/build` and `nodetool app build`.
-- **`run_workflow`** / **`start_background_job`** — execute synchronously or as a
-  background job (poll with `get_job` / `get_job_logs`).
+- **`run_workflow`** / **`start_background_job`** — execute synchronously, or
+  start a detached run and get its job id back at once. Poll `get_job` until it
+  settles: the settled job carries the run's `outputs`, and `get_job_logs`
+  carries its log tail and any node error.
 - **`create_workflow`**, **`search_nodes`**, **`list_nodes`**, **`get_node_info`**,
   **`get_example_workflow`**, **`export_workflow_digraph`** — build and inspect
   graphs against the live node registry.

--- a/packages/agents/src/capabilities/workflows.specs.ts
+++ b/packages/agents/src/capabilities/workflows.specs.ts
@@ -384,7 +384,10 @@ export const validateWorkflowSpec: CapabilitySpec = {
 export const startBackgroundJobSpec: CapabilitySpec = {
   name: "start_background_job",
   description:
-    "Start a workflow running in the background and return a job ID for tracking.",
+    "Start a workflow and return its job id immediately, without waiting for " +
+    "the run. Poll get_job with that id until it settles; the settled job " +
+    "carries the run's outputs. Use run_workflow instead when you want to " +
+    "block until the result is ready.",
   inputSchema: {
     type: "object",
     properties: {

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -193,6 +193,24 @@ const nodetool = (() => {
   const __merge = (a, b) => Object.assign({}, a || {}, b || {});
 
   /**
+   * A job id from either an id or a job/receipt object. \`start()\` answers with
+   * a record, and reaching for the wrong field on it used to reach the tool as
+   * \`job_id: undefined\`, which came back as "Job undefined was not found" —
+   * a message about a job rather than about the call that asked for it.
+   */
+  const __jobId = (idOrJob, method) => {
+    if (typeof idOrJob === "string" && idOrJob) return idOrJob;
+    if (idOrJob && typeof idOrJob === "object") {
+      const id = idOrJob.job_id || idOrJob.id;
+      if (typeof id === "string" && id) return id;
+    }
+    throw new Error(
+      "nodetool.jobs." + method + ": no job id. Pass the id string, or the " +
+      "record nodetool.workflows.start() returned (its id is job_id)."
+    );
+  };
+
+  /**
    * Accept a GraphBuilder, a bare {nodes, edges}, or a workflow record —
    * the shared graph DSL core's normalizer.
    */
@@ -546,6 +564,11 @@ const nodetool = (() => {
         __need("run_workflow")(
           __merge(opts, { workflow_id: id, params: params || {} })
         ),
+      /**
+       * Start a run and return a receipt — {job_id, id, status: "running"} —
+       * without waiting for it. Pass it to nodetool.jobs.wait() and read the
+       * settled job's outputs.
+       */
       start: (id, params) =>
         __need("start_background_job")({
           workflow_id: id,
@@ -894,8 +917,10 @@ const nodetool = (() => {
 
     jobs: {
       list: (opts) => __need("list_jobs")(__merge(opts)),
-      get: (id) => __need("get_job")({ job_id: id }),
-      logs: (id, opts) => __need("get_job_logs")(__merge(opts, { job_id: id })),
+      /** The job row, including the run's outputs once it has settled. */
+      get: (id) => __need("get_job")({ job_id: __jobId(id, "get") }),
+      logs: (id, opts) =>
+        __need("get_job_logs")(__merge(opts, { job_id: __jobId(id, "logs") })),
       /**
        * Poll a background job until it settles, then return the job record.
        * Terminal statuses are completed / failed / cancelled / error (the
@@ -903,18 +928,19 @@ const nodetool = (() => {
        * and the last status seen.
        */
       async wait(id, opts) {
+        const jobId = __jobId(id, "wait");
         const pollMs = Math.max(1000, (opts && opts.pollMs) || 3000);
         const timeoutMs = (opts && opts.timeoutMs) || 600000;
         const terminal = ["completed", "failed", "cancelled", "error"];
         const deadline = Date.now() + timeoutMs;
         let status = "unknown";
         for (;;) {
-          const job = await api.jobs.get(id);
+          const job = await api.jobs.get(jobId);
           status = (job && (job.status || job.state)) || "unknown";
           if (terminal.indexOf(status) >= 0) return job;
           if (Date.now() >= deadline) {
             throw new Error(
-              "nodetool.jobs.wait: job " + id + " did not finish within " +
+              "nodetool.jobs.wait: job " + jobId + " did not finish within " +
               timeoutMs + "ms (last status: " + status + "). Poll it with " +
               "nodetool.jobs.get(id) or read nodetool.jobs.logs(id)."
             );
@@ -1138,7 +1164,8 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   returning something else. \`find(capability,
   {query, provider_hint, prefer_local, limit})\` for the ranked list (returns
   \`{results}\`),
-  \`list({provider, model_type})\` to browse, \`forProvider(provider)\` for one
+  \`list({provider, model_type})\` to browse (also \`{results}\` — neither
+  answers with a bare array), \`forProvider(provider)\` for one
   provider's own catalog. Never guess a model id — pick one, then pass it to
   \`nodetool.media.*\`. To set a node's model property, assign the result's
   \`ref\` verbatim (it is the typed \`{type, provider, id, name}\` value the
@@ -1262,11 +1289,13 @@ const NAMESPACE_DOCS: PromptEntry[] = [
     namespace: "jobs",
     doc: `- \`nodetool.jobs\` — \`list({workflow_id})\`, \`get(jobId)\`, \`logs(jobId)\`,
   \`await wait(jobId, {timeoutMs, pollMs})\` polls until the job settles
-  (completed/failed/cancelled) and returns the job. Pair it with
-  \`nodetool.workflows.start(id, params)\`: start the run, do other work, then
-  \`wait\` on the job id instead of blocking on \`run()\`. \`wait\` replaces a
-  \`get()\` polling loop — start, wait, and read the result in one action,
-  never one \`get()\` per action.`
+  (completed/failed/cancelled) and returns the job, whose \`outputs\` hold what
+  the run produced. Pair it with
+  \`nodetool.workflows.start(id, params)\`: start the run — it returns a
+  receipt immediately, it does not wait — do other work, then \`wait\` on
+  \`receipt.job_id\` instead of blocking on \`run()\`. \`wait\` replaces a
+  \`get()\` polling loop — start, wait, and read \`settled.outputs\` in one
+  action, never one \`get()\` per action.`
   },
   {
     namespace: "collections",
@@ -1289,7 +1318,7 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   },
   {
     namespace: "timelines",
-    doc: `- \`nodetool.timelines\` — \`list()\`, \`validate(idOrDocument)\`, \`versions(id)\`,
+    doc: `- \`nodetool.timelines\` — \`list()\` (→ \`{timelines}\`), \`validate(idOrDocument)\`, \`versions(id)\`,
   \`getVersion(id, n)\`, \`snapshot(id, {name})\`, \`restore(id, n)\`, and
   \`edit(id, ops)\` — the cut itself, server-side: \`[{op: "add_track", type:
   "audio"}, {op: "add_text_clip", text: "Hi"}, {op: "split_clip", target:

--- a/packages/agents/src/evals/codeact-api-core.ts
+++ b/packages/agents/src/evals/codeact-api-core.ts
@@ -1241,12 +1241,15 @@ export function createCoreApiTools(recorder: CodeActToolRecorder): Tool[] {
         if (!job) throw new Error(`No job "${str(params["job_id"])}"`);
         job.polls += 1;
         const done = job.polls > 1;
+        // Same shape `jobRecord` reports: outputs on the settled job, null
+        // while it runs. The fake carried them under `result` and the real
+        // tool carried them nowhere, so an agent taught here found neither.
         return {
           id: job.id,
           workflow_id: job.workflow_id,
           status: done ? "completed" : "running",
           polls: job.polls,
-          result: done ? { outputs: job.outputs } : undefined
+          outputs: done ? job.outputs : null
         };
       }
     ),

--- a/packages/agents/src/tools/mcp-tool-support.ts
+++ b/packages/agents/src/tools/mcp-tool-support.ts
@@ -109,7 +109,11 @@ export function jobRecord(job: Job) {
     started_at: job.started_at ?? null,
     finished_at: job.finished_at ?? null,
     error: job.error_message ?? job.error ?? null,
-    cost: job.cost ?? null
+    cost: job.cost ?? null,
+    // What the run produced, once it settled. A completed job used to report
+    // only that it had completed, so an agent that started a background run
+    // had no way to read its result.
+    outputs: job.runOutputs()
   };
 }
 

--- a/packages/agents/tests/codeact-api-core.test.ts
+++ b/packages/agents/tests/codeact-api-core.test.ts
@@ -148,7 +148,7 @@ const SOLUTIONS: Record<string, string[]> = {
      });
      await finish({
        status: settled.status,
-       shout: settled.result.outputs.shout
+       shout: settled.outputs.shout
      });`
   ],
   "api-batch-existing-workflow": [

--- a/packages/agents/tests/mcp-tools.test.ts
+++ b/packages/agents/tests/mcp-tools.test.ts
@@ -72,6 +72,25 @@ const stubRegistry = {
   validateNode: () => []
 } as unknown as NodeRegistry;
 
+/** Poll the job row until it reaches `status`, so a detached run can be read. */
+async function waitForJobStatus(
+  jobId: string,
+  status: string,
+  timeoutMs = 5000
+): Promise<Job> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const job = (await Job.find(USER, jobId)) as Job | null;
+    if (job && job.status === status) return job;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `job ${jobId} was "${job?.status ?? "missing"}", not "${status}"`
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 async function saveWorkflow(
   fields: Partial<{
     id: string;
@@ -1191,6 +1210,54 @@ describe("start_background_job", () => {
     })) as Record<string, unknown>;
     expect(result.background).toBe(true);
     expect(result.job_id).toEqual(expect.any(String));
+  });
+
+  // `background: true` used to be a label on a blocking call: the tool awaited
+  // the whole run. A live session started a two-minute render this way and its
+  // turn was cancelled before the call returned. With the node parked, this
+  // test hangs forever if the call ever waits again.
+  it("returns while the run is still going, and settles the job with outputs", async () => {
+    const saved = await saveWorkflow({
+      graph: { nodes: [{ id: "slow", type: "test.Slow", data: {} }], edges: [] }
+    });
+    let release!: () => void;
+    const parked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tool = capTool("start_background_job", {
+      workflowEnvironment: async () => ({
+        registry: {
+          ...stubRegistry,
+          getClass: () => undefined
+        } as unknown as NodeRegistry,
+        resolveExecutor: () => ({
+          process: async () => {
+            await parked;
+            return { output: "done" };
+          }
+        })
+      })
+    });
+
+    const receipt = (await tool.process(ctx, {
+      workflow_id: saved.id
+    })) as Record<string, unknown>;
+    expect(receipt.status).toBe("running");
+    expect(receipt.background).toBe(true);
+    // The jobs API keys everything else on `id`; a receipt that spelled it
+    // only `job_id` sent a live session to get_job(undefined).
+    expect(receipt.id).toBe(receipt.job_id);
+    const jobId = String(receipt.job_id);
+    expect((await Job.find(USER, jobId))?.status).toBe("running");
+
+    release();
+    const settled = await waitForJobStatus(jobId, "completed");
+    expect(settled.runOutputs()).toEqual({ slow: ["done"] });
+
+    const record = (await capTool("get_job").process(ctx, {
+      job_id: jobId
+    })) as Record<string, unknown>;
+    expect(record.outputs).toEqual({ slow: ["done"] });
   });
 
   it("userMessage includes workflow_id", () => {

--- a/packages/agents/tests/nodetool-api-nodes-jobs.test.ts
+++ b/packages/agents/tests/nodetool-api-nodes-jobs.test.ts
@@ -182,6 +182,41 @@ describe("nodetool.jobs.wait", () => {
     expect(jobPollCount()).toBe(1);
   });
 
+  // A live session called `wait(job.id)` on the receipt `start()` returns —
+  // which spells its id `job_id` — and the undefined reached the tool, which
+  // answered "Job undefined was not found".
+  it("takes the receipt start() returns, not just an id string", async () => {
+    const { executeTool, calls } = createFakeRouter({ runningPolls: 0 });
+    const session = makeSession(JOB_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `const receipt = { job_id: "job3", status: "running" };
+       const job = await nodetool.jobs.wait(receipt);
+       return job.id;`
+    );
+    expect(obs.ok).toBe(true);
+    expect(obs.result).toBe("job3");
+    expect(calls[0].args).toEqual({ job_id: "job3" });
+  });
+
+  it("names the call, not a phantom job, when the id is missing", async () => {
+    const { executeTool, calls } = createFakeRouter({ runningPolls: 0 });
+    const session = makeSession(JOB_TOOLS, executeTool);
+    const obs = await runAction(
+      session,
+      `try {
+         await nodetool.jobs.wait(undefined);
+         return "no throw";
+       } catch (e) { return e.message; }`
+    );
+    expect(obs.ok).toBe(true);
+    const message = String(obs.result);
+    expect(message).toContain("nodetool.jobs.wait: no job id");
+    expect(message).toContain("job_id");
+    // Nothing was asked of the belt: the mistake is in the call, not the job.
+    expect(calls).toHaveLength(0);
+  });
+
   it("throws a timeout naming the job id and last status", async () => {
     const { executeTool } = createFakeRouter({ runningPolls: -1 });
     const session = makeSession(JOB_TOOLS, executeTool);

--- a/packages/execution/src/service/workflow-run.ts
+++ b/packages/execution/src/service/workflow-run.ts
@@ -29,6 +29,7 @@ import {
 } from "@nodetool-ai/runtime";
 import { normalizeGraph } from "../normalize-graph.js";
 import { collectExecutionSummary } from "../debug/collector.js";
+import type { ExecutionSummary } from "../debug/types.js";
 import {
   buildRunVerdict,
   collectInterventionWarnings
@@ -105,7 +106,11 @@ export interface RunWorkflowOptions {
   params?: Record<string, unknown>;
   /** Return the full debug report (summary + verdict) instead of the run row. */
   debug?: boolean;
-  /** Reported back on the payload; the run itself is identical. */
+  /**
+   * Detach the run: the call returns as soon as the job row exists, and the
+   * run finishes on its own, writing its status and outputs onto the job.
+   * The caller polls `get_job` (or `nodetool.jobs.wait`) for the result.
+   */
   background?: boolean;
   /**
    * Bubble node failures up to the caller instead of resolving them here: the
@@ -189,6 +194,93 @@ async function markJobFailed(job: Job, message: string): Promise<void> {
   }
 }
 
+/**
+ * How much serialized output a job row will carry. Outputs are normally
+ * asset refs and short strings; a run that emits a megabyte of text should
+ * not turn every `get_job` into that megabyte, so past this the row records
+ * the handle names instead and the caller reads the values from the assets.
+ */
+export const MAX_PERSISTED_OUTPUT_BYTES = 256_000;
+
+/** What the row holds instead of an outputs bag it cannot carry. */
+export interface OmittedOutputs {
+  omitted: true;
+  reason: string;
+  handles: string[];
+}
+
+/**
+ * The outputs to store on the job row, or a marker naming the handles when
+ * they are too big to keep. Pure so the size rule is pinned by a test.
+ */
+export function persistableOutputs(
+  outputs: Record<string, unknown>
+): Record<string, unknown> | OmittedOutputs {
+  let size: number;
+  try {
+    size = JSON.stringify(outputs).length;
+  } catch {
+    // Circular or otherwise unserializable — the row cannot hold it either.
+    size = Number.POSITIVE_INFINITY;
+  }
+  if (size <= MAX_PERSISTED_OUTPUT_BYTES) return outputs;
+  const omitted: OmittedOutputs = {
+    omitted: true,
+    reason:
+      `Outputs were ${Number.isFinite(size) ? `${size} bytes` : "not serializable"}, ` +
+      `over the ${MAX_PERSISTED_OUTPUT_BYTES}-byte limit for a job row. ` +
+      "Re-run the workflow with run_workflow to read them, or read the " +
+      "assets the run produced.",
+    handles: Object.keys(outputs)
+  };
+  return omitted;
+}
+
+/** How many log entries a job row keeps — the tail, which explains a failure. */
+export const MAX_PERSISTED_LOG_ENTRIES = 200;
+
+/** Per-entry ceiling, so one runaway line cannot fill the row. */
+const MAX_LOG_CONTENT_CHARS = 2000;
+
+/** One persisted log line, in the shape `get_job_logs` hands back. */
+export interface PersistedJobLog extends Record<string, unknown> {
+  severity: string;
+  node_id: string | null;
+  node_name: string | null;
+  content: string;
+}
+
+/**
+ * The run's log tail plus one line per node that failed.
+ *
+ * `job.logs` had no writer at all: every `get_job_logs` call answered
+ * `total_logs: 0`, and `debug_workflow` reported an empty `logs` array, so the
+ * one tool an agent reaches for after a background run went wrong could not
+ * tell it anything. The messages are already folded for the debug payload;
+ * this keeps the part that survives the run.
+ */
+export function persistableLogs(summary: ExecutionSummary): PersistedJobLog[] {
+  const entries: PersistedJobLog[] = summary.logs.map((log) => ({
+    severity: log.severity,
+    node_id: log.nodeId,
+    node_name: log.nodeName ?? null,
+    content: log.content.slice(0, MAX_LOG_CONTENT_CHARS)
+  }));
+  for (const node of summary.nodes) {
+    if (!node.error) continue;
+    entries.push({
+      severity: "error",
+      node_id: node.nodeId,
+      node_name: node.nodeName ?? null,
+      content: `${node.nodeType ?? "node"} failed: ${node.error}`.slice(
+        0,
+        MAX_LOG_CONTENT_CHARS
+      )
+    });
+  }
+  return entries.slice(-MAX_PERSISTED_LOG_ENTRIES);
+}
+
 async function finalizeWorkflowRunJob(
   job: Job,
   result: WorkflowRunResult
@@ -200,6 +292,14 @@ async function finalizeWorkflowRunJob(
   } else {
     job.markFailed(result.error ?? "Workflow run failed");
   }
+  // Without this a detached run had nowhere to leave its results: the job row
+  // carried a status and nothing else, so `get_job` on a completed background
+  // job answered "completed" and the caller could never read what it produced.
+  job.metadata_json = {
+    ...(job.metadata_json ?? {}),
+    outputs: persistableOutputs(result.outputs ?? {})
+  };
+  job.logs = persistableLogs(collectExecutionSummary(result.messages));
   await job.save();
 }
 
@@ -429,6 +529,40 @@ export async function runWorkflow(
     const message = error instanceof Error ? error.message : String(error);
     await markJobFailed(job, message);
     throw error instanceof Error ? error : new Error(message);
+  }
+
+  if (!interactive && (options.background ?? false)) {
+    // Detached: the payload is the receipt, not the result. Awaiting the run
+    // here made `background: true` a label on a blocking call — an agent that
+    // started a two-minute render still had to sit through it, and its turn
+    // was cancelled before the job it started could be reported.
+    void (async () => {
+      try {
+        const result = await runner.run(
+          { job_id: job.id, workflow_id: workflowId, params },
+          hydratedGraph
+        );
+        await finalizeWorkflowRunJob(job, result);
+      } catch (error) {
+        await markJobFailed(
+          job,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    })();
+    return {
+      kind: "payload",
+      payload: {
+        job_id: job.id,
+        // The jobs API keys every other answer on `id`; a receipt that spells
+        // it only `job_id` sent callers to `get_job(undefined)`.
+        id: job.id,
+        workflow_id: workflowId,
+        status: "running",
+        background: true,
+        poll: `Poll get_job with job_id "${job.id}" until it settles; its outputs are on the settled job.`
+      }
+    };
   }
 
   if (!interactive) {

--- a/packages/execution/tests/workflow-run-outputs.test.ts
+++ b/packages/execution/tests/workflow-run-outputs.test.ts
@@ -1,0 +1,89 @@
+/**
+ * What a settled job row keeps of the run's outputs. A detached run has nowhere
+ * else to leave its answer, so the size rule this pins is the difference
+ * between `get_job` reporting a result and reporting only a status.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  MAX_PERSISTED_LOG_ENTRIES,
+  MAX_PERSISTED_OUTPUT_BYTES,
+  persistableLogs,
+  persistableOutputs
+} from "../src/service/workflow-run.js";
+import { collectExecutionSummary } from "../src/debug/collector.js";
+
+describe("persistableOutputs", () => {
+  it("keeps ordinary outputs — refs and short strings — as they are", () => {
+    const outputs = {
+      script: ["Power up your night."],
+      ad_video: [{ type: "video", uri: "asset://abc.mp4" }]
+    };
+    expect(persistableOutputs(outputs)).toBe(outputs);
+  });
+
+  it("keeps an empty result rather than dropping the key", () => {
+    expect(persistableOutputs({})).toEqual({});
+  });
+
+  it("replaces an oversized result with the handle names and the reason", () => {
+    const big = { transcript: ["x".repeat(MAX_PERSISTED_OUTPUT_BYTES + 1)] };
+    const stored = persistableOutputs(big) as Record<string, unknown>;
+    expect(stored.omitted).toBe(true);
+    expect(stored.handles).toEqual(["transcript"]);
+    expect(String(stored.reason)).toContain(String(MAX_PERSISTED_OUTPUT_BYTES));
+  });
+
+  it("treats an unserializable result as oversized instead of throwing", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic["self"] = cyclic;
+    const stored = persistableOutputs(cyclic) as Record<string, unknown>;
+    expect(stored.omitted).toBe(true);
+    expect(stored.handles).toEqual(["self"]);
+  });
+});
+
+describe("persistableLogs", () => {
+  it("keeps the run's log lines and adds one per failed node", () => {
+    const summary = collectExecutionSummary([
+      { type: "log_update", node_id: "n1", node_name: "Add Clips", severity: "warning", content: "clip skipped" },
+      { type: "node_update", node_id: "n1", node_name: "Add Clips", node_type: "nodetool.timeline.AddClips", status: "error", error: "no renderable clips" }
+    ]);
+    expect(persistableLogs(summary)).toEqual([
+      {
+        severity: "warning",
+        node_id: "n1",
+        node_name: "Add Clips",
+        content: "clip skipped"
+      },
+      {
+        severity: "error",
+        node_id: "n1",
+        node_name: "Add Clips",
+        content: "nodetool.timeline.AddClips failed: no renderable clips"
+      }
+    ]);
+  });
+
+  it("keeps the tail when a run logs more than the row holds", () => {
+    const summary = collectExecutionSummary(
+      Array.from({ length: MAX_PERSISTED_LOG_ENTRIES + 5 }, (_, i) => ({
+        type: "log_update",
+        node_id: "n",
+        severity: "info",
+        content: `line ${i}`
+      }))
+    );
+    const logs = persistableLogs(summary);
+    expect(logs).toHaveLength(MAX_PERSISTED_LOG_ENTRIES);
+    expect(logs[logs.length - 1].content).toBe(
+      `line ${MAX_PERSISTED_LOG_ENTRIES + 4}`
+    );
+  });
+
+  it("truncates a single runaway line", () => {
+    const summary = collectExecutionSummary([
+      { type: "log_update", node_id: null, severity: "info", content: "x".repeat(5000) }
+    ]);
+    expect(persistableLogs(summary)[0].content).toHaveLength(2000);
+  });
+});

--- a/packages/models/src/job.ts
+++ b/packages/models/src/job.ts
@@ -128,6 +128,22 @@ export class Job extends DBModel {
     this.finished_at = new Date().toISOString();
   }
 
+  /**
+   * What the run produced, as the run service stored it when the job settled
+   * (`metadata_json.outputs`), or null for a job that has not finished — or
+   * one that ran before outputs were persisted at all. The jobs table has no
+   * outputs column; `metadata_json` is where a run's answer lives, and this
+   * is the one reader, so every surface reports the same thing.
+   */
+  runOutputs(): Record<string, unknown> | null {
+    const outputs = this.metadata_json?.["outputs"];
+    return outputs !== null &&
+      typeof outputs === "object" &&
+      !Array.isArray(outputs)
+      ? (outputs as Record<string, unknown>)
+      : null;
+  }
+
   markSuspended(
     nodeId: string,
     reason: string,

--- a/packages/runtime/src/providers/manifest-models.ts
+++ b/packages/runtime/src/providers/manifest-models.ts
@@ -23,6 +23,8 @@ interface ManifestInputField {
   apiParamName?: string;
   propType: string;
   enumValues?: string[];
+  /** Whether the endpoint refuses the call without this field. */
+  required?: boolean;
 }
 
 /**
@@ -183,12 +185,60 @@ export function matchesAny(haystack: string, ...needles: string[]): boolean {
   return needles.some((n) => haystack.includes(n));
 }
 
+/**
+ * Endpoints that take an existing clip and hand back another one. Their ids
+ * never spell out "video-to-video", so without this list they fall through to
+ * the generator branch and turn up in the text/image-to-video pickers with no
+ * video to work on.
+ */
+const VIDEO_SOURCE_KEYWORDS = [
+  "extend-video",
+  "extend video",
+  "reframe",
+  "retake",
+  "edit-video",
+  "video-edit",
+  "video edit",
+  "restyle",
+  "outpaint",
+  "inpaint",
+  "background-removal",
+  "background removal",
+  "interpolation",
+  "dubbing",
+  "eraser"
+];
+
+/** A bare `/extend` path segment (`.../ltx-video-13b-dev/extend`). */
+const EXTEND_SEGMENT = /(^|[/\- ])extend([/\- ]|$)/;
+
+/**
+ * Endpoints that need a still (or several) to start from, named in ways the
+ * plain "image-to-video" test misses. They are image-conditioned only: a text
+ * prompt alone is not a call these accept.
+ */
+const IMAGE_CONDITIONED_KEYWORDS = [
+  "first-last-frame-to-video",
+  "first last frame to video",
+  "start-end-to-video",
+  "keyframes-to-video",
+  "frames-to-video",
+  "reference-to-video"
+];
+
 export function inferVideoTasks(name: string, id: string): string[] {
   const hay = `${id} ${name}`.toLowerCase();
   const tasks: string[] = [];
   // Specialized video transforms — kept out of the text/image generation lists.
   if (matchesAny(hay, "lipsync", "lip-sync", "lip sync")) {
     return ["lip_sync"];
+  }
+  // Audio-conditioned generators (LTX's audio-to-video, talking-avatar
+  // endpoints) need a recording, so neither generation picker can call one.
+  // `image-audio-to-video` matches here too, and belongs here: without the
+  // audio the call fails whatever image it gets.
+  if (matchesAny(hay, "audio-to-video", "audio to video", "speech-to-video")) {
+    return ["audio_to_video"];
   }
   if (
     matchesAny(hay, "video-to-video", "video to video", "videotovideo", "v2v")
@@ -212,6 +262,15 @@ export function inferVideoTasks(name: string, id: string): string[] {
     )
   ) {
     return ["video_to_video"];
+  }
+  if (
+    matchesAny(hay, ...VIDEO_SOURCE_KEYWORDS) ||
+    EXTEND_SEGMENT.test(id.toLowerCase())
+  ) {
+    return ["video_to_video"];
+  }
+  if (matchesAny(hay, ...IMAGE_CONDITIONED_KEYWORDS)) {
+    return ["image_to_video"];
   }
   if (matchesAny(hay, "text-to-video", "text to video", "texttovideo")) {
     tasks.push("text_to_video");
@@ -338,6 +397,55 @@ export function loadVideoModels(
   return buildVideoModels(loadManifest(packageName, exportPath), provider);
 }
 
+/**
+ * Does this entry refuse the call without an input of `kind`?
+ *
+ * The declaration, not the name: a manifest field marked `required` is the
+ * endpoint's own statement that it cannot run without that media. Kie's
+ * `uploads` descriptors carry no requiredness, so they answer false and the
+ * name-based inference stands.
+ */
+export function requiresMediaInput(
+  n: ManifestNode,
+  kind: "image" | "video"
+): boolean {
+  // Stryker disable next-line ArrayDeclaration: an entry with no inputFields declares nothing required either way.
+  return (n.inputFields ?? []).some((f) => {
+    const t = f.propType.toLowerCase();
+    return f.required === true && (t === kind || t === `list[${kind}]`);
+  });
+}
+
+/**
+ * Drop the generation tasks an entry's own declared inputs rule out, and fall
+ * back to the transform task when that leaves nothing.
+ *
+ * Inference reads names, and a name is often silent about direction — which is
+ * why an ambiguous generator is tagged with both. A *required* image input is
+ * not silent: `alibaba/qwen-image-3/edit` cannot generate from a prompt alone,
+ * and it was the top-ranked `text_to_image` answer a live session got, because
+ * nothing here read the field that says so.
+ *
+ * Only ever subtracts. Explicit `supportedTasks` never reach this.
+ */
+export function narrowTasksByRequiredInputs(
+  tasks: string[],
+  n: ManifestNode,
+  kind: "image" | "video"
+): string[] {
+  const generationTask = kind === "image" ? "text_to_image" : "text_to_video";
+  const transformTask = kind === "image" ? "image_to_image" : "video_to_video";
+  const drop = new Set<string>();
+  if (requiresMediaInput(n, "image")) drop.add(generationTask);
+  if (kind === "video" && requiresMediaInput(n, "video")) {
+    drop.add("text_to_video");
+    drop.add("image_to_video");
+  }
+  if (drop.size === 0) return tasks;
+  const kept = tasks.filter((t) => !drop.has(t));
+  return kept.length > 0 ? kept : [transformTask];
+}
+
 /** Pure transform: manifest nodes → deduplicated, task-tagged video models. */
 export function buildVideoModels(
   manifest: ManifestNode[],
@@ -350,7 +458,9 @@ export function buildVideoModels(
     const id = nodeId(n);
     if (!id) continue;
     const name = nodeName(n);
-    const tasks = explicitTasks(n) ?? inferVideoTasks(name, id);
+    const tasks =
+      explicitTasks(n) ??
+      narrowTasksByRequiredInputs(inferVideoTasks(name, id), n, "video");
 
     const existing = seen.get(id);
     if (existing) {
@@ -643,7 +753,10 @@ export function buildImageModels(
     // Copy so the mask-input augmentation below never mutates the manifest
     // node's own `supportedTasks` array (which `loadManifest` memoizes and
     // shares across every caller).
-    const tasks = [...(explicitTasks(n) ?? inferImageTasks(name, id))];
+    const tasks = [
+      ...(explicitTasks(n) ??
+        narrowTasksByRequiredInputs(inferImageTasks(name, id), n, "image"))
+    ];
     // Endpoints that declare a mask image input support inpainting (mask-guided
     // editing). Tag them so the inpaint capability/picker can find them.
     if (

--- a/packages/runtime/tests/providers/atlascloud-provider.test.ts
+++ b/packages/runtime/tests/providers/atlascloud-provider.test.ts
@@ -179,10 +179,11 @@ describe("AtlasCloudProvider — getAvailableVideoModels", () => {
     expect(byId.get("bytedance/seedance-2.0/image-to-video")?.supportedTasks).toEqual([
       "image_to_video"
     ]);
-    // reference-to-video is multimodal: tagged both
+    // reference-to-video is image-conditioned: it needs the reference stills,
+    // so it is not an answer to a text_to_video search.
     expect(
       byId.get("bytedance/seedance-2.0/reference-to-video")?.supportedTasks
-    ).toEqual(["text_to_video", "image_to_video"]);
+    ).toEqual(["image_to_video"]);
   });
 });
 

--- a/packages/runtime/tests/providers/manifest-models-hardening.test.ts
+++ b/packages/runtime/tests/providers/manifest-models-hardening.test.ts
@@ -14,6 +14,8 @@ import {
   nodeId,
   nodeName,
   matchesAny,
+  requiresMediaInput,
+  narrowTasksByRequiredInputs,
   inferVideoTasks,
   inferImageTasks,
   buildVideoModels,
@@ -330,6 +332,106 @@ describe("matchesAny", () => {
   });
 });
 
+describe("narrowTasksByRequiredInputs", () => {
+  const requiredImage = {
+    outputType: "image",
+    endpointId: "alibaba/qwen-image-3/edit",
+    inputFields: [
+      { name: "prompt", propType: "str", required: true },
+      { name: "images", propType: "list[image]", required: true }
+    ]
+  };
+
+  it("reads requiredness off the declared fields", () => {
+    expect(requiresMediaInput(requiredImage, "image")).toBe(true);
+    expect(requiresMediaInput(requiredImage, "video")).toBe(false);
+    expect(
+      requiresMediaInput(
+        { inputFields: [{ name: "image", propType: "image" }] },
+        "image"
+      )
+    ).toBe(false);
+    // Kie declares uploads instead of typed fields, and says nothing about
+    // requiredness — inference stands rather than being narrowed on a guess.
+    expect(
+      requiresMediaInput({ uploads: [{ field: "image", kind: "image" }] }, "image")
+    ).toBe(false);
+  });
+
+  // `models.pick("text_to_image")` answered with an image *editor* — every
+  // image endpoint was tagged with both generation tasks, so the pool was
+  // alphabetical and this id sorts first.
+  it("drops text_to_image from an endpoint that requires an image", () => {
+    expect(
+      narrowTasksByRequiredInputs(
+        ["text_to_image", "image_to_image"],
+        requiredImage,
+        "image"
+      )
+    ).toEqual(["image_to_image"]);
+  });
+
+  it("drops text_to_video from a video endpoint that requires an image", () => {
+    expect(
+      narrowTasksByRequiredInputs(
+        ["text_to_video", "image_to_video"],
+        {
+          outputType: "video",
+          inputFields: [{ name: "image", propType: "image", required: true }]
+        },
+        "video"
+      )
+    ).toEqual(["image_to_video"]);
+  });
+
+  it("falls back to the transform task when nothing generative is left", () => {
+    expect(
+      narrowTasksByRequiredInputs(
+        ["text_to_video", "image_to_video"],
+        {
+          outputType: "video",
+          inputFields: [{ name: "video", propType: "video", required: true }]
+        },
+        "video"
+      )
+    ).toEqual(["video_to_video"]);
+  });
+
+  it("leaves an endpoint that requires nothing alone", () => {
+    const tasks = ["text_to_image", "image_to_image"];
+    expect(
+      narrowTasksByRequiredInputs(
+        tasks,
+        {
+          outputType: "image",
+          inputFields: [{ name: "image", propType: "image", required: false }]
+        },
+        "image"
+      )
+    ).toBe(tasks);
+  });
+
+  it("never overrules an explicit supportedTasks declaration", () => {
+    const [model] = buildImageModels(
+      [
+        {
+          outputType: "image",
+          endpointId: "e1",
+          supportedTasks: ["text_to_image"],
+          inputFields: [{ name: "image", propType: "image", required: true }]
+        }
+      ],
+      "p"
+    );
+    expect(model.supportedTasks).toEqual(["text_to_image"]);
+  });
+
+  it("narrows an inferred tagging through buildImageModels", () => {
+    const [model] = buildImageModels([requiredImage], "fal_ai");
+    expect(model.supportedTasks).toEqual(["image_to_image"]);
+  });
+});
+
 describe("inferVideoTasks", () => {
   const cases: [string, string[]][] = [
     ["lipsync", ["lip_sync"]],
@@ -362,6 +464,40 @@ describe("inferVideoTasks", () => {
       "image_to_video"
     ]);
   });
+
+  // A live session searched image_to_video for "ltx" and got back four
+  // audio-to-video endpoints and an extend-video one, because every endpoint
+  // whose id spelled out neither direction was tagged as both generators.
+  const byId: [string, string[]][] = [
+    ["fal-ai/ltx-2-19b/audio-to-video", ["audio_to_video"]],
+    ["fal-ai/ltx-2-19b/distilled/audio-to-video/lora", ["audio_to_video"]],
+    ["fal-ai/longcat-multi-avatar/image-audio-to-video", ["audio_to_video"]],
+    ["argil/avatars/audio-to-video", ["audio_to_video"]],
+    ["fal-ai/ltx-2-19b/extend-video", ["video_to_video"]],
+    ["fal-ai/ltx-video-13b-dev/extend", ["video_to_video"]],
+    ["fal-ai/ltx-2.3/reframe", ["video_to_video"]],
+    ["fal-ai/ltx-2/retake-video", ["video_to_video"]],
+    ["fal-ai/ltx-2.3-quality/outpaint", ["video_to_video"]],
+    ["fal-ai/bernini-r/edit-video", ["video_to_video"]],
+    ["bria/video/background-removal/v3", ["video_to_video"]],
+    ["fal-ai/amt-interpolation/frame-interpolation", ["video_to_video"]],
+    ["fal-ai/elevenlabs/dubbing", ["video_to_video"]],
+    ["decart/lucy-restyle", ["video_to_video"]],
+    ["blackforestlabs/flux-3/first-last-frame-to-video", ["image_to_video"]],
+    ["blackforestlabs/flux-3/keyframes-to-video", ["image_to_video"]],
+    ["bytedance/seedance-2.0/reference-to-video", ["image_to_video"]],
+    // Still a generator: the direction is spelled out, so nothing above bites.
+    ["fal-ai/ltx-2-19b/image-to-video", ["image_to_video"]],
+    ["fal-ai/ltx-2-19b/distilled/image-to-video/lora", ["image_to_video"]],
+    ["fal-ai/heygen/avatar4/image-to-video", ["image_to_video"]],
+    // A lip-sync endpoint keeps its own task even when the id says audio.
+    ["fal-ai/kling-video/lipsync/audio-to-video", ["lip_sync"]]
+  ];
+  for (const [id, expected] of byId) {
+    it(`"${id}" → ${expected.join("+")}`, () => {
+      expect(inferVideoTasks("", id)).toEqual(expected);
+    });
+  }
 });
 
 describe("inferImageTasks", () => {

--- a/packages/runtime/tests/providers/manifest-models.test.ts
+++ b/packages/runtime/tests/providers/manifest-models.test.ts
@@ -33,6 +33,31 @@ describe("manifest-models task inference (FAL manifest)", () => {
     }
   });
 
+  // The catalog-wide form of the failure this fixed: `find_model` for
+  // image_to_video ranked ties alphabetically, so a search for "ltx" answered
+  // with four audio-to-video endpoints and an extend-video one.
+  it("keeps non-generator video endpoints out of the generation pools", () => {
+    const generators = videos.filter(
+      (m) =>
+        m.supportedTasks?.includes("text_to_video") ||
+        m.supportedTasks?.includes("image_to_video")
+    );
+    const offenders = generators
+      .map((m) => m.id)
+      .filter((id) =>
+        /audio-to-video|extend-video|\/extend$|reframe|retake|background-removal/.test(
+          id
+        )
+      );
+    expect(offenders).toEqual([]);
+    expect(
+      byId(videos, "fal-ai/ltx-2-19b/audio-to-video")?.supportedTasks
+    ).toEqual(["audio_to_video"]);
+    expect(
+      byId(videos, "fal-ai/ltx-2-19b/image-to-video")?.supportedTasks
+    ).toEqual(["image_to_video"]);
+  });
+
   it("tags specialized image transforms with a single specific task", () => {
     expect(byId(images, "fal-ai/image-apps-v2/relighting")?.supportedTasks).toEqual([
       "relight"
@@ -69,7 +94,7 @@ describe("manifest-models task inference (FAL manifest)", () => {
     }
   });
 
-  it("tags general image generators with both generation tasks", () => {
+  it("tags a general image generator image_to_image, and text_to_image unless it requires an image", () => {
     const generators = images.filter(
       (m) =>
         m.supportedTasks?.includes("text_to_image") ||
@@ -77,16 +102,27 @@ describe("manifest-models task inference (FAL manifest)", () => {
     );
     expect(generators.length).toBeGreaterThan(0);
     for (const m of generators) {
-      // Every generator carries both generation tasks; mask-declaring endpoints
-      // additionally advertise inpainting (the only permitted extra).
+      // Direction cannot be read off a FAL id, so a generator carries
+      // image_to_image either way; mask-declaring endpoints additionally
+      // advertise inpainting (the only permitted extra).
       const tasks = m.supportedTasks ?? [];
-      expect(tasks).toContain("text_to_image");
       expect(tasks).toContain("image_to_image");
       const extras = tasks.filter(
         (t) => t !== "text_to_image" && t !== "image_to_image"
       );
       expect(extras.every((t) => t === "inpainting")).toBe(true);
     }
+    // Some do generate from a prompt alone…
+    expect(
+      generators.filter((m) => m.supportedTasks?.includes("text_to_image"))
+        .length
+    ).toBeGreaterThan(0);
+    // …and an endpoint whose manifest marks an image input required does not:
+    // `pick("text_to_image")` answered with this editor before the required
+    // inputs were read.
+    expect(
+      byId(images, "alibaba/qwen-image-3/edit")?.supportedTasks
+    ).toEqual(["image_to_image"]);
   });
 
   it("tags mask-declaring edit endpoints with the inpainting task", () => {

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -2221,7 +2221,8 @@ export function toJobResponse(job: Job) {
     started_at: job.started_at ?? null,
     finished_at: job.finished_at ?? null,
     error: job.error ?? null,
-    cost: job.cost ?? null
+    cost: job.cost ?? null,
+    outputs: job.runOutputs()
   };
 }
 


### PR DESCRIPTION
A chat session that built a social-media ad workflow lost most of its rounds to
six defects in the agent-facing surface, none of them in the workflow it was
building. Each is fixed here with a test that fails without the fix.

## What went wrong, and why

**1. `find_model(image_to_video, query: "ltx")` answered with four
audio-to-video endpoints and an extend-video one.** Not a ranking bug:
`inferVideoTasks` tagged every endpoint whose id did not spell out a direction
with *both* generation tasks, so the candidate pool was 70 models, scores tied
at 0, and ties sort alphabetically — `audio-to-video` first.

**2. `models.pick("text_to_image")` answered with `alibaba/qwen-image-3/edit`,
an image editor.** Same cause on the image side: all 677 image endpoints
carried `text_to_image`, and that id sorts first.

**3. `nodetool.jobs.wait(job.id)` → "Job undefined was not found".**
`workflows.start()` answers with a record that spells its id `job_id`;
everything else keys on `id`. The undefined reached the tool, which reported it
as a missing job rather than as a bad call.

**4. `get_job` on a completed run reported no results.** `jobRecord` and
`toJobResponse` carried no outputs and nothing persisted any, so the session
reconstructed its own results by listing recent assets.

**5. `get_job_logs` answered `total_logs: 0`.** `job.logs` has never had a
writer anywhere in the repo, so that tool — and `debug_workflow`'s `logs` array
— could never report anything.

**6. Two turns cancelled waiting on a run.** `background: true` was a field on
the payload and nothing else: `start_background_job` awaited the whole run.

## Changes

`packages/runtime` — task inference reads what an endpoint takes, in two steps.
Names that do say something (`audio-to-video`, `extend-video`, `reframe`,
`retake`, `dubbing`, `first-last-frame-to-video`, `reference-to-video`, …), then
the manifest's own `required` flags: an endpoint that refuses the call without
an image cannot generate from a prompt alone. The second rule only subtracts,
and an explicit `supportedTasks` is never overruled.

`packages/execution`, `packages/models`, `packages/websocket` — a background run
detaches and the call returns a receipt (`job_id` **and** `id`). When it
settles, the row keeps the run's outputs (bounded at 256 KB; past that, the
handle names and the reason) and its log tail plus one line per failed node.
`Job.runOutputs()` is the one reader, so the agent tools and the REST route
cannot drift.

`packages/agents` — `jobs.get/logs/wait` take an id or the receipt, and name the
call when there is neither instead of asking the belt about a phantom job. The
eval world that taught this contract is corrected too: its fake `start` returned
`{id, job_id}` and its fake `get_job` returned `{result: {outputs}}`, neither of
which the real tools ever did.

## Effect, measured on the shipped FAL manifest (561 video, 553 image endpoints)

| task | before | after |
|---|---:|---:|
| `image_to_video` | 404 | 328 |
| `text_to_video` | 389 | 278 |
| `video_to_video` | 48 | 186 |
| `audio_to_video` | 0 | 17 |
| `text_to_image` | 677 | 268 |

An `image_to_video` search for "ltx" now has 39 candidates, all of which take an
image.

## Verification

`npm run test:packages` passes (the three anti-slop plugin suites needed a
`npm install` first — `@oxlint/plugins` was missing from this checkout).
`npm run lint` exits clean. Each fix was inverted once and watched fail:
17 of the 21 new inference cases and both catalog assertions go red on the old
inference, and the detach test times out at 30s against the blocking version.

Not fixed here, because it could not be reproduced without provider keys: the
run in that session completed with the timeline and rendered-video outputs
empty while the same two nodes worked standalone. Fix 5 is what makes that
diagnosable next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eZghTjndiNQYsmCvv2eyJ

---
_Generated by [Claude Code](https://claude.ai/code/session_013eZghTjndiNQYsmCvv2eyJ)_