### PR TITLE
fix(agents): make the CodeAct finish contract visible to the model

### DIFF
--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -1898,8 +1898,10 @@ Plans are validated before execution:
 
 Steps can enforce structured output via JSON schema:
 - `additionalProperties: false` enforced automatically
-- Schema'd steps finalize ONLY through the `finish_step` tool — there is no JSON-from-text extraction path. If `finish_step` is never called, the step fails on `maxIterations` and emits an explicit error result.
+- Schema'd steps finalize ONLY through the finishing tool — `finish_step` in tool mode, `finish()` in a CodeAct action. There is no JSON-from-text extraction path, so a step that never calls it fails and emits an explicit error result.
 - Unstructured steps (no schema) finalize when the model emits a no-tool-call assistant message; that text becomes the result.
+- Two things make that contract visible to a model that believes `return graph` finished the step, because the observation for the losing move used to be indistinguishable from success. A CodeAct observation for a schema'd step that returned a value without finishing carries `finished: false` and a `note` — which says so explicitly when the returned value already matched the schema. And a schema'd step whose turn ended in prose is re-prompted with the contract, at most `MAX_FINISH_NUDGES` (2) times, before it fails.
+- The failure message names the terminal state it actually hit: the provider's error, `exceeded N iterations` only when the loop really used its budget, else "ended after N action(s) / model turn(s) without calling finish", quoting the model's last message.
 
 ### Skills System
 

--- a/packages/agents/src/author-graph.ts
+++ b/packages/agents/src/author-graph.ts
@@ -303,7 +303,7 @@ export function buildAuthoringPreamble(opts: AuthorGraphOptions): string {
 1. Build the graph: \`const graph = workflow(...terminals);\`
 2. Check it: \`await nodetool.workflows.validate(graph)\`. Fix every error it
    reports and validate again. A graph that still has errors is not finished.
-3. Hand it back: \`finish(graph)\` — the object itself, not a re-typed copy.
+3. Hand it back: \`await finish(graph)\` — the object itself, not a re-typed copy.
 
 A \`nodetool.code.Code\` body is code, so check it like code: \`validate_code\`
 after every edit, \`run_code\` with representative inputs when the body does

--- a/packages/agents/src/codeact/codeact-executor.ts
+++ b/packages/agents/src/codeact/codeact-executor.ts
@@ -57,6 +57,7 @@ import {
   validateAgainstSchema
 } from "../utils/json-schema-validate.js";
 import { linkAbort } from "../utils/link-abort.js";
+import { lastProseHint } from "../utils/step-failure.js";
 import { removeThinkTags } from "../utils/think-tags.js";
 import {
   buildToolBridge,
@@ -318,8 +319,42 @@ interface ActionObservation {
   stack?: string;
   logs?: string[];
   finished?: boolean;
+  /** Why `finished` is false, when the action looked like it finished. */
+  note?: string;
   toolCalls: number;
 }
+
+/**
+ * Told to the model when a schema'd action returned a value instead of
+ * finishing. `finished` was previously absent rather than false, so an
+ * observation for the losing move (`return graph`) was byte-identical to one
+ * for a step still in progress — nothing in it said the step had not ended.
+ */
+const RETURN_IS_NOT_FINISH_NOTE =
+  "This step is NOT finished: a returned value is an observation only. " +
+  "Call `await finish(<value>)` inside the action to complete the step.";
+
+const RETURN_MATCHES_SCHEMA_NOTE =
+  "This step is NOT finished: the value you returned matches the required " +
+  "output schema — call finish() on it (`await finish(<that value>)`) inside " +
+  "an execute_code action. Nothing else completes the step.";
+
+/**
+ * Sent as a user message when a schema'd step's turn ended in prose. The model
+ * that built the right value and then described it is one sentence away from a
+ * passing step, and the prose message itself proves it never saw the contract.
+ */
+export const FINISH_CONTRACT_NUDGE =
+  "You answered with prose. This step completes only when you call " +
+  "`await finish(result)` inside an `execute_code` action. If you already " +
+  "built the value, call finish() on it now.";
+
+/**
+ * Re-prompts allowed per step. Bounded because a model that ignores the
+ * contract twice is not going to honor it on the third ask, and each nudge is
+ * a paid provider round.
+ */
+export const MAX_FINISH_NUDGES = 2;
 
 export class CodeActExecutor {
   private readonly task: Task;
@@ -796,6 +831,20 @@ export class CodeActExecutor {
         uiEvents.push(this.taskUpdate(TaskUpdateEvent.StepCompleted));
         uiEvents.push(this.stepResult(finishedResult.value));
         abort.abort();
+      } else if (
+        this.resultSchema !== null &&
+        outcome.success &&
+        observation.result !== undefined &&
+        observation.result !== null
+      ) {
+        // The action produced a value and ended the turn without finishing.
+        // Say so in the observation: an absent `finished` reads as success.
+        observation.finished = false;
+        observation.note =
+          validateAgainstSchema(observation.result, this.resultSchema).length ===
+          0
+            ? RETURN_MATCHES_SCHEMA_NOTE
+            : RETURN_IS_NOT_FINISH_NOTE;
       }
 
       const text = truncateToolResult(JSON.stringify(observation));
@@ -827,61 +876,94 @@ export class CodeActExecutor {
       while (uiEvents.length > 0) yield uiEvents.shift() as ProcessingMessage;
     };
 
-    try {
-      const loopArgs: Parameters<BaseProvider["generateLoop"]>[0] = {
-        messages: history,
-        model: this.model,
-        tools: providerTools,
-        threadId: this.threadId,
-        maxIterations: this.maxIterations,
-        maxTokens: this.maxTokens,
-        sequentialTools: true,
-        workspaceDir: this.context.workspaceDir ?? undefined,
-        signal: abort.signal
-      };
-      if (this.turnBudget) loopArgs.turnBudget = this.turnBudget;
-      const stream = this.provider.generateLoop(loopArgs);
+    // Whether the last generation round used up its iteration budget, as
+    // opposed to the model ending its turn on its own. Only the first case is
+    // "exceeded N iterations"; the loop below distinguishes them.
+    let exhaustedIterations = false;
+    let nudges = 0;
 
-      for await (const item of stream) {
-        if (isToolCall(item)) {
-          const coreTool =
-            item.name === EXECUTE_CODE_TOOL_NAME
-              ? undefined
-              : toolsByName.get(item.name);
-          yield {
-            type: "tool_call_update",
-            node_id: this.step.id,
-            tool_call_id: item.id,
-            name: item.name,
-            args: item.args,
-            message: coreTool
-              ? Tool.resolveMessage(coreTool, item.args)
-              : executeCodeMessage(item.args)
-          } satisfies ToolCallUpdate;
-          yield* drainUi();
-          continue;
-        }
-        if (isChunk(item)) {
-          if (isNonEmptyString(item.content)) {
+    try {
+      for (;;) {
+        const loopArgs: Parameters<BaseProvider["generateLoop"]>[0] = {
+          messages: history,
+          model: this.model,
+          tools: providerTools,
+          threadId: this.threadId,
+          maxIterations: this.maxIterations,
+          maxTokens: this.maxTokens,
+          sequentialTools: true,
+          workspaceDir: this.context.workspaceDir ?? undefined,
+          signal: abort.signal
+        };
+        if (this.turnBudget) loopArgs.turnBudget = this.turnBudget;
+        const stream = this.provider.generateLoop(loopArgs);
+
+        // One assistant message per provider turn, so this counts the round's
+        // iterations against the budget the round was given.
+        let turnsThisRound = 0;
+
+        for await (const item of stream) {
+          if (isToolCall(item)) {
+            const coreTool =
+              item.name === EXECUTE_CODE_TOOL_NAME
+                ? undefined
+                : toolsByName.get(item.name);
             yield {
-              type: "chunk",
+              type: "tool_call_update",
               node_id: this.step.id,
-              content: item.content,
-              done: false
-            } satisfies Chunk;
+              tool_call_id: item.id,
+              name: item.name,
+              args: item.args,
+              message: coreTool
+                ? Tool.resolveMessage(coreTool, item.args)
+                : executeCodeMessage(item.args)
+            } satisfies ToolCallUpdate;
+            yield* drainUi();
+            continue;
+          }
+          if (isChunk(item)) {
+            if (isNonEmptyString(item.content)) {
+              yield {
+                type: "chunk",
+                node_id: this.step.id,
+                content: item.content,
+                done: false
+              } satisfies Chunk;
+            }
+            yield* drainUi();
+            continue;
+          }
+          if ("type" in item && item.type === "message") {
+            const m = (item as { message?: Message }).message;
+            if (m && m.role === "assistant") {
+              turnsThisRound++;
+              lastAssistant =
+                isString(m.content)
+                  ? { ...m, content: removeThinkTags(m.content) }
+                  : m;
+            }
           }
           yield* drainUi();
-          continue;
         }
-        if ("type" in item && item.type === "message") {
-          const m = (item as { message?: Message }).message;
-          if (m && m.role === "assistant") {
-            lastAssistant = isString(m.content)
-              ? { ...m, content: removeThinkTags(m.content) }
-              : m;
-          }
+        exhaustedIterations = turnsThisRound >= this.maxIterations;
+
+        if (!this.shouldNudgeToFinish(lastAssistant, nudges, abort.signal)) {
+          break;
         }
-        yield* drainUi();
+        nudges++;
+        // The provider copies the message array, so this round's transcript
+        // never came back to us. Carrying the prose forward is what makes the
+        // nudge a reply to it instead of a repetition of the brief. An empty
+        // assistant turn is not carried: several provider APIs reject a
+        // content-less message outright.
+        if (lastAssistant && hasContent(lastAssistant)) {
+          history.push(lastAssistant);
+        }
+        history.push({ role: "user", content: FINISH_CONTRACT_NUDGE });
+        log.debug("CodeAct step ended in prose; re-prompting to finish", {
+          stepId: this.step.id,
+          nudge: nudges
+        });
       }
     } catch (e) {
       generationError = e instanceof Error ? e : new Error(String(e));
@@ -914,7 +996,13 @@ export class CodeActExecutor {
       this.step.endTime = Date.now();
       const message = generationError
         ? `Step failed: ${generationError.message}`
-        : `Step failed: exceeded ${this.maxIterations} iterations without completion`;
+        : exhaustedIterations
+          ? `Step failed: exceeded ${this.maxIterations} iterations without completion`
+          : this.resultSchema !== null
+            ? `Step failed: ended after ${this.actionCount} action(s) without ` +
+              `calling finish().${lastProseHint(lastAssistant)}`
+            : `Step failed: ended after ${this.actionCount} action(s) with no ` +
+              `final message to use as the result.`;
       this.step.failed = true;
       this.step.error = message;
       const errorResult = { error: message };
@@ -935,6 +1023,30 @@ export class CodeActExecutor {
         is_task_result: this.useFinishTask
       } satisfies StepResult;
     }
+  }
+
+  /**
+   * Whether to re-prompt after a generation round that produced no result.
+   *
+   * The recoverable case is narrow: a schema'd step whose last assistant
+   * message carried no tool calls — the model stopped to explain instead of
+   * calling `finish()`, and the value it built may still be in `state`. A round
+   * that ended on a tool call ran out of budget instead, which another user
+   * message does not fix, and a cancelled run must not spend a turn at all.
+   */
+  private shouldNudgeToFinish(
+    lastAssistant: Message | null,
+    nudges: number,
+    signal: AbortSignal
+  ): boolean {
+    if (this.step.completed) return false;
+    if (this.resultSchema === null) return false;
+    if (nudges >= MAX_FINISH_NUDGES) return false;
+    if (signal.aborted) return false;
+    if (this.signal?.aborted === true) return false;
+    if (!lastAssistant) return false;
+    const toolCalls = lastAssistant.toolCalls;
+    return !toolCalls || toolCalls.length === 0;
   }
 
   private loadResultSchema(): Record<string, unknown> | null {
@@ -1007,6 +1119,13 @@ export class CodeActExecutor {
       is_task_result: this.useFinishTask
     };
   }
+}
+
+/** Whether a message carries anything a provider will accept as content. */
+function hasContent(message: Message): boolean {
+  const content = message.content;
+  if (isString(content)) return content.trim() !== "";
+  return Array.isArray(content) && content.length > 0;
 }
 
 function isChunk(item: ProviderStreamItem): item is Chunk {

--- a/packages/agents/src/step-executor.ts
+++ b/packages/agents/src/step-executor.ts
@@ -50,6 +50,7 @@ import {
   formatViolations,
   validateAgainstSchema
 } from "./utils/json-schema-validate.js";
+import { lastProseHint } from "./utils/step-failure.js";
 import { removeThinkTags } from "./utils/think-tags.js";
 import {
   isBoolean,
@@ -1099,6 +1100,9 @@ export class StepExecutor {
         if ("type" in item && item.type === "message") {
           const m = (item as { message?: Message }).message;
           if (m && m.role === "assistant") {
+            // One assistant message per provider turn — this is the iteration
+            // count the failure path reports.
+            this.iterations++;
             lastAssistant = isString(m.content)
               ? { ...m, content: removeThinkTags(m.content) }
               : m;
@@ -1129,9 +1133,11 @@ export class StepExecutor {
     }
 
     // If we didn't complete, yield a failure event and a step_result so
-    // downstream steps see an explicit error rather than undefined. When the
-    // provider loop threw, report the real cause; otherwise the step genuinely
-    // ran out of iterations (or an unstructured step produced no final text).
+    // downstream steps see an explicit error rather than undefined. Each
+    // terminal state gets its own sentence: the provider threw, the iteration
+    // budget really ran out, or the model ended its turn without calling
+    // `finish_step`. Reporting them all as "exceeded N iterations" pointed the
+    // reader at a budget that a two-turn step never came near.
     //
     // A failed step is terminal but NOT completed: `failed`/`error` are set and
     // `completed` stays false, so a scheduler cannot treat the failure as a
@@ -1144,7 +1150,13 @@ export class StepExecutor {
         ? `Step failed: result rejected after ${MAX_REPAIR_ROUNDS} attempts — ${this.acceptanceError}`
         : generationError
           ? `Step failed: ${generationError.message}`
-          : `Step failed: exceeded ${this.maxIterations} iterations without completion`;
+          : this.iterations >= this.maxIterations
+            ? `Step failed: exceeded ${this.maxIterations} iterations without completion`
+            : this.resultSchema !== null
+              ? `Step failed: ended after ${this.iterations} model turn(s) ` +
+                `without calling finish_step.${lastProseHint(lastAssistant)}`
+              : `Step failed: ended after ${this.iterations} model turn(s) ` +
+                `with no final message to use as the result.`;
       this.step.failed = true;
       this.step.error = message;
 

--- a/packages/agents/src/utils/step-failure.ts
+++ b/packages/agents/src/utils/step-failure.ts
@@ -1,0 +1,45 @@
+/**
+ * Wording for the terminal state of a step that never produced a result.
+ *
+ * A step can end for reasons that need different answers from whoever reads
+ * the error: the provider threw, the iteration budget ran out, or the model
+ * simply stopped talking without calling the finishing tool. Reporting them
+ * all as "exceeded N iterations" sent debuggers after an iteration budget that
+ * was never touched, so the last case carries what the model actually said
+ * instead.
+ */
+
+import type { Message } from "@nodetool-ai/runtime";
+import { isString } from "./type-guards.js";
+
+/** How much of the model's last message rides along in a failure message. */
+export const PROSE_HINT_MAX_CHARS = 200;
+
+/** The plain text of an assistant message, across both content shapes. */
+function messageText(message: Message | null): string {
+  if (!message) return "";
+  const content = message.content;
+  if (isString(content)) return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => (part.type === "text" ? part.text : ""))
+      .join("")
+      .trim();
+  }
+  return "";
+}
+
+/**
+ * A short quote of the model's last message, ready to append to a failure
+ * message. Empty when the model said nothing quotable, so the caller can
+ * concatenate it unconditionally.
+ */
+export function lastProseHint(message: Message | null): string {
+  const text = messageText(message);
+  if (text === "") return "";
+  const quote =
+    text.length > PROSE_HINT_MAX_CHARS
+      ? `${text.slice(0, PROSE_HINT_MAX_CHARS)}…`
+      : text;
+  return ` Last message: "${quote}"`;
+}

--- a/packages/agents/tests/codeact-finish-contract.test.ts
+++ b/packages/agents/tests/codeact-finish-contract.test.ts
@@ -1,0 +1,339 @@
+/**
+ * The finishing contract of a schema'd CodeAct step: a returned value is an
+ * observation, only `finish()` completes the step, a turn that ends in prose is
+ * re-prompted once (bounded), and the failure message names the terminal state
+ * it really hit.
+ *
+ * A scripted provider drives the real QuickJS sandbox. No network, no model.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  CodeActExecutor,
+  FINISH_CONTRACT_NUDGE,
+  MAX_FINISH_NUDGES
+} from "../src/codeact/codeact-executor.js";
+import type { Step, Task } from "../src/types.js";
+import type {
+  BaseProvider,
+  Message,
+  ProviderStreamItem
+} from "@nodetool-ai/runtime";
+import { createMockContext } from "./_helpers/mock-context.js";
+
+const ANSWER_SCHEMA = {
+  type: "object",
+  properties: { answer: { type: "number" } },
+  required: ["answer"],
+  additionalProperties: false
+};
+
+function makeStep(outputSchema?: object): { step: Step; task: Task } {
+  const step: Step = {
+    id: "step_1",
+    instructions: "Compute the answer",
+    completed: false,
+    dependsOn: [],
+    logs: [],
+    outputSchema: outputSchema ? JSON.stringify(outputSchema) : undefined
+  };
+  return { step, task: { id: "task_1", title: "T", steps: [step] } };
+}
+
+/** One provider turn: a code action, or a final assistant message. */
+type Turn = { code: string } | { assistant: string };
+
+interface ScriptedProvider {
+  provider: BaseProvider;
+  /** The `messages` array each `generateLoop` call was given, in order. */
+  calls: Message[][];
+  /** Every observation string the executor handed back to a code action. */
+  observations: string[];
+}
+
+/**
+ * A provider whose loop is scripted per *call*: `rounds[0]` drives the first
+ * `generateLoop`, `rounds[1]` the second (the nudge round), and so on. The
+ * message shapes mirror BaseProvider.generateLoop — one assistant message per
+ * turn, carrying `toolCalls` when the turn called a tool — because that is what
+ * the executor reads to tell "stopped to explain" from "ran out of budget".
+ */
+function createRoundProvider(
+  rounds: Turn[][],
+  opts: { repeatLast?: boolean; abortOnRound?: AbortController } = {}
+): ScriptedProvider {
+  const calls: Message[][] = [];
+  const observations: string[] = [];
+  let round = 0;
+  const provider = {
+    provider: "fake",
+    hasToolSupport: async () => true,
+    async *generateLoop(args: {
+      messages: Message[];
+      tools?: Array<{
+        name: string;
+        execute?: (a: Record<string, unknown>) => Promise<string | unknown>;
+      }>;
+      signal?: AbortSignal;
+    }): AsyncGenerator<ProviderStreamItem> {
+      calls.push([...args.messages]);
+      const script =
+        rounds[round] ?? (opts.repeatLast ? (rounds[rounds.length - 1] ?? []) : []);
+      round++;
+      const toolMap = new Map((args.tools ?? []).map((t) => [t.name, t]));
+      let seq = 0;
+      for (const turn of script) {
+        if (args.signal?.aborted) break;
+        if ("assistant" in turn) {
+          opts.abortOnRound?.abort();
+          yield {
+            type: "message",
+            message: { role: "assistant", content: turn.assistant }
+          };
+          continue;
+        }
+        const call = {
+          id: `tc_${round}_${++seq}`,
+          name: "execute_code",
+          args: { title: "act", code: turn.code }
+        };
+        yield call;
+        yield {
+          type: "message",
+          message: { role: "assistant", content: null, toolCalls: [call] }
+        };
+        const tool = toolMap.get(call.name);
+        const content = await tool?.execute?.(call.args);
+        const text = typeof content === "string" ? content : JSON.stringify(content);
+        observations.push(text);
+        yield {
+          type: "message",
+          message: { role: "tool", toolCallId: call.id, content: text }
+        };
+      }
+      yield { type: "chunk", content: "", done: true };
+    }
+  } as unknown as BaseProvider;
+  return { provider, calls, observations };
+}
+
+function parseObservation(text: string): {
+  ok: boolean;
+  finished?: boolean;
+  note?: string;
+  result?: unknown;
+} {
+  return JSON.parse(text) as {
+    ok: boolean;
+    finished?: boolean;
+    note?: string;
+    result?: unknown;
+  };
+}
+
+describe("a returned value does not finish a schema'd step", () => {
+  it("says finished:false and names the schema when the returned value would have passed", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const scripted = createRoundProvider([
+      [{ code: `return {answer: 42};` }]
+    ]);
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: createMockContext() as never,
+      provider: scripted.provider,
+      model: "m",
+      tools: []
+    });
+    for await (const _ of executor.execute()) void _;
+
+    const observation = parseObservation(scripted.observations[0] ?? "{}");
+    expect(observation.ok).toBe(true);
+    expect(observation.result).toEqual({ answer: 42 });
+    // The point of the change: the field is present and false, not absent.
+    expect(observation.finished).toBe(false);
+    expect(observation.note).toContain("matches the required output schema");
+    expect(observation.note).toContain("finish()");
+    expect(step.completed).toBe(false);
+  }, 60_000);
+
+  it("says finished:false for a returned value that does not match the schema", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const scripted = createRoundProvider([
+      [{ code: `return {answer: "forty-two"};` }]
+    ]);
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: createMockContext() as never,
+      provider: scripted.provider,
+      model: "m",
+      tools: []
+    });
+    for await (const _ of executor.execute()) void _;
+
+    const observation = parseObservation(scripted.observations[0] ?? "{}");
+    expect(observation.finished).toBe(false);
+    expect(observation.note).toContain("observation only");
+    expect(observation.note).not.toContain("matches the required output schema");
+  }, 60_000);
+
+  it("leaves a finished action's observation alone", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const scripted = createRoundProvider([
+      [{ code: `await finish({answer: 42});` }]
+    ]);
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: createMockContext() as never,
+      provider: scripted.provider,
+      model: "m",
+      tools: []
+    });
+    for await (const _ of executor.execute()) void _;
+
+    const observation = parseObservation(scripted.observations[0] ?? "{}");
+    expect(observation.finished).toBe(true);
+    expect(observation.note).toBeUndefined();
+    expect(executor.getResult()).toEqual({ answer: 42 });
+  }, 60_000);
+});
+
+describe("re-prompting a schema'd step that ended in prose", () => {
+  it("nudges once and completes from the follow-up action", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const scripted = createRoundProvider([
+      [{ assistant: "The answer is 42." }],
+      [{ code: `await finish({answer: 42});` }]
+    ]);
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: createMockContext() as never,
+      provider: scripted.provider,
+      model: "m",
+      tools: []
+    });
+    for await (const _ of executor.execute()) void _;
+
+    expect(scripted.calls).toHaveLength(2);
+    const second = scripted.calls[1] ?? [];
+    expect(second.map((m) => m.role)).toEqual([
+      "system",
+      "user",
+      "assistant",
+      "user"
+    ]);
+    expect(second[3]?.content).toBe(FINISH_CONTRACT_NUDGE);
+    expect(step.completed).toBe(true);
+    expect(executor.getResult()).toEqual({ answer: 42 });
+  }, 60_000);
+
+  it("stops after MAX_FINISH_NUDGES and fails with the prose in the message", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const scripted = createRoundProvider(
+      [[{ assistant: "I already told you the answer is 42." }]],
+      { repeatLast: true }
+    );
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: createMockContext() as never,
+      provider: scripted.provider,
+      model: "m",
+      tools: []
+    });
+    for await (const _ of executor.execute()) void _;
+
+    expect(scripted.calls).toHaveLength(MAX_FINISH_NUDGES + 1);
+    expect(step.completed).toBe(false);
+    expect(step.failed).toBe(true);
+    expect(step.error).toContain("without calling finish()");
+    expect(step.error).toContain("I already told you the answer is 42.");
+  }, 60_000);
+
+  it("does not nudge a schemaless step, which finalizes from its prose", async () => {
+    const { step, task } = makeStep();
+    const scripted = createRoundProvider([
+      [{ assistant: "Done: the answer is 42." }]
+    ]);
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: createMockContext() as never,
+      provider: scripted.provider,
+      model: "m",
+      tools: []
+    });
+    for await (const _ of executor.execute()) void _;
+
+    expect(scripted.calls).toHaveLength(1);
+    expect(step.completed).toBe(true);
+    expect(executor.getResult()).toBe("Done: the answer is 42.");
+  }, 60_000);
+
+  it("does not nudge a cancelled run", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const cancel = new AbortController();
+    const scripted = createRoundProvider(
+      [[{ assistant: "Stopping here." }]],
+      { repeatLast: true, abortOnRound: cancel }
+    );
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: createMockContext() as never,
+      provider: scripted.provider,
+      model: "m",
+      tools: [],
+      signal: cancel.signal
+    });
+    for await (const _ of executor.execute()) void _;
+
+    expect(scripted.calls).toHaveLength(1);
+    expect(step.completed).toBe(false);
+  }, 60_000);
+});
+
+describe("the failure message names the terminal state", () => {
+  it("reports the action count, not a budget it never reached", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    // The turn ends on a tool call, so this is not the prose case: no nudge.
+    const scripted = createRoundProvider([[{ code: `return "thinking";` }]]);
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: createMockContext() as never,
+      provider: scripted.provider,
+      model: "m",
+      tools: [],
+      maxIterations: 20
+    });
+    for await (const _ of executor.execute()) void _;
+
+    expect(scripted.calls).toHaveLength(1);
+    expect(step.error).toBe(
+      "Step failed: ended after 1 action(s) without calling finish()."
+    );
+    expect(step.error).not.toContain("20 iterations");
+  }, 60_000);
+
+  it("still reports iteration exhaustion when the budget really ran out", async () => {
+    const { step, task } = makeStep(ANSWER_SCHEMA);
+    const scripted = createRoundProvider([
+      [{ code: `return 1;` }, { code: `return 2;` }]
+    ]);
+    const executor = new CodeActExecutor({
+      task,
+      step,
+      context: createMockContext() as never,
+      provider: scripted.provider,
+      model: "m",
+      tools: [],
+      maxIterations: 2
+    });
+    for await (const _ of executor.execute()) void _;
+
+    expect(step.error).toContain("exceeded 2 iterations without completion");
+  }, 60_000);
+});

--- a/packages/agents/tests/step-executor.test.ts
+++ b/packages/agents/tests/step-executor.test.ts
@@ -1268,7 +1268,7 @@ describe("StepExecutor", () => {
     expect(executor.getSources()).toEqual([]);
   });
 
-  it("yields StepFailed when step exhausts iterations without completing", async () => {
+  it("yields StepFailed naming the real terminal state when the model ends in prose", async () => {
     const step: Step = {
       id: "step_fail",
       instructions: "Will not complete",
@@ -1320,7 +1320,12 @@ describe("StepExecutor", () => {
     // Terminal, but NOT completed — a dependent step must not run on this.
     expect(step.completed).toBe(false);
     expect(step.failed).toBe(true);
-    expect(step.error).toContain("exceeded 2 iterations");
+    // One provider turn happened, so the iteration budget is not the story.
+    // The error says what the model did instead, and quotes it.
+    expect(step.error).toContain("ended after 1 model turn(s)");
+    expect(step.error).toContain("without calling finish_step");
+    expect(step.error).toContain("I cannot figure this out");
+    expect(step.error).not.toContain("exceeded 2 iterations");
     expect(step.endTime).toBeDefined();
 
     // Should have a StepFailed task_update
@@ -1332,6 +1337,58 @@ describe("StepExecutor", () => {
     // …and the failure is on the protocol-level `error` field, not buried in
     // the result payload.
     const stepResult = messages.find((m) => m.type === "step_result") as any;
-    expect(stepResult.error).toContain("exceeded 2 iterations");
+    expect(stepResult.error).toContain("ended after 1 model turn(s)");
+  });
+
+  it("reports iteration exhaustion only when the budget really ran out", async () => {
+    const step: Step = {
+      id: "step_exhaust",
+      instructions: "Will keep calling a tool",
+      completed: false,
+      dependsOn: [],
+      logs: [],
+      outputSchema: JSON.stringify({
+        type: "object",
+        properties: { answer: { type: "string" } },
+        required: ["answer"]
+      })
+    };
+    const task: Task = { id: "task_exhaust", title: "Exhaust", steps: [step] };
+
+    // Every turn calls a tool, so the loop only stops at maxIterations.
+    let turn = 0;
+    const provider = {
+      ...createMockProvider(),
+      generateMessages: async function* () {
+        yield { id: `tc_${++turn}`, name: "my_tool", args: {} };
+      }
+    } as unknown as BaseProvider;
+
+    const mockTool = asTool({
+      name: "my_tool",
+      description: "A test tool",
+      inputSchema: { type: "object" as const, properties: {}, required: [] },
+      process: vi.fn().mockResolvedValue({ output: "not a result" }),
+      userMessage: () => "Using my_tool",
+      toProviderTool: () => ({
+        name: "my_tool",
+        description: "A test tool",
+        inputSchema: { type: "object", properties: {}, required: [] }
+      })
+    });
+
+    const executor = new StepExecutor({
+      task,
+      step,
+      context: createMockContext(),
+      provider,
+      model: "test-model",
+      tools: [mockTool],
+      maxIterations: 2
+    });
+    for await (const _ of executor.execute()) void _;
+
+    expect(turn).toBe(2);
+    expect(step.error).toContain("exceeded 2 iterations without completion");
   });
 });


### PR DESCRIPTION
## The problem

A schema'd step finalizes **only** through `finish()`. But a step that computed the right answer and `return`ed it got an observation indistinguishable from success — so a model that believed `return graph` had finished the step had no way to learn otherwise. It then failed with a message blaming an iteration budget it had not actually used.

The losing move and the winning move looked the same from inside the loop.

## Three changes

1. **The observation says so.** A schema'd step that returned without finishing gets `finished: false` plus a `note` — which states explicitly when the returned value *already matched the schema*, the case most likely to convince a model it had succeeded.

2. **A prose turn is re-prompted** with the contract, bounded by `MAX_FINISH_NUDGES` (2), then fails. Guarded by `shouldNudgeToFinish`, which declines when the step completed, when there is no schema, when either abort signal fired, or when the last turn made tool calls.

3. **The failure message names the terminal state it actually hit** — the provider's error, `exceeded N iterations` only when the loop really used its budget, otherwise "ended after N action(s) / model turn(s) without calling finish", quoting the model's last message. Extracted to `utils/step-failure.ts` and shared with `step-executor`, so the two loops cannot drift.

`author-graph.ts` gains one line: `await finish(graph)`, matching what the executor now enforces. `AGENTS.md` documents the contract.

## Verification

48/48 across `codeact-finish-contract` (9 new cases), `step-executor`, and `codeact-executor`.

## Two things a reviewer should look at

**The merge resolution in `codeact-executor.ts` is mine.** I kept my restructured loop with `turnsThisRound++` inside it and dropped upstream's duplicate message handler. I scanned every staged file for conflict markers (clean), but that hunk deserves eyes rather than trust.

**Do not read this as fixing a widespread failure.** It was motivated by an optimization-loop iteration reporting a large planning-failure rate. That number turned out to be substantially my own instrumentation corrupting its baseline — a `--cassette` wrapper that silently replaced the provider's own `generateLoop`. On a clean re-measure, `claude_agent_sdk`/sonnet scored **11/11 on graph-e2e with none of these fixes firing**.

The change is still correct: the observation for the losing move was genuinely indistinguishable from success, and the failure message genuinely named the wrong terminal state. But the failure mode is far narrower than the number that prompted the work, and the PR should not claim otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)