### PR TITLE
feat(worker): --ssh-key opens a debug shell on a rented worker

### DIFF
--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -19,6 +19,9 @@
  *   worker stop <id> | --all
  */
 
+import { readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+
 import { Command } from "commander";
 
 import { WorkerManager } from "@nodetool-ai/compute";
@@ -171,11 +174,34 @@ function parsePositiveInt(
   return n;
 }
 
+/**
+ * Read an OpenSSH public key from disk.
+ *
+ * A rented worker exposes only the node-execution bridge, so diagnosing one
+ * means inferring its state from whether whole model loads pass or fail. The
+ * key travels as PUBLIC_KEY and the worker entrypoint installs it before
+ * starting sshd.
+ */
+function readSshPublicKey(path: string): string {
+  const key = readFileSync(resolvePath(path), "utf8").trim();
+  if (!key.startsWith("ssh-") && !key.startsWith("ecdsa-")) {
+    throw new Error(
+      `--ssh-key ${path} is not an OpenSSH public key. ` +
+        "Point it at a .pub file, not a private key."
+    );
+  }
+  if (key.includes("PRIVATE KEY")) {
+    throw new Error(`--ssh-key ${path} is a private key. Use the .pub file.`);
+  }
+  return key;
+}
+
 /** Build a profile `spec` JSON blob from the inline provisioning flags. */
 function specFromFlags(opts: {
   gpu?: string;
   vcpu?: string;
   disk?: string;
+  sshKey?: string;
 }) {
   const spec: Record<string, unknown> = {};
   if (opts.gpu) {
@@ -188,6 +214,9 @@ function specFromFlags(opts: {
   const disk = parsePositiveInt(opts.disk, "--disk");
   if (disk != null) {
     spec.disk = disk;
+  }
+  if (opts.sshKey) {
+    spec.sshPublicKey = readSshPublicKey(opts.sshKey);
   }
   return spec;
 }
@@ -225,6 +254,10 @@ function registerProfile(worker: Command): void {
     .requiredOption("--target <target>", "Provider target (runpod | vast)")
     .requiredOption("--image <image>", "Worker container image")
     .option("--gpu <gpu>", "GPU type (provider-specific)")
+    .option(
+      "--ssh-key <path>",
+      "OpenSSH public key file; exposes 22/tcp so the worker can be debugged"
+    )
     .option("--vcpu <n>", "vCPU count")
     .option(
       "--disk <gb>",
@@ -247,6 +280,7 @@ function registerProfile(worker: Command): void {
             gpu?: string;
             vcpu?: string;
             disk?: string;
+            sshKey?: string;
             tokenPolicy: string;
             idleTimeout?: string;
             maxLifetime?: string;
@@ -323,6 +357,10 @@ function registerCreate(worker: Command): void {
     .option("--target <target>", "Inline: provider target (runpod | vast)")
     .option("--image <image>", "Inline: worker container image")
     .option("--gpu <gpu>", "Inline: GPU type")
+    .option(
+      "--ssh-key <path>",
+      "Inline: OpenSSH public key file; exposes 22/tcp for debugging"
+    )
     .option("--vcpu <n>", "Inline: vCPU count")
     .option(
       "--disk <gb>",
@@ -345,6 +383,7 @@ function registerCreate(worker: Command): void {
           gpu?: string;
           vcpu?: string;
           disk?: string;
+          sshKey?: string;
           tokenPolicy: string;
           idleTimeout?: string;
           maxLifetime?: string;

--- a/packages/compute/src/__tests__/runpod-rest.test.ts
+++ b/packages/compute/src/__tests__/runpod-rest.test.ts
@@ -100,3 +100,41 @@ describe("deployWorkerPod GPU spec", () => {
     expect(body.vcpuCount).toBe(DEFAULT_CPU_VCPU_COUNT);
   });
 });
+
+describe("deployWorkerPod SSH access", () => {
+  it("opens no extra port and sets no key by default", async () => {
+    mockCreateThenRunning();
+
+    await deployWorkerPod(API_KEY, { name: "w", image: "img" });
+
+    const body = createBody();
+    expect(body.ports).toEqual(["7777/http"]);
+    expect((body.env as Record<string, string>).PUBLIC_KEY).toBeUndefined();
+  });
+
+  it("exposes 22/tcp and passes the key when one is supplied", async () => {
+    mockCreateThenRunning();
+
+    await deployWorkerPod(API_KEY, {
+      name: "w",
+      image: "img",
+      sshPublicKey: "ssh-ed25519 AAAAC3Nza key@host",
+    });
+
+    const body = createBody();
+    expect(body.ports).toEqual(["7777/http", "22/tcp"]);
+    expect((body.env as Record<string, string>).PUBLIC_KEY).toBe(
+      "ssh-ed25519 AAAAC3Nza key@host"
+    );
+  });
+
+  it("treats a blank key as no key", async () => {
+    mockCreateThenRunning();
+
+    await deployWorkerPod(API_KEY, { name: "w", image: "img", sshPublicKey: "  " });
+
+    const body = createBody();
+    expect(body.ports).toEqual(["7777/http"]);
+    expect((body.env as Record<string, string>).PUBLIC_KEY).toBeUndefined();
+  });
+});

--- a/packages/compute/src/manager.ts
+++ b/packages/compute/src/manager.ts
@@ -552,6 +552,8 @@ function specFromProfile(
     vcpu: typeof spec.vcpu === "number" ? spec.vcpu : undefined,
     disk: typeof spec.disk === "number" ? spec.disk : undefined,
     env: isStringRecord(spec.env) ? spec.env : undefined,
+    sshPublicKey:
+      typeof spec.sshPublicKey === "string" ? spec.sshPublicKey : undefined,
     token,
   };
 }

--- a/packages/compute/src/providers/runpod-rest.ts
+++ b/packages/compute/src/providers/runpod-rest.ts
@@ -222,6 +222,15 @@ export interface DeployWorkerPodOptions {
   volumeMountPath?: string;
   /** Extra env merged into the container. */
   env?: Record<string, string>;
+  /**
+   * OpenSSH public key. When set, 22/tcp is exposed and the key is passed as
+   * PUBLIC_KEY, which the worker entrypoint installs before starting sshd.
+   *
+   * A rented worker is otherwise reachable only through the node-execution
+   * bridge, so diagnosing one means inferring its state from pass/fail of whole
+   * model loads. A shell turns that into reading the state directly.
+   */
+  sshPublicKey?: string;
   /** Poll budget for the Pod to reach RUNNING + expose its endpoint. */
   timeoutMs?: number;
 }
@@ -249,6 +258,8 @@ export async function deployWorkerPod(
   const exposure = opts.exposure ?? "http";
   const env: Record<string, string> = { ...(opts.env ?? {}) };
   if (opts.workerToken) env.NODETOOL_WORKER_TOKEN = opts.workerToken;
+  const sshKey = opts.sshPublicKey?.trim();
+  if (sshKey) env.PUBLIC_KEY = sshKey;
 
   const isGpu = opts.computeType === "GPU";
   const spec: RunpodPodSpec = {
@@ -260,7 +271,9 @@ export async function deployWorkerPod(
       opts.vcpuCount ??
       (isGpu ? DEFAULT_GPU_VCPU_COUNT : DEFAULT_CPU_VCPU_COUNT),
     gpuTypeIds: opts.gpuTypeIds,
-    ports: [`${internalPort}/${exposure}`],
+    ports: sshKey
+      ? [`${internalPort}/${exposure}`, "22/tcp"]
+      : [`${internalPort}/${exposure}`],
     env,
     containerDiskInGb: opts.containerDiskInGb ?? 20
   };

--- a/packages/compute/src/providers/runpod.ts
+++ b/packages/compute/src/providers/runpod.ts
@@ -71,6 +71,7 @@ export class RunpodPodProvider implements WorkerProvider {
       // stop/resume; merge over any caller env (caller wins on conflict? no —
       // we own HF_HOME, so it goes last).
       env: { ...spec.env, HF_HOME: WORKER_HF_HOME },
+      sshPublicKey: spec.sshPublicKey,
       containerDiskInGb: DEFAULT_CONTAINER_DISK_GB,
       volumeInGb: spec.disk ?? DEFAULT_VOLUME_GB,
       volumeMountPath: WORKER_VOLUME_MOUNT,

--- a/packages/compute/src/providers/types.ts
+++ b/packages/compute/src/providers/types.ts
@@ -62,6 +62,12 @@ export interface WorkerSpec {
   env?: Record<string, string>;
   /** Bearer token the worker authenticates with, when generated/fixed. */
   token?: string;
+  /**
+   * OpenSSH public key. When set, the provider exposes 22/tcp and passes the
+   * key as PUBLIC_KEY so the worker entrypoint starts sshd. Without it a
+   * rented worker can only be reached through the node-execution bridge.
+   */
+  sshPublicKey?: string;
 }
 
 /** Result of a successful `provision` — the attach handoff for an instance. */


### PR DESCRIPTION
## Why

A rented worker exposes only the node-execution bridge. Its state can be inferred only from whether a whole model load passes or fails — one bit, at 2–10 minutes per hypothesis.

Diagnosing the FLUX device-placement failure this week cost five refuted hypotheses for that reason. Reading the pipeline's offload state and its components' devices once would have answered it. The second bug hiding underneath (nodetool-huggingface#62) needed another round.

## What

`worker profile add --ssh-key <path>` and `worker create --ssh-key <path>` read an OpenSSH public key and store it on the profile `spec`, which is free-form JSON — no schema migration.

The RunPod provider then exposes `22/tcp` alongside the worker port and passes the key as `PUBLIC_KEY`. The worker entrypoint (nodetool-core#1016) installs it and starts sshd.

Defaults are untouched: no key means one port, no `PUBLIC_KEY`, no daemon. A blank key counts as no key. The flag rejects a private key rather than uploading one.

## Tests

Three cases in `runpod-rest.test.ts` — default, key supplied, blank key. Each was shown to fail with the change reverted:

```
× exposes 22/tcp and passes the key when one is supplied
  Tests  1 failed | 87 passed (88)
```

Full compute suite: 88 passed. CLI typecheck clean.

## Pairs with

- nodetool-core#1016 — the image half. Neither does anything alone.