### PR TITLE
fix(costs): record image, video and audio spend in the ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2031,8 +2031,11 @@ npm run dev:nodetool -- collections delete my_docs --yes        # Delete (skip c
 
 ### nodetool costs
 
-Aggregates the per-call cost/token records NodeTool tracks for every LLM call,
-read straight from the local DB — no server needed.
+Aggregates the per-call cost records NodeTool tracks for every provider call,
+read straight from the local DB — no server needed. LLM calls carry token
+counts; image, video and audio generation carries the billing unit, the
+quantity and the unit price behind the charge (`costs list` prints them in a
+`units` column, e.g. `5 × seconds @ $0.2050`).
 
 ```bash
 npm run dev:nodetool -- costs summary                           # Overall + per-provider/model
@@ -2041,6 +2044,21 @@ npm run dev:nodetool -- costs list --provider anthropic         # Filter by prov
 npm run dev:nodetool -- costs by-provider                       # Grouped by provider
 npm run dev:nodetool -- costs by-model --provider openai        # Grouped by model
 ```
+
+Generation spend reaches the ledger through `attachRunCostLedger`
+(`@nodetool-ai/execution`), which `ExecutionSession` attaches to every run — so
+a CLI run, a debug run, an app run and the websocket server all record the same
+way, once. A node that knows its own charge (FAL, kie) reports it with
+`context.setProviderCost()` and that number wins, reconciled to the provider's
+actual billed amount afterwards where a billing API exists. Everything else is
+priced off `@nodetool-ai/model-pricing` from the `prediction` message the
+capability call emits. A `nodetool generate` run records its own row: it calls
+the provider directly and no runner would see it.
+
+**A model in no price catalog still gets a row, with a null cost.** It shows in
+`list` as `unpriced` and is counted as `unpriced` in every aggregate, so the
+totals read as a lower bound rather than as free — an empty report is worse
+than no report.
 
 ### nodetool storage
 

--- a/packages/cli/src/commands/costs.ts
+++ b/packages/cli/src/commands/costs.ts
@@ -1,9 +1,14 @@
 /**
- * `nodetool costs` — inspect LLM/provider spend tracked in the local DB.
+ * `nodetool costs` — inspect provider spend tracked in the local DB.
  *
  * Reads the local SQLite `predictions` table directly (in-process), so it works
- * without a running server. Every LLM call NodeTool makes is recorded as a
- * Prediction with token counts and cost; these commands aggregate them.
+ * without a running server. Every provider call NodeTool makes is recorded as a
+ * Prediction — LLM calls with token counts, image/video/audio generation with
+ * the billing unit, quantity and unit price behind the charge.
+ *
+ * A call whose model is in no price catalog is still recorded, with a null
+ * cost. It shows up in `list` and is counted as `unpriced` in the aggregates,
+ * so an unknown price reads as unknown rather than as free.
  */
 
 import type { Command } from "commander";
@@ -19,6 +24,24 @@ function fail(e: unknown): never {
 
 function usd(n: number | null | undefined): string {
   return `$${(n ?? 0).toFixed(4)}`;
+}
+
+/** A cost cell that tells an unpriced call apart from a genuinely free one. */
+function costCell(cost: number | null | undefined): string {
+  return cost == null ? "unpriced" : usd(cost);
+}
+
+/** The units behind a unit-billed charge, e.g. "5 × seconds @ $0.2050". */
+function unitsCell(call: {
+  quantity: number | null;
+  billing_unit: string | null;
+  unit_price: number | null;
+}): string {
+  if (call.billing_unit == null && call.unit_price == null) return "";
+  const quantity = call.quantity ?? 1;
+  const unit = call.billing_unit ?? "run";
+  const price = call.unit_price == null ? "" : ` @ ${usd(call.unit_price)}`;
+  return `${quantity} × ${unit}${price}`;
 }
 
 export function registerCostsCommands(program: Command): void {
@@ -46,14 +69,16 @@ export function registerCostsCommands(program: Command): void {
             total_output_tokens:
               acc.total_output_tokens + p.total_output_tokens,
             total_tokens: acc.total_tokens + p.total_tokens,
-            call_count: acc.call_count + p.call_count
+            call_count: acc.call_count + p.call_count,
+            unpriced_count: acc.unpriced_count + p.unpriced_count
           }),
           {
             total_cost: 0,
             total_input_tokens: 0,
             total_output_tokens: 0,
             total_tokens: 0,
-            call_count: 0
+            call_count: 0,
+            unpriced_count: 0
           }
         );
         if (opts.json) {
@@ -64,15 +89,24 @@ export function registerCostsCommands(program: Command): void {
         printKv({
           total_cost: usd(overall.total_cost),
           total_tokens: overall.total_tokens,
-          calls: overall.call_count
+          calls: overall.call_count,
+          unpriced_calls: overall.unpriced_count
         });
+        if (overall.unpriced_count > 0) {
+          console.log(
+            `\n${overall.unpriced_count} call(s) ran on a model no price ` +
+              `catalog covers, so the total above is a lower bound. ` +
+              `Run \`nodetool costs list\` to see them.`
+          );
+        }
         console.log("\nBy provider");
         printTable(
           byProvider.map((p) => ({
             provider: p.provider,
             cost: usd(p.total_cost),
             tokens: p.total_tokens,
-            calls: p.call_count
+            calls: p.call_count,
+            unpriced: p.unpriced_count
           }))
         );
         console.log("\nBy model");
@@ -82,7 +116,8 @@ export function registerCostsCommands(program: Command): void {
             model: m.model,
             cost: usd(m.total_cost),
             tokens: m.total_tokens,
-            calls: m.call_count
+            calls: m.call_count,
+            unpriced: m.unpriced_count
           }))
         );
         console.log();
@@ -93,7 +128,7 @@ export function registerCostsCommands(program: Command): void {
 
   costs
     .command("list")
-    .description("List recent LLM calls with cost and token counts")
+    .description("List recent provider calls with cost, tokens and billed units")
     .option("--provider <name>", "Filter by provider")
     .option("--model <id>", "Filter by model")
     .option("--limit <n>", "Max results", "50")
@@ -129,9 +164,10 @@ export function registerCostsCommands(program: Command): void {
               created_at: c.created_at ?? "",
               provider: c.provider,
               model: c.model,
-              cost: usd(c.cost),
+              cost: costCell(c.cost),
               in: c.input_tokens ?? "",
-              out: c.output_tokens ?? ""
+              out: c.output_tokens ?? "",
+              units: unitsCell(c)
             }))
           );
         } catch (e) {
@@ -158,7 +194,8 @@ export function registerCostsCommands(program: Command): void {
             cost: usd(p.total_cost),
             input_tokens: p.total_input_tokens,
             output_tokens: p.total_output_tokens,
-            calls: p.call_count
+            calls: p.call_count,
+            unpriced: p.unpriced_count
           }))
         );
       } catch (e) {
@@ -189,7 +226,8 @@ export function registerCostsCommands(program: Command): void {
             cost: usd(m.total_cost),
             input_tokens: m.total_input_tokens,
             output_tokens: m.total_output_tokens,
-            calls: m.call_count
+            calls: m.call_count,
+            unpriced: m.unpriced_count
           }))
         );
       } catch (e) {

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -285,6 +285,7 @@ async function run(
     );
   }
 
+  const startedAt = Date.now();
   let images: Uint8Array[];
   if (opts.image && opts.image.length > 0) {
     const { readFile } = await import("node:fs/promises");
@@ -307,6 +308,22 @@ async function run(
   }
 
   const paths = await writeImages(images, model, opts.output);
+
+  // This bypasses the workflow runner, so nothing else would record the
+  // charge — a generation here has to reach the ledger `nodetool costs` reads
+  // on its own.
+  const { recordGenerationSpend } = await import("@nodetool-ai/execution");
+  const { LOCAL_USER_ID } = await import("./local-db.js");
+  await recordGenerationSpend({
+    userId: LOCAL_USER_ID,
+    provider: providerId,
+    model: model.id,
+    capability: opts.image?.length ? "image_to_image" : "text_to_image",
+    quantity: images.length,
+    params: { width: params.width, height: params.height },
+    nodeType: "nodetool.cli.Generate",
+    durationMs: Date.now() - startedAt
+  });
 
   if (opts.json) {
     console.log(

--- a/packages/cli/tests/costs-command.test.ts
+++ b/packages/cli/tests/costs-command.test.ts
@@ -76,7 +76,8 @@ describe("costs summary", () => {
         total_input_tokens: 200,
         total_output_tokens: 100,
         total_tokens: 300,
-        call_count: 2
+        call_count: 2,
+        unpriced_count: 0
       },
       {
         provider: "anthropic",
@@ -84,7 +85,8 @@ describe("costs summary", () => {
         total_input_tokens: 50,
         total_output_tokens: 25,
         total_tokens: 75,
-        call_count: 1
+        call_count: 1,
+        unpriced_count: 0
       }
     ]);
     aggregateByModel.mockResolvedValueOnce([]);
@@ -96,9 +98,31 @@ describe("costs summary", () => {
     // 1.5 + 0.5 summed from the two provider rows.
     expect(parsed.overall.total_cost).toBe(2);
     expect(parsed.overall.call_count).toBe(3);
+    expect(parsed.overall.unpriced_count).toBe(0);
     expect(parsed.by_provider[0].provider).toBe("openai");
     expect(parsed).toHaveProperty("by_model");
     expect(aggregateByUser).not.toHaveBeenCalled();
+  });
+
+  it("says the total is a lower bound when calls went unpriced", async () => {
+    aggregateByProvider.mockResolvedValueOnce([
+      {
+        provider: "replicate",
+        total_cost: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_tokens: 0,
+        call_count: 3,
+        unpriced_count: 3
+      }
+    ]);
+    aggregateByModel.mockResolvedValueOnce([]);
+    const program = await buildProgram();
+    const { stdout } = await captureOutput(() =>
+      program.parseAsync(["node", "cli", "costs", "summary"])
+    );
+    expect(stdout).toContain("3 call(s) ran on a model no price catalog covers");
+    expect(stdout).toContain("lower bound");
   });
 });
 
@@ -125,6 +149,43 @@ describe("costs list", () => {
       provider: "anthropic",
       model: "claude-sonnet-4-6"
     });
+  });
+
+  it("prints the billed units and marks an unpriced call as such", async () => {
+    paginate.mockResolvedValueOnce([
+      [
+        {
+          created_at: "2026-08-24T00:00:00.000Z",
+          provider: "replicate",
+          model: "bytedance/seedance-1-pro",
+          cost: 1.025,
+          input_tokens: null,
+          output_tokens: null,
+          quantity: 5,
+          billing_unit: "seconds",
+          unit_price: 0.205
+        },
+        {
+          created_at: "2026-08-24T00:00:01.000Z",
+          provider: "replicate",
+          model: "someone/brand-new-model",
+          cost: null,
+          input_tokens: null,
+          output_tokens: null,
+          quantity: 1,
+          billing_unit: null,
+          unit_price: null
+        }
+      ],
+      ""
+    ]);
+    const program = await buildProgram();
+    const { stdout } = await captureOutput(() =>
+      program.parseAsync(["node", "cli", "costs", "list"])
+    );
+    expect(stdout).toContain("5 × seconds @ $0.2050");
+    // A price nobody knows must not read as free.
+    expect(stdout).toContain("unpriced");
   });
 
   it("exits(1) on a non-numeric --limit before touching the DB", async () => {

--- a/packages/execution/package.json
+++ b/packages/execution/package.json
@@ -19,6 +19,7 @@
     "@nodetool-ai/config": "*",
     "@nodetool-ai/gpu": "*",
     "@nodetool-ai/kernel": "*",
+    "@nodetool-ai/model-pricing": "*",
     "@nodetool-ai/models": "*",
     "@nodetool-ai/node-sdk": "*",
     "@nodetool-ai/protocol": "*",

--- a/packages/execution/src/cost-ledger.ts
+++ b/packages/execution/src/cost-ledger.ts
@@ -94,6 +94,15 @@ export interface PricedGeneration {
   assumptions?: string[];
 }
 
+/** What a ledger row records about how its cost was arrived at. */
+interface GenerationMetadata {
+  capability: string | null;
+  price_source?: "model-catalog";
+  price_breakdown?: string;
+  price_assumptions?: string[];
+  unpriced_reason?: string;
+}
+
 /**
  * Price a generation against the model catalogs. Returns `null` when no catalog
  * carries the model, or when the catalog declines to extrapolate — a refusal is
@@ -133,7 +142,7 @@ export async function recordGenerationSpend(
   spend: GenerationSpend
 ): Promise<Prediction | null> {
   const priced = priceGeneration(spend);
-  const metadata: Record<string, unknown> = {
+  const metadata: GenerationMetadata = {
     capability: spend.capability ?? null
   };
   if (priced) {

--- a/packages/execution/src/cost-ledger.ts
+++ b/packages/execution/src/cost-ledger.ts
@@ -1,0 +1,339 @@
+/**
+ * Provider-spend ledger — the write half of `nodetool costs`.
+ *
+ * `BaseProvider` accounts for chat and stream in tokens, and the host writes
+ * that row. Image, video and audio generation had no equivalent: the money went
+ * out and nothing reached the `predictions` table, so a render session read as
+ * free.
+ *
+ * Two kinds of generation reach a ledger row here:
+ *
+ * - A node that knows its own charge calls `context.setProviderCost()`, which
+ *   rides out on the completed `node_update` as `provider_cost`. FAL and kie do
+ *   this — the number comes from the provider, so it wins. When the provider
+ *   also exposes a request-keyed billing API, the estimate is reconciled to the
+ *   actual charge in the background.
+ * - Everything else goes through `ProcessingContext.runProviderPrediction` (and
+ *   its streaming/encoded siblings), which emits a `prediction` message
+ *   carrying provider, model, capability and the job's parameters. That is
+ *   priced here against `@nodetool-ai/model-pricing` — the same catalog the
+ *   editor's cost preview and the pre-run budget gate read.
+ *
+ * A model in no catalog still gets a row, with `cost` left null rather than set
+ * to zero: the call is visible in `nodetool costs`, and a null is countable as
+ * unpriced instead of summing as free. The units behind a price are recorded
+ * next to it (`billing_unit`, `quantity`, `unit_price`, `currency`, plus the
+ * catalog's own breakdown in `metadata`) so a per-second or per-megapixel row
+ * is auditable even when the estimate is imperfect.
+ */
+
+import { createLogger } from "@nodetool-ai/config";
+import { Prediction } from "@nodetool-ai/models";
+import { getModelUnitPrice } from "@nodetool-ai/model-pricing";
+import { extractPricingParams } from "@nodetool-ai/node-sdk";
+import { getCostReconciler } from "@nodetool-ai/runtime";
+import type { ProcessingMessage, ProviderCost } from "@nodetool-ai/protocol";
+
+const log = createLogger("nodetool.execution.cost-ledger");
+
+/**
+ * Capabilities a provider bills per output rather than per token. Chat,
+ * streaming chat and embeddings are absent on purpose: those are token-billed
+ * and already accounted for by `BaseProvider.trackUsage`.
+ */
+const UNIT_BILLED_CAPABILITIES = new Set([
+  "text_to_image",
+  "image_to_image",
+  "inpainting",
+  "text_to_video",
+  "image_to_video",
+  "video_to_video",
+  "upscale_image",
+  "remove_background",
+  "relight_image",
+  "vectorize_image",
+  "lip_sync",
+  "text_to_speech",
+  "text_to_music",
+  "automatic_speech_recognition"
+]);
+
+/** Whether a capability is billed per unit of output (and so belongs here). */
+export function isUnitBilledCapability(
+  capability: string | null | undefined
+): boolean {
+  return capability != null && UNIT_BILLED_CAPABILITIES.has(capability);
+}
+
+/** One generation to price and record. */
+export interface GenerationSpend {
+  userId: string;
+  provider: string;
+  model: string;
+  capability?: string | null;
+  /** Outputs produced — the multiplier on the catalog's per-run price. */
+  quantity?: number;
+  /** What the job stated, in provider parameter spelling (`duration_seconds`, `resolution`, …). */
+  params?: Record<string, unknown> | null;
+  nodeId?: string;
+  nodeType?: string;
+  workflowId?: string | null;
+  durationMs?: number | null;
+}
+
+/** What the catalog answered for a generation, or `null` when it knows no price. */
+export interface PricedGeneration {
+  cost: number;
+  unit_price: number;
+  quantity: number;
+  billing_unit: string;
+  currency: string;
+  /** The catalog's own reasoning, e.g. "5 s × $0.205/s at 720p". */
+  breakdown?: string;
+  /** What the catalog filled in because the job did not state it. */
+  assumptions?: string[];
+}
+
+/**
+ * Price a generation against the model catalogs. Returns `null` when no catalog
+ * carries the model, or when the catalog declines to extrapolate — a refusal is
+ * an answer, and inventing a number would be worse than recording none.
+ */
+export function priceGeneration(
+  spend: GenerationSpend
+): PricedGeneration | null {
+  const quantity = spend.quantity ?? 1;
+  if (!Number.isFinite(quantity) || quantity <= 0) return null;
+
+  const price = getModelUnitPrice(
+    { id: spend.model, provider: spend.provider },
+    extractPricingParams(spend.params)
+  );
+  if (!price || price.declined) return null;
+  if (!Number.isFinite(price.unit_price)) return null;
+
+  const priced: PricedGeneration = {
+    cost: price.unit_price * quantity,
+    unit_price: price.unit_price,
+    quantity,
+    billing_unit: price.billing_unit || (spend.capability ?? "run"),
+    currency: price.currency || "USD"
+  };
+  if (price.breakdown) priced.breakdown = price.breakdown;
+  if (price.assumptions?.length) priced.assumptions = price.assumptions;
+  return priced;
+}
+
+/**
+ * Write one generation to the ledger. Best-effort: a host with no database
+ * (a hermetic run, an eval) must not fail because accounting could not be
+ * persisted — the generation already happened and was already billed.
+ */
+export async function recordGenerationSpend(
+  spend: GenerationSpend
+): Promise<Prediction | null> {
+  const priced = priceGeneration(spend);
+  const metadata: Record<string, unknown> = {
+    capability: spend.capability ?? null
+  };
+  if (priced) {
+    metadata.price_source = "model-catalog";
+    if (priced.breakdown) metadata.price_breakdown = priced.breakdown;
+    if (priced.assumptions) metadata.price_assumptions = priced.assumptions;
+  } else {
+    metadata.unpriced_reason = `No unit price for ${spend.provider}/${spend.model} in the model catalogs`;
+  }
+
+  try {
+    return await Prediction.create<Prediction>({
+      user_id: spend.userId,
+      provider: spend.provider,
+      model: spend.model,
+      node_id: spend.nodeId ?? "",
+      node_type: spend.nodeType ?? "",
+      workflow_id: spend.workflowId ?? null,
+      status: "completed",
+      cost: priced ? priced.cost : null,
+      billing_unit: priced ? priced.billing_unit : (spend.capability ?? null),
+      quantity: priced ? priced.quantity : (spend.quantity ?? 1),
+      unit_price: priced ? priced.unit_price : null,
+      currency: priced ? priced.currency : null,
+      duration: spend.durationMs != null ? spend.durationMs / 1000 : null,
+      metadata
+    });
+  } catch (err) {
+    log.debug("Generation spend not recorded", {
+      provider: spend.provider,
+      model: spend.model,
+      error: err instanceof Error ? err.message : String(err)
+    });
+    return null;
+  }
+}
+
+/** A charge a node reported for itself, as it rides out on `node_update`. */
+export interface NodeCostSpend {
+  userId: string;
+  cost: ProviderCost;
+  nodeId: string;
+  nodeType: string;
+  workflowId: string | null;
+  /** Resolves the provider API key used to look the actual charge up, when one exists. */
+  resolveSecret?: (key: string) => Promise<string | null | undefined>;
+}
+
+/**
+ * Write a node-reported provider charge to the ledger, then refine it into the
+ * provider's actual billed amount in the background when that provider
+ * registered a reconciler. Best-effort throughout.
+ */
+export async function recordNodeProviderCost(
+  spend: NodeCostSpend
+): Promise<Prediction | null> {
+  const { cost } = spend;
+  // A NaN/Infinity amount from a buggy provider call can't be stored: SQLite
+  // has no representation for it and JSON turns it into `null`.
+  if (!Number.isFinite(cost.amount)) return null;
+  try {
+    const prediction = await Prediction.create<Prediction>({
+      user_id: spend.userId,
+      provider: cost.provider,
+      model: cost.model ?? spend.nodeType,
+      node_type: spend.nodeType,
+      node_id: spend.nodeId,
+      workflow_id: spend.workflowId,
+      status: "completed",
+      cost: cost.amount,
+      currency: cost.currency ?? cost.unit ?? null,
+      billing_unit: cost.billing_unit ?? null,
+      quantity: cost.quantity ?? null,
+      unit_price: cost.unit_price ?? null,
+      provider_request_id: cost.provider_request_id ?? null
+    });
+    if (cost.provider_request_id) {
+      void reconcileProviderCost(prediction, spend);
+    }
+    return prediction;
+  } catch (err) {
+    log.debug("Node provider cost not recorded", {
+      provider: cost.provider,
+      error: err instanceof Error ? err.message : String(err)
+    });
+    return null;
+  }
+}
+
+/**
+ * Replace an estimated charge with the provider's actual billed amount, looked
+ * up by request id. Runs detached; leaves the estimate in place when no actual
+ * is available.
+ */
+async function reconcileProviderCost(
+  prediction: Prediction,
+  spend: NodeCostSpend
+): Promise<void> {
+  const reconciler = getCostReconciler(spend.cost.provider);
+  if (!reconciler || !spend.cost.provider_request_id) return;
+  try {
+    const secretKey = `${spend.cost.provider.toUpperCase()}_API_KEY`;
+    const apiKey = await spend.resolveSecret?.(secretKey);
+    const actual = await reconciler({
+      requestId: spend.cost.provider_request_id,
+      endpointId: spend.cost.model ?? null,
+      secrets: apiKey ? { [secretKey]: apiKey } : {}
+    });
+    if (!actual) return;
+    await prediction.update({
+      cost: actual.cost,
+      currency: actual.currency ?? prediction.currency,
+      quantity: actual.quantity ?? prediction.quantity,
+      unit_price: actual.unit_price ?? prediction.unit_price
+    });
+  } catch (err) {
+    log.warn("Failed to reconcile provider cost", {
+      provider: spend.cost.provider,
+      error: err instanceof Error ? err.message : String(err)
+    });
+  }
+}
+
+export interface RunCostLedgerOptions {
+  userId: string;
+  workflowId: string | null;
+  /** Node type for a node id, so a row names the node that spent the money. */
+  nodeType?: (nodeId: string) => string;
+  resolveSecret?: (key: string) => Promise<string | null | undefined>;
+}
+
+/**
+ * A `nodeType` lookup built once per run. Scanning the node list per message
+ * would be O(nodes × messages), which a 20 000-node graph feels.
+ */
+export function nodeTypeLookup(
+  nodes: ReadonlyArray<{ id: string; type: string }>
+): (nodeId: string) => string {
+  const types = new Map(
+    nodes.map((node): [string, string] => [node.id, node.type])
+  );
+  return (nodeId) => types.get(nodeId) ?? "";
+}
+
+/** The slice of `ProcessingContext` the ledger listens on. */
+export interface CostLedgerSource {
+  addMessageListener(listener: (msg: ProcessingMessage) => void): () => void;
+}
+
+/**
+ * Record every generation a run pays for. Returns the detach function.
+ *
+ * Listens on the context rather than on a host's outbound message loop so each
+ * surface — CLI, ws server, app runtime, debug harness — records once, from the
+ * same seam, and cannot drift.
+ */
+export function attachRunCostLedger(
+  context: CostLedgerSource,
+  options: RunCostLedgerOptions
+): () => void {
+  return context.addMessageListener((msg) => {
+    void recordFromMessage(msg, options);
+  });
+}
+
+/**
+ * Ledger one run message: a node's self-reported charge, or a completed
+ * unit-billed prediction. Anything else is not spend and writes nothing.
+ */
+export async function recordFromMessage(
+  msg: ProcessingMessage,
+  options: RunCostLedgerOptions
+): Promise<void> {
+  if (msg.type === "node_update" && msg.status === "completed") {
+    if (!msg.provider_cost) return;
+    await recordNodeProviderCost({
+      userId: options.userId,
+      cost: msg.provider_cost,
+      nodeId: msg.node_id,
+      nodeType: msg.node_type || options.nodeType?.(msg.node_id) || "",
+      workflowId: options.workflowId,
+      resolveSecret: options.resolveSecret
+    });
+    return;
+  }
+
+  if (msg.type !== "prediction" || msg.status !== "completed") return;
+  if (!isUnitBilledCapability(msg.capability)) return;
+  if (!msg.provider || !msg.model) return;
+
+  await recordGenerationSpend({
+    userId: options.userId,
+    provider: msg.provider,
+    model: msg.model,
+    capability: msg.capability,
+    quantity: 1,
+    params: msg.params ?? {},
+    nodeId: msg.node_id,
+    nodeType: options.nodeType?.(msg.node_id) ?? "",
+    workflowId: options.workflowId,
+    durationMs: msg.duration ?? null
+  });
+}

--- a/packages/execution/src/index.ts
+++ b/packages/execution/src/index.ts
@@ -24,6 +24,22 @@ export type {
 } from "./preflight.js";
 export { DEFAULT_MESSAGE_BUFFER_LIMIT } from "./message-stream.js";
 export {
+  attachRunCostLedger,
+  isUnitBilledCapability,
+  nodeTypeLookup,
+  priceGeneration,
+  recordFromMessage,
+  recordGenerationSpend,
+  recordNodeProviderCost
+} from "./cost-ledger.js";
+export type {
+  CostLedgerSource,
+  GenerationSpend,
+  NodeCostSpend,
+  PricedGeneration,
+  RunCostLedgerOptions
+} from "./cost-ledger.js";
+export {
   INTERVENTION_MARK,
   formatInterventionLine,
   formatSupervisedSummary,

--- a/packages/execution/src/service/workflow-run.ts
+++ b/packages/execution/src/service/workflow-run.ts
@@ -25,6 +25,7 @@ import type {
   StorageAdapter,
   Workspace
 } from "@nodetool-ai/runtime";
+import { attachRunCostLedger, nodeTypeLookup } from "../cost-ledger.js";
 import { normalizeGraph } from "../normalize-graph.js";
 import {
   collectPreflightIssues,
@@ -517,6 +518,15 @@ export async function runWorkflow(
         // The host attaches its model interfaces (asset persistence, …) —
         // without them an Output node that stores an image fails the run.
         environment.configureContext?.(executionContext);
+        // This path builds its own runner instead of going through
+        // `ExecutionSession`, so it has to attach the spend ledger itself.
+        // No detach: the listener lives on this context and dies with it.
+        attachRunCostLedger(executionContext, {
+          userId,
+          workflowId,
+          nodeType: nodeTypeLookup(runnableGraph.nodes),
+          resolveSecret: (key) => executionContext.getSecret(key)
+        });
         return executionContext;
       })()
     };

--- a/packages/execution/src/session.ts
+++ b/packages/execution/src/session.ts
@@ -29,6 +29,7 @@ import { normalizeGraph } from "./normalize-graph.js";
 import { assertPreflight } from "./preflight.js";
 import { rewriteOutputNames } from "./output-names.js";
 import { MessageStream } from "./message-stream.js";
+import { attachRunCostLedger, nodeTypeLookup } from "./cost-ledger.js";
 import type { ExecutionSessionOptions } from "./types.js";
 
 const log = createLogger("nodetool.execution.session");
@@ -63,6 +64,7 @@ export class ExecutionSession {
     runTimeoutMs: number | undefined;
     captureMessages: boolean;
     messageBufferLimit: number | undefined;
+    recordCosts: boolean;
   }) {
     this.jobId = init.jobId;
     this.workflowId = init.workflowId;
@@ -72,6 +74,19 @@ export class ExecutionSession {
     this.bridge = init.bridge;
     this.stream = init.captureMessages
       ? new MessageStream(init.context, init.messageBufferLimit)
+      : null;
+
+    // Every generation this run pays for lands in the ledger `nodetool costs`
+    // reads. Attached here, at the one seam all surfaces share, so image and
+    // video spend is recorded whether the run came from the CLI, the debug
+    // harness, an app, or the websocket server.
+    const detachLedger = init.recordCosts
+      ? attachRunCostLedger(init.context, {
+          userId: init.userId,
+          workflowId: init.workflowId,
+          nodeType: nodeTypeLookup(init.graph.nodes),
+          resolveSecret: (key) => init.context.getSecret(key)
+        })
       : null;
 
     if (init.runTimeoutMs && init.runTimeoutMs > 0) {
@@ -133,7 +148,9 @@ export class ExecutionSession {
         init.closeBridge();
         // The terminal message was emitted synchronously before run()
         // resolved (ProcessingContext.emit() calls listeners inline), so the
-        // stream can close now without dropping it.
+        // stream can close now without dropping it. The same holds for the
+        // ledger: every prediction/node_update it prices was already delivered.
+        detachLedger?.();
         this.stream?.close();
       });
 
@@ -303,7 +320,8 @@ export class ExecutionSession {
       closeBridge,
       runTimeoutMs: options.limits?.runTimeoutMs,
       captureMessages: options.captureMessages === true,
-      messageBufferLimit: options.limits?.messageBufferLimit
+      messageBufferLimit: options.limits?.messageBufferLimit,
+      recordCosts: options.recordCosts !== false
     });
   }
 

--- a/packages/execution/src/types.ts
+++ b/packages/execution/src/types.ts
@@ -213,6 +213,13 @@ export interface ExecutionSessionOptions {
    * for the cap that catches a consumer falling behind.
    */
   captureMessages?: boolean;
+  /**
+   * Record what this run spends on provider calls into the `predictions`
+   * ledger `nodetool costs` reads (default `true`). The write is best-effort —
+   * a host with no database is not failed for it — so turning this off is only
+   * for a caller that persists the same spend itself and would double-count.
+   */
+  recordCosts?: boolean;
 }
 
 export type {

--- a/packages/execution/tests/cost-ledger.test.ts
+++ b/packages/execution/tests/cost-ledger.test.ts
@@ -1,0 +1,320 @@
+/**
+ * `nodetool costs` reported nothing for a session whose spend was almost
+ * entirely image and video generation: only LLM calls reached the ledger, so a
+ * multi-hour render read as free.
+ *
+ * These tests pin the write. A run that generates an image or a video lands a
+ * `predictions` row carrying the billing unit, the quantity and the unit price
+ * behind the charge; a model no catalog covers still lands a row, with a null
+ * cost, so the call is visible and countable as unpriced rather than summed as
+ * free.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { Prediction, initTestDb } from "@nodetool-ai/models";
+import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import {
+  attachRunCostLedger,
+  isUnitBilledCapability,
+  priceGeneration,
+  recordFromMessage,
+  recordGenerationSpend,
+  recordNodeProviderCost
+} from "../src/cost-ledger.js";
+
+/**
+ * Models the shipped GenSpend catalog prices, one per billing class. The tests
+ * assert relations (unit × quantity, one duration against another) rather than
+ * the figures — the nightly pricing sync moves those. The durations used stay
+ * inside the model's published `clip_seconds` envelope, outside which the
+ * catalog declines to price rather than extrapolating.
+ */
+const PER_IMAGE = {
+  provider: "replicate",
+  model: "black-forest-labs/flux-schnell"
+};
+const PER_SECOND = { provider: "replicate", model: "bytedance/seedance-1-pro" };
+
+const USER = "u1";
+
+async function rows(): Promise<Prediction[]> {
+  const [items] = await Prediction.paginate(USER, { limit: 100 });
+  return items;
+}
+
+describe("priceGeneration", () => {
+  it("prices a per-image model and multiplies by the images produced", () => {
+    const one = priceGeneration({ userId: USER, ...PER_IMAGE, quantity: 1 });
+    const four = priceGeneration({ userId: USER, ...PER_IMAGE, quantity: 4 });
+
+    expect(one).not.toBeNull();
+    expect(one!.billing_unit).toBe("images");
+    expect(one!.currency).toBe("USD");
+    expect(one!.unit_price).toBeGreaterThan(0);
+    expect(one!.cost).toBeCloseTo(one!.unit_price);
+    expect(four!.cost).toBeCloseTo(one!.unit_price * 4);
+  });
+
+  it("prices a per-second model off the duration the job stated", () => {
+    const five = priceGeneration({
+      userId: USER,
+      ...PER_SECOND,
+      params: { duration_seconds: 5, resolution: "720p" }
+    });
+    const ten = priceGeneration({
+      userId: USER,
+      ...PER_SECOND,
+      params: { duration_seconds: 10, resolution: "720p" }
+    });
+
+    expect(five).not.toBeNull();
+    expect(five!.billing_unit).toBe("seconds");
+    expect(ten!.cost).toBeCloseTo(five!.cost * 2);
+  });
+
+  it("answers null for a model no catalog carries", () => {
+    expect(
+      priceGeneration({
+        userId: USER,
+        provider: "replicate",
+        model: "totally-not-a-real-model-xyz"
+      })
+    ).toBeNull();
+  });
+});
+
+describe("isUnitBilledCapability", () => {
+  it("covers generation and excludes the token-billed capabilities", () => {
+    expect(isUnitBilledCapability("text_to_image")).toBe(true);
+    expect(isUnitBilledCapability("image_to_video")).toBe(true);
+    expect(isUnitBilledCapability("text_to_speech")).toBe(true);
+    // Chat and embeddings are accounted for in tokens by BaseProvider.
+    expect(isUnitBilledCapability("generate_message")).toBe(false);
+    expect(isUnitBilledCapability("generate_messages")).toBe(false);
+    expect(isUnitBilledCapability("generate_embedding")).toBe(false);
+    expect(isUnitBilledCapability(null)).toBe(false);
+  });
+});
+
+describe("recordGenerationSpend", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("writes the units and the unit price alongside the cost", async () => {
+    await recordGenerationSpend({
+      userId: USER,
+      ...PER_SECOND,
+      capability: "image_to_video",
+      params: { duration_seconds: 5, resolution: "720p" },
+      nodeId: "n1",
+      nodeType: "nodetool.video.ImageToVideo",
+      workflowId: "wf-1",
+      durationMs: 42_000
+    });
+
+    const [row] = await rows();
+    expect(row.provider).toBe("replicate");
+    expect(row.model).toBe(PER_SECOND.model);
+    expect(row.node_id).toBe("n1");
+    expect(row.workflow_id).toBe("wf-1");
+    expect(row.billing_unit).toBe("seconds");
+    expect(row.quantity).toBe(1);
+    expect(row.currency).toBe("USD");
+    expect(row.unit_price).toBeGreaterThan(0);
+    expect(row.cost).toBeCloseTo(row.unit_price!);
+    expect(row.duration).toBe(42);
+    expect(row.metadata?.capability).toBe("image_to_video");
+  });
+
+  it("records an unpriced model with a null cost, not a zero", async () => {
+    await recordGenerationSpend({
+      userId: USER,
+      provider: "replicate",
+      model: "totally-not-a-real-model-xyz",
+      capability: "text_to_image"
+    });
+
+    const [row] = await rows();
+    expect(row.cost).toBeNull();
+    expect(row.unit_price).toBeNull();
+    expect(row.metadata?.unpriced_reason).toContain(
+      "totally-not-a-real-model-xyz"
+    );
+
+    // A null cost is countable, which is what keeps the report honest: the
+    // call is present and flagged rather than summed in as free.
+    const summary = await Prediction.aggregateByUser(USER);
+    expect(summary.call_count).toBe(1);
+    expect(summary.unpriced_count).toBe(1);
+    expect(summary.total_cost).toBe(0);
+  });
+});
+
+describe("recordNodeProviderCost", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("keeps the provider's own number and its units", async () => {
+    await recordNodeProviderCost({
+      userId: USER,
+      cost: {
+        provider: "fal",
+        amount: 0.045,
+        unit: "USD",
+        model: "fal-ai/flux/schnell",
+        billing_unit: "megapixels",
+        quantity: 1.5,
+        unit_price: 0.03,
+        currency: "USD"
+      },
+      nodeId: "n2",
+      nodeType: "fal.text_to_image.FluxSchnell",
+      workflowId: "wf-2"
+    });
+
+    const [row] = await rows();
+    expect(row.cost).toBe(0.045);
+    expect(row.billing_unit).toBe("megapixels");
+    expect(row.quantity).toBe(1.5);
+    expect(row.unit_price).toBe(0.03);
+  });
+
+  it("records nothing for a non-finite amount", async () => {
+    await recordNodeProviderCost({
+      userId: USER,
+      cost: { provider: "fal", amount: Number.NaN, unit: "USD" },
+      nodeId: "n2",
+      nodeType: "fal.text_to_image.FluxSchnell",
+      workflowId: null
+    });
+
+    expect(await rows()).toHaveLength(0);
+  });
+});
+
+describe("recordFromMessage", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  const options = {
+    userId: USER,
+    workflowId: "wf-3",
+    nodeType: (id: string) => (id === "n1" ? "nodetool.image.TextToImage" : "")
+  };
+
+  it("ledgers a completed generation prediction", async () => {
+    await recordFromMessage(
+      {
+        type: "prediction",
+        id: "p1",
+        user_id: USER,
+        node_id: "n1",
+        provider: PER_IMAGE.provider,
+        model: PER_IMAGE.model,
+        capability: "text_to_image",
+        status: "completed",
+        params: {},
+        duration: 1_500
+      },
+      options
+    );
+
+    const [row] = await rows();
+    expect(row.model).toBe(PER_IMAGE.model);
+    expect(row.node_type).toBe("nodetool.image.TextToImage");
+    expect(row.cost).toBeGreaterThan(0);
+  });
+
+  it("ignores a running prediction and a chat completion", async () => {
+    const base = {
+      type: "prediction" as const,
+      id: "p2",
+      user_id: USER,
+      node_id: "n1",
+      provider: PER_IMAGE.provider,
+      model: PER_IMAGE.model
+    };
+    await recordFromMessage(
+      { ...base, capability: "text_to_image", status: "running" },
+      options
+    );
+    await recordFromMessage(
+      { ...base, capability: "generate_message", status: "completed" },
+      options
+    );
+
+    expect(await rows()).toHaveLength(0);
+  });
+
+  it("ledgers a node's self-reported charge off node_update", async () => {
+    await recordFromMessage(
+      {
+        type: "node_update",
+        node_id: "n2",
+        node_name: "Flux",
+        node_type: "fal.text_to_image.FluxSchnell",
+        status: "completed",
+        provider_cost: {
+          provider: "fal",
+          amount: 0.02,
+          unit: "USD",
+          model: "fal-ai/flux/schnell"
+        }
+      },
+      options
+    );
+
+    const [row] = await rows();
+    expect(row.provider).toBe("fal");
+    expect(row.cost).toBe(0.02);
+    expect(row.workflow_id).toBe("wf-3");
+  });
+});
+
+describe("attachRunCostLedger", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("records every generation emitted on the run's context, then detaches", async () => {
+    const listeners = new Set<(msg: ProcessingMessage) => void>();
+    const context = {
+      addMessageListener(listener: (msg: ProcessingMessage) => void) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      }
+    };
+    const emit = (msg: ProcessingMessage): void => {
+      for (const listener of listeners) listener(msg);
+    };
+    const generation = (id: string): ProcessingMessage => ({
+      type: "prediction",
+      id,
+      user_id: USER,
+      node_id: "n1",
+      provider: PER_IMAGE.provider,
+      model: PER_IMAGE.model,
+      capability: "text_to_image",
+      status: "completed",
+      params: {}
+    });
+
+    const detach = attachRunCostLedger(context, {
+      userId: USER,
+      workflowId: "wf-4"
+    });
+    emit(generation("p1"));
+    emit(generation("p2"));
+    // The listener writes without blocking the run; let those writes settle.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(await rows()).toHaveLength(2);
+
+    detach();
+    emit(generation("p3"));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(await rows()).toHaveLength(2);
+  });
+});

--- a/packages/execution/tests/session-cost-ledger.test.ts
+++ b/packages/execution/tests/session-cost-ledger.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The ledger has to be wired into the session, not just exist. Only the
+ * websocket runner used to write generation spend, so a `nodetool run`,
+ * `workflows run` or `debug` of the very same graph recorded nothing.
+ *
+ * `ExecutionSession` is the one place every surface constructs a run, so these
+ * tests drive a run through it and read the `predictions` table back.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { BaseNode, NodeRegistry, prop } from "@nodetool-ai/node-sdk";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { Prediction, initTestDb } from "@nodetool-ai/models";
+import { ExecutionSession } from "../src/index.js";
+
+const NO_BRIDGE = async () => null;
+
+/** Emits the `prediction` message every generative capability call emits. */
+class GenerateImage extends BaseNode {
+  static readonly nodeType = "test.execution.GenerateImage";
+  static readonly title = "Generate Image";
+  static readonly description = "Emits a completed image generation";
+
+  @prop({ type: "str", default: "" })
+  declare prompt: string;
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    context?.emit({
+      type: "prediction",
+      id: "pred-1",
+      user_id: "1",
+      node_id: "gen",
+      provider: "replicate",
+      model: "black-forest-labs/flux-schnell",
+      capability: "text_to_image",
+      status: "completed",
+      params: {}
+    });
+    return { output: "image-bytes" };
+  }
+}
+
+/** Reports its own charge the way the FAL and kie nodes do. */
+class BilledNode extends BaseNode {
+  static readonly nodeType = "test.execution.Billed";
+  static readonly title = "Billed";
+  static readonly description = "Reports a provider charge for itself";
+
+  async process(context?: ProcessingContext): Promise<Record<string, unknown>> {
+    context?.setProviderCost("fal", 0.045, "USD", {
+      model: "fal-ai/flux/schnell",
+      billing_unit: "megapixels",
+      quantity: 1.5,
+      unit_price: 0.03,
+      currency: "USD"
+    });
+    return { output: "done" };
+  }
+}
+
+function registryWith(...nodes: Array<typeof BaseNode>): NodeRegistry {
+  const registry = new NodeRegistry();
+  for (const node of nodes) registry.register(node);
+  return registry;
+}
+
+/** The ledger writes without blocking the run; let those writes settle. */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function ledgerRows(): Promise<Prediction[]> {
+  const [rows] = await Prediction.paginate("1", { limit: 100 });
+  return rows;
+}
+
+describe("ExecutionSession cost ledger", () => {
+  beforeEach(() => {
+    initTestDb();
+  });
+
+  it("records a generation the run paid for", async () => {
+    const session = await ExecutionSession.create({
+      graph: {
+        nodes: [{ id: "gen", type: "test.execution.GenerateImage" }],
+        edges: []
+      },
+      registry: registryWith(GenerateImage),
+      bridgeFactory: NO_BRIDGE,
+      workflowId: "wf-1"
+    });
+
+    expect((await session.result).status).toBe("completed");
+    await settle();
+
+    const [row] = await ledgerRows();
+    expect(row).toBeDefined();
+    expect(row.provider).toBe("replicate");
+    expect(row.model).toBe("black-forest-labs/flux-schnell");
+    expect(row.node_type).toBe("test.execution.GenerateImage");
+    expect(row.workflow_id).toBe("wf-1");
+    expect(row.billing_unit).toBe("images");
+    expect(row.cost).toBeGreaterThan(0);
+  });
+
+  it("records a node's self-reported charge exactly once", async () => {
+    const session = await ExecutionSession.create({
+      graph: {
+        nodes: [{ id: "billed", type: "test.execution.Billed" }],
+        edges: []
+      },
+      registry: registryWith(BilledNode),
+      bridgeFactory: NO_BRIDGE,
+      workflowId: "wf-2"
+    });
+
+    expect((await session.result).status).toBe("completed");
+    await settle();
+
+    const rows = await ledgerRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].provider).toBe("fal");
+    expect(rows[0].cost).toBe(0.045);
+    expect(rows[0].billing_unit).toBe("megapixels");
+  });
+
+  it("writes nothing when the host records the spend itself", async () => {
+    const session = await ExecutionSession.create({
+      graph: {
+        nodes: [{ id: "gen", type: "test.execution.GenerateImage" }],
+        edges: []
+      },
+      registry: registryWith(GenerateImage),
+      bridgeFactory: NO_BRIDGE,
+      recordCosts: false
+    });
+
+    expect((await session.result).status).toBe("completed");
+    await settle();
+
+    expect(await ledgerRows()).toHaveLength(0);
+  });
+});

--- a/packages/execution/tests/session-preflight.test.ts
+++ b/packages/execution/tests/session-preflight.test.ts
@@ -40,6 +40,7 @@ vi.mock("@nodetool-ai/models", () => ({
     ensureDefault: vi.fn(async () => ({ isAccessible: () => false }))
   },
   Job: { create: vi.fn() },
+  Prediction: { create: vi.fn() },
   getSecret: vi.fn(async (key: string) => store.secrets[key] ?? null)
 }));
 

--- a/packages/execution/tests/workflow-run-asset-storage.test.ts
+++ b/packages/execution/tests/workflow-run-asset-storage.test.ts
@@ -61,6 +61,7 @@ vi.mock("@nodetool-ai/models", () => ({
   },
   Workspace: { find: vi.fn(async () => null) },
   Job: { create: vi.fn(async () => new FakeJob()) },
+  Prediction: { create: vi.fn() },
   getSecret: vi.fn(async () => null)
 }));
 

--- a/packages/execution/tests/workflow-run-credential-refusal.test.ts
+++ b/packages/execution/tests/workflow-run-credential-refusal.test.ts
@@ -69,6 +69,7 @@ vi.mock("@nodetool-ai/models", () => ({
   },
   Workspace: { find: vi.fn(async () => null) },
   Job: { create: jobCreate },
+  Prediction: { create: vi.fn() },
   getSecret: vi.fn(async (key: string) => state.secrets[key] ?? null)
 }));
 

--- a/packages/models/src/prediction.ts
+++ b/packages/models/src/prediction.ts
@@ -19,6 +19,8 @@ export interface AggregateResult {
   total_output_tokens: number;
   total_tokens: number;
   call_count: number;
+  /** Calls recorded with no price — the totals above are a lower bound. */
+  unpriced_count: number;
 }
 
 export interface ProviderAggregateResult {
@@ -28,6 +30,7 @@ export interface ProviderAggregateResult {
   total_output_tokens: number;
   total_tokens: number;
   call_count: number;
+  unpriced_count: number;
 }
 
 export interface ModelAggregateResult {
@@ -38,6 +41,7 @@ export interface ModelAggregateResult {
   total_output_tokens: number;
   total_tokens: number;
   call_count: number;
+  unpriced_count: number;
 }
 
 interface DashboardProviderResult {
@@ -234,12 +238,14 @@ export class Prediction extends DBModel {
     let total_input_tokens = 0;
     let total_output_tokens = 0;
     let total_tokens = 0;
+    let unpriced_count = 0;
 
     for (const p of rows) {
       total_cost += (p.cost as number) ?? 0;
       total_input_tokens += (p.input_tokens as number) ?? 0;
       total_output_tokens += (p.output_tokens as number) ?? 0;
       total_tokens += (p.total_tokens as number) ?? 0;
+      if (p.cost == null) unpriced_count += 1;
     }
 
     return {
@@ -250,7 +256,8 @@ export class Prediction extends DBModel {
       total_input_tokens,
       total_output_tokens,
       total_tokens,
-      call_count: rows.length
+      call_count: rows.length,
+      unpriced_count
     };
   }
 
@@ -275,7 +282,8 @@ export class Prediction extends DBModel {
           total_input_tokens: 0,
           total_output_tokens: 0,
           total_tokens: 0,
-          call_count: 0
+          call_count: 0,
+          unpriced_count: 0
         };
         groups.set(prov, entry);
       }
@@ -284,6 +292,7 @@ export class Prediction extends DBModel {
       entry.total_output_tokens += (p.output_tokens as number) ?? 0;
       entry.total_tokens += (p.total_tokens as number) ?? 0;
       entry.call_count += 1;
+      if (p.cost == null) entry.unpriced_count += 1;
     }
 
     return [...groups.values()];
@@ -318,7 +327,8 @@ export class Prediction extends DBModel {
           total_input_tokens: 0,
           total_output_tokens: 0,
           total_tokens: 0,
-          call_count: 0
+          call_count: 0,
+          unpriced_count: 0
         };
         groups.set(key, entry);
       }
@@ -327,6 +337,7 @@ export class Prediction extends DBModel {
       entry.total_output_tokens += (p.output_tokens as number) ?? 0;
       entry.total_tokens += (p.total_tokens as number) ?? 0;
       entry.call_count += 1;
+      if (p.cost == null) entry.unpriced_count += 1;
     }
 
     return [...groups.values()];

--- a/packages/models/tests/prediction.test.ts
+++ b/packages/models/tests/prediction.test.ts
@@ -190,6 +190,7 @@ describe("Prediction model", () => {
     expect(overall.total_output_tokens).toBe(25);
     expect(overall.total_tokens).toBe(50);
     expect(overall.call_count).toBe(2);
+    expect(overall.unpriced_count).toBe(0);
 
     const filtered = await Prediction.aggregateByUser("u1", {
       provider: "openai",
@@ -217,6 +218,9 @@ describe("Prediction model", () => {
     expect(byUser.total_input_tokens).toBe(0);
     expect(byUser.total_output_tokens).toBe(0);
     expect(byUser.total_tokens).toBe(0);
+    // A null cost sums as zero but counts as unpriced, so a report can say the
+    // total is a lower bound instead of implying the call was free.
+    expect(byUser.unpriced_count).toBe(1);
 
     const [byProvider] = await Prediction.aggregateByProvider("u1");
     expect(byProvider).toMatchObject({
@@ -225,7 +229,8 @@ describe("Prediction model", () => {
       total_input_tokens: 0,
       total_output_tokens: 0,
       total_tokens: 0,
-      call_count: 1
+      call_count: 1,
+      unpriced_count: 1
     });
 
     const [byModel] = await Prediction.aggregateByModel("u1");
@@ -236,7 +241,8 @@ describe("Prediction model", () => {
       total_input_tokens: 0,
       total_output_tokens: 0,
       total_tokens: 0,
-      call_count: 1
+      call_count: 1,
+      unpriced_count: 1
     });
   });
 

--- a/packages/protocol/src/api-schemas/costs.ts
+++ b/packages/protocol/src/api-schemas/costs.ts
@@ -65,7 +65,13 @@ export const aggregateByUserOutput = z.object({
   total_input_tokens: z.number(),
   total_output_tokens: z.number(),
   total_tokens: z.number(),
-  call_count: z.number()
+  call_count: z.number(),
+  /**
+   * Calls recorded with no price — a generation on a model no catalog covers.
+   * `total_cost` is then a lower bound. Defaulted so a server predating the
+   * field still parses.
+   */
+  unpriced_count: z.number().default(0)
 });
 
 /**
@@ -78,7 +84,8 @@ export const providerAggregate = z.object({
   total_input_tokens: z.number(),
   total_output_tokens: z.number(),
   total_tokens: z.number(),
-  call_count: z.number()
+  call_count: z.number(),
+  unpriced_count: z.number().default(0)
 });
 
 export const aggregateByProviderOutput = z.array(providerAggregate);
@@ -94,7 +101,8 @@ export const modelAggregate = z.object({
   total_input_tokens: z.number(),
   total_output_tokens: z.number(),
   total_tokens: z.number(),
-  call_count: z.number()
+  call_count: z.number(),
+  unpriced_count: z.number().default(0)
 });
 
 export const aggregateByModelOutput = z.array(modelAggregate);

--- a/packages/protocol/tests/api-schemas-costs.test.ts
+++ b/packages/protocol/tests/api-schemas-costs.test.ts
@@ -210,9 +210,24 @@ describe("providerAggregate", () => {
       total_input_tokens: 1000,
       total_output_tokens: 500,
       total_tokens: 1500,
+      call_count: 10,
+      unpriced_count: 2
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.unpriced_count).toBe(2);
+  });
+
+  it("defaults unpriced_count for a server that predates the field", () => {
+    const result = providerAggregate.safeParse({
+      provider: "openai",
+      total_cost: 1.5,
+      total_input_tokens: 1000,
+      total_output_tokens: 500,
+      total_tokens: 1500,
       call_count: 10
     });
     expect(result.success).toBe(true);
+    expect(result.data?.unpriced_count).toBe(0);
   });
 
   it("rejects missing provider", () => {

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -49,6 +49,7 @@ import {
   type NodeValidator
 } from "@nodetool-ai/kernel";
 import {
+  attachRunCostLedger,
   ExecutionSession,
   isExecutionPreflightError,
   toRawGraphInput
@@ -114,7 +115,6 @@ import {
   DIRECT_TOOL_NAMES,
   encodeRawRgbaToPng,
   fetchExternalMedia,
-  getCostReconciler,
   getProcessSandboxModuleCatalog,
   isProviderSessionUpdate,
   isProviderMessageEvent,
@@ -4245,7 +4245,7 @@ export class UnifiedWebSocketRunner {
             outputUpdateSeen = true;
           }
 
-          await this._handleNodeProviderCost(active, outbound, nodeType);
+          this._handleNodeProviderCost(active, outbound);
 
           const isNodeError =
             outbound.type === "node_update" && outbound.status === "error";
@@ -5824,6 +5824,14 @@ export class UnifiedWebSocketRunner {
       (msg) => this.sendDetached(msg),
       { threadId: threadId || null, workflowId }
     );
+    // A chat turn that generates an image or a video spends real money without
+    // ever constructing an ExecutionSession, so the ledger is attached here
+    // too — otherwise the turn is invisible to `nodetool costs`.
+    const detachCostLedger = attachRunCostLedger(ctx, {
+      userId,
+      workflowId: workflowId ?? null,
+      resolveSecret: (key) => ctx.getSecret(key)
+    });
     // Any agent planning inside this turn (e.g. via run_node spawning an
     // Agent node in plan mode) pauses for user plan approval.
     this.attachPlanApproval(ctx, threadId || null, codeactClock);
@@ -6478,6 +6486,7 @@ export class UnifiedWebSocketRunner {
       await this.sendMessage(errorMsgData);
     } finally {
       detachPredictions();
+      detachCostLedger();
       // Whatever is still outstanding never got a result row. Leaving the gap
       // makes the thread malformed — Anthropic rejects a `tool_use` with no
       // `tool_result` — and leaves the model unaware the call was abandoned,
@@ -6504,12 +6513,19 @@ export class UnifiedWebSocketRunner {
     }
   }
 
-  /** Persist and accumulate provider cost from a completed node_update. */
-  private async _handleNodeProviderCost(
+  /**
+   * Accumulate provider cost from a completed node_update into the job total.
+   *
+   * The ledger row is *not* written here. `ExecutionSession` attaches
+   * `attachRunCostLedger` to the same context, so every surface — this server,
+   * the CLI, the debug harness — records the charge once, from one
+   * implementation. Writing it again here would double-count every FAL and kie
+   * generation.
+   */
+  private _handleNodeProviderCost(
     active: ActiveJob,
-    outbound: Record<string, unknown>,
-    nodeType: string
-  ): Promise<void> {
+    outbound: Record<string, unknown>
+  ): void {
     if (
       outbound.type !== "node_update" ||
       outbound.status !== "completed" ||
@@ -6518,117 +6534,16 @@ export class UnifiedWebSocketRunner {
       return;
     }
     const providerCost = outbound.provider_cost as ProviderCost;
-    await this._persistNodeProviderCost(
-      providerCost,
-      String(outbound.node_id ?? ""),
-      nodeType,
-      active.workflowId
-    );
     const amount = (providerCost as { amount?: unknown }).amount;
     if (isFiniteNumber(amount)) {
       active.providerCostTotal = (active.providerCostTotal ?? 0) + amount;
     } else {
       // A non-finite amount (NaN/Infinity from a buggy provider call) can't
-      // be persisted or accumulated above, and JSON can't even represent it
-      // faithfully (`JSON.stringify(NaN)` silently becomes `null`). Rather
-      // than ship a `provider_cost` the wire contract calls a real number,
-      // drop it — the rest of the `node_update` still reports normally.
+      // be accumulated above, and JSON can't even represent it faithfully
+      // (`JSON.stringify(NaN)` silently becomes `null`). Rather than ship a
+      // `provider_cost` the wire contract calls a real number, drop it — the
+      // rest of the `node_update` still reports normally.
       delete outbound.provider_cost;
-    }
-  }
-
-  /**
-   * Persist a node-reported provider cost into the prediction ledger.
-   * Covers generative nodes (FAL, Kie, …) that call
-   * `context.setProviderCost()`. Best-effort: never throws.
-   */
-  private async _persistNodeProviderCost(
-    cost: ProviderCost,
-    nodeId: string,
-    nodeType: string,
-    workflowId: string | null
-  ): Promise<void> {
-    if (!isFiniteNumber(cost.amount)) {
-      return;
-    }
-    try {
-      const prediction = await Prediction.create<Prediction>({
-        user_id: this.userId ?? "1",
-        provider: cost.provider,
-        model: cost.model ?? nodeType,
-        node_type: nodeType,
-        cost: cost.amount,
-        currency: cost.currency ?? cost.unit ?? null,
-        billing_unit: cost.billing_unit ?? null,
-        quantity: cost.quantity ?? null,
-        unit_price: cost.unit_price ?? null,
-        provider_request_id: cost.provider_request_id ?? null,
-        workflow_id: workflowId,
-        node_id: nodeId,
-        status: "completed"
-      });
-      log.debug("Persisted node provider cost", {
-        provider: cost.provider,
-        model: cost.model ?? nodeType,
-        cost: cost.amount
-      });
-      // The amount above is an estimate for providers that bill out-of-band.
-      // If the provider exposes a request-keyed billing API, refine it to the
-      // actual charge in the background (best-effort, never blocks the run).
-      if (cost.provider_request_id) {
-        void this._reconcileProviderCost(
-          prediction,
-          cost.provider,
-          cost.provider_request_id,
-          cost.model ?? null
-        );
-      }
-    } catch (err) {
-      log.warn("Failed to persist node provider cost", {
-        error: err instanceof Error ? err.message : String(err)
-      });
-    }
-  }
-
-  /**
-   * Replace an estimated provider cost with the provider's actual billed
-   * amount, looked up by request id. Runs detached; swallows all errors and
-   * leaves the estimate in place when no actual is available.
-   */
-  private async _reconcileProviderCost(
-    prediction: Prediction,
-    provider: string,
-    requestId: string,
-    endpointId: string | null
-  ): Promise<void> {
-    const reconciler = getCostReconciler(provider);
-    if (!reconciler) return;
-    try {
-      const apiKey = await getSecret(
-        `${provider.toUpperCase()}_API_KEY`,
-        this.userId ?? undefined
-      );
-      const actual = await reconciler({
-        requestId,
-        endpointId,
-        secrets: apiKey ? { [`${provider.toUpperCase()}_API_KEY`]: apiKey } : {}
-      });
-      if (!actual) return;
-      await prediction.update({
-        cost: actual.cost,
-        currency: actual.currency ?? prediction.currency,
-        quantity: actual.quantity ?? prediction.quantity,
-        unit_price: actual.unit_price ?? prediction.unit_price
-      });
-      log.debug("Reconciled provider cost to actual", {
-        provider,
-        requestId,
-        cost: actual.cost
-      });
-    } catch (err) {
-      log.warn("Failed to reconcile provider cost", {
-        error: err instanceof Error ? err.message : String(err)
-      });
     }
   }
 
@@ -7832,7 +7747,7 @@ export class UnifiedWebSocketRunner {
             const nodeId = String(outbound.node_id ?? "");
             const nodeType = nodeTypes.get(nodeId) ?? "";
 
-            await this._handleNodeProviderCost(active, outbound, nodeType);
+            this._handleNodeProviderCost(active, outbound);
 
             // Capture output_update values for the response message
             if (outbound.type === "output_update") {


### PR DESCRIPTION
`nodetool costs` reported nothing for a render session because only LLM calls reached the `predictions` table.

### What was broken

The only code writing a generation row was `unified-websocket-runner._persistNodeProviderCost`, and it fires only for nodes that call `context.setProviderCost()` — which is just `fal-nodes` and `kie-nodes`. Replicate, AtlasCloud, OpenRouter, ElevenLabs and every generic `nodetool.image/video/audio` node recorded nothing on any surface, and `nodetool run`, `workflows run`, `debug`, `app debug`, the headless job runner and `POST /api/workflows/:id/run` wrote nothing at all, for any provider.

### The fix

`packages/execution/src/cost-ledger.ts` is now the single writer, listening on the run's `ProcessingContext`:

- A node's self-reported `provider_cost` is recorded as the provider gave it, then reconciled to the actual billed amount in the background where a billing API exists.
- Every other generation is priced off `@nodetool-ai/model-pricing` from the `prediction` message the capability call emits.

`ExecutionSession` attaches it, so every surface that builds a run records the same way. The service-layer run path and the chat turn attach it directly (neither builds a session), and `nodetool generate` records its own row. The websocket runner keeps job-total accumulation and no longer writes, so nothing double-counts.

### Unpriced models

A model in no catalog gets a row with a null cost rather than none at all. `costs list` shows it as `unpriced` next to the billed units (`5 × seconds @ $0.2050`), and every aggregate carries an `unpriced_count` so the totals read as a lower bound instead of as free.

### Verification

⚠️ `npm run typecheck`, `lint` and `test:affected` could not be run in the agent session (npm/node invocations were refused by tool permissions). CI must confirm.

Fixes #5200

Generated with [Claude Code](https://claude.ai/code)