### PR TITLE
Replace storyboard and script editor images

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ workflow it binds — and import it anywhere.
 
 ### Storyboard — plan a film shot by shot before you pay for video
 
-![NodeTool storyboard](marketing/public/screen_storyboard.png)
+![NodeTool storyboard](marketing/public/surface-storyboard-poster.webp)
 
 Write a brief and a visual style, pick a shot count, and press **Direct**: the
 Director node returns a typed screenplay — logline, style bible, narration,
@@ -206,7 +206,7 @@ with `render_storyboard_stills`, `render_storyboard_clips`, and
 
 ### Script editor — narration as a document, audio derived from it
 
-![NodeTool script editor — the transcript panel beside the sequence it assembles into](.github/assets/creative-agent/assembled-timeline.png)
+![NodeTool script editor — the transcript panel beside the sequence it assembles into](marketing/public/surface-script-poster.webp)
 
 A script lives on its own, line by line and section by section, and the text is
 the source of truth.


### PR DESCRIPTION
Updated images in the README to use new formats.

## What changed

<!-- One paragraph. What the diff does, and why — not a file list. -->

## Verification

<!-- Commands you ran, with their result. Paste the failing output for any
     check you inverted to prove it can fail. -->

- [ ] `npm run test:affected` (the full `npm run test` +
      `npm run test:packages` pass is CI's job, not yours)
- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run dev:nodetool -- harness gate --base main`

## Agent capabilities

Skip this section if the diff adds no capability and changes no capability's
declared contract (name, description, input schema, permission category,
`needsToolCallId`).

- [ ] `npm run capabilities:check` passes
- [ ] Every added or re-declared capability names an eval case or a suite in
      `packages/cli/src/harness/capability-table.ts`, or carries a gap note
      saying what a check for it would look like

## New checks

Skip this section if the diff adds no check, rule, or audit.

- [ ] The check was inverted once and observed failing; the failing command is
      in **Verification** above
- [ ] An audit asserts it found its targets, so it cannot pass by matching
      nothing
