### PR TITLE
fix(web): resolve asset:// video sources through the asset record

### DIFF
--- a/web/src/components/appbuilder/puck/widgets.tsx
+++ b/web/src/components/appbuilder/puck/widgets.tsx
@@ -182,6 +182,8 @@ const VideoItem: React.FC<{ src: string; height: number }> = ({
     <Box
       component="video"
       controls
+      playsInline
+      preload="metadata"
       src={resolved}
       sx={{
         width: "100%",

--- a/web/src/components/asset_viewer/VideoViewer.tsx
+++ b/web/src/components/asset_viewer/VideoViewer.tsx
@@ -33,7 +33,12 @@ const styles = () =>
 const VideoViewer: React.FC<VideoViewerProps> = memo(function VideoViewer({ asset, url }) {
   return (
     <Box className="video-viewer" css={styles()}>
-      <video controls={true} src={asset?.get_url || url || ""}>
+      <video
+        controls={true}
+        playsInline
+        preload="metadata"
+        src={asset?.get_url || url || ""}
+      >
         Your browser does not support the video element.
       </video>
       <Text size="big" color="secondary">

--- a/web/src/components/chat/message/MessageContentRenderer.tsx
+++ b/web/src/components/chat/message/MessageContentRenderer.tsx
@@ -228,6 +228,8 @@ export const MessageContentRenderer: React.FC<MessageContentRendererProps> = Rea
           <video
             ref={videoRef}
             controls
+            playsInline
+            preload="metadata"
             style={videoStyle}
             src={videoObjectUrl}
             aria-label="Video content"

--- a/web/src/components/node/OutputRenderer.tsx
+++ b/web/src/components/node/OutputRenderer.tsx
@@ -686,6 +686,11 @@ const OutputRenderer: React.FC<OutputRendererProps> = ({
           <video
             ref={videoRef}
             controls
+            // iOS Safari plays a video inline only with `playsinline`, and
+            // decodes no frame at all without a preload hint — without both,
+            // the element paints an empty box on a phone.
+            playsInline
+            preload="metadata"
             // nodrag/nopan stop ReactFlow's drag from capturing the pointer so
             // the native controls (scrub, volume) get the mouse events.
             className="nodrag nopan"

--- a/web/src/components/node/output/ChunkRenderer.tsx
+++ b/web/src/components/node/output/ChunkRenderer.tsx
@@ -58,6 +58,8 @@ export const ChunkRenderer: React.FC<Props> = memo(({ chunk }) => {
         <video
           src={chunk.content as string}
           controls
+          playsInline
+          preload="metadata"
           // nodrag/nopan stop ReactFlow's drag from capturing the pointer so
           // the native controls (scrub, volume) get the mouse events.
           className="nodrag nopan"

--- a/web/src/components/node/output/__tests__/useSignedUrl.assetUri.test.tsx
+++ b/web/src/components/node/output/__tests__/useSignedUrl.assetUri.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * `asset://<id>` is an identifier, not a storage key.
+ *
+ * `useSignedUrl` used to hand it to `storage.signUrl` with the scheme stripped,
+ * which signs `<id>` while the object is `<user_id>/<id>.<ext>`. An extension
+ * carried the key far enough for the server's flat-key fallback to find the
+ * object; an extension-less locator — what chat persistence and `save_asset`
+ * produce — resolved to nothing, so every video and audio output that went
+ * through this hook rendered an empty element while images, which resolve
+ * through the asset record, showed fine.
+ */
+import { renderHook } from "@testing-library/react";
+
+const mockUseQuery = jest.fn();
+
+jest.mock("../../../../trpc/client", () => ({
+  trpc: {
+    storage: {
+      signUrl: {
+        useQuery: (...args: unknown[]) => mockUseQuery(...args)
+      }
+    }
+  }
+}));
+
+jest.mock("../../../../hooks/useResolvedMediaUri", () =>
+  jest.requireActual("../../../../hooks/__mocks__/useResolvedMediaUri")
+);
+
+import { mockAssetUrl } from "../../../../hooks/__mocks__/useResolvedMediaUri";
+import { useSignedUrl } from "../hooks";
+
+describe("useSignedUrl", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseQuery.mockReturnValue({ data: undefined });
+  });
+
+  it("resolves an extension-less asset:// through the asset record", () => {
+    const { result } = renderHook(() =>
+      useSignedUrl("asset://9c936089c3d0471a90aa5443f6f46665")
+    );
+
+    expect(result.current).toBe(
+      mockAssetUrl("9c936089c3d0471a90aa5443f6f46665")
+    );
+  });
+
+  it("does not sign an asset id as a storage key", () => {
+    renderHook(() => useSignedUrl("asset://9c936089c3d0471a90aa5443f6f46665"));
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      { key: "" },
+      expect.objectContaining({ enabled: false })
+    );
+  });
+
+  it("resolves an asset:// that carries an extension the same way", () => {
+    const { result } = renderHook(() => useSignedUrl("asset://abc123.mp4"));
+
+    expect(result.current).toBe(mockAssetUrl("abc123.mp4"));
+  });
+
+  it("still signs a /api/storage/ key", () => {
+    mockUseQuery.mockReturnValue({
+      data: { url: "https://signed.test/user-1/abc123.mp4" }
+    });
+
+    const { result } = renderHook(() =>
+      useSignedUrl("/api/storage/user-1/abc123.mp4")
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      { key: "user-1/abc123.mp4" },
+      expect.objectContaining({ enabled: true })
+    );
+    expect(result.current).toBe("https://signed.test/user-1/abc123.mp4");
+  });
+
+  it("passes an https URL through untouched", () => {
+    const { result } = renderHook(() =>
+      useSignedUrl("https://cdn.example.com/clip.mp4")
+    );
+
+    expect(result.current).toBe("https://cdn.example.com/clip.mp4");
+  });
+});

--- a/web/src/components/node/output/hooks.ts
+++ b/web/src/components/node/output/hooks.ts
@@ -6,6 +6,7 @@ import { trpc } from "../../../trpc/client";
 import { bitmapToPngDataUrl } from "../../../lib/workflow/materializeBrowserOutputs";
 import { fileUriToHttpUrl } from "../../../utils/localFile";
 import {
+  useResolvedMediaUri,
   useResolvedMediaUris,
   type MediaLocator
 } from "../../../hooks/useResolvedMediaUri";
@@ -74,13 +75,14 @@ export function toUint8Array(
 }
 
 /**
- * Extracts the storage key from an asset URI.
- * Handles asset:// and /api/storage/ schemes.
- * Returns null for other schemes.
+ * Extracts the storage key from a `/api/storage/` URI.
+ *
+ * `asset://<id>` is deliberately not a key: the object is
+ * `<user_id>/<asset_id>.<ext>`, so signing the bare id resolves nothing —
+ * `useSignedUrl` routes that scheme through the asset record instead.
  */
 function extractStorageKey(uri: string | null | undefined): string | null {
   if (!uri) return null;
-  if (uri.startsWith("asset://")) return uri.slice("asset://".length);
   if (uri.startsWith("/api/storage/")) return uri.slice("/api/storage/".length);
   return null;
 }
@@ -171,9 +173,18 @@ export function getMimeTypeFromUri(
  * For cloud backends (S3/Supabase), returns a pre-signed URL.
  * For the local file backend, returns the /api/storage/ URL.
  * Falls back to resolveAssetUri() while the query is loading.
+ *
+ * `asset://<id>` resolves through the asset record's own `get_url`, the same
+ * path the image branches take. Signing it as a storage key produced a URL for
+ * an object that does not exist — the bytes are `<user_id>/<asset_id>.<ext>`
+ * and the locator carries neither the owner prefix nor the extension — so
+ * every video and audio output whose ref was an extensionless `asset://`
+ * (what chat persistence and `save_asset` produce) rendered an empty element.
  */
 export function useSignedUrl(uri: string | undefined | null): string {
-  const key = extractStorageKey(uri);
+  const isAssetUri = Boolean(uri?.startsWith("asset://"));
+  const assetUrl = useResolvedMediaUri(isAssetUri ? uri : undefined);
+  const key = isAssetUri ? null : extractStorageKey(uri);
   const { data } = trpc.storage.signUrl.useQuery(
     { key: key ?? "" },
     { enabled: Boolean(key), staleTime: 6 * 24 * 60 * 60 * 1000 }
@@ -184,6 +195,9 @@ export function useSignedUrl(uri: string | undefined | null): string {
   const fileHttpUrl = fileUriToHttpUrl(uri);
   if (fileHttpUrl !== null) {
     return fileHttpUrl;
+  }
+  if (isAssetUri) {
+    return assetUrl ?? "";
   }
   return data?.url ?? resolveAssetUri(uri);
 }

--- a/web/src/components/properties/PropertyDropzone.tsx
+++ b/web/src/components/properties/PropertyDropzone.tsx
@@ -436,6 +436,8 @@ const PropertyDropzone = ({
                 <video
                   style={{ width: "100%", height: "auto" }}
                   controls
+                  playsInline
+                  preload="metadata"
                   src={uri}
                   aria-label={filename || "Video"}
                 >

--- a/web/src/components/properties/PropertyListThumb.tsx
+++ b/web/src/components/properties/PropertyListThumb.tsx
@@ -50,7 +50,14 @@ export function ListVideoThumb({
 }) {
   const src = useDisplayUri("video", item);
   return (
-    <video src={src} controls muted preload="metadata" aria-label={label} />
+    <video
+      src={src}
+      controls
+      muted
+      playsInline
+      preload="metadata"
+      aria-label={label}
+    />
   );
 }
 

--- a/web/src/components/ui_primitives/VideoPlayer.tsx
+++ b/web/src/components/ui_primitives/VideoPlayer.tsx
@@ -259,6 +259,7 @@ const VideoPlayerInner: React.FC<VideoPlayerProps> = ({
         loop={loop}
         muted={muted}
         playsInline
+        preload="metadata"
         aria-label="Video player"
         onPlay={handlePlay}
         onPause={handlePause}


### PR DESCRIPTION
Videos rendered nothing in the web app while images in the same place showed fine.

## The bug

`useSignedUrl` (`web/src/components/node/output/hooks.ts`) stripped the `asset://` scheme and handed the bare id to `storage.signUrl`. The stored object is `<user_id>/<asset_id>.<ext>`, so the id alone names nothing. The server's flat-key fallback rescues a locator that carries an extension (`asset://<id>.mp4` → `<user>/<id>.mp4`), but an extension-less `asset://<id>` — what chat persistence and `save_asset` produce — signs a URL for an object that does not exist.

Everything that resolved a media source through this hook was affected:

- `OutputRenderer`'s video branch, via `useVideoSrc`
- `ContentCardBody` (video/audio) and `ExtractVideoFrameBody`, via `useMediaSrc`

Images were not, because they resolve through the asset record (`useResolvedMediaUris` → `get_url`) instead — hence "images work, videos don't". `ChatMarkdown` already had this fix locally; this moves the same handling into the shared hook.

## The fix

`useSignedUrl` routes an `asset://` locator to `useResolvedMediaUri`, i.e. the asset row's own `get_url`. `/api/storage/` keys sign exactly as before, and `file://` and absolute URLs are untouched.

Separately, the `<video>` elements that lacked them now carry `playsInline` and `preload="metadata"`. iOS Safari plays a video inline only with `playsinline`, and decodes no frame without a preload hint, so on a phone those elements paint an empty box even once the source resolves. The elements already carrying these attributes document the same reason.

## Verification

- New suite `web/src/components/node/output/__tests__/useSignedUrl.assetUri.test.tsx` pins the resolution: an extension-less `asset://` resolves through the asset record, the id is never signed as a storage key, and `/api/storage/` keys and https URLs behave as before. Reverting the fix turns 3 of its 5 tests red.
- `npx tsc --noEmit` clean; `oxlint src` reports the same 108 pre-existing warnings as `main`.
- Full web suite: 1155 suites, 13316 tests passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ra9mMAAoRK9DKzvhn2NFiD)_