### PR TITLE
fix(websocket): read suffixed asset refs from the owner-prefixed key on export

### DIFF
--- a/docs/url-egress-inventory.md
+++ b/docs/url-egress-inventory.md
@@ -84,7 +84,7 @@ Everything here fetches a URL somebody else chose, through the protected fetch.
 | Model3DRef / ImageRef → bytes | `packages/video-nodes/src/nodes/model3d/utils.ts` | workflow |
 | `nodetool.model3d.RenderToImage` | `packages/video-nodes/src/nodes/model3d/render.ts` | workflow |
 | chat source images + output auto-save | `packages/websocket/src/unified-websocket-runner.ts` | chat client |
-| asset import by reference | `packages/websocket/src/http-api.ts` | chat client |
+| asset ref → bytes on export | `packages/websocket/src/lib/asset-export.ts` | chat client |
 | `save_asset` / `view_image` | `packages/agents/src/capabilities/assets.ts` | model |
 | `yt_dlp` download | `packages/agents/src/capabilities/media.ts` | model |
 | Apify run artifacts → assets | `packages/agents/src/apify/assets.ts` | provider response |

--- a/packages/runtime/tests/url-egress-inventory.ts
+++ b/packages/runtime/tests/url-egress-inventory.ts
@@ -361,10 +361,10 @@ export const URL_EGRESS_INVENTORY: EgressEntry[] = [
     "Key-value store and dataset file URLs out of an actor run."
   ),
   guardedSafeFetch(
-    "packages/websocket/src/http-api.ts",
-    "asset import by reference",
+    "packages/websocket/src/lib/asset-export.ts",
+    "asset ref → bytes on export",
     "chat-client",
-    "An http(s) ref posted to the asset routes."
+    "An http(s) ref stored on a graph or storyboard, read when packing an export."
   ),
   {
     file: "packages/agents/src/capabilities/media.ts",

--- a/packages/websocket/src/http-api.ts
+++ b/packages/websocket/src/http-api.ts
@@ -45,7 +45,6 @@ import {
   PythonNodeExecutor,
   createPythonBridge,
   logPythonWorkerStderr,
-  safeFetch,
   type NodeExecutor,
   type ProcessingContext,
   type PythonBridge,
@@ -121,6 +120,7 @@ import {
   retrieveAssetBytes,
   normalizeAssetContentType
 } from "./lib/asset-paths.js";
+import { resolveAssetBytesForExport } from "./lib/asset-export.js";
 import { assetObjectKey } from "@nodetool-ai/storage";
 import { getStorageRetentionSettings } from "./storage-retention.js";
 export { getAssetFileName, getAssetStoragePath };
@@ -1342,47 +1342,7 @@ export async function handleWorkflowDslExport(
 
 // ── Workflow bundle export/import (.nodetool) ──────────────────────────
 
-/** Resolve asset bytes for a ref during export, via the asset storage adapter. */
-export async function resolveAssetBytesForExport(
-  ref: string
-): Promise<Uint8Array | null> {
-  try {
-    if (ref.startsWith("asset://")) {
-      const rest = ref.slice("asset://".length).split("?")[0].split("#")[0];
-      const adapter = getAssetAdapter();
-      if (!nodePath.extname(rest)) {
-        const asset = (await Asset.get(rest)) as Asset | null;
-        if (!asset) return null;
-        return await retrieveAssetBytes(
-          adapter,
-          asset.user_id,
-          asset.id,
-          asset.content_type
-        );
-      }
-      // Already a key — owner-prefixed for anything written since the
-      // per-owner layout, flat for older `asset://` refs stored in graphs.
-      return await adapter.retrieve(adapter.uriForKey(rest));
-    }
-    if (ref.includes("/api/storage/")) {
-      const key = decodeURIComponent(
-        ref
-          .slice(ref.indexOf("/api/storage/") + "/api/storage/".length)
-          .split("?")[0]
-      );
-      const adapter = getAssetAdapter();
-      return await adapter.retrieve(adapter.uriForKey(key));
-    }
-    if (/^https?:\/\//.test(ref)) {
-      const res = await safeFetch(ref);
-      if (!res.ok) return null;
-      return new Uint8Array(await res.arrayBuffer());
-    }
-  } catch {
-    // Unresolved — the ref is left as-is in the bundle.
-  }
-  return null;
-}
+export { resolveAssetBytesForExport };
 
 async function loadBundledWorkflow(
   workflowId: string,

--- a/packages/websocket/src/lib/asset-export.ts
+++ b/packages/websocket/src/lib/asset-export.ts
@@ -1,0 +1,74 @@
+/**
+ * Asset byte resolution for the export surfaces — the workflow `.nodetool`
+ * bundle and the storyboard zip. Kept out of `http-api.ts` (which pulls in
+ * `@nodetool-ai/dsl` → `base-nodes` at module load) so a route or a test can
+ * reach it on its own.
+ */
+
+import nodePath from "node:path";
+import { Asset } from "@nodetool-ai/models";
+import { safeFetch } from "@nodetool-ai/runtime";
+import { getAssetAdapter } from "./storage.js";
+import { retrieveAssetBytes } from "./asset-paths.js";
+
+/**
+ * The asset id in an `asset://` locator, or null when the locator names a
+ * storage key instead. `asset://<id>` and `asset://<id>.<ext>` are both ids —
+ * `persistOutput` writes the suffixed form so a renderer can type the media —
+ * while anything carrying a slash is already owner-prefixed.
+ */
+function assetIdOf(rest: string): string | null {
+  if (rest === "" || rest.includes("/")) return null;
+  const ext = nodePath.extname(rest);
+  return ext ? rest.slice(0, -ext.length) : rest;
+}
+
+/** Resolve asset bytes for a ref during export, via the asset storage adapter. */
+export async function resolveAssetBytesForExport(
+  ref: string
+): Promise<Uint8Array | null> {
+  try {
+    if (ref.startsWith("asset://")) {
+      const rest = ref.slice("asset://".length).split("?")[0].split("#")[0];
+      const adapter = getAssetAdapter();
+      const assetId = assetIdOf(rest);
+      if (assetId) {
+        // The row carries the owner, and the bytes live under
+        // `<user_id>/<id>.<ext>` on every backend written since the per-owner
+        // layout. Reading the suffixed ref as a flat key skipped that prefix
+        // and found nothing on S3/Supabase, where no flat object exists.
+        const asset = (await Asset.get(assetId)) as Asset | null;
+        if (asset) {
+          const bytes = await retrieveAssetBytes(
+            adapter,
+            asset.user_id,
+            asset.id,
+            asset.content_type
+          );
+          if (bytes) return bytes;
+        }
+        // No row (or no bytes under either candidate): an older graph can
+        // still name an object that only exists under the flat key.
+        return await adapter.retrieve(adapter.uriForKey(rest));
+      }
+      return await adapter.retrieve(adapter.uriForKey(rest));
+    }
+    if (ref.includes("/api/storage/")) {
+      const key = decodeURIComponent(
+        ref
+          .slice(ref.indexOf("/api/storage/") + "/api/storage/".length)
+          .split("?")[0]
+      );
+      const adapter = getAssetAdapter();
+      return await adapter.retrieve(adapter.uriForKey(key));
+    }
+    if (/^https?:\/\//.test(ref)) {
+      const res = await safeFetch(ref);
+      if (!res.ok) return null;
+      return new Uint8Array(await res.arrayBuffer());
+    }
+  } catch {
+    // Unresolved — the ref is left as-is in the bundle.
+  }
+  return null;
+}

--- a/packages/websocket/src/routes/storyboards.ts
+++ b/packages/websocket/src/routes/storyboards.ts
@@ -11,11 +11,8 @@ import type { FastifyPluginAsync } from "fastify";
 import { Storyboard } from "@nodetool-ai/models";
 import type { Shot } from "@nodetool-ai/protocol";
 import { bridge } from "../lib/bridge.js";
-import {
-  getUserId,
-  resolveAssetBytesForExport,
-  type HttpApiOptions
-} from "../http-api.js";
+import { getUserId, type HttpApiOptions } from "../http-api.js";
+import { resolveAssetBytesForExport } from "../lib/asset-export.js";
 import {
   packStoryboardZip,
   type StoryboardExportInput

--- a/packages/websocket/tests/asset-export.test.ts
+++ b/packages/websocket/tests/asset-export.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for export-time asset resolution — how a stored ref becomes bytes for
+ * the storyboard zip and the `.nodetool` workflow bundle.
+ *
+ * Run with:
+ *   npm run test --workspace=packages/websocket -- asset-export
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { InMemoryStorageAdapter } from "@nodetool-ai/storage";
+import { initTestDb, Asset } from "@nodetool-ai/models";
+
+const adapter = new InMemoryStorageAdapter();
+
+vi.mock("../src/lib/storage.js", () => ({
+  getAssetAdapter: () => adapter,
+  getTempAdapter: () => adapter
+}));
+
+const { resolveAssetBytesForExport } = await import(
+  "../src/lib/asset-export.js"
+);
+
+const bytes = new Uint8Array([1, 2, 3, 4]);
+
+async function makeAsset(userId: string): Promise<Asset> {
+  return (await Asset.create({
+    user_id: userId,
+    name: "still.jpg",
+    content_type: "image/jpeg",
+    parent_id: userId
+  })) as Asset;
+}
+
+describe("resolveAssetBytesForExport", () => {
+  beforeEach(async () => {
+    initTestDb();
+    for (const key of (await adapter.list("")).entries) {
+      await adapter.delete(adapter.uriForKey(key.key));
+    }
+  });
+
+  it("reads a suffixed asset ref from the owner-prefixed key", async () => {
+    const asset = await makeAsset("user-1");
+    await adapter.store(`user-1/${asset.id}.jpg`, bytes, "image/jpeg");
+
+    expect(await resolveAssetBytesForExport(`asset://${asset.id}.jpg`)).toEqual(
+      bytes
+    );
+  });
+
+  it("reads a bare asset ref from the owner-prefixed key", async () => {
+    const asset = await makeAsset("user-1");
+    await adapter.store(`user-1/${asset.id}.jpg`, bytes, "image/jpeg");
+
+    expect(await resolveAssetBytesForExport(`asset://${asset.id}`)).toEqual(
+      bytes
+    );
+  });
+
+  it("falls back to the flat legacy key when no owner-prefixed object exists", async () => {
+    const asset = await makeAsset("user-1");
+    await adapter.store(`${asset.id}.jpg`, bytes, "image/jpeg");
+
+    expect(await resolveAssetBytesForExport(`asset://${asset.id}.jpg`)).toEqual(
+      bytes
+    );
+  });
+
+  it("reads a ref that already carries the owner prefix", async () => {
+    await adapter.store("user-1/a1.jpg", bytes, "image/jpeg");
+
+    expect(await resolveAssetBytesForExport("asset://user-1/a1.jpg")).toEqual(
+      bytes
+    );
+  });
+
+  it("returns null when the object is stored under no candidate key", async () => {
+    const asset = await makeAsset("user-1");
+    await adapter.store(`user-2/${asset.id}.jpg`, bytes, "image/jpeg");
+
+    expect(await resolveAssetBytesForExport(`asset://${asset.id}.jpg`)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed

A storyboard shot stores its still and clip as `asset://<id>.<ext>` — the suffixed form `persistOutput` writes so a renderer can type the media. The export resolver treated any ref carrying an extension as a storage key and retrieved it flat, skipping the `<user_id>/` prefix that every object written since the per-owner layout lives under. On S3/Supabase no flat object exists, so a downloaded board on prod listed every still and clip as "could not be read". Suffixed and bare `asset://` refs now resolve through the asset row, which carries the owner, and `retrieveAssetBytes` tries the owner-prefixed key before the flat legacy one; a ref that already carries a slash stays a key. The same resolver backs the `.nodetool` workflow bundle, which had the same miss. It moved to `lib/asset-export.ts` so the storyboard route and a test can reach it without importing http-api's module graph.

## Verification

- [x] `npm run test:affected` — the only failure is `packages/image-nodes`, 52 WebGPU cases failing on the documented missing Vulkan ICD in this container, unrelated to the diff
- [x] `npm run typecheck` — web and electron clean; mobile reports pre-existing `Cannot find module 'react-native' / 'expo-*'` from its uninstalled Expo tree
- [x] `npm run lint` — no findings in the touched files
- [x] `npm run dev:nodetool -- harness gate --base main` → `Gate: 8/8 selfchecks passed`

New test `packages/websocket/tests/asset-export.test.ts` (5 cases) covers the prod layout, the bare ref, the flat legacy fallback, an already-prefixed ref, and an object under no candidate key.

The reproduction was run before the fix: with the old rule (extension ⇒ flat key), `reads a suffixed asset ref from the owner-prefixed key` fails —

```
 FAIL  tests/asset-export.test.ts > resolveAssetBytesForExport > reads a suffixed asset ref from the owner-prefixed key
      Tests  1 failed | 4 passed (5)
```

## Agent capabilities

No capability added or re-declared.

## New checks

No new check, rule, or audit — the added tests pin the fixed behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_0128RZoHTCiMzKEHXbjTeuHD)_