### PR TITLE
feat(models): send an HF token with a worker model download

### DIFF
--- a/packages/cli/src/commands/worker-models.ts
+++ b/packages/cli/src/commands/worker-models.ts
@@ -14,6 +14,9 @@ import {
   WebsocketPythonBridge,
   type ModelDownloadUpdate
 } from "@nodetool-ai/runtime";
+import { resolveWorkerHfToken } from "@nodetool-ai/huggingface";
+import { getSecret } from "@nodetool-ai/models";
+
 import { printTable, asJson } from "./output.js";
 
 // ---------------------------------------------------------------------------
@@ -31,6 +34,9 @@ function formatBytes(n: number | null | undefined): string {
   }
   return `${value.toFixed(1)} ${units[i]}`;
 }
+
+/** Local single-user id used across the TS stack for secret-store reads. */
+const LOCAL_USER_ID = "1";
 
 function collectOption(value: string, previous: string[] | undefined): string[] {
   return previous ? [...previous, value] : [value];
@@ -205,12 +211,19 @@ function registerDownload(
             }
           };
 
+          // The worker holds no HuggingFace credential, so a gated repo
+          // (FLUX.1-dev, RMBG-2.0, ...) 401s unless this host supplies one.
+          const token = await resolveWorkerHfToken((key) =>
+            getSecret(key, LOCAL_USER_ID)
+          );
+
           await bridge.downloadModel(
             {
               repo_id: opts.repoId,
               path: opts.filePath ?? null,
               allow_patterns: opts.allowPatterns ?? null,
-              ignore_patterns: opts.ignorePatterns ?? null
+              ignore_patterns: opts.ignorePatterns ?? null,
+              token
             },
             render
           );

--- a/packages/huggingface/src/hf-auth.ts
+++ b/packages/huggingface/src/hf-auth.ts
@@ -154,3 +154,47 @@ export async function resolveHfToken(
   if (disableImplicit) return null;
   return cached;
 }
+
+// ---------------------------------------------------------------------------
+// Token for a remote worker
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads one credential out of NodeTool's secret store. Injected rather than
+ * imported so this package keeps no dependency on `@nodetool-ai/models`.
+ */
+export type SecretReader = (
+  key: string
+) => Promise<string | null | undefined> | string | null | undefined;
+
+/**
+ * Resolve the HuggingFace token a host should forward to a remote worker.
+ *
+ * A rented worker has neither a secret store nor `HF_TOKEN` in its
+ * environment, so it can only download public repos. The host resolves the
+ * credential instead and sends it with the `models.download` request
+ * (nodetool-ai/nodetool#5184).
+ *
+ * Order: the user's stored `HF_TOKEN` first, then this process's own
+ * environment and HF token file via {@link getHfToken} — the same token the
+ * local download path already uses. A blank value at either step is not a
+ * credential and yields `undefined`, so the worker takes its own fallback
+ * rather than receiving an empty Bearer header. A secret store that throws
+ * (locked, absent) falls through to the environment instead of failing the
+ * download.
+ */
+export async function resolveWorkerHfToken(
+  readSecret?: SecretReader
+): Promise<string | undefined> {
+  if (readSecret) {
+    try {
+      const stored = await readSecret("HF_TOKEN");
+      if (typeof stored === "string" && stored.trim()) return stored.trim();
+    } catch {
+      // A locked or missing secret store is not an error here — fall through
+      // to the environment. Never log: the failure can carry the key material.
+    }
+  }
+  const local = await getHfToken();
+  return local && local.trim() ? local.trim() : undefined;
+}

--- a/packages/huggingface/src/index.ts
+++ b/packages/huggingface/src/index.ts
@@ -1,7 +1,13 @@
 // @nodetool-ai/huggingface — HuggingFace integration package
 // Cache scanning, model discovery, artifact inspection, and downloads
 
-export { getHfToken, resolveHfToken, clearHfTokenCache } from "./hf-auth.js";
+export {
+  getHfToken,
+  resolveHfToken,
+  clearHfTokenCache,
+  resolveWorkerHfToken
+} from "./hf-auth.js";
+export type { SecretReader } from "./hf-auth.js";
 
 export { HfFastCache, getDefaultHfCacheDir } from "./hf-cache.js";
 

--- a/packages/huggingface/tests/hf-worker-token.test.ts
+++ b/packages/huggingface/tests/hf-worker-token.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for `resolveWorkerHfToken` — the credential a host forwards to a
+ * remote worker with `models.download`.
+ *
+ * A rented worker has no secret store and no HF_TOKEN in its environment, so
+ * gated repos answer 401 there (nodetool-ai/nodetool#5184). The host resolves
+ * the token instead: the user's stored secret first, then this process's own
+ * environment and HF token file.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import { resolveWorkerHfToken, clearHfTokenCache } from "../src/hf-auth.js";
+
+const ENV_KEYS = [
+  "HF_TOKEN",
+  "HF_API_TOKEN",
+  "HUGGING_FACE_HUB_TOKEN",
+  "HF_TOKEN_PATH",
+  "HF_HOME",
+  "XDG_CACHE_HOME"
+];
+
+let savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  // A directory with no token file, so the default ~/.cache/huggingface/token
+  // never leaks into a test.
+  process.env["HF_HOME"] = path.join(os.tmpdir(), "hf-worker-token-no-dir");
+  clearHfTokenCache();
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  }
+  clearHfTokenCache();
+});
+
+describe("resolveWorkerHfToken", () => {
+  it("prefers the user's stored secret over the environment", async () => {
+    process.env["HF_TOKEN"] = "hf_from_env";
+    const asked: string[] = [];
+
+    const token = await resolveWorkerHfToken((key) => {
+      asked.push(key);
+      return "hf_from_secret_store";
+    });
+
+    expect(token).toBe("hf_from_secret_store");
+    expect(asked).toEqual(["HF_TOKEN"]);
+  });
+
+  it("falls back to the environment when nothing is stored", async () => {
+    process.env["HF_TOKEN"] = "hf_from_env";
+
+    expect(await resolveWorkerHfToken(async () => null)).toBe("hf_from_env");
+    expect(await resolveWorkerHfToken()).toBe("hf_from_env");
+  });
+
+  it("treats a blank stored secret as absent", async () => {
+    process.env["HF_TOKEN"] = "hf_from_env";
+
+    expect(await resolveWorkerHfToken(async () => "   ")).toBe("hf_from_env");
+    expect(await resolveWorkerHfToken(async () => "")).toBe("hf_from_env");
+  });
+
+  it("returns undefined when no token exists anywhere", async () => {
+    expect(await resolveWorkerHfToken(async () => null)).toBeUndefined();
+  });
+
+  it("falls through to the environment when the secret store throws", async () => {
+    process.env["HF_TOKEN"] = "hf_from_env";
+
+    const token = await resolveWorkerHfToken(async () => {
+      throw new Error("secret store is locked");
+    });
+
+    expect(token).toBe("hf_from_env");
+  });
+
+  it("trims surrounding whitespace off a stored token", async () => {
+    expect(await resolveWorkerHfToken(async () => "  hf_padded  ")).toBe(
+      "hf_padded"
+    );
+  });
+});

--- a/packages/runtime/src/python-bridge-base.ts
+++ b/packages/runtime/src/python-bridge-base.ts
@@ -1068,9 +1068,18 @@ export abstract class PythonBridgeBase
     onProgress: (update: ModelDownloadUpdate) => void,
     requestId: string = randomUUID()
   ): Promise<void> {
+    // A blank token is not a credential: `Authorization: Bearer ` fails
+    // differently than sending no header at all, and worse for a public repo.
+    // Drop it here so every caller gets the rule, matching the worker's own
+    // handling (nodetool-core#1008).
+    const { token, ...rest } = req;
+    const payload: Record<string, unknown> =
+      typeof token === "string" && token.trim()
+        ? { ...rest, token: token.trim() }
+        : rest;
     return this._streamingDownload(
       "models.download",
-      { ...req },
+      payload,
       // SAFETY: the worker's `models.download` progress frame carries exactly
       // these fields; unlike the comfy update shapes, `ModelDownloadUpdate`
       // declares no index signature, so the frame record does not overlap it.

--- a/packages/runtime/src/python-bridge-types.ts
+++ b/packages/runtime/src/python-bridge-types.ts
@@ -144,6 +144,17 @@ export interface ModelDownloadRequest {
   ignore_patterns?: string[] | null;
   path?: string | null;
   model_type?: string | null;
+  /**
+   * HuggingFace credential for this download only.
+   *
+   * A rented worker is a bare container: no per-user secret store, no
+   * `HF_TOKEN` in its environment, so every gated repo answers 401. The host
+   * therefore passes the token with the request and the worker holds it for
+   * the life of the call (nodetool-core#1008). Omitted or blank, the worker
+   * falls back to its own resolution — `downloadModel` drops a blank value
+   * rather than sending an empty credential.
+   */
+  token?: string | null;
 }
 
 /**

--- a/packages/runtime/tests/model-download-token.test.ts
+++ b/packages/runtime/tests/model-download-token.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression: `models.download` carries an optional HuggingFace token.
+ *
+ * A rented worker holds no credential, so a gated repo (FLUX.1-dev, RMBG-2.0)
+ * answers `401 ... Token present: False`. The host supplies the token per
+ * request and the worker uses it for that download only — the Python half is
+ * nodetool-ai/nodetool-core#1008.
+ *
+ * Drives the real bridge against the in-process fake worker and reads the frame
+ * the worker actually received, so this measures the wire, not the call.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+
+import { WebsocketPythonBridge } from "../src/python-websocket-bridge.js";
+import {
+  startFakeWorker,
+  type FakeWorkerHandle
+} from "./python-websocket-bridge.test-helpers.js";
+
+describe("models.download token", () => {
+  let worker: FakeWorkerHandle | null = null;
+  let bridge: WebsocketPythonBridge | null = null;
+
+  afterEach(async () => {
+    if (bridge) {
+      bridge.close();
+      bridge = null;
+    }
+    if (worker) {
+      await worker.close();
+      worker = null;
+    }
+  });
+
+  /** Connect, run one download, and return the payload the worker received. */
+  async function downloadWith(
+    token: string | null | undefined
+  ): Promise<Record<string, unknown>> {
+    worker = await startFakeWorker(0, { protocolVersion: 2 });
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`
+    });
+    await bridge.connect();
+
+    await bridge.downloadModel({ repo_id: "org/gated", token }, () => {});
+
+    const frames = worker.received("models.download");
+    expect(frames).toHaveLength(1);
+    return frames[0]!.data as Record<string, unknown>;
+  }
+
+  it("sends the token when the host resolved one", async () => {
+    const data = await downloadWith("hf_supplied_by_host");
+    expect(data["token"]).toBe("hf_supplied_by_host");
+    expect(data["repo_id"]).toBe("org/gated");
+  });
+
+  it("omits the field entirely when no token is available", async () => {
+    const data = await downloadWith(undefined);
+    expect(data).not.toHaveProperty("token");
+  });
+
+  it("treats an empty string as absent rather than sending a blank credential", async () => {
+    // `Authorization: Bearer ` fails differently than sending no header, and
+    // worse for a public repo — so a blank value must not reach the wire.
+    const data = await downloadWith("");
+    expect(data).not.toHaveProperty("token");
+  });
+
+  it("treats a whitespace-only token as absent", async () => {
+    const data = await downloadWith("   ");
+    expect(data).not.toHaveProperty("token");
+  });
+
+  it("treats null as absent", async () => {
+    const data = await downloadWith(null);
+    expect(data).not.toHaveProperty("token");
+  });
+
+  it("trims a padded token before sending it", async () => {
+    const data = await downloadWith("  hf_padded\n");
+    expect(data["token"]).toBe("hf_padded");
+  });
+
+  it("keeps the token out of every frame the worker sends back", async () => {
+    worker = await startFakeWorker(0, { protocolVersion: 2 });
+    bridge = new WebsocketPythonBridge({
+      wsUrl: `ws://127.0.0.1:${worker.port}`
+    });
+    await bridge.connect();
+
+    const updates: unknown[] = [];
+    await bridge.downloadModel({ repo_id: "org/gated", token: "hf_secret" }, (u) =>
+      updates.push(u)
+    );
+
+    expect(updates.length).toBeGreaterThan(0);
+    expect(JSON.stringify(updates)).not.toContain("hf_secret");
+  });
+});

--- a/packages/websocket/src/models-api.ts
+++ b/packages/websocket/src/models-api.ts
@@ -30,6 +30,7 @@ import {
   getModelsByHfType,
   deleteCachedHfModel,
   getHuggingfaceFileInfos,
+  resolveWorkerHfToken,
   type HFFileRequest
 } from "@nodetool-ai/huggingface";
 import type { UnifiedModel } from "@nodetool-ai/protocol";
@@ -1362,7 +1363,8 @@ export async function relayWorkerDownload(
   msg: StartDownloadCommand,
   requestId: string = msg.path
     ? `${msg.repo_id ?? ""}/${msg.path}`
-    : (msg.repo_id ?? "")
+    : (msg.repo_id ?? ""),
+  userId: string = "1"
 ): Promise<void> {
   const repoId = msg.repo_id ?? "";
   // The worker already emits a terminal `error`-status progress frame on
@@ -1404,6 +1406,13 @@ export async function relayWorkerDownload(
     return;
   }
 
+  // The worker has no HuggingFace credential of its own, so a gated repo 401s
+  // unless this server supplies one. Resolved here, never taken from `msg` —
+  // that JSON comes from the client.
+  const token = await resolveWorkerHfToken((key) =>
+    getStoredSecret(key, userId)
+  );
+
   try {
     await bridge.downloadModel(
       {
@@ -1411,7 +1420,8 @@ export async function relayWorkerDownload(
         path: msg.path ?? null,
         allow_patterns: msg.allow_patterns ?? null,
         ignore_patterns: msg.ignore_patterns ?? null,
-        model_type: msg.model_type ?? null
+        model_type: msg.model_type ?? null,
+        token
       },
       (update) => {
         if (update.status === "error") {

--- a/packages/websocket/src/plugins/websocket.ts
+++ b/packages/websocket/src/plugins/websocket.ts
@@ -305,7 +305,8 @@ const websocketPlugin: FastifyPluginAsync<WebSocketPluginOptions> = async (
                       pythonBridge,
                       workerManager,
                       msg,
-                      downloadId
+                      downloadId,
+                      req.userId ?? "1"
                     );
                   } finally {
                     workerDownloads.delete(downloadId);

--- a/packages/websocket/src/sdk/sdk-model-download-service.ts
+++ b/packages/websocket/src/sdk/sdk-model-download-service.ts
@@ -59,6 +59,7 @@ interface CreateSdkV1ModelDownloadServiceOptions {
     onProgress: (update: DownloadUpdate) => void
   ) => Promise<void>;
   startWorkerDownload?: (
+    userId: string,
     request: SdkV1ModelDownloadStartRequest,
     operationId: string,
     onProgress: (update: DownloadUpdate) => void
@@ -252,7 +253,7 @@ export function createSdkV1ModelDownloadService(
       const execute = async (): Promise<void> => {
         try {
           if (request.scope === "worker") {
-            await startWorkerDownload!(request, id, update);
+            await startWorkerDownload!(userId, request, id, update);
           } else if (request.model_type.startsWith("tjs.")) {
             await startTransformersJsDownload(
               request,

--- a/packages/websocket/src/server.ts
+++ b/packages/websocket/src/server.ts
@@ -1175,7 +1175,7 @@ function listRegistryRecommendedModels(): UnifiedModel[] {
 }
 
 const sdkModelDownloadService = createSdkV1ModelDownloadService({
-  startWorkerDownload: (request, operationId, onProgress) =>
+  startWorkerDownload: (userId, request, operationId, onProgress) =>
     relayWorkerDownload(
       {
         send: (data) => onProgress(JSON.parse(data) as ModelDownloadUpdate)
@@ -1191,7 +1191,8 @@ const sdkModelDownloadService = createSdkV1ModelDownloadService({
         model_type: request.model_type,
         scope: "worker"
       },
-      operationId
+      operationId,
+      userId
     ),
   cancelWorkerDownload: (operationId) =>
     pythonBridge.cancelModelDownload(operationId)

--- a/packages/websocket/tests/models-api-worker.test.ts
+++ b/packages/websocket/tests/models-api-worker.test.ts
@@ -6,7 +6,9 @@
  * The download relay pipes the bridge's progress frames onto the existing
  * /ws/download socket sink.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 // Keep the local-scope routes hermetic: on a developer machine the real
 // readCachedHfModels scans a (potentially huge) HF cache and blows the test
@@ -19,6 +21,9 @@ vi.mock("@nodetool-ai/huggingface", async (orig) => {
     deleteCachedHfModel: vi.fn().mockResolvedValue(true)
   };
 });
+
+import { clearHfTokenCache } from "@nodetool-ai/huggingface";
+import { clearAllSecretCache } from "@nodetool-ai/models";
 
 import {
   handleModelsApiRequest,
@@ -411,5 +416,89 @@ describe("relayWorkerDownload cancel correlation", () => {
     const errorFrames = sent.filter((s) => s.status === "error");
     expect(errorFrames).toHaveLength(1);
     expect(errorFrames[0].error).toBe("disk full");
+  });
+});
+
+// ── HuggingFace token forwarding ─────────────────────────────────────────────
+//
+// The worker holds no HuggingFace credential, so a gated repo answers
+// `401 ... Token present: False` unless this server sends one with the request
+// (nodetool-ai/nodetool#5184, worker half nodetool-core#1008).
+
+describe("relayWorkerDownload HF token", () => {
+  const ENV_KEYS = ["HF_TOKEN", "HF_API_TOKEN", "HUGGING_FACE_HUB_TOKEN", "HF_HOME"];
+  let savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    // A directory with no token file, so this machine's own saved HF token
+    // cannot decide the outcome.
+    process.env["HF_HOME"] = join(tmpdir(), "models-api-worker-no-token");
+    // Both layers memoize what they resolved: the secret helper caches an
+    // env-sourced value per user, and getHfToken caches the env/token-file
+    // read. Without clearing them a later test reads an earlier test's token.
+    clearHfTokenCache();
+    clearAllSecretCache();
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    clearHfTokenCache();
+    clearAllSecretCache();
+  });
+
+  /** Run one relay and return the request payload the bridge was handed. */
+  async function relayAndCapture(): Promise<Record<string, unknown>> {
+    const downloadModel = vi.fn().mockResolvedValue(undefined);
+    await relayWorkerDownload(
+      { send: () => {} },
+      fakeBridge({ downloadModel }),
+      fakeWorkerManager(ATTACHED),
+      { command: "start_download", repo_id: "org/gated" }
+    );
+    expect(downloadModel).toHaveBeenCalledTimes(1);
+    return downloadModel.mock.calls[0]![0] as Record<string, unknown>;
+  }
+
+  it("forwards the token this server can resolve", async () => {
+    process.env["HF_TOKEN"] = "hf_server_token";
+    expect((await relayAndCapture())["token"]).toBe("hf_server_token");
+  });
+
+  it("sends no token when this server has none", async () => {
+    expect((await relayAndCapture())["token"]).toBeUndefined();
+  });
+
+  it("treats an empty HF_TOKEN as absent", async () => {
+    process.env["HF_TOKEN"] = "";
+    expect((await relayAndCapture())["token"]).toBeUndefined();
+  });
+
+  it("never takes the token from the client's own message", async () => {
+    // `msg` is JSON off the /ws/download socket. A caller-supplied credential
+    // must not be relayed onward as if the server had resolved it.
+    const downloadModel = vi.fn().mockResolvedValue(undefined);
+    await relayWorkerDownload(
+      { send: () => {} },
+      fakeBridge({ downloadModel }),
+      fakeWorkerManager(ATTACHED),
+      {
+        command: "start_download",
+        repo_id: "org/gated",
+        token: "hf_from_client"
+      } as Parameters<typeof relayWorkerDownload>[3]
+    );
+    const req = downloadModel.mock.calls[0]![0] as Record<string, unknown>;
+    expect(req["token"]).toBeUndefined();
   });
 });

--- a/packages/websocket/tests/sdk-model-download-service.test.ts
+++ b/packages/websocket/tests/sdk-model-download-service.test.ts
@@ -185,6 +185,7 @@ describe("SDK model download service", () => {
   it("relays worker progress and cancellation through configured bridge adapters", () => {
     const startWorker = vi.fn(
       async (
+        _userId: string,
         _request: SdkV1ModelDownloadStartRequest,
         _operationId: string,
         onProgress: (update: DownloadUpdate) => void
@@ -214,5 +215,8 @@ describe("SDK model download service", () => {
       downloaded_bytes: 60
     });
     expect(cancelWorker).toHaveBeenCalledExactlyOnceWith(started.operation_id);
+    // The worker download needs the user, so the relay can resolve that user's
+    // HuggingFace token for a gated repo.
+    expect(startWorker.mock.calls[0]![0]).toBe("alice");
   });
 });


### PR DESCRIPTION
## What

`models.download` now carries an optional HuggingFace token, and the two worker-bound call sites resolve one and send it.

TypeScript half of #5184. Worker half: nodetool-ai/nodetool-core#1008 (already open) — this PR sends the field that PR taught the worker to read.

## Why

A rented GPU worker is a bare container. It has no per-user secret store and nothing puts `HF_TOKEN` in its environment, so `get_hf_token()` there resolves to nothing and every gated repo answers:

```
Unauthorized to access 'https://huggingface.co/briaai/RMBG-2.0/resolve/main/.gitattributes'.
Status: 401. Check your Hugging Face token and permissions. Token present: False
```

`Token present: False` is the whole diagnosis. The gated set is FLUX.1-dev, FLUX.1-Fill-dev, Qwen-Image, RMBG-2.0 and Stable Diffusion 2.1 — most of what a GPU gets rented for. A user who can download these on their own machine could not download them onto a worker.

The alternative — baking `HF_TOKEN` into the pod's environment at provision time — puts a long-lived credential in the provider's API request and leaves it readable by anything on the box for the pod's whole life. Per request, the worker holds it for the length of one call.

## What changes

- `ModelDownloadRequest.token?: string | null` (`packages/runtime/src/python-bridge-types.ts`).
- `downloadModel` drops a blank token instead of forwarding it. `Authorization: Bearer ` fails differently than sending no header at all, and worse for a public repo. One implementation, so every caller gets the rule and it matches the worker's own `_request_token`.
- `resolveWorkerHfToken` (`packages/huggingface/src/hf-auth.ts`): the user's stored `HF_TOKEN` first, then this process's environment and HF token file via the existing `getHfToken`. Blank at either step is not a credential. A secret store that throws — locked, absent — falls through to the environment rather than failing the download. It takes the secret reader as a parameter, so `@nodetool-ai/huggingface` gains no dependency on `@nodetool-ai/models`.
- Server: `relayWorkerDownload` resolves the token for the requesting user. It is the single server-side worker download path — both the `/ws/download` socket and the SDK download service go through it — so `startWorkerDownload` grew a `userId` first parameter to match `startHuggingFaceDownload`, and the socket handler passes `req.userId ?? "1"`.
- CLI: `worker models download` resolves for the local user (`"1"`).

## Not the schema

`packages/protocol/src/bridge-frames.ts` models only the six **inbound** frame types the dispatcher switches on (`discover`, `result`, `error`, `chunk`, `progress`, `comfy.event`). Outbound requests like `models.download` are deliberately not modeled — `getBridgeFrameSchema` returns undefined for them — so there was nothing to widen and no unknown-field rejection to clear. Verified by driving a real download through the fake worker, which validates every frame it receives.

## Credential handling

- Resolved on the host, never read off `msg` — that JSON comes from the client over `/ws/download`. A test pins that a client-supplied `token` is not relayed onward.
- Not logged. The bridge logs no request payload on this path (`python-bridge-base.ts` logs a dispatched `execute`'s node type, a malformed inbound frame's type/id, and a provider call's error message; the WebSocket transport logs URLs and socket errors). Nothing serializes the download request.
- Not echoed into a progress or error frame; a test asserts the token appears in no update the worker sends back.
- Not persisted: the SDK service retains `repo_id`/`path`/`model_type`, and `token` is not part of `SdkV1ModelDownloadStartRequest` — it is attached inside the relay.

## Blast radius

Additive on the wire. An install with no token resolvable sends no field and behaves exactly as before; an old worker ignores the field; a new worker with an old host takes its own fallback. The local (non-worker) download path is untouched — that process already resolves its own credential, so forwarding one buys nothing.

`nodetool models download-hf` is local-only (`DownloadManager` against the local cache) and is deliberately not changed.

## What is proven, and what is not

Reported by a maintainer, on a RunPod A40 with `HF_TOKEN` in the pod environment:

```
Unauthorized to access 'https://huggingface.co/briaai/RMBG-2.0/resolve/main/.gitattributes'.
Status: 403. Check your Hugging Face token and permissions. Token present: True
```

Against the same request without a token — 401, `Token present: False` — that is
the mechanism this PR changes: a token supplied by the host arrives where the
download happens. The download still failed, because that credential is not
authorized for the repo's contents; the same token gets 403 from a developer
machine while `/api/models/briaai/RMBG-2.0` returns 200 with `gated = auto`.

**A gated repo completing a download on a worker is unproven.** It needs a
credential authorized for that repo, and it is worth pinning with one once this
lands.

## One uncovered line

The CLI call site in `packages/cli/src/commands/worker-models.ts` has no test.
`packages/cli`'s vitest config replaces `@nodetool-ai/runtime`,
`@nodetool-ai/models` and `@nodetool-ai/config` with empty stub modules, so a
test there can build neither a real bridge nor a real `getSecret`. The four
lines mirror the server relay, which is covered.

## Verification

Reverting each part turns its tests red.

`downloadModel`'s blank-token normalization removed:

```
 × omits the field entirely when no token is available
 × treats an empty string as absent rather than sending a blank credential
 × treats a whitespace-only token as absent
 × treats null as absent
 × trims a padded token before sending it
AssertionError: expected { repo_id: 'org/gated', token: '' } to not have property "token"
      Tests  5 failed | 2 passed (7)
```

The relay no longer passing the token:

```
 FAIL  tests/models-api-worker.test.ts > relayWorkerDownload HF token > forwards the token this server can resolve
AssertionError: expected undefined to be 'hf_server_token'
      Tests  1 failed | 19 passed (20)
```

The resolver's secret-store branch disabled:

```
 × prefers the user's stored secret over the environment
 × trims surrounding whitespace off a stored token
AssertionError: expected 'hf_from_env' to be 'hf_from_secret_store'
      Tests  2 failed | 4 passed (6)
```

The runtime tests read the payload the fake worker actually received, so they measure the wire rather than the call.

One trap the tests had to handle: both layers memoize. `getSecret` caches an env-sourced value per user and `getHfToken` caches its env/token-file read, so without clearing both a later case reads an earlier one's token — which is how the "no token available" case first passed for the wrong reason.

`npm run test:affected`, `npm run typecheck` and `npm run lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138g6jBUaPu6E7bxxYPVGb6


