### PR TITLE
test(websocket): pin the /mcp production gate

### DIFF
--- a/packages/websocket/tests/mcp-mount.test.ts
+++ b/packages/websocket/tests/mcp-mount.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  configuredMcpUrl,
+  isMcpHttpEnabled,
+  MCP_ENABLE_FLAG
+} from "../src/lib/mcp-mount.js";
+
+/**
+ * `isMcpHttpEnabled` decides whether a production deployment opens `/mcp` — a
+ * mount carrying the full agent toolbelt. `server.ts` registers the route by
+ * it and the settings UI reports it, so both readings are pinned here rather
+ * than only through the surfaces that consume them.
+ */
+describe("isMcpHttpEnabled", () => {
+  it("keeps the mount off in production when the flag is unset", () => {
+    expect(isMcpHttpEnabled({ NODETOOL_ENV: "production" })).toBe(false);
+  });
+
+  it("opens the mount in production when the flag is exactly 1", () => {
+    expect(
+      isMcpHttpEnabled({ NODETOOL_ENV: "production", NODETOOL_ENABLE_MCP: "1" })
+    ).toBe(true);
+  });
+
+  it.each(["0", "true", "yes", "", " 1"])(
+    "keeps the mount off in production for the flag value %o",
+    (value) => {
+      expect(
+        isMcpHttpEnabled({
+          NODETOOL_ENV: "production",
+          NODETOOL_ENABLE_MCP: value
+        })
+      ).toBe(false);
+    }
+  );
+
+  it("leaves development on with no flag", () => {
+    expect(isMcpHttpEnabled({ NODETOOL_ENV: "development" })).toBe(true);
+    expect(isMcpHttpEnabled({})).toBe(true);
+  });
+
+  it("names the flag the boot log and the settings UI print", () => {
+    expect(MCP_ENABLE_FLAG).toBe("NODETOOL_ENABLE_MCP");
+  });
+});
+
+describe("configuredMcpUrl", () => {
+  it("returns null with no public URL, so the client falls back to its origin", () => {
+    expect(configuredMcpUrl({})).toBeNull();
+    expect(configuredMcpUrl({ NODETOOL_PUBLIC_URL: "  " })).toBeNull();
+  });
+
+  it("appends /mcp to the configured address without doubling the slash", () => {
+    expect(configuredMcpUrl({ NODETOOL_PUBLIC_URL: "https://n.example" })).toBe(
+      "https://n.example/mcp"
+    );
+    expect(
+      configuredMcpUrl({ NODETOOL_PUBLIC_URL: "https://n.example///" })
+    ).toBe("https://n.example/mcp");
+  });
+});


### PR DESCRIPTION
## What changed

While picking up #5126 I found the issue was already implemented and merged — `NODETOOL_ENABLE_MCP` in #5139, revocable access tokens and the onboarding UI in #5140, and the reporter verified it on their instance on 2026-08-23. Nothing there needs re-doing.

What is missing is a test on the gate itself. `isMcpHttpEnabled` (`packages/websocket/src/lib/mcp-mount.ts`) is the single expression deciding whether a production deployment opens `/mcp`, a mount carrying the full agent toolbelt for whichever user it binds. It shipped with no test of its own. It is covered only sideways today: `oauth-as-routes.test.ts` asserts the OAuth AS 404s when production has no flag, and `trpc-agent-access.test.ts` asserts the settings UI reports the flag's name. Neither fails if the expression changes shape — an accidental `!==` flip, or a loosened value check, would open the surface on every production instance with both suites green.

This adds `packages/websocket/tests/mcp-mount.test.ts` pinning the three readings: unset in production keeps the mount off, exactly `1` opens it, development is unaffected. Near-miss values (`"0"`, `"true"`, `"yes"`, `" 1"`) are included because the flag opts into a network surface, so anything short of the documented value must keep it closed. `configuredMcpUrl` gets the same treatment — null with no public URL (the client then falls back to its own origin), and no doubled slash when one is configured.

Test-only. No production code changes.

## Verification

Red-then-green, proving the test is not vacuous:

- Body replaced with `return true` (mount always open): **6 of 11 fail**.

```
FAIL  tests/mcp-mount.test.ts > isMcpHttpEnabled > keeps the mount off in production when the flag is unset
FAIL  tests/mcp-mount.test.ts > isMcpHttpEnabled > keeps the mount off in production for the flag value '0'
FAIL  tests/mcp-mount.test.ts > isMcpHttpEnabled > keeps the mount off in production for the flag value 'true'
FAIL  tests/mcp-mount.test.ts > isMcpHttpEnabled > keeps the mount off in production for the flag value 'yes'
FAIL  tests/mcp-mount.test.ts > isMcpHttpEnabled > keeps the mount off in production for the flag value ''
FAIL  tests/mcp-mount.test.ts > isMcpHttpEnabled > keeps the mount off in production for the flag value ' 1'
AssertionError: expected true to be false
 Tests  6 failed | 5 passed (11)
```

- Flag branch dropped (`return env["NODETOOL_ENV"] !== "production"`): **1 of 11 fails**.

```
× opens the mount in production when the flag is exactly 1
 Tests  1 failed | 10 passed (11)
```

- Restored: `Tests 11 passed (11)`.
- Full package suite: `npm run test --workspace=packages/websocket` — **219 files / 2428 tests pass**.
- `oxlint packages/websocket/tests/mcp-mount.test.ts` — clean.

Note on the other two root checks: `npm run lint` lints `packages/*/src` and `npm run typecheck` covers web/electron/mobile, so neither has `packages/websocket/tests` in scope. The websocket vitest suite is the check that actually reaches this file, and it is green.

## What a deployment exposes when it sets the flag

Stated plainly, since the flag opens a network surface. `/mcp` is **not** a second door — it inherits the server's auth mode and sits behind the same auth hook as `/api`. The route passes `agentToolsScope` only when `req.userId` resolved; with no user it passes none and `mcp-server.ts` answers `401` at initialize rather than handing out an anonymous full-access session. A session id belongs to the user who opened it, and another user presenting it gets `404`, not `403`, so the response does not confirm the id exists. #5139 also removed `/mcp` from the static-asset auth exemption, which would otherwise have let `GET /mcp` (the SSE stream) past the hook.

So what an operator opens is: an authenticated agent, bound to one real user, holding that user's full agent toolbelt. That is a real grant — an agent that authenticates can drive workflows, read assets and enumerate the account — but it is not an unauthenticated one. This is a different posture from `NODETOOL_ENABLE_EXTENSION_BRIDGE`, whose bridge genuinely is unauthenticated and single-connection; `docs/configuration.md` already says so on that row.

## Agent capabilities

No capability is added and no capability's declared contract changes.

## New checks

One test file. No new rule, gate, or audit.

Refs #5126.