### PR TITLE
feat(protocol): allow the ComfyUI runners on the cloud profile

### DIFF
--- a/docs/CLOUD_NODE_CURATION.md
+++ b/docs/CLOUD_NODE_CURATION.md
@@ -130,6 +130,19 @@ host-filesystem nodes, which are dropped via `CLOUD_NODE_DENYLIST`:
 Admitting it by name rather than whole-listing the namespace keeps any future
 `nodetool.code` node out of the cloud until it is reviewed.
 
+`lib.comfy` is trimmed the same way — the two runners are admitted via
+`CLOUD_NODE_ALLOWLIST`, the namespace is not:
+
+| From `lib.comfy`        | Kept node                                     |
+| ----------------------- | --------------------------------------------- |
+| `RunWorkflow`           | Runs a prompt against a ComfyUI HTTP endpoint |
+| `RunWorkflowOnWorker`   | Runs it over a NodeTool worker's bridge       |
+
+Running a ComfyUI graph is image generation, which is what the profile is for.
+Each node calls the server its own property names, so the address is graph data;
+that egress policy is written down in the ComfyUI row of
+[url-egress-inventory.md](url-egress-inventory.md).
+
 ### Creative media toolkit
 
 | Namespace   | What it is                                            |
@@ -150,7 +163,8 @@ Admitting it by name rather than whole-listing the namespace keeps any future
 - **System/automation:** `lib.os`, `nodetool.workspace`,
   `nodetool.triggers`, `lib.browser`, `lib.video.download`
 - **Databases/cloud/integrations:** `lib.sqlite`, `lib.http`, `lib.graphql`,
-  `lib.mail`, `lib.secret`, `lib.comfy`
+  `lib.mail`, `lib.secret` (`lib.comfy` is dropped as a namespace, but its two
+  runners are allowlisted by name — see above)
 - **Messaging:** `messaging.discord`, `messaging.telegram`
 - **NLP/ML utility:** `lib.nlp`, `vector` (RAG),
   `lib.validate`, `lib.datetime`

--- a/docs/comfyui.md
+++ b/docs/comfyui.md
@@ -20,9 +20,17 @@ Two nodes cover two topologies:
 | Workflow loader in the editor | Yes | No (see [limitations](#known-limitations)) |
 | Outputs | Streamed, one frame per file | Buffered, returned at the end |
 
-Both live in the `lib.comfy` namespace, which ships in the **Developer Tools**
-optional node pack. If the nodes don't appear in the node menu, enable that pack
-first.
+Both live in the `lib.comfy` namespace and ship in the built-in `base` node
+pack, so every install registers them — including a server running the curated
+cloud profile (`NODETOOL_NODE_PROFILE=cloud`, the production default), which
+allowlists the two runners by name while dropping the rest of the namespace.
+See [Cloud Node Curation](CLOUD_NODE_CURATION.md).
+
+If they don't appear in the node menu, that is the menu's own decluttering, not
+a gate: `lib.comfy` sits in the **Developer Tools** group of
+`web/src/config/optionalNodePacks.ts`, hidden from the browsable namespace tree
+until you reveal that group. Search, paste, and saved workflows resolve the
+nodes either way.
 
 ---
 

--- a/docs/url-egress-inventory.md
+++ b/docs/url-egress-inventory.md
@@ -136,7 +136,10 @@ in the data module with its auth scope.
 **Deliberately private hosts.** Reaching an internal address is the feature:
 
 - `packages/runtime/src/comfy-executor.ts` — a ComfyUI server, normally
-  localhost or the LAN. The address comes from settings, never from a graph.
+  localhost or the LAN, so screening private addresses would refuse the ordinary
+  case. The address is the node's `endpoint` property, so the graph author picks
+  it, and `lib.comfy.RunWorkflow` / `lib.comfy.RunWorkflowOnWorker` are
+  allowlisted on the cloud profile.
 - `packages/agents/src/capabilities/web.ts` — `BROWSER_URL`, the operator's
   screenshot service. Every model-named URL in that file goes through
   `safeFetch`; this one is the operator's own.

--- a/packages/protocol/src/cloud-profile.ts
+++ b/packages/protocol/src/cloud-profile.ts
@@ -111,6 +111,13 @@ export const CLOUD_NODE_NAMESPACES: readonly string[] = [
  * - `nodetool.code.Code` — the sandboxed (QuickJS WASM) JavaScript node only.
  *   Admitting it by name rather than whole-listing `nodetool.code` keeps any
  *   future node in that namespace out of the cloud until it is reviewed.
+ * - `lib.comfy.RunWorkflow` / `lib.comfy.RunWorkflowOnWorker` — the two ComfyUI
+ *   runners. Running a ComfyUI graph is image generation, which is what this
+ *   profile is for. Named rather than whole-listed for the same reason as the
+ *   Code node: a later `lib.comfy` node is out until someone reviews it. Each
+ *   node calls the ComfyUI server its `endpoint`/`worker_url` property names,
+ *   so the address is graph data — see the ComfyUI row in
+ *   `docs/url-egress-inventory.md`.
  *
  * `lib.video.download.YtDlpDownload` used to sit here. It is out: a managed
  * multi-tenant server pulling media from arbitrary sites on a user's behalf is
@@ -124,7 +131,10 @@ export const CLOUD_NODE_NAMESPACES: readonly string[] = [
  */
 export const CLOUD_NODE_ALLOWLIST: readonly string[] = [
   // Sandboxed code only.
-  "nodetool.code.Code"
+  "nodetool.code.Code",
+  // ComfyUI runners only — the rest of lib.comfy stays out.
+  "lib.comfy.RunWorkflow",
+  "lib.comfy.RunWorkflowOnWorker"
 ];
 
 /**

--- a/packages/protocol/tests/cloud-profile.test.ts
+++ b/packages/protocol/tests/cloud-profile.test.ts
@@ -163,6 +163,14 @@ describe("code is node-level trimmed; text is whole-listed minus file I/O", () =
     expect(isCloudNodeType("lib.browser.WebFetch")).toBe(false);
   });
 
+  it("keeps only the two ComfyUI runners", () => {
+    expect(isCloudNodeType("lib.comfy.RunWorkflow")).toBe(true);
+    expect(isCloudNodeType("lib.comfy.RunWorkflowOnWorker")).toBe(true);
+    // The namespace is not whole-listed, so anything else added under
+    // lib.comfy stays out until it is allowlisted by name.
+    expect(isCloudNodeType("lib.comfy.Other")).toBe(false);
+  });
+
   it("admits every explicit allowlist entry", () => {
     for (const nodeType of CLOUD_NODE_ALLOWLIST) {
       expect(isCloudNodeType(nodeType)).toBe(true);

--- a/packages/runtime/tests/url-egress-inventory.ts
+++ b/packages/runtime/tests/url-egress-inventory.ts
@@ -397,14 +397,14 @@ export const URL_EGRESS_INVENTORY: EgressEntry[] = [
   {
     file: "packages/runtime/src/comfy-executor.ts",
     owner: "ComfyUI executor",
-    inputSource: "operator",
+    inputSource: "workflow",
     schemes: ["http", "https"],
     authScope: "operator-configured token",
     redirects: "runtime-follows",
     dnsRebinding: "n/a",
     policy: "private-integration",
     guardedBy: [],
-    note: "A Comfy server is normally on localhost or the LAN — reaching it is the feature. The address comes from settings, never from a graph."
+    note: "A Comfy server is normally on localhost or the LAN — reaching it is the feature, so screening private addresses would refuse the ordinary case. The address is the node's `endpoint` property, so the graph author picks it, and the two runners are allowlisted on the cloud profile."
   },
   {
     file: "packages/agents/src/capabilities/web.ts",


### PR DESCRIPTION
Adds `lib.comfy.RunWorkflow` and `lib.comfy.RunWorkflowOnWorker` to `CLOUD_NODE_ALLOWLIST`, so a self-hosted server running `NODETOOL_ENV=production` keeps them without `NODETOOL_NODE_PROFILE=full` re-admitting `lib.secret`, the host-file nodes, `lib.mail` and the triggers. The rest of the namespace stays out.

`docs/comfyui.md` claimed the nodes ship in a Developer Tools node pack. No such server pack exists: they ship in `base`, and Developer Tools is a node-menu visibility group. The doc now names the registry gate and the menu filter separately.

The egress inventory said the ComfyUI address "comes from settings, never from a graph". It is the node's `endpoint` property, so the entry is now `inputSource: workflow`. `comfy-executor.ts` still fetches it unscreened by design (localhost/LAN is the case it exists for) - if this reaches hosted multi-tenant, that wants an allow-private-but-deny-metadata screen as a follow-up.

Closes #5243

Generated with [Claude Code](https://claude.ai/code)