### PR TITLE
fix(agents): name why an ffmpeg inputs ref could not be read

### DIFF
--- a/packages/agents/src/capabilities/media.ts
+++ b/packages/agents/src/capabilities/media.ts
@@ -1374,10 +1374,16 @@ async function stageInputs(
       };
     }
     let bytes: Uint8Array | null = null;
+    let readError: string | undefined;
     try {
       bytes = await loadMediaRefBytes({ uri: ref.trim() }, context);
-    } catch {
-      // Reported as unreadable below; the message names the forms that work.
+    } catch (e) {
+      // Keep why. Naming only the accepted forms is useless to a caller who
+      // already passed one — an unreachable bucket, a revoked credential and a
+      // typo all arrive here, and only the first two are worth retrying. Told
+      // just "pass an asset:// URI", a model re-sends the ref it has and then
+      // starts guessing at URL shapes.
+      readError = e instanceof Error ? e.message : String(e);
     }
     // Zero bytes is a failed read wearing a buffer, the same way it is in
     // `save_asset` — staging it would hand ffmpeg an empty file and the
@@ -1385,8 +1391,12 @@ async function stageInputs(
     if (!bytes || bytes.byteLength === 0) {
       return {
         error:
-          `inputs["${name}"]: could not read ${ref}. Pass an asset:// URI, ` +
-          `the /api/storage/ key a tool returned, or a data: URI.`
+          `inputs["${name}"]: could not read ${ref}. ` +
+          (readError
+            ? `Reading it failed: ${readError}. `
+            : "It resolved to no bytes. ") +
+          `Accepted: an asset:// URI, the /api/storage/ key a tool returned, ` +
+          `or a data: URI.`
       };
     }
     if (bytes.byteLength > MAX_STAGED_INPUT_BYTES) {

--- a/packages/agents/tests/capabilities-media.test.ts
+++ b/packages/agents/tests/capabilities-media.test.ts
@@ -487,6 +487,33 @@ describe("ffmpeg and yt_dlp capabilities", () => {
     }
   });
 
+  it("ffmpeg names why an inputs ref failed to resolve", async () => {
+    // The same shape `view_image` hit: the ref is a perfectly good form, and
+    // the read fails underneath. Reporting only the accepted forms sends the
+    // model back round with the ref it already had — it cannot tell a typo
+    // from an unreachable bucket, so it guesses at the one thing it can change.
+    const dir = await mkdtemp(join(tmpdir(), "ffmpeg-inputs-err-"));
+    try {
+      const context = {
+        userId: "user-1",
+        workspace: createLocalWorkspace(dir),
+        resolveWorkspacePath: (relative: string) => resolve(dir, relative),
+        resolveAssetBytes: async () => {
+          throw new Error("storage backend unreachable");
+        }
+      } as unknown as ProcessingContext;
+
+      const result = (await asTool(ffmpeg).process(context, {
+        args: ["-i", "a.mp4", "out.mp4"],
+        inputs: { "a.mp4": "asset://abc.mp4" }
+      })) as Record<string, unknown>;
+
+      expect(String(result["error"])).toContain("storage backend unreachable");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("ffmpeg points a refused URI at the inputs parameter", async () => {
     const result = (await asTool(ffmpeg).process(
       localWorkspaceContext("/tmp"),


### PR DESCRIPTION
## What

`stageInputs` in `media.ts` caught `loadMediaRefBytes` and threw the reason away. The comment said so out loud:

```ts
} catch {
  // Reported as unreadable below; the message names the forms that work.
}
```

Naming the accepted forms is useless to a caller that already passed one. An unreachable bucket, a revoked credential, and a typo all land in that branch — and only the first two are worth retrying.

**Before:**
```
inputs["a.mp4"]: could not read asset://abc.mp4.
Pass an asset:// URI, the /api/storage/ key a tool returned, or a data: URI.
```

**After:**
```
inputs["a.mp4"]: could not read asset://abc.mp4.
Reading it failed: storage backend unreachable.
Accepted: an asset:// URI, the /api/storage/ key a tool returned, or a data: URI.
```

A ref that genuinely resolves to zero bytes has no cause to report, so that branch now says "It resolved to no bytes" rather than implying a read error nobody observed.

## Why

This is the **second instance** of the defect fixed for `view_image` in #5101. There, a model held a valid asset id, was told only which forms are accepted, and spent seven minutes and a dozen actions guessing `localhost:7777` URLs that the SSRF guard refused. Same shape here, on the ffmpeg staging path.

## Verification

Watched red first:

```
AssertionError: expected 'inputs["a.mp4"]: could not read asset…' to contain 'storage backend unreachable'
Received: "...could not read asset://abc.mp4. Pass an asset:// URI, the /api/storage/ key a tool returned, or a data: URI."
```

46/46 in `capabilities-media.test.ts`, `tsc` clean.

Worth noting how the *second* red caught a bug in my test rather than the code: the fix was already working, but the message read `context.resolveAssetBytes is not a function` — an `asset://` ref resolves through `resolveAssetBytes`, not `storage.retrieve`, so my double was wrong. A looser assertion would have shipped a test that passed for the wrong reason.

## Scope note

I audited all 27 swallowing `catch` blocks and 413 error returns under `capabilities/` looking for more of this class. There are **two**, not a backlog: this one and `view_image`. The rest are legitimate — `documents.ts:50/72` are path-containment predicates returning `boolean`, `scripts.ts:249` is a documented ffprobe-missing fallback, `storyboards.ts:173` returns `null` on purpose, and the `JSON.parse` swallows in `sketches.ts`/`timelines.ts` describe a corrupt stored document the caller cannot act on.

**Not fixed here:** `assets.ts:325` and `:381` carry the same "an http(s) URL" phrasing in `save_asset`'s messages. That file is already modified in #5101, so editing it here would conflict — worth a follow-up on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)