### PR TITLE
feat(marketing): hero headline is two lines

### DIFF
--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -26,10 +26,10 @@ export default function NodeToolHero() {
             id="hero-title"
             className="mt-5 text-5xl font-bold leading-[1.05] tracking-tight text-white md:text-6xl"
           >
-            Describe it. An agent builds it.
+            Describe it.
             <br />
             <span className="bg-gradient-to-r from-rose-400 via-fuchsia-400 to-amber-300 bg-clip-text text-transparent">
-              Images, video, audio, text.
+              An agent builds it.
             </span>
           </h1>
 


### PR DESCRIPTION
## What changed

Follow-up to #5219. The hero headline drops its third line — the media list "Images, video, audio, text." — and breaks the remaining sentence pair across two lines: "Describe it." over a gradient "An agent builds it." The one-line sub and its `/node-based-ai` link are unchanged. Copy-only in `marketing/src/components/NodeToolHero.tsx`.

## Verification

- [ ] `npm run test:affected` — not run; `marketing/` has no test suite and is outside the workspaces `test:affected` maps to.
- [x] `npx tsc --noEmit -p marketing/tsconfig.json` — no diagnostics on the changed file. Pre-existing `Cannot find module 'framer-motion'` errors under `marketing/src/components/developers/` are missing marketing deps in this environment and predate the diff.
- [ ] `npm run lint` — not run.
- [ ] `npm run dev:nodetool -- harness gate --base main` — not run; the diff touches no surface in the harness registry.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KopMf2m6PGrkLGujZFMnJt)_