### PR TITLE
fix(dsl): wire list handles, read saved model shapes, gate stale wiring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1233,7 +1233,9 @@ Checks a workflow against the node registry **without running it** — unknown
 node types, missing required properties, unselected models, model properties
 naming an unregistered provider or a model id that provider does not offer,
 dangling and mis-typed edges, dynamic slots typed with a
-JSON-Schema/TypeScript name instead of NodeTool's (`integer` → `int`), and Code
+JSON-Schema/TypeScript name instead of NodeTool's (`integer` → `int`), DSL
+wiring handles left in a property bag (a connection that was never made), and
+Code
 node bodies. On a DB-id target, where the store is reachable, it also warns
 about declared credentials (`required_settings`, a Code node's `secrets`) this
 install cannot resolve. Returns in well under a second, so it's the cheap

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -255,7 +255,8 @@ from inside an agent:
 - **`validate_workflow`** — static check of an inline `graph` ({nodes, edges})
   being built or a saved `workflow_id`: unknown node types, missing required
   props, unselected models, unregistered providers, model ids the provider does
-  not offer, dangling/mis-typed edges. Sub-second. Run it before the expensive
+  not offer, dangling/mis-typed edges, leftover DSL wiring handles.
+  Sub-second. Run it before the expensive
   `debug`. `create_workflow` and `POST /api/workflows/:id/run|debug` apply the
   provider/model half of this check themselves, so a hallucinated model id is
   refused at save and at run rather than surfacing mid-execution.

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -157,7 +157,7 @@ close the build→verify loop. Run from source with `npm run dev:nodetool -- <cm
 
 | Command | Harness | When |
 |---|---|---|
-| `validate <id\|file>` (`validate.ts`) | Static graph check — unknown nodes, missing props, unselected models, unavailable provider/model ids, dangling or mis-typed edges, and unresolved declared credentials on DB-id targets | **Cheap pre-flight before any run.** Sub-second; no DB for file/DSL targets. Core: `validateGraph` in `node-sdk` |
+| `validate <id\|file>` (`validate.ts`) | Static graph check — unknown nodes, missing props, unselected models, unavailable provider/model ids, dangling or mis-typed edges, leftover DSL wiring handles, and unresolved declared credentials on DB-id targets | **Cheap pre-flight before any run.** Sub-second; no DB for file/DSL targets. Core: `validateGraph` in `node-sdk` |
 | `debug <id\|file>` (`debug.ts`) | Run a workflow end-to-end on the headless kernel and bundle every message/log/output/error/trace; `--browser` adds a real Playwright surface, `--stages` per-stage shots, `--watch` a per-save verdict diff | Run-and-inspect; iterative troubleshooting |
 | `node run <type> --props '{…}'` (`node.ts`) | Single-node harness — instantiate one node, feed a prop bag, print what it emits; `--no-secrets` skips the DB | Isolate one node without authoring a graph |
 | `run <file>` / `workflows run <id>` | Execute a workflow (id, JSON, or DSL `.ts`) | Quick run by id/file |

--- a/packages/agents/src/capabilities/workflows.ts
+++ b/packages/agents/src/capabilities/workflows.ts
@@ -29,6 +29,7 @@ import {
   RUNTIME_MODEL_CATALOGS,
   annotateEscalatedRun,
   jobRecord,
+  leftoverWiringHandleError,
   lightWorkflowList,
   modelSelectionError,
   noRegistryError,
@@ -184,6 +185,8 @@ const createWorkflow: CapabilityExport = {
       run.modelCatalogs ?? RUNTIME_MODEL_CATALOGS
     );
     if (badModels) return badModels;
+    const leftoverHandles = leftoverWiringHandleError(graph);
+    if (leftoverHandles) return leftoverHandles;
     if (run.nodeRegistry) {
       const unselected = unsetModelSelectionError(graph, run.nodeRegistry);
       if (unselected) return unselected;
@@ -247,6 +250,8 @@ const updateWorkflow: CapabilityExport = {
         run.modelCatalogs ?? RUNTIME_MODEL_CATALOGS
       );
       if (badModels) return badModels;
+      const leftoverHandles = leftoverWiringHandleError(graph);
+      if (leftoverHandles) return leftoverHandles;
       if (run.nodeRegistry) {
         const unselected = unsetModelSelectionError(graph, run.nodeRegistry);
         if (unselected) return unselected;

--- a/packages/agents/src/graph-dsl-core.ts
+++ b/packages/agents/src/graph-dsl-core.ts
@@ -60,6 +60,71 @@ function __graphDslBuilder() {
   const isHandle = (value) =>
     value !== null && typeof value === "object" && value.__handle === true;
 
+  const findNestedHandlePath = (value, seen) => {
+    if (value === null || typeof value !== "object") return null;
+    if (seen.indexOf(value) !== -1) return null;
+    seen.push(value);
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const item = value[i];
+        if (isHandle(item)) return "[" + i + "]";
+        const deeper = findNestedHandlePath(item, seen);
+        if (deeper !== null) return "[" + i + "]" + deeper;
+      }
+      return null;
+    }
+    for (const key of Object.keys(value)) {
+      if (isHandle(value[key])) return "." + key;
+      const deeper = findNestedHandlePath(value[key], seen);
+      if (deeper !== null) return "." + key + deeper;
+    }
+    return null;
+  };
+
+  /**
+   * Classify one non-handle property value for wiring. An array whose every
+   * element is a handle is list fan-in — the same shape the editor produces
+   * when several sources feed one list input — and wires one edge per
+   * element. Anything else holding a handle anywhere inside is refused with
+   * the path named.
+   */
+  const classifyValue = (key, value) => {
+    if (Array.isArray(value)) {
+      let sawHandle = false;
+      let sawLiteral = false;
+      for (const item of value) {
+        if (isHandle(item)) sawHandle = true;
+        else sawLiteral = true;
+      }
+      if (!sawHandle) return "plain";
+      if (sawLiteral) {
+        throw new Error(
+          'Property "' +
+            key +
+            '" mixes wired outputs and literal values in one array. Wire ' +
+            "the whole list — every element an output() handle — or pass " +
+            "plain values only."
+        );
+      }
+      return "fanin";
+    }
+    const nested = findNestedHandlePath(value, []);
+    if (nested !== null) {
+      throw new Error(
+        'Property "' +
+          key +
+          '" holds a node output at "' +
+          key +
+          nested +
+          '". A connection is only made from a handle assigned directly to ' +
+          "a property — one buried in an object is not wired, and the node " +
+          "producing it would be left out of the graph. Give each source " +
+          "its own property."
+      );
+    }
+    return "plain";
+  };
+
   const makeHandle = (nodeId, slot) => {
     if (slot !== undefined && (typeof slot !== "string" || slot.length === 0)) {
       throw new Error("output(slot): slot must be a non-empty string");
@@ -104,6 +169,10 @@ function __graphDslBuilder() {
       const value = props[key];
       if (isHandle(value)) {
         addEdge(value.source, value.sourceHandle, targetId, key);
+      } else if (classifyValue(key, value) === "fanin") {
+        for (const handle of value) {
+          addEdge(handle.source, handle.sourceHandle, targetId, key);
+        }
       } else {
         plain[key] = value;
       }

--- a/packages/agents/src/tools/mcp-tool-support.ts
+++ b/packages/agents/src/tools/mcp-tool-support.ts
@@ -404,6 +404,111 @@ export async function modelSelectionError(
 }
 
 /**
+ * The declared property bag of a node, from either graph shape.
+ *
+ * Mirrors `readProperties` in @nodetool-ai/node-sdk's graph-validation: the
+ * kernel shape nests the bag under `properties`, the persisted/editor shape
+ * under `data.properties`, and older hand-written shapes flattened it onto
+ * `data`. Reading only `properties` made every normalized graph — which is
+ * what create_workflow checks, since it normalizes first — look like every
+ * model property was left unselected.
+ */
+function readNodeProperties(node: Record<string, unknown>): Record<string, unknown> {
+  if (isObjectLike(node["properties"])) {
+    return node["properties"] as Record<string, unknown>;
+  }
+  const data = node["data"];
+  if (isObjectLike(data)) {
+    const record = data as Record<string, unknown>;
+    if (isObjectLike(record["properties"])) {
+      return record["properties"] as Record<string, unknown>;
+    }
+    return record;
+  }
+  return {};
+}
+
+/**
+ * True for a DSL wiring handle ({__handle: true, source, sourceHandle}) —
+ * the marker the graph builders create to wire an edge before collecting the
+ * graph. One that survives into a stored property bag means the connection
+ * was never made.
+ */
+function isWiringHandle(value: unknown): boolean {
+  return isObjectLike(value) && (value as Record<string, unknown>)["__handle"] === true;
+}
+
+/** Property paths holding a wiring handle, e.g. `tiles[0]`. */
+function collectWiringHandlePaths(
+  value: unknown,
+  path: string,
+  out: string[],
+  depth = 0
+): void {
+  if (depth > 4) return;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      collectWiringHandlePaths(item, `${path}[${index}]`, out, depth + 1)
+    );
+    return;
+  }
+  if (!isObjectLike(value)) return;
+  if (isWiringHandle(value)) {
+    out.push(path);
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    collectWiringHandlePaths(child, path ? `${path}.${key}` : key, out, depth + 1);
+  }
+}
+
+/**
+ * Refuse a graph whose property bags still hold DSL wiring handles.
+ *
+ * A stored handle is a connection that was never created: the edge does not
+ * exist, so the node producing the value is unreachable and the input either
+ * stays empty or receives the marker itself at run time. This is exactly how
+ * a graph built with handles inside an array property used to save clean and
+ * then fail on its first run ("Image input is required."). Re-authoring the
+ * wiring fixes it; validate_workflow reports the same finding statically.
+ */
+export function leftoverWiringHandleError(graph: unknown): Record<string, unknown> | null {
+  if (!isObjectLike(graph)) return null;
+  const record = graph as { nodes?: unknown };
+  const nodes = Array.isArray(record.nodes) ? record.nodes : [];
+  const issues: Array<Record<string, unknown>> = [];
+  for (const raw of nodes) {
+    if (!isObjectLike(raw)) continue;
+    const node = raw as Record<string, unknown>;
+    const id = String(node["id"] ?? "");
+    const type = String(node["type"] ?? node["node_type"] ?? "");
+    for (const [name, value] of Object.entries(readNodeProperties(node))) {
+      const paths: string[] = [];
+      collectWiringHandlePaths(value, name, paths);
+      for (const path of paths) {
+        issues.push({
+          code: "leftover_wiring_handle",
+          node_id: id,
+          node_type: type,
+          message:
+            `Property "${path}" on node "${id || type}" still holds a ` +
+            "wiring handle — the connection was never created, so the node " +
+            "producing this output may be missing from the graph entirely. " +
+            "Re-wire it as an edge."
+        });
+      }
+    }
+  }
+  if (issues.length === 0) return null;
+  return {
+    error:
+      "The graph stores DSL wiring handles as property values instead of " +
+      "edges. These inputs are not connected.",
+    issues
+  };
+}
+
+/**
  * Refuse a graph whose nodes leave a declared model property unselected.
  *
  * The cheap selection walk above reads only the property bag; an agent that
@@ -457,11 +562,8 @@ export function unsetModelSelectionError(
     const type = String(n["type"] ?? "");
     const id = String(n["id"] ?? "");
     if (!type || !nodeRegistry.has(type)) continue;
-    const properties = isObjectLike(n["properties"])
-      ? (n["properties"] as Record<string, unknown>)
-      : {};
     for (const issue of nodeRegistry.validateNode(
-      { id, type, properties },
+      { id, type, properties: readNodeProperties(n) },
       connected.get(id) ?? new Set<string>()
     )) {
       if (issue.code !== "unset_model") continue;

--- a/packages/agents/tests/dsl-handle-interpolation.test.ts
+++ b/packages/agents/tests/dsl-handle-interpolation.test.ts
@@ -48,4 +48,56 @@ describe("graph DSL — handles are not text", () => {
       }
     ]);
   });
+
+  it("wires an array of handles into one edge per element", async () => {
+    const { graph, error } = await evaluateGraphDsl(`
+      const a = node("nodetool.constant.String", { value: "hello" }, "a");
+      const b = node("nodetool.constant.String", { value: "world" }, "b");
+      node("lib.grid.CombineImageGrid", {
+        tiles: [a.output(), b.output()],
+        columns: 2
+      }, "grid");
+      return graph();
+    `);
+
+    expect(error).toBeUndefined();
+    const grid = graph!.nodes.find((n) => n.id === "grid");
+    // The wired list is carried by the edges, not stored as a property.
+    expect(grid!.properties).toEqual({ columns: 2 });
+    expect(
+      graph!.edges.filter((e) => e.target === "grid" && e.targetHandle === "tiles")
+    ).toEqual([
+      { source: "a", sourceHandle: "output", target: "grid", targetHandle: "tiles" },
+      { source: "b", sourceHandle: "output", target: "grid", targetHandle: "tiles" }
+    ]);
+  });
+
+  it("rejects an array mixing wired outputs and literal values", async () => {
+    const { graph, error } = await evaluateGraphDsl(`
+      const a = node("nodetool.constant.String", { value: "hello" }, "a");
+      node("lib.grid.CombineImageGrid", {
+        tiles: [a.output(), "literal"],
+        columns: 2
+      }, "grid");
+      return graph();
+    `);
+
+    expect(graph).toBeUndefined();
+    expect(error).toContain('"tiles"');
+    expect(error).toContain("mixes wired outputs and literal values");
+  });
+
+  it("rejects a handle buried inside an object value", async () => {
+    const { graph, error } = await evaluateGraphDsl(`
+      const a = node("nodetool.constant.String", { value: "hello" }, "a");
+      node("nodetool.agents.Agent", {
+        options: { source: a.output() }
+      }, "agent");
+      return graph();
+    `);
+
+    expect(graph).toBeUndefined();
+    expect(error).toContain('"options.source"');
+    expect(error).toContain("not wired");
+  });
 });

--- a/packages/agents/tests/dsl-workflow-authoring.test.ts
+++ b/packages/agents/tests/dsl-workflow-authoring.test.ts
@@ -125,11 +125,36 @@ class CodeNode extends BaseNode {
   }
 }
 
+/**
+ * Stand-in for `lib.grid.CombineImageGrid` so an authored program can exercise
+ * list fan-in against a real registry and kernel run without importing
+ * base-nodes. Its `process()` joins the tiles, so the accumulated list is
+ * observable in the workflow output.
+ */
+class FakeCombineImageGrid extends BaseNode {
+  static readonly nodeType = "lib.grid.CombineImageGrid";
+  static readonly title = "Combine Image Grid";
+  static readonly description = "Combine image tiles into one image.";
+  static readonly metadataOutputTypes = { output: "str" };
+
+  @prop({ type: "list[str]", default: [] })
+  declare tiles: unknown[];
+
+  @prop({ type: "int", default: 0 })
+  declare columns: number;
+
+  async process(): Promise<Record<string, unknown>> {
+    const tiles = Array.isArray(this.tiles) ? this.tiles : [];
+    return { output: tiles.map((t) => String(t)).join("|") };
+  }
+}
+
 function buildRegistry(): NodeRegistry {
   const registry = new NodeRegistry();
   registry.register(StringConstant);
   registry.register(OutputNode);
   registry.register(CodeNode);
+  registry.register(FakeCombineImageGrid);
   return registry;
 }
 
@@ -646,6 +671,116 @@ describe("a Code node's dynamic output handle", () => {
     expect(bare.ok).toBe(false);
     expect(bare.error).toContain("nodetool.code.Code");
     expect(bare.error).toContain("name one");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5.5 A list input wired from several sources
+// ---------------------------------------------------------------------------
+
+const GRID_PACKAGES = [
+  DSL,
+  `${DSL}/nodetool.constant`,
+  `${DSL}/lib.grid`,
+  `${DSL}/nodetool.output`
+];
+
+const GRID_PROGRAM = `
+  import { workflow } from "${DSL}";
+  import { string } from "${DSL}/nodetool.constant";
+  import { combineImageGrid } from "${DSL}/lib.grid";
+  import { output } from "${DSL}/nodetool.output";
+
+  const a = string({ value: "hello" });
+  const b = string({ value: "world" });
+  const grid = combineImageGrid({ tiles: [a.output(), b.output()], columns: 2 });
+  return workflow(output({ name: "strip", value: grid.output() }));
+`;
+
+describe("a list input wired from an array of handles", () => {
+  /**
+   * Regression: the collector only followed handles assigned directly to an
+   * input, so `tiles: [a.output(), b.output()]` stored the handle markers as
+   * literal property values, created no edges, and dropped every upstream
+   * node from the graph. The saved two-node workflow validated clean and then
+   * failed on its first run with "Image input is required."
+   */
+  it("wires one edge per element and ships every upstream node", async () => {
+    const outcome = await action(GRID_PROGRAM, { packages: GRID_PACKAGES });
+    expect(outcome.error).toBeUndefined();
+    const graph = outcome.result as GraphShape;
+    expect(graph.nodes.map((n) => n.type).sort()).toEqual([
+      "lib.grid.CombineImageGrid",
+      "nodetool.constant.String",
+      "nodetool.constant.String",
+      "nodetool.output.Output"
+    ]);
+    const grid = graph.nodes.find((n) => n.type === "lib.grid.CombineImageGrid");
+    expect(grid?.properties).toEqual({ columns: 2 });
+    const fanIn = graph.edges.filter(
+      (e) => e.target === "combine_image_grid" && e.targetHandle === "tiles"
+    );
+    expect(fanIn.map((e) => e.source).sort()).toEqual(["string", "string_2"]);
+    expect(fanIn.every((e) => e.sourceHandle === "output")).toBe(true);
+  });
+
+  it("validates, saves and runs the fan-in end to end", async () => {
+    const outcome = await action(
+      `import { validate_workflow, create_workflow, run_workflow } from "${WORKFLOWS}";
+       ${GRID_PROGRAM.replace(
+         "return workflow(",
+         "const graph = workflow("
+       )}
+       const report = await validate_workflow({ graph });
+       if (!report.ok) return { issues: report.issues };
+       const saved = await create_workflow({ name: "Strip", graph });
+       return await run_workflow({ workflow_id: saved.id });`,
+      { run: ungatedRun(), packages: [...GRID_PACKAGES, WORKFLOWS] }
+    );
+    expect(outcome.error).toBeUndefined();
+    const run = outcome.result as {
+      status: string;
+      error: string | null;
+      outputs: Record<string, unknown>;
+      issues?: unknown[];
+    };
+    expect(run.issues ?? []).toEqual([]);
+    expect(run.error).toBeNull();
+    expect(run.status).toBe("completed");
+    const values = (run.outputs["strip"] as string[] | undefined) ?? [];
+    // Arrival order across two parallel sources is not guaranteed.
+    expect(values).toHaveLength(1);
+    expect(String(values[0]).split("|").sort()).toEqual(["hello", "world"]);
+  }, 60_000);
+
+  it("refuses an array mixing wired outputs and literal values", async () => {
+    const outcome = await action(
+      `import { workflow } from "${DSL}";
+       import { string } from "${DSL}/nodetool.constant";
+       import { combineImageGrid } from "${DSL}/lib.grid";
+       const a = string({ value: "hello" });
+       const grid = combineImageGrid({ tiles: [a.output(), "literal"], columns: 2 });
+       return workflow(grid);`,
+      { packages: [DSL, `${DSL}/nodetool.constant`, `${DSL}/lib.grid`] }
+    );
+    expect(outcome.ok).toBe(false);
+    expect(outcome.error).toContain('"tiles"');
+    expect(outcome.error).toContain("mixes wired outputs and literal values");
+  });
+
+  it("refuses a handle buried inside an object value", async () => {
+    const outcome = await action(
+      `import { workflow } from "${DSL}";
+       import { string } from "${DSL}/nodetool.constant";
+       import { code } from "${DSL}/nodetool.code";
+       const a = string({ value: "hello" });
+       const snippet = code({ code: "return {};", options: { source: a.output() } });
+       return workflow(snippet);`,
+      { packages: [DSL, `${DSL}/nodetool.constant`, `${DSL}/nodetool.code`] }
+    );
+    expect(outcome.ok).toBe(false);
+    expect(outcome.error).toContain('"options.source"');
+    expect(outcome.error).toContain("not wired");
   });
 });
 

--- a/packages/agents/tests/mcp-tools.test.ts
+++ b/packages/agents/tests/mcp-tools.test.ts
@@ -328,6 +328,125 @@ describe("create_workflow", () => {
       expect(result.id).toEqual(expect.any(String));
       expect(await Workflow.find(USER, String(result.id))).not.toBeNull();
     });
+
+    /**
+     * A registry that validates the bag it is handed, the way the real one
+     * does. create_workflow normalizes a kernel-shape graph into the editor
+     * shape (bag under `data`) before checking, and the check used to read
+     * only `properties` — so every graph with a selected model was refused
+     * as unselected.
+     */
+    const bagRegistry = {
+      has: (type: string) => type === "nodetool.agents.Agent",
+      getMetadata: () => undefined,
+      resolveMetadata: () => undefined,
+      validateNode: (
+        descriptor: { properties: Record<string, unknown> },
+        connectedHandles: ReadonlySet<string>
+      ) =>
+        connectedHandles.has("model") ||
+        (descriptor.properties["model"] &&
+          typeof descriptor.properties["model"] === "object")
+          ? []
+          : [
+              {
+                code: "unset_model",
+                property: "model",
+                message:
+                  'Property "model" requires a language_model to be selected'
+              }
+            ]
+    } as unknown as NodeRegistry;
+    const bagChecked = capTool("create_workflow", {
+      nodeRegistry: bagRegistry,
+      // Silent catalogs: this test is about the unselected-model gate, not
+      // the provider/model id walk.
+      modelCatalogs: {
+        listProviderIds: () => [],
+        listModelIds: () => undefined
+      }
+    });
+    const agentGraphWithModel = (model: Record<string, unknown>) => ({
+      nodes: [
+        { id: "a1", type: "nodetool.agents.Agent", properties: { model } }
+      ],
+      edges: []
+    });
+
+    it("reads a selected model from the normalized (editor-shape) graph", async () => {
+      const result = (await bagChecked.process(ctx, {
+        name: "WF",
+        graph: agentGraphWithModel({
+          type: "language_model",
+          provider: "kie",
+          id: "m1"
+        })
+      })) as { id?: string; error?: string };
+
+      expect(result.error).toBeUndefined();
+      expect(result.id).toEqual(expect.any(String));
+      expect(await Workflow.find(USER, String(result.id))).not.toBeNull();
+    });
+
+    it("still flags a genuinely empty model on that shape", async () => {
+      const result = (await bagChecked.process(ctx, {
+        name: "WF",
+        graph: graphWithAgent()
+      })) as { error: string; issues: Array<{ code: string }> };
+
+      expect(result.error).toContain("unselected");
+      expect(result.issues[0]?.code).toBe("unset_model");
+      const [saved] = await Workflow.paginate(USER, {});
+      expect(saved).toHaveLength(0);
+    });
+  });
+
+  // A DSL wiring handle stored as a property value means the edge was never
+  // created — the input is unconnected and the node producing the value may
+  // be missing from the graph. Saving such a graph used to succeed silently
+  // and fail on the first run.
+  describe("leftover wiring handle preflight", () => {
+    const handleGraph = () => ({
+      nodes: [
+        {
+          id: "grid",
+          type: "lib.grid.CombineImageGrid",
+          properties: {
+            tiles: [
+              { __handle: true, source: "img", sourceHandle: "output" }
+            ],
+            columns: 3
+          }
+        },
+        { id: "out", type: "nodetool.output.Output", properties: {} }
+      ],
+      edges: []
+    });
+    const checked = capTool("create_workflow", {});
+
+    it("refuses to save a graph whose property holds a wiring handle", async () => {
+      const result = (await checked.process(ctx, {
+        name: "WF",
+        graph: handleGraph()
+      })) as { error: string; issues: Array<{ code: string; message: string }> };
+
+      expect(result.error).toContain("wiring handles");
+      expect(result.issues[0]?.code).toBe("leftover_wiring_handle");
+      expect(result.issues[0]?.message).toContain("tiles[0]");
+      const [saved] = await Workflow.paginate(USER, {});
+      expect(saved).toHaveLength(0);
+    });
+
+    it("saves a clean graph unchanged", async () => {
+      const result = (await checked.process(ctx, {
+        name: "WF",
+        graph: {
+          nodes: [{ id: "out", type: "x.Y", properties: { tiles: ["a"] } }],
+          edges: []
+        }
+      })) as Record<string, unknown>;
+      expect(result.id).toEqual(expect.any(String));
+    });
   });
 
   it("persists the workflow under the calling user", async () => {

--- a/packages/execution/src/service/workflow-run.ts
+++ b/packages/execution/src/service/workflow-run.ts
@@ -17,6 +17,7 @@ import { BoundedHandle, WorkflowRunner } from "@nodetool-ai/kernel";
 import { Job, Workflow, getSecret } from "@nodetool-ai/models";
 import {
   hydrateGraphNodeFlags,
+  propertyTypesForMetadata,
   type NodeRegistry
 } from "@nodetool-ai/node-sdk";
 import type {
@@ -38,6 +39,7 @@ import {
   buildRunVerdict,
   collectInterventionWarnings
 } from "../debug/verdict.js";
+import { rewriteOutputNames } from "../output-names.js";
 import {
   debugSessions,
   DebugSession,
@@ -70,6 +72,42 @@ export type {
 const log = createLogger("nodetool.execution.workflow-run");
 
 type WorkflowRunResult = Awaited<ReturnType<WorkflowRunner["run"]>>;
+
+/**
+ * Hydrate a saved graph for the kernel: registry-resolved execution flags,
+ * plus each node's declared input types under `propertyTypes`.
+ *
+ * Flags-only hydration leaves `propertyTypes` unset, and the kernel reads
+ * list-ness only from that map — so a genuine `list[...]` fan-in (several
+ * upstreams wired into one input, exactly what the editor and the graph DSL
+ * produce) was rejected by correlation analysis as "receives N edges but is
+ * not a list type". The full-fat alternative (`Graph.loadFromDict` with a
+ * resolver, the websocket runner's path) drops every node type this registry
+ * cannot resolve, which a service run over a saved workflow must not do — an
+ * unknown type has to fail loudly at executor resolution, not vanish. So:
+ * flags hydration keeps every node, and the property-type map is stamped from
+ * metadata per node where the registry can speak.
+ */
+function hydrateRunGraph(
+  graph: Parameters<typeof hydrateGraphNodeFlags>[0],
+  registry: NodeRegistry
+): ReturnType<typeof hydrateGraphNodeFlags> {
+  const hydrated = hydrateGraphNodeFlags(graph, registry);
+  for (const node of hydrated.nodes) {
+    const metadata = registry.resolveMetadata(node.type);
+    if (!metadata) continue;
+    node.propertyTypes = {
+      ...propertyTypesForMetadata(metadata),
+      ...(node.propertyTypes ?? {})
+    };
+  }
+  // Resolver-style hydration stamps each node's `name` with the registry
+  // title, which would outrank an Output node's public `name` *property* in
+  // the kernel's collection key. Flags hydration does not stamp one, but the
+  // rewrite makes the two paths agree and is what ExecutionSession applies.
+  rewriteOutputNames(hydrated);
+  return hydrated;
+}
 
 /**
  * What the host brings to a run: the node registry, and — for a host that also
@@ -534,7 +572,7 @@ export async function runWorkflow(
       runnerOptions.supervisor = supervisorHandle;
     }
     runner = new WorkflowRunner(job.id, runnerOptions);
-    hydratedGraph = hydrateGraphNodeFlags(runnableGraph, registry);
+    hydratedGraph = hydrateRunGraph(runnableGraph, registry);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     await markJobFailed(job, message);

--- a/packages/node-sdk/src/graph-validation.ts
+++ b/packages/node-sdk/src/graph-validation.ts
@@ -300,6 +300,35 @@ function readProperties(node: GraphValidationNode): Record<string, unknown> {
   );
 }
 
+/** True for a DSL wiring handle ({__handle: true, source, sourceHandle}). */
+function isWiringHandle(value: unknown): boolean {
+  return isRecord(value) && value["__handle"] === true;
+}
+
+/** Property paths holding a wiring handle, e.g. `tiles[0]`. */
+function collectWiringHandlePaths(
+  value: unknown,
+  path: string,
+  out: string[],
+  depth = 0
+): void {
+  if (depth > MODEL_REF_MAX_DEPTH) return;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      collectWiringHandlePaths(item, `${path}[${index}]`, out, depth + 1)
+    );
+    return;
+  }
+  if (!isRecord(value)) return;
+  if (isWiringHandle(value)) {
+    out.push(path);
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    collectWiringHandlePaths(child, path ? `${path}.${key}` : key, out, depth + 1);
+  }
+}
+
 interface NormEdge {
   id: string;
   source: string;
@@ -1110,6 +1139,30 @@ export function validateGraph(
   // validating the shadowed copy's properties would report everything twice.
   for (const [id, node] of byId) {
     const type = String(node.type ?? "");
+
+    // ── DSL wiring handles stored as property values. The builders mint
+    // these to wire an edge; one that survives into a bag means the
+    // connection was never made, so the input is unconnected and the node
+    // producing it may be missing from the graph entirely. Checked before the
+    // registry guard: the marker is shape-level, not type-level.
+    for (const [propName, value] of Object.entries(readProperties(node))) {
+      const handlePaths: string[] = [];
+      collectWiringHandlePaths(value, propName, handlePaths);
+      for (const path of handlePaths) {
+        issues.push({
+          severity: "error",
+          code: "leftover_wiring_handle",
+          nodeId: id,
+          nodeType: type,
+          message:
+            `Property "${path}" on node "${id}" still holds a wiring ` +
+            "handle — the connection was never created, so the node " +
+            "producing this output may be missing from the graph. Re-wire " +
+            "it as an edge."
+        });
+      }
+    }
+
     if (!type || !registry.has(type)) continue;
     const propIssues = registry.validateNode(
       {

--- a/packages/node-sdk/src/registry.ts
+++ b/packages/node-sdk/src/registry.ts
@@ -592,6 +592,24 @@ function deriveNamespace(nodeType: string): string {
   return lastDot > 0 ? nodeType.slice(0, lastDot) : "";
 }
 
+/**
+ * The declared input types of one node type, as a `propertyTypes`-shaped map
+ * (`{[property]: "list[image]" | "str" | …}`). This is the kernel's authority
+ * on list-ness — correlation analysis and multi-edge fan-in read it — so
+ * hydration paths that do not go through `Graph.loadFromDict` stamp it from
+ * here rather than re-deriving the rendering.
+ */
+export function propertyTypesForMetadata(
+  metadata: NodeMetadata
+): Record<string, string> {
+  return Object.fromEntries(
+    (metadata.properties ?? []).map((prop) => [
+      prop.name,
+      typeMetadataToString(prop.type)
+    ])
+  );
+}
+
 export function createGraphNodeTypeResolver(
   registry: NodeRegistry,
   options: RegistryGraphResolverOptions = {}
@@ -620,12 +638,7 @@ export function createGraphNodeTypeResolver(
       const cls = registry.getClass(nodeType);
       const resolveStreamingInput = cls?.resolveStreamingInput;
 
-      const propertyTypes = Object.fromEntries(
-        (metadata.properties ?? []).map((prop) => [
-          prop.name,
-          typeMetadataToString(prop.type)
-        ])
-      );
+      const propertyTypes = propertyTypesForMetadata(metadata);
       const propertyMeta = Object.fromEntries(
         // Stryker disable next-line ArrayDeclaration: a bogus seed element lacks description/min/max, so the .filter below drops it — the result is unchanged (equivalent).
         (metadata.properties ?? [])

--- a/packages/node-sdk/tests/graph-validation.test.ts
+++ b/packages/node-sdk/tests/graph-validation.test.ts
@@ -95,6 +95,81 @@ describe("validateGraph", () => {
     expect(report.edgeCount).toBe(1);
   });
 
+  it("flags a DSL wiring handle left in a property bag", () => {
+    // The builders mint these to wire an edge. One that survives into a
+    // stored graph means the connection was never created and the node
+    // producing the value may be missing entirely.
+    const registry = fakeRegistry({
+      "lib.grid.CombineImageGrid": meta("lib.grid.CombineImageGrid", { tiles: "list[image]" }, {})
+    });
+    const report = validateGraph(
+      {
+        nodes: [
+          {
+            id: "grid",
+            type: "lib.grid.CombineImageGrid",
+            properties: {
+              tiles: [{ __handle: true, source: "img", sourceHandle: "output" }],
+              columns: 3
+            }
+          }
+        ],
+        edges: []
+      },
+      registry
+    );
+    expect(report.ok).toBe(false);
+    const leftover = report.issues.filter(
+      (i) => i.code === "leftover_wiring_handle"
+    );
+    expect(leftover).toHaveLength(1);
+    expect(leftover[0].severity).toBe("error");
+    expect(leftover[0].message).toContain("tiles[0]");
+    expect(leftover[0].message).toContain("never created");
+  });
+
+  it("flags a wiring handle even when the node type is unknown", () => {
+    const registry = fakeRegistry({});
+    const report = validateGraph(
+      {
+        nodes: [
+          {
+            id: "n1",
+            type: "some.RemovedType",
+            properties: { config: { deep: { __handle: true, source: "x", sourceHandle: "output" } } }
+          }
+        ],
+        edges: []
+      },
+      registry
+    );
+    expect(
+      report.issues.filter((i) => i.code === "leftover_wiring_handle")
+    ).toHaveLength(1);
+  });
+
+  it("does not flag plain object properties as handles", () => {
+    const registry = fakeRegistry({
+      "a.Sink": meta("a.Sink", { in: "list[image]" }, {})
+    });
+    const report = validateGraph(
+      {
+        nodes: [
+          {
+            id: "s",
+            type: "a.Sink",
+            properties: { in: [{ uri: "asset://1" }, { other: true }] }
+          }
+        ],
+        edges: []
+      },
+      registry
+    );
+    expect(
+      report.issues.filter((i) => i.code === "leftover_wiring_handle")
+    ).toEqual([]);
+  });
+
   it("flags unknown node types", () => {
     const registry = fakeRegistry({ "a.Known": meta("a.Known", {}, {}) });
     const report = validateGraph(

--- a/packages/sandbox-packs/sandbox-dsl/SKILL.md
+++ b/packages/sandbox-packs/sandbox-dsl/SKILL.md
@@ -86,6 +86,20 @@ is wired for you:
 const wired = resize({ image: source.output(), width: 512 });
 ```
 
+A `list[...]` input takes an array of handles — one edge per element, and the
+sources run in parallel:
+
+```js
+const strip = combineImageGrid({
+  tiles: [a.output(), b.output(), c.output()],
+  columns: 3
+});
+```
+
+Every element must be a handle; mixing wired outputs and literal values in one
+array throws. A handle buried inside an object value throws too — a connection
+is only made from a handle assigned directly to an input.
+
 A node with several outputs has no default, so `output()` without a slot throws
 and names the slots it has. A slot the node does not have throws the same way.
 

--- a/packages/sandbox-packs/sandbox-dsl/sandbox/core.js
+++ b/packages/sandbox-packs/sandbox-dsl/sandbox/core.js
@@ -47,6 +47,85 @@ export function isOutputHandle(value) {
   );
 }
 
+/**
+ * Find a handle nested inside a prop value — in an array, or under an object
+ * key. Returns the path to the first one, or null.
+ *
+ * A connection is only made from a handle assigned directly to an input (or,
+ * for a list input, from an array of handles). One buried deeper is not wired:
+ * it used to be written verbatim into the node's properties, the node
+ * producing it was never reached, and the graph validated clean with the
+ * producer missing entirely. Reporting the path turns that silent hole into an
+ * error a caller can act on.
+ */
+function findNestedHandlePath(value, seen) {
+  if (value === null || typeof value !== "object") return null;
+  if (seen.indexOf(value) !== -1) return null;
+  seen.push(value);
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      const item = value[i];
+      if (isOutputHandle(item)) return "[" + i + "]";
+      const deeper = findNestedHandlePath(item, seen);
+      if (deeper !== null) return "[" + i + "]" + deeper;
+    }
+    return null;
+  }
+  for (const key of Object.keys(value)) {
+    if (isOutputHandle(value[key])) return "." + key;
+    const deeper = findNestedHandlePath(value[key], seen);
+    if (deeper !== null) return "." + key + deeper;
+  }
+  return null;
+}
+
+/**
+ * Classify one non-handle input value for wiring.
+ *
+ * An array whose every element is a handle is list fan-in — the same shape the
+ * editor produces when several sources feed one `list[...]` input — and wires
+ * one edge per element. Anything else holding a handle anywhere inside is
+ * refused with the path named.
+ */
+function classifyInput(name, value) {
+  if (Array.isArray(value)) {
+    let sawHandle = false;
+    let sawLiteral = false;
+    for (const item of value) {
+      if (isOutputHandle(item)) {
+        sawHandle = true;
+      } else {
+        sawLiteral = true;
+      }
+    }
+    if (!sawHandle) return { kind: "plain" };
+    if (sawLiteral) {
+      throw new Error(
+        'Input "' +
+          name +
+          '" mixes wired outputs and literal values in one array. Wire the ' +
+          "whole list — every element an output() handle — or pass plain " +
+          "values only."
+      );
+    }
+    return { kind: "fanin" };
+  }
+  const nested = findNestedHandlePath(value, []);
+  if (nested !== null) {
+    throw new Error(
+      'Input "' +
+        name +
+        '" holds a node output at "' +
+        name +
+        nested +
+        '". A connection is only made from a handle assigned directly to an ' +
+        "input — one buried in an object is not wired, and the node producing " +
+        "it would be left out of the graph. Give each source its own input."
+    );
+  }
+  return { kind: "plain" };
+}
+
 function createHandle(nodeId, slot) {
   const handle = {
     __handle: true,
@@ -138,6 +217,8 @@ export function workflow(...terminals) {
   const reached = new Map();
   const edges = [];
   const queue = [];
+  /** Inputs fully supplied by edges; their stored values are not shipped. */
+  const wiredInputs = new Set();
 
   const admit = (node) => {
     const id = node && node.nodeId;
@@ -161,22 +242,37 @@ export function workflow(...terminals) {
     const currentId = queue.shift();
     const descriptor = reached.get(currentId);
     for (const [name, value] of Object.entries(descriptor.inputs)) {
-      if (!isOutputHandle(value)) continue;
-      edges.push({
-        id: "e" + (edges.length + 1) + "_" + value.source + "_" + currentId,
-        source: value.source,
-        sourceHandle: value.sourceHandle,
-        target: currentId,
-        targetHandle: name
-      });
-      admit({ nodeId: value.source });
+      let sources;
+      if (isOutputHandle(value)) {
+        sources = [value];
+      } else {
+        const kind = classifyInput(name, value);
+        if (kind.kind !== "fanin") continue;
+        sources = value;
+      }
+      wiredInputs.add(currentId + "." + name);
+      for (const handle of sources) {
+        edges.push({
+          id: "e" + (edges.length + 1) + "_" + handle.source + "_" + currentId,
+          source: handle.source,
+          sourceHandle: handle.sourceHandle,
+          target: currentId,
+          targetHandle: name
+        });
+        admit({ nodeId: handle.source });
+      }
     }
   }
 
   const nodes = [...reached.values()].map((descriptor) => {
     const properties = {};
     for (const [name, value] of Object.entries(descriptor.inputs)) {
-      if (!isOutputHandle(value)) properties[name] = value;
+      if (
+        !isOutputHandle(value) &&
+        !wiredInputs.has(descriptor.nodeId + "." + name)
+      ) {
+        properties[name] = value;
+      }
     }
     return {
       id: descriptor.nodeId,


### PR DESCRIPTION
An agent building a comic-strip workflow (idea → LLM story → 3 parallel image gens → grid) hit three silent failures in a row and spent the session bisecting them. This closes the underlying gaps.

## What broke

1. **Array wiring dropped every upstream node.** `tiles: [a.output(), b.output(), c.output()]` stored the `{__handle}` markers as literal property values, created no edges, and `workflow()`'s reachability walk kept only the grid and output. The saved 2-node graph validated clean (`ok: true`, zero issues) and failed on its first paid run: `Node "combine_image_grid" failed: Image input is required.`
2. **Recovery was blocked.** Every later save — including a minimal one-node image graph with a fully selected model ref — was refused with "The graph leaves one or more model properties unselected." Root cause: `create_workflow` normalizes the graph into editor shape (bag under `data`) before gating, but `unsetModelSelectionError` read only `node.properties`. The mock registry in the old test ignored the bag, so this never showed up in CI. It also explains why the broken first save succeeded: dropping the upstream nodes removed every model property, so the empty-bag read found nothing to flag.
3. **The validator saw nothing wrong** with a graph whose properties held stale wiring markers.

## Fixes

- **sandbox-dsl + legacy prelude**: an array whose every element is a handle is list fan-in — one edge per element, matching what the editor produces for `list[...]` inputs; mixed arrays and handles buried in object values are refused with the path named. SKILL.md documents list wiring.
- **Save gates**: `unsetModelSelectionError` reads property bags from both graph shapes (`properties ?? data.properties ?? data`), mirroring node-sdk's `readProperties`.
- **Stale-wiring gate**: `validateGraph` reports leftover `__handle` markers as errors (`leftover_wiring_handle`), and `create_workflow`/`update_workflow` refuse such graphs before persisting.
- **Run path**: while testing end-to-end, a correctly-authored fan-in still failed through `run_workflow`/\'debug_workflow\' — kernel correlation analysis reads list-ness from `propertyTypes`, which flags-only hydration never resolved. `runWorkflow` now stamps declared input types per node from registry metadata (keeping nodes the registry cannot resolve, unlike the resolver-based hydration, so unknown types still fail loudly at executor resolution) and applies the terminal-name rewrite, agreeing with ExecutionSession and the websocket runner.

## Verification

- New regression tests at every layer: guest-level fan-in author → validate → save → run against the real shipped pack; prelude edge cases; dual-shape model check plus a genuinely-empty model still refused; leftover-handle refusal at validate and save with clean-graph no-op cases.
- Affected suites green (1,026), node-sdk 1,182, execution 290, websocket 2,456; typecheck, lint, and `build:sandbox-dsl:check` clean.