### PR TITLE
fix(runtime): keep the ref a blob-carried output arrived with

### DIFF
--- a/packages/runtime/src/python-node-executor.ts
+++ b/packages/runtime/src/python-node-executor.ts
@@ -54,7 +54,7 @@ const MEDIA_TYPE_ALIASES: Record<string, string> = {
   model_3d: "model_3d"
 };
 
-/** File extensions by ref type. */
+/** Fallback extension when the ref names no format. */
 const EXTENSION_MAP: Record<string, string> = {
   image: ".png",
   audio: ".wav",
@@ -62,13 +62,80 @@ const EXTENSION_MAP: Record<string, string> = {
   model_3d: ".glb"
 };
 
-/** MIME types by ref type. */
+/** Fallback MIME type when the ref names no format. */
 const MIME_MAP: Record<string, string> = {
   image: "image/png",
   audio: "audio/wav",
   video: "video/mp4",
   model_3d: "model/gltf-binary"
 };
+
+/**
+ * MIME type per declared ref format. A ref that says `format: "jpeg"` must not
+ * be stored as `.png` with `image/png`: the extension decides how a browser
+ * and every downstream reader treat the bytes.
+ *
+ * A format absent from this table still shapes the extension — the entry only
+ * decides the content type, which falls back to the media kind's default.
+ */
+const FORMAT_MIME_MAP: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+  gif: "image/gif",
+  bmp: "image/bmp",
+  tiff: "image/tiff",
+  wav: "audio/wav",
+  mp3: "audio/mpeg",
+  flac: "audio/flac",
+  ogg: "audio/ogg",
+  opus: "audio/opus",
+  m4a: "audio/mp4",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  mkv: "video/x-matroska",
+  avi: "video/x-msvideo",
+  glb: "model/gltf-binary",
+  gltf: "model/gltf+json",
+  obj: "model/obj",
+  stl: "model/stl",
+  ply: "model/mesh",
+  fbx: "application/octet-stream"
+};
+
+/**
+ * The format a ref declares, as a storage-key-safe token, or null.
+ *
+ * The value is node-controlled and lands in a storage key, so anything but a
+ * short alphanumeric token is refused rather than sanitized — a format of
+ * `../../etc` has no legitimate reading.
+ */
+function refFormat(ref: Record<string, unknown> | null): string | null {
+  const raw = ref?.["format"];
+  if (!isString(raw)) return null;
+  const format = raw.trim().toLowerCase();
+  return /^[a-z0-9]{1,8}$/.test(format) ? format : null;
+}
+
+/** True when a ref's `data` holds raw bytes rather than an inline payload. */
+function isBinaryPayload(value: unknown): boolean {
+  if (value instanceof Uint8Array || value instanceof ArrayBuffer) return true;
+  return (
+    Array.isArray(value) &&
+    value.some(
+      (item) => item instanceof Uint8Array || item instanceof ArrayBuffer
+    )
+  );
+}
+
+/** The ref the worker sent for this output slot, if it sent one. */
+function carriedRef(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
 
 function normalizeMediaOutputType(outputType: string | undefined): string | null {
   if (!outputType) {
@@ -249,21 +316,41 @@ export class PythonNodeExecutor {
       const mediaType = Object.hasOwn(this.outputTypes, name)
         ? normalizeMediaOutputType(this.outputTypes[name])
         : null;
+      // The ref the worker sent for this slot, when it sent one. Rebuilding a
+      // bare {uri, type} from the media kind drops everything else it carried —
+      // a VideoRef's duration and format, a Model3DRef's material_file and
+      // texture_files, which are what make the asset renderable.
+      // Guarded with Object.hasOwn for the same reason the outputTypes lookup
+      // is: a blob named "__proto__" would otherwise read Object.prototype and
+      // spread its members into the output.
+      const ref = Object.hasOwn(result.outputs, name)
+        ? carriedRef(result.outputs[name])
+        : null;
+
       if (mediaType && context?.storage) {
-        const ext = EXTENSION_MAP[mediaType] ?? "";
-        const contentType = MIME_MAP[mediaType];
+        const format = refFormat(ref);
+        const ext = format ? `.${format}` : (EXTENSION_MAP[mediaType] ?? "");
+        const contentType =
+          (format ? FORMAT_MIME_MAP[format] : undefined) ?? MIME_MAP[mediaType];
         const storageKey = `python-bridge/${randomUUID()}${ext}`;
         const uri = await context.storage.store(
           storageKey,
           blobData,
           contentType
         );
-        outputs[name] = { uri, type: mediaType };
+        outputs[name] = { ...ref, uri, type: mediaType };
+        // The payload is the blob, now at `uri`. A ref that also carries bytes
+        // would duplicate a megabyte-scale payload downstream, so drop them —
+        // tested by value, since an inline non-binary payload (a dataframe's
+        // rows) is content and must survive.
+        if (ref && isBinaryPayload(ref["data"])) {
+          delete (outputs[name] as Record<string, unknown>)["data"];
+        }
       } else if (mediaType) {
         // No storage adapter available: keep the bytes inline but preserve the
         // media kind so downstream nodes receive a typed ref (e.g. ImageRef),
         // not a bare Uint8Array.
-        outputs[name] = { type: mediaType, data: blobData };
+        outputs[name] = { ...ref, type: mediaType, data: blobData };
       } else {
         outputs[name] = blobData;
       }

--- a/packages/runtime/tests/blob-ref-metadata.test.ts
+++ b/packages/runtime/tests/blob-ref-metadata.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Regression: a blob-carried output keeps the ref the worker sent.
+ *
+ * `materializeOutputs` used to rebuild the output as a fresh `{uri, type}` from
+ * the declared media kind, so every other field the ref carried was discarded —
+ * a VideoRef's `duration` and `format`, a Model3DRef's `format`,
+ * `material_file` and `texture_files`, which are what make the asset
+ * renderable (nodetool-ai/nodetool#5188).
+ *
+ * The same line picked the storage extension from a fixed per-kind table, so a
+ * ref declaring `format: "jpeg"` was stored as `.png`.
+ *
+ * Both tests feed the executor an `ExecuteResult` that carries the ref in
+ * `outputs` and its bytes in `blobs` — the host contract. See the PR for what
+ * the worker sends today.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import { PythonNodeExecutor } from "../src/python-node-executor.js";
+import type { PythonStdioBridge } from "../src/index.js";
+import type { ExecuteResult } from "../src/python-bridge-types.js";
+import type { ProcessingContext } from "../src/context.js";
+
+function createBridge(result: ExecuteResult): PythonStdioBridge {
+  return {
+    execute: vi.fn().mockResolvedValue(result),
+    executeStream: vi.fn(),
+    hasNodeType: vi.fn().mockReturnValue(true),
+    getNodeMetadata: vi.fn().mockReturnValue([])
+  } as unknown as PythonStdioBridge;
+}
+
+/** A context whose storage echoes the key it was asked to store under. */
+function createContext(): ProcessingContext {
+  return {
+    jobId: "job-1",
+    workflowId: "wf-1",
+    userId: "user-1",
+    getSecret: vi.fn().mockResolvedValue(null),
+    storage: {
+      retrieve: vi.fn(),
+      store: vi.fn(async (key: string) => `file:///tmp/${key}`),
+      exists: vi.fn().mockResolvedValue(false)
+    }
+  } as unknown as ProcessingContext;
+}
+
+/** The `(key, bytes, contentType)` the executor asked storage to write. */
+function storeCall(ctx: ProcessingContext): [string, Uint8Array, string] {
+  const store = ctx.storage!.store as unknown as {
+    mock: { calls: [string, Uint8Array, string][] };
+  };
+  expect(store.mock.calls).toHaveLength(1);
+  return store.mock.calls[0]!;
+}
+
+describe("blob-carried output metadata", () => {
+  it("keeps a VideoRef's duration and format", async () => {
+    const ctx = createContext();
+    const bridge = createBridge({
+      outputs: {
+        output: {
+          type: "video",
+          uri: "blob://clip",
+          duration: 12.5,
+          format: "webm"
+        }
+      },
+      blobs: { output: new Uint8Array([1, 2, 3]) }
+    });
+    const executor = new PythonNodeExecutor(
+      bridge,
+      "test.VideoNode",
+      {},
+      { output: "VideoRef" },
+      []
+    );
+
+    const out = (await executor.process({}, ctx))["output"] as Record<
+      string,
+      unknown
+    >;
+
+    expect(out["duration"]).toBe(12.5);
+    expect(out["format"]).toBe("webm");
+    expect(out["type"]).toBe("video");
+    // The uri is the one field the host owns: it points at what it just stored,
+    // never at the worker's blob:// pointer.
+    expect(out["uri"]).not.toBe("blob://clip");
+    expect(out["uri"]).toMatch(/^file:\/\/\/tmp\/python-bridge\//);
+  });
+
+  it("keeps a Model3DRef's format, material_file and texture_files", async () => {
+    const ctx = createContext();
+    const bridge = createBridge({
+      outputs: {
+        output: {
+          type: "model_3d",
+          uri: "blob://model",
+          format: "obj",
+          material_file: { type: "image", uri: "file://model.mtl" },
+          texture_files: [{ type: "image", uri: "file://wood.png" }]
+        }
+      },
+      blobs: { output: new Uint8Array([4, 5, 6]) }
+    });
+    const executor = new PythonNodeExecutor(
+      bridge,
+      "test.Model3DNode",
+      {},
+      { output: "Model3DRef" },
+      []
+    );
+
+    const out = (await executor.process({}, ctx))["output"] as Record<
+      string,
+      unknown
+    >;
+
+    expect(out["format"]).toBe("obj");
+    expect(out["material_file"]).toEqual({
+      type: "image",
+      uri: "file://model.mtl"
+    });
+    expect(out["texture_files"]).toEqual([
+      { type: "image", uri: "file://wood.png" }
+    ]);
+  });
+
+  it("stores under the extension and content type the ref declares", async () => {
+    const ctx = createContext();
+    const bridge = createBridge({
+      outputs: { output: { type: "image", uri: "blob://img", format: "jpeg" } },
+      blobs: { output: new Uint8Array([7, 8]) }
+    });
+    const executor = new PythonNodeExecutor(
+      bridge,
+      "test.ImageNode",
+      {},
+      { output: "ImageRef" },
+      []
+    );
+
+    await executor.process({}, ctx);
+
+    const [key, , contentType] = storeCall(ctx);
+    expect(key).toMatch(/\.jpeg$/);
+    expect(contentType).toBe("image/jpeg");
+  });
+
+  it("falls back to the media kind's extension when the ref names no format", async () => {
+    const ctx = createContext();
+    const bridge = createBridge({
+      outputs: { output: { type: "image", uri: "blob://img" } },
+      blobs: { output: new Uint8Array([7, 8]) }
+    });
+    const executor = new PythonNodeExecutor(
+      bridge,
+      "test.ImageNode",
+      {},
+      { output: "ImageRef" },
+      []
+    );
+
+    await executor.process({}, ctx);
+
+    const [key, , contentType] = storeCall(ctx);
+    expect(key).toMatch(/\.png$/);
+    expect(contentType).toBe("image/png");
+  });
+
+  it("refuses a format that would escape the storage key", async () => {
+    const ctx = createContext();
+    const bridge = createBridge({
+      outputs: {
+        output: { type: "image", uri: "blob://img", format: "../../etc/passwd" }
+      },
+      blobs: { output: new Uint8Array([7, 8]) }
+    });
+    const executor = new PythonNodeExecutor(
+      bridge,
+      "test.ImageNode",
+      {},
+      { output: "ImageRef" },
+      []
+    );
+
+    await executor.process({}, ctx);
+
+    const [key] = storeCall(ctx);
+    expect(key).not.toContain("..");
+    expect(key).toMatch(/^python-bridge\/[0-9a-f-]+\.png$/);
+  });
+
+  // ── The behaviour that must NOT change ────────────────────────────────────
+
+  it("an ImageRef travelling as a blob still gets the stored uri and no inline bytes", async () => {
+    const ctx = createContext();
+    const bridge = createBridge({
+      outputs: { output: { type: "image", uri: "blob://img", data: null } },
+      blobs: { output: new Uint8Array([1, 2, 3]) }
+    });
+    const executor = new PythonNodeExecutor(
+      bridge,
+      "test.ImageNode",
+      {},
+      { output: "ImageRef" },
+      []
+    );
+
+    const out = (await executor.process({}, ctx))["output"] as Record<
+      string,
+      unknown
+    >;
+
+    expect(out["type"]).toBe("image");
+    expect(out["uri"]).toMatch(/^file:\/\/\/tmp\/python-bridge\//);
+    expect(out["data"]).toBeFalsy();
+    expect(storeCall(ctx)[1]).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it("drops bytes a ref carries alongside its blob rather than duplicating the payload", async () => {
+    const ctx = createContext();
+    const bytes = new Uint8Array([9, 9, 9]);
+    const bridge = createBridge({
+      outputs: {
+        output: { type: "image", uri: "blob://img", data: bytes, format: "png" }
+      },
+      blobs: { output: bytes }
+    });
+    const executor = new PythonNodeExecutor(
+      bridge,
+      "test.ImageNode",
+      {},
+      { output: "ImageRef" },
+      []
+    );
+
+    const out = (await executor.process({}, ctx))["output"] as Record<
+      string,
+      unknown
+    >;
+
+    // Tested by value, not by field name: the payload lives at `uri` now.
+    expect(out).not.toHaveProperty("data");
+    expect(out["format"]).toBe("png");
+  });
+
+  it("still produces a typed ref with inline bytes when no storage is configured", async () => {
+    const bridge = createBridge({
+      outputs: {
+        output: { type: "video", uri: "blob://clip", duration: 3, format: "mp4" }
+      },
+      blobs: { output: new Uint8Array([1, 2]) }
+    });
+    const executor = new PythonNodeExecutor(
+      bridge,
+      "test.VideoNode",
+      {},
+      { output: "VideoRef" },
+      []
+    );
+
+    const out = (await executor.process({}))["output"] as Record<
+      string,
+      unknown
+    >;
+
+    expect(out["type"]).toBe("video");
+    expect(out["data"]).toEqual(new Uint8Array([1, 2]));
+    // The metadata survives on this branch too — the two branches were
+    // inconsistent before, which is how the bug reached both.
+    expect(out["duration"]).toBe(3);
+    expect(out["format"]).toBe("mp4");
+  });
+
+  it("passes a non-media blob through as raw bytes", async () => {
+    const ctx = createContext();
+    const bridge = createBridge({
+      outputs: {},
+      blobs: { output: new Uint8Array([5, 5]) }
+    });
+    const executor = new PythonNodeExecutor(
+      bridge,
+      "test.RawNode",
+      {},
+      { output: "bytes" },
+      []
+    );
+
+    const out = await executor.process({}, ctx);
+
+    expect(out["output"]).toEqual(new Uint8Array([5, 5]));
+    expect(ctx.storage!.store).not.toHaveBeenCalled();
+  });
+
+  it("ignores a prototype-named output rather than spreading Object.prototype", async () => {
+    const ctx = createContext();
+    const bridge = createBridge({
+      outputs: {},
+      // A computed key, so this is an OWN property — a `__proto__:` literal
+      // would set the prototype instead and test nothing.
+      blobs: { ["__proto__"]: new Uint8Array([1]) } as unknown as Record<
+        string,
+        Uint8Array
+      >
+    });
+    const executor = new PythonNodeExecutor(
+      bridge,
+      "test.EvilNode",
+      {},
+      { output: "ImageRef" },
+      []
+    );
+
+    const out = await executor.process({}, ctx);
+
+    expect(Object.hasOwn(out, "__proto__")).toBe(true);
+    expect(out["__proto__"]).toEqual(new Uint8Array([1]));
+  });
+});


### PR DESCRIPTION
## What

`materializeOutputs` now preserves the ref a blob-carried output arrived with and overwrites only the uri, and picks the storage extension from the ref's declared format.

Fixes #5188. Found by the agent fixing the Python half in nodetool-ai/nodetool-core#1010 — this is that investigation's downstream half.

## Read this first: the worker does not send the ref yet

The issue says the fields are on the wire and the host discards them. **They are not on the wire.** I checked rather than assumed, and the check changes what this PR is.

`_extract_outputs` in nodetool-core (and `_extract_named_outputs` on the streaming path) moves a `blob://`-carried ref's bytes into the frame's blobs map and `continue`s — the ref never reaches `_serialize_value` and never lands in `outputs`. nodetool-core#1010 fixed `_serialize_value`, which is why `DataframeRef` is fixed end to end: a dataframe carries no blob, so it takes the other branch.

Run against nodetool-core `main` (664bf230), a node returning a blob-backed ref through the worker context:

```
--- test.VideoNode2
  outputs: {}
  blobs: {'output': (14, b'FAKE-MP4-BYT')}
--- test.Model3DNode2
  outputs: {}
  blobs: {'output': (9, b'GLB-BYTES')}
```

`outputs` is empty. There is nothing for the host to keep.

So this change is **correct and inert**: it is a no-op against today's worker, and it becomes the fix the moment the worker emits the serialized ref alongside the blob. The companion change is one line in each of those two functions — `outputs[key] = _serialize_value(value)` before moving the bytes — and #1010 already made it safe, because `_serialize_asset_ref` strips binary payloads so the bytes cannot ride along twice. I have not written it; it belongs in the Python repo and someone should own it there.

## Why the host side is still worth fixing

The line is lossy by construction, not by accident: it discards whatever it is given and rebuilds from the type name. Landing the worker change against the current host would move the metadata onto the wire and then throw it away at the last step. This makes the host end ready, and the tests state the contract the worker half has to meet.

## What changed

- The stored-asset branch spreads the received ref and overwrites `uri` — the one field the host owns, since it points at what the host just stored, not at the worker's `blob://` pointer. `type` stays the host's normalized media kind.
- The inline-data branch does the same. The two disagreed before, which is how one line's bug reached both.
- Extension and content type follow the ref's `format` when it declares one: `format: "jpeg"` writes `.jpeg` with `image/jpeg` instead of `.png` with `image/png`. Absent or unrecognized, the per-kind default stands.
- A format is refused unless it matches `^[a-z0-9]{1,8}$`. The value is node-controlled and lands in a storage key, so `../../etc` is rejected rather than sanitized — there is no legitimate reading of it. Pinned by a test.
- A ref whose payload already travels as a blob sheds its `data`. Decided by testing the **value** for bytes, not by the field's name, so an inline non-binary payload (a dataframe's rows) survives — the same rule `_is_binary_payload` uses on the Python side, and for the same reason: matching a field name would either duplicate a megabyte payload or delete real content.
- The `result.outputs` lookup is guarded with `Object.hasOwn`, like the `outputTypes` lookup above it. Output names come from the node, and a blob named `__proto__` would otherwise read `Object.prototype` and spread its members into the output.

## Blast radius

One function, on the path from the Python bridge to the workflow graph. Against today's worker every branch produces exactly what it produced before, because there is no ref to spread and no format to read — the extension change cannot fire either, since `format` arrives only on a ref. Once the worker sends the ref, outputs gain the fields they always should have had and media files land under the right extension. Nothing else reads `python-bridge/<uuid>.<ext>` keys by shape.

## Verification

Reverting the change to the two branches turns five of the ten tests red, and leaves green exactly the ones that pin behaviour that must not change:

```
 × keeps a VideoRef's duration and format
 × keeps a Model3DRef's format, material_file and texture_files
 × stores under the extension and content type the ref declares
 × drops bytes a ref carries alongside its blob rather than duplicating the payload
 × still produces a typed ref with inline bytes when no storage is configured
AssertionError: expected undefined to be 12.5
AssertionError: expected undefined to be 'obj'
AssertionError: expected 'python-bridge/c96bad62-4d4b-43c5-ac80…' to match /\.jpeg$/
AssertionError: expected undefined to be 'png'
AssertionError: expected undefined to be 3
      Tests  5 failed | 5 passed (10)
```

The five that stayed green through the revert are the regression guards: an ImageRef travelling as a blob still gets the stored uri and no inline bytes, the fallback extension still applies, a path-traversing format is still refused, a non-media blob still passes through as raw bytes, and a prototype-named output still lands as an own key.

One trap worth naming: the prototype test first passed for the wrong reason. `{ __proto__: bytes }` in an object literal sets the prototype instead of creating an own key, so it asserted nothing about the guard. It uses a computed key now.

`npm run test:affected`, `npm run typecheck` and `npm run lint` pass.

## Also found, not fixed

`WorkerContext.model3d_from_bytes` in nodetool-core takes a `format` argument and drops it — the returned ref has `format: None`:

```
[node] model3d_from_bytes returned: {'type': 'model_3d', 'uri': 'blob://model3d_output_a5ccfeab', ..., 'format': None, 'material_file': None, 'texture_files': []}
```

So even once the ref reaches the host, a node using the canonical factory has no format to preserve unless it builds the ref itself. That is a third defect in the same chain, in the Python repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138g6jBUaPu6E7bxxYPVGb6
