### PR TITLE
fix(storyboard): pack shot media the ZIP export was dropping, and name what it cannot

### DIFF
--- a/packages/websocket/src/lib/storyboard-export.ts
+++ b/packages/websocket/src/lib/storyboard-export.ts
@@ -30,10 +30,12 @@ export interface StoryboardExportInput {
   shots: Shot[];
 }
 
-/** Media files chosen for one shot, keyed by the shot's position. */
+/** What the archive holds for one shot: a packed path, or why it holds none. */
 interface ShotMedia {
   still?: string;
   clip?: string;
+  /** Refs the shot named that the export could not turn into bytes. */
+  unresolved?: Array<{ kind: "still" | "clip"; source: string }>;
 }
 
 interface MediaRefLike {
@@ -42,13 +44,33 @@ interface MediaRefLike {
   asset_id?: unknown;
 }
 
-/** The uri to resolve bytes from, or null when the ref carries no locator. */
+/** A locator the server can resolve on its own, without the browser's help. */
+function isResolvableSource(uri: string): boolean {
+  return (
+    uri.startsWith("asset://") ||
+    uri.includes("/api/storage/") ||
+    /^https?:\/\//.test(uri) ||
+    uri.startsWith("data:")
+  );
+}
+
+/**
+ * The locator to resolve bytes from, or null when the ref carries none.
+ *
+ * A stored `asset_id` beats the ref's own `uri` when that uri is not something
+ * the server can fetch — a `blob:` or `file://` source is the browser's
+ * handle on the bytes, not the server's, and the asset id names the same
+ * media in terms the storage adapter understands.
+ */
 export function mediaRefSource(ref: unknown): string | null {
   if (!ref || typeof ref !== "object") return null;
   const { uri, asset_id: assetId } = ref as MediaRefLike;
-  if (isString(uri) && uri !== "") return uri;
-  if (isString(assetId) && assetId !== "") return `asset://${assetId}`;
-  return null;
+  const id = isString(assetId) && assetId !== "" ? `asset://${assetId}` : null;
+  if (isString(uri) && uri !== "") {
+    if (isResolvableSource(uri)) return uri;
+    return id ?? uri;
+  }
+  return id;
 }
 
 function shotNumber(shot: Shot, index: number): string {
@@ -128,7 +150,11 @@ export function renderStoryboardMarkdown(
         : null,
       field("Status", shot.status),
       field("Notes", shot.notes),
-      files?.clip ? `- **Clip:** [${files.clip}](${files.clip})` : null
+      files?.clip ? `- **Clip:** [${files.clip}](${files.clip})` : null,
+      ...(files?.unresolved ?? []).map(
+        ({ kind, source }) =>
+          `- **Missing ${kind}:** \`${source}\` could not be read, so it is not in this archive.`
+      )
     ].filter((line): line is string => line !== null);
     if (details.length > 0) {
       lines.push("", ...details);
@@ -166,13 +192,15 @@ export async function packStoryboardZip(
     index: number,
     ref: unknown,
     dir: "stills" | "clips",
-    refType: "image" | "video"
+    refType: "image" | "video",
+    unresolved: NonNullable<ShotMedia["unresolved"]>
   ): Promise<string | undefined> => {
     const source = mediaRefSource(ref);
     if (!source) return undefined;
     const bytes = await fetchAssetBytes(source).catch(() => null);
-    if (!bytes) {
+    if (!bytes || bytes.byteLength === 0) {
       missing.push(source);
+      unresolved.push({ kind: dir === "stills" ? "still" : "clip", source });
       return undefined;
     }
     const name = `${shotNumber(shot, index)}${slugPart(shot)}${mediaExtension(source, refType)}`;
@@ -183,12 +211,28 @@ export async function packStoryboardZip(
 
   let index = 0;
   for (const shot of board.shots) {
-    const still = await addMedia(shot, index, shot.keyframe, "stills", "image");
-    const clip = await addMedia(shot, index, shot.clip, "clips", "video");
-    if (still || clip) {
+    const unresolved: NonNullable<ShotMedia["unresolved"]> = [];
+    const still = await addMedia(
+      shot,
+      index,
+      shot.keyframe,
+      "stills",
+      "image",
+      unresolved
+    );
+    const clip = await addMedia(
+      shot,
+      index,
+      shot.clip,
+      "clips",
+      "video",
+      unresolved
+    );
+    if (still || clip || unresolved.length > 0) {
       const entry: ShotMedia = {};
       if (still) entry.still = still;
       if (clip) entry.clip = clip;
+      if (unresolved.length > 0) entry.unresolved = unresolved;
       media.set(shot.id, entry);
     }
     index += 1;

--- a/packages/websocket/src/routes/storyboards.ts
+++ b/packages/websocket/src/routes/storyboards.ts
@@ -25,6 +25,33 @@ interface RouteOptions {
   apiOptions: HttpApiOptions;
 }
 
+/**
+ * Bytes for one shot's media ref.
+ *
+ * `resolveAssetBytesForExport` covers the stored forms (`asset://`,
+ * `/api/storage/`, and a remote URL through `safeFetch`). A shot generated in
+ * the browser can also carry its still inline as a `data:` URI, which needs no
+ * fetch at all — decode it here rather than teaching the shared resolver about
+ * a form only this surface sees.
+ */
+async function resolveShotMediaBytes(ref: string): Promise<Uint8Array | null> {
+  if (ref.startsWith("data:")) {
+    const comma = ref.indexOf(",");
+    if (comma < 0) return null;
+    const meta = ref.slice(0, comma);
+    const payload = ref.slice(comma + 1);
+    try {
+      return meta.endsWith(";base64")
+        ? new Uint8Array(Buffer.from(payload, "base64"))
+        : new Uint8Array(Buffer.from(decodeURIComponent(payload), "utf8"));
+    } catch {
+      // A malformed data URI is unresolvable media, reported as missing.
+      return null;
+    }
+  }
+  return resolveAssetBytesForExport(ref);
+}
+
 function zipResponse(bytes: Uint8Array, name: string): Response {
   const safe = name.replace(/[^A-Za-z0-9._-]+/g, "_") || "storyboard";
   return new Response(new Uint8Array(bytes), {
@@ -59,9 +86,14 @@ const storyboardsRoutes: FastifyPluginAsync<RouteOptions> = async (
       }
       const doc = board.toDocument();
       const screenplay = doc.screenplay;
+      // The store keeps the shots in both places; a board written by an older
+      // path can carry them only on the screenplay.
+      const shots = (
+        doc.shots.length > 0 ? doc.shots : (screenplay?.shots ?? [])
+      ) as Shot[];
       const input: StoryboardExportInput = {
         name: board.name,
-        shots: doc.shots as Shot[],
+        shots,
         title: screenplay?.title || board.name,
         brief: doc.brief,
         style: doc.style,
@@ -73,7 +105,7 @@ const storyboardsRoutes: FastifyPluginAsync<RouteOptions> = async (
 
       const { bytes } = await packStoryboardZip({
         board: input,
-        fetchAssetBytes: resolveAssetBytesForExport
+        fetchAssetBytes: resolveShotMediaBytes
       });
       return zipResponse(bytes, board.name || screenplay?.title || "storyboard");
     });

--- a/packages/websocket/tests/storyboard-export.test.ts
+++ b/packages/websocket/tests/storyboard-export.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi } from "vitest";
 import { strFromU8, unzipSync } from "fflate";
 import type { Shot } from "@nodetool-ai/protocol";
 import {
+  mediaRefSource,
   packStoryboardZip,
   renderStoryboardMarkdown,
   type StoryboardExportInput
@@ -109,7 +110,7 @@ describe("packStoryboardZip", () => {
     );
   });
 
-  it("reports media it cannot resolve and leaves the shot unlinked", async () => {
+  it("reports media it cannot resolve, in the document as well as the result", async () => {
     const { bytes, missing } = await packStoryboardZip({
       board,
       fetchAssetBytes: async () => null
@@ -118,7 +119,35 @@ describe("packStoryboardZip", () => {
     expect(missing).toEqual(["asset://u1/a1.png", "asset://u1/c1.mp4"]);
     const entries = unzipSync(bytes);
     expect(Object.keys(entries)).toEqual(["storyboard.md"]);
-    expect(strFromU8(entries["storyboard.md"])).not.toContain("stills/");
+    const md = strFromU8(entries["storyboard.md"]);
+    expect(md).not.toContain("stills/");
+    // A zip with no media must say why, per shot — the silent version of this
+    // left the reader with a Markdown file and no explanation.
+    expect(md).toContain(
+      "- **Missing still:** `asset://u1/a1.png` could not be read"
+    );
+    expect(md).toContain(
+      "- **Missing clip:** `asset://u1/c1.mp4` could not be read"
+    );
+  });
+
+  it("treats zero-length bytes as unresolved rather than packing an empty file", async () => {
+    const { bytes, missing } = await packStoryboardZip({
+      board: {
+        name: "b",
+        shots: [
+          shot({
+            id: "s1",
+            index: 0,
+            keyframe: { type: "image", uri: "asset://a1" }
+          })
+        ]
+      },
+      fetchAssetBytes: async () => new Uint8Array()
+    });
+
+    expect(missing).toEqual(["asset://a1"]);
+    expect(Object.keys(unzipSync(bytes))).toEqual(["storyboard.md"]);
   });
 
   it("falls back to the asset id when a ref carries no uri", async () => {
@@ -140,5 +169,38 @@ describe("packStoryboardZip", () => {
       }
     });
     expect(seen).toEqual(["asset://a9"]);
+  });
+});
+
+describe("mediaRefSource", () => {
+  it("takes the uri when the server can resolve it", () => {
+    expect(mediaRefSource({ type: "image", uri: "asset://a1" })).toBe(
+      "asset://a1"
+    );
+    expect(
+      mediaRefSource({ type: "image", uri: "/api/storage/1/a1.png" })
+    ).toBe("/api/storage/1/a1.png");
+    expect(mediaRefSource({ type: "image", uri: "https://cdn/x.png" })).toBe(
+      "https://cdn/x.png"
+    );
+  });
+
+  it("prefers the asset id over a uri only the browser could read", () => {
+    // A `blob:`/`file://` uri is the browser's handle on the bytes. Following
+    // it server-side resolves nothing, and the shot's asset id names the same
+    // media in terms the storage adapter understands.
+    expect(
+      mediaRefSource({ type: "image", uri: "blob:http://x/y", asset_id: "a1" })
+    ).toBe("asset://a1");
+    expect(
+      mediaRefSource({ type: "video", uri: "file:///tmp/c.mp4", asset_id: "c1" })
+    ).toBe("asset://c1");
+  });
+
+  it("falls back to the id, and reports nothing for an empty ref", () => {
+    expect(mediaRefSource({ type: "image", asset_id: "a1" })).toBe("asset://a1");
+    expect(mediaRefSource({ type: "image" })).toBeNull();
+    expect(mediaRefSource({ type: "image", uri: "", asset_id: "" })).toBeNull();
+    expect(mediaRefSource(null)).toBeNull();
   });
 });


### PR DESCRIPTION
## What changed

A downloaded storyboard archive could come back holding nothing but `storyboard.md`, with no way to tell whether the board had no media or the export failed to read it. Two causes, both fixed here. A shot generated in the browser carries the *browser's* handle on the bytes in `uri` — `blob:`, `file://` — which resolves to nothing server-side, so the shot's `asset_id` now wins over a uri the server cannot fetch (`asset://`, `/api/storage/`, `http(s)`, and `data:` still win over the id); a still held inline as a `data:` URI is decoded rather than fetched. The silence was the worse half: an unresolvable ref was skipped without a trace, so the document now names each one under its shot ("**Missing still:** `asset://…` could not be read, so it is not in this archive"). Zero-length bytes count as unresolved instead of packing an empty file, and a board that kept its shots only on `screenplay.shots` now exports them.

## Verification

- [x] `npm run test:affected` — 682 tests plus the `packages/websocket` suite (9 tests, 4 new). One run failed first on `@nodetool-ai/reliability-harness`: my own dev server held port 7777, which its hermetic backend needs; it passes with the port free (27 files, 156 tests)
- [x] `npm run typecheck` — web clean (the mobile leg fails on uninstalled `react-native`/`expo` in this container, unrelated to the diff)
- [x] `npm run lint` — clean
- [x] `npm run nodetool -- harness gate --base main` — `0 selfcheck(s) to run` for these paths

End-to-end against a running server, with a board carrying one shot whose keyframe has a `blob:` uri plus a real `asset_id` and one whose keyframe names a nonexistent asset: the archive packed `stills/01-lighthouse.png` (208 bytes, the uploaded file's size) — that shot produced nothing before this change — and the document reported `- **Missing still:** \`asset://does-not-exist\` could not be read`.

## New checks

- [x] The "missing media is reported" assertion was inverted once (dropping the `unresolved.push`) and observed failing: `AssertionError: expected '# Beacon…' to contain '- **Missing still:** \`asset://u1/a1.p…'`, then restored to 9 passing

## Agent capabilities

No capability added, and no capability's declared contract changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyouACvb56EkSFAezo5w5i)_