### PR TITLE
fix(examples): place the product with an edit model, not strength

### DIFF
--- a/marketing/scripts/recipe-samples.mjs
+++ b/marketing/scripts/recipe-samples.mjs
@@ -45,12 +45,12 @@ export const ROUTES = {
     grade: "upgrade",
     why: "the best text-to-image model reachable from this render. The workflow names FLUX.1 Schnell for speed and cost, which is the right default for a fan-out of throwaway thumbnails and not the right choice for one picture that has to stand on a page",
   },
-  "fal_ai:fal-ai/flux/dev": {
+  "fal_ai:fal-ai/nano-banana/edit": {
     provider: "atlascloud",
     id: "google/nano-banana-pro/edit",
     name: "Nano Banana Pro Edit",
     grade: "upgrade",
-    why: "the best image editor reachable from this render. The exact model was tried first and redrew the product: FLUX.1 Dev at the strength 0.45 the workflow sets, against a prompt describing only the scene, returned a different bottle — the one thing this step must not do",
+    why: "the same instruction-following editor one generation up, reached through the one provider with a live key on this machine — fal's is dead (403)",
   },
   "kie:gpt-image-2-text-to-image": {
     provider: "atlascloud",

--- a/marketing/scripts/recipes.mjs
+++ b/marketing/scripts/recipes.mjs
@@ -170,7 +170,7 @@ export const recipes = [
         template: "put-a-product-on-a-studio-backdrop",
         role: "Place it in a described setting",
         handoff:
-          "In: the cutout and a scene description. Out: the product in that scene. Generating around an existing product, rather than prompting for the whole frame, is what keeps the product unchanged.",
+          "In: the cutout and a scene description. Out: the product in that scene. An edit model told to change only the surroundings, rather than a strength setting on image-to-image, is what keeps the product unchanged.",
       },
       {
         template: "relight-a-product-for-a-seasonal-campaign",

--- a/marketing/src/data/recipeEntries.generated.ts
+++ b/marketing/src/data/recipeEntries.generated.ts
@@ -403,7 +403,7 @@ export const recipeEntries: RecipeEntry[] = [
         "name": "Put a Product on a Studio Backdrop",
         "route": "/templates/put-a-product-on-a-studio-backdrop",
         "role": "Place it in a described setting",
-        "handoff": "In: the cutout and a scene description. Out: the product in that scene. Generating around an existing product, rather than prompting for the whole frame, is what keeps the product unchanged.",
+        "handoff": "In: the cutout and a scene description. Out: the product in that scene. An edit model told to change only the surroundings, rather than a strength setting on image-to-image, is what keeps the product unchanged.",
         "thumbnail": "/templates/put-a-product-on-a-studio-backdrop.jpg",
         "nodeCount": 4,
         "models": [
@@ -413,7 +413,7 @@ export const recipeEntries: RecipeEntry[] = [
           },
           {
             "provider": "fal_ai",
-            "model": "fal-ai/flux/dev"
+            "model": "fal-ai/nano-banana/edit"
           }
         ]
       },

--- a/marketing/src/data/templateCatalog.generated.ts
+++ b/marketing/src/data/templateCatalog.generated.ts
@@ -355,7 +355,7 @@ export const templateCatalog: CatalogCategory[] = [
       {
         "slug": "put-a-product-on-a-studio-backdrop",
         "name": "Put a Product on a Studio Backdrop",
-        "description": "Cut the product out, then place it in a described setting. Two steps rather than one prompt, because generating around an existing product is what keeps the product itself unchanged — the thing a customer is actually buying.",
+        "description": "Cut the product out, then place it in a described setting. The placement step is an instruction-following edit model rather than strength-based image-to-image: a strength value cannot say \"keep this object, change everything else\", and any setting high enough to build the backdrop also redraws the product — the thing a customer is actually buying.",
         "tags": [
           "image"
         ]

--- a/marketing/src/data/templateEntries.generated.ts
+++ b/marketing/src/data/templateEntries.generated.ts
@@ -15231,13 +15231,13 @@ export const templateEntries: TemplateEntry[] = [
   {
     "route": "/templates/put-a-product-on-a-studio-backdrop",
     "title": "Put a Product on a Studio Backdrop — NodeTool AI Workflow Template",
-    "description": "Cut the product out, then place it in a described setting. Two steps rather than one prompt, because generating around an existing product is what keeps the product itself unchanged — the thing a customer is actually buying.",
+    "description": "Cut the product out, then place it in a described setting. The placement step is an instruction-following edit model rather than strength-based image-to-image: a strength value cannot say \"keep this object, change everything else\", and any setting high enough to build the backdrop also redraws the product — the thing a customer is actually buying.",
     "priority": 0.6,
     "changeFrequency": "monthly",
     "indexable": true,
     "slug": "put-a-product-on-a-studio-backdrop",
     "name": "Put a Product on a Studio Backdrop",
-    "summary": "Cut the product out, then place it in a described setting. Two steps rather than one prompt, because generating around an existing product is what keeps the product itself unchanged — the thing a customer is actually buying.",
+    "summary": "Cut the product out, then place it in a described setting. The placement step is an instruction-following edit model rather than strength-based image-to-image: a strength value cannot say \"keep this object, change everything else\", and any setting high enough to build the backdrop also redraws the product — the thing a customer is actually buying.",
     "tags": [
       "image",
       "example"
@@ -15293,7 +15293,7 @@ export const templateEntries: TemplateEntry[] = [
           "x": 660,
           "y": 120,
           "width": 300,
-          "subtitle": "product centred on a warm concrete plinth, soft studio light, shallow depth of field"
+          "subtitle": "Keep the product as it is. Change only what is around it: warm concrete plinth, soft studio key from upper left, blurred background."
         },
         {
           "id": "out",

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Put a Product on a Studio Backdrop.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Put a Product on a Studio Backdrop.json
@@ -5,7 +5,7 @@
   "updated_at": "2026-07-30T16:00:00.000Z",
   "name": "Put a Product on a Studio Backdrop",
   "tool_name": null,
-  "description": "Cut the product out, then place it in a described setting. Two steps rather than one prompt, because generating around an existing product is what keeps the product itself unchanged \u2014 the thing a customer is actually buying.",
+  "description": "Cut the product out, then place it in a described setting. The placement step is an instruction-following edit model rather than strength-based image-to-image: a strength value cannot say \"keep this object, change everything else\", and any setting high enough to build the backdrop also redraws the product \u2014 the thing a customer is actually buying.",
   "tags": [
     "image",
     "example"
@@ -68,16 +68,15 @@
           "model": {
             "type": "image_model",
             "provider": "fal_ai",
-            "id": "fal-ai/flux/dev",
-            "name": "FLUX.1 Dev",
+            "id": "fal-ai/nano-banana/edit",
+            "name": "Nano Banana Edit",
             "path": null,
             "supported_tasks": []
           },
           "image": [],
-          "prompt": "product centred on a warm concrete plinth, soft studio light, shallow depth of field",
+          "prompt": "Keep the product as it is. Change only what is around it: warm concrete plinth, soft studio key from upper left, blurred background.",
           "negative_prompt": "",
           "entities": [],
-          "strength": 0.45,
           "aspect_ratio": "1:1",
           "resolution": "1K"
         },


### PR DESCRIPTION
Fixes #5192.

The placement step composited with nodetool.image.ImageToImage at strength 0.45 against a prompt describing only the scene, so the sampler was free to redraw the product. It now uses fal-ai/nano-banana/edit, the instruction-following editor that Edit a Still with Words already ships, with a prompt that names what must not change. strength is dropped: the endpoint has no such input, and 0.45 was not one of the node's offered values.

Marketing data derived from the graph moves with it: template description, node subtitle, the recipe step's model list and handoff line, plus a ROUTES entry for the new model.

Not done: recipe-samples.manifest.json still records the render that produced the live sample, which ran the old graph. It regenerates on the next render, which needs provider keys. npm and node could not run in the session that wrote this, so validate:examples, typecheck and lint were not run locally; CI covers them.

Generated with [Claude Code](https://claude.ai/code)