### PR TITLE
docs(readme): rewrite in new brand voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,13 @@
 
 ![NodeTool node editor](marketing/public/screen_canvas.webp)
 
-NodeTool is an open-source AI production studio that runs on your machine.
-Describe your idea and the agent writes the script, boards every scene,
-generates the footage, and cuts the timeline — then hands you an editable
-multi-track project, not a flat render.
+NodeTool is an open-source, agent-first AI production studio that runs on your local machine. Describe your concept, and an autonomous agent writes the script, storyboards the scenes, generates the footage, and cuts the timeline. Instead of a flattened video file, it hands you a fully editable multi-track project.
 
-A node canvas, a video timeline, a sketch editor, storyboards, and mini-apps
-share one workspace, and every major model, cloud or local, plugs straight in.
+Every interface—the node canvas, timeline, sketch pad, and script editor—is exposed to the agent. It can wire a graph, paint a layer, or cut a clip on the exact same surfaces you use, then run the result and repair what fails.
 
-It is agent-first: every action you can take in the UI is also an agent tool,
-so an agent can wire a graph, paint a layer, cut a clip, or place a widget on
-the same surfaces you use, then run the result and repair what fails.
-
-* **01 / Pitch** — tell the agent your concept, style, and tone. It drafts the
-  script, casts the voices, and sets the visual direction.
-* **02 / Automate** — it storyboards the scenes, generates the footage, syncs
-  the audio, and cuts it together on a multi-track timeline.
-* **03 / Direct** — jump in at any moment. Swap a voice take, re-roll a clip, or
-  trim frames. The agent builds the foundation; you make the final cut.
+* **01 / Pitch** — tell the agent your concept, style, and tone. It drafts the script, casts the voices, and sets the visual direction.
+* **02 / Automate** — it storyboards scenes, generates footage, syncs audio, and cuts it together on a multi-track timeline.
+* **03 / Direct** — jump in at any moment. Swap a voice take, re-roll a clip, or trim frames. The agent builds the foundation; you make the final cut.
 
 ## Get NodeTool
 
@@ -38,79 +27,44 @@ the same surfaces you use, then run the result and repair what fails.
 | **Windows** | [Download Studio](https://nodetool.ai/studio) | Windows 10+, 8GB+ RAM, 20GB space |
 | **Linux** | [Download Studio](https://nodetool.ai/studio) | Ubuntu 22+, 8GB+ RAM |
 
-**Nodetool** is a free desktop app. Workflows, keys, and files stay local; it
-runs offline against local models, or connects to cloud
-providers when you give it a key.
+**NodeTool** is a free desktop app. Workflows, keys, and files stay local. Run inference on your own hardware, or plug in a provider key to use cloud models without a GPU.
 
-No GPU is needed to start: with a provider key the models run on their servers.
-A GPU only matters once you want inference on your own machine.
-
-[Flatpak CI builds](https://github.com/nodetool-ai/nodetool/actions/workflows/flatpak-ci.yml)
-are available for Linux. Developers can skip the installer and
-[run from source](#development-setup).
+[Flatpak CI builds](https://github.com/nodetool-ai/nodetool/actions/workflows/flatpak-ci.yml) are available for Linux. Developers can skip the installer and [run from source](#development-setup).
 
 ## What you can build
 
-* **[Movie trailer](https://nodetool.ai/use-cases/movie-trailer)** — one logline
-  becomes a storyboard, key art per shot, animated clips, and a cut trailer.
-* **[Documentary teaser](https://nodetool.ai/use-cases/documentary-teaser)** —
-  one sentence becomes a six-shot board, a still per card, animated clips, and a
-  26-second cut.
-* **[Product video](https://nodetool.ai/use-cases/product-video)** — a campaign
-  brief and one product photo become a 16:9 spot, directed by an agent and
-  rendered by a text-to-video model.
-* **[Poster concepts](https://nodetool.ai/use-cases/movie-poster)** — a title,
-  genre, and audience become a creative strategy and a batch of poster
-  concepts, tagline and billing block included.
+* **[Movie trailer](https://nodetool.ai/use-cases/movie-trailer)** — Pitch a logline. The agent boards the shots, generates key art, and cuts the trailer.
+* **[Documentary teaser](https://nodetool.ai/use-cases/documentary-teaser)** — One sentence becomes a six-shot board, stills, and a 26-second cut.
+* **[Product video](https://nodetool.ai/use-cases/product-video)** — A campaign brief and a single product photo become a 16:9 spot, directed by an agent and rendered by a video model.
+* **[Poster concepts](https://nodetool.ai/use-cases/movie-poster)** — A title, genre, and audience become a creative strategy and a batch of poster concepts, complete with tagline and billing block.
 
-More in the [showcase](https://nodetool.ai/showcase) and the
-[template gallery](https://nodetool.ai/templates).
+More in the [showcase](https://nodetool.ai/showcase) and the [template gallery](https://nodetool.ai/templates).
 
 ## Local. Open. Yours.
 
 No locked project formats, no token markups, zero subscription traps.
 
-* **Bring your own keys.** Provider prices, billed by the provider — or open
-  weights on your own hardware for free.
-* **Your files stay yours.** Projects, keys, and footage stay on your machine.
+* **Bring your own keys.** Pay provider prices directly—or run open weights on your own hardware for free.
+* **Your files stay yours.** Projects, API keys, and footage never leave your machine.
 * **Open source.** AGPL-3.0, end to end. Read it, fork it, host it.
 
-If a provider raises prices or deprecates a model, swap the node. The rest of
-the workflow doesn't change.
+If a provider deprecates a model or raises prices, swap the node. The rest of the workflow stays intact.
 
 ## Agents
 
-Most tools bolt a chat panel onto an editor. NodeTool went the other way: **the
-whole app is the toolbelt.** Every editor hands an agent the same actions you
-have — add a node and wire it, paint a layer, cut a clip, revise a shot, voice a
-line, place a widget — across the canvas, sketch pad, storyboard, timeline,
-script editor, 3D scene, and app builder.
+Most tools bolt a chat panel onto an editor. NodeTool built the editors around the agent. The entire app is the toolbelt. Every surface hands the agent the same actions you have: wire a graph, paint a layer, cut a clip, revise a shot, or voice a line.
 
-* **Agents build workflows.** Describe the pipeline; the agent picks the nodes,
-  wires the edges, selects the models, and validates the graph before anything
-  runs. What it leaves behind is a workflow you can inspect, edit, and rerun.
-* **Agents build apps, and test them.** Ask for a mini app and the agent plans
-  the workflows, places the widgets, replays every interaction, and has a second
-  model judge whether the result does what you asked. No passing verdict, no app.
-* **An agent on the failure path.** Supervised runs decide what to do when a
-  step fails mid-run — retry, repair, skip, or stop — inside a decision and cost
-  budget you set, with every intervention logged.
-* **It asks instead of guessing.** When a job needs something only you can
-  decide, the agent stops and asks. Every plan, tool call, prompt, and dollar of
-  model spend is on the record.
-* **Bring your own agent.** The toolbelt is exposed over MCP, so Claude Desktop,
-  Claude Code, Codex, or any MCP-aware agent gets the same tools the built-in
-  chat uses.
+* **Build workflows.** Describe the pipeline. The agent picks the nodes, wires the edges, and validates the graph. What it leaves behind is a workflow you own and control.
+* **Build apps.** Ask for a custom UI. The agent plans the workflow, places widgets, and replays interactions. A separate judge model grades the result. No passing verdict, no app.
+* **Repair on the fly.** Put an agent on the failure path. It decides whether to retry, repair, skip, or stop—strictly within the cost budget you set.
+* **Bring your own agent.** The toolbelt is exposed over MCP. Point Claude Desktop, Claude Code, or Codex at the local server to drive the studio.
 
 ```bash
 nodetool mcp install                  # wire NodeTool into Claude Code / Codex / OpenCode
 npm run build:mcpb                    # → dist/nodetool.mcpb for Claude Desktop
 ```
 
-Under the hood: a planner turns an objective into a DAG of steps, executors walk
-it in parallel, and every LLM call emits an OpenTelemetry span with tokens and
-cost. See the [agent guide](https://docs.nodetool.ai/agents/) and
-[docs/AGENTS.md](docs/AGENTS.md).
+Under the hood: a planner turns an objective into a DAG of steps, executors walk it in parallel, and every LLM call emits an OpenTelemetry span with tokens and cost. See the [agent guide](https://docs.nodetool.ai/agents/) and [docs/AGENTS.md](docs/AGENTS.md).
 
 ## What's in the box
 
@@ -118,165 +72,122 @@ cost. See the [agent guide](https://docs.nodetool.ai/agents/) and
 
 | | |
 | :--- | :--- |
-| **Node canvas** | Drag-and-drop nodes, type-safe connections, live output at every node |
-| **Video editor** | A real multi-track timeline — sequence, composite, and generate clips, then export MP4 |
-| **Sketch editor** | Layered paint canvas — draw, mask, and generate onto layers, feed the result downstream |
-| **Storyboard** | Pitch → screenplay → stills you pick from → clips → an assembled cut |
-| **Script editor** | Draft a script, cast a voice per character, audition takes, send them to a timeline |
-| **Mini apps** | Wire widgets to workflow inputs and outputs and publish a version |
-| **Editing tools as nodes** | Mask, inpaint, outpaint, relight, upscale, layers, compositing |
+| **Node canvas** | Drag-and-drop nodes with type-safe connections. Live output at every step. |
+| **Video editor** | Sequence, composite, and generate clips on a true multi-track timeline. Export direct to MP4. |
+| **Sketch editor** | Paint on layers with blend modes and masks. Bind a layer to a model and generate straight onto the canvas. |
+| **Storyboard** | Pitch a concept, get a screenplay, pick stills, render clips, assemble the cut. |
+| **Script editor** | Draft the script, cast a voice per character, audition takes, send the result to a timeline. |
+| **Mini apps** | Wire widgets to workflow inputs and outputs. Publish a version. |
+| **Editing tools as nodes** | Mask, inpaint, outpaint, relight, upscale, layer, and composite. |
 
 **Run and extend**
 
 | | |
 | :--- | :--- |
-| **Every modality** | Image, video, audio, and text in one workflow |
-| **BYOK everywhere** | OpenAI, Anthropic, Gemini, FAL, KIE, Replicate, ElevenLabs, HuggingFace — no markups |
-| **Local inference** | Ollama, MLX (Apple Silicon), and GGUF |
-| **Document search** | Built-in vector store for indexing and querying your files |
-| **JS scripts** | Versioned JavaScript documents with ports, tests, and a sandbox |
-| **MCP server** | Point Claude Desktop, Claude Code, Codex, or any MCP agent at the toolbelt |
-| **Custom nodes** | Extend in TypeScript or Python |
-| **Deploy & scale** | Self-host with Docker; rent GPU workers (RunPod, Vast) |
-| **Cross-platform** | macOS, Windows, and Linux |
+| **Every modality** | Image, video, audio, and text in one workflow. |
+| **BYOK everywhere** | OpenAI, Anthropic, Gemini, FAL, KIE, Replicate, ElevenLabs, HuggingFace. No markups. |
+| **Local inference** | Run Ollama, MLX (Apple Silicon), and GGUF on your own hardware. |
+| **Document search** | Index and query your files with the built-in vector store. |
+| **JS scripts** | Write versioned JavaScript documents with ports, tests, and a sandbox. |
+| **MCP server** | Point Claude Desktop, Claude Code, Codex, or any MCP agent at the toolbelt. |
+| **Custom nodes** | Extend in TypeScript or Python. |
+| **Deploy & scale** | Self-host with Docker. Rent GPU workers on RunPod or Vast. |
+| **Cross-platform** | Ship to macOS, Windows, and Linux. |
 
 ## The editors
 
 These surfaces share one workspace, and an agent can drive every one of them.
 Full tours live at [docs.nodetool.ai](https://docs.nodetool.ai).
 
+### Script editor — scripting and casting, with the words as the source of truth
+
+![NodeTool script editor — the transcript panel beside the sequence it assembles into](marketing/public/surface-script-poster.webp)
+
+The text is the source of truth. Draft the script, cast a voice per character, and audition alternative takes with automatic word-level sync.
+
+* **Cast a voice per character.** Each speaker carries a provider, model, and voice; every line inherits it unless you override the line.
+* **Takes, not overwrites.** Voicing a line saves a take with its own word timings. Audition several, keep the one you want.
+* **Staleness is visible.** Change a line's text or its voice and the line flags itself against the take that no longer matches — re-voice just that line.
+* **Send it to a timeline.** The current takes assemble into a sequence end to end, word timings riding along as captions.
+
+An agent does the same without the editor open: `voice_script_lines` voices every draft or stale line with its cast voice, and `assemble_script_timeline` cuts the result into a saved sequence that `validate_timeline` then checks.
+
+### Storyboard — board the film shot by shot before you pay for video
+
+![NodeTool storyboard](marketing/public/surface-storyboard-poster.webp)
+
+Board the film before you pay for video. Render cheap stills, pick the best shots, and then generate the clips. Revise a single shot without re-rolling the entire reel.
+
+Pitch a concept and a visual style, pick a shot count, and press **Direct**: the Director node returns a typed screenplay — logline, style bible, narration, music direction, and one structured shot per card with action, camera, motion, and duration.
+
+* **Cheap stages first.** A still costs cents, a clip costs dollars. Generate stills until one looks right, pick it, and only then generate the clip.
+* **Revise one shot, not the reel.** "Make it darker, add rain" runs video-to-video on the existing clip and swaps the result in place. Fixing shot 3 never re-rolls shots 1–5.
+* **Entities keep the cast steady.** Characters, locations, styles, and props are named objects whose canonical descriptor is pasted verbatim into every prompt that names them.
+* **Assemble the cut.** One click lays the rendered shots onto a timeline with narration and music tracks. Every clip stays linked to its shot, so a later revision replaces the clip in the saved cut.
+
+Agents drive the same board through the `ui_storyboard_*` tools, or headlessly with `render_storyboard_stills`, `render_storyboard_clips`, and `assemble_storyboard_timeline` — no browser involved.
+
+[Creative agent guide →](https://docs.nodetool.ai/creative-agent)
+
+### Video editor — a real multi-track timeline, not a black box
+
+![NodeTool video editor](screen_video_editor.png)
+
+A real multi-track timeline, not a black box. Regenerate an AI clip in place without losing your edit. Fine-tune every frame, layer, and audio stem.
+
+Instead of a single unfixable video file, you get a fully editable project. Drop in your own footage or bind a workflow to a clip — text-to-image, image-to-video, or text-to-speech — and generate it in place. Change a parameter and the clip regenerates; tweak the bound workflow and the clip flags itself stale. Fine-tune every frame, layer, and audio stem across video, audio, and overlay tracks, then export the sequence to MP4.
+
+[Video editor guide →](https://docs.nodetool.ai/video-editor)
+
 ### Node editor — build a pipeline by chaining steps
 
 ![NodeTool node editor](marketing/public/screen_workflow.webp)
 
-Double-click to search and add a node, or drag a connection into empty space to
-see compatible next steps. Connector handles are color-coded and the editor
-refuses a mismatch, so an image can't land in a text field. Every node renders
-its output live as the workflow runs; tweak properties on the node, group them,
-or bypass one to test a variation. Pan, zoom, minimap, and search by name for
-large graphs.
+Chain steps and wire the graph. Connector handles are color-coded and type-safe. Live output renders at every node as the workflow runs.
+
+Double-click to search and add a node, or drag a connection into empty space to see compatible next steps. The editor refuses a mismatch, so an image can't land in a text field. Tweak properties on a node, group them, or bypass one to test a variation. Pan, zoom, minimap, and search by name for large graphs.
 
 [Getting started guide →](https://docs.nodetool.ai/getting-started)
+
+### Sketch editor — paint and generate on the same layers
+
+![NodeTool sketch editor](marketing/public/screen_sketch_editor.webp)
+
+Paint, mask, and generate on the same layers. Feed the flattened output directly into the workflow—no export/import round-trips.
+
+Draw and paint with real brushes, build a composition in layers with blend modes and masks, then bind a layer to a model or one of your own workflows and generate image content where you're painting. Change a prompt or an upstream input and the layer flags itself stale; regenerate in place and keep working on top. The node hands the rest of the workflow a flattened image, a mask, and per-layer outputs. It pairs with the editing nodes (mask, inpaint, outpaint, compositing) for sketch-then-generate pipelines.
+
+[Sketch editor guide →](https://docs.nodetool.ai/sketch-editor)
 
 ### Mini apps & app builder — put an interface in front of a workflow
 
 ![NodeTool app builder](marketing/public/screen_app_builder.png)
 
-A workflow is a graph; a mini app is the interface on top of it. Drag fields,
-buttons, and result displays onto a screen, wire each one to an input or output,
-declare which operations a click starts, and publish a version that pins the
-workflows behind it. Results stream into the widgets as the run happens, and the
-graph stays underneath, editable. An operation can run a
-[JS script](docs/js-script-document-design.md) instead of a workflow, for the ten lines of glue that
-don't deserve a graph.
+Wrap a complex graph in a clean UI. Drag fields and buttons onto a screen, bind them to workflow inputs, and publish. The agent can build and test these end-to-end.
 
-Agents build them end to end. `nodetool app build` runs six stages — spec, plan,
-author, check, run, judge — and hands back a bundle only when the app's
-interactions do what the prompt asked. The judge is a second model, configured
-apart from the builder, because a model grading its own work is the weakest
-reviewer available:
+A workflow is a graph; a mini app is the interface on top of it. Drag fields, buttons, and result displays onto a screen, wire each one to an input or output, declare which operations a click starts, and publish a version that pins the workflows behind it. Results stream into the widgets as the run happens, and the graph stays underneath, editable. An operation can run a [JS script](docs/js-script-document-design.md) instead of a workflow, for the ten lines of glue that don't deserve a graph.
+
+Agents build them end to end. `nodetool app build` runs six stages — spec, plan, author, check, run, judge — and hands back a bundle only when the app's interactions do what the prompt asked. The judge is a second model, configured apart from the builder, because a model grading its own work is the weakest reviewer available:
 
 ```bash
 nodetool app build "an app that drafts a note from a prompt" -p anthropic -m claude-sonnet-5
 nodetool app debug <application_id>    # headless: validate bindings, replay interactions
 ```
 
-Export an app as one `.json` bundle — the document plus the full graph of every
-workflow it binds — and import it anywhere.
+Export an app as one `.json` bundle — the document plus the full graph of every workflow it binds — and import it anywhere.
 
 [App builder guide →](https://docs.nodetool.ai/app-builder) ·
 [Mini apps guide →](https://docs.nodetool.ai/mini-apps)
 
-### Storyboard — board the film shot by shot before you pay for video
+### JS scripts — ten lines of JavaScript instead of a node graph
 
-![NodeTool storyboard](marketing/public/surface-storyboard-poster.webp)
+Ten lines of JavaScript instead of a node graph. Versioned, sandbox-tested logic for fast data transformations.
 
-Pitch a concept and a visual style, pick a shot count, and press **Direct**: the
-Director node returns a typed screenplay — logline, style bible, narration,
-music direction, and one structured shot per card with action, camera, motion,
-and duration.
+Reshape an API response, merge two lists, format a date. A JS script is a named, versioned document for exactly that — a body with declared input and output ports, the secrets it may read, a timeout, and saved test cases. It opens in its own tab with a code editor and an assistant panel beside it.
 
-* **Cheap stages first.** A still costs cents, a clip costs dollars. Generate
-  stills until one looks right, pick it, and only then render the clip.
-* **Revise one shot, not the reel.** "Make it darker, add rain" runs
-  video-to-video on the existing clip and swaps the result in place. Fixing shot
-  3 never re-rolls shots 1–5.
-* **Entities keep the cast steady.** Characters, locations, styles, and props
-  are named objects whose canonical descriptor is pasted verbatim into every
-  prompt that names them.
-* **Assemble the cut.** One click lays the rendered shots onto a timeline with
-  narration and music tracks. Every clip stays linked to its shot, so a later
-  revision replaces the clip in the saved cut.
-
-Agents drive the same board through the `ui_storyboard_*` tools, or headlessly
-with `render_storyboard_stills`, `render_storyboard_clips`, and
-`assemble_storyboard_timeline` — no browser involved.
-
-[Creative agent guide →](https://docs.nodetool.ai/creative-agent)
-
-### Script editor — scripting and casting, with the words as the source of truth
-
-![NodeTool script editor — the transcript panel beside the sequence it assembles into](marketing/public/surface-script-poster.webp)
-
-A script lives on its own, line by line and section by section, and the text is
-the source of truth.
-
-* **Cast a voice per character.** Each speaker carries a provider, model, and
-  voice; every line inherits it unless you override the line.
-* **Takes, not overwrites.** Voicing a line saves a take with its own word
-  timings. Audition several, keep the one you want.
-* **Staleness is visible.** Change a line's text or its voice and the line flags
-  itself against the take that no longer matches — re-voice just that line.
-* **Send it to a timeline.** The current takes assemble into a sequence end to
-  end, word timings riding along as captions.
-
-An agent does the same without the editor open: `voice_script_lines` voices
-every draft or stale line with its cast voice, and `assemble_script_timeline`
-cuts the result into a saved sequence that `validate_timeline` then checks.
-
-### Video editor — a real multi-track timeline, not a black box
-
-![NodeTool video editor](screen_video_editor.png)
-
-Instead of a single unfixable video file, you get a fully editable project.
-Drop in your own footage or bind a workflow to a clip — text-to-image,
-image-to-video, or text-to-speech — and generate it in place. Change a parameter
-and the clip regenerates; tweak the bound workflow and the clip flags itself
-stale. Fine-tune every frame, layer, and audio stem across video, audio, and
-overlay tracks, then export the sequence to MP4.
-
-[Video editor guide →](https://docs.nodetool.ai/video-editor)
-
-### Sketch editor — paint and generate on the same layers
-
-![NodeTool sketch editor](marketing/public/screen_sketch_editor.webp)
-
-Draw and paint with real brushes, build a composition in layers with blend modes
-and masks, then bind a layer to a model or one of your own workflows and
-generate image content where you're painting. Change a prompt or an upstream
-input and the layer flags itself stale; regenerate in place and keep working on
-top. The node hands the rest of the workflow a flattened image, a mask, and
-per-layer outputs — no export/import round-trip. It pairs with the editing nodes
-(mask, inpaint, outpaint, compositing) for sketch-then-generate pipelines.
-
-[Sketch editor guide →](https://docs.nodetool.ai/sketch-editor)
-
-### JS scripts — ten lines of JavaScript instead of a graph
-
-Reshape an API response, merge two lists, format a date. A JS script is a named,
-versioned document for exactly that — a body with declared input and output
-ports, the secrets it may read, a timeout, and saved test cases. It opens in its
-own tab with a code editor and an assistant panel beside it.
-
-* **Runs in the sandbox.** A QuickJS guest that starts with nothing: `fetch` and
-  the workspace are capabilities the host grants, under a per-run cap and an
-  SSRF guard. Every installed sandbox pack — date-fns, papaparse, cheerio,
-  exceljs, pdf-lib, and thirty more — resolves by import.
-* **Reusable.** Call it from a mini app as an operation, link it as a Code
-  node's body, invoke it from an agent, or compose it from another script.
-* **Tested like code.** Save cases with inputs and expected outputs;
-  `nodetool jsscript test` grades them and exits non-zero on a failure. Version
-  history is per script, with restore.
+* **Runs in the sandbox.** A QuickJS guest that starts with nothing: `fetch` and the workspace are capabilities the host grants, under a per-run cap and an SSRF guard. Every installed sandbox pack — date-fns, papaparse, cheerio, exceljs, pdf-lib, and thirty more — resolves by import.
+* **Reusable.** Call it from a mini app as an operation, link it as a Code node's body, invoke it from an agent, or compose it from another script.
+* **Tested like code.** Save cases with inputs and expected outputs; `nodetool jsscript test` grades them and exits non-zero on a failure. Version history is per script, with restore.
 
 ```bash
 nodetool jsscript validate my-script.json
@@ -284,10 +195,7 @@ nodetool jsscript run my-script.json --inputs '{"numbers":[1,2,3]}'
 nodetool jsscript test <id>
 ```
 
-Agents get the same surface through `list_js_scripts`, `save_js_script`,
-`run_js_script`, and `test_js_script`. See
-[docs/js-script-document-design.md](docs/js-script-document-design.md) and the
-[JavaScript sandbox](docs/javascript-sandbox.md).
+Agents get the same surface through `list_js_scripts`, `save_js_script`, `run_js_script`, and `test_js_script`. See [docs/js-script-document-design.md](docs/js-script-document-design.md) and the [JavaScript sandbox](docs/javascript-sandbox.md).
 
 ## How NodeTool compares
 
@@ -299,17 +207,11 @@ Agents get the same surface through `list_js_scripts`, `save_js_script`,
 | **Models** | Every major provider, BYOK | Stable Diffusion | Curated marketplace | API integrations |
 | **Source & pricing** | AGPL-3.0, provider prices | Open source, free | Closed, credits | Fair-code, subscription |
 
-**vs ComfyUI.** ComfyUI exposes every parameter for engineers who want them.
-NodeTool keeps the node graph, gives it an interface that doesn't fight you, and
-covers the rest of the stack — video, audio, text, document search.
+**vs ComfyUI.** ComfyUI exposes every parameter for engineers who want them. NodeTool keeps the node graph, gives it an interface that doesn't fight you, and covers the rest of the stack: video, audio, text, document search.
 
-**vs Weavy.** Weavy was the closed-source canvas for creative AI. After the
-Figma acquisition, the roadmap belongs to someone else. NodeTool is the open
-alternative — same node-based canvas, your keys, your files, no acquisition
-risk.
+**vs Weavy.** Weavy was the closed-source canvas for creative AI. After the Figma acquisition, the roadmap belongs to someone else. NodeTool is the open alternative: same node-based canvas, your keys, your files, no acquisition risk.
 
-**vs n8n.** n8n is for business workflows and API plumbing. NodeTool is built
-for creative work — models, masks, layers, video, audio, RAG.
+**vs n8n.** n8n is for business workflows and API plumbing. NodeTool is built for creative work: models, masks, layers, video, audio, RAG.
 
 ## Documentation
 
@@ -319,8 +221,8 @@ for creative work — models, masks, layers, video, audio, RAG.
 - **[App Builder](https://docs.nodetool.ai/app-builder)** — Place widgets, wire them to a workflow, publish
 - **[Creative Agent](https://docs.nodetool.ai/creative-agent)** — Storyboard a film, gate the spend, assemble the cut
 - **[JavaScript Sandbox](https://docs.nodetool.ai/javascript-sandbox)** — What JS scripts and Code nodes can reach
-- **[Video Editor](https://docs.nodetool.ai/video-editor)** — Sequence and AI-generate clips on a timeline
-- **[Sketch Editor](https://docs.nodetool.ai/sketch-editor)** — Draw, mask, and AI-generate on a layered canvas
+- **[Video Editor](https://docs.nodetool.ai/video-editor)** — Sequence and generate clips on a timeline
+- **[Sketch Editor](https://docs.nodetool.ai/sketch-editor)** — Draw, mask, and generate on a layered canvas
 - **[Node Packs](https://docs.nodetool.ai/packs)** — Available nodes and integrations
 - **[Custom Nodes](https://docs.nodetool.ai/developer/custom-nodes-guide)** — Extend NodeTool
 - **[Provider Guides](https://docs.nodetool.ai/developer/providers/)** — Add new models & nodes for any provider
@@ -333,7 +235,7 @@ ______________________________________________________________________
 
 ## CLI & Server (npm)
 
-Run the server, execute workflows, drive agents, or chat from the terminal:
+Run the server, execute workflows, drive agents, or chat from the terminal.
 
 ```bash
 # Install globally (Node.js 22.x required)
@@ -365,7 +267,7 @@ npx --package=@nodetool-ai/cli nodetool serve
 npx --package=@nodetool-ai/cli nodetool-chat
 ```
 
-Every surface is drivable headlessly, so an agent can check its own work:
+Every surface runs headlessly, so an agent checks its own work:
 `nodetool validate` (static graph check), `nodetool debug` (run a workflow and
 read a verdict), `nodetool app debug` (replay an app's interactions),
 `nodetool node run` (one node in isolation), and `nodetool eval` (score the
@@ -377,7 +279,7 @@ ______________________________________________________________________
 
 ## Architecture
 
-NodeTool is a monorepo with a TypeScript backend, React frontend, Electron desktop shell, and React Native mobile app.
+NodeTool is a monorepo: TypeScript backend, React frontend, Electron desktop shell, React Native mobile app.
 
 ```
 nodetool/
@@ -396,7 +298,7 @@ nodetool/
 └── docs/              # Jekyll documentation site
 ```
 
-For a detailed architecture overview, see [ARCHITECTURE.md](ARCHITECTURE.md).
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the detailed breakdown.
 
 ______________________________________________________________________
 
@@ -415,7 +317,7 @@ ______________________________________________________________________
 
 That's the whole setup. On first run `start.sh` checks your Node version, copies
 `.env.example` to `.env`, installs dependencies, rebuilds the native SQLite
-module, and builds the backend packages — then starts the server. Every run
+module, and builds the backend packages, then starts the server. Every run
 after skips straight to starting it. Other modes:
 
 ```bash
@@ -453,7 +355,7 @@ custom nodes, the API, deployment, and troubleshooting.
 
 ### Python Nodes (optional)
 
-Python nodes (HuggingFace, MLX, Apple integrations) run via the `PythonStdioBridge`, which spawns a Python worker process that communicates over stdin/stdout. The bridge connects lazily on the first workflow that uses Python nodes — no separate setup is needed for the TypeScript backend.
+Python nodes (HuggingFace, MLX, Apple integrations) run via the `PythonStdioBridge`, which spawns a Python worker process that communicates over stdin/stdout. The bridge connects lazily on the first workflow that uses Python nodes. No separate setup for the TypeScript backend.
 
 ### Electron App
 
@@ -465,7 +367,7 @@ The Electron app auto-detects your active Conda environment. Settings are stored
 - **Linux/macOS**: `~/.config/nodetool/settings.yaml`
 - **Windows**: `%APPDATA%\nodetool\settings.yaml`
 
-> **Native module rebuild.** The backend always runs on vanilla Node (system Node in dev, the bundled Node 22.x in prod — same ABI), so the one source-built native module, `better-sqlite3`, is compiled against **Node** headers. This runs automatically from the root `postinstall` (`electron/scripts/rebuild-native.mjs`) after `npm install`/`npm ci` finishes, so a clean checkout builds in a single command. If you ever see a `NODE_MODULE_VERSION` mismatch, force a rebuild:
+> **Native module rebuild.** The backend always runs on vanilla Node (system Node in dev, the bundled Node 22.x in prod — same ABI), so the one source-built native module, `better-sqlite3`, is compiled against **Node** headers. This runs automatically from the root `postinstall` (`electron/scripts/rebuild-native.mjs`) after `npm install`/`npm ci` finishes, so a clean checkout builds in a single command. If you see a `NODE_MODULE_VERSION` mismatch, force a rebuild:
 >
 > ```bash
 > npm run rebuild:native
@@ -504,7 +406,7 @@ cd web && npm test && npm run lint
 cd web && npx playwright install chromium && npm run test:e2e
 ```
 
-Electron has no Playwright suite; `cd electron && npm test` runs its Jest tests.
+Electron has no Playwright suite. `cd electron && npm test` runs its Jest tests.
 
 For detailed testing documentation, see [web/TESTING.md](web/TESTING.md).
 
@@ -514,7 +416,7 @@ ______________________________________________________________________
 
 We welcome bug reports, feature requests, code contributions, and new nodes.
 
-Please open an issue before starting major work so we can coordinate.
+Open an issue before starting major work so we can coordinate.
 
 ### Acknowledgements
 


### PR DESCRIPTION
## Summary
- Replaces the hero/intro copy with the new confident, creator-first brand voice
- Rewrites "What you can build," "Local. Open. Yours.," "Agents," and the two "What's in the box" tables with punchy, imperative copy
- Reorders and rewrites "The editors" section into pipeline order: Script editor → Storyboard → Video editor → Node editor → Sketch editor → Mini apps & app builder → JS scripts
- Strips conversational filler from the developer-facing sections (CLI, Architecture, Setup, Testing); no code blocks, commands, versions, or paths changed

## Test plan
- [x] Reviewed rendered Markdown for broken links/images (URLs preserved from the original file)
- [x] Confirmed all code blocks, commands, and version numbers are unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011bwmAWJoFGrLAaTKLHLxCu

---
_Generated by [Claude Code](https://claude.ai/code/session_011bwmAWJoFGrLAaTKLHLxCu)_