### PR TITLE
fix(runtime): block file creation through a dangling in-workspace symlink

### DIFF
--- a/packages/runtime/src/storage-workspace.ts
+++ b/packages/runtime/src/storage-workspace.ts
@@ -142,6 +142,17 @@ async function realPathWithinRoot(
     try {
       return within(await fs.realpath(parent));
     } catch {
+      // realpath failed — either this ancestor is genuinely absent, or it is
+      // itself a dangling symlink. lstat, not the loop's next iteration,
+      // tells them apart: a dangling symlink exists at this exact path and
+      // must never be walked past, or a symlink one level up pointing
+      // straight at the root would resolve "within" by accident.
+      try {
+        await fs.lstat(parent);
+        return false;
+      } catch {
+        // Genuinely absent: keep climbing.
+      }
       const next = path.dirname(parent);
       if (next === parent) return false;
       parent = next;


### PR DESCRIPTION
## What changed

`realPathWithinRoot` in `packages/runtime/src/storage-workspace.ts` walks up
ancestor directories when `realpath` fails, to find the nearest existing
ancestor and check *that* is contained in the workspace root. The walk-up
loop retried `realpath` on each parent but never `lstat`'d it, so on a
dangling symlink (an in-workspace symlink whose target directory was
deleted) it stepped straight past the symlink itself to an ancestor that
*does* resolve — the workspace root — and reported containment as `true`.
`EditFileTool`'s create-file path then attempted `mkdir` through the dead
symlink and failed with a raw `ENOENT` instead of being refused with
`WorkspacePathError` naming the escape.

The fix adds an `lstat` check on each ancestor in the walk-up loop, mirroring
the check `isCreatableWithinRoot` (`packages/agents/src/workspace-paths.ts`)
already does for the same scenario in a separate helper: an ancestor that
`lstat`s successfully but doesn't resolve via `realpath` exists as a
(dangling) symlink and must never be walked past.

CI reported `EditFileTool symlink containment > refuses to create through a
DANGLING symlink that escapes the workspace` failing in
`packages/agents/tests/edit-search-tools.test.ts`; that test exercises
`storage-workspace.ts` through `EditFileTool` → `Workspace.write`.

## Verification

- [x] `npm run test --workspace=packages/agents -- edit-search-tools.test.ts` — 15/15 passed (was 1 failing before the fix, reproduced the CI failure locally)
- [x] `npm run test --workspace=packages/runtime -- storage-workspace` — 51/51 passed
- [x] `npm run lint --workspace=packages/runtime` (tsc --noEmit) and `oxlint` on the changed file — clean
- [x] `npm run test:affected` — clean apart from an unrelated flaky hook timeout in `packages/text-nodes` (`nlp-parity.test.ts`, an NLP library load timeout unrelated to this diff), which passed on retry (198/198)
- [ ] `npm run typecheck` — blocked in this sandbox by a pre-existing, unrelated gap: `packages/agents/tsconfig.json` is missing a `references` entry for `../model3d`, so `@nodetool-ai/agents` doesn't build project-wide in a clean checkout. Not caused by or related to this diff (which only touches `packages/runtime`).
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run (same build-order gap blocks it in this sandbox)

## New checks

N/A — no new check, rule, or audit; fixes an existing containment check's blind spot.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MbimkA53KBos4WMdcNEkA8)_