### PR TITLE
feat(agents): report missing credentials from validate_workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1072,6 +1072,18 @@ pass an inline `graph` ({nodes, edges}) to check a graph being built, or a
 `workflow_id` to fetch and validate a saved one. The validator core is
 `validateGraph` in `@nodetool-ai/node-sdk`.
 
+The credential warning reaches that tool too, on a graph as well as a saved
+workflow. The run answers which of the declared names this install holds
+(`CapabilityRun.availableSecrets`, built from the context by
+`contextSecretAvailability`), and the issue tells the agent where a person sets
+one — plus `request_secret` where the run can raise that dialog, and never on a
+headless run, where the call fails closed. A run with no reachable store
+carries no callback and the check is skipped: nothing could answer, and
+reporting every declared key as absent would warn on every graph. The hosts
+that inject are audited by
+`packages/agents/tests/capability-run-secrets-audit.test.ts`, which records the
+runs that deliberately omit it and how many calls each is allowed.
+
 ### nodetool timeline validate / debug (Timeline Harness)
 
 Checks a timeline sequence without rendering it, and replays a scripted edit

--- a/docs/failure-mode-roadmap.md
+++ b/docs/failure-mode-roadmap.md
@@ -73,31 +73,7 @@ resolvers, no bridge connection, and no persistence acceptance.
 
 Run `npm run test --workspace=packages/execution -- session-preflight`.
 
-## 3. Include missing secrets in `validate_workflow`
-
-Status: OPEN.
-
-`validate_workflow` calls `validateGraph` in
-`packages/agents/src/capabilities/workflows.ts`. Changing
-`modelSelectionError` does not change this capability.
-
-Implementation:
-
-1. Add optional `availableSecrets(keys)` to `CreateCapabilityRunOptions` and
-   propagate it through `createCapabilityRun` to `CapabilityRun`.
-2. Pass it to `validateGraph` from `validate_workflow`.
-3. Enumerate every `createCapabilityRun` call site in an audit test. Server,
-   CLI, and MCP hosts with a real secret resolver must inject a callback that
-   uses their `ProcessingContext`. Hermetic eval hosts must omit it explicitly.
-4. A `missing_secret` issue must name the key and direct the agent to
-   Settings > Credentials. Mention `request_secret` only when that capability
-   is present in the run's registered capability set.
-
-Tests must show that a missing key produces an issue, an available key clears
-it, and an absent callback preserves current output. Run
-`npm run test --workspace=packages/agents -- workflows`.
-
-## 4. Make media resolution the browser rendering boundary
+## 3. Make media resolution the browser rendering boundary
 
 Status: OPEN. Follow-up to #4873, #4929, #5028, #5078, #5122, and #5123.
 
@@ -122,7 +98,7 @@ Acceptance: upload -> graph input -> render works for image, video, and audio;
 the primitives cover stored locators and HTTPS URLs; the lint fixture proves
 the rule can fail.
 
-## 5. Preserve provider behavior through decorators
+## 4. Preserve provider behavior through decorators
 
 Status: OPEN. Issue #5109.
 
@@ -145,7 +121,7 @@ method-existence test cannot detect this.
 The current implementation must fail the new test before the fix. Then run
 `npm run test --workspace=packages/runtime -- provider-decorator-inertness`.
 
-## 6. Detect generated provider metadata drift
+## 5. Detect generated provider metadata drift
 
 Status: OPEN.
 
@@ -163,7 +139,7 @@ Status: OPEN.
    non-zero exit, and restoring it.
 6. Confirm that two consecutive fixture-mode runs are byte-stable.
 
-## 7. Add live provider contract probes
+## 6. Add live provider contract probes
 
 Status: OPEN. This is separate from cassette replay.
 
@@ -186,7 +162,7 @@ Acceptance: removing a field from a raw response fixture fails its decoder
 test; a changed live shape fails the nightly probe; retained artifacts contain
 no secrets or signed URLs.
 
-## 8. Require an eval case for each agent capability
+## 7. Require an eval case for each agent capability
 
 Status: OPEN. Evidence: #5095, #5100, #5103, #5105, and #5107.
 
@@ -208,7 +184,7 @@ Status: OPEN. Evidence: #5095, #5100, #5103, #5105, and #5107.
 Tests must cover a capability-only failure, a capability-plus-eval pass, an
 unregistered-file failure, and a non-agent surface that needs no eval.
 
-## 9. Inventory and consolidate SSRF screening
+## 8. Inventory and consolidate SSRF screening
 
 Status: OPEN. Evidence: #5101.
 
@@ -232,7 +208,7 @@ Tests must reject alternate IPv4 forms, IPv4-mapped IPv6, loopback, private
 networks, metadata addresses, and redirects to blocked addresses. Run
 `npm run test --workspace=packages/runtime -- safe-url`.
 
-## 10. Add property tests to seven pure helpers
+## 9. Add property tests to seven pure helpers
 
 Status: OPEN. Use one PR per row. Before adding `fast-check`, record why the
 current dependencies and table-driven tests are insufficient, check its latest
@@ -258,11 +234,11 @@ and stable source order as the tie-breaker for duplicate indexes in #5116.
 Split #4909 into one execution normalization property and one node-sdk
 validation property.
 
-## 11. Complete editor input-path coverage
+## 10. Complete editor input-path coverage
 
 Status: OPEN. Use three separate PRs.
 
-### 11A. Shortcut action mapping
+### 10A. Shortcut action mapping
 
 `web/src/config/shortcuts.ts` already owns shortcuts and rejects duplicate
 slugs. Add a typed action ID used by menus and handlers. Test missing actions,
@@ -270,7 +246,7 @@ duplicate normalized combinations within the same active editor context and
 OS, Electron-only actions in web menus, and the command-menu shortcut on
 Windows and macOS. Duplicate combinations in disjoint contexts remain valid.
 
-### 11B. Canvas drop journeys
+### 10B. Canvas drop journeys
 
 Add web Playwright journeys for file drop, node creation from a dropped
 connection at the cursor, and run-selected with multiple nodes. Use
@@ -279,7 +255,7 @@ Electron Playwright dependency, config, script, packaged-app fixture, and
 Windows CI job. Update `AGENTS.md` and Electron testing docs with the command.
 Run the case on Windows; a Windows-style string on macOS is not sufficient.
 
-### 11C. Dialog containment audit
+### 10C. Dialog containment audit
 
 `PositionedDialog` already clamps to the viewport. Enumerate other dialog
 primitives and direct users in a checked-in audit with a non-zero count. A
@@ -289,6 +265,14 @@ add one 600 x 600 px test per migrated primitive.
 
 ## Completed work
 
+- **Missing secrets in `validate_workflow`:** shipped 2026-08-22.
+  `CapabilityRun.availableSecrets` carries the host's answer,
+  `contextSecretAvailability` builds it from a context that can reach a store,
+  and `getAllMcpTools` takes the factory as `secretAvailability`. The
+  `missing_secret` issue names the key and Settings → Credentials, and adds
+  `request_secret` only where the run can raise the dialog. Covered by
+  `packages/agents/tests/mcp-tools.test.ts` and the call-site audit
+  `capability-run-secrets-audit.test.ts`.
 - **Workflow credential preflight:** shipped 2026-08-22 in node-sdk,
   execution, and CLI. The two execution credential suites cover it.
 - **Production Python opt-in:**

--- a/packages/agents/src/author-graph.ts
+++ b/packages/agents/src/author-graph.ts
@@ -40,6 +40,7 @@ import { toolForCapabilityName } from "./capabilities/lazy-tool.js";
 import {
   UNGATED,
   createCapabilityRun,
+  contextSecretAvailability,
   type CreateCapabilityRunOptions
 } from "./capabilities/index.js";
 import {
@@ -261,6 +262,10 @@ export function buildAuthoringBelt(opts: AuthorGraphOptions): Tool[] {
   const runOptions: CreateCapabilityRunOptions = {
     context: opts.context,
     gate: UNGATED,
+    // The belt carries `validate_workflow`, so a graph the child authors
+    // against a provider this install has no key for comes back saying so.
+    // A hermetic caller's context resolves no secrets and gets no callback.
+    availableSecrets: contextSecretAvailability(opts.context),
     nodeRegistry: opts.registry
   };
   if (opts.providers) runOptions.providers = opts.providers;

--- a/packages/agents/src/capabilities/index.ts
+++ b/packages/agents/src/capabilities/index.ts
@@ -6,6 +6,7 @@
 
 export { PERMISSION_CATEGORIES } from "./types.js";
 export type {
+  AvailableSecretsResolver,
   CapabilitySpec,
   CapabilityImpl,
   CapabilityRun,
@@ -53,6 +54,7 @@ export {
 export type { CapabilityRunSource } from "./adapters.js";
 export {
   UNGATED,
+  contextSecretAvailability,
   createCapabilityRun,
   resolveCapabilityMessage,
   ungatedCapabilityRun

--- a/packages/agents/src/capabilities/invoke.ts
+++ b/packages/agents/src/capabilities/invoke.ts
@@ -24,6 +24,7 @@ import { withSnakeCaseAliases } from "./args.js";
 import { findCapability } from "./registry.js";
 import type { LongTermMemory } from "../long-term-memory.js";
 import type {
+  AvailableSecretsResolver,
   CapabilityExport,
   CapabilityGate,
   CapabilityLoaders,
@@ -61,7 +62,33 @@ export const UNGATED: CapabilityGate = {
 export function ungatedCapabilityRun(
   context: ProcessingContext
 ): CapabilityRun {
-  return createCapabilityRun({ context, gate: UNGATED });
+  return createCapabilityRun({
+    context,
+    gate: UNGATED,
+    availableSecrets: contextSecretAvailability(context)
+  });
+}
+
+/**
+ * The availability callback for a run whose context can reach a secret store,
+ * and `undefined` for one that cannot.
+ *
+ * Every host resolves the same way BaseNode's secret injection does — a key
+ * with a non-empty value is available — so this is the one implementation
+ * instead of one per host. It reads values, but only to test them: nothing
+ * leaves the callback except the set of names that resolved.
+ */
+export function contextSecretAvailability(
+  context: ProcessingContext
+): AvailableSecretsResolver | undefined {
+  if (!context.hasSecretResolver) return undefined;
+  return async (keys) => {
+    const found = new Set<string>();
+    for (const key of keys) {
+      if (await context.getSecret(key)) found.add(key);
+    }
+    return found;
+  };
 }
 
 export interface CreateCapabilityRunOptions {
@@ -71,6 +98,14 @@ export interface CreateCapabilityRunOptions {
   /** Opens the bespoke secret dialog; see {@link CapabilityRun.secretPrompt}. */
   secretPrompt?: SecretPrompt;
   subAgent?: SubAgentRuntime;
+  /**
+   * Which declared credentials this install holds; see
+   * {@link CapabilityRun.availableSecrets}. Build it with
+   * {@link contextSecretAvailability} — a host that omits it turns off
+   * `validate_workflow`'s `missing_secret` check rather than reporting every
+   * declared key as absent.
+   */
+  availableSecrets?: AvailableSecretsResolver;
   nodeRegistry?: NodeRegistry;
   providers?: Record<string, BaseProvider>;
   examples?: ExampleWorkflowCatalog;
@@ -106,6 +141,7 @@ export function createCapabilityRun(
     client: options.client,
     secretPrompt: options.secretPrompt,
     subAgent: options.subAgent,
+    availableSecrets: options.availableSecrets,
     nodeRegistry: options.nodeRegistry,
     providers: options.providers,
     examples: options.examples,

--- a/packages/agents/src/capabilities/types.ts
+++ b/packages/agents/src/capabilities/types.ts
@@ -126,6 +126,19 @@ export type SecretPrompt = (
 ) => Promise<SecretPromptStatus>;
 
 /**
+ * Which of `keys` this host's secret store can resolve.
+ *
+ * The graph validator needs an availability *set*, not values, and it fails
+ * toward silence: a run that carries no resolver reports no missing
+ * credential, because "no store was reachable" is not evidence that a key is
+ * absent. A host installs one only where it can actually answer — see
+ * {@link CapabilityRun.availableSecrets}.
+ */
+export type AvailableSecretsResolver = (
+  keys: readonly string[]
+) => Promise<ReadonlySet<string>> | ReadonlySet<string>;
+
+/**
  * provider, model, `parentTools()`, `forwardMessage` — what `run_subtask` and
  * `run_search` take as constructor options today.
  */
@@ -151,6 +164,14 @@ export interface CapabilityRun {
   readonly secretPrompt?: SecretPrompt;
   /** What `run_subtask` / `run_search` need. */
   readonly subAgent?: SubAgentRuntime;
+  /**
+   * Answers which declared credentials this install holds, so
+   * `validate_workflow` can report a graph whose nodes need a key nobody has
+   * set — the same `missing_secret` warning `nodetool validate` gives on a DB
+   * target. Absent on a run with no reachable store (a hermetic eval), and
+   * the check is then skipped rather than guessed at.
+   */
+  readonly availableSecrets?: AvailableSecretsResolver;
   // The injected singletons `getAllMcpTools` takes today (mcp-tools.ts).
   readonly nodeRegistry?: NodeRegistry;
   readonly providers?: Record<string, BaseProvider>;

--- a/packages/agents/src/capabilities/workflows.ts
+++ b/packages/agents/src/capabilities/workflows.ts
@@ -22,6 +22,7 @@
  */
 
 import type { JsonSchema } from "@nodetool-ai/runtime";
+import type { GraphValidationReport } from "@nodetool-ai/node-sdk";
 import type { Workflow as WorkflowRow } from "@nodetool-ai/models";
 import {
   NO_EXAMPLES,
@@ -39,6 +40,8 @@ import {
   workflowRecord
 } from "../tools/mcp-tool-support.js";
 import { declareDynamicOutputsInGraph } from "../dynamic-slots.js";
+import { findCapability } from "./registry.js";
+import { REQUEST_SECRET_TOOL_NAME } from "./settings.specs.js";
 import type {
   CapabilityExport,
   CapabilityModule,
@@ -664,24 +667,79 @@ const validateWorkflow: CapabilityExport = {
       nodes?: unknown[];
       edges?: unknown[];
     };
-    const { validateGraph } = await import("@nodetool-ai/node-sdk");
-    return validateGraph(
-      {
-        nodes: declared.nodes as never[],
-        edges: (declared.edges ?? []) as never[]
-      },
-      {
-        has: (type) => registry.has(type),
-        getMetadata: (type) => registry.getMetadata(type),
-        validateNode: (descriptor, connectedHandles) =>
-          registry.validateNode(descriptor, connectedHandles),
-        listProviderIds: () => catalogs.listProviderIds(),
-        listModelIds: (provider, modelType) =>
-          catalogs.listModelIds(provider, modelType)
-      }
+    const { collectSecretRequirementSites, validateGraph } = await import(
+      "@nodetool-ai/node-sdk"
     );
+    const registryView = {
+      has: (type: string) => registry.has(type),
+      getMetadata: (type: string) => registry.getMetadata(type),
+      validateNode: (
+        descriptor: Parameters<typeof registry.validateNode>[0],
+        connectedHandles: Parameters<typeof registry.validateNode>[1]
+      ) => registry.validateNode(descriptor, connectedHandles),
+      listProviderIds: () => catalogs.listProviderIds(),
+      listModelIds: (provider: string, modelType: string) =>
+        catalogs.listModelIds(provider, modelType)
+    };
+    const checked = {
+      nodes: declared.nodes as never[],
+      edges: (declared.edges ?? []) as never[]
+    };
+
+    // The credentials the graph's nodes declare are collected first so the
+    // host resolves exactly those names — one store round trip per
+    // requirement, not one per key it holds. A run with no reachable store
+    // carries no resolver and the check is skipped: reporting every declared
+    // key as missing because nothing could answer is the false alarm this
+    // whole path fails toward silence to avoid.
+    let availableSecrets: ReadonlySet<string> | undefined;
+    if (run.availableSecrets) {
+      const sites = collectSecretRequirementSites(checked, registryView);
+      if (sites.length > 0) {
+        availableSecrets = await run.availableSecrets(
+          sites.map((site) => site.key)
+        );
+      }
+    }
+
+    const report = validateGraph(checked, registryView, { availableSecrets });
+    return await withSecretRemediation(run, report);
   }
 };
+
+/**
+ * Tell the agent what to do about a `missing_secret` warning.
+ *
+ * The validator says a key is missing; only the run knows how this agent can
+ * get one set. Settings → Credentials is always the answer a person can act
+ * on; `request_secret` is added only where this run can actually serve it —
+ * it needs the capability *and* a host that can raise the dialog, and a
+ * headless run has neither, so naming it there sends the agent at a call that
+ * fails closed.
+ */
+async function withSecretRemediation(
+  run: CapabilityRun,
+  report: GraphValidationReport
+): Promise<GraphValidationReport> {
+  if (!report.issues.some((issue) => issue.code === "missing_secret")) {
+    return report;
+  }
+  const canAsk =
+    run.secretPrompt !== undefined &&
+    (await findCapability(REQUEST_SECRET_TOOL_NAME)) !== undefined;
+  const remediation = canAsk
+    ? "Ask the user to set it in Settings → Credentials, or call " +
+      `\`${REQUEST_SECRET_TOOL_NAME}\` to have them enter it now.`
+    : "Ask the user to set it in Settings → Credentials.";
+  return {
+    ...report,
+    issues: report.issues.map((issue) =>
+      issue.code === "missing_secret"
+        ? { ...issue, message: `${issue.message} ${remediation}` }
+        : issue
+    )
+  };
+}
 
 // ---------------------------------------------------------------------------
 // start_background_job

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -61,6 +61,7 @@ export {
 } from "./tools/mcp-tools.js";
 export type {
   GetAllMcpToolsOptions,
+  SecretAvailabilityFactory,
   ExampleWorkflowCatalog,
   WorkflowDslExporter,
   PackageAssetLister,
@@ -103,10 +104,12 @@ export {
   capabilitySpec,
   listCapabilitySpecs,
   createCapabilityRun,
+  contextSecretAvailability,
   resolveCapabilityMessage,
   UNGATED
 } from "./capabilities/index.js";
 export type {
+  AvailableSecretsResolver,
   CapabilitySpec,
   CapabilityImpl,
   CapabilityRun,

--- a/packages/agents/src/tools/mcp-tools.ts
+++ b/packages/agents/src/tools/mcp-tools.ts
@@ -23,6 +23,7 @@ import {
   UNGATED,
   createCapabilityRun,
   toolFromLazyCapability,
+  type AvailableSecretsResolver,
   type CapabilityRun
 } from "../capabilities/index.js";
 import { capabilitySpec } from "../capabilities/registry.js";
@@ -44,6 +45,7 @@ type RunSource = (context: ProcessingContext) => CapabilityRun;
 
 /** What a host injects into the workflow capabilities. */
 interface WorkflowCapabilityDeps {
+  secretAvailability?: SecretAvailabilityFactory;
   registry?: NodeRegistry;
   examples?: ExampleWorkflowCatalog;
   exportDsl?: WorkflowDslExporter;
@@ -61,6 +63,7 @@ function workflowCapabilityRun(
   return createCapabilityRun({
     context,
     gate: UNGATED,
+    availableSecrets: deps.secretAvailability?.(context),
     nodeRegistry: deps.registry,
     examples: deps.examples,
     exportDsl: deps.exportDsl,
@@ -172,7 +175,23 @@ export interface GetAllMcpToolsOptions {
    * registry but still benefits from these tools.
    */
   providers?: Record<string, BaseProvider>;
+  /**
+   * Builds the run's `availableSecrets` callback from its context — pass
+   * `contextSecretAvailability` where a real secret store backs the run. It is
+   * a factory rather than a callback because the belt is assembled once and
+   * every call brings its own `ProcessingContext`.
+   *
+   * Without it `validate_workflow` skips the `missing_secret` check, which is
+   * what a hermetic host wants: nothing can answer, and reporting every
+   * declared credential as absent would be a false alarm on every graph.
+   */
+  secretAvailability?: SecretAvailabilityFactory;
 }
+
+/** See {@link GetAllMcpToolsOptions.secretAvailability}. */
+export type SecretAvailabilityFactory = (
+  context: ProcessingContext
+) => AvailableSecretsResolver | undefined;
 
 export function getAllMcpTools(options: GetAllMcpToolsOptions = {}): Tool[] {
   // Every name here is a capability. The belt is assembled from the registry's
@@ -186,7 +205,8 @@ export function getAllMcpTools(options: GetAllMcpToolsOptions = {}): Tool[] {
       examples: options.examples,
       exportDsl: options.exportDsl,
       workflowEnvironment: options.workflowEnvironment,
-      listPackageAssets: options.listPackageAssets
+      listPackageAssets: options.listPackageAssets,
+      secretAvailability: options.secretAvailability
     });
 
   const withRun = (name: string, run: RunSource): Tool => {

--- a/packages/agents/tests/capability-run-secrets-audit.test.ts
+++ b/packages/agents/tests/capability-run-secrets-audit.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Every host that builds a `CapabilityRun` must decide, in writing, whether
+ * that run can answer which credentials this install holds.
+ *
+ * `validate_workflow` reports a `missing_secret` warning only for a run
+ * carrying `availableSecrets`. A host that forgets it does not get a wrong
+ * answer — it gets *no* answer, silently, which is the failure mode that let
+ * the agent surface pass a graph `nodetool validate` warns about. A per-site
+ * fix does not hold that: the next host to be added omits it the same way.
+ * So the audit reads the sources.
+ *
+ * The omission list is not an exemption. An entry means that run cannot tell a
+ * key nobody set from one it could not look up, and the reason has to say why
+ * that is the right answer there.
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const packagesDir = join(repoRoot, "packages");
+
+function* sourceFiles(dir: string): Generator<string> {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) {
+      continue;
+    }
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) yield* sourceFiles(full);
+    else if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) yield full;
+  }
+}
+
+/** `createCapabilityRun({...})` call sites, with their whole options object. */
+function callSites(source: string): string[] {
+  const sites: string[] = [];
+  const marker = "createCapabilityRun(";
+  let from = 0;
+  for (;;) {
+    const at = source.indexOf(marker, from);
+    if (at === -1) break;
+    from = at + marker.length;
+    // An import, a re-export, or the declaration itself is not a call.
+    const before = source[at - 1];
+    if (before !== undefined && /[\w.]/.test(before)) continue;
+    if (source.slice(Math.max(0, at - 9), at) === "function ") continue;
+    let depth = 0;
+    let end = at + marker.length - 1;
+    for (let i = end; i < source.length; i++) {
+      const ch = source[i];
+      if (ch === "(") depth++;
+      else if (ch === ")") {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    sites.push(source.slice(at, end + 1));
+  }
+  return sites;
+}
+
+/**
+ * Runs that knowingly cannot report a missing credential, and why. Every one
+ * of them serves a fixed, narrow capability set that never validates a graph.
+ *
+ * `sites` is how many omitting calls that file is allowed, so a file that is
+ * partly wired — `mcp-tools.ts` builds five runs and only the workflow belt
+ * validates graphs — cannot absorb a sixth omission unnoticed.
+ */
+const OMITS_SECRET_RESOLVER: Record<string, { reason: string; sites: number }> =
+  {
+    // Serves exactly the one tool it wraps; that tool builds its own run, and
+    // this one never reaches an implementation that validates a graph.
+    "packages/agents/src/capabilities/gate-tools.ts": {
+      reason: "one-call run over a single wrapped tool",
+      sites: 1
+    },
+    "packages/agents/src/capabilities/files.ts": {
+      reason: "workspace file capabilities only",
+      sites: 1
+    },
+    "packages/agents/src/capabilities/google.ts": {
+      reason: "Google Workspace capabilities only",
+      sites: 1
+    },
+    "packages/agents/src/capabilities/scripts.ts": {
+      reason: "internal run for generate_speech",
+      sites: 1
+    },
+    // The `ui_*` document tools, node discovery, `find_model`/`list_models`,
+    // and the media belt. None validates a graph; the workflow belt above
+    // them does, and it injects.
+    "packages/agents/src/tools/mcp-tools.ts": {
+      reason: "document, discovery, model and media belts validate no graph",
+      sites: 4
+    }
+  };
+
+/**
+ * A site whose whole argument is one identifier carries its options in a
+ * variable (`createCapabilityRun(runOptions)`), so read that declaration
+ * instead — otherwise the audit reports a wired host as an omission.
+ */
+function resolvedSite(source: string, site: string): string {
+  const arg = site.slice("createCapabilityRun(".length, -1).trim();
+  if (!/^[A-Za-z_$][\w$]*$/.test(arg)) return site;
+  const at = source.search(
+    new RegExp(`(const|let|var)\\s+${arg}\\s*[:=]`)
+  );
+  if (at === -1) return site;
+  const open = source.indexOf("{", at);
+  if (open === -1) return site;
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) return source.slice(at, i + 1);
+    }
+  }
+  return site;
+}
+
+function auditedSites(): Array<{ file: string; site: string }> {
+  const found: Array<{ file: string; site: string }> = [];
+  for (const file of sourceFiles(packagesDir)) {
+    const source = readFileSync(file, "utf8");
+    if (!source.includes("createCapabilityRun(")) continue;
+    for (const site of callSites(source)) {
+      found.push({
+        file: relative(repoRoot, file),
+        site: resolvedSite(source, site)
+      });
+    }
+  }
+  return found;
+}
+
+describe("CapabilityRun secret-availability audit", () => {
+  /** file → how many of its calls pass no `availableSecrets`. */
+  function omissionCounts(): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const { file, site } of auditedSites()) {
+      if (site.includes("availableSecrets")) continue;
+      counts[file] = (counts[file] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  it("every host either resolves secrets or is a recorded omission", () => {
+    const unexpected = Object.entries(omissionCounts())
+      .filter(
+        ([file, count]) => OMITS_SECRET_RESOLVER[file]?.sites !== count
+      )
+      .map(([file, count]) => `${file} (${count})`);
+    expect(unexpected).toEqual([]);
+  });
+
+  // An entry that no longer describes anything silently widens the audit.
+  it("every recorded omission still omits", () => {
+    const counts = omissionCounts();
+    const stale = Object.keys(OMITS_SECRET_RESOLVER).filter(
+      (rel) => (counts[rel] ?? 0) === 0
+    );
+    expect(stale).toEqual([]);
+  });
+
+  // A walk that matched nothing would pass both assertions above.
+  it("finds the call sites it claims to audit", () => {
+    const sites = auditedSites();
+    expect(sites.length).toBeGreaterThan(10);
+    const files = new Set(sites.map((s) => s.file));
+    // The three hosts with a real secret store, named rather than counted.
+    expect(files).toContain(
+      "packages/websocket/src/unified-websocket-runner.ts"
+    );
+    expect(files).toContain("packages/websocket/src/mcp-agent-tools.ts");
+    expect(files).toContain("packages/cli/src/stdin.ts");
+  });
+
+  // The belt hosts inject through `getAllMcpTools`, which takes a factory
+  // rather than a resolver — a different option the audit above cannot see.
+  it("the server's host deps supply a secret-availability factory", () => {
+    const source = readFileSync(
+      join(repoRoot, "packages/websocket/src/mcp-tool-deps.ts"),
+      "utf8"
+    );
+    expect(source).toContain("secretAvailability: contextSecretAvailability");
+  });
+});

--- a/packages/agents/tests/mcp-tools.test.ts
+++ b/packages/agents/tests/mcp-tools.test.ts
@@ -819,6 +819,128 @@ describe("validate_workflow", () => {
   });
 });
 
+// The credential half. `validate_workflow` reported a graph as clean when the
+// node it names needs a key nobody has set — the same graph `nodetool validate`
+// warns about on a DB target — because nothing on this surface ever asked the
+// store.
+describe("validate_workflow missing credentials", () => {
+  const KEYED = "ns.NeedsKey";
+  const keyedRegistry = {
+    has: (type: string) => type === KEYED,
+    getMetadata: () => ({
+      properties: [],
+      outputs: [],
+      required_settings: ["FAL_API_KEY"]
+    }),
+    validateNode: () => []
+  } as unknown as NodeRegistry;
+
+  const graph = {
+    nodes: [{ id: "n1", type: KEYED, properties: {} }],
+    edges: []
+  };
+
+  /** What the host answers for the keys the graph declares. */
+  function validatorWith(
+    available: string[] | null,
+    extra: CapabilityDeps = {}
+  ): Tool {
+    const deps: CapabilityDeps = {
+      nodeRegistry: keyedRegistry,
+      modelCatalogs: RUNTIME_MODEL_CATALOGS,
+      ...extra
+    };
+    if (available !== null) {
+      deps.availableSecrets = (keys) =>
+        new Set(keys.filter((key) => available.includes(key)));
+    }
+    return capTool("validate_workflow", deps);
+  }
+
+  type Report = {
+    ok: boolean;
+    issues: Array<{ code: string; message: string; nodeId?: string }>;
+  };
+
+  it("warns, naming the key and where to set it", async () => {
+    const result = (await validatorWith([]).process(ctx, { graph })) as Report;
+    const issue = result.issues.find((i) => i.code === "missing_secret");
+    expect(issue?.nodeId).toBe("n1");
+    expect(issue?.message).toContain("FAL_API_KEY");
+    expect(issue?.message).toContain("Settings → Credentials");
+    // A warning informs; it does not refuse the graph.
+    expect(result.ok).toBe(true);
+  });
+
+  it("stays silent once the host resolves the key", async () => {
+    const result = (await validatorWith(["FAL_API_KEY"]).process(ctx, {
+      graph
+    })) as Report;
+    expect(result.issues.some((i) => i.code === "missing_secret")).toBe(false);
+  });
+
+  it("reports nothing when the run carries no resolver", async () => {
+    const result = (await validatorWith(null).process(ctx, {
+      graph
+    })) as Report;
+    expect(result.issues.some((i) => i.code === "missing_secret")).toBe(false);
+    expect(result.ok).toBe(true);
+  });
+
+  it("asks only for the names the graph declares", async () => {
+    const asked: string[][] = [];
+    const tool = capTool("validate_workflow", {
+      nodeRegistry: keyedRegistry,
+      modelCatalogs: RUNTIME_MODEL_CATALOGS,
+      availableSecrets: (keys) => {
+        asked.push([...keys]);
+        return new Set<string>();
+      }
+    });
+    await tool.process(ctx, { graph });
+    expect(asked).toEqual([["FAL_API_KEY"]]);
+  });
+
+  it("does not ask at all when the graph declares nothing", async () => {
+    const asked: string[][] = [];
+    const bareRegistry = {
+      has: () => true,
+      getMetadata: () => ({ properties: [], outputs: [] }),
+      validateNode: () => []
+    } as unknown as NodeRegistry;
+    const tool = capTool("validate_workflow", {
+      nodeRegistry: bareRegistry,
+      modelCatalogs: RUNTIME_MODEL_CATALOGS,
+      availableSecrets: (keys) => {
+        asked.push([...keys]);
+        return new Set<string>();
+      }
+    });
+    await tool.process(ctx, {
+      graph: { nodes: [{ id: "n1", type: "ns.A" }], edges: [] }
+    });
+    expect(asked).toEqual([]);
+  });
+
+  // Pointing a headless agent at `request_secret` sends it at a call that
+  // fails closed, so the mention is gated on the run being able to serve it.
+  it("names request_secret only when the run can raise the dialog", async () => {
+    const withDialog = (await validatorWith([], {
+      secretPrompt: async () => "saved"
+    }).process(ctx, { graph })) as Report;
+    expect(
+      withDialog.issues.find((i) => i.code === "missing_secret")?.message
+    ).toContain("request_secret");
+
+    const headless = (await validatorWith([]).process(ctx, {
+      graph
+    })) as Report;
+    expect(
+      headless.issues.find((i) => i.code === "missing_secret")?.message
+    ).not.toContain("request_secret");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Timeline / Sketch validation
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/stdin.ts
+++ b/packages/cli/src/stdin.ts
@@ -28,6 +28,7 @@ import { applySystemPrompt, createCliCodeActTurn } from "./chat-codeact.js";
 import { createChatContext } from "./chat-context.js";
 import {
   createCapabilityRun,
+  contextSecretAvailability,
   getBuiltinTools,
   toolForCapabilityName,
   UNGATED
@@ -259,6 +260,7 @@ export async function runStdinMode(opts: StdinModeOptions): Promise<void> {
       createCapabilityRun({
         context,
         gate: UNGATED,
+        availableSecrets: contextSecretAvailability(context),
         subAgent: {
           provider: prov,
           model: opts.model,

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -1801,6 +1801,20 @@ export class ProcessingContext {
     );
   }
 
+  /**
+   * Whether this run can reach a secret store at all.
+   *
+   * {@link getSecret} answers `null` both for "no store is wired" and for "the
+   * store does not hold this key", which a caller asking *which* of a list of
+   * credentials exists cannot tell apart — and reporting every declared
+   * credential as missing because no store was reachable is exactly the
+   * false alarm the graph validator's `missing_secret` check refuses to raise.
+   * A host installs the availability callback only when this is true.
+   */
+  get hasSecretResolver(): boolean {
+    return this._secretResolver !== null;
+  }
+
   async getSecret(key: string): Promise<string | null> {
     if (!this._secretResolver) return null;
     const value = await this._secretResolver(key, this.userId);

--- a/packages/websocket/src/mcp-agent-tools.ts
+++ b/packages/websocket/src/mcp-agent-tools.ts
@@ -43,6 +43,7 @@ import {
   toolForCapabilityName,
   UNGATED,
   createCapabilityRun,
+  contextSecretAvailability,
   type CapabilityRun,
   NODETOOL_API_NAMESPACE_TOOLS,
   MCP_GUEST_CONTRACT,
@@ -342,6 +343,7 @@ function collectBridgedTools(
       createCapabilityRun({
         context,
         gate: UNGATED,
+        availableSecrets: contextSecretAvailability(context),
         loaders: { timeline: loadTimelineForUser }
       })
     ),
@@ -351,6 +353,7 @@ function collectBridgedTools(
       createCapabilityRun({
         context,
         gate: UNGATED,
+        availableSecrets: contextSecretAvailability(context),
         loaders: { sketch: loadSketchForUser }
       })
     ),
@@ -369,7 +372,12 @@ function collectBridgedTools(
     ].map((name) => toolForCapabilityName(name)),
     ...["find_model", "list_models"].map((name) =>
       toolForCapabilityName(name, (context) =>
-        createCapabilityRun({ context, gate: UNGATED, providers })
+        createCapabilityRun({
+          context,
+          gate: UNGATED,
+          availableSecrets: contextSecretAvailability(context),
+          providers
+        })
       )
     )
   ];
@@ -643,6 +651,7 @@ export function registerAgentMcpTools(
       sessionAllow: new Set<string>(),
       requestApproval: async () => "allow"
     },
+    availableSecrets: contextSecretAvailability(context),
     nodeRegistry: options.registry,
     ...mcpToolHostDeps({
       registry: options.registry,

--- a/packages/websocket/src/mcp-tool-deps.ts
+++ b/packages/websocket/src/mcp-tool-deps.ts
@@ -11,6 +11,7 @@
  */
 
 import { workflowToDsl } from "@nodetool-ai/dsl";
+import { contextSecretAvailability } from "@nodetool-ai/agents";
 import type {
   ExampleWorkflowCatalog,
   GetAllMcpToolsOptions
@@ -65,10 +66,17 @@ export function mcpToolHostDeps(
   options: HttpApiOptions = {}
 ): Pick<
   GetAllMcpToolsOptions,
-  "examples" | "exportDsl" | "listPackageAssets" | "workflowEnvironment"
+  | "examples"
+  | "exportDsl"
+  | "listPackageAssets"
+  | "workflowEnvironment"
+  | "secretAvailability"
 > {
   return {
     examples: createExampleWorkflowCatalog(options),
+    // This server has a secret store, so `validate_workflow` can tell a
+    // credential nobody set from one it simply could not look up.
+    secretAvailability: contextSecretAvailability,
     exportDsl: (graph, opts) =>
       workflowToDsl(
         graph as Parameters<typeof workflowToDsl>[0],

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -177,6 +177,7 @@ import {
   gateTools,
   capabilityFromTool,
   createCapabilityRun,
+  contextSecretAvailability,
   UNGATED,
   extractInjectableImages,
   PLAN_APPROVAL_CONTEXT_KEY,
@@ -5701,7 +5702,11 @@ export class UnifiedWebSocketRunner {
       clock: codeactClock
     };
     const gatedRun = (context: ProcessingContext): CapabilityRun =>
-      createCapabilityRun({ context, gate: chatGate });
+      createCapabilityRun({
+        context,
+        gate: chatGate,
+        availableSecrets: contextSecretAvailability(context)
+      });
     const rawToolbelt: Tool[] = [
       ...getAgentToolbelt(),
       ...(googleWorkspace ? getGoogleWorkspaceTools() : []),
@@ -5779,6 +5784,7 @@ export class UnifiedWebSocketRunner {
           // Ungated on purpose, as before: spawning a child loop has no side
           // effect of its own, and the child's tools are the gated `baseTools`.
           gate: UNGATED,
+          availableSecrets: contextSecretAvailability(context),
           subAgent: subAgentRuntime
         });
       serverTools.unshift(toolForCapabilityName("run_subtask", delegationRun));
@@ -5886,6 +5892,7 @@ export class UnifiedWebSocketRunner {
     this.chatCapabilityRun = createCapabilityRun({
       context: ctx,
       gate: chatGate,
+      availableSecrets: contextSecretAvailability(ctx),
       nodeRegistry: this.nodeRegistry,
       providers: chatProviders,
       subAgent: subAgentRuntime,


### PR DESCRIPTION
Item 3 of `docs/failure-mode-roadmap.md`.

## The gap

`nodetool validate` warns when a graph's nodes declare a credential this install cannot resolve — but only on a DB-id target, because the store round trip lives in the CLI command. `validate_workflow` never made that call, so the agent surface reported the same graph as clean and an authoring agent could ship a workflow that dies at the first provider call. `validateGraph` already accepted an `availableSecrets` set; nothing on this path filled it.

## What changed

**The run carries the answer.** `CapabilityRun.availableSecrets(keys)` returns which of the declared names resolve. `contextSecretAvailability(context)` builds one — and returns `undefined` for a context with no secret resolver, which is what `ProcessingContext.hasSecretResolver` (new) exists to tell apart: `getSecret` answers `null` both for "no store is wired" and "the store lacks this key", and warning on every declared key because nothing could answer is the false alarm the rest of this validator fails toward silence to avoid.

**`validate_workflow` collects the requirement sites first**, so a host resolves exactly the names the graph declares — one round trip per requirement, not per key it holds. A graph declaring nothing makes no call at all.

**The issue says what to do about it.** It names the key and Settings → Credentials, and adds `request_secret` only where the run can actually raise that dialog. A headless run carries no `secretPrompt` and the call fails closed there, so naming it would send the agent at a dead end.

**Hosts inject per site**: the websocket chat runner, the MCP mount, the CLI chat host, and the graph-authoring belt. Belt hosts inject through `getAllMcpTools({secretAvailability})`, which takes a *factory* over the context rather than a resolver, because the belt is assembled once and every call brings its own `ProcessingContext`; `mcpToolHostDeps()` supplies it for the server and the CLI agent.

## Tests

`packages/agents/tests/mcp-tools.test.ts` — a missing key produces the issue, an available key clears it, an absent callback preserves current output, only the declared names are asked for, a graph declaring nothing asks nothing, and `request_secret` is named only when the run can serve it.

`packages/agents/tests/capability-run-secrets-audit.test.ts` (new) reads the sources: every `createCapabilityRun` call in `packages/*/src` either passes `availableSecrets` or is a recorded omission carrying a reason **and an allowed site count**, so a partly-wired file (`mcp-tools.ts` builds five runs; only the workflow belt validates graphs) cannot absorb one more unnoticed. It also asserts it found the call sites it claims to audit, and names the three real hosts rather than counting them.

Both new checks were inverted once and observed failing:

- disabling the resolver call in `workflows.ts` → 3 of the 6 behavior tests fail (the other 3 are silence assertions, which pass by construction).
- deleting the option from `packages/cli/src/stdin.ts` → `expected [ 'packages/cli/src/stdin.ts (1)' ] to deeply equal []`.

## Verification

```
npm run build:packages                          # 57/57
npm run test --workspace=packages/agents        # 3318 passed
npm run test --workspace=packages/websocket     # 2320 passed
npm run test --workspace=packages/cli           # 631 passed
npm run test --workspace=packages/runtime       # 2886 passed
npm run lint                                    # clean (warnings pre-existing)
nodetool harness gate --base HEAD~1             # 3/3 selfchecks passed
```

`npm run test` (web/electron/mobile) was not run — the diff touches no frontend code and `nodetool affected` names none of those workspaces.

Docs: the `nodetool validate` section of `AGENTS.md` now describes the agent-side warning and points at the audit; the roadmap item moves to Completed work and the remaining items renumber.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gm6EDUG8inpTQ1UAnfmFS6)_