### PR TITLE
fix(runtime): treat content-filter refusals as a retryable class

### DIFF
--- a/docs/workflow-supervisor-design.md
+++ b/docs/workflow-supervisor-design.md
@@ -205,6 +205,28 @@ No `substitute` in either state — the PRD's rule ("Repair never" for streams) 
 
 Excluded verdicts are removed from the agent's schema **and** from the kernel's allowed set (§5.1) — the schema is UX, the allowed set is the guarantee.
 
+### 5.4a Content-filter refusals in an unsupervised run
+
+One failure class degrades without a supervisor: a provider content filter
+refusing to generate. Veo 3.1 filtered one shot of a five-shot trailer on an
+ordinary cinematic shot description, the same prompt passed on retry, and the
+blocked take was not charged — so the refusal is non-deterministic and
+provider-side, not a defect in the request.
+
+It is answered at two levels. `ProcessingContext.runProviderPrediction` retries
+a refusal `CONTENT_FILTER_MAX_RETRIES` times with backoff, so most never reach
+the node. One that survives reaches the actor as a `ContentFilterRefusal`
+(`@nodetool-ai/runtime`), and the actor takes the `skip` path — retiring that
+invocation's lineage, exactly as the verdict does — when the invocation is one
+item of a fan-out and nothing has been emitted yet. Everything else still
+fails: a single-shot invocation has no siblings whose spend a failure would
+discard, and an emitted stream has partial output downstream that a retired
+lineage would contradict.
+
+A **supervised** run is unchanged. The refusal escalates like any other
+failure, because putting an agent on the failure path is what `--supervise` is
+for; `skip` is already in its allowed set (§5.4).
+
 ### 5.5 Cancellation and timeouts
 
 Each `decide()` call gets its own `AbortSignal`, derived from the run's signal plus a decision timeout (default 60s). The signal is not decoration around the `await`: it threads through `StepExecutor` into `provider.generateLoop({signal})`, so abort actually terminates the in-flight LLM request rather than orphaning it to keep consuming tokens after `cancel()`. Abort or timeout → `fail`. This is what keeps `cancel()` instant *and* free (PRD scenario 8): a pending decision is killed, not merely un-awaited.

--- a/packages/kernel/src/actor.ts
+++ b/packages/kernel/src/actor.ts
@@ -34,6 +34,7 @@ import type {
 import {
   createInvocationAccount,
   inInvocationAccount,
+  isContentFilterRefusal,
   isRecoverableNodeError,
   providerFailureDetail
 } from "@nodetool-ai/runtime";
@@ -1184,7 +1185,11 @@ export class NodeActor {
         return await inInvocationAccount(account, invoke);
       } catch (err) {
         if (err instanceof WorkflowSuspendedError) throw err;
-        if (!this._supervisor) throw err;
+        if (!this._supervisor) {
+          if (!this._degradeOnContentFilter(err, false)) throw err;
+          await this._skipInvocation();
+          return SKIPPED;
+        }
 
         const verdict = await this._escalate(err, inputs, attempt, account, {
           streamingOutput: false,
@@ -1382,6 +1387,46 @@ export class NodeActor {
     );
   }
 
+  /**
+   * Whether to drop this item instead of the run, after the provider's own
+   * bounded retries failed to get past its content filter. The built-in policy
+   * for an unsupervised run — a supervised one escalates instead, because
+   * putting an agent on the failure path is what `--supervise` is for.
+   *
+   * Veo filtered one shot of a five-shot trailer on an ordinary cinematic
+   * prompt. Failing the node there fails the run and discards the four shots
+   * already generated and paid for, which is worse than delivering a four-shot
+   * cut and saying which shot was refused.
+   *
+   * Only for an invocation that is one item of a fan-out: a non-empty
+   * correlation lineage says an upstream item keyed this invocation, so the
+   * siblings are real work a failure would throw away. A single-shot node has
+   * no siblings to protect and still fails loudly. An invocation that already
+   * emitted is out too — its partial output is downstream, so retiring the
+   * lineage now would tell joins nothing arrived.
+   */
+  private _degradeOnContentFilter(err: unknown, emitted: boolean): boolean {
+    if (emitted || !isContentFilterRefusal(err)) return false;
+    const lineage = this._currentInvocationLineage;
+    if (!lineage || Object.keys(lineage).length === 0) return false;
+
+    const detail = err instanceof Error ? err.message : String(err);
+    // Stryker disable next-line StringLiteral,ObjectLiteral: diagnostic log args only
+    log.warn("Dropping content-filtered item", {
+      nodeId: this.node.id,
+      type: this.node.type,
+      detail
+    });
+    this._emitMessage({
+      type: "log_update",
+      node_id: this.node.id,
+      node_name: this.node.name ?? this.node.type,
+      severity: "warning",
+      content: `Dropped one item: the provider's content filter refused it and retrying did not clear it. The rest of the run continues. ${detail}`
+    });
+    return true;
+  }
+
   private async _executeWithInputs(
     inputs: Record<string, unknown>
   ): Promise<void> {
@@ -1459,7 +1504,11 @@ export class NodeActor {
       } catch (err) {
         if (err instanceof WorkflowSuspendedError) throw err;
         if (err instanceof RoutingError) throw err.cause;
-        if (!this._supervisor) throw err;
+        if (!this._supervisor) {
+          if (!this._degradeOnContentFilter(err, emitted)) throw err;
+          await this._skipInvocation();
+          return;
+        }
         const verdict = await this._escalate(err, inputs, attempt, account, {
           streamingOutput: true,
           streamingInput: false,

--- a/packages/kernel/tests/content-filter-degradation.test.ts
+++ b/packages/kernel/tests/content-filter-degradation.test.ts
@@ -1,0 +1,161 @@
+/**
+ * A content-filter refusal costs the item, not the run.
+ *
+ * Veo filtered one shot of a five-shot trailer. Classified as a hard error
+ * that fails the node, which fails the run, which discards the four shots
+ * already generated and paid for — so in a fan-out the kernel retires just the
+ * refused item's lineage and lets the rest of the cut through.
+ *
+ * The blast radius is what is under test, so both edges are pinned: an
+ * ordinary failure in the same graph still fails the run, and so does a
+ * refusal with no siblings to protect.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ContentFilterRefusal } from "@nodetool-ai/runtime";
+import type { LogUpdate } from "@nodetool-ai/protocol";
+import {
+  aggregateOutput,
+  collectNode,
+  dataEdge,
+  forwardOutput,
+  iterationOutput,
+  runWorkflow,
+  seedSource,
+  type Edge,
+  type NodeDescriptor
+} from "./correlation/_harness.js";
+import type { NodeExecutor } from "../src/actor.js";
+
+const SHOTS = ["shot-1", "shot-2", "shot-3"];
+
+/** Renders every shot but `refused`, which the provider filters. */
+function animator(refused: string, error: Error): NodeExecutor {
+  return {
+    async process(ins) {
+      if (ins.value === refused) throw error;
+      return { value: `${ins.value}.mp4` };
+    }
+  };
+}
+
+const REFUSAL = (): ContentFilterRefusal =>
+  new ContentFilterRefusal(
+    "videos were filtered out because they violated Vertex AI's usage guidelines",
+    { provider: "gemini", model: "veo-3.1-generate-preview" }
+  );
+
+/** shots ⇉ animate → collect → sink, one invocation per shot. */
+function fanOut(): { nodes: NodeDescriptor[]; edges: Edge[] } {
+  return {
+    nodes: [
+      {
+        id: "shots",
+        type: "test.Seed",
+        is_streaming_input: true,
+        outputs: { value: "any" },
+        output_correlation: { value: iterationOutput("shots") }
+      },
+      {
+        id: "animate",
+        type: "test.Work",
+        outputs: { value: "any" },
+        output_correlation: { value: forwardOutput("value") }
+      },
+      {
+        id: "collect",
+        type: "nodetool.control.Collect",
+        is_streaming_input: true,
+        input_mode: "stream",
+        outputs: { output: "list[any]" },
+        output_correlation: { output: aggregateOutput("input_item") }
+      },
+      { id: "sink", type: "test.Sink", is_streaming_input: true }
+    ],
+    edges: [
+      dataEdge("shots", "value", "animate", "value", "eShots"),
+      dataEdge("animate", "value", "collect", "input_item", "eAnimate"),
+      dataEdge("collect", "output", "sink", "value", "eCollect")
+    ]
+  };
+}
+
+function shotSource(): NodeExecutor {
+  return seedSource(
+    SHOTS.map((value, index) => ({
+      value,
+      lineage: { "shots:shots": { index } }
+    }))
+  );
+}
+
+describe("content-filter refusal in a fan-out", () => {
+  it("drops the refused shot and delivers the rest of the cut", async () => {
+    const { result, captured } = await runWorkflow({
+      jobId: "content-filter-fanout",
+      ...fanOut(),
+      executors: {
+        shots: shotSource(),
+        animate: animator("shot-2", REFUSAL()),
+        collect: collectNode()
+      },
+      captureFrom: { sink: ["value"] }
+    });
+
+    expect(result.status).toBe("completed");
+    const envs = captured.get("sink")!.get("value")!;
+    expect(envs).toHaveLength(1);
+    expect(envs[0].data).toEqual(["shot-1.mp4", "shot-3.mp4"]);
+
+    // Dropped, not swallowed: the run says which item went and why.
+    const dropped = result.messages.filter(
+      (m): m is LogUpdate =>
+        m.type === "log_update" && m.content.includes("Dropped one item")
+    );
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].node_id).toBe("animate");
+    expect(dropped[0].severity).toBe("warning");
+    expect(dropped[0].content).toContain("usage guidelines");
+  });
+
+  it("still fails the run on an ordinary error", async () => {
+    const { result } = await runWorkflow({
+      jobId: "content-filter-fanout-hard-error",
+      ...fanOut(),
+      executors: {
+        shots: shotSource(),
+        animate: animator("shot-2", new Error("401 Incorrect API key")),
+        collect: collectNode()
+      },
+      captureFrom: { sink: ["value"] }
+    });
+
+    expect(result.status).toBe("failed");
+  });
+});
+
+describe("content-filter refusal outside a fan-out", () => {
+  it("fails the run when the invocation has no siblings to protect", async () => {
+    const { result } = await runWorkflow({
+      jobId: "content-filter-single",
+      nodes: [
+        {
+          id: "shot",
+          type: "nodetool.input.StringInput",
+          name: "shot",
+          properties: { value: "shot-2" }
+        },
+        { id: "animate", type: "test.Work", outputs: { value: "any" } },
+        { id: "sink", type: "test.Sink", is_streaming_input: true }
+      ],
+      edges: [
+        dataEdge("shot", "value", "animate", "value", "eShot"),
+        dataEdge("animate", "value", "sink", "value", "eAnimate")
+      ],
+      executors: { animate: animator("shot-2", REFUSAL()) },
+      captureFrom: { sink: ["value"] }
+    });
+
+    expect(result.status).toBe("failed");
+  });
+});

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -158,6 +158,11 @@ import type {
   MessageContent,
   ProviderStreamItem
 } from "./providers/types.js";
+import {
+  CONTENT_FILTER_MAX_RETRIES,
+  contentFilterRetryDelayMs,
+  isContentFilterRefusal
+} from "./providers/content-filter.js";
 import type { NodeExecutor } from "./node-executor.js";
 import {
   getProcessSandboxModuleCatalog,
@@ -3386,13 +3391,53 @@ export class ProcessingContext {
     this.emitPrediction("running", req, id, null, undefined, startedAt);
     try {
       const provider = await this.getProvider(req.provider);
-      const output = await this.dispatchCapability(provider, req);
+      const output = await this.retryContentFilterRefusal(req, () =>
+        this.dispatchCapability(provider, req)
+      );
       this.emitPrediction("completed", req, id, output, undefined, startedAt);
       return output;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.emitPrediction("failed", req, id, null, message, startedAt);
       throw error;
+    }
+  }
+
+  /**
+   * Run a prediction, retrying a content-filter refusal a bounded number of
+   * times. The filter is non-deterministic — Veo refused one shot of a
+   * five-shot trailer on an ordinary cinematic prompt and passed the same
+   * prompt on retry — and a refused take is not charged, so the cheap answer to
+   * a refusal is to ask again before failing the node that asked.
+   *
+   * A refusal that survives the retries is rethrown as-is, so the kernel can
+   * still drop the item rather than the run.
+   */
+  private async retryContentFilterRefusal<T>(
+    req: ProviderPredictionRequest,
+    attemptFn: () => Promise<T>
+  ): Promise<T> {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await attemptFn();
+      } catch (error) {
+        if (
+          !isContentFilterRefusal(error) ||
+          attempt > CONTENT_FILTER_MAX_RETRIES
+        ) {
+          throw error;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        this.emit({
+          type: "log_update",
+          node_id: req.nodeId ?? "",
+          node_name: req.nodeId ?? "",
+          workflow_id: req.workflowId ?? this.workflowId ?? null,
+          severity: "warning",
+          content: `${req.provider}/${req.model} content-filtered this request (attempt ${attempt} of ${CONTENT_FILTER_MAX_RETRIES + 1}); retrying. ${message}`
+        });
+        await waitForRetry(contentFilterRetryDelayMs(attempt), this.signal);
+      }
     }
   }
 

--- a/packages/runtime/src/providers/content-filter.ts
+++ b/packages/runtime/src/providers/content-filter.ts
@@ -1,0 +1,107 @@
+/**
+ * Content-filter refusals, as a class apart from hard errors.
+ *
+ * Veo 3.1 filtered one shot of a five-shot trailer on an ordinary cinematic
+ * prompt ("a lighthouse in a storm"), the same prompt passed on retry, and the
+ * blocked take was not charged. Classified as a hard error, that refusal fails
+ * the node, fails the run, and discards the four shots already generated and
+ * paid for.
+ *
+ * So a refusal gets its own class. `ProcessingContext.runProviderPrediction`
+ * retries it a bounded number of times, and the kernel actor drops the item
+ * instead of the run when the invocation is one item of a fan-out.
+ *
+ * A provider that gives us structured evidence (Veo's `raiMediaFilteredReasons`)
+ * throws the class directly. For the rest, {@link isContentFilterRefusal}
+ * matches the message text, because that is all a provider hands back.
+ */
+
+import { isObjectLike, isString } from "../type-predicates.js";
+
+/** Extra attempts after a refusal, before the refusal reaches the node. */
+export const CONTENT_FILTER_MAX_RETRIES = 2;
+
+/** Delay before attempt N+1 after a refusal. */
+export function contentFilterRetryDelayMs(attempt: number): number {
+  return Math.min(1_000 * 2 ** (attempt - 1), 8_000);
+}
+
+/**
+ * A provider refused to generate because its content filter rejected the
+ * prompt or the result. Not a failure of the request — the same request often
+ * succeeds on a retry.
+ */
+export class ContentFilterRefusal extends Error {
+  /** Provider id as the runtime knows it (e.g. `gemini`). */
+  readonly provider?: string;
+  readonly model?: string;
+  /** Provider-supplied reason codes, when it gives any. */
+  readonly reasons?: readonly string[];
+
+  constructor(
+    message: string,
+    opts: {
+      provider?: string;
+      model?: string;
+      reasons?: readonly string[];
+    } = {}
+  ) {
+    super(message);
+    this.name = "ContentFilterRefusal";
+    this.provider = opts.provider;
+    this.model = opts.model;
+    this.reasons = opts.reasons;
+  }
+}
+
+/**
+ * Phrasings providers use when their filter — not the request — is what
+ * failed. Each entry names the provider it came from.
+ */
+const REFUSAL_PATTERNS: readonly RegExp[] = [
+  // Google Veo / Vertex RAI: "... videos were filtered out because they
+  // violated Vertex AI's usage guidelines", and the raw response field.
+  /filtered out because .*violat/i,
+  /\brai[_ ]?(?:media[_ ]?)?filtered/i,
+  // Gemini text and image: blocked prompt / blocked candidate.
+  /\bPROHIBITED_CONTENT\b/,
+  /blocked (?:due to|by) (?:the )?safety/i,
+  // OpenAI images and moderation.
+  /rejected as a result of our safety system/i,
+  /\bcontent[_ ]policy[_ ]violation\b/i,
+  /\bmoderation_blocked\b/i,
+  // Azure OpenAI.
+  /content management policy/i,
+  // FAL / Replicate / KIE image and video models.
+  /\bnsfw\b[^.]*\bdetect/i,
+  /flagged as sensitive/i,
+  /\bsensitive words?\b/i,
+  // Phrasings shared across providers.
+  /\b(?:content|safety) filters?\b/i,
+  /violates? (?:our |the )?(?:content|usage) (?:polic|guideline)/i
+];
+
+/** True for {@link ContentFilterRefusal} from any copy of this package. */
+export function isContentFilterRefusalError(
+  error: unknown
+): error is ContentFilterRefusal {
+  return error instanceof Error && error.name === "ContentFilterRefusal";
+}
+
+/**
+ * True when this failure is a content-filter refusal — the class, or a message
+ * carrying one of the phrasings providers use for it.
+ */
+export function isContentFilterRefusal(error: unknown): boolean {
+  if (isContentFilterRefusalError(error)) return true;
+  const message = refusalText(error);
+  return message !== "" && REFUSAL_PATTERNS.some((p) => p.test(message));
+}
+
+function refusalText(error: unknown): string {
+  if (isString(error)) return error;
+  if (isObjectLike(error) && "message" in error && isString(error.message)) {
+    return error.message;
+  }
+  return "";
+}

--- a/packages/runtime/src/providers/gemini-provider.ts
+++ b/packages/runtime/src/providers/gemini-provider.ts
@@ -5,6 +5,10 @@ import { sniffAudioMime } from "./audio-mime.js";
 import { sniffVideoMime } from "./video-mime.js";
 import { safeFetch } from "./safe-url.js";
 import {
+  ContentFilterRefusal,
+  isContentFilterRefusal
+} from "./content-filter.js";
+import {
   isBoolean,
   isFiniteNumber,
   isNonEmptyString,
@@ -160,12 +164,23 @@ interface GeminiModelsPage {
   nextPageToken?: string;
 }
 
+/**
+ * Veo reports a content-filtered take by counting it out of the response
+ * rather than by failing the operation: `raiMediaFilteredCount` rises, the
+ * reasons list carries the support codes, and `generatedSamples` comes back
+ * short — or empty, when every take was filtered.
+ */
+interface GeminiRaiFilterFields {
+  raiMediaFilteredCount?: number;
+  raiMediaFilteredReasons?: string[];
+}
+
 interface GeminiVideoOperation {
   name?: string;
   done?: boolean;
   error?: { message?: string; code?: number; status?: string };
-  response?: {
-    generateVideoResponse?: {
+  response?: GeminiRaiFilterFields & {
+    generateVideoResponse?: GeminiRaiFilterFields & {
       generatedSamples?: Array<{ video?: { uri?: string } }>;
     };
     generatedVideos?: Array<{ video?: { uri?: string } }>;
@@ -2104,6 +2119,30 @@ export class GeminiProvider extends BaseProvider {
     );
   }
 
+  /**
+   * The refusal to raise when an operation came back with no video, or null
+   * when nothing says the filter is why. A filtered take leaves the operation
+   * successful and the samples empty, so without this the caller sees only
+   * "No video URI in response" — indistinguishable from a broken response, and
+   * fatal to a run that has already paid for its other shots.
+   */
+  private videoContentFilterRefusal(
+    operation: GeminiVideoOperation,
+    modelId: string
+  ): ContentFilterRefusal | null {
+    const rai = operation.response?.generateVideoResponse ?? operation.response;
+    const reasons = rai?.raiMediaFilteredReasons ?? [];
+    const filtered = rai?.raiMediaFilteredCount ?? 0;
+    if (filtered <= 0 && reasons.length === 0) return null;
+    const detail = reasons.length
+      ? reasons.join("; ")
+      : "no reason given by the provider";
+    return new ContentFilterRefusal(
+      `Veo filtered every generated video for this prompt: ${detail}`,
+      { provider: "gemini", model: modelId, reasons }
+    );
+  }
+
   private async waitForVideoOperation(
     operation: GeminiVideoOperation,
     timeoutSeconds?: number | null,
@@ -2147,6 +2186,14 @@ export class GeminiProvider extends BaseProvider {
       throw new Error("Video generation timed out");
     }
     if (current.error?.message) {
+      // Vertex answers a filtered prompt through the operation's error slot
+      // ("videos were filtered out because they violated ... usage
+      // guidelines"), so the refusal has to be recognized here too.
+      if (isContentFilterRefusal(current.error.message)) {
+        throw new ContentFilterRefusal(current.error.message, {
+          provider: "gemini"
+        });
+      }
       throw new Error(
         `Gemini video generation failed: ${current.error.message}`
       );
@@ -2230,6 +2277,8 @@ export class GeminiProvider extends BaseProvider {
     );
     const videoUri = this.getVideoUri(operation);
     if (!videoUri) {
+      const refusal = this.videoContentFilterRefusal(operation, modelId);
+      if (refusal) throw refusal;
       throw new Error("No video URI in response");
     }
     return this.downloadGeminiVideo(videoUri, signal);
@@ -2303,6 +2352,8 @@ export class GeminiProvider extends BaseProvider {
     );
     const videoUri = this.getVideoUri(operation);
     if (!videoUri) {
+      const refusal = this.videoContentFilterRefusal(operation, modelId);
+      if (refusal) throw refusal;
       throw new Error("No video URI in response");
     }
     return this.downloadGeminiVideo(videoUri, signal);

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -208,6 +208,10 @@ export {
 } from "./provider-error.js";
 export type { ProviderFailureDetail } from "./provider-error.js";
 export {
+  ContentFilterRefusal,
+  isContentFilterRefusal
+} from "./content-filter.js";
+export {
   checkCredential,
   isCredentialVerifiable,
   verifiableCredentialKeys

--- a/packages/runtime/tests/content-filter-retry.test.ts
+++ b/packages/runtime/tests/content-filter-retry.test.ts
@@ -1,0 +1,110 @@
+/**
+ * `runProviderPrediction` retries a content-filter refusal.
+ *
+ * Veo filtered one shot of a five-shot trailer on an ordinary cinematic prompt
+ * and passed the same prompt on retry, and the blocked take was not charged —
+ * so the first answer to a refusal is to ask again, before it ever reaches the
+ * node that asked.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ProcessingContext } from "../src/context.js";
+import { BaseProvider } from "../src/providers/base-provider.js";
+import { ContentFilterRefusal } from "../src/providers/content-filter.js";
+import type { Message, ProviderStreamItem } from "../src/providers/types.js";
+import type { LogUpdate } from "@nodetool-ai/protocol";
+
+/** Fails `failures` times with `error`, then returns one byte. */
+class FlakyImageProvider extends BaseProvider {
+  attempts = 0;
+  constructor(
+    private readonly failures: number,
+    private readonly error: Error
+  ) {
+    super("flaky");
+  }
+
+  override async textToImage(): Promise<Uint8Array> {
+    this.attempts += 1;
+    if (this.attempts <= this.failures) throw this.error;
+    return new Uint8Array([7]);
+  }
+
+  async generateMessage(): Promise<Message> {
+    throw new Error("not used");
+  }
+
+  async *generateMessages(): AsyncGenerator<ProviderStreamItem> {
+    throw new Error("not used");
+  }
+}
+
+function predict(ctx: ProcessingContext): Promise<unknown> {
+  return ctx.runProviderPrediction({
+    provider: "flaky",
+    capability: "text_to_image",
+    model: "veo-3.1-generate-preview",
+    nodeId: "animate",
+    params: { prompt: "a lighthouse in a storm" }
+  });
+}
+
+const REFUSAL = new ContentFilterRefusal(
+  "videos were filtered out because they violated Vertex AI's usage guidelines"
+);
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("ProcessingContext – content-filter retry", () => {
+  it("retries a refusal and returns the take that gets through", async () => {
+    vi.useFakeTimers();
+    const provider = new FlakyImageProvider(1, REFUSAL);
+    const ctx = new ProcessingContext({ jobId: "j1" });
+    ctx.registerProvider("flaky", provider);
+
+    const pending = predict(ctx);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(await pending).toEqual(new Uint8Array([7]));
+    expect(provider.attempts).toBe(2);
+
+    const log = ctx
+      .getMessages()
+      .find((m): m is LogUpdate => m.type === "log_update");
+    expect(log?.severity).toBe("warning");
+    expect(log?.content).toContain("content-filtered");
+    // The prediction the node sees succeeded — no failure was reported for it.
+    const statuses = ctx
+      .getMessages()
+      .filter((m) => m.type === "prediction")
+      .map((m) => (m as { status: string }).status);
+    expect(statuses).toEqual(["running", "completed"]);
+  });
+
+  it("gives up after a bounded number of attempts, refusal intact", async () => {
+    vi.useFakeTimers();
+    const provider = new FlakyImageProvider(Infinity, REFUSAL);
+    const ctx = new ProcessingContext({ jobId: "j1" });
+    ctx.registerProvider("flaky", provider);
+
+    const pending = predict(ctx).catch((err: unknown) => err);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(await pending).toBe(REFUSAL);
+    expect(provider.attempts).toBe(3);
+  });
+
+  it("does not retry an ordinary provider failure", async () => {
+    const provider = new FlakyImageProvider(
+      1,
+      new Error("401 Incorrect API key provided")
+    );
+    const ctx = new ProcessingContext({ jobId: "j1" });
+    ctx.registerProvider("flaky", provider);
+
+    await expect(predict(ctx)).rejects.toThrow("401");
+    expect(provider.attempts).toBe(1);
+  });
+});

--- a/packages/runtime/tests/providers/content-filter.test.ts
+++ b/packages/runtime/tests/providers/content-filter.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Classification of provider content-filter refusals.
+ *
+ * The point of the class is that it separates a refusal from a hard error, so
+ * both halves are pinned here: the phrasings providers actually send, and the
+ * ordinary failures that must NOT be read as refusals — misclassifying a 401
+ * as retryable burns three attempts on a credential that will never work.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  ContentFilterRefusal,
+  contentFilterRetryDelayMs,
+  isContentFilterRefusal,
+  isContentFilterRefusalError
+} from "../../src/providers/content-filter.js";
+
+describe("isContentFilterRefusal", () => {
+  it("recognizes the class", () => {
+    const err = new ContentFilterRefusal("filtered", {
+      provider: "gemini",
+      model: "veo-3.1-generate-preview",
+      reasons: ["58061214"]
+    });
+    expect(isContentFilterRefusalError(err)).toBe(true);
+    expect(isContentFilterRefusal(err)).toBe(true);
+    expect(err.provider).toBe("gemini");
+    expect(err.reasons).toEqual(["58061214"]);
+  });
+
+  it.each([
+    // The message from the issue, verbatim.
+    "Gemini video generation failed: videos were filtered out because they violated Vertex AI's usage guidelines",
+    "raiMediaFilteredCount: 1",
+    "Candidate blocked: PROHIBITED_CONTENT",
+    "The response was blocked due to safety concerns",
+    "Your request was rejected as a result of our safety system.",
+    "400 content_policy_violation",
+    "moderation_blocked",
+    "The response was filtered due to the prompt triggering Azure OpenAI's content management policy",
+    "NSFW content detected in the output image",
+    "Input flagged as sensitive",
+    "Your prompt contains sensitive words",
+    "Blocked by the safety filter",
+    "This prompt violates our usage policy"
+  ])("recognizes %s", (message) => {
+    expect(isContentFilterRefusal(new Error(message))).toBe(true);
+    expect(isContentFilterRefusal(message)).toBe(true);
+  });
+
+  it.each([
+    "401 Incorrect API key provided",
+    "403 Your request was blocked.",
+    "429 Rate limit reached for this model",
+    "fetch failed",
+    "Video generation timed out",
+    "No video URI in response",
+    "No operation name for polling",
+    "Poll failed 500: upstream error"
+  ])("does not classify %s", (message) => {
+    expect(isContentFilterRefusal(new Error(message))).toBe(false);
+  });
+
+  it("classifies nothing when there is no message to read", () => {
+    expect(isContentFilterRefusal(undefined)).toBe(false);
+    expect(isContentFilterRefusal(null)).toBe(false);
+    expect(isContentFilterRefusal({})).toBe(false);
+    expect(isContentFilterRefusal(new Error(""))).toBe(false);
+  });
+
+  it("backs off between attempts and stops climbing", () => {
+    expect(contentFilterRetryDelayMs(1)).toBe(1_000);
+    expect(contentFilterRetryDelayMs(2)).toBe(2_000);
+    expect(contentFilterRetryDelayMs(20)).toBe(8_000);
+  });
+});

--- a/packages/runtime/tests/providers/gemini-veo-content-filter.test.ts
+++ b/packages/runtime/tests/providers/gemini-veo-content-filter.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Veo content-filter refusals reach the caller as ContentFilterRefusal.
+ *
+ * A filtered take leaves the long-running operation *successful* with no
+ * samples in it, so without the RAI fields the caller only ever saw "No video
+ * URI in response" — a hard error, which fails the node and discards whatever
+ * the rest of a fan-out already generated and paid for.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { GeminiProvider } from "../../src/providers/gemini-provider.js";
+import { isContentFilterRefusalError } from "../../src/providers/content-filter.js";
+import type { VideoModel } from "../../src/providers/types.js";
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    json: async () => body,
+    text: async () => JSON.stringify(body)
+  } as unknown as Response;
+}
+
+function providerReturning(operation: unknown): GeminiProvider {
+  const fetchFn = vi.fn(async () =>
+    jsonResponse(operation)
+  ) as unknown as typeof fetch;
+  return new GeminiProvider(
+    { GEMINI_API_KEY: "k" },
+    { fetchFn, sleepFn: async () => {} }
+  );
+}
+
+const IMAGE = new Uint8Array([1, 2, 3, 4]);
+const MODEL: VideoModel = {
+  id: "veo-3.1-generate-preview",
+  name: "Veo 3.1",
+  provider: "gemini"
+};
+
+describe("Veo content-filter refusals", () => {
+  it("raises a refusal when every take was RAI-filtered", async () => {
+    const provider = providerReturning({
+      name: "operations/1",
+      done: true,
+      response: {
+        generateVideoResponse: {
+          generatedSamples: [],
+          raiMediaFilteredCount: 1,
+          raiMediaFilteredReasons: [
+            "58061214: Your prompt was flagged by Responsible AI"
+          ]
+        }
+      }
+    });
+
+    const error = await provider
+      .imageToVideo([IMAGE], { model: MODEL, prompt: "a lighthouse in a storm" })
+      .catch((err: unknown) => err);
+
+    expect(isContentFilterRefusalError(error)).toBe(true);
+    expect((error as Error).message).toContain("58061214");
+  });
+
+  it("raises a refusal from the operation's error slot", async () => {
+    const provider = providerReturning({
+      name: "operations/2",
+      done: true,
+      error: {
+        code: 400,
+        message:
+          "videos were filtered out because they violated Vertex AI's usage guidelines"
+      }
+    });
+
+    const error = await provider
+      .textToVideo({ model: MODEL, prompt: "a lighthouse in a storm" })
+      .catch((err: unknown) => err);
+
+    expect(isContentFilterRefusalError(error)).toBe(true);
+  });
+
+  it("keeps an empty response without RAI fields a hard error", async () => {
+    const provider = providerReturning({
+      name: "operations/3",
+      done: true,
+      response: { generateVideoResponse: { generatedSamples: [] } }
+    });
+
+    const error = await provider
+      .textToVideo({ model: MODEL, prompt: "a lighthouse in a storm" })
+      .catch((err: unknown) => err);
+
+    expect(isContentFilterRefusalError(error)).toBe(false);
+    expect((error as Error).message).toBe("No video URI in response");
+  });
+});


### PR DESCRIPTION
Closes #5195

### The problem

Veo 3.1 content-filtered one shot of a five-shot trailer on an ordinary cinematic prompt. The same prompt passed on retry and the blocked take was not charged, but the refusal reached the kernel as a hard error: the node failed, the run failed, and the four shots already generated and paid for were discarded.

Veo reports a filtered take on a *successful* long-running operation with no samples in it (`raiMediaFilteredCount` / `raiMediaFilteredReasons`), so the caller only ever saw `No video URI in response` — indistinguishable from a broken response.

### The change

**A refusal gets its own class.** `ContentFilterRefusal` (`packages/runtime/src/providers/content-filter.ts`), recognized either from a provider's structured evidence or from the phrasings providers put in the message (Vertex, Gemini, OpenAI, Azure, FAL/Replicate/KIE).

**Bounded retry at the provider seam.** `runProviderPrediction` — the one choke point every media capability goes through — retries a refusal twice with backoff and logs each retry, so most never reach the node.

**Per-item degradation in a fan-out.** A refusal that survives reaches the actor, which retires just that invocation's lineage — the same path the supervisor's `skip` verdict takes — and emits a `log_update` naming the dropped item. Downstream `Collect` gets four shots instead of five and the cut ships.

Everything else still fails the run: an ordinary error, a single-shot invocation with no siblings to protect, and a stream that already emitted (its partial output is downstream, so a retired lineage would contradict it). A supervised run is unchanged — the refusal escalates like any other failure, because putting an agent on the failure path is what `--supervise` is for.

### Tests

- `packages/runtime/tests/providers/content-filter.test.ts` — both halves of the classifier: thirteen real provider phrasings match, and eight ordinary failures (401, 403, 429, `fetch failed`, timeout) do not.
- `packages/runtime/tests/providers/gemini-veo-content-filter.test.ts` — the RAI-filtered operation and the operation-error path raise the refusal; an empty response without RAI fields stays a hard error.
- `packages/runtime/tests/content-filter-retry.test.ts` — retries and succeeds, gives up after three attempts, and does not retry a 401.
- `packages/kernel/tests/content-filter-degradation.test.ts` — a three-shot fan-out delivers `["shot-1.mp4", "shot-3.mp4"]` and reports the drop; the same graph with an ordinary error, and a refusal outside a fan-out, both still fail.

### Not verified locally

`npm`, `npx` and `node` were all denied by the sandbox in this session, so `typecheck`, `lint` and `test:affected` did not run — CI is the first execution of this diff.

Generated with [Claude Code](https://claude.ai/code)