### PR TITLE
feat(execution): run the workflow preflight in ExecutionSession

### DIFF
--- a/docs/failure-mode-roadmap.md
+++ b/docs/failure-mode-roadmap.md
@@ -42,38 +42,7 @@ Acceptance:
 - Production without the enable flag returns 404.
 - `npm run test --workspace=packages/websocket` passes.
 
-## 2. Run workflow preflight in `ExecutionSession`
-
-Status: OPEN.
-
-`runWorkflow` rejects bad models, providers, and credentials before job
-acceptance. `ExecutionSession.create` does not, so `workflows run` can fail
-after upstream work has started.
-
-Implementation:
-
-1. Add optional model catalogs and an optional provider-configuration checker
-   to `ExecutionSessionOptions`. Default both to the runtime implementations
-   used by `runWorkflow`. A custom provider host must supply both.
-2. Select the `ProcessingContext` before bridge connection.
-3. After normalization, call `modelSelectionErrors` and the selected
-   provider-configuration checker.
-4. Resolve secrets with `(key) => context.getSecret(key)`. Do not import the
-   models database into `session.ts`.
-5. Refuse before Python bridge connection and `persistence.onAccepted`.
-6. Add a typed `ExecutionPreflightError` whose issue list is the common refusal
-   contract used by the CLI and service adapters.
-7. Update all hosts enumerated by
-   `execution-session-hydration-audit.test.ts`. Custom-provider hosts must pass
-   their catalogs.
-
-Add `packages/execution/tests/session-preflight.test.ts`. Cover unknown models,
-unregistered providers, missing credentials, default and injected secret
-resolvers, no bridge connection, and no persistence acceptance.
-
-Run `npm run test --workspace=packages/execution -- session-preflight`.
-
-## 3. Include missing secrets in `validate_workflow`
+## 2. Include missing secrets in `validate_workflow`
 
 Status: OPEN.
 
@@ -97,7 +66,7 @@ Tests must show that a missing key produces an issue, an available key clears
 it, and an absent callback preserves current output. Run
 `npm run test --workspace=packages/agents -- workflows`.
 
-## 4. Make media resolution the browser rendering boundary
+## 3. Make media resolution the browser rendering boundary
 
 Status: OPEN. Follow-up to #4873, #4929, #5028, #5078, #5122, and #5123.
 
@@ -122,7 +91,7 @@ Acceptance: upload -> graph input -> render works for image, video, and audio;
 the primitives cover stored locators and HTTPS URLs; the lint fixture proves
 the rule can fail.
 
-## 5. Preserve provider behavior through decorators
+## 4. Preserve provider behavior through decorators
 
 Status: OPEN. Issue #5109.
 
@@ -145,7 +114,7 @@ method-existence test cannot detect this.
 The current implementation must fail the new test before the fix. Then run
 `npm run test --workspace=packages/runtime -- provider-decorator-inertness`.
 
-## 6. Detect generated provider metadata drift
+## 5. Detect generated provider metadata drift
 
 Status: OPEN.
 
@@ -163,7 +132,7 @@ Status: OPEN.
    non-zero exit, and restoring it.
 6. Confirm that two consecutive fixture-mode runs are byte-stable.
 
-## 7. Add live provider contract probes
+## 6. Add live provider contract probes
 
 Status: OPEN. This is separate from cassette replay.
 
@@ -186,7 +155,7 @@ Acceptance: removing a field from a raw response fixture fails its decoder
 test; a changed live shape fails the nightly probe; retained artifacts contain
 no secrets or signed URLs.
 
-## 8. Require an eval case for each agent capability
+## 7. Require an eval case for each agent capability
 
 Status: OPEN. Evidence: #5095, #5100, #5103, #5105, and #5107.
 
@@ -208,7 +177,7 @@ Status: OPEN. Evidence: #5095, #5100, #5103, #5105, and #5107.
 Tests must cover a capability-only failure, a capability-plus-eval pass, an
 unregistered-file failure, and a non-agent surface that needs no eval.
 
-## 9. Inventory and consolidate SSRF screening
+## 8. Inventory and consolidate SSRF screening
 
 Status: OPEN. Evidence: #5101.
 
@@ -232,7 +201,7 @@ Tests must reject alternate IPv4 forms, IPv4-mapped IPv6, loopback, private
 networks, metadata addresses, and redirects to blocked addresses. Run
 `npm run test --workspace=packages/runtime -- safe-url`.
 
-## 10. Add property tests to seven pure helpers
+## 9. Add property tests to seven pure helpers
 
 Status: OPEN. Use one PR per row. Before adding `fast-check`, record why the
 current dependencies and table-driven tests are insufficient, check its latest
@@ -258,11 +227,11 @@ and stable source order as the tie-breaker for duplicate indexes in #5116.
 Split #4909 into one execution normalization property and one node-sdk
 validation property.
 
-## 11. Complete editor input-path coverage
+## 10. Complete editor input-path coverage
 
 Status: OPEN. Use three separate PRs.
 
-### 11A. Shortcut action mapping
+### 10A. Shortcut action mapping
 
 `web/src/config/shortcuts.ts` already owns shortcuts and rejects duplicate
 slugs. Add a typed action ID used by menus and handlers. Test missing actions,
@@ -270,7 +239,7 @@ duplicate normalized combinations within the same active editor context and
 OS, Electron-only actions in web menus, and the command-menu shortcut on
 Windows and macOS. Duplicate combinations in disjoint contexts remain valid.
 
-### 11B. Canvas drop journeys
+### 10B. Canvas drop journeys
 
 Add web Playwright journeys for file drop, node creation from a dropped
 connection at the cursor, and run-selected with multiple nodes. Use
@@ -279,7 +248,7 @@ Electron Playwright dependency, config, script, packaged-app fixture, and
 Windows CI job. Update `AGENTS.md` and Electron testing docs with the command.
 Run the case on Windows; a Windows-style string on macOS is not sufficient.
 
-### 11C. Dialog containment audit
+### 10C. Dialog containment audit
 
 `PositionedDialog` already clamps to the viewport. Enumerate other dialog
 primitives and direct users in a checked-in audit with a non-zero count. A
@@ -291,6 +260,13 @@ add one 600 x 600 px test per migrated primitive.
 
 - **Workflow credential preflight:** shipped 2026-08-22 in node-sdk,
   execution, and CLI. The two execution credential suites cover it.
+- **`ExecutionSession` preflight:** shipped 2026-08-22. The model and
+  credential checks moved to `packages/execution/src/preflight.ts` (no models
+  import), `ExecutionSession.create` selects its context and refuses through
+  `ExecutionPreflightError` before the Python bridge and
+  `persistence.onAccepted`, and `runWorkflow` refuses through the same
+  contract. `session-preflight.test.ts` covers both directions;
+  `execution-session-hydration-audit.test.ts` audits every host.
 - **Production Python opt-in:**
   `NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION=1` is implemented in
   `python-stdio-bridge.ts` and documented in `docs/configuration.md`.

--- a/examples/workflows/inputs_model_selectors_cli.json
+++ b/examples/workflows/inputs_model_selectors_cli.json
@@ -35,8 +35,8 @@
           "value": {
             "type": "video_model",
             "provider": "fal_ai",
-            "id": "fal-ai/kling-video",
-            "name": "Kling"
+            "id": "fal-ai/kling-video/v3/standard/text-to-video",
+            "name": "Kling v3"
           }
         }
       },

--- a/packages/agents/src/execute-agent-graph.ts
+++ b/packages/agents/src/execute-agent-graph.ts
@@ -158,14 +158,23 @@ export async function* executeAgentGraph(
   // registry. `resolveNodeType` is what also resolves `propertyTypes`, without
   // which every `list[...]` handle reads as non-list — see
   // packages/execution/tests/execution-session-hydration-audit.test.ts.
-  const session = await ExecutionSession.create({
-    graph: toRawGraphInput(resolvedGraph),
-    registry,
-    resolveNodeType: createGraphNodeTypeResolver(registry).resolveNodeType,
-    context: runContext,
-    params: opts.inputs ?? {},
-    captureMessages: true
-  });
+  // A refusal from `create()` (unknown model, unregistered provider, missing
+  // credential) is the caller's to report; the forwarding listener is this
+  // function's to remove before it propagates.
+  let session: ExecutionSession;
+  try {
+    session = await ExecutionSession.create({
+      graph: toRawGraphInput(resolvedGraph),
+      registry,
+      resolveNodeType: createGraphNodeTypeResolver(registry).resolveNodeType,
+      context: runContext,
+      params: opts.inputs ?? {},
+      captureMessages: true
+    });
+  } catch (err) {
+    removeListener();
+    throw err;
+  }
 
   // An outer abort must stop the kernel run itself — without this the graph
   // keeps executing (and burning provider calls) until it finishes on its

--- a/packages/agents/src/workflow-agent.ts
+++ b/packages/agents/src/workflow-agent.ts
@@ -125,7 +125,17 @@ export async function* runWorkflowAsAgent(
     captureMessages: true
   };
   if (supervisor) sessionOptions.supervisor = supervisor;
-  const session = await ExecutionSession.create(sessionOptions);
+  // `create()` refuses a graph this runtime cannot honour (unknown model,
+  // unregistered provider, missing credential) before the kernel starts. The
+  // refusal is the caller's to report, but the forwarding listener is this
+  // function's to remove — otherwise a refused run leaves one attached.
+  let session: ExecutionSession;
+  try {
+    session = await ExecutionSession.create(sessionOptions);
+  } catch (err) {
+    removeListener();
+    throw err;
+  }
 
   const onAbort = (): void => session.cancel("cancelled");
   if (signal?.aborted) session.cancel("cancelled");

--- a/packages/base-nodes/tests/input-and-data-examples-run.test.ts
+++ b/packages/base-nodes/tests/input-and-data-examples-run.test.ts
@@ -52,7 +52,14 @@ async function execute(
     registry,
     resolveNodeType: createGraphNodeTypeResolver(registry).resolveNodeType,
     jobId: `input-example-${file}`,
-    params
+    params,
+    // These examples carry model references but never call a provider — the
+    // model-selector nodes pass the reference through as a value. The run
+    // preflight cannot tell that apart from a node about to spend money, so
+    // it would demand ANTHROPIC_API_KEY/FAL_API_KEY/OPENAI_API_KEY for a
+    // suite that contacts nothing. Declaring "no provider configuration
+    // required" states here what this file's header already claims.
+    providerConfiguration: () => []
   } as never);
   const result = await session.result;
   return {
@@ -200,8 +207,8 @@ describe("inputs_model_selectors_cli", () => {
       {
         type: "video_model",
         provider: "fal_ai",
-        id: "fal-ai/kling-video",
-        name: "Kling"
+        id: "fal-ai/kling-video/v3/standard/text-to-video",
+        name: "Kling v3"
       }
     ]);
     expect(out["asr"]).toEqual([

--- a/packages/cli/src/debug/server-runner.ts
+++ b/packages/cli/src/debug/server-runner.ts
@@ -9,7 +9,10 @@
  */
 import { getDefaultAssetsPath } from "@nodetool-ai/config";
 import { getSecret } from "@nodetool-ai/models";
-import { ExecutionSession } from "@nodetool-ai/execution";
+import {
+  ExecutionSession,
+  isExecutionPreflightError
+} from "@nodetool-ai/execution";
 import type { ProcessingMessage } from "@nodetool-ai/protocol";
 import { ProcessingContext, FileStorageAdapter } from "@nodetool-ai/runtime";
 import { summarizeInterventions } from "@nodetool-ai/execution/debug";
@@ -106,7 +109,32 @@ export async function runOnServer(
     sessionOptions.supervisor = supervisor.handle;
     sessionOptions.captureMessages = true;
   }
-  const session = await ExecutionSession.create(sessionOptions);
+  // A run this runtime cannot honour (unknown model, unregistered provider,
+  // missing credential) is refused by `create()` before the kernel starts.
+  // The harness's job is to report why a run did not happen, so the refusal
+  // becomes a failed report rather than a thrown stack.
+  let session: ExecutionSession;
+  try {
+    session = await ExecutionSession.create(sessionOptions);
+  } catch (err) {
+    if (!isExecutionPreflightError(err)) throw err;
+    supervisor?.handle.close();
+    const summary = collectExecutionSummary([]);
+    summary.status = "failed";
+    summary.error = err.message;
+    return {
+      report: {
+        surface: "server",
+        ok: false,
+        status: "failed",
+        error: err.message,
+        durationMs: Date.now() - startedAt,
+        summary,
+        trace: null
+      },
+      rawMessages: []
+    };
+  }
 
   const interventionLines = supervisor
     ? streamInterventionLines(

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -41,6 +41,7 @@ import { installLocalModelInterfaces } from "./local-model-interfaces.js";
 import { getDefaultDbPath, getDefaultAssetsPath } from "@nodetool-ai/config";
 import {
   ExecutionSession,
+  isExecutionPreflightError,
   type RawGraphInput
 } from "@nodetool-ai/execution";
 import {
@@ -305,6 +306,15 @@ function asJson(data: unknown): void {
 // installing them before `setupDb()` is safe.
 await installLocalModelInterfaces();
 
+/**
+ * What to print when a run command fails. A preflight refusal already reads as
+ * a complete explanation — printing the error class in front of it only buries
+ * the secret name the user has to go set.
+ */
+function describeRunFailure(error: unknown): string {
+  return isExecutionPreflightError(error) ? error.message : String(error);
+}
+
 // ---------------------------------------------------------------------------
 // info
 // ---------------------------------------------------------------------------
@@ -419,7 +429,7 @@ addSupervisorOptions(
         }
       }
     } catch (e) {
-      console.error(String(e));
+      console.error(describeRunFailure(e));
       process.exit(1);
     }
   }
@@ -888,7 +898,7 @@ addSupervisorOptions(
 
       process.exit(result.status === "completed" ? 0 : 1);
     } catch (e) {
-      console.error(String(e));
+      console.error(describeRunFailure(e));
       process.exit(1);
     }
   }

--- a/packages/execution/README.md
+++ b/packages/execution/README.md
@@ -82,6 +82,7 @@ const session = await ExecutionSession.create({
   limits: { runTimeoutMs, bufferLimit },  // nodeTimeoutMs: not yet supported, see above
   requireTerminalResult: true,  // optional — output-name rewriting
   captureMessages: true,        // optional — required to read `messages` below
+  catalogs, providerConfiguration,  // optional — preflight, see below
 });
 
 // Only with `captureMessages: true`, and only if you actually drain it:
@@ -98,6 +99,16 @@ session.cancel("reason");     // the ONLY cancel; limits.runTimeoutMs = cancel("
 
 const result = await session.result;  // RunResult — never rejects
 ```
+
+`create()` refuses before it spends anything. After normalization — and ahead
+of the Python bridge, `persistence.onAccepted`, and the kernel — it checks the
+graph's model selections against the provider catalogs and each selected
+provider's credentials against `context.getSecret`, and throws
+`ExecutionPreflightError` (`.issues` is the machine-readable list, `.message`
+the text a host prints). Without it a missing key failed at the node that
+needed it, after the upstream half of the graph had already run and billed.
+`catalogs` and `providerConfiguration` default to the process-wide provider
+registry; a host whose providers are not in that registry must pass both.
 
 Inside the facade: `hydrateGraphNodeFlags` (plus the graph normalization
 `headless-job-runner.ts` used to do inline — editor-only pruning, `data` →

--- a/packages/execution/src/index.ts
+++ b/packages/execution/src/index.ts
@@ -3,6 +3,25 @@
  */
 export { ExecutionSession } from "./session.js";
 export { normalizeGraph, toRawGraphInput } from "./normalize-graph.js";
+export {
+  assertPreflight,
+  collectPreflightIssues,
+  ExecutionPreflightError,
+  formatPreflightDetail,
+  isExecutionPreflightError,
+  modelSelectionErrors,
+  providerConfigurationChecker,
+  unconfiguredProviderErrors,
+  RUNTIME_CATALOGS
+} from "./preflight.js";
+export type {
+  CredentialResolver,
+  ExecutionPreflightIssue,
+  PreflightIssueKind,
+  PreflightOptions,
+  ProviderConfigurationChecker,
+  RunModelCatalogs
+} from "./preflight.js";
 export { DEFAULT_MESSAGE_BUFFER_LIMIT } from "./message-stream.js";
 export {
   INTERVENTION_MARK,

--- a/packages/execution/src/preflight.ts
+++ b/packages/execution/src/preflight.ts
@@ -1,0 +1,227 @@
+/**
+ * Run preflight — the checks that must refuse a graph *before* anything is
+ * paid for.
+ *
+ * A graph that names a provider this runtime does not have, or a model that
+ * provider does not offer, or a credential nobody stored, fails at the node
+ * that needs it — after the upstream half of the graph has already run and
+ * billed. Both checks front-run that failure, and both live here (rather than
+ * in the run service) so `ExecutionSession` can call them without importing
+ * the models database.
+ *
+ * Both fail toward silence: an empty provider registry means the registry
+ * could not be reached, and an unregistered provider id is left to the
+ * model-selection check rather than guessed at.
+ */
+import { rewriteBypassedNodes } from "@nodetool-ai/kernel";
+import {
+  collectModelProviders,
+  collectModelSelectionIssues
+} from "@nodetool-ai/node-sdk";
+import {
+  getProviderSecretKey,
+  isProviderConfigured,
+  listOfflineModelIds,
+  listRegisteredProviderIds
+} from "@nodetool-ai/runtime";
+import { normalizeGraph } from "./normalize-graph.js";
+import { isRecord } from "./predicates.js";
+
+/** Provider/model catalogs the preflight checks a graph's selections against. */
+export interface RunModelCatalogs {
+  listProviderIds: () => readonly string[];
+  listModelIds: (
+    provider: string,
+    modelType: string
+  ) => readonly string[] | undefined;
+}
+
+/** The catalogs of the process-wide provider registry. */
+export const RUNTIME_CATALOGS: RunModelCatalogs = {
+  listProviderIds: () => listRegisteredProviderIds(),
+  listModelIds: (provider, modelType) =>
+    listOfflineModelIds(provider, modelType)
+};
+
+/** Model selections in a graph that no configured provider can honour. */
+export function modelSelectionErrors(
+  graph: { nodes?: unknown },
+  catalogs: RunModelCatalogs = RUNTIME_CATALOGS
+): string[] {
+  const nodes = graph.nodes;
+  if (!Array.isArray(nodes)) return [];
+  return collectModelSelectionIssues({ nodes: nodes as never[] }, catalogs)
+    .filter((issue) => issue.severity === "error")
+    .map(
+      (issue) => `Node "${issue.nodeId}" (${issue.nodeType}): ${issue.message}`
+    );
+}
+
+/** How the preflight resolves a credential — the way the coming run will. */
+export interface CredentialResolver {
+  resolveSecret: (
+    key: string
+  ) => Promise<string | null | undefined> | string | null | undefined;
+}
+
+/**
+ * Providers a graph selects whose required credentials this runtime cannot
+ * resolve, one message each.
+ *
+ * The provider registry knows exactly which kwargs are load-bearing (an empty
+ * declaration means "resolve from store, then env"), and a provider built
+ * without one throws the `*_API_KEY is required` error mid-run that this check
+ * exists to front-run. Unregistered ids are skipped: the model-selection check
+ * already reports those as errors, and guessing at an unknown provider's
+ * credentials would be noise.
+ */
+export async function unconfiguredProviderErrors(
+  graph: { nodes?: unknown; edges?: unknown },
+  resolver: CredentialResolver,
+  providerIds: readonly string[] = listRegisteredProviderIds()
+): Promise<string[]> {
+  const nodes = graph.nodes;
+  if (!Array.isArray(nodes)) return [];
+  const graphNodes = nodes.filter(isRecord);
+  const graphEdges = Array.isArray(graph.edges)
+    ? graph.edges.filter(isRecord)
+    : [];
+  const effectiveGraph = rewriteBypassedNodes(
+    normalizeGraph({ nodes: graphNodes, edges: graphEdges })
+  );
+  const known = new Set(providerIds);
+  const errors: string[] = [];
+  for (const provider of collectModelProviders({
+    nodes: effectiveGraph.nodes,
+    edges: effectiveGraph.edges
+  })) {
+    if (!known.has(provider)) continue;
+    if (
+      await isProviderConfigured(provider, (key) => resolver.resolveSecret(key))
+    ) {
+      continue;
+    }
+    const keyName = getProviderSecretKey(provider);
+    errors.push(
+      keyName
+        ? `Provider "${provider}" needs "${keyName}", which is not set on ` +
+            "this server. Store the secret " +
+            `"${keyName}" for this user (Settings → Credentials), or switch ` +
+            "the model to a provider you have configured."
+        : `Provider "${provider}" is missing its required configuration ` +
+            "(base URL or credential) on this server. Complete it in " +
+            "Settings → Providers before running."
+    );
+  }
+  return errors;
+}
+
+/**
+ * How the preflight decides whether a provider a graph selects is configured.
+ *
+ * Defaults to {@link unconfiguredProviderErrors} over the process-wide
+ * provider registry. A host whose providers are not in that registry (a
+ * cassette, a fake, an in-process custom provider) supplies its own — together
+ * with its own {@link RunModelCatalogs}, since the two checks read the same
+ * registry.
+ */
+export type ProviderConfigurationChecker = (
+  graph: { nodes?: unknown; edges?: unknown },
+  resolver: CredentialResolver
+) => Promise<readonly string[]> | readonly string[];
+
+/** A checker over an explicit provider list, for a host with its own registry. */
+export function providerConfigurationChecker(
+  providerIds: readonly string[]
+): ProviderConfigurationChecker {
+  return (graph, resolver) =>
+    unconfiguredProviderErrors(graph, resolver, providerIds);
+}
+
+export type PreflightIssueKind = "model" | "credential";
+
+/** One reason a run was refused before it started. */
+export interface ExecutionPreflightIssue {
+  kind: PreflightIssueKind;
+  message: string;
+}
+
+const HEADINGS = {
+  model: "Workflow selects providers or models this runtime cannot honour:",
+  credential: "Workflow selects providers whose credentials are not configured:"
+} satisfies Record<PreflightIssueKind, string>;
+
+/** The refusal text every host prints — one section per issue kind. */
+export function formatPreflightDetail(
+  issues: readonly ExecutionPreflightIssue[]
+): string {
+  const sections: string[] = [];
+  for (const kind of ["model", "credential"] as const) {
+    const messages = issues
+      .filter((issue) => issue.kind === kind)
+      .map((issue) => issue.message);
+    if (messages.length > 0) {
+      sections.push(`${HEADINGS[kind]}\n${messages.join("\n")}`);
+    }
+  }
+  return sections.join("\n\n");
+}
+
+/**
+ * The refusal contract shared by `ExecutionSession`, the run service, and the
+ * CLI adapters: a typed error whose `issues` are machine-readable and whose
+ * `message` is the text a host prints verbatim.
+ */
+export class ExecutionPreflightError extends Error {
+  override readonly name = "ExecutionPreflightError";
+  readonly issues: readonly ExecutionPreflightIssue[];
+
+  constructor(issues: readonly ExecutionPreflightIssue[]) {
+    super(formatPreflightDetail(issues));
+    this.issues = issues;
+  }
+}
+
+export function isExecutionPreflightError(
+  value: unknown
+): value is ExecutionPreflightError {
+  return value instanceof ExecutionPreflightError;
+}
+
+export interface PreflightOptions {
+  catalogs?: RunModelCatalogs;
+  providerConfiguration?: ProviderConfigurationChecker;
+  /** Resolves a credential the way the coming run will. */
+  resolveSecret: CredentialResolver["resolveSecret"];
+}
+
+/**
+ * Every reason to refuse `graph`, model selections first.
+ *
+ * A graph whose model selections are already unhonourable stops there: a
+ * provider that is not registered has no credentials to check, so running the
+ * second check would only add noise to a refusal that is already decided.
+ */
+export async function collectPreflightIssues(
+  graph: { nodes?: unknown; edges?: unknown },
+  options: PreflightOptions
+): Promise<ExecutionPreflightIssue[]> {
+  const models = modelSelectionErrors(graph, options.catalogs);
+  if (models.length > 0) {
+    return models.map((message) => ({ kind: "model", message }));
+  }
+  const checker = options.providerConfiguration ?? unconfiguredProviderErrors;
+  const credentials = await checker(graph, {
+    resolveSecret: options.resolveSecret
+  });
+  return credentials.map((message) => ({ kind: "credential", message }));
+}
+
+/** {@link collectPreflightIssues}, as a refusal. */
+export async function assertPreflight(
+  graph: { nodes?: unknown; edges?: unknown },
+  options: PreflightOptions
+): Promise<void> {
+  const issues = await collectPreflightIssues(graph, options);
+  if (issues.length > 0) throw new ExecutionPreflightError(issues);
+}

--- a/packages/execution/src/service/app-run-server.ts
+++ b/packages/execution/src/service/app-run-server.ts
@@ -15,6 +15,7 @@
 import { randomUUID } from "node:crypto";
 import { getDefaultAssetsPath } from "@nodetool-ai/config";
 import { ExecutionSession } from "../session.js";
+import { isExecutionPreflightError } from "../preflight.js";
 import { collectExecutionSummary } from "../debug/collector.js";
 import type {
   AppServerRunInput,
@@ -67,7 +68,30 @@ export function createAppServerRunner(
     if (input.timeoutMs !== undefined) {
       sessionOptions.limits = { runTimeoutMs: input.timeoutMs };
     }
-    const session = await ExecutionSession.create(sessionOptions);
+    // A graph this runtime cannot honour is refused before the kernel starts.
+    // The simulator's contract is a report, so a refusal becomes a failed run
+    // it can complain about — not a throw out of the simulation.
+    let session: ExecutionSession;
+    try {
+      session = await ExecutionSession.create(sessionOptions);
+    } catch (err) {
+      if (!isExecutionPreflightError(err)) throw err;
+      const summary = collectExecutionSummary([]);
+      summary.status = "failed";
+      summary.error = err.message;
+      return {
+        report: {
+          surface: "server",
+          ok: false,
+          status: "failed",
+          error: err.message,
+          durationMs: Date.now() - startedAt,
+          summary,
+          trace: null
+        },
+        rawMessages: []
+      };
+    }
     // `session.result` never rejects: a kernel failure resolves as
     // `status: "failed"`, which the simulator turns into a complaint.
     const result = await session.result;

--- a/packages/execution/src/service/workflow-run.ts
+++ b/packages/execution/src/service/workflow-run.ts
@@ -13,29 +13,24 @@
  */
 
 import { createLogger } from "@nodetool-ai/config";
-import {
-  BoundedHandle,
-  rewriteBypassedNodes,
-  WorkflowRunner
-} from "@nodetool-ai/kernel";
+import { BoundedHandle, WorkflowRunner } from "@nodetool-ai/kernel";
 import { Job, Workflow, getSecret } from "@nodetool-ai/models";
 import {
-  collectModelProviders,
-  collectModelSelectionIssues,
   hydrateGraphNodeFlags,
   type NodeRegistry
 } from "@nodetool-ai/node-sdk";
-import {
-  getProviderSecretKey,
-  isProviderConfigured,
-  listOfflineModelIds,
-  listRegisteredProviderIds,
-  type NodeExecutor,
-  type ProcessingContext,
-  type StorageAdapter,
-  type Workspace
+import type {
+  NodeExecutor,
+  ProcessingContext,
+  StorageAdapter,
+  Workspace
 } from "@nodetool-ai/runtime";
 import { normalizeGraph } from "../normalize-graph.js";
+import {
+  collectPreflightIssues,
+  formatPreflightDetail,
+  type RunModelCatalogs
+} from "../preflight.js";
 import { collectExecutionSummary } from "../debug/collector.js";
 import type { ExecutionSummary } from "../debug/types.js";
 import {
@@ -54,12 +49,22 @@ import {
   buildWorkspaceExecutionContext,
   resolveWorkflowWorkspace
 } from "./workflow-workspace.js";
-import {
-  isFunctionValue,
-  isNumber,
-  isRecord,
-  isString
-} from "../predicates.js";
+import { isFunctionValue, isNumber, isString } from "../predicates.js";
+
+// The preflight moved to `../preflight.ts` so `ExecutionSession` can run the
+// same checks without importing the models database. Re-exported here because
+// this module is where every host already reaches for them.
+export {
+  modelSelectionErrors,
+  unconfiguredProviderErrors,
+  formatPreflightDetail,
+  ExecutionPreflightError
+} from "../preflight.js";
+export type {
+  CredentialResolver,
+  ExecutionPreflightIssue,
+  RunModelCatalogs
+} from "../preflight.js";
 
 const log = createLogger("nodetool.execution.workflow-run");
 
@@ -93,21 +98,6 @@ export interface WorkflowRunEnvironment {
   assetStorage?: StorageAdapter | null;
   storage?: StorageAdapter | null;
 }
-
-/** Provider/model catalogs the pre-flight checks a graph's selections against. */
-export interface RunModelCatalogs {
-  listProviderIds: () => readonly string[];
-  listModelIds: (
-    provider: string,
-    modelType: string
-  ) => readonly string[] | undefined;
-}
-
-const RUNTIME_CATALOGS: RunModelCatalogs = {
-  listProviderIds: () => listRegisteredProviderIds(),
-  listModelIds: (provider, modelType) =>
-    listOfflineModelIds(provider, modelType)
-};
 
 export interface RunWorkflowOptions {
   workflowId: string;
@@ -181,79 +171,6 @@ export function boundedRunOption(
     return undefined;
   }
   return Math.min(value, max);
-}
-
-/** Model selections in a graph that no configured provider can honour. */
-export function modelSelectionErrors(
-  graph: { nodes?: unknown },
-  catalogs: RunModelCatalogs = RUNTIME_CATALOGS
-): string[] {
-  const nodes = graph.nodes;
-  if (!Array.isArray(nodes)) return [];
-  return collectModelSelectionIssues({ nodes: nodes as never[] }, catalogs)
-    .filter((issue) => issue.severity === "error")
-    .map(
-      (issue) => `Node "${issue.nodeId}" (${issue.nodeType}): ${issue.message}`
-    );
-}
-
-/** How the preflight resolves a credential — the way the coming run will. */
-export interface CredentialResolver {
-  resolveSecret: (
-    key: string
-  ) => Promise<string | null | undefined> | string | null | undefined;
-}
-
-/**
- * Providers a graph selects whose required credentials this runtime cannot
- * resolve, one message each.
- *
- * The provider registry knows exactly which kwargs are load-bearing (an empty
- * declaration means "resolve from store, then env"), and a provider built
- * without one throws the `*_API_KEY is required` error mid-run that this check
- * exists to front-run. Unregistered ids are skipped: the model-selection check
- * already reports those as errors, and guessing at an unknown provider's
- * credentials would be noise.
- */
-export async function unconfiguredProviderErrors(
-  graph: { nodes?: unknown; edges?: unknown },
-  resolver: CredentialResolver,
-  providerIds: readonly string[] = listRegisteredProviderIds()
-): Promise<string[]> {
-  const nodes = graph.nodes;
-  if (!Array.isArray(nodes)) return [];
-  const graphNodes = nodes.filter(isRecord);
-  const graphEdges = Array.isArray(graph.edges)
-    ? graph.edges.filter(isRecord)
-    : [];
-  const effectiveGraph = rewriteBypassedNodes(
-    normalizeGraph({ nodes: graphNodes, edges: graphEdges })
-  );
-  const known = new Set(providerIds);
-  const errors: string[] = [];
-  for (const provider of collectModelProviders({
-    nodes: effectiveGraph.nodes,
-    edges: effectiveGraph.edges
-  })) {
-    if (!known.has(provider)) continue;
-    if (
-      await isProviderConfigured(provider, (key) => resolver.resolveSecret(key))
-    ) {
-      continue;
-    }
-    const keyName = getProviderSecretKey(provider);
-    errors.push(
-      keyName
-        ? `Provider "${provider}" needs "${keyName}", which is not set on ` +
-            "this server. Store the secret " +
-            `"${keyName}" for this user (Settings → Credentials), or switch ` +
-            "the model to a provider you have configured."
-        : `Provider "${provider}" is missing its required configuration ` +
-            "(base URL or credential) on this server. Complete it in " +
-            "Settings → Providers before running."
-    );
-  }
-  return errors;
 }
 
 /** Mark a job failed and persist it, best effort. */
@@ -493,26 +410,19 @@ export async function runWorkflow(
   // legacy `type`.
   const runnableGraph = normalizeGraph(workflow.getGraph());
 
-  const badModels = modelSelectionErrors(runnableGraph, options.catalogs);
-  if (badModels.length > 0) {
-    return {
-      kind: "error",
-      status: 400,
-      detail: `Workflow selects providers or models this runtime cannot honour:\n${badModels.join("\n")}`
-    };
-  }
-
-  // Same gate, one layer down: a provider that would construct without its
-  // key fails mid-run today, after the upstream half of the graph is paid
-  // for. Refuse here, before the job row exists, and name the secret.
-  const badCredentials = await unconfiguredProviderErrors(runnableGraph, {
+  // The same refusal `ExecutionSession` raises, one layer up: a provider that
+  // would construct without its key fails mid-run today, after the upstream
+  // half of the graph is paid for. Refuse here, before the job row exists,
+  // and name the secret.
+  const preflightIssues = await collectPreflightIssues(runnableGraph, {
+    catalogs: options.catalogs,
     resolveSecret: (key) => getSecret(key, userId)
   });
-  if (badCredentials.length > 0) {
+  if (preflightIssues.length > 0) {
     return {
       kind: "error",
       status: 400,
-      detail: `Workflow selects providers whose credentials are not configured:\n${badCredentials.join("\n")}`
+      detail: formatPreflightDetail(preflightIssues)
     };
   }
 

--- a/packages/execution/src/session.ts
+++ b/packages/execution/src/session.ts
@@ -26,6 +26,7 @@ import type {
 import { createExecutorResolver } from "./executor-resolver.js";
 import { buildWorkspaceExecutionContext } from "./service/workflow-workspace.js";
 import { normalizeGraph } from "./normalize-graph.js";
+import { assertPreflight } from "./preflight.js";
 import { rewriteOutputNames } from "./output-names.js";
 import { MessageStream } from "./message-stream.js";
 import type { ExecutionSessionOptions } from "./types.js";
@@ -184,6 +185,32 @@ export class ExecutionSession {
 
     const normalized = normalizeGraph(options.graph);
 
+    // A caller that brings no context still gets one that can reach the
+    // secret store. The bare `new ProcessingContext(...)` this replaced
+    // resolved no secret at all, so a graph with a provider node failed on
+    // credentials the install had — the same defect the service-layer run
+    // path shipped with. Selected here, ahead of the bridge, because the
+    // preflight below resolves credentials through it.
+    const context =
+      options.context ??
+      buildWorkspaceExecutionContext({
+        jobId,
+        workflowId,
+        userId: "1",
+        workspace: null
+      });
+
+    // Refuse a graph this runtime cannot honour before anything is paid for:
+    // ahead of the Python bridge (a worker spawn), ahead of
+    // `persistence.onAccepted` (a job row), and ahead of the kernel. Without
+    // this, a bad model id or a missing key failed at the node that needed it
+    // — after the upstream half of the graph had already run and billed.
+    await assertPreflight(normalized, {
+      catalogs: options.catalogs,
+      providerConfiguration: options.providerConfiguration,
+      resolveSecret: (key) => context.getSecret(key)
+    });
+
     // A caller injecting its own `resolveExecutor` (see the option doc)
     // typically also owns its own Python bridge — never connect a second one
     // behind its back. `bridgeFactory` remains available for that caller to
@@ -236,20 +263,6 @@ export class ExecutionSession {
     if (options.requireTerminalResult) {
       rewriteOutputNames(hydrated);
     }
-
-    // A caller that brings no context still gets one that can reach the
-    // secret store. The bare `new ProcessingContext(...)` this replaced
-    // resolved no secret at all, so a graph with a provider node failed on
-    // credentials the install had — the same defect the service-layer run
-    // path shipped with.
-    const context =
-      options.context ??
-      buildWorkspaceExecutionContext({
-        jobId,
-        workflowId,
-        userId: "1",
-        workspace: null
-      });
 
     const resolveExecutor =
       options.resolveExecutor ?? createExecutorResolver(registry!, bridge);

--- a/packages/execution/src/types.ts
+++ b/packages/execution/src/types.ts
@@ -16,6 +16,10 @@ import type {
 } from "@nodetool-ai/kernel";
 import type { NodeRegistry } from "@nodetool-ai/node-sdk";
 import type {
+  ProviderConfigurationChecker,
+  RunModelCatalogs
+} from "./preflight.js";
+import type {
   PythonBridgeBase,
   ProcessingContext,
   PythonJobLifecycle
@@ -182,6 +186,22 @@ export interface ExecutionSessionOptions {
    * surface and the one place strict mode is meant to be on by default.
    */
   strict?: boolean;
+  /**
+   * Provider/model catalogs the run preflight checks the graph's selections
+   * against. Defaults to the process-wide provider registry — the same
+   * catalogs `runWorkflow` uses.
+   */
+  catalogs?: RunModelCatalogs;
+  /**
+   * How the preflight decides a selected provider is configured. Defaults to
+   * `unconfiguredProviderErrors` over the process-wide provider registry.
+   *
+   * A host whose providers are not in that registry (a cassette, a fake, an
+   * in-process custom provider) must supply this **and** `catalogs`: the two
+   * checks read the same registry, so replacing one and not the other refuses
+   * a graph the host can in fact run.
+   */
+  providerConfiguration?: ProviderConfigurationChecker;
   /**
    * Capture every emitted message into `session.messages` (default `false`).
    * Off by default because capture is retention: the queue holds each message

--- a/packages/execution/tests/execution-session-hydration-audit.test.ts
+++ b/packages/execution/tests/execution-session-hydration-audit.test.ts
@@ -88,6 +88,59 @@ const KNOWN_UNHYDRATED: Record<string, string> = {
     "app bindings resolve outputs by the un-hydrated key"
 };
 
+/**
+ * Hosts that let an `ExecutionPreflightError` propagate instead of handling
+ * it, with where it is answered. An entry here is a decision, not an
+ * exemption: it says the refusal reaches a user through someone else's
+ * reporting, and names who.
+ */
+const PREFLIGHT_PROPAGATORS: Record<string, string> = {
+  // Called only from `nodetool run --supervise`, whose catch prints the
+  // refusal through `describeRunFailure`.
+  "packages/cli/src/run-dsl-supervised.ts":
+    "propagates to the `nodetool run` command's own reporting",
+  // A refused graph is a failed eval case; the harness records the throw as
+  // that case's error, which is exactly what a graph the runtime cannot
+  // honour should score.
+  "packages/cli/src/evals/graph-runner.ts":
+    "a refusal is the eval case's failure",
+  // Both run a planned graph inside an agent turn. The refusal is the agent
+  // loop's to report — these only detach their forwarding listener on the way
+  // out, which their own `catch` around `create()` does.
+  "packages/agents/src/execute-agent-graph.ts":
+    "propagates to the agent loop after detaching its message listener",
+  "packages/agents/src/workflow-agent.ts":
+    "propagates to the agent loop after detaching its message listener"
+};
+
+describe("ExecutionSession preflight audit", () => {
+  it("every host either handles a preflight refusal or documents who does", () => {
+    const offenders: string[] = [];
+    let hosts = 0;
+    for (const file of sourceFiles(packagesDir)) {
+      const source = readFileSync(file, "utf8");
+      if (!source.includes("ExecutionSession.create(")) continue;
+      hosts++;
+      if (source.includes("isExecutionPreflightError")) continue;
+      offenders.push(relative(repoRoot, file));
+    }
+    // The audit is only meaningful if it saw the hosts it claims to audit.
+    expect(hosts).toBeGreaterThan(5);
+    expect(offenders.filter((f) => !(f in PREFLIGHT_PROPAGATORS))).toEqual([]);
+  });
+
+  it("every propagator entry still names a real host that propagates", () => {
+    const stale = Object.keys(PREFLIGHT_PROPAGATORS).filter((rel) => {
+      const source = readFileSync(join(repoRoot, rel), "utf8");
+      return (
+        !source.includes("ExecutionSession.create(") ||
+        source.includes("isExecutionPreflightError")
+      );
+    });
+    expect(stale).toEqual([]);
+  });
+});
+
 describe("ExecutionSession hydration audit", () => {
   it("no surface passes a registry without a resolveNodeType", () => {
     const offenders: string[] = [];

--- a/packages/execution/tests/session-preflight.test.ts
+++ b/packages/execution/tests/session-preflight.test.ts
@@ -1,0 +1,263 @@
+/**
+ * `ExecutionSession` refuses a graph this runtime cannot honour before it
+ * spends anything on it.
+ *
+ * `runWorkflow` has refused bad models, providers, and credentials since the
+ * credential preflight shipped, but `ExecutionSession.create` did not — so
+ * every host that goes through the facade instead of the run service (the CLI
+ * `workflows run`, `nodetool run`, the debug harness, the websocket runner)
+ * still failed at the node that needed the key, after the upstream half of the
+ * graph had already run and billed.
+ *
+ * Both directions are pinned: the refusal fires and names the secret, and it
+ * stays silent once the resolver answers. So is the "before" half — the Python
+ * bridge is never connected and `persistence.onAccepted` is never called, the
+ * two side effects that make a late refusal expensive.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { BaseNode, NodeRegistry, prop } from "@nodetool-ai/node-sdk";
+import { ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  ExecutionSession,
+  ExecutionPreflightError,
+  isExecutionPreflightError,
+  providerConfigurationChecker,
+  type RunModelCatalogs
+} from "../src/index.js";
+
+/**
+ * The store behind the *default* secret resolver — the one the facade builds
+ * when a caller brings no context. Mocked at the module boundary because that
+ * resolver reads the models database, which a unit test has no business
+ * initializing.
+ */
+const store = vi.hoisted(() => ({ secrets: {} as Record<string, string> }));
+
+vi.mock("@nodetool-ai/models", () => ({
+  Workflow: { find: vi.fn(async () => null) },
+  Workspace: {
+    find: vi.fn(async () => null),
+    ensureDefault: vi.fn(async () => ({ isAccessible: () => false }))
+  },
+  Job: { create: vi.fn() },
+  getSecret: vi.fn(async (key: string) => store.secrets[key] ?? null)
+}));
+
+/** A node carrying a model selection — the only shape the preflight reads. */
+class Generate extends BaseNode {
+  static readonly nodeType = "test.execution.Generate";
+  static readonly title = "Generate";
+  static readonly description = "Selects a model";
+
+  @prop({ type: "object", default: {} })
+  declare model: Record<string, unknown>;
+
+  async process(): Promise<Record<string, unknown>> {
+    return { output: String(this.model["id"] ?? "") };
+  }
+}
+
+function registry(): NodeRegistry {
+  const reg = new NodeRegistry();
+  reg.register(Generate);
+  return reg;
+}
+
+const graphSelecting = (provider: string, id = "gpt-image-2") => ({
+  nodes: [
+    {
+      id: "n1",
+      type: "test.execution.Generate",
+      properties: { model: { type: "image_model", provider, id } }
+    }
+  ],
+  edges: []
+});
+
+/** A context whose secret store holds exactly `values`. */
+function contextWith(values: Record<string, string>): ProcessingContext {
+  return new ProcessingContext({
+    jobId: "preflight-test",
+    workflowId: null,
+    userId: "1",
+    storage: null,
+    workspace: null,
+    secretResolver: (key: string) => values[key] ?? null
+  });
+}
+
+async function refusalOf(
+  options: Parameters<typeof ExecutionSession.create>[0]
+): Promise<ExecutionPreflightError> {
+  try {
+    await ExecutionSession.create(options);
+  } catch (err) {
+    if (isExecutionPreflightError(err)) return err;
+    throw err;
+  }
+  throw new Error("expected ExecutionSession.create to refuse");
+}
+
+describe("ExecutionSession preflight", () => {
+  const savedKey = process.env["OPENAI_API_KEY"];
+
+  beforeEach(() => {
+    delete process.env["OPENAI_API_KEY"];
+  });
+
+  afterEach(() => {
+    if (savedKey === undefined) delete process.env["OPENAI_API_KEY"];
+    else process.env["OPENAI_API_KEY"] = savedKey;
+  });
+
+  it("refuses a provider no registry knows", async () => {
+    const error = await refusalOf({
+      graph: graphSelecting("totally-not-a-provider"),
+      registry: registry(),
+      bridgeFactory: async () => null,
+      context: contextWith({})
+    });
+    expect(error.issues.map((i) => i.kind)).toEqual(["model"]);
+    expect(error.message).toContain('"totally-not-a-provider"');
+  });
+
+  it("refuses a model the provider does not offer", async () => {
+    const catalogs: RunModelCatalogs = {
+      listProviderIds: () => ["openai"],
+      listModelIds: () => ["gpt-image-1"]
+    };
+    const error = await refusalOf({
+      graph: graphSelecting("openai", "totally-not-a-real-model-xyz"),
+      registry: registry(),
+      bridgeFactory: async () => null,
+      catalogs,
+      context: contextWith({})
+    });
+    expect(error.issues.map((i) => i.kind)).toEqual(["model"]);
+    expect(error.message).toContain("totally-not-a-real-model-xyz");
+  });
+
+  it("refuses a registered provider whose credential nothing resolves", async () => {
+    const error = await refusalOf({
+      graph: graphSelecting("openai"),
+      registry: registry(),
+      bridgeFactory: async () => null,
+      context: contextWith({})
+    });
+    expect(error.issues.map((i) => i.kind)).toEqual(["credential"]);
+    expect(error.message).toContain("OPENAI_API_KEY");
+    expect(error.message).toContain("Settings");
+  });
+
+  it("resolves the credential through the injected context's store", async () => {
+    const session = await ExecutionSession.create({
+      graph: graphSelecting("openai"),
+      registry: registry(),
+      bridgeFactory: async () => null,
+      context: contextWith({ OPENAI_API_KEY: "sk-injected" })
+    });
+    expect((await session.result).status).toBe("completed");
+  });
+
+  it("reports model issues alone — an unregistered provider has no credential to check", async () => {
+    const error = await refusalOf({
+      graph: graphSelecting("totally-not-a-provider"),
+      registry: registry(),
+      bridgeFactory: async () => null,
+      context: contextWith({})
+    });
+    expect(error.issues.every((i) => i.kind === "model")).toBe(true);
+  });
+
+  it("connects no Python bridge and accepts no job when it refuses", async () => {
+    const bridgeFactory = vi.fn(async () => null);
+    const onAccepted = vi.fn();
+    await refusalOf({
+      graph: graphSelecting("openai"),
+      registry: registry(),
+      bridgeFactory,
+      persistence: { onAccepted },
+      context: contextWith({})
+    });
+    expect(bridgeFactory).not.toHaveBeenCalled();
+    expect(onAccepted).not.toHaveBeenCalled();
+  });
+
+  it("leaves a graph with no model selection untouched", async () => {
+    const bridgeFactory = vi.fn(async () => null);
+    const session = await ExecutionSession.create({
+      graph: {
+        nodes: [
+          {
+            id: "n1",
+            type: "test.execution.Generate",
+            properties: { model: {} }
+          }
+        ],
+        edges: []
+      },
+      registry: registry(),
+      bridgeFactory,
+      context: contextWith({})
+    });
+    expect((await session.result).status).toBe("completed");
+    expect(bridgeFactory).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a custom-provider host declare its own registry", async () => {
+    const catalogs: RunModelCatalogs = {
+      listProviderIds: () => ["cassette"],
+      listModelIds: () => ["replay-1"]
+    };
+    const session = await ExecutionSession.create({
+      graph: graphSelecting("cassette", "replay-1"),
+      registry: registry(),
+      bridgeFactory: async () => null,
+      catalogs,
+      // The cassette needs no credential; the process-wide registry has never
+      // heard of it, so the default checker would say nothing either way.
+      providerConfiguration: providerConfigurationChecker([]),
+      context: contextWith({})
+    });
+    expect((await session.result).status).toBe("completed");
+  });
+});
+
+describe("ExecutionSession preflight — default secret resolver", () => {
+  const savedKey = process.env["OPENAI_API_KEY"];
+
+  beforeEach(() => {
+    delete process.env["OPENAI_API_KEY"];
+    store.secrets = {};
+  });
+
+  afterEach(() => {
+    if (savedKey === undefined) delete process.env["OPENAI_API_KEY"];
+    else process.env["OPENAI_API_KEY"] = savedKey;
+    store.secrets = {};
+  });
+
+  const options = () => ({
+    graph: graphSelecting("openai"),
+    registry: registry(),
+    bridgeFactory: async () => null
+  });
+
+  it("refuses when the store the facade's own context reads holds nothing", async () => {
+    const error = await refusalOf(options());
+    expect(error.issues.map((i) => i.kind)).toEqual(["credential"]);
+    expect(error.message).toContain("OPENAI_API_KEY");
+  });
+
+  it("runs once that same store answers", async () => {
+    store.secrets["OPENAI_API_KEY"] = "sk-stored";
+    const session = await ExecutionSession.create(options());
+    expect((await session.result).status).toBe("completed");
+  });
+
+  it("accepts the env value the provider itself would read", async () => {
+    process.env["OPENAI_API_KEY"] = "sk-env";
+    const session = await ExecutionSession.create(options());
+    expect((await session.result).status).toBe("completed");
+  });
+});

--- a/packages/execution/tests/workflow-run-credentials.test.ts
+++ b/packages/execution/tests/workflow-run-credentials.test.ts
@@ -114,8 +114,13 @@ describe("unconfiguredProviderErrors", () => {
   });
 
   it("ignores a saved model replaced by an incoming data edge", async () => {
+    // The source node has to exist: `normalizeGraph` prunes an edge whose
+    // endpoints it cannot find, and a pruned edge shadows nothing.
     const graph = {
-      ...graphWithProvider("openai"),
+      nodes: [
+        { id: "model-source", type: "test.ModelSource", properties: {} },
+        ...graphWithProvider("openai").nodes
+      ],
       edges: [
         {
           source: "model-source",

--- a/packages/websocket/src/headless-job-runner.ts
+++ b/packages/websocket/src/headless-job-runner.ts
@@ -19,6 +19,7 @@
 import { createLogger, getDefaultAssetsPath } from "@nodetool-ai/config";
 import {
   ExecutionSession,
+  isExecutionPreflightError,
   normalizeGraph,
   toRawGraphInput,
   type RunResult
@@ -232,7 +233,29 @@ export async function startHeadlessJob(
   if (supervisor) {
     sessionOptions.supervisor = supervisor;
   }
-  const session = await ExecutionSession.create(sessionOptions);
+  // The job row already exists, so a refusal must finalize it — a bare throw
+  // stranded it at "running" forever. `create()` refuses a graph this runtime
+  // cannot honour (unknown model, unregistered provider, missing credential)
+  // before the kernel starts.
+  let session: ExecutionSession;
+  try {
+    session = await ExecutionSession.create(sessionOptions);
+  } catch (err) {
+    if (!isExecutionPreflightError(err)) throw err;
+    await persistTerminalStatus(job.id, {
+      status: "failed",
+      error: err.message,
+      outputs: {},
+      messages: []
+    } as RunResult);
+    log.info("Headless job refused", { jobId: job.id, error: err.message });
+    return {
+      jobId: job.id,
+      status: "failed",
+      error: err.message,
+      outputs: {}
+    };
+  }
 
   const result = await session.result;
 

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -48,7 +48,11 @@ import {
   type NodeTypeResolver,
   type NodeValidator
 } from "@nodetool-ai/kernel";
-import { ExecutionSession, toRawGraphInput } from "@nodetool-ai/execution";
+import {
+  ExecutionSession,
+  isExecutionPreflightError,
+  toRawGraphInput
+} from "@nodetool-ai/execution";
 import { createRunSupervisor } from "./run-supervisor.js";
 import {
   chatTurnRegistry,
@@ -3801,7 +3805,25 @@ export class UnifiedWebSocketRunner {
     if (supervisor) {
       sessionOptions.supervisor = supervisor;
     }
-    const session = await ExecutionSession.create(sessionOptions);
+    // A graph this runtime cannot honour (unknown model, unregistered
+    // provider, missing credential) is refused before the kernel starts.
+    // Route it through the same terminal `job_update` a failed pre-run hook
+    // uses: a bare throw reaches handleCommand as a generic `invalid_command`
+    // the UI never associates with the job, so the run appears to spin
+    // forever instead of failing with the reason.
+    let session: ExecutionSession;
+    try {
+      session = await ExecutionSession.create(sessionOptions);
+    } catch (err) {
+      if (!isExecutionPreflightError(err)) throw err;
+      await this.emitBeforeRunFailure(
+        jobId,
+        workflowId,
+        err,
+        executionOptions.persistence === "job"
+      );
+      return;
+    }
 
     const active: ActiveJob = {
       jobId,
@@ -5357,19 +5379,28 @@ export class UnifiedWebSocketRunner {
       );
     }
 
-    const session = await ExecutionSession.create({
-      graph: toRawGraphInput(graph),
-      resolveExecutor: (node) =>
-        this.resolveExecutor(
-          node as { id: string; type: string; [key: string]: unknown }
-        ),
-      bridgeFactory: async () => null,
-      jobLifecycleBridge: this.pythonBridge ?? null,
-      jobId,
-      context,
-      params: {},
-      validateNode: this.validateNode
-    });
+    // A node selecting a model this runtime cannot honour is refused before
+    // the kernel starts; the tool answers with the reason, like every other
+    // preparation failure here.
+    let session: ExecutionSession;
+    try {
+      session = await ExecutionSession.create({
+        graph: toRawGraphInput(graph),
+        resolveExecutor: (node) =>
+          this.resolveExecutor(
+            node as { id: string; type: string; [key: string]: unknown }
+          ),
+        bridgeFactory: async () => null,
+        jobLifecycleBridge: this.pythonBridge ?? null,
+        jobId,
+        context,
+        params: {},
+        validateNode: this.validateNode
+      });
+    } catch (err) {
+      if (!isExecutionPreflightError(err)) throw err;
+      return { error: err.message };
+    }
     const result = await session.result;
 
     // Capture the node's completed result from the streamed updates.

--- a/reliability/harness/src/drivers/kernel.ts
+++ b/reliability/harness/src/drivers/kernel.ts
@@ -30,7 +30,11 @@ import {
   type RawGraphInput
 } from "@nodetool-ai/execution";
 import { createGraphNodeTypeResolver } from "@nodetool-ai/node-sdk";
-import { InMemoryStorageAdapter, ProcessingContext } from "@nodetool-ai/runtime";
+import {
+  InMemoryStorageAdapter,
+  ProcessingContext,
+  listRegisteredProviderIds
+} from "@nodetool-ai/runtime";
 import type { Journey, JourneyInteraction } from "../core/journey.js";
 import {
   makeFrame,
@@ -42,6 +46,7 @@ import { AnchorWaiter } from "./anchors.js";
 import { buildJourneyRegistry } from "./registry.js";
 import { journeyPythonBridgeFactory } from "./python-bridge.js";
 import { getInjectedHostStorage } from "../faults/host-faults.js";
+import { RELIABILITY_FAULT_PROVIDER_ID } from "../faults/provider-faults.js";
 import type { RunDriver } from "./types.js";
 
 async function pumpMessages(
@@ -153,6 +158,25 @@ export class KernelDriver implements RunDriver {
             // checks (pending inbox work, pending control responses) are
             // always thrown violations, not log warnings.
             strict: true,
+            // This driver is a custom-provider host: journeys wire an LLM
+            // node to `reliability-fault-llm`, which `provider-faults.ts`
+            // registers process-wide only while a provider fault is active.
+            // The run preflight would otherwise refuse every journey that
+            // names it with no fault applied — which is how the
+            // unregistered-fault-name case reports, so the harness could no
+            // longer report it. Declaring the catalog keeps a typo'd provider
+            // an error while letting the fault id through; model ids are
+            // fixtures with no offline catalog, so they stay unchecked.
+            catalogs: {
+              listProviderIds: () => [
+                ...listRegisteredProviderIds(),
+                RELIABILITY_FAULT_PROVIDER_ID
+              ],
+              listModelIds: () => undefined
+            },
+            // Journeys are hermetic: the fault provider needs no credential,
+            // and no journey may depend on a real key being present.
+            providerConfiguration: () => [],
             // This driver records the message stream frame by frame
             // (`pumpMessages` below), so it's one of the few callers that
             // actually drains `session.messages` — capture is opt-in exactly


### PR DESCRIPTION
Implements item 2 of `docs/failure-mode-roadmap.md`.

## The gap

`runWorkflow` refuses bad models, providers, and credentials before the job row
exists. `ExecutionSession.create` did not, so every host that goes through the
facade instead of the run service — the CLI `workflows run` and `run`, the
debug harness, the websocket runner, the headless job runner, the app
simulator — still failed at the node that needed the key, after the upstream
half of the graph had already run and billed.

## What changed

- **`packages/execution/src/preflight.ts` (new).** `modelSelectionErrors` and
  `unconfiguredProviderErrors` move here, out of `service/workflow-run.ts`,
  because that module imports the models database and `session.ts` must not.
  Adds `ExecutionPreflightError` — `.issues` is the machine-readable list,
  `.message` the text a host prints — plus `collectPreflightIssues` and
  `assertPreflight`. `workflow-run.ts` re-exports the moved symbols, so its
  public surface is unchanged.
- **`ExecutionSession.create`** selects its `ProcessingContext` ahead of the
  bridge (the preflight resolves credentials through `context.getSecret`) and
  refuses after normalization — before `bridgeFactory` runs and before
  `persistence.onAccepted`, the two side effects that make a late refusal
  expensive.
- **New options `catalogs` and `providerConfiguration`,** both defaulting to
  the process-wide provider registry — the same implementations `runWorkflow`
  uses. A host whose providers are not in that registry passes both; passing
  one and not the other would refuse a graph it can in fact run, so the option
  doc says so.
- **`runWorkflow`** builds its 400 from the same issue list through
  `formatPreflightDetail`, so the refusal text is one contract rather than two
  copies.

## Hosts

Each `ExecutionSession.create` host either answers the refusal on its own
channel or is listed as a propagator with who answers it:

| Host | Disposition |
|---|---|
| `unified-websocket-runner.ts` (job start) | terminal `job_update` via `emitBeforeRunFailure` — a bare throw reached `handleCommand` as a generic `invalid_command` the UI never associates with the job |
| `unified-websocket-runner.ts` (`run_node`) | `{ error }` bag, like its other preparation failures |
| `headless-job-runner.ts` | finalizes the already-created job row — a throw stranded it at `running` |
| `cli/src/debug/server-runner.ts` | a failed `ServerRunReport`; the harness's job is to report why a run did not happen |
| `execution/service/app-run-server.ts` | a failed run report the simulator complains about |
| `cli/src/nodetool.ts` | prints `error.message` alone, so the secret name is not buried behind the class name |
| `agents/execute-agent-graph.ts`, `workflow-agent.ts` | propagate to the agent loop, detaching their forwarding listener on the way out |
| `cli/src/run-dsl-supervised.ts`, `cli/src/evals/graph-runner.ts` | propagate; documented in the audit |

## Tests

`packages/execution/tests/session-preflight.test.ts` (11 cases): unknown
provider, unknown model, missing credential, credential resolved through an
injected context, credential resolved through the default (store-backed)
resolver and through env, model issues reported alone, a custom-provider host's
own catalogs, no bridge connection and no `persistence.onAccepted` on refusal,
and a graph with no model selection left untouched.

A new audit in `execution-session-hydration-audit.test.ts` enumerates every
host and asserts it found more than five before checking them.

Both gates were inverted once:

- `if (false) await assertPreflight(...)` in `session.ts` → **6 of 11 cases
  fail** (`npx vitest run tests/session-preflight.test.ts`).
- Removing one propagator entry → the audit names the file
  (`npx vitest run tests/execution-session-hydration-audit.test.ts`).

Suites run: `execution` (275 passed), `cli` (631), `agents` (3308),
`websocket` (2320). Lint and typecheck clean on every changed file.

## Second commit: a red test this PR did not cause

`workflow-run-credentials.test.ts` → *"ignores a saved model replaced by an
incoming data edge"* was already failing on the branch base. `normalizeGraph`
prunes an edge whose source or target is not in the node list, and the fixture's
`model-source` was never declared — so the edge was pruned before it could
shadow the saved model, and the case asserted the opposite of what it
exercised. The pruning is correct, so the fixture is the bug; the neighbouring
bypass case already declares its source node and this one now does too.

Verified both ways: with the phantom source the helper reports one credential
error, with a real source it reports none — the edge does the shadowing the
case is named for.

## Not from this change

`packages/cli` build fails with `Cannot find module '@nodetool-ai/telegram'`.
`packages/telegram` exists but is not linked into `node_modules` in the
sandbox this was developed in; CI does not hit it.