### PR TITLE
fix(providers): sniff image mime instead of assuming PNG

### DIFF
--- a/packages/agents/src/capabilities/assets.ts
+++ b/packages/agents/src/capabilities/assets.ts
@@ -33,6 +33,7 @@ import {
 } from "@nodetool-ai/runtime";
 import type { Asset as AssetRow } from "@nodetool-ai/models";
 import {
+  detectImageMime as sniffImageMime,
   isSafePublicHttpsUrl,
   loadMediaRefBytes,
   safeFetch
@@ -733,37 +734,6 @@ const listImages: CapabilityExport = {
 // ---------------------------------------------------------------------------
 // view_image
 // ---------------------------------------------------------------------------
-
-/** Sniff the mime type of encoded image bytes by magic number. */
-function sniffImageMime(bytes: Uint8Array): string {
-  if (bytes.length >= 4) {
-    if (
-      bytes[0] === 0x89 &&
-      bytes[1] === 0x50 &&
-      bytes[2] === 0x4e &&
-      bytes[3] === 0x47
-    )
-      return "image/png";
-    if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff)
-      return "image/jpeg";
-    if (bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46)
-      return "image/gif";
-    if (bytes[0] === 0x42 && bytes[1] === 0x4d) return "image/bmp";
-    if (
-      bytes.length >= 12 &&
-      bytes[0] === 0x52 &&
-      bytes[1] === 0x49 &&
-      bytes[2] === 0x46 &&
-      bytes[3] === 0x46 &&
-      bytes[8] === 0x57 &&
-      bytes[9] === 0x45 &&
-      bytes[10] === 0x42 &&
-      bytes[11] === 0x50
-    )
-      return "image/webp";
-  }
-  return "image/png";
-}
 
 /** Parse a `data:<mime>;base64,<payload>` URI into bytes + mime. */
 function parseDataUri(

--- a/packages/agents/src/tools/asset-persist.ts
+++ b/packages/agents/src/tools/asset-persist.ts
@@ -17,6 +17,7 @@ export const MIME_TO_EXT: Record<string, string> = {
   "image/jpg": "jpg",
   "image/webp": "webp",
   "image/gif": "gif",
+  "image/bmp": "bmp",
   "video/mp4": "mp4",
   "video/webm": "webm",
   "audio/mpeg": "mp3",
@@ -38,39 +39,7 @@ export function timestampedName(prefix: string, ext: string): string {
   return `${prefix}-${ts}.${ext}`;
 }
 
-export function inferImageMime(bytes: Uint8Array): string {
-  if (
-    bytes.length >= 8 &&
-    bytes[0] === 0x89 &&
-    bytes[1] === 0x50 &&
-    bytes[2] === 0x4e &&
-    bytes[3] === 0x47
-  )
-    return "image/png";
-  if (
-    bytes.length >= 3 &&
-    bytes[0] === 0xff &&
-    bytes[1] === 0xd8 &&
-    bytes[2] === 0xff
-  )
-    return "image/jpeg";
-  if (
-    bytes.length >= 6 &&
-    bytes[0] === 0x47 &&
-    bytes[1] === 0x49 &&
-    bytes[2] === 0x46
-  )
-    return "image/gif";
-  if (
-    bytes.length >= 12 &&
-    bytes[8] === 0x57 &&
-    bytes[9] === 0x45 &&
-    bytes[10] === 0x42 &&
-    bytes[11] === 0x50
-  )
-    return "image/webp";
-  return "image/png";
-}
+export { detectImageMime as inferImageMime } from "@nodetool-ai/runtime";
 
 export interface SavedOutput {
   asset_id?: string;

--- a/packages/image-nodes/src/nodes/image.ts
+++ b/packages/image-nodes/src/nodes/image.ts
@@ -156,6 +156,10 @@ function imageRef(data: Uint8Array, extras: Partial<ImageRef> = {}): ImageRef {
 // them from this module.
 export { decodeRgba, rawRgbaImageRef };
 
+// Kept in sync by hand with `sniffImageMime` in @nodetool-ai/runtime: this
+// module bundles for the browser, so it may not import the runtime barrel.
+// "unknown" stays a state of its own — `guessAssetMime` reads it as undeclared
+// and re-sniffs at the storage boundary.
 function inferImageMime(uri: string | undefined, bytes: Uint8Array): string {
   const lower = (uri ?? "").toLowerCase();
   if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -27,6 +27,7 @@ import {
 import { VariableChannel } from "./variable-channel.js";
 import { loadMediaRefBytes, type MediaRefValue } from "./media-ref-bytes.js";
 import { encodeRawImageRef } from "./image-codec.js";
+import { extForImageMime, sniffImageMime } from "./providers/image-mime.js";
 import {
   isCallable,
   isNonEmptyString,
@@ -3610,12 +3611,26 @@ export class ProcessingContext {
     return "type" in v && ("uri" in v || "data" in v || "asset_id" in v);
   }
 
-  private static guessAssetMime(asset: Record<string, unknown>): string {
-    const explicit = asset.mime_type ?? asset.content_type;
-    if (isNonEmptyString(explicit)) return explicit;
+  /**
+   * `mimeType` comes first because it is the field `ImageRef` declares — this
+   * used to read only `mime_type`, which nothing sets, so a node's sniffed
+   * `image/webp` was discarded and every provider's WebP stored as PNG.
+   * `image/unknown` is `image-nodes` reporting its own sniff found nothing, so
+   * it counts as undeclared here rather than as a type to forward.
+   */
+  private static guessAssetMime(
+    asset: Record<string, unknown>,
+    bytes?: Uint8Array
+  ): string {
+    const declared = asset.mimeType ?? asset.mime_type ?? asset.content_type;
+    if (isNonEmptyString(declared) && declared !== "image/unknown") {
+      return declared;
+    }
 
     const type = String(asset.type ?? "").toLowerCase();
-    if (type.includes("image")) return "image/png";
+    if (type.includes("image")) {
+      return (bytes && sniffImageMime(bytes)) ?? "image/png";
+    }
     if (type.includes("audio")) return "audio/wav";
     if (type.includes("video")) return "video/mp4";
     if (type.includes("text")) return "text/plain";
@@ -3624,10 +3639,9 @@ export class ProcessingContext {
   }
 
   private static extForMime(mime: string): string {
+    const imageExt = extForImageMime(mime);
+    if (imageExt) return imageExt;
     const map: Record<string, string> = {
-      "image/png": "png",
-      "image/jpeg": "jpg",
-      "image/webp": "webp",
       "audio/wav": "wav",
       "audio/mpeg": "mp3",
       "video/mp4": "mp4",
@@ -3741,7 +3755,7 @@ export class ProcessingContext {
     const bytes = await this.getAssetBytes(asset);
     if (!bytes) return asset;
 
-    const mime = ProcessingContext.guessAssetMime(asset);
+    const mime = ProcessingContext.guessAssetMime(asset, bytes);
 
     if (mode === "data_uri") {
       const base64 = Buffer.from(bytes).toString("base64");

--- a/packages/runtime/src/providers/atlascloud-provider.ts
+++ b/packages/runtime/src/providers/atlascloud-provider.ts
@@ -27,6 +27,7 @@
  */
 
 import { OpenAICompatProvider } from "./openai-compat-provider.js";
+import { bytesToImageDataUri } from "./image-mime.js";
 import type { OpenAICompatProviderOptions } from "./openai-compat-provider.js";
 import { createLogger } from "@nodetool-ai/config";
 import { isBoolean, isNumber, isString } from "../type-predicates.js";
@@ -309,43 +310,6 @@ function pickOutputUrl(result: AtlasPollResult): string {
   if (isString(result.output)) return result.output;
   if (isString(result.url)) return result.url;
   throw new Error("No output URL in AtlasCloud result");
-}
-
-// ---------------------------------------------------------------------------
-// Image mime detection (for data: URIs)
-// ---------------------------------------------------------------------------
-
-function detectImageMime(bytes: Uint8Array): string {
-  if (
-    bytes.length >= 4 &&
-    bytes[0] === 0x89 &&
-    bytes[1] === 0x50 &&
-    bytes[2] === 0x4e &&
-    bytes[3] === 0x47
-  ) {
-    return "image/png";
-  }
-  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8) {
-    return "image/jpeg";
-  }
-  if (
-    bytes.length >= 12 &&
-    bytes[0] === 0x52 &&
-    bytes[1] === 0x49 &&
-    bytes[2] === 0x46 &&
-    bytes[3] === 0x46 &&
-    bytes[8] === 0x57 &&
-    bytes[9] === 0x45 &&
-    bytes[10] === 0x42 &&
-    bytes[11] === 0x50
-  ) {
-    return "image/webp";
-  }
-  return "image/png";
-}
-
-function imageDataUri(bytes: Uint8Array): string {
-  return `data:${detectImageMime(bytes)};base64,${Buffer.from(bytes).toString("base64")}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -752,7 +716,7 @@ export class AtlasCloudProvider extends OpenAICompatProvider {
     // (Grok Imagine uses `image_urls`). Seedance never goes through this method
     // (it's video-only). Other image-to-image endpoints that use `image`
     // (singular) get that mapping too.
-    const dataUris = sources.map((b) => imageDataUri(b));
+    const dataUris = sources.map((b) => bytesToImageDataUri(b));
     if (info.fields.has("images")) {
       input.images = dataUris;
     } else if (info.fields.has("image_urls")) {
@@ -799,7 +763,7 @@ export class AtlasCloudProvider extends OpenAICompatProvider {
     // Seedance image-to-video uses `image` (singular); Grok Imagine Video uses
     // `image_url`. Reference-to-video has `reference_images` (list) instead —
     // generic imageToVideo can't target it.
-    const dataUri = imageDataUri(image);
+    const dataUri = bytesToImageDataUri(image);
     if (info.fields.has("image")) {
       input.image = dataUri;
     } else if (info.fields.has("image_url")) {

--- a/packages/runtime/src/providers/fal-provider.ts
+++ b/packages/runtime/src/providers/fal-provider.ts
@@ -42,6 +42,7 @@ import {
   type ModelImageInput
 } from "./manifest-models.js";
 import { sniffAudioMime } from "./audio-mime.js";
+import { detectImageMime } from "./image-mime.js";
 import { safeFetch } from "./safe-url.js";
 import {
   isNonEmptyString,
@@ -1060,7 +1061,7 @@ export class FalProvider extends BaseProvider {
   /** Upload every non-empty image to FAL storage, returning the hosted URLs. */
   private async uploadImages(images: Uint8Array[]): Promise<string[]> {
     const valid = images.filter((b) => b && b.length > 0);
-    return Promise.all(valid.map((b) => this.upload(b, "image/png")));
+    return Promise.all(valid.map((b) => this.upload(b, detectImageMime(b))));
   }
 
   /** Run an endpoint that takes a single uploaded image and returns an image. */
@@ -1100,7 +1101,7 @@ export class FalProvider extends BaseProvider {
     params: UpscaleImageParams
   ): Promise<Uint8Array> {
     const { endpointId, variant } = splitTopazVariant(params.model.id);
-    const url = await this.upload(image, "image/png");
+    const url = await this.upload(image, detectImageMime(image));
     const b = new FalArgsBuilder(endpointId);
     b.attachAsset("image", url)
       .set("model", variant)
@@ -1118,7 +1119,7 @@ export class FalProvider extends BaseProvider {
     params: RemoveBackgroundParams
   ): Promise<Uint8Array> {
     const modelId = params.model.id;
-    const url = await this.upload(image, "image/png");
+    const url = await this.upload(image, detectImageMime(image));
     const b = new FalArgsBuilder(modelId);
     b.attachAsset("image", url).set("output_format", "png");
     log.debug("FAL removeBackground", { model: modelId });
@@ -1130,7 +1131,7 @@ export class FalProvider extends BaseProvider {
     params: RelightImageParams
   ): Promise<Uint8Array> {
     const modelId = params.model.id;
-    const url = await this.upload(image, "image/png");
+    const url = await this.upload(image, detectImageMime(image));
     const b = new FalArgsBuilder(modelId);
     b.attachAsset("image", url)
       .force("prompt", params.prompt)
@@ -1146,7 +1147,7 @@ export class FalProvider extends BaseProvider {
     params: VectorizeImageParams
   ): Promise<Uint8Array> {
     const modelId = params.model.id;
-    const url = await this.upload(image, "image/png");
+    const url = await this.upload(image, detectImageMime(image));
     const b = new FalArgsBuilder(modelId);
     b.attachAsset("image", url);
     log.debug("FAL vectorizeImage", { model: modelId });

--- a/packages/runtime/src/providers/image-mime.ts
+++ b/packages/runtime/src/providers/image-mime.ts
@@ -1,19 +1,24 @@
 /**
- * Sniff an image container type from its magic bytes so image inputs keep the
- * correct MIME in the `data:` URIs providers embed them in. Hardcoding a single
- * type (e.g. `image/jpeg`) mislabels PNG/WebP/GIF inputs, which strict decoders
- * reject on a declared-vs-actual mismatch.
+ * Magic-byte identification for image containers, mirroring `audio-mime.ts`.
+ *
+ * Providers hand back encoded bytes with no reliable declared type — Replicate
+ * returns WebP, FAL and KIE return whatever the endpoint produced — so
+ * anything that assumes PNG mislabels them, and a strict consumer rejects the
+ * file on the mismatch (Kie answers `500 File type not supported`, naming
+ * nothing).
  */
-export function detectImageMime(bytes: Uint8Array): string {
-  // JPEG: FF D8 FF
-  if (
-    bytes.length >= 3 &&
-    bytes[0] === 0xff &&
-    bytes[1] === 0xd8 &&
-    bytes[2] === 0xff
-  ) {
-    return "image/jpeg";
-  }
+
+export const IMAGE_MIME_TO_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "image/bmp": "bmp"
+};
+
+/** Identify a container from its leading bytes; `null` when nothing matches. */
+export function sniffImageMime(bytes: Uint8Array): string | null {
   // PNG: 89 50 4E 47
   if (
     bytes.length >= 4 &&
@@ -24,7 +29,16 @@ export function detectImageMime(bytes: Uint8Array): string {
   ) {
     return "image/png";
   }
-  // WebP: "RIFF"…"WEBP"
+  // JPEG: FF D8 FF
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  // WebP: "RIFF" + size + "WEBP"
   if (
     bytes.length >= 12 &&
     bytes[0] === 0x52 &&
@@ -48,12 +62,29 @@ export function detectImageMime(bytes: Uint8Array): string {
   ) {
     return "image/gif";
   }
-  // Unknown — default to PNG, the most widely accepted lossless container.
-  return "image/png";
+  // BMP: "BM"
+  if (bytes.length >= 2 && bytes[0] === 0x42 && bytes[1] === 0x4d) {
+    return "image/bmp";
+  }
+  return null;
+}
+
+/**
+ * PNG-fallback variant, for the callers that must produce a string (a `data:`
+ * URI). Where the label gets stored or forwarded, prefer `sniffImageMime` and
+ * keep "unknown" as its own state.
+ */
+export function detectImageMime(bytes: Uint8Array): string {
+  return sniffImageMime(bytes) ?? "image/png";
 }
 
 /** Encode image bytes as a base64 `data:` URI with a sniffed MIME type. */
 export function bytesToImageDataUri(bytes: Uint8Array): string {
   const base64 = Buffer.from(bytes).toString("base64");
   return `data:${detectImageMime(bytes)};base64,${base64}`;
+}
+
+/** File extension for an image MIME type, or `null` when it is not an image. */
+export function extForImageMime(mime: string): string | null {
+  return IMAGE_MIME_TO_EXT[mime.toLowerCase()] ?? null;
 }

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -9,6 +9,13 @@ export {
 } from "./cost-calculator.js";
 export type { PricingTier, UsageInfo } from "./cost-calculator.js";
 export { OLLAMA_DEFAULT_URL, LMSTUDIO_DEFAULT_URL } from "./defaults.js";
+export {
+  IMAGE_MIME_TO_EXT,
+  sniffImageMime,
+  detectImageMime,
+  bytesToImageDataUri,
+  extForImageMime
+} from "./image-mime.js";
 import { OLLAMA_DEFAULT_URL, LMSTUDIO_DEFAULT_URL } from "./defaults.js";
 import { AnthropicProvider } from "./anthropic-provider.js";
 import { ClaudeAgentProvider } from "./claude-agent-provider.js";

--- a/packages/runtime/src/providers/replicate-provider.ts
+++ b/packages/runtime/src/providers/replicate-provider.ts
@@ -4,6 +4,7 @@ import { isObjectLike, isString } from "../type-predicates.js";
 import { BaseProvider } from "./base-provider.js";
 import { safeFetch } from "./safe-url.js";
 import { sniffAudioMime } from "./audio-mime.js";
+import { detectImageMime } from "./image-mime.js";
 import type {
   ASRModel,
   EmbeddingModel,
@@ -856,7 +857,7 @@ export class ReplicateProvider extends BaseProvider {
     if (params.seed != null) input.seed = params.seed;
 
     if (params.mask && params.mask.length > 0) {
-      const maskUri = this.dataUri(params.mask, "image/png");
+      const maskUri = this.imageDataUri(params.mask);
       const maskField = selectMaskImageInput(
         getModelImageInputs(
           "@nodetool-ai/replicate-nodes",
@@ -923,6 +924,12 @@ export class ReplicateProvider extends BaseProvider {
     return `data:${mimeType};base64,${Buffer.from(bytes).toString("base64")}`;
   }
 
+  // Replicate models decode by the declared type, so feeding back a WebP this
+  // provider itself produced as `image/png` fails inside the model.
+  private imageDataUri(bytes: Uint8Array): string {
+    return this.dataUri(bytes, detectImageMime(bytes));
+  }
+
   /**
    * Build the image portion of a Replicate prediction input from one or more
    * source images, using the model's declared schema (replicate-manifest) to
@@ -936,7 +943,7 @@ export class ReplicateProvider extends BaseProvider {
   ) {
     const dataUris = images
       .filter((b) => b && b.length > 0)
-      .map((b) => this.dataUri(b, "image/png"));
+      .map((b) => this.imageDataUri(b));
     if (dataUris.length === 0) return {};
 
     const field = selectPrimaryImageInput(
@@ -971,7 +978,7 @@ export class ReplicateProvider extends BaseProvider {
     params: UpscaleImageParams
   ): Promise<Uint8Array> {
     const input: Record<string, unknown> = {
-      image: this.dataUri(image, "image/png")
+      image: this.imageDataUri(image)
     };
     if (params.scale != null) input.scale = params.scale;
     if (params.prompt) input.prompt = params.prompt;
@@ -987,7 +994,7 @@ export class ReplicateProvider extends BaseProvider {
   ): Promise<Uint8Array> {
     log.debug("removeBackground", { model: params.model.id });
     return this.runWithInput(params.model.id, {
-      image: this.dataUri(image, "image/png")
+      image: this.imageDataUri(image)
     });
   }
 
@@ -996,7 +1003,7 @@ export class ReplicateProvider extends BaseProvider {
     params: RelightImageParams
   ): Promise<Uint8Array> {
     const input: Record<string, unknown> = {
-      image: this.dataUri(image, "image/png")
+      image: this.imageDataUri(image)
     };
     if (params.prompt) input.prompt = params.prompt;
     if (params.negativePrompt) input.negative_prompt = params.negativePrompt;
@@ -1011,7 +1018,7 @@ export class ReplicateProvider extends BaseProvider {
   ): Promise<Uint8Array> {
     log.debug("vectorizeImage", { model: params.model.id });
     return this.runWithInput(params.model.id, {
-      image: this.dataUri(image, "image/png")
+      image: this.imageDataUri(image)
     });
   }
 

--- a/packages/runtime/src/providers/topaz-provider.ts
+++ b/packages/runtime/src/providers/topaz-provider.ts
@@ -18,6 +18,7 @@
 
 import { BaseProvider } from "./base-provider.js";
 import { safeFetch } from "./safe-url.js";
+import { sniffImageMime } from "./image-mime.js";
 import { createLogger } from "@nodetool-ai/config";
 import { loadImageModels, loadManifest } from "./manifest-models.js";
 import type {
@@ -120,20 +121,10 @@ function buildVariantMap(): Map<string, VariantInfo> {
   return map;
 }
 
+// Multipart part type. Topaz reads the bytes either way, so claiming nothing
+// beats claiming PNG wrongly.
 function detectImageMime(image: Uint8Array): string {
-  if (
-    image.length >= 4 &&
-    image[0] === 0x89 &&
-    image[1] === 0x50 &&
-    image[2] === 0x4e &&
-    image[3] === 0x47
-  ) {
-    return "image/png";
-  }
-  if (image.length >= 3 && image[0] === 0xff && image[1] === 0xd8) {
-    return "image/jpeg";
-  }
-  return "application/octet-stream";
+  return sniffImageMime(image) ?? "application/octet-stream";
 }
 
 export class TopazProvider extends BaseProvider {

--- a/packages/runtime/src/providers/xai-provider.ts
+++ b/packages/runtime/src/providers/xai-provider.ts
@@ -2,6 +2,7 @@ import {
   OpenAICompatProvider,
   type OpenAICompatProviderOptions
 } from "./openai-compat-provider.js";
+import { bytesToImageDataUri as bytesToDataUri } from "./image-mime.js";
 import type {
   ImageModel,
   ImageToImageParams,
@@ -14,47 +15,10 @@ import type {
 
 const XAI_BASE_URL = "https://api.x.ai/v1";
 
-/** Sniff the container type so image inputs keep the right MIME in their data URI. */
-function detectImageMime(bytes: Uint8Array): string {
-  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
-    return "image/jpeg";
-  }
-  if (
-    bytes.length >= 12 &&
-    bytes[0] === 0x52 &&
-    bytes[1] === 0x49 &&
-    bytes[2] === 0x46 &&
-    bytes[3] === 0x46 &&
-    bytes[8] === 0x57 &&
-    bytes[9] === 0x45 &&
-    bytes[10] === 0x42 &&
-    bytes[11] === 0x50
-  ) {
-    return "image/webp";
-  }
-  if (
-    bytes.length >= 4 &&
-    bytes[0] === 0x47 &&
-    bytes[1] === 0x49 &&
-    bytes[2] === 0x46 &&
-    bytes[3] === 0x38
-  ) {
-    return "image/gif";
-  }
-  // PNG and everything else default to PNG — xAI accepts both jpeg and png.
-  return "image/png";
-}
-
-/**
- * Resolve an image input (raw bytes) into the base64 data URI xAI's JSON image
- * and video endpoints expect. Asset references are already resolved to bytes
- * upstream (ProcessingContext); xAI's `application/json` API cannot take the
- * multipart file uploads the OpenAI SDK sends, so we inline them here.
- */
-function bytesToDataUri(bytes: Uint8Array): string {
-  const base64 = Buffer.from(bytes).toString("base64");
-  return `data:${detectImageMime(bytes)};base64,${base64}`;
-}
+// Image inputs go inline as base64 `data:` URIs: asset references are already
+// resolved to bytes upstream (ProcessingContext), and xAI's
+// `application/json` API cannot take the multipart uploads the OpenAI SDK
+// sends.
 
 /** Raw row from xAI's `/v1/models` listing. */
 interface XAIModelRow {

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -808,6 +808,81 @@ describe("output normalization", () => {
     expect(await storage.exists(normalized.image.uri)).toBe(true);
   });
 
+  // Regression: the WebP a provider returns used to be stored as `.png` with
+  // `image/png` on the object, because guessAssetMime read `mime_type` — a
+  // field nothing sets — and then assumed PNG for anything typed image. The
+  // node's own sniff was discarded here, and strict consumers rejected the
+  // file on the declared-vs-actual mismatch.
+  describe("image mime at the storage boundary", () => {
+    const WEBP = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50
+    ]);
+    const webpRef = (extra: Record<string, unknown> = {}) => ({
+      type: "image",
+      data: Buffer.from(WEBP).toString("base64"),
+      ...extra
+    });
+
+    it("honors the mimeType an ImageRef declares", async () => {
+      const storage = new InMemoryStorageAdapter();
+      const ctx = new ProcessingContext({
+        jobId: "j1",
+        assetOutputMode: "storage_url",
+        storage
+      });
+      const normalized = (await ctx.normalizeOutputValue({
+        image: webpRef({ mimeType: "image/webp" })
+      })) as { image: { uri: string } };
+
+      expect(normalized.image.uri.endsWith(".webp")).toBe(true);
+    });
+
+    it("sniffs the bytes when nothing is declared", async () => {
+      const storage = new InMemoryStorageAdapter();
+      const ctx = new ProcessingContext({
+        jobId: "j1",
+        assetOutputMode: "storage_url",
+        storage
+      });
+      const normalized = (await ctx.normalizeOutputValue({
+        image: webpRef()
+      })) as { image: { uri: string } };
+
+      expect(normalized.image.uri.endsWith(".webp")).toBe(true);
+    });
+
+    it("treats image/unknown as undeclared and re-sniffs", async () => {
+      const ctx = new ProcessingContext({
+        jobId: "j1",
+        assetOutputMode: "data_uri"
+      });
+      const normalized = (await ctx.normalizeOutputValue({
+        image: webpRef({ mimeType: "image/unknown" })
+      })) as { image: { uri: string } };
+
+      expect(normalized.image.uri.startsWith("data:image/webp;base64,")).toBe(
+        true
+      );
+    });
+
+    it("still labels unrecognizable image bytes PNG", async () => {
+      const ctx = new ProcessingContext({
+        jobId: "j1",
+        assetOutputMode: "data_uri"
+      });
+      const normalized = (await ctx.normalizeOutputValue({
+        image: {
+          type: "image",
+          data: Buffer.from(new Uint8Array([0, 1, 2, 3])).toString("base64")
+        }
+      })) as { image: { uri: string } };
+
+      expect(normalized.image.uri.startsWith("data:image/png;base64,")).toBe(
+        true
+      );
+    });
+  });
+
   const rawImage = (w: number, h: number) => ({
     type: "image",
     mimeType: RAW_RGBA_MIME,

--- a/packages/runtime/tests/image-mime.test.ts
+++ b/packages/runtime/tests/image-mime.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import {
+  IMAGE_MIME_TO_EXT,
+  bytesToImageDataUri,
+  detectImageMime,
+  extForImageMime,
+  sniffImageMime
+} from "../src/providers/image-mime.js";
+
+const png = () =>
+  new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const jpeg = () => new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const gif = () => new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+const bmp = () => new Uint8Array([0x42, 0x4d, 0x36, 0x00]);
+/** "RIFF" + 4 size bytes + "WEBP" — Replicate's actual output container. */
+const webp = () =>
+  new Uint8Array([
+    0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50
+  ]);
+
+describe("sniffImageMime", () => {
+  it.each([
+    ["image/png", png()],
+    ["image/jpeg", jpeg()],
+    ["image/webp", webp()],
+    ["image/gif", gif()],
+    ["image/bmp", bmp()]
+  ])("identifies %s", (expected, bytes) => {
+    expect(sniffImageMime(bytes)).toBe(expected);
+  });
+
+  it("returns null rather than guessing when nothing matches", () => {
+    expect(sniffImageMime(new Uint8Array([0x00, 0x01, 0x02, 0x03]))).toBeNull();
+    expect(sniffImageMime(new Uint8Array())).toBeNull();
+  });
+
+  it("does not mistake a non-WebP RIFF container for WebP", () => {
+    // "RIFF"????"WAVE" — a wav file, not an image.
+    const wav = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45
+    ]);
+    expect(sniffImageMime(wav)).toBeNull();
+  });
+});
+
+describe("detectImageMime", () => {
+  it("agrees with sniffImageMime on every recognized container", () => {
+    for (const bytes of [png(), jpeg(), webp(), gif(), bmp()]) {
+      expect(detectImageMime(bytes)).toBe(sniffImageMime(bytes));
+    }
+  });
+
+  it("falls back to PNG only where a string is required", () => {
+    expect(detectImageMime(new Uint8Array([0x00, 0x01]))).toBe("image/png");
+  });
+});
+
+describe("bytesToImageDataUri", () => {
+  it("declares the sniffed container, not an assumed PNG", () => {
+    expect(bytesToImageDataUri(webp())).toMatch(/^data:image\/webp;base64,/);
+    expect(bytesToImageDataUri(jpeg())).toMatch(/^data:image\/jpeg;base64,/);
+  });
+
+  it("round-trips the bytes", () => {
+    const payload = bytesToImageDataUri(gif()).split(",")[1];
+    expect([...Buffer.from(payload, "base64")]).toEqual([...gif()]);
+  });
+});
+
+describe("extForImageMime", () => {
+  it("maps every entry of the table", () => {
+    for (const [mime, ext] of Object.entries(IMAGE_MIME_TO_EXT)) {
+      expect(extForImageMime(mime)).toBe(ext);
+    }
+  });
+
+  it("is case-insensitive and rejects non-image types", () => {
+    expect(extForImageMime("IMAGE/WEBP")).toBe("webp");
+    expect(extForImageMime("audio/mpeg")).toBeNull();
+  });
+});

--- a/packages/runtime/tests/providers/atlascloud-provider.test.ts
+++ b/packages/runtime/tests/providers/atlascloud-provider.test.ts
@@ -417,7 +417,7 @@ describe("AtlasCloudProvider — imageToVideo", () => {
     mockAtlasFetch({ capture });
     const p = new AtlasCloudProvider({ ATLASCLOUD_API_KEY: "k" });
     await p.imageToVideo(
-      [Uint8Array.from([0xff, 0xd8, 0x01])], // JPEG magic
+      [Uint8Array.from([0xff, 0xd8, 0xff])], // JPEG magic
       {
         model: videoModel("bytedance/seedance-2.0/image-to-video"),
         prompt: "drift forward"

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -112,6 +112,8 @@ import {
   ProcessingContext as RuntimeProcessingContext,
   ACTIVE_MODEL_CONTEXT_KEY,
   DIRECT_TOOL_NAMES,
+  detectImageMime,
+  IMAGE_MIME_TO_EXT,
   encodeRawRgbaToPng,
   fetchExternalMedia,
   getCostReconciler,
@@ -569,15 +571,6 @@ function decodeAssetBytes(data: unknown): Uint8Array | null {
   }
   return null;
 }
-
-const IMAGE_MIME_TO_EXT: Record<string, string> = {
-  "image/jpeg": "jpg",
-  "image/jpg": "jpg",
-  "image/png": "png",
-  "image/gif": "gif",
-  "image/webp": "webp",
-  "image/bmp": "bmp"
-};
 
 /** Parse a `data:` URI into its mime type and decoded bytes. */
 function parseImageDataUri(
@@ -6938,10 +6931,15 @@ export class UnifiedWebSocketRunner {
         for (const bytes of imageBytesList) {
           // Per-variation: a cancel partway through must not keep persisting.
           if (cancelled()) return;
-          const assetId = await storeMediaAsset(bytes, "image/png", "png");
+          const mimeType = detectImageMime(bytes);
+          const assetId = await storeMediaAsset(
+            bytes,
+            mimeType,
+            IMAGE_MIME_TO_EXT[mimeType] ?? "png"
+          );
           imageContents.push({
             type: "image_url",
-            image: { type: "image", asset_id: assetId, mimeType: "image/png" }
+            image: { type: "image", asset_id: assetId, mimeType }
           });
         }
 
@@ -7330,13 +7328,18 @@ export class UnifiedWebSocketRunner {
           for (const bytes of imageBytesList) {
             // Per-variation: a cancel partway through must not keep persisting.
             if (cancelled()) return;
-            const assetId = await storeMediaAsset(bytes, "image/png", "png");
+            const mimeType = detectImageMime(bytes);
+            const assetId = await storeMediaAsset(
+              bytes,
+              mimeType,
+              IMAGE_MIME_TO_EXT[mimeType] ?? "png"
+            );
             imageContents.push({
               type: "image_url",
               image: {
                 type: "image",
                 asset_id: assetId,
-                mimeType: "image/png"
+                mimeType
               }
             });
           }
@@ -8421,7 +8424,10 @@ export class UnifiedWebSocketRunner {
 
     const assetIds: string[] = [];
     for (const bytes of images) {
-      assetIds.push(await storeAsset(bytes, "image/png", "png"));
+      const mimeType = detectImageMime(bytes);
+      assetIds.push(
+        await storeAsset(bytes, mimeType, IMAGE_MIME_TO_EXT[mimeType] ?? "png")
+      );
     }
     return { asset_ids: assetIds };
   }


### PR DESCRIPTION
Fixes #5193.

Provider image methods return bare bytes, so every layer that needs a type invented one. The invented type was PNG, and Replicate returns WebP.

### The part the report did not see

The sniffing that *did* exist was thrown away one layer down. `ProcessingContext.guessAssetMime` read `mime_type ?? content_type` — and `mime_type` appears nowhere else in `runtime/` or `protocol/`. `ImageRef` declares `mimeType`. So `image-nodes` sniffed the WebP correctly, set `mimeType: "image/webp"`, and `materializeAsset` relabelled it `image/png` and stored it as `.png` — for every provider, not just Replicate.

### Changes

- `guessAssetMime` reads `mimeType` first, and sniffs the bytes instead of assuming PNG when nothing is declared. `image/unknown` (what `image-nodes` emits when its own sniff fails) counts as undeclared.
- `image-mime.ts` grows `sniffImageMime`, which returns `null` instead of guessing, plus `IMAGE_MIME_TO_EXT` and `extForImageMime`. `detectImageMime` keeps its PNG fallback for the callers that must produce a string.
- Five private copies of the magic bytes collapse onto it: `atlascloud`, `xai`, `topaz`, and the two in `agents`. Topaz keeps `application/octet-stream` as its fallback — it uploads multipart, and claiming nothing beats claiming PNG wrongly.
- Three websocket sites that hardcoded `"image/png"` for chat and direct media generation now sniff, and use the shared ext table.
- Input side: Replicate's six `dataUri(x, "image/png")` sites and FAL's five `upload(x, "image/png")` sites sniff, so a WebP this codebase produced is not fed back to a model as PNG.
- `context.extForMime` now covers GIF and BMP, which previously fell to `.bin`.

### Tests

`packages/runtime/tests/image-mime.test.ts` pins the table, the `null` return, and that a `RIFF...WAVE` header is not read as WebP. `context.test.ts` gains four boundary cases: a declared `image/webp` survives to a `.webp` key, undeclared WebP bytes are sniffed, `image/unknown` is re-sniffed, and unrecognizable bytes still land on PNG.

### Not done

**The `{data, mimeType}` return type.** 68 method declarations across 20 provider files plus every caller, well past the <400 LOC target. The bytes are identical on both sides of the boundary, so sniffing where the label is assigned fixes the same failure. What the interface change would add is the provider's `Content-Type` header, which magic bytes cannot recover — worth a follow-up, not a blocker.

**`image-nodes` keeps its own copy of the table.** That module bundles for the browser and deliberately avoids the runtime barrel. A `./image-mime` subpath export would work, but it needs alias entries in a dozen `vitest.config.ts` files and browser-bundle verification. Its sniffer was correct already — it was the consumer that discarded the result — so it carries a comment pointing at the shared one instead.

**`meshy-provider.ts` keeps its own too: it narrows to PNG-or-JPEG on purpose, which is what the Meshy API accepts.

### Verification

⚠️ **I could not run `test:affected`, `typecheck`, or `lint` in this environment** — every `npm`/`npx`/`vitest` invocation was refused by the sandbox. The diff was checked by reading (call sites re-grepped, package dependencies confirmed, dead identifiers checked) and the `unslop` checklist applied, but CI is the first real run.

Generated with [Claude Code](https://claude.ai/code)