### PR TITLE
feat(models): delete Ollama models over tRPC

### DIFF
--- a/packages/runtime/src/providers/ollama-provider.ts
+++ b/packages/runtime/src/providers/ollama-provider.ts
@@ -402,6 +402,28 @@ export class OllamaProvider extends BaseProvider {
       }));
   }
 
+  /**
+   * Delete a model from the Ollama server's local store. Ollama answers
+   * `DELETE /api/delete` with 200 on success and 404 when the model is not
+   * installed; a 404 is reported as `false` rather than thrown, so a
+   * double-delete is not an error.
+   */
+  async deleteModel(model: string): Promise<boolean> {
+    const response = await this._fetch(`${this.apiUrl}/api/delete`, {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model })
+    });
+    if (response.status === 404) {
+      return false;
+    }
+    if (!response.ok) {
+      throw new Error(`Ollama delete failed (${response.status})`);
+    }
+    this._modelInfoCache.delete(model);
+    return true;
+  }
+
   async getAvailableEmbeddingModels(): Promise<EmbeddingModel[]> {
     const models = await this.getAvailableLanguageModels();
     return models.map((m) => ({

--- a/packages/runtime/tests/providers/ollama-provider.test.ts
+++ b/packages/runtime/tests/providers/ollama-provider.test.ts
@@ -44,6 +44,39 @@ describe("OllamaProvider", () => {
     });
   });
 
+  it("deletes a model via DELETE /api/delete", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({}));
+    const provider = new OllamaProvider(
+      { OLLAMA_API_URL: "http://localhost:11434" },
+      { fetchFn: fetchFn as unknown as typeof fetch }
+    );
+
+    await expect(provider.deleteModel("llama3.1:8b")).resolves.toBe(true);
+    expect(fetchFn).toHaveBeenCalledWith("http://localhost:11434/api/delete", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "llama3.1:8b" })
+    });
+  });
+
+  it("reports a missing model as not deleted and throws on other errors", async () => {
+    const notFound = vi.fn().mockResolvedValue(jsonResponse({}, false, 404));
+    const providerA = new OllamaProvider(
+      { OLLAMA_API_URL: "http://localhost:11434" },
+      { fetchFn: notFound as unknown as typeof fetch }
+    );
+    await expect(providerA.deleteModel("gone:latest")).resolves.toBe(false);
+
+    const serverError = vi.fn().mockResolvedValue(jsonResponse({}, false, 500));
+    const providerB = new OllamaProvider(
+      { OLLAMA_API_URL: "http://localhost:11434" },
+      { fetchFn: serverError as unknown as typeof fetch }
+    );
+    await expect(providerB.deleteModel("x:latest")).rejects.toThrow(
+      "Ollama delete failed (500)"
+    );
+  });
+
   it("fetches available models from /api/tags", async () => {
     const fetchFn = vi.fn().mockResolvedValue(
       jsonResponse({

--- a/packages/websocket/src/trpc/routers/models.ts
+++ b/packages/websocket/src/trpc/routers/models.ts
@@ -11,6 +11,7 @@ import {
   listRegisteredProviderIds,
   RECOMMENDED_MODELS,
   OLLAMA_DEFAULT_URL,
+  OllamaProvider,
   LMSTUDIO_DEFAULT_URL,
   type ProviderId,
   type RecommendedUnifiedModel
@@ -1430,6 +1431,26 @@ export const modelsRouter = router({
       []
     )
   ),
+
+  /**
+   * Delete a model from the local Ollama server. Returns false when Ollama is
+   * not configured or does not have the model.
+   */
+  ollamaDelete: protectedProcedure
+    .input(z.object({ model: z.string().min(1) }))
+    .output(z.boolean())
+    .mutation(async ({ ctx, input }) =>
+      safeProviderCall(
+        "ollama delete",
+        { provider: "ollama", userId: ctx.userId },
+        async () => {
+          const instance = await instantiateProvider("ollama", ctx.userId);
+          if (!(instance instanceof OllamaProvider)) return false;
+          return instance.deleteModel(input.model);
+        },
+        false
+      )
+    ),
 
   llmByProvider: protectedProcedure
     .input(providerInput)

--- a/packages/websocket/src/trpc/sandbox-coverage.ts
+++ b/packages/websocket/src/trpc/sandbox-coverage.ts
@@ -438,6 +438,12 @@ export const SANDBOX_API_COVERAGE: Readonly<
       "a third party. A run that could start or delete a download " +
       "could fill the disk or remove a model other runs depend on."
   },
+  "models.ollamaDelete": {
+    withheld:
+      "Model management writes to host disk and pulls gigabytes from " +
+      "a third party. A run that could start or delete a download " +
+      "could fill the disk or remove a model other runs depend on."
+  },
   "models.providers": { capability: "list_provider_models" },
   "models.pullOllamaModel": {
     withheld:

--- a/web/src/components/hugging_face/model_list/DeleteModelDialog.tsx
+++ b/web/src/components/hugging_face/model_list/DeleteModelDialog.tsx
@@ -53,10 +53,12 @@ const DeleteModelDialog: React.FC<DeleteModelDialogProps> = ({
   };
 
   const deleteOllamaModel = async (modelName: string) => {
-    // Ollama DELETE is not implemented in tRPC (no streaming needed for delete);
-    // for now this is a no-op that resolves immediately.
-    // TODO: add models.ollamaDelete tRPC procedure when Ollama delete is ported.
-    console.warn("Ollama model delete not yet available via tRPC", modelName);
+    const deleted = await trpc.models.ollamaDelete.mutate({ model: modelName });
+    if (!deleted) {
+      throw new Error(
+        `Ollama did not delete ${modelName} — the server may be unreachable or the model already gone.`
+      );
+    }
     return modelName;
   };
 

--- a/web/src/components/hugging_face/model_list/__tests__/DeleteModelDialog.ollama.test.tsx
+++ b/web/src/components/hugging_face/model_list/__tests__/DeleteModelDialog.ollama.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+import { stub } from "../../../../test-utils/doubles";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "@mui/material/styles";
+import mockTheme from "../../../../__mocks__/themeMock";
+import type { UnifiedModel } from "../../../../stores/ApiTypes";
+
+const mockOllamaDelete = jest.fn();
+const mockHfDelete = jest.fn();
+
+jest.mock("../../../../lib/trpc", () => ({
+  trpc: {
+    models: {
+      huggingfaceDelete: { mutate: (...a: unknown[]) => mockHfDelete(...a) },
+      ollamaDelete: { mutate: (...a: unknown[]) => mockOllamaDelete(...a) }
+    }
+  }
+}));
+
+jest.mock("../../../../utils/fileExplorer", () => ({
+  isFileExplorerAvailable: () => false,
+  openOllamaPath: jest.fn(),
+  openInExplorer: jest.fn()
+}));
+
+const mockAddNotification = jest.fn();
+jest.mock("../../../../stores/NotificationStore", () => ({
+  useNotificationStore: (selector: (s: unknown) => unknown) =>
+    selector({ addNotification: mockAddNotification })
+}));
+
+const mockUseModels = jest.fn();
+jest.mock("../useModels", () => ({
+  useModels: (...a: unknown[]) => mockUseModels(...a)
+}));
+
+import DeleteModelDialog from "../DeleteModelDialog";
+
+const OLLAMA_MODEL: UnifiedModel = stub<UnifiedModel>({
+  id: "llama3.1:8b",
+  name: "llama3.1:8b",
+  repo_id: "llama3.1:8b",
+  type: "llama_model",
+  path: null
+});
+
+const renderDialog = (onClose = () => undefined) => {
+  const qc = new QueryClient();
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <QueryClientProvider client={qc}>
+        <DeleteModelDialog modelId="llama3.1:8b" onClose={onClose} />
+      </QueryClientProvider>
+    </ThemeProvider>
+  );
+};
+
+beforeEach(() => {
+  mockOllamaDelete.mockReset().mockResolvedValue(true);
+  mockHfDelete.mockReset().mockResolvedValue(true);
+  mockAddNotification.mockReset();
+  mockUseModels.mockReset().mockReturnValue({ allModels: [OLLAMA_MODEL] });
+});
+
+describe("DeleteModelDialog — Ollama models", () => {
+  it("deletes through models.ollamaDelete and closes", async () => {
+    const onClose = jest.fn();
+    renderDialog(onClose);
+
+    await userEvent.click(screen.getByRole("button", { name: /^Delete$/i }));
+
+    await waitFor(() =>
+      expect(mockOllamaDelete).toHaveBeenCalledWith({ model: "llama3.1:8b" })
+    );
+    expect(mockHfDelete).not.toHaveBeenCalled();
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("reports a refused delete instead of claiming success", async () => {
+    mockOllamaDelete.mockResolvedValue(false);
+    const onClose = jest.fn();
+    renderDialog(onClose);
+
+    await userEvent.click(screen.getByRole("button", { name: /^Delete$/i }));
+
+    await waitFor(() =>
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error" })
+      )
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed

The Model Manager's delete dialog resolved the Ollama branch as a no-op — it logged `"Ollama model delete not yet available via tRPC"`, reported success, and the model came back on the next refresh. This implements the TODO that stub carried. `OllamaProvider.deleteModel` calls `DELETE /api/delete`, reporting Ollama's 404 as `false` instead of throwing so a double-delete is not an error, and drops the model's cached `/api/show` metadata. `models.ollamaDelete` exposes it with the same `{model}` input the `pullOllamaModel` stub takes, returning `false` when Ollama is not configured; it is classified `withheld` in `sandbox-coverage.ts` for the reason the other model-management procedures carry — a run that can delete a model can remove one other runs depend on. The dialog now throws when the delete is refused, so the existing error path shows the user a failure instead of a false success.

## Verification

- [x] `npm run test:affected` — all affected suites passed (exit 0). One earlier failure in `@nodetool-ai/image-nodes` (52 tests, "No WebGPU adapter available (Node/Dawn)") was the missing Vulkan ICD documented in AGENTS.md, not this diff: after `apt-get install -y mesa-vulkan-drivers` that package is 231/231 green.
- [x] `npm run typecheck` — web and electron clean. Mobile fails to resolve `react-native`/`expo-*` because `mobile/node_modules` is absent in this container; the diff touches no mobile file.
- [x] `npm run lint` — exit 0 (pre-existing warnings only); the new test file is clean under `oxlint`.
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 6/6 selfchecks passed`
- [x] `npm run capabilities:check` — `capability table is current (201 capabilities)`

Tests added: `OllamaProvider.deleteModel` (request shape, 404 → `false`, 500 → throw) in `packages/runtime/tests/providers/ollama-provider.test.ts`, and `DeleteModelDialog.ollama.test.tsx` covering both the successful delete and the refused one.

The sandbox-coverage gate was inverted once to prove it bites — removing the `models.ollamaDelete` entry fails `packages/websocket/tests/sandbox-api-coverage.test.ts`:

```
AssertionError: new API surface must be classified in src/trpc/sandbox-coverage.ts —
say which capability covers it, or why sandboxed code may not have it:
expected [ 'models.ollamaDelete' ] to deeply equal []
+   "models.ollamaDelete",
      Tests  1 failed | 5 passed (6)
```

## Agent capabilities

No capability added, and no capability's declared contract changed. `models.ollamaDelete` is a tRPC procedure withheld from sandboxed code, not a capability.

## New checks

No new check, rule, or audit — the coverage entry registers this procedure with an existing gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_015C6SnuTCVMpZ8BC1cdWN7q)_