### PR TITLE
fix(agents): screen the view_image URL passthrough

### DIFF
--- a/packages/agents/src/capabilities/assets.ts
+++ b/packages/agents/src/capabilities/assets.ts
@@ -32,7 +32,11 @@ import {
   type ProcessingContext
 } from "@nodetool-ai/runtime";
 import type { Asset as AssetRow } from "@nodetool-ai/models";
-import { loadMediaRefBytes, safeFetch } from "@nodetool-ai/runtime";
+import {
+  isSafePublicHttpsUrl,
+  loadMediaRefBytes,
+  safeFetch
+} from "@nodetool-ai/runtime";
 import { mimeForPath } from "../sandbox-media-ref.js";
 import { MIME_TO_EXT } from "../tools/asset-persist.js";
 import { userIdOf } from "../tools/mcp-tool-support.js";
@@ -812,6 +816,7 @@ export const viewImageCore: CapabilityImpl = async (run, params) => {
   let sourceBytes: Uint8Array | null = null;
   let sourceMime = "image/png";
   let passthroughUri: string | undefined;
+  let resolveError: string | undefined;
 
   if (imageId.startsWith("data:")) {
     const parsed = parseDataUri(imageId);
@@ -819,6 +824,22 @@ export const viewImageCore: CapabilityImpl = async (run, params) => {
     sourceBytes = parsed.bytes;
     sourceMime = parsed.mimeType;
   } else if (/^https?:\/\//i.test(imageId)) {
+    // Screen it. This uri goes out as `image_content.uri` for the *provider* to
+    // fetch, so an unscreened one is not an SSRF against this host — the reach
+    // it buys is the provider's network, not ours. It was still the only
+    // model-supplied URL in this module that skipped the guard every other one
+    // meets: `save_asset` refuses exactly these through `safeFetch`, and a
+    // model that cannot tell which of two image tools screens its input is
+    // being taught that the boundary is arbitrary.
+    if (!isSafePublicHttpsUrl(imageId)) {
+      return {
+        error:
+          `Refused to load image from "${imageId}". ` +
+          `Only public https:// URLs are handed to the vision provider — ` +
+          `plain http, localhost, and private or link-local addresses are refused. ` +
+          `Pass an asset id, an asset:// URI, or a data: URI instead.`
+      };
+    }
     passthroughUri = imageId;
   } else {
     try {
@@ -827,14 +848,28 @@ export const viewImageCore: CapabilityImpl = async (run, params) => {
         sourceBytes = bytes;
         sourceMime = sniffImageMime(bytes);
       }
-    } catch {
-      // fall through to the not-found error below
+    } catch (e) {
+      // Keep why. A caller that passed a perfectly good asset id — one
+      // `save_asset` just minted — gets this same branch when the row exists
+      // but its bytes do not resolve (no configured storage, an unreachable
+      // bucket, a revoked credential). Told only "pass an asset id", an agent
+      // re-passes the id it already has, then guesses URL shapes; the reason
+      // is the one thing that stops that loop.
+      resolveError = e instanceof Error ? e.message : String(e);
     }
   }
 
   if (!sourceBytes && !passthroughUri) {
     return {
-      error: `Could not load image "${imageId}". Pass an asset id, asset:// URI, http(s) URL, or data: URI.`
+      error:
+        `Could not load image "${imageId}". ` +
+        (resolveError
+          ? `Resolving it failed: ${resolveError}. `
+          : "Nothing resolved for it. ") +
+        `Accepted: an asset id, an asset:// URI, a public https:// URL, or a ` +
+        `data: URI. A localhost or private-address URL is refused, so guessing ` +
+        `a local server URL will not work — if you already hold the bytes, ` +
+        `pass them as a data: URI.`
     };
   }
 

--- a/packages/agents/tests/capabilities-assets.test.ts
+++ b/packages/agents/tests/capabilities-assets.test.ts
@@ -351,6 +351,88 @@ describe("view_image", () => {
     expect(extractInjectableImages(result)).not.toBeNull();
   });
 
+  it.each([
+    ["loopback", "http://localhost:7777/api/storage/abc.png"],
+    ["loopback by ip", "https://127.0.0.1:7777/api/storage/abc.png"],
+    ["cloud metadata", "http://169.254.169.254/latest/meta-data/iam"],
+    ["private range", "https://10.0.0.5/internal.png"],
+    ["plain http to a public host", "http://example.com/logo.png"]
+  ])("refuses a %s URL instead of handing it to the vision provider", async (
+    _label,
+    url
+  ) => {
+    // The passthrough hands `image_content.uri` to the vision provider, which
+    // fetches it from *their* network — so this is not an SSRF against our
+    // host. It is still the one model-supplied URL in this path that never met
+    // the guard every other outbound URL here meets, and `save_asset` already
+    // refuses exactly these through `safeFetch`.
+    const resolveAssetBytes = vi.fn(async () => ({
+      bytes: new Uint8Array(),
+      attempts: [] as string[]
+    }));
+    const ctx = makeContext({ resolveAssetBytes });
+    const result = (await asTool("view_image", ctx).process(ctx, {
+      image_id: url
+    })) as Record<string, unknown>;
+
+    expect(result.ok).toBeUndefined();
+    expect(result.image_content).toBeUndefined();
+    expect(String(result.error)).toContain("refused");
+    // Refused at the URL, not by falling through to an asset lookup.
+    expect(resolveAssetBytes).not.toHaveBeenCalled();
+  });
+
+  it("still passes a public https URL to the provider", async () => {
+    // The guard must not close the door it exists to leave open.
+    const ctx = makeContext();
+    const result = (await asTool("view_image", ctx).process(ctx, {
+      image_id: "https://example.com/logo.png"
+    })) as Record<string, unknown>;
+
+    expect(result.ok).toBe(true);
+    expect(result.image_content).toEqual({
+      uri: "https://example.com/logo.png",
+      mimeType: "image/png"
+    });
+  });
+
+  it("names why resolution failed instead of only naming the accepted forms", async () => {
+    // The shape a headless run hits: `save_asset` minted a real id, the row
+    // exists, and its bytes do not resolve. Reporting only "pass an asset id"
+    // sends an agent back round with the id it already had.
+    const ctx = makeContext({
+      resolveAssetBytes: vi.fn(async () => {
+        throw new Error("storage backend unreachable");
+      })
+    });
+    const result = (await asTool("view_image", ctx).process(ctx, {
+      image_id: "7bbcb4b593644b3abfe6abcfcd96aa60"
+    })) as Record<string, unknown>;
+
+    expect(String(result.error)).toContain("storage backend unreachable");
+    expect(String(result.error)).toContain("data: URI");
+    // It used to offer "http(s) URL" as an accepted form. That is what sent a
+    // headless agent guessing `localhost:7777` URL shapes for seven minutes
+    // while it held a valid id: the message recommended a form that cannot
+    // work here, and the guard then refused every attempt.
+    expect(String(result.error)).not.toContain("http(s)");
+    expect(String(result.error)).toContain("localhost");
+  });
+
+  it("says nothing resolved when the lookup answered with no bytes", async () => {
+    const ctx = makeContext({
+      resolveAssetBytes: vi.fn(async () => ({
+        bytes: new Uint8Array(),
+        attempts: [] as string[]
+      }))
+    });
+    const result = (await asTool("view_image", ctx).process(ctx, {
+      image_id: "empty-asset"
+    })) as Record<string, unknown>;
+
+    expect(String(result.error)).toContain("Nothing resolved for it");
+  });
+
   it("runs the argument check the tool ran, with the same envelope", async () => {
     const ctx = makeContext();
     const result = (await asTool("view_image", ctx).process(ctx, {})) as Record<


### PR DESCRIPTION
## What

`view_image` accepted any `http(s)` `image_id` and handed it to the vision provider as `image_content.uri` without screening:

```ts
} else if (/^https?:\/\//i.test(imageId)) {
  passthroughUri = imageId;   // straight through
}
```

It now runs `isSafePublicHttpsUrl` first, and the not-found message no longer recommends a URL form that cannot work in a headless run.

## Why

**The passthrough.** This is not an SSRF against our host — the provider fetches that URI from *their* network. It was still the only model-supplied URL in this module that skipped the guard every other one meets: `save_asset` already refuses exactly these through `safeFetch`. A model that cannot tell which of two image tools screens its input is being taught that the boundary is arbitrary.

**The message.** It read `Pass an asset id, asset:// URI, http(s) URL, or data: URI` — advertising `http(s) URL` as accepted. An agent holding a valid asset id whose bytes failed to resolve was pointed at a form with nothing behind it in a headless run. Observed cost: seven minutes and a dozen actions guessing `localhost:7777` URL shapes, every one refused by the guard, while it already held the id it needed. The message now names https only, says local and private addresses are refused, and points at a `data:` URI.

## Verification

Six tests written and **watched fail first** — all five URL shapes passed through unscreened before the change, and the message assertion failed on the old text. Then 40 passing across `capabilities-assets`, `capabilities-coverage`, `capabilities-registry`. `tsc --noEmit` and `oxlint` clean.

Covered: loopback by name and by IP, the cloud metadata address (`169.254.169.254`), a private range, plain `http` to a public host, and one test pinning that a **public https URL still reaches the provider unchanged** — so the guard does not close the door it exists to leave open.

I also probed `isSafePublicHttpsUrl` against inet_aton evasion (`2130706433`, `0x7f000001`, `0177.0.0.1`, `127.1`, `[::1]`); it blocks all of them, so the new check is not bypassable that way.

## Not in this PR

`packages/runtime/src/media-ref-bytes.ts:205` does a raw `fetch(uri)` on any http(s) media ref with no guard. Unlike the above, **that one runs on our host** — a media ref naming `169.254.169.254` is a real SSRF. It is pre-existing and known: `atlascloud-factory.ts:427` routes around it, commenting that "loadMediaRefBytes downloads http(s) unguarded."

Left alone deliberately. It feeds 17+ call sites across node packages, and a test there deliberately pins plain-http fetching, so picking a policy means deciding whether self-hosted LAN/localhost media refs keep resolving. That is a product call with a blast radius, not a drive-by fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)