### PR TITLE
fix(cli): stop --json failing a completed run on large binary outputs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -115,6 +115,14 @@ nodetool workflows run workflow_abc123 --params '{"input": "hello"}'
 nodetool workflows run ./my_workflow.json --json
 ```
 
+`--json` never expands a large binary output into the JSON text. An image,
+audio, or video payload over 64 KiB is written to
+`nodetool-output/<job_id>/payload-N.<ext>` and appears as
+`{"$file": "…", "bytes": N, "mimeType": "…"}` in its place; the path is
+reported on stderr. Image nodes emit raw RGBA as their in-flight format, so a
+raw ref is PNG-encoded on the way out. `nodetool run` and `nodetool node run`
+do the same, spilling into `nodetool-output/`.
+
 ### `nodetool workflows export-dsl <workflow_id_or_file>`
 
 Exports a workflow as a TypeScript DSL file.

--- a/packages/cli/src/commands/node.ts
+++ b/packages/cli/src/commands/node.ts
@@ -68,8 +68,9 @@ export function registerNodeCommands(program: Command): void {
         }
         const result = await runSingleNode(nodeType, runOptions);
 
+        const { printRunJson, previewJson } = await import("../run-json.js");
         if (opts.json) {
-          console.log(JSON.stringify(result, null, 2));
+          await printRunJson(result);
         } else {
           const mark = result.ok ? "✅" : "❌";
           console.log(
@@ -79,7 +80,7 @@ export function registerNodeCommands(program: Command): void {
           if (result.chunks.length > 0) {
             console.log(`\nEmitted ${result.chunks.length} record(s):`);
             for (const chunk of result.chunks) {
-              console.log(`  ${JSON.stringify(chunk).slice(0, 500)}`);
+              console.log(`  ${previewJson(chunk, 500)}`);
             }
           } else if (result.ok) {
             console.log("\n(no output emitted)");

--- a/packages/cli/src/nodetool.ts
+++ b/packages/cli/src/nodetool.ts
@@ -417,21 +417,18 @@ addSupervisorOptions(
         results = await runDslFile(absolutePath);
       }
 
+      const { printRunJson, previewJson } = await import("./run-json.js");
       if (opts.json) {
         // A supervised run reports what the supervisor did alongside the
         // outputs; an unsupervised one keeps the bare results shape.
-        console.log(
-          JSON.stringify(
-            supervisorConfig ? { results, interventions } : results,
-            null,
-            2
-          )
+        await printRunJson(
+          supervisorConfig ? { results, interventions } : results
         );
       } else {
         for (const [workflowName, outputs] of Object.entries(results)) {
           console.log(`\n${workflowName}:`);
           for (const [key, value] of Object.entries(outputs)) {
-            console.log(`  ${key}: ${JSON.stringify(value)}`);
+            console.log(`  ${key}: ${previewJson(value)}`);
           }
         }
       }
@@ -887,8 +884,11 @@ addSupervisorOptions(
         });
       }
 
+      const { printRunJson, previewJson } = await import("./run-json.js");
       if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
+        await printRunJson(result, {
+          outputDir: resolve(process.cwd(), "nodetool-output", jobId)
+        });
       } else {
         console.log(`Status: ${result.status}`);
         if (result.error) console.error(`Error: ${result.error}`);
@@ -896,7 +896,7 @@ addSupervisorOptions(
           if (Array.isArray(outputs) && outputs.length > 0) {
             console.log(`\nNode ${nodeId}:`);
             for (const out of outputs) {
-              console.log(`  ${JSON.stringify(out).slice(0, 200)}`);
+              console.log(`  ${previewJson(out, 200)}`);
             }
           }
         }

--- a/packages/cli/src/run-json.ts
+++ b/packages/cli/src/run-json.ts
@@ -1,0 +1,186 @@
+/**
+ * JSON reporting for a finished run.
+ *
+ * A run that reaches here has already executed and been paid for, so reporting
+ * must not be able to fail it. Two things sit between a run result and a JSON
+ * string. GPU image nodes emit raw-RGBA bytes as their in-flight format so
+ * chained shader ops skip the codec, and every boundary that hands out a
+ * portable image encodes them first (`packages/runtime/src/image-codec.ts`) —
+ * this is that boundary for the CLI. And three 1024² frames in one
+ * `JSON.stringify(…, null, 2)` exceed what a single JS string can hold.
+ *
+ * So binary payloads at or over `maxInlineBytes` are written next to the run
+ * and replaced by a `$file` pointer, and a stringify that still overflows
+ * degrades to a summary instead of throwing.
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { isRawRgbaImage } from "@nodetool-ai/protocol";
+import { encodeRawImageRef } from "@nodetool-ai/runtime";
+import {
+  isFunctionValue,
+  isObjectLike,
+  isRecord,
+  isString
+} from "./predicates.js";
+
+/**
+ * Above this many bytes a payload is written to disk. A byte array in JSON is
+ * one number per byte, so even a modest buffer costs megabytes of text and is
+ * unusable to whatever reads it.
+ */
+const DEFAULT_MAX_INLINE_BYTES = 64 * 1024;
+
+export interface RunJsonOptions {
+  /**
+   * Where oversized payloads are written, created on the first spill. Callers
+   * with a run id should scope this per run so a later run does not overwrite
+   * files the printed JSON still points at.
+   */
+  outputDir?: string;
+  /** Binary payloads of at least this many bytes go to disk instead. */
+  maxInlineBytes?: number;
+}
+
+/** What replaces a binary payload that was written to disk. */
+interface BinaryPointer {
+  $file: string;
+  bytes: number;
+  mimeType?: string;
+}
+
+interface Spill {
+  dir: string;
+  limit: number;
+  files: string[];
+}
+
+/** The file extension for `mimeType`, or `bin` when it names nothing usable. */
+function extensionFor(mimeType: string | undefined): string {
+  const subtype = mimeType?.split("/")[1]?.split(";")[0]?.replace(/\+.*$/, "");
+  return subtype && /^[a-z0-9.-]+$/i.test(subtype) ? subtype : "bin";
+}
+
+function writeBinary(
+  data: Uint8Array,
+  mimeType: string | undefined,
+  spill: Spill
+): BinaryPointer {
+  if (spill.files.length === 0) {
+    mkdirSync(spill.dir, { recursive: true });
+  }
+  const file = join(
+    spill.dir,
+    `payload-${spill.files.length}.${extensionFor(mimeType)}`
+  );
+  writeFileSync(file, data);
+  spill.files.push(file);
+  const pointer: BinaryPointer = { $file: file, bytes: data.byteLength };
+  if (mimeType) {
+    pointer.mimeType = mimeType;
+  }
+  return pointer;
+}
+
+async function encodeImage(
+  ref: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  try {
+    const encoded = await encodeRawImageRef(ref);
+    return isObjectLike(encoded) ? encoded : ref;
+  } catch {
+    // No codec on this install (sharp missing). Keep the raw ref: its bytes
+    // still spill to disk below rather than being dropped.
+    return ref;
+  }
+}
+
+/**
+ * Walk `value`, PNG-encoding raw-RGBA images and spilling large binaries.
+ * `mimeType` is the one declared by the nearest enclosing object, so a ref's
+ * `data` is named by its own `mimeType`.
+ */
+async function prepare(
+  value: unknown,
+  mimeType: string | undefined,
+  spill: Spill
+): Promise<unknown> {
+  if (value instanceof Uint8Array) {
+    return value.byteLength >= spill.limit
+      ? writeBinary(value, mimeType, spill)
+      : value;
+  }
+  if (Array.isArray(value)) {
+    return Promise.all(value.map((item) => prepare(item, mimeType, spill)));
+  }
+  if (!isObjectLike(value)) {
+    return value;
+  }
+  // A value with its own serializer (a `Date`, say) decides its own JSON.
+  // Decomposing it into own enumerable properties turns a timestamp into `{}`.
+  if (isFunctionValue(value.toJSON)) {
+    return value;
+  }
+
+  const record = isRawRgbaImage(value) ? await encodeImage(value) : value;
+  const childMime = isString(record.mimeType) ? record.mimeType : mimeType;
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(record)) {
+    out[key] = await prepare(item, childMime, spill);
+  }
+  return out;
+}
+
+/** The JSON text for a run result, plus every payload file it points at. */
+export async function formatRunJson(
+  value: unknown,
+  opts: RunJsonOptions = {}
+): Promise<{ json: string; files: string[] }> {
+  const spill: Spill = {
+    dir: opts.outputDir ?? resolve(process.cwd(), "nodetool-output"),
+    limit: opts.maxInlineBytes ?? DEFAULT_MAX_INLINE_BYTES,
+    files: []
+  };
+  try {
+    const prepared = await prepare(value, undefined, spill);
+    return { json: JSON.stringify(prepared, null, 2), files: spill.files };
+  } catch (e) {
+    // Whatever went wrong here, the run itself is done. Report the failure as
+    // JSON on the JSON channel instead of raising it over a finished run.
+    const summary = {
+      error: `Result could not be serialized as JSON: ${String(e)}`,
+      keys: isRecord(value) ? Object.keys(value) : [],
+      files: spill.files
+    };
+    return { json: JSON.stringify(summary, null, 2), files: spill.files };
+  }
+}
+
+/** Print a run result as JSON, noting on stderr where any payloads landed. */
+export async function printRunJson(
+  value: unknown,
+  opts: RunJsonOptions = {}
+): Promise<void> {
+  const { json, files } = await formatRunJson(value, opts);
+  console.log(json);
+  const first = files[0];
+  if (first) {
+    console.error(`Wrote ${files.length} payload file(s) to ${dirname(first)}`);
+  }
+}
+
+/**
+ * One-line rendering of a value for the human-readable output. Byte arrays are
+ * described rather than expanded, so a 4 MB frame does not cost tens of
+ * megabytes of text on its way to being truncated to `maxChars`.
+ */
+export function previewJson(value: unknown, maxChars?: number): string {
+  // `JSON.stringify` is typed `string` but returns undefined for an undefined
+  // or non-serializable root.
+  const text: string | undefined = JSON.stringify(value, (_key, item: unknown) =>
+    item instanceof Uint8Array ? `<${item.byteLength} bytes>` : item
+  );
+  if (text === undefined) return "undefined";
+  if (maxChars === undefined || text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}…`;
+}

--- a/packages/cli/tests/run-json.test.ts
+++ b/packages/cli/tests/run-json.test.ts
@@ -1,0 +1,183 @@
+/**
+ * `--json` reporting of a finished run (#5198).
+ *
+ * A `lib.image.*` node emits raw-RGBA bytes as its in-flight format, so a run
+ * of several 1024² frames used to overflow V8's string limit inside
+ * `JSON.stringify(result, null, 2)` — failing the report of a run that had
+ * already completed and been paid for. These pin the two halves of the fix:
+ * raw-RGBA refs go through the shared PNG encoder at this boundary, and binary
+ * payloads over the ceiling are written to disk rather than expanded byte by
+ * byte into the JSON text.
+ *
+ * `@nodetool-ai/protocol` and `@nodetool-ai/runtime` are stubbed for this
+ * package's tests (see vitest.config.ts), so the predicate and the encoder are
+ * supplied here. The encoder's own behaviour is pinned by
+ * packages/runtime/tests/image-codec.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const RAW_RGBA_MIME = "image/x-raw-rgba";
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+vi.mock("@nodetool-ai/protocol", () => ({
+  RAW_RGBA_MIME: "image/x-raw-rgba",
+  isRawRgbaImage: (value: unknown) => {
+    if (!value || typeof value !== "object") return false;
+    const v = value as Record<string, unknown>;
+    return (
+      v.type === "image" &&
+      v.mimeType === "image/x-raw-rgba" &&
+      v.data instanceof Uint8Array &&
+      typeof v.width === "number" &&
+      typeof v.height === "number" &&
+      v.data.length === v.width * v.height * 4
+    );
+  }
+}));
+
+vi.mock("@nodetool-ai/runtime", () => ({
+  encodeRawImageRef: async (ref: Record<string, unknown>) => {
+    const width = ref.width as number;
+    const height = ref.height as number;
+    return {
+      ...ref,
+      mimeType: "image/png",
+      // Stands in for the real PNG: signed, and smaller than the raw pixels.
+      data: new Uint8Array([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+        ...new Uint8Array(width * height)
+      ])
+    };
+  }
+}));
+
+import { formatRunJson, previewJson } from "../src/run-json.js";
+
+let outputDir: string;
+
+beforeEach(() => {
+  outputDir = mkdtempSync(join(tmpdir(), "run-json-"));
+});
+
+afterEach(() => {
+  rmSync(outputDir, { recursive: true, force: true });
+});
+
+/** `w`x`h` opaque-red straight-alpha RGBA8, the in-flight image-node output. */
+function rawImage(w: number, h: number) {
+  const data = new Uint8Array(w * h * 4);
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = 255;
+    data[i + 3] = 255;
+  }
+  return { type: "image", mimeType: RAW_RGBA_MIME, width: w, height: h, data };
+}
+
+describe("formatRunJson", () => {
+  it("keeps a payload under the ceiling inline", async () => {
+    const { json, files } = await formatRunJson(
+      { outputs: { a: [{ data: new Uint8Array([1, 2, 3]) }] } },
+      { outputDir, maxInlineBytes: 64 }
+    );
+    expect(files).toEqual([]);
+    expect(JSON.parse(json).outputs.a[0].data).toEqual({
+      "0": 1,
+      "1": 2,
+      "2": 3
+    });
+  });
+
+  it("writes a payload at or over the ceiling to disk and points at it", async () => {
+    const data = new Uint8Array(4096).fill(7);
+    const { json, files } = await formatRunJson(
+      { outputs: { a: [{ type: "audio", mimeType: "audio/wav", data }] } },
+      { outputDir, maxInlineBytes: 1024 }
+    );
+
+    expect(files).toHaveLength(1);
+    const file = files[0];
+    const pointer = JSON.parse(json).outputs.a[0].data;
+    expect(pointer).toEqual({ $file: file, bytes: 4096, mimeType: "audio/wav" });
+    expect(file).toMatch(/payload-0\.wav$/);
+    expect(readFileSync(file)).toEqual(Buffer.from(data));
+    // The bytes are gone from the text — that is the whole point.
+    expect(json.length).toBeLessThan(1000);
+  });
+
+  it("PNG-encodes a raw-RGBA ref before it leaves the process", async () => {
+    const { json, files } = await formatRunJson(
+      { outputs: { image: [rawImage(64, 64)] } },
+      { outputDir, maxInlineBytes: 1024 }
+    );
+
+    const ref = JSON.parse(json).outputs.image[0];
+    expect(ref.mimeType).toBe("image/png");
+    expect(json).not.toContain(RAW_RGBA_MIME);
+    expect(files[0]).toMatch(/payload-0\.png$/);
+    const written = readFileSync(files[0]);
+    expect(Array.from(written.subarray(0, 8))).toEqual(PNG_SIGNATURE);
+    expect(written.byteLength).toBeLessThan(64 * 64 * 4);
+  });
+
+  it("names an encoded payload by its own mimeType, not an enclosing one", async () => {
+    const { files } = await formatRunJson(
+      { mimeType: "application/json", image: rawImage(32, 32) },
+      { outputDir, maxInlineBytes: 1024 }
+    );
+    expect(files[0]).toMatch(/\.png$/);
+  });
+
+  it("labels a payload with no known mimeType .bin", async () => {
+    const { files } = await formatRunJson(
+      { data: new Uint8Array(2048) },
+      { outputDir, maxInlineBytes: 1024 }
+    );
+    expect(files[0]).toMatch(/payload-0\.bin$/);
+  });
+
+  it("leaves a value that serializes itself alone", async () => {
+    const { json } = await formatRunJson(
+      { started: new Date("2026-08-24T00:00:00.000Z") },
+      { outputDir }
+    );
+    expect(JSON.parse(json).started).toBe("2026-08-24T00:00:00.000Z");
+  });
+
+  it("reports a serialization failure as JSON instead of throwing", async () => {
+    const { json } = await formatRunJson(
+      { status: "completed", outputs: { a: 1n } },
+      { outputDir }
+    );
+    const report = JSON.parse(json);
+    expect(report.error).toMatch(/could not be serialized/);
+    expect(report.keys).toEqual(["status", "outputs"]);
+  });
+
+  it("still reports the files it spilled when serialization fails", async () => {
+    const { json, files } = await formatRunJson(
+      { image: rawImage(32, 32), broken: 1n },
+      { outputDir, maxInlineBytes: 1 }
+    );
+    expect(files).toHaveLength(1);
+    expect(JSON.parse(json).files).toEqual(files);
+  });
+});
+
+describe("previewJson", () => {
+  it("describes byte arrays instead of expanding them", () => {
+    expect(previewJson({ data: new Uint8Array(4_194_304) })).toBe(
+      '{"data":"<4194304 bytes>"}'
+    );
+  });
+
+  it("truncates to maxChars", () => {
+    expect(previewJson({ text: "x".repeat(100) }, 10)).toBe('{"text":"x…');
+  });
+
+  it("leaves a value under maxChars whole", () => {
+    expect(previewJson({ a: 1 }, 100)).toBe('{"a":1}');
+  });
+});


### PR DESCRIPTION
Fixes #5198.

`workflows run --json` threw `RangeError: Invalid string length` on a run of several 1024² images - after the generations had been paid for. The fix is at the CLI output boundary, not in the image nodes:

- raw-RGBA refs now go through the shared `encodeRawImageRef`, as the ws runner and asset storage already do;
- binary payloads over 64 KiB are written to `nodetool-output/<job_id>/payload-N.<ext>` and replaced by a `{$file, bytes, mimeType}` pointer;
- a stringify that still fails reports the failure as JSON instead of raising over a finished run;
- the human-readable branches stop building the full multi-MB string before truncating it.

`lib.image.color.BrightnessContrast` is unchanged - it uses the same `runShaderNode` as every sibling, so encoding there would cost the chained-shader optimization and leave the failure reachable through the rest of the namespace.

Not covered: `nodetool debug --json` and the debug bundle's `report.json`, which can hit the same ceiling.

CI must run typecheck/lint/tests - they could not run in the authoring environment.

Generated with [Claude Code](https://claude.ai/code)