### PR TITLE
fix(web): cancel model downloads and target the active worker

### DIFF
--- a/web/src/components/hugging_face/DownloadProgress.tsx
+++ b/web/src/components/hugging_face/DownloadProgress.tsx
@@ -110,24 +110,36 @@ export const DownloadProgress: React.FC<{
   minimal?: boolean;
 }> = memo(({ name, minimal }) => {
   const download = useModelDownloadStore((state) => state.downloads[name]);
-  const { cancelDownload, removeDownload, wsConnectionState, reconnectWebSocket } =
-    useModelDownloadStore(
-      useShallow((state) => ({
-        cancelDownload: state.cancelDownload,
-        removeDownload: state.removeDownload,
-        wsConnectionState: state.wsConnectionState,
-        reconnectWebSocket: state.reconnectWebSocket
-      }))
-    );
+  const {
+    cancelDownload,
+    cancelAndRemoveDownload,
+    removeDownload,
+    wsConnectionState,
+    reconnectWebSocket
+  } = useModelDownloadStore(
+    useShallow((state) => ({
+      cancelDownload: state.cancelDownload,
+      cancelAndRemoveDownload: state.cancelAndRemoveDownload,
+      removeDownload: state.removeDownload,
+      wsConnectionState: state.wsConnectionState,
+      reconnectWebSocket: state.reconnectWebSocket
+    }))
+  );
   const isDisconnected = wsConnectionState === "disconnected";
   const isReconnecting = wsConnectionState === "connecting";
 
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
 
+  // The card keeps the cancelled entry visible so the manager can show what
+  // happened; the inline row dismisses itself instead.
   const handleCancelDownload = useCallback(() => {
-    cancelDownload(name);
+    void cancelDownload(name);
   }, [name, cancelDownload]);
+
+  const handleCancelAndDismiss = useCallback(() => {
+    void cancelAndRemoveDownload(name);
+  }, [name, cancelAndRemoveDownload]);
 
   const [now, setNow] = useState(Date.now());
 
@@ -135,6 +147,10 @@ export const DownloadProgress: React.FC<{
     download.status === "running" ||
     download.status === "progress" ||
     download.status === "start";
+
+  // A pending download is only queued, but it is cancellable all the same.
+  const canCancel =
+    isActive || download.status === "pending";
 
   useEffect(() => {
     if (!isActive) return;
@@ -240,6 +256,8 @@ export const DownloadProgress: React.FC<{
         ? "Done"
         : download.status === "error"
         ? "Error"
+        : download.status === "cancelled"
+        ? "Cancelled"
         : totalBytes > 0
         ? `${percent.toFixed(0)}%`
         : "…";
@@ -281,6 +299,15 @@ export const DownloadProgress: React.FC<{
               </Caption>
             )}
           </FlexRow>
+          {canCancel && (
+            <CloseButton
+              onClick={handleCancelAndDismiss}
+              buttonSize="small"
+              tooltip="Cancel download"
+              nodrag={false}
+              sx={{ flexShrink: 0 }}
+            />
+          )}
         </FlexRow>
       </Tooltip>
     );

--- a/web/src/components/hugging_face/ModelPackCard.tsx
+++ b/web/src/components/hugging_face/ModelPackCard.tsx
@@ -31,6 +31,8 @@ import {
   canCheckHfCache,
   getHfCacheKey
 } from "../../utils/hfCache";
+import { Tooltip } from "../ui_primitives";
+import { useModelDownloadTarget } from "../../hooks/useModelDownloadTarget";
 
 interface ModelPackCardProps {
   pack: ModelPack;
@@ -71,6 +73,7 @@ const ModelPackCard: React.FC<ModelPackCardProps> = ({
       ensureStatuses: state.ensureStatuses
     }))
   );
+  const downloadTarget = useModelDownloadTarget();
 
   const activeDownloads = useMemo(
     () => pack.models.filter((model) => activeDownloadSet.has(model.id)),
@@ -224,23 +227,31 @@ const ModelPackCard: React.FC<ModelPackCardProps> = ({
       </Box>
 
       <FlexRow align="center" justify="space-between" sx={{ px: 2, pb: 2, pt: 0 }}>
-        <EditorButton
-          variant={allDownloaded ? "outlined" : "contained"}
-          size="small"
-          startIcon={allDownloaded ? <CheckCircleIcon /> : <DownloadIcon />}
-          onClick={handleDownloadAll}
-          disabled={allDownloaded || isDownloading}
-          sx={{
-            textTransform: "none",
-            fontWeight: 600
-          }}
+        <Tooltip
+          title={
+            pack.total_size
+              ? `Download ${formatBytes(pack.total_size)} to ${downloadTarget.label}`
+              : `Downloads to ${downloadTarget.label}`
+          }
         >
-          {allDownloaded
-            ? "All Downloaded"
-            : someDownloaded
-              ? `Download ${pack.models.length - downloadedModels.size} Remaining`
-              : "Download All"}
-        </EditorButton>
+          <EditorButton
+            variant={allDownloaded ? "outlined" : "contained"}
+            size="small"
+            startIcon={allDownloaded ? <CheckCircleIcon /> : <DownloadIcon />}
+            onClick={handleDownloadAll}
+            disabled={allDownloaded || isDownloading}
+            sx={{
+              textTransform: "none",
+              fontWeight: 600
+            }}
+          >
+            {allDownloaded
+              ? "All Downloaded"
+              : someDownloaded
+                ? `Download ${pack.models.length - downloadedModels.size} Remaining`
+                : "Download All"}
+          </EditorButton>
+        </Tooltip>
 
         <ToolbarIconButton
           icon={<ExpandMoreIcon />}

--- a/web/src/components/hugging_face/__tests__/DownloadProgress.minimal.test.tsx
+++ b/web/src/components/hugging_face/__tests__/DownloadProgress.minimal.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * DownloadProgress (minimal inline variant) tests
+ *
+ * The model select dialog renders this row while a recommended model
+ * downloads. The row must offer a cancel affordance while the download is
+ * active; cancelling dismisses the row through the store's cancel-and-remove
+ * action so it returns to its pre-download state.
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+
+import { DownloadProgress } from "../DownloadProgress";
+import mockTheme from "../../../__mocks__/themeMock";
+
+const cancelAndRemoveDownload = jest.fn().mockResolvedValue(true);
+
+jest.mock("../../../stores/ModelDownloadStore", () => ({
+  useModelDownloadStore: jest.fn((selector: (state: unknown) => unknown) =>
+    selector({
+      downloads: {
+        "org/model": {
+          id: "org/model",
+          status: "running",
+          downloadedBytes: 500,
+          totalBytes: 1000,
+          totalFiles: 2,
+          downloadedFiles: 1,
+          currentFiles: ["model.safetensors"],
+          speed: null,
+          speedHistory: []
+        }
+      },
+      cancelAndRemoveDownload,
+      removeDownload: jest.fn(),
+      wsConnectionState: "connected",
+      reconnectWebSocket: jest.fn()
+    })
+  )
+}));
+
+import { useModelDownloadStore } from "../../../stores/ModelDownloadStore";
+
+const renderRow = () =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <DownloadProgress name="org/model" minimal />
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  (useModelDownloadStore as unknown as jest.Mock).mockClear();
+  cancelAndRemoveDownload.mockClear();
+});
+
+it("shows a cancel button while the download is active", () => {
+  renderRow();
+  expect(
+    screen.getByRole("button", { name: "Cancel download" })
+  ).toBeInTheDocument();
+});
+
+it("cancels and dismisses the row on click", async () => {
+  const user = userEvent.setup();
+  renderRow();
+
+  await user.click(screen.getByRole("button", { name: "Cancel download" }));
+
+  expect(cancelAndRemoveDownload).toHaveBeenCalledWith("org/model");
+});
+
+it("hides the cancel button once the download completes", () => {
+  const hook = useModelDownloadStore as unknown as jest.Mock;
+  const original = hook.getMockImplementation();
+  hook.mockImplementation((selector: (state: unknown) => unknown) =>
+    selector({
+      downloads: {
+        "org/model": {
+          id: "org/model",
+          status: "completed",
+          downloadedBytes: 1000,
+          totalBytes: 1000,
+          totalFiles: 2,
+          downloadedFiles: 2,
+          currentFiles: [],
+          speed: null,
+          speedHistory: []
+        }
+      },
+      cancelAndRemoveDownload,
+      removeDownload: jest.fn(),
+      wsConnectionState: "connected",
+      reconnectWebSocket: jest.fn()
+    })
+  );
+
+  try {
+    renderRow();
+    expect(
+      screen.queryByRole("button", { name: "Cancel download" })
+    ).not.toBeInTheDocument();
+  } finally {
+    hook.mockImplementation(original);
+  }
+});

--- a/web/src/components/hugging_face/model_list/ModelListHeader.tsx
+++ b/web/src/components/hugging_face/model_list/ModelListHeader.tsx
@@ -21,6 +21,8 @@ import { useShallow } from "zustand/react/shallow";
 import { ScopeToggle } from "./ScopeToggle";
 import { SourceToggle } from "./SourceToggle";
 import { HUB_RESULT_LIMIT } from "./useModels";
+import { useModelDownloadTarget } from "../../../hooks/useModelDownloadTarget";
+import { Caption, Tooltip } from "../../ui_primitives";
 
 interface ModelListHeaderProps {
   totalCount: number;
@@ -84,6 +86,11 @@ const ModelListHeader: React.FC<ModelListHeaderProps> = ({
   );
   const theme = useTheme();
   const isOnboarding = source === "onboarding";
+  // The Local/Worker toggle changes what you browse; downloads always land on
+  // the attached worker while one is connected. State that explicitly so the
+  // view toggle never reads as a download destination.
+  const { scope: downloadScope, label: downloadTargetLabel } =
+    useModelDownloadTarget();
 
   const handleSliderChange = (_: Event, value: number | number[]) => {
     const v = Array.isArray(value) ? value[0] : value;
@@ -136,6 +143,20 @@ const ModelListHeader: React.FC<ModelListHeaderProps> = ({
         )}
 
         <SourceToggle source={source} onChange={onSourceChange} />
+
+        {downloadScope === "worker" && !isOnboarding && (
+          <Tooltip title={`Every model you download lands on ${downloadTargetLabel} while this worker is attached.`}>
+            <Caption
+              sx={{
+                whiteSpace: "nowrap",
+                color: "text.secondary",
+                flexShrink: 0
+              }}
+            >
+              Downloads → {downloadTargetLabel}
+            </Caption>
+          </Tooltip>
+        )}
 
         {!isOnboarding && (
           <ScopeToggle

--- a/web/src/components/model_menu/ModelList.tsx
+++ b/web/src/components/model_menu/ModelList.tsx
@@ -10,6 +10,7 @@ import {
   EmptyState,
   Box,
   Text,
+  Caption,
   BORDER_RADIUS,
   SPACING,
   getSpacingPx,
@@ -163,6 +164,11 @@ interface ModelListProps<TModel extends ModelSelectorModel> {
    * star. Omitted for pickers with no per-modality default (e.g. raw HF).
    */
   modelType?: string;
+  /**
+   * Human-readable download destination (worker name or "this computer"),
+   * shown on the download section header and each download button.
+   */
+  downloadTargetLabel?: string;
 }
 
 function ModelList<TModel extends ModelSelectorModel>({
@@ -174,7 +180,8 @@ function ModelList<TModel extends ModelSelectorModel>({
   downloadModels = [],
   onDownloadSelect,
   onDownloadStart,
-  modelType
+  modelType,
+  downloadTargetLabel
 }: ModelListProps<TModel>) {
   const isFavorite = useModelPreferencesStore((s) => s.isFavorite);
   const getAvailability = useModelAvailability();
@@ -403,6 +410,7 @@ function ModelList<TModel extends ModelSelectorModel>({
           <div style={style}>
             <FlexRow
               align="flex-end"
+              justify="space-between"
               sx={{
                 px: 1.5,
                 pt: 1.5,
@@ -421,6 +429,21 @@ function ModelList<TModel extends ModelSelectorModel>({
               >
                 Available to download
               </Text>
+              {downloadTargetLabel && (
+                <Tooltip
+                  title={`Downloads land on ${downloadTargetLabel} — where models run in this session.`}
+                >
+                  <Caption
+                    sx={{
+                      fontSize: "var(--fontSizeSmaller)",
+                      color: "text.secondary",
+                      whiteSpace: "nowrap"
+                    }}
+                  >
+                    → {downloadTargetLabel}
+                  </Caption>
+                </Tooltip>
+              )}
             </FlexRow>
           </div>
         );
@@ -432,11 +455,12 @@ function ModelList<TModel extends ModelSelectorModel>({
           checking={row.model.checking}
           onSelect={() => onDownloadSelect?.(row.model)}
           onDownload={() => onDownloadStart?.(row.model)}
+          targetLabel={downloadTargetLabel}
           style={style}
         />
       );
     },
-    [flatRows, renderRow, onDownloadSelect, onDownloadStart]
+    [flatRows, renderRow, onDownloadSelect, onDownloadStart, downloadTargetLabel]
   );
 
   return (

--- a/web/src/components/model_menu/shared/ModelMenuDialogBase.tsx
+++ b/web/src/components/model_menu/shared/ModelMenuDialogBase.tsx
@@ -34,6 +34,8 @@ import type { DownloadableModel } from "../ModelList";
 import ModelPackCard from "../../hugging_face/ModelPackCard";
 import { useModelDownloadStore } from "../../../stores/ModelDownloadStore";
 import { useHfCacheStatusStore } from "../../../stores/HfCacheStatusStore";
+import { useWorkerCachedModelIds } from "../../../hooks/useWorkerCachedModels";
+import { useModelDownloadTarget } from "../../../hooks/useModelDownloadTarget";
 import {
   buildHfCacheRequest,
   canCheckHfCache,
@@ -195,6 +197,12 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
   const cachePending = useHfCacheStatusStore((s) => s.pending);
   const cacheVersion = useHfCacheStatusStore((s) => s.version);
   const ensureStatuses = useHfCacheStatusStore((s) => s.ensureStatuses);
+  // Downloads land where execution happens: on the attached worker when one
+  // is connected, otherwise this machine. The worker's cache is also the
+  // authoritative "already downloaded" source while it is attached.
+  const { scope: downloadScope, label: downloadTargetLabel } =
+    useModelDownloadTarget();
+  const workerCachedIds = useWorkerCachedModelIds();
 
   // A fresh `[]` fallback would re-key every memo in useModelMenuData.
   const {
@@ -269,10 +277,11 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
         model.type ?? "",
         model.path ?? undefined,
         model.path ? undefined : (model.allow_patterns ?? undefined),
-        model.path ? undefined : (model.ignore_patterns ?? undefined)
+        model.path ? undefined : (model.ignore_patterns ?? undefined),
+        downloadScope
       );
     },
-    [startDownload]
+    [startDownload, downloadScope]
   );
 
   // Recommended models that can be downloaded, folded into the main list under
@@ -316,16 +325,22 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
   const downloadModels = useMemo<DownloadableModel[]>(() => {
     return downloadCandidates.map((m) => {
       const key = getHfCacheKey(m);
+      // With a worker attached, its cache is where the model is needed; a
+      // repo cached there counts as downloaded even when this machine's
+      // local cache check says otherwise.
+      const inWorkerCache = workerCachedIds.has(key);
       const downloaded =
         m.downloaded === true ||
         m.type === "llama_model" ||
-        !!cacheStatuses[key];
+        !!cacheStatuses[key] ||
+        inWorkerCache;
       const checking =
+        !inWorkerCache &&
         canCheckHfCache(m) &&
         (cachePending[key] || cacheStatuses[key] === undefined);
       return { ...m, downloaded, checking };
     });
-  }, [downloadCandidates, cacheStatuses, cachePending]);
+  }, [downloadCandidates, cacheStatuses, cachePending, workerCachedIds]);
 
   const handleDownloadAllFromPack = useCallback(
     (packModels: UnifiedModel[]) => {
@@ -558,6 +573,7 @@ function ModelMenuDialogBase<TModel extends ModelSelectorModel>({
           onDownloadSelect={handleSelectRecommended}
           onDownloadStart={handleStartDownload}
           modelType={modelType}
+          downloadTargetLabel={downloadTargetLabel}
         />
       </Box>
     </FlexColumn>

--- a/web/src/components/model_menu/shared/RecommendedDownloadRow.tsx
+++ b/web/src/components/model_menu/shared/RecommendedDownloadRow.tsx
@@ -21,6 +21,8 @@ interface RecommendedDownloadRowProps {
   checking: boolean;
   onSelect: () => void;
   onDownload: () => void;
+  /** Human-readable download destination, shown on the Download button. */
+  targetLabel?: string;
   style?: React.CSSProperties;
 }
 
@@ -36,6 +38,7 @@ const RecommendedDownloadRow: React.FC<RecommendedDownloadRowProps> = ({
   checking,
   onSelect,
   onDownload,
+  targetLabel,
   style
 }) => {
   const theme = useTheme();
@@ -164,14 +167,22 @@ const RecommendedDownloadRow: React.FC<RecommendedDownloadRowProps> = ({
             </EditorButton>
           </Tooltip>
         ) : (
-          <EditorButton
-            variant="outlined"
-            onClick={handleDownloadClick}
-            startIcon={<DownloadIcon sx={{ fontSize: "1.1em" }} />}
-            sx={{ flexShrink: 0 }}
+          <Tooltip
+            title={
+              model.size_on_disk
+                ? `Download ${formatBytes(model.size_on_disk)} to ${targetLabel ?? "this computer"}`
+                : `Downloads to ${targetLabel ?? "this computer"}`
+            }
           >
-            Download
-          </EditorButton>
+            <EditorButton
+              variant="outlined"
+              onClick={handleDownloadClick}
+              startIcon={<DownloadIcon sx={{ fontSize: "1.1em" }} />}
+              sx={{ flexShrink: 0 }}
+            >
+              Download
+            </EditorButton>
+          </Tooltip>
         )}
       </FlexRow>
     </div>

--- a/web/src/hooks/useModelDownloadTarget.ts
+++ b/web/src/hooks/useModelDownloadTarget.ts
@@ -1,0 +1,29 @@
+import { useMemo } from "react";
+import { useWorkers } from "./useWorkers";
+import type { ModelScope } from "../stores/ModelManagerStore";
+
+export interface ModelDownloadTarget {
+  /** Where a model download must land for execution to see it. */
+  scope: ModelScope;
+  /** Human-readable destination: the worker's profile name or "this computer". */
+  label: string;
+}
+
+/**
+ * Resolve where model downloads currently land. With an attached worker,
+ * nodes execute there, so models are needed on the worker volume — the same
+ * rule the Model Manager applies to its downloads.
+ */
+export const useModelDownloadTarget = (): ModelDownloadTarget => {
+  const { activeWorker } = useWorkers();
+
+  return useMemo(
+    () => ({
+      scope: activeWorker ? "worker" : "local",
+      label: activeWorker
+        ? (activeWorker.profile_name ?? activeWorker.id)
+        : "this computer"
+    }),
+    [activeWorker]
+  );
+};

--- a/web/src/stores/ModelDownloadStore.ts
+++ b/web/src/stores/ModelDownloadStore.ts
@@ -112,7 +112,19 @@ interface ModelDownloadStore {
     ignorePatterns?: string[] | null,
     scope?: ModelScope
   ) => void;
-  cancelDownload: (id: string) => void;
+  /**
+   * Ask the server to cancel a download. Resolves `true` when the cancel
+   * reached the server (or aborted a local controller), `false` when only a
+   * local "cancelled" mark was possible.
+   */
+  cancelDownload: (id: string) => Promise<boolean>;
+  /**
+   * Cancel and, when the cancel reached the server, drop the row entirely —
+   * the inline dialog row returns to its pre-download state instead of
+   * lingering as a cancelled entry. Keeps the entry on failure so the user
+   * can see the download is still out of reach.
+   */
+  cancelAndRemoveDownload: (id: string) => Promise<boolean>;
   isDialogOpen: boolean;
   openDialog: () => void;
   closeDialog: () => void;
@@ -296,6 +308,12 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
             for (const key of MODEL_CACHE_KEYS) {
               queryClient?.invalidateQueries({ queryKey: [key] });
             }
+            // A worker-scoped download lands on the worker's volume; refresh
+            // the worker cache list (prefix key matches every worker id) so
+            // rows flip from "Download" to selectable immediately.
+            queryClient?.invalidateQueries({
+              queryKey: ["worker-cached-models"]
+            });
             useHfCacheStatusStore.getState().invalidate([id]);
           }
         } else if (data?.status === "error") {
@@ -508,13 +526,14 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
     if (download?.abortController) {
       download.abortController.abort();
       get().updateDownload(id, { status: "cancelled" });
-      return;
+      return true;
     }
 
     try {
       const ws = await get().connectWebSocket();
       ws.send(JSON.stringify({ command: "cancel_download", id: id }));
       get().updateDownload(id, { status: "cancelled" });
+      return true;
     } catch (error) {
       console.error(
         "[ModelDownloadStore] Failed to connect for cancel:",
@@ -527,7 +546,19 @@ export const useModelDownloadStore = create<ModelDownloadStore>((set, get) => ({
         status: "cancelled",
         message: "Could not reach server to cancel; download may still be running on server."
       });
+      return false;
     }
+  },
+
+  cancelAndRemoveDownload: async (id) => {
+    const reachedServer = await get().cancelDownload(id);
+    if (reachedServer) {
+      // Remove only after cancelDownload settled: its updateDownload would
+      // otherwise re-create the entry (updateDownload bootstraps missing
+      // rows), and the next progress frame would resurrect the row.
+      get().removeDownload(id);
+    }
+    return reachedServer;
   },
 
   isDialogOpen: false,

--- a/web/src/stores/__tests__/ModelDownloadStore.test.ts
+++ b/web/src/stores/__tests__/ModelDownloadStore.test.ts
@@ -35,6 +35,7 @@ beforeEach(() => {
       removeDownload: originalDownloadState.removeDownload,
       startDownload: originalDownloadState.startDownload,
       cancelDownload: originalDownloadState.cancelDownload,
+      cancelAndRemoveDownload: originalDownloadState.cancelAndRemoveDownload,
       openDialog: originalDownloadState.openDialog,
       closeDialog: originalDownloadState.closeDialog
     },
@@ -226,8 +227,94 @@ describe("ModelDownloadStore", () => {
       expect(invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["tts-models"]
       });
+      // A worker-scoped download lands on the worker volume; the worker
+      // cache list (prefix key, any worker id) must refresh too.
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["worker-cached-models"]
+      });
     } finally {
       global.WebSocket = originalWebSocket;
     }
+  });
+
+  describe("cancelDownload", () => {
+    test("returns true and marks cancelled when the server is reachable", async () => {
+      const sendMock = jest.fn();
+      const mockWs = stub<WebSocket>({
+        send: sendMock,
+        readyState: WebSocket.OPEN
+      });
+      useModelDownloadStore.setState(
+        { connectWebSocket: jest.fn().mockResolvedValue(mockWs) },
+        false
+      );
+      useModelDownloadStore.getState().addDownload("org/m");
+
+      await expect(
+        useModelDownloadStore.getState().cancelDownload("org/m")
+      ).resolves.toBe(true);
+
+      expect(sendMock).toHaveBeenCalledWith(
+        JSON.stringify({ command: "cancel_download", id: "org/m" })
+      );
+      expect(
+        useModelDownloadStore.getState().downloads["org/m"]?.status
+      ).toBe("cancelled");
+    });
+
+    test("returns false and keeps the row when the server is unreachable", async () => {
+      useModelDownloadStore.setState(
+        { connectWebSocket: jest.fn().mockRejectedValue(new Error("down")) },
+        false
+      );
+      useModelDownloadStore.getState().addDownload("org/m");
+
+      await expect(
+        useModelDownloadStore.getState().cancelDownload("org/m")
+      ).resolves.toBe(false);
+
+      const download = useModelDownloadStore.getState().downloads["org/m"];
+      expect(download?.status).toBe("cancelled");
+      expect(download?.message).toMatch(/Could not reach server/);
+    });
+  });
+
+  describe("cancelAndRemoveDownload", () => {
+    test("removes the entry after a successful cancel", async () => {
+      const mockWs = stub<WebSocket>({
+        send: jest.fn(),
+        readyState: WebSocket.OPEN
+      });
+      useModelDownloadStore.setState(
+        { connectWebSocket: jest.fn().mockResolvedValue(mockWs) },
+        false
+      );
+      useModelDownloadStore.getState().addDownload("org/m");
+
+      await expect(
+        useModelDownloadStore.getState().cancelAndRemoveDownload("org/m")
+      ).resolves.toBe(true);
+
+      expect(
+        useModelDownloadStore.getState().downloads["org/m"]
+      ).toBeUndefined();
+    });
+
+    test("keeps the cancelled entry when cancel fails", async () => {
+      useModelDownloadStore.setState(
+        { connectWebSocket: jest.fn().mockRejectedValue(new Error("down")) },
+        false
+      );
+      useModelDownloadStore.getState().addDownload("org/m");
+
+      await expect(
+        useModelDownloadStore.getState().cancelAndRemoveDownload("org/m")
+      ).resolves.toBe(false);
+
+      // The download is still out there; dropping the row would hide it.
+      expect(
+        useModelDownloadStore.getState().downloads["org/m"]?.status
+      ).toBe("cancelled");
+    });
   });
 });


### PR DESCRIPTION
## Problem

Two failures in the model select dialog, one small and one structural:

1. **Downloads could not be cancelled from the dialog.** The inline progress row (`DownloadProgress minimal`) renders only a bar and a label — the cancel button exists only in the Download Manager card. An accidental multi-GB download could not be stopped where it was started.
2. **The dialog ignored worker attachment.** With a worker attached, nodes execute on the worker volume, but the dialog always downloaded to `scope: "local"` and checked only the local FS cache for "already downloaded". Models sitting on the worker showed as downloadable; new downloads landed where execution would never see them.

## Changes

**Cancel**
- `DownloadProgress` minimal variant shows an × while the download is pending/running (web/src/components/hugging_face/DownloadProgress.tsx).
- New store action `cancelAndRemoveDownload` cancels and drops the row only when the cancel reached the server; on failure the row stays visible as Cancelled rather than hiding a still-running download. `cancelDownload` now returns success. The Download Manager card keeps its current behavior: cancel keeps the entry so its state stays readable.

**Worker-aware scope**
- Dialog downloads follow the Model Manager rule: land on the attached worker when one is connected, otherwise this machine. New `useModelDownloadTarget` hook centralizes that rule.
- The worker's cache list (`useWorkerCachedModelIds`) counts toward "downloaded", replacing an ad-hoc patch that existed only in the HuggingFace wrapper dialog — every modality picker now gets it via the shared base.
- A completed download invalidates the `worker-cached-models` query so rows flip to selectable immediately.

**Target + size indication**
- Dialog download buttons read "Download 3.1 GB to <worker>"; the section header shows "→ <target>".
- Model pack "Download All" carries the same tooltip with the pack total.
- Model Manager header shows "Downloads → <worker>" while a worker is attached — the Local/Worker toggle changes what you browse, not where downloads land, and that distinction was previously invisible outside an empty-state banner.

No backend changes: `/ws/download` already routes `start_download` by `scope` and `cancel_download` to local, TJS, or worker downloads.

## Verification

- `web` typecheck and lint pass.
- 3,268 web tests pass, including 5 new: cancel returns/dismisses semantics in `ModelDownloadStore.test.ts` (success + unreachable-server branch), worker-cache invalidation on completion, and the minimal-row cancel affordance in `DownloadProgress.minimal.test.tsx`.
- Backend suites unaffected; `@nodetool-ai/websocket` (2,432) and `@nodetool-ai/agents` (3,398) pass in isolation.