### PR TITLE
fix(cli): give the piped-stdin turn the builtin toolbelt

### DIFF
--- a/packages/cli/src/stdin.ts
+++ b/packages/cli/src/stdin.ts
@@ -28,6 +28,7 @@ import { applySystemPrompt, createCliCodeActTurn } from "./chat-codeact.js";
 import { createChatContext } from "./chat-context.js";
 import {
   createCapabilityRun,
+  getBuiltinTools,
   toolForCapabilityName,
   UNGATED
 } from "@nodetool-ai/agents";
@@ -234,7 +235,14 @@ export async function runStdinMode(opts: StdinModeOptions): Promise<void> {
   // the websocket server exposes.
   const buildDirectTools = (prov: BaseProvider | null): Tool[] => {
     if (!prov) return [];
-    const baseTools: Tool[] = [];
+    // The builtin belt. This used to be an `extras` parameter that only the
+    // (now removed) `--sandbox` flag ever filled, so a normal CLI run reached
+    // the model with nothing on it: no `view_image`, so a headless turn could
+    // not look at an image at all, and every `nodetool.media.*` method threw
+    // naming a tool the belt did not carry. `createCliCodeActTurn` adds
+    // `execute_code` itself and appends `view_image` only if it finds it here,
+    // which is why an empty belt silently removed the one channel for pixels.
+    const baseTools: Tool[] = getBuiltinTools();
     const forwardMessage = (msg: ProcessingMessage) => {
       if (msg.type === "chunk") {
         process.stdout.write((msg as { content?: string }).content ?? "");

--- a/packages/cli/tests/stdin.test.ts
+++ b/packages/cli/tests/stdin.test.ts
@@ -101,6 +101,26 @@ vi.mock("@nodetool-ai/agents", () => ({
   // The delegation tools reach the belt as capabilities now; the CLI names
   // them, so the mock answers by name.
   UNGATED: { mode: "auto", sessionAllow: new Set<string>() },
+  // A representative belt: one core tool (goes top level beside
+  // `execute_code`), one sandbox-only tool, and `view_image` — the one channel
+  // that puts pixels in front of the model, which the turn appends only when
+  // it finds it on the belt.
+  getBuiltinTools: () =>
+    ["read_file", "critique_image", "view_image"].map((name) => ({
+      name,
+      description: `stub ${name}`,
+      inputSchema: { type: "object" },
+      toProviderTool() {
+        return {
+          name: this.name,
+          description: this.description,
+          inputSchema: this.inputSchema
+        };
+      },
+      async process() {
+        return null;
+      }
+    })),
   createCapabilityRun: (options: unknown) => options,
   toolForCapabilityName: (name: string) => ({
     name,
@@ -423,11 +443,16 @@ describe("runStdinMode — direct provider chat", () => {
       tools: Array<{ name: string }>;
       messages: Array<{ role: string; content: string }>;
     };
-    // `run_subtask` is a core tool, so it rides alongside `execute_code`;
-    // everything else on the belt stays inside the sandbox.
+    // The split: core tools ride alongside `execute_code` (`run_subtask` from
+    // the delegation pair, `read_file` off the belt), and `view_image` is
+    // appended because pixels have no other channel. `critique_image` is on
+    // the same belt and is absent here — a non-core tool stays inside the
+    // sandbox, reachable by import rather than as a provider tool.
     expect(call.tools.map((t) => t.name)).toEqual([
       "execute_code",
-      "run_subtask"
+      "run_subtask",
+      "read_file",
+      "view_image"
     ]);
     expect(call.messages[0]).toEqual({
       role: "system",


### PR DESCRIPTION
## What

`packages/cli/src/stdin.ts` built its toolbelt from an `extras` parameter that only `--sandbox` ever populated, and then only with Docker tools. For an ordinary run the belt started **empty**, so `getBuiltinTools()` output never reached it:

```ts
const baseTools: Tool[] = getBuiltinTools();
```

## Why

A piped CLI turn could not call `view_image` — or any other builtin — so it could not look at an image it had just generated. This is what made the `view_image` failure in #5101 reachable in the first place.

## The split, and why the test pins it

Core tools are offered to the provider at the top level; a non-core capability stays reachable inside the sandbox instead of being promoted. The test asserts the belt is exactly:

```
["execute_code", "run_subtask", "read_file", "view_image"]
```

with `critique_image` deliberately **absent** — it is in the mocked `getBuiltinTools()` return, so its absence proves the split is doing the filtering rather than everything being passed through.

## Verification

`packages/cli` `stdin.test.ts`: 19/19 passing.

## Note on scope

An earlier claim in this session — that commit `c648f1bec` had regressed this — was **wrong and is retracted**. I checked the parent commit: `extraTools` was only ever populated under `--sandbox`. The removal was correct cleanup; the belt was always empty for normal runs. This PR adds something that was never there, rather than restoring something that broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)