### PR TITLE
fix(runtime): decode Python uint64 byte counts as numbers, not BigInt

### DIFF
--- a/packages/runtime/src/python-bridge-codec.ts
+++ b/packages/runtime/src/python-bridge-codec.ts
@@ -1,0 +1,44 @@
+/**
+ * The msgpack codec both Python-bridge transports share.
+ *
+ * Python's msgpack encodes any integer above 2^32 as a `uint64` (wire type
+ * 0xcf), and msgpackr decodes a `uint64` to a **BigInt** by default. That
+ * silently breaks the bridge's own typed contract: `ModelDownloadUpdate`
+ * declares `total_bytes: number`, so every consumer does plain arithmetic on
+ * it — and a BigInt makes `downloaded / total` throw `TypeError: Cannot mix
+ * BigInt and other types`, `Math.trunc()` throw, and `z.number()` reject the
+ * frame. A remote model download over 4 GiB (most diffusion models) hit all
+ * three, and the failure surfaced as an undecodable frame.
+ *
+ * Nothing on this wire needs more than 2^53: the values that cross the 2^32
+ * line are byte counts and millisecond timestamps. So the decoder reads int64
+ * as a number, and the declared types become true again.
+ *
+ * `mapsAsObjects` is NOT a preference — it restores a default. msgpackr's
+ * module-level `unpack` sets it; a hand-built `Unpackr` does not, and would
+ * hand every caller a `Map` instead of a frame object.
+ */
+
+import { pack, Unpackr } from "msgpackr";
+
+const unpackr = new Unpackr({
+  int64AsType: "number",
+  mapsAsObjects: true
+});
+
+/** Encode one bridge message to msgpack bytes. */
+export function packBridgeMessage(msg: Record<string, unknown>): Buffer {
+  return pack(msg);
+}
+
+/**
+ * Decode one msgpack payload into a bridge message, reading int64 as a number
+ * rather than a BigInt (see the module comment).
+ */
+export function unpackBridgeMessage(
+  payload: Buffer | Uint8Array
+): Record<string, unknown> {
+  // SAFETY: every frame on this wire is a msgpack map; a worker that sends
+  // anything else is a protocol desync the callers already handle.
+  return unpackr.unpack(payload) as Record<string, unknown>;
+}

--- a/packages/runtime/src/python-stdio-bridge.ts
+++ b/packages/runtime/src/python-stdio-bridge.ts
@@ -13,7 +13,10 @@
  * supplies the stdio transport (subprocess spawn + length-prefixed framing).
  */
 
-import { pack, unpack } from "msgpackr";
+import {
+  packBridgeMessage,
+  unpackBridgeMessage
+} from "./python-bridge-codec.js";
 import { getNodeBuiltinSync } from "@nodetool-ai/config";
 
 // Python bridge is fundamentally Node-only (subprocess + raw FDs).
@@ -321,7 +324,7 @@ export class PythonStdioBridge extends PythonBridgeBase {
     try {
       this._frameDecoder.push(chunk, (payload) => {
         try {
-          const msg = unpack(payload) as Record<string, unknown>;
+          const msg = unpackBridgeMessage(payload);
           this._handleMessage(msg);
         } catch (err) {
           throw new Error(`Failed to decode msgpack frame: ${err}`);
@@ -357,7 +360,7 @@ export class PythonStdioBridge extends PythonBridgeBase {
     if (!this._process?.stdin || !this._connected) {
       throw new Error("Not connected to Python worker");
     }
-    const payload = Buffer.from(pack(msg));
+    const payload = Buffer.from(packBridgeMessage(msg));
     if (payload.length > MAX_BRIDGE_FRAME_SIZE) {
       throw new Error(
         `Outgoing Python bridge frame exceeds max size (${payload.length} > ${MAX_BRIDGE_FRAME_SIZE})`

--- a/packages/runtime/src/python-websocket-bridge.ts
+++ b/packages/runtime/src/python-websocket-bridge.ts
@@ -18,7 +18,10 @@
  * "reconnected". An explicit {@link close} disables reconnect.
  */
 
-import { pack, unpack } from "msgpackr";
+import {
+  packBridgeMessage,
+  unpackBridgeMessage
+} from "./python-bridge-codec.js";
 
 import WebSocket from "ws";
 
@@ -445,7 +448,7 @@ export class WebsocketPythonBridge extends PythonBridgeBase {
     this._messageListener = (data: WebSocket.RawData) => {
       try {
         const buf = this._toUint8Array(data);
-        const msg = unpack(buf) as Record<string, unknown>;
+        const msg = unpackBridgeMessage(buf);
         this._handleMessage(msg);
       } catch (err) {
         log.error(`Failed to decode WebSocket frame: ${err}`);
@@ -486,7 +489,7 @@ export class WebsocketPythonBridge extends PythonBridgeBase {
     if (!this._ws || !this._connected) {
       throw new Error("Not connected to Python worker");
     }
-    const payload = pack(msg);
+    const payload = packBridgeMessage(msg);
     if (payload.length > MAX_BRIDGE_FRAME_SIZE) {
       throw new Error(
         `Outgoing Python bridge frame exceeds max size (${payload.length} > ${MAX_BRIDGE_FRAME_SIZE})`

--- a/packages/runtime/tests/python-bridge-codec.test.ts
+++ b/packages/runtime/tests/python-bridge-codec.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Regression: a remote model download over 4 GiB used to kill the bridge.
+ *
+ * Python's msgpack encodes an integer above 2^32 as a `uint64` (wire type
+ * 0xcf). msgpackr decodes that to a BigInt unless told otherwise, so
+ * `ModelDownloadUpdate.total_bytes` — declared `number` — arrived as a BigInt
+ * and every consumer that divides, truncates or Zod-validates it threw. The
+ * observable failure was `TypeError: Cannot mix BigInt and other types`,
+ * logged as an undecodable frame, on any repo larger than 4 GiB (which is most
+ * diffusion models).
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { pack, unpack } from "msgpackr";
+
+import {
+  packBridgeMessage,
+  unpackBridgeMessage
+} from "../src/python-bridge-codec.js";
+import { WebsocketPythonBridge } from "../src/python-websocket-bridge.js";
+import type { ModelDownloadUpdate } from "../src/python-bridge-types.js";
+import {
+  startFakeWorker,
+  type FakeWorkerHandle
+} from "./python-websocket-bridge.test-helpers.js";
+
+/** 16 GiB — above 2^32, so Python emits it as a uint64. */
+const HUGE = 17179869184;
+
+/**
+ * Encode like Python's msgpack does, which is the only way to produce the
+ * frame that broke: msgpackr's own `pack` writes a large JS number as a
+ * float64 (0xcb) and never as a uint64, so it cannot reproduce this.
+ */
+function pyPack(value: unknown): Uint8Array {
+  const out: number[] = [];
+  const write = (v: unknown): void => {
+    if (v === null || v === undefined) {
+      out.push(0xc0);
+    } else if (typeof v === "boolean") {
+      out.push(v ? 0xc3 : 0xc2);
+    } else if (typeof v === "number") {
+      if (!Number.isInteger(v) || v < 0) {
+        throw new Error("pyPack only covers non-negative integers");
+      }
+      if (v < 0x80) {
+        out.push(v);
+      } else if (v <= 0xffffffff) {
+        out.push(0xce, (v >>> 24) & 0xff, (v >>> 16) & 0xff, (v >>> 8) & 0xff, v & 0xff);
+      } else {
+        const hi = Math.floor(v / 0x100000000);
+        const lo = v >>> 0;
+        out.push(
+          0xcf,
+          (hi >>> 24) & 0xff, (hi >>> 16) & 0xff, (hi >>> 8) & 0xff, hi & 0xff,
+          (lo >>> 24) & 0xff, (lo >>> 16) & 0xff, (lo >>> 8) & 0xff, lo & 0xff
+        );
+      }
+    } else if (typeof v === "string") {
+      const bytes = new TextEncoder().encode(v);
+      if (bytes.length < 32) {
+        out.push(0xa0 | bytes.length);
+      } else {
+        out.push(0xd9, bytes.length);
+      }
+      out.push(...bytes);
+    } else if (Array.isArray(v)) {
+      out.push(0x90 | v.length);
+      for (const item of v) write(item);
+    } else {
+      const entries = Object.entries(v as Record<string, unknown>);
+      out.push(0x80 | entries.length);
+      for (const [k, val] of entries) {
+        write(k);
+        write(val);
+      }
+    }
+  };
+  write(value);
+  return new Uint8Array(out);
+}
+
+describe("python bridge codec", () => {
+  it("reads a Python uint64 as a number, not a BigInt", () => {
+    const wire = pyPack({ total_bytes: HUGE });
+
+    // The trap this codec exists to close — pinned so a msgpackr upgrade that
+    // changes the default is visible here rather than in a broken download.
+    expect(typeof (unpack(wire) as Record<string, unknown>).total_bytes).toBe(
+      "bigint"
+    );
+
+    const decoded = unpackBridgeMessage(wire);
+    expect(typeof decoded.total_bytes).toBe("number");
+    expect(decoded.total_bytes).toBe(HUGE);
+    // What every consumer actually does with it.
+    expect(Math.round(((HUGE / 2) / (decoded.total_bytes as number)) * 100)).toBe(50);
+  });
+
+  it("decodes an ordinary frame exactly like msgpackr's own unpack", () => {
+    const frame = {
+      type: "result",
+      request_id: "abc",
+      data: { outputs: { a: [1, 2] }, ok: true, missing: null }
+    };
+    const bytes = packBridgeMessage(frame);
+    // A hand-built Unpackr drops `mapsAsObjects`, which would hand callers a
+    // Map instead of a frame object and break the whole bridge.
+    expect(unpackBridgeMessage(bytes)).toEqual(unpack(bytes));
+    expect(unpackBridgeMessage(bytes)).toEqual(frame);
+  });
+
+  it("keeps binary payloads as bytes", () => {
+    const bytes = packBridgeMessage({ blob: new Uint8Array([1, 2, 3]) });
+    const blob = unpackBridgeMessage(bytes).blob;
+    expect(blob).toBeInstanceOf(Uint8Array);
+    expect(Array.from(blob as Uint8Array)).toEqual([1, 2, 3]);
+  });
+});
+
+describe("model download over 4 GiB", () => {
+  let worker: FakeWorkerHandle | undefined;
+  let bridge: WebsocketPythonBridge | undefined;
+
+  afterEach(async () => {
+    bridge?.close();
+    await worker?.close();
+    worker = undefined;
+    bridge = undefined;
+  });
+
+  it("delivers a uint64 byte count to onProgress as a usable number", async () => {
+    // "hang" so the fake worker emits its start frame and then stays quiet —
+    // this test drives the rest of the exchange with real Python wire bytes.
+    worker = await startFakeWorker(0, { downloadMode: "hang" });
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`,
+      autoRestart: false
+    });
+    await bridge.connect();
+
+    const requestId = "download-1";
+    const seen: ModelDownloadUpdate[] = [];
+    const progressed = new Promise<void>((resolve) => {
+      const done = bridge!.downloadModel(
+        { repo_id: "org/huge" },
+        (u) => {
+          seen.push(u);
+          if (u.status === "progress") resolve();
+        },
+        requestId
+      );
+      void done.catch(() => {});
+    });
+
+    // Wait for the bridge to register the request, then answer as Python does.
+    await new Promise((r) => setTimeout(r, 50));
+    const socket = [...worker.sockets()][0];
+    socket.send(
+      pyPack({
+        type: "progress",
+        request_id: requestId,
+        data: {
+          status: "progress",
+          repo_id: "org/huge",
+          path: null,
+          model_type: null,
+          downloaded_bytes: HUGE / 2,
+          total_bytes: HUGE,
+          downloaded_files: 1,
+          current_files: ["model.safetensors"],
+          total_files: 2
+        }
+      })
+    );
+    await progressed;
+    socket.send(
+      pack({
+        type: "result",
+        request_id: requestId,
+        data: { repo_id: "org/huge", status: "completed" }
+      })
+    );
+
+    const update = seen.find((u) => u.status === "progress");
+    expect(update).toBeDefined();
+    expect(typeof update!.total_bytes).toBe("number");
+    expect(update!.total_bytes).toBe(HUGE);
+    // The arithmetic the CLI and the web download store do on every frame.
+    expect(
+      Math.floor((update!.downloaded_bytes / update!.total_bytes) * 100)
+    ).toBe(50);
+  });
+});


### PR DESCRIPTION
## What

Both Python-bridge transports now share one msgpack codec that reads int64 as a number.

## Why

Python's msgpack encodes any integer above 2^32 as a `uint64`, and msgpackr decodes a `uint64` to a **BigInt** by default. `ModelDownloadUpdate.total_bytes` is declared `number`, so consumers do plain arithmetic on it:

- `packages/cli/src/commands/worker-models.ts:192` — `u.downloaded_bytes / u.total_bytes` throws
- `packages/websocket/src/sdk/sdk-model-download-service.ts:243` — `Math.trunc(bigint)` throws
- `packages/protocol/src/bridge-frames.ts:215` — `z.number()` rejects the frame

Any remote model download over 4 GiB hit this, which is most diffusion models. Downloading `stabilityai/sdxl-turbo` onto a RunPod worker logged `TypeError: Cannot mix BigInt and other types` as an undecodable frame on every progress update.

Nothing on this wire needs more than 2^53 — the values crossing 2^32 are byte counts and millisecond timestamps.

## One trap worth naming

`mapsAsObjects` in the new codec restores a default, it is not a preference. msgpackr's module-level `unpack` sets it; a hand-built `Unpackr` does not, and without it every frame would arrive as a `Map` instead of a frame object. A parity test pins that against `unpack` itself.

## Verification

The regression test encodes the frame the way Python does — msgpackr's own `pack` writes a large number as a float64 (`0xcb`) and cannot reproduce a `uint64` — and drives it through the real `downloadModel` path against the fake worker.

Reverting the fix turns both halves red:

```
FAIL  reads a Python uint64 as a number, not a BigInt
FAIL  delivers a uint64 byte count to onProgress as a usable number
      Tests  2 failed | 2 passed (4)
```

`test:affected` (63 suites, 682 tests), `typecheck` and `lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138g6jBUaPu6E7bxxYPVGb6