### PR TITLE
fix(agents): close authored-workflow failure modes end to end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1247,7 +1247,9 @@ could not be reached, and a catalog only enumerable over the network (Anthropic,
 Ollama, ASR ids anywhere) reports nothing rather than calling a real id a typo.
 The check runs at graph *creation* time too — `validate_workflow` sits on the
 authoring agent's belt, `create_workflow` refuses to save a graph whose
-provider or model the model hallucinated — and
+provider or model the model hallucinated, and one whose model properties are
+left unselected (nothing stamps models in at run time, so every Agent node
+would die on "Select a model") — and
 `POST /api/workflows/:id/run|debug` refuses the run with a
 400 before the job row exists, instead of failing on the model node after the
 upstream half of the graph has been paid for. The same refusal covers

--- a/packages/agents/src/capabilities/jobs.specs.ts
+++ b/packages/agents/src/capabilities/jobs.specs.ts
@@ -74,7 +74,9 @@ export const getJobSpec: CapabilitySpec = {
 
 export const getJobLogsSpec: CapabilitySpec = {
   name: "get_job_logs",
-  description: "Get logs for a job to debug workflow executions.",
+  description:
+    "Get logs for a job to debug workflow executions. Answers the log tail " +
+    "even when the job failed; its failure message is under `job_error`.",
   inputSchema: GET_JOB_LOGS_SCHEMA,
   category: "read",
   userMessage: (params) => `Getting logs for job ${params["job_id"]}`

--- a/packages/agents/src/capabilities/jobs.ts
+++ b/packages/agents/src/capabilities/jobs.ts
@@ -60,7 +60,12 @@ const getJob: CapabilityExport = {
     const jobId = String(params["job_id"]);
     const job = await Job.find(userIdOf(run.context), jobId);
     if (!job) return { error: `Job ${jobId} was not found.` };
-    return { ...jobRecord(job), params: job.params ?? null };
+    const record = jobRecord(job);
+    // The job's own failure message is payload, not a tool failure — a bare
+    // `error` string at the result root makes the CodeAct bridge throw and
+    // discard everything else on a failed job.
+    const { error, ...rest } = record;
+    return { ...rest, job_error: error ?? null, params: job.params ?? null };
   }
 };
 
@@ -75,10 +80,12 @@ const getJobLogs: CapabilityExport = {
     // failure. Previously it was forwarded to an endpoint that ignored it.
     const limit = Number(params["limit"] ?? 200);
     const logs = job.logs ?? [];
+    // `job_error`, not `error`: the call succeeded even when the job did not,
+    // and a root-level `error` string reads as a tool failure downstream.
     return {
       job_id: job.id,
       status: job.status,
-      error: job.error_message ?? job.error ?? null,
+      job_error: job.error_message ?? job.error ?? null,
       total_logs: logs.length,
       logs: logs.slice(Math.max(0, logs.length - limit))
     };

--- a/packages/agents/src/capabilities/workflows.ts
+++ b/packages/agents/src/capabilities/workflows.ts
@@ -36,6 +36,7 @@ import {
   outcomeResult,
   resolveRunEnvironment,
   summarizeWorkflowGraph,
+  unsetModelSelectionError,
   userIdOf,
   workflowRecord
 } from "../tools/mcp-tool-support.js";
@@ -183,6 +184,10 @@ const createWorkflow: CapabilityExport = {
       run.modelCatalogs ?? RUNTIME_MODEL_CATALOGS
     );
     if (badModels) return badModels;
+    if (run.nodeRegistry) {
+      const unselected = unsetModelSelectionError(graph, run.nodeRegistry);
+      if (unselected) return unselected;
+    }
 
     const created = (await Workflow.create({
       user_id: userIdOf(run.context),
@@ -242,6 +247,10 @@ const updateWorkflow: CapabilityExport = {
         run.modelCatalogs ?? RUNTIME_MODEL_CATALOGS
       );
       if (badModels) return badModels;
+      if (run.nodeRegistry) {
+        const unselected = unsetModelSelectionError(graph, run.nodeRegistry);
+        if (unselected) return unselected;
+      }
       fields.graph = graph;
     }
     if (isString(params["name"])) fields.name = params["name"];

--- a/packages/agents/src/codeact/graph-dsl-package.ts
+++ b/packages/agents/src/codeact/graph-dsl-package.ts
@@ -107,4 +107,6 @@ capability modules. Both forms reach one implementation past one gate.
   gets them from \`nodetool.workflows.run(saved.id, params)\`; a workflow id on
   its own answers a question they did not ask.
 - \`nodetool.workflows.debug(id, params)\` reports per-node status when a run
-  fails and the graph looks right.`;
+  fails and the graph looks right. It answers \`{workflow_id, run, job,
+  workflow}\`: read \`run.status\`, \`run.outputs\` (keyed by output name; each
+  name holds an array of emitted values) and \`run.verdict.issues\`.`;

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -608,10 +608,26 @@ const nodetool = (() => {
         __need("debug_workflow")(
           __merge(opts, { workflow_id: id, params: params || {} })
         ),
-      validate: (target) =>
-        typeof target === "string"
+      async validate(target) {
+        const report = await (typeof target === "string"
           ? __need("validate_workflow")({ workflow_id: target })
-          : __need("validate_workflow")({ graph: __graphJson(target) }),
+          : __need("validate_workflow")({ graph: __graphJson(target) }));
+        // A report with errors is a refusal, not data: throw so a caller
+        // that forgets to check report.ok cannot carry a broken graph into a
+        // paid run.
+        if (report && report.ok === false && Array.isArray(report.issues)) {
+          const messages = report.issues
+            .map(function (i) {
+              return i && i.message;
+            })
+            .filter(Boolean);
+          throw new Error(
+            "Graph validation failed:\\n- " +
+              messages.slice(0, 8).join("\\n- ")
+          );
+        }
+        return report;
+      },
       /**
        * Answer an escalation from an interactive run/debug. Action is one of
        * the escalation's allowedActions; pass {outputs} with "substitute",
@@ -1182,7 +1198,12 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   \`create(name, graph, {description, tags})\`, \`versions(id)\`, \`getVersion(id, n)\`,
   \`snapshot(id, {name})\`, \`restore(id, n)\`, \`deleteVersion(id, n)\`,
   \`open(id?)\` (the editable object
-  model — see the graph-editing section). An interactive run returns an
+  model — see the graph-editing section). \`validate\` answers
+  \`{ok, issues}\` and throws when the graph has errors. \`debug\` runs the
+  workflow and answers one report: \`{workflow_id, run, job, workflow}\` where
+  \`run\` carries \`{status, outputs, error, verdict}\`, \`job\` carries status,
+  cost and logs, and \`outputs\` is keyed by output name with an array of
+  emitted values per name (\`outputs.hook[0]\`). An interactive run returns an
   escalation: answer it with \`resolve(sessionId, escalationId, action,
   {outputs, reason, apply_to})\` — retry/substitute/skip/end_stream/fail — and
   get the next escalation or the final report. Write the whole

--- a/packages/agents/src/evals/codeact-api-core.ts
+++ b/packages/agents/src/evals/codeact-api-core.ts
@@ -395,10 +395,11 @@ class CoreWorld {
   }
 }
 
+/** Same shape the real `validate_workflow` answers: {ok, counts, issues}. */
 interface ValidationReport {
-  valid: boolean;
-  errors: string[];
-  warnings: string[];
+  ok: boolean;
+  counts: { errors: number; warnings: number; info: number };
+  issues: Array<{ severity: string; message: string }>;
 }
 
 function validateGraph(graph: WorldGraph): ValidationReport {
@@ -450,7 +451,15 @@ function validateGraph(graph: WorldGraph): ValidationReport {
   if (!graph.nodes.some((n) => n.type === "nodetool.output.Output")) {
     warnings.push("Graph has no output node, so a run reports nothing.");
   }
-  return { valid: errors.length === 0, errors, warnings };
+  const issues = [
+    ...errors.map((message) => ({ severity: "error", message })),
+    ...warnings.map((message) => ({ severity: "warning", message }))
+  ];
+  return {
+    ok: errors.length === 0,
+    counts: { errors: errors.length, warnings: warnings.length, info: 0 },
+    issues
+  };
 }
 
 /** Evaluate the graph. `skipNodeId` yields "" for that node (escalation skip). */
@@ -645,9 +654,11 @@ export function createCoreApiTools(recorder: CodeActToolRecorder): Tool[] {
       (params) => {
         const graph = toGraph(params["graph"]);
         const check = validateGraph(graph);
-        if (!check.valid) {
+        if (!check.ok) {
           throw new Error(
-            `Refusing to save an invalid graph: ${check.errors.join("; ")}`
+            `Refusing to save an invalid graph: ${check.issues
+              .map((i) => i.message)
+              .join("; ")}`
           );
         }
         const id = world.id("wf");

--- a/packages/agents/src/tools/mcp-tool-support.ts
+++ b/packages/agents/src/tools/mcp-tool-support.ts
@@ -373,7 +373,9 @@ export const RUNTIME_MODEL_CATALOGS: ModelCatalogs = {
  * registered. This is the cheap half of `validateGraph` — a property walk, no
  * registry metadata — so a creation tool can afford it on every call.
  *
- * Returns null when every selection resolves.
+ * Returns null when every selection resolves. Unselected models are checked
+ * separately by {@link unsetModelSelectionError}, which needs registry
+ * metadata this walk deliberately avoids.
  */
 export async function modelSelectionError(
   graph: unknown,
@@ -398,6 +400,88 @@ export async function modelSelectionError(
       node_type: issue.nodeType,
       message: issue.message
     }))
+  };
+}
+
+/**
+ * Refuse a graph whose nodes leave a declared model property unselected.
+ *
+ * The cheap selection walk above reads only the property bag; an agent that
+ * omits `model` entirely (as the DSL does) stores nothing to find, and full
+ * graph validation never runs on the create path. Without this gate such a
+ * workflow saves fine and every Agent node dies on "Select a model" at run
+ * time — after the upstream half of the graph executed and was paid for.
+ *
+ * Reuses `registry.validateNode`'s own `unset_model` finding (which skips
+ * edge-connected properties) so both surfaces report one thing.
+ */
+export function unsetModelSelectionError(
+  graph: unknown,
+  nodeRegistry: {
+    has: (type: string) => boolean;
+    validateNode: (
+      descriptor: { id: string; type: string; properties: Record<string, unknown> },
+      connectedHandles: ReadonlySet<string>
+    ) => Array<{ code?: string; message: string }>;
+  }
+): Record<string, unknown> | null {
+  if (!isObjectLike(graph)) return null;
+  const record = graph as { nodes?: unknown; edges?: unknown };
+  const nodes = Array.isArray(record.nodes) ? record.nodes : [];
+  if (nodes.length === 0) return null;
+
+  // Property names fed by an incoming data edge are supplied at run time;
+  // their stored defaults are not what executes.
+  const connected = new Map<string, Set<string>>();
+  for (const raw of Array.isArray(record.edges) ? record.edges : []) {
+    if (!isObjectLike(raw)) continue;
+    const edge = raw as Record<string, unknown>;
+    if (edge["edge_type"] === "control" || edge["type"] === "control") continue;
+    const target = String(edge["target"] ?? "");
+    const handle = String(
+      edge["targetHandle"] ?? edge["target_handle"] ?? ""
+    );
+    if (!target || !handle) continue;
+    let handles = connected.get(target);
+    if (!handles) {
+      handles = new Set<string>();
+      connected.set(target, handles);
+    }
+    handles.add(handle);
+  }
+
+  const issues: Array<Record<string, unknown>> = [];
+  for (const node of nodes) {
+    if (!isObjectLike(node)) continue;
+    const n = node as Record<string, unknown>;
+    const type = String(n["type"] ?? "");
+    const id = String(n["id"] ?? "");
+    if (!type || !nodeRegistry.has(type)) continue;
+    const properties = isObjectLike(n["properties"])
+      ? (n["properties"] as Record<string, unknown>)
+      : {};
+    for (const issue of nodeRegistry.validateNode(
+      { id, type, properties },
+      connected.get(id) ?? new Set<string>()
+    )) {
+      if (issue.code !== "unset_model") continue;
+      issues.push({
+        code: "unset_model",
+        node_id: id,
+        node_type: type,
+        message:
+          `${issue.message} Pick a model with find_model and assign its ` +
+          "`ref` before saving."
+      });
+    }
+  }
+  if (issues.length === 0) return null;
+  return {
+    error:
+      "The graph leaves one or more model properties unselected. Every " +
+      "model node needs a selected model at save time — nothing stamps one " +
+      "in at run time.",
+    issues
   };
 }
 

--- a/packages/agents/tests/codeact-api-core.test.ts
+++ b/packages/agents/tests/codeact-api-core.test.ts
@@ -72,7 +72,8 @@ const SOLUTIONS: Record<string, string[]> = {
        output({ name: "greeting", value: joined.output() })
      );
      const check = await nodetool.workflows.validate(graph);
-     if (!check.valid) throw new Error(JSON.stringify(check.errors));
+     if (!check.ok)
+       throw new Error(check.issues.map((i) => i.message).join("; "));
      const saved = await nodetool.workflows.create("Greeter", graph);
      const run = await nodetool.workflows.run(saved.id, { name: "Ada" });
      await finish({ greeting: run.outputs.greeting });`

--- a/packages/agents/tests/dsl-workflow-authoring.test.ts
+++ b/packages/agents/tests/dsl-workflow-authoring.test.ts
@@ -453,22 +453,17 @@ describe("running an authored graph on the kernel", () => {
     };
     expect(run.error).toBeNull();
     expect(run.status).toBe("completed");
-    // The value is what the program computes. The key is not the name the
-    // program gave it — see the defect pinned below.
     expect(Object.values(run.outputs)).toEqual([["HELLO!"]]);
   }, 60_000);
 
   /**
-   * OPEN DEFECT. The kernel keys a workflow output by the output node's
-   * descriptor `name` (`node.name ?? node.id`), which shipped example graphs
-   * carry beside `type`. The DSL pack's `workflow()` emits `name` only inside
-   * `properties`, so an authored graph's outputs come back under the
-   * auto-generated node id. An agent that writes `output({name: "loud"})` and
-   * then reads `run.outputs.loud` finds nothing. Flip this to `loud` when
-   * `workflow()` lifts the property onto the descriptor (or the runner reads
-   * `properties.name`).
+   * The kernel keys a workflow output by the output node's descriptor `name`
+   * (`node.name ?? node.id`), which shipped example graphs carry beside
+   * `type`. The DSL pack's `workflow()` emits `name` only inside
+   * `properties`, so the runner promotes the property for `nodetool.output.*`
+   * sinks and an authored graph's outputs come back under the declared name.
    */
-  it("returns the output under the node id, not the declared name", async () => {
+  it("returns the output under the declared name, not the node id", async () => {
     const outcome = await action(
       `import { create_workflow, run_workflow } from "${WORKFLOWS}";
        ${SHOUT_PROGRAM.replace("return workflow(out);", "const graph = workflow(out);")}
@@ -478,7 +473,7 @@ describe("running an authored graph on the kernel", () => {
     );
     expect(outcome.error).toBeUndefined();
     expect((outcome.result as { outputs: unknown }).outputs).toEqual({
-      output: ["HELLO!"]
+      loud: ["HELLO!"]
     });
   }, 60_000);
 

--- a/packages/agents/tests/mcp-tools.test.ts
+++ b/packages/agents/tests/mcp-tools.test.ts
@@ -267,6 +267,69 @@ describe("create_workflow", () => {
     });
   });
 
+  // A graph whose model properties are left at the default saves fine and
+  // then every Agent node dies on "Select a model" at run time — after the
+  // upstream half of the graph executed. Nothing stamps models in later.
+  describe("unset model preflight", () => {
+    const modelRegistry = {
+      has: (type: string) => type === "nodetool.agents.Agent",
+      getMetadata: () => undefined,
+      resolveMetadata: () => undefined,
+      validateNode: (
+        _descriptor: unknown,
+        connectedHandles: ReadonlySet<string>
+      ) =>
+        connectedHandles.has("model")
+          ? []
+          : [
+              {
+                code: "unset_model",
+                property: "model",
+                message:
+                  'Property "model" requires a language_model to be selected'
+              }
+            ]
+    } as unknown as NodeRegistry;
+    const checked = capTool("create_workflow", { nodeRegistry: modelRegistry });
+    const graphWithAgent = (edges: unknown[] = []) => ({
+      nodes: [
+        { id: "a1", type: "nodetool.agents.Agent", properties: {} },
+        { id: "src", type: "nodetool.input.StringInput", properties: {} }
+      ],
+      edges
+    });
+
+    it("refuses a workflow whose agent node has no model selected", async () => {
+      const result = (await checked.process(ctx, {
+        name: "WF",
+        graph: graphWithAgent()
+      })) as { error: string; issues: Array<{ code: string; node_id: string }> };
+
+      expect(result.error).toContain("unselected");
+      expect(result.issues[0]?.code).toBe("unset_model");
+      expect(result.issues[0]?.node_id).toBe("a1");
+      const [saved] = await Workflow.paginate(USER, {});
+      expect(saved).toHaveLength(0);
+    });
+
+    it("allows a model property fed by an edge", async () => {
+      const result = (await checked.process(ctx, {
+        name: "WF",
+        graph: graphWithAgent([
+          {
+            id: "e1",
+            source: "src",
+            sourceHandle: "output",
+            target: "a1",
+            targetHandle: "model"
+          }
+        ])
+      })) as Record<string, unknown>;
+      expect(result.id).toEqual(expect.any(String));
+      expect(await Workflow.find(USER, String(result.id))).not.toBeNull();
+    });
+  });
+
   it("persists the workflow under the calling user", async () => {
     const result = (await tool.process(ctx, {
       name: "Test WF",

--- a/packages/agents/tests/mcp-tools.test.ts
+++ b/packages/agents/tests/mcp-tools.test.ts
@@ -1277,6 +1277,25 @@ describe("get_job", () => {
     expect(result.status).toBe("completed");
   });
 
+  // A failed job's own failure message is payload, not a tool failure: a bare
+  // `error` string at the root made the CodeAct bridge throw and discard the
+  // rest of the record.
+  it("carries a failed job's message under job_error, not error", async () => {
+    const job = (await Job.create({
+      workflow_id: "wf-1",
+      user_id: USER,
+      status: "failed",
+      error: "Node \"x\" failed: boom"
+    })) as Job;
+    const result = (await tool.process(ctx, { job_id: job.id })) as Record<
+      string,
+      unknown
+    >;
+    expect(result["status"]).toBe("failed");
+    expect(result["job_error"]).toBe('Node "x" failed: boom');
+    expect(Object.prototype.hasOwnProperty.call(result, "error")).toBe(false);
+  });
+
   it("reports a job that is not the caller's", async () => {
     const result = (await tool.process(ctx, {
       job_id: "job-123"
@@ -1307,6 +1326,26 @@ describe("get_job_logs", () => {
         logs: [{ message: "two" }, { message: "three" }]
       }
     );
+  });
+
+  // The call succeeded even though the job did not — a root-level `error`
+  // string made every failed job's logs unreadable through the sandbox bridge.
+  it("answers a failed job's logs with the failure under job_error", async () => {
+    const job = (await Job.create({
+      workflow_id: "wf-1",
+      user_id: USER,
+      status: "failed",
+      error: "AtlasCloud job failed: request body field <image> is required",
+      logs: [{ message: "submitting" }]
+    })) as Job;
+    const result = (await tool.process(ctx, { job_id: job.id })) as Record<
+      string,
+      unknown
+    >;
+    expect(result["status"]).toBe("failed");
+    expect(result["job_error"]).toContain("AtlasCloud");
+    expect(result["logs"]).toEqual([{ message: "submitting" }]);
+    expect(Object.prototype.hasOwnProperty.call(result, "error")).toBe(false);
   });
 
   it("userMessage includes job_id", () => {

--- a/packages/kernel/src/runner.ts
+++ b/packages/kernel/src/runner.ts
@@ -1585,7 +1585,7 @@ export class WorkflowRunner {
 
             // If this is an output node, collect the result
             if (this._isOutputNode(node)) {
-              const name = node.name ?? node.id;
+              const name = this._outputCollectionKey(node);
               if (!this._outputs.has(name)) {
                 this._outputs.set(name, []);
               }
@@ -2431,6 +2431,30 @@ export class WorkflowRunner {
       return propertyName;
     }
     return node.name ?? node.id;
+  }
+
+  /**
+   * Key a terminal node's outputs are collected under.
+   *
+   * DSL-authored graphs carry the public name in the Output node's `name`
+   * *property* (`output({ name: "hook", value })`) — the descriptor's
+   * top-level `name` is absent, and the auto-generated node id (`output`,
+   * `output_2`, …) is all that would remain. Promote the property for
+   * output-typed nodes so a run's outputs are keyed by the name the author
+   * asked for. Mirrors `_getExternalInputName` on the input side and the
+   * websocket runner's `require_terminal_result` rewrite; gating on
+   * `nodetool.output.` keeps other terminal sinks keyed by id.
+   */
+  private _outputCollectionKey(node: NodeDescriptor): string {
+    if (isString(node.name) && node.name.trim()) return node.name;
+    if (node.type.startsWith("nodetool.output.")) {
+      const properties = isObjectValue(node.properties) ? node.properties : {};
+      const propertyName = isString(properties.name)
+        ? properties.name.trim()
+        : "";
+      if (propertyName) return propertyName;
+    }
+    return node.id;
   }
 
   private _emit(msg: ProcessingMessage): void {

--- a/packages/kernel/tests/e2e/runner-lifecycle.test.ts
+++ b/packages/kernel/tests/e2e/runner-lifecycle.test.ts
@@ -264,6 +264,57 @@ describe("RUNNER-015: Output node (sink) captures result in outputs map", () => 
 // RUNNER-016: Multiple output nodes
 // ---------------------------------------------------------------------------
 
+describe("RUNNER-015b: DSL Output nodes are keyed by their name property", () => {
+  // The guest DSL writes the public name into the Output node's `name`
+  // *property*; without promotion a run's outputs were keyed by the
+  // auto-generated node ids (`output`, `output_2`, …) and every named output
+  // read as missing.
+  it("promotes properties.name on nodetool.output.* sinks over the node id", async () => {
+    const registry = makeRegistry();
+    const runner = makeRunner(registry);
+
+    const nodes: NodeDescriptor[] = [
+      inp("src", "val"),
+      nd("output", "nodetool.output.Output", {}, { name: "hook" }),
+      nd("output_2", "nodetool.output.Output", {}, { name: "thread" })
+    ];
+    const edges: Edge[] = [
+      de("src", "value", "output", "value"),
+      de("src", "value", "output_2", "value")
+    ];
+
+    const result = await runner.run(
+      { job_id: "runner-015b", params: { val: 42 } },
+      { nodes, edges }
+    );
+
+    expect(result.status).toBe("completed");
+    expect(result.outputs["hook"]).toContain(42);
+    expect(result.outputs["thread"]).toContain(42);
+    expect(result.outputs["output"]).toBeUndefined();
+    expect(result.outputs["output_2"]).toBeUndefined();
+  });
+
+  it("leaves other terminal sinks keyed by node id", async () => {
+    const registry = makeRegistry();
+    const runner = makeRunner(registry);
+
+    const nodes: NodeDescriptor[] = [
+      inp("src", "val"),
+      nd("sink", Passthrough.nodeType, {}, { name: "result" })
+    ];
+    const edges: Edge[] = [de("src", "value", "sink", "value")];
+
+    const result = await runner.run(
+      { job_id: "runner-015b-id", params: { val: 42 } },
+      { nodes, edges }
+    );
+
+    expect(result.outputs["sink"]).toContain(42);
+    expect(result.outputs["result"]).toBeUndefined();
+  });
+});
+
 describe("RUNNER-016: Multiple output nodes all capture their results", () => {
   it("two sinks both appear in result.outputs", async () => {
     const registry = makeRegistry();

--- a/packages/runtime/src/providers/manifest-models.ts
+++ b/packages/runtime/src/providers/manifest-models.ts
@@ -416,19 +416,23 @@ export function loadVideoModels(
  * Does this entry refuse the call without an input of `kind`?
  *
  * The declaration, not the name: a manifest field marked `required` is the
- * endpoint's own statement that it cannot run without that media. Kie's
- * `uploads` descriptors carry no requiredness, so they answer false and the
- * name-based inference stands.
+ * endpoint's own statement that it cannot run without that media. Read across
+ * both manifest conventions — FAL/Replicate `inputFields` (`propType`) and
+ * AtlasCloud/Kie `fields` (`type`). Kie's `uploads` descriptors carry no
+ * requiredness, so they answer false and the name-based inference stands.
  */
 export function requiresMediaInput(
   n: ManifestNode,
   kind: "image" | "video"
 ): boolean {
+  const required = (t: string, fRequired?: boolean): boolean =>
+    fRequired === true && (t === kind || t === `list[${kind}]`);
   // Stryker disable next-line ArrayDeclaration: an entry with no inputFields declares nothing required either way.
-  return (n.inputFields ?? []).some((f) => {
-    const t = f.propType.toLowerCase();
-    return f.required === true && (t === kind || t === `list[${kind}]`);
-  });
+  if (n.inputFields?.some((f) => required(f.propType.toLowerCase(), f.required))) {
+    return true;
+  }
+  // Stryker disable next-line ArrayDeclaration: same rationale for the fields convention.
+  return n.fields?.some((f) => required(f.type.toLowerCase(), f.required)) ?? false;
 }
 
 /**

--- a/packages/runtime/tests/providers/manifest-models-hardening.test.ts
+++ b/packages/runtime/tests/providers/manifest-models-hardening.test.ts
@@ -371,6 +371,52 @@ describe("narrowTasksByRequiredInputs", () => {
     ).toEqual(["image_to_image"]);
   });
 
+  // AtlasCloud manifests describe inputs under `fields` (`type`, not
+  // `propType`). Blind to that convention, `requiresMediaInput` answered
+  // false for every entry, and edit-only endpoints like
+  // `openai/gpt-image-2/edit` ranked as top text_to_image answers — then
+  // failed at call time with "request body field <image> is required".
+  it("reads requiredness off AtlasCloud/Kie-style fields too", () => {
+    const atlasEdit = {
+      outputType: "image",
+      modelId: "openai/gpt-image-2/edit",
+      fields: [
+        { name: "prompt", type: "str", required: true },
+        { name: "images", type: "list[image]", required: true }
+      ]
+    };
+    expect(requiresMediaInput(atlasEdit, "image")).toBe(true);
+    expect(requiresMediaInput(atlasEdit, "video")).toBe(false);
+    expect(
+      requiresMediaInput(
+        { fields: [{ name: "image", type: "image", required: false }] },
+        "image"
+      )
+    ).toBe(false);
+    expect(
+      narrowTasksByRequiredInputs(
+        ["text_to_image", "image_to_image"],
+        atlasEdit,
+        "image"
+      )
+    ).toEqual(["image_to_image"]);
+  });
+
+  it("an edit-only endpoint stops qualifying as a text_to_image model", () => {
+    const [model] = buildImageModels([
+      {
+        outputType: "image",
+        modelId: "openai/gpt-image-2/edit",
+        fields: [
+          { name: "prompt", type: "str", required: true },
+          { name: "images", type: "list[image]", required: true }
+        ]
+      }
+    ], "atlascloud");
+    expect(model.id).toBe("openai/gpt-image-2/edit");
+    expect(model.supportedTasks).toEqual(["image_to_image"]);
+  });
+
   it("drops text_to_video from a video endpoint that requires an image", () => {
     expect(
       narrowTasksByRequiredInputs(

--- a/packages/sandbox-packs/sandbox-dsl/SKILL.md
+++ b/packages/sandbox-packs/sandbox-dsl/SKILL.md
@@ -45,8 +45,14 @@ import { validate_workflow, create_workflow, run_workflow, debug_workflow }
 const graph = workflow(output({ name: "image", value: smaller.output() }));
 
 const check = await validate_workflow({ graph });
-if (!check.valid) throw new Error(JSON.stringify(check.errors));
+if (!check.ok) throw new Error(check.issues.map((i) => i.message).join("; "));
+```
 
+`validate_workflow` answers `{ok, counts, issues}` — `ok` is false only when
+the graph has errors, and each issue carries `{severity, code, message}`.
+Warnings do not set `ok` false; read them off `issues`.
+
+```js
 const saved = await create_workflow({ name: "Thumbnailer", graph });
 const run = await run_workflow({
   workflow_id: saved.id,
@@ -55,9 +61,16 @@ const run = await run_workflow({
 ```
 
 `run_workflow` answers `{status, outputs}`. When a run fails and the graph looks
-right, `debug_workflow({workflow_id, params})` runs it again and reports a
-per-node status, the logs, and the outputs each node produced — which node
-failed, not just that one did.
+right, `debug_workflow({workflow_id, params})` runs it again and answers one
+report: `{workflow_id, run, job, workflow}`. `run` carries
+`{status, outputs, error, verdict}` — `outputs` is keyed by output name and
+each name holds an array of emitted values (`run.outputs.image[0]`). `job`
+carries status, cost and logs; `verdict.headline` and `verdict.issues` say
+which node failed and why.
+
+Every model property must be selected before you save: assign a `find_model`
+result's `ref` to the node's `model`. A graph saved with unselected models is
+refused by `create_workflow`, because nothing stamps models in at run time.
 
 Where the session mounts no capability modules, the same three verbs are
 `nodetool.workflows.validate/create/run/debug`. Both forms reach one

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1282,12 +1282,16 @@ You author the graph yourself, in an \`execute_code\` action. Drive this loop:
    import — and write the graph in the same action:
    \`workflow(...terminals)\` returns \`{nodes, edges}\`.
 3. \`await nodetool.workflows.validate(graph)\` — costs nothing and catches a
-   missing property, a dangling edge, or a model nobody selected. Fix what it
-   reports before spending anything.
+   missing property, a dangling edge, or a model nobody selected. It throws on
+   errors; fix what it reports before spending anything.
 4. \`await nodetool.workflows.create(name, graph, {description})\` — save it
-   under a clear name. The returned id is what run and debug take.
+   under a clear name. The returned id is what run and debug take. Assign a
+   \`find_model\` ref to every model property first: an unselected model is
+   refused at save time and would fail the run otherwise.
 5. \`await nodetool.workflows.debug(id, params)\` — run it and get final status,
-   outputs, errors, and job logs in one report. \`nodetool.workflows.run(id,
+   outputs, errors, and job logs in one report shaped
+   \`{workflow_id, run, job, workflow}\`; \`run.outputs\` is keyed by output name
+   and each name holds an array of emitted values. \`nodetool.workflows.run(id,
    params)\` is a plain run; \`nodetool.nodes.run(type, inputs)\` probes a single
    suspect node in isolation.
 6. On failure, fix the graph and save again. There is no update call: each fix


### PR DESCRIPTION
## What broke

A live chat session ("build a workflow that will impress AI people on X") hit five platform failure modes in a row: a graph validated green and saved, then every Agent node died on `Select a model` after the upstream half ran; the debug report's shape took three guess-and-inspect rounds to read; `nodetool.jobs.logs()` threw on the failed job instead of returning its logs; `models.pick("text_to_image")` returned an edit-only AtlasCloud route that failed with `request body field <image> is required`; and the workflow's named outputs came back keyed `output_2`/`output_3`.

Each is a code fix; none is agent-prompting.

## Fixes

- **Unselected models pass save, fail at run time.** The cheap model-id walk reads only the property bag — an agent that omits `model` (as the DSL does) stores nothing to find, and nothing stamps models in at kernel run time. New `unsetModelSelectionError` runs the registry's own `unset_model` finding at create/update time and refuses with an error naming `find_model`; edge-connected props are skipped (`packages/agents/src/tools/mcp-tool-support.ts`, `packages/agents/src/capabilities/workflows.ts`). `nodetool.workflows.validate` now throws when the report carries errors, so a caller that misreads `{ok, issues}` cannot carry a broken graph into a paid run (`nodetool-api.ts`).
- **Edit-only image endpoints ranked as text_to_image.** `requiresMediaInput` read only the FAL/Replicate `inputFields[].propType` convention; AtlasCloud manifests declare inputs under `fields[].type`, so all 70 entries passed as generators and `/edit` routes won the alphabetical tie-break. It now reads both conventions, so `narrowTasksByRequiredInputs` strips the generation task before ranking (`packages/runtime/src/providers/manifest-models.ts`).
- **Named outputs lost.** The kernel keyed terminal outputs by `node.name ?? node.id`; DSL-authored graphs carry the name only in `properties.name`. The runner promotes it for `nodetool.output.*` sinks, mirroring the input side and the websocket runner's `require_terminal_result` rewrite (`packages/kernel/src/runner.ts`). One test pinned this exact behavior as an "OPEN DEFECT" — flipped to pin the fix.
- **Failed jobs unreadable through the sandbox.** `get_job_logs`/`get_job` carried the job's failure message as a bare root-level `error` string, which the CodeAct bridge converts into a thrown exception — discarding the logs it explained. Renamed to `job_error` (`packages/agents/src/capabilities/jobs.ts`).
- **Docs taught shapes that do not exist.** SKILL.md said `check.valid`/`check.errors`; the eval world faked `{valid, errors}` instead of the real `{ok, counts, issues}`; debug's `{workflow_id, run, job, workflow}` envelope was documented nowhere. All aligned on what the tools answer (SKILL.md, graph-dsl prompt section, websocket chat prompt, eval world).

Not touched: output values remaining arrays per name (documented contract), and the `flux/schnell` vs `flux-1/schnell` ranking split (both are real fal endpoints; generated-metadata drift).

## Verification

- `npm run test:affected` green across packages, web, and electron (new tests: unset-model refusal + edge-connected allowance, AtlasCloud fields convention, output-name promotion, `job_error` payload)
- `npm run typecheck`, `npm run lint` clean