### PR TITLE
fix(video): make a model's required prompt legible before the run

### DIFF
--- a/packages/agents/src/capabilities/workflows.ts
+++ b/packages/agents/src/capabilities/workflows.ts
@@ -679,7 +679,12 @@ const validateWorkflow: CapabilityExport = {
       ) => registry.validateNode(descriptor, connectedHandles),
       listProviderIds: () => catalogs.listProviderIds(),
       listModelIds: (provider: string, modelType: string) =>
-        catalogs.listModelIds(provider, modelType)
+        catalogs.listModelIds(provider, modelType),
+      listRequiredTextInputs: (
+        provider: string,
+        modelType: string,
+        modelId: string
+      ) => catalogs.listRequiredTextInputs?.(provider, modelType, modelId)
     };
     const checked = {
       nodes: declared.nodes as never[],

--- a/packages/agents/src/tools/graph-validation-registry.ts
+++ b/packages/agents/src/tools/graph-validation-registry.ts
@@ -9,6 +9,7 @@
 
 import {
   listOfflineModelIds,
+  listOfflineRequiredTextInputs,
   listRegisteredProviderIds
 } from "@nodetool-ai/runtime";
 import {
@@ -53,7 +54,11 @@ export function metadataAwareRegistry(
     listModelIds: (provider, modelType) =>
       registry.listModelIds
         ? registry.listModelIds(provider, modelType)
-        : listOfflineModelIds(provider, modelType)
+        : listOfflineModelIds(provider, modelType),
+    listRequiredTextInputs: (provider, modelType, modelId) =>
+      registry.listRequiredTextInputs
+        ? registry.listRequiredTextInputs(provider, modelType, modelId)
+        : listOfflineRequiredTextInputs(provider, modelType, modelId)
   };
 }
 

--- a/packages/agents/src/tools/mcp-tool-support.ts
+++ b/packages/agents/src/tools/mcp-tool-support.ts
@@ -16,6 +16,7 @@
 import type { ProcessingContext } from "@nodetool-ai/runtime";
 import {
   listOfflineModelIds,
+  listOfflineRequiredTextInputs,
   listRegisteredProviderIds
 } from "@nodetool-ai/runtime";
 import type { GraphValidationIssue, NodeRegistry } from "@nodetool-ai/node-sdk";
@@ -347,12 +348,20 @@ export interface ModelCatalogs {
     provider: string,
     modelType: string
   ) => readonly string[] | undefined;
+  /** Optional: a catalog that cannot answer omits it and the check is skipped. */
+  listRequiredTextInputs?: (
+    provider: string,
+    modelType: string,
+    modelId: string
+  ) => readonly string[] | undefined;
 }
 
 export const RUNTIME_MODEL_CATALOGS: ModelCatalogs = {
   listProviderIds: () => listRegisteredProviderIds(),
   listModelIds: (provider, modelType) =>
-    listOfflineModelIds(provider, modelType)
+    listOfflineModelIds(provider, modelType),
+  listRequiredTextInputs: (provider, modelType, modelId) =>
+    listOfflineRequiredTextInputs(provider, modelType, modelId)
 };
 
 /**

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Directed Film to Timeline.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Directed Film to Timeline.json
@@ -65,6 +65,17 @@
         "edge_type": "data"
       },
       {
+        "id": "e_shots_animate",
+        "source": "shots",
+        "sourceHandle": "shot_prompt",
+        "target": "animate",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
         "id": "e_animate_collect",
         "source": "animate",
         "sourceHandle": "output",

--- a/packages/base-nodes/nodetool/examples/nodetool-base/Movie Trailer Generator.json
+++ b/packages/base-nodes/nodetool/examples/nodetool-base/Movie Trailer Generator.json
@@ -87,6 +87,17 @@
         "edge_type": "data"
       },
       {
+        "id": "e-shots-animate",
+        "source": "shots",
+        "sourceHandle": "shot_prompt",
+        "target": "animate",
+        "targetHandle": "prompt",
+        "ui_properties": {
+          "className": "str"
+        },
+        "edge_type": "data"
+      },
+      {
         "id": "e-animate-collect",
         "source": "animate",
         "sourceHandle": "output",

--- a/packages/cli/src/validate/index.ts
+++ b/packages/cli/src/validate/index.ts
@@ -13,7 +13,8 @@ import {
 } from "@nodetool-ai/node-sdk";
 import {
   listRegisteredProviderIds,
-  listOfflineModelIds
+  listOfflineModelIds,
+  listOfflineRequiredTextInputs
 } from "@nodetool-ai/runtime";
 import { resolveTarget } from "../debug/target.js";
 import type { DebugGraph, DebugTargetInfo } from "../debug/types.js";
@@ -68,7 +69,12 @@ export async function runValidate(
       // everything else returns undefined and goes unchecked rather than
       // guessed at. ASR and language catalogs are not in any manifest.
       listModelIds: (provider: string, modelType: string) =>
-        listOfflineModelIds(provider, modelType)
+        listOfflineModelIds(provider, modelType),
+      listRequiredTextInputs: (
+        provider: string,
+        modelType: string,
+        modelId: string
+      ) => listOfflineRequiredTextInputs(provider, modelType, modelId)
     };
   }
   // Declared credentials are collected first so the host resolves exactly

--- a/packages/node-sdk/src/graph-validation.ts
+++ b/packages/node-sdk/src/graph-validation.ts
@@ -117,6 +117,12 @@ export interface GraphValidationIssue {
    * - "missing_provider" (error): a model reference carries an id but no
    *   provider, so nothing can route it. See
    *   {@link collectModelSelectionIssues} for this and its two siblings.
+   * - "missing_required_model_input" (info): a node leaves a property blank
+   *   that the model it selects declares required, so swapping the model
+   *   breaks the graph. Only reported where the provider enumerates its
+   *   requirements offline. `info` because the graph is not broken, it is
+   *   model-specific — and because the manifests are generated, so a wrong
+   *   `required` must not fail a build.
    * - "missing_secret" (warning): a node declares a credential
    *   ({@link collectSecretRequirementSites}) that `options.availableSecrets`
    *   cannot resolve. Only reported when a set was supplied; warning because
@@ -172,6 +178,17 @@ export interface GraphValidationRegistry {
   listModelIds?(
     provider: string,
     modelType: string
+  ): readonly string[] | undefined;
+  /**
+   * Text inputs `modelId` declares it will not run without, named the way the
+   * node's own properties are, or undefined when that cannot be established
+   * without a network call. Optional and silent-by-default like its two
+   * siblings above.
+   */
+  listRequiredTextInputs?(
+    provider: string,
+    modelType: string,
+    modelId: string
   ): readonly string[] | undefined;
 }
 
@@ -763,6 +780,83 @@ export function collectModelSelectionIssues(
   return issues;
 }
 
+/** A property value that reaches a provider as "the caller set nothing". */
+function isBlankPropertyValue(value: unknown): boolean {
+  if (value === undefined || value === null) return true;
+  if (isString(value)) return value.trim().length === 0;
+  if (Array.isArray(value)) return value.length === 0;
+  return false;
+}
+
+/**
+ * Properties a node leaves blank that the model it selects declares it will not
+ * run without.
+ *
+ * A generic media node takes one shape and routes it to whichever provider the
+ * `model` property names, and those providers disagree about what is optional:
+ * Veo 3.1 animates an image with no prompt, Kling refuses the same call with
+ * `500 This field is required` — no field named, no node named, after the
+ * upstream half of the graph has been paid for. The requirement is already
+ * written down in the generated provider manifests; this is the check that
+ * reads it while the graph is still being authored.
+ *
+ * Reported at `info`, which is the honest severity: the graph is not wrong, it
+ * is *model-specific*. Pinned to Veo it runs; the finding is that swapping the
+ * model breaks it. `info` also keeps it below the `--warnings-as-errors`
+ * ratchet the shipped-examples gate runs at, so a generated manifest that marks
+ * something required by mistake cannot fail a build over a graph that works.
+ *
+ * Only where every part of the answer is known: the provider must enumerate its
+ * requirements offline, the node must declare a property of that name, nothing
+ * may feed it, and the model reference must be the node's own top-level
+ * property. Anything less is silence.
+ */
+function collectRequiredModelInputIssues(
+  nodeId: string,
+  nodeType: string,
+  node: GraphValidationNode,
+  declaredProperties: ReadonlySet<string>,
+  connectedHandles: ReadonlySet<string>,
+  registry: Pick<GraphValidationRegistry, "listRequiredTextInputs">
+): GraphValidationIssue[] {
+  if (!registry.listRequiredTextInputs) return [];
+  const properties = readProperties(node);
+  const issues: GraphValidationIssue[] = [];
+  const reported = new Set<string>();
+  for (const { path, propertyName, ref } of collectNodeModelRefs(node)) {
+    // A model nested in a settings object or a list configures something other
+    // than this node's own inputs, so its requirements say nothing about them.
+    if (path !== propertyName) continue;
+    const provider = modelProviderOf(ref);
+    const modelId = modelIdOf(ref);
+    if (provider === undefined || modelId === undefined) continue;
+    const required = registry.listRequiredTextInputs(
+      provider,
+      modelKindOf(ref),
+      modelId
+    );
+    if (!required) continue;
+    for (const name of required) {
+      if (reported.has(name)) continue;
+      if (!declaredProperties.has(name)) continue;
+      if (connectedHandles.has(name)) continue;
+      if (!isBlankPropertyValue(properties[name])) continue;
+      reported.add(name);
+      issues.push({
+        severity: "info",
+        code: "missing_required_model_input",
+        nodeId,
+        nodeType,
+        message:
+          `Node "${nodeId}" leaves "${name}" empty, and model "${modelId}" ` +
+          `(${provider}) declares it required. Set "${name}" or wire it — ` +
+          "until then, swapping this node's model breaks the graph."
+      });
+    }
+  }
+  return issues;
+}
+
 export interface SecretRequirementSite {
   nodeId: string;
   nodeType: string;
@@ -1039,13 +1133,30 @@ export function validateGraph(
       });
     }
 
+    const meta = registry.getMetadata(type);
+
+    // ── Properties blank that the selected model declares required. The
+    // registry's own check above knows which properties this node requires; it
+    // cannot know which ones the model behind `model` requires.
+    if (meta) {
+      issues.push(
+        ...collectRequiredModelInputIssues(
+          id,
+          type,
+          node,
+          new Set(meta.properties.map((prop) => prop.name)),
+          connectedByNode.get(id) ?? new Set<string>(),
+          registry
+        )
+      );
+    }
+
     // ── Properties the node does not have. A misspelled name is dead data:
     // the value sits in the graph, the real property keeps its default, and
     // nothing reports it. A required property left unset is already an error
     // above, so what reaches here is an optional one silently ignored — a
     // warning, not a refusal. Nodes taking dynamic properties are exempt:
     // an undeclared name is the feature there.
-    const meta = registry.getMetadata(type);
     if (meta && meta.supports_dynamic_inputs !== true) {
       const declaredNames = new Set(meta.properties.map((prop) => prop.name));
       const dynamic = readDynamicProperties(node);

--- a/packages/node-sdk/tests/graph-validation.test.ts
+++ b/packages/node-sdk/tests/graph-validation.test.ts
@@ -747,6 +747,161 @@ describe("unknown_model", () => {
   });
 });
 
+// A generic media node routes one shape to whichever provider its `model`
+// names, and they disagree about what is optional. Veo 3.1 animates an image
+// with no prompt; Kling answers the same call with `500 This field is
+// required`, naming neither the field nor the node. The manifests already say
+// which — this is the check that reads them at author time.
+describe("missing_required_model_input", () => {
+  const REQUIRED_BY_MODEL: Record<string, readonly string[]> = {
+    "kling-2.6/image-to-video": ["prompt"],
+    "veo-3.1-generate-preview": []
+  };
+  const registry = {
+    has: () => true,
+    getMetadata: () =>
+      ({
+        properties: [{ name: "prompt" }, { name: "image" }, { name: "model" }],
+        outputs: []
+      }) as never,
+    validateNode: () => [],
+    listProviderIds: () => ["kie", "gemini"],
+    listModelIds: () => undefined,
+    listRequiredTextInputs: (
+      _provider: string,
+      _modelType: string,
+      modelId: string
+    ) => REQUIRED_BY_MODEL[modelId]
+  };
+  const graphWith = (
+    modelId: string,
+    properties: Record<string, unknown> = {},
+    edges: unknown[] = []
+  ) => ({
+    nodes: [
+      {
+        id: "animate",
+        type: "nodetool.video.ImageToVideo",
+        data: {
+          model: { type: "video_model", provider: "kie", id: modelId },
+          ...properties
+        }
+      }
+    ],
+    edges: edges as never[]
+  });
+  const findIssue = (report: { issues: { code: string }[] }) =>
+    report.issues.find((i) => i.code === "missing_required_model_input");
+
+  it("reports a required text input left blank", () => {
+    const report = validateGraph(graphWith("kling-2.6/image-to-video"), registry);
+    const issue = findIssue(report) as { message?: string } | undefined;
+    expect(issue?.message).toContain("prompt");
+    expect(issue?.message).toContain("kling-2.6/image-to-video");
+  });
+
+  // `info`, so it stays below the `--warnings-as-errors` ratchet the shipped-
+  // examples gate runs at. The graph is model-specific, not broken, and the
+  // manifests behind the finding are generated — a wrong `required` must not
+  // fail a build. Asserting the counts, not just `ok`, is the point.
+  it("neither fails the report nor counts as a warning", () => {
+    const report = validateGraph(graphWith("kling-2.6/image-to-video"), registry);
+    expect(report.ok).toBe(true);
+    expect(report.counts.warnings).toBe(0);
+    expect(report.counts.info).toBeGreaterThan(0);
+  });
+
+  it("treats whitespace as blank", () => {
+    const report = validateGraph(
+      graphWith("kling-2.6/image-to-video", { prompt: "   " }),
+      registry
+    );
+    expect(findIssue(report)).toBeDefined();
+  });
+
+  it("accepts a prompt that is set", () => {
+    const report = validateGraph(
+      graphWith("kling-2.6/image-to-video", { prompt: "a fox in snow" }),
+      registry
+    );
+    expect(findIssue(report)).toBeUndefined();
+  });
+
+  // The fix the issue asks the shipped trailer graph to make: the per-shot
+  // prompt arrives over an edge, so the property is blank and correct.
+  it("accepts a prompt fed by an edge", () => {
+    const report = validateGraph(
+      graphWith("kling-2.6/image-to-video", {}, [
+        {
+          id: "e",
+          source: "shots",
+          sourceHandle: "shot_prompt",
+          target: "animate",
+          targetHandle: "prompt"
+        }
+      ]),
+      registry
+    );
+    expect(findIssue(report)).toBeUndefined();
+  });
+
+  it("says nothing about a model that declares no requirement", () => {
+    const report = validateGraph(graphWith("veo-3.1-generate-preview"), registry);
+    expect(findIssue(report)).toBeUndefined();
+  });
+
+  // Fails toward silence like every other catalog check here.
+  it("skips a model the catalog cannot answer for", () => {
+    const report = validateGraph(graphWith("some/unlisted-model"), registry);
+    expect(findIssue(report)).toBeUndefined();
+  });
+
+  it("skips the check when the caller supplies no lister", () => {
+    const { listRequiredTextInputs: _omit, ...noLister } = registry;
+    const report = validateGraph(graphWith("kling-2.6/image-to-video"), noLister);
+    expect(findIssue(report)).toBeUndefined();
+  });
+
+  // A requirement names an input of the node that selects it. A property the
+  // node does not declare cannot be the thing the model is asking for.
+  it("ignores a required name the node has no property for", () => {
+    const narrow = {
+      ...registry,
+      getMetadata: () =>
+        ({ properties: [{ name: "image" }, { name: "model" }], outputs: [] }) as never
+    };
+    const report = validateGraph(graphWith("kling-2.6/image-to-video"), narrow);
+    expect(findIssue(report)).toBeUndefined();
+  });
+
+  // A model nested in a settings object or a list configures something other
+  // than this node's own inputs.
+  it("ignores a model that is not the node's own top-level property", () => {
+    const report = validateGraph(
+      {
+        nodes: [
+          {
+            id: "animate",
+            type: "nodetool.video.ImageToVideo",
+            properties: {
+              config: {
+                model: {
+                  type: "video_model",
+                  provider: "kie",
+                  id: "kling-2.6/image-to-video"
+                }
+              }
+            }
+          }
+        ],
+        edges: []
+      },
+      registry
+    );
+    expect(findIssue(report)).toBeUndefined();
+  });
+});
+
 describe("model selections in nested properties", () => {
   const registry = {
     has: () => true,

--- a/packages/runtime/src/providers/index.ts
+++ b/packages/runtime/src/providers/index.ts
@@ -219,6 +219,7 @@ export type {
 } from "./credential-check.js";
 export {
   listOfflineModelIds,
+  listOfflineRequiredTextInputs,
   offlineModelIndexProviders
 } from "./offline-model-index.js";
 // OpenAI OAuth subsystem is intentionally NOT re-exported here. Its callback

--- a/packages/runtime/src/providers/kie-provider.ts
+++ b/packages/runtime/src/providers/kie-provider.ts
@@ -1221,6 +1221,39 @@ export class KieProvider extends BaseProvider {
     }
   }
 
+  /**
+   * Refuse a call whose required text field is blank, naming the field and the
+   * model.
+   *
+   * Kie answers one with `500 {"msg":"This field is required"}` — no field, no
+   * model, and by then the rest of the graph has been paid for. Reaching it is
+   * easy from a generic node: `nodetool.video.ImageToVideo` treats `prompt` as
+   * optional because Veo 3.1 does, so pointing the same node at
+   * `kling-2.6/image-to-video` sends a blank one. `applyRequiredDefaults` does
+   * not save it — the manifest's declared default for such a field is `""`,
+   * which is the value the endpoint rejects.
+   *
+   * Text only. A required media field arrives under its upload descriptor's API
+   * name (`images` is sent as `image_urls`), so reading it off the input bag
+   * under the manifest's name would refuse a call that is correctly formed.
+   */
+  private assertRequiredTextFields(
+    input: Record<string, unknown>,
+    fields: ModelInputField[],
+    modelId: string
+  ): void {
+    for (const field of fields) {
+      if (!field.required || field.type !== "str") continue;
+      const value = input[field.name];
+      if (isString(value) && value.trim().length > 0) continue;
+      throw new Error(
+        `Kie model "${modelId}" requires "${field.name}", which is empty. ` +
+          `Set the node's "${field.name}" property (or wire it), or choose a ` +
+          "model that does not require it."
+      );
+    }
+  }
+
   private applyVideoDuration(
     input: Record<string, unknown>,
     fields: ModelInputField[],
@@ -1432,6 +1465,7 @@ export class KieProvider extends BaseProvider {
     this.applyVideoDuration(input, fields, params);
     this.applyRequiredDefaults(input, fields);
     this.clampToDeclaredMax(input, fields);
+    this.assertRequiredTextFields(input, fields, modelId);
 
     log.debug("Kie imageToVideo", { model: modelId, images: imageUrls.length });
 

--- a/packages/runtime/src/providers/manifest-models.ts
+++ b/packages/runtime/src/providers/manifest-models.ts
@@ -42,6 +42,17 @@ interface ManifestField {
   max?: number;
 }
 
+/**
+ * Kie-style validation rule. `not_empty` is the endpoint saying, in the
+ * manifest, that it refuses a blank value for that field — the kie node factory
+ * checks these before spending an API call.
+ */
+interface ManifestValidation {
+  field: string;
+  rule: string;
+  message?: string;
+}
+
 /** Kie-style asset upload descriptor (carries the real API param name). */
 interface ManifestUpload {
   field: string;
@@ -74,6 +85,8 @@ interface ManifestNode {
   fields?: ManifestField[];
   /** Kie ships asset upload descriptors (field → API param mapping). */
   uploads?: ManifestUpload[];
+  /** Kie ships per-endpoint validation rules the node factory enforces. */
+  validation?: ManifestValidation[];
   /** Kie: routes the model through the Suno music API. */
   useSuno?: boolean;
   /** Kie: Suno API endpoint path for this model. */
@@ -638,6 +651,60 @@ export function getModelInputFields(
     }
     return field;
   });
+}
+
+function requiredTextInputsOf(entry: ManifestNode): string[] {
+  const names = new Set<string>();
+  const textFields = new Set<string>();
+  // Kie: `fields`, where `name` is the API param.
+  for (const field of entry.fields ?? []) {
+    if (field.type.toLowerCase() !== "str") continue;
+    textFields.add(field.name);
+    if (field.required === true) names.add(field.name);
+  }
+  // Kie also states it a second way, as the rules the node factory enforces
+  // before spending a call. Most entries say both; some say only this one.
+  for (const rule of entry.validation ?? []) {
+    if (rule.rule === "not_empty" && textFields.has(rule.field)) {
+      names.add(rule.field);
+    }
+  }
+  // FAL / Replicate: `inputFields`. The declared `name` is the property name;
+  // `apiParamName` is the wire name, which is not what a node property is called.
+  for (const field of entry.inputFields ?? []) {
+    if (field.required === true && field.propType.toLowerCase() === "str") {
+      names.add(field.name);
+    }
+  }
+  return [...names];
+}
+
+/**
+ * Text fields `modelId` refuses to run without, by the name the manifest gives
+ * them — which is also the name the generic media nodes give the matching
+ * property, so a caller can match one against the other.
+ *
+ * Restricted to text on purpose. A required *media* field is fed through the
+ * node's own image/video wiring under a different API name (kie's `images`
+ * arrives as `image_urls`), and a required number or enum carries a default the
+ * provider fills in. What is left is the case that actually fails: a text field
+ * the endpoint rejects when blank. `kling-2.6/image-to-video` declares `prompt`
+ * required in both conventions and answers an empty one with
+ * `500 This field is required`, naming neither the field nor the model.
+ *
+ * Undefined means the model is not in this manifest — "cannot tell", never
+ * "requires nothing". An entry that declares none returns an empty list.
+ */
+export function getRequiredTextInputNames(
+  packageName: string,
+  exportPath: string,
+  modelId: string
+): string[] | undefined {
+  const entry = loadManifest(packageName, exportPath).find(
+    (n) => nodeId(n) === modelId
+  );
+  if (!entry) return undefined;
+  return requiredTextInputsOf(entry);
 }
 
 /** Kie execution metadata carried on a manifest entry. */

--- a/packages/runtime/src/providers/offline-model-index.ts
+++ b/packages/runtime/src/providers/offline-model-index.ts
@@ -19,6 +19,7 @@
  * node runs, after the rest of the graph has already been paid for.
  */
 import {
+  getRequiredTextInputNames,
   loadImageModels,
   loadVideoModels,
   loadTTSModels,
@@ -100,6 +101,29 @@ export function listOfflineModelIds(
 
   cache.set(key, result);
   return result;
+}
+
+/**
+ * Text inputs `modelId` declares it will not run without, or `undefined` when
+ * that cannot be established offline.
+ *
+ * Same silence rules as {@link listOfflineModelIds}: an unknown provider, an
+ * unclassified model type, an unreadable manifest, or a model the manifest does
+ * not carry all answer `undefined`. An entry that declares no required text
+ * input answers `[]` — that one is knowledge, not a gap.
+ */
+export function listOfflineRequiredTextInputs(
+  provider: string,
+  modelType: string,
+  modelId: string
+): readonly string[] | undefined {
+  const source = MANIFEST_SOURCES[provider];
+  if (!source || !LOADER_BY_MODEL_TYPE[modelType]) return undefined;
+  try {
+    return getRequiredTextInputNames(source.pkg, source.path, modelId);
+  } catch {
+    return undefined;
+  }
 }
 
 /** Providers whose ids {@link listOfflineModelIds} can check. */

--- a/packages/runtime/tests/providers/kie-provider.test.ts
+++ b/packages/runtime/tests/providers/kie-provider.test.ts
@@ -184,6 +184,46 @@ describe("KieProvider — imageToVideo", () => {
 
     expect(createdInputs[0].duration).toBe("5");
   });
+
+  // The failure the trailer graph hit. `nodetool.video.ImageToVideo` treats
+  // `prompt` as optional because Veo 3.1 does, so the same node pointed at
+  // Kling sent a blank one and Kie answered `500 This field is required` —
+  // naming neither the field nor the node. Refuse it here instead, before the
+  // generation task is created.
+  it("refuses a blank prompt a model declares required, naming both", async () => {
+    mockKieFlow(["https://kie.cdn/frame.png"]);
+    const provider = new KieProvider({ KIE_API_KEY: "k" });
+
+    const call = provider.imageToVideo([new Uint8Array([9])], {
+      model: {
+        id: "kling-2.6/image-to-video",
+        name: "Kling 2.6",
+        provider: "kie"
+      },
+      prompt: ""
+    });
+
+    await expect(call).rejects.toThrow("prompt");
+    await expect(call).rejects.toThrow("kling-2.6/image-to-video");
+  });
+
+  it("lets the same model through once the prompt is set", async () => {
+    const { createdInputs } = mockKieFlow(["https://kie.cdn/frame.png"]);
+    const provider = new KieProvider({ KIE_API_KEY: "k" });
+
+    await provider.imageToVideo([new Uint8Array([9])], {
+      model: {
+        id: "kling-2.6/image-to-video",
+        name: "Kling 2.6",
+        provider: "kie"
+      },
+      prompt: "the bridge buckles as the car clears the gap"
+    });
+
+    expect(createdInputs[0].prompt).toBe(
+      "the bridge buckles as the car clears the gap"
+    );
+  });
 });
 
 describe("KieProvider — TTS", () => {

--- a/packages/runtime/tests/providers/manifest-models.test.ts
+++ b/packages/runtime/tests/providers/manifest-models.test.ts
@@ -4,6 +4,7 @@ import {
   buildTTSModels,
   getManifestNodeMeta,
   getModelInputFields,
+  getRequiredTextInputNames,
   isKieMusicNode,
   loadImageModels,
   loadMusicModels,
@@ -419,6 +420,49 @@ describe("getModelInputFields", () => {
 
   it("returns [] for an unknown model id", () => {
     expect(getModelInputFields(KIE_PKG, KIE_MANIFEST, "nope/nope")).toEqual([]);
+  });
+});
+
+// The requirement that broke the trailer graph. Read off the real shipped
+// manifests, because the check is worth exactly as much as the data behind it:
+// a `required` flag the generator stopped emitting would leave the validator
+// silently reporting nothing.
+describe("getRequiredTextInputNames", () => {
+  it("reads Kie's required `prompt` for a Kling image-to-video model", () => {
+    expect(
+      getRequiredTextInputNames(KIE_PKG, KIE_MANIFEST, "kling-2.6/image-to-video")
+    ).toContain("prompt");
+  });
+
+  it("reads FAL's required `prompt` for a Kling image-to-video endpoint", () => {
+    expect(
+      getRequiredTextInputNames(
+        FAL_PKG,
+        FAL_MANIFEST,
+        "fal-ai/kling-video/v2.5-turbo/pro/image-to-video"
+      )
+    ).toContain("prompt");
+  });
+
+  // A required media field arrives under its upload descriptor's API name
+  // (`images` is sent as `image_urls`), so reporting it would make a caller
+  // look for a property that is already correctly wired.
+  it("reports no media or enum field, however required", () => {
+    const names = getRequiredTextInputNames(
+      KIE_PKG,
+      KIE_MANIFEST,
+      "kling-2.6/image-to-video"
+    );
+    expect(names).not.toContain("images");
+    expect(names).not.toContain("duration");
+    expect(names).not.toContain("sound");
+  });
+
+  // "Cannot tell" and "requires nothing" must not be the same answer.
+  it("returns undefined for a model the manifest does not carry", () => {
+    expect(
+      getRequiredTextInputNames(KIE_PKG, KIE_MANIFEST, "nope/nope")
+    ).toBeUndefined();
   });
 });
 

--- a/packages/video-nodes/src/nodes/video.ts
+++ b/packages/video-nodes/src/nodes/video.ts
@@ -517,7 +517,8 @@ export class ImageToVideoNode extends BaseNode {
     type: "str",
     default: "",
     title: "Prompt",
-    description: "Optional text prompt to guide the video animation"
+    description:
+      "Text prompt to guide the video animation. Veo animates an image without one; Kling refuses an empty one. Leaving it blank ties the graph to the models that treat it as optional."
   })
   declare prompt: string;
 


### PR DESCRIPTION
Closes #5197

### 1. The graph

`Movie Trailer Generator` now wires `shots.shot_prompt` into `animate.prompt` instead of relying on the keyframe to carry the intent. `Directed Film to Timeline` had the identical wiring and got the same edge.

### 2. The check

Every Kling image-to-video entry already declares `prompt` required — KIE in `fields[].required` plus a `not_empty` validation rule, FAL in `inputFields[].required` — and nothing read it at author time.

- `getRequiredTextInputNames` reads both manifest conventions
- `listOfflineRequiredTextInputs` exposes it with the same fail-toward-silence rules as the model-id index
- `validateGraph` reports `missing_required_model_input` when the property is blank, unwired, declared by the node, and the model is the node's own top-level property
- Wired into `nodetool validate` and `validate_workflow`

Text fields only: a required media field arrives under its upload descriptor's API name, so checking it would flag a correctly-wired node.

### Why `info` and not `warning`

The shipped-examples gate runs at `--warnings-as-errors`. The authoring environment could not execute it, and AGENTS.md says to report rather than enforce what has not been reproduced. The at-risk class was audited by hand — the transform models (esrgan, clarity-upscaler, rembg, bria, vectorize, relighting, lipsync) declare no required text field — but not exhaustively.

`info` is also correct on the merits: a graph pinned to Veo with a blank prompt runs. It is model-specific, not broken.

### 3. The run-time message

`KieProvider.imageToVideo` refuses a blank required text field by name before creating the task, so the 500 becomes a sentence naming the model and the field. `applyRequiredDefaults` did not save it — the declared default is `""`, which is the value the endpoint rejects.

### Verification

⚠️ `typecheck`, `lint` and `test:affected` could not be run in the authoring environment (npm/npx/node were not permitted). Tests are written but unexecuted. Please run all three plus `npm run validate:examples` before merging.

🤖 Generated with [Claude Code](https://claude.ai/code)