### PR TITLE
fix(web): start the app-builder Resources section closed

### DIFF
--- a/web/src/components/appbuilder/AppDataPanel.tsx
+++ b/web/src/components/appbuilder/AppDataPanel.tsx
@@ -580,7 +580,11 @@ const AppDataPanel: React.FC<AppDataPanelProps> = ({
           </FlexColumn>
         </CollapsibleSection>
 
-        <CollapsibleSection title="Resources" compact>
+        {/*
+          CollapsibleSection defaults to open, so a section that starts closed
+          has to say so — omitting the prop made the header click collapse it.
+        */}
+        <CollapsibleSection title="Resources" defaultOpen={false} compact>
           <FlexColumn gap={SPACING.md} fullWidth>
             <Caption color="secondary">
               An asset, timeline, storyboard, or sketch a picker or gallery can


### PR DESCRIPTION
`AppDataPanel › pins a named document of the selected kind` fails on `main` with `Unable to find an accessible element with the role "button" and name /add resource/i`.

## Cause

`CollapsibleSection` destructures `defaultOpen = true`, so `<CollapsibleSection title="Resources" compact>` rendered **open**. Both Resources tests click the header to open the section — which actually collapsed it.

The content survives the click because MUI `Collapse` keeps children mounted and takes 200 ms to reach `visibility: hidden`. `binds all documents of the selected kind` clicks "Add resource" inside that window and passes; `pins a named document of the selected kind` first changes the kind select and waits on a second `resources.list` query, by which time the collapse has finished and the button is no longer in the accessible tree.

Confirmed by instrumenting the panel: after the kind change the Resources header reports `aria-expanded="false"`, the "Add resource" button is only findable with `{ hidden: true }`, and `handleToggle` fires exactly once — on the test's own header click, not on the menu-item click.

## Fix

Pass `defaultOpen={false}` on the Resources section, matching what its tests and the header click already assumed. Operations and Variables already pass `defaultOpen` explicitly.

## Verification

- Reproduced the failure locally on this branch before the change (same assertion, same message).
- `npx jest src/components/appbuilder` — 34 suites, 361 tests, all pass.
- `npx tsc --noEmit` and `npx oxlint` on the touched file — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZwGFGDWb7xk8Ax6kTifQU)_