### PR TITLE
feat(storyboard): open stills and clips fullscreen

### DIFF
--- a/web/src/components/storyboard/ShotCard.tsx
+++ b/web/src/components/storyboard/ShotCard.tsx
@@ -10,10 +10,11 @@
  */
 
 import React, { memo, useCallback, useMemo, useState } from "react";
-import type { Shot, ShotStatus } from "@nodetool-ai/protocol";
+import type { ImageRef, Shot, ShotStatus, VideoRef } from "@nodetool-ai/protocol";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import FullscreenIcon from "@mui/icons-material/Fullscreen";
 
 import {
   Box,
@@ -35,6 +36,7 @@ import {
   type StatusType
 } from "../ui_primitives";
 import ImageRefPreview from "../node/ImageRefPreview";
+import ShotMediaViewer from "./ShotMediaViewer";
 import ShotTakesGallery from "./ShotTakesGallery";
 import ShotScriptPanel from "./ShotScriptPanel";
 import { useStoryboardStore } from "../../stores/storyboard/StoryboardStore";
@@ -139,6 +141,10 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   const [reviseOpen, setReviseOpen] = useState(false);
   const [reviseText, setReviseText] = useState("");
   const [confirmDelete, setConfirmDelete] = useState(false);
+  // The still or clip the fullscreen viewer shows; null when it is closed.
+  const [viewerMedia, setViewerMedia] = useState<ImageRef | VideoRef | null>(
+    null
+  );
 
   const meta = STATUS_META[shot.status];
   // Why the last still or clip failed. Kept on the shot's job state until the
@@ -155,6 +161,17 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
   // `asset://` locator, but the card renders the keyframe when it cannot.
   const clipUri = useResolvedMediaUri(shot.clip);
   const shotName = `${shot.index + 1}. ${shot.slug ?? "Untitled shot"}`;
+  // What the preview shows is what fullscreen opens: the clip once there is
+  // one, the selected still before that.
+  const previewMedia: ImageRef | VideoRef | null = clipUri
+    ? (shot.clip as VideoRef)
+    : (shot.keyframe ?? null);
+  const handleOpenViewer = useCallback(() => {
+    if (previewMedia) {
+      setViewerMedia(previewMedia);
+    }
+  }, [previewMedia]);
+  const handleCloseViewer = useCallback(() => setViewerMedia(null), []);
 
   // A start that throws records its reason on the shot's job state (and
   // toasts it), which is what `renderError` above shows — so the rejection is
@@ -217,7 +234,7 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
           : undefined)
       }}
     >
-      <Box sx={previewSx}>
+      <Box sx={previewSx} onDoubleClick={previewMedia ? handleOpenViewer : undefined}>
         {clipUri ? (
           <VideoPlayer locator={shot.clip} />
         ) : (
@@ -231,6 +248,27 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
                 No still yet
               </Caption>
             }
+          />
+        )}
+        {previewMedia && !isGenerating && (
+          <ToolbarIconButton
+            icon={<FullscreenIcon sx={{ fontSize: "1em" }} />}
+            tooltip="View fullscreen (double-click)"
+            ariaLabel={
+              clipUri ? "View clip fullscreen" : "View still fullscreen"
+            }
+            onClick={handleOpenViewer}
+            sx={{
+              position: "absolute",
+              top: SPACING.xs,
+              right: SPACING.xs,
+              bgcolor: "c_scrim_soft",
+              opacity: 0,
+              ".shot-card:hover &": { opacity: 1 },
+              "&:focus-visible": { opacity: 1 },
+              // Touch devices cannot hover; keep the affordance reachable.
+              "@media (pointer: coarse)": { opacity: 1 }
+            }}
           />
         )}
         {failed && !isGenerating && !shot.keyframe && !shot.clip && (
@@ -458,6 +496,7 @@ const ShotCardInner: React.FC<ShotCardProps> = ({
           {`Remove “${shotName}” from the board. Generated stills and clips stay in your asset library.`}
         </Text>
       </Dialog>
+      <ShotMediaViewer media={viewerMedia} onClose={handleCloseViewer} />
     </Card>
   );
 };

--- a/web/src/components/storyboard/ShotMediaViewer.tsx
+++ b/web/src/components/storyboard/ShotMediaViewer.tsx
@@ -1,0 +1,45 @@
+/**
+ * ShotMediaViewer
+ *
+ * Fullscreen viewer for one storyboard still or clip. A board holds its media
+ * as `asset://` locators, so the URL and content type come from the asset
+ * record; the viewer itself is the one the asset explorer opens, which is what
+ * gives the shot media a download, copy, and info panel for free.
+ */
+
+import React, { memo } from "react";
+import type { ImageRef, VideoRef } from "@nodetool-ai/protocol";
+
+import AssetViewer from "../assets/AssetViewer";
+import { useResolvedMedia } from "../../hooks/useResolvedMediaUri";
+
+interface ShotMediaViewerProps {
+  /** The still or clip to show, or nothing when the viewer is closed. */
+  media: ImageRef | VideoRef | null | undefined;
+  onClose: () => void;
+}
+
+const ShotMediaViewerInner: React.FC<ShotMediaViewerProps> = ({
+  media,
+  onClose
+}) => {
+  const { url, contentType } = useResolvedMedia(media ?? undefined);
+
+  if (!media || !url) {
+    return null;
+  }
+
+  return (
+    <AssetViewer
+      url={url}
+      contentType={contentType ?? (media.type === "video" ? "video/*" : "image/*")}
+      open
+      onClose={onClose}
+    />
+  );
+};
+
+export const ShotMediaViewer = memo(ShotMediaViewerInner);
+ShotMediaViewer.displayName = "ShotMediaViewer";
+
+export default ShotMediaViewer;

--- a/web/src/components/storyboard/ShotTakesGallery.tsx
+++ b/web/src/components/storyboard/ShotTakesGallery.tsx
@@ -12,6 +12,7 @@
 
 import React, { memo, useCallback, useMemo, useState } from "react";
 import type { ImageRef, Shot, VideoRef } from "@nodetool-ai/protocol";
+import FullscreenIcon from "@mui/icons-material/Fullscreen";
 
 import {
   Box,
@@ -20,11 +21,13 @@ import {
   EditorButton,
   FlexColumn,
   FlexRow,
+  ToolbarIconButton,
   BORDER_RADIUS,
   SPACING,
   getSpacingPx
 } from "../ui_primitives";
 import OutputRenderer from "../node/OutputRenderer";
+import ShotMediaViewer from "./ShotMediaViewer";
 import {
   sameMediaRef,
   useStoryboardStore
@@ -67,6 +70,23 @@ const takeThumbSx = {
   }
 } as const;
 
+const takeWrapSx = {
+  position: "relative",
+  display: "inline-flex"
+} as const;
+
+const viewButtonSx = {
+  position: "absolute",
+  top: SPACING.micro,
+  right: SPACING.micro,
+  bgcolor: "c_scrim_soft",
+  opacity: 0,
+  ".takes:hover &": { opacity: 1 },
+  "&:focus-visible": { opacity: 1 },
+  // Touch devices cannot hover; keep the affordance reachable.
+  "@media (pointer: coarse)": { opacity: 1 }
+} as const;
+
 const versionKey = (ref: ImageRef | VideoRef, index: number): string =>
   ref.asset_id ?? ref.uri ?? String(index);
 
@@ -76,6 +96,10 @@ const ShotTakesGalleryInner: React.FC<ShotTakesGalleryProps> = ({
   readOnly
 }) => {
   const [expanded, setExpanded] = useState(false);
+  // The take the fullscreen viewer shows; null when it is closed.
+  const [viewerMedia, setViewerMedia] = useState<ImageRef | VideoRef | null>(
+    null
+  );
   const selectKeyframeVersion = useStoryboardStore(
     (state) => state.selectKeyframeVersion
   );
@@ -121,6 +145,8 @@ const ShotTakesGalleryInner: React.FC<ShotTakesGalleryProps> = ({
     [selectClipVersion, boardId, shot.id, clips]
   );
 
+  const handleCloseViewer = useCallback(() => setViewerMedia(null), []);
+
   const handleToggle = useCallback(() => {
     setExpanded((prev) => !prev);
   }, []);
@@ -149,26 +175,35 @@ const ShotTakesGalleryInner: React.FC<ShotTakesGalleryProps> = ({
       {stills.length > 1 && (
         <FlexRow gap={SPACING.micro} align="center" wrap className="still-thumbs">
           {stills.map((still, i) => (
-            <Box
-              key={versionKey(still, i)}
-              component="button"
-              type="button"
-              aria-label={`Use still ${i + 1}`}
-              aria-pressed={i === selectedStill}
-              disabled={readOnly}
-              onClick={() => handleSelectStill(i)}
-              sx={takeThumbSx}
-            >
-              {stillThumbSrcs[i] ? (
-                <ResponsiveImage
-                  locator={still}
-                  alt=""
-                  fit="cover"
-                  sx={{ width: "100%", height: "100%" }}
-                />
-              ) : (
-                <span>{i + 1}</span>
-              )}
+            <Box key={versionKey(still, i)} sx={takeWrapSx}>
+              <Box
+                component="button"
+                type="button"
+                aria-label={`Use still ${i + 1}`}
+                aria-pressed={i === selectedStill}
+                disabled={readOnly}
+                onClick={() => handleSelectStill(i)}
+                onDoubleClick={() => setViewerMedia(still)}
+                sx={takeThumbSx}
+              >
+                {stillThumbSrcs[i] ? (
+                  <ResponsiveImage
+                    locator={still}
+                    alt=""
+                    fit="cover"
+                    sx={{ width: "100%", height: "100%" }}
+                  />
+                ) : (
+                  <span>{i + 1}</span>
+                )}
+              </Box>
+              <ToolbarIconButton
+                icon={<FullscreenIcon sx={{ fontSize: "1em" }} />}
+                tooltip="View fullscreen"
+                ariaLabel={`View still ${i + 1} fullscreen`}
+                onClick={() => setViewerMedia(still)}
+                sx={viewButtonSx}
+              />
             </Box>
           ))}
         </FlexRow>
@@ -178,14 +213,21 @@ const ShotTakesGalleryInner: React.FC<ShotTakesGalleryProps> = ({
         <FlexRow gap={SPACING.micro} align="center" wrap className="clip-chips">
           <Caption color="secondary">Clips</Caption>
           {clips.map((clip, i) => (
-            <Chip
-              key={versionKey(clip, i)}
-              compact
-              clickable={!readOnly}
-              color={i === selectedClip ? "primary" : "default"}
-              label={`Take ${i + 1}`}
-              onClick={readOnly ? undefined : () => handleSelectClip(i)}
-            />
+            <FlexRow key={versionKey(clip, i)} align="center" gap={0}>
+              <Chip
+                compact
+                clickable={!readOnly}
+                color={i === selectedClip ? "primary" : "default"}
+                label={`Take ${i + 1}`}
+                onClick={readOnly ? undefined : () => handleSelectClip(i)}
+              />
+              <ToolbarIconButton
+                icon={<FullscreenIcon sx={{ fontSize: "1em" }} />}
+                tooltip="View fullscreen"
+                ariaLabel={`View clip take ${i + 1} fullscreen`}
+                onClick={() => setViewerMedia(clip)}
+              />
+            </FlexRow>
           ))}
         </FlexRow>
       )}
@@ -209,6 +251,8 @@ const ShotTakesGalleryInner: React.FC<ShotTakesGalleryProps> = ({
           )}
         </FlexColumn>
       )}
+
+      <ShotMediaViewer media={viewerMedia} onClose={handleCloseViewer} />
     </FlexColumn>
   );
 };

--- a/web/src/components/storyboard/__tests__/ShotCard.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotCard.test.tsx
@@ -13,6 +13,15 @@ const generateRevisedClipMock = jest.fn(async () => undefined);
 // by hooks/__tests__/useResolvedMediaUri.test.tsx).
 jest.mock("../../../hooks/useResolvedMediaUri");
 
+// The fullscreen viewer is the asset explorer's, which pulls in routing and
+// server state; stub it and assert what the card hands it.
+jest.mock("../../assets/AssetViewer", () => ({
+  __esModule: true,
+  default: ({ url, contentType }: { url: string; contentType: string }) => (
+    <div data-testid="asset-viewer">{`${contentType}:${url}`}</div>
+  )
+}));
+
 jest.mock("../../../hooks/storyboard/useGenerateShot", () => ({
   useGenerateShot: () => ({
     generateKeyframe: jest.fn(async () => undefined),
@@ -271,6 +280,48 @@ describe("ShotCard", () => {
     const dialog = await screen.findByRole("dialog");
     await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
     expect(removeShotMock).toHaveBeenCalledWith("board-1", "shot-1");
+  });
+
+  it("opens the still fullscreen from the preview", async () => {
+    renderCard(
+      makeShot({
+        status: "keyframe_ready",
+        keyframe: { type: "image", uri: "asset://img-9", asset_id: "img-9" }
+      })
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "View still fullscreen" })
+    );
+
+    expect(screen.getByTestId("asset-viewer")).toHaveTextContent(
+      "image/*:https://assets.test/img-9"
+    );
+  });
+
+  it("opens the clip fullscreen once the shot is rendered", async () => {
+    renderCard(
+      makeShot({
+        status: "rendered",
+        keyframe: { type: "image", uri: "asset://img-9", asset_id: "img-9" },
+        clip: { type: "video", uri: "asset://vid-9", asset_id: "vid-9" }
+      })
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "View clip fullscreen" })
+    );
+
+    expect(screen.getByTestId("asset-viewer")).toHaveTextContent(
+      "video/*:https://assets.test/vid-9"
+    );
+  });
+
+  it("offers no fullscreen viewer for a shot with no media", () => {
+    renderCard(makeShot());
+    expect(
+      screen.queryByRole("button", { name: /fullscreen/i })
+    ).not.toBeInTheDocument();
   });
 
   it("hides the management controls in read-only mode", () => {

--- a/web/src/components/storyboard/__tests__/ShotTakesGallery.test.tsx
+++ b/web/src/components/storyboard/__tests__/ShotTakesGallery.test.tsx
@@ -18,6 +18,15 @@ jest.mock("../../node/OutputRenderer", () => ({
   )
 }));
 
+// The fullscreen viewer is the asset explorer's, which pulls in routing and
+// server state; stub it and assert what the gallery hands it.
+jest.mock("../../assets/AssetViewer", () => ({
+  __esModule: true,
+  default: ({ url, contentType }: { url: string; contentType: string }) => (
+    <div data-testid="asset-viewer">{`${contentType}:${url}`}</div>
+  )
+}));
+
 const syncShotClipToTimelineMock = jest.fn();
 jest.mock("../../../stores/storyboard/timelineSync", () => ({
   syncShotClipToTimeline: (...args: unknown[]) =>
@@ -137,6 +146,44 @@ describe("ShotTakesGallery", () => {
       BOARD,
       shot.id,
       "vid-1"
+    );
+  });
+
+  it("opens a still take fullscreen without changing the selection", async () => {
+    const shot = makeShot({
+      keyframe: image(2),
+      keyframe_versions: [image(1), image(2)]
+    });
+    seedShot(shot);
+    renderGallery(shot);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "View still 1 fullscreen" })
+    );
+
+    expect(screen.getByTestId("asset-viewer")).toHaveTextContent(
+      "image/*:https://assets.test/img-1"
+    );
+    const updated = useStoryboardStore
+      .getState()
+      .boards[BOARD]?.shots.find((s) => s.id === shot.id);
+    expect(updated?.keyframe).toEqual(image(2));
+  });
+
+  it("opens a clip take fullscreen, read-only included", async () => {
+    const shot = makeShot({
+      clip: video(2),
+      clip_versions: [video(1), video(2)]
+    });
+    seedShot(shot);
+    renderGallery(shot, true);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "View clip take 1 fullscreen" })
+    );
+
+    expect(screen.getByTestId("asset-viewer")).toHaveTextContent(
+      "video/*:https://assets.test/vid-1"
     );
   });
 


### PR DESCRIPTION
## What changed

A shot's media was only viewable at card size — the preview box is around 300px wide and the take thumbnails smaller still — so judging a render meant hunting the asset down in the explorer. The shot card's preview and every take in the takes gallery now open the asset explorer's fullscreen viewer, which brings download, copy, and the info panel carrying the prompt that produced the asset. A new `ShotMediaViewer` resolves the shot's `asset://` locator to the URL and content type the viewer needs, so a still opens as an image and a clip as a video. On the card the button reveals on hover (always visible on coarse pointers) and a double-click on the preview does the same; in the takes gallery each still thumbnail and each clip take chip gets its own button, and viewing never changes which take is selected — it works read-only too.

## Verification

- [x] `npx jest src/components/storyboard` — 9 suites, 78 tests passed (5 new)
- [x] `npx jest --findRelatedTests` on the three changed/added components — 3 suites, 34 tests passed
- [x] `npm run lint` — passes; the one `src/components/storyboard` warning (`StoryboardPreview.tsx:75` exhaustive-deps) predates this diff
- [x] `npm run typecheck` — 190 pre-existing errors, all `Cannot find module '@nodetool-ai/*'` from unbuilt package `dist/` in this sandbox; none in `storyboard`
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run: needs built packages, and the diff touches no harness-covered surface

New tests inverted once to prove they can fail — with the viewer render disabled in `ShotCard`:

```
✕ opens the still fullscreen from the preview (244 ms)
✕ opens the clip fullscreen once the shot is rendered (126 ms)
✓ offers no fullscreen viewer for a shot with no media (35 ms)
```

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BDMKDnQN4ETCcpKomrrZT

---
_Generated by [Claude Code](https://claude.ai/code/session_012BDMKDnQN4ETCcpKomrrZT)_