### PR TITLE
docs(marketing): rewrite landing copy around direct/build messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NodeTool
 
-*Every model. Your keys. Your canvas.*
+*You direct the vision. The agent builds the film.*
 
 [![Stars](https://img.shields.io/github/stars/nodetool-ai/nodetool?style=social)](https://github.com/nodetool-ai/nodetool/stargazers)
 [![Downloads](https://img.shields.io/github/downloads/nodetool-ai/nodetool/total?color=3fb950)](https://github.com/nodetool-ai/nodetool/releases)
@@ -11,14 +11,24 @@
 
 ![NodeTool node editor](marketing/public/screen_canvas.webp)
 
-NodeTool is an open-source creative AI suite that runs on your machine. A
-node-based canvas, a video timeline, a sketch editor, storyboards and mini-apps
-share one workspace, and every major AI model, cloud or local, plugs straight
-in.
+NodeTool is an open-source AI production studio that runs on your machine.
+Describe your idea and the agent writes the script, boards every scene,
+generates the footage, and cuts the timeline — then hands you an editable
+multi-track project, not a flat render.
+
+A node canvas, a video timeline, a sketch editor, storyboards, and mini-apps
+share one workspace, and every major model, cloud or local, plugs straight in.
 
 It is agent-first: every action you can take in the UI is also an agent tool,
 so an agent can wire a graph, paint a layer, cut a clip, or place a widget on
 the same surfaces you use, then run the result and repair what fails.
+
+* **01 / Pitch** — tell the agent your concept, style, and tone. It drafts the
+  script, casts the voices, and sets the visual direction.
+* **02 / Automate** — it storyboards the scenes, generates the footage, syncs
+  the audio, and cuts it together on a multi-track timeline.
+* **03 / Direct** — jump in at any moment. Swap a voice take, re-roll a clip, or
+  trim frames. The agent builds the foundation; you make the final cut.
 
 ## Get NodeTool
 
@@ -56,14 +66,14 @@ are available for Linux. Developers can skip the installer and
 More in the [showcase](https://nodetool.ai/showcase) and the
 [template gallery](https://nodetool.ai/templates).
 
-## Why NodeTool
+## Local. Open. Yours.
 
-Closed platforms lock you in. NodeTool is built for independence.
+No locked project formats, no token markups, zero subscription traps.
 
-* **Independent pricing.** Your own API keys, provider prices, no markup — or
-  local models for free.
-* **Independent data.** Workflows, keys, and files stay on your machine.
-* **Independent software.** Open source, AGPL-3.0.
+* **Bring your own keys.** Provider prices, billed by the provider — or open
+  weights on your own hardware for free.
+* **Your files stay yours.** Projects, keys, and footage stay on your machine.
+* **Open source.** AGPL-3.0, end to end. Read it, fork it, host it.
 
 If a provider raises prices or deprecates a model, swap the node. The rest of
 the workflow doesn't change.
@@ -109,10 +119,10 @@ cost. See the [agent guide](https://docs.nodetool.ai/agents/) and
 | | |
 | :--- | :--- |
 | **Node canvas** | Drag-and-drop nodes, type-safe connections, live output at every node |
-| **Video editor** | Multi-track timeline — sequence, composite, and AI-generate clips, then export MP4 |
+| **Video editor** | A real multi-track timeline — sequence, composite, and generate clips, then export MP4 |
 | **Sketch editor** | Layered paint canvas — draw, mask, and generate onto layers, feed the result downstream |
-| **Storyboard** | Brief → screenplay → stills you pick from → clips → an assembled cut |
-| **Script editor** | Write a script, cast a voice per speaker, audition takes, send them to a timeline |
+| **Storyboard** | Pitch → screenplay → stills you pick from → clips → an assembled cut |
+| **Script editor** | Draft a script, cast a voice per character, audition takes, send them to a timeline |
 | **Mini apps** | Wire widgets to workflow inputs and outputs and publish a version |
 | **Editing tools as nodes** | Mask, inpaint, outpaint, relight, upscale, layers, compositing |
 
@@ -121,7 +131,7 @@ cost. See the [agent guide](https://docs.nodetool.ai/agents/) and
 | | |
 | :--- | :--- |
 | **Every modality** | Image, video, audio, and text in one workflow |
-| **BYOK everywhere** | OpenAI, Anthropic, Gemini, FAL, KIE, Replicate, ElevenLabs, HuggingFace |
+| **BYOK everywhere** | OpenAI, Anthropic, Gemini, FAL, KIE, Replicate, ElevenLabs, HuggingFace — no markups |
 | **Local inference** | Ollama, MLX (Apple Silicon), and GGUF |
 | **Document search** | Built-in vector store for indexing and querying your files |
 | **JS scripts** | Versioned JavaScript documents with ports, tests, and a sandbox |
@@ -177,11 +187,11 @@ workflow it binds — and import it anywhere.
 [App builder guide →](https://docs.nodetool.ai/app-builder) ·
 [Mini apps guide →](https://docs.nodetool.ai/mini-apps)
 
-### Storyboard — plan a film shot by shot before you pay for video
+### Storyboard — board the film shot by shot before you pay for video
 
 ![NodeTool storyboard](marketing/public/surface-storyboard-poster.webp)
 
-Write a brief and a visual style, pick a shot count, and press **Direct**: the
+Pitch a concept and a visual style, pick a shot count, and press **Direct**: the
 Director node returns a typed screenplay — logline, style bible, narration,
 music direction, and one structured shot per card with action, camera, motion,
 and duration.
@@ -204,14 +214,14 @@ with `render_storyboard_stills`, `render_storyboard_clips`, and
 
 [Creative agent guide →](https://docs.nodetool.ai/creative-agent)
 
-### Script editor — narration as a document, audio derived from it
+### Script editor — scripting and casting, with the words as the source of truth
 
 ![NodeTool script editor — the transcript panel beside the sequence it assembles into](marketing/public/surface-script-poster.webp)
 
 A script lives on its own, line by line and section by section, and the text is
 the source of truth.
 
-* **Cast a voice per speaker.** Each speaker carries a provider, model, and
+* **Cast a voice per character.** Each speaker carries a provider, model, and
   voice; every line inherits it unless you override the line.
 * **Takes, not overwrites.** Voicing a line saves a take with its own word
   timings. Audition several, keep the one you want.
@@ -224,15 +234,16 @@ An agent does the same without the editor open: `voice_script_lines` voices
 every draft or stale line with its cast voice, and `assemble_script_timeline`
 cuts the result into a saved sequence that `validate_timeline` then checks.
 
-### Video editor — a generation-aware multi-track timeline
+### Video editor — a real multi-track timeline, not a black box
 
 ![NodeTool video editor](screen_video_editor.png)
 
+Instead of a single unfixable video file, you get a fully editable project.
 Drop in your own footage or bind a workflow to a clip — text-to-image,
 image-to-video, or text-to-speech — and generate it in place. Change a parameter
 and the clip regenerates; tweak the bound workflow and the clip flags itself
-stale. Composite a live preview across video, audio, and overlay tracks, then
-export the sequence to MP4.
+stale. Fine-tune every frame, layer, and audio stem across video, audio, and
+overlay tracks, then export the sequence to MP4.
 
 [Video editor guide →](https://docs.nodetool.ai/video-editor)
 
@@ -282,7 +293,7 @@ Agents get the same surface through `list_js_scripts`, `save_js_script`,
 
 | | NodeTool | ComfyUI | Weavy | n8n |
 | :--- | :--- | :--- | :--- | :--- |
-| **Built for** | Creatives working with AI | Stable Diffusion power users | Creative teams (now part of Figma) | Business workflows |
+| **Built for** | Filmmakers and creators working with AI | Stable Diffusion power users | Creative teams (now part of Figma) | Business workflows |
 | **Modalities** | Image, video, audio, text | Image, video | Image, video | Text |
 | **Agents** | Every editor is a toolbelt; agents build, run, and repair | Community extensions | Assistant features | AI nodes in a workflow |
 | **Models** | Every major provider, BYOK | Stable Diffusion | Curated marketplace | API integrations |

--- a/marketing/NARRATIVE.md
+++ b/marketing/NARRATIVE.md
@@ -8,15 +8,16 @@ same change.
 
 ## Positioning line
 
-**From prompt to final cut on one canvas.**
+**You direct the vision. The agent builds the film.**
 
-The hero claim is not the feature list and not the category label. It is the
-outcome: one workspace carries the piece from the first prompt to the finished
-cut, with no export hops between tools. The previous line — *"Describe the
-piece. Keep the workflow."* — survives as claim 1 below: a closed tool
-generates behind glass and hands you a file; NodeTool's agent generates *and*
-hands you the graph that made it — a normal, inspectable file you can open,
-rewire, and run again.
+The hero claim is not the feature list and not the category label. It names who
+does what: the agent handles the tedious stretch between a blank page and a
+rough cut — script, board, footage, sound, cut — and the creator stays the
+director throughout. The earlier lines — *"From prompt to final cut on one
+canvas"* and *"Describe the piece. Keep the workflow."* — survive as claims 1
+and 2 below: a closed tool generates behind glass and hands you a file;
+NodeTool's agent generates *and* hands you the multi-track project that made
+it, a normal, editable file you can open, re-cut, and run again.
 
 "The agent-first creative workspace" stays as the category descriptor in
 `<title>`, meta descriptions, and schema. It is accurate and it is what people
@@ -27,22 +28,25 @@ search for. It is not the H1: it names a category instead of a benefit.
 Everything below the hero earns its place by advancing one of three claims, in
 this order of importance:
 
-1. **The agent builds something you own.** Not chat that tells you what to do,
-   and not a black box that returns a render. Show the graph appearing, the node
-   being edited, the run resuming from the middle.
-2. **One canvas, generation through finish.** Image, video, audio, text, plus
-   the editors — storyboard, timeline, sketch, script — so a piece never leaves
-   the workspace to be finished.
-3. **Independence.** Your keys, your files, your models, AGPL-3.0, local option.
-   Stated as fact, never as a pitch.
+1. **Agentic automation, and what it leaves behind.** Not chat that tells you
+   what to do, and not a black box that returns a render. The agent does the
+   heavy lifting and hands back a multi-track project you can still edit. Show
+   the graph appearing, the node being edited, the run resuming from the middle.
+2. **One canvas, pitch through final cut.** Image, video, audio, text, plus the
+   editors — storyboard, timeline, sketch, script — so a piece never leaves the
+   workspace to be finished.
+3. **Creative sovereignty.** Your keys, your files, your models, AGPL-3.0, local
+   option. No token markups, no locked project formats. Stated as fact, never as
+   a pitch.
 
 Provider lists, node counts, tool counts, and architecture belong under those
 claims, not next to them.
 
 ## Order of the page
 
-Hero → the status quo (the pain, once, briefly) → the demo → use cases with real
-output → the three claims above → proof → comparisons → download.
+Hero → the status quo (the pain, once, briefly) → the demo → the three steps
+(Pitch / Automate / Direct) → use cases with real output → the three claims
+above → proof → comparisons → download.
 
 The pain section comes before any feature because the features only mean
 something against it. Comparisons come late: a reader who is convinced does not
@@ -50,9 +54,9 @@ need them, and a reader who is not will scroll to them.
 
 ## Audience
 
-The front door speaks to **creatives and small teams** — filmmakers, designers,
-marketers, content studios — who want production output without becoming ML
-engineers or paying a credit tax.
+The front door speaks to **filmmakers, directors, and creators** — plus the
+small teams around them: designers, marketers, content studios — who want
+production output without becoming ML engineers or paying a token tax.
 
 Technical depth is the back door, not the doorway: `/developers`, `/agents`, the
 CLI and SDK pages. Keeping it off the homepage is what stops the site reading as
@@ -84,11 +88,16 @@ better than a manufactured superlative.
 
 Beyond [docs/WRITING_STYLE.md](../docs/WRITING_STYLE.md), which applies here too:
 
-- "Workspace" or "studio", not "workflow builder" — the latter undersells the
+- "Studio" or "canvas", not "workflow builder" — the latter undersells the
   editors and puts us in the n8n bracket.
+- "Agent", not "the AI" or "the algorithm". "Pitch" or "direct", not "prompt
+  engineering". "Takes" and "cast", not "generations" and "outputs".
+- "Multi-track timeline", not "output" or "render" — the result is a workspace,
+  not a locked file.
+- "Filmmakers", "directors", "creators" — never "users" or "content creators".
 - "Every major model, your keys" instead of a fourteen-name provider list. Name
   providers where a reader is checking for a specific one (pricing, model pages).
 - Concrete over categorical: "a Seedance run that costs $0.18 on KIE costs $0.18
   here" beats "no markup".
-- No "seamless", "powerful", "unlock", "empower". If a sentence survives its own
-  deletion, delete it.
+- No "magic", "revolutionary", "seamless", "powerful", "unlock", "empower". If a
+  sentence survives its own deletion, delete it.

--- a/marketing/src/app/cloud/layout.tsx
+++ b/marketing/src/app/cloud/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 
 const TITLE = "The Agent-First Workspace in Your Browser — NodeTool Cloud (Alpha)";
 const DESCRIPTION =
-  "The agent-first workspace in your browser — no install, no GPU required. Tell the agent what you want and it builds and runs the workflow. NodeTool Cloud is the hosted, browser-based edition of the open-source NodeTool platform, currently in alpha (not yet generally available). Bring your own API keys for OpenAI, Anthropic, Gemini, Replicate, and more. AGPL-3.0.";
+  "The agent-first studio in your browser — no install, no GPU required. Pitch your idea and the agent drafts the script, boards the scenes, generates the footage, and cuts a timeline you can still edit. NodeTool Cloud is the hosted, browser-based edition of the open-source NodeTool platform, currently in alpha (not yet generally available). Bring your own API keys for OpenAI, Anthropic, Gemini, Replicate, and more. AGPL-3.0.";
 
 export const metadata: Metadata = {
   title: TITLE,

--- a/marketing/src/app/cloud/opengraph-image.tsx
+++ b/marketing/src/app/cloud/opengraph-image.tsx
@@ -6,8 +6,8 @@ export const contentType = ogContentType;
 
 export default function Image() {
   return ogImage(
-    "Visual AI workflows in your browser",
-    "Zero setup, no GPU. Bring your own keys to every provider.",
+    "The agent-first studio in your browser",
+    "Zero setup, no GPU. Bring your own keys, no token markups.",
     { image: "screen_chat.png", accent: "cyan", eyebrow: "Cloud — Alpha" }
   );
 }

--- a/marketing/src/app/cloud/page.tsx
+++ b/marketing/src/app/cloud/page.tsx
@@ -56,7 +56,7 @@ const proPoints = [
   {
     icon: Zap,
     title: "Start in 30 seconds",
-    body: "Sign in and describe what you want to make. Start from the agent, an existing workflow, or a blank canvas — no installer, no drivers, nothing beyond a browser tab.",
+    body: "Sign in and pitch the piece. Start from the agent, an existing workflow, or a blank canvas — no installer, no drivers, nothing beyond a browser tab.",
   },
   {
     icon: Globe,
@@ -71,7 +71,7 @@ const proPoints = [
   {
     icon: KeyRound,
     title: "Bring your own keys",
-    body: "OpenAI, Anthropic, Gemini, Mistral, Groq, Replicate, FAL, ElevenLabs, and HuggingFace all bill your account directly, not ours.",
+    body: "OpenAI, Anthropic, Gemini, Mistral, Groq, Replicate, FAL, ElevenLabs, and HuggingFace all bill your account directly, not ours. No token markups.",
   },
   {
     icon: RefreshCcw,
@@ -212,18 +212,18 @@ export default function CloudPage() {
                   id="cloud-hero-title"
                   className="mt-6 text-4xl md:text-6xl font-bold tracking-tight text-white leading-[1.05]"
                 >
-                  The agent-first workspace
+                  The agent-first studio
                   <br />
                   <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-300 to-cyan-300">
                     in your browser.
                   </span>
                 </h1>
                 <p className="mt-6 text-lg text-slate-300 leading-relaxed max-w-xl">
-                  NodeTool Cloud is the hosted version of the same open-source,
-                  agent-first app. There is nothing to install and no hardware
-                  to set up: sign in, say what you want, and the agent builds
-                  the workflow and runs it. Bring your own API keys for
-                  whichever providers you want to use.
+                  NodeTool Cloud is the hosted version of the same open-source
+                  studio. Nothing to install, no hardware to set up: sign in,
+                  pitch your idea, and the agent builds the film on a canvas
+                  you can still edit. Bring your own API keys for whichever
+                  providers you want to use.
                 </p>
                 <div className="mt-6 rounded-lg border border-amber-500/30 bg-amber-500/[0.06] p-4 text-sm text-amber-100/90 max-w-xl">
                   <strong className="text-amber-200">Heads up:</strong> Cloud is

--- a/marketing/src/app/creatives/page.tsx
+++ b/marketing/src/app/creatives/page.tsx
@@ -27,9 +27,9 @@ import UseCasesShowcase from "../../components/UseCasesShowcase";
 // Features for creative professionals
 const creativeFeatures = [
   {
-    title: "Visual Workflow Canvas",
+    title: "One canvas, pitch to final cut",
     description:
-      "Snap blocks together into complete creative workflows, so the whole process sits on one screen, from brief to final render.",
+      "Snap blocks together into a complete production, so the whole piece sits on one screen — brief, shots, sound, and the cut.",
     icon: Layers,
     image: "/screen_canvas.png",
     features: [
@@ -39,17 +39,17 @@ const creativeFeatures = [
     ],
   },
   {
-    title: "Image generation & editing",
+    title: "Key art and image editing",
     description:
-      "Run Flux, Qwen-Image, Nano-Banana, Z-Image, gpt-image, and the rest. Generate, mask, inpaint, outpaint, relight, and upscale, all on the canvas.",
+      "Route a shot through Flux, Qwen-Image, Nano-Banana, Z-Image, or gpt-image. Generate, mask, inpaint, outpaint, relight, and upscale on the same canvas.",
     icon: Wand2,
     image: "/disaster_girl.mp4",
     features: ["Masks, inpaint, outpaint", "Multi-model support", "Batch processing"],
   },
   {
-    title: "Video workflows",
+    title: "Model freedom for every shot",
     description:
-      "Put Seedance, Kling, Veo, Runway, and Sora next to your editing steps. Generate, transform, and join clips without exporting between tools.",
+      "Put Seedance, Kling, Veo, Runway, and Sora next to your editing steps. Generate, re-roll, and join clips without exporting between tools.",
     icon: Video,
     image: "/sora.mp4",
     features: [
@@ -59,9 +59,9 @@ const creativeFeatures = [
     ],
   },
   {
-    title: "Storyboard, script, and cut",
+    title: "Scripting, casting, and the cut",
     description:
-      "Turn a one-line brief into a shot list, approve the cheap stills before paying to render clips, voice the script line by line, and assemble the result in the timeline editor.",
+      "Turn a one-line pitch into a shot list, approve the cheap stills before paying to render clips, cast a voice per character, and assemble the takes on a multi-track timeline.",
     icon: Clapperboard,
     image: "/screen_storyboard.png",
     features: [
@@ -71,9 +71,9 @@ const creativeFeatures = [
     ],
   },
   {
-    title: "Audio on the same surface",
+    title: "Score and sound, same canvas",
     description:
-      "Write music with Suno, make voices with ElevenLabs, and turn speech into text with Whisper. Same canvas, no extra tabs.",
+      "Write music with Suno, cast voices with ElevenLabs, and transcribe with Whisper. Same canvas, no extra tabs, audio stems you can still edit.",
     icon: Music,
     image: "/suno.png",
     features: ["Stem separation", "Music generation", "Voice generation"],
@@ -135,26 +135,27 @@ export default function CreativesPage() {
                 <div className="relative inline-flex items-center gap-2.5 px-6 py-2.5 rounded-full border border-rose-500/30 bg-gradient-to-r from-rose-500/[0.08] via-amber-500/[0.05] to-cyan-500/[0.08] mb-10 shadow-[0_0_40px_-10px_rgba(244,63,94,0.35)]">
                   <Sparkles className="w-4 h-4 text-rose-400" />
                   <span className="text-sm font-medium text-white tracking-wide">
-                    The agent-first canvas for working creatives
+                    The agent-first studio for filmmakers and creators
                   </span>
                 </div>
 
                 <h1 className="text-5xl md:text-7xl lg:text-[5.5rem] font-bold tracking-tight leading-[1.05] mb-10">
-                  <span className="text-white">Say it.</span>{" "}
+                  <span className="text-white">You direct the vision.</span>{" "}
                   <span className="text-transparent bg-clip-text bg-gradient-to-r from-rose-400 via-amber-300 via-emerald-300 to-cyan-400">
-                    Watch it made.
+                    The agent builds the film.
                   </span>
                   <br />
                   <span className="text-white/90 text-3xl md:text-5xl lg:text-6xl">
-                    Image, music &amp; video in one agent-first studio.
+                    Image, music &amp; video in one open studio.
                   </span>
                 </h1>
 
                 <p className="text-lg md:text-xl text-slate-400 mb-12 max-w-3xl mx-auto leading-relaxed">
-                  Every model. Your keys. Your agent. Describe the piece and the
-                  agent plans the shots, builds the workflow, and runs Seedance,
-                  Kling, Veo, Runway, Luma, Suno, and Flux in one open-source
-                  workspace — no marked-up credits, nothing locking you in.
+                  Pitch your concept and the agent drafts the script, boards
+                  every scene, generates the footage, and cuts a multi-track
+                  timeline you can still edit. Route your shots through
+                  Seedance, Kling, Veo, Runway, Luma, Suno, and Flux on your own
+                  keys — no token markups, no platform lock-in.
                 </p>
 
                 <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-14">
@@ -170,7 +171,7 @@ export default function CreativesPage() {
                     className="inline-flex items-center gap-2.5 px-9 py-4 rounded-full border border-white/15 bg-[#0a0a14]/70 backdrop-blur-sm text-white font-semibold hover:bg-white/5 hover:border-white/25 transition-all"
                   >
                     <Play className="w-5 h-5" />
-                    See how it works
+                    Watch the agent work
                   </a>
                 </div>
 
@@ -241,12 +242,12 @@ export default function CreativesPage() {
                 Built-in video editor
               </div>
               <h2 className="text-3xl md:text-4xl font-bold text-white mb-4 tracking-tight">
-                Generate AI video and audio straight onto the timeline.
+                A real timeline. Not a black box.
               </h2>
               <p className="text-lg text-slate-400 leading-relaxed">
-                Type a prompt at the playhead, pick a model, and the new clip drops onto
-                the track — video and audio on one multi-track timeline. Trim, split, and
-                arrange like any editor, then export a finished cut.
+                The agent hands you an editable multi-track project, not a flat
+                render. Prompt a model at the playhead and the clip drops onto
+                the track, then trim frames, layer stems, and export the cut.
               </p>
             </motion.div>
 
@@ -505,17 +506,16 @@ export default function CreativesPage() {
               className="text-center mb-16"
             >
               <h2 className="text-3xl md:text-5xl font-bold text-white mb-6">
-                Why creatives{" "}
+                Why directors{" "}
                 <span className="text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 to-cyan-400">
                   choose NodeTool
                 </span>
               </h2>
               <p className="text-lg text-slate-400 max-w-2xl mx-auto leading-relaxed">
-                The agent does the assembling, and what it leaves behind is a
-                process you can open, tweak, and run again. The second
-                variation costs minutes, not another afternoon — and when a
-                step looks wrong, you change that step instead of starting
-                over.
+                The agent does the heavy lifting, and what it leaves behind is a
+                project you can open, re-cut, and run again. The second version
+                costs minutes, not another afternoon — and when a shot looks
+                wrong, you re-roll that shot instead of the reel.
               </p>
             </motion.div>
 
@@ -531,18 +531,18 @@ export default function CreativesPage() {
                   borderColor: "border-emerald-500/20",
                 },
                 {
-                  title: "No credits. No markup.",
+                  title: "No token markups",
                   description:
-                    "Studio is free and open source under AGPL-3.0. Bring your own keys and pay providers directly.",
+                    "Studio is free and open source under AGPL-3.0. Bring your own keys and pay providers their published prices.",
                   icon: Sparkles,
                   color: "text-amber-400",
                   bgColor: "bg-amber-500/10",
                   borderColor: "border-amber-500/20",
                 },
                 {
-                  title: "Every model on one canvas",
+                  title: "Model freedom",
                   description:
-                    "Seedance, Kling, Veo, Runway, Luma, Suno, ElevenLabs, Flux, Ideogram, and more. Switch the moment a better one arrives.",
+                    "Seedance, Kling, Veo, Runway, Luma, Suno, ElevenLabs, Flux, Ideogram, and open weights on your own hardware. Switch the moment a better one arrives.",
                   icon: Zap,
                   color: "text-amber-400",
                   bgColor: "bg-teal-500/10",
@@ -586,14 +586,15 @@ export default function CreativesPage() {
               viewport={{ once: true }}
             >
               <h2 className="text-3xl md:text-5xl font-bold text-white mb-6">
-                Every model. Your keys. <br />
+                Ready to <br />
                 <span className="text-transparent bg-clip-text bg-gradient-to-r from-rose-400 via-amber-400 to-cyan-400">
-                  Your canvas.
+                  call action?
                 </span>
               </h2>
               <p className="text-xl text-slate-400 mb-10 max-w-2xl mx-auto">
-                Download NodeTool, connect the providers you already pay for,
-                and start your next piece on a canvas you actually own.
+                Download the open-source studio for macOS, Windows, and Linux.
+                Connect the providers you already pay for, and start your next
+                film on a canvas you own.
               </p>
               <a
                 href="https://github.com/nodetool-ai/nodetool/releases"

--- a/marketing/src/app/layout.tsx
+++ b/marketing/src/app/layout.tsx
@@ -24,7 +24,7 @@ const jetBrainsMono = JetBrains_Mono({
 export const metadata: Metadata = {
   title: "NodeTool — The agent-first creative workspace",
   description:
-    "NodeTool is the open-source, agent-first creative workspace. Every editor — canvas, sketch pad, storyboard, timeline, app builder — is exposed to agents as tools: say what you want and the agent builds the workflow and runs it across every major model, using your own keys. You pay providers directly: no credits, no markup, no lock-in.",
+    "You direct the vision. The agent builds the film. Describe your idea and NodeTool's agent writes the script, boards every scene, generates the footage, and cuts a multi-track timeline you can still edit — the open-source, agent-first creative workspace. Run open weights locally or bring your own API keys. No credits, no markups, no lock-in.",
   metadataBase: new URL("https://nodetool.ai"),
   alternates: {
     canonical: "/",
@@ -59,7 +59,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "NodeTool — The agent-first creative workspace",
     description:
-      "Every editor is exposed to agents as tools: say what you want and the agent builds the workflow and runs it across every major model, using your own keys. Open source, and you pay provider prices.",
+      "Describe your idea. The agent writes the script, boards every scene, generates the footage, and cuts the timeline — and hands you an editable multi-track project, not a flat render. Open source, your own keys, provider prices.",
     url: "https://nodetool.ai",
     siteName: "NodeTool",
     images: [
@@ -75,7 +75,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "NodeTool — The agent-first creative workspace",
     description:
-      "Every model. Your keys. Your agent. The open-source, agent-first creative workspace: an agent builds and runs your workflows across every major provider, at their published prices.",
+      "You direct the vision. The agent builds the film. Open-source AI film production on a real multi-track timeline — your keys, your models, your files.",
     images: ["/preview.png"],
   },
 };

--- a/marketing/src/app/marketing/page.tsx
+++ b/marketing/src/app/marketing/page.tsx
@@ -31,9 +31,9 @@ const marketingBenefits = [
     icon: TrendingUp,
   },
   {
-    title: "Every model, your keys",
+    title: "Model freedom",
     description:
-      "Flux, Veo, Kling, Seedance, Suno, ElevenLabs, and more, all run with your own provider keys at list price. No credit packs and no per-seat markup.",
+      "Route each asset through Flux, Veo, Kling, Seedance, Suno, or ElevenLabs on your own provider keys at list price — or run open weights locally. No credit packs, no per-seat markup.",
     icon: Zap,
   },
   {
@@ -137,11 +137,11 @@ export default function MarketingSegmentPage() {
                 </h1>
 
                 <p className="text-lg md:text-xl text-slate-400 mb-12 max-w-3xl mx-auto leading-relaxed">
-                  Hand the brief to an agent: it builds the workflow that turns
-                  out product videos, ad creative, social calendars, and brand
-                  assets from every major model, run with your own keys. No
-                  marked-up credits, nothing locking you in, and built for
-                  steady output rather than one-off polish.
+                  Pitch the brief to an agent and it builds the workflow that
+                  turns out product videos, ad creative, social calendars, and
+                  brand assets — routed through every major model on your own
+                  keys. No token markups, no platform lock-in, and every asset
+                  lands as an editable project rather than a flat render.
                 </p>
 
                 <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-14">
@@ -362,14 +362,15 @@ export default function MarketingSegmentPage() {
               viewport={{ once: true }}
             >
               <h2 className="text-3xl md:text-5xl font-bold text-white mb-6">
-                Every model. Your keys. <br />
+                Ready to ship <br />
                 <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-400 via-emerald-400 to-cyan-400">
-                  Campaign volume.
+                  at campaign volume?
                 </span>
               </h2>
               <p className="text-xl text-slate-400 mb-10 max-w-2xl mx-auto">
-                Download NodeTool, connect the providers you already pay for,
-                and build the workflow that produces your next campaign.
+                Download the open-source studio for macOS, Windows, and Linux.
+                Connect the providers you already pay for, and build the
+                workflow that produces your next campaign.
               </p>
               <SmartDownloadButton
                 icon={<Download className="w-6 h-6" />}

--- a/marketing/src/app/opengraph-image.tsx
+++ b/marketing/src/app/opengraph-image.tsx
@@ -6,8 +6,8 @@ export const contentType = ogContentType;
 
 export default function Image() {
   return ogImage(
-    "From prompt to final cut on one canvas",
-    "Every model. Your keys. One workspace.",
+    "You direct the vision. The agent builds the film.",
+    "Every model. Your keys. A timeline you can still edit.",
     { image: "screen_canvas.png", accent: "blue" }
   );
 }

--- a/marketing/src/app/page.tsx
+++ b/marketing/src/app/page.tsx
@@ -434,14 +434,13 @@ export default function Home() {
               id="closing-cta-title"
               className="text-3xl md:text-4xl font-bold tracking-tight text-white"
             >
-              Built out in the open.
+              Ready to call action?
             </h2>
             <p className="mt-4 text-lg text-slate-300">
-              Describe what you want to create. Watch the agent build it. Keep
-              the whole project. NodeTool is free, open-source software built
-              alongside working artists, designers, and video editors —
-              download the desktop app, or try it in your browser with nothing
-              to install.
+              Download the open-source studio for macOS, Windows, and Linux.
+              Free, AGPL-3.0, and built alongside working filmmakers, designers,
+              and video editors. Or open it in your browser with nothing to
+              install.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <SmartDownloadButton

--- a/marketing/src/app/pricing/page.tsx
+++ b/marketing/src/app/pricing/page.tsx
@@ -98,8 +98,8 @@ export default function PricingPage() {
           <p className="mt-5 text-lg leading-relaxed text-slate-300">
             NodeTool Studio is free and open source. NodeTool Cloud is a
             subscription that covers hosting. In both, you bring your own API keys
-            and pay each provider their list price. There are no credits, no
-            markup, and no restricted list of models.
+            and pay each provider their list price. No credit packs, no token
+            markups, and no curated list of models you are stuck with.
           </p>
         </section>
 

--- a/marketing/src/app/solutions/[slug]/page.tsx
+++ b/marketing/src/app/solutions/[slug]/page.tsx
@@ -209,8 +209,8 @@ export default async function SolutionPage({
               Build it on your own machine
             </h2>
             <p className="mt-4 text-lg leading-relaxed text-slate-400">
-              Free, open source, and yours to run. Download Studio, open the template, and make
-              it yours with your own keys.
+              Download the open-source studio for macOS, Windows, and Linux. Open
+              the template and direct it yourself, on your own keys.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <SmartDownloadButton

--- a/marketing/src/app/studio/layout.tsx
+++ b/marketing/src/app/studio/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 
 const TITLE = "NodeTool Studio — The Agent-First Desktop App";
 const DESCRIPTION =
-  "NodeTool Studio is the open-source, agent-first desktop app: every editor is exposed to agents as tools, and the agent runs on your own hardware. Tell it what you want and it builds and runs workflows with Ollama, MLX, and GGUF models locally — offline, data on disk. macOS, Windows, Linux. AGPL-3.0.";
+  "NodeTool Studio is the open-source, agent-first desktop app: every editor is exposed to agents as tools, and the agent runs on your own hardware. Pitch a concept and it drafts the script, boards the scenes, generates the footage, and cuts a multi-track timeline you can still edit — on Ollama, MLX, and GGUF models running locally, offline, files on disk. macOS, Windows, Linux. AGPL-3.0.";
 
 export const metadata: Metadata = {
   title: TITLE,

--- a/marketing/src/app/studio/opengraph-image.tsx
+++ b/marketing/src/app/studio/opengraph-image.tsx
@@ -6,8 +6,8 @@ export const contentType = ogContentType;
 
 export default function Image() {
   return ogImage(
-    "AI that runs on your machine",
-    "Desktop app. Runs Ollama and MLX models offline. Your own keys.",
+    "An AI studio that runs on your hardware",
+    "Desktop app. Open weights via Ollama and MLX, offline. Your own keys.",
     { image: "screen_assets.png", accent: "emerald", eyebrow: "Studio" }
   );
 }

--- a/marketing/src/app/studio/page.tsx
+++ b/marketing/src/app/studio/page.tsx
@@ -60,12 +60,12 @@ const proPoints = [
   },
   {
     icon: Shield,
-    title: "Your data never leaves the device",
-    body: "Workflows, files, prompts, and results stay on your disk. Nothing is reported back to us, and nothing leaves the machine unless you call a remote provider on purpose.",
+    title: "Your files never leave the device",
+    body: "Projects, footage, prompts, and takes stay on your disk. Nothing is reported back to us, and nothing leaves the machine unless you call a remote provider on purpose.",
   },
   {
     icon: Cpu,
-    title: "Run open models on your machine",
+    title: "Run open weights locally",
     body: "Ollama, MLX for Apple Silicon, llama.cpp, and Hugging Face all work with the same building blocks. Pick any open model and pay no usage fees.",
   },
   {
@@ -202,18 +202,18 @@ export default function StudioPage() {
                   id="studio-hero-title"
                   className="mt-6 text-4xl md:text-6xl font-bold tracking-tight text-white leading-[1.05]"
                 >
-                  An agent-first studio that
+                  An agent-first studio
                   <br />
                   <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-300 to-orange-300">
-                    runs on your machine.
+                    that runs on your hardware.
                   </span>
                 </h1>
                 <p className="mt-6 text-lg text-slate-300 leading-relaxed max-w-xl">
-                  NodeTool Studio is the desktop app for people who want their
-                  models, data — and their agent — on their own machine. Tell
-                  the agent what you want and it builds and runs the workflow
-                  with free local models via Ollama and MLX, or with your own
-                  keys for a cloud provider whenever you need one.
+                  NodeTool Studio is the desktop app for creators who want
+                  their models, their files, and their agent on their own
+                  machine. Pitch a concept and the agent builds the piece on
+                  open weights running locally through Ollama and MLX, or on
+                  your own API keys when a cloud model is the right call.
                 </p>
                 <div className="mt-8 flex flex-col gap-3">
                   <SmartDownloadButton

--- a/marketing/src/app/use-cases/documentary-teaser/page.tsx
+++ b/marketing/src/app/use-cases/documentary-teaser/page.tsx
@@ -181,11 +181,11 @@ export default function DocumentaryTeaserUseCase() {
                 Documentary Teaser Generator
               </h1>
               <p className="mt-6 text-lg md:text-xl text-slate-400 leading-relaxed">
-                Describe the film in a sentence and the storyboard comes back
+                Pitch the film in a sentence and the storyboard comes back
                 readable: a card per shot, a still on every card. Approve the
-                stills, animate those, and the clips land on a timeline you cut
-                and export. The board below is one run — a deep-sea series
-                teaser, surface to abyss in six shots.
+                stills, animate those, and the clips land on a multi-track
+                timeline you cut and export. The board below is one run — a
+                deep-sea series teaser, surface to abyss in six shots.
               </p>
             </motion.div>
 
@@ -391,11 +391,11 @@ export default function DocumentaryTeaserUseCase() {
           <div className="mx-auto max-w-6xl px-6 lg:px-8">
             <div className="mb-12 max-w-2xl">
               <h2 className="text-3xl md:text-4xl font-bold tracking-tight">
-                Make it yours
+                Direct it yourself
               </h2>
               <p className="mt-4 text-lg text-slate-400 leading-relaxed">
-                Nothing here is locked. Change the look, change the model,
-                change one shot — the rest of the board stays where you left it.
+                Nothing here is locked. Re-roll a clip, swap a model, or trim
+                one shot — the rest of the board stays where you left it.
               </p>
             </div>
 
@@ -436,8 +436,8 @@ export default function DocumentaryTeaserUseCase() {
                   <p className="mt-4 text-slate-400 leading-relaxed">
                     The board needs one model per job, and each is a dropdown.
                     They are called with your own keys — the bill comes from the
-                    provider, not from us, and you can switch any of them for a
-                    better model the day it ships.
+                    provider, not from us, with no token markups, and you can
+                    switch any of them for a better model the day it ships.
                   </p>
                   <div className="mt-6 inline-flex items-center gap-2 rounded-full border border-emerald-500/25 bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-300">
                     <Check className="h-4 w-4" />
@@ -485,8 +485,8 @@ export default function DocumentaryTeaserUseCase() {
               Board your first dive
             </h2>
             <p className="mt-4 text-lg text-slate-400 leading-relaxed">
-              Free, open source, and yours to run. Download Studio, open the
-              storyboard, and board a teaser from one line today.
+              Download the open-source studio for macOS, Windows, and Linux,
+              open the storyboard, and board a teaser from one line today.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <SmartDownloadButton

--- a/marketing/src/app/use-cases/movie-poster/page.tsx
+++ b/marketing/src/app/use-cases/movie-poster/page.tsx
@@ -130,10 +130,10 @@ export default function MoviePosterUseCase() {
                 Movie Poster Generator
               </h1>
               <p className="mt-6 text-lg md:text-xl text-slate-400 leading-relaxed">
-                Type a title, a genre, and an audience. The canvas writes a real
+                Pitch a title, a genre, and an audience. The agent writes a real
                 creative strategy and renders a batch of cinematic poster
-                concepts, no designer, no brief deck, one canvas you can re-run
-                for any film.
+                concepts — no designer, no brief deck, one canvas you re-run for
+                any film.
               </p>
             </motion.div>
 
@@ -300,11 +300,11 @@ export default function MoviePosterUseCase() {
           <div className="mx-auto max-w-6xl px-6 lg:px-8">
             <div className="mb-12 max-w-2xl">
               <h2 className="text-3xl md:text-4xl font-bold tracking-tight">
-                Make it yours
+                Direct it yourself
               </h2>
               <p className="mt-4 text-lg text-slate-400 leading-relaxed">
-                Nothing here is locked. Swap models, shift the tone, or point it
-                at a different title.
+                Nothing here is locked. Swap models, shift the tone, re-roll a
+                concept, or point the whole thing at a different title.
               </p>
             </div>
 
@@ -344,8 +344,8 @@ export default function MoviePosterUseCase() {
                   </h2>
                   <p className="mt-4 text-slate-400 leading-relaxed">
                     Called with your own keys. The bill comes from the provider,
-                    not from us, and you can switch any of them for a better
-                    model the day it ships.
+                    not from us — no token markups — and you can switch any of
+                    them for a better model the day it ships.
                   </p>
                   <div className="mt-6 inline-flex items-center gap-2 rounded-full border border-emerald-500/25 bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-300">
                     <Check className="h-4 w-4" />
@@ -390,8 +390,8 @@ export default function MoviePosterUseCase() {
               Design your poster set
             </h2>
             <p className="mt-4 text-lg text-slate-400 leading-relaxed">
-              Free, open source, and yours to run. Download Studio, open this
-              workflow, and render a campaign in minutes.
+              Download the open-source studio for macOS, Windows, and Linux,
+              open this workflow, and render a campaign in minutes.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <SmartDownloadButton

--- a/marketing/src/app/use-cases/movie-trailer/page.tsx
+++ b/marketing/src/app/use-cases/movie-trailer/page.tsx
@@ -174,10 +174,11 @@ export default function MovieTrailerUseCase() {
                 Movie Trailer Generator
               </h1>
               <p className="mt-6 text-lg md:text-xl text-slate-400 leading-relaxed">
-                Write one line about your film. It comes back as a storyboard
-                you can read: a card per shot, a still on every card. Approve
-                the ones you like, animate those, and the clips land on a
-                timeline you cut and export. It works the way a shoot does.
+                Pitch your film in one line. It comes back as a storyboard you
+                can read: a card per shot, a still on every card. Approve the
+                shots you like, animate those, and the clips land on a
+                multi-track timeline you cut and export. It works the way a
+                shoot does.
               </p>
             </motion.div>
 
@@ -431,11 +432,11 @@ export default function MovieTrailerUseCase() {
           <div className="mx-auto max-w-6xl px-6 lg:px-8">
             <div className="mb-12 max-w-2xl">
               <h2 className="text-3xl md:text-4xl font-bold tracking-tight">
-                Make it yours
+                Direct it yourself
               </h2>
               <p className="mt-4 text-lg text-slate-400 leading-relaxed">
-                Nothing here is locked. Change the look, change the model,
-                change one shot — the rest of the board stays where you left it.
+                Nothing here is locked. Re-roll a clip, swap a model, or trim
+                one shot — the rest of the board stays where you left it.
               </p>
             </div>
 
@@ -475,8 +476,8 @@ export default function MovieTrailerUseCase() {
                   </h2>
                   <p className="mt-4 text-slate-400 leading-relaxed">
                     Called with your own keys. The bill comes from the provider,
-                    not from us, and you can switch any of them for a better
-                    model the day it ships.
+                    not from us — no token markups — and you can switch any of
+                    them for a better model the day it ships.
                   </p>
                   <div className="mt-6 inline-flex items-center gap-2 rounded-full border border-emerald-500/25 bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-300">
                     <Check className="h-4 w-4" />
@@ -521,8 +522,8 @@ export default function MovieTrailerUseCase() {
               Cut your first trailer
             </h2>
             <p className="mt-4 text-lg text-slate-400 leading-relaxed">
-              Free, open source, and yours to run. Download Studio, open the
-              storyboard, and board a teaser from one line today.
+              Download the open-source studio for macOS, Windows, and Linux,
+              open the storyboard, and board a teaser from one line today.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <SmartDownloadButton

--- a/marketing/src/app/use-cases/product-video/page.tsx
+++ b/marketing/src/app/use-cases/product-video/page.tsx
@@ -121,9 +121,10 @@ export default function ProductVideoUseCase() {
                 Product Video Generator
               </h1>
               <p className="mt-6 text-lg md:text-xl text-slate-400 leading-relaxed">
-                Turn a campaign brief and a single product photo into a
-                cinematic 16:9 product video. No editor, no agency, one
-                canvas you can re-run for every new product.
+                Pitch a campaign brief and one product photo, and the agent
+                returns a cinematic 16:9 spot on an editable timeline. No
+                agency, no export hops, one canvas you re-run for every new
+                product.
               </p>
             </motion.div>
 
@@ -296,11 +297,11 @@ export default function ProductVideoUseCase() {
           <div className="mx-auto max-w-6xl px-6 lg:px-8">
             <div className="mb-12 max-w-2xl">
               <h2 className="text-3xl md:text-4xl font-bold tracking-tight">
-                Make it yours
+                Direct it yourself
               </h2>
               <p className="mt-4 text-lg text-slate-400 leading-relaxed">
-                Nothing here is locked. Swap models, change the tone, or point it
-                at a different product.
+                Nothing here is locked. Swap models, shift the tone, re-roll a
+                shot, or point the whole thing at a different product.
               </p>
             </div>
 
@@ -340,8 +341,8 @@ export default function ProductVideoUseCase() {
                   </h2>
                   <p className="mt-4 text-slate-400 leading-relaxed">
                     Called with your own keys. The bill comes from the provider,
-                    not from us, and you can switch any of them for a better
-                    model the day it ships.
+                    not from us — no token markups — and you can switch any of
+                    them for a better model the day it ships.
                   </p>
                   <div className="mt-6 inline-flex items-center gap-2 rounded-full border border-emerald-500/25 bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-300">
                     <Check className="h-4 w-4" />
@@ -386,8 +387,8 @@ export default function ProductVideoUseCase() {
               Build your product video
             </h2>
             <p className="mt-4 text-lg text-slate-400 leading-relaxed">
-              Free, open source, and yours to run. Download Studio, open this
-              workflow, and ship your first spot today.
+              Download the open-source studio for macOS, Windows, and Linux,
+              open this workflow, and ship your first spot today.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <SmartDownloadButton

--- a/marketing/src/components/BuildRunDeploy.tsx
+++ b/marketing/src/components/BuildRunDeploy.tsx
@@ -45,30 +45,30 @@ export default function BuildRunDeploy() {
       <div className="scroll-fade grid grid-cols-1 gap-6 md:grid-cols-3">
         <Card
           step="01"
-          title="Start with an idea"
+          title="Pitch"
           icon={<Workflow className="h-6 w-6" />}
           accent="blue"
-          description="Describe your goal — a product video, a movie trailer, a social campaign. That's all it takes to begin. Prefer to wire it yourself? It's the same canvas."
+          description="Tell the agent your concept, style, and tone. It drafts the script, casts the voices, and sets the visual direction. Prefer to wire it yourself? It's the same canvas."
         >
           <BuildVisual />
         </Card>
 
         <Card
           step="02"
-          title="Watch it build in real time"
+          title="Automate"
           icon={<PlayCircle className="h-6 w-6" />}
           accent="fuchsia"
-          description="The agent selects the right tools, connects the steps on your board, and runs them from start to finish — generation, editing, and assembly chained into a finished piece, on your own accounts at provider prices."
+          description="The agent storyboards scenes, generates the footage, syncs the audio, and cuts it all together on a multi-track timeline — running on your own accounts at provider prices."
         >
           <RunVisual />
         </Card>
 
         <Card
           step="03"
-          title="Take full control"
+          title="Direct"
           icon={<Wand2 className="h-6 w-6" />}
           accent="amber"
-          description="Click into any step to swap a tool, change an image, or adjust a prompt. Everything remains editable, and the workflow is yours to save and reuse."
+          description="Jump in at any moment. Swap a voice take, re-roll a clip, or trim frames. The agent builds the foundation; you refine the final cut."
         >
           <EditVisual />
         </Card>

--- a/marketing/src/components/ChatUISection.tsx
+++ b/marketing/src/components/ChatUISection.tsx
@@ -33,9 +33,9 @@ export default function ChatUISection() {
             transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            A standard chatbot gives you text. <br />
+            A chatbot gives you a transcript. <br />
             <span className="text-white">
-              This agent builds your actual project.
+              The agent gives you the project.
             </span>
           </motion.h2>
 
@@ -46,10 +46,10 @@ export default function ChatUISection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            NodeTool&apos;s AI assistant doesn&apos;t just chat. It operates
-            the studio tools for you: it sets up the steps directly on your
-            canvas, generates the assets, and keeps every part visible so you
-            can tweak, rerun, or reuse it.
+            NodeTool&apos;s agent operates the studio for you. It lays the
+            steps out on your canvas, generates the takes, and leaves every
+            part on the table — so you can swap a model, re-roll a shot, or
+            run the whole thing again.
           </motion.p>
 
           <motion.a

--- a/marketing/src/components/ComparisonSection.tsx
+++ b/marketing/src/components/ComparisonSection.tsx
@@ -203,7 +203,7 @@ export default function ComparisonSection({
                 Where NodeTool fits
               </div>
               <h3 className="text-2xl md:text-3xl font-semibold text-white mb-5 tracking-tight">
-                Every model. Your keys. Your canvas.
+                Model freedom. No platform lock-in.
               </h3>
               <p className="text-slate-300 leading-relaxed mb-4 text-[1.025rem]">
                 Take Seedance, one of today&apos;s best video models. It is sold
@@ -212,9 +212,9 @@ export default function ComparisonSection({
                 Kling arrives, you switch to it in one click.
               </p>
               <p className="text-slate-400 leading-relaxed text-[1.025rem]">
-                That is what staying independent buys you: the best model at the
-                best price each week, and nothing to lose if your favorite tool
-                is bought by someone else.
+                That is what sovereignty buys you: the best model at the best
+                price each week, and nothing to lose if your favorite tool gets
+                bought, repriced, or shut down.
               </p>
             </div>
           </div>

--- a/marketing/src/components/CostDashboardSection.tsx
+++ b/marketing/src/components/CostDashboardSection.tsx
@@ -103,8 +103,9 @@ export default function CostDashboardSection() {
           </h3>
           <p className="mt-4 text-lg leading-relaxed text-slate-300">
             NodeTool records what each step costs and adds it up by workflow,
-            provider, or model. Because you use your own keys and pay providers
-            directly, these are the amounts you are actually billed.
+            provider, or model. Because you bring your own keys and pay
+            providers directly, with no token markups, these are the amounts you
+            are actually billed.
           </p>
         </div>
 

--- a/marketing/src/components/FeaturesSection.tsx
+++ b/marketing/src/components/FeaturesSection.tsx
@@ -5,10 +5,10 @@ import { motion } from "framer-motion";
 import Tilt3D from "./Tilt3D";
 import {
   Workflow,
-  Database,
   Layers,
   MousePointer2,
-  Activity,
+  Mic,
+  Film,
 } from "lucide-react";
 
 interface FeaturesSectionProps {
@@ -46,9 +46,9 @@ export default function FeaturesSection({
             transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            One canvas <br />
+            One canvas. <br />
             <span className="text-white">
-              for the whole craft
+              The whole production.
             </span>
           </motion.h2>
 
@@ -59,9 +59,9 @@ export default function FeaturesSection({
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Image, video, audio, and text on a single visual canvas, with the
-            editing tools you already rely on sitting right next to the models.
-            You direct the whole piece instead of generating parts of it.
+            Script, storyboard, footage, sound, and the cut — on one canvas,
+            with the editing tools sitting right next to the models. You direct
+            the whole piece instead of generating parts of it.
           </motion.p>
         </div>
 
@@ -112,37 +112,37 @@ export default function FeaturesSection({
         >
           {[
             {
-              title: "Edit where you generate",
+              title: "Scripting & casting",
               description:
-                "Mask, retouch, extend, relight, upscale, layer, and composite. The editing tools you reach for live on the same canvas as the models.",
-              icon: MousePointer2,
+                "Go from prompt to screenplay in seconds. Draft dialogue, cast character voices, and audition alternate line readings with automatic word-level sync.",
+              icon: Mic,
               color: "text-blue-400",
               bg: "bg-blue-500/10",
               border: "border-blue-500/20",
             },
             {
-              title: "Watch every step render",
+              title: "Any model, local or cloud",
               description:
-                "Results appear as each step finishes. Inspect any frame, swap a model, and re-run from that point on.",
-              icon: Activity,
+                "Route your shots through Flux, Seedance, Wan, Whisper, ElevenLabs, Suno, and the rest — or run open weights locally on your own hardware. No platform lock-in.",
+              icon: Layers,
               color: "text-purple-400",
               bg: "bg-purple-500/10",
               border: "border-purple-500/20",
             },
             {
-              title: "Your keys, provider prices",
+              title: "A real timeline, not a black box",
               description:
-                "Bring your own keys for FAL, KIE, OpenAI, Anthropic, Gemini, Replicate, and the rest. The bill comes from the provider, not from us.",
-              icon: Database,
+                "Instead of a single unfixable video file, the agent hands you a fully editable multi-track project. Fine-tune every frame, layer, and audio stem.",
+              icon: Film,
               color: "text-emerald-400",
               bg: "bg-emerald-500/10",
               border: "border-emerald-500/20",
             },
             {
-              title: "Image, video, audio, text",
+              title: "Edit where you generate",
               description:
-                "Flux, Seedance, Wan, ControlNet, Whisper, ElevenLabs, and Suno, all on one canvas under their real names. You always know which model you are running.",
-              icon: Layers,
+                "Mask, retouch, extend, relight, upscale, layer, and composite. The tools you reach for live on the same canvas as the models.",
+              icon: MousePointer2,
               color: "text-orange-400",
               bg: "bg-orange-500/10",
               border: "border-orange-500/20",

--- a/marketing/src/components/ModelSupportSection.tsx
+++ b/marketing/src/components/ModelSupportSection.tsx
@@ -98,9 +98,9 @@ export default function ModelSupportSection({
                         transition={{ duration: 0.25 }}
                         className="text-4xl md:text-5xl font-bold tracking-tight text-white mb-6"
                     >
-                        The newest models,{" "}
+                        Model freedom.{" "}
                         <span className="text-white">
-                            the day they arrive.
+                            No platform lock-in.
                         </span>
                     </motion.h2>
 
@@ -111,9 +111,10 @@ export default function ModelSupportSection({
                         transition={{ duration: 0.25, delay: 0.05 }}
                         className="text-lg text-slate-400 leading-relaxed"
                     >
-                        The leading image, video, audio, and language models from
-                        every major provider, or the same kind of models running
-                        on your own computer when you prefer that.
+                        Route your shots through the best video, image, audio,
+                        and language models on the market — or run open weights
+                        locally on your own hardware. Switch between them with
+                        one click.
                     </motion.p>
                 </div>
 

--- a/marketing/src/components/NodeToolHero.tsx
+++ b/marketing/src/components/NodeToolHero.tsx
@@ -35,22 +35,23 @@ export default function NodeToolHero() {
             id="hero-title"
             className="mt-5 text-balance text-[clamp(2rem,7.5vw,3.25rem)] font-bold leading-[1.1] tracking-tight text-white lg:text-[clamp(2.25rem,3.6vw,3.25rem)]"
           >
-            <span className="block">Describe it.</span>
+            <span className="block">You direct the vision.</span>
             <span className="block bg-gradient-to-r from-rose-400 via-fuchsia-400 to-amber-300 bg-clip-text pb-[0.12em] text-transparent">
-              An agent makes the film.
+              The agent builds the film.
             </span>
           </h1>
 
           <p className="mt-5 max-w-lg text-lg leading-relaxed text-slate-300">
-            It writes the script, boards the shots, generates the footage, and
-            cuts the timeline — on an open{" "}
+            Describe your idea. The agent writes the script, boards every
+            scene, generates the footage, and cuts the timeline — end-to-end
+            production on an open{" "}
             <a
               href="/node-based-ai"
               className="text-slate-200 underline decoration-slate-500/50 underline-offset-2 transition-colors hover:text-white hover:decoration-slate-300"
             >
               node-based canvas
-            </a>{" "}
-            that stays yours.
+            </a>
+            , with complete creative control.
           </p>
 
           <div className="mt-7 flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -75,11 +76,11 @@ export default function NodeToolHero() {
             </li>
             <li className="flex items-center gap-1.5">
               <KeyRound className="h-3.5 w-3.5 text-emerald-400" />
-              Your own provider accounts, no credits
+              Your own API keys, no token markups
             </li>
             <li className="flex items-center gap-1.5">
               <Code2 className="h-3.5 w-3.5 text-blue-400" />
-              Open source, yours to keep
+              Open source, you own the files
             </li>
           </ul>
         </div>

--- a/marketing/src/components/OwnershipSection.tsx
+++ b/marketing/src/components/OwnershipSection.tsx
@@ -6,23 +6,23 @@ import { Shield, Cpu, Globe, Lock } from "lucide-react";
 
 const features = [
   {
-    title: "Use your own provider keys",
-    body: "Connect directly to OpenAI, Anthropic, Gemini, FAL, KIE, Replicate, and specialized video generators. Your account keys stay on your disk in Studio, encrypted in Cloud.",
+    title: "Bring your own keys",
+    body: "Connect directly to OpenAI, Anthropic, Gemini, FAL, KIE, Replicate, and the specialized video models. Your keys stay on your disk in Studio, encrypted in Cloud.",
     icon: Lock,
   },
   {
-    title: "Pay official rates directly",
-    body: "Skip artificial credit systems. If an image costs $0.03 to generate through a provider, you pay exactly $0.03 to that provider. NodeTool takes no cut.",
+    title: "No token markups",
+    body: "No credit packs, no subscription traps. If an image costs $0.03 at the provider, you pay $0.03 to the provider. NodeTool takes no cut.",
     icon: Shield,
   },
   {
-    title: "100% open source",
-    body: "Free to use and inspect. Studio and Cloud are built from the same AGPL-3.0 source, with no artificial paywalls or locked features, and you can host it yourself at any time.",
+    title: "Open source, end to end",
+    body: "Studio and Cloud are built from the same AGPL-3.0 source, with no paywalled features. Read it, fork it, or host it yourself at any time.",
     icon: Globe,
   },
   {
-    title: "Run private models on your computer",
-    body: "Download and run free, open-weight models locally on your own hardware — MLX, Ollama, llama.cpp, vLLM, and LM Studio — with no internet connection.",
+    title: "Run it on your own hardware",
+    body: "Download open-weight models and run inference locally — MLX, Ollama, llama.cpp, vLLM, and LM Studio — with no internet connection.",
     icon: Cpu,
   },
 ];
@@ -47,7 +47,7 @@ export default function OwnershipSection({
             transition={{ duration: 0.25 }}
             className="text-4xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Access top AI tools directly. <br />
+            Local. Open. Yours. <br />
             <span className="text-slate-300">No middlemen, no markups.</span>
           </motion.h2>
           <motion.p
@@ -57,10 +57,10 @@ export default function OwnershipSection({
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-400 leading-relaxed"
           >
-            Pick the best AI service for the job — OpenAI, Google, Anthropic,
-            or a specialized image and video engine — and switch between them
-            with one click. NodeTool charges you what the providers charge, and
-            is released under a license that outlives whoever built it.
+            No locked project formats, no token markups, zero subscription
+            traps. Run inference locally or bring your own API keys, and switch
+            between providers with one click. You own the files, the workflow,
+            and the final cut.
           </motion.p>
         </div>
 

--- a/marketing/src/components/ScriptEditorSection.tsx
+++ b/marketing/src/components/ScriptEditorSection.tsx
@@ -67,7 +67,7 @@ export default function ScriptEditorSection() {
               transition={{ duration: 0.25 }}
               className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
             >
-              Write the script, <span className="text-white">then voice it</span>
+              Scripting <span className="text-white">&amp; casting</span>
             </motion.h2>
 
             <motion.p
@@ -77,11 +77,11 @@ export default function ScriptEditorSection() {
               transition={{ duration: 0.25, delay: 0.05 }}
               className="text-lg text-slate-300 leading-relaxed"
             >
-              A script is its own document, not a byproduct of a timeline. The
-              words are the source of truth and the audio is derived from them:
-              draft the lines, cast a voice per speaker, voice the script, and
-              send the takes to a timeline as clips that carry word-level
-              captions.
+              Go from prompt to screenplay in seconds. Draft the dialogue,
+              cast a voice per character, and audition alternate line readings
+              with automatic word-level sync. The script is its own document —
+              the words are the source of truth, and the takes are derived from
+              them.
             </motion.p>
           </div>
 

--- a/marketing/src/components/StatusQuoSection.tsx
+++ b/marketing/src/components/StatusQuoSection.tsx
@@ -10,20 +10,20 @@ import { ArrowRight } from "lucide-react";
 
 const frictions = [
   {
-    where: "Juggling five browser tabs",
-    what: "One app for images, another for animation, a third for voiceovers, and a separate video editor to stitch them together.",
+    where: "Five browser tabs per shot",
+    what: "One app for images, another for animation, a third for voiceovers, and a separate editor to stitch it together.",
   },
   {
     where: "Export, import, repeat",
-    what: "Moving files between apps loses your settings, prompts, and original ideas along the way.",
+    what: "Every hop between apps drops your settings, your prompts, and the reasoning behind them.",
   },
   {
-    where: "Paying marked-up credit packs",
-    what: "Buying expensive proprietary credits locked to whatever tools that platform chooses for you.",
+    where: "Token markups on every take",
+    what: "Credit packs priced above what the models cost, spendable only on the models that platform picked.",
   },
   {
-    where: "Losing access when tools change",
-    what: "Subscriptions jump in price, features disappear, and your projects are trapped in someone else's system.",
+    where: "One flat file, no way back in",
+    what: "A finished render you cannot re-cut, in a project format that opens nowhere else.",
   },
 ];
 
@@ -45,13 +45,13 @@ export default function StatusQuoSection() {
                 id="status-quo-title"
                 className="text-2xl font-bold tracking-tight text-white md:text-3xl"
               >
-                Creating one project
+                One film
                 <br />
-                shouldn&apos;t require five separate apps.
+                shouldn&apos;t take five separate apps.
               </h2>
               <p className="mt-4 text-slate-400 leading-relaxed">
-                Work on a single visual board. Use your own AI accounts. Keep
-                the complete project file when you&apos;re done.
+                Direct it on one canvas. Run it on your own accounts. Keep the
+                editable project when you&apos;re done.
               </p>
               <a
                 href="#differences"

--- a/marketing/src/components/StoryboardSection.tsx
+++ b/marketing/src/components/StoryboardSection.tsx
@@ -65,10 +65,10 @@ export default function StoryboardSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-300 leading-relaxed"
           >
-            Write a brief and a visual style, press Direct, and get a shot list
-            back — action, camera, motion, and duration per card. Approve the
-            stills you like, render only those into clips, then assemble the
-            whole thing into the timeline editor in one click.
+            Pitch a concept and a visual style, press Direct, and get a shot
+            list back — action, camera, motion, and duration per card. Approve
+            the stills you like, animate only those, then lay the whole thing
+            onto the multi-track timeline in one click.
           </motion.p>
         </div>
 

--- a/marketing/src/components/SurfaceShowcase.tsx
+++ b/marketing/src/components/SurfaceShowcase.tsx
@@ -36,7 +36,7 @@ const SURFACES: Surface[] = [
     label: "Storyboard",
     icon: Clapperboard,
     headline: "Visual storyboards",
-    body: "Plan out scenes card by card. Generate low-cost draft images first to lock in the look before spending time and compute on full animation.",
+    body: "Board the film shot by shot. Generate cheap stills first to lock the look, then pay to animate only the shots you approved.",
     asset: "surface-storyboard",
     deepLink: "#storyboard",
   },
@@ -44,8 +44,8 @@ const SURFACES: Surface[] = [
     id: "script",
     label: "Script & voice",
     icon: FileText,
-    headline: "Script & voice studio",
-    body: "Write your script, assign unique AI voices to each character, and generate natural-sounding dialogue takes. Change the words and the take goes stale, so you see what still needs voicing.",
+    headline: "Scripting & casting",
+    body: "Draft the dialogue, cast a voice per character, and audition alternate line readings. Change the words and the take flags itself stale, so you see exactly what still needs voicing.",
     asset: "surface-script",
     deepLink: "#script-editor",
   },
@@ -53,8 +53,8 @@ const SURFACES: Surface[] = [
     id: "timeline",
     label: "Timeline",
     icon: Film,
-    headline: "Timeline video editor",
-    body: "Arrange, trim, and layer AI-generated video and audio clips across multiple tracks to render a finished video. An agent edits the same document when you ask it to tighten the opening.",
+    headline: "Multi-track timeline",
+    body: "Arrange, trim, and layer generated video and audio across multiple tracks, down to the frame and the stem. The agent edits the same document when you ask it to tighten the opening.",
     asset: "surface-timeline",
     deepLink: "#timeline-editor",
   },
@@ -141,13 +141,13 @@ export default function SurfaceShowcase() {
             id="surfaces-title"
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Professional editing tools built right next to the AI
+            Professional post, right next to the models
           </h2>
           <p className="text-lg text-slate-300">
-            Edit and refine your work directly on the canvas without switching
-            software. A storyboard becomes a script, the script becomes takes,
-            the takes land on a timeline — and an agent works every one of them
-            through the tools you click.
+            Cut and refine on the same canvas you generate on, with no export
+            hops. A storyboard becomes a script, the script becomes takes, the
+            takes land on a multi-track timeline — and the agent works every one
+            of them through the tools you click.
           </p>
         </div>
 

--- a/marketing/src/components/TimelineEditorSection.tsx
+++ b/marketing/src/components/TimelineEditorSection.tsx
@@ -22,7 +22,7 @@ const highlights = [
   {
     icon: Download,
     title: "Export a finished cut",
-    body: "Render the whole sequence to a single video — the edit happens where you generate, not in another app.",
+    body: "Render the whole sequence to one video. The cut happens where you generate, not in another app.",
   },
 ];
 
@@ -55,7 +55,7 @@ export default function TimelineEditorSection() {
             transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white mb-6"
           >
-            Built-in <span className="text-white">video editor</span>
+            A real timeline. <span className="text-white">Not a black box.</span>
           </motion.h2>
 
           <motion.p
@@ -65,9 +65,9 @@ export default function TimelineEditorSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-lg text-slate-300 leading-relaxed"
           >
-            Generate AI video and audio straight onto a multi-track timeline.
-            Prompt a model at the playhead, drop the clip on a track, then trim,
-            split, and export a finished cut.
+            Instead of a single unfixable video file, the agent hands you a
+            fully editable multi-track project. Generate at the playhead, then
+            fine-tune every frame, layer, and audio stem before you export.
           </motion.p>
         </div>
 

--- a/marketing/src/components/UseCasesShowcase.tsx
+++ b/marketing/src/components/UseCasesShowcase.tsx
@@ -57,7 +57,7 @@ export default function UseCasesShowcase() {
             transition={{ duration: 0.25 }}
             className="text-3xl md:text-5xl font-bold tracking-tight text-white"
           >
-            From a brief to a finished asset
+            From a pitch to a finished cut
           </motion.h2>
           <motion.p
             initial={false}
@@ -66,8 +66,8 @@ export default function UseCasesShowcase() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 leading-relaxed"
           >
-            Real workflows you can open, run, and change. Each one runs from the
-            brief to the finished piece without leaving the canvas, and every one
+            Real projects you can open, run, and re-cut. Each one runs from the
+            pitch to the finished piece without leaving the canvas, and every one
             is built from the blocks you get on day one.
           </motion.p>
         </div>

--- a/marketing/src/components/agents/AgentBuildRunDeploy.tsx
+++ b/marketing/src/components/agents/AgentBuildRunDeploy.tsx
@@ -23,12 +23,12 @@ export default function AgentBuildRunDeploy() {
             <div className="relative mx-auto max-w-6xl w-full z-10">
                 <div className="mb-12 text-center max-w-2xl mx-auto">
                     <h2 className="text-4xl md:text-5xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-white via-slate-200 to-slate-400 mb-4 tracking-tight">
-                        Say it. Watch it build. Keep it.
+                        Pitch. Automate. Direct.
                     </h2>
                     <p className="text-slate-400 text-lg">
-                        The agent works with the same tools you click. It builds the actual
-                        workflow on your canvas, runs it in front of you, and leaves behind
-                        something you can rerun — not a chat transcript.
+                        The agent works with the same tools you click. It lays the
+                        workflow out on your canvas, runs it in front of you, and leaves
+                        an editable project behind — not a chat transcript.
                     </p>
                 </div>
 

--- a/marketing/src/components/agents/AgentsGraphHero.tsx
+++ b/marketing/src/components/agents/AgentsGraphHero.tsx
@@ -115,9 +115,10 @@ export default function AgentsGraphHero() {
                             NodeTool isn&apos;t a chat box bolted onto an editor. Every surface —
                             the node canvas, the sketch pad, the storyboard, the video timeline,
                             the app builder — is exposed to agents as tools, around 120 in all.
-                            Hand over a brief and the agent plans the shots, builds the workflow,
-                            runs it across Flux, Seedance, Veo, Kling, Suno, and ElevenLabs, and
-                            retries what misses. You direct, it executes.
+                            Pitch a concept and the agent drafts the script, boards the scenes,
+                            generates the footage across Flux, Seedance, Veo, Kling, Suno, and
+                            ElevenLabs, and cuts the timeline. You direct the vision; it does
+                            the heavy lifting.
                         </p>
 
                         <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -133,7 +134,7 @@ export default function AgentsGraphHero() {
                         <div className="mt-8 flex items-center justify-center gap-6 text-sm text-slate-400 font-medium">
                             <span className="flex items-center gap-2"><Command className="w-4 h-4" /> Open Source</span>
                             <span className="w-1 h-1 rounded-full bg-slate-700" />
-                            <span>Your own keys, paid straight to the provider</span>
+                            <span>Your own keys, no token markups</span>
                             <span className="w-1 h-1 rounded-full bg-slate-700" />
                             <span>Every decision on screen</span>
                         </div>

--- a/marketing/src/components/developers/DevelopersHero.tsx
+++ b/marketing/src/components/developers/DevelopersHero.tsx
@@ -43,11 +43,10 @@ export default function DevelopersHero() {
           className="mt-6 text-lg sm:text-xl text-slate-300 max-w-2xl mx-auto leading-relaxed"
         >
           One execution layer instead of a stack of provider SDKs and
-          hand-rolled orchestration: the same open-source, TypeScript-first
-          runtime powers the visual canvas, the agent, and your code. Write a
-          custom node, drive the canvas from a CLI, generate workflows in
-          code — or point Claude Code at the MCP server and let an agent do
-          it: every editor action is also a tool, with validators and debug
+          hand-rolled orchestration. The same open-source, TypeScript-first
+          runtime powers the canvas, the agent, and your code. Write a custom
+          node, drive the canvas from the CLI, or point Claude Code at the MCP
+          server: every editor action is also a tool, with validators and debug
           harnesses built for the agent loop.
         </motion.p>
 

--- a/marketing/src/data/faqEntries.ts
+++ b/marketing/src/data/faqEntries.ts
@@ -85,7 +85,7 @@ const seeds: FaqSeed[] = [
     slug: "what-is-nodetool",
     question: "What is NodeTool?",
     answerMd:
-      "NodeTool is the open creative AI workspace. Every major model from every major provider, including FAL, KIE, OpenAI, Anthropic, Gemini, and Replicate, sits on one visual canvas that you run on your own machine or in the browser. Image, video, music, and text share that canvas, alongside agents that carry out longer jobs step by step.",
+      "NodeTool is the open AI production studio. You direct the vision and the agent builds the film: it drafts the script, boards every scene, generates the footage, and cuts a multi-track timeline you can still edit. Every major model from every major provider, including FAL, KIE, OpenAI, Anthropic, Gemini, and Replicate, sits on one visual canvas that you run on your own machine or in the browser.",
     category: "general",
     relatedRoute: "/",
     surfaces: ["landing", "agents", "comparison"],

--- a/marketing/src/data/landingEntries.ts
+++ b/marketing/src/data/landingEntries.ts
@@ -59,7 +59,7 @@ export const landingEntries: LandingEntry[] = [
     eyebrow: "Use case",
     headline: "AI Music Video Generator",
     subhead:
-      "Drop in a track and a concept. An agent breaks the song into scenes, renders each as key art, and animates them into a cut that moves with the music.",
+      "Drop in a track and a concept. The agent breaks the song into scenes, renders each as key art, and cuts them to the beat on a timeline you can still edit.",
     featuredTemplate: "music-video-visualizer",
     highlights: [
       "Beat-aware scene breakdown from one prompt",
@@ -96,7 +96,7 @@ export const landingEntries: LandingEntry[] = [
     eyebrow: "Use case",
     headline: "AI Social Media Content Generator",
     subhead:
-      "Describe a campaign and a cadence. An agent plans the calendar, a list generator writes each post, and matching visuals render for every slot.",
+      "Pitch a campaign and a cadence. The agent plans the calendar, writes each post, and renders matching visuals for every slot.",
     featuredTemplate: "social-media-calendar-filler",
     highlights: [
       "A full calendar of posts from one brief",
@@ -133,7 +133,7 @@ export const landingEntries: LandingEntry[] = [
     eyebrow: "Use case",
     headline: "AI YouTube Thumbnail Generator",
     subhead:
-      "Give it a video title and a hook. The canvas drafts thumbnail concepts, renders a batch of variants, and lays in the text so you can pick a winner.",
+      "Give it a video title and a hook. The agent drafts thumbnail concepts, renders a batch of variants, and lays in the text so you can pick a winner.",
     featuredTemplate: "hook-and-thumbnail-factory",
     highlights: [
       "A batch of thumbnail variants per title",

--- a/marketing/src/lib/siteSchema.ts
+++ b/marketing/src/lib/siteSchema.ts
@@ -14,7 +14,7 @@ export const softwareApplicationSchema: JsonLdObject = {
   "@type": "SoftwareApplication",
   name: "NodeTool",
   description:
-    "NodeTool is the open-source, agent-first creative workspace. Every editor — the node canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools, around 120 in all: say what you want and the agent builds the workflow and runs it across every major model from every major provider, using your own keys. It runs as a desktop app on macOS, Windows, and Linux, or in the browser with NodeTool Cloud.",
+    "NodeTool is the open-source, agent-first creative workspace for film production. Every editor — the node canvas, sketch pad, storyboard, video timeline, script editor, 3D scene, and app builder — is exposed to agents as tools, around 120 in all: pitch your concept and the agent drafts the script, casts the voices, boards the scenes, generates the footage, and cuts a multi-track timeline you can still edit, running on every major model from every major provider with your own keys. It runs as a desktop app on macOS, Windows, and Linux, or in the browser with NodeTool Cloud.",
   applicationCategory: "MultimediaApplication",
   applicationSubCategory: "Creative AI Workspace",
   operatingSystem: "macOS, Windows, Linux",
@@ -68,7 +68,7 @@ export const organizationSchema: JsonLdObject = {
     "https://discord.gg/WmQTWZRcYE",
   ],
   description:
-    "NodeTool builds the open, agent-first creative workspace: every editor is exposed to agents as tools, connecting every major model from every major provider using the user's own keys, available as a desktop app and as a hosted browser edition.",
+    "NodeTool builds the open, agent-first creative workspace: every editor is exposed to agents as tools, connecting every major model from every major provider using the creator's own keys, available as a desktop app and as a hosted browser edition.",
 };
 
 /** The demo video on the home page. Emitted by the page that shows it. */
@@ -77,7 +77,7 @@ export const demoVideoSchema: JsonLdObject = {
   "@type": "VideoObject",
   name: "NodeTool — the open, agent-first creative workspace (demo)",
   description:
-    "A walkthrough of NodeTool: connecting image, video, audio, and text models from every major provider on one visual canvas, using your own keys.",
+    "A trailer built end to end in NodeTool: the agent drafts the script, boards the shots, generates the footage, and cuts the timeline — on one canvas, with your own keys.",
   thumbnailUrl: "https://nodetool.ai/preview.png",
   contentUrl: "https://nodetool.ai/demo.mp4",
   uploadDate: "2026-01-01",


### PR DESCRIPTION
## What changed

Reframes the marketing site and the README on one claim: the creator directs, the agent does the heavy lifting, and what comes back is an editable multi-track project rather than a flat render. The home hero becomes "You direct the vision. The agent builds the film."; the three-step block is renamed Pitch / Automate / Direct on the home page, the agents page, and the README; the feature highlights become scripting & casting, model freedom, and a real timeline instead of a black box; the ownership block leads with "Local. Open. Yours." and states no token markups, no locked project formats, no subscription traps; closing CTAs land on "Ready to call action?" plus the platform list. Vocabulary is swept to the brand terms throughout — agent (not "the AI"), pitch/direct (not prompting), takes/cast (not generations/outputs), multi-track timeline (not output/render), filmmakers/creators (not users). Page metadata, OG image strings, JSON-LD descriptions, and `marketing/NARRATIVE.md` are updated in the same change, so the homepage copy and the narrative doc do not disagree.

Pages touched: `/`, `/creatives`, `/studio`, `/cloud`, `/marketing`, `/agents`, `/developers`, `/pricing`, `/solutions/*`, the four `/use-cases/*` pages, and the landing FAQ row. The `/alternatives/*` competitor pages are deliberately left alone: their positioning already leads with sovereignty and BYOK, and rewriting hand-tuned, query-specific copy would only dilute it.

## Verification

Backend packages had to be built first — `web`'s typecheck fails on unresolved `@nodetool-ai/*` subpath imports without it, on files this diff does not touch.

```
npm run build:packages          # 58/58 successful
cd web && npx tsc --noEmit      # exit 0
cd electron && npx tsc --noEmit # exit 0
cd marketing && npx tsc -p tsconfig.json --noEmit
                                # only pre-existing TS2307/TS7016 on absent deps
                                # (framer-motion, @heroicons, lodash) — marketing
                                # is not a root workspace, so its node_modules
                                # are not installed here
npm run lint                    # passes; warnings only, all pre-existing
npm run nodetool -- harness gate --base HEAD~1 --dry-run
                                # 39 changed files touch 0 surfaces, 0 selfchecks
```

- [x] `npm run typecheck` — web and electron clean. `typecheck:mobile` fails on missing `react-native` / `expo` / `expo-haptics` modules and the cascading implicit-`any` errors those produce; `mobile/` is intentionally not a root workspace and its dependency tree is not installed in this environment. No mobile file is in the diff.
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base main` (run as `harness gate --base HEAD~1`, since the local `main` ref is stale) — no surfaces touched.
- [ ] `npm run test:affected` — not run. The selector maps `marketing/**` to no workspace and falls back to selecting `packages`, `web`, `electron`, and `mobile` in full. Nothing in those trees imports `marketing/`, and the diff is prose only, so the full pass would cover none of what changed. CI runs it on the PR.

The marketing e2e smoke suite asserts titles and H1 counts, not body copy, and none of its asserted strings are in the diff.

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Exj6XNYyQdXDsdF4fZQTPY


---
_Generated by [Claude Code](https://claude.ai/code/session_01Exj6XNYyQdXDsdF4fZQTPY)_