### PR TITLE
feat(web): untie the workspace explorer from the open workflow

### DIFF
--- a/web/src/__mocks__/themeMock.ts
+++ b/web/src/__mocks__/themeMock.ts
@@ -91,6 +91,7 @@ interface MockVarsPalette {
   FilledInput?: { bg: string; hoverBg: string; disabledBg: string };
   TableCell?: { border: string };
   Tooltip?: { bg: string };
+  Skeleton?: { bg: string };
   OutlinedInput?: { border: string; hoverBorder: string };
   Slider?: Record<string, string>;
   Chip?: {
@@ -479,6 +480,9 @@ draft.vars.palette.TableCell = {
 };
 draft.vars.palette.Tooltip = {
   bg: "rgba(97, 97, 97, 0.92)",
+};
+draft.vars.palette.Skeleton = {
+  bg: "rgba(255, 255, 255, 0.11)",
 };
 draft.vars.palette.OutlinedInput = {
   border: "rgba(255, 255, 255, 0.23)",

--- a/web/src/components/workspaces/WorkspaceTree.tsx
+++ b/web/src/components/workspaces/WorkspaceTree.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import React, { memo, useCallback, useEffect, useRef, useState } from "react";
-import { useShallow } from "zustand/react/shallow";
 import isEqual from "../../utils/isEqual";
 import { useQuery } from "@tanstack/react-query";
 import { FileInfo } from "../../stores/ApiTypes";
@@ -14,9 +13,8 @@ import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import AddIcon from "@mui/icons-material/Add";
 import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import { RefreshButton, SettingsButton } from "../ui_primitives";
-import { useWorkflowManager } from "../../contexts/WorkflowManagerContext";
 import { openPageTab } from "../workspace/openPageTab";
-import { useCurrentWorkspace } from "../../hooks/useCurrentWorkspace";
+import { useWorkspaceExplorer } from "../../hooks/useWorkspaceExplorer";
 import WorkspaceSelect from "./WorkspaceSelect";
 import PanelHeadline from "../ui/PanelHeadline";
 
@@ -273,70 +271,51 @@ const shouldLoadChildren = (item: TreeViewItem | undefined): boolean => {
   );
 };
 
+/**
+ * Browser for the files in a workspace folder.
+ *
+ * Independent of the graph editor: it shows whichever workspace the user
+ * picked here, works with no workflow open, and changing that pick moves only
+ * this tree — a workflow keeps whatever workspace its runs write to.
+ */
 const WorkspaceTree: React.FC = () => {
   const theme = useTheme();
   const [files, setFiles] = useState<TreeViewItem[]>([]);
   const filesRef = useRef<TreeViewItem[]>([]);
   filesRef.current = files;
   const [selectedFilePath, setSelectedFilePath] = useState<string>("");
-  const [filesWorkspaceId, setFilesWorkspaceId] = useState<string | undefined>();
-  const filesWorkspaceIdRef = useRef<string | undefined>(undefined);
-  filesWorkspaceIdRef.current = filesWorkspaceId;
-  const previousWorkflowId = useRef<string | null | undefined>(undefined);
-  const { currentWorkflowId, getCurrentWorkflow } = useWorkflowManager(
-    useShallow((state) => ({
-      currentWorkflowId: state.currentWorkflowId,
-      getCurrentWorkflow: state.getCurrentWorkflow
-    }))
-  );
 
-  const currentWorkflow = getCurrentWorkflow();
-  const workflowId = currentWorkflowId ?? currentWorkflow?.id;
-  const { workspaceId, setWorkspaceId } = useCurrentWorkspace();
+  const {
+    workspaceId,
+    setWorkspaceId,
+    isLoading: isLoadingWorkspaces
+  } = useWorkspaceExplorer();
+  const workspaceIdRef = useRef<string | undefined>(workspaceId);
+  workspaceIdRef.current = workspaceId;
 
   const {
     data: initialFiles,
     isLoading: isLoadingFiles,
     refetch: refetchFiles
   } = useQuery({
-    queryKey: ["workspace-files", filesWorkspaceId],
-    queryFn: () => fetchWorkspaceFiles(filesWorkspaceId!),
-    enabled: Boolean(filesWorkspaceId)
+    queryKey: ["workspace-files", workspaceId],
+    queryFn: () => fetchWorkspaceFiles(workspaceId!),
+    enabled: Boolean(workspaceId)
   });
 
-  const handleWorkspaceChange = useCallback(
-    async (newWorkspaceId: string | undefined) => {
-      await setWorkspaceId(newWorkspaceId);
-      setFilesWorkspaceId(newWorkspaceId);
-    },
-    [setWorkspaceId]
-  );
-
+  // The query answers with the root listing; lazily-loaded children are merged
+  // into this copy as folders expand.
   useEffect(() => {
-    if (initialFiles) {
-      setFiles(initialFiles);
-    }
+    setFiles(initialFiles ?? []);
   }, [initialFiles]);
 
   useEffect(() => {
     setSelectedFilePath("");
-    setFiles([]);
-  }, [filesWorkspaceId, workflowId]);
-
-  useEffect(() => {
-    if (workflowId !== previousWorkflowId.current) {
-      previousWorkflowId.current = workflowId;
-      setFilesWorkspaceId(workspaceId ?? undefined);
-      return;
-    }
-    if (filesWorkspaceId === undefined && workspaceId) {
-      setFilesWorkspaceId(workspaceId);
-    }
-  }, [filesWorkspaceId, workflowId, workspaceId]);
+  }, [workspaceId]);
 
   const loadItemChildren = useCallback(
     async (itemId: string) => {
-      const wsId = filesWorkspaceIdRef.current;
+      const wsId = workspaceIdRef.current;
       if (!wsId) return;
 
       const currentFiles = filesRef.current;
@@ -404,25 +383,6 @@ const WorkspaceTree: React.FC = () => {
       ? selectedFilePath.split("/").filter(Boolean)
       : [];
 
-  if (!workflowId) {
-    return (
-      <Box css={workspaceTreeStyles(theme)}>
-        <PanelHeadline title="Workspace Explorer" docsTopic="workspaces" />
-        <div className="empty-workspace">
-          <FolderOpenIcon
-            sx={{ fontSize: 40, opacity: 0.3, color: "text.secondary" }}
-          />
-          <Text size="small" color="secondary">
-            No workflow selected
-          </Text>
-          <Caption color="secondary">
-            Open a workflow to access its workspace files
-          </Caption>
-        </div>
-      </Box>
-    );
-  }
-
   return (
     <Box css={workspaceTreeStyles(theme)}>
       <PanelHeadline
@@ -439,8 +399,8 @@ const WorkspaceTree: React.FC = () => {
 
       <div className="workspace-selector">
         <WorkspaceSelect
-          value={workspaceId ?? undefined}
-          onChange={handleWorkspaceChange}
+          value={workspaceId}
+          onChange={setWorkspaceId}
         />
         <SettingsButton
           className="settings-button"
@@ -484,7 +444,16 @@ const WorkspaceTree: React.FC = () => {
       )}
 
       <div className="file-tree-container">
-        {!workspaceId ? (
+        {isLoadingWorkspaces || isLoadingFiles ? (
+          <div className="skeleton-tree">
+            <Skeleton variant="text" width="60%" height={24} />
+            <Skeleton variant="text" width="45%" height={24} sx={{ ml: 2 }} />
+            <Skeleton variant="text" width="70%" height={24} sx={{ ml: 2 }} />
+            <Skeleton variant="text" width="50%" height={24} />
+            <Skeleton variant="text" width="55%" height={24} sx={{ ml: 2 }} />
+            <Skeleton variant="text" width="40%" height={24} />
+          </div>
+        ) : !workspaceId ? (
           <div className="empty-workspace">
             <FolderOpenIcon
               sx={{ fontSize: 40, opacity: 0.3, color: "text.secondary" }}
@@ -502,15 +471,6 @@ const WorkspaceTree: React.FC = () => {
             >
               Create Workspace
             </EditorButton>
-          </div>
-        ) : isLoadingFiles ? (
-          <div className="skeleton-tree">
-            <Skeleton variant="text" width="60%" height={24} />
-            <Skeleton variant="text" width="45%" height={24} sx={{ ml: 2 }} />
-            <Skeleton variant="text" width="70%" height={24} sx={{ ml: 2 }} />
-            <Skeleton variant="text" width="50%" height={24} />
-            <Skeleton variant="text" width="55%" height={24} sx={{ ml: 2 }} />
-            <Skeleton variant="text" width="40%" height={24} />
           </div>
         ) : files.length > 0 ? (
           <div onDoubleClick={handleTreeDoubleClick}>

--- a/web/src/components/workspaces/__tests__/WorkspaceTree.test.tsx
+++ b/web/src/components/workspaces/__tests__/WorkspaceTree.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@mui/material/styles";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import mockTheme from "../../../__mocks__/themeMock";
+import WorkspaceTree from "../WorkspaceTree";
+import { useWorkspaceExplorerStore } from "../../../stores/WorkspaceExplorerStore";
+
+const defaultWorkspace = {
+  id: "ws-default",
+  name: "Default",
+  path: "/data/workspaces/u1",
+  is_default: true
+};
+const renders = {
+  id: "ws-renders",
+  name: "Renders",
+  path: "/home/me/renders",
+  is_default: false
+};
+
+const listFiles = jest.fn();
+
+jest.mock("../../../trpc/client", () => ({
+  trpcClient: {
+    workspace: {
+      listFiles: { query: (input: unknown) => listFiles(input) }
+    }
+  }
+}));
+
+jest.mock("../../../hooks/useWorkspaces", () => ({
+  useWorkspaces: () => ({
+    workspaces: [defaultWorkspace, renders],
+    canManage: true,
+    defaultWorkspace,
+    isLoading: false,
+    error: null
+  }),
+  useWorkspaceCacheWriter: () => jest.fn()
+}));
+
+// No WorkflowManagerProvider and no workflow: the tree must still resolve a
+// workspace and list it. Jest maps the workflow-manager context to a mock whose
+// current workflow is always null, so a tree that reads it renders its old
+// "No workflow selected" state here and these tests go red.
+const renderTree = () =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <ThemeProvider theme={mockTheme}>
+        <WorkspaceTree />
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+
+describe("WorkspaceTree", () => {
+  beforeEach(() => {
+    listFiles.mockReset();
+    listFiles.mockResolvedValue([
+      { name: "notes.md", path: "notes.md", is_dir: false, size: 12 }
+    ]);
+    useWorkspaceExplorerStore.getState().setBrowsedWorkspaceId(null);
+  });
+
+  it("lists the default workspace's files with no workflow open", async () => {
+    renderTree();
+    expect(await screen.findByText("notes.md")).toBeInTheDocument();
+    expect(listFiles).toHaveBeenCalledWith({ id: "ws-default", path: "." });
+  });
+
+  it("browses the workspace the user picked, not a workflow's", async () => {
+    renderTree();
+    await screen.findByText("notes.md");
+
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.click(await screen.findByText(renders.path));
+
+    await waitFor(() => {
+      expect(listFiles).toHaveBeenCalledWith({ id: "ws-renders", path: "." });
+    });
+    expect(useWorkspaceExplorerStore.getState().browsedWorkspaceId).toBe(
+      "ws-renders"
+    );
+  });
+});

--- a/web/src/hooks/__tests__/useWorkspaceExplorer.test.tsx
+++ b/web/src/hooks/__tests__/useWorkspaceExplorer.test.tsx
@@ -1,0 +1,77 @@
+import { renderHook, act } from "@testing-library/react";
+
+import { useWorkspaceExplorer } from "../useWorkspaceExplorer";
+import { useWorkspaceExplorerStore } from "../../stores/WorkspaceExplorerStore";
+
+const defaultWorkspace = {
+  id: "ws-default",
+  name: "Default",
+  path: "/data/workspaces/u1",
+  is_default: true
+};
+const renders = {
+  id: "ws-renders",
+  name: "Renders",
+  path: "/home/me/renders",
+  is_default: false
+};
+
+let workspaces: Array<typeof defaultWorkspace> = [];
+let isLoading = false;
+
+jest.mock("../useWorkspaces", () => ({
+  useWorkspaces: () => ({
+    workspaces,
+    canManage: true,
+    defaultWorkspace: workspaces.find((w) => w.is_default) ?? workspaces[0],
+    isLoading,
+    error: null
+  })
+}));
+
+describe("useWorkspaceExplorer", () => {
+  beforeEach(() => {
+    workspaces = [defaultWorkspace, renders];
+    isLoading = false;
+    act(() => {
+      useWorkspaceExplorerStore.getState().setBrowsedWorkspaceId(null);
+    });
+  });
+
+  it("browses the default workspace until the user picks one", () => {
+    const { result } = renderHook(() => useWorkspaceExplorer());
+    expect(result.current.workspaceId).toBe("ws-default");
+    expect(result.current.workspace?.name).toBe("Default");
+  });
+
+  it("remembers the picked workspace", () => {
+    const { result } = renderHook(() => useWorkspaceExplorer());
+    act(() => {
+      result.current.setWorkspaceId("ws-renders");
+    });
+    expect(result.current.workspaceId).toBe("ws-renders");
+    expect(useWorkspaceExplorerStore.getState().browsedWorkspaceId).toBe(
+      "ws-renders"
+    );
+  });
+
+  it("ignores a remembered workspace that no longer exists", () => {
+    act(() => {
+      useWorkspaceExplorerStore.getState().setBrowsedWorkspaceId("ws-deleted");
+    });
+    const { result } = renderHook(() => useWorkspaceExplorer());
+    expect(result.current.workspaceId).toBe("ws-default");
+  });
+
+  it("reports no workspace only while the list is empty", () => {
+    workspaces = [];
+    const { result } = renderHook(() => useWorkspaceExplorer());
+    expect(result.current.workspaceId).toBeUndefined();
+  });
+
+  it("reports the list's loading state", () => {
+    isLoading = true;
+    const { result } = renderHook(() => useWorkspaceExplorer());
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/web/src/hooks/useWorkspaceExplorer.ts
+++ b/web/src/hooks/useWorkspaceExplorer.ts
@@ -1,0 +1,57 @@
+import { useCallback } from "react";
+
+import { useWorkspaceExplorerStore } from "../stores/WorkspaceExplorerStore";
+import { useWorkspaces } from "./useWorkspaces";
+import type { WorkspaceResponse } from "../stores/ApiTypes";
+
+interface WorkspaceExplorerSelection {
+  workspaceId: string | undefined;
+  workspace: WorkspaceResponse | undefined;
+  setWorkspaceId: (newWorkspaceId: string | undefined) => void;
+  isLoading: boolean;
+}
+
+/**
+ * Which workspace the Workspace Explorer shows.
+ *
+ * The user's own choice, persisted, falling back to the default workspace —
+ * which the server creates while answering the list call, so the explorer has
+ * something to show on a healthy install with no workflow open. A remembered
+ * id that no longer exists (deleted workspace, another machine) loses to the
+ * default rather than leaving the tree pointed at nothing.
+ *
+ * Nothing here reads or writes a workflow. Compare {@link useCurrentWorkspace},
+ * which resolves where the *active workflow's* run writes.
+ */
+export const useWorkspaceExplorer = (): WorkspaceExplorerSelection => {
+  const { workspaces, defaultWorkspace, isLoading } = useWorkspaces();
+
+  const browsedWorkspaceId = useWorkspaceExplorerStore(
+    (state) => state.browsedWorkspaceId
+  );
+  const setBrowsedWorkspaceId = useWorkspaceExplorerStore(
+    (state) => state.setBrowsedWorkspaceId
+  );
+
+  const knownBrowsed =
+    browsedWorkspaceId &&
+    workspaces.some((workspace) => workspace.id === browsedWorkspaceId)
+      ? browsedWorkspaceId
+      : null;
+
+  const workspaceId = knownBrowsed ?? defaultWorkspace?.id ?? null;
+
+  const setWorkspaceId = useCallback(
+    (newWorkspaceId: string | undefined) => {
+      setBrowsedWorkspaceId(newWorkspaceId ?? null);
+    },
+    [setBrowsedWorkspaceId]
+  );
+
+  return {
+    workspaceId: workspaceId ?? undefined,
+    workspace: workspaces.find((workspace) => workspace.id === workspaceId),
+    setWorkspaceId,
+    isLoading
+  };
+};

--- a/web/src/stores/WorkspaceExplorerStore.ts
+++ b/web/src/stores/WorkspaceExplorerStore.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/**
+ * Which workspace the Workspace Explorer is browsing.
+ *
+ * Kept apart from {@link useCurrentWorkspaceStore}: that one remembers where
+ * the next *run* writes and follows the active workflow, while this is a
+ * viewing choice. Browsing a folder must not repoint a workflow, and switching
+ * workflow tabs must not move the explorer out from under the user.
+ */
+interface WorkspaceExplorerState {
+  browsedWorkspaceId: string | null;
+  setBrowsedWorkspaceId: (id: string | null) => void;
+}
+
+export const useWorkspaceExplorerStore = create<WorkspaceExplorerState>()(
+  persist(
+    (set) => ({
+      browsedWorkspaceId: null,
+      setBrowsedWorkspaceId: (id) => set({ browsedWorkspaceId: id })
+    }),
+    { name: "nodetool-workspace-explorer" }
+  )
+);


### PR DESCRIPTION
## What changed

The Workspace Explorer showed files only while a workflow was open ("Open a workflow to access its workspace files"), reset its folder to the active workflow's workspace on every tab switch, and patched-and-saved the workflow when the user picked a different folder to browse. Browsing is a viewing choice, and the panel mounts under `/workspace` where there may be no workflow at all. The tree now reads its own persisted selection — `WorkspaceExplorerStore` resolved by `useWorkspaceExplorer`, falling back to the default workspace the server creates while answering the list call — so it works with no workflow open, keeps the folder the user picked across workflow switches, and writes nothing to a workflow. `useCurrentWorkspace` is unchanged and still answers where the *active workflow's run* writes, for the composer chip, the workflow form, and the save-destination hint. The loading branch moved ahead of the empty branch so the panel shows its skeleton while the workspace list is in flight instead of flashing "No workspace selected"; `themeMock` gains the `Skeleton` palette slot MUI derives only in a real CSS-variables palette, which is what let that branch render under Jest.

## Verification

- [x] `npm run test:affected -- --base HEAD` — 264 suites, 2294 passed, 1 skipped. (Plain `test:affected` diffs against a stale local `origin/main` here and selects all four trees; that run additionally fails `@nodetool-ai/image-nodes` on `vkCreateInstance failed with VK_ERROR_INCOMPATIBLE_DRIVER` — the missing Vulkan ICD documented in AGENTS.md, in a package this diff does not touch.)
- [x] `npm run typecheck` — `web` and `electron` clean (0 errors under `web/`). `mobile` fails on absent Expo/React Native deps, which are not installed in this container and are unrelated to the diff.
- [x] `npm run lint` — exit 0.
- [x] `npm run nodetool -- harness gate --base HEAD~1` — 1 surface touched (`web-editor`), 0 selfchecks to run.

Both new `WorkspaceTree` tests were run against the pre-change component (`git stash push -- web/src/components/workspaces/WorkspaceTree.tsx`) and both went red, so they pin the behavior rather than passing vacuously:

```
--- original WorkspaceTree ---
    ✕ lists the default workspace's files with no workflow open (50 ms)
    ✕ browses the workspace the user picked, not a workflow's (4 ms)
Tests:       2 failed, 2 total
--- restored ---
    ✓ lists the default workspace's files with no workflow open (178 ms)
    ✓ browses the workspace the user picked, not a workflow's (312 ms)
Tests:       2 passed, 2 total
```

## Agent capabilities

No capability added or re-declared.

## New checks

No check, rule, or audit added — the two new suites are behavior tests, inverted above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTSKz7vB1AjZP8TYspXEGi)_