### PR TITLE
fix(runtime): snapshot cassette messages instead of aliasing the caller's array

### DIFF
--- a/packages/runtime/src/providers/cassette-provider.ts
+++ b/packages/runtime/src/providers/cassette-provider.ts
@@ -315,6 +315,21 @@ export function normalizeRequest(args: {
   return request;
 }
 
+/**
+ * Deep-copy the messages of a request that is about to be stored.
+ *
+ * {@link normalizeRequest} deliberately aliases `args.messages` — it feeds the
+ * hash, which is taken while the array still holds this call's state, and
+ * cloning the whole conversation on every replay lookup would be wasted work.
+ * A *recorded* interaction outlives the call, though, and agent loops append
+ * to that same array between calls: kept as a reference, every interaction in
+ * a saved cassette ends up showing the conversation's final state rather than
+ * what its own call was sent. Snapshot at the moment of recording.
+ */
+function snapshotRequest(request: CassetteRequest): CassetteRequest {
+  return { ...request, messages: request.messages.map(cloneMessage) };
+}
+
 /** Stable hash of a request, scoped by method so the two surfaces never mix. */
 export function hashRequest(
   method: CassetteMethod,
@@ -559,7 +574,7 @@ export class CassetteProvider extends BaseProvider {
     const interaction: CassetteInteraction = {
       hash,
       method: "generateMessage",
-      request,
+      request: snapshotRequest(request),
       response: cloneMessage(result)
     };
     if (usage) {
@@ -630,7 +645,7 @@ export class CassetteProvider extends BaseProvider {
     const interaction: CassetteInteraction = {
       hash,
       method: "generateMessages",
-      request,
+      request: snapshotRequest(request),
       response: captured
     };
     if (usage) {

--- a/packages/runtime/tests/providers/cassette-provider.test.ts
+++ b/packages/runtime/tests/providers/cassette-provider.test.ts
@@ -170,6 +170,57 @@ describe("CassetteProvider record → replay (generateMessages)", () => {
   });
 });
 
+describe("CassetteProvider records what each call was sent", () => {
+  /**
+   * An agent loop appends to one `messages` array and calls the provider again
+   * with that same array. A recorded interaction that keeps the reference ends
+   * up showing the conversation's final state, so every interaction in a saved
+   * cassette reads as though it were the last one — which makes the cassette
+   * useless as a transcript of how the run got there.
+   */
+  it("snapshots messages instead of aliasing the caller's array", async () => {
+    const cassette = createEmptyCassette();
+    const fake = new FakeProvider({ textResponse: "ok", shouldStream: true });
+    const recorder = new CassetteProvider(fake, { mode: "record", cassette });
+
+    // The array the "agent loop" owns and keeps appending to.
+    const conversation: Message[] = [{ role: "user", content: "first" }];
+
+    await collect(
+      recorder.generateMessages({ messages: conversation, model: "fake-model" })
+    );
+    conversation.push({ role: "assistant", content: "reply" });
+    conversation.push({ role: "user", content: "second" });
+    await collect(
+      recorder.generateMessages({ messages: conversation, model: "fake-model" })
+    );
+
+    expect(cassette.interactions).toHaveLength(2);
+    // The first call was sent exactly one message; the second, three.
+    expect(cassette.interactions[0]!.request.messages).toHaveLength(1);
+    expect(cassette.interactions[1]!.request.messages).toHaveLength(3);
+    expect(cassette.interactions[0]!.request.messages[0]!.content).toBe(
+      "first"
+    );
+  });
+
+  it("keeps a recorded message stable when the caller mutates it in place", async () => {
+    const cassette = createEmptyCassette();
+    const fake = new FakeProvider({ textResponse: "ok", shouldStream: true });
+    const recorder = new CassetteProvider(fake, { mode: "record", cassette });
+
+    const message: Message = { role: "user", content: "original" };
+    await collect(
+      recorder.generateMessages({ messages: [message], model: "fake-model" })
+    );
+    message.content = "mutated after the call";
+
+    expect(cassette.interactions[0]!.request.messages[0]!.content).toBe(
+      "original"
+    );
+  });
+});
+
 describe("CassetteProvider record → replay (generateMessage)", () => {
   it("replays the single-shot message without the inner provider", async () => {
     const cassette = createEmptyCassette();


### PR DESCRIPTION
## The bug

`normalizeRequest` kept a **reference** to the caller's `messages` array instead of a copy. Every recorded interaction therefore pointed at the same growing array, and a cassette written from a multi-turn run showed the conversation's *final* state for every interaction in it.

That defeats the point of a cassette: the recording could not reproduce the call it claimed to record.

## The fix

```ts
function snapshotRequest(request: CassetteRequest): CassetteRequest {
  return { ...request, messages: request.messages.map(cloneMessage) };
}
```

Applied at both push sites.

The **hashing** path still aliases, deliberately, and carries a comment saying why: the hash is taken while the array holds that call's state, so it is correct there, and cloning on every replay lookup would be wasted work. Worth a reviewer's eye — the asymmetry is intentional, not an oversight.

## Verification

Two new tests, **both watched fail before the fix**:

- "snapshots messages instead of aliasing the caller's array" — caller appends after the call
- "keeps a recorded message stable when the caller mutates it in place"

Full suite: 27/27 passing.

## Context

This came out of building a `--cassette` flag for an agent optimization loop. That flag itself was **reverted** and is not in this PR: wrapping a provider in `CassetteProvider` replaced `OpenAIProvider`'s Responses-API loop and `ClaudeAgentProvider`'s SDK loop with the generic base loop, because the decorator does not override `generateLoop`. Proven by running one case both ways — it failed wrapped and passed unwrapped.

The aliasing bug is real and independent of that, so it ships on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)