### PR TITLE
fix(chain-editor): make input connections reachable and auto-wiring smarter

### DIFF
--- a/docs/chain-editor.md
+++ b/docs/chain-editor.md
@@ -47,7 +47,12 @@ Click the **Add Node** button at the end of the chain. The **Node Picker Dialog*
 
 ![Node Picker](assets/screenshots/web-chain-editor-picker.png)
 
-Pick a node and it's inserted at the end. The editor automatically wires a single input from the previous step.
+Pick a node and it's inserted at the chosen position. The editor wires one of
+its inputs to the nearest step above that produces a value of a matching type —
+preferring that step's selected output, and preferring an input whose type
+matches exactly over one typed `any`. Insert into the middle of a chain and the
+step below follows: an input it took from the step now above the new card moves
+to the new card's output when the types allow.
 
 ---
 
@@ -74,7 +79,12 @@ Incompatible connections are highlighted in red and the editor suggests a compat
 
 Each card has:
 
-- **Input Mapping Selector** — pick which output of the previous card becomes this card's input. This is useful when a previous step returns multiple values (e.g., `text`, `metadata`).
+- **Input Mapping Selector** — every field carries a link button that picks
+  which earlier step's output fills it, not just the previous card's. The menu
+  lists the compatible outputs first and shows the incompatible ones greyed out
+  with the type they produce, so a mismatch is visible rather than missing.
+  Wired fields show the source step instead of an editor; the unlink button
+  gives the editor back.
 - **Output Selector** — if this card has multiple outputs, pick the one that should flow into the next step.
 
 Both selectors show the data type, so you can spot mismatches quickly.

--- a/web/src/components/chain_editor/ChainNodeProperties.tsx
+++ b/web/src/components/chain_editor/ChainNodeProperties.tsx
@@ -197,6 +197,10 @@ export const ChainNodeProperties: React.FC<ChainNodePropertiesProps> = ({
   }
 
   const secondary = theme.vars.palette.secondary.main;
+  // The connect button is offered whenever an earlier step exists, not only
+  // when one is type-compatible — otherwise there is no way to open the picker
+  // and see why nothing fits.
+  const canConnect = previousNodes.length > 0;
 
   return (
     <NodeContext.Provider value={store}>
@@ -213,9 +217,6 @@ export const ChainNodeProperties: React.FC<ChainNodePropertiesProps> = ({
             );
             const sourceCompatible =
               !sourceOutput || areTypesCompatible(sourceOutput.type, prop.type);
-            const hasCompatibleSource = (
-              sourcesByInput.get(prop.name) ?? []
-            ).some((o) => o.compatible);
             const value = values[prop.name] ?? prop.default;
 
             if (mapping) {
@@ -301,7 +302,7 @@ export const ChainNodeProperties: React.FC<ChainNodePropertiesProps> = ({
                 key={prop.name}
                 sx={{ position: "relative" }}
               >
-                {hasCompatibleSource && (
+                {canConnect && (
                   <Box
                     sx={{
                       position: "absolute",
@@ -316,21 +317,20 @@ export const ChainNodeProperties: React.FC<ChainNodePropertiesProps> = ({
                       tooltip="Use output from a previous step"
                       onClick={(e) => handleOpenPicker(prop.name, e.currentTarget)}
                       icon={
-                        <AddLinkIcon
-                          sx={{
-                            fontSize: 16,
-                            color: theme.vars.palette.text.disabled,
-                            transition: MOTION.all,
-                            ".chain-property-item:hover &, .MuiIconButton-root:focus-visible &":
-                              { color: secondary },
-                          }}
-                        />
+                        <AddLinkIcon sx={{ fontSize: 16, color: secondary }} />
                       }
-                      sx={{ p: 0.5 }}
+                      sx={{
+                        p: 0.5,
+                        borderRadius: BORDER_RADIUS.xs,
+                        border: `1px solid ${secondary}40`,
+                        backgroundColor: theme.vars.palette.background.paper,
+                        transition: MOTION.all,
+                        "&:hover": { backgroundColor: `${secondary}20` },
+                      }}
                     />
                   </Box>
                 )}
-                <Box sx={hasCompatibleSource ? { pr: 3.5 } : undefined}>
+                <Box sx={canConnect ? { pr: 3.5 } : undefined}>
                   {createElement(Component, {
                     property: prop,
                     value,
@@ -374,7 +374,14 @@ export const ChainNodeProperties: React.FC<ChainNodePropertiesProps> = ({
 
           {compatibleOptions.length === 0 && (
             <EditorMenuItem disabled>
-              <ListItemText primary="No compatible outputs in previous steps" />
+              <ListItemText
+                primary="No compatible outputs in previous steps"
+                secondary={
+                  activeProp
+                    ? `This field takes ${formatType(activeProp.type)}`
+                    : undefined
+                }
+              />
             </EditorMenuItem>
           )}
 

--- a/web/src/components/chain_editor/__tests__/ChainNodeProperties.test.tsx
+++ b/web/src/components/chain_editor/__tests__/ChainNodeProperties.test.tsx
@@ -152,7 +152,9 @@ describe("ChainNodeProperties", () => {
     expect(onSetInputMapping).toHaveBeenCalledWith("text", null);
   });
 
-  it("hides the connect affordance when no previous step has a compatible output", () => {
+  it("offers the connect affordance even when no previous output fits, and says so", async () => {
+    const user = userEvent.setup();
+
     render(
       <ChainNodeProperties
         nodeId="n1"
@@ -161,6 +163,26 @@ describe("ChainNodeProperties", () => {
         values={{}}
         inputMappings={{}}
         previousNodes={[previousNodes[0]]}
+        onUpdate={jest.fn()}
+        onSetInputMapping={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /connect count/i }));
+    expect(
+      screen.getByText("No compatible outputs in previous steps")
+    ).toBeInTheDocument();
+  });
+
+  it("hides the connect affordance on the first node, which has no earlier step", () => {
+    render(
+      <ChainNodeProperties
+        nodeId="n1"
+        nodeType="test.Target"
+        properties={[makeProperty("count", intType)]}
+        values={{}}
+        inputMappings={{}}
+        previousNodes={[]}
         onUpdate={jest.fn()}
         onSetInputMapping={jest.fn()}
       />

--- a/web/src/components/chain_editor/__tests__/chainTypes.test.ts
+++ b/web/src/components/chain_editor/__tests__/chainTypes.test.ts
@@ -101,10 +101,19 @@ describe("areTypesCompatible", () => {
     expect(areTypesCompatible(listStr, listStr2)).toBe(true);
   });
 
-  it("list types are compatible regardless of element types (same base type)", () => {
+  it("list types with mismatched element types are not compatible", () => {
     const listStr = makeType("list", { type_args: [makeType("str")] });
     const listInt = makeType("list", { type_args: [makeType("int")] });
-    expect(areTypesCompatible(listStr, listInt)).toBe(true);
+    expect(areTypesCompatible(listStr, listInt)).toBe(false);
+  });
+
+  it("str is compatible with an enum target", () => {
+    expect(areTypesCompatible(makeType("str"), makeType("enum"))).toBe(true);
+  });
+
+  it("T is compatible with a list[T] collect target", () => {
+    const listStr = makeType("list", { type_args: [makeType("str")] });
+    expect(areTypesCompatible(makeType("str"), listStr)).toBe(true);
   });
 
   it("bare list is compatible with typed list (same base type)", () => {

--- a/web/src/components/chain_editor/__tests__/useChainEditorStore.test.ts
+++ b/web/src/components/chain_editor/__tests__/useChainEditorStore.test.ts
@@ -132,6 +132,116 @@ describe("useChainEditorStore", () => {
     });
   });
 
+  describe("auto-connect on add", () => {
+    it("wires the new node to the previous node's selected output", () => {
+      const metaA = makeMetadata("test.A", [], [makeOutput("out", "str")]);
+      const metaB = makeMetadata("test.B", [makeProp("text", "str")], []);
+
+      act(() => {
+        useChainEditorStore.getState().addNode(metaA);
+        useChainEditorStore.getState().addNode(metaB);
+      });
+
+      const { chain, connections } = useChainEditorStore.getState();
+      expect(chain[1].inputMappings).toEqual({
+        text: { sourceNodeId: chain[0].id, sourceOutput: "out" }
+      });
+      expect(connections).toHaveLength(1);
+    });
+
+    it("prefers the input whose type matches exactly over an any input", () => {
+      const metaA = makeMetadata("test.A", [], [makeOutput("out", "image")]);
+      const metaB = makeMetadata(
+        "test.B",
+        [makeProp("data", "any"), makeProp("image", "image")],
+        []
+      );
+
+      act(() => {
+        useChainEditorStore.getState().addNode(metaA);
+        useChainEditorStore.getState().addNode(metaB);
+      });
+
+      const { chain } = useChainEditorStore.getState();
+      expect(Object.keys(chain[1].inputMappings)).toEqual(["image"]);
+    });
+
+    it("walks further back when the immediately previous node has no match", () => {
+      const metaA = makeMetadata("test.A", [], [makeOutput("out", "image")]);
+      const metaB = makeMetadata("test.B", [], [makeOutput("out", "audio")]);
+      const metaC = makeMetadata("test.C", [makeProp("image", "image")], []);
+
+      act(() => {
+        useChainEditorStore.getState().addNode(metaA);
+        useChainEditorStore.getState().addNode(metaB);
+        useChainEditorStore.getState().addNode(metaC);
+      });
+
+      const { chain } = useChainEditorStore.getState();
+      expect(chain[2].inputMappings).toEqual({
+        image: { sourceNodeId: chain[0].id, sourceOutput: "out" }
+      });
+    });
+
+    it("leaves inputs unwired when nothing earlier produces a matching type", () => {
+      const metaA = makeMetadata("test.A", [], [makeOutput("out", "audio")]);
+      const metaB = makeMetadata("test.B", [makeProp("image", "image")], []);
+
+      act(() => {
+        useChainEditorStore.getState().addNode(metaA);
+        useChainEditorStore.getState().addNode(metaB);
+      });
+
+      expect(useChainEditorStore.getState().chain[1].inputMappings).toEqual({});
+    });
+
+    it("splices a mid-chain insert into the flow, re-pointing the follower", () => {
+      const metaA = makeMetadata("test.A", [], [makeOutput("out", "str")]);
+      const metaC = makeMetadata("test.C", [makeProp("text", "str")], []);
+      const metaB = makeMetadata(
+        "test.B",
+        [makeProp("text", "str")],
+        [makeOutput("out", "str")]
+      );
+
+      act(() => {
+        useChainEditorStore.getState().addNode(metaA);
+        useChainEditorStore.getState().addNode(metaC);
+      });
+      act(() => {
+        useChainEditorStore.getState().addNode(metaB, 1);
+      });
+
+      const { chain } = useChainEditorStore.getState();
+      expect(chain.map((n) => n.nodeType)).toEqual(["test.A", "test.B", "test.C"]);
+      expect(chain[1].inputMappings).toEqual({
+        text: { sourceNodeId: chain[0].id, sourceOutput: "out" }
+      });
+      expect(chain[2].inputMappings).toEqual({
+        text: { sourceNodeId: chain[1].id, sourceOutput: "out" }
+      });
+    });
+
+    it("leaves the follower alone when the inserted node's output does not fit", () => {
+      const metaA = makeMetadata("test.A", [], [makeOutput("out", "str")]);
+      const metaC = makeMetadata("test.C", [makeProp("text", "str")], []);
+      const metaB = makeMetadata("test.B", [], [makeOutput("out", "audio")]);
+
+      act(() => {
+        useChainEditorStore.getState().addNode(metaA);
+        useChainEditorStore.getState().addNode(metaC);
+      });
+      act(() => {
+        useChainEditorStore.getState().addNode(metaB, 1);
+      });
+
+      const { chain } = useChainEditorStore.getState();
+      expect(chain[2].inputMappings).toEqual({
+        text: { sourceNodeId: chain[0].id, sourceOutput: "out" }
+      });
+    });
+  });
+
   describe("removeNode", () => {
     it("removes a node by id", () => {
       act(() => { useChainEditorStore.getState().addNode(makeMetadata("test.Node")); });

--- a/web/src/components/chain_editor/chainTypes.ts
+++ b/web/src/components/chain_editor/chainTypes.ts
@@ -12,6 +12,7 @@ import type {
 } from "../../stores/ApiTypes";
 import type { TypeMetadata } from "../../stores/ApiTypes";
 import type { Node, Edge } from "../../stores/ApiTypes";
+import { isConnectable } from "../../utils/TypeHandler";
 
 /** Describes where a single input gets its data from. */
 export interface InputSource {
@@ -46,23 +47,22 @@ export interface ChainConnection {
   targetInput: string;
 }
 
+/**
+ * Whether a source output can feed a target input.
+ *
+ * Delegates to the graph editor's rule so the chain editor accepts exactly
+ * what dragging an edge on the canvas accepts (str → enum, T → list[T],
+ * unions, dicts, cv ↔ chunk), plus int → float, which is safe to widen and
+ * which the canvas rule leaves out.
+ */
 export function areTypesCompatible(
   source: TypeMetadata,
   target: TypeMetadata
 ): boolean {
-  if (source.type === "any" || target.type === "any") return true;
-  if (source.type === target.type) return true;
-  if (source.type === "int" && target.type === "float") return true;
-  if (target.type === "union" && target.type_args.length > 0) {
-    return target.type_args.some((arg) => areTypesCompatible(source, arg));
-  }
-  if (
-    source.type === "list" &&
-    target.type === "list" &&
-    source.type_args.length > 0 &&
-    target.type_args.length > 0
-  ) {
-    return areTypesCompatible(source.type_args[0], target.type_args[0]);
+  if (isConnectable(source, target)) return true;
+  // int widens to float, including inside a union or list target.
+  if (source.type === "int") {
+    return isConnectable({ ...source, type: "float" }, target);
   }
   return false;
 }
@@ -76,12 +76,35 @@ export function getCompatibleInputs(
   );
 }
 
+/**
+ * Rank a candidate input for an auto-connection.
+ * Higher wins; ties fall back to declaration order.
+ */
+function inputScore(prop: Property, outputName: string, outputType: TypeMetadata): number {
+  let score = 0;
+  if (prop.type.type === outputType.type) score += 4;
+  if (prop.name === outputName) score += 3;
+  if (prop.type.type === "any") score -= 2;
+  return score;
+}
+
 export function findBestInput(
   metadata: NodeMetadata,
-  outputType: TypeMetadata
+  outputType: TypeMetadata,
+  outputName = ""
 ): string | null {
   const compatible = getCompatibleInputs(metadata, outputType);
-  return compatible.length > 0 ? compatible[0].name : null;
+  if (compatible.length === 0) return null;
+  let best = compatible[0];
+  let bestScore = inputScore(best, outputName, outputType);
+  for (const prop of compatible.slice(1)) {
+    const score = inputScore(prop, outputName, outputType);
+    if (score > bestScore) {
+      best = prop;
+      bestScore = score;
+    }
+  }
+  return best.name;
 }
 
 export interface WorkflowGraph {
@@ -129,4 +152,35 @@ export function buildConnections(chain: ChainNode[]): ChainConnection[] {
     }
   }
   return connections;
+}
+
+/**
+ * Pick the input mappings a newly inserted node should start with.
+ *
+ * Walks backwards from the insertion point and takes the first earlier node
+ * that produces something this node can accept — its selected output first,
+ * then its other outputs. Returns an empty map when nothing matches.
+ */
+export function autoMapInputs(
+  metadata: NodeMetadata,
+  chain: ChainNode[],
+  index: number
+): InputMappings {
+  for (let i = Math.min(index, chain.length) - 1; i >= 0; i--) {
+    const prev = chain[i];
+    const outputs = [...prev.metadata.outputs].sort((a, b) => {
+      const aSel = a.name === prev.selectedOutput ? 0 : 1;
+      const bSel = b.name === prev.selectedOutput ? 0 : 1;
+      return aSel - bSel;
+    });
+    for (const output of outputs) {
+      const input = findBestInput(metadata, output.type, output.name);
+      if (input) {
+        return {
+          [input]: { sourceNodeId: prev.id, sourceOutput: output.name },
+        };
+      }
+    }
+  }
+  return {};
 }

--- a/web/src/components/chain_editor/useChainEditorStore.ts
+++ b/web/src/components/chain_editor/useChainEditorStore.ts
@@ -6,7 +6,7 @@ import { create } from "zustand";
 import useMetadataStore from "../../stores/MetadataStore";
 import type { NodeMetadata, Workflow } from "../../stores/ApiTypes";
 import type { ChainNode, ChainConnection, InputMappings, InputSource } from "./chainTypes";
-import { buildConnections, chainToGraph, findBestInput } from "./chainTypes";
+import { areTypesCompatible, autoMapInputs, buildConnections, chainToGraph } from "./chainTypes";
 
 function generateId(): string {
   return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
@@ -89,23 +89,8 @@ export const useChainEditorStore = create<ChainEditorState>((set, get) => ({
     const defaultOutput =
       metadata.outputs.length > 0 ? metadata.outputs[0].name : "";
 
-    // Auto-map from previous node if compatible
-    const inputMappings: InputMappings = {};
-    if (idx > 0) {
-      const prev = chain[idx - 1];
-      const prevOutput = prev.metadata.outputs.find(
-        (o) => o.name === prev.selectedOutput
-      );
-      if (prevOutput) {
-        const bestInput = findBestInput(metadata, prevOutput.type);
-        if (bestInput) {
-          inputMappings[bestInput] = {
-            sourceNodeId: prev.id,
-            sourceOutput: prev.selectedOutput,
-          };
-        }
-      }
-    }
+    // Auto-map from the nearest earlier node that produces a matching value.
+    const inputMappings = autoMapInputs(metadata, chain, idx);
 
     const newNode: ChainNode = {
       id: generateId(),
@@ -119,6 +104,26 @@ export const useChainEditorStore = create<ChainEditorState>((set, get) => ({
 
     const updated = [...chain];
     updated.splice(idx, 0, newNode);
+
+    // Inserting into the middle splices the new node into the flow: an input
+    // on the following node that was fed by the node now above the new one
+    // moves to the new node's output, when the types allow it.
+    const follower = updated[idx + 1];
+    const displacedSource = idx > 0 ? updated[idx - 1].id : null;
+    const newOutput = metadata.outputs.find((o) => o.name === defaultOutput);
+    if (follower && displacedSource && newOutput) {
+      const remapped: InputMappings = {};
+      for (const [inputName, source] of Object.entries(follower.inputMappings)) {
+        const prop = follower.metadata.properties.find((p) => p.name === inputName);
+        remapped[inputName] =
+          source.sourceNodeId === displacedSource &&
+          prop &&
+          areTypesCompatible(newOutput.type, prop.type)
+            ? { sourceNodeId: newNode.id, sourceOutput: defaultOutput }
+            : source;
+      }
+      updated[idx + 1] = { ...follower, inputMappings: remapped };
+    }
 
     set({ chain: updated, connections: buildConnections(updated) });
   },


### PR DESCRIPTION
Two reports about the web chain editor: inputs cannot be connected, and adding a node does not wire it to the step above.

## Why the connect button was missing

`ChainNodeProperties` only rendered the link button on a field when `areTypesCompatible` found a compatible output on some earlier step. That predicate was a private, weaker copy of the graph editor's `isConnectable`:

- no `str → enum`, no `T → list[T]` collect handles, no `object` targets, no dict element checks, no `cv ↔ chunk`
- `source.type === target.type` came first, so **every** list was compatible with every other list regardless of element type

So on many fields no affordance appeared at all, and some connections it did offer would have been rejected on the canvas.

## Changes

- `areTypesCompatible` delegates to `isConnectable` from `utils/TypeHandler`, plus `int → float` (also inside a union or list target), which the canvas rule leaves out.
- The connect button renders whenever there is any earlier step, so the picker can always be opened. Incompatible sources stay listed and disabled, and the empty state now names the type the field takes instead of just saying nothing fits.
- The button gets a border and the secondary colour, instead of sitting in `text.disabled` until hover.
- Auto-wiring on add (`autoMapInputs`) walks back past the previous node when it produces nothing usable, prefers that node's selected output, prefers an input whose type matches exactly over one typed `any`, and prefers an input named like the output.
- Inserting mid-chain splices the new node into the flow: an input on the follower that was fed by the node now above the new one moves to the new node's output when the types allow.
- `docs/chain-editor.md` updated where it described the old behaviour.

## Verification

- `npx jest src/components/chain_editor` — 50 → 56 tests, all passing. New store tests cover walk-back, exact-type preference, the no-match case, and both splice cases; new component tests cover the button being offered with no compatible source and absent on the first node.
- Two existing `chainTypes` assertions changed on purpose: `list[str] → list[int]` is now **not** compatible (it was only compatible because of the loose base-type shortcut), and the connect-affordance test now asserts the button is offered.
- Inverted the walk-back loop bound once to confirm the new test fails on the old behaviour, then restored it.
- `npx tsc --noEmit` (web) clean; `oxlint` on the touched tree clean; `npm run lint:anti-slop:enforced` and `npm run lint:design --workspace=web` pass.

Note: `mobile/src/types/graphEditor.ts` carries the same loose copy of `areTypesCompatible` and has the same gap. Mobile cannot import `web/src/utils`, so fixing it is a separate change and is left out here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcboyYECo5ApNqmyJ8LhGW)_