### PR TITLE
fix(agents): repair four defects one agent session hit

### DIFF
--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -652,7 +652,21 @@ and specifier shape live in `@nodetool-ai/protocol`
 declare one. `createCapabilityDispatcher` validates module key, export name and
 argument list on every call, then delegates to `invoke` — it never gates on its
 own, so the import path and the belt bridge reach one implementation past one
-gate. The flat `tools.<name>()` global is gone: every capability is an import,
+gate.
+
+`coerceCapabilityArgs` (`capabilities/args.ts`) is the argument half of that
+check, and it both folds and refuses. It folds camelCase onto snake_case, a
+lone string onto the first required string field, and a bare `id` onto the one
+required `*_id` key — only when there is exactly one, so nothing is guessed.
+Then it refuses a call that brought arguments but not the required ones,
+naming the call, the missing keys and what was passed instead. Before that,
+`get_workflow({ id })` reached the implementation as `workflow_id: undefined`
+and answered **"Workflow undefined was not found"** — a report about a missing
+workflow for what was a misspelled argument, and one an agent read as a broken
+database. It cost six calls and three wrong theories in one session. A call
+with *no* arguments is still passed through: `{}` is the documented shape for
+the capabilities that require nothing, and for the rest the implementation's own
+"x is required" already names the field. The flat `tools.<name>()` global is gone: every capability is an import,
 and what a session added at its own call site is grafted onto `.../session`
 (client `ui_*` tools onto `.../ui`) so one import shape covers everything. The
 `nodetool` object model stays a global.
@@ -739,6 +753,18 @@ injection through `getAllMcpTools(options)`:
 
 The server builds all three in `packages/websocket/src/mcp-tool-deps.ts` and
 spreads `mcpToolHostDeps()` into every `getAllMcpTools` call site.
+
+A fourth, `providers`, adds `find_model` and `list_models` — and only those.
+They enumerate the injected map, so without one they can say nothing but "no
+providers configured". The media tools (`generate_image`, `generate_speech`, …)
+used to be added beside them and are built-ins now: each reaches a provider
+through `context.runProviderPrediction` and reads nothing off the run, so the
+map was never their dependency. Gating them on it meant a host that injects
+none — a Code node, a JS script — got a belt that could `critique_image` and
+`score_image_adherence` but had no way to make an image, and
+`nodetool.media.generateImage` threw `tool "generate_image" is not in this
+toolbelt` after the run had paid for the prompt that produced its argument.
+Pinned by `tests/sandbox-belt-reach.test.ts`.
 
 ## Script Voicing Tools (`src/tools/script-voice-tools.ts`)
 

--- a/packages/agents/src/capabilities/args.ts
+++ b/packages/agents/src/capabilities/args.ts
@@ -2,9 +2,17 @@
  * Guest and model calls miss the documented argument shape in a few
  * predictable ways: camelCase keys where the schema is snake_case, a lone
  * string where the first required field is a string, a name plus an options
- * object. Fold those here so every entrance (import, belt, MCP) agrees.
+ * object, `id` where the schema says `workflow_id`. Fold those here so every
+ * entrance (import, belt, MCP) agrees.
  *
  * Nested records are left alone — Apify actor input keeps its own names.
+ *
+ * What is left over after folding is checked rather than passed on. A call
+ * that supplied arguments but not the required ones used to reach the
+ * implementation with the key `undefined`, and the implementation then reported
+ * on the *entity*: `get_workflow({ id })` came back "Workflow undefined was not
+ * found", which reads as a missing workflow and is really a misspelled
+ * argument. The report belongs to the call.
  */
 
 import type { JsonSchema } from "@nodetool-ai/runtime";
@@ -41,6 +49,10 @@ export function withSnakeCaseAliases(
  * A leading string fills the first required string field when that field is
  * missing from a following options object — `save_asset("reel.mp4", {source})`
  * and `get_apify_actor_schema("owner/name")`.
+ *
+ * Throws when the folded record is still missing a required field, naming the
+ * call rather than letting the implementation report on an entity it looked up
+ * under `undefined`.
  */
 export function coerceCapabilityArgs(
   spec: CapabilityArgSpec,
@@ -51,7 +63,7 @@ export function coerceCapabilityArgs(
     return {};
   }
   if (isRecord(first) && args.length === 1) {
-    return withSnakeCaseAliases(first);
+    return checked(spec, withIdAlias(spec, withSnakeCaseAliases(first)));
   }
   if (isString(first)) {
     const key = firstRequiredStringKey(spec.inputSchema);
@@ -60,14 +72,98 @@ export function coerceCapabilityArgs(
     }
     const extra = extraRecord(args[1], spec, args.length);
     if (key in extra) {
-      return withSnakeCaseAliases(extra);
+      return checked(spec, withSnakeCaseAliases(extra));
     }
-    return withSnakeCaseAliases({ ...extra, [key]: first });
+    return checked(spec, withSnakeCaseAliases({ ...extra, [key]: first }));
   }
   if (isRecord(first) && args.length === 2 && isRecord(args[1])) {
-    return withSnakeCaseAliases({ ...first, ...args[1] });
+    return checked(
+      spec,
+      withIdAlias(spec, withSnakeCaseAliases({ ...first, ...args[1] }))
+    );
   }
   throw new Error(oneObjectMessage(spec));
+}
+
+/**
+ * Copy a bare `id` onto the one required `*_id` key when that key is absent.
+ *
+ * Only when there is exactly one such key, so nothing has to be guessed: a spec
+ * requiring both `workflow_id` and `job_id` gets no alias and the missing-key
+ * report below instead. `get_workflow`, `run_workflow`, `debug_workflow` and
+ * every other single-subject capability are what this covers, and `id` is what
+ * a caller reaches for after `create_workflow` answered with a record whose own
+ * field is `id`.
+ */
+function withIdAlias(
+  spec: CapabilityArgSpec,
+  args: Record<string, unknown>
+): Record<string, unknown> {
+  const id = args["id"];
+  if (id === undefined || id === null) return args;
+  const [key, ...rest] = requiredKeys(spec.inputSchema).filter((name) =>
+    name.endsWith("_id")
+  );
+  if (key === undefined || rest.length > 0) return args;
+  if (args[key] !== undefined && args[key] !== null) return args;
+  return { ...args, [key]: id };
+}
+
+/**
+ * The required keys a record does not carry. `null` counts as missing: it is
+ * what a guest reaching for an absent field passes, and `String(null)` reaching
+ * a lookup is the same wrong answer `undefined` gives.
+ */
+function missingRequiredArgs(
+  spec: CapabilityArgSpec,
+  args: Record<string, unknown>
+): string[] {
+  return requiredKeys(spec.inputSchema).filter(
+    (key) => args[key] === undefined || args[key] === null
+  );
+}
+
+/**
+ * Name the call, the keys it is missing, and — when it passed something — what
+ * it passed instead, which is usually the whole diagnosis.
+ */
+function missingArgsMessage(
+  spec: CapabilityArgSpec,
+  missing: readonly string[],
+  args: Record<string, unknown>
+): string {
+  const plural = missing.length === 1 ? "argument" : "arguments";
+  const got = Object.keys(args);
+  const gotPart =
+    got.length > 0 ? ` Got: ${got.join(", ")}.` : " Got no arguments.";
+  return (
+    `${spec.name}: missing required ${plural} ${missing.join(", ")}.` + gotPart
+  );
+}
+
+/**
+ * Refuse a call that brought arguments but not the required ones. A call with
+ * no arguments at all is left alone: `{}` reaching the implementation is the
+ * documented shape for the several capabilities whose schema requires nothing,
+ * and for the rest the implementation's own "x is required" already names the
+ * field rather than an entity.
+ */
+function checked(
+  spec: CapabilityArgSpec,
+  args: Record<string, unknown>
+): Record<string, unknown> {
+  if (Object.keys(args).length === 0) return args;
+  const missing = missingRequiredArgs(spec, args);
+  if (missing.length > 0) {
+    throw new Error(missingArgsMessage(spec, missing, args));
+  }
+  return args;
+}
+
+function requiredKeys(schema: JsonSchema): string[] {
+  const required = schema.required;
+  if (!Array.isArray(required)) return [];
+  return required.filter((key): key is string => isString(key));
 }
 
 function extraRecord(
@@ -85,11 +181,8 @@ function extraRecord(
 }
 
 function firstRequiredStringKey(schema: JsonSchema): string | undefined {
-  const required = schema.required;
-  if (!Array.isArray(required)) return undefined;
   const properties = schema.properties;
-  for (const key of required) {
-    if (!isString(key)) continue;
+  for (const key of requiredKeys(schema)) {
     const field = isRecord(properties) ? properties[key] : undefined;
     if (isRecord(field) && field.type === "string") {
       return key;
@@ -99,10 +192,7 @@ function firstRequiredStringKey(schema: JsonSchema): string | undefined {
 }
 
 function oneObjectMessage(spec: CapabilityArgSpec): string {
-  const required = spec.inputSchema.required;
-  const keys = Array.isArray(required)
-    ? required.filter((key): key is string => isString(key))
-    : [];
+  const keys = requiredKeys(spec.inputSchema);
   const shape = keys.length > 0 ? ` ({ ${keys.join(", ")} })` : "";
   return `${spec.name} takes one arguments object${shape}`;
 }

--- a/packages/agents/src/capabilities/jobs.specs.ts
+++ b/packages/agents/src/capabilities/jobs.specs.ts
@@ -45,7 +45,11 @@ export const GET_JOB_LOGS_SCHEMA: JsonSchema = {
 
 export const listJobsSpec: CapabilitySpec = {
   name: "list_jobs",
-  description: "List jobs (workflow executions) with optional filtering.",
+  description:
+    "List jobs (workflow executions) with optional filtering. Each entry " +
+    "carries status, timing, error and the names of the outputs the run " +
+    "produced — not the outputs themselves. Use get_job to read a job's " +
+    "values.",
   inputSchema: LIST_JOBS_SCHEMA,
   category: "read",
   userMessage: (params) => {
@@ -57,7 +61,8 @@ export const listJobsSpec: CapabilitySpec = {
 export const getJobSpec: CapabilitySpec = {
   name: "get_job",
   description:
-    "Get details about a specific job including status, timing, and error info.",
+    "Get details about a specific job including status, timing, error info, " +
+    "and the outputs the run produced.",
   inputSchema: {
     type: "object",
     properties: {

--- a/packages/agents/src/capabilities/jobs.ts
+++ b/packages/agents/src/capabilities/jobs.ts
@@ -13,7 +13,11 @@
  */
 
 import type { JsonSchema } from "@nodetool-ai/runtime";
-import { jobRecord, userIdOf } from "../tools/mcp-tool-support.js";
+import {
+  jobRecord,
+  jobSummaryRecord,
+  userIdOf
+} from "../tools/mcp-tool-support.js";
 import type { CapabilityExport, CapabilityModule } from "./types.js";
 import {
   listJobsSpec,
@@ -45,7 +49,9 @@ const listJobs: CapabilityExport = {
       page.workflowId = workflowId;
     }
     const [jobs, next] = await Job.paginate(userIdOf(run.context), page);
-    return { jobs: jobs.map(jobRecord), next: next || null };
+    // Summaries, not full records: a listing reports which jobs exist and how
+    // they settled. `get_job` reads one job's outputs.
+    return { jobs: jobs.map(jobSummaryRecord), next: next || null };
   }
 };
 

--- a/packages/agents/src/capabilities/web.specs.ts
+++ b/packages/agents/src/capabilities/web.specs.ts
@@ -138,7 +138,10 @@ export const takeScreenshotSpec: CapabilitySpec = {
         default: "screenshot.png"
       }
     },
-    required: ["url", "output_file"]
+    // `output_file` carries a default and the implementation applies it, so
+    // requiring it said the opposite of what the schema next to it said —
+    // and told every model a screenshot needs a filename chosen for it.
+    required: ["url"]
   },
   category: "read",
   userMessage: (params) => {

--- a/packages/agents/src/capabilities/workflows.ts
+++ b/packages/agents/src/capabilities/workflows.ts
@@ -537,6 +537,16 @@ const debugWorkflow: CapabilityExport = {
       params: (params["params"] as Record<string, unknown>) ?? {},
       interactive: params["interactive"] === true
     });
+    // A run the service refused never started, so there is no report to nest.
+    // Nesting it under `run` put the failure where nothing looks: the caller
+    // reads a `{workflow_id, run}` record, and the sandbox dispatcher — which
+    // throws on a top-level `{error}` so a guest cannot compute with a
+    // failure — sees an ordinary object. A 404 came back as a value the guest
+    // logged as `Status: 404` and carried on from. `run_workflow` and
+    // `start_background_job` already return this at the top level.
+    if (outcome.kind !== "payload") {
+      return outcomeResult(outcome);
+    }
     const result = outcomeResult(outcome);
 
     // An escalated run has produced no report yet — the job is parked on the

--- a/packages/agents/src/tools/builtin-tools.ts
+++ b/packages/agents/src/tools/builtin-tools.ts
@@ -10,7 +10,10 @@
  * Capabilities that need something a run must carry (a node registry, a vector
  * collection, a provider map, an example catalog) are NOT listed here; the
  * subsystem that owns the dependency builds them — `getAllMcpTools`,
- * base-nodes, sandbox-tools.
+ * base-nodes, sandbox-tools. Reaching a provider at call time is not such a
+ * dependency: `runProviderPrediction` is on the context, so the media tools
+ * belong here even though `find_model` — which enumerates the injected
+ * provider map — does not.
  *
  * In particular the recursive-decomposition primitive (`run_subtask`) and the
  * read-only fan-out search primitive (`run_search`) are intentionally excluded:
@@ -139,6 +142,22 @@ export const BUILTIN_TOOL_NAMES: readonly string[] = [
 
   // Video understanding (a multimodal chat model reads a whole clip)
   "understand_video",
+
+  // Media generation. Each reaches a provider through
+  // `ProcessingContext.runProviderPrediction` and reads nothing off the run, so
+  // a context is the whole dependency — the same one `critique_image` above and
+  // `render_storyboard_stills` already run on. They used to be added only
+  // beside `find_model`/`list_models`, which do need the injected provider map,
+  // so a host that injected none — a Code node, a JS script — got a belt that
+  // could judge an image and score its adherence but had no way to make one.
+  "generate_image",
+  "edit_image",
+  "generate_video",
+  "animate_image",
+  "generate_speech",
+  "generate_music",
+  "transcribe_audio",
+  "embed_text",
 
   // Web
   "browser",

--- a/packages/agents/src/tools/mcp-tool-support.ts
+++ b/packages/agents/src/tools/mcp-tool-support.ts
@@ -99,8 +99,19 @@ export function workflowRecord(workflow: Workflow) {
   };
 }
 
-/** A job row as the tools report it — the same fields `/api/jobs` returns. */
-export function jobRecord(job: Job) {
+/**
+ * A job row without what the run produced — every field of {@link jobRecord}
+ * but `outputs`, plus the output names so a caller can see there is something
+ * to fetch. This is what a *listing* reports.
+ *
+ * A job's outputs are the whole answer of a workflow, and `list_jobs` defaults
+ * to a hundred of them. One agent listing carried 140 KB of beat sheets past a
+ * 25 KB tool-result cap — twice, to read a `status` field — and what was cut
+ * was the tail of the JSON, so nothing downstream could parse it either.
+ * `get_job` is where a value is read, one job at a time.
+ */
+export function jobSummaryRecord(job: Job) {
+  const outputs = job.runOutputs();
   return {
     id: job.id,
     user_id: job.user_id,
@@ -111,6 +122,16 @@ export function jobRecord(job: Job) {
     finished_at: job.finished_at ?? null,
     error: job.error_message ?? job.error ?? null,
     cost: job.cost ?? null,
+    // Names, not values: "this job produced `beat_sheet` and `keyframes`; call
+    // get_job to read them" is the sentence a listing can afford.
+    output_names: outputs === null ? null : Object.keys(outputs)
+  };
+}
+
+/** A job row as the tools report it — the same fields `/api/jobs` returns. */
+export function jobRecord(job: Job) {
+  return {
+    ...jobSummaryRecord(job),
     // What the run produced, once it settled. A completed job used to report
     // only that it had completed, so an agent that started a background run
     // had no way to read its result.

--- a/packages/agents/src/tools/mcp-tools.ts
+++ b/packages/agents/src/tools/mcp-tools.ts
@@ -278,23 +278,18 @@ export function getAllMcpTools(options: GetAllMcpToolsOptions = {}): Tool[] {
   if (options.providers && Object.keys(options.providers).length > 0) {
     // The providers map rides on the run and is read at call time, so a host
     // that fills it lazily still serves what it resolved after construction.
+    // Only the two catalog capabilities read it: `find_model` and `list_models`
+    // enumerate the map itself, so without one they can only answer "no
+    // providers configured". The media tools that used to be added here go
+    // through `context.runProviderPrediction` and read nothing off the run, so
+    // they are built-ins now (`BUILTIN_TOOL_NAMES`) and a host that injects no
+    // map still gets them.
     const providers = options.providers;
     const modelRun = (context: ProcessingContext): CapabilityRun =>
       createCapabilityRun({ context, gate: UNGATED, providers });
-    const mediaRun = (context: ProcessingContext): CapabilityRun =>
-      createCapabilityRun({ context, gate: UNGATED });
     tools.push(
       withRun("find_model", modelRun),
-      withRun("list_models", modelRun),
-      ...[
-        "generate_image",
-        "edit_image",
-        "generate_video",
-        "animate_image",
-        "generate_speech",
-        "transcribe_audio",
-        "embed_text"
-      ].map((name) => withRun(name, mediaRun))
+      withRun("list_models", modelRun)
     );
   }
 

--- a/packages/agents/tests/browser-tools.test.ts
+++ b/packages/agents/tests/browser-tools.test.ts
@@ -213,7 +213,12 @@ describe("ScreenshotTool", () => {
   it("has correct name and schema", () => {
     expect(tool.name).toBe("take_screenshot");
     expect((tool.inputSchema as any).required).toContain("url");
-    expect((tool.inputSchema as any).required).toContain("output_file");
+    // `output_file` carries a default and the implementation applies it, so
+    // it is optional. Requiring it said the opposite of the default beside it.
+    expect((tool.inputSchema as any).required).not.toContain("output_file");
+    expect((tool.inputSchema as any).properties.output_file.default).toBe(
+      "screenshot.png"
+    );
   });
 
   it("returns error when url is missing", async () => {

--- a/packages/agents/tests/capabilities-args.test.ts
+++ b/packages/agents/tests/capabilities-args.test.ts
@@ -28,6 +28,27 @@ const GET_SCHEMA = {
   } as JsonSchema
 };
 
+const GET_WORKFLOW = {
+  name: "get_workflow",
+  inputSchema: {
+    type: "object",
+    properties: { workflow_id: { type: "string" } },
+    required: ["workflow_id"]
+  } as JsonSchema
+};
+
+const TWO_IDS = {
+  name: "two_ids",
+  inputSchema: {
+    type: "object",
+    properties: {
+      workflow_id: { type: "string" },
+      job_id: { type: "string" }
+    },
+    required: ["workflow_id", "job_id"]
+  } as JsonSchema
+};
+
 describe("withSnakeCaseAliases", () => {
   it("copies actorId onto actor_id when actor_id is absent", () => {
     expect(withSnakeCaseAliases({ actorId: "apify/instagram-scraper" })).toEqual({
@@ -94,5 +115,99 @@ describe("coerceCapabilityArgs", () => {
     expect(() => coerceCapabilityArgs(SAVE_ASSET, [1])).toThrow(
       /save_asset takes one arguments object \(\{ name \}\)/
     );
+  });
+});
+
+describe("coerceCapabilityArgs argument checking", () => {
+  // `get_workflow({ id })` reached the implementation as `workflow_id:
+  // undefined` and came back "Workflow undefined was not found" — a report
+  // about a missing workflow for what was a misspelled argument.
+  it("copies a bare id onto the one required *_id key", () => {
+    expect(coerceCapabilityArgs(GET_WORKFLOW, [{ id: "wf-1" }])).toEqual({
+      id: "wf-1",
+      workflow_id: "wf-1"
+    });
+  });
+
+  it("leaves an explicit workflow_id alone", () => {
+    expect(
+      coerceCapabilityArgs(GET_WORKFLOW, [{ id: "ignored", workflow_id: "kept" }])
+    ).toEqual({ id: "ignored", workflow_id: "kept" });
+  });
+
+  it("does not guess when two *_id keys are required", () => {
+    expect(() =>
+      coerceCapabilityArgs(TWO_IDS, [{ id: "x" }])
+    ).toThrow(/two_ids: missing required arguments workflow_id, job_id/);
+  });
+
+  it("names the call, the missing key, and what was passed instead", () => {
+    expect(() =>
+      coerceCapabilityArgs(SAVE_ASSET, [{ source: "https://example.com/a.mp4" }])
+    ).toThrow(/save_asset: missing required argument name\. Got: source\./);
+  });
+
+  it("treats an explicit null as missing", () => {
+    expect(() =>
+      coerceCapabilityArgs(SAVE_ASSET, [{ name: null, source: "s" }])
+    ).toThrow(/save_asset: missing required argument name/);
+  });
+
+  it("leaves a call with no arguments to the implementation", () => {
+    expect(coerceCapabilityArgs(SAVE_ASSET, [])).toEqual({});
+  });
+
+  it("accepts a camelCase key that aliases onto the required one", () => {
+    expect(coerceCapabilityArgs(GET_SCHEMA, [{ actorId: "a/b" }])).toEqual({
+      actorId: "a/b",
+      actor_id: "a/b"
+    });
+  });
+});
+
+describe("every capability spec", () => {
+  it("requires only keys it declares as properties", async () => {
+    const { listCapabilitySpecs } = await import(
+      "../src/capabilities/registry.js"
+    );
+    const undeclared: string[] = [];
+    for (const spec of listCapabilitySpecs()) {
+      const required = spec.inputSchema.required;
+      if (!Array.isArray(required)) continue;
+      const properties = spec.inputSchema.properties ?? {};
+      for (const key of required) {
+        if (typeof key === "string" && !(key in properties)) {
+          undeclared.push(`${spec.name}.${key}`);
+        }
+      }
+    }
+    // A required key with no property is a spec the argument check would
+    // reject calls against and no caller could satisfy from the schema alone.
+    expect(undeclared).toEqual([]);
+  });
+
+  it("does not require a key it also gives a default", async () => {
+    const { listCapabilitySpecs } = await import(
+      "../src/capabilities/registry.js"
+    );
+    const contradictory: string[] = [];
+    for (const spec of listCapabilitySpecs()) {
+      const required = spec.inputSchema.required;
+      if (!Array.isArray(required)) continue;
+      const properties = (spec.inputSchema.properties ?? {}) as Record<
+        string,
+        { default?: unknown }
+      >;
+      for (const key of required) {
+        if (typeof key !== "string") continue;
+        if (properties[key]?.default !== undefined) {
+          contradictory.push(`${spec.name}.${key}`);
+        }
+      }
+    }
+    // A default says "omitting this is fine"; `required` says it is not. The
+    // argument check believes `required`, so a spec saying both would start
+    // refusing calls that used to work.
+    expect(contradictory).toEqual([]);
   });
 });

--- a/packages/agents/tests/capabilities-dispatcher.test.ts
+++ b/packages/agents/tests/capabilities-dispatcher.test.ts
@@ -205,10 +205,13 @@ describe("the gate", () => {
   it("prompts for a write capability reached through the import", async () => {
     const prompts: ApprovalRequest[] = [];
     const run = gatedRun("default", "deny", prompts);
+    // A well-formed call: the argument check refuses a call missing a
+    // required field before the gate runs, and asking a person to approve
+    // something that cannot run is the wrong order.
     const outcome = await action(
       run,
       `import { create_workflow } from "${WORKFLOWS}";\n` +
-        `return await create_workflow({ name: "x", objective: "y" });`
+        `return await create_workflow({ name: "x", graph: { nodes: [], edges: [] } });`
     );
     expect(prompts.map((p) => p.toolName)).toEqual(["create_workflow"]);
     expect(prompts[0].category).toBe("write");
@@ -216,6 +219,28 @@ describe("the gate", () => {
     // prelude surfaces as the action's error.
     expect(outcome.ok).toBe(false);
     expect(outcome.error).toContain("declined to run");
+  });
+
+  /**
+   * The argument check runs before the gate, so a call that cannot run never
+   * becomes a question for a person. The message names the call rather than
+   * the entity: `get_workflow({ id })` used to reach the implementation as
+   * `workflow_id: undefined` and answer "Workflow undefined was not found".
+   */
+  it("refuses a call missing a required argument without prompting", async () => {
+    const prompts: ApprovalRequest[] = [];
+    const run = gatedRun("default", "deny", prompts);
+    const outcome = await action(
+      run,
+      `import { create_workflow } from "${WORKFLOWS}";\n` +
+        `return await create_workflow({ name: "x", objective: "y" });`
+    );
+    expect(prompts).toEqual([]);
+    expect(outcome.ok).toBe(false);
+    expect(outcome.error).toContain(
+      "create_workflow: missing required argument graph"
+    );
+    expect(outcome.error).toContain("Got: name, objective");
   });
 
   it("never prompts for a read capability, on either path", async () => {

--- a/packages/agents/tests/capabilities-jobs.test.ts
+++ b/packages/agents/tests/capabilities-jobs.test.ts
@@ -120,6 +120,42 @@ describe("jobs capabilities against the database", () => {
     expect(tail.logs).toEqual([{ message: "two" }, { message: "three" }]);
   });
 
+  /**
+   * A listing reports which jobs exist; `get_job` reports what one produced.
+   * They were the same record, so `list_jobs` — which defaults to a hundred —
+   * carried every job's full outputs. One agent listing ran to 140 KB of beat
+   * sheets, was cut at the 25 KB tool-result cap mid-JSON, and had been called
+   * to read a `status` field.
+   */
+  it("lists jobs without the values they produced", async () => {
+    const job = (await Job.create({
+      user_id: USER,
+      workflow_id: "wf-outputs",
+      status: "completed",
+      params: {},
+      graph: { nodes: [], edges: [] }
+    })) as Job;
+    job.metadata_json = { outputs: { beat_sheet: "x".repeat(50_000) } };
+    await job.save();
+
+    const listed = (await asTool("list_jobs").process(ctx, {
+      workflow_id: "wf-outputs"
+    })) as { jobs: Array<Record<string, unknown>> };
+    const entry = listed.jobs.find((j) => j.id === job.id);
+    expect(entry).toBeDefined();
+    expect(entry).not.toHaveProperty("outputs");
+    // The names are there, so the agent knows a `get_job` is worth making.
+    expect(entry?.output_names).toEqual(["beat_sheet"]);
+    expect(JSON.stringify(listed).length).toBeLessThan(5_000);
+
+    const got = (await asTool("get_job").process(ctx, {
+      job_id: job.id
+    })) as Record<string, unknown>;
+    expect((got.outputs as Record<string, string>).beat_sheet).toHaveLength(
+      50_000
+    );
+  });
+
   it("cancels a running job, and says so when there was nothing to cancel", async () => {
     const job = (await Job.create({
       user_id: USER,

--- a/packages/agents/tests/capability-run-secrets-audit.test.ts
+++ b/packages/agents/tests/capability-run-secrets-audit.test.ts
@@ -97,12 +97,14 @@ const OMITS_SECRET_RESOLVER: Record<string, { reason: string; sites: number }> =
       reason: "internal run for generate_speech",
       sites: 1
     },
-    // The `ui_*` document tools, node discovery, `find_model`/`list_models`,
-    // and the media belt. None validates a graph; the workflow belt above
-    // them does, and it injects.
+    // The `ui_*` document tools, node discovery, and `find_model`/
+    // `list_models`. None validates a graph; the workflow belt above them
+    // does, and it injects. The media belt was a fourth site and is gone: the
+    // media tools are built-ins now, over the run `getBuiltinTools()` builds,
+    // which does inject.
     "packages/agents/src/tools/mcp-tools.ts": {
-      reason: "document, discovery, model and media belts validate no graph",
-      sites: 4
+      reason: "document, discovery and model belts validate no graph",
+      sites: 3
     }
   };
 

--- a/packages/agents/tests/mcp-tools.test.ts
+++ b/packages/agents/tests/mcp-tools.test.ts
@@ -762,6 +762,23 @@ describe("debug_workflow", () => {
     })) as Record<string, unknown>;
     expect(report.workflow).toBeUndefined();
   });
+
+  /**
+   * A refused run never started, so there is no report to nest it in. Nested
+   * under `run`, the failure was invisible to the sandbox dispatcher — which
+   * throws on a top-level `{error}` precisely so a guest cannot compute with
+   * one — and a 404 came back as a value an agent logged as `Status: 404` and
+   * carried on from. `run_workflow` has always answered at the top level.
+   */
+  it("reports a workflow it cannot find as an error, not as a report", async () => {
+    const tool = capTool("debug_workflow", { nodeRegistry: stubRegistry });
+    const result = (await tool.process(ctx, {
+      workflow_id: "wf-does-not-exist"
+    })) as Record<string, unknown>;
+    expect(String(result.error)).toContain("not found");
+    expect(result.status).toBe(404);
+    expect(result.run).toBeUndefined();
+  });
 });
 
 describe("resolve_workflow_escalation", () => {
@@ -1751,7 +1768,7 @@ describe("getAllMcpTools", () => {
     expect(names).not.toContain("find_model");
   });
 
-  it("adds find_model + media tools when providers are supplied (with registry)", () => {
+  it("adds the model catalog tools when providers are supplied (with registry)", () => {
     const registry = {
       listMetadata: () => [],
       getMetadata: () => undefined
@@ -1762,29 +1779,31 @@ describe("getAllMcpTools", () => {
     }).map((t) => t.name);
     expect(names).toContain("find_model");
     expect(names).toContain("list_models");
-    expect(names).toContain("generate_image");
-    expect(names).toContain("edit_image");
-    expect(names).toContain("generate_video");
-    expect(names).toContain("animate_image");
-    expect(names).toContain("generate_speech");
-    expect(names).toContain("transcribe_audio");
-    expect(names).toContain("embed_text");
   });
 
-  it("adds find_model + media tools when providers supplied WITHOUT a registry (multi-task path)", () => {
+  it("adds them without a registry too (multi-task path)", () => {
     const names = getAllMcpTools({
       providers: { fake: {} as unknown as BaseProvider }
     }).map((t) => t.name);
     expect(names).toContain("find_model");
-    expect(names).toContain("generate_image");
-    expect(names).toContain("generate_speech");
-    expect(names).toContain("embed_text");
+    expect(names).toContain("list_models");
   });
 
-  it("omits the provider-backed tools when no providers are supplied", () => {
+  it("omits the model catalog tools when no providers are supplied", () => {
     const names = getAllMcpTools().map((t) => t.name);
     expect(names).not.toContain("find_model");
     expect(names).not.toContain("list_models");
+  });
+
+  // The media tools read nothing off the run — `runProviderPrediction` is on
+  // the context — so the provider map is not their dependency and never was.
+  // Adding them here meant a host that injected none (a Code node, a JS
+  // script) had no way to generate anything, while `critique_image` on the
+  // same belt could judge an image it could not make.
+  it("leaves the media tools to the built-in belt", () => {
+    const names = getAllMcpTools({
+      providers: { fake: {} as unknown as BaseProvider }
+    }).map((t) => t.name);
     expect(names).not.toContain("generate_image");
     expect(names).not.toContain("generate_speech");
   });

--- a/packages/agents/tests/sandbox-belt-reach.test.ts
+++ b/packages/agents/tests/sandbox-belt-reach.test.ts
@@ -22,7 +22,10 @@ import {
   SERPAPI_TOOL_NAMES
 } from "../src/tools/external-capability-tools.js";
 import { runInSandbox } from "../src/js-sandbox.js";
-import { NODETOOL_API_PRELUDE_FULL } from "../src/codeact/nodetool-api.js";
+import {
+  NODETOOL_API_NAMESPACE_TOOLS,
+  NODETOOL_API_PRELUDE_FULL
+} from "../src/codeact/nodetool-api.js";
 import { TOOLS_PRELUDE } from "../src/codeact/tools-prelude.js";
 
 const PRELUDE = `${TOOLS_PRELUDE}\n${NODETOOL_API_PRELUDE_FULL}`;
@@ -59,6 +62,71 @@ describe("the sandbox toolbelt", () => {
   it("names every tool once", () => {
     const names = assembleSandboxToolbelt().map((tool) => tool.name);
     expect(new Set(names).size).toBe(names.length);
+  });
+
+  /**
+   * The same failure one namespace over. `nodetool.media.generateImage` is in
+   * the object model and `Object.keys(nodetool.media)` lists it, but the tool
+   * behind it was added only beside `find_model`, which needs an injected
+   * provider map this belt has none of. So a Code node that had just spent
+   * four LLM calls writing twenty-five keyframe prompts got
+   * `tool "generate_image" is not in this toolbelt` twenty-five times.
+   *
+   * Nothing about generation needs the map: these go through
+   * `context.runProviderPrediction`, the same call `critique_image` and
+   * `render_storyboard_stills` — both already here — make.
+   */
+  it("can generate media, not only judge it", () => {
+    const names = new Set(assembleSandboxToolbelt().map((tool) => tool.name));
+    for (const name of [
+      "generate_image",
+      "edit_image",
+      "generate_video",
+      "animate_image",
+      "generate_speech",
+      "generate_music",
+      "transcribe_audio",
+      "embed_text"
+    ]) {
+      expect(names.has(name)).toBe(true);
+    }
+  });
+
+  /**
+   * The object model's own promise: a namespace it reports as live must be
+   * callable. `capabilities()` filters `NODETOOL_API_NAMESPACE_TOOLS` by the
+   * belt, so a name it returns is one `__need` will not throw on.
+   */
+  it("serves the whole media namespace the object model advertises", () => {
+    const names = new Set(assembleSandboxToolbelt().map((tool) => tool.name));
+    const advertised = NODETOOL_API_NAMESPACE_TOOLS["media"] ?? [];
+    const missing = advertised.filter((name) => !names.has(name));
+    // `yt_dlp` is dropped under the cloud profile; nothing else may be.
+    expect(missing.filter((name) => name !== "yt_dlp")).toEqual([]);
+  });
+
+  /**
+   * The failure as the guest met it: a Code node body calling the object
+   * model, over the belt a Code node really gets.
+   */
+  it("dispatches nodetool.media.generateImage instead of throwing", async () => {
+    const names = assembleSandboxToolbelt().map((tool) => tool.name);
+    const result = await run(
+      `const r = await nodetool.media.generateImage("a red fox in snow", {
+         provider: "fal_ai",
+         model_id: "fal-ai/flux/schnell"
+       });
+       return r.called;`,
+      names
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.result).toBe("generate_image");
+  });
+
+  it("reports media as a live namespace", async () => {
+    const names = assembleSandboxToolbelt().map((tool) => tool.name);
+    const result = await run(`return nodetool.capabilities().media;`, names);
+    expect(result.result).toContain("generate_image");
   });
 });
 

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -40,8 +40,8 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     contract: "500f60f725d0",
     selfcheck: "capability-suites",
     suites: [
+      "packages/agents/tests/capabilities-args.test.ts",
       "packages/agents/tests/capabilities-dispatcher.test.ts",
-      "packages/agents/tests/capabilities-gate-parity.test.ts",
     ],
   },
   {
@@ -306,7 +306,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-media.test.ts",
-      "packages/agents/tests/mcp-tools.test.ts",
     ],
   },
   {
@@ -317,7 +316,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-media.test.ts",
-      "packages/agents/tests/mcp-tools.test.ts",
     ],
   },
   {
@@ -328,7 +326,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-media.test.ts",
-      "packages/agents/tests/mcp-tools.test.ts",
     ],
   },
   {
@@ -360,7 +357,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-media.test.ts",
-      "packages/agents/tests/mcp-tools.test.ts",
     ],
   },
   {
@@ -371,7 +367,6 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-media.test.ts",
-      "packages/agents/tests/mcp-tools.test.ts",
     ],
   },
   {
@@ -392,6 +387,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-media.test.ts",
+      "packages/agents/tests/mcp-tools.test.ts",
     ],
     evals: [
       {
@@ -659,7 +655,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "list_jobs",
     module: "jobs",
     impl: "packages/agents/src/capabilities/jobs.ts",
-    contract: "28a42cc21664",
+    contract: "2d22d3a3e08e",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-jobs.test.ts",
@@ -670,7 +666,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "get_job",
     module: "jobs",
     impl: "packages/agents/src/capabilities/jobs.ts",
-    contract: "09a18e26091b",
+    contract: "2beacec6db44",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-jobs.test.ts",
@@ -1146,7 +1142,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     name: "take_screenshot",
     module: "web",
     impl: "packages/agents/src/capabilities/web.ts",
-    contract: "363807424500",
+    contract: "fae5f5a3d1c0",
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-web.test.ts",

--- a/packages/cli/src/harness/capability-table.ts
+++ b/packages/cli/src/harness/capability-table.ts
@@ -1146,6 +1146,7 @@ export const CAPABILITY_COVERAGE: readonly CapabilityCoverageEntry[] = [
     selfcheck: "capability-suites",
     suites: [
       "packages/agents/tests/capabilities-web.test.ts",
+      "packages/agents/tests/browser-tools.test.ts",
     ],
   },
   {

--- a/packages/cli/src/harness/registry.ts
+++ b/packages/cli/src/harness/registry.ts
@@ -403,7 +403,7 @@ export const HARNESSES: HarnessEntry[] = [
     command:
       "npm run test --workspace=packages/agents -- capabilities capability " +
       "mcp-tools memory-tools workflow-version-tools nodetool-api-workflows " +
-      "sandbox-package-docs sandbox-package-listing",
+      "sandbox-package-docs sandbox-package-listing browser-tools",
     kind: "static",
     capabilities: ["no-db", "gated"],
     docs: "packages/agents/AGENTS.md § Capability coverage",
@@ -414,7 +414,7 @@ export const HARNESSES: HarnessEntry[] = [
         "npm run capabilities:check && " +
         "npm run test --workspace=packages/agents -- capabilities capability " +
         "mcp-tools memory-tools workflow-version-tools nodetool-api-workflows " +
-        "sandbox-package-docs sandbox-package-listing",
+        "sandbox-package-docs sandbox-package-listing browser-tools",
       cost: "cheap"
     }
   },

--- a/scripts/sync-capability-coverage.mjs
+++ b/scripts/sync-capability-coverage.mjs
@@ -42,6 +42,10 @@ const SUITE_EXTRAS = [
   "nodetool-api-workflows.test.ts",
   "mcp-tools.test.ts",
   "memory-tools.test.ts",
+  // Drives `take_screenshot`, `browser` and `http_request` by wire name and
+  // asserts their schemas. Outside the `capabilit*-` naming convention, so the
+  // pool missed the one suite that actually pins those contracts.
+  "browser-tools.test.ts",
   "sandbox-package-docs.test.ts",
   "sandbox-package-listing.test.ts",
   "code-capabilities.test.ts",


### PR DESCRIPTION
## What changed

A chat session built a storyboard workflow, ran it, and lost most of an hour to four separate defects; this fixes each one. **Media generation was missing from the Code node and JS script belt** — `getAllMcpTools` added `generate_image` and friends only beside `find_model`/`list_models`, gated on an injected provider map. Those two enumerate the map; the media tools reach a provider through `context.runProviderPrediction` and read nothing off the run, exactly like `critique_image` and `render_storyboard_stills`, which were already built-ins. So a host that injects none got a belt that could judge an image and score its adherence but had no way to make one, and 25 keyframes died on `tool "generate_image" is not in this toolbelt` after four LLM calls had been paid for to write their prompts. **`coerceCapabilityArgs` never checked required arguments**, so `get_workflow({ id })` reached the lookup as `workflow_id: undefined` and answered "Workflow undefined was not found" — a report about a missing workflow for a misspelled argument, which cost six calls and three wrong theories; it now folds a bare `id` onto the one required `*_id` key (only when there is exactly one, so nothing is guessed) and otherwise refuses, naming the call, the missing keys and what was passed. **`debug_workflow` nested a refused run under `run`**, where the sandbox dispatcher's top-level `{error}` throw could not see it, so a 404 came back as a value the agent logged as `Status: 404` and worked around; it answers at the top level now, as `run_workflow` already did. And **`list_jobs` mapped a hundred jobs through the full `jobRecord`**, outputs included — one listing carried 140 KB of beat sheets past a 25 KB tool-result cap, twice, to read a `status` field, and the cut fell mid-JSON so nothing downstream could parse it either; listings now report `output_names` and `get_job` reports values.

The spec check added for the argument fix caught a fifth, latent defect: `take_screenshot` declared `output_file` required *and* gave it a default, telling every model a screenshot needs a filename chosen for it.

Not fixed, and worth naming: there is still no way to run or debug an inline graph without saving it, which is why that session left seven throwaway workflows in the user's library. `runWorkflow` is keyed on a stored row (run mode, job creation, preflight), so that is a design change rather than a patch. `find_model`/`list_models` also stay off the sandbox belt — they genuinely enumerate the provider map, which is resolved per-user and asynchronously while that belt is assembled synchronously per process.

## Verification

- [x] `npm run test:affected` — run per package, because turbo's parallel run times out `@nodetool-ai/chat`'s 5s `countTextTokens` and 60s index-import tests on this box; that package passes alone (32/32) and this diff touches nothing it imports.
  - `packages/agents` — **223 files, 3449 passed**, 1 skipped
  - `packages/websocket` — **222 files, 2456 passed**
  - `packages/cli` — **56 files, 673 passed**
  - `packages/code-nodes` — **13 files, 222 passed**
- [x] `npm run typecheck` — exit 0
- [x] `npm run lint` — exit 0 (only pre-existing warnings, none in touched files)
- [x] `npm run nodetool -- harness gate --base HEAD~1` — `Gate: 2/2 selfchecks passed`, 255/255 graphs validate

Each new check was inverted once and observed failing, per rule 7:

```
$ git stash push -- src/tools/builtin-tools.ts src/tools/mcp-tools.ts && vitest run tests/sandbox-belt-reach.test.ts
  × can generate media, not only judge it
  × serves the whole media namespace the object model advertises
  × dispatches nodetool.media.generateImage instead of throwing
  × reports media as a live namespace
 Test Files  1 failed (1)

$ git stash push -- src/capabilities/args.ts && vitest run tests/capabilities-args.test.ts tests/capabilities-dispatcher.test.ts
  × copies a bare id onto the one required *_id key
  × does not guess when two *_id keys are required
  × names the call, the missing key, and what was passed instead
  × treats an explicit null as missing
  × refuses a call missing a required argument without prompting
 Test Files  2 failed (2)

$ git stash push -- src/capabilities/workflows.ts src/tools/mcp-tool-support.ts src/capabilities/jobs.ts && vitest run tests/mcp-tools.test.ts tests/capabilities-jobs.test.ts
  × lists jobs without the values they produced
  × reports a workflow it cannot find as an error, not as a report
 Test Files  2 failed (2)
```

The spec audit is the one that found something on its first run rather than being written to a known target:

```
$ vitest run tests/capabilities-args.test.ts
 FAIL  every capability spec > does not require a key it also gives a default
AssertionError: expected [ 'take_screenshot.output_file' ] to deeply equal []
```

## Agent capabilities

- [x] `npm run capabilities:check` passes — `capability table is current (224 capabilities)`
- [x] Three contracts moved. `take_screenshot` now names `packages/agents/tests/browser-tools.test.ts`, which drives it by wire name and asserts its schema; the sync's suite pool could not see that file (it takes `capabilit*-` plus a hand-kept extras list), so the second commit adds it — a real attribution gap, not a workaround for the gate.

  `list_jobs` and `get_job` changed description text only, and the check covering the new contract is **`packages/agents/tests/capabilities-jobs.test.ts › lists jobs without the values they produced`**, which asserts the listing carries `output_names` and no `outputs`, and that `get_job` still returns the 50 000-character value. Their `suites` arrays cannot move to say so: the sync caps the list at two, and both slots already hold the suites that cover them. The gate reports this as an advisory violation and still exits 0.

## New checks

- [x] Each inverted once and observed failing — output above
- [x] The two spec audits assert over `listCapabilitySpecs()` and would pass vacuously only on an empty registry; the second found `take_screenshot.output_file` on its first run, which is the proof it matches something

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKYFo62jn8tWokke5EdoNc

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKYFo62jn8tWokke5EdoNc)_