### PR TITLE
fix(web): show a spinner while a document tab loads

### DIFF
--- a/web/src/components/workspace/ChatSurface.tsx
+++ b/web/src/components/workspace/ChatSurface.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import { FlexColumn } from "../ui_primitives";
@@ -9,6 +9,7 @@ import useGlobalChatStore, {
 } from "../../stores/GlobalChatStore";
 import type { Message, LanguageModel } from "../../stores/ApiTypes";
 import { useWorkspaceTabsStore } from "../../stores/WorkspaceTabsStore";
+import DocumentLoadStatus from "./DocumentLoadStatus";
 
 const whenChatStoreHydrated = (): Promise<void> => {
   const persistApi = useGlobalChatStore.persist;
@@ -40,6 +41,10 @@ const NO_MESSAGES: Message[] = [];
  */
 const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
   const runtime = useThreadRuntime(refId);
+  // Until the thread's messages are in, an empty cache is indistinguishable
+  // from an empty conversation, and the tab greets the user with the welcome
+  // screen for a thread that has history.
+  const [loadingThread, setLoadingThread] = useState(true);
 
   const { currentThreadId, thread, messages } = useGlobalChatStore(
     useShallow((state) => ({
@@ -98,6 +103,7 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
   const threadKnown = thread !== undefined;
   useEffect(() => {
     let cancelled = false;
+    setLoadingThread(true);
     const hydrate = async () => {
       try {
         await whenChatStoreHydrated();
@@ -117,6 +123,10 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
       } catch (error) {
         if (!cancelled) {
           console.error("Failed to load chat thread:", error);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingThread(false);
         }
       }
     };
@@ -177,9 +187,14 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
     [sendMessage, selectedModel, refId]
   );
 
-  const welcomePlaceholder = useMemo(
-    () => <WelcomePlaceholder onSuggestionClick={handleSuggestionClick} />,
-    [handleSuggestionClick]
+  const noMessagesPlaceholder = useMemo(
+    () =>
+      loadingThread ? (
+        <DocumentLoadStatus state="loading" label="conversation" />
+      ) : (
+        <WelcomePlaceholder onSuggestionClick={handleSuggestionClick} />
+      ),
+    [loadingThread, handleSuggestionClick]
   );
 
   const handleNewChat = useCallback(async () => {
@@ -217,7 +232,7 @@ const ChatSurface = ({ refId, active }: ChatSurfaceProps) => {
         currentLogUpdate={runtime.logUpdate}
         workflowId={workflowId}
         chatSource="workspace_chat"
-        noMessagesPlaceholder={welcomePlaceholder}
+        noMessagesPlaceholder={noMessagesPlaceholder}
         showNewChatButton
       />
     </FlexColumn>

--- a/web/src/components/workspace/DocumentLoadStatus.tsx
+++ b/web/src/components/workspace/DocumentLoadStatus.tsx
@@ -1,0 +1,39 @@
+import type { DocumentLoadState } from "../../stores/documentSync";
+import { EmptyState, FlexColumn, LoadingSpinner } from "../ui_primitives";
+
+interface DocumentLoadStatusProps {
+  state: Exclude<DocumentLoadState, "ready">;
+  /** The document type, lowercase, as it reads mid-sentence: "storyboard". */
+  label: string;
+}
+
+/**
+ * What a document surface shows in place of itself until its initial server
+ * load settles.
+ *
+ * The store-backed surfaces (storyboard, script, JS script) seed an empty
+ * document on mount and fill it in when the server responds, so rendering them
+ * straight away shows an empty document — indistinguishable from a document
+ * that really is empty. This shows the load instead.
+ */
+const DocumentLoadStatus = ({ state, label }: DocumentLoadStatusProps) => (
+  <FlexColumn
+    fullWidth
+    fullHeight
+    align="center"
+    justify="center"
+    sx={{ minHeight: 0 }}
+  >
+    {state === "loading" ? (
+      <LoadingSpinner text={`Loading ${label}…`} />
+    ) : (
+      <EmptyState
+        variant="error"
+        title={`Could not load this ${label}`}
+        description="The server did not answer. Close the tab and open it again to retry."
+      />
+    )}
+  </FlexColumn>
+);
+
+export default DocumentLoadStatus;

--- a/web/src/components/workspace/JsScriptSurface.tsx
+++ b/web/src/components/workspace/JsScriptSurface.tsx
@@ -34,6 +34,7 @@ import JsScriptAgentPanel from "../jsScript/JsScriptAgentPanel";
 import JsScriptRunConsole from "../jsScript/JsScriptRunConsole";
 import type { JsScriptRunRequest } from "../jsScript/JsScriptRunDialog";
 import ResizableSideDock from "../chat/assistant/ResizableSideDock";
+import DocumentLoadStatus from "./DocumentLoadStatus";
 
 interface JsScriptSurfaceProps {
   refId: string;
@@ -97,7 +98,7 @@ const JsScriptSurface = ({ refId, mode, active }: JsScriptSurfaceProps) => {
     ensureScript(refId);
   }, [ensureScript, refId]);
 
-  useJsScriptServerSync(refId);
+  const loadState = useJsScriptServerSync(refId);
   useJsScriptAgentBridge(refId);
 
   useDocumentUndoShortcuts({
@@ -146,6 +147,12 @@ const JsScriptSurface = ({ refId, mode, active }: JsScriptSurfaceProps) => {
     ],
     []
   );
+
+  // The store seeds an empty script on mount, so rendering before the server
+  // copy lands looks like a script with an empty body.
+  if (loadState !== "ready") {
+    return <DocumentLoadStatus state={loadState} label="JS script" />;
+  }
 
   const editor = <JsScriptEditorPane scriptId={refId} readOnly={readOnly} />;
   const runConsole = (

--- a/web/src/components/workspace/ScriptSurface.tsx
+++ b/web/src/components/workspace/ScriptSurface.tsx
@@ -29,6 +29,7 @@ import ScriptDocumentPane from "../script/ScriptDocumentPane";
 import ScriptCastPanel from "../script/ScriptCastPanel";
 import ScriptAgentPanel from "../script/ScriptAgentPanel";
 import ResizableSideDock from "../chat/assistant/ResizableSideDock";
+import DocumentLoadStatus from "./DocumentLoadStatus";
 
 interface ScriptSurfaceProps {
   refId: string;
@@ -73,7 +74,7 @@ const ScriptSurface = ({ refId, mode, active }: ScriptSurfaceProps) => {
     ensureScript(refId);
   }, [ensureScript, refId]);
 
-  useScriptServerSync(refId);
+  const loadState = useScriptServerSync(refId);
   useScriptAgentBridge(refId);
 
   useDocumentUndoShortcuts({
@@ -115,6 +116,12 @@ const ScriptSurface = ({ refId, mode, active }: ScriptSurfaceProps) => {
     ) : (
       <ScriptAgentPanel scriptId={refId} />
     );
+
+  // The store seeds an empty script on mount, so rendering before the server
+  // copy lands looks like a script with no lines.
+  if (loadState !== "ready") {
+    return <DocumentLoadStatus state={loadState} label="script" />;
+  }
 
   // On mobile the fixed 320px side dock would crush the document, so the cast
   // and assistant panels move into a bottom sheet reached by two floating

--- a/web/src/components/workspace/StoryboardSurface.tsx
+++ b/web/src/components/workspace/StoryboardSurface.tsx
@@ -19,6 +19,7 @@ import StoryboardBoard from "../storyboard/StoryboardBoard";
 import StoryboardQueueOverlay from "../storyboard/StoryboardQueueOverlay";
 import StoryboardAgentPanel from "../storyboard/StoryboardAgentPanel";
 import ResizableSideDock from "../chat/assistant/ResizableSideDock";
+import DocumentLoadStatus from "./DocumentLoadStatus";
 
 interface StoryboardSurfaceProps {
   refId: string;
@@ -67,7 +68,7 @@ const StoryboardSurface = ({ refId, mode, active }: StoryboardSurfaceProps) => {
     ensureBoard(refId);
   }, [ensureBoard, refId]);
 
-  useStoryboardServerSync(refId);
+  const loadState = useStoryboardServerSync(refId);
 
   useDocumentUndoShortcuts({
     active,
@@ -121,6 +122,12 @@ const StoryboardSurface = ({ refId, mode, active }: StoryboardSurfaceProps) => {
       assembleError
     ]
   );
+
+  // The store seeds an empty board on mount, so rendering before the server
+  // copy lands looks like a board with no shots.
+  if (loadState !== "ready") {
+    return <DocumentLoadStatus state={loadState} label="storyboard" />;
+  }
 
   if (isMobile && mode !== "view") {
     return (

--- a/web/src/components/workspace/__tests__/DocumentSurfaceLoading.test.tsx
+++ b/web/src/components/workspace/__tests__/DocumentSurfaceLoading.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Document surfaces hold their content behind the initial server load.
+ *
+ * The store seeds an empty document on mount, so a surface that renders
+ * straight away shows an empty board/script — indistinguishable from one that
+ * really is empty. Each waits on its sync hook instead.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+
+import StoryboardSurface from "../StoryboardSurface";
+import ScriptSurface from "../ScriptSurface";
+import mockTheme from "../../../__mocks__/themeMock";
+import type { DocumentLoadState } from "../../../stores/documentSync";
+
+jest.mock("@mui/material/useMediaQuery", () => () => false);
+
+let storyboardLoadState: DocumentLoadState = "loading";
+let scriptLoadState: DocumentLoadState = "loading";
+
+jest.mock("../../../hooks/storyboard/useStoryboardServerSync", () => ({
+  useStoryboardServerSync: () => storyboardLoadState
+}));
+jest.mock("../../../hooks/script/useScriptServerSync", () => ({
+  useScriptServerSync: () => scriptLoadState
+}));
+
+jest.mock("../../../hooks/storyboard/useStoryboardAgentBridge", () => ({
+  useStoryboardAgentBridge: jest.fn()
+}));
+jest.mock("../../../hooks/script/useScriptAgentBridge", () => ({
+  useScriptAgentBridge: jest.fn()
+}));
+jest.mock("../../../hooks/useDocumentUndoShortcuts", () => ({
+  useDocumentUndoShortcuts: jest.fn()
+}));
+jest.mock("../../../stores/storyboard/StoryboardGenerationStore", () => ({
+  useStoryboardGenerationSubscriptions: jest.fn()
+}));
+jest.mock("../../../hooks/storyboard/useDirectScreenplay", () => ({
+  useDirectScreenplay: () => ({
+    direct: jest.fn(),
+    directing: false,
+    error: null
+  })
+}));
+jest.mock("../../../hooks/storyboard/useAssembleTimeline", () => ({
+  useAssembleTimeline: () => ({
+    assemble: jest.fn(),
+    assembling: false,
+    error: null
+  })
+}));
+
+jest.mock("../../storyboard/StoryboardBoard", () => ({
+  __esModule: true,
+  default: () => <div>storyboard board</div>
+}));
+jest.mock("../../storyboard/StoryboardQueueOverlay", () => ({
+  __esModule: true,
+  default: () => null
+}));
+jest.mock("../../storyboard/StoryboardAgentPanel", () => ({
+  __esModule: true,
+  default: () => null
+}));
+jest.mock("../../script/ScriptDocumentPane", () => ({
+  __esModule: true,
+  default: () => <div>script document</div>
+}));
+jest.mock("../../script/ScriptCastPanel", () => ({
+  __esModule: true,
+  default: () => null
+}));
+jest.mock("../../script/ScriptAgentPanel", () => ({
+  __esModule: true,
+  default: () => null
+}));
+
+const withTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>);
+
+describe("document surfaces during the initial load", () => {
+  it("shows a spinner instead of an empty storyboard", () => {
+    storyboardLoadState = "loading";
+    withTheme(<StoryboardSurface refId="board-1" mode="edit" active />);
+
+    expect(screen.getByText("Loading storyboard…")).toBeInTheDocument();
+    expect(screen.queryByText("storyboard board")).not.toBeInTheDocument();
+  });
+
+  it("renders the storyboard once the load lands", () => {
+    storyboardLoadState = "ready";
+    withTheme(<StoryboardSurface refId="board-1" mode="edit" active />);
+
+    expect(screen.getByText("storyboard board")).toBeInTheDocument();
+    expect(screen.queryByText("Loading storyboard…")).not.toBeInTheDocument();
+  });
+
+  it("says so when a storyboard cannot be loaded", () => {
+    storyboardLoadState = "error";
+    withTheme(<StoryboardSurface refId="board-1" mode="edit" active />);
+
+    expect(
+      screen.getByText("Could not load this storyboard")
+    ).toBeInTheDocument();
+  });
+
+  it("shows a spinner instead of an empty script", () => {
+    scriptLoadState = "loading";
+    withTheme(<ScriptSurface refId="script-1" mode="edit" active />);
+
+    expect(screen.getByText("Loading script…")).toBeInTheDocument();
+    expect(screen.queryByText("script document")).not.toBeInTheDocument();
+  });
+
+  it("renders the script once the load lands", () => {
+    scriptLoadState = "ready";
+    withTheme(<ScriptSurface refId="script-1" mode="edit" active />);
+
+    expect(screen.getByText("script document")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/workspace/__tests__/JsScriptSurfaceMobile.test.tsx
+++ b/web/src/components/workspace/__tests__/JsScriptSurfaceMobile.test.tsx
@@ -16,7 +16,7 @@ import mockTheme from "../../../__mocks__/themeMock";
 jest.mock("@mui/material/useMediaQuery", () => () => true);
 
 jest.mock("../../../hooks/jsScript/useJsScriptServerSync", () => ({
-  useJsScriptServerSync: jest.fn()
+  useJsScriptServerSync: jest.fn(() => "ready")
 }));
 jest.mock("../../../hooks/jsScript/useJsScriptAgentBridge", () => ({
   useJsScriptAgentBridge: jest.fn()

--- a/web/src/hooks/jsScript/__tests__/useJsScriptServerSync.test.tsx
+++ b/web/src/hooks/jsScript/__tests__/useJsScriptServerSync.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
+import type { DocumentLoadState } from "../../../stores/documentSync";
 import { act } from "react";
 import { trpc, trpcClient } from "../../../trpc/client";
 import {
@@ -59,7 +60,7 @@ const loaded = async (): Promise<void> => {
 
 /** Mount the hook and wait for the initial load to record a server revision. */
 const mountLoaded = async (): Promise<
-  ReturnType<typeof renderHook<void, unknown>>
+  ReturnType<typeof renderHook<DocumentLoadState, unknown>>
 > => {
   const rendered = renderHook(() => useJsScriptServerSync("js-1"));
   await loaded();

--- a/web/src/hooks/jsScript/useJsScriptServerSync.ts
+++ b/web/src/hooks/jsScript/useJsScriptServerSync.ts
@@ -13,7 +13,7 @@
  * caller that wrote into the store can learn whether the write persisted.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { jsScriptDocument } from "@nodetool-ai/protocol/api-schemas/js-scripts.js";
 import { trpc, trpcClient } from "../../trpc/client";
 import {
@@ -22,7 +22,10 @@ import {
   type JsScriptSaveStatus
 } from "../../stores/jsScript/JsScriptStore";
 import { getErrorMessage } from "../../utils/errorHandling";
-import { registerDocumentSync } from "../../stores/documentSync";
+import {
+  registerDocumentSync,
+  type DocumentLoadState
+} from "../../stores/documentSync";
 import {
   isPermanentSaveError,
   MAX_TRANSIENT_SAVE_RETRIES
@@ -56,8 +59,11 @@ const responseToEntry = (
 const isNotFound = (error: unknown): boolean =>
   /not found/i.test(getErrorMessage(error));
 
-export const useJsScriptServerSync = (scriptId: string): void => {
+export const useJsScriptServerSync = (
+  scriptId: string
+): DocumentLoadState => {
   const utils = trpc.useUtils();
+  const [loadState, setLoadState] = useState<DocumentLoadState>("loading");
   const syncedRef = useRef<JsScriptEntry | null>(null);
   const inFlightRef = useRef(false);
   // The save currently in flight, so a flush can await it instead of starting
@@ -75,6 +81,7 @@ export const useJsScriptServerSync = (scriptId: string): void => {
   useEffect(() => {
     let disposed = false;
     const store = useJsScriptStore;
+    setLoadState("loading");
 
     const applyResponse = (
       res: JsScriptResponse,
@@ -279,7 +286,16 @@ export const useJsScriptServerSync = (scriptId: string): void => {
 
     registerJsScriptSaver(scriptId, flushNow);
 
-    loadPromiseRef.current = load();
+    // The initial load gates rendering: a script with no server revision once
+    // it has settled is one that failed to load. Later reloads (CAS conflict,
+    // resource_change) leave the state alone — the surface already has a
+    // document to show.
+    loadPromiseRef.current = load().finally(() => {
+      if (disposed) return;
+      setLoadState(
+        store.getState().serverRevisions[scriptId] ? "ready" : "error"
+      );
+    });
     void loadPromiseRef.current;
 
     return () => {
@@ -292,6 +308,8 @@ export const useJsScriptServerSync = (scriptId: string): void => {
       else void save(true);
     };
   }, [scriptId]);
+
+  return loadState;
 };
 
 export default useJsScriptServerSync;

--- a/web/src/hooks/script/useScriptServerSync.ts
+++ b/web/src/hooks/script/useScriptServerSync.ts
@@ -10,7 +10,7 @@
  * Copied from useStoryboardServerSync — same machinery, script payload.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { trpc, trpcClient } from "../../trpc/client";
 import {
   useScriptStore,
@@ -18,7 +18,10 @@ import {
   type ScriptSaveStatus
 } from "../../stores/script/ScriptStore";
 import { getErrorMessage } from "../../utils/errorHandling";
-import { registerDocumentSync } from "../../stores/documentSync";
+import {
+  registerDocumentSync,
+  type DocumentLoadState
+} from "../../stores/documentSync";
 import {
   isPermanentSaveError,
   MAX_TRANSIENT_SAVE_RETRIES
@@ -52,8 +55,11 @@ const responseToScript = (
 const isNotFound = (error: unknown): boolean =>
   /not found/i.test(getErrorMessage(error));
 
-export const useScriptServerSync = (scriptId: string): void => {
+export const useScriptServerSync = (
+  scriptId: string
+): DocumentLoadState => {
   const utils = trpc.useUtils();
+  const [loadState, setLoadState] = useState<DocumentLoadState>("loading");
   const syncedRef = useRef<ScriptDraft | null>(null);
   const inFlightRef = useRef(false);
   const flushAfterSaveRef = useRef(false);
@@ -67,6 +73,7 @@ export const useScriptServerSync = (scriptId: string): void => {
   useEffect(() => {
     let disposed = false;
     const store = useScriptStore;
+    setLoadState("loading");
 
     // `statusAfter` is applied only once the server copy has actually replaced
     // the local one, so the indicator never claims a state before it's true.
@@ -233,7 +240,16 @@ export const useScriptServerSync = (scriptId: string): void => {
       }
     });
 
-    void load();
+    // The initial load gates rendering: a script with no server revision once
+    // it has settled is one that failed to load. Later reloads (CAS conflict,
+    // resource_change) leave the state alone — the surface already has a
+    // document to show.
+    void load().finally(() => {
+      if (disposed) return;
+      setLoadState(
+        store.getState().serverRevisions[scriptId] ? "ready" : "error"
+      );
+    });
 
     return () => {
       disposed = true;
@@ -244,6 +260,8 @@ export const useScriptServerSync = (scriptId: string): void => {
       else void save(true);
     };
   }, [scriptId]);
+
+  return loadState;
 };
 
 export default useScriptServerSync;

--- a/web/src/hooks/storyboard/__tests__/useStoryboardServerSync.test.tsx
+++ b/web/src/hooks/storyboard/__tests__/useStoryboardServerSync.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
+import type { DocumentLoadState } from "../../../stores/documentSync";
 import { act } from "react";
 import { trpc, trpcClient } from "../../../trpc/client";
 import { useStoryboardStore } from "../../../stores/storyboard/StoryboardStore";
@@ -71,7 +72,7 @@ beforeEach(() => {
 
 /** Mount the hook and wait for the initial load to record a server revision. */
 const mountLoaded = async (): Promise<
-  ReturnType<typeof renderHook<void, unknown>>
+  ReturnType<typeof renderHook<DocumentLoadState, unknown>>
 > => {
   const rendered = renderHook(() => useStoryboardServerSync("board-1"));
   await waitFor(() =>

--- a/web/src/hooks/storyboard/useStoryboardServerSync.ts
+++ b/web/src/hooks/storyboard/useStoryboardServerSync.ts
@@ -17,7 +17,7 @@
  * caller that wrote into the store can learn whether the write persisted.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { trpc, trpcClient } from "../../trpc/client";
 import {
   useStoryboardStore,
@@ -25,7 +25,10 @@ import {
 } from "../../stores/storyboard/StoryboardStore";
 import type { Screenplay, Shot } from "@nodetool-ai/protocol";
 import { getErrorMessage } from "../../utils/errorHandling";
-import { registerDocumentSync } from "../../stores/documentSync";
+import {
+  registerDocumentSync,
+  type DocumentLoadState
+} from "../../stores/documentSync";
 import {
   isPermanentSaveError,
   MAX_TRANSIENT_SAVE_RETRIES
@@ -96,8 +99,11 @@ const isNotFound = (error: unknown): boolean =>
 const isConflict = (error: unknown): boolean =>
   /modified since last read/i.test(getErrorMessage(error));
 
-export const useStoryboardServerSync = (boardId: string): void => {
+export const useStoryboardServerSync = (
+  boardId: string
+): DocumentLoadState => {
   const utils = trpc.useUtils();
+  const [loadState, setLoadState] = useState<DocumentLoadState>("loading");
   // The board object reference last written to / read from the server; any
   // other reference in the store means unsaved local edits.
   const syncedRef = useRef<StoryboardBoard | null>(null);
@@ -119,6 +125,7 @@ export const useStoryboardServerSync = (boardId: string): void => {
   useEffect(() => {
     let disposed = false;
     const store = useStoryboardStore;
+    setLoadState("loading");
 
     const applyResponse = (res: StoryboardResponse): void => {
       if (disposed) return;
@@ -315,7 +322,16 @@ export const useStoryboardServerSync = (boardId: string): void => {
     // long as this board is open.
     registerStoryboardSaver(boardId, flushNow);
 
-    loadPromiseRef.current = load();
+    // The initial load is the one that gates rendering: a board with no server
+    // revision after it has settled is a board that failed to load. Later
+    // reloads (CAS conflict, resource_change) leave the state alone — the
+    // surface already has a document to show.
+    loadPromiseRef.current = load().finally(() => {
+      if (disposed) return;
+      setLoadState(
+        store.getState().serverRevisions[boardId] ? "ready" : "error"
+      );
+    });
     void loadPromiseRef.current;
 
     return () => {
@@ -330,6 +346,8 @@ export const useStoryboardServerSync = (boardId: string): void => {
       else void save(true);
     };
   }, [boardId]);
+
+  return loadState;
 };
 
 export default useStoryboardServerSync;

--- a/web/src/stores/documentSync.ts
+++ b/web/src/stores/documentSync.ts
@@ -21,6 +21,13 @@
  */
 import { useNotificationStore } from "./NotificationStore";
 
+/**
+ * Where a document editor is in its initial server load. A surface that renders
+ * an empty document while `"loading"` looks like an empty document, so surfaces
+ * show a spinner until the first load settles.
+ */
+export type DocumentLoadState = "loading" | "ready" | "error";
+
 /** `resource_type` as the backend spells it: the lowercased model class name. */
 export type SyncedDocumentType =
   | "timelinesequence"


### PR DESCRIPTION
## What changed

Storyboard, script and JS script tabs seed an empty document in their store on mount and fill it in when the server answers, so opening one showed an empty board/script first — indistinguishable from a document that really is empty. Chat tabs showed the welcome screen before the thread's messages arrived. The three server-sync hooks now report where their initial load is (`DocumentLoadState`: `loading | ready | error`, exported from `stores/documentSync.ts`) and each surface renders the new `DocumentLoadStatus` until it settles; a load that fails says so instead of spinning forever. `ChatSurface` swaps its no-messages placeholder for the same spinner while hydrating, so the composer stays mounted. Timeline, image, sketch, text, 3D and application tabs already gated on their query's `isLoading` and are unchanged.

Load state is derived from the store's own server revision after the initial load settles, so only that first load gates rendering — a CAS-conflict reload or a `resource_change` reload leaves the surface showing the document it already has.

## Verification

- [x] `npm run test:affected` — 214 suites, 2019 passed, 3 skipped
- [x] `npm run typecheck` — no new errors in `web/src`. The pre-existing `TS2307` failures against unbuilt `@nodetool-ai/*` packages remain (`npm run build:packages` fails here on `@nodetool-ai/model3d` not resolving, unrelated to this diff)
- [x] `npm run lint` — exit 0
- [ ] `npm run dev:nodetool -- harness gate --base main` — **could not run**: the CLI fails to start in this environment because `build:packages` fails on the pre-existing `@nodetool-ai/model3d` resolution error. The diff is web-only UI and touches no harness-registered surface.

New test `web/src/components/workspace/__tests__/DocumentSurfaceLoading.test.tsx` was inverted (disabling the `StoryboardSurface` gate) and observed failing:

```
✕ shows a spinner instead of an empty storyboard
✓ renders the storyboard once the load lands
✕ says so when a storyboard cannot be loaded
✓ shows a spinner instead of an empty script
✓ renders the script once the load lands
Tests: 2 failed, 3 passed, 5 total
```

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added — the new file is a component test, and its inverted-run output is above.

---
_Generated by [Claude Code](https://claude.ai/code/session_015S8MhJbsRuRQVCk4xsmJAu)_