### PR TITLE
fix(runtime): resolve uploaded assets wired into a graph

### DIFF
--- a/packages/execution/src/service/app-debug-service.ts
+++ b/packages/execution/src/service/app-debug-service.ts
@@ -28,6 +28,7 @@ import {
 import type { JsScriptDocument } from "@nodetool-ai/protocol/api-schemas/js-scripts.js";
 import type { JsScriptOperationRunner } from "../app-debug/script-operation.js";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
+import type { StorageAdapter } from "@nodetool-ai/runtime";
 import {
   applicationTarget,
   inlineDocumentTarget,
@@ -108,6 +109,8 @@ export interface AppDebugDeps {
    * such an operation reports as unexecutable instead of being skipped.
    */
   runScript?: JsScriptOperationRunner;
+  /** The store `asset://<id>` inputs in the app's workflows resolve through. */
+  assetStorage?: StorageAdapter | null;
 }
 
 /** A pinned script version the user owns, for a script operation. */
@@ -268,7 +271,8 @@ export async function runApplicationDebug(
         loadFromDb: (id: string) =>
           (deps.loadWorkflow ?? loadUserWorkflow)(userId, id),
         runOnServer: createAppServerRunner(userId, registry, {
-          jobPrefix: "app-debug-run"
+          jobPrefix: "app-debug-run",
+          assetStorage: deps.assetStorage ?? null
         }),
         loadScript: (scriptId: string, scriptVersion: number) =>
           loadUserJsScript(userId, scriptId, scriptVersion)

--- a/packages/execution/src/service/app-run-server.ts
+++ b/packages/execution/src/service/app-run-server.ts
@@ -22,11 +22,21 @@ import type {
 } from "../app-debug/index.js";
 import { getSecret } from "@nodetool-ai/models";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
-import { FileStorageAdapter, ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  FileStorageAdapter,
+  ProcessingContext,
+  type StorageAdapter
+} from "@nodetool-ai/runtime";
 
 export interface AppServerRunnerOptions {
   /** Job-id prefix, so a run is attributable to the surface that started it. */
   jobPrefix?: string;
+  /**
+   * The store `asset://<id>` inputs resolve through. Only the local assets dir
+   * on a `file` backend, so a host on S3/Supabase must pass its own or the
+   * run reads every uploaded input as empty.
+   */
+  assetStorage?: StorageAdapter | null;
 }
 
 export function createAppServerRunner(
@@ -43,7 +53,8 @@ export function createAppServerRunner(
       workflowId: input.workflowId,
       userId,
       secretResolver: (key: string) => getSecret(key, userId),
-      storage: new FileStorageAdapter(getDefaultAssetsPath())
+      storage: new FileStorageAdapter(getDefaultAssetsPath()),
+      assetStorage: options.assetStorage ?? null
     });
     const sessionOptions: Parameters<typeof ExecutionSession.create>[0] = {
       graph: input.graph,

--- a/packages/execution/src/service/workflow-run.ts
+++ b/packages/execution/src/service/workflow-run.ts
@@ -25,6 +25,7 @@ import {
   listRegisteredProviderIds,
   type NodeExecutor,
   type ProcessingContext,
+  type StorageAdapter,
   type Workspace
 } from "@nodetool-ai/runtime";
 import { normalizeGraph } from "../normalize-graph.js";
@@ -76,6 +77,13 @@ export interface WorkflowRunEnvironment {
    * nodes that persist artifacts — every image Output — fail their run.
    */
   configureContext?: (context: ProcessingContext) => void;
+  /**
+   * The store `asset://<id>` inputs resolve through, and the temp store for
+   * runtime-materialized refs. A host that brings neither runs with a context
+   * that can write assets but not read them.
+   */
+  assetStorage?: StorageAdapter | null;
+  storage?: StorageAdapter | null;
 }
 
 /** Provider/model catalogs the pre-flight checks a graph's selections against. */
@@ -512,7 +520,9 @@ export async function runWorkflow(
           jobId: job.id,
           workflowId,
           userId,
-          workspace
+          workspace,
+          storage: environment.storage ?? null,
+          assetStorage: environment.assetStorage ?? null
         });
         // The host attaches its model interfaces (asset persistence, …) —
         // without them an Output node that stores an image fails the run.

--- a/packages/execution/src/service/workflow-workspace.ts
+++ b/packages/execution/src/service/workflow-workspace.ts
@@ -110,6 +110,12 @@ export function usesCloudWorkspaces(): boolean {
  * image in a chat turn and get a 401 from the same provider when it ran the
  * workflow it had just built. The resolver is scoped to the run's own user,
  * which is the only account whose secrets this run may read.
+ *
+ * So do the storage adapters. A context with none resolves no `asset://` ref
+ * at all — every uploaded image wired into a graph reached its node empty, and
+ * the node reported "The input image is empty". The host passes the same two
+ * adapters the streaming WebSocket runner uses; a host that passes neither
+ * keeps the old read-nothing behaviour rather than guessing at a backend.
  */
 export function buildWorkspaceExecutionContext(opts: {
   jobId: string;
@@ -121,12 +127,18 @@ export function buildWorkspaceExecutionContext(opts: {
     key: string,
     userId: string
   ) => Promise<string | null | undefined> | string | null | undefined;
+  /** Temp store for runtime-materialized refs. */
+  storage?: StorageAdapter | null;
+  /** Asset store `asset://<id>` references resolve through. */
+  assetStorage?: StorageAdapter | null;
 }): ProcessingContext {
   return new ProcessingContext({
     jobId: opts.jobId,
     workflowId: opts.workflowId ?? null,
     userId: opts.userId,
     workspace: opts.workspace,
+    storage: opts.storage ?? null,
+    assetStorage: opts.assetStorage ?? null,
     secretResolver:
       opts.secretResolver ??
       ((key: string, userId: string) => getSecret(key, userId))

--- a/packages/execution/tests/workflow-run-asset-storage.test.ts
+++ b/packages/execution/tests/workflow-run-asset-storage.test.ts
@@ -1,0 +1,120 @@
+/**
+ * An uploaded asset wired into a graph must reach the node that reads it.
+ *
+ * The service-layer run path (REST `/api/workflows/:id/run|debug`, tRPC, MCP)
+ * built its ProcessingContext with no storage adapters at all, so every
+ * `asset://<id>` input resolved to nothing: an Image To Image node fed a
+ * freshly uploaded photo failed with "The input image is empty". The host now
+ * hands the run the same asset store the streaming WebSocket runner uses.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  BaseNode,
+  NodeRegistry,
+  prop,
+  type GraphInput
+} from "@nodetool-ai/node-sdk";
+import {
+  InMemoryStorageAdapter,
+  type ProcessingContext
+} from "@nodetool-ai/runtime";
+
+const graph: GraphInput = {
+  nodes: [
+    {
+      id: "n1",
+      type: "test.execution.ReadAsset",
+      data: { uri: "asset://abc" }
+    }
+  ],
+  edges: []
+};
+
+class FakeJob {
+  id = "job-1";
+  status = "running";
+  error: string | null = null;
+  logs: unknown[] = [];
+  metadata_json: Record<string, unknown> | null = null;
+  markCompleted(): void {
+    this.status = "completed";
+  }
+  markCancelled(): void {
+    this.status = "cancelled";
+  }
+  markFailed(message: string): void {
+    this.status = "failed";
+    this.error = message;
+  }
+  async save(): Promise<void> {}
+}
+
+vi.mock("@nodetool-ai/models", () => ({
+  Workflow: {
+    find: vi.fn(async () => ({
+      id: "wf-1",
+      name: "Read Asset",
+      run_mode: "workflow",
+      getGraph: () => graph
+    }))
+  },
+  Workspace: { find: vi.fn(async () => null) },
+  Job: { create: vi.fn(async () => new FakeJob()) },
+  getSecret: vi.fn(async () => null)
+}));
+
+const { runWorkflow } = await import("../src/service/workflow-run.js");
+
+/** Reports how many bytes its `uri` resolved to — 0 when it resolved none. */
+class ReadAsset extends BaseNode {
+  static readonly nodeType = "test.execution.ReadAsset";
+  static readonly title = "Read Asset";
+  static readonly description = "Resolves an asset ref to its byte count";
+
+  @prop({ type: "str", default: "" })
+  declare uri: string;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    const { bytes } = (await context?.resolveAssetBytes(this.uri)) ?? {
+      bytes: null
+    };
+    return { output: bytes?.length ?? 0 };
+  }
+}
+
+async function runWith(
+  assetStorage: InMemoryStorageAdapter | null
+): Promise<Record<string, unknown[]>> {
+  const registry = new NodeRegistry();
+  registry.register(ReadAsset);
+  const outcome = await runWorkflow({
+    workflowId: "wf-1",
+    userId: "user-7",
+    environment: { registry, assetStorage },
+    resolveWorkspace: async () => null
+  });
+  if (outcome.kind !== "payload") {
+    throw new Error(`run failed: ${outcome.detail}`);
+  }
+  return outcome.payload.outputs as Record<string, unknown[]>;
+}
+
+describe("runWorkflow asset resolution", () => {
+  it("reads an uploaded asset through the host's asset store", async () => {
+    const assetStorage = new InMemoryStorageAdapter();
+    // The layout an upload writes: owner-prefixed, extension on disk, while
+    // the graph's ref carries neither.
+    await assetStorage.store(
+      "user-7/abc.jpeg",
+      new Uint8Array([1, 2, 3, 4]),
+      "image/jpeg"
+    );
+
+    expect((await runWith(assetStorage)).n1).toEqual([4]);
+  });
+
+  it("resolves nothing when the host brings no asset store", async () => {
+    expect((await runWith(null)).n1).toEqual([0]);
+  });
+});

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -2717,11 +2717,19 @@ export class ProcessingContext {
       // with the id, since the URN extension may differ from the one on disk
       // (e.g. jpeg vs jpg). Only reached when the exact-key lookups all miss.
       //
-      // Try a narrow prefix first (S3 treats `list(bareId)` as a raw-string
-      // prefix match — bounded to a handful of entries) before falling back to
-      // a root listing for adapters that treat the prefix as a folder path
-      // (memory/supabase). Avoids `list("")` becoming a multi-thousand-object
-      // scan on production S3 backends.
+      // Try a narrow prefix first (S3 treats `list(<owner>/<bareId>)` as a
+      // raw-string prefix match — bounded to a handful of entries) before
+      // widening. `list("")` is the last resort: it is a multi-thousand-object
+      // scan on production S3 backends, and on Supabase it lists only the
+      // bucket's immediate children — which under the owner-prefixed layout
+      // are folders, so it never sees an asset at all.
+      //
+      // The owner prefix is what makes this work for uploads. They are stored
+      // at `<userId>/<id>.<ext>`, and a ref that carries no extension
+      // (`asset://<id>`, or a bare `asset_id`) misses every exact-key lookup
+      // above. Listing the owner's own folder finds it on every adapter:
+      // hierarchical ones (file/supabase/memory) list its children, and
+      // prefix-matching ones (S3) stay scoped to that one user.
       const bareId = idCandidates[idCandidates.length - 1];
       if (bareId) {
         const tryListing = async (
@@ -2757,7 +2765,12 @@ export class ProcessingContext {
           }
           return null;
         };
-        for (const prefix of [bareId, ""]) {
+        const owner = this.userId;
+        const prefixes =
+          owner && !bareId.startsWith(`${owner}/`)
+            ? [`${owner}/${bareId}`, bareId, owner, ""]
+            : [bareId, ""];
+        for (const prefix of prefixes) {
           const bytes = await tryListing(prefix);
           if (bytes) {
             return { bytes, attempts };

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -11,7 +11,8 @@ import {
   S3StorageAdapter,
   resolveWorkspacePath,
   type S3Client,
-  type MessageCreateRequestLike
+  type MessageCreateRequestLike,
+  type StorageListResult
 } from "../src/context.js";
 import type { ProcessingMessage, NodeUpdate } from "@nodetool-ai/protocol";
 import { RAW_RGBA_MIME } from "@nodetool-ai/protocol";
@@ -1027,6 +1028,24 @@ describe("FileStorageAdapter", () => {
   });
 });
 
+/**
+ * Supabase Storage semantics: `list(path)` returns the immediate children of a
+ * pseudo-directory — never a recursive walk, and empty for a path that is not
+ * one. `InMemoryStorageAdapter.list` is prefix-matching and recursive, so it
+ * cannot show what an owner-prefixed key does to a root listing.
+ */
+class FolderListingAdapter extends InMemoryStorageAdapter {
+  override async list(prefix: string): Promise<StorageListResult> {
+    const dir = prefix.replace(/\/+$/, "");
+    const all = await super.list("");
+    const entries = all.entries.filter((entry) => {
+      const slash = entry.key.lastIndexOf("/");
+      return (slash < 0 ? "" : entry.key.slice(0, slash)) === dir;
+    });
+    return { entries, commonPrefixes: [] };
+  }
+}
+
 describe("ProcessingContext.resolveAssetBytes", () => {
   it("resolves an asset:// URN against the storage adapter (key <id>.<ext>)", async () => {
     const storage = new InMemoryStorageAdapter();
@@ -1089,6 +1108,41 @@ describe("ProcessingContext.resolveAssetBytes", () => {
 
     const { bytes } = await ctx.resolveAssetBytes("asset://user-7/abc.png");
     expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([3, 4]));
+  });
+
+  it("resolves an extension-less ref under the owner prefix (folder-listing backend)", async () => {
+    // Regression: an uploaded asset is stored at `<userId>/<id>.<ext>`, but the
+    // graph carries `asset://<id>` with no extension (that is what the editor
+    // writes into a Constant Image node, and what a bare `asset_id` yields).
+    // Every exact-key lookup misses, so resolution falls to the prefix
+    // listing — and on Supabase `list("")` returns only the bucket's immediate
+    // children, which under this layout are folders. The image reached the
+    // node empty and it reported "The input image is empty".
+    const storage = new FolderListingAdapter();
+    await storage.store("user-7/abc.jpeg", new Uint8Array([5, 6, 7]), "image/jpeg");
+    const ctx = new ProcessingContext({ jobId: "j1", userId: "user-7", storage });
+
+    const { bytes } = await ctx.resolveAssetBytes("asset://abc");
+    expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([5, 6, 7]));
+  });
+
+  it("still skips the thumbnail when listing the owner prefix", async () => {
+    const storage = new FolderListingAdapter();
+    await storage.store("user-7/abc_thumb.jpg", new Uint8Array([9]), "image/jpeg");
+    await storage.store("user-7/abc.jpeg", new Uint8Array([5, 6, 7]), "image/jpeg");
+    const ctx = new ProcessingContext({ jobId: "j1", userId: "user-7", storage });
+
+    const { bytes } = await ctx.resolveAssetBytes("asset://abc");
+    expect(Uint8Array.from(bytes ?? [])).toEqual(new Uint8Array([5, 6, 7]));
+  });
+
+  it("does not read another owner's asset of the same id", async () => {
+    const storage = new FolderListingAdapter();
+    await storage.store("user-8/abc.jpeg", new Uint8Array([1, 1]), "image/jpeg");
+    const ctx = new ProcessingContext({ jobId: "j1", userId: "user-7", storage });
+
+    const { bytes } = await ctx.resolveAssetBytes("asset://abc");
+    expect(bytes).toBeNull();
   });
 
   it("resolves a bare `/api/storage/<key>` path against the storage adapter", async () => {

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -1036,7 +1036,12 @@ describe("FileStorageAdapter", () => {
  */
 class FolderListingAdapter extends InMemoryStorageAdapter {
   override async list(prefix: string): Promise<StorageListResult> {
-    const dir = prefix.replace(/\/+$/, "");
+    // Trim trailing slashes without a regex: `/\/+$/` over a caller-supplied
+    // prefix is the polynomial backtracking (CWE-1333) the real Supabase
+    // adapter documents avoiding, and an asset ref reaches this prefix.
+    let end = prefix.length;
+    while (end > 0 && prefix[end - 1] === "/") end -= 1;
+    const dir = prefix.slice(0, end);
     const all = await super.list("");
     const entries = all.entries.filter((entry) => {
       const slash = entry.key.lastIndexOf("/");

--- a/packages/websocket/src/headless-job-runner.ts
+++ b/packages/websocket/src/headless-job-runner.ts
@@ -32,6 +32,7 @@ import type { SupervisorRunOptions } from "@nodetool-ai/protocol";
 import { FileStorageAdapter, ProcessingContext } from "@nodetool-ai/runtime";
 import { createRunSupervisor } from "./run-supervisor.js";
 import { resolveWorkflowWorkspace } from "./lib/workflow-workspace.js";
+import { getAssetAdapter } from "./lib/storage.js";
 
 const log = createLogger("nodetool.websocket.headless-job");
 
@@ -187,6 +188,10 @@ export async function startHeadlessJob(
     userId,
     secretResolver: getSecret,
     storage: new FileStorageAdapter(getDefaultAssetsPath()),
+    // `asset://<id>` inputs resolve through the configured asset store, which
+    // is only the local assets dir on a `file` backend. Without it a triggered
+    // run on an S3/Supabase deployment reads every uploaded input as empty.
+    assetStorage: getAssetAdapter(),
     workspace
   });
 

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -56,7 +56,8 @@ import {
   safeFetch,
   type NodeExecutor,
   type ProcessingContext,
-  type PythonBridge
+  type PythonBridge,
+  type StorageAdapter
 } from "@nodetool-ai/runtime";
 import { createAssetModelInterface } from "./lib/asset-model-interface.js";
 import { verdictSchema } from "@nodetool-ai/protocol";
@@ -81,7 +82,7 @@ import {
   storeAssetWithThumbnail,
   thumbnailKey
 } from "./lib/thumbnail.js";
-import { getAssetAdapter } from "./lib/storage.js";
+import { getAssetAdapter, getTempAdapter } from "./lib/storage.js";
 import {
   probeHasAudio,
   extractAudio,
@@ -363,6 +364,8 @@ type WorkflowRuntimeEnvironment = {
     [key: string]: unknown;
   }) => NodeExecutor;
   configureContext: (context: ProcessingContext) => void;
+  assetStorage: StorageAdapter;
+  storage: StorageAdapter;
 };
 
 export async function getWorkflowRuntimeEnvironment(
@@ -538,7 +541,13 @@ export async function getWorkflowRuntimeEnvironment(
           context.setModelInterfaces({
             createAsset: createAssetModelInterface
           });
-        }
+        },
+        // The stores the run reads through. `asset://<id>` inputs — every
+        // uploaded image wired into a graph — live in the asset store; without
+        // it the reference resolves to nothing and the node runs on an empty
+        // input. Same pair the streaming WebSocket runner uses.
+        assetStorage: getAssetAdapter(),
+        storage: getTempAdapter()
       };
     })();
   }

--- a/packages/websocket/src/lib/app-debug-service.ts
+++ b/packages/websocket/src/lib/app-debug-service.ts
@@ -19,6 +19,7 @@ import type {
 } from "@nodetool-ai/execution/service";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
 import { ApiErrorCode } from "../error-codes.js";
+import { getAssetAdapter } from "./storage.js";
 import { throwApiError } from "../trpc/error-formatter.js";
 import type { HttpApiOptions } from "../http-api.js";
 
@@ -54,6 +55,8 @@ export async function runApplicationDebug(
       // A script operation runs the QuickJS sandbox, which lives above the
       // execution package — the server is where both are in reach.
       runScript: createJsScriptAppRunner(userId, { secretResolver: getSecret }),
+      // Same store the workflow run path reads `asset://<id>` inputs through.
+      assetStorage: getAssetAdapter(),
       ...deps
     });
   } catch (error) {


### PR DESCRIPTION
An uploaded image dropped onto a Constant Image node failed the run with `The input image is empty.` — an `asset://` input reached its node as zero bytes. Two independent defects, both on the read side of the reference.

## The run path had no storage adapters at all

`buildWorkspaceExecutionContext` built the run's `ProcessingContext` with jobId, workflowId, userId, workspace and secrets — and nothing else. With neither adapter set, `resolveAssetBytes` had nothing to read through: it fell to the `/api/storage` HTTP hop (which only addresses a key carrying an extension, so a bare id is skipped outright) and then to an unauthenticated `/api/assets` metadata request. Every reference resolved to null, and `ImageToImage` threw `The input image is empty.` (`packages/image-nodes/src/nodes/image.ts:1961`).

This governs REST `/api/workflows/:id/run|debug` — what the `debug_workflow` tool calls — plus tRPC, MCP, and the triggered headless runner. The streaming WebSocket runner already passed `assetStorage`, which is why generating in a chat turn worked while running the same graph did not.

The host now hands the run the same asset and temp adapters that runner uses, threaded through `WorkflowRunEnvironment`. A host that passes neither keeps the old behaviour rather than guessing at a backend.

## The resolver could not find an extension-less ref under the owner prefix

Uploads are stored at `<userId>/<id>.<ext>`, while the editor writes `asset://<id>` — the canonical id form, deliberately without an extension (`web/src/utils/mediaRef.ts`). Every exact-key lookup therefore misses and resolution falls to the prefix listing, which tried only the bare id and the bucket root. On Supabase `list("")` returns the root's immediate children, which under this layout are folders — so it saw no asset at all, and no ref of this shape could ever resolve there.

It now lists the owner's own prefix. That works on every adapter: hierarchical ones (file/supabase/memory) list its children, prefix-matching ones (S3) stay scoped to that one user instead of scanning the bucket. The `_thumb` exclusion and the existing lookup order are unchanged.

## Tests

Both were confirmed to fail without their fix and pass with it.

- `packages/runtime/tests/context.test.ts` — a `FolderListingAdapter` reproducing Supabase's list semantics (immediate children only). Covers the extension-less ref, the thumbnail sibling, and that another owner's asset of the same id is not read.
- `packages/execution/tests/workflow-run-asset-storage.test.ts` — `runWorkflow` end to end over a node that resolves its ref, against an asset stored in the layout an upload writes. The second case pins that a host bringing no store still resolves nothing.

## Verification

`harness gate --base HEAD~1` ran 3/3 selfchecks green, including the 5 Ring 0 reliability journeys. `build:packages` builds. `test:packages` is green apart from environment gaps in the sandbox: `packages/cli` cannot build because `node_modules/@nodetool-ai/telegram` is unlinked here (identical failure with the changes stashed), `npm run lint` cannot load its oxlint JS plugin (`@oxlint/plugins` absent — linting the touched files directly is clean), and `image-nodes` hits the documented WebGPU/Dawn driver gap, passing 231/231 once lavapipe is extracted and `VK_DRIVER_FILES` is set. No web, electron or mobile files are touched.

## Not covered

`POST /api/applications/build` (`packages/agents/src/app-build/build-service.ts`) still runs with a hardcoded local file adapter and no asset store. A build authors its own workflows from a prompt, so no uploaded asset is in play; wiring it needs either a new host seam or a second adapter instance outside the server's singleton, and neither belongs in this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRVVT6hQAUfHstYYtCUJoF)_