### PR TITLE
feat(chat): reference and display entities in chat messages

### DIFF
--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -37,6 +37,7 @@ import {
 } from "./type-predicates.js";
 import {
   expandAssetReferences,
+  expandEntityRefs,
   inlineTextAssetRefs
 } from "./prompt-asset-refs.js";
 import { getNodeBuiltinSync } from "@nodetool-ai/config";
@@ -3185,13 +3186,23 @@ export class ProcessingContext {
         }
         return [unresolvedNote("video", part.video.uri)];
       }
-      if (part.type === "text" && part.text.includes("asset://")) {
+      if (part.type === "text") {
+        // Entity mentions resolve first: each `entity://<id>` becomes the
+        // entity's name inline, a "Consistency references" line carrying its
+        // descriptor, and an `asset://` token for its reference image — which
+        // the asset pass below then turns into a real image block. Resolving
+        // here, per turn, is what makes a later rename or re-description
+        // reach every message that already mentions the entity.
+        const text = await expandEntityRefs(part.text, this, true);
+        if (!text.includes("asset://")) {
+          return text === part.text ? [part] : [{ type: "text", text }];
+        }
         // First split out image / audio mentions into their own blocks; what
         // stays as text is then run through the document inliner so any
         // .md/.txt/.csv mentions become their decoded contents. The image and
         // audio blocks fall through to the URI-resolution branches above on a
         // second pass so the provider receives data URIs.
-        const expanded = expandAssetReferences(part.text);
+        const expanded = expandAssetReferences(text);
         const out: MessageContent[] = [];
         for (const sub of expanded) {
           if (sub.type === "text") {

--- a/packages/runtime/tests/context.test.ts
+++ b/packages/runtime/tests/context.test.ts
@@ -1482,6 +1482,87 @@ describe("ProcessingContext – asset helper methods", () => {
     }
   });
 
+  it("resolveMessageMediaUris expands entity:// mentions into name, descriptor and image", async () => {
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+    const ctx = new ProcessingContext({
+      jobId: "j1",
+      userId: "u1",
+      modelInterfaces: {
+        getAssetInfo: async ({ assetId }) =>
+          assetId === "ent1"
+            ? {
+                id: "ent1",
+                content_type: "image/png",
+                name: "marta.png",
+                metadata: {
+                  nodetool_entity: {
+                    kind: "character",
+                    name: "Marta",
+                    descriptor: "a tall woman in a red coat"
+                  }
+                }
+              }
+            : null
+      },
+      fetchFn: async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith("/api/assets/ent1.png")) {
+          return new Response(
+            JSON.stringify({ id: "ent1", get_url: "/api/storage/ent1.png" }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        if (url.endsWith("/api/storage/ent1.png")) {
+          return new Response(pngBytes, {
+            status: 200,
+            headers: { "content-type": "image/png" }
+          });
+        }
+        return new Response("not found", { status: 404 });
+      }
+    });
+
+    const resolved = await ctx.resolveMessageMediaUris([
+      {
+        role: "user",
+        content: [{ type: "text", text: "a shot of entity://ent1 at dusk" }]
+      }
+    ]);
+
+    const parts = resolved[0].content as Array<Record<string, any>>;
+    expect(parts[0].type).toBe("text");
+    expect(parts[0].text).toContain("a shot of Marta at dusk");
+    expect(parts[0].text).toContain(
+      "Consistency references:\n- Marta: a tall woman in a red coat"
+    );
+    // The entity's reference image rides in as a real image block.
+    expect(parts[1].type).toBe("image_url");
+    expect(parts[1].image.uri).toBe(
+      `data:image/png;base64,${Buffer.from(pngBytes).toString("base64")}`
+    );
+  });
+
+  it("resolveMessageMediaUris drops an entity:// mention it cannot resolve", async () => {
+    const ctx = new ProcessingContext({ jobId: "j1", userId: "u1" });
+
+    const resolved = await ctx.resolveMessageMediaUris([
+      { role: "user", content: [{ type: "text", text: "see entity://gone here" }] }
+    ]);
+
+    expect(resolved[0].content).toEqual([{ type: "text", text: "see here" }]);
+  });
+
+  it("resolveMessageMediaUris leaves entity-free text untouched", async () => {
+    const ctx = new ProcessingContext({ jobId: "j1", userId: "u1" });
+    const part = { type: "text", text: "plain prose" } as const;
+
+    const resolved = await ctx.resolveMessageMediaUris([
+      { role: "user", content: [part] }
+    ]);
+
+    expect(resolved[0].content).toEqual([part]);
+  });
+
   it("resolveMessageMediaUris dereferences asset:// image URIs to data URIs", async () => {
     const root = await mkdtemp(join(tmpdir(), "nodetool-resolve-asset-media-"));
     try {

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -1347,6 +1347,13 @@ editor; use a plain link when you only reference one. An embed counts as that
 resource's one link for the reply — don't also link it. Other resource kinds
 have no inline renderer: link them, never embed them with image syntax.
 
+Production entities (characters, locations, styles, props) have their own
+scheme: write \`entity://<id>\` as bare text — no markdown link, no label — and
+the chat UI shows a chip with the entity's name, reference thumbnail and
+descriptor. Use it when you name an entity the user can already see in their
+library; \`list_entities\` gives you the ids. It is not one of the resource
+kinds above and none of the link budget applies.
+
 # File types
 References to documents, images, videos, or audio files have the shape:
 - \`type\`: document | image | video | audio

--- a/web/src/components/chat/composer/MediaChatComposer.tsx
+++ b/web/src/components/chat/composer/MediaChatComposer.tsx
@@ -73,15 +73,11 @@ import type {
   TTSModel,
   VideoModel
 } from "../../../stores/ApiTypes";
-import {
-  isModelSelected,
-  type Entity,
-  type ModelSelection
-} from "@nodetool-ai/protocol";
+import { isModelSelected, type ModelSelection } from "@nodetool-ai/protocol";
 import type { MediaGenerationRequest } from "../types/media.types";
 import { assetToUri } from "../../node_types/editing/promptComposer/promptTokens";
-import { resolveAssetUri } from "../../node/output";
 import { useTextareaAssetMention } from "./useTextareaAssetMention";
+import { MentionedEntities } from "./MentionedEntities";
 import { FilePreview } from "./FilePreview";
 import { useFileHandling } from "../hooks/useFileHandling";
 import { useDragAndDrop } from "../hooks/useDragAndDrop";
@@ -280,44 +276,13 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
     [addDroppedFiles]
   );
 
-  // A picked entity reads as part of the message: the hook inlines its name
-  // into the text; here its reference image is attached for consistency.
-  const handleSelectEntity = useCallback(
-    (entity: Entity) => {
-      const refUri = entity.reference_images?.[0]?.uri ?? "";
-      if (!refUri) {
-        return;
-      }
-      // Entity reference images are stored as `<id>.<ext>` keys, so the URL
-      // path carries the extension the asset URI needs.
-      const extMatch = refUri.split(/[?#]/)[0].match(/\.([A-Za-z0-9]+)$/);
-      const ext = extMatch ? extMatch[1].toLowerCase() : "";
-      addDroppedFiles([
-        {
-          id: "",
-          // The preview needs a displayable URL (data:/http(s):/`/`-prefixed);
-          // a raw `asset://…` ref renders as a generic file icon. Resolve it to
-          // the storage URL for the thumbnail while keeping the `asset://` ref
-          // in `assetUri` for the model.
-          dataUri: resolveAssetUri(refUri),
-          type: ext ? `image/${ext === "jpg" ? "jpeg" : ext}` : "image/png",
-          name: entity.name || entity.id,
-          assetUri: ext
-            ? `asset://${entity.id}.${ext}`
-            : `asset://${entity.id}`
-        }
-      ]);
-    },
-    [addDroppedFiles]
-  );
-
   const { mentionMenu, handleKeyDown: handleMentionKeyDown } =
     useTextareaAssetMention({
       textareaRef,
       value: prompt,
       setValue: setPrompt,
       onSelectAsset: handleSelectAsset,
-      onSelectEntity: handleSelectEntity
+      includeEntities: true
     });
 
   const {
@@ -932,6 +897,8 @@ const MediaChatComposer: React.FC<MediaChatComposerProps> = ({
             ))}
           </div>
         )}
+
+        <MentionedEntities value={prompt} setValue={setPrompt} />
 
         <textarea
           ref={textareaRef}

--- a/web/src/components/chat/composer/MentionedEntities.tsx
+++ b/web/src/components/chat/composer/MentionedEntities.tsx
@@ -1,0 +1,98 @@
+/**
+ * MentionedEntities — the entities the current prompt references.
+ *
+ * A picked entity is written into the textarea as its `entity://<id>` token,
+ * which a plain textarea cannot render as a chip. This row is the readable
+ * half: it derives the chips from the text itself, so it can never disagree
+ * with what will be sent, and deleting a chip removes the token.
+ */
+import React, { useCallback, useMemo } from "react";
+
+import { Chip, FlexRow, SPACING } from "../../ui_primitives";
+import { ENTITY_KIND_COLOR, ENTITY_KIND_ICON } from "../../entities/entityKind";
+import { useEntities } from "../../../serverState/useEntities";
+import {
+  entityIdsInPrompt,
+  removeEntityMentions
+} from "../../node_types/editing/promptComposer/promptTokens";
+
+interface MentionedEntitiesProps {
+  /** The composer's current text. */
+  value: string;
+  /** Replace the composer's text (used to drop a removed entity's tokens). */
+  setValue: (next: string) => void;
+}
+
+const MentionedEntityChip: React.FC<{
+  id: string;
+  name: string;
+  kind: keyof typeof ENTITY_KIND_ICON;
+  descriptor: string;
+  onRemove: (id: string) => void;
+}> = ({ id, name, kind, descriptor, onRemove }) => {
+  const Icon = ENTITY_KIND_ICON[kind];
+  const handleDelete = useCallback(() => onRemove(id), [id, onRemove]);
+  return (
+    <Chip
+      compact
+      color={ENTITY_KIND_COLOR[kind]}
+      icon={<Icon />}
+      label={name}
+      title={descriptor || `${name} · ${kind}`}
+      onDelete={handleDelete}
+    />
+  );
+};
+
+export const MentionedEntities: React.FC<MentionedEntitiesProps> = ({
+  value,
+  setValue
+}) => {
+  const { data: entities } = useEntities();
+
+  // An id with no entity behind it (deleted, or another user's) is dropped
+  // rather than shown as an unnamed chip — the server drops the token too.
+  const mentioned = useMemo(() => {
+    const ids = entityIdsInPrompt(value);
+    if (ids.length === 0 || !entities) {
+      return [];
+    }
+    const byId = new Map(entities.map((entity) => [entity.id, entity]));
+    return ids.flatMap((id) => {
+      const entity = byId.get(id);
+      return entity ? [entity] : [];
+    });
+  }, [value, entities]);
+
+  const handleRemove = useCallback(
+    (id: string) => setValue(removeEntityMentions(value, id)),
+    [value, setValue]
+  );
+
+  if (mentioned.length === 0) {
+    return null;
+  }
+
+  return (
+    <FlexRow
+      gap={SPACING.xs}
+      wrap
+      align="center"
+      className="mentioned-entities"
+      data-testid="mentioned-entities"
+    >
+      {mentioned.map((entity) => (
+        <MentionedEntityChip
+          key={entity.id}
+          id={entity.id}
+          name={entity.name}
+          kind={entity.kind}
+          descriptor={entity.descriptor}
+          onRemove={handleRemove}
+        />
+      ))}
+    </FlexRow>
+  );
+};
+
+export default MentionedEntities;

--- a/web/src/components/chat/composer/__tests__/MentionedEntities.test.tsx
+++ b/web/src/components/chat/composer/__tests__/MentionedEntities.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import type { Entity } from "@nodetool-ai/protocol";
+
+import { MentionedEntities } from "../MentionedEntities";
+import mockTheme from "../../../../__mocks__/themeMock";
+import { stub } from "../../../../test-utils/doubles";
+
+const ENTITIES = stub<Entity[]>([
+  {
+    type: "entity",
+    id: "e1",
+    kind: "character",
+    name: "Marta",
+    descriptor: "red-haired detective"
+  },
+  {
+    type: "entity",
+    id: "e2",
+    kind: "location",
+    name: "The Pier",
+    descriptor: "a rotting boardwalk"
+  }
+]);
+
+const mockUseEntities = jest.fn();
+
+jest.mock("../../../../serverState/useEntities", () => ({
+  useEntities: () => mockUseEntities()
+}));
+
+const renderRow = (value: string, setValue = jest.fn()) => {
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <MentionedEntities value={value} setValue={setValue} />
+    </ThemeProvider>
+  );
+  return setValue;
+};
+
+describe("MentionedEntities", () => {
+  beforeEach(() => {
+    mockUseEntities.mockReturnValue({ data: ENTITIES });
+  });
+
+  it("renders nothing when the prompt references no entity", () => {
+    renderRow("just a prompt");
+    expect(screen.queryByTestId("mentioned-entities")).toBeNull();
+  });
+
+  it("names each entity the prompt references, in order", () => {
+    renderRow("entity://e2 at night with entity://e1");
+
+    expect(screen.getByText("The Pier")).toBeInTheDocument();
+    expect(screen.getByText("Marta")).toBeInTheDocument();
+  });
+
+  it("shows one chip when the same entity is mentioned twice", () => {
+    renderRow("entity://e1 waves at entity://e1");
+    expect(screen.getAllByText("Marta")).toHaveLength(1);
+  });
+
+  it("skips an id with no entity behind it", () => {
+    renderRow("entity://gone");
+    expect(screen.queryByTestId("mentioned-entities")).toBeNull();
+  });
+
+  it("removing a chip strips that entity's tokens from the prompt", async () => {
+    const user = userEvent.setup();
+    const setValue = renderRow("a shot of entity://e1 at entity://e2");
+
+    // MUI's Chip delete affordance; the first chip is Marta's.
+    await user.click(screen.getAllByTestId("CancelIcon")[0]);
+
+    expect(setValue).toHaveBeenCalledWith("a shot of at entity://e2");
+  });
+});

--- a/web/src/components/chat/composer/__tests__/useTextareaAssetMention.test.tsx
+++ b/web/src/components/chat/composer/__tests__/useTextareaAssetMention.test.tsx
@@ -126,8 +126,8 @@ describe("findMentionTrigger", () => {
 
 const Harness: React.FC<{
   onSelectAsset: (asset: Asset) => void;
-  onSelectEntity?: (entity: Entity) => void;
-}> = ({ onSelectAsset, onSelectEntity }) => {
+  includeEntities?: boolean;
+}> = ({ onSelectAsset, includeEntities }) => {
   const ref = useRef<HTMLTextAreaElement>(null);
   const [value, setValue] = useState("");
   const { mentionMenu, handleKeyDown } = useTextareaAssetMention({
@@ -135,7 +135,7 @@ const Harness: React.FC<{
     value,
     setValue,
     onSelectAsset,
-    onSelectEntity
+    includeEntities
   });
   return (
     <>
@@ -252,7 +252,7 @@ describe("useTextareaAssetMention", () => {
     expect(screen.getByTestId("asset-mention-menu")).toBeInTheDocument();
   });
 
-  it("hides entities when the host provides no onSelectEntity", async () => {
+  it("hides entities unless the host opts in", async () => {
     const user = userEvent.setup();
     render(<Harness onSelectAsset={jest.fn()} />);
 
@@ -261,13 +261,10 @@ describe("useTextareaAssetMention", () => {
     expect(screen.queryByTestId("entity-tile-e1")).not.toBeInTheDocument();
   });
 
-  it("selecting an entity inlines its name in place of the @query", async () => {
+  it("selecting an entity inlines its entity:// token in place of the @query", async () => {
     const user = userEvent.setup();
     const onSelectAsset = jest.fn();
-    const onSelectEntity = jest.fn();
-    render(
-      <Harness onSelectAsset={onSelectAsset} onSelectEntity={onSelectEntity} />
-    );
+    render(<Harness onSelectAsset={onSelectAsset} includeEntities />);
     const textarea = screen.getByLabelText("prompt") as HTMLTextAreaElement;
 
     await user.type(textarea, "hi @mar");
@@ -275,16 +272,15 @@ describe("useTextareaAssetMention", () => {
 
     // Entities come first in the combined order, so Enter picks Marta.
     await user.keyboard("{Enter}");
-    expect(onSelectEntity).toHaveBeenCalledWith(MOCK_ENTITIES[0]);
     expect(onSelectAsset).not.toHaveBeenCalled();
-    await waitFor(() => expect(textarea.value).toBe("hi Marta "));
+    await waitFor(() => expect(textarea.value).toBe("hi entity://e1 "));
   });
 
   it("keyboard nav crosses from entities into assets", async () => {
     const user = userEvent.setup();
     const onSelectAsset = jest.fn();
     render(
-      <Harness onSelectAsset={onSelectAsset} onSelectEntity={jest.fn()} />
+      <Harness onSelectAsset={onSelectAsset} includeEntities />
     );
     const textarea = screen.getByLabelText("prompt");
 

--- a/web/src/components/chat/composer/useTextareaAssetMention.tsx
+++ b/web/src/components/chat/composer/useTextareaAssetMention.tsx
@@ -15,6 +15,7 @@ import { Z_INDEX } from "../../ui_primitives";
 import { useRecentAssetsStore } from "../../../stores/RecentAssetsStore";
 import { AssetMentionMenu } from "../../node_types/editing/promptComposer/AssetMentionMenu";
 import { useAssetMentionSearch } from "../../node_types/editing/promptComposer/useAssetMentionSearch";
+import { entityToUri } from "../../node_types/editing/promptComposer/promptTokens";
 
 /** An active `@`-mention span in a textarea's value. */
 interface MentionTrigger {
@@ -89,10 +90,11 @@ interface UseTextareaAssetMentionOptions {
   /** Called with the picked asset once the `@query` has been removed. */
   onSelectAsset: (asset: Asset) => void;
   /**
-   * Called with the picked entity after its name has replaced the `@query`
-   * in the text. When omitted, entities are not offered in the picker.
+   * Offer library entities alongside assets. A picked entity is written into
+   * the text as its `entity://<id>` token, so unlike an asset the host has
+   * nothing to attach and there is no selection callback.
    */
-  onSelectEntity?: (entity: Entity) => void;
+  includeEntities?: boolean;
 }
 
 /**
@@ -107,7 +109,7 @@ export const useTextareaAssetMention = ({
   value,
   setValue,
   onSelectAsset,
-  onSelectEntity
+  includeEntities = false
 }: UseTextareaAssetMentionOptions): UseTextareaAssetMention => {
   const addRecentAsset = useRecentAssetsStore((state) => state.addRecentAsset);
 
@@ -131,11 +133,10 @@ export const useTextareaAssetMention = ({
     loadMoreSaved,
     handleRename
   } = useAssetMentionSearch(trigger ? trigger.query : null);
-  // Entities are only offered when the host can do something with one. The
-  // shared empty array keeps the identity stable when there is no handler; a
+  // The shared empty array keeps the identity stable when entities are off; a
   // fresh `[]` per render invalidated `selectIndex` and the portaled menu's
   // memo on every keystroke.
-  const entities = (onSelectEntity && matchedEntities) || NO_ENTITIES;
+  const entities = (includeEntities && matchedEntities) || NO_ENTITIES;
 
   const measure = useCallback(() => {
     const el = textareaRef.current;
@@ -258,21 +259,23 @@ export const useTextareaAssetMention = ({
     [trigger, value, setValue, onSelectAsset, addRecentAsset, close]
   );
 
-  // An entity reads as part of the sentence: its name replaces the typed
-  // `@query` inline, then the host attaches its reference image.
+  // An entity reads as part of the sentence, so its reference goes inline where
+  // the `@query` was — as the `entity://<id>` token the Prompt composer also
+  // stores. The server resolves it per turn into the entity's name, its
+  // descriptor and its reference image, so a later rename or re-description
+  // reaches messages that were already sent.
   const selectEntity = useCallback(
     (entity: Entity) => {
       if (trigger) {
-        const inserted = `${entity.name} `;
+        const inserted = `${entityToUri(entity)} `;
         pendingCaretRef.current = trigger.start + inserted.length;
         setValue(
           value.slice(0, trigger.start) + inserted + value.slice(trigger.end)
         );
       }
-      onSelectEntity?.(entity);
       close();
     },
-    [trigger, value, setValue, onSelectEntity, close]
+    [trigger, value, setValue, close]
   );
 
   // Combined selection order: entities first, then the active asset bucket.

--- a/web/src/components/chat/message/ChatMarkdown.tsx
+++ b/web/src/components/chat/message/ChatMarkdown.tsx
@@ -18,6 +18,8 @@ import { BASE_URL } from "../../../stores/BASE_URL";
 import { trpc } from "../../../trpc/client";
 import { useResolvedMedia } from "../../../hooks/useResolvedMediaUri";
 import ResourceChip from "./ResourceChip";
+import { EntityMentionChip } from "../../node_types/editing/promptComposer/EntityMentionChip";
+import { remarkEntityMentions } from "./remarkEntityMentions";
 import { isNumber, isString } from "../../../utils/typePredicates";
 import "../../../styles/markdown/github-markdown.css";
 
@@ -86,12 +88,18 @@ const markdownStyles = css({
   }
 });
 
-const REMARK_PLUGINS: Options["remarkPlugins"] = [remarkGfm];
+const REMARK_PLUGINS: Options["remarkPlugins"] = [
+  remarkGfm,
+  remarkEntityMentions
+];
 const REHYPE_PLUGINS: Options["rehypePlugins"] = [rehypeRaw];
+
+/** An `entity://<id>` mention — its own scheme, not one of the resource kinds. */
+const isEntityUri = (url: string): boolean => url.startsWith("entity://");
 
 /** react-markdown drops unknown schemes; resource URIs (asset://, timeline://, …) are ours. */
 const urlTransform: NonNullable<Options["urlTransform"]> = (url) =>
-  isResourceUri(url) ? url : defaultUrlTransform(url);
+  isResourceUri(url) || isEntityUri(url) ? url : defaultUrlTransform(url);
 
 /** Link text as a plain string — `[**Bold**](…)` hands the `a` override nodes. */
 const linkText = (node: React.ReactNode): string => {
@@ -366,6 +374,11 @@ const ChatMarkdown: React.FC<ChatMarkdownProps> = React.memo(({
         ),
       a: ({ node: _node, ...props }: { node?: unknown } & React.ComponentPropsWithoutRef<"a">) => {
         const { href, children } = props;
+        if (href && isEntityUri(href)) {
+          return (
+            <EntityMentionChip uri={href} label={linkText(children) || href} />
+          );
+        }
         if (href?.startsWith("asset://")) {
           return (
             <ChatMarkdownAssetLink

--- a/web/src/components/chat/message/__tests__/ChatMarkdown.entityMentions.test.tsx
+++ b/web/src/components/chat/message/__tests__/ChatMarkdown.entityMentions.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@mui/material/styles";
+import ChatMarkdown from "../ChatMarkdown";
+import mockTheme from "../../../../__mocks__/themeMock";
+
+const mockUseAssetById = jest.fn();
+
+jest.mock("../../../../serverState/useAssetById", () => ({
+  useAssetById: (...args: unknown[]) => mockUseAssetById(...args)
+}));
+
+jest.mock("../../../../trpc/client", () => ({
+  trpc: {
+    storage: {
+      signUrl: {
+        useQuery: () => ({ data: undefined })
+      }
+    }
+  }
+}));
+
+jest.mock("../../../../hooks/useResolvedMediaUri");
+
+jest.mock("../../../../lib/chat/openResource", () => ({
+  __esModule: true,
+  openResource: jest.fn(),
+  canOpenResource: () => false
+}));
+
+/**
+ * react-markdown is ESM-only and globally mocked as a passthrough. This
+ * stand-in does what the branch under test needs: pull `[label](href)` out of
+ * the text, run the href through `urlTransform` the way react-markdown does,
+ * and hand what survives to `components.a`. The bare-token half of the feature
+ * is the remark plugin, covered in `remarkEntityMentions.test.ts`.
+ */
+jest.mock("react-markdown", () => {
+  const react = jest.requireActual<typeof import("react")>("react");
+  const SAFE_SCHEME = /^(https?|mailto|irc|ircs|xmpp):/i;
+  const defaultUrlTransform = (url: string): string =>
+    SAFE_SCHEME.test(url) || !url.includes(":") ? url : "";
+  const LINK = /\[([^\]]*)\]\(([^)]+)\)/g;
+  const MockMarkdown = ({
+    children,
+    components,
+    urlTransform
+  }: {
+    children?: string;
+    components?: {
+      a?: React.ComponentType<React.ComponentPropsWithoutRef<"a">>;
+    };
+    urlTransform?: (url: string) => string | null | undefined;
+  }) => {
+    const content = children ?? "";
+    const Anchor = components?.a;
+    const transform = urlTransform ?? defaultUrlTransform;
+    const parts: React.ReactNode[] = [];
+    let cursor = 0;
+    let match: RegExpExecArray | null;
+    LINK.lastIndex = 0;
+    while ((match = LINK.exec(content)) !== null) {
+      parts.push(content.slice(cursor, match.index));
+      const href = transform(match[2]);
+      parts.push(
+        Anchor && href
+          ? react.createElement(Anchor, { href, key: match.index }, match[1])
+          : match[1]
+      );
+      cursor = match.index + match[0].length;
+    }
+    parts.push(content.slice(cursor));
+    return react.createElement(react.Fragment, null, ...parts);
+  };
+  return { __esModule: true, default: MockMarkdown, defaultUrlTransform };
+});
+
+const renderMarkdown = (content: string) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ChatMarkdown content={content} />
+    </ThemeProvider>
+  );
+
+describe("ChatMarkdown entity mentions", () => {
+  beforeEach(() => {
+    mockUseAssetById.mockReturnValue({
+      data: {
+        id: "ent1",
+        thumb_url: "https://cdn.test/ent1-thumb.png",
+        metadata: {
+          nodetool_entity: {
+            kind: "character",
+            name: "Marta",
+            descriptor: "a tall woman in a red coat"
+          }
+        }
+      }
+    });
+  });
+
+  it("renders an entity:// link as a chip carrying the entity's name", () => {
+    renderMarkdown("A shot of [ent1](entity://ent1) at dusk.");
+
+    expect(screen.getByText("Marta")).toBeInTheDocument();
+    expect(screen.queryByText("entity://ent1")).toBeNull();
+    // The chip replaces the anchor — an entity URI has nowhere to navigate.
+    expect(screen.getByText("Marta").closest("a")).toBeNull();
+  });
+
+  it("resolves the entity live, so a rename shows on an old message", () => {
+    mockUseAssetById.mockReturnValue({
+      data: {
+        id: "ent1",
+        metadata: {
+          nodetool_entity: {
+            kind: "character",
+            name: "Marta Reyes",
+            descriptor: "a tall woman in a red coat"
+          }
+        }
+      }
+    });
+    renderMarkdown("[ent1](entity://ent1)");
+
+    expect(screen.getByText("Marta Reyes")).toBeInTheDocument();
+  });
+
+  it("falls back to the link text when the entity cannot be read", () => {
+    mockUseAssetById.mockReturnValue({ data: undefined });
+    renderMarkdown("[ent1](entity://ent1)");
+
+    expect(screen.getByText("ent1")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/chat/message/__tests__/remarkEntityMentions.test.ts
+++ b/web/src/components/chat/message/__tests__/remarkEntityMentions.test.ts
@@ -1,0 +1,101 @@
+import {
+  remarkEntityMentions,
+  splitEntityMentions
+} from "../remarkEntityMentions";
+
+interface MdastNode {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MdastNode[];
+}
+
+const paragraph = (value: string): MdastNode => ({
+  type: "root",
+  children: [{ type: "paragraph", children: [{ type: "text", value }] }]
+});
+
+const transform = (tree: MdastNode): MdastNode => {
+  remarkEntityMentions()(tree);
+  return tree;
+};
+
+describe("splitEntityMentions", () => {
+  it("returns null for text with no entity token", () => {
+    expect(splitEntityMentions("just prose")).toBeNull();
+  });
+
+  it("splits a token out of the surrounding text", () => {
+    expect(splitEntityMentions("a shot of entity://ent1 at dusk")).toEqual([
+      { type: "text", value: "a shot of " },
+      { type: "link", url: "entity://ent1", children: [{ type: "text", value: "ent1" }] },
+      { type: "text", value: " at dusk" }
+    ]);
+  });
+
+  it("treats a trailing dot as sentence punctuation", () => {
+    expect(splitEntityMentions("meet entity://ent1.")).toEqual([
+      { type: "text", value: "meet " },
+      { type: "link", url: "entity://ent1", children: [{ type: "text", value: "ent1" }] },
+      { type: "text", value: "." }
+    ]);
+  });
+
+  it("splits every token in the value", () => {
+    const parts = splitEntityMentions("entity://a and entity://b");
+    expect(parts?.filter((part) => part.type === "link").map((part) => part.url)).toEqual([
+      "entity://a",
+      "entity://b"
+    ]);
+  });
+});
+
+describe("remarkEntityMentions", () => {
+  it("rewrites text nodes anywhere in the tree", () => {
+    const tree = transform(paragraph("with entity://ent1 here"));
+    const children = tree.children?.[0].children ?? [];
+    expect(children.map((child) => child.type)).toEqual(["text", "link", "text"]);
+  });
+
+  it("leaves a code span untouched", () => {
+    const tree = transform({
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [{ type: "inlineCode", value: "entity://ent1" }]
+        }
+      ]
+    });
+    expect(tree.children?.[0].children).toEqual([
+      { type: "inlineCode", value: "entity://ent1" }
+    ]);
+  });
+
+  it("does not nest a link inside an existing link", () => {
+    const tree = transform({
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "link",
+              url: "entity://ent1",
+              children: [{ type: "text", value: "entity://ent1" }]
+            }
+          ]
+        }
+      ]
+    });
+    const link = tree.children?.[0].children?.[0];
+    expect(link?.children).toEqual([{ type: "text", value: "entity://ent1" }]);
+  });
+
+  it("leaves a tree with no tokens alone", () => {
+    const tree = transform(paragraph("nothing to see"));
+    expect(tree.children?.[0].children).toEqual([
+      { type: "text", value: "nothing to see" }
+    ]);
+  });
+});

--- a/web/src/components/chat/message/remarkEntityMentions.ts
+++ b/web/src/components/chat/message/remarkEntityMentions.ts
@@ -1,0 +1,97 @@
+/**
+ * remarkEntityMentions — turn bare `entity://<id>` tokens in chat prose into
+ * mdast link nodes, so ChatMarkdown's `a` override can render them as entity
+ * chips.
+ *
+ * The composer writes an `@`-mention as the raw token (the same encoding the
+ * Prompt composer stores and the runtime expands), and the token stays in the
+ * persisted message. Without this the reader sees the URN.
+ *
+ * It runs on the tree, not the source string, so a token quoted inside a code
+ * span or fence is left alone — and an `entity://` URL a link already points
+ * at is not re-wrapped, which mdast forbids.
+ */
+
+/** The subset of mdast this plugin reads. Narrow on purpose: the tree it walks
+ *  carries positions and node types remark defines, none of which matter here. */
+interface MdastNode {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MdastNode[];
+}
+
+/** Matches one `entity://<id>` token; mirrors the prompt tokenizer's arm. */
+const ENTITY_URI_RE = /entity:\/\/[A-Za-z0-9._~-]+/g;
+
+/** Node types whose text is literal and must not be rewritten. */
+const OPAQUE_TYPES = new Set(["code", "inlineCode", "link", "linkReference"]);
+
+/** Trailing dots are sentence punctuation, not part of the id. */
+const trimTrailingDots = (token: string): string => {
+  let end = token.length;
+  while (end > 0 && token[end - 1] === ".") {
+    end--;
+  }
+  return token.slice(0, end);
+};
+
+/**
+ * Split one text value into text and link nodes, or `null` when it carries no
+ * entity token (so the caller can leave the node untouched).
+ */
+export const splitEntityMentions = (value: string): MdastNode[] | null => {
+  const out: MdastNode[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  ENTITY_URI_RE.lastIndex = 0;
+  while ((match = ENTITY_URI_RE.exec(value)) !== null) {
+    const uri = trimTrailingDots(match[0]);
+    const id = uri.slice("entity://".length);
+    if (!id) {
+      continue;
+    }
+    if (match.index > cursor) {
+      out.push({ type: "text", value: value.slice(cursor, match.index) });
+    }
+    out.push({
+      type: "link",
+      url: uri,
+      children: [{ type: "text", value: id }]
+    });
+    cursor = match.index + uri.length;
+  }
+  if (out.length === 0) {
+    return null;
+  }
+  if (cursor < value.length) {
+    out.push({ type: "text", value: value.slice(cursor) });
+  }
+  return out;
+};
+
+const walk = (node: MdastNode): void => {
+  const children = node.children;
+  if (!children || OPAQUE_TYPES.has(node.type)) {
+    return;
+  }
+  let index = 0;
+  while (index < children.length) {
+    const child = children[index];
+    if (child.type === "text" && child.value) {
+      const replacement = splitEntityMentions(child.value);
+      if (replacement) {
+        children.splice(index, 1, ...replacement);
+        index += replacement.length;
+        continue;
+      }
+    } else {
+      walk(child);
+    }
+    index++;
+  }
+};
+
+export const remarkEntityMentions = () => (tree: MdastNode): void => {
+  walk(tree);
+};

--- a/web/src/components/node_types/editing/promptComposer/__tests__/promptTokens.test.ts
+++ b/web/src/components/node_types/editing/promptComposer/__tests__/promptTokens.test.ts
@@ -1,10 +1,12 @@
 import {
   assetMediaKind,
   assetToUri,
+  entityIdsInPrompt,
   entityToUri,
   extForAsset,
   parseAssetUri,
   parseEntityUri,
+  removeEntityMentions,
   tokenizePromptLine,
   variablesInPrompt
 } from "../promptTokens";
@@ -129,6 +131,53 @@ describe("promptTokens", () => {
     it("round-trips the entity URN helpers", () => {
       expect(entityToUri({ id: "abc" })).toBe("entity://abc");
       expect(parseEntityUri("entity://abc")).toBe("abc");
+    });
+  });
+
+  describe("entityIdsInPrompt", () => {
+    it("collects distinct ids in order across lines", () => {
+      expect(
+        entityIdsInPrompt("entity://b meets entity://a\nagain entity://b")
+      ).toEqual(["b", "a"]);
+    });
+
+    it("returns nothing for a prompt with no entity mention", () => {
+      expect(entityIdsInPrompt("asset://a.png {{ v }}")).toEqual([]);
+    });
+  });
+
+  describe("removeEntityMentions", () => {
+    it("drops the token and the space before it", () => {
+      expect(
+        removeEntityMentions("a shot of entity://e1 at dusk", "e1")
+      ).toBe("a shot of at dusk");
+    });
+
+    it("drops the space after a token that opens the line", () => {
+      expect(removeEntityMentions("entity://e1 at dusk", "e1")).toBe("at dusk");
+    });
+
+    it("drops a trailing token and the space before it", () => {
+      expect(removeEntityMentions("a shot of entity://e1", "e1")).toBe(
+        "a shot of"
+      );
+    });
+
+    it("removes every mention of the one entity, leaving the others", () => {
+      expect(
+        removeEntityMentions("entity://a and entity://b and entity://a", "a")
+      ).toBe("and entity://b and");
+    });
+
+    it("leaves text alone when the entity is not mentioned", () => {
+      const text = "a shot of entity://e2  with  wide  spacing";
+      expect(removeEntityMentions(text, "e1")).toBe(text);
+    });
+
+    it("keeps the trailing dot that punctuated the sentence", () => {
+      expect(removeEntityMentions("we meet entity://e1.", "e1")).toBe(
+        "we meet."
+      );
     });
   });
 });

--- a/web/src/components/node_types/editing/promptComposer/promptTokens.ts
+++ b/web/src/components/node_types/editing/promptComposer/promptTokens.ts
@@ -223,6 +223,55 @@ export const tokenizePromptLine = (line: string): PromptToken[] => {
 export const tokenizePrompt = (text: string): PromptToken[][] =>
   text.split("\n").map(tokenizePromptLine);
 
+/** Collect the distinct entity ids referenced in a prompt string, in order. */
+export const entityIdsInPrompt = (text: string): string[] => {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const line of tokenizePrompt(text)) {
+    for (const token of line) {
+      if (token.kind === "entity" && !seen.has(token.entityId)) {
+        seen.add(token.entityId);
+        ids.push(token.entityId);
+      }
+    }
+  }
+  return ids;
+};
+
+/** Matches one `entity://<id>` token; mirrors the entity arm of {@link TOKEN_RE}. */
+const ENTITY_URI_RE = /entity:\/\/[A-Za-z0-9._~-]+/g;
+
+/**
+ * Drop every `entity://<id>` token for one entity from a prompt, closing the
+ * gap it leaves — the space before the token, or the one after it when the
+ * token opened the line. Text around the tokens is spliced out verbatim, so
+ * nothing else in the prompt is reformatted.
+ *
+ * Used by the chat composer's chip row, where removing a chip has to
+ * un-reference the entity in the text the chip was derived from.
+ */
+export const removeEntityMentions = (text: string, entityId: string): string => {
+  let out = "";
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  ENTITY_URI_RE.lastIndex = 0;
+  while ((match = ENTITY_URI_RE.exec(text)) !== null) {
+    const uri = trimTrailingDots(match[0]);
+    if (parseEntityUri(uri) !== entityId) {
+      continue;
+    }
+    let head = out + text.slice(cursor, match.index);
+    cursor = match.index + uri.length;
+    if (head.endsWith(" ")) {
+      head = head.slice(0, -1);
+    } else if (text[cursor] === " ") {
+      cursor += 1;
+    }
+    out = head;
+  }
+  return out + text.slice(cursor);
+};
+
 /** Collect the distinct variable expressions referenced in a prompt string. */
 export const variablesInPrompt = (text: string): string[] => {
   const names = new Set<string>();


### PR DESCRIPTION
## What changed

The chat `@` mention picker already listed library entities, but picking one inlined its bare name and hand-attached its reference image — so the descriptor never reached the model, the attached image could not follow a later entity edit, and the sent message carried no entity to display. A picked entity now writes the `entity://<id>` token the Prompt composer already stores, and that token is what travels: `ProcessingContext.resolveMessageMediaUris` expands it per turn through `expandEntityRefs` (name inline, descriptor in a consistency block, reference image as an `asset://` token the existing asset pass turns into a real image block), so a rename or re-description reaches messages already sent. On the way back, a new `remarkEntityMentions` plugin rewrites a bare token in chat prose into an mdast link node and `ChatMarkdown` renders it as the entity chip — name, kind, thumbnail, descriptor on hover — which lets the assistant name an entity the same way (the convention is documented in the chat system prompt under "Linking resources"). Because a plain textarea cannot show a chip, `MentionedEntities` renders a row of what the current prompt references, derived from the text itself so it cannot disagree with what will be sent, and deleting a chip strips that entity's tokens. The hook's `onSelectEntity` callback becomes an `includeEntities` flag: with the token written into the text there is nothing left for the host to attach.

## Verification

- [x] `npm run test:affected -- --base HEAD` — packages green after installing `mesa-vulkan-drivers` (the documented headless-Vulkan gap; `@nodetool-ai/image-nodes` fails without an ICD). One further run hit a 30s timeout in `packages/cli/tests/run-dsl.test.ts`, which spawns the CLI as a subprocess; it passes in isolation (`10 passed`) and is load-induced, not from this diff.
- [x] `npx jest` in `web/` — 1173 suites, 13479 tests passed
- [x] `npx jest` in `electron/` — 63 suites, 684 tests passed
- [x] `npm run typecheck` — web and electron clean. `typecheck:mobile` fails on `Cannot find module 'react-native'` etc. because `mobile/node_modules` is not installed in this container; `mobile/` is untouched by the diff.
- [x] `npm run lint` — exit 0
- [x] `npm run nodetool -- harness gate --base HEAD~1` — `Gate: 3/3 selfchecks passed` (5 Ring 0 reliability journeys included)

New tests, all observed passing:

- `packages/runtime/tests/context.test.ts` — expansion into name + descriptor + image block, an unresolvable token dropped, entity-free text returned untouched
- `web/src/components/chat/message/__tests__/remarkEntityMentions.test.ts` — splitting, trailing-dot punctuation, code spans left alone, no link nested in a link
- `web/src/components/chat/message/__tests__/ChatMarkdown.entityMentions.test.tsx` — the chip renders the live name (a rename shows on an old message) and falls back to the link text when the entity cannot be read
- `web/src/components/chat/composer/__tests__/MentionedEntities.test.tsx` — chips derived from the text, deduped, unknown ids skipped, removal rewrites the prompt
- `promptTokens.test.ts` — `entityIdsInPrompt` and `removeEntityMentions` (gap closing before/after/at line start, other entities preserved, unrelated text byte-identical)

## Agent capabilities

No capability's declared contract changed. The convention the assistant needs lives in the chat system prompt in `unified-websocket-runner.ts`, not in a capability description — an earlier draft put it in `list_entities`, and `harness gate` correctly refused it because no agent-side suite or eval can check a browser rendering convention. `npm run capabilities:check` reports "capability table is current (224 capabilities)" and `packages/cli/src/harness/capability-table.ts` is unmodified.

## New checks

No check, rule, or audit added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LkpyvLJYaFRdBD11311wUC)_