### PR TITLE
fix(agents): replace literal NUL bytes in creative-pipeline separators

### DIFF
--- a/packages/agents/src/evals/surfaces/creative-pipeline.ts
+++ b/packages/agents/src/evals/surfaces/creative-pipeline.ts
@@ -884,7 +884,7 @@ export const TIDEWATCH_BRIEF: CreativeBrief = {
 };
 
 const actionsOf = (s: CreativePipelineFinalState) =>
-  s.storyboard.shots.map((sh) => sh.action.toLowerCase()).join("   ");
+  s.storyboard.shots.map((sh) => sh.action.toLowerCase()).join(" \0 ");
 
 const featuresCovered = (s: CreativePipelineFinalState) => {
   const hay = actionsOf(s);
@@ -892,9 +892,9 @@ const featuresCovered = (s: CreativePipelineFinalState) => {
 };
 
 const forbiddenAvoided = (s: CreativePipelineFinalState) => {
-  const hay = `${actionsOf(s)}   ${s.sketch.layers
+  const hay = `${actionsOf(s)} \0 ${s.sketch.layers
     .map((l) => l.name.toLowerCase())
-    .join("   ")}`;
+    .join(" \0 ")}`;
   return s.brief.forbid.every((f) => !hay.includes(f.toLowerCase()));
 };
 


### PR DESCRIPTION
Three `join()` separators in the creative-pipeline eval surface held a **literal NUL byte** instead of the `\0` escape:

```diff
-  s.storyboard.shots.map((sh) => sh.action.toLowerCase()).join(" ^@ ");
+  s.storyboard.shots.map((sh) => sh.action.toLowerCase()).join(" \0 ");
```

(`^@` is `cat -v` rendering the raw byte.)

## Why it matters

Git staged the file as **binary**, so all 1238 lines were invisible to `grep` and to diff review. A file nobody can search is a file nobody can review — this is the trap AGENTS.md names under "byte-count the file for stray control characters".

The value is unchanged: `"\0" === String.fromCharCode(0)`. Only the source encoding differs.

## Verification

- NUL-free by byte count: 48802 bytes before and after `tr -d '\000'`, difference **0**.
- `git diff --numstat` now reports `3 3` rather than `- -`, i.e. git sees text.
- `creative-pipeline-tool-loop` suite: 20/20 passing.

Worth noting how the first measurement lied: `grep -c $'\0'` reported 1238 matches, because bash cannot hold a NUL in a string — `$'\0'` is the empty string, so it matched every line. The byte-count comparison above is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)