### PR TITLE
feat(agents): let model rankings decide an agent's default model

### DIFF
--- a/docs/canonical-model-intelligence-design.md
+++ b/docs/canonical-model-intelligence-design.md
@@ -3,8 +3,9 @@
 Status: passes 1–3 and 4a are implemented (accessors + artifact in
 `packages/model-pricing`, the rankings sync + nightly workflow, the
 `find_model` rank term, the enriched `/api/models/recommended/*`
-endpoints). The picker work in pass 4 and the first real rankings
-artifact (which lands via the nightly sync PR) are still open.
+endpoints), and the first real artifact has landed — 168 routes, ranked
+across five tasks. Rankings now *lead* the agent's default model choice
+(§4 below). The picker work in pass 4 is still open.
 
 ## The problem
 
@@ -180,11 +181,32 @@ rankedForTask(task): RankedCanonicalModel[]             // leaderboard, canonica
 ### 4. Consumers
 
 **`find_model` / `nodetool.models.pick`** (`packages/agents/src/capabilities/models.ts`).
-Today's score is additive: recommended +100, provider hint +200, model hint
-+250, local +150. Add one bounded term — `normalized × 80` for the requested
-task — below the explicit-preference bonuses, so a user hint still outranks
-a leaderboard, and attach `rank`/`of`/`canonical` to the returned
-candidates. Two routes to one canonical model collapse to the better-priced
+The score is a ladder of tiers, each above the sum of everything below it
+(`SCORE_TIERS`): model hint 2000, provider hint 1000, `prefer_local` 500,
+a leaderboard position 200 + `normalized × 80`, `RECOMMENDED_MODELS` 100,
+locally served 30. Two consequences worth stating plainly:
+
+- **Rankings lead the default pick.** With no hint from the caller, the
+  first hit is the top of the leaderboard for the task. The first version
+  of this term sat *below* the recommended bonus (≤ 80 against +100), which
+  meant the hand-pinned list still decided every default: `find_model
+  ("text_to_video")` answered with `openai:sora-2`, a model the artifact
+  does not rank at all, over the rank-1 route. An agent asking only for a
+  capability now gets the best model for the job.
+- **A ranked candidate does not also take the recommended bonus.** +100 on
+  top of a 0…80 span would let the static list reorder the leaderboard,
+  which is the blindness the term exists to fix. `RECOMMENDED_MODELS`
+  keeps ordering what the artifact says nothing about — language,
+  embedding and ASR models, local models, anything unmatched.
+
+Results are also one row per canonical model rather than one per route:
+`gpt-image-2` is reachable through atlascloud (two endpoints), kie (two) and
+openai, and a top-5 of five routes to one model shows an agent one model. The
+best-scoring route survives, the rest are listed under its `alternate_routes`.
+
+A preference the caller actually stated — a provider, a model, `prefer_local`
+— still outranks any leaderboard position. Each candidate carries
+`rank`/`of`/`canonical` in the answer. Two routes to one canonical model collapse to the better-priced
 one in the top results, with the alternates listed under it. The agent
 answer the draft asked for ("Kling 3 Pro, FAL, rank 2 of 41, $0.18/s — also
 via kie at $0.14/s") falls out of `routesFor` + `getGenspendPrice`, both

--- a/packages/agents/src/capabilities/models.specs.ts
+++ b/packages/agents/src/capabilities/models.specs.ts
@@ -111,7 +111,7 @@ export const LIST_MODELS_SCHEMA: JsonSchema = {
 export const findModelSpec: CapabilitySpec = {
   name: "find_model",
   description:
-    "Find a real {provider, model_id} for a generic AI node by capability. Pass `query` to search by name when the user named a model ('flux schnell'), otherwise omit it to get the recommended ranking. Returns models from providers the user has configured, ranked by match/recommended/downloaded/preferences. Each result carries `ref` — the typed value to assign to a node's model property verbatim — and, for models with a quality ranking, `canonical`, `ranked_task`, `rank`/`of`, and `alternate_routes` (other providers serving the same model). Call this before adding any generic AI node (TextToImage, TextToVideo, TextToSpeech, etc.).",
+    "Find a real {provider, model_id} for a generic AI node by capability. Omit `query` and the first result is the best model for the job: image, video, speech and music candidates are ordered by their quality leaderboard for the task. Pass `query` only when the user named a model ('flux schnell'), or `provider_hint` / `model_hint` / `prefer_local` when they stated a preference — those outrank the leaderboard. Results are one row per model, not per route: a model several providers serve appears once, with the others under `alternate_routes`. Each result carries `ref` — the typed value to assign to a node's model property verbatim — and, for ranked models, `canonical`, `ranked_task`, `rank`/`of`, and `alternate_routes` (other providers serving the same model). Call this before adding any generic AI node (TextToImage, TextToVideo, TextToSpeech, etc.) — never guess a model id.",
   inputSchema: FIND_MODEL_INPUT_SCHEMA,
   category: "read",
   userMessage: (params) =>

--- a/packages/agents/src/capabilities/models.ts
+++ b/packages/agents/src/capabilities/models.ts
@@ -10,6 +10,12 @@
  * is read at call time, so a host that fills the map lazily — the MCP mount
  * does — still serves the models it resolved after construction.
  *
+ * `find_model` is where an agent's default model choice is made: with no hint
+ * from the caller it answers with the model that tops the quality leaderboard
+ * for the task (see {@link SCORE_TIERS}), so an agent that just asks for a
+ * capability gets the best model for the job rather than the first one a
+ * provider happens to list.
+ *
  * Design: docs/tool-class-retirement-design.md § Migration.
  */
 
@@ -317,11 +323,43 @@ function hintMatch(model: AnyModel, hints: Set<string>): boolean {
 }
 
 /**
- * The most a leaderboard position can add to a candidate's score. Below every
- * explicit preference (recommended +100, provider hint +200, model hint +250),
- * so a user who named a provider or a model still gets it first: rankings
- * order the field, they never overrule the caller.
+ * The score ladder. Each tier outranks the sum of every tier below it, so the
+ * order between two candidates is a decision rather than an arithmetic
+ * accident:
+ *
+ * | tier | addend | when |
+ * |---|---:|---|
+ * | model hint | 2000 | the caller named this model |
+ * | provider hint | 1000 | the caller named this provider |
+ * | prefer_local | 500 | the caller asked for local and this runs locally |
+ * | leaderboard | 200 + 0…80 | the artifact ranks this model for the task |
+ * | recommended | 100 | `RECOMMENDED_MODELS` pins it and nothing ranks it |
+ * | downloaded | 30 | a local provider serves it |
+ *
+ * What the ladder decides: with no hint from the caller, the default pick is
+ * the model that tops the leaderboard for the task — `find_model`, and so
+ * `nodetool.models.pick`, answer with the best model for the job rather than
+ * with whichever one the static `RECOMMENDED_MODELS` list happens to pin.
+ * The pinned list still orders what the artifact says nothing about: language,
+ * embedding and ASR models, local models, and any model the rankings have
+ * never heard of.
+ *
+ * A caller's own preference still wins: naming a provider or a model, or
+ * asking for local, outranks any leaderboard position. Rankings order the
+ * field; they never overrule the caller.
  */
+export const SCORE_TIERS = {
+  modelHint: 2000,
+  providerHint: 1000,
+  preferLocal: 500,
+  ranked: 200,
+  recommended: 100,
+  downloaded: 30,
+  /** Nudge against a hosted model when the caller asked for local. */
+  remote: -5
+} as const;
+
+/** The most a leaderboard *position* adds, on top of {@link SCORE_TIERS}.ranked. */
 export const RANK_BONUS_MAX = 80;
 
 /**
@@ -456,17 +494,6 @@ export function scoreCandidate(
   const { providerId, model } = input;
   const downloaded = LOCAL_PROVIDER_IDS.has(providerId);
 
-  let score = 0;
-  if (input.recommended) score += 100;
-  if (downloaded) score += 30;
-  // Explicit user preferences outrank the default recommended bonus.
-  if (input.providerHint && providerId === input.providerHint) score += 200;
-  if (hintMatch(model, input.modelHints)) score += 250;
-  if (input.preferLocal && downloaded) score += 150;
-  else if (input.preferLocal && !downloaded) score -= 5;
-
-  // Quality last and bounded at +80: it orders the field below every
-  // preference the caller stated.
   const ranking = rankCandidate(
     providerId,
     model.id,
@@ -474,7 +501,27 @@ export function scoreCandidate(
     input.rankedCapability,
     artifact
   );
-  score += ranking.bonus;
+  const ranked = ranking.fields.rank !== undefined;
+
+  let score = 0;
+  if (downloaded) score += SCORE_TIERS.downloaded;
+  if (input.providerHint && providerId === input.providerHint) {
+    score += SCORE_TIERS.providerHint;
+  }
+  if (hintMatch(model, input.modelHints)) score += SCORE_TIERS.modelHint;
+  if (input.preferLocal) {
+    score += downloaded ? SCORE_TIERS.preferLocal : SCORE_TIERS.remote;
+  }
+
+  if (ranked) {
+    // The leaderboard decides among the models it covers, so a candidate it
+    // ranks does not also take the recommended bonus: +100 on top of a 0…80
+    // span would let the static list reorder the leaderboard, which is the
+    // blindness this term exists to fix.
+    score += SCORE_TIERS.ranked + ranking.bonus;
+  } else if (input.recommended) {
+    score += SCORE_TIERS.recommended;
+  }
 
   return { score, downloaded, fields: ranking.fields };
 }
@@ -651,13 +698,33 @@ const findModel: CapabilityExport = {
     const answer: FindModelAnswer = {
       capability,
       total: collected.length,
-      results: collected.slice(0, limit)
+      results: bestRoutePerModel(collected).slice(0, limit)
     };
     if (queryMatched !== undefined) answer.query_matched = queryMatched;
     if (notes.length > 0) answer.note = notes.join(" ");
     return answer;
   }
 };
+
+/**
+ * One row per canonical model: its best-scoring route, in the order the sort
+ * left them. Without this a top-5 for `text_to_image` is five routes to the
+ * same leaderboard leader (atlascloud's two endpoints, kie's, openai's) and
+ * the caller sees one model. The routes that drop out are not lost — each
+ * survivor names them in `alternate_routes`.
+ *
+ * A candidate the artifact does not group carries no `canonical` and is never
+ * collapsed: two unranked models are two models.
+ */
+function bestRoutePerModel(results: FindModelResult[]): FindModelResult[] {
+  const seen = new Set<string>();
+  return results.filter((result) => {
+    if (!result.canonical) return true;
+    if (seen.has(result.canonical)) return false;
+    seen.add(result.canonical);
+    return true;
+  });
+}
 
 /** One ranked candidate `find_model` returns. */
 interface RankedModel extends CandidateRankingFields {

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -687,9 +687,9 @@ const nodetool = (() => {
       find: (capability, opts) =>
         __need("find_model")(__merge(opts, { capability: capability })),
       /**
-       * Resolve ONE model for a capability — the top-ranked hit, ready to
-       * pass to nodetool.media.*. To put it in a node's model property,
-       * assign the result's "ref" field verbatim (the flat fields use
+       * Resolve ONE model for a capability — the leaderboard's best for that
+       * task, ready to pass to nodetool.media.*. To put it in a node's model
+       * property, assign the result's "ref" field verbatim (the flat fields use
        * "model_id"; the property wants "id"). Throws when no configured
        * provider offers the capability.
        */
@@ -1223,8 +1223,10 @@ const NAMESPACE_DOCS: PromptEntry[] = [
     doc: `- \`nodetool.models\` — model discovery. \`find_model\` / \`list_models\` are
   direct tool calls, so a plain lookup is one call and not an action; these are
   the same lookups from inside an action, where a picked model feeds the next
-  call. \`await pick(capability)\` resolves ONE ranked model
-  (e.g. \`pick("text_to_image")\` → \`{provider, model_id, ref}\`). When the user
+  call. \`await pick(capability)\` resolves ONE model — the best for that job,
+  the top of the quality leaderboard for image, video, speech and music
+  (e.g. \`pick("text_to_image")\` → \`{provider, model_id, ref}\`). Do not shop
+  around: pick with no options IS the good default. When the user
   named a model, search for it in the SAME call:
   \`pick("text_to_image", {query: "flux schnell"})\` — \`query\` is free text over
   model id and name, and \`pick\` throws when nothing matches instead of

--- a/packages/agents/tests/capabilities-models-rankings.test.ts
+++ b/packages/agents/tests/capabilities-models-rankings.test.ts
@@ -14,17 +14,30 @@ import type {
   ProcessingContext,
   ProviderId
 } from "@nodetool-ai/runtime";
+import {
+  modelRankings,
+  routesFor
+} from "@nodetool-ai/model-pricing/model-rankings";
 import type { ModelRankingsArtifact } from "@nodetool-ai/model-pricing/model-rankings";
 import { toolFromCapability } from "../src/capabilities/adapters.js";
 import { UNGATED, createCapabilityRun } from "../src/capabilities/invoke.js";
 import {
   RANK_BONUS_MAX,
+  SCORE_TIERS,
   findModel,
   rankCandidate,
   scoreCandidate
 } from "../src/capabilities/models.js";
 
 const ctx = { userId: "u1" } as ProcessingContext;
+
+/** One provider route read out of the shipped artifact, with its rank. */
+interface RankedRoute {
+  provider: string;
+  modelId: string;
+  name: string;
+  rank: number;
+}
 
 /**
  * Two routes to one canonical video model, plus a second model ranked lower.
@@ -86,20 +99,20 @@ describe("the rank term", () => {
       FIXTURE
     );
     expect(unranked.score).toBe(0);
-    expect(ranked.score).toBe(RANK_BONUS_MAX);
+    expect(ranked.score).toBe(SCORE_TIERS.ranked + RANK_BONUS_MAX);
     expect(ranked.score).toBeGreaterThan(unranked.score);
   });
 
-  it("scales with the leaderboard position, bounded at 80", () => {
+  it("scales with the leaderboard position, bounded at 80 over the floor", () => {
     const top = scoreCandidate({ ...RANKED, task: "text_to_video" }, FIXTURE);
     const mid = scoreCandidate({ ...RANKED, task: "image_to_video" }, FIXTURE);
-    expect(top.score).toBe(80);
-    expect(mid.score).toBe(40);
+    expect(top.score).toBe(SCORE_TIERS.ranked + 80);
+    expect(mid.score).toBe(SCORE_TIERS.ranked + 40);
   });
 
   it("falls back to the model's best task when the caller named none", () => {
     const best = scoreCandidate(RANKED, FIXTURE);
-    expect(best.score).toBe(80);
+    expect(best.score).toBe(SCORE_TIERS.ranked + 80);
     expect(best.fields.ranked_task).toBe("text_to_video");
   });
 
@@ -114,7 +127,7 @@ describe("the rank term", () => {
     expect(language.fields.canonical).toBe("kling-3-pro");
   });
 
-  it("stays below every explicit preference", () => {
+  it("stays below every preference the caller stated", () => {
     const ranked = scoreCandidate({ ...RANKED, task: "text_to_video" }, FIXTURE);
     const hintedProvider = scoreCandidate(
       { ...UNRANKED, task: "text_to_video", providerHint: "fal_ai" },
@@ -128,13 +141,78 @@ describe("the rank term", () => {
       },
       FIXTURE
     );
-    const recommended = scoreCandidate(
-      { ...UNRANKED, task: "text_to_video", recommended: true },
+    const local = scoreCandidate(
+      {
+        ...UNRANKED,
+        providerId: "ollama",
+        task: "text_to_video",
+        preferLocal: true
+      },
       FIXTURE
     );
     expect(hintedProvider.score).toBeGreaterThan(ranked.score);
     expect(hintedModel.score).toBeGreaterThan(ranked.score);
-    expect(recommended.score).toBeGreaterThan(ranked.score);
+    expect(local.score).toBeGreaterThan(ranked.score);
+  });
+
+  it("leads the hand-pinned recommended list", () => {
+    // The default pick — no hint of any kind — is the leaderboard's best, not
+    // whichever model RECOMMENDED_MODELS pins. Before the ladder, recommended
+    // (+100) outscored any rank (≤ +80), so `find_model("text_to_video")`
+    // answered with the pinned openai model even though the artifact does not
+    // rank it at all.
+    const rankedTop = scoreCandidate(
+      { ...RANKED, task: "text_to_video" },
+      FIXTURE
+    );
+    const rankedLow = scoreCandidate(
+      {
+        ...RANKED,
+        model: { id: "fal-ai/minor-video", name: "Minor Video", provider: "fal_ai" },
+        task: "text_to_video"
+      },
+      FIXTURE
+    );
+    const recommendedUnranked = scoreCandidate(
+      { ...UNRANKED, task: "text_to_video", recommended: true },
+      FIXTURE
+    );
+    expect(rankedTop.score).toBeGreaterThan(recommendedUnranked.score);
+    expect(rankedLow.score).toBeGreaterThan(recommendedUnranked.score);
+    expect(rankedTop.score).toBeGreaterThan(rankedLow.score);
+  });
+
+  it("does not let the recommended bonus reorder the leaderboard", () => {
+    // A pinned model that the artifact also ranks takes the rank tier only:
+    // +100 on top of a 0…80 span would let the static list jump a better-
+    // ranked model, which is the blindness the rank term exists to fix.
+    const pinnedButLower = scoreCandidate(
+      {
+        ...RANKED,
+        model: { id: "fal-ai/minor-video", name: "Minor Video", provider: "fal_ai" },
+        task: "text_to_video",
+        recommended: true
+      },
+      FIXTURE
+    );
+    const betterRanked = scoreCandidate(
+      { ...RANKED, task: "text_to_video" },
+      FIXTURE
+    );
+    expect(betterRanked.score).toBeGreaterThan(pinnedButLower.score);
+  });
+
+  it("still orders by the recommended list where nothing is ranked", () => {
+    const recommended = scoreCandidate(
+      { ...UNRANKED, task: "text_to_video", recommended: true },
+      FIXTURE
+    );
+    const plain = scoreCandidate(
+      { ...UNRANKED, task: "text_to_video" },
+      FIXTURE
+    );
+    expect(recommended.score).toBe(SCORE_TIERS.recommended);
+    expect(recommended.score).toBeGreaterThan(plain.score);
   });
 });
 
@@ -181,41 +259,131 @@ describe("the ranking fields", () => {
 });
 
 describe("the shipped artifact", () => {
-  it("leaves find_model's answer exactly as it was", async () => {
-    // The shipped artifact is empty until the sync lands, so every result must
-    // carry the pre-rankings shape and nothing else.
-    class FakeImageProvider extends BaseProvider {
-      constructor(
-        id: ProviderId,
-        private readonly models: ImageModel[]
-      ) {
-        super(id);
-      }
-      override async getAvailableImageModels(): Promise<ImageModel[]> {
-        return this.models;
-      }
+  class FakeImageProvider extends BaseProvider {
+    constructor(
+      id: ProviderId,
+      readonly served: ImageModel[]
+    ) {
+      super(id);
     }
-    const tool = toolFromCapability(
-      findModel.spec,
-      findModel.impl,
-      (context) =>
-        createCapabilityRun({
-          context,
-          gate: UNGATED,
-          providers: {
-            fal_ai: new FakeImageProvider("fal_ai" as ProviderId, [
-              {
-                id: "fal-ai/flux/schnell",
-                name: "Flux Schnell",
-                provider: "fal_ai"
-              } as ImageModel
-            ])
-          }
-        })
+    override async getAvailableImageModels(): Promise<ImageModel[]> {
+      return this.served;
+    }
+  }
+
+  function findModelOver(
+    providers: Record<string, BaseProvider>
+  ): ReturnType<typeof toolFromCapability> {
+    return toolFromCapability(findModel.spec, findModel.impl, (context) =>
+      createCapabilityRun({ context, gate: UNGATED, providers })
     );
-    const result = (await tool.process(ctx, {
-      capability: "text_to_image"
+  }
+
+  /** The best and the worst text-to-image route the shipped artifact carries. */
+  function extremes(): { top: RankedRoute; bottom: RankedRoute } {
+    const routes: RankedRoute[] = [];
+    for (const [key, entry] of Object.entries(modelRankings.models)) {
+      const rank = entry.tasks?.["text_to_image"];
+      const colon = key.indexOf(":");
+      if (!rank || colon <= 0) continue;
+      routes.push({
+        provider: key.slice(0, colon),
+        modelId: key.slice(colon + 1),
+        name: entry.name,
+        rank: rank.rank
+      });
+    }
+    routes.sort((a, b) => a.rank - b.rank);
+    const top = routes[0];
+    const bottom = routes[routes.length - 1];
+    // A one-model leaderboard would make the ordering assertion vacuous.
+    expect(top).toBeDefined();
+    expect(bottom.rank).toBeGreaterThan(top.rank);
+    return { top, bottom };
+  }
+
+  it("orders find_model's answer by the leaderboard", async () => {
+    const { top, bottom } = extremes();
+    const providers: Record<string, BaseProvider> = {};
+    // Served worst-first, so the answer's order can only come from the score.
+    for (const route of [bottom, top]) {
+      providers[route.provider] = new FakeImageProvider(
+        route.provider as ProviderId,
+        [
+          {
+            id: route.modelId,
+            name: route.name,
+            provider: route.provider,
+            supportedTasks: ["text_to_image"]
+          } as ImageModel
+        ]
+      );
+    }
+    const result = (await findModelOver(providers).process(ctx, {
+      capability: "text_to_image",
+      task: "text_to_image"
     })) as { results: Record<string, unknown>[] };
+    expect(result.results[0]["model_id"]).toBe(top.modelId);
+    expect(result.results[0]["rank"]).toBe(top.rank);
+    expect(result.results[1]["model_id"]).toBe(bottom.modelId);
+    // Scored apart, not merely sorted apart: the ids also happen to sort this
+    // way, so equal scores would let the tiebreak pass this test on nothing.
+    expect(result.results[0]["score"]).toBeGreaterThan(
+      Number(result.results[1]["score"])
+    );
+  });
+
+  it("answers with one row per model, not one per route", async () => {
+    // The leaderboard leader is reachable through several providers. Five of
+    // those routes in a top-5 would show the caller one model.
+    const { top } = extremes();
+    const entry = modelRankings.models[`${top.provider}:${top.modelId}`];
+    const siblings = routesFor(entry?.canonical ?? "");
+    expect(siblings.length).toBeGreaterThan(1);
+
+    const providers: Record<string, BaseProvider> = {};
+    for (const route of siblings) {
+      const existing = providers[route.provider];
+      const model = {
+        id: route.modelId,
+        name: entry?.name ?? route.modelId,
+        provider: route.provider,
+        supportedTasks: ["text_to_image"]
+      } as ImageModel;
+      providers[route.provider] = new FakeImageProvider(
+        route.provider as ProviderId,
+        existing instanceof FakeImageProvider
+          ? [...existing.served, model]
+          : [model]
+      );
+    }
+
+    const result = (await findModelOver(providers).process(ctx, {
+      capability: "text_to_image",
+      task: "text_to_image"
+    })) as { results: Record<string, unknown>[]; total: number };
+    expect(result.total).toBe(siblings.length);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]["canonical"]).toBe(entry?.canonical);
+    expect(
+      (result.results[0]["alternate_routes"] as unknown[]).length
+    ).toBe(siblings.length - 1);
+  });
+
+  it("leaves an unranked model's answer in the pre-rankings shape", async () => {
+    // No entry for this id in the artifact, so no ranking field appears and
+    // the score is what it was before rankings existed.
+    const result = (await findModelOver({
+      fal_ai: new FakeImageProvider("fal_ai" as ProviderId, [
+        {
+          id: "fal-ai/flux/schnell",
+          name: "Flux Schnell",
+          provider: "fal_ai"
+        } as ImageModel
+      ])
+    }).process(ctx, { capability: "text_to_image" })) as {
+      results: Record<string, unknown>[];
+    };
     expect(Object.keys(result.results[0]).sort()).toEqual([
       "downloaded",
       "model_id",

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -237,7 +237,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "find_model",
     module: "models",
     impl: "packages/agents/src/capabilities/models.ts",
-    contract: "93b414be8776",
+    contract: "035763b68b4a",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-models.test.ts",

--- a/packages/model-pricing/tests/model-rankings.test.ts
+++ b/packages/model-pricing/tests/model-rankings.test.ts
@@ -1,7 +1,8 @@
 /**
- * The rankings accessors. The shipped artifact is empty until the first sync,
- * so the grouping and leaderboard behavior is pinned against a fixture passed
- * in as an argument — the accessors take the artifact, so no module is mocked.
+ * The rankings accessors. Grouping and leaderboard behavior is pinned against
+ * a fixture passed in as an argument — the accessors take the artifact, so no
+ * module is mocked. The shipped artifact is whatever the last sync wrote, so
+ * the block below asserts its invariants rather than its contents.
  */
 import { describe, it, expect } from "vitest";
 import {
@@ -55,16 +56,66 @@ const fixture: ModelRankingsArtifact = {
 };
 
 describe("the shipped artifact", () => {
-  it("is empty but valid, so every accessor answers with nothing", () => {
+  it("carries the schema this package reads", () => {
     expect(modelRankings.schemaVersion).toBe(1);
     expect(modelRankings.source).toBe("artificialanalysis.ai");
-    expect(modelRankings.generatedAt).toBeNull();
-    expect(modelRankings.models).toEqual({});
+    // Empty until a sync runs, a timestamp after — never something else.
+    if (Object.keys(modelRankings.models).length === 0) {
+      expect(modelRankings.generatedAt).toBeNull();
+    } else {
+      expect(modelRankings.generatedAt).toEqual(expect.any(String));
+    }
+  });
 
-    expect(getModelRank("fal_ai", "fal-ai/kling-video/v3/pro")).toBeNull();
-    expect(getCanonicalId("fal_ai", "fal-ai/kling-video/v3/pro")).toBeNull();
-    expect(routesFor("kling-3-pro")).toEqual([]);
-    expect(rankedForTask("text_to_video")).toEqual([]);
+  it("keys every entry `provider:model_id` and groups it by a canonical id", () => {
+    const entries = Object.entries(modelRankings.models);
+    for (const [key, entry] of entries) {
+      const colon = key.indexOf(":");
+      expect(colon).toBeGreaterThan(0);
+      expect(key.length).toBeGreaterThan(colon + 1);
+      expect(entry.canonical).toBeTruthy();
+      expect(entry.name).toBeTruthy();
+    }
+  });
+
+  it("gives every route to one model identical tasks", () => {
+    // Quality is a property of the model, never of the route — the accessors
+    // and `find_model`'s rank term both rely on it.
+    const byCanonical = new Map<string, Record<string, unknown>>();
+    for (const entry of Object.values(modelRankings.models)) {
+      const first = byCanonical.get(entry.canonical);
+      if (first) {
+        expect(entry.tasks).toEqual(first);
+      } else {
+        byCanonical.set(entry.canonical, entry.tasks);
+      }
+    }
+  });
+
+  it("answers for a route it carries and with nothing for one it does not", () => {
+    const [key, entry] = Object.entries(modelRankings.models)[0] ?? [];
+    if (!key || !entry) {
+      // An empty artifact is a valid shipped state: every accessor is total.
+      expect(getModelRank("fal_ai", "fal-ai/kling-video/v3/pro")).toBeNull();
+      expect(rankedForTask("text_to_video")).toEqual([]);
+      return;
+    }
+    const colon = key.indexOf(":");
+    const provider = key.slice(0, colon);
+    const modelId = key.slice(colon + 1);
+    expect(getModelRank(provider, modelId)).toMatchObject({
+      canonical: entry.canonical
+    });
+    expect(getCanonicalId(provider, modelId)).toBe(entry.canonical);
+    expect(routesFor(entry.canonical).length).toBeGreaterThan(0);
+    for (const task of Object.keys(entry.tasks)) {
+      expect(rankedForTask(task).length).toBeGreaterThan(0);
+    }
+
+    expect(getModelRank(provider, "nodetool-test/not-a-real-model")).toBeNull();
+    expect(getCanonicalId("nodetool-test", modelId)).toBeNull();
+    expect(routesFor("nodetool-test-not-a-canonical-id")).toEqual([]);
+    expect(rankedForTask("not_a_task")).toEqual([]);
   });
 });
 

--- a/packages/websocket/tests/models-api-rankings.test.ts
+++ b/packages/websocket/tests/models-api-rankings.test.ts
@@ -4,11 +4,13 @@
  * leaderboard after them, one row per canonical model.
  *
  * The helper takes the artifact as a parameter, so a fixture drives it
- * directly — nothing here mocks a module, and the endpoint tests below run
- * against the shipped (empty) artifact.
+ * directly — nothing here mocks a module. The endpoint tests below run
+ * against the shipped artifact, whose contents the nightly sync rewrites, so
+ * they assert the merge's invariants rather than a fixed list of models.
  */
 import { describe, it, expect } from "vitest";
 import { RECOMMENDED_MODELS } from "@nodetool-ai/runtime";
+import { rankedForTask } from "@nodetool-ai/model-pricing";
 import type { ModelRankingsArtifact } from "@nodetool-ai/model-pricing";
 import type { UnifiedModel } from "@nodetool-ai/protocol";
 import {
@@ -129,34 +131,83 @@ describe("mergeRankedRecommendations", () => {
 });
 
 describe("recommended endpoints with the shipped artifact", () => {
-  const cases: Array<[string, string]> = [
-    ["/recommended/image/text-to-image", "text_to_image"],
-    ["/recommended/image/image-to-image", "image_to_image"],
-    ["/recommended/video/text-to-video", "text_to_video"],
-    ["/recommended/video/image-to-video", "image_to_video"]
+  /**
+   * What the endpoint must answer for a ranked task, whatever the sync last
+   * wrote: the pinned entries first and unchanged, then the task's
+   * leaderboard in rank order, one row per canonical model, and nothing
+   * listed twice.
+   */
+  async function expectPinnedThenRanked(
+    path: string,
+    task: string,
+    base: UnifiedModel[],
+    type: string
+  ): Promise<void> {
+    const res = await handleModelsApiRequest(get(path));
+    expect(res!.status).toBe(200);
+    const body = (await res!.json()) as UnifiedModel[];
+
+    expect(body.slice(0, base.length)).toEqual(
+      JSON.parse(JSON.stringify(base))
+    );
+
+    const pinnedKeys = new Set(
+      base.map((model) => `${model.provider ?? ""}::${model.id}`)
+    );
+    const expectedTail = rankedForTask(task)
+      .filter(
+        (entry) =>
+          !entry.routes.some((route) =>
+            pinnedKeys.has(`${route.provider}::${route.modelId}`)
+          )
+      )
+      .map((entry) => entry.name);
+    expect(body.slice(base.length).map((model) => model.name)).toEqual(
+      expectedTail
+    );
+
+    for (const model of body.slice(base.length)) {
+      expect(model.type).toBe(type);
+    }
+    const keys = body.map((model) => `${model.provider ?? ""}::${model.id}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  }
+
+  const cases: Array<[string, string, string]> = [
+    ["/recommended/image/text-to-image", "text_to_image", "image_model"],
+    ["/recommended/image/image-to-image", "image_to_image", "image_model"],
+    ["/recommended/video/text-to-video", "text_to_video", "video_model"],
+    ["/recommended/video/image-to-video", "image_to_video", "video_model"]
   ];
 
-  for (const [path, task] of cases) {
-    it(`GET ${path} still returns exactly the pinned entries`, async () => {
-      const res = await handleModelsApiRequest(get(path));
-      expect(res!.status).toBe(200);
-      expect(await res!.json()).toEqual(
-        JSON.parse(JSON.stringify(pinned(task)))
-      );
+  for (const [path, task, type] of cases) {
+    it(`GET ${path} pins first, then the ${task} leaderboard`, async () => {
+      await expectPinnedThenRanked(path, task, pinned(task), type);
     });
   }
 
-  it("GET /recommended/tts and /recommended/music are unchanged", async () => {
-    const tts = await handleModelsApiRequest(get("/recommended/tts"));
-    const music = await handleModelsApiRequest(get("/recommended/music"));
-    const byModality = (modality: string): unknown =>
-      JSON.parse(
-        JSON.stringify(
-          RECOMMENDED_MODELS.filter((model) => model.modality === modality)
-        )
-      );
+  it("GET /recommended/tts and /recommended/music merge by modality", async () => {
+    const byModality = (modality: string): UnifiedModel[] =>
+      RECOMMENDED_MODELS.filter((model) => model.modality === modality);
 
-    expect(await tts!.json()).toEqual(byModality("tts"));
-    expect(await music!.json()).toEqual(byModality("music"));
+    await expectPinnedThenRanked(
+      "/recommended/tts",
+      "text_to_speech",
+      byModality("tts"),
+      "tts_model"
+    );
+    await expectPinnedThenRanked(
+      "/recommended/music",
+      "text_to_music",
+      byModality("music"),
+      "music_model"
+    );
+  });
+
+  it("has something to merge, so the assertions above are not vacuous", () => {
+    // A leaderboard that answered with nothing would make every tail above an
+    // empty list, and the endpoint tests would pass on an empty artifact.
+    expect(rankedForTask("text_to_image").length).toBeGreaterThan(0);
+    expect(rankedForTask("text_to_video").length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## What changed

`find_model` is where an agent picks a model, and its rank term sat below the recommended bonus (≤ +80 against +100), so the hand-pinned `RECOMMENDED_MODELS` list still decided every default — `find_model("text_to_video")` answered with `openai:sora-2`, a model the rankings artifact does not rank at all, over the rank-1 route. Scoring is now an explicit ladder (`SCORE_TIERS`), each tier above the sum of everything below it: model hint 2000, provider hint 1000, `prefer_local` 500, leaderboard 200 + `normalized × 80`, recommended 100, downloaded 30. A ranked candidate does not also take the recommended bonus, or the static list could still reorder the leaderboard; preferences the caller actually stated keep winning, and the pinned list keeps ordering what the artifact says nothing about (language, embedding and ASR models, local models, anything unmatched). The answer also collapses to one row per canonical model — `gpt-image-2` is reachable through five routes, so a top-5 used to be five copies of one model; the best-scoring route survives and names the rest in `alternate_routes`. Tool descriptions, the `nodetool.models.pick` prompt text, and the design doc say what the default now is.

## Verification

- [x] `npm run test:affected` — green except `packages/base-nodes` `image-*-examples-run`, which fail on this box with `No WebGPU adapter available (Node/Dawn)`: no Vulkan ICD installed, the environment gap AGENTS.md documents, unrelated to this diff. `npm run test --workspace=packages/agents` on its own: 3349 passed, 5 skipped.
- [x] `npm run typecheck` — web and electron clean (`typecheck:web` / `typecheck:electron` exit 0). `typecheck:mobile` fails on this box because `mobile/node_modules` is not installed (`Cannot find module 'expo-file-system/legacy'`, `react-native`, …); it fails identically without this diff.
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 8/8 selfchecks passed`

Inverted to prove the new tests bite (restored afterwards):

- `SCORE_TIERS.ranked: 200 → 0` → `× leads the hand-pinned recommended list`
- `RANK_BONUS_MAX: 80 → 0` and `ranked → 0` → 6 failures, including `× orders find_model's answer by the leaderboard`
- dropping the `bestRoutePerModel` call → `× answers with one row per model, not one per route`

## Agent capabilities

- [x] `npm run capabilities:check` passes — `find_model`'s contract fingerprint is re-synced (its description changed)
- [x] `find_model` already names `capability-suites` plus its suites in `packages/cli/src/harness/capability-table.ts`; the ordering rules are pinned in `packages/agents/tests/capabilities-models-rankings.test.ts`

## New checks

No new rule or audit — the change is covered by tests, each inverted once above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwZhNgc3igs7dc5XJnXT49

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwZhNgc3igs7dc5XJnXT49)_