### PR TITLE
fix(storyboard): report why a still or clip render failed

### DIFF
--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -40,6 +40,7 @@ import ShotScriptPanel from "./ShotScriptPanel";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
 import { entitiesForShot } from "../../stores/storyboard/shotEntities";
 import { useGenerateShot } from "../../hooks/storyboard/useGenerateShot";
+import { useStoryboardGenerationStore } from "../../stores/storyboard/StoryboardGenerationStore";
 import { useShotDuration } from "../../hooks/storyboard/useShotDuration";
 import { useEntities } from "../../serverState/useEntities";
 import { ENTITY_KIND_COLOR } from "../entities/entityKind";
@@ -140,6 +141,13 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const meta = STATUS_META[shot.status];
+  // Why the last still or clip failed. Kept on the shot's job state until the
+  // next attempt registers, so the card can say more than "Failed".
+  const renderError = useStoryboardGenerationStore((state) => {
+    const job = state.shotJobs[shot.id];
+    return job?.status === "failed" ? job.errorMessage : undefined;
+  });
+  const failed = shot.status === "failed";
   const isGenerating =
     shot.status === "keyframe_generating" || shot.status === "clip_generating";
   const camera = cameraLine(shot);
@@ -148,18 +156,23 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   const clipUri = useResolvedMediaUri(shot.clip);
   const shotName = `${shot.index + 1}. ${shot.slug ?? "Untitled shot"}`;
 
+  // A start that throws records its reason on the shot's job state (and
+  // toasts it), which is what `renderError` above shows — so the rejection is
+  // already reported and only needs to not go unhandled.
   const handleGenerateStill = useCallback(() => {
-    void generateKeyframe(boardId, shot);
+    void generateKeyframe(boardId, shot).catch(() => undefined);
   }, [generateKeyframe, boardId, shot]);
 
   const handleGenerateClip = useCallback(() => {
-    void generateClip(boardId, shot);
+    void generateClip(boardId, shot).catch(() => undefined);
   }, [generateClip, boardId, shot]);
 
   const handleReviseConfirm = useCallback(() => {
     const instruction = reviseText.trim();
     if (instruction.length > 0) {
-      void generateRevisedClip(boardId, shot, instruction);
+      void generateRevisedClip(boardId, shot, instruction).catch(
+        () => undefined
+      );
     }
     setReviseOpen(false);
     setReviseText("");
@@ -219,6 +232,22 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
               </Caption>
             }
           />
+        )}
+        {failed && !isGenerating && !shot.keyframe && !shot.clip && (
+          <FlexColumn
+            align="center"
+            justify="center"
+            sx={{
+              position: "absolute",
+              inset: 0,
+              bgcolor: "c_scrim_soft",
+              p: SPACING.sm
+            }}
+          >
+            <Caption sx={{ color: "error.main", textAlign: "center" }}>
+              Render failed
+            </Caption>
+          </FlexColumn>
         )}
         {isGenerating && (
           <FlexColumn
@@ -307,6 +336,16 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
             )}
           </FlexRow>
         </FlexRow>
+
+        {failed && (
+          <Caption
+            role="alert"
+            data-testid="shot-render-error"
+            sx={{ color: "error.main" }}
+          >
+            {renderError ?? "The render failed. Try again."}
+          </Caption>
+        )}
 
         <Text lineClamp={3}>{shot.action}</Text>
 

--- a/web/src/components/storyboard/StoryboardBoard.tsx
+++ b/web/src/components/storyboard/StoryboardBoard.tsx
@@ -222,14 +222,16 @@ const StoryboardBoardInner: React.FC<StoryboardBoardProps> = ({
   );
 
   const { generateKeyframe, generateClip } = useGenerateShot();
+  // A shot that cannot start records the reason on itself (its card shows it,
+  // and it is toasted), so one failure must not stop the rest of the batch.
   const handleGenerateAllStills = useCallback(() => {
     for (const shot of pendingStills) {
-      void generateKeyframe(boardId, shot);
+      void generateKeyframe(boardId, shot).catch(() => undefined);
     }
   }, [pendingStills, generateKeyframe, boardId]);
   const handleGenerateAllClips = useCallback(() => {
     for (const shot of pendingClips) {
-      void generateClip(boardId, shot);
+      void generateClip(boardId, shot).catch(() => undefined);
     }
   }, [pendingClips, generateClip, boardId]);
 

--- a/web/src/components/storyboard/__tests__/ShotCard.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotCard.test.tsx
@@ -7,7 +7,7 @@ import mockTheme from "../../../__mocks__/themeMock";
 
 // Keep the card's generation hook and image ladder out of the render — this test
 // only asserts the card's presentation and button gating, not generation.
-const generateRevisedClipMock = jest.fn();
+const generateRevisedClipMock = jest.fn(async () => undefined);
 // Media sources resolve through TanStack Query; these suites render no
 // QueryClientProvider, so use the manual mock (resolution itself is covered
 // by hooks/__tests__/useResolvedMediaUri.test.tsx).
@@ -15,8 +15,8 @@ jest.mock("../../../hooks/useResolvedMediaUri");
 
 jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
   useGenerateShot: () => ({
-    generateKeyframe: jest.fn(),
-    generateClip: jest.fn(),
+    generateKeyframe: jest.fn(async () => undefined),
+    generateClip: jest.fn(async () => undefined),
     generateRevisedClip: generateRevisedClipMock
   })
 }));
@@ -113,6 +113,7 @@ jest.mock("../../../serverState/useEntities", () => ({
 }));
 
 import ShotCard from "../ShotCard";
+import { useStoryboardGenerationStore } from "../../../stores/storyboard/StoryboardGenerationStore";
 
 const makeShot = (overrides: Partial<Shot> = {}): Shot => ({
   type: "shot",
@@ -138,6 +139,36 @@ describe("ShotCard", () => {
     updateShotMock.mockClear();
     linkedScriptId = null;
     lineIsVoiced = true;
+  });
+
+  it("shows why the last render failed", () => {
+    // Seed the job state directly: this suite mocks the storyboard store, so
+    // the action that would write it has nothing to write to.
+    useStoryboardGenerationStore.setState({
+      shotJobs: {
+        "shot-1": {
+          shotId: "shot-1",
+          boardId: "board-1",
+          jobId: "job-1",
+          workflowId: "wf",
+          kind: "keyframe",
+          status: "failed",
+          errorMessage: "Out of credits"
+        }
+      }
+    });
+    renderCard(makeShot({ status: "failed" }));
+    expect(screen.getByTestId("shot-render-error")).toHaveTextContent(
+      "Out of credits"
+    );
+    useStoryboardGenerationStore.setState({ shotJobs: {} });
+  });
+
+  it("falls back to a generic reason when the job state is gone", () => {
+    renderCard(makeShot({ status: "failed" }));
+    expect(screen.getByTestId("shot-render-error")).toHaveTextContent(
+      "The render failed. Try again."
+    );
   });
 
   it("renders the shot action and status label", () => {

--- a/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
+++ b/web/src/components/storyboard/__tests__/StoryboardBoard.test.tsx
@@ -54,8 +54,8 @@ jest.mock("../ScriptLinkControl", () => ({
 
 jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
   useGenerateShot: () => ({
-    generateKeyframe: jest.fn(),
-    generateClip: jest.fn()
+    generateKeyframe: jest.fn(async () => undefined),
+    generateClip: jest.fn(async () => undefined)
   })
 }));
 

--- a/web/src/hooks/storyboard/__tests__/useGenerateShot.test.tsx
+++ b/web/src/hooks/storyboard/__tests__/useGenerateShot.test.tsx
@@ -206,3 +206,38 @@ describe("clip length on a script-linked board", () => {
     expect(scriptQuery).not.toHaveBeenCalled();
   });
 });
+
+describe("a start that fails", () => {
+  it("records the reason on the shot and rethrows", async () => {
+    run.mockRejectedValue(new Error("No image model configured"));
+    const { result } = renderHook(() => useGenerateShot());
+
+    await act(async () => {
+      await expect(result.current.generateKeyframe(BOARD, shot)).rejects.toThrow(
+        "No image model configured"
+      );
+    });
+
+    const job = useStoryboardGenerationStore.getState().shotJobs[shot.id];
+    expect(job?.status).toBe("failed");
+    expect(job?.errorMessage).toBe("No image model configured");
+    expect(
+      useStoryboardStore.getState().getBoard(BOARD)?.shots[0].status
+    ).toBe("failed");
+  });
+
+  it("records a reason when the runner returns no job id", async () => {
+    run.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useGenerateShot());
+
+    await act(async () => {
+      await expect(
+        result.current.generateKeyframe(BOARD, shot)
+      ).rejects.toThrow("Workflow runner did not return a job id");
+    });
+
+    expect(
+      useStoryboardGenerationStore.getState().shotJobs[shot.id]?.errorMessage
+    ).toBe("Workflow runner did not return a job id");
+  });
+});

--- a/web/src/hooks/storyboard/useGenerateShot.ts
+++ b/web/src/hooks/storyboard/useGenerateShot.ts
@@ -33,6 +33,7 @@ import {
   type ShotJobKind
 } from "../../stores/storyboard/StoryboardGenerationStore";
 import { fetchShotDurationSeconds } from "./useShotDuration";
+import { getErrorMessage } from "../../utils/errorHandling";
 
 const GEN_NODE_ID = "gen";
 const OUT_NODE_ID = "out";
@@ -176,6 +177,9 @@ export const useGenerateShot = (): UseGenerateShotResult => {
   const registerJob = useStoryboardGenerationStore(
     (state) => state.registerJob
   );
+  const recordStartFailure = useStoryboardGenerationStore(
+    (state) => state.recordStartFailure
+  );
   // Library entities; a board's `entityIds` picks which ones season prompts.
   const { data: allEntities } = useEntities();
   // Model catalog, for checking whether the still model can take entity
@@ -234,11 +238,22 @@ export const useGenerateShot = (): UseGenerateShotResult => {
           },
           false
         );
+      } catch (error) {
+        // A start that throws has no job and therefore no message stream to
+        // report on: record the reason on the shot so the card and a toast
+        // can show it, then rethrow for callers that await (the agent tools).
+        recordStartFailure(
+          shot.id,
+          boardId,
+          kind,
+          getErrorMessage(error, "Could not start the render.")
+        );
+        throw error;
       } finally {
         startingShots.delete(shot.id);
       }
     },
-    [registerJob]
+    [registerJob, recordStartFailure]
   );
 
   const generateKeyframe = useCallback(

--- a/web/src/stores/storyboard/StoryboardGenerationStore.ts
+++ b/web/src/stores/storyboard/StoryboardGenerationStore.ts
@@ -21,6 +21,7 @@ import {
   type WebSocketMessage
 } from "../../lib/websocket/GlobalWebSocketManager";
 import { normalizeOutputUpdateValue, isOutputUpdate } from "../outputUpdateValue";
+import { useNotificationStore } from "../NotificationStore";
 import { useStoryboardStore } from "./StoryboardStore";
 import { syncShotClipToTimeline } from "./timelineSync";
 import { isNumber, isString } from "../../utils/typePredicates";
@@ -86,6 +87,17 @@ interface StoryboardGenerationStoreState {
     extra?: { assetId?: string; errorMessage?: string }
   ) => void;
   updateJobProgress: (jobId: string, progress: number) => void;
+  /**
+   * Record a failure that happened before the job existed — the run request
+   * itself threw, so there is no job id and no WebSocket stream to report it.
+   * Without this the shot silently stays "planned" and the user sees nothing.
+   */
+  recordStartFailure: (
+    shotId: string,
+    boardId: string,
+    kind: ShotJobKind,
+    errorMessage: string
+  ) => void;
   clear: (shotId: string) => void;
   getShotJobState: (shotId: string) => ShotJobState | undefined;
 }
@@ -134,6 +146,44 @@ const deriveMembership = (
       ? prev.failedShotIds
       : nextFailed
   };
+};
+
+// ── Failure reporting ────────────────────────────────────────────────────────
+
+const KIND_LABEL: Record<ShotJobKind, string> = {
+  keyframe: "Still",
+  clip: "Clip"
+};
+
+/** "3. Wide of the pier" — the name the card shows, for the failure toast. */
+const shotLabel = (boardId: string, shotId: string): string => {
+  const shot = useStoryboardStore
+    .getState()
+    .getBoard(boardId)
+    ?.shots.find((s) => s.id === shotId);
+  if (!shot) {
+    return "shot";
+  }
+  return `${shot.index + 1}. ${shot.slug ?? "Untitled shot"}`;
+};
+
+/**
+ * Toast a failed render. The card carries the same message, but a board can be
+ * long and a still can fail while the user is looking elsewhere — one job, one
+ * notification (dedupeKey), replacing the previous one for that job.
+ */
+const notifyShotFailure = (job: ShotJobState): void => {
+  const reason = job.errorMessage?.trim();
+  useNotificationStore.getState().addNotification({
+    type: "error",
+    alert: true,
+    content: `${KIND_LABEL[job.kind]} failed for ${shotLabel(
+      job.boardId,
+      job.shotId
+    )}${reason ? `: ${reason}` : "."}`,
+    dedupeKey: `storyboard-shot-failed:${job.shotId}`,
+    replaceExisting: true
+  });
 };
 
 // ── Store ────────────────────────────────────────────────────────────────────
@@ -211,6 +261,7 @@ export const useStoryboardGenerationStore =
         useStoryboardStore
           .getState()
           .setShotStatus(existing.boardId, shotId, "failed");
+        notifyShotFailure(updated);
       }
     },
 
@@ -231,6 +282,36 @@ export const useStoryboardGenerationStore =
           [shotId]: { ...existing, progress: safeProgress }
         }
       }));
+    },
+
+    recordStartFailure: (shotId, boardId, kind, errorMessage) => {
+      const jobState: ShotJobState = {
+        shotId,
+        boardId,
+        // No job was created, so there is nothing to subscribe to or cancel.
+        // The id only keys the reverse lookup, which nothing will hit.
+        jobId: `unstarted:${shotId}`,
+        workflowId: "",
+        kind,
+        status: "failed",
+        errorMessage
+      };
+      set((state) => {
+        const nextShotJobs = { ...state.shotJobs, [shotId]: jobState };
+        const nextJobToShot = { ...state.jobToShot };
+        const previous = state.shotJobs[shotId];
+        if (previous) {
+          delete nextJobToShot[previous.jobId];
+        }
+        nextJobToShot[jobState.jobId] = shotId;
+        return {
+          shotJobs: nextShotJobs,
+          jobToShot: nextJobToShot,
+          ...deriveMembership(nextShotJobs, state)
+        };
+      });
+      useStoryboardStore.getState().setShotStatus(boardId, shotId, "failed");
+      notifyShotFailure(jobState);
     },
 
     clear: (shotId) => {

--- a/web/src/stores/storyboard/__tests__/StoryboardGenerationStore.test.ts
+++ b/web/src/stores/storyboard/__tests__/StoryboardGenerationStore.test.ts
@@ -21,6 +21,7 @@ import {
   type StoryboardJobContext
 } from "../StoryboardGenerationStore";
 import { useStoryboardStore } from "../StoryboardStore";
+import { useNotificationStore } from "../../NotificationStore";
 
 const BOARD = "board-t";
 const context = (shotId: string, kind: "keyframe" | "clip"): StoryboardJobContext => ({
@@ -180,5 +181,74 @@ describe("updateJobStatus", () => {
     const job = useStoryboardGenerationStore.getState().shotJobs["s-plain"];
     expect(job?.status).toBe("completed");
     expect(job?.errorMessage).toBeUndefined();
+  });
+});
+
+describe("failure reporting", () => {
+  beforeEach(() => {
+    useNotificationStore.getState().clearNotifications();
+  });
+
+  it("keeps the job error and notifies when a job fails", () => {
+    seedShot("s-fail");
+    const gen = useStoryboardGenerationStore.getState();
+    gen.registerJob("s-fail", BOARD, "job-fail", "wf", "keyframe");
+
+    __handleShotJobMessageForTests("job-fail", context("s-fail", "keyframe"), {
+      type: "job_update",
+      status: "failed",
+      error: "Provider rejected the prompt"
+    } as never);
+
+    const job = useStoryboardGenerationStore.getState().shotJobs["s-fail"];
+    expect(job?.status).toBe("failed");
+    expect(job?.errorMessage).toBe("Provider rejected the prompt");
+
+    const notification =
+      useNotificationStore.getState().notifications.at(-1);
+    expect(notification?.type).toBe("error");
+    expect(notification?.content).toContain("Provider rejected the prompt");
+  });
+
+  it("reports a completed job that produced no output", () => {
+    seedShot("s-empty");
+    const gen = useStoryboardGenerationStore.getState();
+    gen.registerJob("s-empty", BOARD, "job-empty", "wf", "keyframe");
+
+    __handleShotJobMessageForTests("job-empty", context("s-empty", "keyframe"), {
+      type: "job_update",
+      status: "completed"
+    } as never);
+
+    expect(
+      useStoryboardGenerationStore.getState().shotJobs["s-empty"]?.errorMessage
+    ).toBe("Workflow finished without producing an output.");
+    expect(
+      useNotificationStore.getState().notifications.at(-1)?.content
+    ).toContain("Workflow finished without producing an output.");
+  });
+
+  it("records a failure that happened before any job existed", () => {
+    seedShot("s-unstarted");
+    useStoryboardGenerationStore
+      .getState()
+      .recordStartFailure("s-unstarted", BOARD, "keyframe", "No model chosen");
+
+    const job =
+      useStoryboardGenerationStore.getState().shotJobs["s-unstarted"];
+    expect(job?.status).toBe("failed");
+    expect(job?.errorMessage).toBe("No model chosen");
+    expect(
+      useStoryboardGenerationStore.getState().failedShotIds
+    ).toContain("s-unstarted");
+    expect(
+      useStoryboardStore
+        .getState()
+        .getBoard(BOARD)
+        ?.shots.find((s) => s.id === "s-unstarted")?.status
+    ).toBe("failed");
+    expect(
+      useNotificationStore.getState().notifications.at(-1)?.content
+    ).toContain("No model chosen");
   });
 });


### PR DESCRIPTION
## What changed

A storyboard shot whose still or clip failed showed a "Failed" chip and nothing else — the job's error message was already stored on `ShotJobState.errorMessage` and never rendered anywhere. Worse, a render that threw *before* a job existed (no image model configured, the run request rejected) was swallowed entirely: `ShotCard` and `StoryboardBoard` call `void generateKeyframe(...)`, so the rejection went nowhere and the shot stayed on "planned" with no sign anything had been attempted. The card now renders the job's error message (with fallback text when the job state is gone, e.g. after a reload), a failed shot with no media says so in its preview tile, and every failure — job-reported or start-time — raises one toast naming the shot, so a still that fails while the user is scrolled elsewhere is still visible. `startJob` records a start-time throw on the shot via the new `recordStartFailure` action before rethrowing, so the agent tools that `await` these calls keep the error while the UI reports it too.

## Verification

- [x] `npm run test:affected` — 5 suites, 47 tests passed (adds: two `useGenerateShot` cases for a rejecting run and a runner returning no job id, three `StoryboardGenerationStore` cases for job failure / empty output / start failure, two `ShotCard` cases for the message and its fallback)
- [x] `npm run typecheck` — no errors in the touched files. The run reports pre-existing `TS2307` failures for unbuilt node packages (`@nodetool-ai/image-nodes`, `audio-nodes`, `video-nodes`) that this diff does not touch.
- [x] `npm run lint` — passes; only pre-existing warnings.
- [ ] `npm run dev:nodetool -- harness gate --base main` — could not run in this environment: `npm run build:packages` fails on `@nodetool-ai/agents` because `@nodetool-ai/model3d` is not linked into `node_modules` (a stale install, unrelated to this diff), so the CLI cannot start. The diff is web-only.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

---
_Generated by [Claude Code](https://claude.ai/code/session_018eAULJxwAb3iob4AT8TA3G)_