### PR TITLE
feat(agents): add background sub-agent delegation (start_subtask / wait_subtasks)

### DIFF
--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -1216,15 +1216,29 @@ pipe and nests in the UI the same way.
 | `SubAgentTool` | Base class for tools that expose a sub-agent to a parent model — subclasses declare the tool surface, translate params into a `SubAgentToolRun`, and pick the child toolset; the base owns depth gate, streaming, tagging, settlement |
 
 Every spawn site goes through it: `RunSubtaskTool` (inherits the full parent
-belt, stitches itself in for recursion) and `RunSearchTool` (read-only
-allowlist, breadth-scaled iteration budget) are thin `SubAgentTool`
-subclasses. A generator that is not a CodeAct child streams through
+belt, stitches itself in for recursion), `RunSearchTool` (read-only
+allowlist, breadth-scaled iteration budget), and `StartSubtaskTool` (same
+child but returns a `subtask_id` receipt immediately so the parent keeps
+its turn) are thin `SubAgentTool` subclasses. `WaitSubtasksTool` reads the
+same per-turn `BackgroundSubtaskRegistry` (`src/background-subtasks.ts`) that
+the background pump settles — `wait_subtasks({ids?, timeout_ms?})` blocks
+until every requested record left "running" (or on timeout/abort, which
+return current statuses instead of throwing). The registry lives on
+`SubAgentToolRuntime.background`, one per chat turn, built by the host
+(websocket runner, CLI); a host with no registry refuses by name. A
+background subtask's events still stream to the UI tagged with
+`parent_tool_call_id`/`subtask_depth`, and nesting depth is still gated
+by `enterSubAgentDepth`. In CodeAct: `await nodetool.agents.start(prompt)`
++ `await nodetool.agents.wait({ids, timeoutMs})` — fan out while you
+keep working. A generator that is not a CodeAct child streams through
 `forwardSubAgentStream` directly. A new delegation tool should be another
 subclass, not another copy of the machinery.
 
 Tests: `tests/subagent.test.ts` (pure-function coverage), plus the spawn-site
-suites (`tests/run-subtask-tool.test.ts`, `tests/run-search-tool.test.ts`)
-which exercise the core end-to-end.
+suites (`tests/run-subtask-tool.test.ts`, `tests/run-search-tool.test.ts`,
+`tests/background-subtasks.test.ts` for `start`/`wait` and the registry,
+`tests/capabilities-agents.test.ts` through the capability seam) which
+exercise the core end-to-end.
 
 ## Code-shaped orchestration is CodeAct, not a mode
 
@@ -1239,6 +1253,7 @@ inside an `execute_code` action:
 | Script primitive | CodeAct equivalent |
 |---|---|
 | `await agent(prompt, opts?)` | `await nodetool.agents.run(prompt)` (a `run_subtask` child) |
+| `await agent.start(prompt)` + `await agent.wait({ids})` | `await nodetool.agents.start(prompt)` + `await nodetool.agents.wait({ids})` — background spawn, collect later |
 | `await parallel(thunks)` | `await Promise.all(...)`, or `nodetool.batch` for a bound |
 | `await pipeline(items, ...stages)` | `nodetool.batch(items, async (item) => …)` |
 | `log(message)` | `console.log(message)` |

--- a/packages/agents/src/background-subtasks.ts
+++ b/packages/agents/src/background-subtasks.ts
@@ -1,0 +1,191 @@
+/**
+ * Background subtask registry — the per-turn state behind `start_subtask` and
+ * `wait_subtasks`.
+ *
+ * A host creates one per chat turn and hangs it on the
+ * `SubAgentToolRuntime.background` field. Every `start_subtask` call in that
+ * turn registers its child here; the child's detached pump settles it when the
+ * loop ends. `wait_subtasks` blocks on the records instead of on the parent's
+ * tool call, which is what lets the parent keep working while children run.
+ *
+ * The settlement input is structurally compatible with `SubAgentOutcome` (plus
+ * an `{aborted: true}` variant) so this module imports nothing from
+ * `subagent.ts` — one less edge to cycle.
+ */
+
+export type BackgroundSubtaskStatus =
+  | "running"
+  | "completed"
+  | "failed"
+  | "aborted";
+
+/** What a pump hands back when the child loop is over. */
+export type BackgroundSubtaskSettlement =
+  | { ok: true; result: unknown }
+  | { ok: false; error: string }
+  | { aborted: true };
+
+export interface BackgroundSubtaskSnapshot {
+  readonly subtask_id: string;
+  readonly description: string;
+  /** Child recursion depth (1 = spawned by the root loop). */
+  readonly depth: number;
+  readonly status: BackgroundSubtaskStatus;
+  /** Present when status is "completed". */
+  readonly result?: unknown;
+  /** Present when status is "failed". */
+  readonly error?: string;
+}
+
+/** A wait result row: a snapshot, or an unknown id the caller named. */
+export type WaitedSubtask =
+  | BackgroundSubtaskSnapshot
+  | { subtask_id: string; status: "unknown" };
+
+export interface WaitBackgroundOptions {
+  /** Collect only these ids; omit to collect every record in the registry. */
+  ids?: readonly string[];
+  /** How long to block. Clamped to [1s, MAX_WAIT_TIMEOUT_MS]. */
+  timeoutMs?: number;
+  /** Aborting resolves immediately with current statuses. */
+  signal?: AbortSignal;
+}
+
+export const DEFAULT_WAIT_TIMEOUT_MS = 300_000;
+export const MAX_WAIT_TIMEOUT_MS = 900_000;
+
+const MIN_WAIT_TIMEOUT_MS = 1_000;
+
+/**
+ * Tracks background sub-agents for one turn. Not concurrency-safe across
+ * threads by design: every mutation happens on the turn's own async path.
+ */
+export class BackgroundSubtaskRegistry {
+  private readonly records = new Map<string, BackgroundSubtaskSnapshotImpl>();
+  private version = 0;
+  private waiters: Array<() => void> = [];
+
+  /** Register a freshly spawned child as "running". */
+  start(id: string, description: string, depth: number): void {
+    if (this.records.has(id)) return;
+    this.records.set(id, {
+      subtask_id: id,
+      description,
+      depth,
+      status: "running"
+    });
+  }
+
+  /** Mark a child settled. Unknown ids are ignored — start() owns the keys. */
+  settle(id: string, settlement: BackgroundSubtaskSettlement): void {
+    const record = this.records.get(id);
+    if (!record || record.status !== "running") return;
+    if (aborted(settlement)) {
+      record.status = "aborted";
+    } else if (settlement.ok) {
+      record.status = "completed";
+      record.result = settlement.result;
+    } else {
+      record.status = "failed";
+      record.error = settlement.error;
+    }
+    this.version++;
+    this.notifyWaiters();
+  }
+
+  /** Current state of every record, oldest first. */
+  snapshot(): BackgroundSubtaskSnapshot[] {
+    return [...this.records.values()].map((r) => ({ ...r }));
+  }
+
+  /** How many records this turn has started. */
+  get size(): number {
+    return this.records.size;
+  }
+
+  /** Records still running. */
+  get runningCount(): number {
+    let n = 0;
+    for (const r of this.records.values()) if (r.status === "running") n++;
+    return n;
+  }
+
+  /**
+   * Resolve once every requested record left "running", or on timeout or
+   * abort — whichever comes first. Timeout and abort resolve with the
+   * current statuses rather than throwing; a partial answer beats no answer.
+   */
+  async wait(opts: WaitBackgroundOptions = {}): Promise<WaitedSubtask[]> {
+    const requested = opts.ids?.length ? opts.ids : [...this.records.keys()];
+    const timeoutMs = clampTimeout(opts.timeoutMs);
+
+    const rowsFor = (): WaitedSubtask[] =>
+      requested.map((id) => {
+        const record = this.records.get(id);
+        return record ? { ...record } : { subtask_id: id, status: "unknown" };
+      });
+
+    const allSettled = (): boolean =>
+      requested.every((id) => {
+        const r = this.records.get(id);
+        return !r || r.status !== "running";
+      });
+
+    if (allSettled()) return rowsFor();
+
+    const deadline = new Promise<"timeout">((resolve) => {
+      const timer = setTimeout(() => resolve("timeout"), timeoutMs);
+      if (typeof timer.unref === "function") timer.unref();
+    });
+    const abortedP = abortPromise(opts.signal);
+
+    for (;;) {
+      if (allSettled()) return rowsFor();
+      const outcome = await Promise.race([
+        this.untilNextVersion(this.version),
+        deadline,
+        abortedP
+      ]);
+      if (outcome === "aborted" || outcome === "timeout") return rowsFor();
+      // "notified": loop, re-check at the top.
+    }
+  }
+
+  private untilNextVersion(seen: number): Promise<"notified"> {
+    if (this.version !== seen) return Promise.resolve("notified");
+    return new Promise<"notified">((resolve) => {
+      this.waiters.push(() => resolve("notified"));
+    });
+  }
+
+  private notifyWaiters(): void {
+    const waiters = this.waiters;
+    this.waiters = [];
+    for (const w of waiters) w();
+  }
+}
+
+interface BackgroundSubtaskSnapshotImpl extends BackgroundSubtaskSnapshot {
+  status: BackgroundSubtaskStatus;
+  result?: unknown;
+  error?: string;
+}
+
+function aborted(
+  s: BackgroundSubtaskSettlement
+): s is { aborted: true } {
+  return (s as { aborted?: boolean }).aborted === true;
+}
+
+function clampTimeout(raw: number | undefined): number {
+  const value = typeof raw === "number" && Number.isFinite(raw) ? raw : DEFAULT_WAIT_TIMEOUT_MS;
+  return Math.min(Math.max(Math.floor(value), MIN_WAIT_TIMEOUT_MS), MAX_WAIT_TIMEOUT_MS);
+}
+
+function abortPromise(signal: AbortSignal | undefined): Promise<"aborted"> {
+  if (!signal) return new Promise<"aborted">(() => {});
+  if (signal.aborted) return Promise.resolve("aborted");
+  return new Promise<"aborted">((resolve) => {
+    signal.addEventListener("abort", () => resolve("aborted"), { once: true });
+  });
+}

--- a/packages/agents/src/capabilities/agents.specs.ts
+++ b/packages/agents/src/capabilities/agents.specs.ts
@@ -11,6 +11,12 @@
 import type { CapabilitySpec } from "./types.js";
 import type { JsonSchema } from "@nodetool-ai/runtime";
 import { READ_ONLY_SEARCH_DESCRIPTION } from "../prompts/read-only-search-prompt.js";
+import {
+  START_SUBTASK_DESCRIPTION,
+  START_SUBTASK_SCHEMA,
+  WAIT_SUBTASKS_DESCRIPTION,
+  WAIT_SUBTASKS_SCHEMA
+} from "../prompts/background-subtask-prompt.js";
 import { isString } from "../utils/type-guards.js";
 
 export const RUN_SUBTASK_DESCRIPTION = [
@@ -103,8 +109,36 @@ export const runSearchSpec: CapabilitySpec = {
   }
 };
 
+export const startSubtaskSpec: CapabilitySpec = {
+  name: "start_subtask",
+  description: START_SUBTASK_DESCRIPTION,
+  inputSchema: START_SUBTASK_SCHEMA,
+  // The child's events nest under the caller's card, which needs the caller's
+  // tool-call id — same as `run_subtask`.
+  needsToolCallId: true,
+  // Spawning has no side effect of its own; the child loop's tools are gated
+  // inside it. The registry bookkeeping is per-turn state, not a mutation.
+  category: "read",
+  userMessage: (params) => {
+    const desc =
+      isString(params["description"]) ? params["description"].trim() : "";
+    return desc
+      ? `Starting background subtask: ${desc}`
+      : "Starting background subtask";
+  }
+};
+
+export const waitSubtasksSpec: CapabilitySpec = {
+  name: "wait_subtasks",
+  description: WAIT_SUBTASKS_DESCRIPTION,
+  inputSchema: WAIT_SUBTASKS_SCHEMA,
+  category: "read"
+};
+
 /** Every spec this module declares, in declaration order. */
 export const agentsSpecs: readonly CapabilitySpec[] = [
   runSubtaskSpec,
-  runSearchSpec
+  runSearchSpec,
+  startSubtaskSpec,
+  waitSubtasksSpec
 ];

--- a/packages/agents/src/capabilities/agents.ts
+++ b/packages/agents/src/capabilities/agents.ts
@@ -1,9 +1,10 @@
 /**
  * The `agents` capability module — delegation to a child agent loop.
  *
- * Two capabilities, `run_subtask` and `run_search`, and unlike every other
- * ported namespace their classes stay exactly as they are. `SubAgentTool` is
- * not a schema plus a function: it owns the depth gate, the child context, the
+ * Four capabilities: `run_subtask` (blocking), `run_search` (read-only
+ * child), `start_subtask` (background spawn) and `wait_subtasks` (collect).
+ * Unlike every other ported namespace their classes stay exactly as they
+ * are. `SubAgentTool` is not a schema plus a function: it owns the depth gate, the child context, the
  * streamed events, the tagging, and the settlement, and the runner constructs
  * one per turn over that turn's provider, model, toolbelt snapshot, and
  * forwarder. Reimplementing that here would be a second copy of the machinery
@@ -35,6 +36,8 @@ import type {
 import {
   runSubtaskSpec,
   runSearchSpec,
+  startSubtaskSpec,
+  waitSubtasksSpec,
   RUN_SUBTASK_DESCRIPTION,
   RUN_SUBTASK_SCHEMA,
   RUN_SEARCH_SCHEMA
@@ -110,10 +113,34 @@ const runSearch: CapabilityExport = {
   }
 };
 
-/** Both delegation capabilities. */
+const startSubtask: CapabilityExport = {
+  spec: startSubtaskSpec,
+  impl: async (run, args) => {
+    const { StartSubtaskTool } = await import("../tools/start-subtask-tool.js");
+    const tool = new StartSubtaskTool(subAgentRuntime(run, "start_subtask"));
+    return runSubAgentTool(tool, run, args);
+  }
+};
+
+const waitSubtasks: CapabilityExport = {
+  spec: waitSubtasksSpec,
+  impl: async (run, args) => {
+    const { WaitSubtasksTool } = await import("../tools/wait-subtasks-tool.js");
+    const runtime = subAgentRuntime(run, "wait_subtasks");
+    return Tool.executeTool(
+      new WaitSubtasksTool({ background: runtime.background }),
+      run.context,
+      args
+    );
+  }
+};
+
+/** Every delegation capability. */
 export const AGENT_CAPABILITIES: readonly CapabilityExport[] = [
   runSubtask,
-  runSearch
+  runSearch,
+  startSubtask,
+  waitSubtasks
 ];
 
 export const module: CapabilityModule = {
@@ -121,4 +148,4 @@ export const module: CapabilityModule = {
   exports: AGENT_CAPABILITIES
 };
 
-export { runSubtask, runSearch };
+export { runSubtask, runSearch, startSubtask, waitSubtasks };

--- a/packages/agents/src/codeact/nodetool-api.ts
+++ b/packages/agents/src/codeact/nodetool-api.ts
@@ -44,7 +44,7 @@ export const NODETOOL_API_NAMESPACE_TOOLS: Record<string, readonly string[]> = {
   // as raw catalog signatures.
   packs: ["list_sandbox_packages", "get_sandbox_package_docs"],
   nodes: ["search_nodes", "get_node_info", "list_nodes", "run_node"],
-  agents: ["run_subtask"],
+  agents: ["run_subtask", "start_subtask", "wait_subtasks"],
   models: ["find_model", "list_models", "list_provider_models"],
   media: [
     "generate_image",
@@ -555,7 +555,8 @@ const nodetool = (() => {
        * conversation — put everything it needs into the prompt, and ask for
        * JSON there when you want structure. Runs take real time and money;
        * delegate work that benefits from a fresh focused context, not
-       * one-tool errands.
+       * one-tool errands. Blocks until the child finishes; fan out with
+       * \`Promise.all\` or \`nodetool.batch\`.
        */
       run(prompt, opts) {
         const text = String(prompt === undefined || prompt === null ? "" : prompt);
@@ -564,6 +565,36 @@ const nodetool = (() => {
           text.split(/\\s+/).slice(0, 6).join(" ") ||
           "Subtask";
         return __need("run_subtask")({ description: description, prompt: text });
+      },
+      /**
+       * Start a sub-agent WITHOUT blocking: returns
+       * \`{subtask_id, status: "running"}\` right away while the child works.
+       * Collect results later in the same action with \`wait()\` — results of
+       * subtasks you never wait for are lost to the turn.
+       */
+      start(prompt, opts) {
+        const text = String(prompt === undefined || prompt === null ? "" : prompt);
+        const description =
+          (opts && opts.description) ||
+          text.split(/\\s+/).slice(0, 6).join(" ") ||
+          "Subtask";
+        return __need("start_subtask")({ description: description, prompt: text });
+      },
+      /**
+       * Wait for background subagents started with \`start()\`. Pass
+       * \`{ids: [...], timeoutMs}\` to bound the block. Resolves with rows:
+       * \`{subtask_id, status, result | error}\`. Never end an action with
+       * unwaited subtasks whose results you still need.
+       */
+      wait(opts) {
+        return __need("wait_subtasks")(
+          opts
+            ? {
+                ids: opts.ids,
+                timeout_ms: opts.timeoutMs
+              }
+            : {}
+        );
       }
     },
 
@@ -1245,7 +1276,11 @@ const NAMESPACE_DOCS: PromptEntry[] = [
   spawns a child with this belt's tools but a FRESH context: the prompt must be
   self-contained (ask for JSON in it when you want structure back). Fan out
   with \`nodetool.batch(prompts, (p) => nodetool.agents.run(p))\` — one
-  settled \`{ok, value | error}\` entry per prompt. Delegate work that benefits
+  settled \`{ok, value | error}\` entry per prompt. For independent work that
+  can run while you do something else, \`start(prompt)\` returns
+  \`(subtask_id)\` immediately and \`await wait({ids})\` collects
+  \`(status, result | error)\` later in the same action — never end without
+  waiting for results you need. Delegate work that benefits
   from a fresh focused context, not one-tool errands.`
   },
   {

--- a/packages/agents/src/evals/codeact-api-core.ts
+++ b/packages/agents/src/evals/codeact-api-core.ts
@@ -560,6 +560,7 @@ const EXAMPLE_WORKFLOWS: readonly WorldWorkflow[] = [
  */
 export function createCoreApiTools(recorder: CodeActToolRecorder): Tool[] {
   const world = new CoreWorld();
+  const pendingBg = new Map<string, { description: string; result: unknown }>();
 
   const tool = <TResult>(
     name: string,
@@ -1525,6 +1526,48 @@ export function createCoreApiTools(recorder: CodeActToolRecorder): Tool[] {
             words: prompt.split(/\s+/).filter((w) => w.length > 0).length
           }
         };
+      }
+    ),
+    tool(
+      "start_subtask",
+      "Start a background sub-agent and return a receipt immediately.",
+      { description: s, prompt: s },
+      (params) => {
+        const prompt = str(params["prompt"]);
+        const numbers = (prompt.match(/\d+(?:\.\d+)?/g) ?? []).map(Number);
+        const id = `bg-${world.assets.size + 1}`;
+        const result = {
+          sum: numbers.reduce((total, n) => total + n, 0),
+          numbers,
+          words: prompt.split(/\s+/).filter((w) => w.length > 0).length
+        };
+        pendingBg.set(id, { description: str(params["description"]), result });
+        return { subtask_id: id, description: str(params["description"]), status: "running" };
+      }
+    ),
+    tool(
+      "wait_subtasks",
+      "Collect background sub-agent results.",
+      {
+        ids: { type: "array", items: s },
+        timeout_ms: { type: "number" }
+      },
+      (params) => {
+        const ids = Array.isArray(params["ids"])
+          ? (params["ids"] as unknown[]).map(String)
+          : [...pendingBg.keys()];
+        const subtasks = ids.map((id) => {
+          const entry = pendingBg.get(id);
+          return entry
+            ? {
+                subtask_id: id,
+                description: entry.description,
+                status: "completed" as const,
+                result: entry.result
+              }
+            : { subtask_id: id, status: "unknown" as const };
+        });
+        return { subtasks, all_settled: true };
       }
     )
   ];

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -224,6 +224,26 @@ export type {
   ForwardMessage
 } from "./tools/run-subtask-tool.js";
 export {
+  StartSubtaskTool
+} from "./tools/start-subtask-tool.js";
+export type { StartSubtaskToolOptions } from "./tools/start-subtask-tool.js";
+export {
+  WaitSubtasksTool
+} from "./tools/wait-subtasks-tool.js";
+export type { WaitSubtasksToolOptions } from "./tools/wait-subtasks-tool.js";
+export {
+  BackgroundSubtaskRegistry,
+  DEFAULT_WAIT_TIMEOUT_MS,
+  MAX_WAIT_TIMEOUT_MS
+} from "./background-subtasks.js";
+export type {
+  BackgroundSubtaskStatus,
+  BackgroundSubtaskSettlement,
+  BackgroundSubtaskSnapshot,
+  WaitedSubtask,
+  WaitBackgroundOptions
+} from "./background-subtasks.js";
+export {
   RunSearchTool,
   READ_ONLY_TOOL_NAMES
 } from "./tools/run-search-tool.js";

--- a/packages/agents/src/prompts/background-subtask-prompt.ts
+++ b/packages/agents/src/prompts/background-subtask-prompt.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared wire text for the background delegation pair (`start_subtask` /
+ * `wait_subtasks`).
+ *
+ * A data-only leaf, like `read-only-search-prompt.ts`: the tool classes and
+ * the capability specs both import from here so one string stands behind
+ * every surface and the halves cannot drift.
+ */
+
+import type { JsonSchema } from "@nodetool-ai/runtime";
+
+export const START_SUBTASK_DESCRIPTION = [
+  "Spawn a background subtask: a fresh agent loop that starts now and keeps",
+  "running while you continue. Returns a receipt (`subtask_id`) immediately",
+  "instead of waiting for the result.",
+  "",
+  "Use this when independent work can run while you do something else —",
+  "research one question while you draft another section, fan out over many",
+  "sources. The child inherits your full toolset, sees none of this chat",
+  "history, and can recurse with `start_subtask`/`run_subtask` up to the",
+  "depth limit.",
+  "",
+  "Collect results with `wait_subtasks`. If you finish your answer before",
+  "calling it, the results are lost to this turn — always wait for what you",
+  "actually need. For work you need before anything else, use `run_subtask`,",
+  "which blocks and returns the text directly."
+].join("\n");
+
+export const START_SUBTASK_SCHEMA: JsonSchema = {
+  type: "object",
+  properties: {
+    description: {
+      type: "string",
+      description:
+        "Short user-facing label for the subtask (3-7 words). Shown in the UI card."
+    },
+    prompt: {
+      type: "string",
+      description:
+        'Full task description for the subagent. Self-contained — the subagent does not see the parent\'s chat history. If you need a structured response, say so here (e.g. "reply as JSON with fields x, y, z").'
+    }
+  },
+  required: ["description", "prompt"],
+  additionalProperties: false
+};
+
+export const WAIT_SUBTASKS_DESCRIPTION = [
+  "Wait for background subtasks started with `start_subtask` and collect",
+  "their results.",
+  "",
+  "Blocks until every requested subtask has finished, or until the timeout.",
+  "Each row reports status (`completed`, `failed`, `aborted`, or still",
+  "`running` past a timeout) plus the subagent's final message or error.",
+  "Omit `ids` to collect everything this turn has started."
+].join("\n");
+
+export const WAIT_SUBTASKS_SCHEMA: JsonSchema = {
+  type: "object",
+  properties: {
+    ids: {
+      type: "array",
+      items: { type: "string" },
+      description:
+        "Subtask ids to collect (from `start_subtask` receipts). Omit to collect all."
+    },
+    timeout_ms: {
+      type: "number",
+      description:
+        "How long to block, in milliseconds (1000–900000). Default 300000 (5 min). On timeout, running subtasks are reported as still running."
+    }
+  },
+  additionalProperties: false
+};

--- a/packages/agents/src/subagent.ts
+++ b/packages/agents/src/subagent.ts
@@ -41,6 +41,7 @@ import type {
   TurnBudget
 } from "@nodetool-ai/runtime";
 import type { ProcessingMessage, StepResult } from "@nodetool-ai/protocol";
+import type { BackgroundSubtaskRegistry } from "./background-subtasks.js";
 import { CodeActExecutor } from "./codeact/codeact-executor.js";
 import { Tool } from "./tools/base-tool.js";
 import {
@@ -376,6 +377,12 @@ export interface SubAgentToolRuntime {
   maxDepth?: number;
   /** Max LLM iterations per child loop. */
   maxIterations?: number;
+  /**
+   * Per-turn registry behind `start_subtask` / `wait_subtasks`. A host that
+   * does not build one (an MCP mount, a headless harness) leaves the field
+   * off, and background delegation refuses by name instead of half-working.
+   */
+  background?: BackgroundSubtaskRegistry;
 }
 
 /** What one invocation of a {@link SubAgentTool} should run. */

--- a/packages/agents/src/tools/start-subtask-tool.ts
+++ b/packages/agents/src/tools/start-subtask-tool.ts
@@ -1,0 +1,208 @@
+/**
+ * `start_subtask` — the background half of delegation.
+ *
+ * Same child as {@link RunSubtaskTool} — full inherited toolset, depth gate,
+ * tagged event forwarding — but `process()` returns a receipt immediately and
+ * the child loop runs detached, pumped by a promise this class owns. The
+ * per-turn {@link BackgroundSubtaskRegistry} (on
+ * `SubAgentToolRuntime.background`) is the handoff: the pump settles the
+ * record when the child ends, and `wait_subtasks` reads the same records.
+ *
+ * A host that builds no registry refuses with `background_unavailable`
+ * instead of spawning a child nobody can collect.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import {
+  enterSubAgentDepth,
+  forwardSubAgentStream,
+  runSubAgent,
+  SubAgentTool,
+  type SubAgentToolRun,
+  type SubAgentToolRuntime
+} from "../subagent.js";
+import type { BackgroundSubtaskRegistry } from "../background-subtasks.js";
+import {
+  START_SUBTASK_DESCRIPTION,
+  START_SUBTASK_SCHEMA
+} from "../prompts/background-subtask-prompt.js";
+import { Tool } from "./base-tool.js";
+import { RunSubtaskTool } from "./run-subtask-tool.js";
+import { WaitSubtasksTool } from "./wait-subtasks-tool.js";
+import { TOOL_CALL_ID_FIELD } from "./subtask-fields.js";
+import { isString } from "../utils/type-guards.js";
+
+export interface StartSubtaskToolOptions extends SubAgentToolRuntime {
+  /** Registry shared with this turn's `wait_subtasks` tool. */
+  background?: BackgroundSubtaskRegistry;
+  /** Max LLM iterations per child loop. Defaults to 20. */
+  maxIterations?: number;
+}
+
+const DEFAULT_MAX_ITERATIONS = 20;
+
+export class StartSubtaskTool extends SubAgentTool {
+  readonly name = "start_subtask";
+  readonly description = START_SUBTASK_DESCRIPTION;
+  readonly jsonSchema = START_SUBTASK_SCHEMA;
+
+  private readonly registry?: BackgroundSubtaskRegistry;
+
+  constructor(opts: StartSubtaskToolOptions) {
+    super({ ...opts, maxIterations: opts.maxIterations ?? DEFAULT_MAX_ITERATIONS });
+    this.registry = opts.background;
+  }
+
+  protected buildRun(
+    params: Record<string, unknown>
+  ): SubAgentToolRun | { error: string; message: string } {
+    const description = isString(params.description)
+      ? params.description.trim()
+      : "";
+    const prompt = isString(params.prompt) ? params.prompt.trim() : "";
+    if (!prompt) {
+      return {
+        error: "missing_prompt",
+        message: "`prompt` is required and must be a non-empty string."
+      };
+    }
+    return {
+      instructions: prompt,
+      title: description || "subtask",
+      errorCode: "subtask_failed",
+      noResultCode: "subtask_no_result",
+      noResultMessage: "Subtask ended without producing a final assistant message.",
+      errorExtras: { description: description || null }
+    };
+  }
+
+  protected buildChildToolset(parentTools: Tool[]): Tool[] {
+    const names = new Set(parentTools.map((t) => t.name));
+    const extras: Tool[] = [];
+    if (!names.has("run_subtask")) {
+      extras.push(new RunSubtaskTool(this.runtimeForChild()));
+    }
+    if (!names.has("start_subtask")) extras.push(this);
+    if (!names.has("wait_subtasks")) {
+      extras.push(new WaitSubtasksTool({ background: this.registry }));
+    }
+    return extras.length > 0 ? [...extras, ...parentTools] : parentTools;
+  }
+
+  private runtimeForChild(): import("../subagent.js").SubAgentToolRuntime {
+    return {
+      provider: this.provider,
+      model: this.model,
+      parentTools: this.parentToolsFn,
+      forwardMessage: this.forward,
+      maxDepth: this.maxDepth,
+      maxIterations: this.maxIterations,
+      background: this.registry
+    };
+  }
+
+  userMessage(params: Record<string, unknown>): string {
+    const desc = isString(params.description) ? params.description.trim() : "";
+    return desc
+      ? `Starting background subtask: ${desc}`
+      : "Starting background subtask";
+  }
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    if (!this.registry) {
+      return {
+        error: "background_unavailable",
+        message:
+          "`start_subtask` needs a background registry, but this run carries " +
+          "no `SubAgentToolRuntime.background`. Use `run_subtask`, which " +
+          "blocks and returns the result directly."
+      };
+    }
+
+    const gate = enterSubAgentDepth(context, this.maxDepth, this.depthNoun);
+    if (!gate.ok) return gate.refusal;
+
+    const run = this.buildRun(params);
+    if ("error" in run) return run;
+
+    const parentToolCallId = isString(params[TOOL_CALL_ID_FIELD])
+      ? params[TOOL_CALL_ID_FIELD]
+      : null;
+
+    const id = randomUUID();
+    this.registry.start(id, run.title, gate.depth);
+
+    const gen = runSubAgent({
+      context: gate.childCtx,
+      provider: this.provider,
+      model: this.model,
+      tools: this.buildChildToolset(this.parentToolsFn()),
+      instructions: run.instructions,
+      title: run.title,
+      outputSchema: run.outputSchema,
+      systemPrompt: run.systemPrompt,
+      maxIterations: run.maxIterations ?? this.maxIterations,
+      signal: context.signal
+    });
+
+    void this.pump(gen, id, parentToolCallId, gate.depth, context.signal);
+
+    return {
+      subtask_id: id,
+      description: run.title,
+      status: "running",
+      message:
+        "The subtask is running in the background. Call wait_subtasks to " +
+        "collect its result — include this subtask_id to wait for it alone."
+    };
+  }
+
+  /**
+   * Drive the detached child to settlement. Never throws: every path lands
+   * in a registry settle, so `wait_subtasks` always sees a terminal status.
+   */
+  private async pump(
+    gen: AsyncGenerator<ProcessingMessage>,
+    id: string,
+    parentToolCallId: string | null,
+    depth: number,
+    signal: AbortSignal
+  ): Promise<void> {
+    try {
+      const { aborted, value } = await forwardSubAgentStream(gen, {
+        forward: this.forward,
+        parentToolCallId,
+        depth,
+        label: this.name,
+        signal
+      });
+      if (aborted) {
+        this.registry?.settle(id, { aborted: true });
+      } else if (!value || !value.ok) {
+        this.registry?.settle(id, {
+          ok: false,
+          error: value ? value.error : "Background subagent stream ended early."
+        });
+      } else if (value.result === null || value.result === undefined) {
+        // Match run_subtask's settlement vocabulary: a child that ends with
+        // no final message is a failure, not a null success.
+        this.registry?.settle(id, {
+          ok: false,
+          error: "subtask_no_result"
+        });
+      } else {
+        this.registry?.settle(id, value);
+      }
+    } catch (e) {
+      this.registry?.settle(id, {
+        ok: false,
+        error: e instanceof Error ? e.message : String(e)
+      });
+    }
+  }
+}

--- a/packages/agents/src/tools/tool-permissions.ts
+++ b/packages/agents/src/tools/tool-permissions.ts
@@ -174,6 +174,11 @@ export const TOOL_PERMISSION_CATEGORIES: Readonly<
   // list_directory/read_shared only); the call itself has no side effects, so
   // it always runs ungated.
   run_search: "read",
+  // start_subtask spawns the same kind of child, detached; the registry it
+  // writes to is per-turn bookkeeping, not an external mutation. wait_subtasks
+  // only reads that registry.
+  start_subtask: "read",
+  wait_subtasks: "read",
 
   // --- write: produces files / artifacts / costly media ---
   write_file: "write",

--- a/packages/agents/src/tools/wait-subtasks-tool.ts
+++ b/packages/agents/src/tools/wait-subtasks-tool.ts
@@ -1,0 +1,97 @@
+/**
+ * `wait_subtasks` — collect the results of background sub-agents.
+ *
+ * The blocking counterpart to {@link StartSubtaskTool}. Reads the same
+ * per-turn {@link BackgroundSubtaskRegistry} and resolves when every
+ * requested record left "running", on timeout, or when the turn's abort
+ * signal fires — a stop button must never leave the parent parked in a wait.
+ * Timeout and abort return current statuses instead of throwing; a partial
+ * answer beats no answer.
+ */
+
+import type { ProcessingContext } from "@nodetool-ai/runtime";
+import { Tool } from "./base-tool.js";
+import {
+  DEFAULT_WAIT_TIMEOUT_MS,
+  MAX_WAIT_TIMEOUT_MS,
+  type BackgroundSubtaskRegistry,
+  type WaitedSubtask
+} from "../background-subtasks.js";
+import {
+  WAIT_SUBTASKS_DESCRIPTION,
+  WAIT_SUBTASKS_SCHEMA
+} from "../prompts/background-subtask-prompt.js";
+import { isString } from "../utils/type-guards.js";
+
+const MIN_WAIT_TIMEOUT_MS = 1_000;
+
+export interface WaitSubtasksToolOptions {
+  /** The registry this turn's `start_subtask` calls write to. */
+  background?: BackgroundSubtaskRegistry;
+}
+
+export class WaitSubtasksTool extends Tool {
+  readonly name = "wait_subtasks";
+  readonly description = WAIT_SUBTASKS_DESCRIPTION;
+  readonly jsonSchema = WAIT_SUBTASKS_SCHEMA;
+
+  private readonly registry?: BackgroundSubtaskRegistry;
+
+  constructor(opts: WaitSubtasksToolOptions) {
+    super();
+    this.registry = opts.background;
+  }
+
+  async process(
+    context: ProcessingContext,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    if (!this.registry) {
+      return {
+        error: "background_unavailable",
+        message:
+          "`wait_subtasks` needs a background registry, but this run carries " +
+          "no `SubAgentToolRuntime.background`. Nothing can be running in " +
+          "the background here."
+      };
+    }
+    if (this.registry.size === 0) {
+      return {
+        subtasks: [],
+        message:
+          "No background subtasks have been started in this turn. Start one " +
+          "with start_subtask."
+      };
+    }
+
+    const ids = stringArray(params.ids);
+    const timeoutMs = clampTimeout(params.timeout_ms);
+    const rows = await this.registry.wait({
+      ids,
+      timeoutMs,
+      signal: context.signal
+    });
+    return {
+      subtasks: rows,
+      all_settled: rows.every((row) => row.status !== "running")
+    };
+  }
+}
+
+function stringArray(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const values = raw.filter(isString);
+  return values.length > 0 ? values : undefined;
+}
+
+function clampTimeout(raw: unknown): number | undefined {
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw <= 0) {
+    return DEFAULT_WAIT_TIMEOUT_MS;
+  }
+  return Math.min(
+    Math.max(Math.floor(raw), MIN_WAIT_TIMEOUT_MS),
+    MAX_WAIT_TIMEOUT_MS
+  );
+}
+
+export type { WaitedSubtask };

--- a/packages/agents/tests/background-subtasks.test.ts
+++ b/packages/agents/tests/background-subtasks.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi } from "vitest";
+import { ProcessingContext, BaseProvider } from "@nodetool-ai/runtime";
+import type { ProcessingMessage } from "@nodetool-ai/protocol";
+import {
+  BackgroundSubtaskRegistry,
+  StartSubtaskTool,
+  WaitSubtasksTool,
+  SUBTASK_DEPTH_KEY,
+  TOOL_CALL_ID_FIELD
+} from "../src/index.js";
+
+function makeCtx(): ProcessingContext {
+  return new ProcessingContext({ jobId: "test-job", userId: "test" });
+}
+
+type StreamItem =
+  | { type: "chunk"; content: string; done?: boolean }
+  | { id: string; name: string; args: Record<string, unknown> };
+
+/**
+ * Minimal mock BaseProvider — the same shape run-subtask-tool.test.ts uses.
+ * `gates` holds one promise per generateMessages call, resolved by the test
+ * to hold the child loop open before its scripted response plays.
+ */
+function createMockProvider(gates: Array<Promise<void>> = []) {
+  let callIndex = 0;
+  const responseSequence: Array<Array<StreamItem>> = [
+    [{ type: "chunk", content: "late answer", done: true }]
+  ];
+  return {
+    provider: "mock",
+    hasToolSupport: async () => true,
+    generateMessages: async function* () {
+      const gate = gates[callIndex];
+      callIndex++;
+      if (gate) await gate;
+      const items = responseSequence[0] ?? [];
+      for (const item of items) yield item;
+    },
+    async *generateMessagesTraced(...args: any[]) {
+      yield* (this as any).generateMessages(...args);
+    },
+    generateLoop(args: unknown) {
+      return (
+        BaseProvider.prototype as { generateLoop: (a: unknown) => unknown }
+      ).generateLoop.call(this, args);
+    },
+    async generateMessageTraced(...args: any[]) {
+      return (this as any).generateMessage(...args);
+    },
+    generateMessage: vi.fn(),
+    getAvailableLanguageModels: vi.fn().mockResolvedValue([]),
+    getAvailableImageModels: vi.fn().mockResolvedValue([]),
+    getAvailableVideoModels: vi.fn().mockResolvedValue([]),
+    getAvailableTTSModels: vi.fn().mockResolvedValue([]),
+    getAvailableASRModels: vi.fn().mockResolvedValue([]),
+    getAvailableEmbeddingModels: vi.fn().mockResolvedValue([]),
+    getContainerEnv: () => ({}),
+    textToImage: vi.fn(),
+    imageToImage: vi.fn(),
+    textToSpeech: vi.fn(),
+    automaticSpeechRecognition: vi.fn(),
+    textToVideo: vi.fn(),
+    imageToVideo: vi.fn(),
+    generateEmbedding: vi.fn(),
+    isContextLengthError: () => false
+  } as any;
+}
+
+describe("BackgroundSubtaskRegistry", () => {
+  it("tracks start → settle → snapshot", () => {
+    const registry = new BackgroundSubtaskRegistry();
+    registry.start("a", "Research X", 1);
+    registry.start("b", "Draft Y", 1);
+    expect(registry.size).toBe(2);
+    expect(registry.runningCount).toBe(2);
+
+    registry.settle("a", { ok: true, result: "done" });
+    registry.settle("b", { ok: false, error: "boom" });
+
+    const rows = registry.snapshot();
+    expect(rows.map((r) => [r.subtask_id, r.status])).toEqual([
+      ["a", "completed"],
+      ["b", "failed"]
+    ]);
+    expect(registry.runningCount).toBe(0);
+  });
+
+  it("marks an aborted settlement and ignores double settles", () => {
+    const registry = new BackgroundSubtaskRegistry();
+    registry.start("a", "X", 1);
+    registry.settle("a", { aborted: true });
+    registry.settle("a", { ok: true, result: "late" });
+    const [row] = registry.snapshot();
+    expect(row.status).toBe("aborted");
+    expect(row.result).toBeUndefined();
+  });
+
+  it("wait resolves when every requested record settles", async () => {
+    const registry = new BackgroundSubtaskRegistry();
+    registry.start("a", "X", 1);
+    const pending = registry.wait({ ids: ["a"], timeoutMs: 5_000 });
+    registry.settle("a", { ok: true, result: 42 });
+    const rows = await pending;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ subtask_id: "a", status: "completed", result: 42 });
+  });
+
+  it("wait reports unknown ids without blocking", async () => {
+    const registry = new BackgroundSubtaskRegistry();
+    const rows = await registry.wait({ ids: ["ghost"], timeoutMs: 1_000 });
+    expect(rows).toEqual([{ subtask_id: "ghost", status: "unknown" }]);
+  });
+
+  it("wait returns running statuses on timeout", async () => {
+    const registry = new BackgroundSubtaskRegistry();
+    registry.start("a", "X", 1);
+    const rows = await registry.wait({ timeoutMs: 50 });
+    expect(rows[0].status).toBe("running");
+  });
+
+  it("wait resolves immediately when nothing is running", async () => {
+    const registry = new BackgroundSubtaskRegistry();
+    registry.start("a", "X", 1);
+    registry.settle("a", { ok: false, error: "nope" });
+    const rows = await registry.wait({ timeoutMs: 5_000 });
+    expect(rows[0].status).toBe("failed");
+  });
+
+  it("wait honors an abort signal", async () => {
+    const registry = new BackgroundSubtaskRegistry();
+    registry.start("a", "X", 1);
+    const controller = new AbortController();
+    const pending = registry.wait({
+      timeoutMs: 30_000,
+      signal: controller.signal
+    });
+    controller.abort();
+    const rows = await pending;
+    expect(rows[0].status).toBe("running");
+  });
+});
+
+describe("StartSubtaskTool", () => {
+  function makeTool(
+    provider: ReturnType<typeof createMockProvider>,
+    registry: BackgroundSubtaskRegistry | undefined,
+    forwarded: ProcessingMessage[] = []
+  ): StartSubtaskTool {
+    return new StartSubtaskTool({
+      provider,
+      model: "mock",
+      parentTools: () => [],
+      forwardMessage: (m) => {
+        forwarded.push(m);
+      },
+      background: registry
+    });
+  }
+
+  it("declares the start_subtask identity and schema", () => {
+    const tool = makeTool(createMockProvider(), new BackgroundSubtaskRegistry());
+    expect(tool.name).toBe("start_subtask");
+    expect(tool.needsToolCallId).toBe(true);
+    const schema = tool.inputSchema as Record<string, unknown>;
+    expect(schema.required).toEqual(["description", "prompt"]);
+  });
+
+  it("refuses without a background registry", async () => {
+    const tool = makeTool(createMockProvider(), undefined);
+    const result = (await tool.process(makeCtx(), {
+      description: "d",
+      prompt: "p"
+    })) as Record<string, unknown>;
+    expect(result.error).toBe("background_unavailable");
+  });
+
+  it("still enforces the recursion depth gate", async () => {
+    const tool = makeTool(createMockProvider(), new BackgroundSubtaskRegistry());
+    const ctx = makeCtx();
+    ctx.set(SUBTASK_DEPTH_KEY, 3);
+    const result = (await tool.process(ctx, {
+      description: "deep",
+      prompt: "recurse"
+    })) as Record<string, unknown>;
+    expect(result.error).toBe("max_recursion_depth_reached");
+  });
+
+  it("returns a receipt immediately and settles the record later", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const provider = createMockProvider([gate]);
+    const registry = new BackgroundSubtaskRegistry();
+    const forwarded: ProcessingMessage[] = [];
+    const tool = makeTool(provider, registry, forwarded);
+    const ctx = makeCtx();
+
+    const receipt = (await Promise.race([
+      tool.process(ctx, {
+        description: "Research",
+        prompt: "go do research",
+        [TOOL_CALL_ID_FIELD]: "tc_root"
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("process() blocked")), 1_000)
+      )
+    ])) as Record<string, unknown>;
+
+    expect(receipt.status).toBe("running");
+    expect(typeof receipt.subtask_id).toBe("string");
+    expect(registry.runningCount).toBe(1);
+
+    // Child events stream while the parent moved on.
+    release();
+    await vi.waitFor(() => expect(registry.runningCount).toBe(0));
+
+    const [row] = registry.snapshot();
+    expect(row.status).toBe("completed");
+    expect(row.description).toBe("Research");
+    expect(row.depth).toBe(1);
+    expect(row.result).toContain("late answer");
+
+    const tagged = forwarded.find(
+      (m) =>
+        (m as { parent_tool_call_id?: string }).parent_tool_call_id ===
+        "tc_root"
+    ) as { subtask_depth?: number } | undefined;
+    expect(tagged?.subtask_depth).toBe(1);
+  });
+
+  it("reports a failed child through wait_subtasks", async () => {
+    // An empty provider sequence yields no final message → no_result failure.
+    const provider = createMockProvider();
+    (provider as { generateMessages: unknown }).generateMessages =
+      async function* () {
+        // yields nothing at all
+      };
+    const registry = new BackgroundSubtaskRegistry();
+    const tool = makeTool(provider, registry);
+    const ctx = makeCtx();
+
+    const receipt = (await tool.process(ctx, {
+      description: "dies quietly",
+      prompt: "p"
+    })) as Record<string, unknown>;
+
+    const rows = (await new WaitSubtasksTool({ background: registry }).process(
+      ctx,
+      { ids: [receipt.subtask_id], timeout_ms: 5_000 }
+    )) as { subtasks: Array<{ status: string; error?: string }> };
+    expect(rows.subtasks[0].status).toBe("failed");
+  });
+});
+
+describe("WaitSubtasksTool", () => {
+  it("refuses without a registry", async () => {
+    const tool = new WaitSubtasksTool({});
+    const result = (await tool.process(makeCtx(), {})) as Record<
+      string,
+      unknown
+    >;
+    expect(result.error).toBe("background_unavailable");
+  });
+
+  it("answers with guidance when nothing was started", async () => {
+    const tool = new WaitSubtasksTool({ background: new BackgroundSubtaskRegistry() });
+    const result = (await tool.process(makeCtx(), {})) as Record<string, unknown>;
+    expect(result.subtasks).toEqual([]);
+    expect(String(result.message)).toContain("No background subtasks");
+  });
+
+  it("collects results for the whole turn", async () => {
+    const registry = new BackgroundSubtaskRegistry();
+    registry.start("a", "First", 1);
+    registry.start("b", "Second", 1);
+    registry.settle("a", { ok: true, result: "one" });
+
+    const tool = new WaitSubtasksTool({ background: registry });
+    // b never settles → the timeout path reports it as still running.
+    const result = (await tool.process(makeCtx(), { timeout_ms: 100 })) as {
+      subtasks: Array<{ subtask_id: string; status: string }>;
+      all_settled: boolean;
+    };
+    expect(result.subtasks.map((r) => r.subtask_id)).toEqual(["a", "b"]);
+    expect(result.all_settled).toBe(false);
+  });
+
+  it("collects only requested ids", async () => {
+    const registry = new BackgroundSubtaskRegistry();
+    registry.start("a", "First", 1);
+    registry.start("b", "Second", 1);
+    registry.settle("a", { ok: true, result: "one" });
+    registry.settle("b", { aborted: true });
+
+    const tool = new WaitSubtasksTool({ background: registry });
+    const result = (await tool.process(makeCtx(), {
+      ids: ["b"]
+    })) as { subtasks: Array<{ subtask_id: string; status: string }> };
+    expect(result.subtasks).toEqual([
+      { subtask_id: "b", depth: 1, description: "Second", status: "aborted" }
+    ]);
+  });
+
+  it("returns promptly when the turn aborts mid-wait", async () => {
+    const registry = new BackgroundSubtaskRegistry();
+    registry.start("slow", "Slow", 1);
+    const tool = new WaitSubtasksTool({ background: registry });
+    const ctx = makeCtx();
+    const controller = new AbortController();
+    // `signal` is a plain mutable field; swap in one we control.
+    (ctx as { signal: AbortSignal }).signal = controller.signal;
+    const started = Date.now();
+    const pending = tool.process(ctx, {});
+    setTimeout(() => controller.abort(), 20);
+    await pending;
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+});

--- a/packages/agents/tests/capabilities-agents.test.ts
+++ b/packages/agents/tests/capabilities-agents.test.ts
@@ -1,7 +1,8 @@
 /**
- * The `agents` capability module: `run_subtask` and `run_search`.
+ * The `agents` capability module: `run_subtask`, `run_search`,
+ * `start_subtask` and `wait_subtasks`.
  *
- * These two are the exception to the port. `SubAgentTool` owns the depth gate,
+ * These are the exception to the port. `SubAgentTool` owns the depth gate,
  * the child context, the streamed events and the settlement, and the runner
  * constructs one per turn over that turn's provider, model, toolbelt snapshot
  * and forwarder — so the classes stay untouched and the capability is the
@@ -18,7 +19,9 @@ import type { ProcessingMessage } from "@nodetool-ai/protocol";
 import {
   AGENT_CAPABILITIES,
   runSearch,
-  runSubtask
+  runSubtask,
+  startSubtask,
+  waitSubtasks
 } from "../src/capabilities/agents.js";
 import {
   capabilityModuleDrift,
@@ -27,12 +30,14 @@ import {
 import { UNGATED, createCapabilityRun } from "../src/capabilities/invoke.js";
 import { permissionCategoryFor } from "../src/tools/tool-permissions.js";
 import type { SubAgentToolRuntime } from "../src/subagent.js";
+import { BackgroundSubtaskRegistry } from "../src/background-subtasks.js";
 import {
   SUBTASK_DEPTH_KEY,
   TOOL_CALL_ID_FIELD
 } from "../src/tools/subtask-fields.js";
 import { RunSubtaskTool } from "../src/tools/run-subtask-tool.js";
 import { RunSearchTool } from "../src/tools/run-search-tool.js";
+import { StartSubtaskTool } from "../src/tools/start-subtask-tool.js";
 
 function makeCtx(): ProcessingContext {
   return new ProcessingContext({ jobId: "test-job", userId: "test" });
@@ -104,12 +109,14 @@ function stubRuntime(
 }
 
 describe("the agents capability module", () => {
-  it("registers without drift and exports both wire names", async () => {
+  it("registers without drift and exports every delegation wire name", async () => {
     expect(await capabilityModuleDrift()).toEqual([]);
     const mod = await loadCapabilityModule("agents");
     expect(mod.exports.map((e) => e.spec.name)).toEqual([
       "run_subtask",
-      "run_search"
+      "run_search",
+      "start_subtask",
+      "wait_subtasks"
     ]);
   });
 
@@ -139,12 +146,22 @@ describe("the agents capability module", () => {
     expect(runSearch.spec.userMessage?.({ query: "where is X" })).toBe(
       search.userMessage({ query: "where is X" })
     );
+
+    const start = new StartSubtaskTool(stubRuntime());
+    expect(startSubtask.spec.name).toBe(start.name);
+    expect(startSubtask.spec.description).toBe(start.description);
+    expect(startSubtask.spec.inputSchema).toEqual(start.inputSchema);
+    expect(
+      startSubtask.spec.userMessage?.({ description: "Research X" })
+    ).toBe(start.userMessage({ description: "Research X" }));
   });
 
   it("names the missing field when the run carries no sub-agent runtime", async () => {
     const run = createCapabilityRun({ context: makeCtx(), gate: UNGATED });
     await expect(run.invoke("run_subtask", {})).rejects.toThrow(/`subAgent`/);
     await expect(run.invoke("run_search", {})).rejects.toThrow(/`subAgent`/);
+    await expect(run.invoke("start_subtask", {})).rejects.toThrow(/`subAgent`/);
+    await expect(run.invoke("wait_subtasks", {})).rejects.toThrow(/`subAgent`/);
   });
 
   it("spawns a child loop and nests its events under the parent call", async () => {
@@ -207,5 +224,74 @@ describe("the agents capability module", () => {
       unknown
     >;
     expect(result.error).toBe("missing_query");
+  });
+
+  it("spawns in the background and collects through the same registry", async () => {
+    const registry = new BackgroundSubtaskRegistry();
+    const forwarded: ProcessingMessage[] = [];
+    const run = createCapabilityRun({
+      context: makeCtx(),
+      gate: UNGATED,
+      subAgent: stubRuntime({
+        provider: createMockProvider([
+          [{ type: "chunk", content: "background answer", done: true }]
+        ]),
+        forwardMessage: (m) => {
+          forwarded.push(m);
+        },
+        background: registry
+      })
+    });
+
+    const receipt = (await run.invoke("start_subtask", {
+      description: "fan-out worker",
+      prompt: "work while the parent moves on",
+      [TOOL_CALL_ID_FIELD]: "tc_root"
+    })) as Record<string, unknown>;
+    expect(receipt.status).toBe("running");
+    expect(registry.runningCount).toBe(1);
+
+    const waited = (await run.invoke("wait_subtasks", {})) as {
+      subtasks: Array<Record<string, unknown>>;
+      all_settled: boolean;
+    };
+    expect(waited.all_settled).toBe(true);
+    expect(waited.subtasks).toHaveLength(1);
+    expect(waited.subtasks[0]).toMatchObject({
+      subtask_id: receipt.subtask_id,
+      status: "completed"
+    });
+    expect(String(waited.subtasks[0].result)).toContain("background answer");
+
+    const nested = forwarded.find(
+      (m) =>
+        (m as { parent_tool_call_id?: string }).parent_tool_call_id ===
+        "tc_root"
+    ) as { subtask_depth?: number } | undefined;
+    expect(nested?.subtask_depth).toBe(1);
+  });
+
+  it("refuses background delegation when the host builds no registry", async () => {
+    const spawn = createCapabilityRun({
+      context: makeCtx(),
+      gate: UNGATED,
+      subAgent: stubRuntime()
+    });
+    const result = (await spawn.invoke("start_subtask", {
+      description: "d",
+      prompt: "p"
+    })) as Record<string, unknown>;
+    expect(result.error).toBe("background_unavailable");
+
+    const wait = createCapabilityRun({
+      context: makeCtx(),
+      gate: UNGATED,
+      subAgent: stubRuntime()
+    });
+    const waited = (await wait.invoke("wait_subtasks", {})) as Record<
+      string,
+      unknown
+    >;
+    expect(waited.error).toBe("background_unavailable");
   });
 });

--- a/packages/agents/tests/capabilities-registry.test.ts
+++ b/packages/agents/tests/capabilities-registry.test.ts
@@ -214,6 +214,7 @@ const CAPABILITY_CATEGORY_SNAPSHOT: Record<string, PermissionCategory> = {
   set_workflow_access: "external",
   share_result: "read",
   start_background_job: "execute",
+  start_subtask: "read",
   take_node_stream: "read",
   take_screenshot: "read",
   test_code: "execute",
@@ -249,6 +250,7 @@ const CAPABILITY_CATEGORY_SNAPSHOT: Record<string, PermissionCategory> = {
   vector_text_search: "read",
   view_image: "read",
   voice_script_lines: "write",
+  wait_subtasks: "read",
   web_search: "read",
   write_file: "write",
   yt_dlp: "external"

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -687,7 +687,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "get_job_logs",
     module: "jobs",
     impl: "packages/agents/src/capabilities/jobs.ts",
-    contract: "a0efde46e363",
+    contract: "e4eb72a3bb2e",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-jobs.test.ts",
@@ -1272,6 +1272,26 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     module: "agents",
     impl: "packages/agents/src/capabilities/agents.ts",
     contract: "4d4c6ddc88ee",
+    selfcheck: "capability-suites",
+    suites: [
+      "packages/agents/tests/capabilities-agents.test.ts",
+    ],
+  },
+  {
+    name: "start_subtask",
+    module: "agents",
+    impl: "packages/agents/src/capabilities/agents.ts",
+    contract: "cbd1367c51d6",
+    selfcheck: "capability-suites",
+    suites: [
+      "packages/agents/tests/capabilities-agents.test.ts",
+    ],
+  },
+  {
+    name: "wait_subtasks",
+    module: "agents",
+    impl: "packages/agents/src/capabilities/agents.ts",
+    contract: "761238019e95",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-agents.test.ts",

--- a/packages/cli/src/stdin.ts
+++ b/packages/cli/src/stdin.ts
@@ -27,6 +27,7 @@ import { processChat } from "@nodetool-ai/chat";
 import { applySystemPrompt, createCliCodeActTurn } from "./chat-codeact.js";
 import { createChatContext } from "./chat-context.js";
 import {
+  BackgroundSubtaskRegistry,
   createCapabilityRun,
   contextSecretAvailability,
   getBuiltinTools,
@@ -251,31 +252,44 @@ export async function runStdinMode(opts: StdinModeOptions): Promise<void> {
         process.stderr.write(`[tool] ${msg.name}\n`);
       }
     };
-    // Both delegation tools reach the belt as capabilities over one runtime.
+    // All delegation tools reach the belt as capabilities over one runtime.
     // The class is still what runs — the `agents` module builds one per call —
     // so the depth gate, the child's inherited belt (with a `run_subtask` of
     // its own stitched in, since this snapshot predates the tools below it)
-    // and the event tagging are unchanged.
+    // and the event tagging are unchanged. The background registry is built
+    // ONCE here (not inside `delegationRun`) so every `start_subtask` call
+    // this turn writes records the same turn's `wait_subtasks` reads.
+    const backgroundSubtasks = new BackgroundSubtaskRegistry();
+    const subAgentRuntime = {
+      provider: prov,
+      model: opts.model,
+      parentTools: () => baseTools,
+      forwardMessage,
+      background: backgroundSubtasks
+    };
     const delegationRun = (context: ProcessingContext) =>
       createCapabilityRun({
         context,
         gate: UNGATED,
         availableSecrets: contextSecretAvailability(context),
-        subAgent: {
-          provider: prov,
-          model: opts.model,
-          parentTools: () => baseTools,
-          forwardMessage
-        }
+        subAgent: subAgentRuntime
       });
     const subtaskTool = toolForCapabilityName("run_subtask", delegationRun);
+    const startSubtaskTool = toolForCapabilityName(
+      "start_subtask",
+      delegationRun
+    );
+    const waitSubtasksTool = toolForCapabilityName(
+      "wait_subtasks",
+      delegationRun
+    );
     // Read-only fan-out search (on by default). Filters baseTools to its
     // read-only allowlist internally, so passing the full snapshot is correct.
     if (opts.enableReadOnlySearch !== false) {
       const searchTool = toolForCapabilityName("run_search", delegationRun);
-      return [searchTool, subtaskTool, ...baseTools];
+      return [searchTool, subtaskTool, startSubtaskTool, waitSubtasksTool, ...baseTools];
     }
-    return [subtaskTool, ...baseTools];
+    return [subtaskTool, startSubtaskTool, waitSubtasksTool, ...baseTools];
   };
 
   /**

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -183,6 +183,7 @@ import {
   capabilityFromTool,
   createCapabilityRun,
   contextSecretAvailability,
+  BackgroundSubtaskRegistry,
   UNGATED,
   extractInjectableImages,
   PLAN_APPROVAL_CONTEXT_KEY,
@@ -5718,14 +5719,17 @@ export class UnifiedWebSocketRunner {
         provider,
         model,
         parentTools: () => baseTools,
-        forwardMessage: forwardSubtaskMessage
+        forwardMessage: forwardSubtaskMessage,
+        background: new BackgroundSubtaskRegistry()
       };
-      // Both delegation tools reach the belt as capabilities over this
+      // All four delegation tools reach the belt as capabilities over this
       // runtime. The class is still what runs — the `agents` module builds one
       // per call — so the depth gate, the child's inherited belt (with a
       // `run_subtask` of its own stitched in by `buildChildToolset`, since this
       // snapshot deliberately predates the unshift), and the
       // `parent_tool_call_id` / `subtask_depth` tagging are unchanged.
+      // `start_subtask` / `wait_subtasks` share the per-turn registry above:
+      // spawn returns immediately, and the parent collects on its own terms.
       const delegationRun = (context: ProcessingContext) =>
         createCapabilityRun({
           context,
@@ -5736,6 +5740,12 @@ export class UnifiedWebSocketRunner {
           subAgent: subAgentRuntime
         });
       serverTools.unshift(toolForCapabilityName("run_subtask", delegationRun));
+      serverTools.unshift(
+        toolForCapabilityName("start_subtask", delegationRun)
+      );
+      serverTools.unshift(
+        toolForCapabilityName("wait_subtasks", delegationRun)
+      );
 
       // Read-only fan-out search (opt-in). Reuses the same runtime — the
       // capability filters the parent belt to its read-only allowlist


### PR DESCRIPTION
Implements O2 — background subtasks so the top-level agent is not blocked while a child runs.

**What changed**
- Per-turn `BackgroundSubtaskRegistry` (`packages/agents/src/background-subtasks.ts`) on `SubAgentToolRuntime.background`. `start_subtask` returns `{subtask_id, status:"running"}` immediately and pumps the child detached (tagged `parent_tool_call_id`/`subtask_depth` events still stream); `wait_subtasks` collects by id or all, with timeout and AbortSignal (stop cancels the wait).
- New capabilities `start_subtask` / `wait_subtasks` (`agents.specs.ts`, `agents.ts`), permission `read`, capability table sync (+`get_job_logs` contract refresh from stale main), hosts wire one registry per turn (`unified-websocket-runner.ts`, `stdin.ts`).
- CodeAct object model `nodetool.agents.start` / `wait` and namespace docs (`codeact/nodetool-api.ts`), eval world shim (`codeact-api-core.ts`).
- Coverage: `tests/background-subtasks.test.ts` (registry + tools), extended `tests/capabilities-agents.test.ts` through the capability seam, updated `capabilities-registry` snapshot.

**Verification**
- `npm run typecheck` pass (web/electron/mobile)
- `npm run lint` pass
- `agents` suite: 223 passed | 1 skipped (was 110 failed before template-literal fix); targeted suites 50 passed