### PR TITLE
fix(runtime): remove the wall-clock race from the bridge setTarget test

### DIFF
--- a/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test-helpers.ts
@@ -100,6 +100,13 @@ export interface FakeWorkerHandle {
    * No-op when gateUpgrade was false or after the upgrade was already released.
    */
   releaseUpgrade: () => void;
+  /**
+   * True once a gated WebSocket upgrade has reached the server and is being
+   * held. This is the observable a test should wait on instead of sleeping:
+   * "the socket is genuinely CONNECTING" is a fact about the server, not a
+   * duration, and a fixed sleep only guesses at it.
+   */
+  upgradePending: () => boolean;
 }
 
 /**
@@ -175,12 +182,26 @@ export function startFakeWorker(
 ): Promise<FakeWorkerHandle> {
   // When gateUpgrade: true, the first WS upgrade is held until releaseUpgrade()
   // is called. Captured via verifyClient's async callback form.
+  //
+  // `verifyClient` fires only once the upgrade request reaches the server, so a
+  // caller cannot know whether it has run yet. Releasing before it fired used to
+  // be a silent no-op — the upgrade was then held forever and the handshake
+  // never settled, which surfaces as a test timeout with nothing to read. On a
+  // busy CI runner that is exactly the order that happens. `releaseRequested`
+  // makes an early release apply to the next upgrade instead of vanishing, so
+  // ordering cannot decide the outcome.
   let pendingRelease: (() => void) | null = null;
+  let releaseRequested = false;
   const verifyClient = initialOptions.gateUpgrade
     ? (
         _info: Record<string, unknown>,
         cb: (res: boolean) => void
       ) => {
+        if (releaseRequested) {
+          releaseRequested = false;
+          cb(true);
+          return;
+        }
         pendingRelease = () => {
           pendingRelease = null;
           cb(true);
@@ -558,8 +579,14 @@ export function startFakeWorker(
         },
         received: (t: string) => receivedByType.get(t) ?? [],
         releaseUpgrade: () => {
-          pendingRelease?.();
-        }
+          if (pendingRelease) {
+            pendingRelease();
+            return;
+          }
+          // The upgrade has not arrived yet — arm it rather than drop it.
+          releaseRequested = true;
+        },
+        upgradePending: () => pendingRelease !== null
       });
     });
   });

--- a/packages/runtime/tests/python-websocket-bridge.test.ts
+++ b/packages/runtime/tests/python-websocket-bridge.test.ts
@@ -632,9 +632,12 @@ describe("WebsocketPythonBridge", () => {
           // expected to reject — the handshake gets aborted by setTarget
         });
 
-        // Give the TCP connection to worker A a moment to establish so the socket
-        // is genuinely CONNECTING (not just queued).
-        await new Promise((r) => setTimeout(r, 30));
+        // Wait for the state the race needs rather than guessing at a duration:
+        // worker A's upgrade has reached the server and is being held, so the
+        // socket is genuinely CONNECTING. This was a fixed 30ms sleep, which is
+        // ample on an idle machine and not guaranteed on a loaded CI runner —
+        // the test then timed out at 30s with nothing to read.
+        await waitFor(() => workerA.upgradePending(), 5000);
 
         let reconnected = false;
         bridge.on("reconnected", () => { reconnected = true; });
@@ -666,6 +669,32 @@ describe("WebsocketPythonBridge", () => {
       } finally {
         await workerA.close();
         await workerB.close();
+      }
+    });
+
+    it("releaseUpgrade before the upgrade arrives still releases it", async () => {
+      // The ordering CI hit. `verifyClient` only fires once the upgrade request
+      // reaches the server, and `releaseUpgrade()` used to call whatever was
+      // pending *at that moment* — so a release that ran first was dropped, the
+      // upgrade was then held forever, and the handshake never settled. On a
+      // loaded runner that is a 30s test timeout with no assertion to read.
+      //
+      // Ordering must not decide the outcome, so a release that arrives early
+      // now applies to the next upgrade instead of vanishing.
+      const worker = await startFakeWorker(0, { gateUpgrade: true });
+      try {
+        // Release before anything has connected — the losing order.
+        worker.releaseUpgrade();
+
+        bridge = new WebsocketPythonBridge({
+          wsUrl: `ws://127.0.0.1:${worker.port}`,
+          startupTimeoutMs: 3000
+        });
+        await bridge.connect();
+
+        expect(bridge.isConnected).toBe(true);
+      } finally {
+        await worker.close();
       }
     });
 


### PR DESCRIPTION
## The failure

```
FAIL tests/python-websocket-bridge.test.ts >
  late-resolving old-URL handshake cannot clobber the new target (provision→setTarget race)
Error: Test timed out in 30000ms.
```

Timed out at 30s in CI; takes 2.5s locally. It **hung** — it is not slow. Seen on #5109, whose diff touches one unrelated file.

## Two wall-clock assumptions

**The sleep.** The test slept a fixed 30ms to get worker A's socket "genuinely CONNECTING" before calling `setTarget`:

```js
// Give the TCP connection to worker A a moment to establish so the socket
// is genuinely CONNECTING (not just queued).
await new Promise((r) => setTimeout(r, 30));
```

That is a guess at a *duration* standing in for a *fact about the server*. Ample on an idle machine; not guaranteed on a loaded runner — the failing run logged 385s of import time. It now waits on the fact:

```js
await waitFor(() => workerA.upgradePending(), 5000);
```

**The dropped release — this is what actually hung it.** `verifyClient` fires only once the upgrade request reaches the server, and `releaseUpgrade()` called whatever was pending *at that instant*:

```js
releaseUpgrade: () => { pendingRelease?.(); }
```

A release that ran first hit a `null` and was silently dropped. The upgrade was then held forever, the handshake never settled, and the test sat until the 30s timeout — which is why the CI log carried no assertion, just a timeout. An early release is now armed for the next upgrade instead of vanishing, so ordering cannot decide the outcome.

## Reproduced before fixing

The mechanism was confirmed by observation, not by reading. A test that calls `releaseUpgrade()` before connecting — the losing order — fails against the old helper with the same symptom as CI:

```
× releaseUpgrade before the upgrade arrives still releases it 10006ms
Error: Test timed out in 10000ms.
```

It passes now and stays as the regression test.

(An earlier attempt to reproduce by setting the sleep to `0` did **not** fail: localhost is fast enough to win the race anyway. That mattered — the sleep is the symptom, the dropped release is the cause, and only the second reproduction distinguishes them.)

## Verification

Green on an idle box proves little when load is the trigger, so it was checked under contention: **six concurrent suite runs on four cores, 162 test executions, all passing**. 27/27 single-run. `tsc` and `oxlint` clean.

## Scope

Test and test-helper only — no source change. The bridge behaviour under test is unchanged; what changed is that the test now observes a state instead of betting on a clock. The race it covers (`834f55637`) is still exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)