### PR TITLE
fix(chat,timeline): stop generated media vanishing from a reply

### DIFF
--- a/packages/video-nodes/src/nodes/timeline.ts
+++ b/packages/video-nodes/src/nodes/timeline.ts
@@ -717,6 +717,108 @@ export class TimelineTranscriptNode extends BaseNode {
   }
 }
 
+/** Content types AddClips falls back to when the bytes say nothing. */
+const CLIP_CONTENT_TYPE_FALLBACK: Record<string, string> = {
+  image: "image/png",
+  audio: "audio/wav",
+  video: "video/mp4"
+};
+
+const CLIP_CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  webp: "image/webp",
+  wav: "audio/wav",
+  mp3: "audio/mpeg",
+  ogg: "audio/ogg",
+  flac: "audio/x-flac",
+  m4a: "audio/x-m4a",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime"
+};
+
+const startsWithBytes = (bytes: Uint8Array, ascii: string, at = 0): boolean => {
+  if (bytes.length < at + ascii.length) return false;
+  for (let i = 0; i < ascii.length; i++) {
+    if (bytes[at + i] !== ascii.charCodeAt(i)) return false;
+  }
+  return true;
+};
+
+/** The content type the bytes themselves declare, or null when unrecognized. */
+function sniffContentType(
+  mediaType: string,
+  bytes: Uint8Array
+): string | null {
+  if (startsWithBytes(bytes, "RIFF") && startsWithBytes(bytes, "WAVE", 8)) {
+    return "audio/wav";
+  }
+  if (startsWithBytes(bytes, "RIFF") && startsWithBytes(bytes, "WEBP", 8)) {
+    return "image/webp";
+  }
+  if (startsWithBytes(bytes, "ID3")) return "audio/mpeg";
+  // MPEG audio frame sync: 11 set bits. Two bytes is weak evidence, so trust
+  // it only where the clip is already known to be audio.
+  if (
+    mediaType === "audio" &&
+    bytes.length >= 2 &&
+    bytes[0] === 0xff &&
+    (bytes[1]! & 0xe0) === 0xe0
+  ) {
+    return "audio/mpeg";
+  }
+  if (startsWithBytes(bytes, "OggS")) return "audio/ogg";
+  if (startsWithBytes(bytes, "fLaC")) return "audio/x-flac";
+  if (startsWithBytes(bytes, "\x89PNG")) return "image/png";
+  if (bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+    return "image/jpeg";
+  }
+  if (startsWithBytes(bytes, "GIF8")) return "image/gif";
+  // Matroska/WebM EBML header.
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x1a &&
+    bytes[1] === 0x45 &&
+    bytes[2] === 0xdf &&
+    bytes[3] === 0xa3
+  ) {
+    return "video/webm";
+  }
+  if (startsWithBytes(bytes, "ftyp", 4)) {
+    if (startsWithBytes(bytes, "qt", 8)) return "video/quicktime";
+    if (startsWithBytes(bytes, "M4A", 8)) return "audio/x-m4a";
+    return "video/mp4";
+  }
+  return null;
+}
+
+/**
+ * The content type to store a clip's bytes under.
+ *
+ * The stored asset's file extension and the `Content-Type` the browser is
+ * served both come from this, so guessing by media kind alone mislabels
+ * anything that is not the kind's default container: a WAV voiceover saved as
+ * `audio/mpeg` reaches the player as a `.mp3` it cannot decode. Read the bytes
+ * first, then the source URI's extension, and only then fall back to the kind.
+ */
+export function clipContentType(
+  mediaType: string,
+  bytes: Uint8Array,
+  uri: string | undefined
+): string {
+  const sniffed = sniffContentType(mediaType, bytes);
+  if (sniffed) return sniffed;
+  const extension = (uri ?? "").toLowerCase().split(/[?#]/)[0]!.split(".").pop();
+  const byExtension = extension
+    ? CLIP_CONTENT_TYPE_BY_EXTENSION[extension]
+    : undefined;
+  if (byExtension) return byExtension;
+  return CLIP_CONTENT_TYPE_FALLBACK[mediaType] ?? "application/octet-stream";
+}
+
 /** Output handles AddClipsToTimelineNode.process() emits. */
 type AddClipsToTimelineNodeOutputs = {
   output: { type: string; id: string };
@@ -834,12 +936,11 @@ export class AddClipsToTimelineNode extends BaseNode {
             );
             continue;
           }
-          const contentType =
-            mediaType === "video"
-              ? "video/mp4"
-              : mediaType === "audio"
-                ? "audio/mpeg"
-                : "image/png";
+          const contentType = clipContentType(
+            mediaType,
+            bytes,
+            isString(item.uri) ? item.uri : undefined
+          );
           const created = (await context.createAsset({
             name: `clip-${i + 1}`,
             contentType,

--- a/packages/video-nodes/tests/timeline-nodes.test.ts
+++ b/packages/video-nodes/tests/timeline-nodes.test.ts
@@ -517,3 +517,60 @@ describe("extractedAudioLinkIds", () => {
     );
   });
 });
+
+/**
+ * The stored content type decides both the asset's file extension and the
+ * `Content-Type` the browser is served, so a WAV voiceover labelled
+ * `audio/mpeg` reaches the chat player as a `.mp3` it cannot decode. That is
+ * what happened to a generated voiceover: `AddClips` labelled every audio clip
+ * `audio/mpeg` regardless of the bytes.
+ */
+describe("AddClipsToTimelineNode clip content types", () => {
+  const base64 = (bytes: number[]): string =>
+    Buffer.from(bytes).toString("base64");
+
+  const wavBytes = [
+    0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45
+  ];
+  const webmBytes = [0x1a, 0x45, 0xdf, 0xa3, 0x01, 0x00, 0x00, 0x00];
+  const jpegBytes = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46];
+
+  const contentTypesFor = async (
+    clips: Array<Record<string, unknown>>
+  ): Promise<string[]> => {
+    const context = stubContext(null);
+    const node = new AddClipsToTimelineNode();
+    node.assign({ timeline: { type: "timeline", id: null }, clips });
+    await node.process(context as never);
+    return context.createAsset.mock.calls.map(
+      (call) => (call[0] as { contentType: string }).contentType
+    );
+  };
+
+  it("reads the container out of the bytes instead of the media kind", async () => {
+    const types = await contentTypesFor([
+      { type: "audio", data: base64(wavBytes) },
+      { type: "video", data: base64(webmBytes) },
+      { type: "image", data: base64(jpegBytes) }
+    ]);
+
+    expect(types).toEqual(["audio/wav", "video/webm", "image/jpeg"]);
+  });
+
+  it("falls back to the source URI's extension for unrecognized bytes", async () => {
+    const types = await contentTypesFor([
+      { type: "audio", data: base64([1, 2, 3, 4]), uri: "https://x.test/a.ogg" }
+    ]);
+
+    expect(types).toEqual(["audio/ogg"]);
+  });
+
+  it("falls back to the media kind when nothing else says", async () => {
+    const types = await contentTypesFor([
+      { type: "audio", data: base64([1, 2, 3, 4]) },
+      { type: "video", data: base64([1, 2, 3, 4]) }
+    ]);
+
+    expect(types).toEqual(["audio/wav", "video/mp4"]);
+  });
+});

--- a/web/src/components/chat/message/ChatMarkdown.tsx
+++ b/web/src/components/chat/message/ChatMarkdown.tsx
@@ -9,7 +9,7 @@ import InlineResourcePreview, {
   isInlinePreviewUri
 } from "./InlineResourcePreview";
 import "../../../styles/markdown/nodetool-markdown.css";
-import { SPACING, getSpacingPx } from "../../ui_primitives";
+import { Caption, FlexColumn, SPACING, getSpacingPx } from "../../ui_primitives";
 import { CodeBlock } from "./markdown_elements/CodeBlock";
 import { PreRenderer } from "./markdown_elements/PreRenderer";
 import { BORDER_RADIUS } from "../../ui_primitives";
@@ -122,37 +122,54 @@ const extractStorageKey = (uri: string | null | undefined): string | null => {
 
 const useChatAsset = (
   src: string | undefined
-): { resolvedSrc: string | undefined; contentType: string | undefined } => {
+): {
+  resolvedSrc: string | undefined;
+  contentType: string | undefined;
+  pending: boolean;
+} => {
   // `asset://<id>` is an id, not a storage key (`<user>/<id>.<ext>`).
   const isAssetUri = Boolean(src?.startsWith("asset://"));
   const fromAsset = useResolvedMedia(isAssetUri ? src : undefined);
   const key = isAssetUri ? null : extractStorageKey(src);
-  const { data } = trpc.storage.signUrl.useQuery(
+  const { data, isPending, isError } = trpc.storage.signUrl.useQuery(
     { key: key ?? "" },
     { enabled: Boolean(key), staleTime: 6 * 24 * 60 * 60 * 1000 }
   );
   if (!src) {
-    return { resolvedSrc: undefined, contentType: undefined };
+    return { resolvedSrc: undefined, contentType: undefined, pending: false };
   }
   if (isAssetUri) {
     return {
       resolvedSrc: fromAsset.url,
-      contentType: fromAsset.contentType
+      contentType: fromAsset.contentType,
+      pending: fromAsset.pending
     };
   }
   if (key) {
     // Legacy `/api/storage/<key>` markdown — resolve through the signed-URL
     // path so owner-prefixed keys and cloud backends work.
-    return { resolvedSrc: data?.url, contentType: undefined };
+    return {
+      resolvedSrc: data?.url,
+      contentType: undefined,
+      pending: isPending && !isError
+    };
   }
   const pkgPath = packageAssetHttpPath(src);
   if (pkgPath) {
-    return { resolvedSrc: `${BASE_URL}${pkgPath}`, contentType: undefined };
+    return {
+      resolvedSrc: `${BASE_URL}${pkgPath}`,
+      contentType: undefined,
+      pending: false
+    };
   }
   if (src.startsWith("/api/")) {
-    return { resolvedSrc: `${BASE_URL}${src}`, contentType: undefined };
+    return {
+      resolvedSrc: `${BASE_URL}${src}`,
+      contentType: undefined,
+      pending: false
+    };
   }
-  return { resolvedSrc: src, contentType: undefined };
+  return { resolvedSrc: src, contentType: undefined, pending: false };
 };
 
 /**
@@ -242,15 +259,42 @@ const ChatMarkdownMedia: React.FC<{
   );
 };
 
+/**
+ * An embed whose media never resolved.
+ *
+ * Rendering nothing was the old behavior, and it is indistinguishable from the
+ * agent never having answered: a generated clip whose asset row is gone, or
+ * whose object cannot be signed, left an empty gap in the reply. Show the
+ * resource instead, so the reader knows something was there and can open it.
+ */
+const UnresolvedMedia: React.FC<{ href: string; label: string }> = ({
+  href,
+  label
+}) => (
+  <FlexColumn
+    gap={SPACING.xs}
+    align="flex-start"
+    data-testid="unresolved-media"
+  >
+    {isResourceUri(href) ? (
+      <ResourceChip uri={href} label={label || href} />
+    ) : null}
+    <Caption color="secondary">This media could not be loaded.</Caption>
+  </FlexColumn>
+);
+
 const ChatMarkdownImg: React.FC<React.ComponentPropsWithoutRef<"img">> = ({
   src,
   alt,
   ...props
 }) => {
   const href = src != null ? src : "";
-  const { resolvedSrc, contentType } = useChatAsset(href || undefined);
+  const { resolvedSrc, contentType, pending } = useChatAsset(href || undefined);
   if (!resolvedSrc) {
-    return null;
+    // Still resolving: render nothing rather than flashing a failure.
+    return pending || !href ? null : (
+      <UnresolvedMedia href={href} label={alt ?? ""} />
+    );
   }
   const kind = mediaKind(href, resolvedSrc, contentType) ?? "image";
   return (

--- a/web/src/components/chat/message/__tests__/ChatMarkdown.assetVideo.test.tsx
+++ b/web/src/components/chat/message/__tests__/ChatMarkdown.assetVideo.test.tsx
@@ -22,8 +22,11 @@ jest.mock("../../../../hooks/useResolvedMediaUri", () =>
 import {
   mockAssetContentType,
   mockAssetUrl,
+  mockMissingAsset,
+  mockPendingAsset,
   resetMockAssetContentTypes
 } from "../../../../hooks/__mocks__/useResolvedMediaUri";
+import { screen } from "@testing-library/react";
 
 // The map the component sees: `jest.mock` above swapped the module the
 // component imports, and reaching the manual mock by its own path hands this
@@ -260,5 +263,36 @@ describe("ChatMarkdown asset video", () => {
     expect(audio).toHaveAttribute("aria-label", "Narration");
     expect(container.querySelector("img")).toBeNull();
     expect(container.querySelector("video")).toBeNull();
+  });
+
+  /**
+   * A generated clip whose asset cannot be resolved — the row is gone, or the
+   * storage object cannot be signed — used to render nothing at all, so the
+   * reply showed a heading and an empty gap where the video should be.
+   */
+  it("shows the resource instead of nothing when the asset cannot be resolved", () => {
+    mockUseQuery.mockReturnValue({ data: undefined });
+    mockMissingAsset("ea27206c96404a11b5d8ba35735edf2f");
+
+    const { container } = renderMarkdown(
+      "![Opening Hook Clip](asset://ea27206c96404a11b5d8ba35735edf2f.mp4)"
+    );
+
+    expect(container.querySelector("video")).toBeNull();
+    expect(screen.getByTestId("unresolved-media")).toBeInTheDocument();
+    expect(screen.getByText("Opening Hook Clip")).toBeInTheDocument();
+    expect(screen.getByText("This media could not be loaded.")).toBeInTheDocument();
+  });
+
+  it("renders nothing while the asset lookup is still in flight", () => {
+    mockUseQuery.mockReturnValue({ data: undefined });
+    mockPendingAsset("d3f1ed729a6a4b45b759e95a6134e196");
+
+    const { container } = renderMarkdown(
+      "![Feature Clip](asset://d3f1ed729a6a4b45b759e95a6134e196.mp4)"
+    );
+
+    expect(container.querySelector("video")).toBeNull();
+    expect(screen.queryByTestId("unresolved-media")).toBeNull();
   });
 });

--- a/web/src/hooks/__mocks__/useResolvedMediaUri.ts
+++ b/web/src/hooks/__mocks__/useResolvedMediaUri.ts
@@ -23,18 +23,44 @@ export type MediaLocator =
 export const mockAssetUrl = (assetId: string): string =>
   `https://assets.test/${assetId}`;
 
+/**
+ * Asset ids a test wants to resolve to nothing — the shape of an asset whose
+ * row is gone or whose object cannot be signed.
+ */
+export const mockMissingAssets = new Set<string>();
+
+export const mockMissingAsset = (assetId: string): void => {
+  mockMissingAssets.add(assetId);
+};
+
+/** Asset ids whose lookup a test wants to leave in flight. */
+export const mockPendingAssets = new Set<string>();
+
+export const mockPendingAsset = (assetId: string): void => {
+  mockPendingAssets.add(assetId);
+};
+
+const isPendingAsset = (source: MediaLocator): boolean => {
+  const id = assetIdOf(source);
+  return id !== undefined && mockPendingAssets.has(id);
+};
+
 const resolve = (source: MediaLocator): string | undefined => {
   const uri = typeof source === "string" ? source : (source?.uri ?? undefined);
   const declared = typeof source === "object" ? source?.asset_id : undefined;
   if (declared) {
-    return mockAssetUrl(declared);
+    return mockMissingAssets.has(declared) ? undefined : mockAssetUrl(declared);
   }
   // Everything but an asset locator resolves exactly as it does in the app.
   const staticUrl = realResolveStaticMediaUri(uri);
   if (staticUrl !== null) {
     return staticUrl || undefined;
   }
-  return mockAssetUrl((uri as string).slice("asset://".length));
+  const id = (uri as string).slice("asset://".length);
+  const bareId = id.replace(/\.[^.]+$/, "");
+  return mockMissingAssets.has(id) || mockMissingAssets.has(bareId)
+    ? undefined
+    : mockAssetUrl(id);
 };
 
 export const resolveStaticMediaUri = realResolveStaticMediaUri;
@@ -57,6 +83,8 @@ export const mockAssetContentType = (locator: string, mime: string): void => {
 export const resetMockAssetContentTypes = (): void => {
   contentTypeByLocator.clear();
   mockAssetContentTypes.clear();
+  mockMissingAssets.clear();
+  mockPendingAssets.clear();
 };
 
 const locatorUri = (source: MediaLocator): string | undefined =>
@@ -72,11 +100,17 @@ const assetIdOf = (source: MediaLocator): string | undefined => {
 
 export const useResolvedMedia = (
   source: MediaLocator
-): { url: string | undefined; contentType: string | undefined } => {
+): {
+  url: string | undefined;
+  contentType: string | undefined;
+  pending: boolean;
+} => {
   const uri = locatorUri(source);
   const id = assetIdOf(source);
+  const pending = isPendingAsset(source);
   return {
-    url: resolve(source),
+    url: pending ? undefined : resolve(source),
+    pending,
     contentType:
       (uri ? contentTypeByLocator.get(uri) : undefined) ??
       (id ? mockAssetContentTypes.get(id) : undefined)

--- a/web/src/hooks/useResolvedMediaUri.ts
+++ b/web/src/hooks/useResolvedMediaUri.ts
@@ -58,6 +58,14 @@ const locatorParts = (
 export type ResolvedMedia = {
   url: string | undefined;
   contentType: string | undefined;
+  /**
+   * True while the asset lookup is still in flight. A caller that renders
+   * nothing without a URL needs this to tell "not yet" from "never": an asset
+   * whose row is gone, or whose object cannot be signed, resolves to no URL
+   * forever, and silently rendering nothing leaves the reader with an empty
+   * gap and no way to reach the media.
+   */
+  pending: boolean;
 };
 
 export function useResolvedMedia(source: MediaLocator): ResolvedMedia {
@@ -68,18 +76,24 @@ export function useResolvedMedia(source: MediaLocator): ResolvedMedia {
   // disabled — hooks cannot be called conditionally, so gate the query instead.
   const needsAsset = staticUrl === null && Boolean(assetId);
 
-  const { data: asset } = useQuery({
+  const {
+    data: asset,
+    isPending,
+    isError
+  } = useQuery({
     queryKey: ["asset", assetId],
     queryFn: () => getAsset(assetId as string),
     enabled: needsAsset
   });
 
   if (staticUrl !== null) {
-    return { url: staticUrl || undefined, contentType: undefined };
+    return { url: staticUrl || undefined, contentType: undefined, pending: false };
   }
   return {
     url: asset?.get_url ?? undefined,
-    contentType: asset?.content_type ?? undefined
+    contentType: asset?.content_type ?? undefined,
+    // A disabled query reports `pending` forever, so gate on the id path.
+    pending: needsAsset && isPending && !isError
   };
 }
 


### PR DESCRIPTION
Reported as "I can't see the videos in this chat — neither timeline nor clips": an agent generated two clips and assembled a timeline, embedded them in its reply, and the reply showed headings with nothing under them.

I checked the rendering path first and it is not the problem. The deployed bundle carries the current `ChatMarkdown` (verified against `app.nodetool.ai/assets/…`, byte-for-byte the same logic as `main`), and the markdown layer hands the embed through intact — `[x](asset://<id>.mp4)` and `[x](timeline://<id>)` both reach `components.img` with the URI unmangled, which I confirmed by running the real `react-markdown` + `remarkGfm` + `rehypeRaw` pipeline with this file's `urlTransform`. What is wrong is what happens when resolution fails, plus one way the stored asset can be made unplayable.

## Silent failure in `ChatMarkdown`

`ChatMarkdownImg` returned `null` whenever `useChatAsset` produced no URL. An asset whose row is gone, or whose storage object cannot be signed (`toAssetResponse` catches a signing failure and reports `get_url: null`), resolves to no URL *forever* — so the embed rendered as an empty gap, with no error, no link, and nothing to click. That is exactly the reported symptom, and it also hides whatever the underlying cause is from the next person to look.

It now renders the resource chip plus one line of explanation once the lookup settles, and still renders nothing while it is in flight, so a slow lookup does not flash a failure. Telling those two states apart needed a new `pending` flag on `useResolvedMedia`; a disabled query reports `pending` forever, so it is gated on the id path.

## Wrong content type in `AddClips`

`nodetool.timeline.AddClips` labelled every clip asset by media kind alone — `audio/mpeg`, `video/mp4`, `image/png` — regardless of the bytes it was handed. The stored asset's file extension and the `Content-Type` the browser is served both derive from that label, so the WAV voiceover in the reported thread was stored as `<id>.mp3` served as `audio/mpeg`: bytes no player is obliged to decode, on the audio track of the timeline whose preview would not show.

`clipContentType` now reads the container out of the bytes (RIFF/WAVE, ID3 and MPEG frame sync, OggS, fLaC, PNG/JPEG/GIF/WEBP, EBML, `ftyp` brands), falls back to the source URI's extension, and only then to the kind. The two-byte MPEG frame-sync check is trusted only for clips already known to be audio — it is weak evidence on its own.

## Tests

Both fixes ship a reproduction, and I checked each one fails without its fix:

- `ChatMarkdown.assetVideo.test.tsx` — an unresolvable `asset://<id>.mp4` shows the chip and the reason instead of nothing; a lookup still in flight shows nothing. Reverting the component to `return null` turns the first red.
- `timeline-nodes.test.ts` — WAV/WebM/JPEG bytes are stored as `audio/wav` / `video/webm` / `image/jpeg`; an unrecognized payload falls back to the URI extension, then to the kind. Restoring the hardcoded map turns two of the three red.

Checks run: `web` typecheck, full `npx jest` in `web` (1152 suites, 13276 tests), `packages/video-nodes` (195), `packages/websocket` (2315), `npm run lint`, and `nodetool harness gate --base origin/main` (no selfchecks selected by this diff). `@oxlint/plugins` was missing from this sandbox's `node_modules` and had to be installed before `lint` could load the web config — an environment gap, not a change here.

## Not fixed here

In the reported run the workflow's own `timeline` and `ad_video` outputs came back empty while the clip outputs did not, which is why the agent ran `AddClips` and `RenderTimeline` by hand afterwards. The job finished `completed` with no error and no logs, so something downstream of the Code node that packs the clips produced nothing silently. Reproducing that needs a real provider run, so it is out of scope for this PR and worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DojryK9XVpUqeDCpMM7FRA

---
_Generated by [Claude Code](https://claude.ai/code/session_01DojryK9XVpUqeDCpMM7FRA)_