### PR TITLE
perf(sandbox): cut QuickJS boundary and per-run setup cost

### DIFF
--- a/docs/javascript-sandbox.md
+++ b/docs/javascript-sandbox.md
@@ -50,7 +50,9 @@ process and shared. Each invocation gets a fresh runtime and context.
    are deleted. The entry module additionally deletes the timer globals, which
    the wrapper library re-installs on every evaluation.
 6. **Run**, under an interrupt handler on a CPU deadline and a wall-clock race.
-7. **Serialize.** `serializeResult` walks the returned value (cycle-safe,
+7. **Serialize.** The guest encodes its result with the JSON transport (see
+   [Marshaling rules](#marshaling-rules)) and the host decodes it, then
+   `serializeResult` walks the returned value (cycle-safe,
    depth-capped at 32) converting typed arrays at any depth, then truncates to
    `maxOutputSize`. Object-typed globals are deep-replaced on the host, which is
    how the Code node's `state` survives between invocations.
@@ -260,6 +262,19 @@ symptom is silent data corruption, not an error.
   map.
 - **Object globals sync back.** After the guest runs, object-typed globals are
   deep-replaced on the host. Primitives pass by value and do not sync.
+- **Structured data crosses as JSON, not as handles.** The wrapper marshals an
+  object node by node — four `evalCode` compilations plus a property-by-property
+  descriptor copy each — so a run handed 5 000 rows spent ~2 s reading them and
+  ~0.8 s handing them back. `sandbox-json-transport.ts` moves one string
+  instead: the guest builds its result with `JSON.stringify` and the host parses
+  it, the host encodes injected globals for the prelude to parse, and `emit` /
+  `output` arguments take the same path. Typed arrays and strings over 8 KB ride
+  a sidecar the marshaler moves whole; dates, non-finite numbers and `undefined`
+  properties carry markers, because JSON alone would flatten or drop them. A
+  value the encoder cannot represent — a function, a bigint, a `Map`, a class
+  instance — falls back to the wrapper's own marshaling. A **cycle** is refused
+  outright: the wrapper follows it until the runtime aborts, so a cyclic global
+  fails the run by name and a cyclic result comes back as `String(value)`.
 
 ## Security model
 

--- a/docs/javascript-sandbox.md
+++ b/docs/javascript-sandbox.md
@@ -43,11 +43,20 @@ process and shared. Each invocation gets a fresh runtime and context.
    the body of a top-level-awaited async IIFE, so `return value` becomes the
    module's default export. Code acorn cannot parse falls through to `wrapCode`
    unchanged, so a syntax error reaches the user as they wrote it.
-4. **Install the module loader** — only when the run declares modules. Without
-   `modules`, no loader exists and every `import` resolves nothing.
+4. **Install the module loader** — always, because it is also what the wrapper's
+   own Node-compat preamble resolves through. That preamble compiles ~12KB of
+   polyfills into every fresh runtime, and the prelude below deletes most of what
+   they install, so `BOOTSTRAP_MODULE_SOURCES` (`sandbox-bootstrap-modules.ts`)
+   serves four of them as empty modules and `node:util` as the two classes the
+   guest keeps. `node:url` still comes from the wrapper: `URL` and
+   `URLSearchParams` are guest capabilities. Measured: 5.96ms → 3.28ms of setup
+   per run. Guest specifiers resolve only what the run declares; without
+   `modules`, every guest `import` resolves nothing.
 5. **Init prelude.** `eval`, `Function` and the wrapper's unconditional stubs
    (`Buffer`, `process`, `env`, `Headers`, `Request`, `Response`, `performance`)
-   are deleted. The entry module additionally deletes the timer globals, which
+   are deleted. Four of those no longer exist to delete — the bootstrap above
+   never installs them — and the deletions stay as the guard for a wrapper
+   release that puts them back some other way. The entry module additionally deletes the timer globals, which
    the wrapper library re-installs on every evaluation.
 6. **Run**, under an interrupt handler on a CPU deadline and a wall-clock race.
 7. **Serialize.** The guest encodes its result with the JSON transport (see

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -459,6 +459,19 @@ around every tool- and plan-approval round trip.
   `describeEngineFailure` turns them into an actionable message instead of raw
   assertion text. Anything not attributable to the engine is re-thrown, so a
   genuine host bug still crashes.
+- The wrapper's Node-compat bootstrap is served cheaper sources
+  (`src/sandbox-bootstrap-modules.ts`). Before our sandboxed function is called
+  it compiles ~12KB of polyfills — `node:buffer`, `node:util`, `node:url`,
+  `Headers`, `Request`, `Response` — into the fresh runtime, and the init
+  prelude then deletes `Buffer`, `Headers`, `Request` and `Response`. Those
+  imports resolve through *our* module loader, so four are served as empty
+  modules and `node:util` as the `TextEncoder`/`TextDecoder` pair the guest
+  keeps; `node:url` still comes from the wrapper, because `URL` and
+  `URLSearchParams` are capabilities and a hand-rolled URL parser is not a
+  saving worth making. Measured: 5.96ms → 3.28ms of per-run setup, against
+  0.34ms for a bare QuickJS context. A wrapper release that renames these
+  modules loses the saving silently, so `tests/js-sandbox-modules.test.ts`
+  asserts that every id we stub is one the bootstrap actually requests.
 - Structured data crosses as JSON, not as handles
   (`src/sandbox-json-transport.ts`). The wrapper marshals an object node by node
   — four `evalCode` compilations plus a descriptor copy per property — so a run

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -459,6 +459,21 @@ around every tool- and plan-approval round trip.
   `describeEngineFailure` turns them into an actionable message instead of raw
   assertion text. Anything not attributable to the engine is re-thrown, so a
   genuine host bug still crashes.
+- Structured data crosses as JSON, not as handles
+  (`src/sandbox-json-transport.ts`). The wrapper marshals an object node by node
+  — four `evalCode` compilations plus a descriptor copy per property — so a run
+  handed 5 000 rows spent ~2 s reading them and ~0.8 s handing them back before
+  running a line of its own. The guest now builds its result with
+  `JSON.stringify` and the host parses it, the host encodes injected globals for
+  the prelude to parse, and `emit`/`output` arguments take the same path;
+  measured 17–35× on those shapes. Typed arrays and strings over 8 KB ride a
+  sidecar the marshaler moves whole, so bytes keep the fast native serializer
+  and a megabyte of text is not escaped and unescaped. Dates, non-finite
+  numbers and `undefined` properties carry markers. A value the encoder cannot
+  represent (a function, a bigint, a `Map`, a class instance) falls back to the
+  wrapper's marshaling; a **cycle** is refused by name, because the fallback
+  follows it until the runtime aborts. Benchmark:
+  `npm run bench:sandbox --workspace=packages/agents`.
 - Binary crosses the boundary asymmetrically. Guest → host is handled by the
   typed-array serializers (`addSerializer`), so a guest `Uint8Array` reaches a
   bridge as a native one. Host → guest is not: a returned `Uint8Array` arrives

--- a/packages/agents/bench/sandbox-boundary.ts
+++ b/packages/agents/bench/sandbox-boundary.ts
@@ -1,0 +1,92 @@
+/**
+ * What one sandbox run spends moving data across the QuickJS boundary.
+ *
+ * Run it before and after touching `sandbox-json-transport.ts`, the init
+ * prelude, or any bridge: the shapes below are the ones whose cost is dominated
+ * by marshaling rather than by the guest's own work, so a regression shows up
+ * here before it shows up in a workflow.
+ *
+ *   npm run bench:sandbox --workspace=packages/agents
+ *
+ * Numbers are wall clock for a whole `runInSandbox` call, best of N, after a
+ * warm-up run that pays for the WASM module. Roughly 10 ms of every row is the
+ * fixed cost of building a guest context.
+ */
+
+import { performance } from "node:perf_hooks";
+import { runInSandbox, type RunSandboxOptions } from "../src/js-sandbox.js";
+
+const REPS = Number(process.env.BENCH_REPS ?? 3);
+
+async function bench(label: string, options: () => RunSandboxOptions) {
+  const first = await runInSandbox(options());
+  if (!first.success) throw new Error(`${label}: ${first.error}`);
+  const times: number[] = [];
+  for (let i = 0; i < REPS; i++) {
+    const started = performance.now();
+    const result = await runInSandbox(options());
+    times.push(performance.now() - started);
+    if (!result.success) throw new Error(`${label}: ${result.error}`);
+  }
+  times.sort((a, b) => a - b);
+  console.log(`${label.padEnd(38)} ${times[0].toFixed(1)}ms`);
+}
+
+const rows = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    id: i,
+    name: `row${i}`,
+    tags: ["a", "b"]
+  }));
+
+const cold = performance.now();
+await runInSandbox({ code: "return 1;" });
+console.log(`cold start (engine load included)      ${(performance.now() - cold).toFixed(1)}ms\n`);
+
+await bench("fixed cost (return 1)", () => ({ code: "return 1;" }));
+await bench("cpu: 5M iterations", () => ({
+  code: "let s = 0; for (let i = 0; i < 5_000_000; i++) s += i; return s;"
+}));
+
+console.log("\n-- guest → host --");
+await bench("return 1k objects", () => ({
+  code: "return Array.from({length:1000},(_,i)=>({id:i,name:'row'+i,tags:['a','b']}));"
+}));
+await bench("return 5k objects", () => ({ code: `return Array.from({length:5000},(_,i)=>({id:i,name:'row'+i,tags:['a','b']}));` }));
+await bench("return 1MB string", () => ({
+  code: "return 'x'.repeat(1_000_000);",
+  limits: { maxOutputSize: 10_000_000 }
+}));
+await bench("return 1MB bytes", () => ({ code: "return new Uint8Array(1_000_000);" }));
+await bench("emit 1k objects in one call", () => ({
+  code: "await emit('out', Array.from({length:1000},(_,i)=>({id:i}))); return 1;",
+  onEmit: async () => undefined
+}));
+await bench("emit 1k values one at a time", () => ({
+  code: "for (let i = 0; i < 1000; i++) await emit('out', {i}); return 1;",
+  onEmit: async () => undefined
+}));
+
+console.log("\n-- host → guest --");
+await bench("inject 1k rows", () => ({
+  code: "return inputs.rows.length;",
+  globals: { inputs: { rows: rows(1000) } }
+}));
+await bench("inject 5k rows", () => ({
+  code: "return inputs.rows.length;",
+  globals: { inputs: { rows: rows(5000) } }
+}));
+await bench("inject 1k rows, return them", () => ({
+  code: "return inputs.rows;",
+  globals: { inputs: { rows: rows(1000) } }
+}));
+await bench("inject a 1MB string", () => ({
+  code: "return inputs.text.length;",
+  globals: { inputs: { text: "x".repeat(1_000_000) } }
+}));
+
+console.log("\n-- round trip --");
+await bench("state sync-back over 1k rows", () => ({
+  code: "state.rows = inputs.rows; return state.rows.length;",
+  globals: { inputs: { rows: rows(1000) }, state: {} }
+}));

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:mutation": "stryker run",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "bench:sandbox": "tsx bench/sandbox-boundary.ts"
   },
   "dependencies": {
     "@jitl/quickjs-ng-wasmfile-release-sync": "^0.31.0",

--- a/packages/agents/src/js-sandbox-worker/interpreter.ts
+++ b/packages/agents/src/js-sandbox-worker/interpreter.ts
@@ -57,6 +57,7 @@ import {
   type GuestBytes
 } from "../sandbox-bytes.js";
 import { MEDIA_REF_MEMBERS } from "../sandbox-media-ref.js";
+import { BOOTSTRAP_MODULE_SOURCES } from "../sandbox-bootstrap-modules.js";
 import {
   decodeGuestPayload,
   encodeHostRecord,
@@ -514,8 +515,9 @@ export interface GuestModuleHost {
  *
  * 1. **bootstrap** — the wrapper's `import 'node:buffer'` and the rest of its
  *    compat preamble run before our sandboxed function is called. They resolve
- *    through the library's own normalizer and loader, or the runtime never
- *    starts.
+ *    through the library's own normalizer, and through its loader for anything
+ *    {@link BOOTSTRAP_MODULE_SOURCES} does not serve a cheaper source for, or
+ *    the runtime never starts.
  * 2. **guest, linking** — only the run's declared specifiers and their
  *    intra-pack siblings resolve. Everything else — `node:*`, the compat
  *    modules the bootstrap warmed, absolute paths, `../` escapes, encoded
@@ -662,7 +664,14 @@ export function createGuestModuleHost(
           }
           const source = sources.get(moduleName);
           if (source !== undefined) return { value: `${hardening}${source}` };
-          if (phase === "bootstrap") return fallback(moduleName, context);
+          if (phase === "bootstrap") {
+            // The wrapper's own compat preamble. Most of what it compiles into
+            // every fresh runtime, the init prelude deletes a moment later, so
+            // it is served something cheaper — see BOOTSTRAP_MODULE_SOURCES.
+            const stub = BOOTSTRAP_MODULE_SOURCES.get(moduleName);
+            if (stub !== undefined) return { value: stub };
+            return fallback(moduleName, context);
+          }
           return {
             error: new Error(`Module "${moduleName}" is not available`)
           };

--- a/packages/agents/src/js-sandbox-worker/interpreter.ts
+++ b/packages/agents/src/js-sandbox-worker/interpreter.ts
@@ -57,6 +57,14 @@ import {
   type GuestBytes
 } from "../sandbox-bytes.js";
 import { MEDIA_REF_MEMBERS } from "../sandbox-media-ref.js";
+import {
+  decodeGuestPayload,
+  encodeHostRecord,
+  GUEST_GLOBALS_JSON_BINDING,
+  GUEST_GLOBALS_SIDECAR_BINDING,
+  GUEST_JSON_TRANSPORT_SOURCE,
+  GUEST_MARSHAL_GLOBAL
+} from "../sandbox-json-transport.js";
 import type { ResolvedSandboxLimits } from "../js-sandbox.js";
 import { isFunction, isObjectLike } from "../utils/type-guards.js";
 
@@ -299,11 +307,28 @@ export const BLOCKED_TIMER_GLOBALS = [
  * the timer globals the engine re-installs per evaluation (see
  * {@link BLOCKED_TIMER_GLOBALS}).
  */
-export function wrapCode(code: string, prelude = ""): string {
+export function wrapCode(
+  code: string,
+  prelude = "",
+  encodeResult = false
+): string {
+  const [open, close] = resultEncoding(encodeResult);
   return `${dropTimersStatement()}${prelude}
-export default await (async () => {
+export default ${open}await (async () => {
 ${code}
-})();`;
+})()${close};`;
+}
+
+/**
+ * Wrap the module's default export in the guest's JSON encoder, or leave it
+ * alone. Both halves sit on the lines the IIFE already occupies, so
+ * {@link entryBodyLineOffset} — and every stack trace mapped through it — is
+ * unchanged either way.
+ */
+function resultEncoding(encodeResult: boolean): [string, string] {
+  return encodeResult
+    ? [`globalThis.${GUEST_MARSHAL_GLOBAL}(`, ")"]
+    : ["", ""];
 }
 
 function dropTimersStatement(): string {
@@ -329,7 +354,11 @@ function dropTimersStatement(): string {
  * denies them at runtime (see {@link createGuestModuleHost}); rewriting them
  * here would only move a runtime denial into a confusing compile-time one.
  */
-export function buildEntryModule(code: string, prelude = ""): string {
+export function buildEntryModule(
+  code: string,
+  prelude = "",
+  encodeResult = false
+): string {
   let program: acorn.Program;
   try {
     program = acorn.parse(code, {
@@ -339,13 +368,13 @@ export function buildEntryModule(code: string, prelude = ""): string {
       allowReturnOutsideFunction: true
     });
   } catch {
-    return wrapCode(code, prelude);
+    return wrapCode(code, prelude, encodeResult);
   }
 
   const imports = program.body.filter(
     (node): node is acorn.ImportDeclaration => node.type === "ImportDeclaration"
   );
-  if (imports.length === 0) return wrapCode(code, prelude);
+  if (imports.length === 0) return wrapCode(code, prelude, encodeResult);
 
   const hoisted: string[] = [];
   let body = "";
@@ -359,11 +388,12 @@ export function buildEntryModule(code: string, prelude = ""): string {
   }
   body += code.slice(cursor);
 
+  const [open, close] = resultEncoding(encodeResult);
   return `${hoisted.join(" ")}
 ${dropTimersStatement()}${prelude}
-export default await (async () => {
+export default ${open}await (async () => {
 ${body}
-})();`;
+})()${close};`;
 }
 
 /**
@@ -796,8 +826,14 @@ export async function runInterpreter(
       bridges.getSecret = wrap(bridges.getSecret as never);
       bridges.assetToSandbox = wrap(bridges.assetToSandbox as never);
       bridges.sandboxToAsset = wrap(bridges.sandboxToAsset as never);
-      bridges.emit = wrap(bridges.emit as never);
-      bridges.output = wrap(bridges.output as never);
+      // The guest hands these an encoded payload (see the prelude): decode it
+      // back into a value before the host sink ever sees it.
+      const decodeValueArg =
+        (fn: (name: unknown, value: unknown) => Promise<unknown>) =>
+        async (name: unknown, payload: unknown) =>
+          fn(name, decodeGuestPayload(payload));
+      bridges.emit = wrap(decodeValueArg(bridges.emit as never));
+      bridges.output = wrap(decodeValueArg(bridges.output as never));
       // The input bridges are not in EXPOSED_BRIDGE_NAMES — the prelude
       // captures them, builds `stream` on top, and deletes them. The take is
       // async like every other host call; the open probe is synchronous and
@@ -876,11 +912,42 @@ export async function runInterpreter(
       // the guest and throws inside the library's detached marshaling
       // continuation. `guardHostProcess` on the caller's side keeps that from
       // killing the process, but the run still fails.
+      // Data globals cross as one JSON string the prelude parses, because the
+      // wrapper installs an object property-by-property — ~400 µs per object
+      // node, which a Code node fed a few thousand rows pays before its first
+      // statement. A value JSON plus the transport's markers cannot carry
+      // (a function, a cycle, a class instance) keeps the wrapper's own path.
+      const dataGlobals: Record<string, unknown> = {};
       for (const [name, value] of Object.entries(globals)) {
-        bridges[name] =
-          isFunction(value)
-            ? wrap(value as (...a: unknown[]) => Promise<unknown>)
-            : value;
+        if (isFunction(value)) {
+          bridges[name] = wrap(value as (...a: unknown[]) => Promise<unknown>);
+        } else if (value === null || typeof value !== "object") {
+          // A primitive crosses as a primitive: `newString` is one copy, while
+          // JSON would escape the text only to parse it back again.
+          bridges[name] = value;
+        } else {
+          dataGlobals[name] = value;
+        }
+      }
+      if (Object.keys(dataGlobals).length > 0) {
+        const encoded = encodeHostRecord(dataGlobals);
+        if (encoded.cyclic.length > 0) {
+          // The fallback cannot take these: the wrapper's marshaler follows a
+          // cycle until the runtime aborts, which fails the run with an
+          // assertion instead of saying what was wrong with the input.
+          throw new Error(
+            `Cannot pass ${encoded.cyclic
+              .map((name) => `"${name}"`)
+              .join(", ")} into the sandbox: the value refers back to itself`
+          );
+        }
+        bridges[GUEST_GLOBALS_JSON_BINDING] = encoded.json;
+        if (encoded.sidecar.length > 0) {
+          bridges[GUEST_GLOBALS_SIDECAR_BINDING] = encoded.sidecar;
+        }
+        for (const name of encoded.skipped) {
+          bridges[name] = dataGlobals[name];
+        }
       }
 
       // `expose` manages its own internal Scope; the second arg is unused.
@@ -991,8 +1058,15 @@ globalThis.sleep = __wrap(globalThis.sleep);
 globalThis.getSecret = __wrap(globalThis.getSecret);
 globalThis.assetToSandbox = __wrap(globalThis.assetToSandbox);
 globalThis.sandboxToAsset = __wrap(globalThis.sandboxToAsset);
-globalThis.emit = __wrap(globalThis.emit);
-globalThis.output = __wrap(globalThis.output);
+// emit and output carry the run's data, so their argument takes the same
+// JSON transport the result does — a single \`emit(rows)\` otherwise pays the
+// wrapper's per-object marshal on the way out.
+const __rawEmit = __wrap(globalThis.emit);
+const __rawOutput = __wrap(globalThis.output);
+globalThis.emit = (name, value) =>
+  __rawEmit(name, globalThis.${GUEST_MARSHAL_GLOBAL}(value));
+globalThis.output = (name, value) =>
+  __rawOutput(name, globalThis.${GUEST_MARSHAL_GLOBAL}(value));
 const __ws = globalThis.workspace;
 globalThis.workspace = {
   read: __wrap(__ws.read),
@@ -1202,6 +1276,7 @@ globalThis.crypto = {
   digest: __wrap(__crypto.digest),
   hmac: __wrap(__crypto.hmac)
 };
+${GUEST_JSON_TRANSPORT_SOURCE}
 ${DELETED_GUEST_GLOBALS.map((n) => `delete globalThis.${n};`).join("\n")}
 ${
   wasmCall === undefined
@@ -1247,7 +1322,8 @@ export default true;`,
             capabilityCall === undefined
               ? ""
               : ` delete globalThis.${SANDBOX_CAPABILITY_DISPATCH_GLOBAL};`
-          }`
+          }`,
+          true
         ),
         "user-code"
       );
@@ -1263,20 +1339,27 @@ export default true;`,
       // across invocations.
       let syncedGlobals: Record<string, unknown> | undefined;
       if (syncTargetNames.length > 0) {
-        const extractor = `export default {${syncTargetNames
+        const extractor = `export default globalThis.${GUEST_MARSHAL_GLOBAL}({${syncTargetNames
           .map(
             (n) =>
               `${n}: (typeof ${n} !== 'undefined' && ${n} !== null) ? ${n} : null`
           )
-          .join(", ")}};`;
+          .join(", ")}});`;
         const syncResp = await evalCode(extractor, "sandbox-sync");
-        if (syncResp.ok && isObjectLike(syncResp.data)) {
-          syncedGlobals = syncResp.data as Record<string, unknown>;
+        if (syncResp.ok) {
+          const decoded = decodeGuestPayload(syncResp.data);
+          if (isObjectLike(decoded)) {
+            syncedGlobals = decoded;
+          }
         }
       }
 
       return userResult.ok
-        ? { ok: true, data: userResult.data, syncedGlobals }
+        ? {
+            ok: true,
+            data: decodeGuestPayload(userResult.data),
+            syncedGlobals
+          }
         : { ok: false, error: userResult.error, syncedGlobals };
     },
     {

--- a/packages/agents/src/js-sandbox.ts
+++ b/packages/agents/src/js-sandbox.ts
@@ -113,6 +113,11 @@ import {
 } from "./wasm-sandbox/host.js";
 import { runInWorker } from "./js-sandbox-worker/host.js";
 import { assertFetchUrlAllowed } from "./network-guard.js";
+import {
+  GUEST_GLOBALS_JSON_BINDING,
+  GUEST_GLOBALS_SIDECAR_BINDING,
+  GUEST_MARSHAL_GLOBAL
+} from "./sandbox-json-transport.js";
 import type { RunInWorkerOptions } from "./js-sandbox-worker/host.js";
 import {
   deriveBridgeShape,
@@ -2753,7 +2758,10 @@ export const RESERVED_SANDBOX_NAMES: ReadonlySet<string> = new Set<string>([
   SANDBOX_CAPABILITY_BRIDGE_BINDING,
   SANDBOX_CAPABILITY_DISPATCH_GLOBAL,
   SANDBOX_INPUT_TAKE_BINDING,
-  SANDBOX_STREAM_OPEN_BINDING
+  SANDBOX_STREAM_OPEN_BINDING,
+  GUEST_MARSHAL_GLOBAL,
+  GUEST_GLOBALS_JSON_BINDING,
+  GUEST_GLOBALS_SIDECAR_BINDING
 ]);
 
 /**

--- a/packages/agents/src/sandbox-bootstrap-modules.ts
+++ b/packages/agents/src/sandbox-bootstrap-modules.ts
@@ -1,0 +1,103 @@
+/**
+ * What the guest's Node-compat bootstrap loads, in place of the wrapper's own
+ * polyfills.
+ *
+ * Before our sandboxed function is called, `@sebastianwessel/quickjs` evaluates
+ * a fixed preamble in the fresh context:
+ *
+ * ```js
+ * import 'node:buffer'; import 'node:util'; import 'node:url';
+ * import '@node_compatibility/headers'; import '@node_compatibility/request';
+ * import '@node_compatibility/response';
+ * ```
+ *
+ * Twelve kilobytes of JavaScript, compiled and evaluated into a new runtime on
+ * **every run** — 4.3 ms of a 12 ms empty run, against 0.34 ms for a bare
+ * QuickJS context. And most of it is thrown away immediately: the init prelude
+ * deletes `Buffer`, `Headers`, `Request` and `Response` before user code exists,
+ * because guest code has no business with host-shaped Node globals.
+ *
+ * Those imports resolve through the run's own module loader
+ * (`createGuestModuleHost`), which is ours, so the bootstrap can be served
+ * something cheaper instead of being fought. Four of the six become empty
+ * modules. `node:util` becomes the two classes the guest actually keeps, in
+ * place of promisify/callbackify/inherits/deprecate/types it never sees.
+ * `node:url` is served by the wrapper unchanged, because `URL` and
+ * `URLSearchParams` are guest capabilities and a hand-rolled URL parser is not
+ * a saving worth making.
+ *
+ * Measured on this repo's engine: wrapper setup 5.96 ms → 3.28 ms per run.
+ *
+ * The failure modes are deliberately lopsided. A wrapper release that renames
+ * or moves these modules makes the map miss, the real polyfill loads, and the
+ * only loss is the saving — pinned by "the compat bootstrap loads our stubs" in
+ * `tests/js-sandbox-modules.test.ts`, which fails loudly rather than silently
+ * costing 2.7 ms. A release that imports something our `node:util` does not
+ * export fails every sandbox run in the suite, which is as loud as it gets.
+ *
+ * Browser-safe: nothing here imports a Node builtin.
+ */
+
+/** A module whose only job is to exist, for an `import` that wants no export. */
+const EMPTY_MODULE = "export default {};";
+
+/**
+ * `TextEncoder`/`TextDecoder`, which the wrapper's `node:util` installs as
+ * globals and which the guest surface documents.
+ *
+ * The `encodeURIComponent`/`unescape` pair is UTF-8 the way the wrapper's own
+ * polyfill does it, so the bytes a guest sees are the bytes it saw before. Both
+ * classes are also exported by name: the wrapper's `node:buffer` imports them
+ * that way, and although that module is empty here, a future one may not be.
+ */
+const UTIL_MODULE = `
+class TextEncoder {
+  encode(input = "") {
+    const utf8 = unescape(encodeURIComponent(input));
+    const out = new Uint8Array(utf8.length);
+    for (let i = 0; i < utf8.length; i++) out[i] = utf8.charCodeAt(i);
+    return out;
+  }
+}
+class TextDecoder {
+  constructor(encoding = "utf-8") {
+    if (encoding !== "utf-8") throw new Error("Only utf-8 encoding is supported");
+  }
+  decode(input = new Uint8Array()) {
+    let text = "";
+    for (let i = 0; i < input.length; i++) text += String.fromCharCode(input[i]);
+    return decodeURIComponent(escape(text));
+  }
+}
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;
+export { TextEncoder, TextDecoder };
+export default { TextEncoder, TextDecoder };
+`;
+
+/**
+ * Module id → the source served during the wrapper's bootstrap phase. The ids
+ * are what its own normalizer produces for the specifiers above; anything not
+ * listed loads from the wrapper as before.
+ */
+export const BOOTSTRAP_MODULE_SOURCES: ReadonlyMap<string, string> = new Map([
+  // Deleted by the init prelude the moment the bootstrap finishes.
+  ["/node_modules/buffer", EMPTY_MODULE],
+  ["/node_modules/@node_compatibility/headers", EMPTY_MODULE],
+  ["/node_modules/@node_compatibility/request", EMPTY_MODULE],
+  ["/node_modules/@node_compatibility/response", EMPTY_MODULE],
+  // Kept, minus everything the guest cannot reach.
+  ["/node_modules/util", UTIL_MODULE]
+]);
+
+/**
+ * The globals the bootstrap no longer installs, in the order a reader would
+ * check them. Exported so a test can assert they are gone at the source rather
+ * than after the prelude's `delete`, which would hide a missed stub.
+ */
+export const BOOTSTRAP_DROPPED_GLOBALS = [
+  "Buffer",
+  "Headers",
+  "Request",
+  "Response"
+] as const;

--- a/packages/agents/src/sandbox-json-transport.ts
+++ b/packages/agents/src/sandbox-json-transport.ts
@@ -1,0 +1,352 @@
+/**
+ * JSON transport for structured data across the QuickJS boundary.
+ *
+ * The wrapper marshals a value handle-by-handle: every object node costs four
+ * `evalCode` compilations inside the guest plus a `newFunction` allocation, and
+ * every property crosses as its own descriptor. Measured on this repo's engine
+ * that is ~150 µs per object node out of the guest and ~400 µs per object node
+ * into it — a Code node handed 5 000 rows spent 1.9 s reading them and another
+ * 0.8 s handing them back, before running a line of its own.
+ *
+ * Both directions carry JSON-shaped data, so the fast path is to move one
+ * string: the guest builds its answer with `JSON.stringify` and the host parses
+ * it, and the host encodes its globals here for the init prelude to parse.
+ * Measured on the same shapes, 20–25× either way.
+ *
+ * Two kinds of value would lose by that trade, and both ride *beside* the JSON
+ * in a sidecar the marshaler moves in one piece — a typed array (base64 inside
+ * the guest costs more than the marshal it replaces) and a string past
+ * {@link SIDECAR_STRING_THRESHOLD} (escaping a megabyte to unescape it again is
+ * two passes the primitive path never makes). A {@link JSON_SIDECAR_MARKER}
+ * holds its place by index.
+ *
+ * What JSON alone still cannot carry is carried by markers, so the round trip
+ * keeps the types the structured path preserved:
+ *
+ * - **dates** — an ISO string under {@link JSON_DATE_MARKER}, revived as a
+ *   `Date`. A `state.lastRun` that survives a Code node's invocations stays a
+ *   `Date` rather than degrading to a string on its first round trip.
+ * - **non-finite numbers** — `NaN` and the infinities under {@link
+ *   JSON_NUMBER_MARKER}. `JSON.stringify` writes them as `null`.
+ * - **undefined** — {@link JSON_UNDEFINED_MARKER}, so a property whose value is
+ *   `undefined` keeps its key. `JSON.stringify` drops it.
+ *
+ * Anything else — a function, a symbol, a bigint, a `Map`, a class instance —
+ * makes the encoder refuse that value, and its caller falls back to the
+ * wrapper's own marshaling, which is slow but total. The fast path never has to
+ * guess.
+ *
+ * A **cycle** is the one thing neither path carries: the wrapper's marshaler
+ * recurses until the runtime aborts with `list_empty(&rt->gc_obj_list)`, which
+ * kills the run with an assertion instead of an answer. So a cyclic global is
+ * refused by name, and a cyclic result becomes `String(value)` — the fallback
+ * `serializeResult` already documents for a value `JSON.stringify` rejects.
+ *
+ * Browser-safe: nothing here imports a Node builtin.
+ */
+
+import {
+  encodeBase64,
+  SANDBOX_BYTES_MARKER,
+  SANDBOX_SERIALIZE_MAX_DEPTH
+} from "./sandbox-bytes.js";
+import { isObjectLike } from "./utils/type-guards.js";
+
+/** Marker key carrying an ISO timestamp for a `Date`. */
+export const JSON_DATE_MARKER = "__nodetool_sandbox_date__";
+
+/** Marker key carrying `"NaN"`, `"Infinity"`, or `"-Infinity"`. */
+export const JSON_NUMBER_MARKER = "__nodetool_sandbox_number__";
+
+/** Marker key standing in for an `undefined` property value. */
+export const JSON_UNDEFINED_MARKER = "__nodetool_sandbox_undefined__";
+
+/** Marker key carrying an index into the payload's sidecar. */
+export const JSON_SIDECAR_MARKER = "__nodetool_sandbox_side__";
+
+/**
+ * Strings at least this long travel in the sidecar rather than inside the JSON.
+ * Below it the escape/unescape pass is noise next to the run's fixed cost; a
+ * megabyte of text is where it stops being.
+ */
+export const SIDECAR_STRING_THRESHOLD = 8192;
+
+/** The global the guest parks its encoder on. */
+export const GUEST_MARSHAL_GLOBAL = "__nodetool_marshal__";
+
+/** The global carrying the host's encoded globals for the prelude to read. */
+export const GUEST_GLOBALS_JSON_BINDING = "__nodetool_globals_json__";
+
+/** The global carrying the sidecar those encoded globals index into. */
+export const GUEST_GLOBALS_SIDECAR_BINDING = "__nodetool_globals_side__";
+
+// ---------------------------------------------------------------------------
+// Host → guest
+// ---------------------------------------------------------------------------
+
+function isPlainObject(value: unknown): boolean {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/** Returned in place of a value that has no JSON representation. */
+const UNREPRESENTABLE = Symbol("unrepresentable");
+
+/**
+ * Returned in place of a value that refers back to itself. It is reported apart
+ * from {@link UNREPRESENTABLE} because the fallback does not cover it: the
+ * wrapper's own marshaler recurses until the runtime aborts, so a caller has to
+ * refuse a cycle rather than hand it over.
+ */
+const CYCLIC = Symbol("cyclic");
+
+function toJsonTree(
+  value: unknown,
+  sidecar: string[],
+  seen: Set<unknown>,
+  depth: number
+): unknown {
+  if (value === null) return null;
+  if (value === undefined) return { [JSON_UNDEFINED_MARKER]: true };
+  switch (typeof value) {
+    case "boolean":
+      return value;
+    case "string":
+      return value.length >= SIDECAR_STRING_THRESHOLD
+        ? { [JSON_SIDECAR_MARKER]: sidecar.push(value) - 1 }
+        : value;
+    case "number":
+      return Number.isFinite(value)
+        ? value
+        : { [JSON_NUMBER_MARKER]: String(value) };
+    case "function":
+    case "symbol":
+    case "bigint":
+      return UNREPRESENTABLE;
+    default:
+      break;
+  }
+  if (depth >= SANDBOX_SERIALIZE_MAX_DEPTH) return UNREPRESENTABLE;
+  if (seen.has(value)) return CYCLIC;
+  if (value instanceof Date) {
+    return { [JSON_DATE_MARKER]: value.toISOString() };
+  }
+  if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+    // Bytes cannot ride the sidecar into the guest: a host `Uint8Array` arrives
+    // there as a numeric-keyed object, which is the whole reason the base64
+    // marker exists.
+    const view = value as ArrayBufferView;
+    return {
+      [SANDBOX_BYTES_MARKER]: encodeBase64(
+        new Uint8Array(view.buffer, view.byteOffset, view.byteLength)
+      )
+    };
+  }
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const out: unknown[] = new Array(value.length);
+      for (let i = 0; i < value.length; i++) {
+        const encoded = toJsonTree(value[i], sidecar, seen, depth + 1);
+        if (encoded === UNREPRESENTABLE || encoded === CYCLIC) return encoded;
+        out[i] = encoded;
+      }
+      return out;
+    }
+    if (!isPlainObject(value)) return UNREPRESENTABLE;
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      const encoded = toJsonTree(entry, sidecar, seen, depth + 1);
+      if (encoded === UNREPRESENTABLE || encoded === CYCLIC) return encoded;
+      out[key] = encoded;
+    }
+    return out;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+/** What one encoded batch of host globals hands the guest prelude. */
+export interface HostRecordEncoding {
+  /** JSON for the guest to parse: `{name: value}` over the accepted entries. */
+  readonly json: string;
+  /** Values the JSON refers to by index, moved whole rather than escaped. */
+  readonly sidecar: readonly string[];
+  /** Entries no JSON representation covers. The caller marshals these itself. */
+  readonly skipped: readonly string[];
+  /** Entries that refer back to themselves. Neither path can carry these. */
+  readonly cyclic: readonly string[];
+}
+
+/**
+ * Encode a batch of named host values for the guest to `JSON.parse` and revive.
+ *
+ * One batch means one sidecar and one parse. An entry holding something JSON
+ * plus the markers cannot carry is reported in `skipped` instead of failing the
+ * batch, so one exotic global costs only itself; an entry that refers back to
+ * itself is reported in `cyclic`, which no path can carry.
+ */
+export function encodeHostRecord(
+  values: Record<string, unknown>
+): HostRecordEncoding {
+  const sidecar: string[] = [];
+  const skipped: string[] = [];
+  const cyclic: string[] = [];
+  const tree: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(values)) {
+    const encoded = toJsonTree(value, sidecar, new Set(), 0);
+    if (encoded === CYCLIC) {
+      cyclic.push(name);
+      continue;
+    }
+    if (encoded === UNREPRESENTABLE) {
+      skipped.push(name);
+      continue;
+    }
+    tree[name] = encoded;
+  }
+  return { json: JSON.stringify(tree), sidecar, skipped, cyclic };
+}
+
+// ---------------------------------------------------------------------------
+// Guest → host
+// ---------------------------------------------------------------------------
+
+function reviveHostTree(value: unknown, sidecar: readonly unknown[]): unknown {
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      value[i] = reviveHostTree(value[i], sidecar);
+    }
+    return value;
+  }
+  if (!isObjectLike(value)) return value;
+  const sideIndex = value[JSON_SIDECAR_MARKER];
+  if (typeof sideIndex === "number") return sidecar[sideIndex];
+  const iso = value[JSON_DATE_MARKER];
+  if (typeof iso === "string") return new Date(iso);
+  const nonFinite = value[JSON_NUMBER_MARKER];
+  if (typeof nonFinite === "string") return Number(nonFinite);
+  if (value[JSON_UNDEFINED_MARKER] === true) return undefined;
+  for (const key of Object.keys(value)) {
+    value[key] = reviveHostTree(value[key], sidecar);
+  }
+  return value;
+}
+
+/**
+ * Decode what the guest's encoder produced: either a JSON string plus the
+ * sidecar its markers index, or a value the guest handed over as-is (a
+ * primitive, or something `JSON.stringify` refused) under `raw`.
+ *
+ * The guest owns this string, so a body that overwrites the encoder can hand
+ * back nonsense. That is not an escalation — the guest owned its own result
+ * either way — so a payload that will not parse decodes as `undefined` rather
+ * than failing the run.
+ */
+export function decodeGuestPayload(payload: unknown): unknown {
+  if (!isObjectLike(payload)) return payload;
+  const json = payload.j;
+  if (typeof json !== "string") {
+    return "raw" in payload ? payload.raw : undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return undefined;
+  }
+  const sidecar = Array.isArray(payload.b) ? (payload.b as unknown[]) : [];
+  if (!isObjectLike(parsed)) return undefined;
+  const revived = reviveHostTree(parsed, sidecar);
+  return isObjectLike(revived) ? revived.v : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Guest-side sources
+// ---------------------------------------------------------------------------
+
+/**
+ * The guest half, spliced into the init prelude: the encoder the entry module
+ * and the sync extractor call, and the parse of whatever globals the host
+ * encoded.
+ *
+ * `__bytesMarker` and `fromBase64` are defined earlier in the prelude, so this
+ * source has to follow them.
+ */
+export const GUEST_JSON_TRANSPORT_SOURCE = `
+const __ntSide = [];
+globalThis.${GUEST_MARSHAL_GLOBAL} = (value) => {
+  // A primitive already crosses as a primitive — stringifying a megabyte of
+  // text only to parse it back on the host is the one trade JSON loses.
+  if (value === null || (typeof value !== "object" && typeof value !== "string")) {
+    return { raw: value };
+  }
+  __ntSide.length = 0;
+  let json;
+  try {
+    json = JSON.stringify({ v: value }, function (key, encoded) {
+      const raw = this[key];
+      if (typeof raw === "string") {
+        return raw.length >= ${SIDECAR_STRING_THRESHOLD}
+          ? { ${JSON.stringify(JSON_SIDECAR_MARKER)}: __ntSide.push(raw) - 1 }
+          : raw;
+      }
+      if (typeof raw === "number" && !Number.isFinite(raw)) {
+        return { ${JSON.stringify(JSON_NUMBER_MARKER)}: String(raw) };
+      }
+      if (raw instanceof Date) {
+        return { ${JSON.stringify(JSON_DATE_MARKER)}: raw.toISOString() };
+      }
+      if (ArrayBuffer.isView(raw) && !(raw instanceof DataView)) {
+        return {
+          ${JSON.stringify(JSON_SIDECAR_MARKER)}: __ntSide.push(
+            raw instanceof Uint8Array
+              ? raw
+              : new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength)
+          ) - 1
+        };
+      }
+      if (raw === undefined && encoded === undefined) {
+        return { ${JSON.stringify(JSON_UNDEFINED_MARKER)}: true };
+      }
+      return encoded;
+    });
+  } catch (e) {
+    // A cycle (or a bigint) has no JSON form, and handing the value to the
+    // wrapper's marshaler instead recurses until the runtime aborts. String()
+    // is what serializeResult falls back to for the same values.
+    __ntSide.length = 0;
+    return { raw: String(value) };
+  }
+  // An empty sidecar is left off: an empty array still costs the wrapper a
+  // whole object node to marshal, which is most of a small payload's cost.
+  return __ntSide.length === 0 ? { j: json } : { j: json, b: __ntSide.slice() };
+};
+const __ntReviveHost = (value, side) => {
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) value[i] = __ntReviveHost(value[i], side);
+    return value;
+  }
+  if (!value || typeof value !== "object") return value;
+  const index = value[${JSON.stringify(JSON_SIDECAR_MARKER)}];
+  if (typeof index === "number") return side[index];
+  const bytes = value[__bytesMarker];
+  if (typeof bytes === "string") return globalThis.fromBase64(bytes);
+  const iso = value[${JSON.stringify(JSON_DATE_MARKER)}];
+  if (typeof iso === "string") return new Date(iso);
+  const num = value[${JSON.stringify(JSON_NUMBER_MARKER)}];
+  if (typeof num === "string") return Number(num);
+  if (value[${JSON.stringify(JSON_UNDEFINED_MARKER)}] === true) return undefined;
+  for (const key of Object.keys(value)) value[key] = __ntReviveHost(value[key], side);
+  return value;
+};
+if (typeof globalThis.${GUEST_GLOBALS_JSON_BINDING} === "string") {
+  const __ntHostSide = globalThis.${GUEST_GLOBALS_SIDECAR_BINDING} || [];
+  const __ntGlobals = JSON.parse(globalThis.${GUEST_GLOBALS_JSON_BINDING});
+  delete globalThis.${GUEST_GLOBALS_JSON_BINDING};
+  delete globalThis.${GUEST_GLOBALS_SIDECAR_BINDING};
+  for (const __ntKey of Object.keys(__ntGlobals)) {
+    globalThis[__ntKey] = __ntReviveHost(__ntGlobals[__ntKey], __ntHostSide);
+  }
+}
+`;

--- a/packages/agents/tests/js-sandbox-modules.test.ts
+++ b/packages/agents/tests/js-sandbox-modules.test.ts
@@ -20,6 +20,13 @@ import {
 // The loading/denial contract lives as data, so the browser suite
 // (packages/workflow-runner/e2e) runs the same cases in a real Chromium.
 import {
+  BOOTSTRAP_DROPPED_GLOBALS,
+  BOOTSTRAP_MODULE_SOURCES
+} from "../src/sandbox-bootstrap-modules.js";
+import { loadQuickJs } from "@sebastianwessel/quickjs";
+import * as quickJsVariant from "@jitl/quickjs-ng-wasmfile-release-sync";
+import { createGuestModuleHost } from "../src/js-sandbox-worker/interpreter.js";
+import {
   fixtureResolution,
   GEO_MODULE,
   SANDBOX_MODULE_FIXTURES
@@ -166,5 +173,116 @@ describe("guest module kinds", () => {
     });
     expect(result.success).toBe(false);
     expect(result.error).toContain("truncated WASM binary");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The wrapper's Node-compat bootstrap
+// ---------------------------------------------------------------------------
+
+describe("the compat bootstrap loads our stubs", () => {
+  // The wrapper compiles ~12KB of Node polyfills into every fresh runtime
+  // before our code runs, and the prelude then deletes most of what they
+  // installed. `BOOTSTRAP_MODULE_SOURCES` serves it something cheaper. These
+  // cases drive the real engine, so a wrapper release that renames those
+  // modules fails here rather than quietly costing 2.7ms a run.
+
+  it("leaves the globals it no longer installs undefined", async () => {
+    // Probed against the engine directly, with our module host but without our
+    // init prelude: the prelude deletes these globals too, so asserting through
+    // `runInSandbox` would pass whether or not a stub was ever served.
+    const { runSandboxed } = await loadQuickJs(
+      (quickJsVariant as { default: unknown }).default as never
+    );
+    const host = createGuestModuleHost(undefined);
+    // Every id we stub must be one the bootstrap actually asks for. Without
+    // this, a renamed module falls through to the real polyfill and the only
+    // symptom is 2.7ms a run — invisible to any assertion about globals.
+    const requested: string[] = [];
+    const options = {
+      ...host.options,
+      getModuleLoader: (fs: never, runtimeOptions: never) => {
+        const loader = host.options.getModuleLoader!(fs, runtimeOptions);
+        return (name: string, context: never) => {
+          requested.push(name);
+          return loader(name, context);
+        };
+      }
+    };
+    const seen = await runSandboxed<string>(
+      async ({ evalCode }) => {
+        const probe = await evalCode(
+          `export default ${JSON.stringify([...BOOTSTRAP_DROPPED_GLOBALS])}
+            .map((name) => name + ":" + typeof globalThis[name]).join(" ");`,
+          "probe"
+        );
+        if (!probe.ok) throw new Error("probe failed");
+        return probe.data as string;
+      },
+      { env: {}, ...(options as typeof host.options) }
+    );
+    expect(seen).toBe(
+      BOOTSTRAP_DROPPED_GLOBALS.map((name) => `${name}:undefined`).join(" ")
+    );
+    expect(requested).toEqual(
+      expect.arrayContaining([...BOOTSTRAP_MODULE_SOURCES.keys()])
+    );
+  });
+
+  it("keeps TextEncoder and TextDecoder, bytes unchanged", async () => {
+    const result = await runInSandbox({
+      code: `const bytes = new TextEncoder().encode("héllo 日本 😀");
+             return {
+               bytes: Array.from(bytes),
+               roundTrip: new TextDecoder().decode(bytes),
+               ascii: Array.from(new TextEncoder().encode("ab"))
+             };`
+    });
+    expect(result.success).toBe(true);
+    const value = result.result as {
+      bytes: number[];
+      roundTrip: string;
+      ascii: number[];
+    };
+    // The same UTF-8 the wrapper's own polyfill produced: 2 bytes for é,
+    // 3 each for 日本, 4 for the emoji.
+    expect(value.bytes.length).toBe(18);
+    expect(value.roundTrip).toBe("héllo 日本 😀");
+    expect(value.ascii).toEqual([97, 98]);
+    expect(
+      new TextDecoder().decode(new Uint8Array(value.bytes))
+    ).toBe("héllo 日本 😀");
+  });
+
+  it("rejects an encoding TextDecoder never supported", async () => {
+    const result = await runInSandbox({
+      code: `new TextDecoder("utf-16"); return 1;`
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("utf-8");
+  });
+
+  it("keeps URL and URLSearchParams, which it still loads from the wrapper", async () => {
+    const result = await runInSandbox({
+      code: `const u = new URL("https://x.test/a/b?q=1&q=2#f");
+             return [u.protocol, u.hostname, u.pathname, u.search, u.hash,
+                     u.searchParams.get("q"), typeof URLSearchParams].join("|");`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("https:|x.test|/a/b|?q=1&q=2|#f|1|function");
+  });
+
+  it("serves a stub only in the bootstrap phase", () => {
+    const host = createGuestModuleHost(undefined);
+    const loader = host.options.getModuleLoader!(
+      undefined as never,
+      undefined as never
+    );
+    const id = [...BOOTSTRAP_MODULE_SOURCES.keys()][0];
+    expect((loader(id, undefined as never) as { value: string }).value).toBe(
+      BOOTSTRAP_MODULE_SOURCES.get(id)
+    );
+    host.enterGuestPhase();
+    expect(loader(id, undefined as never)).toHaveProperty("error");
   });
 });

--- a/packages/agents/tests/sandbox-json-transport.test.ts
+++ b/packages/agents/tests/sandbox-json-transport.test.ts
@@ -1,0 +1,250 @@
+/**
+ * The JSON transport that moves structured data across the QuickJS boundary,
+ * and the round trips it has to keep intact.
+ *
+ * The unit half pins the encoder's contract — what it represents, what it
+ * refuses. The end-to-end half runs real guest code, because the interesting
+ * failures are the ones where host and guest disagree about a marker.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  decodeGuestPayload,
+  encodeHostRecord,
+  JSON_DATE_MARKER,
+  JSON_NUMBER_MARKER,
+  JSON_SIDECAR_MARKER,
+  JSON_UNDEFINED_MARKER,
+  SIDECAR_STRING_THRESHOLD
+} from "../src/sandbox-json-transport.js";
+import { SANDBOX_BYTES_MARKER } from "../src/sandbox-bytes.js";
+import { runInSandbox } from "../src/js-sandbox.js";
+
+// ---------------------------------------------------------------------------
+// encodeHostRecord
+// ---------------------------------------------------------------------------
+
+describe("encodeHostRecord", () => {
+  it("encodes plain data as ordinary JSON", () => {
+    const { json, sidecar, skipped } = encodeHostRecord({
+      inputs: { rows: [{ id: 1 }, { id: 2 }], name: "x" }
+    });
+    expect(skipped).toEqual([]);
+    expect(sidecar).toEqual([]);
+    expect(JSON.parse(json)).toEqual({
+      inputs: { rows: [{ id: 1 }, { id: 2 }], name: "x" }
+    });
+  });
+
+  it("marks the values JSON drops or flattens", () => {
+    const { json } = encodeHostRecord({
+      when: new Date("2020-01-02T03:04:05.000Z"),
+      nan: Number.NaN,
+      inf: Number.POSITIVE_INFINITY,
+      holder: { missing: undefined }
+    });
+    const tree = JSON.parse(json);
+    expect(tree.when).toEqual({
+      [JSON_DATE_MARKER]: "2020-01-02T03:04:05.000Z"
+    });
+    expect(tree.nan).toEqual({ [JSON_NUMBER_MARKER]: "NaN" });
+    expect(tree.inf).toEqual({ [JSON_NUMBER_MARKER]: "Infinity" });
+    expect(tree.holder).toEqual({
+      missing: { [JSON_UNDEFINED_MARKER]: true }
+    });
+  });
+
+  it("moves a long string to the sidecar and leaves a short one inline", () => {
+    const long = "x".repeat(SIDECAR_STRING_THRESHOLD);
+    const { json, sidecar } = encodeHostRecord({ long, short: "hi" });
+    const tree = JSON.parse(json);
+    expect(tree.long).toEqual({ [JSON_SIDECAR_MARKER]: 0 });
+    expect(tree.short).toBe("hi");
+    expect(sidecar).toEqual([long]);
+  });
+
+  it("base64-tags bytes, which cannot ride the sidecar into the guest", () => {
+    const { json } = encodeHostRecord({ bytes: new Uint8Array([1, 2, 3]) });
+    expect(JSON.parse(json).bytes).toEqual({
+      [SANDBOX_BYTES_MARKER]: "AQID"
+    });
+  });
+
+  it("skips only the entry it cannot represent", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const { json, skipped, cyclic: cyclicNames } = encodeHostRecord({
+      fine: { a: 1 },
+      fn: { call: () => 1 },
+      cyclic,
+      instance: new (class Thing {})(),
+      map: new Map([["a", 1]]),
+      big: { n: 1n }
+    });
+    expect([...skipped].sort()).toEqual(["big", "fn", "instance", "map"]);
+    expect(cyclicNames).toEqual(["cyclic"]);
+    expect(JSON.parse(json)).toEqual({ fine: { a: 1 } });
+  });
+
+  it("does not mistake a repeated value for a cycle", () => {
+    const shared = { a: 1 };
+    const { json, cyclic } = encodeHostRecord({ pair: [shared, shared] });
+    expect(cyclic).toEqual([]);
+    expect(JSON.parse(json).pair).toEqual([{ a: 1 }, { a: 1 }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decodeGuestPayload
+// ---------------------------------------------------------------------------
+
+describe("decodeGuestPayload", () => {
+  it("splices the sidecar back in by index", () => {
+    const bytes = new Uint8Array([9, 9]);
+    const decoded = decodeGuestPayload({
+      j: JSON.stringify({
+        v: { text: { [JSON_SIDECAR_MARKER]: 0 }, blob: { [JSON_SIDECAR_MARKER]: 1 } }
+      }),
+      b: ["long", bytes]
+    });
+    expect(decoded).toEqual({ text: "long", blob: bytes });
+  });
+
+  it("passes a raw payload straight through", () => {
+    expect(decodeGuestPayload({ raw: "plain" })).toBe("plain");
+    expect(decodeGuestPayload({ raw: undefined })).toBeUndefined();
+  });
+
+  it("answers undefined for a payload it cannot parse", () => {
+    expect(decodeGuestPayload({ j: "{not json" })).toBeUndefined();
+    expect(decodeGuestPayload({ j: 42 })).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End to end through a real guest
+// ---------------------------------------------------------------------------
+
+describe("sandbox JSON transport end to end", () => {
+  it("round-trips structured data unchanged", async () => {
+    const result = await runInSandbox({
+      code: `return { rows: [{ id: 1, tags: ["a"] }, { id: 2, tags: [] }], count: 2, ok: true, none: null };`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      rows: [
+        { id: 1, tags: ["a"] },
+        { id: 2, tags: [] }
+      ],
+      count: 2,
+      ok: true,
+      none: null
+    });
+  });
+
+  it("carries bytes out of the guest as a typed array", async () => {
+    const result = await runInSandbox({
+      code: `return { head: new Uint8Array([137, 80, 78]), n: 3 };`
+    });
+    const value = result.result as { head: Uint8Array; n: number };
+    expect(value.head).toBeInstanceOf(Uint8Array);
+    expect(Array.from(value.head)).toEqual([137, 80, 78]);
+    expect(value.n).toBe(3);
+  });
+
+  it("carries a long string out whole", async () => {
+    const result = await runInSandbox({
+      code: `return { text: "y".repeat(${SIDECAR_STRING_THRESHOLD * 2}) };`,
+      limits: { maxOutputSize: 10_000_000 }
+    });
+    const value = result.result as { text: string };
+    expect(value.text.length).toBe(SIDECAR_STRING_THRESHOLD * 2);
+    expect(value.text.startsWith("yyy")).toBe(true);
+  });
+
+  it("returns a bare string without an envelope around it", async () => {
+    const result = await runInSandbox({ code: `return "hello";` });
+    expect(result.result).toBe("hello");
+  });
+
+  it("answers String(value) for a cyclic result instead of aborting the runtime", async () => {
+    const result = await runInSandbox({
+      code: `const a = { name: "a" }; a.self = a; return a;`
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("[object Object]");
+  });
+
+  it("reads injected globals the guest never marshaled", async () => {
+    const result = await runInSandbox({
+      code: `return { n: inputs.rows.length, first: inputs.rows[0].name, bytes: Array.from(inputs.blob), when: inputs.when instanceof Date };`,
+      globals: {
+        inputs: {
+          rows: [{ name: "one" }, { name: "two" }],
+          blob: new Uint8Array([1, 2]),
+          when: new Date("2021-05-06T07:08:09.000Z")
+        }
+      }
+    });
+    expect(result.result).toEqual({
+      n: 2,
+      first: "one",
+      bytes: [1, 2],
+      when: true
+    });
+  });
+
+  it("injects a global the transport refuses through the wrapper's own path", async () => {
+    const result = await runInSandbox({
+      code: `return typeof cfg.hello;`,
+      globals: { cfg: { hello: () => "hi" } }
+    });
+    expect(result.result).toBe("function");
+  });
+
+  it("refuses a cyclic global by name rather than aborting the runtime", async () => {
+    const cyclic: Record<string, unknown> = { name: "loop" };
+    cyclic.self = cyclic;
+    const result = await runInSandbox({
+      code: `return cfg.name;`,
+      globals: { cfg: cyclic }
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('"cfg"');
+    expect(result.error).toContain("refers back to itself");
+  });
+
+  it("syncs an object global back to the host, dates included", async () => {
+    const state: Record<string, unknown> = { runs: 0 };
+    await runInSandbox({
+      code: `state.runs += 1; state.last = new Date("2022-03-04T05:06:07.000Z"); state.rows = [{ id: 1 }]; return state.runs;`,
+      globals: { state }
+    });
+    expect(state.runs).toBe(1);
+    expect(state.last).toBeInstanceOf(Date);
+    expect((state.last as Date).toISOString()).toBe("2022-03-04T05:06:07.000Z");
+    expect(state.rows).toEqual([{ id: 1 }]);
+  });
+
+  it("delivers emitted values decoded, bytes and all", async () => {
+    const seen: unknown[] = [];
+    const result = await runInSandbox({
+      code: `await emit("out", { rows: [{ id: 1 }], blob: new Uint8Array([7]) }); await emit("out", "plain"); return 1;`,
+      onEmit: async (_name, value) => {
+        seen.push(value);
+      }
+    });
+    expect(result.success).toBe(true);
+    const first = seen[0] as { rows: unknown; blob: Uint8Array };
+    expect(first.rows).toEqual([{ id: 1 }]);
+    expect(Array.from(first.blob)).toEqual([7]);
+    expect(seen[1]).toBe("plain");
+  });
+
+  it("records outputs decoded", async () => {
+    const result = await runInSandbox({
+      code: `await output("rows", [{ id: 1 }, { id: 2 }]); return "done";`
+    });
+    expect(result.outputs).toEqual({ rows: [{ id: 1 }, { id: 2 }] });
+  });
+});


### PR DESCRIPTION
## What changed

Two commits, both from profiling one `runInSandbox` call.

**1. Structured data crosses as JSON, not as handles.** `handleToNative` compiles four JS source strings inside the guest per object node (isNull, detectErrorType, isArray, getConstructorName) plus a `newFunction` and a descriptor copy per property, and `getHandle` installs an object into the guest the same way — ~150 µs per object node out and ~400 µs in, so 5 000 rows cost 2.0 s to inject and 1.7 s to return before the body ran a line. The guest now builds its result with `JSON.stringify` and the host parses it, the host encodes injected globals for the init prelude to parse, and `emit`/`output` arguments and the object-global sync-back take the same path. Typed arrays and strings over 8 KB ride a sidecar the marshaler moves whole; dates, non-finite numbers and `undefined` properties carry markers. A value the encoder cannot represent (a function, a bigint, a `Map`, a class instance) falls back to the wrapper's own marshaling; a cycle does not, because that fallback follows it until the runtime aborts with `list_empty(&rt->gc_obj_list)` — a cyclic global is now refused by name and a cyclic result comes back as `String(value)`, where both previously killed the run with an Emscripten assertion.

**2. The wrapper's Node-compat bootstrap is served cheaper modules.** Before our sandboxed function is called, `@sebastianwessel/quickjs` compiles ~12 KB of polyfills — `node:buffer`, `node:util`, `node:url`, `Headers`, `Request`, `Response` — into every fresh runtime, and the init prelude then deletes `Buffer`, `Headers`, `Request` and `Response`. Those imports resolve through *our* module loader, so four are served as empty modules and `node:util` as the `TextEncoder`/`TextDecoder` pair the guest keeps. `node:url` still comes from the wrapper: `URL` and `URLSearchParams` are capabilities, and a hand-rolled URL parser is not a saving worth making. The encoder keeps the wrapper's own `encodeURIComponent`/`unescape` UTF-8, pinned on `"héllo 日本 😀"` so the 2-, 3- and 4-byte cases all round-trip.

This deliberately stops short of owning context creation and the eval path. That would save the remaining ~3 ms but means reimplementing `createEvalCodeFunction` — module eval, promise resolution, handle lifetimes — which is the code whose leaks the `neverReject` convention already works around.

Serialization itself is now at the engine floor: both ends use native JSON, a binary codec would be interpreted JavaScript inside QuickJS competing with C, and QuickJS's own binary format has no host-side reader.

Measured with the benchmark this adds (`npm run bench:sandbox --workspace=packages/agents`), best of three, whole `runInSandbox` calls:

| shape | before | after |
|---|---:|---:|
| fixed cost (return 1) | 12.4 ms | 9.8 ms |
| return 1k objects | 351 ms | 15 ms |
| return 5k objects | 1701 ms | 48 ms |
| emit 1k objects in one call | 166 ms | 12 ms |
| inject 1k rows | 407 ms | 23 ms |
| inject 5k rows | 1990 ms | 77 ms |
| inject 1k rows, return them | 738 ms | 30 ms |
| state sync-back over 1k rows | 713 ms | 31 ms |
| return 1MB string | 13 ms | 13 ms |
| return 1MB bytes | 11 ms | 12 ms |
| cpu: 5M iterations | 393 ms | 401 ms |

The 2.6 ms off the fixed cost is paid by every run, including the small ones a workflow runs thousands of. One shape costs more: a run emitting many tiny values one at a time pays ~30 µs of envelope on a ~230 µs round trip (246 ms → 283 ms over 1 000 emits); a batch emit is 14× cheaper, so the trade holds.

## Verification

- [x] `npm run test:affected` — one pre-existing failure, unrelated to this diff: `packages/websocket/tests/models-api-rankings.test.ts` (5 tests) and `packages/model-pricing/tests/model-rankings.test.ts` (1 test), which pin the shipped rankings artifact as empty. Main's own tip commit `bc4560a4` ("chore(rankings): sync model rankings artifact (#5164)") filled that artifact with 3 027 lines and left the tests alone: `git diff origin/main HEAD -- packages/model-pricing packages/models` is empty, `git show bc4560a4:…/tests/model-rankings.test.ts` still asserts `generatedAt` is null, and `git show bc4560a4:…/model-rankings.json` has `"generatedAt": "2026-08-23T14:41:05.304Z"`. The base branch is red on this check; will merge base once it recovers. `packages/base-nodes` image tests need `mesa-vulkan-drivers` locally and pass with it (14 passed).
- [x] `npm run typecheck` — web and electron clean. `mobile/` reports missing `react-native`/`expo` modules, an install gap in this container (mobile is not a root workspace), untouched by this diff.
- [x] `npm run lint` — 0 errors.
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 1/1 selfchecks passed` (252/252 graphs validate cleanly).

Sandbox suites run directly (`js-sandbox`, `-modules`, `-media`, `-emit`, `-stream`, `-audio-video`, `-wasm`, `sandbox-secrets`, `host-modules`, `codeact-sandbox-packages`, `sandbox-json-transport`): 392 passed, 1 skipped. `packages/code-nodes`: 222 passed.

## Agent capabilities

No capability added, and no capability's declared contract changed.

## New checks

Two: `tests/sandbox-json-transport.test.ts` (20 tests) and "the compat bootstrap loads our stubs" in `tests/js-sandbox-modules.test.ts` (5 tests).

- [x] Each was inverted and observed failing.

Dropping the sidecar from the guest payload (`return { j: json };`):

```
 FAIL  carries bytes out of the guest as a typed array
 FAIL  carries a long string out whole
 FAIL  delivers emitted values decoded, bytes and all
      Tests  3 failed | 17 passed (20)
```

The bootstrap canary needed two inversions, because the obvious assertion is unfalsifiable: the init prelude deletes `Buffer`/`Headers`/`Request`/`Response` anyway, so probing them through `runInSandbox` passes whether or not a stub was ever served. It now probes the engine directly, with our module host and without our prelude — renaming the `buffer` stub gives:

```
Expected: "Buffer:undefined Headers:undefined Request:undefined Response:undefined"
Received: "Buffer:function  Headers:undefined Request:undefined Response:undefined"
```

A renamed `node:util` stub is invisible even to that (the real polyfill still installs `TextEncoder`), so the test also asserts the stronger invariant — every id we stub is one the bootstrap actually requests. Renaming it gives:

```
-   "/node_modules/util-renamed-by-a-wrapper-release",
      Tests  1 failed | 37 passed (38)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFaZrZu49mE3StqYpZxhih