### PR TITLE
fix(compute): keep the worker idle clock ticking for every host

### DIFF
--- a/packages/cli/src/commands/worker-models.ts
+++ b/packages/cli/src/commands/worker-models.ts
@@ -9,7 +9,10 @@
  */
 
 import type { Command } from "commander";
-import { WorkerManager } from "@nodetool-ai/compute";
+import {
+  WorkerManager,
+  attachWorkerActivityHeartbeat
+} from "@nodetool-ai/compute";
 import {
   WebsocketPythonBridge,
   type ModelDownloadUpdate
@@ -52,9 +55,11 @@ async function openBridge(
   workerId?: string
 ): Promise<WebsocketPythonBridge> {
   let conn: { wsUrl: string; token: string | null };
+  let instanceId: string;
 
   if (workerId) {
     conn = await manager.connectionInfo(workerId);
+    instanceId = workerId;
   } else {
     const active = await manager.getActiveWorker();
     if (!active) {
@@ -63,12 +68,20 @@ async function openBridge(
       );
     }
     conn = { wsUrl: active.ws_url, token: active.token };
+    instanceId = active.id;
   }
 
   const bridge = new WebsocketPythonBridge({
     wsUrl: conn.wsUrl,
     workerToken: conn.token ?? undefined,
     autoRestart: false
+  });
+
+  // A model download runs for tens of minutes and sends nothing outbound after
+  // the request — the reaper would otherwise pause the pod mid-download. This
+  // touches the worker the command names, not the attached one.
+  attachWorkerActivityHeartbeat(bridge, {
+    resolveInstanceId: async () => instanceId
   });
 
   await bridge.connect();

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -63,7 +63,8 @@ import {
   ProcessingContext,
   FileStorageAdapter,
   createLocalWorkspace,
-  initTelemetry
+  initTelemetry,
+  onPythonBridgeCreated
 } from "@nodetool-ai/runtime";
 import type { AssetOutputMode } from "@nodetool-ai/runtime";
 import { mkdirSync } from "node:fs";
@@ -81,6 +82,8 @@ import { registerPackCommands } from "./commands/packs.js";
 import { registerDeployCommands } from "./commands/deploy.js";
 import { registerHfCommands } from "./commands/models-hf.js";
 import { registerWorkerCommands } from "./commands/worker.js";
+import { installWorkerActivityHeartbeat } from "@nodetool-ai/compute";
+
 import { registerRecommendedCommand } from "./commands/models-recommended.js";
 import { registerAgentCommands } from "./commands/agent.js";
 import { registerDbCommands } from "./commands/db.js";
@@ -2412,6 +2415,10 @@ mcp
 registerPackageCommands(program);
 registerPackCommands(program);
 registerWorkerCommands(program);
+
+// Any command that opens a remote Python bridge keeps the attached worker's
+// idle clock fresh, so the reaper doesn't pause a GPU that is mid-job.
+installWorkerActivityHeartbeat(onPythonBridgeCreated);
 
 // ---------------------------------------------------------------------------
 // deploy — registered from commands/deploy.ts

--- a/packages/compute/src/__tests__/worker-heartbeat.test.ts
+++ b/packages/compute/src/__tests__/worker-heartbeat.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for the worker idle-clock heartbeat — the shared listener every
+ * DB-having host attaches to its Python bridge so the reaper measures idle
+ * time from real traffic instead of the creation timestamp.
+ */
+
+import { describe, it, expect } from "vitest";
+import { EventEmitter } from "node:events";
+
+import {
+  attachWorkerActivityHeartbeat,
+  installWorkerActivityHeartbeat,
+  type WorkerActivitySource,
+} from "../worker-heartbeat.js";
+
+const flush = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+describe("attachWorkerActivityHeartbeat", () => {
+  it("touches the resolved instance on activity", async () => {
+    const touched: string[] = [];
+    const bridge = new EventEmitter();
+    attachWorkerActivityHeartbeat(bridge, {
+      resolveInstanceId: async () => "w-1",
+      touch: async (id) => {
+        touched.push(id);
+      },
+    });
+
+    bridge.emit("activity");
+    await flush();
+
+    expect(touched).toEqual(["w-1"]);
+  });
+
+  it("collapses a burst into one write and beats again after the window", async () => {
+    const touched: string[] = [];
+    let nowMs = 0;
+    const bridge = new EventEmitter();
+    attachWorkerActivityHeartbeat(bridge, {
+      resolveInstanceId: async () => "w-1",
+      touch: async (id) => {
+        touched.push(id);
+      },
+      now: () => nowMs,
+      throttleMs: 10_000,
+    });
+
+    for (let i = 0; i < 100; i++) bridge.emit("activity");
+    await flush();
+    expect(touched).toHaveLength(1);
+
+    nowMs = 9_999;
+    bridge.emit("activity");
+    await flush();
+    expect(touched).toHaveLength(1);
+
+    nowMs = 10_000;
+    bridge.emit("activity");
+    await flush();
+    expect(touched).toHaveLength(2);
+  });
+
+  it("writes nothing when no worker is attached", async () => {
+    let calls = 0;
+    const bridge = new EventEmitter();
+    attachWorkerActivityHeartbeat(bridge, {
+      resolveInstanceId: async () => null,
+      touch: async () => {
+        calls++;
+      },
+    });
+
+    bridge.emit("activity");
+    await flush();
+
+    expect(calls).toBe(0);
+  });
+
+  it("swallows a failed touch — the clock must not break the run", async () => {
+    const bridge = new EventEmitter();
+    attachWorkerActivityHeartbeat(bridge, {
+      resolveInstanceId: async () => {
+        throw new Error("db not initialized");
+      },
+      touch: async () => {},
+    });
+
+    expect(() => bridge.emit("activity")).not.toThrow();
+    await flush();
+  });
+
+  it("detaches on request", async () => {
+    let calls = 0;
+    const bridge = new EventEmitter();
+    const detach = attachWorkerActivityHeartbeat(bridge, {
+      resolveInstanceId: async () => "w-1",
+      touch: async () => {
+        calls++;
+      },
+    });
+
+    detach();
+    bridge.emit("activity");
+    await flush();
+
+    expect(calls).toBe(0);
+    expect(bridge.listenerCount("activity")).toBe(0);
+  });
+});
+
+describe("installWorkerActivityHeartbeat", () => {
+  it("heartbeats every bridge the host creates after installing", async () => {
+    const touched: string[] = [];
+    const observers: Array<(bridge: WorkerActivitySource) => void> = [];
+    const uninstall = installWorkerActivityHeartbeat(
+      (observer) => {
+        observers.push(observer);
+        return () => {
+          observers.length = 0;
+        };
+      },
+      {
+        resolveInstanceId: async () => "w-1",
+        touch: async (id) => {
+          touched.push(id);
+        },
+      }
+    );
+
+    expect(observers).toHaveLength(1);
+    const first = new EventEmitter();
+    const second = new EventEmitter();
+    for (const bridge of [first, second]) observers[0]!(bridge);
+
+    first.emit("activity");
+    second.emit("activity");
+    await flush();
+    expect(touched).toEqual(["w-1", "w-1"]);
+
+    uninstall();
+    expect(observers).toHaveLength(0);
+  });
+});

--- a/packages/compute/src/index.ts
+++ b/packages/compute/src/index.ts
@@ -7,6 +7,15 @@ export type {
   WorkerOrphan,
 } from "./manager.js";
 export { runReaperOnce, startReaper } from "./reaper.js";
+export {
+  attachWorkerActivityHeartbeat,
+  installWorkerActivityHeartbeat,
+} from "./worker-heartbeat.js";
+export type {
+  BridgeCreationRegistrar,
+  WorkerActivityHeartbeatOptions,
+  WorkerActivitySource,
+} from "./worker-heartbeat.js";
 export type { ReaperDeps, ReaperHandle, ReaperManager } from "./reaper.js";
 export { RunpodPodProvider } from "./providers/runpod.js";
 export { VastProvider } from "./providers/vast.js";

--- a/packages/compute/src/worker-heartbeat.ts
+++ b/packages/compute/src/worker-heartbeat.ts
@@ -1,0 +1,116 @@
+// Worker idle-clock heartbeat.
+//
+// The reaper pauses an instance after `idle_timeout_minutes` of inactivity,
+// measured from `last_activity_at`. That column only moves when something
+// touches it, and the only thing that can is a host with database access that
+// is watching the Python bridge. This module is that wiring, kept out of any
+// single host so every DB-having host — the websocket server, the CLI —
+// installs the same behaviour instead of each reimplementing it.
+//
+// The bridge is taken structurally (an event emitter with an `"activity"`
+// event) so `@nodetool-ai/compute` stays free of a `@nodetool-ai/runtime`
+// dependency, the same way `WorkerManager` does.
+
+import {
+  touchWorkerInstance,
+  type WorkerInstance,
+} from "@nodetool-ai/models";
+
+import { WorkerManager } from "./manager.js";
+
+/**
+ * The slice of a Python bridge the heartbeat needs: the `"activity"` event the
+ * remote WebSocket bridge emits on every frame it sends or receives. A local
+ * stdio bridge never emits it, so attaching to one is inert.
+ */
+export interface WorkerActivitySource {
+  on(event: "activity", listener: () => void): void;
+  off?(event: "activity", listener: () => void): void;
+}
+
+/**
+ * How often a burst of bridge traffic is allowed to become a DB write. The
+ * reaper runs once a minute and its windows are measured in minutes, so
+ * second-level freshness is ample and one write per frame is waste.
+ */
+const TOUCH_THROTTLE_MS = 10_000;
+
+/** Options for {@link attachWorkerActivityHeartbeat}. */
+export interface WorkerActivityHeartbeatOptions {
+  /**
+   * Resolve the instance whose clock this bridge's traffic belongs to.
+   * Returning null skips the touch (no worker attached).
+   */
+  resolveInstanceId: () => Promise<string | null>;
+  /** Write the timestamp. Injected for tests; defaults to the model accessor. */
+  touch?: (id: string) => Promise<WorkerInstance | void>;
+  /** Current epoch ms. Injected for tests. */
+  now?: () => number;
+  /** Throttle window in ms. Injected for tests. */
+  throttleMs?: number;
+}
+
+/**
+ * Keep a worker's `last_activity_at` fresh from real bridge traffic.
+ *
+ * Returns a function that detaches the listener. Every touch is best-effort:
+ * a rejected resolve or write is swallowed, because keeping a cost-guard clock
+ * fresh must never break the execution it is observing.
+ */
+export function attachWorkerActivityHeartbeat(
+  bridge: WorkerActivitySource,
+  options: WorkerActivityHeartbeatOptions
+): () => void {
+  const now = options.now ?? Date.now;
+  const touch = options.touch ?? touchWorkerInstance;
+  const throttleMs = options.throttleMs ?? TOUCH_THROTTLE_MS;
+
+  // -Infinity, not 0: the first beat must fire whatever the clock reads.
+  let lastTouchAt = Number.NEGATIVE_INFINITY;
+  const listener = (): void => {
+    const nowMs = now();
+    if (nowMs - lastTouchAt < throttleMs) return;
+    lastTouchAt = nowMs;
+    void options
+      .resolveInstanceId()
+      .then((id) => (id ? touch(id) : undefined))
+      .catch(() => {
+        // best-effort: the idle clock must not crash the run it measures
+      });
+  };
+
+  bridge.on("activity", listener);
+  return () => bridge.off?.("activity", listener);
+}
+
+/**
+ * A host's hook for observing every Python bridge it creates —
+ * `onPythonBridgeCreated` from `@nodetool-ai/runtime`. Taken as a parameter so
+ * this package keeps no runtime dependency.
+ */
+export type BridgeCreationRegistrar = (
+  observer: (bridge: WorkerActivitySource) => void
+) => () => void;
+
+/**
+ * Install the heartbeat on every bridge the host creates from now on, resolving
+ * the attached worker through a lazily-built {@link WorkerManager}. Returns a
+ * function that uninstalls it.
+ *
+ * This is what a host without its own long-lived bridge — the CLI — calls once
+ * at startup. It opens no database and builds no bridge; the manager appears
+ * only when a bridge first reports traffic.
+ */
+export function installWorkerActivityHeartbeat(
+  register: BridgeCreationRegistrar,
+  overrides: Partial<WorkerActivityHeartbeatOptions> = {}
+): () => void {
+  let manager: WorkerManager | null = null;
+  const resolveInstanceId = async (): Promise<string | null> => {
+    manager ??= new WorkerManager();
+    return (await manager.getActiveWorker())?.id ?? null;
+  };
+  return register((bridge) => {
+    attachWorkerActivityHeartbeat(bridge, { resolveInstanceId, ...overrides });
+  });
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -145,7 +145,11 @@ export {
   WebsocketPythonBridge,
   type WebsocketPythonBridgeOptions
 } from "./python-websocket-bridge.js";
-export { createPythonBridge } from "./python-bridge-factory.js";
+export {
+  createPythonBridge,
+  onPythonBridgeCreated
+} from "./python-bridge-factory.js";
+export type { PythonBridgeObserver } from "./python-bridge-factory.js";
 export {
   encodeFrame,
   FrameDecoder,

--- a/packages/runtime/src/python-bridge-factory.ts
+++ b/packages/runtime/src/python-bridge-factory.ts
@@ -31,6 +31,41 @@ import type { PythonBridgeBase } from "./python-bridge-base.js";
 import type { PythonBridgeOptions } from "./python-bridge-types.js";
 
 /**
+ * Called with every bridge {@link createPythonBridge} builds.
+ *
+ * The hook exists so a host can attach cross-cutting wiring to bridges it
+ * never sees constructed — the worker idle-clock heartbeat, whose listener
+ * needs database access this package does not have. Registering is what makes
+ * a host a heartbeat source; a host that registers nothing is unaffected.
+ */
+export type PythonBridgeObserver = (bridge: PythonBridgeBase) => void;
+
+const bridgeObservers = new Set<PythonBridgeObserver>();
+
+/**
+ * Register an observer for every bridge created from now on. Returns a
+ * function that unregisters it. An observer that throws is ignored: bridge
+ * creation must not fail because a bystander did.
+ */
+export function onPythonBridgeCreated(
+  observer: PythonBridgeObserver
+): () => void {
+  bridgeObservers.add(observer);
+  return () => bridgeObservers.delete(observer);
+}
+
+function notifyBridgeObservers(bridge: PythonBridgeBase): PythonBridgeBase {
+  for (const observer of bridgeObservers) {
+    try {
+      observer(bridge);
+    } catch {
+      // best-effort: an observer must not break the bridge it observes
+    }
+  }
+  return bridge;
+}
+
+/**
  * Create the appropriate Python worker bridge for the current environment.
  *
  * Returns a {@link WebsocketPythonBridge} when a WebSocket URL is supplied via
@@ -44,11 +79,13 @@ export function createPythonBridge(
   if (wsUrl && wsUrl.trim()) {
     const workerToken =
       options.workerToken ?? process.env["NODETOOL_WORKER_TOKEN"];
-    return new WebsocketPythonBridge({
-      ...options,
-      wsUrl: wsUrl.trim(),
-      workerToken
-    });
+    return notifyBridgeObservers(
+      new WebsocketPythonBridge({
+        ...options,
+        wsUrl: wsUrl.trim(),
+        workerToken
+      })
+    );
   }
-  return new PythonStdioBridge(options);
+  return notifyBridgeObservers(new PythonStdioBridge(options));
 }

--- a/packages/runtime/src/python-websocket-bridge.ts
+++ b/packages/runtime/src/python-websocket-bridge.ts
@@ -449,6 +449,11 @@ export class WebsocketPythonBridge extends PythonBridgeBase {
       try {
         const buf = this._toUint8Array(data);
         const msg = unpackBridgeMessage(buf);
+        // A decoded inbound frame is activity too. Requests are sent once and
+        // then answered over minutes — a model download streams progress with
+        // no outbound frame at all — so an outbound-only clock freezes while
+        // the worker is at its busiest.
+        this.emit("activity");
         this._handleMessage(msg);
       } catch (err) {
         log.error(`Failed to decode WebSocket frame: ${err}`);
@@ -499,9 +504,11 @@ export class WebsocketPythonBridge extends PythonBridgeBase {
     this._ws.send(payload, { binary: true });
     // Every outbound frame to the remote worker is fresh activity. The cost
     // guard's reaper measures idle time from `last_activity_at`, and this bridge
-    // is its designated heartbeat source: the server listens for "activity" and
-    // touches the attached worker instance so an actively-executing worker is
-    // never reaped as idle (see WorkerManager.getActiveWorker / touchWorkerInstance).
+    // is its designated heartbeat source: any host with database access listens
+    // for "activity" and touches the worker instance, so an actively-executing
+    // worker is never reaped as idle. The listener is
+    // `attachWorkerActivityHeartbeat` in @nodetool-ai/compute, wired by the
+    // server and by the CLI through `onPythonBridgeCreated`.
     this.emit("activity");
   }
 

--- a/packages/runtime/tests/bridge-activity-heartbeat.test.ts
+++ b/packages/runtime/tests/bridge-activity-heartbeat.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression: the bridge's "activity" event is the reaper's idle-clock
+ * heartbeat, so it must fire on traffic in both directions.
+ *
+ * A model download sends one request frame and then receives progress for tens
+ * of minutes. With an outbound-only heartbeat the clock stops the moment the
+ * work starts, which is how a busy A40 was paused mid-download.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+
+import { WebsocketPythonBridge } from "../src/python-websocket-bridge.js";
+import { createPythonBridge } from "../src/python-bridge-factory.js";
+import type { PythonBridgeBase } from "../src/python-bridge-base.js";
+import { onPythonBridgeCreated } from "../src/python-bridge-factory.js";
+import {
+  startFakeWorker,
+  type FakeWorkerHandle
+} from "./python-websocket-bridge.test-helpers.js";
+
+describe("bridge activity heartbeat", () => {
+  let worker: FakeWorkerHandle | null = null;
+  let bridge: WebsocketPythonBridge | null = null;
+
+  afterEach(async () => {
+    if (bridge) {
+      bridge.close();
+      bridge = null;
+    }
+    if (worker) {
+      await worker.close();
+      worker = null;
+    }
+  });
+
+  it("emits activity for frames the worker sends back, not only for sends", async () => {
+    worker = await startFakeWorker(0, { protocolVersion: 2 });
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`
+    });
+    await bridge.connect();
+
+    let outbound = 0;
+    let total = 0;
+    bridge.on("activity", () => total++);
+    const send = (
+      bridge as unknown as { _send: (m: Record<string, unknown>) => void }
+    )._send.bind(bridge);
+    (
+      bridge as unknown as { _send: (m: Record<string, unknown>) => void }
+    )._send = (m) => {
+      outbound++;
+      send(m);
+    };
+
+    await bridge.downloadModel({ repo_id: "org/m" }, () => {});
+
+    // One request frame goes out; start, progress and the terminal result come
+    // back. An outbound-only clock would see exactly one beat for the whole
+    // download.
+    expect(outbound).toBe(1);
+    expect(total).toBeGreaterThan(outbound);
+  });
+
+  it("hands every bridge it builds to a registered observer", () => {
+    const seen: PythonBridgeBase[] = [];
+    const uninstall = onPythonBridgeCreated((b) => seen.push(b));
+    try {
+      const created = createPythonBridge({ wsUrl: "ws://127.0.0.1:1" });
+      expect(seen).toEqual([created]);
+    } finally {
+      uninstall();
+    }
+    createPythonBridge({ wsUrl: "ws://127.0.0.1:1" });
+    expect(seen).toHaveLength(1);
+  });
+
+  it("survives an observer that throws", () => {
+    const uninstall = onPythonBridgeCreated(() => {
+      throw new Error("observer blew up");
+    });
+    try {
+      expect(() =>
+        createPythonBridge({ wsUrl: "ws://127.0.0.1:1" })
+      ).not.toThrow();
+    } finally {
+      uninstall();
+    }
+  });
+});

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -54,6 +54,7 @@ import { setDefaultModelInterfaces } from "@nodetool-ai/runtime";
 import { serverModelInterfaces } from "./unified-websocket-runner.js";
 import {
   WorkerManager,
+  attachWorkerActivityHeartbeat,
   startReaper,
   type WorkerConnection
 } from "@nodetool-ai/compute";
@@ -65,8 +66,7 @@ import {
   isAccessToken,
   MCP_OAUTH_ACCESS_TOKEN_PREFIX,
   migrateSqliteDb,
-  runSeeds,
-  touchWorkerInstance
+  runSeeds
 } from "@nodetool-ai/models";
 import { isMcpHttpEnabled, MCP_ENABLE_FLAG } from "./lib/mcp-mount.js";
 import {
@@ -651,23 +651,12 @@ pythonBridge.on("exit", (code: number) => {
 
 // Keep the attached worker's `last_activity_at` fresh so the cost guard's
 // reaper measures idle time from real bridge traffic, not from creation. The
-// remote WebSocket bridge emits "activity" on every outbound frame; we touch
-// the active worker instance, throttled so high-frequency traffic doesn't turn
-// into a DB write per frame (the reaper runs every 60s; second-level freshness
-// is ample). A local stdio bridge never emits "activity", so this is inert
-// there. Failures are swallowed — a touch must never break execution.
-const WORKER_TOUCH_THROTTLE_MS = 10_000;
-let lastWorkerTouchAt = 0;
-pythonBridge.on("activity", () => {
-  const nowMs = Date.now();
-  if (nowMs - lastWorkerTouchAt < WORKER_TOUCH_THROTTLE_MS) return;
-  lastWorkerTouchAt = nowMs;
-  void workerManager
-    .getActiveWorker()
-    .then((active) => (active ? touchWorkerInstance(active.id) : undefined))
-    .catch(() => {
-      // best-effort: keeping the idle clock fresh must not crash the runner
-    });
+// throttling and the best-effort write live in @nodetool-ai/compute so the CLI
+// gets the same behaviour; a local stdio bridge emits no "activity", so this is
+// inert there.
+attachWorkerActivityHeartbeat(pythonBridge, {
+  resolveInstanceId: async () =>
+    (await workerManager.getActiveWorker())?.id ?? null
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The worker idle heartbeat moves out of the websocket server into `@nodetool-ai/compute`, and every host that creates a Python bridge installs it. The bridge also counts inbound frames as activity.

Fixes #5185.

## Why

The reaper pauses an instance after its profile's idle window, measured from `worker_instances.last_activity_at`. Only a host watching the bridge can move that column, and the only listener lived in `packages/websocket/src/server.ts`. A CLI job — `nodetool run`, `workflows run`, `debug`, `worker models download` — never touched the row, so the reaper measured idle from the creation timestamp and paused a busy GPU. Measured on a live A40: ~50 minutes containing a 24.7 GB download and five generations, `last_activity_at` still equal to `created_at`, status `stopped`.

Half of the fix is the direction of the traffic. `_send` emitted `"activity"` only on outbound frames, and a download sends one request and then receives progress for tens of minutes. Relocating the listener alone would have left the clock frozen during exactly the work that provoked the report, so the WebSocket bridge now emits on a decoded inbound frame too. Nothing on this protocol arrives unsolicited — an idle worker still reads as idle.

## Shape

- `packages/compute/src/worker-heartbeat.ts` — `attachWorkerActivityHeartbeat(bridge, {resolveInstanceId})`, the throttled best-effort touch the server used to inline. Same 10s window (the reaper runs every 60s), same swallowed errors. The bridge is taken structurally, so compute keeps no `@nodetool-ai/runtime` dependency, the way `WorkerManager` does.
- `createPythonBridge` gains `onPythonBridgeCreated`, so a host wires cross-cutting behaviour onto bridges it never sees constructed. Registering nothing changes nothing.
- `packages/cli/src/nodetool.ts` installs it once — `installWorkerActivityHeartbeat(onPythonBridgeCreated)`. It opens no database and builds no bridge; the `WorkerManager` appears only when a bridge first carries traffic.
- `worker models` builds its bridge directly, so it attaches by hand and names the worker the command targets, not the attached one.

## A latent bug the injected clock caught

The server code this replaces started its throttle stamp at `0`, so the first
beat fired only because `Date.now()` is large. Under the fake clock the compute
test injects, the first beat was silently dropped — `0 - 0 < throttle`. The
stamp now starts at `-Infinity`, so the first beat fires whatever the clock
reads. Nothing in production hit this; nothing in production could have found
it either, which is the argument for injecting the clock rather than reading
`Date.now()` inline.

## Blast radius

Behaviour for the server is unchanged; the same listener now lives one package over. A local stdio bridge emits no `"activity"`, so this stays inert for a local worker. The cost direction is the one to watch: the clock now advances on inbound frames, so a worker whose bridge is receiving is not idle. That is the point, and no path on this protocol sends unsolicited frames — WebSocket protocol pings do not reach the message handler.

One line is uncovered: the CLI's `installWorkerActivityHeartbeat(onPythonBridgeCreated)` call in `packages/cli/src/nodetool.ts`. `packages/cli`'s vitest config replaces `@nodetool-ai/runtime`, `@nodetool-ai/models` and `@nodetool-ai/config` with empty stub modules, so a test there cannot drive the real bridge factory (importing the wiring fails with `TypeError: createLogger is not a function`). The composition it calls — register, attach, touch — is tested in `packages/compute` against an injected registrar; what no test exercises is that one call site.

One thing left alone: `packages/websocket/src/http-api.ts` creates per-request bridges through the factory and the server does not register the observer, since it attaches to its own long-lived bridge directly. Those bridges resolve a graph and close; they do not hold a GPU for an hour.

## Verification

Reverting each half turns the tests red.

Inbound frames (`this.emit("activity")` removed from the message listener):

```
 × emits activity for frames the worker sends back, not only for sends
AssertionError: expected 1 to be greater than 1
      Tests  1 failed | 2 passed (3)
```

The factory hook (`notifyBridgeObservers` reduced to a pass-through):

```
 × hands every bridge it builds to a registered observer
AssertionError: expected [] to deeply equal [ Array(1) ]
      Tests  1 failed | 2 passed (3)
```

The listener (`bridge.on("activity", listener)` removed):

```
 × touches the resolved instance on activity
 × collapses a burst into one write and beats again after the window
 × heartbeats every bridge the host creates after installing
      Tests  3 failed | 3 passed (6)
```

The download test drives the real `downloadModel` against the in-process fake worker and counts beats against outbound frames, so it measures the reported scenario rather than the event.

`npm run test:affected` (48 packages, plus the full web and electron suites), `npm run typecheck` and `npm run lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138g6jBUaPu6E7bxxYPVGb6

