### PR TITLE
docs(marketing): rewrite /developers copy developer-to-developer

### DIFF
--- a/marketing/src/components/developers/AgentSandboxSection.tsx
+++ b/marketing/src/components/developers/AgentSandboxSection.tsx
@@ -45,21 +45,21 @@ const namespaces = [
 const facts = [
   {
     icon: Layers,
-    title: "One provider tool",
+    title: "Token savings, by construction",
     body:
-      "The model sees execute_code({ code }) and nothing else. A single action chains, loops over, branches on and reduces any number of tool calls — where the JSON-per-call loop spent one round trip each.",
+      "The data stays in the guest isolate. You do not pay to pass giant JSON arrays back and forth to the model — only the reduction crosses into its context. The model sees execute_code({ code }) and nothing else.",
   },
   {
     icon: ShieldCheck,
-    title: "No new privilege",
+    title: "Zero new privileges",
     body:
-      "Every imported function is a tool the model could have called directly, and per-step allowlists stay a boundary. Third-party packs need session consent; an off-allowlist import stops the action before the guest starts.",
+      "An agent gets the same limits and the same toolbelt as a developer writing a Code node. Every imported function is a tool the model could have called directly; an off-allowlist import stops the action before the guest starts, and third-party packs need session consent.",
   },
   {
     icon: Eye,
-    title: "Still observable",
+    title: "Fully observable",
     body:
-      "Each call inside an action surfaces to the host as a tool_call_update, so composition does not become opacity. A per-action cap of 50 tool calls bounds a runaway loop.",
+      "Every call inside an action still surfaces to the host as a tool_call_update, so composition does not become opacity. Tool calls are hard-capped at 50 per action, which stops a runaway loop.",
   },
 ];
 
@@ -86,7 +86,7 @@ export default function AgentSandboxSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
-            Agents drive NodeTool from inside the sandbox
+            Agents write code, not tool calls
           </motion.h2>
           <motion.p
             initial={false}
@@ -95,11 +95,12 @@ export default function AgentSandboxSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 max-w-3xl mx-auto"
           >
-            An agent step acts by writing a program, not by emitting a tool
-            call. The program runs in the same isolate your Code node runs in,
-            with 208 platform tools reachable as imports across 33 namespaces.
-            The action&apos;s return value, logs and thrown errors come back as
-            the observation for the next turn.
+            Standard tool-calling is a round trip per call: emit JSON, wait,
+            loop. With CodeAct the agent writes a whole JavaScript program
+            instead, and it runs in the same isolate your Code node runs in. It
+            loops, branches and reduces locally, reaching 208 platform tools as
+            imports across 33 namespaces. Its return value, logs and thrown
+            errors are the observation for the next turn.
           </motion.p>
         </div>
 
@@ -113,9 +114,8 @@ export default function AgentSandboxSection() {
           >
             <CodeBlock code={actionCode} language="typescript" />
             <p className="mt-4 text-sm text-slate-400">
-              The payload stays in the guest. Only the reduction crosses into
-              the model&apos;s context, which is where the token savings in the
-              CodeAct and code-execution-with-MCP results come from.
+              Five tool calls, one action, one observation. The payload never
+              leaves the guest — only the reduction does.
             </p>
           </motion.div>
 
@@ -132,9 +132,9 @@ export default function AgentSandboxSection() {
               </span>
             </h3>
             <p className="mt-2 text-sm text-slate-400">
-              33 namespaces, 208 tools. Only the ones an action imports are
-              mounted, so an import costs one module&apos;s dependency cone
-              rather than the whole registry.
+              33 namespaces, 208 tools. Only what an action imports gets
+              mounted, so you pay for one module&apos;s dependency cone rather
+              than the whole registry.
             </p>
             <div className="mt-5 flex flex-wrap gap-2">
               {namespaces.map((ns) => (
@@ -147,10 +147,9 @@ export default function AgentSandboxSection() {
               ))}
             </div>
             <p className="mt-5 text-sm text-slate-400">
-              Everything a capability touches resolves against the run&apos;s
-              own user id, and missing and not-yours are one answer, so a run
-              cannot probe for ids. What is deliberately unreachable is written
-              down per procedure and checked against the live router.
+              Every capability resolves against the run&apos;s own user id, and
+              &quot;missing&quot; and &quot;not yours&quot; are the same answer,
+              so a run cannot probe for ids.
             </p>
           </motion.div>
         </div>
@@ -182,15 +181,15 @@ export default function AgentSandboxSection() {
           className="mt-8 rounded-2xl bg-gradient-to-br from-emerald-900/15 to-slate-900/20 p-6 sm:p-8 ring-1 ring-emerald-500/20"
         >
           <h3 className="text-xl font-semibold text-white">
-            Your body and its action are the same program
+            Your code and the agent&apos;s are the same program
           </h3>
           <p className="mt-3 max-w-3xl text-slate-400">
             A Code node body is code a person saved. An action is code the model
-            just wrote. They differ in what the host granted them — the packs a
-            session consented to, the secret names in scope, the tools on the
-            belt — and in nothing else. The engine, the limits, the marshaling
-            and the import surface are one implementation, so what you test by
-            hand is what the agent gets at runtime.
+            just wrote. The only difference is what the host granted each one:
+            the packs a session consented to, the secret names in scope, the
+            tools on the belt. Engine, limits, marshaling and imports are one
+            implementation, so what you test by hand is what the agent gets at
+            runtime.
           </p>
           <div className="mt-6 flex flex-wrap gap-3">
             <a

--- a/marketing/src/components/developers/DeveloperPlatformSection.tsx
+++ b/marketing/src/components/developers/DeveloperPlatformSection.tsx
@@ -32,21 +32,21 @@ npm run dev:nodetool -- serve   # HTTP + WebSocket on :7777`;
 const cards = [
   {
     icon: Blocks,
-    title: "Custom nodes",
+    title: "Custom nodes in 15 lines",
     body:
-      "Extend BaseNode, decorate the properties, implement process(). Register the package and the node appears in the canvas, in the DSL codegen, and as a sandbox-flow callable — one definition, every surface.",
+      "Extend BaseNode, decorate the properties, implement process(). Register the package and the node shows up in the visual canvas, in the DSL codegen, and as a sandbox-flow callable. One definition, every surface.",
   },
   {
     icon: Plug,
-    title: "MCP, for agents outside NodeTool",
+    title: "Native MCP support",
     body:
-      "The toolbelt speaks MCP. nodetool mcp install wires up a CLI agent; the .mcpb bundle installs into Claude Desktop by drag-and-drop and hot-attaches when the server appears. A deployed server is reached at /mcp with a token minted in settings.",
+      "The whole toolbelt speaks Model Context Protocol. nodetool mcp install wires up a CLI agent in one command; the .mcpb bundle installs into Claude Desktop by drag-and-drop and hot-attaches when the server appears. A deployed server is reached at /mcp with a token minted in settings.",
   },
   {
     icon: Server,
-    title: "Run it yourself",
+    title: "Self-host anywhere",
     body:
-      "The deploy unit is a self-contained container image with the frontend and the example workflows baked in. Docker Compose for self-hosting, or the deploy tooling for SSH, RunPod, GCP and Supabase targets. AGPL-3.0, your keys, your files.",
+      "AGPL-3.0. The deploy unit is one self-contained container image with the frontend and the example workflows baked in: Docker Compose for your own box, or the deploy tooling for SSH, RunPod, GCP and Supabase. Your keys, your files, providers billed directly.",
   },
 ];
 
@@ -62,7 +62,7 @@ export default function DeveloperPlatformSection() {
             transition={{ duration: 0.25 }}
             className="inline-flex items-center gap-2 rounded-full bg-slate-500/10 px-4 py-1.5 text-sm font-medium text-slate-300 ring-1 ring-inset ring-slate-500/20 mb-4"
           >
-            Around the sandbox
+            Extend and deploy
           </motion.span>
           <motion.h2
             id="platform-title"
@@ -72,7 +72,7 @@ export default function DeveloperPlatformSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
-            The rest of the runtime
+            The rest of the runtime is yours too
           </motion.h2>
           <motion.p
             initial={false}
@@ -81,9 +81,9 @@ export default function DeveloperPlatformSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 max-w-3xl mx-auto"
           >
-            Sandboxed code is where you spend most of your time. Below it sits
+            Sandboxed code is where you spend most of your time. Under it sits
             an actor-model kernel, a node SDK, an HTTP and WebSocket API, and a
-            container you can run on your own boxes.
+            container image you can run on your own hardware.
           </motion.p>
         </div>
 
@@ -130,8 +130,8 @@ export default function DeveloperPlatformSection() {
             <p className="mt-4 text-sm text-slate-400">
               The <span className="font-mono text-slate-300">@nodetool-ai</span>{" "}
               packages are not on npm yet, so host-side imports resolve from a
-              source checkout. The sandbox specifiers on this page are a
-              different thing: they resolve inside the guest, and every pack
+              source checkout. The sandbox specifiers elsewhere on this page are
+              a different thing — they resolve inside the guest, and every pack
               listed above ships with the app.
             </p>
           </motion.div>

--- a/marketing/src/components/developers/DevelopersHero.tsx
+++ b/marketing/src/components/developers/DevelopersHero.tsx
@@ -1,14 +1,24 @@
 "use client";
 import React from "react";
 import { motion } from "framer-motion";
-import { Boxes, Cpu, Lock, Terminal, Workflow } from "lucide-react";
+import { Boxes, Cpu, Globe, Workflow } from "lucide-react";
 
-const pills = [
-  { icon: Cpu, text: "QuickJS-ng WASM guest" },
-  { icon: Boxes, text: "38 sandbox packs" },
-  { icon: Workflow, text: "424 nodes as callables" },
-  { icon: Terminal, text: "208 platform tools" },
-  { icon: Lock, text: "Capability-scoped per run" },
+const claims = [
+  {
+    icon: Globe,
+    title: "Capabilities are globals",
+    body: "Host-granted permissions — fetch, workspace, secrets, media — are injected as globals for that run.",
+  },
+  {
+    icon: Boxes,
+    title: "Libraries are imports",
+    body: "38 built-in utility packs, reached with a standard ES import. No library global, no second route.",
+  },
+  {
+    icon: Workflow,
+    title: "Nodes are functions",
+    body: "Call any of 424 AI nodes as a standard async function. await is the edge, a variable is the wire.",
+  },
 ];
 
 export default function DevelopersHero() {
@@ -34,7 +44,7 @@ export default function DevelopersHero() {
           transition={{ duration: 0.25, delay: 0.05 }}
           className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight"
         >
-          <span className="text-white">The sandbox is the API. </span>
+          <span className="text-white">One execution environment. </span>
           <span className="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 via-purple-400 to-teal-400">
             Write it, or let an agent write it.
           </span>
@@ -46,31 +56,30 @@ export default function DevelopersHero() {
           transition={{ duration: 0.25, delay: 0.05 }}
           className="mt-6 text-lg sm:text-xl text-slate-300 max-w-2xl mx-auto leading-relaxed"
         >
-          Every piece of JavaScript NodeTool did not write itself runs in one
-          QuickJS WebAssembly isolate: a Code node body, a saved script, and
-          every action an agent takes. Same engine, same limits, same imports.
-          Capabilities are globals the host granted for that run. Libraries are
-          imports. And 424 AI nodes are async functions you can{" "}
-          <code className="rounded bg-slate-800/80 px-1.5 py-0.5 font-mono text-base text-teal-300">
-            await
-          </code>
-          .
+          Write a custom Code node, save a reusable script, or let an agent
+          generate the logic. It all runs in the same QuickJS WebAssembly
+          isolate — same engine, same limits, same imports.
         </motion.p>
 
         <motion.div
           initial={false}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.25, delay: 0.08 }}
-          className="mt-8 flex flex-wrap justify-center gap-3"
+          className="mt-10 grid gap-4 sm:grid-cols-3 text-left"
         >
-          {pills.map((item) => (
-            <span
-              key={item.text}
-              className="inline-flex items-center gap-2 rounded-lg bg-slate-800/60 px-4 py-2 text-sm text-slate-300 ring-1 ring-slate-700/50"
+          {claims.map((claim) => (
+            <div
+              key={claim.title}
+              className="rounded-2xl bg-slate-800/40 p-5 ring-1 ring-slate-700/50"
             >
-              <item.icon className="h-4 w-4 text-violet-400" />
-              {item.text}
-            </span>
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-violet-500/10 ring-1 ring-violet-500/20">
+                <claim.icon className="h-4 w-4 text-violet-400" />
+              </div>
+              <p className="mt-3 text-base font-semibold text-white">
+                {claim.title}
+              </p>
+              <p className="mt-1.5 text-sm text-slate-400">{claim.body}</p>
+            </div>
           ))}
         </motion.div>
 

--- a/marketing/src/components/developers/SandboxAuthoringSection.tsx
+++ b/marketing/src/components/developers/SandboxAuthoringSection.tsx
@@ -34,21 +34,21 @@ nodetool debug my-workflow.json --watch`;
 const cards = [
   {
     icon: CheckCircle2,
-    title: "One analysis, every caller",
+    title: "Sub-second static analysis",
     body:
-      "The AST that reports an unresolvable import, a bare read of a node input, or a declared output nothing writes lives in one package. The CLI validator, the authoring planner and the editor all read it, so a body cannot pass in one surface and fail in another.",
-  },
-  {
-    icon: GitCompare,
-    title: "--watch prints the diff, not the report",
-    body:
-      "Re-run on every save and see only what moved: verdict transitions, issues that appeared and resolved, token and cost movement. The edit-verify loop reads as a changelog instead of a fresh wall of output.",
+      "jsscript validate runs an AST check: unresolvable imports, undefined names, a bare read of a node input, a declared output nothing writes. Milliseconds, before you pay for a run. One implementation serves the CLI, the authoring planner and the editor, so a body cannot pass in one surface and fail in another.",
   },
   {
     icon: Recycle,
-    title: "Scripts compose, bounded",
+    title: "Headless testing",
     body:
-      "A script runs inside its own envelope — its declared secrets intersected with the caller's allowance, its own timeout, its own imports. Composition is capped at depth 4 with a script-id chain, so a cycle fails the call naming it.",
+      "jsscript test runs the document's own saved cases and exits non-zero on any failure. No browser, no database — a file target is enough, which is what makes it usable from a pre-commit hook or CI.",
+  },
+  {
+    icon: GitCompare,
+    title: "Diff-based watch mode",
+    body:
+      "debug --watch does not spam the terminal. On save it prints only what moved: verdict transitions, issues that appeared and resolved, token and cost movement. The edit-verify loop reads as a changelog.",
   },
 ];
 
@@ -65,7 +65,7 @@ export default function SandboxAuthoringSection() {
             className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-4 py-1.5 text-sm font-medium text-emerald-300 ring-1 ring-inset ring-emerald-500/20 mb-4"
           >
             <Terminal className="h-4 w-4" />
-            The author loop
+            The developer loop
           </motion.span>
           <motion.h2
             id="authoring-title"
@@ -75,7 +75,7 @@ export default function SandboxAuthoringSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
-            Validate, run, test — headless, from a file
+            You don&apos;t need a browser to build
           </motion.h2>
           <motion.p
             initial={false}
@@ -84,8 +84,8 @@ export default function SandboxAuthoringSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 max-w-3xl mx-auto"
           >
-            Every surface is drivable without a browser, and a file target needs
-            no database. The same three verbs an agent reaches as{" "}
+            Everything is drivable from the CLI, and a file target needs no
+            database. The three verbs an agent reaches as{" "}
             <span className="font-mono text-slate-300">validate_code</span>,{" "}
             <span className="font-mono text-slate-300">run_code</span> and{" "}
             <span className="font-mono text-slate-300">test_code</span> are the
@@ -104,11 +104,10 @@ export default function SandboxAuthoringSection() {
             <h3 className="text-lg font-semibold text-white mb-4">The script</h3>
             <CodeBlock code={scriptBody} language="typescript" />
             <p className="mt-4 text-sm text-slate-400">
-              A body that mentions{" "}
-              <code className="font-mono text-teal-300">stream</code> runs once
-              for the whole stream and pulls its own items. Time parked on a
-              take is clock-suspended, so a slow upstream cannot kill a correct
-              consumer.
+              Scripts compose inside their own envelope: declared secrets
+              intersected with the caller&apos;s allowance, own timeout, own
+              imports. Depth is capped at 4 with a script-id chain, so a cycle
+              fails the call and names it.
             </p>
           </motion.div>
 
@@ -122,8 +121,8 @@ export default function SandboxAuthoringSection() {
             <h3 className="text-lg font-semibold text-white mb-4">The loop</h3>
             <CodeBlock code={loopCommands} language="bash" />
             <p className="mt-4 text-sm text-slate-400">
-              Static checks return in well under a second, which is what makes
-              them the pre-flight rather than an afterthought.
+              Static checks return in well under a second. That is what makes
+              them a pre-flight instead of an afterthought.
             </p>
           </motion.div>
         </div>

--- a/marketing/src/components/developers/SandboxDslSection.tsx
+++ b/marketing/src/components/developers/SandboxDslSection.tsx
@@ -59,9 +59,9 @@ const tabs = [
     pack: "@nodetool-ai/sandbox-flow",
     icon: Workflow,
     accent: "text-teal-300",
-    headline: "await is the edge. A variable is the wire.",
+    headline: "Use this when you just want the data.",
     blurb:
-      "424 node types across 68 namespace modules, each a generated async function whose name and inputs come from the node's own metadata. The call resolves the node from the registry, injects secrets, runs process(), and returns the outputs record — the same execution the kernel performs, minus the actor.",
+      "Functions are direct, awaitable API calls. You handle concurrency with Promise.all and branching with if/else. Nothing is scheduled: the call resolves the node from the registry, injects secrets, runs process(), and returns the outputs — the same execution the kernel performs, minus the actor.",
     code: flowCode,
     stats: [
       ["424", "node callables"],
@@ -69,8 +69,8 @@ const tabs = [
       ["0", "graphs built"],
     ],
     notes: [
-      "if, for, try and retry are themselves. The pack ships no control-flow combinators.",
-      "Nothing is saved or scheduled. The call runs the node and resolves to its outputs.",
+      "if, for and try are themselves. The pack ships no control-flow combinators.",
+      "Each callable is generated from the node's own metadata, so its inputs are the node's inputs.",
       "Recursion is capped at depth 4, with 16 concurrently open streams per run.",
     ],
   },
@@ -80,9 +80,9 @@ const tabs = [
     pack: "@nodetool-ai/sandbox-dsl",
     icon: GitBranch,
     accent: "text-violet-300",
-    headline: "When the graph itself is the deliverable.",
+    headline: "Use this when you want an artifact.",
     blurb:
-      "441 builders across 70 namespace modules, generated from the same registry metadata as the visual catalog. A node function returns a reference; assign a handle to an input and the edge is wired for you. The result is kernel-shaped { nodes, edges } you hand straight to validate or create.",
+      "Nothing executes. Each call builds up a workflow graph instead — assign a handle to an input and the edge is wired for you. What you get back is kernel-shaped { nodes, edges }: validate it, run it on a server, or open it in the visual editor.",
     code: dslCode,
     stats: [
       ["441", "node builders"],
@@ -90,9 +90,9 @@ const tabs = [
       ["1", "graph per workflow() call"],
     ],
     notes: [
-      "A node type this pack does not export has no import to resolve, so a hallucinated type fails before the program runs.",
-      "A handle is not text: interpolating one throws rather than writing [object Object] into a property and wiring no edge.",
-      "Pure computation. No model is called, no asset resolves, no node executes.",
+      "The builders come from the same registry metadata the visual canvas draws from.",
+      "A node type the pack does not export has no import to resolve, so a hallucinated type fails before the program runs.",
+      "A handle is not text: interpolating one throws, rather than writing [object Object] into a property and wiring no edge.",
     ],
   },
 ] as const;
@@ -113,7 +113,7 @@ export default function SandboxDslSection() {
             className="inline-flex items-center gap-2 rounded-full bg-teal-500/10 px-4 py-1.5 text-sm font-medium text-teal-300 ring-1 ring-inset ring-teal-500/20 mb-4"
           >
             <Workflow className="h-4 w-4" />
-            The DSL inside the sandbox
+            Flow vs. DSL
           </motion.span>
           <motion.h2
             id="dsl-title"
@@ -123,7 +123,7 @@ export default function SandboxDslSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
-            Every node NodeTool ships, as an import
+            Pick your paradigm
           </motion.h2>
           <motion.p
             initial={false}
@@ -132,10 +132,9 @@ export default function SandboxDslSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 max-w-3xl mx-auto"
           >
-            Two packs, one codegen pass, the same node catalog the canvas draws
-            from. One runs a node and hands you the values. The other builds the
-            graph and hands you something you can open in the editor. Pick by
-            what you want at the end.
+            Every node NodeTool ships is available as an import. We expose them
+            two ways, and which one you want depends on what you need at the
+            end: the values, or the graph that produced them.
           </motion.p>
         </div>
 
@@ -216,13 +215,13 @@ export default function SandboxDslSection() {
           transition={{ duration: 0.25 }}
           className="mt-10 rounded-2xl bg-slate-800/40 p-6 sm:p-8 ring-1 ring-slate-700/50"
         >
-          <h3 className="text-lg font-semibold text-white">Which one, and why not the kernel</h3>
+          <h3 className="text-lg font-semibold text-white">Which one to reach for</h3>
           <div className="mt-5 grid gap-5 md:grid-cols-3">
             <div>
               <p className="font-mono text-sm text-teal-300">sandbox-flow</p>
               <p className="mt-2 text-sm text-slate-400">
                 You want values. Branching, retries and concurrency are plain
-                JavaScript, and each call still opens a{" "}
+                JavaScript, and every call still opens a{" "}
                 <span className="font-mono text-slate-300">node.process</span>{" "}
                 span and bills through the run&apos;s own context.
               </p>
@@ -230,17 +229,17 @@ export default function SandboxDslSection() {
             <div>
               <p className="font-mono text-sm text-violet-300">sandbox-dsl</p>
               <p className="mt-2 text-sm text-slate-400">
-                You want an artifact — something to open in the editor, validate,
-                supervise, or hand to the server. The graph is data until
-                something checks it, so validate before you save.
+                You want an artifact — something to open in the editor,
+                validate, supervise, or hand to the server. The graph is just
+                data until something checks it, so validate before you save.
               </p>
             </div>
             <div>
               <p className="font-mono text-sm text-slate-300">WorkflowRunner</p>
               <p className="mt-2 text-sm text-slate-400">
-                An actor per node, correlated lineage, end-of-stream propagation.
-                Right for the editor and for supervised runs, and overhead when
-                the caller is code that just wants a value.
+                An actor per node, correlated lineage, end-of-stream
+                propagation. Right for the editor and for supervised runs, pure
+                overhead when the caller is code that just wants a value.
               </p>
             </div>
           </div>

--- a/marketing/src/components/developers/SandboxGrantSection.tsx
+++ b/marketing/src/components/developers/SandboxGrantSection.tsx
@@ -15,7 +15,7 @@ const limits: Array<[string, string, string]> = [
   ["Redirect hops", "5", "re-checked at every hop"],
   ["Output size", "100 KB", "10 MB"],
   ["Media handles", "256 MB per run", "total encoded payload"],
-  ["Tool calls per action", "50", "bounds a runaway loop"],
+  ["Tool calls per action", "50", "stops a runaway loop"],
 ];
 
 const guarantees = [
@@ -23,31 +23,31 @@ const guarantees = [
     icon: ShieldCheck,
     title: "No dynamic code generation",
     body:
-      "eval and Function are deleted before any user code evaluates, and dynamic import() is denied outright. Enforcement sits in the module normalizer rather than the loader, because QuickJS serves a cached module without consulting the loader.",
+      "No eval, no Function constructor, and dynamic import() is blocked outright. Enforcement sits in the module normalizer, not the loader — QuickJS serves a cached module without ever consulting the loader.",
   },
   {
     icon: KeyRound,
-    title: "Secrets are scoped, and never written",
+    title: "Scoped secrets, and no setter",
     body:
-      "A run declares the names it needs and the bridge refuses every other one, so a node that talks to one service cannot read another's credentials. There is no setter: request_secret takes a name and a reason, the user types the key in their own client, and the value never enters the guest, the websocket frame, or the model's context.",
+      "A script declares the secrets it needs up front and the bridge refuses every other name, so a node that talks to one service cannot read another's credentials. Writing one goes through the user's own client: request_secret takes a name and a reason, never a value. The credential never enters the guest, the websocket frame, or an LLM context.",
   },
   {
     icon: Network,
-    title: "SSRF guard, per hop",
+    title: "SSRF guard, on every hop",
     body:
-      "fetch refuses loopback, link-local and private ranges, including IPv6 forms and IPv4-mapped addresses, and re-checks on every redirect. The switch that lifts it is host-set only, so guest code cannot enable it for itself.",
+      "The built-in fetch blocks loopback, link-local and private ranges, including IPv6 forms and IPv4-mapped addresses, and validates every single redirect hop. The switch that lifts it is host-set only, so guest code cannot enable it for itself.",
   },
   {
     icon: Radar,
-    title: "Workspace containment",
+    title: "Strict workspace containment",
     body:
-      "Every workspace call resolves inside the run's root and re-checks the symlink-resolved real path immediately before the operation. Widening it to the host filesystem is a host-set switch that defaults off.",
+      "workspace.read, write and the rest are jailed to the run's root directory, with symlinks resolved and the real path re-checked immediately before every operation. Widening it to the host filesystem is a host-set switch that defaults off.",
   },
   {
     icon: Timer,
-    title: "Cancellation, and a clock that suspends",
+    title: "Hard abort, suspendable clock",
     body:
-      "Once the abort signal fires, every subsequent bridge call fails fast and the guest unwinds. Time parked waiting on a person's approval is added back, so a prompt nobody answers does not kill the program that asked.",
+      "Once the abort signal fires, every bridge call after it fails fast and the guest unwinds. Time parked waiting on a human approval is credited back, so a prompt nobody answers does not kill the program that asked.",
   },
 ];
 
@@ -64,7 +64,7 @@ export default function SandboxGrantSection() {
             className="inline-flex items-center gap-2 rounded-full bg-sky-500/10 px-4 py-1.5 text-sm font-medium text-sky-300 ring-1 ring-inset ring-sky-500/20 mb-4"
           >
             <ShieldCheck className="h-4 w-4" />
-            The grant
+            Security and limits
           </motion.span>
           <motion.h2
             id="limits-title"
@@ -74,7 +74,7 @@ export default function SandboxGrantSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
-            Every limit is a number with a ceiling
+            Locked down by default
           </motion.h2>
           <motion.p
             initial={false}
@@ -83,10 +83,10 @@ export default function SandboxGrantSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 max-w-3xl mx-auto"
           >
-            A caller can tighten any limit, or raise it within bounds. No caller
-            can switch a protection off, and nothing inside the guest can raise
-            its own. These are the defaults a Code node and an agent action both
-            start from.
+            Hard ceilings: 64 MB guest heap, 30 s of CPU, a 512 KB call stack.
+            A caller can tighten any limit or raise it within bounds. Nobody can
+            switch a protection off, and nothing inside the guest can raise its
+            own. A Code node and an agent action start from the same numbers.
           </motion.p>
         </div>
 

--- a/marketing/src/components/developers/SandboxPacksSection.tsx
+++ b/marketing/src/components/developers/SandboxPacksSection.tsx
@@ -42,21 +42,21 @@ const hostPacks = [
 const rules = [
   {
     icon: Package,
-    title: "A pack is two declarative files",
+    title: "A pack is two config files",
     body:
-      "A package.json manifest and a SKILL.md. No shipped pack authors a line of code — the compiler bundles the npm dependency into the guest, cached by content digest, never by version.",
+      "A package.json manifest and a SKILL.md. No shipped pack writes a line of code — the compiler bundles the npm dependency into the guest and caches it by content digest, never by version.",
   },
   {
     icon: ServerCog,
     title: "Host-side when the guest cannot hold it",
     body:
-      "zip runs on the host because a 50 MB inflation cap enforced inside the guest is enforced by code the guest can decline to call. tfjs, because model weights outlive a run and outsize the 64 MB heap.",
+      "zip runs on the host because an inflation cap enforced inside the guest is enforced by code the guest can decline to call. tfjs runs there because model weights outlive a run and outsize the 64 MB heap.",
   },
   {
     icon: ShieldAlert,
     title: "A pack cannot bring host code",
     body:
-      "kind: \"host\" carries an id, never an implementation, and the id resolves only if a first-party table pins that exact package to it. The per-run dispatcher re-checks on every call.",
+      "kind: \"host\" carries an id, never an implementation, and that id resolves only if a first-party table pins the exact package to it. The per-run dispatcher re-checks on every call.",
   },
 ];
 
@@ -83,7 +83,7 @@ export default function SandboxPacksSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
-            38 libraries, available out of the box
+            38 built-in sandbox packs
           </motion.h2>
           <motion.p
             initial={false}
@@ -92,10 +92,10 @@ export default function SandboxPacksSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 max-w-3xl mx-auto"
           >
-            There is no library global and no second route. A body declares what
-            it needs by importing it, and the packs those imports name are
-            resolved against the installed catalog before the guest starts — so
-            an import nobody serves fails the node, not the run.
+            Bodies declare what they need by importing it. Every import is
+            resolved against the installed catalog before the guest starts, so
+            importing something we do not serve fails the node immediately —
+            not halfway through a run you already paid for.
           </motion.p>
         </div>
 
@@ -119,10 +119,11 @@ export default function SandboxPacksSection() {
           >
             <div className="rounded-2xl bg-slate-800/40 p-6 ring-1 ring-slate-700/50">
               <h3 className="text-sm font-semibold text-teal-300">
-                Compiled into the guest
+                Guest-compiled
               </h3>
               <p className="mt-1 text-xs text-slate-500">
-                esbuild bundle, scope-aware scan, QuickJS admission probe
+                Lightweight libraries bundled straight into the isolate by
+                esbuild, then scanned and probed before admission
               </p>
               <div className="mt-4 flex flex-wrap gap-2">
                 {guestPacks.map((p) => (
@@ -137,11 +138,11 @@ export default function SandboxPacksSection() {
             </div>
             <div className="rounded-2xl bg-slate-800/40 p-6 ring-1 ring-slate-700/50">
               <h3 className="text-sm font-semibold text-violet-300">
-                Run on the host, reached through a generated facade
+                Host-bridged
               </h3>
               <p className="mt-1 text-xs text-slate-500">
-                Needs Node builtins, a DOM, or a limit the guest could not
-                enforce on itself
+                Heavy workloads, Node builtins, a DOM, or a limit the guest
+                could not enforce on itself — reached through a generated facade
               </p>
               <div className="mt-4 flex flex-wrap gap-2">
                 {hostPacks.map((p) => (

--- a/marketing/src/components/developers/SandboxSection.tsx
+++ b/marketing/src/components/developers/SandboxSection.tsx
@@ -23,44 +23,44 @@ const capabilities = [
     icon: Globe,
     name: "fetch",
     detail:
-      "HTTP with the SSRF guard in front of it. 20 calls, 1 MB bodies, 15 s each, redirects re-checked hop by hop.",
+      "HTTP with the SSRF guard in front of it. 20 calls, 1 MB bodies, 15 s each, every redirect re-checked.",
   },
   {
     icon: HardDrive,
     name: "workspace",
     detail:
-      "read, write, list, stat, copy, move, mkdir, remove — resolved inside the run's workspace root, symlinks realpathed before every call.",
+      "read, write, list, stat, copy, move, mkdir, remove. Jailed to the run's workspace root, symlinks resolved before every call.",
   },
   {
     icon: KeyRound,
     name: "nodetool.secrets",
     detail:
-      "get, tryGet, list, narrowed to the names the node declared. There is no setter anywhere in the guest.",
+      "get, tryGet, list — narrowed to the names the node declared. There is no setter anywhere in the guest.",
   },
   {
     icon: ImageIcon,
     name: "image / audio / video",
     detail:
-      "Decode, trim, resize, mix, composite. Transforms return handles, so encoded payloads stay on the host while calls chain.",
+      "Decode, trim, resize, mix, composite. Transforms return handles, so the bytes stay on the host while you chain calls.",
   },
   {
     icon: Radio,
     name: "emit / output / stream",
     detail:
-      "The node's IO contract. emit streams a value now under backpressure, output records a final, stream() pulls connected handles as they arrive.",
+      "The node's IO contract. emit streams a value now under backpressure, output records a final, stream() pulls items as they arrive.",
   },
   {
     icon: Cpu,
     name: "media / canvas / crypto / format",
     detail:
-      "Resolve a ref to bytes, draw a 2D surface replayed on a real host context, hash with WebCrypto, format with the host's Intl.",
+      "Resolve a ref to bytes, draw on a 2D surface replayed on a real host context, hash with WebCrypto, format with the host's Intl.",
   },
 ];
 
 const deleted = [
   ["eval and Function", "Deleted before a single line of user code evaluates."],
-  ["setTimeout and friends", "Their callbacks would fire outside the never-reject convention. sleep(ms) is the only timer."],
-  ["Ambient modules", "A body that imports nothing gets no loader at all. Dynamic import() is always denied."],
+  ["setTimeout and friends", "Their callbacks would fire outside the run's error contract. sleep(ms) is the only timer."],
+  ["Ambient modules", "A body that imports nothing gets no loader at all. Dynamic import() is denied outright."],
   ["Buffer, process, env", "The Node-compat preamble never installs them, and the prelude deletes them anyway."],
 ];
 
@@ -87,7 +87,7 @@ export default function SandboxSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="text-3xl sm:text-4xl font-bold text-white"
           >
-            Capabilities are globals. Libraries are imports.
+            A stripped-down guest, and what the host hands it
           </motion.h2>
           <motion.p
             initial={false}
@@ -96,9 +96,10 @@ export default function SandboxSection() {
             transition={{ duration: 0.25, delay: 0.05 }}
             className="mt-4 text-lg text-slate-400 max-w-3xl mx-auto"
           >
-            The guest starts with less than plain QuickJS. Everything past that
-            is a bridge the host built for this run, bound to its limits and its
-            abort signal. Nothing in the guest can widen a grant it was given.
+            Your code starts with less than plain QuickJS. Everything past that
+            is a bridge the host built for this specific run, bound to its
+            limits and its abort signal. Nothing in the guest can widen a grant
+            it was given.
           </motion.p>
         </div>
 
@@ -117,10 +118,10 @@ export default function SandboxSection() {
             </p>
             <CodeBlock code={codeNodeBody} language="typescript" />
             <p className="mt-4 text-sm text-slate-400">
-              <span className="text-slate-200 font-medium">The body decides the mode.</span>{" "}
+              <span className="text-slate-200 font-medium">The body picks the mode.</span>{" "}
               Mention <code className="font-mono text-teal-300">stream(name)</code> and it runs
-              once for the whole stream and pulls its own items. Never mention
-              it and it runs once per incoming item. Nothing is configured.
+              once for the whole stream, pulling its own items. Leave it out and
+              it runs once per incoming item. There is nothing to configure.
             </p>
           </motion.div>
 


### PR DESCRIPTION
## What changed

The sandbox page said the right things in the wrong register: long sentences that stacked three ideas each, and headings that named a concept ("The grant", "Anatomy of a run") rather than the claim. This rewrites the copy across all eight `/developers` sections so each one leads with what it does for the reader — same facts, same numbers, same code blocks, shorter sentences. The hero drops from a five-clause paragraph to two sentences plus three cards (capabilities are globals / libraries are imports / nodes are functions); "38 libraries, available out of the box" becomes "38 built-in sandbox packs" with the two lists relabelled guest-compiled and host-bridged; the DSL tabs are headed by when to use them ("just want the data" / "want an artifact") instead of by a slogan; CodeAct opens on the round trip per call it removes; the limits section leads with the hard ceilings; the author loop becomes "You don't need a browser to build" with three cards keyed to the three commands; the closing section becomes "Extend and deploy". Two factual corrections fell out of the rewrite: the 50-per-action cap is on tool calls, not loop iterations, and `nodetool mcp install` wires up a CLI agent while Claude Desktop takes the `.mcpb` bundle.

## Verification

`marketing/` is not a root npm workspace, so the root `typecheck`/`lint`/`test:affected` scripts do not reach it. Ran its own equivalents from `marketing/`:

- `npx tsc --noEmit -p tsconfig.json` — clean, no diagnostics
- `npx next lint --dir src/components/developers --dir src/app/developers` — `✔ No ESLint warnings or errors`
- `npx next build` — succeeded; `/developers` prerendered, and the rendered HTML was read back to proofread every line of copy
- Parse-checked all eight components with esbuild, and confirmed that check rejects deliberately broken TSX rather than passing everything

- [x] `npm run typecheck` (marketing-local equivalent, see above)
- [x] `npm run lint` (marketing-local equivalent, see above)
- [ ] `npm run test:affected` — no test targets this tree; `marketing/` has no unit suite and the diff is copy-only
- [ ] `npm run dev:nodetool -- harness gate --base main` — no surface in the harness registry covers `marketing/`

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJ2Ai8aP4Kdd9DEHs2P5qw)_