### PR TITLE
feat(websocket): opt-in /mcp mount in production, bound to its user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,21 @@ services:
       # Optional OAuth redirect when served behind a domain/proxy:
       # AUTH_REDIRECT_URL: "${AUTH_REDIRECT_URL:-}"
 
+      # ── MCP over HTTP and Python nodes ─────────────────────────────────────
+      # Both surfaces are off because NODETOOL_ENV is "production" above.
+      #
+      # /mcp — the streamable-HTTP MCP mount an agent connects to. It sits
+      # behind the same auth hook as /api and binds the user that hook resolved,
+      # so an unauthenticated request is refused at initialize. Session ids are
+      # scoped to their owner. See docs/self-hosted-deployment.md.
+      # NODETOOL_ENABLE_MCP: "1"
+      #
+      # Python nodes. The published image ships no Python worker, so this flag
+      # alone does nothing: derive an image that installs nodetool-core and
+      # point NODETOOL_PYTHON at its interpreter.
+      # NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION: "1"
+      # NODETOOL_PYTHON: "/usr/local/bin/python3"
+
       # Model provider keys — only the ones you use. Values come from .env.
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,11 @@ NODETOOL_PYTHON=/opt/conda/envs/nodetool/bin/python nodetool serve
 The bridge is a local-only feature: when `NODETOOL_ENV=production` it refuses to
 connect, and a workflow reaching a Python node fails with "Python bridge is
 disabled in production". Set `NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION=1` to
-override that on a host where you do want the worker.
+override that on a host where you do want the worker. The flag alone is not
+enough on the published Docker image: it ships no Python worker, so derive an
+image that installs `nodetool-core` and point `NODETOOL_PYTHON` at that
+interpreter. See [Self-hosted deployment › MCP over HTTP and Python
+nodes](self-hosted-deployment.md#mcp-over-http-and-python-nodes).
 
 The three `NODETOOL_PYTHON_*_TIMEOUT_MS` variables bound how long the server
 waits on the worker. Raise `NODETOOL_PYTHON_EXECUTE_TIMEOUT_MS` past its
@@ -446,6 +450,7 @@ missing binary.
 | `NODETOOL_REQUIRE_SDK_AUTH_V1` | Require a token on the SDK **discovery** routes even when the server does not enforce auth | no | `1` only. Those routes (`capabilities`, `models`, `node-types`, `workflows`, `workflow-interfaces`, `workflows/:id/interface`) are otherwise auth-exempt in local trust mode, since they only describe the server. Set it when a local-mode server is reachable beyond loopback. A server that already enforces auth requires the token regardless |
 | `NODETOOL_EXTENSION_DIST` | Directory holding the built Chrome extension served by `/api/extension/download` | no | Set by the desktop app to its bundled copy. When unset (or pointing at a directory with no `manifest.json`), the server walks up from its own directory and the working directory looking for `chrome-extension/dist`. See [Chrome Extension](chrome-extension.md#downloading-a-prebuilt-copy) |
 | `NODETOOL_ENABLE_EXTENSION_BRIDGE` | Keep the `/ws/extension` CDP bridge open when `NODETOOL_ENV=production` | no | Off in production unless set to exactly `1`; on everywhere else. The bridge is unauthenticated and single-connection — whoever connects becomes *the* extension socket and can proxy CDP through the server — so enable it only on a deployment that actually drives the browser extension. When disabled the server logs that at startup and the route is not registered |
+| `NODETOOL_ENABLE_MCP` | Keep the `/mcp` streamable-HTTP mount registered when `NODETOOL_ENV=production` | no | Off in production unless set to exactly `1`; on everywhere else. The mount inherits the server's auth mode — it is not a second door — and binds the user the auth hook resolved, so a request it cannot authenticate gets `401` at initialize instead of an anonymous session. A session id belongs to the user who opened it: another user presenting it gets `404`. When disabled the server logs that at startup and the route is not registered. See [Self-hosted deployment › MCP over HTTP and Python nodes](self-hosted-deployment.md#mcp-over-http-and-python-nodes) |
 | `NODETOOL_HOST_BINARY_CONCURRENCY` | Host binaries (`ffmpeg`, `yt-dlp`) the media capabilities may run at once | no | Default `2`; the rest queue, so one run cannot take every core from the request handlers. Read per spawn, as a whole number ≥ 1 — anything unparseable or non-positive keeps the default. Raise it on a machine with cores to spare and lower it on a shared one |
 | `NODETOOL_BROWSER_HEADLESS` | Whether browser-automation nodes launch Chrome headless | no | Server-side browser tools are headless unless this is exactly `false` |
 | `NODETOOL_SHIPPED_PACKS_DIR` | Roots the sandbox packs that ship with NodeTool are read from | no | Comma-, semicolon-, or `PATH`-separator-delimited, same as `NODETOOL_PACK_SEARCH_PATHS`. Candidates that do not exist are dropped, so a bad path yields no packs rather than an error. Unset, the loader looks for `_sandbox/` beside the bundled `server.mjs` (packaged desktop app, Docker image), then walks up to `packages/sandbox-packs` (a checkout). Set it only for a host that stages the packs somewhere else. See [Sandbox package design](sandbox-package-design.md) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,8 +158,8 @@ disabled in production". Set `NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION=1` to
 override that on a host where you do want the worker. The flag alone is not
 enough on the published Docker image: it ships no Python worker, so derive an
 image that installs `nodetool-core` and point `NODETOOL_PYTHON` at that
-interpreter. See [Self-hosted deployment › MCP over HTTP and Python
-nodes](self-hosted-deployment.md#mcp-over-http-and-python-nodes).
+interpreter. See
+[Self-hosted deployment](self-hosted-deployment.md#mcp-over-http-and-python-nodes).
 
 The three `NODETOOL_PYTHON_*_TIMEOUT_MS` variables bound how long the server
 waits on the worker. Raise `NODETOOL_PYTHON_EXECUTE_TIMEOUT_MS` past its

--- a/docs/production-mcp-python-flags-plan.md
+++ b/docs/production-mcp-python-flags-plan.md
@@ -1,6 +1,6 @@
 # Plan: MCP over HTTP and the Python bridge on a production server
 
-Status: proposed — 2026-08-22.
+Status: implemented — 2026-08-22.
 
 ## Problem
 

--- a/docs/self-hosted-deployment.md
+++ b/docs/self-hosted-deployment.md
@@ -337,6 +337,74 @@ nodetool deploy users-reset-token local alice
 nodetool deploy users-remove local alice --force
 ```
 
+## MCP over HTTP and Python nodes
+
+Two surfaces are off when `NODETOOL_ENV=production` — which the published image,
+`fly.toml`, and `docker-compose.yml` all set. Each has an opt-in flag.
+
+### `/mcp` — `NODETOOL_ENABLE_MCP=1`
+
+The streamable-HTTP MCP mount carries the full agent toolbelt, so it registers
+in production only with the flag:
+
+```yaml
+environment:
+  NODETOOL_ENABLE_MCP: "1"
+```
+
+Without it the route is not registered, `/mcp` answers 404, and the boot log
+names the flag.
+
+The mount is not a second door. It sits behind the same `onRequest` auth hook as
+`/api`, and binds the user that hook resolved: a request it cannot authenticate
+is refused at initialize with 401, never given an anonymous session. The session
+id in the `mcp-session-id` header is scoped to its owner — a second user
+presenting the same id gets `404 Session not found`, the same answer as an id
+that never existed.
+
+How an agent authenticates depends on the server's auth mode:
+
+- **Supabase mode** (`SUPABASE_URL` + `SUPABASE_KEY`): the agent sends a
+  Supabase access token as `Authorization: Bearer <jwt>`, like any web client.
+  The MCP session then belongs to that Supabase user.
+- **Local mode behind a VPN**: set `NODETOOL_TRUST_LOCAL_NETWORKS` to the VPN's
+  CIDR. Requests from that range are trusted as user `1` with no token. Scope it
+  to the VPN — anything reaching the server from a trusted range gets the whole
+  toolbelt.
+- **A bot or bridge**: mint a delegated token through the integration routes
+  (`NODETOOL_INTEGRATION_TOKEN`) and send it as the bearer token. The session
+  binds the linked account rather than a shared identity.
+
+Not covered by the flag: the tRPC `mcpConfig` router stays disabled in
+production. It edits MCP *client* config files on the server's filesystem, which
+has no meaning on a shared host.
+
+### Python nodes — `NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION=1`
+
+The Python bridge refuses to connect in production. The flag lifts that:
+
+```yaml
+environment:
+  NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION: "1"
+  NODETOOL_PYTHON: "/opt/conda/envs/nodetool/bin/python"
+```
+
+**The published image ships no Python worker.** `ghcr.io/nodetool-ai/nodetool`
+carries the TypeScript server only, so the flag by itself changes nothing except
+the error you get. To run Python nodes, derive an image that installs
+`nodetool-core` and set `NODETOOL_PYTHON` to that interpreter:
+
+```dockerfile
+FROM ghcr.io/nodetool-ai/nodetool:latest
+RUN pip install --no-cache-dir nodetool-core
+ENV NODETOOL_PYTHON=/usr/local/bin/python3 \
+    NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION=1
+```
+
+With the flag set and no interpreter found, the boot log says
+`Python not found — Python nodes will not be available`. With the flag unset it
+names the flag instead, so the log tells you which of the two you are missing.
+
 ## Manual Troubleshooting
 
 ### Container Logs

--- a/packages/websocket/src/mcp-server.ts
+++ b/packages/websocket/src/mcp-server.ts
@@ -26,9 +26,9 @@ export interface McpServerOptions {
    * User scope for the session. Required: every capability runs against one
    * user's secrets and assets, so a session that cannot name a user has no
    * surface at all. `source` documents why the binding is safe: "stdio-local"
-   * (single-user `nodetool mcp serve`) or "local-dev-http" (the non-production
-   * /mcp mount). An authenticated multi-user mount must pass the session's real
-   * userId here.
+   * (single-user `nodetool mcp serve`), "local-dev-http" (the non-production
+   * /mcp mount), or "http-session" (the production mount behind
+   * NODETOOL_ENABLE_MCP, which passes the user the auth hook resolved).
    */
   agentToolsScope?: {
     userId: string;
@@ -85,6 +85,39 @@ const sessionTransports = new Map<
   WebStandardStreamableHTTPServerTransport
 >();
 
+// The user each HTTP session was initialized for. A multi-user mount hands out
+// session ids over an authenticated channel, but the id alone must not be a
+// bearer credential: every later request is checked against the owner recorded
+// here.
+const sessionOwners = new Map<string, string>();
+
+function forgetSession(sessionId: string): void {
+  sessionTransports.delete(sessionId);
+  sessionOwners.delete(sessionId);
+}
+
+/**
+ * True when the session exists and belongs to somebody other than the caller.
+ * A session with no recorded owner (stdio, or a mount that predates the
+ * binding) is left alone — the transport map is the authority there.
+ */
+function isForeignSession(
+  sessionId: string,
+  options?: McpServerOptions
+): boolean {
+  const owner = sessionOwners.get(sessionId);
+  if (owner === undefined) return false;
+  return owner !== options?.agentToolsScope?.userId;
+}
+
+/**
+ * Answer as if the session did not exist. A 403 would confirm the id is real to
+ * a caller who guessed it; a 404 tells them nothing.
+ */
+function sessionNotFound(): Response {
+  return new Response("Session not found", { status: 404 });
+}
+
 export function getLocalMcpServerUrl(): string {
   const port = Number(process.env["PORT"] ?? 7777);
   const tlsEnabled = Boolean(process.env["TLS_CERT"] && process.env["TLS_KEY"]);
@@ -121,6 +154,7 @@ export async function handleMcpHttpRequest(
     // Check for existing session
     const sessionId = request.headers.get("mcp-session-id");
     if (sessionId && sessionTransports.has(sessionId)) {
+      if (isForeignSession(sessionId, options)) return sessionNotFound();
       const transport = sessionTransports.get(sessionId)!;
       return transport.handleRequest(request);
     }
@@ -129,7 +163,7 @@ export async function handleMcpHttpRequest(
     // request (leaking both). Reject it — only an initialize request without a
     // session id creates a new session.
     if (sessionId) {
-      return new Response("Session not found", { status: 404 });
+      return sessionNotFound();
     }
 
     // A session this mount cannot bind to a user is refused here, at
@@ -140,18 +174,20 @@ export async function handleMcpHttpRequest(
     }
 
     // New session — create transport and server
+    const ownerUserId = options.agentToolsScope.userId;
     const transport = new WebStandardStreamableHTTPServerTransport({
       enableJsonResponse: true,
       sessionIdGenerator: () => crypto.randomUUID(),
       onsessioninitialized: (id) => {
         sessionTransports.set(id, transport);
+        sessionOwners.set(id, ownerUserId);
       }
     });
     // Evict the session when the transport closes (client disconnect without an
     // explicit DELETE) so sessionTransports — and the McpServer each entry keeps
     // alive — does not grow unbounded over the process lifetime.
     transport.onclose = () => {
-      if (transport.sessionId) sessionTransports.delete(transport.sessionId);
+      if (transport.sessionId) forgetSession(transport.sessionId);
     };
 
     const server = createMcpServer(options);
@@ -161,22 +197,30 @@ export async function handleMcpHttpRequest(
 
   if (method === "GET") {
     const sessionId = request.headers.get("mcp-session-id");
-    if (sessionId && sessionTransports.has(sessionId)) {
+    if (
+      sessionId &&
+      sessionTransports.has(sessionId) &&
+      !isForeignSession(sessionId, options)
+    ) {
       const transport = sessionTransports.get(sessionId)!;
       return transport.handleRequest(request);
     }
-    return new Response("Session not found", { status: 404 });
+    return sessionNotFound();
   }
 
   if (method === "DELETE") {
     const sessionId = request.headers.get("mcp-session-id");
-    if (sessionId && sessionTransports.has(sessionId)) {
+    if (
+      sessionId &&
+      sessionTransports.has(sessionId) &&
+      !isForeignSession(sessionId, options)
+    ) {
       const transport = sessionTransports.get(sessionId)!;
       const response = await transport.handleRequest(request);
-      sessionTransports.delete(sessionId);
+      forgetSession(sessionId);
       return response;
     }
-    return new Response("Session not found", { status: 404 });
+    return sessionNotFound();
   }
 
   return new Response("Method not allowed", { status: 405 });

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -682,6 +682,12 @@ const isProduction = process.env["NODETOOL_ENV"] === "production";
 // In production, bind to all interfaces unless HOST is explicitly set
 const host = process.env["HOST"] ?? (isProduction ? "0.0.0.0" : "127.0.0.1");
 
+// The `/mcp` streamable-HTTP mount. Off in production by default: it carries
+// the full agent toolbelt for whichever user it binds, so a deployment opts in
+// with NODETOOL_ENABLE_MCP=1 and authenticates the agent like any other client.
+const mcpHttpEnabled =
+  !isProduction || process.env["NODETOOL_ENABLE_MCP"] === "1";
+
 // Reverse proxies whose X-Forwarded-For header may be trusted to determine the
 // real client IP. Comma-separated IPs/CIDRs (e.g. "127.0.0.1,10.0.0.0/8").
 // When empty, X-Forwarded-For is NOT trusted: req.ip falls back to the socket
@@ -901,13 +907,16 @@ app.addHook("onRequest", async (req, reply) => {
   }
 
   // Static frontend assets don't require auth (served by fastifyStatic)
+  // `GET /mcp` is the MCP SSE stream, not a static asset — it must go through
+  // auth so the mount can bind the session's user.
   if (
     hasStaticApp &&
     req.method === "GET" &&
     !pathname.startsWith("/api") &&
     !pathname.startsWith("/ws") &&
     !pathname.startsWith("/v1") &&
-    !pathname.startsWith("/trpc")
+    !pathname.startsWith("/trpc") &&
+    !pathname.startsWith("/mcp")
   ) {
     return;
   }
@@ -1368,10 +1377,11 @@ await app.register(
 if (triggersEnabled()) {
   await app.register(createTriggerWebhookRoute());
 }
-// MCP endpoints are only available in local/dev mode — not in production.
-// The configuration endpoints moved to the tRPC `mcpConfig` router; the
-// `/mcp` proxy below is a bare MCP over-HTTP transport and stays on REST.
-if (!isProduction) {
+// The `/mcp` mount is a bare MCP over-HTTP transport (the configuration
+// endpoints moved to the tRPC `mcpConfig` router, which stays local-only). In
+// production it registers only with NODETOOL_ENABLE_MCP=1, and it binds the
+// user the auth hook resolved rather than the local single user.
+if (mcpHttpEnabled) {
   app.all("/mcp", async (req, reply) => {
     const protocol = httpsOptions ? "https" : "http";
     const url = `${protocol}://${req.headers.host ?? `127.0.0.1:${port}`}${req.url}`;
@@ -1408,15 +1418,20 @@ if (!isProduction) {
       ...({ duplex: "half" })
     } as RequestInit);
 
-    // This mount is non-production only (see the isProduction guard above)
-    // and serves the local single user. An authenticated multi-user mount
-    // must derive agentToolsScope from the session instead.
+    // The scope is the user the auth hook resolved for this request. With no
+    // user, no scope is passed and mcp-server.ts answers 401 at initialize
+    // instead of handing out an anonymous full-access session.
     const response = await handleMcpHttpRequest(request, {
       metadataRoots,
       registry,
       examplesDir: apiOptions.examplesDir,
       frontendRendererRegistry,
-      agentToolsScope: { userId: "1", source: "local-dev-http" }
+      agentToolsScope: req.userId
+        ? {
+            userId: req.userId,
+            source: isProduction ? "http-session" : "local-dev-http"
+          }
+        : undefined
     });
     if (!response) {
       reply.status(404).send({ error: "Not found" });
@@ -1430,6 +1445,10 @@ if (!isProduction) {
     const payload = Buffer.from(await response.arrayBuffer());
     reply.send(payload);
   });
+} else {
+  log.info(
+    "MCP over HTTP (/mcp) disabled in production; set NODETOOL_ENABLE_MCP=1 to enable"
+  );
 }
 
 log.info(`Routes registered [${startupMs()}]`);
@@ -1483,6 +1502,7 @@ app.setNotFoundHandler((req, reply) => {
     !pathname.startsWith("/v1") &&
     !pathname.startsWith("/oauth") &&
     !pathname.startsWith("/trpc") &&
+    !pathname.startsWith("/mcp") &&
     !pathname.includes(".")
   ) {
     return reply.sendFile("index.html");
@@ -1663,9 +1683,11 @@ if (pythonBridge.isAvailable()) {
       );
     });
 } else {
+  const pythonAllowedInProduction =
+    process.env["NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION"] === "1";
   log.info(
-    isProduction
-      ? "Python bridge disabled in production — Python nodes will not be available"
+    isProduction && !pythonAllowedInProduction
+      ? "Python bridge disabled in production — Python nodes will not be available; set NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION=1 to enable (the image ships no Python worker: install nodetool-core and point NODETOOL_PYTHON at that interpreter)"
       : "Python not found — Python nodes will not be available"
   );
 }

--- a/packages/websocket/tests/mcp-server.test.ts
+++ b/packages/websocket/tests/mcp-server.test.ts
@@ -395,6 +395,83 @@ describe("session scope", () => {
     expect(() => createMcpServer()).toThrow(MCP_SCOPE_REQUIRED_MESSAGE);
   });
 
+  const initializeBody = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "test", version: "1.0.0" }
+    }
+  });
+
+  async function openHttpSession(userId: string): Promise<string> {
+    const response = await handleMcpHttpRequest(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream"
+        },
+        body: initializeBody
+      }),
+      { agentToolsScope: { userId, source: "http-session" } }
+    );
+    expect(response!.status).toBe(200);
+    const sessionId = response!.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+    return sessionId!;
+  }
+
+  function sessionRequest(method: string, sessionId: string): Request {
+    return new Request("http://localhost/mcp", {
+      method,
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        "mcp-session-id": sessionId
+      },
+      ...(method === "POST"
+        ? {
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 2,
+              method: "tools/list",
+              params: {}
+            })
+          }
+        : {})
+    });
+  }
+
+  it("lets the owning user resume an HTTP session", async () => {
+    const sessionId = await openHttpSession("alice");
+    const response = await handleMcpHttpRequest(
+      sessionRequest("POST", sessionId),
+      { agentToolsScope: { userId: "alice", source: "http-session" } }
+    );
+    expect(response!.status).toBe(200);
+  });
+
+  it("hides another user's HTTP session behind a 404", async () => {
+    const sessionId = await openHttpSession("alice");
+    for (const method of ["POST", "GET", "DELETE"]) {
+      const response = await handleMcpHttpRequest(
+        sessionRequest(method, sessionId),
+        { agentToolsScope: { userId: "mallory", source: "http-session" } }
+      );
+      expect(response!.status).toBe(404);
+      expect(await response!.text()).toBe("Session not found");
+    }
+    // The owner still has it — the refusals did not evict the session.
+    const owned = await handleMcpHttpRequest(
+      sessionRequest("DELETE", sessionId),
+      { agentToolsScope: { userId: "alice", source: "http-session" } }
+    );
+    expect(owned!.status).toBeLessThan(400);
+  });
+
   it("refuses an unscoped HTTP initialize with the fix named", async () => {
     const response = await handleMcpHttpRequest(
       new Request("http://localhost/mcp", {


### PR DESCRIPTION
## What changed

Implements `docs/production-mcp-python-flags-plan.md`. `NODETOOL_ENABLE_MCP=1` registers the `/mcp` streamable-HTTP mount when `NODETOOL_ENV=production`; without it the route does not exist and the boot log names the flag. The mount no longer binds every session to user `"1"` — it passes the user the auth hook resolved (`source: "http-session"` in production), so a request it cannot authenticate hits the existing 401 at initialize instead of getting an anonymous full-access session. Session ids stop working as bearer credentials: `mcp-server.ts` records each session's owner at initialize and answers `404 Session not found` — not 403, which would confirm the id is real — on POST, GET, and DELETE from anyone else. `GET /mcp` is the SSE stream and the auth hook's static-asset exemption skipped auth for any GET outside `/api`, `/ws`, `/v1`, `/trpc` when a static app is served, so it bypassed auth; `/mcp` is now excluded from that exemption and from the SPA 404 fallback. The Python bridge gets no new flag: the production boot log now names the existing `NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION=1` and the fact that the image ships no Python worker, and the docs say how to derive an image that has one.

## Verification

- [x] `npm run typecheck` — web and electron clean (`typecheck:web`, `typecheck:electron` both exit 0). The mobile leg fails on `Cannot find module 'react-native' / 'expo'`: `mobile/node_modules` is not installed in this environment and no mobile file is touched.
- [x] `npm run lint` — exit 0.
- [x] `npm run test --workspace=packages/websocket` — 214 files, 2324 tests passed. `nodetool affected` names only this package; the repo-wide `npm run test` was not run.
- [x] `npm run dev:nodetool -- harness gate --base origin/main` — 0 selfchecks to run; `docker-smoke` printed as manual. Docker is unavailable here, so the equivalent checks were run against the built server directly (below).

Live checks against `packages/websocket/dist/server.js` with `NODETOOL_ENV=production`:

```
# no flag
MCP over HTTP (/mcp) disabled in production; set NODETOOL_ENABLE_MCP=1 to enable
Python bridge disabled in production — … set NODETOOL_ALLOW_PYTHON_BRIDGE_IN_PRODUCTION=1 to enable
POST /mcp -> 404

# NODETOOL_ENABLE_MCP=1, local mode
POST /mcp initialize -> 200, mcp-session-id: 6f389802-…
GET  /mcp            -> 404 Session not found   (reaches the mount, not the SPA)

# NODETOOL_ENABLE_MCP=1, Supabase mode, STATIC_FOLDER set
POST /mcp no token -> 401
GET  /mcp no token -> 401 {"error":"Unauthorized"}
GET  /            -> 200 <html>spa</html>       (static exemption still works)
```

Inverted checks:

- Session ownership. Forcing `isForeignSession` to always return false: `FAIL tests/mcp-server.test.ts > session scope > hides another user's HTTP session behind a 404 — AssertionError: expected 200 to be 404`.
- Static-asset exemption. Removing `!pathname.startsWith("/mcp")` from the built server and re-booting in Supabase mode: unauthenticated `GET /mcp` returns `Session not found [404]` — it reached the MCP handler with no auth. With the guard it is 401.

## Agent capabilities

No capability added, and no declared contract changed.

## New checks

- [x] The ownership check was inverted once and observed failing; the failing output is in **Verification**.
- [x] Not an audit — the two added tests open a real HTTP session and assert on its id, so they cannot pass by matching nothing.


---
_Generated by [Claude Code](https://claude.ai/code/session_0147AkEgVyxVwCem9kxYm4Fm)_