### PR TITLE
fix(web): fix iOS double-tap needed to select a model

### DIFF
--- a/web/src/components/MobileClassProvider.tsx
+++ b/web/src/components/MobileClassProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react';
+import React, { useEffect, useLayoutEffect } from 'react';
 import { useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
@@ -6,10 +6,23 @@ interface MobileClassProviderProps {
   children: React.ReactNode;
 }
 
+const noop = () => {};
+
 const MobileClassProvider: React.FC<MobileClassProviderProps> = ({ children }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isCoarsePointer = useMediaQuery('(pointer: coarse)');
+
+  // iOS Safari only lets `:hover`/`:active` apply to a tap once some element on
+  // the page has a real touch listener bound; without one, tapping anything
+  // that matches a `:hover` rule (e.g. any MUI ListItemButton row) just
+  // "materializes" the hover state and needs a second tap to actually click —
+  // the classic "double tap to select" bug (e.g. the model picker's rows).
+  // Binding one no-op listener here, once, fixes it app-wide.
+  useEffect(() => {
+    document.addEventListener('touchstart', noop, { passive: true });
+    return () => document.removeEventListener('touchstart', noop);
+  }, []);
 
   // useLayoutEffect: apply class pre-paint so first frame is mobile-styled.
   useLayoutEffect(() => {


### PR DESCRIPTION
## Summary

- Fixes a report that the model select menu on mobile browsers needed two taps to select a model.
- Root cause: model picker rows (`web/src/components/model_menu/ModelList.tsx`) render as `<div role="button">` with matching `:hover` CSS rules (MUI's `ListItemButton` hover style, plus the app's favorite-star/pin hover reveal). iOS Safari requires a first tap to "materialize" `:hover`/`:active` on any element that isn't natively interactive (`<a href>`, `<button>`, etc.) but matches a `:hover` rule, so the real tap only registers on the second try. This is WebKit-specific and doesn't reproduce in Chromium-based emulation, which synthesizes `click` on a single tap regardless.
- Fix: bind one no-op `touchstart` listener to `document` in `MobileClassProvider` (mounted once at the app root). This is WebKit's own documented escape hatch — once any element on the page has a real touch listener bound, Safari stops requiring the double-tap materialization app-wide, fixing not just the model picker but any other list/menu with the same hover-styled-non-native-element pattern.
- Considered rendering the rows as real `<button>` elements instead, but reverted: the rows contain nested favorite/pin buttons, and nesting `<button>` inside `<button>` is invalid HTML with unpredictable touch behavior.

## Test plan

- [x] `npx tsc --noEmit` and `npx oxlint` on the changed file — clean
- [ ] Manually verify on an iOS Safari device: model picker no longer needs a double tap to select a model

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FXyH3tu4HFsguAT6ZDjNGy)_