### PR TITLE
fix(web): match checkpoint families to model-manager goals

### DIFF
--- a/web/src/components/hugging_face/model_list/__tests__/modelFit.test.ts
+++ b/web/src/components/hugging_face/model_list/__tests__/modelFit.test.ts
@@ -91,7 +91,24 @@ describe("goalsForModel", () => {
     ).toEqual(new Set(["vision"]));
   });
 
-  it("splits llama_model into chat vs embedding by name", () => {
+  it("maps checkpoint families to the goal their pipeline serves", () => {
+    for (const type of [
+      "hf.stable_diffusion",
+      "hf.stable_diffusion_xl",
+      "hf.flux",
+      "hf.flux_kontext",
+      "hf.qwen_image",
+      "hf.qwen_image_edit",
+      "hf.real_esrgan"
+    ]) {
+      expect(goalsForModel(model({ type }))).toEqual(new Set(["image-gen"]));
+    }
+    for (const type of ["hf.qwen2_5_vl", "hf.qwen3_vl"]) {
+      expect(goalsForModel(model({ type }))).toEqual(new Set(["vision"]));
+    }
+  });
+
+  it("splits GGUF models into chat vs embedding by name", () => {
     expect(
       goalsForModel(model({ type: "llama_model", name: "qwen3.5:9b" }))
     ).toEqual(new Set(["chat"]));
@@ -101,6 +118,9 @@ describe("goalsForModel", () => {
     expect(
       goalsForModel(model({ type: "llama_model", name: "bge-m3" }))
     ).toEqual(new Set(["embedding"]));
+    expect(
+      goalsForModel(model({ type: "llama_cpp_model", name: "qwen3.5-9b.gguf" }))
+    ).toEqual(new Set(["chat"]));
   });
 
   it("returns no goals for a type nothing covers", () => {

--- a/web/src/components/hugging_face/model_list/modelFit.ts
+++ b/web/src/components/hugging_face/model_list/modelFit.ts
@@ -91,7 +91,36 @@ export const MODEL_GOALS: readonly ModelGoal[] = [
   goal("image-gen", "Create images", "Generate or restyle images from prompts", [
     "text-to-image",
     "image-to-image",
-    "inpainting"
+    "inpainting",
+    // Checkpoint families. A diffusion generator is typed by the pipeline that
+    // loads it, not by the task it performs, so the task tokens above miss
+    // every Stable Diffusion, FLUX, and Qwen-Image checkpoint in the catalog.
+    "stable-diffusion",
+    "stable-diffusion-checkpoint",
+    "stable-diffusion-xl",
+    "stable-diffusion-xl-checkpoint",
+    "stable-diffusion-3",
+    "stable-diffusion-3-checkpoint",
+    "stable-diffusion-xl-refiner",
+    "stable-diffusion-xl-refiner-checkpoint",
+    "flux",
+    "flux-checkpoint",
+    "flux-fp8",
+    "flux-fp8-checkpoint",
+    "flux-kontext",
+    "flux-kontext-checkpoint",
+    "flux-fill",
+    "flux-fill-checkpoint",
+    "flux-depth",
+    "flux-depth-checkpoint",
+    "flux-redux",
+    "flux-redux-checkpoint",
+    "qwen-image",
+    "qwen-image-checkpoint",
+    "qwen-image-edit",
+    "qwen-image-edit-checkpoint",
+    "real-esrgan",
+    "unconditional-image-generation"
   ]),
   goal("vision", "Understand images", "Describe, classify, or analyze images and documents", [
     "image-text-to-text",
@@ -103,7 +132,14 @@ export const MODEL_GOALS: readonly ModelGoal[] = [
     "document-question-answering",
     "zero-shot-image-classification",
     "depth-estimation",
-    "mask-generation"
+    "mask-generation",
+    // Vision-language checkpoint families, typed by loader like the image
+    // generators above.
+    "qwen2-5-vl",
+    "qwen3-vl",
+    "qwen-vl",
+    "minicpm",
+    "got-ocr"
   ]),
   goal("transcribe", "Transcribe speech", "Turn audio recordings into text", [
     "automatic-speech-recognition"
@@ -124,11 +160,12 @@ export const MODEL_GOALS: readonly ModelGoal[] = [
 ];
 
 /**
- * GGUF chat and embedding models share the one `llama_model` type, so the
- * type alone can't split them; the model families all carry these markers in
- * their names.
+ * GGUF chat and embedding models share the one `llama_model` type (the
+ * llama.cpp runtime lists them as `llama_cpp_model`), so the type alone can't
+ * split them; the model families all carry these markers in their names.
  */
 const LLAMA_EMBED_NAME = /embed|bge|minilm|e5|arctic/i;
+const GGUF_TYPES = new Set(["llama_model", "llama_cpp_model"]);
 
 const normalizeTask = (raw: string): string =>
   raw
@@ -152,7 +189,7 @@ export const goalsForModel = (model: UnifiedModel): Set<string> => {
       }
     }
   }
-  if (model.type === "llama_model") {
+  if (model.type && GGUF_TYPES.has(model.type)) {
     const name = model.name || model.id || "";
     result.add(LLAMA_EMBED_NAME.test(name) ? "embedding" : "chat");
   }


### PR DESCRIPTION
## The bug

`goalsForModel` matched only *task* tokens (`text-to-image`, `image-to-image`, `inpainting`). A diffusion model is typed by the **pipeline that loads it**, not the task it performs, so `hf.stable_diffusion`, `hf.flux`, `hf.qwen_image` and friends normalized to tokens no goal contained — and matched nothing.

Counted against a live catalog, the models with no goal at all:

```
hf.stable_diffusion       91      hf.qwen3_vl        20
hf.stable_diffusion_xl    36      llama_cpp_model    17
hf.flux                   14      hf.qwen2_5_vl      12
```

The last one has a separate cause: the GGUF chat-vs-embedding split keyed on `model.type === "llama_model"`, and the llama.cpp runtime lists its models as `llama_cpp_model`.

## The fix

- **Create images** gains the generator families — SD / SDXL / SD3 and their `*_checkpoint` variants, FLUX with Kontext / Fill / Depth / Redux, Qwen-Image, Qwen-Image-Edit, Real-ESRGAN, unconditional-image-generation.
- **Understand images** gains `qwen2_5_vl`, `qwen3_vl`, `qwen_vl`, `minicpm`, `got_ocr`.
- The GGUF name split now covers `llama_cpp_model` as well as `llama_model`.

**Components stay out on purpose**: LoRAs, VAEs, ControlNets, IP-Adapters and CLIP/T5 encoders condition a generator, they are not one, so they keep matching no goal.

## Measured

Against a live backend serving 772 recommended models, with the model manager open in a browser:

| filter | before | after |
|---|---:|---:|
| Create images | 29 | **78** |
| Chat & agents | 145 | 162 (llama.cpp) |

## Tests

New case pins seven checkpoint families to `image-gen` and two Qwen-VL families to `vision`; the GGUF case gains `llama_cpp_model`. `npm run typecheck` and `oxlint` clean, 7 suites / 37 tests via `test:affected`.

## Related

Companion to nodetool-ai/nodetool-mlx#11, which types the MLX packs' recommended models by task. The two are independent — this one fixes every pack's models, that one stops the MLX pack emitting untyped ones.