### PR TITLE
fix(runtime): read every Replicate output shape, not just output[0]

### DIFF
--- a/docs/provider-contract-probes.md
+++ b/docs/provider-contract-probes.md
@@ -3,8 +3,8 @@
 A cassette proves NodeTool still handles a response a provider gave us once. It
 cannot notice that the provider changed the response today — replay never
 reaches the network, so a renamed field or a dropped usage block is invisible
-until a user hits it. The contract probes close that gap for the four providers
-whose wire shapes a run depends on most: OpenAI, Gemini, fal, and KIE.
+until a user hits it. The contract probes close that gap for the providers whose
+wire shapes a run depends on most: OpenAI, Gemini, fal, KIE, and Replicate.
 
 A probe has two halves, and both run the **same production decoder**:
 
@@ -39,6 +39,7 @@ and — where a live call is cheap enough — the single request that fetches it
 | `kie.error-envelope` | `kieEnvelopeError` | 1 request, free |
 | `kie.create-task` | `decodeKieTaskSubmission` | fixture only |
 | `kie.record-info` | `decodeKieRecordInfo` + `decodeKieResultUrls` | fixture only |
+| `replicate.prediction-output` | `decodeReplicateOutput` | fixture only |
 
 The budget is **one request and USD 0.05 per provider per run**, enforced by
 `runProbes` and asserted by the manifest test. A fixture-only entry must say in

--- a/packages/runtime/src/providers/contract/probe-manifest.ts
+++ b/packages/runtime/src/providers/contract/probe-manifest.ts
@@ -38,9 +38,15 @@ import {
   decodeKieTaskSubmission,
   kieEnvelopeError
 } from "../kie-provider.js";
+import { decodeReplicateOutput } from "../replicate-provider.js";
 
 /** Providers the first manifest covers. */
-export type ProbeProvider = "openai" | "gemini" | "fal_ai" | "kie";
+export type ProbeProvider =
+  | "openai"
+  | "gemini"
+  | "fal_ai"
+  | "kie"
+  | "replicate";
 
 /** The one live HTTP request an entry may make per run. */
 export interface LiveProbeSpec {
@@ -408,6 +414,31 @@ export const PROBE_MANIFEST: ProbeManifestEntry[] = [
     requiredFields: ["data.state", "data.resultJson"],
     live: null,
     liveGap: "A finished record requires a paid job."
+  },
+  {
+    id: "replicate.prediction-output",
+    provider: "replicate",
+    target: "GET https://api.replicate.com/v1/predictions/:id (flux-schnell)",
+    decoder: "decodeReplicateOutput",
+    fixture: "replicate/prediction-flux-schnell.json",
+    check: (raw) => {
+      const prediction = raw as Record<string, unknown>;
+      expect(
+        prediction.status === "succeeded",
+        `prediction fixture has status "${String(prediction.status)}"`
+      );
+      const target = decodeReplicateOutput(prediction.output);
+      expect(target !== null, "prediction output decoded to no file");
+      expect(
+        target?.kind === "url" && target.url.startsWith("https://"),
+        "prediction output did not decode to an https locator"
+      );
+    },
+    requiredFields: ["status", "output", "output.0"],
+    live: null,
+    liveGap:
+      "Replicate has no free endpoint that answers a finished prediction — " +
+      "obtaining one means paying for a generation."
   }
 ];
 

--- a/packages/runtime/src/providers/replicate-provider.ts
+++ b/packages/runtime/src/providers/replicate-provider.ts
@@ -1,6 +1,6 @@
 import Replicate from "replicate";
 import { createLogger } from "@nodetool-ai/config";
-import { isObjectLike, isString } from "../type-predicates.js";
+import { isCallable, isObjectLike, isString } from "../type-predicates.js";
 import { BaseProvider } from "./base-provider.js";
 import { safeFetch } from "./safe-url.js";
 import { sniffAudioMime } from "./audio-mime.js";
@@ -46,6 +46,114 @@ interface ReplicateProviderOptions {
   /** Inject a pre-built Replicate client (mainly for testing). */
   client?: Replicate;
   fetchFn?: typeof fetch;
+}
+
+/** Where a prediction's file output lives, resolved before any I/O runs. */
+export type ReplicateOutputTarget =
+  | { kind: "url"; url: string }
+  | { kind: "stream"; stream: ReadableStream<Uint8Array> };
+
+/** A nested string counts as a locator only when it looks like one. */
+const URL_LIKE = /^(https?:|data:)/;
+
+/** The walk is over a provider's JSON, so bound how deep it goes. */
+const MAX_OUTPUT_DEPTH = 6;
+
+/**
+ * Resolve a `replicate.run()` result to the one file it carries.
+ *
+ * The SDK walks the prediction's output and swaps every `https:`/`data:`
+ * string for a `FileOutput`, objects and nested arrays included, so a model
+ * answering `{"image": <FileOutput>}` is as ordinary as one answering
+ * `["https://…"]`. Reading only `output[0]` drops the first and reports "no
+ * usable output" for a prediction that succeeded.
+ */
+export function decodeReplicateOutput(
+  output: unknown
+): ReplicateOutputTarget | null {
+  // A bare string output is itself the locator (the model's contract),
+  // whether or not it parses as a URL.
+  if (isString(output)) {
+    return output ? { kind: "url", url: output } : null;
+  }
+  return decodeOutputValue(output, 0);
+}
+
+function decodeOutputValue(
+  value: unknown,
+  depth: number
+): ReplicateOutputTarget | null {
+  if (depth > MAX_OUTPUT_DEPTH || !isObjectLike(value)) return null;
+
+  // FileOutput extends ReadableStream, so `getReader` is on its prototype.
+  // Prefer it over `url()`: those bytes are already in flight.
+  if ("getReader" in value) {
+    return { kind: "stream", stream: value as ReadableStream<Uint8Array> };
+  }
+
+  // FileOutput also exposes `url()`, and some models answer a plain `{url}`.
+  if ("url" in value) {
+    const raw = (value as { url: unknown }).url;
+    const url = isCallable(raw) ? raw.call(value) : raw;
+    if (url) return { kind: "url", url: String(url) };
+  }
+
+  const items: unknown[] = Array.isArray(value)
+    ? value
+    : Object.values(value as Record<string, unknown>);
+  for (const item of items) {
+    const found = isString(item)
+      ? decodeOutputLeaf(item)
+      : decodeOutputValue(item, depth + 1);
+    if (found) return found;
+  }
+  return null;
+}
+
+function decodeOutputLeaf(item: string): ReplicateOutputTarget | null {
+  return URL_LIKE.test(item) ? { kind: "url", url: item } : null;
+}
+
+async function drainStream(
+  stream: ReadableStream<Uint8Array>
+): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    total += value.length;
+  }
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
+/** `safeFetch` speaks https only, so an inline output is decoded here. */
+function decodeDataUri(uri: string): Uint8Array {
+  const comma = uri.indexOf(",");
+  if (comma < 0) throw new Error("Malformed data URI in Replicate output");
+  const body = uri.slice(comma + 1);
+  if (uri.slice(0, comma).endsWith(";base64")) {
+    return new Uint8Array(Buffer.from(body, "base64"));
+  }
+  return new TextEncoder().encode(decodeURIComponent(body));
+}
+
+/** A short, credential-free description of an output the decoder rejected. */
+function describeOutputShape(output: unknown): string {
+  if (output == null) return String(output);
+  if (Array.isArray(output)) return `an array of ${output.length}`;
+  if (isObjectLike(output)) {
+    return `an object with keys [${Object.keys(output).slice(0, 8).join(", ")}]`;
+  }
+  return `a ${typeof output}`;
 }
 
 /**
@@ -755,40 +863,23 @@ export class ReplicateProvider extends BaseProvider {
   // ---------------------------------------------------------------------------
 
   private async _fetchOutputBytes(output: unknown): Promise<Uint8Array> {
-    // replicate.run() returns FileOutput (ReadableStream) for file models,
-    // or a string URL, or an array of URLs/FileOutputs.
-    let target: unknown = output;
-    if (Array.isArray(output)) {
-      target = output[0];
+    const target = decodeReplicateOutput(output);
+    if (!target) {
+      throw new Error(
+        "Replicate prediction returned no usable output " +
+          `(output was ${describeOutputShape(output)})`
+      );
     }
+    return target.kind === "stream"
+      ? drainStream(target.stream)
+      : this._fetchUrlBytes(target.url);
+  }
 
-    // FileOutput is a ReadableStream — read it to bytes
-    if (isObjectLike(target) && "getReader" in target) {
-      const reader = (target as ReadableStream<Uint8Array>).getReader();
-      const chunks: Uint8Array[] = [];
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        chunks.push(value);
-      }
-      const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
-      const result = new Uint8Array(totalLength);
-      let offset = 0;
-      for (const chunk of chunks) {
-        result.set(chunk, offset);
-        offset += chunk.length;
-      }
-      return result;
-    }
-
-    // String URL — fetch the bytes
-    if (isString(target)) {
-      const res = await safeFetch(target);
-      if (!res.ok) throw new Error(`Failed to fetch output: ${res.status}`);
-      return new Uint8Array(await res.arrayBuffer());
-    }
-
-    throw new Error("Replicate prediction returned no usable output");
+  private async _fetchUrlBytes(url: string): Promise<Uint8Array> {
+    if (url.startsWith("data:")) return decodeDataUri(url);
+    const res = await safeFetch(url);
+    if (!res.ok) throw new Error(`Failed to fetch output: ${res.status}`);
+    return new Uint8Array(await res.arrayBuffer());
   }
 
   async textToImage(params: TextToImageParams): Promise<Uint8Array> {

--- a/packages/runtime/tests/fixtures/provider-contract/replicate/prediction-flux-schnell.json
+++ b/packages/runtime/tests/fixtures/provider-contract/replicate/prediction-flux-schnell.json
@@ -1,0 +1,35 @@
+{
+  "id": "0000000000000000000000000000",
+  "model": "black-forest-labs/flux-schnell",
+  "version": "c846a69991daf4c0e5d016514849d14ee5b2e6846ce6b9d6f21369e564cfe51e",
+  "input": {
+    "prompt": "a red fox in snow",
+    "go_fast": true,
+    "megapixels": "1",
+    "num_outputs": 1,
+    "aspect_ratio": "1:1",
+    "output_format": "webp",
+    "output_quality": 80,
+    "num_inference_steps": 4
+  },
+  "output": [
+    "https://replicate.delivery/example/out-0.webp"
+  ],
+  "logs": "Using seed: 0\n",
+  "error": null,
+  "status": "succeeded",
+  "data_removed": false,
+  "created_at": "2026-08-24T00:00:00.000Z",
+  "started_at": "2026-08-24T00:00:01.000Z",
+  "completed_at": "2026-08-24T00:00:03.000Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/0000000000000000000000000000/cancel",
+    "get": "https://api.replicate.com/v1/predictions/0000000000000000000000000000",
+    "stream": "https://stream.replicate.com/v1/files/example"
+  },
+  "metrics": {
+    "image_count": 1,
+    "predict_time": 1.85,
+    "total_time": 3.0
+  }
+}

--- a/packages/runtime/tests/providers/provider-contract-probes.test.ts
+++ b/packages/runtime/tests/providers/provider-contract-probes.test.ts
@@ -64,12 +64,13 @@ function withoutPath(value: unknown, path: string): unknown {
 }
 
 describe("provider contract probe manifest", () => {
-  it("covers the four providers the roadmap names", () => {
+  it("covers the providers the roadmap names", () => {
     expect(probeProviders().sort()).toEqual([
       "fal_ai",
       "gemini",
       "kie",
-      "openai"
+      "openai",
+      "replicate"
     ]);
     expect(PROBE_MANIFEST.length).toBeGreaterThanOrEqual(4);
   });

--- a/packages/runtime/tests/providers/replicate-output-decoder.test.ts
+++ b/packages/runtime/tests/providers/replicate-output-decoder.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Each case is a shape `replicate.run()`'s output walk can produce. Reading
+ * only `output[0]` dropped most of them and reported "no usable output" for a
+ * prediction that succeeded (#5194).
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  decodeReplicateOutput,
+  ReplicateProvider
+} from "../../src/providers/replicate-provider.js";
+
+const IMG = new Uint8Array([137, 80, 78, 71]);
+const URL_A = "https://replicate.delivery/pbxt/a.webp";
+const URL_B = "https://replicate.delivery/pbxt/b.webp";
+
+/** The SDK's FileOutput: a ReadableStream that also carries `url()`. */
+function fileOutput(url: string, bytes: Uint8Array) {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    }
+  }) as ReadableStream<Uint8Array> & { url: () => URL };
+  stream.url = () => new URL(url);
+  return stream;
+}
+
+/** A FileOutput that lost its stream half — only the locator is left. */
+function urlOnlyOutput(url: string) {
+  return { url: () => new URL(url) };
+}
+
+function stubFetchOk(bytes: Uint8Array) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    arrayBuffer: () => Promise.resolve(bytes.buffer)
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function textToImage(output: unknown) {
+  const provider = new ReplicateProvider(
+    { REPLICATE_API_TOKEN: "r8_test" },
+    {
+      client: {
+        run: vi.fn().mockResolvedValue(output),
+        stream: vi.fn()
+      } as never
+    }
+  );
+  return provider.textToImage({
+    model: {
+      id: "black-forest-labs/flux-schnell",
+      name: "FLUX schnell",
+      provider: "replicate"
+    },
+    prompt: "a red fox in snow"
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("decodeReplicateOutput", () => {
+  it("reads an array of URL strings (flux-schnell, flux-dev)", () => {
+    expect(decodeReplicateOutput([URL_A, URL_B])).toEqual({
+      kind: "url",
+      url: URL_A
+    });
+  });
+
+  it("reads a bare string output, URL-shaped or not", () => {
+    expect(decodeReplicateOutput(URL_A)).toEqual({ kind: "url", url: URL_A });
+    expect(decodeReplicateOutput("/tmp/out.png")).toEqual({
+      kind: "url",
+      url: "/tmp/out.png"
+    });
+  });
+
+  it("reads a FileOutput nested under an object key", () => {
+    const decoded = decodeReplicateOutput({ image: fileOutput(URL_A, IMG) });
+    expect(decoded?.kind).toBe("stream");
+  });
+
+  it("reads an object whose file sits behind a non-file sibling", () => {
+    expect(decodeReplicateOutput({ seed: 12345, output: [URL_A] })).toEqual({
+      kind: "url",
+      url: URL_A
+    });
+  });
+
+  it("reads an array of objects that wrap the url", () => {
+    expect(decodeReplicateOutput([{ url: URL_A }])).toEqual({
+      kind: "url",
+      url: URL_A
+    });
+  });
+
+  it("skips array elements that carry no file", () => {
+    expect(decodeReplicateOutput([null, "not a url", URL_B])).toEqual({
+      kind: "url",
+      url: URL_B
+    });
+  });
+
+  it("calls url() when the FileOutput has no stream half", () => {
+    expect(decodeReplicateOutput(urlOnlyOutput(URL_A))).toEqual({
+      kind: "url",
+      url: URL_A
+    });
+  });
+
+  it("prefers the stream over url() — the bytes are already in flight", () => {
+    expect(decodeReplicateOutput(fileOutput(URL_A, IMG))?.kind).toBe("stream");
+  });
+
+  it("does not mistake a nested non-URL string for a locator", () => {
+    expect(decodeReplicateOutput({ prompt: "a red fox in snow" })).toBeNull();
+  });
+
+  it("returns null for outputs that carry no file", () => {
+    expect(decodeReplicateOutput(null)).toBeNull();
+    expect(decodeReplicateOutput(123)).toBeNull();
+    expect(decodeReplicateOutput("")).toBeNull();
+    expect(decodeReplicateOutput([])).toBeNull();
+    expect(decodeReplicateOutput({})).toBeNull();
+  });
+});
+
+describe("ReplicateProvider output handling", () => {
+  it("returns the bytes of an object-wrapped FileOutput", async () => {
+    await expect(
+      textToImage({ image: fileOutput(URL_A, IMG) })
+    ).resolves.toEqual(IMG);
+  });
+
+  it("fetches the url of an array-of-objects output", async () => {
+    const fetchMock = stubFetchOk(IMG);
+    await expect(textToImage([{ url: URL_A }])).resolves.toEqual(IMG);
+    expect(fetchMock.mock.calls[0][0]).toBe(URL_A);
+  });
+
+  it("decodes an inline data URI, which safeFetch cannot reach", async () => {
+    const uri = `data:image/png;base64,${Buffer.from(IMG).toString("base64")}`;
+    await expect(textToImage([uri])).resolves.toEqual(IMG);
+  });
+
+  it("names the shape it got when nothing in the output is a file", async () => {
+    await expect(textToImage({ seed: 1, nsfw: true })).rejects.toThrow(
+      "no usable output (output was an object with keys [seed, nsfw])"
+    );
+    await expect(textToImage([])).rejects.toThrow(
+      "no usable output (output was an array of 0)"
+    );
+  });
+});


### PR DESCRIPTION
### The bug

`replicate.run()` does not hand back the prediction's raw `output`. It runs it through `transform()` (`node_modules/replicate/lib/util.js:343`), which walks arrays and objects recursively and swaps every `https:`/`data:` string for a `FileOutput`. So `{"image": <FileOutput>}` and `[{"url": "…"}]` are as ordinary a result as `["https://…"]`.

`_fetchOutputBytes` read two of those shapes — a bare string, and `output[0]` when it is a stream or a string. Everything else hit the throw, so a prediction that succeeded was reported as "returned no usable output", and the message named no shape. The node path already handled all of it in `extractUrl()` (`packages/replicate-nodes/src/replicate-base.ts:246`); the provider path was the weaker of two decoders for the same API.

### The fix

`decodeReplicateOutput()` is now a pure function over the output. It walks arrays and object values to a bounded depth, prefers a `FileOutput`'s stream over its `url()`, accepts a plain `{url}`, and skips elements that carry no file instead of committing to index 0. A nested string must look like a locator, so `{"prompt": "a red fox"}` is not fetched. The failure message names the shape, keys only — no prompt or signed URL reaches a log.

Pins the shape as a contract fixture: `replicate.prediction-output` decodes a raw flux-schnell prediction body, and the probe test deletes `status`, `output`, and `output.0` in turn to prove the check can fail.

### Not verified

The failure was **not reproduced** — no `REPLICATE_API_TOKEN`, and the checked-in schemas show no schnell-vs-dev asymmetry (both declare `output` as an array of URI strings). This widens the decoder to every shape the SDK's walk can produce; it is not confirmed to be the shape schnell returns. If schnell still fails, the new message names the shape.

`npm run typecheck`, `lint`, and `test:affected` were blocked by sandbox permissions and did not run. CI is the first real signal.

Resolves #5194

Generated with [Claude Code](https://claude.ai/code)