### PR TITLE
fix(video-nodes): bound AddAudio output to the picture

### DIFF
--- a/docs/nodes/catalog.json
+++ b/docs/nodes/catalog.json
@@ -15257,6 +15257,13 @@
           "description": "If True, mix new audio with existing. If False, replace existing audio.",
           "required": false,
           "default": false
+        },
+        {
+          "name": "output_length",
+          "type": "enum",
+          "description": "How long the output is. 'video' matches the picture: a longer audio track is trimmed, a shorter one padded with silence. 'longest' keeps both streams whole, so a track that outruns the picture leaves the output playing over nothing.",
+          "required": false,
+          "default": "video"
         }
       ],
       "outputs": [

--- a/docs/nodes/nodetool/video/addaudio.md
+++ b/docs/nodes/nodetool/video/addaudio.md
@@ -22,6 +22,7 @@ Add an audio track to a video, replacing or mixing with existing audio.
 | audio | `audio` | The audio file to add to the video. | `{"type":"audio","uri":"","asset_id":null,"data"...` |
 | volume | `float` | Volume adjustment for the added audio. 1.0 is original volume. | `1` |
 | mix | `bool` | If True, mix new audio with existing. If False, replace existing audio. | `false` |
+| output_length | `enum` | How long the output is. 'video' matches the picture: a longer audio track is trimmed, a shorter one padded with silence. 'longest' keeps both streams whole, so a track that outruns the picture leaves the output playing over nothing. | `video` |
 
 ## Outputs
 

--- a/packages/dsl/src/flow/generated/nodetool.video.ts
+++ b/packages/dsl/src/flow/generated/nodetool.video.ts
@@ -391,6 +391,7 @@ export type AddAudioInputs = {
   audio?: AudioRef;
   volume?: number;
   mix?: boolean;
+  output_length?: "video" | "longest";
 };
 
 export interface AddAudioOutputs {

--- a/packages/dsl/src/generated/nodetool.video.ts
+++ b/packages/dsl/src/generated/nodetool.video.ts
@@ -377,6 +377,7 @@ export type AddAudioInputs = {
   audio?: Connectable<AudioRef>;
   volume?: Connectable<number>;
   mix?: Connectable<boolean>;
+  output_length?: Connectable<"video" | "longest">;
 };
 
 export interface AddAudioOutputs {

--- a/packages/video-nodes/AGENTS.md
+++ b/packages/video-nodes/AGENTS.md
@@ -41,6 +41,20 @@ default across props.
   as an asset/`file://`/`http` URI yielded empty bytes and the node silently
   returned the video with no audio.
 
+## Muxing audio against picture
+
+- **A node that muxes an audio stream onto a video must decide the output
+  length itself.** Left to the muxer, the file is as long as the *longer*
+  stream: a music model that ignores the requested duration returns a whole
+  song, and a 25-second clip came out four minutes long, with three and a half
+  minutes of nothing after the picture ended. `AddAudio` pads the audio with
+  `apad` and ends the file with `-shortest`, which bounds a long track to the
+  picture and stops a short one from cutting the picture off; its
+  `output_length` property opts back into the unbounded behavior. The other
+  mux sites are already bounded — `Overlay` mixes with `amix=duration=first`
+  over the main video's own audio, `Transition` uses `xfade`/`acrossfade`, and
+  both `normalizeConcatSegment` and `mixAudioInto` pass `-shortest`.
+
 ## ffmpeg numbered sequences
 
 - **Number frame files with a contiguous counter incremented only on a successful

--- a/packages/video-nodes/src/nodes/video.ts
+++ b/packages/video-nodes/src/nodes/video.ts
@@ -2503,6 +2503,16 @@ export class AddAudioVideoNode extends VideoTransformNode {
   })
   declare mix: boolean;
 
+  @prop({
+    type: "enum",
+    default: "video",
+    title: "Output Length",
+    description:
+      "How long the output is. 'video' matches the picture: a longer audio track is trimmed, a shorter one padded with silence. 'longest' keeps both streams whole, so a track that outruns the picture leaves the output playing over nothing.",
+    values: ["video", "longest"]
+  })
+  declare output_length: string;
+
   async process(context?: ProcessingContext): Promise<AddAudioVideoNodeOutputs> {
     const v = await videoBytesAsync(this.video, context);
     const a = await audioBytesAsync(this.audio, context);
@@ -2518,6 +2528,13 @@ export class AddAudioVideoNode extends VideoTransformNode {
     try {
       const volume = Math.max(0, Number(this.volume ?? 1));
       const mix = Boolean(this.mix);
+      // Left to the muxer the file is as long as the *longer* stream, so a
+      // music model that ignores the requested duration turns a 25-second clip
+      // into a four-minute one. `apad` makes the audio endless and `-shortest`
+      // then ends the file with the picture, which also stops a short audio
+      // track from cutting the picture off.
+      const trimToVideo = String(this.output_length ?? "video") !== "longest";
+      const pad = trimToVideo ? ",apad" : "";
 
       const buildArgs = (useMix: boolean): string[] => {
         const args: string[] = [
@@ -2528,14 +2545,14 @@ export class AddAudioVideoNode extends VideoTransformNode {
         if (useMix) {
           args.push(
             "-filter_complex",
-            `[1:a]volume=${volume}[newaud];[0:a][newaud]amix=inputs=2:duration=first[aout]`,
+            `[1:a]volume=${volume}[newaud];[0:a][newaud]amix=inputs=2:duration=longest${pad}[aout]`,
             "-map", "0:v:0",
             "-map", "[aout]",
             "-c:v", "copy"
           );
-        } else if (volume !== 1) {
+        } else if (volume !== 1 || trimToVideo) {
           args.push(
-            "-filter_complex", `[1:a]volume=${volume}[aout]`,
+            "-filter_complex", `[1:a]volume=${volume}${pad}[aout]`,
             "-map", "0:v:0",
             "-map", "[aout]",
             "-c:v", "copy",
@@ -2549,6 +2566,7 @@ export class AddAudioVideoNode extends VideoTransformNode {
             "-c:a", "aac"
           );
         }
+        if (trimToVideo) args.push("-shortest");
         args.push(outputPath);
         return args;
       };

--- a/packages/video-nodes/tests/regression-video.test.ts
+++ b/packages/video-nodes/tests/regression-video.test.ts
@@ -734,6 +734,77 @@ describe("AddAudioVideoNode — uses volume and mix inputs", () => {
   });
 });
 
+// ─── 10b. AddAudio length policy ───────────────────────────────────────────────
+
+describe("AddAudioVideoNode — bounds the output to the picture", () => {
+  it("trims an audio track to the picture by default", async () => {
+    const node = new AddAudioVideoNode();
+    node.assign({
+      video: videoRef([1, 2, 3, 4]),
+      audio: audioRef([10, 20, 30, 40]),
+      volume: 1.0,
+      mix: false
+    });
+    await node.process().catch(() => undefined);
+
+    const args = ffmpegArgString();
+    expect(args).toContain("apad");
+    expect(args).toContain("-shortest");
+  });
+
+  it("trims when mixing too, and mixes the whole bed before trimming", async () => {
+    const node = new AddAudioVideoNode();
+    node.assign({
+      video: videoRef([1, 2, 3, 4]),
+      audio: audioRef([10, 20, 30, 40]),
+      volume: 0.7,
+      mix: true
+    });
+    await node.process().catch(() => undefined);
+
+    const args = ffmpegArgString();
+    expect(args).toContain("amix=inputs=2:duration=longest,apad");
+    expect(args).toContain("-shortest");
+  });
+
+  it("keeps the replace fallback bounded when mixing fails", async () => {
+    const node = new AddAudioVideoNode();
+    node.assign({
+      video: videoRef([1, 2, 3, 4]),
+      audio: audioRef([10, 20, 30, 40]),
+      volume: 1.0,
+      mix: true
+    });
+    await node.process().catch(() => undefined);
+
+    // The mocked ffmpeg always fails, so the mix attempt falls back to plain
+    // replacement. That second command must carry the guard as well.
+    const calls = ffmpegCalls();
+    expect(calls.length).toBe(2);
+    const fallback = calls[1].join(" ");
+    expect(fallback).not.toContain("amix");
+    expect(fallback).toContain("apad");
+    expect(fallback).toContain("-shortest");
+  });
+
+  it("output_length=longest keeps both streams whole", async () => {
+    const node = new AddAudioVideoNode();
+    node.assign({
+      video: videoRef([1, 2, 3, 4]),
+      audio: audioRef([10, 20, 30, 40]),
+      volume: 1.0,
+      mix: false,
+      output_length: "longest"
+    });
+    await node.process().catch(() => undefined);
+
+    const args = ffmpegArgString();
+    expect(args).not.toContain("apad");
+    expect(args).not.toContain("-shortest");
+    expect(args).toContain("1:a:0");
+  });
+});
+
 // ─── 11. ChromaKey ───────────────────────────────────────────────────────────
 
 describe("ChromaKeyVideoNode — uses the color ref value, not [object Object]", () => {


### PR DESCRIPTION
`nodetool.video.AddAudio` never told ffmpeg where to end, so the muxer wrote whatever the **longer** stream was — a music model that ignores the requested duration turned a 25-second clip into a four-minute file.

The node now pads the audio with `apad` and ends the file with `-shortest`. The pad matters: plain `-shortest` alone would introduce the opposite bug — an audio track that stops early would cut the picture off. With the pad the picture decides the end in both directions.

A new `output_length` enum (`"video"` default, `"longest"`) opts back into the unbounded behavior. All three arg-building branches carry the guard, including the mix→replace fallback. Mixing moves from `amix:duration=first` to `duration=longest` so the whole bed reaches the mix before the trim decides the end.

The sibling mux sites were checked and are already bounded: `Overlay` mixes with `duration=first` over the main video's own audio, `Transition` uses `xfade`/`acrossfade`, and both `normalizeConcatSegment` and `mixAudioInto` pass `-shortest`. The rule is now recorded in `packages/video-nodes/AGENTS.md`.

### Not verified

`npm run typecheck`, `lint` and `test:affected` could not be run in the authoring environment (no approval for npm), so the four new tests are unverified — CI is the first real run. The generated DSL/docs entries were hand-written for the same reason; re-run `npm run codegen:dsl` if the check leg disagrees.

Closes #5199

Generated with [Claude Code](https://claude.ai/code)