### PR TITLE
fix(validate): close three gaps in the example and workspace gates

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -216,7 +216,9 @@ jobs:
           #      commit 2c0fd8fad), hence is-test:false — they stay a required
           #      gate even when skip-tests drops the bulk test legs.
           #   3. `npm run validate:examples` — rot detector for the shipped
-          #      example workflows: `nodetool validate` against the current node
+          #      example workflows, both `packages/**/examples/` (templates and
+          #      app bundles) and `examples/workflows/` (the CLI samples):
+          #      `nodetool validate` against the current node
           #      registry (unknown node types, missing required properties,
           #      unselected models, dangling/mis-typed edges).
           #      --warnings-as-errors (set in the script) so a warning-level

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1723,6 +1723,12 @@ rebuild/test: the owning package plus its downstream dependents, and a
 `build:packages` only when a decorator package (loads from `dist/`) is affected.
 Avoids reflexively running the full 1–2 min build.
 
+Workspaces come from the root `package.json`, not from a scan of `packages/` —
+`reliability/harness` is a workspace too, and a scan of one directory reported
+every change under it as belonging to nothing. `reliability/journeys/` maps to
+the harness that runs it (`EXTRA_WORKSPACE_PATHS` in
+`packages/cli/src/affected/affected.ts`).
+
 ```bash
 npm run dev:nodetool -- affected                       # uses git working-tree changes
 npm run dev:nodetool -- affected --base main           # diff against a ref

--- a/packages/cli/src/affected/affected.ts
+++ b/packages/cli/src/affected/affected.ts
@@ -27,7 +27,24 @@ export interface PackageInfo {
   dir: string;
   /** Internal `@nodetool-ai/*` dependencies declared in package.json. */
   internalDeps: string[];
+  /** Extra repo-relative dirs this workspace owns — see EXTRA_WORKSPACE_PATHS. */
+  ownedPaths?: string[];
 }
+
+/**
+ * Directories that belong to a workspace without living inside it.
+ *
+ * `reliability/journeys/` holds the journey manifests, fixtures, and goldens
+ * the reliability harness runs; editing one changes what
+ * `nodetool reliability run` does, but the files sit outside
+ * `reliability/harness/`, so a path-prefix match alone reports them as
+ * belonging to no workspace.
+ */
+export const EXTRA_WORKSPACE_PATHS: Readonly<
+  Record<string, readonly string[]>
+> = {
+  "@nodetool-ai/reliability-harness": ["reliability/journeys"]
+};
 
 export interface AffectedResult {
   /** Workspaces directly containing a changed file. */
@@ -43,17 +60,26 @@ export interface AffectedResult {
 }
 
 /** Top-level non-package workspaces that consume packages but have no dependents. */
-const TOP_LEVEL_WORKSPACES = ["web", "electron", "mobile"] as const;
+export const TOP_LEVEL_WORKSPACES = ["web", "electron", "mobile"] as const;
 
 function matchWorkspace(
   file: string,
   packages: ReadonlyArray<PackageInfo>
 ): string | null {
   const norm = file.replace(/^\.\//, "").replace(/\\/g, "/");
-  // Most specific (longest dir) first so packages/foo-bar wins over packages/foo.
-  const sorted = [...packages].sort((a, b) => b.dir.length - a.dir.length);
-  for (const pkg of sorted) {
-    if (norm === pkg.dir || norm.startsWith(pkg.dir + "/")) return pkg.name;
+  const owned: Array<{ path: string; name: string }> = [];
+  for (const pkg of packages) {
+    owned.push({ path: pkg.dir, name: pkg.name });
+    for (const extra of pkg.ownedPaths ?? []) {
+      owned.push({ path: extra, name: pkg.name });
+    }
+  }
+  // Most specific (longest path) first so packages/foo-bar wins over packages/foo.
+  owned.sort((a, b) => b.path.length - a.path.length);
+  for (const entry of owned) {
+    if (norm === entry.path || norm.startsWith(entry.path + "/")) {
+      return entry.name;
+    }
   }
   for (const top of TOP_LEVEL_WORKSPACES) {
     if (norm === top || norm.startsWith(top + "/")) return top;

--- a/packages/cli/src/commands/affected.ts
+++ b/packages/cli/src/commands/affected.ts
@@ -7,6 +7,8 @@
 import type { Command } from "commander";
 import {
   computeAffected,
+  EXTRA_WORKSPACE_PATHS,
+  TOP_LEVEL_WORKSPACES,
   type AffectedResult,
   type PackageInfo
 } from "../affected/affected.js";
@@ -39,12 +41,36 @@ export function registerAffectedCommand(program: Command): void {
         const here = dirname(fileURLToPath(import.meta.url));
         // dist layout: packages/cli/dist/commands → repo root is four up.
         const repoRoot = resolve(here, "..", "..", "..", "..");
-        const packagesDir = join(repoRoot, "packages");
+
+        // Workspaces come from the root package.json, not from a scan of
+        // packages/ — `reliability/harness` is a workspace too, and scanning
+        // one directory reported every change under it as belonging to no
+        // workspace at all.
+        const rootPkg = JSON.parse(
+          readFileSync(join(repoRoot, "package.json"), "utf8")
+        ) as { workspaces?: string[] };
+        const topLevel = new Set<string>(TOP_LEVEL_WORKSPACES);
+        const dirs: string[] = [];
+        for (const entry of rootPkg.workspaces ?? []) {
+          const pattern = entry.replace(/\/$/, "");
+          if (!pattern.endsWith("/*")) {
+            dirs.push(pattern);
+            continue;
+          }
+          const parent = pattern.slice(0, -2);
+          if (!existsSync(join(repoRoot, parent))) continue;
+          for (const child of readdirSync(join(repoRoot, parent), {
+            withFileTypes: true
+          })) {
+            if (child.isDirectory()) dirs.push(`${parent}/${child.name}`);
+          }
+        }
 
         const packages: PackageInfo[] = [];
-        for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
-          if (!entry.isDirectory()) continue;
-          const pkgJsonPath = join(packagesDir, entry.name, "package.json");
+        for (const dir of dirs) {
+          // web/electron get their own command shape in computeAffected.
+          if (topLevel.has(dir)) continue;
+          const pkgJsonPath = join(repoRoot, dir, "package.json");
           if (!existsSync(pkgJsonPath)) continue;
           try {
             const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as {
@@ -59,10 +85,11 @@ export function registerAffectedCommand(program: Command): void {
             };
             packages.push({
               name: pkg.name,
-              dir: `packages/${entry.name}`,
+              dir,
               internalDeps: Object.keys(allDeps).filter((d) =>
                 d.startsWith("@nodetool-ai/")
-              )
+              ),
+              ownedPaths: [...(EXTRA_WORKSPACE_PATHS[pkg.name] ?? [])]
             });
           } catch {
             // A malformed package.json shouldn't abort the whole mapping.

--- a/packages/cli/src/harness/registry.ts
+++ b/packages/cli/src/harness/registry.ts
@@ -415,7 +415,10 @@ export const SURFACES: SurfaceEntry[] = [
       "packages/runtime/",
       "packages/node-sdk/",
       "packages/base-nodes/",
-      "reliability/"
+      "reliability/",
+      // The CLI-facing example graphs. `npm run validate:examples` scans them,
+      // so a diff that edits one runs the validate selfcheck.
+      "examples/workflows/"
     ]
   },
   {

--- a/packages/cli/tests/affected.test.ts
+++ b/packages/cli/tests/affected.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   computeAffected,
   DECORATOR_PACKAGES,
+  EXTRA_WORKSPACE_PATHS,
   type PackageInfo
 } from "../src/affected/affected.js";
 
@@ -87,5 +91,71 @@ describe("computeAffected", () => {
   it("exposes the documented decorator package set", () => {
     expect(DECORATOR_PACKAGES.has("@nodetool-ai/base-nodes")).toBe(true);
     expect(DECORATOR_PACKAGES.has("@nodetool-ai/cli")).toBe(false);
+  });
+
+  it("maps a workspace outside packages/ to itself", () => {
+    const pkgs: PackageInfo[] = [
+      ...PKGS,
+      {
+        name: "@nodetool-ai/reliability-harness",
+        dir: "reliability/harness",
+        internalDeps: ["@nodetool-ai/node-sdk"]
+      }
+    ];
+    const r = computeAffected(["reliability/harness/src/index.ts"], pkgs);
+    expect(r.changed).toEqual(["@nodetool-ai/reliability-harness"]);
+    expect(r.unmatched).toEqual([]);
+    expect(r.commands).toContain(
+      "npm run test --workspace=reliability/harness"
+    );
+  });
+
+  it("maps a workspace's extra owned dirs to it", () => {
+    const pkgs: PackageInfo[] = [
+      {
+        name: "@nodetool-ai/reliability-harness",
+        dir: "reliability/harness",
+        internalDeps: [],
+        ownedPaths: ["reliability/journeys"]
+      }
+    ];
+    const r = computeAffected(
+      ["reliability/journeys/linear-text-pipeline/workflow.json"],
+      pkgs
+    );
+    expect(r.changed).toEqual(["@nodetool-ai/reliability-harness"]);
+    expect(r.unmatched).toEqual([]);
+  });
+});
+
+describe("EXTRA_WORKSPACE_PATHS", () => {
+  const repoRoot = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+    ".."
+  );
+
+  it("names workspaces the root package.json declares", () => {
+    const workspaces = new Set<string>(
+      (
+        JSON.parse(
+          readFileSync(join(repoRoot, "package.json"), "utf8")
+        ) as { workspaces?: string[] }
+      ).workspaces ?? []
+    );
+    for (const name of Object.keys(EXTRA_WORKSPACE_PATHS)) {
+      const owner = [...workspaces].find((dir) => {
+        try {
+          const pkg = JSON.parse(
+            readFileSync(join(repoRoot, dir, "package.json"), "utf8")
+          ) as { name?: string };
+          return pkg.name === name;
+        } catch {
+          return false;
+        }
+      });
+      expect(owner, `no workspace is named ${name}`).toBeDefined();
+    }
   });
 });

--- a/packages/node-sdk/src/graph-validation.ts
+++ b/packages/node-sdk/src/graph-validation.ts
@@ -10,7 +10,10 @@
  * Takes a {@link GraphValidationRegistry} (the slice of NodeRegistry it needs)
  * so it can be unit-tested with a fake and reused by the CLI and agent tools.
  */
-import type { DynamicSlotMeta } from "@nodetool-ai/protocol";
+import {
+  migrateGraphNodeTypes,
+  type DynamicSlotMeta
+} from "@nodetool-ai/protocol";
 import {
   getProcessSandboxModuleCatalog,
   type SandboxModuleCatalog
@@ -920,10 +923,16 @@ export function collectJsScriptLinks(
 }
 
 export function validateGraph(
-  graph: GraphValidationInput,
+  rawGraph: GraphValidationInput,
   registry: GraphValidationRegistry,
   options: GraphValidationOptions = {}
 ): GraphValidationReport {
+  // Validate what the runner will execute. `Graph.loadFromDict` rewrites
+  // removed node types through NODE_TYPE_MIGRATIONS on every load, so a saved
+  // graph carrying one runs fine — but validating the raw graph reported the
+  // migrated-away type as `unknown_node` and refused it. Two shipped examples
+  // (text_transforms_cli, text_regex_parse_cli) sat in exactly that gap.
+  const graph = migrateGraphNodeTypes(rawGraph);
   const sandboxModuleCatalog =
     options.sandboxModuleCatalog !== undefined
       ? options.sandboxModuleCatalog

--- a/packages/node-sdk/tests/graph-validation.test.ts
+++ b/packages/node-sdk/tests/graph-validation.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/graph-validation.js";
 import type { NodeMetadata } from "../src/metadata.js";
 import type { NodePropertyValidationIssue } from "../src/validation.js";
+import { NODE_TYPE_MIGRATIONS } from "@nodetool-ai/protocol";
 import {
   refuseSandboxDelivery,
   setProcessSandboxModuleCatalog,
@@ -102,6 +103,34 @@ describe("validateGraph", () => {
     );
     expect(report.ok).toBe(false);
     expect(report.issues.some((i) => i.code === "unknown_node")).toBe(true);
+  });
+
+  it("validates the migrated type, not the removed one", () => {
+    // `Graph.loadFromDict` rewrites nodetool.text.TrimWhitespace to
+    // nodetool.code.Code on load, so the graph the runner sees never carries
+    // the removed type — the validator must migrate first or it refuses a
+    // workflow that runs.
+    const migration = NODE_TYPE_MIGRATIONS.find(
+      (m) => m.from === "nodetool.text.TrimWhitespace"
+    );
+    expect(migration?.to).toBe("nodetool.code.Code");
+    const registry = fakeRegistry({
+      "nodetool.code.Code": meta("nodetool.code.Code", {}, { output: "str" })
+    });
+    const report = validateGraph(
+      {
+        nodes: [
+          {
+            id: "1",
+            type: "nodetool.text.TrimWhitespace",
+            data: { trim_start: true, trim_end: true }
+          }
+        ],
+        edges: []
+      },
+      registry
+    );
+    expect(report.issues.filter((i) => i.code === "unknown_node")).toEqual([]);
   });
 
   it("flags duplicate node ids", () => {

--- a/packages/protocol/src/graph.ts
+++ b/packages/protocol/src/graph.ts
@@ -606,7 +606,14 @@ return { output: needles.some(needle => haystack.includes(needle)) };`
   ),
   textToCodeMigration(
     "nodetool.text.TrimWhitespace",
-    "return { output: inputs.text.trim() };"
+    // trim_start/trim_end were real per-instance properties (both default
+    // true) — read them from the dynamic inputs instead of always trimming
+    // both ends.
+    `const text = String(inputs.text ?? "");
+const trimStart = inputs.trim_start === undefined ? true : Boolean(inputs.trim_start);
+const trimEnd = inputs.trim_end === undefined ? true : Boolean(inputs.trim_end);
+const started = trimStart ? text.trimStart() : text;
+return { output: trimEnd ? started.trimEnd() : started };`
   ),
   textToCodeMigration(
     "nodetool.text.CollapseWhitespace",
@@ -713,7 +720,16 @@ return { output };`
   ),
   textToCodeMigration(
     "nodetool.text.IndexOf",
-    "return { output: inputs.text.indexOf(inputs.substring) };"
+    // case_sensitive was a real per-instance property (default true) — honor
+    // it instead of always matching case-sensitively.
+    `const text = String(inputs.text ?? "");
+const substring = String(inputs.substring ?? "");
+const caseSensitive = inputs.case_sensitive === undefined ? true : Boolean(inputs.case_sensitive);
+return {
+  output: caseSensitive
+    ? text.indexOf(substring)
+    : text.toLowerCase().indexOf(substring.toLowerCase())
+};`
   ),
   textToCodeMigration(
     "nodetool.text.SurroundWith",

--- a/packages/protocol/tests/node-migrations.test.ts
+++ b/packages/protocol/tests/node-migrations.test.ts
@@ -284,6 +284,26 @@ describe("migrateGraphNodeTypes", () => {
       });
     });
 
+    it("keeps reading the per-instance properties the removed node had", () => {
+      // `moveRemainingPropertiesToDynamic` puts these on the Code node's
+      // dynamic inputs; a body that ignores one silently changes behavior,
+      // and the graph validator reports it as an unused input.
+      const readsInputs: Record<string, string[]> = {
+        "nodetool.text.TrimWhitespace": ["trim_start", "trim_end"],
+        "nodetool.text.IndexOf": ["substring", "case_sensitive"]
+      };
+      for (const [from, inputs] of Object.entries(readsInputs)) {
+        const code = NODE_TYPE_MIGRATIONS.find((m) => m.from === from)
+          ?.setProperties?.code;
+        expect(typeof code, `missing migration for ${from}`).toBe("string");
+        for (const input of inputs) {
+          expect(String(code), `${from} drops ${input}`).toContain(
+            `inputs.${input}`
+          );
+        }
+      }
+    });
+
     it("covers every Tier 1 nodetool.text.* removal with a Code node migration", () => {
       const expectedFromTypes = [
         "nodetool.text.Split",

--- a/scripts/validate-examples.mjs
+++ b/scripts/validate-examples.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-// Rot detector for the shipped example workflows (packages/*/examples/**/*.json):
+// Rot detector for the shipped example workflows (packages/*/examples/**/*.json
+// and the repo-root examples/workflows/*.json):
 // nodes get renamed, properties change, models get deprecated, and a shipped
 // example that references a now-unknown node type or a missing required
 // property is broken for every new install. `nodetool validate` catches this
@@ -42,6 +43,49 @@ const repoRoot = resolve(scriptDir, "..");
 const cliValidate = join(repoRoot, "packages/cli/dist/validate/index.js");
 const cliRender = join(repoRoot, "packages/cli/dist/commands/validate.js");
 
+// Examples whose graphs drive nodes that exist only in the Python worker. The
+// TypeScript registry cannot know those types, so `unknown_node` for exactly
+// these names is expected — and nothing else is: every other issue in these
+// files still fails the gate. The list is also checked from the other side. A
+// name that stops firing (the node got a TypeScript port, or the example
+// stopped using it) fails the gate too, so an exemption cannot outlive the
+// reason it was written.
+//
+// Nothing else belongs here. A type that was *removed* from the registry with
+// a NODE_TYPE_MIGRATIONS entry is not unknown: `validateGraph` migrates the
+// graph first, exactly as `Graph.loadFromDict` does at run time.
+const PYTHON_ONLY_NODES = {
+  "examples/workflows/lib_librosa_mfcc_cli.json": ["lib.librosa.analysis.MFCC"],
+  "examples/workflows/lib_pedalboard_reverb_cli.json": ["lib.pedalboard.Reverb"]
+};
+
+/**
+ * Drop the `unknown_node` issues naming a declared Python-only type, and
+ * report which of them actually fired. Counts and `ok` are recomputed from
+ * what is left, so a file with nothing but exempt issues renders as valid.
+ */
+function withoutPythonOnlyNodes(report, allowed) {
+  if (allowed.length === 0) return { report, exercised: [] };
+  const allow = new Set(allowed);
+  const exercised = new Set();
+  const issues = report.issues.filter((issue) => {
+    const exempt =
+      issue.code === "unknown_node" && allow.has(issue.nodeType ?? "");
+    if (exempt) exercised.add(issue.nodeType);
+    return !exempt;
+  });
+  const counts = { errors: 0, warnings: 0, info: 0 };
+  for (const issue of issues) {
+    if (issue.severity === "error") counts.errors += 1;
+    else if (issue.severity === "warning") counts.warnings += 1;
+    else counts.info += 1;
+  }
+  return {
+    report: { ...report, issues, counts, ok: counts.errors === 0 },
+    exercised: [...exercised]
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Worker: validate one graph file per request, reusing one registry.
 // ---------------------------------------------------------------------------
@@ -63,15 +107,18 @@ if (!isMainThread) {
       return;
     }
     let output = null;
+    let exercised = [];
     try {
       const { report } = await runValidate(job.path, deps);
-      if (!report.ok || report.counts.warnings > 0) {
-        output = renderValidation(report).join("\n");
+      const filtered = withoutPythonOnlyNodes(report, job.pythonOnlyNodes ?? []);
+      exercised = filtered.exercised;
+      if (!filtered.report.ok || filtered.report.counts.warnings > 0) {
+        output = renderValidation(filtered.report).join("\n");
       }
     } catch (err) {
       output = err instanceof Error ? (err.stack ?? err.message) : String(err);
     }
-    parentPort.postMessage({ index: job.index, output });
+    parentPort.postMessage({ index: job.index, output, exercised });
   });
 
   // Ready for the first job.
@@ -85,7 +132,11 @@ if (!isMainThread) {
 // ---------------------------------------------------------------------------
 
 // Walk packages/**/examples/**/*.json — mirrors the `find packages -path
-// '*examples*' -name '*.json'` used by workflow-example-validation.yaml.
+// '*examples*' -name '*.json'` used by workflow-example-validation.yaml — and
+// examples/workflows/*.json at the repo root. The root tree sat outside the
+// scan, so a stale model id or node type there drifted with the gate green —
+// and those are the CLI-facing examples examples/workflows/README.md tells
+// people to run.
 function findExamples(dir) {
   const results = [];
   for (const entry of readdirSync(dir)) {
@@ -154,10 +205,19 @@ function runPool(jobs) {
             return;
           }
           const index = next++;
-          worker.postMessage({ index, path: jobs[index].path });
+          worker.postMessage({
+            index,
+            path: jobs[index].path,
+            pythonOnlyNodes: jobs[index].pythonOnlyNodes ?? []
+          });
         };
         worker.on("message", (msg) => {
-          if (!msg.ready) results[msg.index] = msg.output;
+          if (!msg.ready) {
+            results[msg.index] = {
+              output: msg.output,
+              exercised: msg.exercised ?? []
+            };
+          }
           send();
         });
         worker.on("error", rejectWorker);
@@ -168,11 +228,21 @@ function runPool(jobs) {
 }
 
 async function main() {
-  const examples = findExamples(join(repoRoot, "packages")).sort();
+  const packageExamples = findExamples(join(repoRoot, "packages")).sort();
+  const rootExamples = findExamples(join(repoRoot, "examples/workflows")).sort();
+
+  if (rootExamples.length === 0) {
+    console.error(
+      "No example JSON files found under examples/workflows/ — check the search path."
+    );
+    process.exit(1);
+  }
+
+  const examples = [...packageExamples, ...rootExamples];
   const bundles = examples.filter((f) => f.endsWith(".app.json"));
   const workflowExamples = examples.filter((f) => !f.endsWith(".app.json"));
 
-  if (workflowExamples.length === 0) {
+  if (packageExamples.length === 0) {
     console.error(
       "No example JSON files found under packages/**/examples/ — check the search path."
     );
@@ -195,7 +265,23 @@ async function main() {
   // main thread already knows is broken (an unparseable bundle, say).
   const jobs = [];
   for (const file of workflowExamples) {
-    jobs.push({ label: file.slice(repoRoot.length + 1), path: file });
+    const label = file.slice(repoRoot.length + 1);
+    jobs.push({
+      label,
+      path: file,
+      pythonOnlyNodes: PYTHON_ONLY_NODES[label] ?? []
+    });
+  }
+
+  const declaredFiles = Object.keys(PYTHON_ONLY_NODES).filter(
+    (label) => !jobs.some((job) => job.label === label)
+  );
+  if (declaredFiles.length > 0) {
+    console.error(
+      `PYTHON_ONLY_NODES names ${declaredFiles.length} file(s) the scan does not ` +
+        `reach:\n  ${declaredFiles.join("\n  ")}\nRemove the entry or fix the path.`
+    );
+    process.exit(1);
   }
 
   // Each bundle's embedded workflows are written to a scratch file and run
@@ -226,7 +312,24 @@ async function main() {
 
   const pending = jobs.filter((job) => job.path !== undefined);
   const outputs = await runPool(pending);
-  for (const [i, job] of pending.entries()) job.output = outputs[i];
+  for (const [i, job] of pending.entries()) {
+    job.output = outputs[i].output;
+    // An exemption that no longer fires is stale: the node was ported to
+    // TypeScript, or the example stopped using it. Either way the entry now
+    // hides whatever else it would cover, so it fails the gate.
+    const unused = (job.pythonOnlyNodes ?? []).filter(
+      (type) => !outputs[i].exercised.includes(type)
+    );
+    if (unused.length > 0) {
+      job.output = [
+        job.output,
+        `stale PYTHON_ONLY_NODES entry in scripts/validate-examples.mjs — ` +
+          `no longer reported as unknown: ${unused.join(", ")}`
+      ]
+        .filter(Boolean)
+        .join("\n");
+    }
+  }
 
   rmSync(scratch, { recursive: true, force: true });
 


### PR DESCRIPTION
## What

Three gates that were reporting green over ground they never touched.

### 1. `nodetool affected` never named `reliability/`

The command scanned `packages/` only, so a change under `reliability/harness`
— a workspace declared in the root `package.json` — mapped to no workspace at
all, and the reliability journeys it runs mapped to nothing either.

Workspaces now come from the root `package.json`. A workspace can also declare
directories it owns outside its own tree (`EXTRA_WORKSPACE_PATHS`), which is
how `reliability/journeys/` reaches the harness that runs it.

```
$ nodetool affected reliability/harness/src/index.ts reliability/journeys/linear-text-pipeline/workflow.json
  dependent @nodetool-ai/cli
  changed   @nodetool-ai/reliability-harness
```

### 2. `npm run validate:examples` never scanned `examples/workflows/`

The scan covered `packages/**/examples/` only, leaving the 33 CLI samples the
repo's own README tells people to run as the shipped graphs nothing validated.
Both roots are scanned now, and an empty result from either fails the script
rather than passing quietly.

### 3. What the wider scan then found

Four of the 33 failed, all on `unknown_node` — but only two of them for a
Python-only node:

- **`nodetool.text.*` types are not Python-only.** `TrimWhitespace`,
  `RegexMatch`, `Chunk` and friends were *removed* with a
  `NODE_TYPE_MIGRATIONS` entry; `Graph.loadFromDict` rewrites them to
  `nodetool.code.Code` on every load, so those graphs run fine. The validator
  was refusing what the runner accepts. `validateGraph` now migrates the graph
  first, exactly as the runner does — so it validates what will execute.
- **Two migration snippets silently dropped properties.** `TrimWhitespace`
  ignored `trim_start`/`trim_end`, `IndexOf` ignored `case_sensitive`; a graph
  setting `trim_start: false` got both ends trimmed anyway. Both bodies now
  read them from the dynamic inputs, matching the pattern the neighbouring
  migrations already use. Surfaced by the `code_unused_input` warnings the
  migrated graphs produce.
- **The two genuinely Python-only examples** (librosa MFCC, pedalboard Reverb)
  get a named exemption for exactly those node types. Every other issue in
  those files still fails the gate, and an entry that stops firing fails it
  too, so an exemption cannot outlive the reason it was written.

The `workflow-execution` harness surface now lists `examples/workflows/`, so
`harness gate` runs the validate selfcheck on a diff that touches one.

## Proving the new checks can fail

Each was inverted once and watched go red, then restored:

| Inversion | Result |
|---|---|
| bogus node type in `examples/workflows/variables_cli.json` | `FAIL … 251/252`, exit 1 |
| extra dead name in a `PYTHON_ONLY_NODES` entry | `stale PYTHON_ONLY_NODES entry … lib.pedalboard.NoLongerUsed` |
| exemption naming a file the scan cannot reach | `PYTHON_ONLY_NODES names 1 file(s) the scan does not reach` |
| `validateGraph` without the migration pass | new node-sdk test fails |

## Verification

- `npm run validate:examples` — 252/252 (was 248/252 once the root tree was in scope)
- `npm run test:packages` — 108/108 tasks
- `npm run typecheck` — clean (web, electron, mobile)
- `npm run lint` — clean
- `npm run test:web` / `:electron` / `:mobile` — green except the
  already-red-on-main `AppDataPanel › pins a named document of the selected
  kind`, which this diff does not touch
- `nodetool harness gate --base main` — 3/3 selfchecks
- `packages/base-nodes` needed `mesa-vulkan-drivers` locally (the documented
  headless-WebGPU gap); with it installed, 2027 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01AusSZiKUaxYqaQicNwWHsz)_