### PR TITLE
chore(rankings): standardize the Artificial Analysis key name

### DIFF
--- a/.github/workflows/model-rankings-sync.yml
+++ b/.github/workflows/model-rankings-sync.yml
@@ -10,7 +10,7 @@ name: Model Rankings Sync
 #
 # The sync needs no provider API keys and no built packages: the canonical slugs
 # and their provider routes come from the shipped GenSpend price catalog in the
-# same package. It does need `ARTIFICIALANALYSIS_API_KEY` — without one the
+# same package. It does need `ARTIFICIAL_ANALYSIS_API_KEY` — without one the
 # script exits 0 having fetched nothing, which is what a fork gets.
 
 on:
@@ -43,7 +43,7 @@ jobs:
 
       - name: Sync rankings
         env:
-          ARTIFICIALANALYSIS_API_KEY: ${{ secrets.ARTIFICIALANALYSIS_API_KEY }}
+          ARTIFICIAL_ANALYSIS_API_KEY: ${{ secrets.ARTIFICIAL_ANALYSIS_API_KEY }}
         run: npm run sync:model-rankings -- --report model-rankings-report.json
 
       - name: Upload match report

--- a/scripts/sync-model-rankings.mjs
+++ b/scripts/sync-model-rankings.mjs
@@ -21,7 +21,7 @@
  *   node scripts/sync-model-rankings.mjs --report r.json
  *   node scripts/sync-model-rankings.mjs --from-dir fixtures/   # <task>.json each
  *
- * Needs `ARTIFICIALANALYSIS_API_KEY` unless `--from-dir` is given. Without one
+ * Needs `ARTIFICIAL_ANALYSIS_API_KEY` unless `--from-dir` is given. Without one
  * the run is a no-op that exits 0: a fork's CI has no secret, and a missing key
  * is not a broken pipeline.
  *
@@ -313,10 +313,10 @@ async function main() {
     return;
   }
 
-  const apiKey = process.env.ARTIFICIALANALYSIS_API_KEY ?? "";
+  const apiKey = process.env.ARTIFICIAL_ANALYSIS_API_KEY ?? "";
   if (!args.fromDir && !apiKey) {
     console.log(
-      "skipped: no ARTIFICIALANALYSIS_API_KEY — nothing fetched, artifact left as shipped."
+      "skipped: no ARTIFICIAL_ANALYSIS_API_KEY — nothing fetched, artifact left as shipped."
     );
     return;
   }


### PR DESCRIPTION
## What changed

The model-rankings sync read its credential from `ARTIFICIALANALYSIS_API_KEY`, which runs the vendor's two words together and matches nothing else in the repo. Every site now uses `ARTIFICIAL_ANALYSIS_API_KEY` and only that name — the `process.env` read in `scripts/sync-model-rankings.mjs`, its skip message, the doc comment above it, and the `env`/`secrets` pair in `.github/workflows/model-rankings-sync.yml`. There is deliberately no fallback to the old name: the request was one key and nothing else.

The nightly workflow's repository secret has to be renamed to match. Until it is, the sync exits 0 having fetched nothing and leaves the shipped artifact alone — the same path a fork with no secret takes — so nothing breaks in the meantime, but no rankings refresh either.

## Verification

- [x] `npm run test:affected` — the two `packages/protocol` failures are `Cannot find package 'ajv/dist/2020.js'`, a missing dependency in this container; 971 tests pass and this diff touches no package source.
- [x] `npm run typecheck` — 199 errors with the change stashed and the same set with it applied; all are `Cannot find module '@nodetool-ai/*'` from unbuilt packages in this container, none from the diff.
- [x] `npm run lint` — passes.
- [x] Behavior check with the variable unset:

```
$ env -u ARTIFICIALANALYSIS_API_KEY -u ARTIFICIAL_ANALYSIS_API_KEY node scripts/sync-model-rankings.mjs
skipped: no ARTIFICIAL_ANALYSIS_API_KEY — nothing fetched, artifact left as shipped.
exit=0
```

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUUAMhEtHDazVaDZGdtPZg)_