### PR TITLE
fix(web): allow cross-origin media in the app's CSP

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -55,7 +55,7 @@
     <link rel="manifest" href="/manifest.json" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://rsms.me; font-src 'self' data: https://fonts.gstatic.com https://rsms.me; img-src 'self' data: blob: https:; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https: wss: blob: data:; media-src 'self' blob:; frame-src 'self' http://127.0.0.1:*;"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://rsms.me; font-src 'self' data: https://fonts.gstatic.com https://rsms.me; img-src 'self' data: blob: https:; media-src 'self' data: blob: https:; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https: wss: blob: data:; frame-src 'self' http://127.0.0.1:*;"
     />
     <meta name="referrer" content="no-referrer-when-downgrade" />
     <meta name="theme-color" content="#000000" />

--- a/web/src/__tests__/contentSecurityPolicy.test.ts
+++ b/web/src/__tests__/contentSecurityPolicy.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The app's CSP is the one place a `<video>` can fail for a reason no
+ * component can see.
+ *
+ * Deployed, an asset's `get_url` is a signed URL on the storage host — a
+ * different origin than the page. `img-src` allows `https:`, so images loaded;
+ * `media-src` was `'self' blob:`, so every cross-origin video and audio source
+ * was blocked, and Safari painted the crossed-out play button. Local dev and
+ * Electron hid it: Vite proxies `/api` to the same origin, and Electron ships
+ * its own, wider policy.
+ *
+ * Media and images come from the same asset URLs, so the two directives have to
+ * accept the same sources.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const INDEX_HTML = join(__dirname, "..", "..", "index.html");
+
+function cspDirectives(): Map<string, string[]> {
+  const html = readFileSync(INDEX_HTML, "utf8");
+  const meta = /http-equiv="Content-Security-Policy"\s*\n?\s*content="([^"]+)"/.exec(
+    html
+  );
+  if (!meta) {
+    throw new Error("no Content-Security-Policy meta tag in index.html");
+  }
+  const directives = new Map<string, string[]>();
+  for (const part of meta[1].split(";")) {
+    const [name, ...sources] = part.trim().split(/\s+/);
+    if (name) {
+      directives.set(name, sources);
+    }
+  }
+  return directives;
+}
+
+describe("index.html Content-Security-Policy", () => {
+  it("declares both img-src and media-src", () => {
+    const csp = cspDirectives();
+    expect(csp.get("img-src")).toBeDefined();
+    expect(csp.get("media-src")).toBeDefined();
+  });
+
+  it("accepts every image source for media too", () => {
+    const csp = cspDirectives();
+    const media = new Set(csp.get("media-src"));
+    const missing = (csp.get("img-src") ?? []).filter((s) => !media.has(s));
+
+    expect(missing).toEqual([]);
+  });
+
+  it("allows the cross-origin https sources signed asset URLs use", () => {
+    expect(cspDirectives().get("media-src")).toContain("https:");
+  });
+});


### PR DESCRIPTION
Videos never played in the deployed web app — the asset viewer, chat replies, node outputs and mini apps all showed Safari's crossed-out play button, while images in the same places loaded fine.

## The bug

`web/index.html` declares:

```
img-src   'self' data: blob: https:;
media-src 'self' blob:;
```

Deployed, an asset's `get_url` is a signed URL on the storage host — a different origin than the page. Images are allowed from any https origin; media is not, so the browser blocks every `<video>` and `<audio>` source before a byte is fetched. Safari paints a CSP-blocked video as the crossed-out play button, which is exactly the reported symptom.

Two things hid this:

- **Local dev**: `BASE_URL` is empty and Vite proxies `/api` to the page's own origin, so `media-src 'self'` passes.
- **Electron**: `electron/index.html` ships its own, wider policy (`media-src 'self' blob: mediadevices: *`).

Only the deployed web app, where asset URLs are cross-origin, hits it — which is why it read as a "mobile web" problem: the phone is where the deployed app gets used.

This supersedes my earlier guess in #5122. That change is still correct on its own (an extension-less `asset://` was signed as a storage key), but it was not what kept videos off the screen.

## The fix

`media-src` now accepts what `img-src` accepts: `'self' data: blob: https:`. Both directives serve the same asset URLs, so there is no reason for them to differ.

`index.html` is the only web entry point carrying a CSP — `app-preview.html`, `demo.html`, `e2e-runner.html`, `graph.html` and `perf-realtime.html` declare none, and Electron's is unchanged.

## Verification

- `web/src/__tests__/contentSecurityPolicy.test.ts` parses the meta tag and asserts every `img-src` source is also accepted by `media-src`, so the two cannot drift apart again. Restoring the old `media-src` turns 2 of its 3 tests red.
- `npx tsc --noEmit` clean; `oxlint src` reports the same 108 pre-existing warnings as `main`.

The CSP is enforced by the browser, so this is verified by reading the policy rather than by a headless run — confirming it needs loading the deployed app on a phone once this ships.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ra9mMAAoRK9DKzvhn2NFiD)_