### PR TITLE
fix(agents): stop the subtask eval reporting a failed case as a success

### DIFF
--- a/packages/agents/src/evals/subtask-eval.ts
+++ b/packages/agents/src/evals/subtask-eval.ts
@@ -79,6 +79,16 @@ export interface SubtaskCaseResult {
   skipped: boolean;
   /** The parent loop ran to a natural stop without a fatal provider error. */
   accepted: boolean;
+  /**
+   * Accepted AND every expectation check passed. This — not {@link accepted} —
+   * is what the suite's success rate and the `--min-success` gate read. A
+   * parent that answered correctly by doing the work itself is live but has
+   * failed the only thing a delegation case measures, and reporting that as a
+   * success made the suite a scoreboard that could not go red.
+   */
+  success: boolean;
+  /** Expectation checks that failed. Zero is required for {@link success}. */
+  criticalFailures: number;
   score: number;
   checks: EvalCheck[];
   /** Number of subtasks spawned. */
@@ -101,8 +111,15 @@ export interface SubtaskEvalReport {
     total: number;
     skipped: number;
     accepted: number;
-    /** accepted / (total - skipped) */
+    /** Cases that were accepted AND passed every expectation check. */
+    successful: number;
+    /** success / (total - skipped) — the gated metric. */
     successRate: number;
+    /**
+     * accepted / (total - skipped). A liveness signal, not a result: a parent
+     * that called no tools at all still scores 100% on it.
+     */
+    completionRate: number;
     /** Mean expectation score over non-skipped cases. */
     meanScore: number;
     avgSubtasks: number;
@@ -389,21 +406,28 @@ async function runCase(
     subtaskResults: subtaskTool.spawns.map((s) => s.resultText)
   };
 
+  const expectationChecks = accepted
+    ? checkSubtaskExpectations(observation, evalCase.expect)
+    : [];
   const checks: EvalCheck[] = [
-    { name: "accepted", pass: accepted, detail: error }
+    { name: "accepted", pass: accepted, detail: error },
+    ...expectationChecks
   ];
-  if (accepted) {
-    checks.push(...checkSubtaskExpectations(observation, evalCase.expect));
-  }
   const score = accepted
     ? checks.filter((c) => c.pass).length / checks.length
     : 0;
+  // Every expectation check is the point of its case — required parent and
+  // child tools, delegation depth, forbidden tools. None is advisory, so any
+  // failure disqualifies the run rather than merely lowering its score.
+  const criticalFailures = expectationChecks.filter((c) => !c.pass).length;
 
   return {
     caseId: evalCase.id,
     description: evalCase.description,
     skipped: false,
     accepted,
+    success: accepted && criticalFailures === 0,
+    criticalFailures,
     score,
     checks,
     subtasks: subtaskTool.spawns.length,
@@ -432,6 +456,8 @@ export async function runSubtaskEval(
         description: evalCase.description,
         skipped: true,
         accepted: false,
+        success: false,
+        criticalFailures: 0,
         score: 0,
         checks: [],
         subtasks: 0,
@@ -447,7 +473,7 @@ export async function runSubtaskEval(
     const result = await runCase(evalCase, opts);
     const failed = result.checks.filter((c) => !c.pass);
     opts.onEvent?.(
-      `  ${result.accepted ? "PASS" : "FAIL"} score=${result.score.toFixed(2)} ` +
+      `  ${result.success ? "PASS" : "FAIL"} score=${result.score.toFixed(2)} ` +
         `subtasks=${result.subtasks} depth=${result.maxDepth} ` +
         `${Math.round(result.durationMs / 1000)}s` +
         (failed.length > 0
@@ -459,11 +485,14 @@ export async function runSubtaskEval(
 
   const ran = results.filter((r) => !r.skipped);
   const acceptedResults = ran.filter((r) => r.accepted);
+  const successful = ran.filter((r) => r.success);
   const summary = {
     total: results.length,
     skipped: results.length - ran.length,
     accepted: acceptedResults.length,
-    successRate: ran.length > 0 ? acceptedResults.length / ran.length : 0,
+    successful: successful.length,
+    successRate: ran.length > 0 ? successful.length / ran.length : 0,
+    completionRate: ran.length > 0 ? acceptedResults.length / ran.length : 0,
     meanScore:
       ran.length > 0 ? ran.reduce((a, r) => a + r.score, 0) / ran.length : 0,
     avgSubtasks:
@@ -504,7 +533,7 @@ export function formatSubtaskReport(report: SubtaskEvalReport): string {
     lines.push(
       [
         r.caseId.padEnd(22),
-        (r.skipped ? "skip" : r.accepted ? "pass" : "FAIL").padEnd(7),
+        (r.skipped ? "skip" : r.success ? "pass" : "FAIL").padEnd(7),
         (r.skipped ? "-" : r.score.toFixed(2)).padEnd(6),
         String(r.subtasks).padEnd(5),
         String(r.maxDepth).padEnd(6),
@@ -519,7 +548,8 @@ export function formatSubtaskReport(report: SubtaskEvalReport): string {
   const s = report.summary;
   lines.push("");
   lines.push(
-    `success ${s.accepted}/${s.total - s.skipped} (${(s.successRate * 100).toFixed(0)}%)` +
+    `success ${s.successful}/${s.total - s.skipped} (${(s.successRate * 100).toFixed(0)}%)` +
+      `  completed ${s.accepted}/${s.total - s.skipped}` +
       `  mean score ${s.meanScore.toFixed(2)}` +
       `  avg subtasks ${s.avgSubtasks.toFixed(1)}` +
       (s.totalCostUsd > 0 ? `  cost $${s.totalCostUsd.toFixed(4)}` : "") +

--- a/packages/agents/tests/subtask-eval.test.ts
+++ b/packages/agents/tests/subtask-eval.test.ts
@@ -141,6 +141,53 @@ describe("runSubtaskEval (scripted provider, end-to-end)", () => {
     expect(report.summary.successRate).toBe(1);
   });
 
+  it("does not report success for a run that never delegated", async () => {
+    // The parent does the work itself at depth 0 and answers correctly. Nothing
+    // throws, so the run is *live* — but every delegation check the case exists
+    // to test fails, and a suite that calls this a success is measuring nothing.
+    const action = (code: string) => ({
+      type: "tool_call" as const,
+      name: EXECUTE_CODE_TOOL_NAME,
+      args: { title: "Running a code action", code }
+    });
+    const provider = new ScriptedProvider([
+      () => [
+        action(
+          `import { calculate } from "@nodetool-ai/sandbox-nodetool/session";\n` +
+            `await calculate({ a: 47, op: "multiply", b: 89 });`
+        )
+      ],
+      () => [{ type: "chunk", content: "The product is 4183.", done: true }]
+    ]);
+
+    const computeCase = SUBTASK_EVAL_CASES.find(
+      (c) => c.id === "delegate-compute"
+    ) as SubtaskEvalCase;
+
+    const report = await runSubtaskEval({
+      provider,
+      model: "fake",
+      providers: { fake: provider },
+      cases: [computeCase]
+    });
+
+    const result = report.cases[0];
+    // The parent never delegated: no subtask, no depth-1 tool call.
+    expect(result.subtasks).toBe(0);
+    expect(result.maxDepth).toBe(0);
+    const failed = result.checks.filter((c) => !c.pass).map((c) => c.name);
+    expect(failed).toContain("child:calculate");
+    expect(failed).toContain("depth>=1");
+
+    // Liveness is still reported — the loop ran to a stop without a provider
+    // error — but it is not a result.
+    expect(report.summary.successRate).toBe(0);
+    expect(report.summary.completionRate).toBe(1);
+    expect(result.accepted).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.criticalFailures).toBeGreaterThan(0);
+  });
+
   it("skips a case flagged needsModelProviders when none are configured", async () => {
     const provider = new ScriptedProvider([
       () => [{ type: "chunk", content: "x", done: true }]


### PR DESCRIPTION
## The bug

`subtask-eval.ts` computed acceptance as:

```ts
const accepted = error === undefined;
```

A case counted as a **success** whenever the run did not throw — regardless of whether a single expectation check passed.

Observed on `delegate-read-write`: score **0.44**, every delegation check failed, and the suite printed:

```
success 1/1 (100%)
```

That is the one thing a delegation suite exists to measure. A parent that does the work itself at depth 0 and answers correctly is *live*, not *correct*.

## Why it matters beyond this suite

A scoreboard that cannot go red steers an optimization loop into noise. This was found while auditing why an earlier optimization iteration chased a delta that turned out not to exist.

## The fix

Split liveness from result, the shape `tool-loop-eval.ts` already uses:

```ts
success = accepted && criticalFailures === 0
```

- `successRate` — and therefore the `--min-success` CI gate — now counts successes.
- `completionRate` reports "ran to a stop without a provider error" separately. It is a liveness signal: a parent that called zero tools scores 100% on it.
- The summary line used `s.accepted` as its numerator, which is the literal source of the `100%`. It now reads `s.successful` and prints `completed` beside it.

Every expectation check is treated as disqualifying — required parent and child tools, delegation depth, forbidden tools. None is advisory; each is the point of its case. (`tool-loop-eval` distinguishes critical/standard/advisory because its checks genuinely differ in kind; these don't.)

## Verification

The test was **watched fail against the old code** first:

```
AssertionError: expected 1 to be +0
  report.summary.successRate: 1
```

It constructs a parent that computes inline at depth 0, spawns no subtask, and fails `child:calculate` and `depth>=1` — then asserts `successRate === 0`, `completionRate === 1`, `accepted === true`, `success === false`.

7/7 in `subtask-eval.test.ts`. `packages/agents` and `packages/cli` both typecheck clean.

## Expect scores to drop

The next real-model run of this suite will report **lower** numbers than before. That is the fix working: the suite was overcounting. Nothing regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)