### PR TITLE
fix(marketing): keep the hero headline on two lines at every width

### DIFF
--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -24,11 +24,10 @@ export default function NodeToolHero() {
 
           <h1
             id="hero-title"
-            className="mt-5 text-5xl font-bold leading-[1.05] tracking-tight text-white md:text-6xl"
+            className="mt-5 text-[clamp(2rem,7.5vw,3.25rem)] font-bold leading-[1.05] tracking-tight text-white lg:text-[clamp(2.25rem,4.1vw,3.5rem)]"
           >
-            Describe it.
-            <br />
-            <span className="bg-gradient-to-r from-rose-400 via-fuchsia-400 to-amber-300 bg-clip-text text-transparent">
+            <span className="block whitespace-nowrap">Describe it.</span>
+            <span className="block whitespace-nowrap bg-gradient-to-r from-rose-400 via-fuchsia-400 to-amber-300 bg-clip-text text-transparent">
               An agent builds it.
             </span>
           </h1>


### PR DESCRIPTION
## What changed

The homepage h1 was a fixed `text-6xl` sitting in a 5/12 grid column, so between roughly 1024px and 1280px the second line broke after "builds" and orphaned "it." on a third line. Each line is now its own `whitespace-nowrap` block and the size is fluid — `clamp(2rem, 7.5vw, 3.25rem)` below `lg`, `clamp(2.25rem, 4.1vw, 3.5rem)` at `lg` and up. The 3.5rem cap is measured, not guessed: "An agent builds it." renders 8.63em wide and the copy column tops out at 483px once the container hits its max width, so 56px is the largest size that still fits. Copy is unchanged.

## Verification

Rendered the real page (`next dev`) in Chromium and measured the h1 at 390, 640, 768, 1024, 1180, 1280, 1440, 1600, 1920, and 2560px — one line box per span and no overflow at every width:

```
1024 {"fs":41.98,"col":377,"lines":[1,1],"fits":true}
1280 {"fs":52.48,"col":483,"lines":[1,1],"fits":true}
1440 {"fs":56,"col":483,"lines":[1,1],"fits":true}
1920 {"fs":56,"col":483,"lines":[1,1],"fits":true}
```

The same measurement caught a real failure before the 3.5rem cap was added, which is what it was written to detect — the headline ran past the column and under the video:

```
1440 {"fs":59.04,"col":483,"text":493,"fits":false}
1920 {"fs":60,"col":483,"text":501,"fits":false}
```

- `npx tsc --noEmit -p marketing/tsconfig.json` — clean

`marketing/` is not a root workspace, so `npm run test:affected`, root `typecheck`, `lint`, and `harness gate` do not reach this diff; the repo checks above are the ones that apply.

## Agent capabilities

No capability added or changed.

## New checks

No check, rule, or audit added — the breakpoint measurement was a one-off render, not a committed gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_0147xQxeGzVUeemSgREQyPFa)_