### PR TITLE
fix(storyboard): carry each shot clip's own audio into the assembled cut

### DIFF
--- a/docs/creative-agent.md
+++ b/docs/creative-agent.md
@@ -75,9 +75,13 @@ Agents drive the same surface through thirteen `ui_storyboard_*` tools:
 
 **Assemble timeline** turns the rendered shots into a persisted timeline
 sequence and opens the editor: shot clips laid end to end on a video track,
-the screenplay's narration and music as draft text-to-audio clips on their
-own tracks, the script panel carrying the screenplay text. From here it's a
-normal edit — trim, transitions, audio mix, captions — and export.
+each clip's own sound on a linked **Shot Audio** track next to it, the
+screenplay's narration and music as draft text-to-audio clips on their own
+tracks, the script panel carrying the screenplay text. Timeline playback and
+export mix audio clips, never a video element's track, so the shot-audio
+clips are how a video model's dialogue and room tone reach the cut — mute one
+when a shot should play silent under narration. From here it's a normal edit
+— trim, transitions, audio mix, captions — and export.
 
 Every assembled clip stays linked to its shot. Revise a shot on the
 storyboard afterward and the new render replaces the clip in the persisted

--- a/packages/agents/tests/capabilities-storyboards.test.ts
+++ b/packages/agents/tests/capabilities-storyboards.test.ts
@@ -586,7 +586,8 @@ describe("storyboards capability behaviour", () => {
     )) as { ok: boolean; clip_count: number; width: number; height: number };
     expect(assembled).toMatchObject({
       ok: true,
-      clip_count: 1,
+      // The shot's clip and the audio twin that carries its sound.
+      clip_count: 2,
       width: 1920,
       height: 1080
     });
@@ -619,8 +620,12 @@ describe("storyboards capability behaviour", () => {
     expect(assembled.duration_ms).toBe(2000);
 
     const document = (await sequenceOf(assembled.timeline_id)).toDocument();
-    expect(document.tracks.map((t) => t.name)).toEqual(["Shots", "Voiceover"]);
-    const voiceover = document.clips.filter((c) => c.mediaType === "audio");
+    expect(document.tracks.map((t) => t.name)).toEqual([
+      "Shots",
+      "Shot Audio",
+      "Voiceover"
+    ]);
+    const voiceover = document.clips.filter((c) => c.scriptLineId);
     expect(voiceover.map((c) => [c.scriptLineId, c.storyboardShotId])).toEqual([
       ["l1", "s1"],
       ["l2", "s2"]
@@ -641,7 +646,11 @@ describe("storyboards capability behaviour", () => {
     expect(assembled.script_id).toBeNull();
 
     const document = (await sequenceOf(assembled.timeline_id)).toDocument();
-    expect(document.tracks.map((t) => t.name)).toEqual(["Shots", "Narration"]);
+    expect(document.tracks.map((t) => t.name)).toEqual([
+      "Shots",
+      "Shot Audio",
+      "Narration"
+    ]);
     expect(
       document.clips.some((c) => c.prompt === "A quiet town at dusk.")
     ).toBe(true);
@@ -665,7 +674,7 @@ describe("storyboards capability behaviour", () => {
     expect(assembled.warnings?.[0]).toContain("sc-deleted");
 
     const document = (await sequenceOf(assembled.timeline_id)).toDocument();
-    expect(document.tracks.map((t) => t.name)).toEqual(["Shots"]);
+    expect(document.tracks.map((t) => t.name)).toEqual(["Shots", "Shot Audio"]);
   });
 
   it("keeps tracks the board does not own when re-assembling", async () => {
@@ -716,13 +725,14 @@ describe("storyboards capability behaviour", () => {
     const document = (await sequenceOf(first.timeline_id)).toDocument();
     expect(document.tracks.map((t) => t.name)).toContain("Sound design");
     expect(document.clips.filter((c) => c.name === "Wind")).toHaveLength(1);
-    // The board's own clips were rewritten, not doubled: one shot clip and
-    // one voiceover clip for the single linked line.
+    // The board's own clips were rewritten, not doubled: one shot clip, its
+    // audio twin, and one voiceover clip for the single linked line.
     expect(
       document.clips.filter((c) => c.storyboardShotId === "s1").length
-    ).toBe(2);
+    ).toBe(3);
     expect(document.tracks.map((t) => t.name)).toEqual([
       "Shots",
+      "Shot Audio",
       "Voiceover",
       "Sound design"
     ]);

--- a/packages/agents/tests/creative-pipeline-tool-loop.test.ts
+++ b/packages/agents/tests/creative-pipeline-tool-loop.test.ts
@@ -241,8 +241,9 @@ describe("createCreativePipelineBridge", () => {
 
     const state = bridge.finalState();
     expect(state.assembledLinked).toBe(true);
-    // Two shot clips plus one voiceover clip per voiced line.
-    expect(state.timeline.clips).toHaveLength(4);
+    // Two shot clips, their audio twins, and one voiceover clip per voiced
+    // line.
+    expect(state.timeline.clips).toHaveLength(6);
     const voice = state.timeline.documentClips.filter((c) => c.scriptLineId);
     expect(voice).toHaveLength(2);
     for (const clip of voice) {

--- a/packages/agents/tests/storyboard-render-tools.test.ts
+++ b/packages/agents/tests/storyboard-render-tools.test.ts
@@ -322,8 +322,8 @@ describe("storyboard render tools", () => {
     };
 
     expect(result.duration_ms).toBe(5000);
-    // Two shot clips plus the narration clip.
-    expect(result.clip_count).toBe(3);
+    // Two shot clips, their audio twins, plus the narration clip.
+    expect(result.clip_count).toBe(5);
     expect(result.skipped_shot_ids).toEqual(["s2"]);
     expect(result).toMatchObject({ width: 1080, height: 1920 });
 

--- a/packages/execution/tests/linked-timeline-validate.test.ts
+++ b/packages/execution/tests/linked-timeline-validate.test.ts
@@ -78,7 +78,8 @@ describe("buildLinkedTimeline → validateTimelineSequence", () => {
       }
     });
 
-    expect(assembled.clips).toHaveLength(6);
+    // Two shots, their audio twins, three voiceover lines, one music bed.
+    expect(assembled.clips).toHaveLength(8);
 
     const result = validateTimelineSequence({
       tracks: assembled.tracks,

--- a/packages/timeline/src/linked.ts
+++ b/packages/timeline/src/linked.ts
@@ -5,9 +5,11 @@
  * owns the words — and this is where they meet. Shots lay out end to end as in
  * `buildStoryboardTimeline`, but each one is as long as the takes it covers
  * (`linkedShotDurationMs`), and every voiced line gets its own clip on the
- * voiceover track, parked where its words fall inside the shot. The whole-cut
- * narration draft clip is gone: the script says the words now, so a prompt
- * spanning the cut would be a second, competing answer.
+ * voiceover track, parked where its words fall inside the shot. Each shot also
+ * keeps the sound of its own rendered clip, on the shot-audio track
+ * `buildStoryboardTimeline` uses. The whole-cut narration draft clip is gone:
+ * the script says the words now, so a prompt spanning the cut would be a
+ * second, competing answer.
  *
  * Each voiceover clip carries both linkage families —
  * `scriptId`/`scriptLineId` and `storyboardBoardId`/`storyboardShotId` — so the
@@ -20,7 +22,7 @@
  */
 
 import type { Shot } from "@nodetool-ai/protocol";
-import { makeClip, makeTrack } from "./defaults.js";
+import { createTimeOrderedUuid, makeClip, makeTrack } from "./defaults.js";
 import {
   currentTake,
   effectiveVoice,
@@ -33,7 +35,9 @@ import {
   scriptLinesById
 } from "./script-link.js";
 import {
+  SHOT_AUDIO_TRACK_NAME,
   isAssemblableShot,
+  shotAudioClip,
   shotDurationMs,
   type AssembledTimeline
 } from "./storyboard.js";
@@ -61,8 +65,13 @@ export function buildLinkedTimeline(
   const linesById = scriptLinesById(input.script.sections);
 
   const shotTrack = makeTrack({ type: "video", name: "Shots", index: 0 });
-  const voiceTrack = makeTrack({ type: "audio", name: "Voiceover", index: 1 });
-  const tracks: TimelineTrack[] = [shotTrack, voiceTrack];
+  const shotAudioTrack = makeTrack({
+    type: "audio",
+    name: SHOT_AUDIO_TRACK_NAME,
+    index: 1
+  });
+  const voiceTrack = makeTrack({ type: "audio", name: "Voiceover", index: 2 });
+  const tracks: TimelineTrack[] = [shotTrack, shotAudioTrack, voiceTrack];
   const clips: TimelineClip[] = [];
   const skippedShotIds: string[] = [];
   const skippedLineIds: string[] = [];
@@ -84,21 +93,21 @@ export function buildLinkedTimeline(
     const shotStartMs = cursorMs;
     const durationMs =
       linkedShotDurationMs(shot, linesById) ?? shotDurationMs(shot);
-    clips.push(
-      makeClip({
-        trackId: shotTrack.id,
-        name: shot.slug ?? `Shot ${shot.index + 1}`,
-        startMs: shotStartMs,
-        durationMs,
-        mediaType: "video",
-        sourceType: "imported",
-        status: "generated",
-        currentAssetId: shot.clip?.asset_id ?? undefined,
-        storyboardBoardId: input.boardId,
-        storyboardShotId: shot.id,
-        versions: []
-      })
-    );
+    const videoClip = makeClip({
+      trackId: shotTrack.id,
+      name: shot.slug ?? `Shot ${shot.index + 1}`,
+      startMs: shotStartMs,
+      durationMs,
+      mediaType: "video",
+      sourceType: "imported",
+      status: "generated",
+      currentAssetId: shot.clip?.asset_id ?? undefined,
+      linkId: createTimeOrderedUuid(),
+      storyboardBoardId: input.boardId,
+      storyboardShotId: shot.id,
+      versions: []
+    });
+    clips.push(videoClip, shotAudioClip(videoClip, shotAudioTrack.id));
     cursorMs += durationMs;
 
     let offsetMs = 0;

--- a/packages/timeline/src/storyboard.ts
+++ b/packages/timeline/src/storyboard.ts
@@ -8,20 +8,55 @@
  *
  * Rendered shots become imported, asset-backed video clips laid end to end in
  * shot order, each stamped with `storyboardBoardId`/`storyboardShotId` so a
- * later shot revision can round-trip into the cut. Narration and music become
- * draft text-to-audio clips on their own tracks — the timeline's generation
- * machinery renders them on demand.
+ * later shot revision can round-trip into the cut. Every shot clip also gets an
+ * audio twin on its own track (`shotAudioClip`), because the preview and the
+ * export mute video elements and take sound only from audio clips. Narration
+ * and music become draft text-to-audio clips on their own tracks — the
+ * timeline's generation machinery renders them on demand.
  *
  * `buildStoryboardPreviewTimeline` is the same mapping for the in-editor
  * player, where a board that is only half rendered still has to play.
  */
 
 import type { Shot } from "@nodetool-ai/protocol";
-import { makeClip, makeTrack } from "./defaults.js";
+import { createTimeOrderedUuid, makeClip, makeTrack } from "./defaults.js";
 import type { TimelineClip, TimelineTrack } from "./types.js";
 
 /** Clip length used for a shot that carries no duration. */
 export const DEFAULT_SHOT_MS = 4000;
+
+/** Track holding the sound that came with the shots' own rendered clips. */
+export const SHOT_AUDIO_TRACK_NAME = "Shot Audio";
+
+/**
+ * The audio twin of a shot's video clip.
+ *
+ * A rendered shot carries its own sound — dialogue the video model spoke, room
+ * tone, whatever the render produced — but every surface that plays a timeline
+ * mutes its video elements and mixes audio clips only, so without a twin that
+ * sound never reaches the cut. The twin points at the same asset, sits at the
+ * same place, and shares a `linkId` with the video clip so the two move and
+ * trim together.
+ */
+export function shotAudioClip(
+  videoClip: TimelineClip,
+  trackId: string
+): TimelineClip {
+  return makeClip({
+    trackId,
+    name: `${videoClip.name} (audio)`,
+    startMs: videoClip.startMs,
+    durationMs: videoClip.durationMs,
+    mediaType: "audio",
+    sourceType: "imported",
+    status: "generated",
+    currentAssetId: videoClip.currentAssetId,
+    linkId: videoClip.linkId,
+    storyboardBoardId: videoClip.storyboardBoardId,
+    storyboardShotId: videoClip.storyboardShotId,
+    versions: []
+  });
+}
 
 export interface StoryboardAssemblyInput {
   /** Board id stamped onto each clip, linking the cut back to the board. */
@@ -71,33 +106,45 @@ export function buildStoryboardTimeline(
     .map((s) => s.id);
 
   const shotTrack = makeTrack({ type: "video", name: "Shots", index: 0 });
+  const shotAudioTrack = makeTrack({
+    type: "audio",
+    name: SHOT_AUDIO_TRACK_NAME,
+    index: 1
+  });
   const tracks: TimelineTrack[] = [shotTrack];
   const clips: TimelineClip[] = [];
 
   let cursorMs = 0;
   for (const shot of assemblable) {
     const durationMs = shotDurationMs(shot);
-    clips.push(
-      makeClip({
-        trackId: shotTrack.id,
-        name: shot.slug ?? `Shot ${shot.index + 1}`,
-        startMs: cursorMs,
-        durationMs,
-        mediaType: "video",
-        sourceType: "imported",
-        status: "generated",
-        currentAssetId: shot.clip?.asset_id ?? undefined,
-        storyboardBoardId: input.boardId,
-        storyboardShotId: shot.id,
-        versions: []
-      })
-    );
+    const videoClip = makeClip({
+      trackId: shotTrack.id,
+      name: shot.slug ?? `Shot ${shot.index + 1}`,
+      startMs: cursorMs,
+      durationMs,
+      mediaType: "video",
+      sourceType: "imported",
+      status: "generated",
+      currentAssetId: shot.clip?.asset_id ?? undefined,
+      linkId: createTimeOrderedUuid(),
+      storyboardBoardId: input.boardId,
+      storyboardShotId: shot.id,
+      versions: []
+    });
+    clips.push(videoClip, shotAudioClip(videoClip, shotAudioTrack.id));
     cursorMs += durationMs;
+  }
+  if (cursorMs > 0) {
+    tracks.push(shotAudioTrack);
   }
 
   const narration = input.narration?.trim();
   if (narration && cursorMs > 0) {
-    const track = makeTrack({ type: "audio", name: "Narration", index: 1 });
+    const track = makeTrack({
+      type: "audio",
+      name: "Narration",
+      index: tracks.length
+    });
     tracks.push(track);
     clips.push(
       makeClip({
@@ -167,8 +214,9 @@ export interface StoryboardPreviewTimeline {
  * shot that so far has only a keyframe holds that still for the shot's length,
  * and a shot with neither is dropped. A selected take plays whatever the shot's
  * lifecycle status says, so a preview keeps working while the board is still
- * rendering. Narration and music are left out — they are draft prompts with no
- * audio behind them yet.
+ * rendering. Each played clip gets its audio twin, so a preview sounds like the
+ * assembled cut. Narration and music are left out — they are draft prompts with
+ * no audio behind them yet.
  */
 export function buildStoryboardPreviewTimeline(
   input: StoryboardPreviewInput
@@ -176,10 +224,16 @@ export function buildStoryboardPreviewTimeline(
   const ordered = [...input.shots].sort((a, b) => a.index - b.index);
 
   const shotTrack = makeTrack({ type: "video", name: "Shots", index: 0 });
+  const shotAudioTrack = makeTrack({
+    type: "audio",
+    name: SHOT_AUDIO_TRACK_NAME,
+    index: 1
+  });
   const tracks: TimelineTrack[] = [shotTrack];
   const clips: TimelineClip[] = [];
   const skippedShotIds: string[] = [];
   const stillShotIds: string[] = [];
+  let hasShotAudio = false;
 
   let cursorMs = 0;
   for (const shot of ordered) {
@@ -195,22 +249,30 @@ export function buildStoryboardPreviewTimeline(
     }
 
     const durationMs = shotDurationMs(shot);
-    clips.push(
-      makeClip({
-        trackId: shotTrack.id,
-        name: shot.slug ?? `Shot ${shot.index + 1}`,
-        startMs: cursorMs,
-        durationMs,
-        mediaType: clipAssetId ? "video" : "image",
-        sourceType: "imported",
-        status: "generated",
-        currentAssetId: assetId,
-        storyboardBoardId: input.boardId,
-        storyboardShotId: shot.id,
-        versions: []
-      })
-    );
+    const shotClip = makeClip({
+      trackId: shotTrack.id,
+      name: shot.slug ?? `Shot ${shot.index + 1}`,
+      startMs: cursorMs,
+      durationMs,
+      mediaType: clipAssetId ? "video" : "image",
+      sourceType: "imported",
+      status: "generated",
+      currentAssetId: assetId,
+      linkId: clipAssetId ? createTimeOrderedUuid() : undefined,
+      storyboardBoardId: input.boardId,
+      storyboardShotId: shot.id,
+      versions: []
+    });
+    clips.push(shotClip);
+    // A held keyframe is a still: there is no rendered clip to take sound from.
+    if (clipAssetId) {
+      clips.push(shotAudioClip(shotClip, shotAudioTrack.id));
+      hasShotAudio = true;
+    }
     cursorMs += durationMs;
+  }
+  if (hasShotAudio) {
+    tracks.push(shotAudioTrack);
   }
 
   return {

--- a/packages/timeline/tests/linked.test.ts
+++ b/packages/timeline/tests/linked.test.ts
@@ -78,9 +78,11 @@ function renderedShot(
   };
 }
 
-/** Clip ids and track ids are minted per call; compare everything else. */
+/** Clip, track and link ids are minted per call; compare everything else. */
 const withoutIds = (clips: TimelineClip[]) =>
-  clips.map(({ id: _id, trackId: _trackId, ...rest }) => rest);
+  clips.map(
+    ({ id: _id, trackId: _trackId, linkId: _linkId, ...rest }) => rest
+  );
 const trackShape = (tracks: TimelineTrack[]) =>
   tracks.map(({ id: _id, ...rest }) => rest);
 
@@ -147,12 +149,38 @@ describe("buildLinkedTimeline", () => {
       }
     });
 
-    const audio = result.clips.find((c) => c.mediaType === "audio");
+    const audio = result.clips.find((c) => c.scriptLineId);
     expect(audio).toBeDefined();
     expect(audio?.scriptId).toBe("script-9");
     expect(audio?.scriptLineId).toBe("a");
     expect(audio?.storyboardBoardId).toBe("board-9");
     expect(audio?.storyboardShotId).toBe("s1");
+  });
+
+  it("keeps each shot's own sound next to the voiceover", () => {
+    const result = buildLinkedTimeline({
+      boardId: "board-1",
+      shots: [renderedShot("s1", 0, { script_line_ids: ["a"] })],
+      script: {
+        scriptId: "script-1",
+        cast,
+        sections: [section([voicedLine("a", 1000)])]
+      }
+    });
+
+    const video = result.clips.find((c) => c.mediaType === "video");
+    const shotAudioTrack = result.tracks.find((t) => t.name === "Shot Audio");
+    const shotAudio = result.clips.find(
+      (c) => c.trackId === shotAudioTrack?.id
+    );
+    expect(shotAudio?.currentAssetId).toBe("clip-s1");
+    expect(shotAudio?.startMs).toBe(0);
+    expect(shotAudio?.durationMs).toBe(1000);
+    expect(shotAudio?.linkId).toBe(video?.linkId);
+    expect(shotAudio?.scriptLineId).toBeUndefined();
+    // The words still come from the script's take, on their own track.
+    const voiceover = result.clips.find((c) => c.scriptLineId === "a");
+    expect(voiceover?.currentAssetId).toBe("asset-a");
   });
 
   it("carries the same clip payload buildScriptTimeline writes", () => {
@@ -200,6 +228,7 @@ describe("buildLinkedTimeline", () => {
 
     expect(result.tracks.map((t) => t.name)).toEqual([
       "Shots",
+      "Shot Audio",
       "Voiceover",
       "Music"
     ]);
@@ -359,13 +388,20 @@ describe("unlinked assembly is unchanged", () => {
     expect(trackShape(result.tracks)).toEqual([
       { name: "Shots", type: "video", index: 0, visible: true, locked: false },
       {
-        name: "Narration",
+        name: "Shot Audio",
         type: "audio",
         index: 1,
         visible: true,
         locked: false
       },
-      { name: "Music", type: "audio", index: 2, visible: true, locked: false }
+      {
+        name: "Narration",
+        type: "audio",
+        index: 2,
+        visible: true,
+        locked: false
+      },
+      { name: "Music", type: "audio", index: 3, visible: true, locked: false }
     ]);
     expect(withoutIds(result.clips)).toEqual([
       {
@@ -382,10 +418,36 @@ describe("unlinked assembly is unchanged", () => {
         versions: []
       },
       {
+        name: "Lighthouse (audio)",
+        startMs: 0,
+        durationMs: 2000,
+        mediaType: "audio",
+        sourceType: "imported",
+        status: "generated",
+        currentAssetId: "clip-s1",
+        storyboardBoardId: "board-1",
+        storyboardShotId: "s1",
+        locked: false,
+        versions: []
+      },
+      {
         name: "Shot 2",
         startMs: 2000,
         durationMs: DEFAULT_SHOT_MS,
         mediaType: "video",
+        sourceType: "imported",
+        status: "generated",
+        currentAssetId: "clip-s2",
+        storyboardBoardId: "board-1",
+        storyboardShotId: "s2",
+        locked: false,
+        versions: []
+      },
+      {
+        name: "Shot 2 (audio)",
+        startMs: 2000,
+        durationMs: DEFAULT_SHOT_MS,
+        mediaType: "audio",
         sourceType: "imported",
         status: "generated",
         currentAssetId: "clip-s2",

--- a/packages/timeline/tests/storyboard.test.ts
+++ b/packages/timeline/tests/storyboard.test.ts
@@ -9,6 +9,7 @@ import {
   buildStoryboardPreviewTimeline,
   buildStoryboardTimeline
 } from "../src/storyboard.js";
+import type { TimelineClip } from "../src/types.js";
 
 function makeShot(overrides: Partial<Shot> & Pick<Shot, "id" | "index">): Shot {
   return {
@@ -23,6 +24,10 @@ const clipRef = (assetId: string) =>
   ({ type: "video", asset_id: assetId }) as const;
 const keyframeRef = (assetId: string) =>
   ({ type: "image", asset_id: assetId }) as const;
+
+/** The picture clips — every shot also contributes its audio twin. */
+const pictureClips = (clips: TimelineClip[]) =>
+  clips.filter((c) => c.mediaType !== "audio");
 
 // ── buildStoryboardTimeline ───────────────────────────────────────────
 
@@ -47,8 +52,8 @@ describe("buildStoryboardTimeline", () => {
       ]
     });
 
-    expect(result.clips).toHaveLength(1);
-    expect(result.clips[0].currentAssetId).toBe("asset-a");
+    expect(pictureClips(result.clips)).toHaveLength(1);
+    expect(pictureClips(result.clips)[0].currentAssetId).toBe("asset-a");
     expect(result.skippedShotIds).toEqual(["b", "c"]);
     expect(result.durationMs).toBe(DEFAULT_SHOT_MS);
   });
@@ -68,13 +73,61 @@ describe("buildStoryboardTimeline", () => {
       ]
     });
 
-    const narration = result.clips.find((c) => c.mediaType === "audio");
+    const narration = result.clips.find((c) => c.name === "Narration");
     expect(narration).toBeDefined();
     expect(narration?.prompt).toBe("the light turns");
     expect(narration?.status).toBe("draft");
     expect(narration?.startMs).toBe(0);
     expect(narration?.durationMs).toBe(2500);
-    expect(result.tracks.map((t) => t.name)).toEqual(["Shots", "Narration"]);
+    expect(result.tracks.map((t) => t.name)).toEqual([
+      "Shots",
+      "Shot Audio",
+      "Narration"
+    ]);
+  });
+
+  it("gives every shot clip an audio twin that shares its asset and place", () => {
+    const result = buildStoryboardTimeline({
+      boardId: "board-1",
+      shots: [
+        makeShot({
+          id: "a",
+          index: 0,
+          slug: "Lighthouse",
+          status: "rendered",
+          duration_seconds: 2,
+          clip: clipRef("asset-a")
+        })
+      ]
+    });
+
+    const video = result.clips.find((c) => c.mediaType === "video");
+    const audio = result.clips.find((c) => c.mediaType === "audio");
+    expect(audio?.name).toBe("Lighthouse (audio)");
+    expect(audio?.currentAssetId).toBe("asset-a");
+    expect(audio?.startMs).toBe(video?.startMs);
+    expect(audio?.durationMs).toBe(video?.durationMs);
+    expect(audio?.status).toBe("generated");
+    expect(audio?.sourceType).toBe("imported");
+    expect(audio?.storyboardShotId).toBe("a");
+    expect(audio?.storyboardBoardId).toBe("board-1");
+    const audioTrack = result.tracks.find((t) => t.name === "Shot Audio");
+    expect(audio?.trackId).toBe(audioTrack?.id);
+    expect(audioTrack?.type).toBe("audio");
+    // Linked so a trim or a move on the picture takes the sound with it.
+    expect(audio?.linkId).toBeTruthy();
+    expect(audio?.linkId).toBe(video?.linkId);
+  });
+
+  it("leaves out the shot-audio track when no shot is assemblable", () => {
+    const result = buildStoryboardTimeline({
+      boardId: "board-1",
+      narration: "the light turns",
+      shots: [makeShot({ id: "a", index: 0, status: "planned" })]
+    });
+
+    expect(result.clips).toEqual([]);
+    expect(result.tracks.map((t) => t.name)).toEqual(["Shots"]);
   });
 });
 
@@ -96,7 +149,7 @@ describe("buildStoryboardPreviewTimeline", () => {
       ]
     });
 
-    expect(result.clips).toHaveLength(1);
+    expect(pictureClips(result.clips)).toHaveLength(1);
     const clip = result.clips[0];
     expect(clip.mediaType).toBe("video");
     expect(clip.sourceType).toBe("imported");
@@ -127,6 +180,31 @@ describe("buildStoryboardPreviewTimeline", () => {
     expect(result.clips[0].status).toBe("generated");
     expect(result.clips[0].currentAssetId).toBe("still-a");
     expect(result.stillShotIds).toEqual(["a"]);
+    // A still has no rendered clip, so there is no sound to twin.
+    expect(result.clips).toHaveLength(1);
+    expect(result.tracks.map((t) => t.name)).toEqual(["Shots"]);
+  });
+
+  it("twins the audio of every played clip, stills excluded", () => {
+    const result = buildStoryboardPreviewTimeline({
+      boardId: "board-1",
+      shots: [
+        makeShot({
+          id: "a",
+          index: 0,
+          duration_seconds: 2,
+          clip: clipRef("asset-a")
+        }),
+        makeShot({ id: "b", index: 1, keyframe: keyframeRef("still-b") })
+      ]
+    });
+
+    const audio = result.clips.filter((c) => c.mediaType === "audio");
+    expect(audio).toHaveLength(1);
+    expect(audio[0].currentAssetId).toBe("asset-a");
+    expect(audio[0].startMs).toBe(0);
+    expect(audio[0].durationMs).toBe(2000);
+    expect(result.tracks.map((t) => t.name)).toEqual(["Shots", "Shot Audio"]);
   });
 
   it("plays a selected take whose shot is not yet marked rendered", () => {
@@ -143,7 +221,7 @@ describe("buildStoryboardPreviewTimeline", () => {
       ]
     });
 
-    expect(result.clips).toHaveLength(1);
+    expect(pictureClips(result.clips)).toHaveLength(1);
     expect(result.clips[0].mediaType).toBe("video");
     expect(result.clips[0].currentAssetId).toBe("asset-a");
     expect(result.stillShotIds).toEqual([]);
@@ -192,13 +270,10 @@ describe("buildStoryboardPreviewTimeline", () => {
       ]
     });
 
-    expect(result.clips.map((c) => c.storyboardShotId)).toEqual([
-      "a",
-      "b",
-      "c"
-    ]);
-    expect(result.clips.map((c) => c.startMs)).toEqual([0, 2000, 6000]);
-    expect(result.clips.map((c) => c.durationMs)).toEqual([
+    const picture = pictureClips(result.clips);
+    expect(picture.map((c) => c.storyboardShotId)).toEqual(["a", "b", "c"]);
+    expect(picture.map((c) => c.startMs)).toEqual([0, 2000, 6000]);
+    expect(picture.map((c) => c.durationMs)).toEqual([
       2000,
       DEFAULT_SHOT_MS,
       1000
@@ -221,7 +296,7 @@ describe("buildStoryboardPreviewTimeline", () => {
       ]
     });
 
-    expect(result.clips.map((c) => c.durationMs)).toEqual([
+    expect(pictureClips(result.clips).map((c) => c.durationMs)).toEqual([
       DEFAULT_SHOT_MS,
       DEFAULT_SHOT_MS
     ]);
@@ -237,15 +312,15 @@ describe("buildStoryboardPreviewTimeline", () => {
       ]
     });
 
-    expect(result.tracks).toHaveLength(1);
+    expect(result.tracks.map((t) => t.name)).toEqual(["Shots", "Shot Audio"]);
     expect(result.tracks[0].type).toBe("video");
-    expect(result.tracks[0].name).toBe("Shots");
-    for (const clip of result.clips) {
+    const picture = pictureClips(result.clips);
+    for (const clip of picture) {
       expect(clip.storyboardBoardId).toBe("board-42");
       expect(clip.trackId).toBe(result.tracks[0].id);
       expect(clip.versions).toEqual([]);
     }
-    expect(result.clips.map((c) => c.storyboardShotId)).toEqual(["a", "b"]);
-    expect(result.clips.map((c) => c.name)).toEqual(["Shot 1", "Shot 2"]);
+    expect(picture.map((c) => c.storyboardShotId)).toEqual(["a", "b"]);
+    expect(picture.map((c) => c.name)).toEqual(["Shot 1", "Shot 2"]);
   });
 });

--- a/web/src/components/storyboard/__tests__/assembleTimeline.test.ts
+++ b/web/src/components/storyboard/__tests__/assembleTimeline.test.ts
@@ -67,11 +67,12 @@ describe("buildTimelineDocument", () => {
       })
     );
 
-    expect(doc.tracks).toHaveLength(1);
+    expect(doc.tracks.map((t) => t.name)).toEqual(["Shots", "Shot Audio"]);
     expect(doc.tracks[0].type).toBe("video");
-    expect(doc.clips).toHaveLength(2);
+    const picture = doc.clips.filter((c) => c.mediaType === "video");
+    expect(picture).toHaveLength(2);
 
-    const [first, second] = doc.clips;
+    const [first, second] = picture;
     expect(first.name).toBe("Opening");
     expect(first.startMs).toBe(0);
     expect(first.durationMs).toBe(5000);
@@ -95,7 +96,7 @@ describe("buildTimelineDocument", () => {
         ]
       })
     );
-    expect(doc.clips.filter((c) => c.storyboardShotId)).toHaveLength(1);
+    expect(doc.clips.filter((c) => c.mediaType === "video")).toHaveLength(1);
     expect(doc.skippedShotIds).toEqual(["pending"]);
   });
 
@@ -115,9 +116,13 @@ describe("buildTimelineDocument", () => {
     );
 
     const audioTracks = doc.tracks.filter((t) => t.type === "audio");
-    expect(audioTracks.map((t) => t.name)).toEqual(["Narration", "Music"]);
+    expect(audioTracks.map((t) => t.name)).toEqual([
+      "Shot Audio",
+      "Narration",
+      "Music"
+    ]);
 
-    const audioClips = doc.clips.filter((c) => c.mediaType === "audio");
+    const audioClips = doc.clips.filter((c) => c.bindingKind === "text-to-audio");
     expect(audioClips).toHaveLength(2);
     for (const clip of audioClips) {
       expect(clip.bindingKind).toBe("text-to-audio");
@@ -212,6 +217,7 @@ describe("buildTimelineDocument, linked to a script", () => {
     // The script says the words now — no whole-cut narration draft clip.
     expect(doc.tracks.map((t) => t.name)).toEqual([
       "Shots",
+      "Shot Audio",
       "Voiceover",
       "Music"
     ]);
@@ -225,6 +231,7 @@ describe("buildTimelineDocument, linked to a script", () => {
     expect(doc.skippedLineIds).toEqual([]);
     expect(doc.tracks.map((t) => t.name)).toEqual([
       "Shots",
+      "Shot Audio",
       "Narration",
       "Music"
     ]);

--- a/web/src/components/storyboard/__tests__/previewSequence.test.ts
+++ b/web/src/components/storyboard/__tests__/previewSequence.test.ts
@@ -92,8 +92,9 @@ describe("buildPreviewSequence", () => {
     expect(preview).not.toBeNull();
     const { sequence, stillShotIds, skippedShotIds } = preview!;
 
-    expect(sequence.clips).toHaveLength(2);
-    const [first, second] = sequence.clips;
+    // The played clip, its audio twin, and the held still.
+    expect(sequence.clips).toHaveLength(3);
+    const [first, , second] = sequence.clips;
     expect(first.name).toBe("Opening");
     expect(first.mediaType).toBe("video");
     expect(first.currentAssetId).toBe("clip-a");
@@ -106,7 +107,7 @@ describe("buildPreviewSequence", () => {
     expect(second.durationMs).toBe(3000);
 
     expect(sequence.durationMs).toBe(8000);
-    expect(sequence.tracks).toHaveLength(1);
+    expect(sequence.tracks.map((t) => t.name)).toEqual(["Shots", "Shot Audio"]);
     expect(stillShotIds).toEqual(["b"]);
     expect(skippedShotIds).toEqual(["empty"]);
   });

--- a/web/src/hooks/script/__tests__/useAssembleScriptTimeline.test.ts
+++ b/web/src/hooks/script/__tests__/useAssembleScriptTimeline.test.ts
@@ -190,6 +190,7 @@ describe("useAssembleScriptTimeline", () => {
     const doc = updateMutate.mock.calls[0][0].document;
     expect(doc.tracks.map((t: { name: string }) => t.name)).toEqual([
       "Shots",
+      "Shot Audio",
       "Voiceover"
     ]);
     const voice = doc.clips.filter((c: TimelineClip) => c.scriptLineId);

--- a/web/src/hooks/storyboard/__tests__/useAssembleTimeline.test.ts
+++ b/web/src/hooks/storyboard/__tests__/useAssembleTimeline.test.ts
@@ -177,6 +177,7 @@ describe("useAssembleTimeline", () => {
     const doc = updateMutate.mock.calls[0][0].document;
     expect(doc.tracks.map((t: { name: string }) => t.name)).toEqual([
       "Shots",
+      "Shot Audio",
       "Voiceover"
     ]);
     const voice = doc.clips.filter((c: TimelineClip) => c.scriptLineId);
@@ -208,6 +209,7 @@ describe("useAssembleTimeline", () => {
     const doc = updateMutate.mock.calls[0][0].document;
     expect(doc.tracks.map((t: { name: string }) => t.name)).toEqual([
       "Shots",
+      "Shot Audio",
       "Narration"
     ]);
     expect(doc.clips.some((c: TimelineClip) => c.scriptLineId)).toBe(false);
@@ -249,6 +251,7 @@ describe("useAssembleTimeline", () => {
     const doc = updateMutate.mock.calls[0][0].document;
     expect(doc.tracks.map((t: { name: string }) => t.name)).toEqual([
       "Shots",
+      "Shot Audio",
       "Score"
     ]);
     expect(

--- a/web/src/hooks/storyboard/useAssembleTimeline.ts
+++ b/web/src/hooks/storyboard/useAssembleTimeline.ts
@@ -2,9 +2,10 @@
  * useAssembleTimeline
  *
  * The storyboard → timeline handoff: creates a persisted timeline sequence,
- * writes rendered shots as asset-backed clips (plus draft narration/music
- * clips), links the board to the sequence, and opens the timeline tab. When the
- * board links a script, the script's takes are cut in with the shots — shot
+ * writes rendered shots as asset-backed clips — each with the audio twin that
+ * carries the shot's own sound — plus draft narration/music clips, links the
+ * board to the sequence, and opens the timeline tab. When the board links a
+ * script, the script's takes are cut in with the shots — shot
  * lengths follow the words and every voiced line gets its own voiceover clip.
  * When the board is already linked to a sequence (re-assemble after a re-render
  * or a re-voice), that sequence is rewritten in place instead of a second one
@@ -57,8 +58,10 @@ export const useAssembleTimeline = (): UseAssembleTimelineResult => {
       // way an unlinked one does — a deleted script must not break assemble.
       const script = scriptId ? await loadLinkedScript(scriptId) : null;
       const doc = buildTimelineDocument(board, script);
+      // The video clips only: a shot also contributes its audio twin, and a
+      // jointly assembled cut stamps the shot keys onto voiceover clips too.
       const shotClips = doc.clips.filter(
-        (clip) => clip.storyboardShotId && !clip.scriptLineId
+        (clip) => clip.storyboardShotId && clip.mediaType === "video"
       );
       if (shotClips.length === 0) {
         const message =

--- a/web/src/stores/storyboard/__tests__/timelineSync.test.ts
+++ b/web/src/stores/storyboard/__tests__/timelineSync.test.ts
@@ -243,7 +243,7 @@ const newTake: ScriptTake = {
 describe("back-sync into a jointly assembled sequence", () => {
   it("stamps both linkage families onto every voiceover clip", () => {
     const sequence = jointSequence();
-    const voice = sequence.clips.filter((c) => c.mediaType === "audio");
+    const voice = sequence.clips.filter((c) => c.scriptLineId);
     expect(voice).toHaveLength(2);
     for (const clip of voice) {
       expect(clip.scriptId).toBe("script-1");
@@ -316,10 +316,28 @@ describe("back-sync into a jointly assembled sequence", () => {
 
     await syncShotClipToTimeline("board-1", "shot-1", "clip-1-b");
 
-    const before = sequence.clips.filter((c) => c.mediaType === "audio");
+    const before = sequence.clips.filter((c) => c.scriptLineId);
     const after = (
       updateMutate.mock.calls[0][0].document.clips as TimelineClip[]
-    ).filter((c) => c.mediaType === "audio");
+    ).filter((c) => c.scriptLineId);
     expect(after).toEqual(before);
+  });
+
+  it("revising a shot hands the new take to its audio twin too", async () => {
+    seedJoint();
+    getQuery.mockResolvedValue(jointSequence());
+    updateMutate.mockResolvedValue({});
+
+    await syncShotClipToTimeline("board-1", "shot-1", "clip-1-b");
+
+    const clips = updateMutate.mock.calls[0][0].document.clips as TimelineClip[];
+    const twin = clips.find(
+      (c) =>
+        c.mediaType === "audio" &&
+        c.storyboardShotId === "shot-1" &&
+        !c.scriptLineId
+    );
+    expect(twin?.currentAssetId).toBe("clip-1-b");
+    expect(twin?.status).toBe("generated");
   });
 });

--- a/web/src/stores/storyboard/timelineSync.ts
+++ b/web/src/stores/storyboard/timelineSync.ts
@@ -3,8 +3,9 @@
  * timeline.
  *
  * When a board has been assembled (board.timelineId set) and a shot's clip is
- * re-rendered, the linked timeline clip (matched by `storyboardShotId`) gets
- * the new asset. Uses a get→CAS-update cycle against the persisted document;
+ * re-rendered, the timeline clips that shot owns (matched by
+ * `storyboardShotId`) get the new asset — the video clip and the audio twin
+ * that carries the shot's own sound. Uses a get→CAS-update cycle against the persisted document;
  * an editor that has the sequence open picks the change up on next load.
  * Failures are logged, never thrown — a sync miss must not fail the shot.
  */
@@ -32,9 +33,9 @@ export async function syncShotClipToTimeline(
         return clip;
       }
       // A jointly assembled cut stamps the shot keys onto the voiceover clips
-      // too, so the shot's own clip is the video one. Without this, re-rendering
-      // a shot would hand its video asset to the line's audio clip.
-      if (clip.mediaType !== "video") {
+      // too, and those play the script's takes. The shot's own clips — the
+      // video one and its audio twin — carry no line.
+      if (clip.scriptLineId) {
         return clip;
       }
       if (clip.currentAssetId === assetId) {


### PR DESCRIPTION
## What changed

Assembling a storyboard laid its rendered shots on a video track and nothing else, so a clip that came back from the video model with dialogue or room tone played silent — every surface that runs a timeline mutes its video elements (`PreviewCompositor`, `OffscreenVideoPool`) and mixes audio clips only (`AudioGraph`, `renderTimelineAudio`). Each shot clip now gets an audio twin on a "Shot Audio" track: same asset, same start and length, sharing a `linkId` with the picture so the two move and trim together — the same pairing the drag-and-drop video import already builds. The twin lives in the shared mapping in `@nodetool-ai/timeline`, so the editor, the headless `assemble_storyboard_timeline` tool and the board preview player all produce it, and a jointly assembled cut keeps the twin next to the script's voiceover clips rather than in place of them. A held keyframe still gets no twin — there is no rendered clip to take sound from. Re-rendering a shot hands the new asset to both clips: the back-sync now tells a shot's own clips from a voiceover clip by the line the latter carries, instead of by media type.

## Verification

- [x] Targeted suites in place of `npm run test:affected` — the affected planner selected "everything" because the base diff carries unrelated generated files from merges since the checkout. Run: `packages/timeline` (260 passed), `packages/agents` (3398 passed), `packages/execution` (275 passed), and `web` `src/components/storyboard src/hooks/storyboard src/stores/storyboard` (144 passed) plus `src/components/timeline src/stores/timeline src/hooks/timeline src/lib` (1267 passed).
- [x] `npm run typecheck` — web and electron clean. Mobile fails to resolve `expo`/`react-native` because `mobile/node_modules` is absent in this container; no mobile file is touched.
- [x] `npm run lint` — clean (only pre-existing warnings elsewhere in the repo).
- [ ] `npm run dev:nodetool -- harness gate --base main` — planned only (`--dry-run`); its selfchecks cover surfaces unrelated to this diff in the same run.

Not verified here: that Chromium decodes an `mp4` asset through `decodeAudioData` for the twin. It is the same fetch-and-decode path `AudioGraph` already runs for every audio clip, and a shot rendered without an audio track just fails that decode with a warning and stays silent, as it does today.

## Agent capabilities

No capability is added and no declared contract changes — `assemble_storyboard_timeline` keeps its schema; only the document it writes gains the twin clips (and `clip_count` counts them).

## New checks

No new check, rule, or audit. New tests pin the twin's asset, placement, link and provenance, its absence on a keyframe still and on a board with nothing assemblable, and the back-sync handing a revised take to both clips.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiMvnWuF5Su2pani4anqUX)_