### PR TITLE
feat(marketing): rewrite landing page copy in plainer language

### DIFF
--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -434,13 +434,14 @@ export default function Home() {
               id="closing-cta-title"
               className="text-3xl md:text-4xl font-bold tracking-tight text-white"
             >
-              Stop stitching tools together. Own your creative pipeline.
+              Built out in the open.
             </h2>
             <p className="mt-4 text-lg text-slate-300">
-              Tell the agent what you want, watch the workflow run, and keep a
-              process you can edit and reuse. Free, open source, and yours to
-              run: download Studio, or try Cloud (alpha) in the browser with
-              nothing to install.
+              Describe what you want to create. Watch the agent build it. Keep
+              the whole project. NodeTool is free, open-source software built
+              alongside working artists, designers, and video editors —
+              download the desktop app, or try it in your browser with nothing
+              to install.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <SmartDownloadButton
@@ -454,7 +455,7 @@ export default function Home() {
                 onClick={() => track("Try Cloud")}
                 className="inline-flex items-center justify-center gap-2 rounded-xl border border-blue-500/40 bg-blue-500/10 px-6 py-3.5 text-sm font-semibold text-blue-200 transition-all hover:border-blue-400 hover:bg-blue-500/20 focus-ring"
               >
-                Try NodeTool Cloud
+                Try NodeTool in your browser
               </a>
               <a
                 href="https://github.com/nodetool-ai/nodetool"

--- a/marketing/src/components/AppBuilderSection.tsx
+++ b/marketing/src/components/AppBuilderSection.tsx
@@ -55,8 +55,8 @@ export default function AppBuilderSection() {
             transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Turn a workflow into{" "}
-            <span className="text-white">an app anyone can use</span>
+            Turn workflows into{" "}
+            <span className="text-white">simple apps you can share</span>
           </motion.h2>
 
           <motion.p
@@ -66,9 +66,10 @@ export default function AppBuilderSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-300 leading-relaxed"
           >
-            The app builder puts a screen in front of a graph: a few fields, a
-            Run button, and the results. Hand someone that instead of a canvas —
-            and keep the workflow underneath, still yours to open and change.
+            Once you build a workflow, turn it into a clean interface with a
+            few input boxes and a Generate button. Hand that screen to a
+            teammate or client so they get results without navigating the
+            canvas underneath — which stays yours to open and change.
           </motion.p>
         </div>
 

--- a/marketing/src/components/BuildRunDeploy.tsx
+++ b/marketing/src/components/BuildRunDeploy.tsx
@@ -45,30 +45,30 @@ export default function BuildRunDeploy() {
       <div className="scroll-fade grid grid-cols-1 gap-6 md:grid-cols-3">
         <Card
           step="01"
-          title="Describe the outcome"
+          title="Start with an idea"
           icon={<Workflow className="h-6 w-6" />}
           accent="blue"
-          description="Tell the agent what you want to make — a campaign, a trailer, a set of product shots. That's the whole first step. (Prefer to wire it yourself? It's the same canvas.)"
+          description="Describe your goal — a product video, a movie trailer, a social campaign. That's all it takes to begin. Prefer to wire it yourself? It's the same canvas."
         >
           <BuildVisual />
         </Card>
 
         <Card
           step="02"
-          title="Watch it build and run"
+          title="Watch it build in real time"
           icon={<PlayCircle className="h-6 w-6" />}
           accent="fuchsia"
-          description="The agent chooses the models, tools, and steps, builds the workflow on your canvas, and runs it in front of you — generation, editing, and assembly chained into a finished piece, on your own keys at provider prices."
+          description="The agent selects the right tools, connects the steps on your board, and runs them from start to finish — generation, editing, and assembly chained into a finished piece, on your own accounts at provider prices."
         >
           <RunVisual />
         </Card>
 
         <Card
           step="03"
-          title="Take control"
+          title="Take full control"
           icon={<Wand2 className="h-6 w-6" />}
           accent="amber"
-          description="Inspect any step, swap a model, change an input, and run again from there. Refine the result in the built-in editors, then save the workflow and reuse it for the next job."
+          description="Click into any step to swap a tool, change an image, or adjust a prompt. Everything remains editable, and the workflow is yours to save and reuse."
         >
           <EditVisual />
         </Card>

--- a/marketing/src/components/ChatUISection.tsx
+++ b/marketing/src/components/ChatUISection.tsx
@@ -33,9 +33,9 @@ export default function ChatUISection() {
             transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            The agent doesn&apos;t just answer. <br />
+            A standard chatbot gives you text. <br />
             <span className="text-white">
-              It leaves the work behind.
+              This agent builds your actual project.
             </span>
           </motion.h2>
 
@@ -46,11 +46,10 @@ export default function ChatUISection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            A chatbot leaves you a transcript. This agent has the whole studio
-            as its toolbelt — it builds the actual workflow on your canvas,
-            runs it in front of you, and every decision becomes part of the
-            canvas. Inspect it, change it, rerun it, or reuse it for the next
-            job.
+            NodeTool&apos;s AI assistant doesn&apos;t just chat. It operates
+            the studio tools for you: it sets up the steps directly on your
+            canvas, generates the assets, and keeps every part visible so you
+            can tweak, rerun, or reuse it.
           </motion.p>
 
           <motion.a

--- a/marketing/src/components/ComparisonSection.tsx
+++ b/marketing/src/components/ComparisonSection.tsx
@@ -71,7 +71,7 @@ export default function ComparisonSection({
             transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white"
           >
-            Where NodeTool fits among your tools
+            Bring all your creative tools under one roof.
           </motion.h2>
           <motion.p
             initial={false}
@@ -81,26 +81,26 @@ export default function ComparisonSection({
             className="mt-4 text-lg text-slate-400 leading-relaxed max-w-2xl"
           >
             You&apos;re probably using two or three of these already. Here&apos;s
-            what changes when they live on one canvas.
+            what changes when they all live on one canvas.
           </motion.p>
         </header>
 
         <div className="scroll-fade grid grid-cols-1 md:grid-cols-3 gap-px bg-slate-800/60 border border-slate-800/80 rounded-2xl overflow-hidden">
           <ComparisonCard
-            competitor="ComfyUI"
-            sentence="ComfyUI is an editor for image models. NodeTool is the studio around it: image, video, music, and words on one canvas, with every major model a click away."
+            competitor="Image-only node tools (like ComfyUI)"
+            sentence="Specialized node tools only create pictures. NodeTool provides a complete studio that connects images, video, audio, text, and editing on one canvas."
             reducedMotion={reducedMotion}
             delay={0}
           />
           <ComparisonCard
-            competitor="Figma Weave / closed canvases"
-            sentence="Closed tools tie you to a credit system and a hand-picked list of models. NodeTool is open source: every provider, your own keys, and the prices those providers publish."
+            competitor="Closed platforms"
+            sentence="Other platforms force you into monthly credit bundles and restricted feature lists. NodeTool is open source: you use your direct provider accounts and pay raw rates with no middleman markup."
             reducedMotion={reducedMotion}
             delay={0.05}
           />
           <ComparisonCard
-            competitor="A dozen browser tabs"
-            sentence="Midjourney, Runway, Photoshop, ElevenLabs, and Suno each sit in their own tab, and none of them talk to each other. NodeTool brings them onto one canvas you can run, share, and run again."
+            competitor="A dozen separate web apps"
+            sentence="Instead of copying files between disconnected websites, NodeTool connects your favorite AI tools into a single, repeatable workflow."
             reducedMotion={reducedMotion}
             delay={0.1}
           />

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Download, Cloud, Code2, KeyRound, Layers } from "lucide-react";
+import { Download, PlayCircle, Code2, KeyRound, Layers } from "lucide-react";
 import HeroDemoPlayer from "./HeroDemoPlayer";
 import { SmartDownloadButton } from "../app/SmartDownloadButton";
 import { track } from "../lib/analytics";
@@ -26,26 +26,32 @@ export default function NodeToolHero() {
             id="hero-title"
             className="mt-6 text-5xl font-bold leading-[1.05] tracking-tight text-white md:text-6xl"
           >
-            From prompt to final cut
+            Describe what you want to make.
+            <br />
+            An AI agent builds the steps.
             <br />
             <span className="bg-gradient-to-r from-rose-400 via-fuchsia-400 to-amber-300 bg-clip-text text-transparent">
-              on one canvas.
+              You keep the entire process.
             </span>
           </h1>
 
           <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-300 md:text-lg">
-            NodeTool is the open-source, agent-first creative workspace: one{" "}
+            NodeTool is an open-source creative studio for making images,
+            video, audio, and text in one place.
+          </p>
+
+          <p className="mt-4 max-w-xl text-base leading-relaxed text-slate-400">
+            Design your project using built-in editors for sketching, scripts,
+            storyboards, and video timelines. Do it by hand, or tell an AI
+            agent what you need — it builds the{" "}
             <a
               href="/node-based-ai"
-              className="text-slate-100 underline decoration-slate-500/50 underline-offset-2 transition-colors hover:text-white hover:decoration-slate-300"
+              className="text-slate-200 underline decoration-slate-500/50 underline-offset-2 transition-colors hover:text-white hover:decoration-slate-300"
             >
-              node-based
-            </a>{" "}
-            canvas that combines generative AI models with a multi-track
-            timeline, layered sketching, storyboards, and scripts — driven by
-            you, or by an agent that builds the workflow and runs it, leaving
-            the whole process open for you to inspect, edit, and reuse. Every
-            major model, your own keys, provider prices.
+              visual pipeline
+            </a>
+            , runs it, and leaves you with an editable project you can change
+            or reuse anytime.
           </p>
 
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -54,27 +60,27 @@ export default function NodeToolHero() {
               classNameOverride="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-6 py-3.5 text-sm font-semibold text-white shadow-lg shadow-blue-900/40 transition-all hover:bg-blue-500 hover:shadow-blue-900/60"
             />
             <a
-              href="/cloud"
-              onClick={() => track("Try Cloud", { placement: "hero" })}
+              href="#demo-video"
+              onClick={() => track("View Demo", { placement: "hero" })}
               className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl border border-slate-700 bg-slate-900/60 px-6 py-3.5 text-sm font-semibold text-slate-100 transition-all hover:border-slate-500 hover:bg-slate-800/60 focus-ring"
             >
-              <Cloud className="h-4 w-4" />
-              Try the Cloud alpha
+              <PlayCircle className="h-4 w-4" />
+              See it in action
             </a>
           </div>
 
           <ul className="mt-8 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs font-medium text-slate-300">
             <li className="flex items-center gap-1.5">
               <Layers className="h-3.5 w-3.5 text-fuchsia-400" />
-              Agents drive every editor
+              Built-in editors for every step
             </li>
             <li className="flex items-center gap-1.5">
               <KeyRound className="h-3.5 w-3.5 text-emerald-400" />
-              Pay providers directly
+              Your own provider accounts
             </li>
             <li className="flex items-center gap-1.5">
               <Code2 className="h-3.5 w-3.5 text-blue-400" />
-              Open source, runs anywhere
+              Open source, yours to keep
             </li>
           </ul>
         </div>

--- a/marketing/src/components/OwnershipSection.tsx
+++ b/marketing/src/components/OwnershipSection.tsx
@@ -6,23 +6,23 @@ import { Shield, Cpu, Globe, Lock } from "lucide-react";
 
 const features = [
   {
-    title: "Your keys, every provider",
-    body: "Bring your own keys to FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and more. Keys stay on your disk in Studio, encrypted in Cloud. We never mark up model calls.",
+    title: "Use your own provider keys",
+    body: "Connect directly to OpenAI, Anthropic, Gemini, FAL, KIE, Replicate, and specialized video generators. Your account keys stay on your disk in Studio, encrypted in Cloud.",
     icon: Lock,
   },
   {
-    title: "Provider prices, no credits",
-    body: "No in-house credits and no minimum top-up. You pay providers exactly what they charge: a Seedance run that costs $0.18 on KIE costs $0.18 in NodeTool.",
+    title: "Pay official rates directly",
+    body: "Skip artificial credit systems. If an image costs $0.03 to generate through a provider, you pay exactly $0.03 to that provider. NodeTool takes no cut.",
     icon: Shield,
   },
   {
-    title: "Open source, always",
-    body: "Studio on the desktop and Cloud in the browser are built from the same AGPL-3.0 source. Nothing is held back for a paid tier, and you can host it yourself at any time.",
+    title: "100% open source",
+    body: "Free to use and inspect. Studio and Cloud are built from the same AGPL-3.0 source, with no artificial paywalls or locked features, and you can host it yourself at any time.",
     icon: Globe,
   },
   {
-    title: "Run models on your own machine",
-    body: "MLX, Ollama, llama.cpp, vLLM, and LM Studio are supported by default. Once a model is downloaded, it keeps running with no internet connection.",
+    title: "Run private models on your computer",
+    body: "Download and run free, open-weight models locally on your own hardware — MLX, Ollama, llama.cpp, vLLM, and LM Studio — with no internet connection.",
     icon: Cpu,
   },
 ];
@@ -47,8 +47,8 @@ export default function OwnershipSection({
             transition={{ duration: 0.25 }}
             className="text-4xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Your keys. Your files. <br />
-            <span className="text-slate-300">Your roadmap.</span>
+            Access top AI tools directly. <br />
+            <span className="text-slate-300">No middlemen, no markups.</span>
           </motion.h2>
           <motion.p
             initial={false}
@@ -57,10 +57,10 @@ export default function OwnershipSection({
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Every closed AI tool ends the same way: a price rise, fewer models,
-            or an acquisition that quietly rewrites the roadmap. NodeTool runs
-            whichever models you choose, charges you what the providers charge,
-            and is released under a license that outlives whoever built it.
+            Pick the best AI service for the job — OpenAI, Google, Anthropic,
+            or a specialized image and video engine — and switch between them
+            with one click. NodeTool charges you what the providers charge, and
+            is released under a license that outlives whoever built it.
           </motion.p>
         </div>
 

--- a/marketing/src/components/SiteFooter.tsx
+++ b/marketing/src/components/SiteFooter.tsx
@@ -82,8 +82,9 @@ export default function SiteFooter() {
               </span>
             </a>
             <p className="mt-3 max-w-xs text-sm text-slate-300">
-              The open, agent-first creative workspace. Describe the work. The
-              agent builds the process. You keep the workflow.
+              Free, open-source software built alongside working artists,
+              designers, and video editors. Describe what you want to create,
+              watch the agent build it, keep the whole project.
             </p>
           </div>
 

--- a/marketing/src/components/StatusQuoSection.tsx
+++ b/marketing/src/components/StatusQuoSection.tsx
@@ -10,20 +10,20 @@ import { ArrowRight } from "lucide-react";
 
 const frictions = [
   {
-    where: "Five tabs",
-    what: "Midjourney for the still, Runway for the motion, ElevenLabs for the voice, Premiere to put it together.",
+    where: "Juggling five browser tabs",
+    what: "One app for images, another for animation, a third for voiceovers, and a separate video editor to stitch them together.",
   },
   {
     where: "Export, import, repeat",
-    what: "Every handoff costs you the thread — the prompt, the seed, the reason you made that choice.",
+    what: "Moving files between apps loses your settings, prompts, and original ideas along the way.",
   },
   {
-    where: "Credits you bought in advance",
-    what: "Paid at a markup, spent on a list of models somebody else picked for you.",
+    where: "Paying marked-up credit packs",
+    what: "Buying expensive proprietary credits locked to whatever tools that platform chooses for you.",
   },
   {
-    where: "The tool you rely on gets acquired",
-    what: "Prices move, models disappear, and your work sits inside somebody else's roadmap.",
+    where: "Losing access when tools change",
+    what: "Subscriptions jump in price, features disappear, and your projects are trapped in someone else's system.",
   },
 ];
 
@@ -45,13 +45,13 @@ export default function StatusQuoSection() {
                 id="status-quo-title"
                 className="text-2xl font-bold tracking-tight text-white md:text-3xl"
               >
-                Making one piece
+                Creating one project
                 <br />
-                shouldn&apos;t take five subscriptions.
+                shouldn&apos;t require five separate apps.
               </h2>
               <p className="mt-4 text-slate-400 leading-relaxed">
-                Stop exporting. Start finishing. One canvas, your keys, and a
-                workflow file that is yours to keep when the piece is done.
+                Work on a single visual board. Use your own AI accounts. Keep
+                the complete project file when you&apos;re done.
               </p>
               <a
                 href="#differences"

--- a/marketing/src/components/SurfaceShowcase.tsx
+++ b/marketing/src/components/SurfaceShowcase.tsx
@@ -35,8 +35,8 @@ const SURFACES: Surface[] = [
     id: "storyboard",
     label: "Storyboard",
     icon: Clapperboard,
-    headline: "Direct the shots before you pay for them",
-    body: "Stills cost cents and clips cost dollars, so the board settles the framing first. Revise one shot and the other five stay as they were.",
+    headline: "Visual storyboards",
+    body: "Plan out scenes card by card. Generate low-cost draft images first to lock in the look before spending time and compute on full animation.",
     asset: "surface-storyboard",
     deepLink: "#storyboard",
   },
@@ -44,8 +44,8 @@ const SURFACES: Surface[] = [
     id: "script",
     label: "Script & voice",
     icon: FileText,
-    headline: "A script that knows who says each line",
-    body: "Lines carry a cast voice. Change the words and the take goes stale, so you can see what still needs voicing before you spend on it.",
+    headline: "Script & voice studio",
+    body: "Write your script, assign unique AI voices to each character, and generate natural-sounding dialogue takes. Change the words and the take goes stale, so you see what still needs voicing.",
     asset: "surface-script",
     deepLink: "#script-editor",
   },
@@ -53,8 +53,8 @@ const SURFACES: Surface[] = [
     id: "timeline",
     label: "Timeline",
     icon: Film,
-    headline: "A real multi-track cut, not a render queue",
-    body: "Clips, audio, captions, and transitions on one timeline — the same document an agent edits when you ask it to tighten the opening.",
+    headline: "Timeline video editor",
+    body: "Arrange, trim, and layer AI-generated video and audio clips across multiple tracks to render a finished video. An agent edits the same document when you ask it to tighten the opening.",
     asset: "surface-timeline",
     deepLink: "#timeline-editor",
   },
@@ -62,8 +62,8 @@ const SURFACES: Surface[] = [
     id: "sketch",
     label: "Sketch",
     icon: Brush,
-    headline: "Layers you paint and layers a model fills",
-    body: "Paint a mask, bind a layer to a prompt or a workflow, and regenerate that layer alone. The rest of the canvas holds still.",
+    headline: "Layered drawing canvas",
+    body: "Sketch, paint with brushes, and blend hand-drawn elements with AI-generated layers. Bind a layer to a prompt and regenerate that layer alone.",
     asset: "surface-sketch",
     deepLink: "#sketch-editor",
   },
@@ -141,12 +141,13 @@ export default function SurfaceShowcase() {
             id="surfaces-title"
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Five editors, one document
+            Professional editing tools built right next to the AI
           </h2>
           <p className="text-lg text-slate-300">
-            Not five tabs across five products. A storyboard becomes a script,
-            the script becomes takes, the takes land on a timeline — and an
-            agent works every one of them through the tools you click.
+            Edit and refine your work directly on the canvas without switching
+            software. A storyboard becomes a script, the script becomes takes,
+            the takes land on a timeline — and an agent works every one of them
+            through the tools you click.
           </p>
         </div>
 

--- a/marketing/src/components/WaysInSection.tsx
+++ b/marketing/src/components/WaysInSection.tsx
@@ -17,37 +17,37 @@ import {
 
 const entries = [
   {
-    intent: "Run it on your machine",
+    intent: "Desktop app",
     name: "Studio",
     href: "/studio",
-    body: "The desktop app: your files, your local models, your GPU. The most control, fully offline if you want.",
+    body: "Runs directly on your computer. Keeps your files and settings private on your hard drive, with optional offline support.",
     icon: Monitor,
     accent: "text-amber-300",
     chip: "border-amber-500/30 bg-amber-500/10",
   },
   {
-    intent: "Try it in the browser",
+    intent: "In your browser",
     name: "Cloud",
     href: "/cloud",
-    body: "Nothing to install. Sign in and start building — currently in alpha, and the fastest way to see what NodeTool is.",
+    body: "Runs in your web browser with zero installation needed. The fastest way to jump in and start creating. Currently in alpha.",
     icon: Cloud,
     accent: "text-blue-300",
     chip: "border-blue-500/30 bg-blue-500/10",
   },
   {
-    intent: "Make visual work",
+    intent: "For creators",
     name: "Creatives",
     href: "/creatives",
-    body: "Start from the piece you want — images, video, music — and let the agent handle the models and the plumbing.",
+    body: "Focus on the creative vision — images, video, voice — and let the software handle the technical plumbing.",
     icon: Sparkles,
     accent: "text-rose-300",
     chip: "border-rose-500/30 bg-rose-500/10",
   },
   {
-    intent: "Build and integrate",
+    intent: "For developers",
     name: "Developers",
     href: "/developers",
-    body: "SDK, CLI, custom nodes, and an MCP server: one execution layer under the canvas, the agent, and your code.",
+    body: "Connect custom scripts, automate tasks, and integrate your own code into the visual canvas, through the SDK, the CLI, or an MCP server.",
     icon: Code2,
     accent: "text-violet-300",
     chip: "border-violet-500/30 bg-violet-500/10",
@@ -80,13 +80,12 @@ export default function WaysInSection() {
             id="ways-in-title"
             className="text-3xl md:text-5xl font-bold tracking-tight text-white"
           >
-            Pick the way in that fits you.
+            Choose the setup that fits your workflow.
           </h2>
           <p className="mt-4 text-lg text-slate-400 leading-relaxed max-w-2xl">
-            Studio, Cloud, and the pages for creatives, developers, and
-            marketers are not five products. They are five ways to use the
-            same open-source workspace: the same agent, the same workflows,
-            the same models.
+            Whether you use the desktop app or the browser version, you get
+            the exact same features, tools, and capabilities: the same agent,
+            the same workflows, the same models.
           </p>
         </header>
 


### PR DESCRIPTION
## What changed

Rewrites the landing page copy to the approved plainer wording, section by section: hero, the problem block, the agent explainer, the three how-it-works steps, the ways-to-use cards, the comparison cards, the pricing/providers block, the five editor tabs, the app-builder section, and the footer plus closing CTA. Sections, layout, and components are unchanged — only strings, with two exceptions: the hero's secondary CTA is now "See it in action" pointing at the on-page demo video instead of `/cloud` (Cloud stays reachable from the header, the ways-in cards, and the closing CTA), and its icon changes from `Cloud` to `PlayCircle` to match. The hero's `track()` call reuses the existing `View Demo` event rather than widening the `TrackEvent` union. The `/node-based-ai` internal link is kept in the hero, now on "visual pipeline".

## Verification

- [ ] `npm run test:affected` — not run: `marketing/` has no test suite in this selection and its dependencies are not installed in this sandbox.
- [x] `npx tsc --noEmit -p marketing/tsconfig.json` — no errors in any changed file. The remaining output is pre-existing `TS2307`/`TS7016` module-resolution errors from `marketing/node_modules` not being installed here (`framer-motion`, `@heroicons/react`, `lodash`), in files this diff does not touch. It caught one real error in my change (an unlisted `TrackEvent` string), which is fixed above.
- [ ] `npm run lint` — `next lint` cannot run here: `Failed to load config "next/core-web-vitals"`, marketing dependencies are not installed.
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run; the diff touches no harness-covered surface (marketing site copy only).

Grepped for other references to the replaced strings: `marketing/src/app/opengraph-image.tsx`, `marketing/scripts/generate-brand-assets.mjs`, and the `/cloud`, `/pricing`, `/studio` pages still carry the old "From prompt to final cut" line and their own Cloud CTAs. Those are outside the landing page and left as they are.

## Agent capabilities

No capabilities added or changed.

## New checks

No checks, rules, or audits added.

---
_Generated by [Claude Code](https://claude.ai/code/session_018hkF8aYR4KiuM8dzgBhJkz)_