### PR TITLE
feat(approvals): ask about what a code action does, not its code

### DIFF
--- a/packages/agents/src/codeact/execute-code-contract.ts
+++ b/packages/agents/src/codeact/execute-code-contract.ts
@@ -19,6 +19,11 @@
  *
  * It fails closed. A call with no `risk`, or one carrying a value that is not
  * in the enum, is read as `high`.
+ *
+ * The call also carries a `description`: what the program will do, in plain
+ * sentences. That is what the approval dialog asks about. The code stays
+ * available behind a fold, but a user answering "do you want to do this?"
+ * should not have to read JavaScript to know what they are agreeing to.
  */
 
 import type { CapabilityGate } from "../capabilities/types.js";
@@ -36,6 +41,9 @@ export const ACTION_RISK_VALUES = ["low", "high"] as const;
  * user-facing label the UI shows for the action card while the code runs —
  * the code itself is a detail view, so without a title the user sees only
  * "Execute Code". `risk` is what auto mode reads (see the module comment).
+ * `description` is what the approval box reads: a high-risk action asks the
+ * user, and a wall of unfolded JavaScript is not a question anyone can answer,
+ * so the model states in plain sentences what the program will do.
  * Required: a strict schema (additionalProperties: false) must list every
  * property under `required` for OpenAI structured outputs.
  */
@@ -58,12 +66,22 @@ export const EXECUTE_CODE_INPUT_SCHEMA = {
         "spends real money. In auto mode a low-risk action runs unattended " +
         "and a high-risk one asks the user once. Say high when unsure."
     },
+    description: {
+      type: "string",
+      description:
+        "Plain-language account of what this action will do, shown in the " +
+        "approval dialog when it asks the user. One to three sentences, no " +
+        "code: name what it changes, deletes, sends, or spends, and on what " +
+        '(e.g. "Deletes the 3 archived workflows listed above. They cannot ' +
+        'be restored."). Required when risk is "high" — that is the only ' +
+        'text the user decides on. Write "" for a low-risk action.'
+    },
     code: {
       type: "string",
       description: "The JavaScript program to run."
     }
   },
-  required: ["title", "risk", "code"],
+  required: ["title", "risk", "description", "code"],
   additionalProperties: false
 } as const;
 
@@ -71,6 +89,17 @@ export const EXECUTE_CODE_INPUT_SCHEMA = {
 export function executeCodeMessage(args: Record<string, unknown>): string {
   const title = isString(args?.["title"]) ? args["title"].trim() : "";
   return title || "Executing code action";
+}
+
+/**
+ * The plain-language account of a code action, for the approval dialog. Empty
+ * when the model wrote none — the dialog then falls back to the title.
+ */
+export function executeCodeDescription(
+  args: Record<string, unknown> | null | undefined
+): string {
+  const raw = args?.["description"];
+  return isString(raw) ? raw.trim() : "";
 }
 
 /** The risk a call declared, reading anything unrecognized as `high`. */
@@ -112,7 +141,8 @@ export async function admitCodeAction(
       risk: declaredActionRisk(args),
       code: isString(args["code"]) ? args["code"] : ""
     },
-    message: executeCodeMessage(args)
+    message: executeCodeMessage(args),
+    description: executeCodeDescription(args)
   });
 
   if (answer === "deny") {

--- a/packages/agents/src/codeact/prompt.ts
+++ b/packages/agents/src/codeact/prompt.ts
@@ -65,6 +65,12 @@ Rules:
   user loses work they never agreed to lose. Keep the destructive or costly
   part in its own action: the routine work around it then still runs
   unattended.
+- A \`"high"\` risk call also carries a \`description\`: one to three plain
+  sentences naming what the program will change, delete, send, or spend, and
+  on what. That is the text the approval dialog asks the user about — the code
+  sits behind a fold — so a description that restates the title, or describes
+  the code instead of its effect, is a user clicking Allow on something they
+  could not read. Write \`""\` for a \`"low"\` risk call; nobody is asked.
 - Chain the WHOLE pipeline into one action: call several tools, loop over
   items, branch on intermediate results, retry inside try/catch, and
   post-process in the same program. Assign each expensive intermediate to

--- a/packages/agents/src/tools/tool-permissions.ts
+++ b/packages/agents/src/tools/tool-permissions.ts
@@ -323,6 +323,12 @@ export interface ApprovalRequest {
   args: Record<string, unknown>;
   /** Resolved user-facing status (LLM `_message` or the tool's template). */
   message: string;
+  /**
+   * What the call will do, in plain sentences, for the approval dialog to ask
+   * about. A high-risk code action supplies one (`execute_code`'s
+   * `description`); most calls have none and the dialog shows `message`.
+   */
+  description?: string;
 }
 
 export type RequestApproval = (

--- a/packages/agents/tests/codeact-action-risk.test.ts
+++ b/packages/agents/tests/codeact-action-risk.test.ts
@@ -8,6 +8,7 @@ import type { ProcessingContext } from "@nodetool-ai/runtime";
 import {
   admitCodeAction,
   declaredActionRisk,
+  executeCodeDescription,
   EXECUTE_CODE_INPUT_SCHEMA,
   EXECUTE_CODE_TOOL_NAME
 } from "../src/codeact/execute-code-contract.js";
@@ -40,10 +41,17 @@ function makeGate(
   return { gate, asked };
 }
 
-const lowAction = { title: "Counting rows", risk: "low", code: "return 1;" };
+const lowAction = {
+  title: "Counting rows",
+  risk: "low",
+  description: "",
+  code: "return 1;"
+};
 const highAction = {
   title: "Deleting the old workflows",
   risk: "high",
+  description:
+    "Deletes the 3 archived workflows listed above. They cannot be restored.",
   code: "return 1;"
 };
 
@@ -51,12 +59,30 @@ describe("the execute_code contract", () => {
   it("carries risk as a required enum", () => {
     const schema = EXECUTE_CODE_INPUT_SCHEMA;
     expect(schema.properties.risk.enum).toEqual(["low", "high"]);
-    expect(schema.required).toEqual(["title", "risk", "code"]);
+    expect(schema.required).toEqual(["title", "risk", "description", "code"]);
     // OpenAI structured outputs reject a strict schema that leaves a property
     // out of `required`.
     expect(Object.keys(schema.properties).sort()).toEqual(
       [...schema.required].sort()
     );
+  });
+});
+
+describe("executeCodeDescription", () => {
+  it("reads what the model wrote, trimmed", () => {
+    expect(executeCodeDescription(highAction)).toBe(
+      "Deletes the 3 archived workflows listed above. They cannot be restored."
+    );
+    expect(executeCodeDescription({ description: "  spaced  " })).toBe(
+      "spaced"
+    );
+  });
+
+  it("is empty when there is none to read", () => {
+    expect(executeCodeDescription(lowAction)).toBe("");
+    expect(executeCodeDescription({})).toBe("");
+    expect(executeCodeDescription(null)).toBe("");
+    expect(executeCodeDescription({ description: 42 })).toBe("");
   });
 });
 
@@ -109,9 +135,12 @@ describe("admitCodeAction", () => {
     expect(asked[0]).toMatchObject({
       toolName: EXECUTE_CODE_TOOL_NAME,
       category: "execute",
-      message: "Deleting the old workflows"
+      message: "Deleting the old workflows",
+      // What the dialog asks about: the effect, not the program.
+      description:
+        "Deletes the 3 archived workflows listed above. They cannot be restored."
     });
-    // The user sees the program they are approving.
+    // The program is still there to unfold.
     expect(asked[0].args).toEqual({
       title: "Deleting the old workflows",
       risk: "high",
@@ -147,6 +176,8 @@ describe("admitCodeAction", () => {
     });
     expect(admission.allowed).toBe(false);
     expect(asked).toHaveLength(1);
+    // No description written, so the dialog has only the title to ask about.
+    expect(asked[0].description).toBe("");
   });
 });
 

--- a/packages/websocket/src/mcp-agent-tools.ts
+++ b/packages/websocket/src/mcp-agent-tools.ts
@@ -821,7 +821,10 @@ export function registerAgentMcpTools(
   // gate runs in `auto` with an always-allow approval (there is no MCP client
   // to prompt), so the declared risk decides nothing on this surface. A
   // missing one still reads as `high` — it just resolves to allow.
-  const optionalOnMcp = new Set(["title", "risk"]);
+  //
+  // `description` follows `risk`: it is the text an approval dialog asks the
+  // user about, and this surface never opens one.
+  const optionalOnMcp = new Set(["title", "risk", "description"]);
   const actionSchema = session.providerTool.inputSchema;
   const actionShape = jsonSchemaToZodShape({
     ...actionSchema,

--- a/packages/websocket/src/unified-websocket-runner.ts
+++ b/packages/websocket/src/unified-websocket-runner.ts
@@ -5089,6 +5089,7 @@ export class UnifiedWebSocketRunner {
       tool_name: request.toolName,
       category: request.category,
       message: request.message,
+      description: request.description ?? "",
       args: request.args
     });
     try {

--- a/web/src/components/chat/message/ToolApprovalCard.tsx
+++ b/web/src/components/chat/message/ToolApprovalCard.tsx
@@ -4,8 +4,16 @@ import { css } from "@emotion/react";
 import { useTheme } from "@mui/material/styles";
 import type { Theme } from "@mui/material/styles";
 import { EditorButton } from "../../editor_ui";
-import { Caption, FlexColumn, FlexRow, Text, BORDER_RADIUS } from "../../ui_primitives";
+import {
+  Caption,
+  CollapsibleSection,
+  FlexColumn,
+  FlexRow,
+  Text,
+  BORDER_RADIUS
+} from "../../ui_primitives";
 import { formatToolName } from "../../../utils/formatUtils";
+import { isString } from "../../../utils/typePredicates";
 import type { ApprovalDecision } from "../../../stores/GlobalChatStore";
 
 interface ToolApprovalCardProps {
@@ -13,9 +21,21 @@ interface ToolApprovalCardProps {
   toolName: string;
   category: string;
   message: string;
+  /**
+   * Plain-sentence account of what the call will do. A high-risk code action
+   * carries one; when it is empty the card asks about `message` instead.
+   */
+  description?: string;
   args: Record<string, unknown>;
   onResolve: (approvalId: string, decision: ApprovalDecision) => void;
 }
+
+/** The question the card asks, by what the call is about to do. */
+const QUESTIONS: Record<string, string> = {
+  execute: "Run this action?",
+  write: "Make this change?",
+  external: "Allow this action?"
+};
 
 const styles = (theme: Theme) =>
   css({
@@ -23,11 +43,19 @@ const styles = (theme: Theme) =>
     borderRadius: BORDER_RADIUS.lg,
     background: `rgb(${theme.vars.palette.warning.mainChannel} / 0.06)`,
     padding: theme.spacing(3, 4),
+    ".approval-question": {
+      color: theme.vars.palette.grey[0]
+    },
     ".approval-tool": {
       fontFamily: theme.fontFamily2,
       color: theme.vars.palette.grey[0]
     },
-    ".approval-args": {
+    ".approval-risk": {
+      color: theme.vars.palette.warning.main,
+      textTransform: "uppercase",
+      letterSpacing: "0.06em"
+    },
+    ".approval-detail": {
       margin: 0,
       padding: theme.spacing(2, 3),
       borderRadius: BORDER_RADIUS.md,
@@ -39,36 +67,52 @@ const styles = (theme: Theme) =>
       lineHeight: 1.5,
       whiteSpace: "pre-wrap",
       wordBreak: "break-word",
-      maxHeight: 180,
+      maxHeight: 320,
       overflow: "auto"
     }
   });
 
 /**
- * Inline approval prompt for a gated tool call. Shows the agent's message, the
- * tool name + category, and a compact view of the call arguments, with three
- * decisions: Allow (this call), Allow for this chat (session grant), Deny.
+ * Inline approval prompt for a gated tool call. It asks one question — do you
+ * want this done? — and answers it with the caller's own account of the call
+ * (`description`, else the status message). The code and the remaining
+ * arguments stay folded: a wall of unfolded JavaScript is not something a user
+ * can answer yes or no to, but it has to be readable for the ones who want it.
+ *
+ * Three decisions: Allow (this call), Allow for this chat (session grant), Deny.
  */
 const ToolApprovalCard: React.FC<ToolApprovalCardProps> = ({
   approvalId,
   toolName,
   category,
   message,
+  description,
   args,
   onResolve
 }) => {
   const theme = useTheme();
   const cssStyles = useMemo(() => styles(theme), [theme]);
 
-  const argsText = useMemo(() => {
-    try {
-      return JSON.stringify(args ?? {}, null, 2);
-    } catch {
-      return String(args);
-    }
+  const question = QUESTIONS[category] ?? "Allow this action?";
+  const summary = description?.trim() || message;
+  const isHighRisk = args?.["risk"] === "high";
+
+  const code = useMemo(() => {
+    const raw = args?.["code"];
+    return isString(raw) && raw.trim().length > 0 ? raw : null;
   }, [args]);
 
-  const hasArgs = argsText !== "{}" && argsText.trim().length > 0;
+  const argsText = useMemo(() => {
+    const rest: Record<string, unknown> = { ...(args ?? {}) };
+    delete rest["code"];
+    const keys = Object.keys(rest);
+    if (keys.length === 0) return null;
+    try {
+      return JSON.stringify(rest, null, 2);
+    } catch {
+      return String(rest);
+    }
+  }, [args]);
 
   const handleAllow = useCallback(
     () => onResolve(approvalId, "allow"),
@@ -84,9 +128,17 @@ const ToolApprovalCard: React.FC<ToolApprovalCardProps> = ({
   );
 
   return (
-    <div css={cssStyles} className="tool-approval-card" role="group">
+    <div
+      css={cssStyles}
+      className="tool-approval-card"
+      role="group"
+      aria-label={question}
+    >
       <FlexColumn gap={1}>
-        {message && <Text size="normal">{message}</Text>}
+        <Text size="normal" weight={600} className="approval-question">
+          {question}
+        </Text>
+        {summary && <Text size="normal">{summary}</Text>}
         <FlexRow gap={0.5} align="center">
           <Text size="small" weight={600} className="approval-tool">
             {formatToolName(toolName)}
@@ -94,8 +146,40 @@ const ToolApprovalCard: React.FC<ToolApprovalCardProps> = ({
           <Caption size="smaller" color="secondary">
             {category}
           </Caption>
+          {isHighRisk && (
+            <Caption size="smaller" className="approval-risk">
+              high risk
+            </Caption>
+          )}
         </FlexRow>
-        {hasArgs && <pre className="approval-args">{argsText}</pre>}
+        {code && (
+          <CollapsibleSection
+            compact
+            defaultOpen={false}
+            unmountOnExit
+            title={
+              <Caption size="small" color="secondary">
+                Show code
+              </Caption>
+            }
+          >
+            <pre className="approval-detail approval-code">{code}</pre>
+          </CollapsibleSection>
+        )}
+        {argsText && (
+          <CollapsibleSection
+            compact
+            defaultOpen={false}
+            unmountOnExit
+            title={
+              <Caption size="small" color="secondary">
+                Show arguments
+              </Caption>
+            }
+          >
+            <pre className="approval-detail approval-args">{argsText}</pre>
+          </CollapsibleSection>
+        )}
         <FlexRow gap={1} align="center">
           <EditorButton
             variant="contained"

--- a/web/src/components/chat/message/__tests__/ToolApprovalCard.test.tsx
+++ b/web/src/components/chat/message/__tests__/ToolApprovalCard.test.tsx
@@ -1,0 +1,111 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import ToolApprovalCard from "../ToolApprovalCard";
+import mockTheme from "../../../../__mocks__/themeMock";
+
+const onResolve = jest.fn();
+
+const CODE = "await deleteWorkflows(ids);\nreturn ids.length;";
+
+interface CardProps {
+  toolName?: string;
+  category?: string;
+  message?: string;
+  description?: string;
+  args?: Record<string, unknown>;
+}
+
+const renderCard = (overrides: CardProps = {}) =>
+  render(
+    <ThemeProvider theme={mockTheme}>
+      <ToolApprovalCard
+        approvalId="appr_1"
+        toolName={overrides.toolName ?? "execute_code"}
+        category={overrides.category ?? "execute"}
+        message={overrides.message ?? "Deleting the old workflows"}
+        description={
+          "description" in overrides
+            ? overrides.description
+            : "Deletes the 3 archived workflows listed above. They cannot be restored."
+        }
+        args={
+          overrides.args ?? { title: "Deleting the old workflows", risk: "high", code: CODE }
+        }
+        onResolve={onResolve}
+      />
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  onResolve.mockReset();
+});
+
+describe("ToolApprovalCard", () => {
+  it("asks about the description, not the code", () => {
+    renderCard();
+    expect(screen.getByText("Run this action?")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Deletes the 3 archived workflows/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/deleteWorkflows/)).not.toBeInTheDocument();
+  });
+
+  it("unfolds the code for whoever wants to read it", async () => {
+    const user = userEvent.setup();
+    renderCard();
+    await user.click(screen.getByText("Show code"));
+    expect(screen.getByText(/deleteWorkflows/)).toBeInTheDocument();
+  });
+
+  it("falls back to the status message when no description was written", () => {
+    renderCard({ description: "" });
+    expect(screen.getByText("Deleting the old workflows")).toBeInTheDocument();
+  });
+
+  it("marks a high-risk call", () => {
+    renderCard();
+    expect(screen.getByText("high risk")).toBeInTheDocument();
+  });
+
+  it("asks a write call about the change it makes", () => {
+    renderCard({
+      toolName: "delete_workflow",
+      category: "write",
+      message: "Deleting workflow wf_1",
+      description: "",
+      args: { workflow_id: "wf_1" }
+    });
+    expect(screen.getByText("Make this change?")).toBeInTheDocument();
+    expect(screen.getByText("Deleting workflow wf_1")).toBeInTheDocument();
+    // No code to fold, so only the arguments are offered.
+    expect(screen.queryByText("Show code")).not.toBeInTheDocument();
+    expect(screen.getByText("Show arguments")).toBeInTheDocument();
+  });
+
+  it("offers no folds for a call with no arguments", () => {
+    renderCard({
+      toolName: "publish",
+      category: "external",
+      description: "",
+      args: {}
+    });
+    expect(screen.getByText("Allow this action?")).toBeInTheDocument();
+    expect(screen.queryByText("Show code")).not.toBeInTheDocument();
+    expect(screen.queryByText("Show arguments")).not.toBeInTheDocument();
+  });
+
+  it("reports each decision under the approval id", async () => {
+    const user = userEvent.setup();
+    renderCard();
+    await user.click(screen.getByRole("button", { name: "Allow" }));
+    expect(onResolve).toHaveBeenCalledWith("appr_1", "allow");
+    await user.click(
+      screen.getByRole("button", { name: "Allow for this chat" })
+    );
+    expect(onResolve).toHaveBeenCalledWith("appr_1", "allow_for_chat");
+    await user.click(screen.getByRole("button", { name: "Deny" }));
+    expect(onResolve).toHaveBeenCalledWith("appr_1", "deny");
+  });
+});

--- a/web/src/components/chat/thread/ChatThreadView.test.tsx
+++ b/web/src/components/chat/thread/ChatThreadView.test.tsx
@@ -142,6 +142,7 @@ describe("ChatThreadView", () => {
           tool_name: "write_file",
           category: "write",
           message: "Approval for A",
+          description: "",
           args: {}
         },
         "approval-b": {
@@ -149,6 +150,7 @@ describe("ChatThreadView", () => {
           tool_name: "run_command",
           category: "execute",
           message: "Approval for B",
+          description: "",
           args: {}
         }
       }

--- a/web/src/components/chat/thread/ChatThreadView.tsx
+++ b/web/src/components/chat/thread/ChatThreadView.tsx
@@ -984,6 +984,7 @@ const ChatThreadView: React.FC<ChatThreadViewProps> = ({
                       toolName={approval.tool_name}
                       category={approval.category}
                       message={approval.message}
+                      description={approval.description}
                       args={approval.args}
                       onResolve={resolveApproval}
                     />

--- a/web/src/core/chat/chatProtocol.ts
+++ b/web/src/core/chat/chatProtocol.ts
@@ -94,6 +94,12 @@ interface ToolApprovalRequestMessage {
   tool_name: string;
   category: "write" | "execute" | "external";
   message: string;
+  /**
+   * What the call will do, in plain sentences — what the card asks about. A
+   * high-risk code action carries one; most calls leave it empty and the card
+   * asks about `message` instead.
+   */
+  description?: string;
   args: Record<string, unknown>;
 }
 

--- a/web/src/stores/GlobalChatStore.ts
+++ b/web/src/stores/GlobalChatStore.ts
@@ -99,6 +99,8 @@ interface PendingApproval {
   tool_name: string;
   category: string;
   message: string;
+  /** Plain-sentence account of the call; empty when the caller sent none. */
+  description: string;
   args: Record<string, unknown>;
 }
 
@@ -110,6 +112,7 @@ interface ToolApprovalRequest {
   tool_name: string;
   category: "write" | "execute" | "external";
   message: string;
+  description?: string;
   args: Record<string, unknown>;
 }
 
@@ -598,6 +601,7 @@ const useGlobalChatStore = create<GlobalChatState>()(
               tool_name: req.tool_name,
               category: req.category,
               message: req.message,
+              description: req.description ?? "",
               args: req.args
             }
           }


### PR DESCRIPTION
## What changed

A high-risk `execute_code` action asks the user before it runs, and the approval card printed the whole program as unfolded JSON — not a question anyone can answer without reading JavaScript. The call now carries a `description`: one to three plain sentences naming what it will change, delete, send, or spend. It rides through the gate (`ApprovalRequest.description`), over the `tool_approval_request` frame, and into `ToolApprovalCard`, which leads with a question ("Run this action?" / "Make this change?" / "Allow this action?"), puts the description under it, and folds the code away behind "Show code". Remaining arguments fold the same way, so every gated call reads as a decision instead of a payload dump; a high-risk call is marked as such. `description` is required by the strict provider schema and empty for a low-risk action, which is never prompted. On MCP it joins `title` and `risk` as optional — that session's gate runs `auto` with an always-allow approval, so no dialog ever reads it.

## Verification

- [x] `npm run test:affected` — `All affected suites passed.` (19 backend packages, web, electron)
- [x] `npm run typecheck` — web and electron clean. `typecheck:mobile` fails on `Cannot find module 'react-native'`: `mobile/` is not a root workspace and has no `node_modules` in this container. Pre-existing and untouched by this diff.
- [x] `npm run lint` — exit 0
- [x] `npm run dev:nodetool -- harness gate --base main` — `Gate: 1/1 selfchecks passed`, 255/255 graphs validate

Two failures during the run were environmental, not this diff:
- 14 shader-backed image tests in `packages/base-nodes` failed with `No WebGPU adapter available (Node/Dawn)`. Installed `mesa-vulkan-drivers` per AGENTS.md and re-ran: `Test Files 2 passed (2) / Tests 14 passed (14)`.
- `tests/mcp-server.test.ts` failed on the new required field; that is the MCP relaxation described above, now fixed in the diff.

New card test, inverted to prove it bites — flipping the code fold's `defaultOpen` to `true`:

```
✕ asks about the description, not the code (93 ms)
✓ unfolds the code for whoever wants to read it (120 ms)
Tests: 1 failed, 6 passed, 7 total
```

Restored, and the suite is green (7/7). `packages/agents/tests/codeact-action-risk.test.ts` covers `executeCodeDescription` and asserts the approval request carries the description while the args still carry the program: 14/14.

## Agent capabilities

`execute_code` is the codeact provider tool, not a registry capability; no capability's declared contract changed.

- [x] `npm run capabilities:check` passes — `capability table is current (224 capabilities)`

## New checks

No check, rule, or audit added — the inverted test above is a unit test for the new card behavior, and its failing output is in **Verification**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAyCVMSnhfoR48da35aDDs)_