### PR TITLE
feat(chat): render tool calls as a connected timeline

### DIFF
--- a/web/src/components/chat/feedback/MediaPredictionStatus.tsx
+++ b/web/src/components/chat/feedback/MediaPredictionStatus.tsx
@@ -74,7 +74,7 @@ export const MediaPredictionInline: React.FC<MediaPredictionRowProps> = memo(
           component="span"
           size="small"
           color="secondary"
-          className="tool-message"
+          className="media-prediction-label"
           truncate
         >
           <ShimmerText>

--- a/web/src/components/chat/message/MessageView.tsx
+++ b/web/src/components/chat/message/MessageView.tsx
@@ -35,17 +35,20 @@ import {
   FlexColumn,
   ShimmerText,
   Collapse,
+  SPACING,
   ToolbarIconButton
 } from "../../ui_primitives";
+import type { SvgIconComponent } from "@mui/icons-material";
 import ErrorIcon from "@mui/icons-material/Error";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import PersonOutlineRoundedIcon from "@mui/icons-material/PersonOutlineRounded";
 import HubOutlinedIcon from "@mui/icons-material/HubOutlined";
 import ArticleOutlinedIcon from "@mui/icons-material/ArticleOutlined";
 import { useAssetStore } from "../../../stores/AssetStore";
 import { useNotificationStore } from "../../../stores/NotificationStore";
 import { useWorkspaceTabsStore } from "../../../stores/WorkspaceTabsStore";
-import { getToolVisual } from "./toolCallIcon";
+import { getToolIcon } from "./toolCallIcon";
 
 import AgentExecutionView from "./AgentExecutionView";
 import MediaOutputGroup from "./MediaOutputGroup";
@@ -63,6 +66,7 @@ import {
   toolCallGroupPreview,
   type ToolCallRun
 } from "./groupToolCalls";
+import { toolCallPhrase, toolCallRunDisplay } from "./toolCallPhrase";
 
 /**
  * PrettyJson - Memoized component for displaying formatted JSON.
@@ -85,21 +89,6 @@ const PrettyJson: React.FC<{ value: unknown }> = React.memo(({ value }) => {
 });
 PrettyJson.displayName = "PrettyJson";
 
-/**
- * `run_subtask` is the recursive-decomposition primitive. We render its
- * tool-call card differently from generic tools: the LLM-provided `title`
- * becomes the headline, `instructions` go into the expanded section, and a
- * tree icon signals that this card represents a deeper sub-execution.
- */
-const RUN_SUBTASK_TOOL_NAME = "run_subtask";
-
-/**
- * `execute_code` is the CodeAct action primitive (docs/codeact-design.md):
- * its one argument is a JavaScript program, so the card renders it as a
- * highlighted code block instead of a JSON-escaped string.
- */
-const EXECUTE_CODE_TOOL_NAME = "execute_code";
-
 function formatTime(dateStr?: string | null): string | null {
   if (!dateStr) {
     return null;
@@ -117,14 +106,48 @@ function formatTime(dateStr?: string | null): string | null {
 }
 
 /**
- * ToolCallCard - Memoized component for displaying tool calls.
- * Extracted outside MessageView to prevent recreation on every render.
+ * `run_subtask` is the recursive-decomposition primitive: its LLM-provided
+ * `description` becomes the row label and `prompt` goes into the expanded
+ * section, so the row reads as the work rather than as a tool name.
  */
-const ToolCallCard: React.FC<{
+const RUN_SUBTASK_TOOL_NAME = "run_subtask";
+
+/**
+ * `execute_code` is the CodeAct action primitive (docs/codeact-design.md):
+ * its one argument is a JavaScript program, so the row renders it as a
+ * highlighted code block instead of a JSON-escaped string.
+ */
+const EXECUTE_CODE_TOOL_NAME = "execute_code";
+
+/**
+ * ToolRowRail — the glyph column and the hairline that ties one row to the
+ * next. The rail is what makes a sequence of calls read as a timeline rather
+ * than a stack of cards.
+ */
+const ToolRowRail: React.FC<{
+  Icon: SvgIconComponent;
+  connected: boolean;
+}> = React.memo(({ Icon, connected }) => (
+  <div className="tool-row-rail" aria-hidden>
+    <span className="tool-row-glyph">
+      <Icon />
+    </span>
+    {connected && <span className="tool-row-connector" />}
+  </div>
+));
+ToolRowRail.displayName = "ToolRowRail";
+
+/**
+ * ToolCallRow - one call in the timeline: a glyph, what it did, and the thing
+ * it did it to. Arguments and the result live behind the row.
+ */
+const ToolCallRow: React.FC<{
   tc: ToolCall;
   result?: { name?: string | null; content: unknown };
   durationMs?: number | null;
-}> = React.memo(({ tc, result, durationMs }) => {
+  connected?: boolean;
+  tight?: boolean;
+}> = React.memo(({ tc, result, durationMs, connected = false, tight = false }) => {
   const isSubtask = tc.name === RUN_SUBTASK_TOOL_NAME;
   const isCodeAction = tc.name === EXECUTE_CODE_TOOL_NAME;
   const [open, setOpen] = useState(false);
@@ -139,7 +162,7 @@ const ToolCallCard: React.FC<{
   );
 
   // For run_subtask we lift `description` / `prompt` (Claude-Code Task naming)
-  // out of args into headline + expanded body. Tolerate the older
+  // out of args into label + expanded body. Tolerate the older
   // `title`/`instructions` keys for messages already in the DB.
   const rawArgs =
     (tc.args as Record<string, unknown> | null | undefined) ?? null;
@@ -200,144 +223,120 @@ const ToolCallCard: React.FC<{
     }
   }, []);
 
-  // For subtasks we keep the title + "Subtask" badge as the headline. For
-  // regular tool calls we drop the tool name entirely and let the LLM-authored
-  // `tc.message` carry the row — falling back to the formatted tool name only
-  // when no message was provided.
+  // The LLM-authored `message` is the best label when there is one; otherwise
+  // the tool's category supplies a verb phrase. Either way the distinctive
+  // argument rides alongside in mono, unless the label already names it.
   const liveMessage = isRunning ? runningToolMessage || tc.message : tc.message;
-  const fallbackName = formatToolName(tc.name);
-  const headline = isSubtask
-    ? subtaskTitle || fallbackName
+  const phrase = toolCallPhrase(tc);
+  const label = isSubtask
+    ? subtaskTitle || formatToolName(tc.name)
     : isCodeAction
-      ? actionTitle || liveMessage || fallbackName
-      : liveMessage || fallbackName;
-  const showSeparateMessage = isSubtask && !!liveMessage;
-  const headlineLabel = isSubtask ? "Subtask" : null;
-  const { Icon: ToolIcon, accent } = getToolVisual(tc.name);
+      ? actionTitle || liveMessage || formatToolName(tc.name)
+      : liveMessage || phrase.label;
+  const detail =
+    !isSubtask &&
+    !isCodeAction &&
+    phrase.detail &&
+    !label.includes(phrase.detail)
+      ? phrase.detail
+      : null;
+  const ToolIcon = getToolIcon(tc.name);
 
   return (
     <div
-      className={`tool-call-card${isRunning ? " running" : ""}${
-        isSubtask ? " run-subtask" : ""
-      }`}
+      className={`tool-row${isRunning ? " running" : ""}${
+        isSubtask ? " subtask" : ""
+      }${tight ? " tight" : ""}`}
     >
-      <FlexRow
-        className={`tool-call-header${hasDetails ? " expandable" : ""}`}
-        align="center"
-        fullWidth
-        gap={1}
-        role={hasDetails ? "button" : undefined}
-        tabIndex={hasDetails ? 0 : undefined}
-        aria-expanded={hasDetails ? open : undefined}
-        onClick={hasDetails ? handleToggleOpen : undefined}
-        onKeyDown={hasDetails ? handleHeaderKeyDown : undefined}
-      >
-        <span className={`tool-icon-tile accent-${accent}`} aria-hidden>
-          <ToolIcon />
-        </span>
-        <FlexRow align="center" gap={1} sx={{ minWidth: 0, flex: 1 }}>
-          {headlineLabel && (
-            <Text
-              component="span"
-              size="small"
-              className="tool-call-badge"
-            >
-              {headlineLabel}
-            </Text>
-          )}
+      <ToolRowRail Icon={ToolIcon} connected={connected} />
+      <div className="tool-row-main">
+        <FlexRow
+          className={`tool-row-header${hasDetails ? " expandable" : ""}`}
+          align="center"
+          fullWidth
+          gap={SPACING.xs}
+          role={hasDetails ? "button" : undefined}
+          tabIndex={hasDetails ? 0 : undefined}
+          aria-expanded={hasDetails ? open : undefined}
+          onClick={hasDetails ? handleToggleOpen : undefined}
+          onKeyDown={hasDetails ? handleHeaderKeyDown : undefined}
+        >
           <Text
             component="span"
             size="small"
-            weight={500}
-            className="tool-call-name"
-            truncate
+            className="tool-row-label"
+            truncate={!isSubtask}
           >
-            {isRunning ? <ShimmerText>{headline}</ShimmerText> : headline}
+            {isRunning ? <ShimmerText>{label}</ShimmerText> : label}
           </Text>
-          {showSeparateMessage && (
-            <Text
-              component="span"
-              size="small"
-              className="tool-message"
-              truncate
-            >
-              {liveMessage}
-            </Text>
-          )}
-          {/* Show the raw tool identifier only when the headline is an
-              LLM-authored message — otherwise it would duplicate the
-              formatted tool name sitting right next to it. */}
-          {!isSubtask && !!liveMessage && (
-            <span className="tool-call-id">{tc.name}</span>
-          )}
-        </FlexRow>
-        <FlexRow align="center" gap={1} sx={{ flexShrink: 0 }}>
+          {detail && <span className="tool-row-detail">{detail}</span>}
+          <span className="tool-row-gap" />
           {durationLabel && (
-            <span className="tool-call-duration">{durationLabel}</span>
+            <span className="tool-row-duration">{durationLabel}</span>
           )}
           {hasDetails && (
             <ExpandMoreIcon
-              className={`expand-icon${open ? " expanded" : ""}`}
+              className={`tool-row-chevron${open ? " expanded" : ""}`}
               aria-hidden
             />
           )}
         </FlexRow>
-      </FlexRow>
-      {isRunning &&
-        isCodeAction &&
-        activePredictions.map((prediction) => (
-          <MediaPredictionInline key={prediction.id} prediction={prediction} />
-        ))}
-      <Collapse in={open} timeout="auto" unmountOnExit>
-        <FlexColumn className="tool-call-details" gap={0.5}>
-          {isSubtask && subtaskInstructions && (
-            <FlexColumn gap={0.5}>
-              <Caption className="tool-section-title">Instructions</Caption>
-              <Text size="small" className="subtask-instructions">
-                {subtaskInstructions}
-              </Text>
-            </FlexColumn>
-          )}
-          {formattedActionCode && (
-            <FlexColumn gap={0.5}>
-              <Caption className="tool-section-title">Code</Caption>
-              <CodeBlock inline={false} className="language-javascript">
-                {formattedActionCode}
-              </CodeBlock>
-            </FlexColumn>
-          )}
-          {hasArgs && (
-            <FlexColumn gap={0.5}>
-              <Caption className="tool-section-title">
-                {isSubtask ? "Other arguments" : "Arguments"}
-              </Caption>
-              <PrettyJson value={displayArgs} />
-            </FlexColumn>
-          )}
-          {hasResult && (
-            <FlexColumn gap={0.5}>
-              <FlexRow
-                className="tool-section-header"
-                align="center"
-                justify="space-between"
-                fullWidth
-              >
-                <Caption className="tool-section-title">Result</Caption>
-                <CopyButton
-                  value={resultContent}
-                  tooltip="Copy result"
-                  buttonSize="small"
-                />
-              </FlexRow>
-              <ToolResult toolName={tc.name} content={resultContent} />
-            </FlexColumn>
-          )}
-        </FlexColumn>
-      </Collapse>
+        {isRunning &&
+          isCodeAction &&
+          activePredictions.map((prediction) => (
+            <MediaPredictionInline key={prediction.id} prediction={prediction} />
+          ))}
+        <Collapse in={open} timeout="auto" unmountOnExit>
+          <FlexColumn className="tool-row-details" gap={SPACING.xs}>
+            {isSubtask && subtaskInstructions && (
+              <FlexColumn gap={SPACING.xs}>
+                <Caption className="tool-section-title">Instructions</Caption>
+                <Text size="small" className="subtask-instructions">
+                  {subtaskInstructions}
+                </Text>
+              </FlexColumn>
+            )}
+            {formattedActionCode && (
+              <FlexColumn gap={SPACING.xs}>
+                <Caption className="tool-section-title">Code</Caption>
+                <CodeBlock inline={false} className="language-javascript">
+                  {formattedActionCode}
+                </CodeBlock>
+              </FlexColumn>
+            )}
+            {hasArgs && (
+              <FlexColumn gap={SPACING.xs}>
+                <Caption className="tool-section-title">
+                  {isSubtask ? "Other arguments" : "Arguments"}
+                </Caption>
+                <PrettyJson value={displayArgs} />
+              </FlexColumn>
+            )}
+            {hasResult && (
+              <FlexColumn gap={SPACING.xs}>
+                <FlexRow
+                  className="tool-section-header"
+                  align="center"
+                  justify="space-between"
+                  fullWidth
+                >
+                  <Caption className="tool-section-title">Result</Caption>
+                  <CopyButton
+                    value={resultContent}
+                    tooltip="Copy result"
+                    buttonSize="small"
+                  />
+                </FlexRow>
+                <ToolResult toolName={tc.name} content={resultContent} />
+              </FlexColumn>
+            )}
+          </FlexColumn>
+        </Collapse>
+      </div>
     </div>
   );
 });
-ToolCallCard.displayName = "ToolCallCard";
+ToolCallRow.displayName = "ToolCallRow";
 
 type ToolResultLookup = Record<
   string,
@@ -350,15 +349,16 @@ type CallTiming = {
 };
 
 /**
- * Collapsed run of consecutive same-tool calls. Expands to the individual
- * cards. Closed by default — the point is to hide a stack of identical rows.
+ * ToolCallCountRow - a run of same-tool calls the timeline shows as one
+ * counted row ("Ran 3 searches"). Expands to a row per call.
  */
-const ToolCallRunCard: React.FC<{
+const ToolCallCountRow: React.FC<{
   name: string;
   calls: ToolCall[];
   durationFor: (tc: ToolCall) => CallTiming;
   messageCreatedAt?: string | null;
-}> = React.memo(({ name, calls, durationFor, messageCreatedAt }) => {
+  connected?: boolean;
+}> = React.memo(({ name, calls, durationFor, messageCreatedAt, connected = false }) => {
   const [open, setOpen] = useState(false);
   const runningToolCallId = useGlobalChatStore(
     (s) => s.currentRunningToolCallId
@@ -366,8 +366,8 @@ const ToolCallRunCard: React.FC<{
   const isRunning = calls.some(
     (tc) => tc.id && runningToolCallId === tc.id
   );
-  const { Icon: ToolIcon, accent } = getToolVisual(name);
-  const headline = toolCallGroupHeadline(name, calls);
+  const ToolIcon = getToolIcon(name);
+  const label = toolCallGroupHeadline(name, calls);
   const preview = toolCallGroupPreview(name, calls);
 
   const handleToggleOpen = useCallback(() => {
@@ -413,92 +413,115 @@ const ToolCallRunCard: React.FC<{
       : null;
 
   return (
-    <div
-      className={`tool-call-card tool-call-run${isRunning ? " running" : ""}`}
-    >
-      <FlexRow
-        className="tool-call-header expandable"
-        align="center"
-        fullWidth
-        gap={1}
-        role="button"
-        tabIndex={0}
-        aria-expanded={open}
-        aria-label={`${headline}, ${calls.length} ${name}`}
-        onClick={handleToggleOpen}
-        onKeyDown={handleHeaderKeyDown}
-      >
-        <span className={`tool-icon-tile accent-${accent}`} aria-hidden>
-          <ToolIcon />
-        </span>
-        <FlexColumn sx={{ minWidth: 0, flex: 1 }} gap={0}>
-          <FlexRow align="center" gap={1} sx={{ minWidth: 0 }}>
-            <Text
-              component="span"
-              size="small"
-              weight={500}
-              className="tool-call-name"
-              truncate
-            >
-              {isRunning ? <ShimmerText>{headline}</ShimmerText> : headline}
-            </Text>
-            <span className="tool-call-id">
-              {name} ×{calls.length}
-            </span>
-          </FlexRow>
+    <div className={`tool-row tool-row-count${isRunning ? " running" : ""}`}>
+      <ToolRowRail Icon={ToolIcon} connected={connected} />
+      <div className="tool-row-main">
+        <FlexRow
+          className="tool-row-header expandable"
+          align="center"
+          fullWidth
+          gap={SPACING.xs}
+          role="button"
+          tabIndex={0}
+          aria-expanded={open}
+          aria-label={`${label}, ${calls.length} ${name}`}
+          onClick={handleToggleOpen}
+          onKeyDown={handleHeaderKeyDown}
+        >
+          <Text
+            component="span"
+            size="small"
+            className="tool-row-label"
+            truncate
+          >
+            {isRunning ? <ShimmerText>{label}</ShimmerText> : label}
+          </Text>
           {preview && !open && (
-            <Text
-              component="span"
-              size="smaller"
-              color="secondary"
-              className="tool-call-run-preview"
-              truncate
-            >
-              {preview}
-            </Text>
+            <span className="tool-row-detail">{preview}</span>
           )}
-        </FlexColumn>
-        <FlexRow align="center" gap={1} sx={{ flexShrink: 0 }}>
+          <span className="tool-row-gap" />
           {progressLabel && (
-            <span className="tool-call-run-progress">{progressLabel}</span>
+            <span className="tool-row-duration">{progressLabel}</span>
           )}
           {durationLabel && (
-            <span className="tool-call-duration">{durationLabel}</span>
+            <span className="tool-row-duration">{durationLabel}</span>
           )}
           <ExpandMoreIcon
-            className={`expand-icon${open ? " expanded" : ""}`}
+            className={`tool-row-chevron${open ? " expanded" : ""}`}
             aria-hidden
           />
         </FlexRow>
-      </FlexRow>
-      <Collapse in={open} timeout="auto" unmountOnExit>
-        <FlexColumn className="tool-call-run-items" gap={0}>
-          {calls.map((tc, i) => {
-            const { toolResult, durationMs: callDuration } = durationFor(tc);
-            return (
-              <ToolCallCard
-                key={tc.id || i}
-                tc={tc}
-                result={toolResult}
-                durationMs={callDuration}
-              />
-            );
-          })}
-        </FlexColumn>
-      </Collapse>
+        <Collapse in={open} timeout="auto" unmountOnExit>
+          <FlexColumn className="tool-row-children" gap={SPACING.none}>
+            {calls.map((tc, i) => {
+              const { toolResult, durationMs: callDuration } = durationFor(tc);
+              return (
+                <ToolCallRow
+                  key={tc.id || i}
+                  tc={tc}
+                  result={toolResult}
+                  durationMs={callDuration}
+                  tight={i > 0}
+                />
+              );
+            })}
+          </FlexColumn>
+        </Collapse>
+      </div>
     </div>
   );
 });
-ToolCallRunCard.displayName = "ToolCallRunCard";
-
+ToolCallCountRow.displayName = "ToolCallCountRow";
 
 /**
- * ToolCallGroup - Renders a message's tool calls as a chain. Consecutive
- * calls of the same groupable tool collapse into one run card. Mixed tools
- * keep the section label, hairline rule, and summary bar. A single visual
- * item (one card or one run) has no chain chrome.
+ * One entry in the rendered timeline. A run of same-tool calls becomes either
+ * a row per call (`tight` on all but the first) or one counted row —
+ * `toolCallRunDisplay` decides, on whether each call names a place worth
+ * reading.
  */
-const ToolCallGroup: React.FC<{
+type TimelineRow =
+  | { key: string; kind: "call"; call: ToolCall; tight: boolean }
+  | { key: string; kind: "count"; name: string; calls: ToolCall[] };
+
+function timelineRows(runs: readonly ToolCallRun[]): TimelineRow[] {
+  const rows: TimelineRow[] = [];
+  runs.forEach((run, i) => {
+    if (run.kind === "single") {
+      rows.push({
+        key: run.call.id || `call-${i}`,
+        kind: "call",
+        call: run.call,
+        tight: false
+      });
+      return;
+    }
+    if (toolCallRunDisplay(run.name, run.calls) === "list") {
+      run.calls.forEach((call, j) => {
+        rows.push({
+          key: call.id || `call-${i}-${j}`,
+          kind: "call",
+          call,
+          tight: j > 0
+        });
+      });
+      return;
+    }
+    rows.push({
+      key: run.calls[0]?.id || `run-${run.name}-${i}`,
+      kind: "count",
+      name: run.name,
+      calls: run.calls
+    });
+  });
+  return rows;
+}
+
+/**
+ * ToolCallTimeline - a message's tool calls as a connected sequence of rows.
+ * Two or more rows carry a footer that reports how long the whole sequence
+ * took and folds the rows away.
+ */
+const ToolCallTimeline: React.FC<{
   toolCalls: ToolCall[];
   toolResultsByCallId?: ToolResultLookup;
   messageCreatedAt?: string | null;
@@ -531,35 +554,42 @@ const ToolCallGroup: React.FC<{
     [toolResultsByCallId, messageCreatedAt]
   );
 
-  const runs = useMemo(
-    () => groupConsecutiveToolCalls(toolCalls),
+  const rows = useMemo(
+    () => timelineRows(groupConsecutiveToolCalls(toolCalls)),
     [toolCalls]
   );
 
-  const renderRun = useCallback(
-    (run: ToolCallRun, i: number) => {
-      if (run.kind === "single") {
-        const { toolResult, durationMs } = durationFor(run.call);
+  const renderRow = useCallback(
+    (row: TimelineRow, i: number) => {
+      // The hairline runs to the next row unless that row sits tight against
+      // this one — a cluster of same-tool calls reads as one step.
+      const next = rows[i + 1];
+      const connected = next !== undefined && !(next.kind === "call" && next.tight);
+      if (row.kind === "call") {
+        const { toolResult, durationMs } = durationFor(row.call);
         return (
-          <ToolCallCard
-            key={run.call.id || i}
-            tc={run.call}
+          <ToolCallRow
+            key={row.key}
+            tc={row.call}
             result={toolResult}
             durationMs={durationMs}
+            connected={connected}
+            tight={row.tight}
           />
         );
       }
       return (
-        <ToolCallRunCard
-          key={run.calls[0]?.id || `run-${run.name}-${i}`}
-          name={run.name}
-          calls={run.calls}
+        <ToolCallCountRow
+          key={row.key}
+          name={row.name}
+          calls={row.calls}
           durationFor={durationFor}
           messageCreatedAt={messageCreatedAt}
+          connected={connected}
         />
       );
     },
-    [durationFor, messageCreatedAt]
+    [rows, durationFor, messageCreatedAt]
   );
 
   const isRunning = toolCalls.some(
@@ -581,67 +611,49 @@ const ToolCallGroup: React.FC<{
     return { completedCount: completed, totalDurationMs: maxMs };
   }, [toolCalls, durationFor]);
 
-  // One visual item (a single card or one collapsed run) needs no chain chrome.
-  if (runs.length <= 1) {
-    return <>{runs.map(renderRun)}</>;
+  // A lone row is its own summary — no footer, nothing to fold.
+  if (rows.length <= 1) {
+    return <div className="tool-timeline">{rows.map(renderRow)}</div>;
   }
 
   const totalDurationLabel =
     totalDurationMs !== null ? formatDuration(totalDurationMs) : null;
+  const stepsLabel = `${toolCalls.length} steps`;
+  const footerLabel = isRunning
+    ? `Working · ${completedCount}/${toolCalls.length}`
+    : totalDurationLabel
+      ? `Worked for ${totalDurationLabel}`
+      : stepsLabel;
 
   return (
-    <div className="tool-call-group">
+    <div className="tool-timeline">
+      <Collapse in={open} timeout="auto" unmountOnExit>
+        <div className="tool-timeline-rows">{rows.map(renderRow)}</div>
+      </Collapse>
       <FlexRow
-        className="tool-call-group-header"
+        className="tool-timeline-footer"
         align="center"
-        gap={1}
+        // Matches the row grid's column gap so the footer text lines up with
+        // the labels above it.
+        gap={SPACING.md}
         role="button"
         tabIndex={0}
         aria-expanded={open}
         onClick={handleToggleOpen}
         onKeyDown={handleKeyDown}
       >
-        <Text
-          component="span"
-          size="small"
-          className="tool-call-group-label"
-        >
-          {isRunning ? (
-            <ShimmerText>Tool execution chain</ShimmerText>
-          ) : (
-            "Tool execution chain"
-          )}
+        <span className="tool-row-glyph" aria-hidden>
+          <DragIndicatorIcon />
+        </span>
+        <Text component="span" size="small" className="tool-timeline-summary">
+          {isRunning ? <ShimmerText>{footerLabel}</ShimmerText> : footerLabel}
         </Text>
-        <span className="tool-call-group-rule" aria-hidden />
-        <ExpandMoreIcon
-          className={`expand-icon${open ? " expanded" : ""}`}
-          aria-hidden
-        />
+        {!open && <span className="tool-row-detail">{stepsLabel}</span>}
       </FlexRow>
-      <Collapse in={open} timeout="auto" unmountOnExit>
-        <FlexColumn className="tool-call-chain" gap={1}>
-          {runs.map(renderRun)}
-          <FlexRow className="tool-call-summary" align="center" gap={1.5}>
-            <span className="tool-call-summary-count">
-              {completedCount}/{toolCalls.length} completed
-            </span>
-            {totalDurationLabel && (
-              <>
-                <span className="tool-call-summary-divider" aria-hidden>
-                  |
-                </span>
-                <span className="tool-call-summary-duration">
-                  {totalDurationLabel}
-                </span>
-              </>
-            )}
-          </FlexRow>
-        </FlexColumn>
-      </Collapse>
     </div>
   );
 });
-ToolCallGroup.displayName = "ToolCallGroup";
+ToolCallTimeline.displayName = "ToolCallTimeline";
 
 function markdownAssetFilename(text: string): string {
   const firstLine = text
@@ -926,7 +938,7 @@ export const MessageView: React.FC<
             {message.role === "assistant" &&
               Array.isArray(message.tool_calls) &&
               !message.agent_execution_id && ( // Don't render tool cards for agent tasks here (they are in AgentExecutionView)
-                <ToolCallGroup
+                <ToolCallTimeline
                   toolCalls={message.tool_calls}
                   toolResultsByCallId={toolResultsByCallId}
                   messageCreatedAt={message.created_at}

--- a/web/src/components/chat/message/ResourceChip.tsx
+++ b/web/src/components/chat/message/ResourceChip.tsx
@@ -24,19 +24,26 @@ import { parseResourceUri, type ResourceKind, type ResourceUri } from "@nodetool
 import { BORDER_RADIUS, Chip, SPACING, TYPOGRAPHY, getSpacingPx } from "../../ui_primitives";
 import { useResolvedMediaUri } from "../../../hooks/useResolvedMediaUri";
 import { canOpenResource, openResource } from "../../../lib/chat/openResource";
-import type { ToolAccent } from "./toolCallIcon";
 
 interface ResourceChipProps {
   uri: string;
   label: string;
 }
 
+/** Accent keys resolve to theme palette colors on the chip. */
+type ChipAccent =
+  | "info"
+  | "warning"
+  | "success"
+  | "primary"
+  | "secondary"
+  | "neutral";
+
 interface KindVisual {
   Icon: SvgIconComponent;
-  accent: ToolAccent;
+  accent: ChipAccent;
 }
 
-/** Kinds share the accent vocabulary of `getToolVisual` so chat reads as one surface. */
 const KIND_VISUALS = {
   asset: { Icon: ImageOutlinedIcon, accent: "secondary" },
   workflow: { Icon: AccountTreeOutlinedIcon, accent: "primary" },
@@ -52,7 +59,7 @@ const KIND_VISUALS = {
 
 type ChipColor = "default" | "primary" | "secondary" | "success" | "warning" | "error" | "info";
 
-const chipColor = (accent: ToolAccent): ChipColor =>
+const chipColor = (accent: ChipAccent): ChipColor =>
   accent === "neutral" ? "default" : accent;
 
 const IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".avif"];

--- a/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
+++ b/web/src/components/chat/message/__tests__/MessageView.toolCalls.test.tsx
@@ -46,8 +46,8 @@ const toolCall = (id: string, name: string): ToolCall => ({
   args: {}
 });
 
-describe("MessageView tool-call grouping", () => {
-  it("renders multiple tool calls as an expanded execution chain with a summary", () => {
+describe("MessageView tool-call timeline", () => {
+  it("renders every call as a connected row under one footer", () => {
     renderView({
       id: "m1",
       role: "assistant",
@@ -59,11 +59,13 @@ describe("MessageView tool-call grouping", () => {
       ]
     } as Message);
 
-    expect(screen.getByText("Tool execution chain")).toBeInTheDocument();
-    // Expanded by default: every card is visible along with the summary bar.
+    expect(document.querySelectorAll(".tool-timeline-rows > .tool-row"))
+      .toHaveLength(4);
+    expect(screen.getByText("Ran 1 search")).toBeInTheDocument();
     expect(screen.getByText("Run Tests")).toBeInTheDocument();
-    expect(screen.getByText("Search")).toBeInTheDocument();
-    expect(screen.getByText("0/4 completed")).toBeInTheDocument();
+    expect(screen.getByText("4 steps")).toBeInTheDocument();
+    // The hairline runs to the next row, and stops at the last one.
+    expect(document.querySelectorAll(".tool-row-connector")).toHaveLength(3);
   });
 
   it("rerenders only the active message when a thought is toggled", async () => {
@@ -92,7 +94,7 @@ describe("MessageView tool-call grouping", () => {
     expect(screen.getByText("Private reasoning")).toBeInTheDocument();
   });
 
-  it("collapses the chain when the section header is toggled", async () => {
+  it("folds the rows away when the footer is toggled", async () => {
     const user = userEvent.setup();
     renderView({
       id: "m2",
@@ -102,18 +104,16 @@ describe("MessageView tool-call grouping", () => {
 
     expect(screen.getByText("Run Tests")).toBeInTheDocument();
 
-    await user.click(
-      screen.getByRole("button", { name: /tool execution chain/i })
-    );
+    await user.click(screen.getByRole("button", { name: /2 steps/i }));
 
     // Collapse unmounts its children once the exit transition finishes.
     await waitFor(() => {
       expect(screen.queryByText("Run Tests")).not.toBeInTheDocument();
     });
-    expect(screen.queryByText("Search")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ran 1 search")).not.toBeInTheDocument();
   });
 
-  it("counts a call with an empty result as completed in the summary", () => {
+  it("counts a call with an empty result as completed in the footer", () => {
     render(
       <ThemeProvider theme={mockTheme}>
         <MessageView
@@ -134,20 +134,19 @@ describe("MessageView tool-call grouping", () => {
       </ThemeProvider>
     );
 
-    expect(screen.getByText("1/2 completed")).toBeInTheDocument();
+    expect(screen.getByText("2 steps")).toBeInTheDocument();
   });
 
-  it("renders a single tool call inline without the group wrapper", () => {
+  it("renders a lone tool call with no footer and no hairline", () => {
     renderView({
       id: "m3",
       role: "assistant",
       tool_calls: [toolCall("a", "search")]
     } as Message);
 
-    expect(
-      screen.queryByText(/tool execution chain/i)
-    ).not.toBeInTheDocument();
-    expect(screen.getByText("Search")).toBeInTheDocument();
+    expect(document.querySelector(".tool-timeline-footer")).toBeNull();
+    expect(document.querySelector(".tool-row-connector")).toBeNull();
+    expect(screen.getByText("Ran 1 search")).toBeInTheDocument();
   });
 
   it("collapses consecutive same-tool calls into one closed run", () => {
@@ -176,19 +175,15 @@ describe("MessageView tool-call grouping", () => {
       ]
     } as Message);
 
-    expect(
-      screen.queryByText(/tool execution chain/i)
-    ).not.toBeInTheDocument();
+    expect(document.querySelector(".tool-timeline-footer")).toBeNull();
     expect(screen.getByText("Searching the web")).toBeInTheDocument();
-    expect(screen.getByText("web_search ×3")).toBeInTheDocument();
     expect(
       screen.getByText("facebook ads · tiktok creative · linkedin tests")
     ).toBeInTheDocument();
-    expect(screen.queryByText("0/3 completed")).not.toBeInTheDocument();
-    expect(document.querySelector(".tool-call-run-items")).toBeNull();
+    expect(document.querySelector(".tool-row-children")).toBeNull();
   });
 
-  it("expands a tool-call run to show each call", async () => {
+  it("expands a counted run to a row per call", async () => {
     const user = userEvent.setup();
     renderView({
       id: "m-run-open",
@@ -213,11 +208,11 @@ describe("MessageView tool-call grouping", () => {
       screen.getByRole("button", { name: /searching the web, 2 web_search/i })
     );
 
-    expect(document.querySelectorAll(".tool-call-run-items .tool-call-card"))
+    expect(document.querySelectorAll(".tool-row-children .tool-row"))
       .toHaveLength(2);
   });
 
-  it("keeps execute_code cards ungrouped next to a search run", () => {
+  it("keeps execute_code rows ungrouped next to a search run", () => {
     renderView({
       id: "m-mixed",
       role: "assistant",
@@ -242,12 +237,11 @@ describe("MessageView tool-call grouping", () => {
       ]
     } as Message);
 
-    expect(screen.getByText("Tool execution chain")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /planning ad framework research/i })
     ).toBeInTheDocument();
-    expect(screen.getByText("web_search ×2")).toBeInTheDocument();
-    expect(screen.getByText("0/3 completed")).toBeInTheDocument();
+    expect(screen.getByText("Searching the web")).toBeInTheDocument();
+    expect(screen.getByText("3 steps")).toBeInTheDocument();
   });
 });
 
@@ -268,7 +262,7 @@ describe("MessageView CodeAct actions", () => {
       ]
     } as Message);
 
-    // CodeAct cards start collapsed — the program is behind the header.
+    // CodeAct rows start collapsed — the program is behind the row.
     expect(screen.queryByText("Code")).not.toBeInTheDocument();
     expect(document.querySelector(".code-block-container")).toBeNull();
 
@@ -290,7 +284,7 @@ describe("MessageView CodeAct actions", () => {
     expect(screen.queryByText("Arguments")).not.toBeInTheDocument();
   });
 
-  it("shows the action's title as the card headline", () => {
+  it("shows the action's title as the row label", () => {
     renderView({
       id: "m6",
       role: "assistant",
@@ -316,7 +310,7 @@ describe("MessageView CodeAct actions", () => {
     expect(screen.queryByText("Arguments")).not.toBeInTheDocument();
   });
 
-  it("shows the in-flight media prediction on a running execute_code card", () => {
+  it("shows the in-flight media prediction on a running execute_code row", () => {
     const store = asMock(useGlobalChatStore);
     const state = {
       currentThreadId: "t1",

--- a/web/src/components/chat/message/__tests__/groupToolCalls.test.ts
+++ b/web/src/components/chat/message/__tests__/groupToolCalls.test.ts
@@ -3,7 +3,6 @@ import type { Message, ToolCall } from "../../../../stores/ApiTypes";
 import {
   collapseToolCallOnlyMessages,
   groupConsecutiveToolCalls,
-  groupCountLabel,
   mergeableToolName,
   toolCallGroupHeadline,
   toolCallGroupPreview
@@ -114,18 +113,7 @@ describe("toolCallGroupHeadline", () => {
       call("a", "browser", { message: "Fetching https://a.example" }),
       call("b", "browser", { message: "Fetching https://b.example" })
     ];
-    expect(toolCallGroupHeadline("browser", calls)).toBe("Fetching 2 pages");
-  });
-});
-
-describe("groupCountLabel", () => {
-  it("pluralizes web searches and browser fetches", () => {
-    expect(groupCountLabel("web_search", 9)).toBe("9 web searches");
-    expect(groupCountLabel("browser", 5)).toBe("Fetching 5 pages");
-  });
-
-  it("uses a times-sign label for other tools", () => {
-    expect(groupCountLabel("read_file", 4)).toBe("4× Read File");
+    expect(toolCallGroupHeadline("browser", calls)).toBe("Opened 2 pages");
   });
 });
 

--- a/web/src/components/chat/message/__tests__/toolCallPhrase.test.ts
+++ b/web/src/components/chat/message/__tests__/toolCallPhrase.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "@jest/globals";
+import type { ToolCall } from "../../../../stores/ApiTypes";
+import {
+  toolCallCountLabel,
+  toolCallDetail,
+  toolCallPhrase,
+  toolCallRunDisplay,
+  toolPhraseKind
+} from "../toolCallPhrase";
+
+const call = (name: string, args: Record<string, unknown> = {}): ToolCall => ({
+  id: name,
+  name,
+  args
+});
+
+describe("toolPhraseKind", () => {
+  it("buckets by keyword", () => {
+    expect(toolPhraseKind("web_search")).toBe("search");
+    expect(toolPhraseKind("browser")).toBe("page");
+    expect(toolPhraseKind("write_file")).toBe("write");
+    expect(toolPhraseKind("read_file")).toBe("read");
+    expect(toolPhraseKind("run_workflow")).toBe("run");
+    expect(toolPhraseKind("frobnicate")).toBe("generic");
+  });
+
+  it("treats a missing name as generic", () => {
+    expect(toolPhraseKind(null)).toBe("generic");
+  });
+});
+
+describe("toolCallDetail", () => {
+  it("keeps a URL's host and path, dropping the scheme and www", () => {
+    expect(
+      toolCallDetail(call("browser", { url: "https://www.example.com/a/b?c=1" }))
+    ).toBe("example.com/a/b?c=1");
+  });
+
+  it("cuts a URL back to its host in short mode", () => {
+    expect(
+      toolCallDetail(
+        call("browser", { url: "https://www.example.com/a/b" }),
+        "short"
+      )
+    ).toBe("example.com");
+  });
+
+  it("drops a trailing root path", () => {
+    expect(toolCallDetail(call("browser", { url: "https://example.com/" }))).toBe(
+      "example.com"
+    );
+  });
+
+  it("returns a path or query verbatim", () => {
+    expect(toolCallDetail(call("read_file", { path: "src/index.ts" }))).toBe(
+      "src/index.ts"
+    );
+    expect(toolCallDetail(call("web_search", { query: "meta stock" }))).toBe(
+      "meta stock"
+    );
+  });
+
+  it("returns null when nothing distinctive is there", () => {
+    expect(toolCallDetail(call("web_search"))).toBeNull();
+    expect(toolCallDetail(call("web_search", { limit: 5 }))).toBeNull();
+  });
+});
+
+describe("toolCallPhrase", () => {
+  it("phrases a page open with its URL", () => {
+    expect(
+      toolCallPhrase(call("browser", { url: "https://finance.yahoo.com/quote/META/" }))
+    ).toEqual({ label: "Opened page", detail: "finance.yahoo.com/quote/META/" });
+  });
+
+  it("phrases a search with its query", () => {
+    expect(toolCallPhrase(call("web_search", { query: "meta stock" }))).toEqual({
+      label: "Searched",
+      detail: "meta stock"
+    });
+  });
+
+  it("counts a search that carries no query", () => {
+    expect(toolCallPhrase(call("web_search"))).toEqual({
+      label: "Ran 1 search",
+      detail: null
+    });
+  });
+
+  it("falls back to the tool's own name for an unrecognized tool", () => {
+    expect(toolCallPhrase(call("frobnicate", { target: "x" }))).toEqual({
+      label: "Frobnicate",
+      detail: "x"
+    });
+  });
+});
+
+describe("toolCallCountLabel", () => {
+  it("phrases a run as what it did", () => {
+    expect(toolCallCountLabel("web_search", 2)).toBe("Ran 2 searches");
+    expect(toolCallCountLabel("web_search", 1)).toBe("Ran 1 search");
+    expect(toolCallCountLabel("browser", 5)).toBe("Opened 5 pages");
+    expect(toolCallCountLabel("write_file", 3)).toBe("Made 3 edits");
+  });
+
+  it("names an unrecognized tool and how often it ran", () => {
+    expect(toolCallCountLabel("frobnicate", 4)).toBe("Frobnicate 4 times");
+  });
+});
+
+describe("toolCallRunDisplay", () => {
+  const page = (url: string) => call("browser", { url });
+
+  it("lists a short run of page opens, each naming its URL", () => {
+    expect(
+      toolCallRunDisplay("browser", [
+        page("https://a.example/one"),
+        page("https://b.example/two")
+      ])
+    ).toBe("list");
+  });
+
+  it("counts a run whose calls name no location", () => {
+    expect(
+      toolCallRunDisplay("web_search", [
+        call("web_search", { query: "a" }),
+        call("web_search", { query: "b" })
+      ])
+    ).toBe("count");
+  });
+
+  it("counts a run too long to read as rows", () => {
+    expect(
+      toolCallRunDisplay(
+        "browser",
+        Array.from({ length: 5 }, (_, i) => page(`https://x.example/${i}`))
+      )
+    ).toBe("count");
+  });
+});

--- a/web/src/components/chat/message/groupToolCalls.ts
+++ b/web/src/components/chat/message/groupToolCalls.ts
@@ -7,8 +7,8 @@
  */
 
 import type { Message, ToolCall } from "../../../stores/ApiTypes";
-import { formatToolName } from "../../../utils/formatUtils";
 import { isObjectLike, isString } from "../../../utils/typePredicates";
+import { toolCallCountLabel, toolCallDetail } from "./toolCallPhrase";
 
 /** Tools that never collapse — each call is a distinct unit of work. */
 const UNGROUPABLE_TOOL_NAMES = new Set([
@@ -21,17 +21,6 @@ const UNGROUPABLE_TOOL_NAMES = new Set([
 
 /** Minimum consecutive same-name calls before a run becomes a group. */
 const TOOL_CALL_GROUP_THRESHOLD = 2;
-
-const DISTINCTIVE_ARG_KEYS = [
-  "query",
-  "url",
-  "uri",
-  "path",
-  "file",
-  "filename",
-  "target",
-  "q"
-] as const;
 
 const PREVIEW_LIMIT = 3;
 
@@ -86,17 +75,7 @@ export function toolCallGroupHeadline(name: string, calls: readonly ToolCall[]):
   if (shared) {
     return messages[0];
   }
-  return groupCountLabel(name, calls.length);
-}
-
-export function groupCountLabel(name: string, count: number): string {
-  if (name === "web_search") {
-    return count === 1 ? "1 web search" : `${count} web searches`;
-  }
-  if (name === "browser") {
-    return count === 1 ? "Fetching 1 page" : `Fetching ${count} pages`;
-  }
-  return `${count}× ${formatToolName(name)}`;
+  return toolCallCountLabel(name, calls.length);
 }
 
 /**
@@ -111,7 +90,7 @@ export function toolCallGroupPreview(
   const values: string[] = [];
   const seen = new Set<string>();
   for (const call of calls) {
-    const value = distinctiveArgValue(call);
+    const value = toolCallDetail(call, "short");
     if (!value || seen.has(value)) {
       continue;
     }
@@ -129,37 +108,6 @@ export function toolCallGroupPreview(
   const extra = values.length - shown.length;
   const joined = shown.join(" · ");
   return extra > 0 ? `${joined} +${extra}` : joined;
-}
-
-function distinctiveArgValue(call: ToolCall): string | null {
-  const args = call.args;
-  if (!isObjectLike(args)) {
-    return null;
-  }
-  for (const key of DISTINCTIVE_ARG_KEYS) {
-    const raw = args[key];
-    if (!isString(raw)) {
-      continue;
-    }
-    const trimmed = raw.trim();
-    if (trimmed.length === 0) {
-      continue;
-    }
-    return compactArgValue(key, trimmed);
-  }
-  return null;
-}
-
-function compactArgValue(key: string, value: string): string {
-  if (key !== "url" && key !== "uri") {
-    return value;
-  }
-  try {
-    const url = new URL(value);
-    return url.hostname.replace(/^www\./, "");
-  } catch {
-    return value;
-  }
 }
 
 function messageHasVisibleContent(message: Message): boolean {

--- a/web/src/components/chat/message/toolCallIcon.tsx
+++ b/web/src/components/chat/message/toolCallIcon.tsx
@@ -1,8 +1,11 @@
 /**
- * toolCallIcon — maps a tool name to a category icon + accent color for the
- * tool execution chain. Categories are keyword-driven so any provider's tool
- * naming (snake_case, MCP `mcp__server__tool`, `ui_*`) lands in a sensible
- * bucket; unknown tools fall back to a neutral wrench.
+ * toolCallIcon — maps a tool name to a category glyph for the tool-call
+ * timeline. Categories are keyword-driven so any provider's naming
+ * (snake_case, MCP `mcp__server__tool`, `ui_*`) lands in a sensible bucket;
+ * unknown tools fall back to a neutral wrench.
+ *
+ * The timeline is monochrome: the glyph says what kind of work happened, the
+ * row's text says what it did. No per-tool color.
  */
 
 import type { SvgIconComponent } from "@mui/icons-material";
@@ -15,61 +18,40 @@ import ImageOutlinedIcon from "@mui/icons-material/ImageOutlined";
 import AccountTreeOutlinedIcon from "@mui/icons-material/AccountTreeOutlined";
 import BuildOutlinedIcon from "@mui/icons-material/BuildOutlined";
 
-/** Accent keys resolve to theme palette colors in the chat styles. */
-export type ToolAccent =
-  | "info"
-  | "warning"
-  | "success"
-  | "primary"
-  | "secondary"
-  | "neutral";
-
-interface ToolVisual {
-  Icon: SvgIconComponent;
-  accent: ToolAccent;
-}
-
-const CATEGORIES: Array<{ pattern: RegExp; visual: ToolVisual }> = [
-  {
-    pattern: /subtask|agent|task/,
-    visual: { Icon: AccountTreeOutlinedIcon, accent: "primary" }
-  },
+const CATEGORIES: Array<{ pattern: RegExp; Icon: SvgIconComponent }> = [
+  { pattern: /subtask|agent|task/, Icon: AccountTreeOutlinedIcon },
   {
     pattern: /database|query|sql|collection|vector|index|table|record/,
-    visual: { Icon: StorageRoundedIcon, accent: "info" }
+    Icon: StorageRoundedIcon
   },
-  {
-    pattern: /search|find|grep|glob|lookup|list/,
-    visual: { Icon: SearchRoundedIcon, accent: "warning" }
-  },
+  { pattern: /search|find|grep|glob|lookup|list/, Icon: SearchRoundedIcon },
   {
     pattern: /file|read|write|edit|directory|folder|asset|document|save|open/,
-    visual: { Icon: DescriptionOutlinedIcon, accent: "warning" }
+    Icon: DescriptionOutlinedIcon
   },
   {
     pattern: /http|web|fetch|url|browser|download|upload|request|api|notif|send|mail|message/,
-    visual: { Icon: PublicRoundedIcon, accent: "success" }
+    Icon: PublicRoundedIcon
   },
   {
     pattern: /image|video|audio|speech|generate|render|draw|media/,
-    visual: { Icon: ImageOutlinedIcon, accent: "secondary" }
+    Icon: ImageOutlinedIcon
   },
   {
     pattern: /shell|bash|terminal|command|exec|run|code|script|node|workflow/,
-    visual: { Icon: TerminalRoundedIcon, accent: "primary" }
+    Icon: TerminalRoundedIcon
   }
 ];
 
-const DEFAULT_VISUAL: ToolVisual = {
-  Icon: BuildOutlinedIcon,
-  accent: "neutral"
-};
-
-export function getToolVisual(name?: string | null): ToolVisual {
-  if (!name) return DEFAULT_VISUAL;
-  const normalized = name.toLowerCase();
-  for (const { pattern, visual } of CATEGORIES) {
-    if (pattern.test(normalized)) return visual;
+export function getToolIcon(name?: string | null): SvgIconComponent {
+  if (!name) {
+    return BuildOutlinedIcon;
   }
-  return DEFAULT_VISUAL;
+  const normalized = name.toLowerCase();
+  for (const { pattern, Icon } of CATEGORIES) {
+    if (pattern.test(normalized)) {
+      return Icon;
+    }
+  }
+  return BuildOutlinedIcon;
 }

--- a/web/src/components/chat/message/toolCallPhrase.ts
+++ b/web/src/components/chat/message/toolCallPhrase.ts
@@ -1,0 +1,217 @@
+/**
+ * Row phrasing for the tool-call timeline.
+ *
+ * A row reads as a sentence about what happened — "Opened page nodetool.ai",
+ * "Ran 2 searches" — not as a tool identifier. The verb comes from the tool's
+ * category; the detail is its most distinctive argument (a URL, a path, a
+ * query), rendered in mono so it stands apart from the prose.
+ */
+
+import type { ToolCall } from "../../../stores/ApiTypes";
+import { formatToolName } from "../../../utils/formatUtils";
+import { isObjectLike, isString } from "../../../utils/typePredicates";
+
+/** What a tool does, as far as the row phrasing is concerned. */
+export type ToolPhraseKind =
+  | "search"
+  | "page"
+  | "read"
+  | "write"
+  | "run"
+  | "generic";
+
+/**
+ * Keywords are matched against whole name segments, not substrings: `cat`
+ * inside `frobnicate` is not a file read, and the first bucket that matches
+ * any segment wins.
+ */
+const KINDS: Array<{ words: readonly string[]; kind: ToolPhraseKind }> = [
+  { words: ["search", "grep", "glob", "lookup", "query"], kind: "search" },
+  {
+    words: ["browser", "crawl", "scrape", "fetch", "http", "url", "download", "visit"],
+    kind: "page"
+  },
+  {
+    words: ["write", "edit", "save", "update", "create", "delete", "upload"],
+    kind: "write"
+  },
+  { words: ["read", "open", "cat", "list"], kind: "read" },
+  { words: ["run", "exec", "execute", "bash", "shell", "command", "script"], kind: "run" }
+];
+
+/** Name segments, splitting on snake_case, camelCase and MCP's `__`. */
+function nameSegments(name: string): string[] {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((segment) => segment.length > 0);
+}
+
+export function toolPhraseKind(name: string | null | undefined): ToolPhraseKind {
+  if (!name) {
+    return "generic";
+  }
+  const segments = new Set(nameSegments(name));
+  for (const { words, kind } of KINDS) {
+    if (words.some((word) => segments.has(word))) {
+      return kind;
+    }
+  }
+  return "generic";
+}
+
+/** Argument keys that identify *which* thing a call acted on. */
+const DETAIL_KEYS = [
+  "url",
+  "uri",
+  "path",
+  "file",
+  "filename",
+  "target",
+  "query",
+  "q"
+] as const;
+
+/** A single row's label plus the mono-rendered thing it acted on. */
+export interface ToolRowPhrase {
+  label: string;
+  detail: string | null;
+}
+
+/**
+ * The distinctive value a call acted on: a URL, a path, or a query. `"short"`
+ * cuts a URL back to its hostname, for the one-line preview under a counted
+ * row where several of them share the line. Null when the arguments carry
+ * nothing worth reading.
+ */
+export function toolCallDetail(
+  call: ToolCall,
+  mode: "full" | "short" = "full"
+): string | null {
+  const args = call.args;
+  if (!isObjectLike(args)) {
+    return null;
+  }
+  for (const key of DETAIL_KEYS) {
+    const raw = args[key];
+    if (!isString(raw)) {
+      continue;
+    }
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    if (key !== "url" && key !== "uri") {
+      return trimmed;
+    }
+    return mode === "short" ? urlHost(trimmed) : compactUrl(trimmed);
+  }
+  return null;
+}
+
+/** Argument keys that name a location rather than free text. */
+const LOCATION_KEYS = ["url", "uri", "path", "file", "filename"] as const;
+
+/** Whether a call's detail identifies a location rather than free text. */
+export function hasLocationDetail(call: ToolCall): boolean {
+  const args = call.args;
+  if (!isObjectLike(args)) {
+    return false;
+  }
+  return LOCATION_KEYS.some((key) => {
+    const raw = args[key];
+    return isString(raw) && raw.trim().length > 0;
+  });
+}
+
+function urlHost(value: string): string {
+  try {
+    return new URL(value).hostname.replace(/^www\./, "");
+  } catch {
+    return value;
+  }
+}
+
+function compactUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    const path = url.pathname === "/" ? "" : url.pathname;
+    return `${url.hostname.replace(/^www\./, "")}${path}${url.search}`;
+  } catch {
+    return value;
+  }
+}
+
+/** How a run of same-tool calls renders: one row each, or one counted row. */
+export type RunDisplay = "list" | "count";
+
+/** Above this, a run is always counted — a wall of rows is not a timeline. */
+const MAX_LISTED_RUN = 4;
+
+export function toolCallRunDisplay(
+  name: string,
+  calls: readonly ToolCall[]
+): RunDisplay {
+  if (calls.length > MAX_LISTED_RUN) {
+    return "count";
+  }
+  const kind = toolPhraseKind(name);
+  if (kind !== "page" && kind !== "read" && kind !== "write") {
+    return "count";
+  }
+  return calls.every(hasLocationDetail) ? "list" : "count";
+}
+
+const plural = (count: number, word: string) => {
+  if (count === 1) {
+    return word;
+  }
+  return /(?:s|x|ch|sh)$/.test(word) ? `${word}es` : `${word}s`;
+};
+
+/** The label for a run collapsed to a single counted row. */
+export function toolCallCountLabel(name: string, count: number): string {
+  switch (toolPhraseKind(name)) {
+    case "search":
+      return `Ran ${count} ${plural(count, "search")}`;
+    case "page":
+      return `Opened ${count} ${plural(count, "page")}`;
+    case "read":
+      return `Read ${count} ${plural(count, "item")}`;
+    case "write":
+      return `Made ${count} ${plural(count, "edit")}`;
+    case "run":
+      return count === 1
+        ? `Ran ${formatToolName(name)}`
+        : `Ran ${formatToolName(name)} ${count} times`;
+    default:
+      return count === 1
+        ? formatToolName(name)
+        : `${formatToolName(name)} ${count} times`;
+  }
+}
+
+/** The label and detail for one call's row. */
+export function toolCallPhrase(call: ToolCall): ToolRowPhrase {
+  const name = call.name ?? "";
+  const detail = toolCallDetail(call);
+  switch (toolPhraseKind(name)) {
+    case "search":
+      return detail
+        ? { label: "Searched", detail }
+        : { label: "Ran 1 search", detail: null };
+    case "page":
+      return detail
+        ? { label: "Opened page", detail }
+        : { label: "Opened 1 page", detail: null };
+    case "read":
+      return { label: detail ? "Read" : formatToolName(name), detail };
+    case "write":
+      return { label: detail ? "Edited" : formatToolName(name), detail };
+    default:
+      // `run` and everything unrecognized: the tool's own name is the clearest
+      // thing we can say, with whatever it acted on beside it.
+      return { label: formatToolName(name), detail };
+  }
+}

--- a/web/src/components/chat/thread/ChatThreadView.styles.ts
+++ b/web/src/components/chat/thread/ChatThreadView.styles.ts
@@ -2,6 +2,10 @@ import { css } from "@emotion/react";
 import type { Theme } from "@mui/material/styles";
 import { MOTION, BORDER_RADIUS, TYPOGRAPHY, SPACING } from "../../ui_primitives";
 
+/** Glyph column width and single-line row height for the tool-call timeline. */
+const TOOL_RAIL_WIDTH = 20;
+const TOOL_ROW_HEIGHT = 22;
+
 export const createStyles = (theme: Theme) => ({
   chatThreadViewRoot: css({
     backgroundColor: theme.vars.palette.background.default,
@@ -359,165 +363,176 @@ export const createStyles = (theme: Theme) => ({
       ...TYPOGRAPHY.sans.label
     },
 
-    // ── Tool execution chain ────────────────────────────────────────────────
-    // A message's tool calls render as a chain: tiny uppercase section label
-    // with a hairline rule, one bordered card per call, and a summary bar.
-    ".tool-call-group": {
+    // ── Tool call timeline ──────────────────────────────────────────────────
+    // A message's tool calls read as a sequence of steps, not a stack of
+    // cards: a glyph column, a hairline tying each row to the next, the verb
+    // phrase for what happened, and the thing it happened to in mono. A
+    // sequence of two or more ends in a footer that folds the rows away.
+    ".tool-timeline": {
       width: "100%",
-      margin: theme.spacing(0.5, 0)
+      margin: theme.spacing(SPACING.xs, 0)
     },
 
-    ".tool-call-group-header": {
-      cursor: "pointer",
-      userSelect: "none",
-      borderRadius: BORDER_RADIUS.sm,
-      padding: theme.spacing(0.25, 0),
-      "&:focus-visible": {
-        outline: `2px solid ${theme.vars.palette.primary.main}`,
-        outlineOffset: 1
-      }
+    ".tool-row": {
+      display: "grid",
+      gridTemplateColumns: `${TOOL_RAIL_WIDTH}px 1fr`,
+      columnGap: theme.spacing(SPACING.md),
+      minWidth: 0
     },
 
-    ".tool-call-group-label": {
-      color: theme.vars.palette.text.secondary,
-      textTransform: "uppercase",
-      letterSpacing: "0.08em",
-      whiteSpace: "nowrap"
+    ".tool-row-rail": {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      minHeight: TOOL_ROW_HEIGHT
     },
 
-    ".tool-call-group-rule": {
-      height: 1,
-      flex: 1,
-      background: theme.vars.palette.divider
-    },
-
-    ".tool-call-chain": {
-      marginTop: theme.spacing(1)
-    },
-
-    ".tool-call-summary": {
-      background: theme.vars.palette.action.hover,
-      borderRadius: BORDER_RADIUS.sm,
-      padding: theme.spacing(0.5, 1.5),
-      color: theme.vars.palette.text.secondary,
-      fontSize: "var(--fontSizeSmaller)"
-    },
-
-    ".tool-call-summary-divider": {
-      opacity: 0.3
-    },
-
-    ".tool-call-summary-duration": {
-      fontFamily: theme.fontFamily2,
-      fontVariantNumeric: "tabular-nums"
-    },
-
-    ".tool-call-card": {
-      width: "100%",
-      borderRadius: BORDER_RADIUS.md,
-      background: theme.vars.palette.action.hover,
-      overflow: "hidden",
-      marginBottom: 0
-    },
-
-    ".tool-icon-tile": {
-      width: 24,
-      height: 24,
-      borderRadius: BORDER_RADIUS.sm,
+    ".tool-row-glyph": {
+      width: TOOL_RAIL_WIDTH,
+      height: TOOL_ROW_HEIGHT,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
       flexShrink: 0,
+      color: theme.vars.palette.text.disabled,
+      "& svg": { fontSize: 16 }
+    },
+
+    ".tool-row-connector": {
+      flex: 1,
+      width: 1,
+      minHeight: theme.spacing(SPACING.sm),
+      background: theme.vars.palette.divider
+    },
+
+    ".tool-row-main": {
+      minWidth: 0,
+      paddingBottom: theme.spacing(SPACING.xs)
+    },
+
+    // A run of same-tool calls sits flush, so the cluster reads as one step.
+    ".tool-row.tight .tool-row-main": {
+      paddingBottom: 0
+    },
+
+    ".tool-row-header": {
+      minHeight: TOOL_ROW_HEIGHT,
+      lineHeight: 1.3,
+      borderRadius: BORDER_RADIUS.sm,
+      padding: theme.spacing(SPACING.none, SPACING.sm),
+      marginLeft: theme.spacing(-SPACING.sm)
+    },
+
+    ".tool-row-header.expandable": {
+      cursor: "pointer",
+      userSelect: "none",
+      transition: MOTION.background,
+      "&:hover": {
+        background: theme.vars.palette.action.hover
+      },
+      "&:focus-visible": {
+        outline: `2px solid ${theme.vars.palette.primary.main}`,
+        outlineOffset: -2
+      }
+    },
+
+    ".tool-row-label": {
       color: theme.vars.palette.text.secondary,
-      background: theme.vars.palette.action.hover,
-      "& svg": { fontSize: 15 }
+      minWidth: 0
     },
 
-    ".tool-icon-tile.accent-info": {
-      color: theme.vars.palette.info.main,
-      background: `rgb(${theme.vars.palette.info.mainChannel} / 0.12)`
-    },
-    ".tool-icon-tile.accent-warning": {
-      color: theme.vars.palette.warning.main,
-      background: `rgb(${theme.vars.palette.warning.mainChannel} / 0.12)`
-    },
-    ".tool-icon-tile.accent-success": {
-      color: theme.vars.palette.success.main,
-      background: `rgb(${theme.vars.palette.success.mainChannel} / 0.12)`
-    },
-    ".tool-icon-tile.accent-primary": {
-      color: theme.vars.palette.primary.main,
-      background: `rgb(${theme.vars.palette.primary.mainChannel} / 0.12)`
-    },
-    ".tool-icon-tile.accent-secondary": {
-      color: theme.vars.palette.secondary.main,
-      background: `rgb(${theme.vars.palette.secondary.mainChannel} / 0.12)`
+    ".tool-row.running .tool-row-label": {
+      color: theme.vars.palette.text.primary
     },
 
-    ".tool-call-id": {
+    ".tool-row.subtask .tool-row-label": {
+      // Subtask titles are a phrase, not an identifier — let them wrap.
+      whiteSpace: "normal",
+      color: theme.vars.palette.text.primary
+    },
+
+    // The thing the row acted on: a URL, a path, a query. Mono so it reads
+    // apart from the prose that names the action.
+    ".tool-row-detail": {
       fontFamily: theme.fontFamily2,
       fontSize: "var(--fontSizeSmaller)",
       color: theme.vars.palette.text.disabled,
       whiteSpace: "nowrap",
       overflow: "hidden",
-      textOverflow: "ellipsis"
+      textOverflow: "ellipsis",
+      minWidth: 0
     },
 
-    ".tool-call-duration": {
+    ".tool-row-gap": {
+      flex: 1,
+      minWidth: theme.spacing(SPACING.md)
+    },
+
+    ".tool-row-duration": {
       fontFamily: theme.fontFamily2,
       fontSize: "var(--fontSizeSmaller)",
-      color: theme.vars.palette.text.secondary,
+      color: theme.vars.palette.text.disabled,
       fontVariantNumeric: "tabular-nums",
-      whiteSpace: "nowrap"
+      whiteSpace: "nowrap",
+      flexShrink: 0
     },
 
-    ".tool-call-details": {
-      padding: theme.spacing(1, 1.5, 1.25),
-      borderTop: `1px solid ${theme.vars.palette.divider}`,
+    // The chevron is an affordance, not decoration: it shows on approach.
+    ".tool-row-chevron": {
+      transition: MOTION.all,
+      color: theme.vars.palette.text.disabled,
+      fontSize: 15,
+      flexShrink: 0,
+      opacity: 0
+    },
+
+    ".tool-row-header:hover .tool-row-chevron, .tool-row-header:focus-visible .tool-row-chevron, .tool-row-chevron.expanded":
+      {
+        opacity: 1
+      },
+
+    ".tool-row-chevron.expanded": {
+      transform: "rotate(180deg)"
+    },
+
+    ".tool-row-details": {
+      padding: theme.spacing(SPACING.xs, 0, SPACING.md),
       minWidth: 0,
       ".code-block-container": {
         marginBottom: 0
       }
     },
 
-    ".tool-call-card.running .tool-call-name": {
-      color: theme.vars.palette.info.main
+    ".tool-row-children": {
+      paddingBottom: theme.spacing(SPACING.xs)
     },
 
-    // `run_subtask` cards stand apart from generic tool calls — a light
-    // accent border + soft background marks them as a deeper sub-execution.
-    ".tool-call-card.run-subtask": {
-      borderLeft: `2px solid ${theme.vars.palette.primary.main}`,
-      background: `rgb(${theme.vars.palette.primary.mainChannel} / 0.04)`,
-      marginBottom: theme.spacing(0.5)
-    },
-
-    ".tool-call-card.run-subtask .tool-call-badge": {
-      letterSpacing: "0.04em",
-      textTransform: "uppercase",
-      color: theme.vars.palette.primary.main,
-      lineHeight: 1,
-      padding: theme.spacing(0.5, 1.5),
-      border: `1px solid ${theme.vars.palette.primary.main}55`,
-      borderRadius: BORDER_RADIUS.sm,
-      background: "transparent",
-      flexShrink: 0
-    },
-
-    ".tool-call-card.run-subtask .tool-call-name": {
-      // Subtask titles tend to be a phrase, not a snake_case identifier — let
-      // them wrap rather than truncate so the user can read the whole thing.
-      whiteSpace: "normal",
-      fontWeight: 500,
-      color: theme.vars.palette.text.primary,
-      fontSize: "var(--fontSizeSmall)"
-    },
-
-    ".tool-call-card.run-subtask .subtask-instructions": {
+    ".subtask-instructions": {
       whiteSpace: "pre-wrap",
       color: theme.vars.palette.text.secondary,
-      fontSize: "var(--fontSizeSmall)",
       lineHeight: 1.45
+    },
+
+    ".tool-timeline-footer": {
+      cursor: "pointer",
+      userSelect: "none",
+      marginTop: theme.spacing(SPACING.xs),
+      borderRadius: BORDER_RADIUS.sm,
+      padding: theme.spacing(SPACING.none, SPACING.sm),
+      marginLeft: theme.spacing(-SPACING.sm),
+      minHeight: TOOL_ROW_HEIGHT,
+      transition: MOTION.background,
+      "&:hover": {
+        background: theme.vars.palette.action.hover
+      },
+      "&:focus-visible": {
+        outline: `2px solid ${theme.vars.palette.primary.main}`,
+        outlineOffset: -2
+      }
+    },
+
+    ".tool-timeline-summary": {
+      color: theme.vars.palette.text.disabled
     },
 
     ".chat-message.tool-calls-only": {
@@ -535,38 +550,6 @@ export const createStyles = (theme: Theme) => ({
       display: "flex",
       flexDirection: "column",
       gap: "0.1em"
-    },
-
-    ".chat-message.has-tool-calls .tool-call-card + .tool-call-card": {
-      marginTop: theme.spacing(1)
-    },
-
-    ".tool-call-run-preview": {
-      color: theme.vars.palette.text.secondary,
-      lineHeight: 1.3,
-      paddingRight: theme.spacing(SPACING.sm)
-    },
-
-    ".tool-call-run-progress": {
-      fontFamily: theme.fontFamily2,
-      fontSize: "var(--fontSizeSmaller)",
-      color: theme.vars.palette.text.secondary,
-      fontVariantNumeric: "tabular-nums",
-      whiteSpace: "nowrap"
-    },
-
-    ".tool-call-run-items": {
-      borderTop: `1px solid ${theme.vars.palette.divider}`
-    },
-
-    ".tool-call-run-items .tool-call-card": {
-      background: "transparent",
-      borderRadius: 0
-    },
-
-    ".tool-call-run-items .tool-call-card + .tool-call-card": {
-      marginTop: 0,
-      borderTop: `1px solid ${theme.vars.palette.divider}`
     },
 
     ".chat-message.has-tool-calls .markdown": {
@@ -591,69 +574,22 @@ export const createStyles = (theme: Theme) => ({
         marginBottom: "0.2em"
       },
 
-    ".chat-message.tool-calls-only .tool-call-card:last-child": {
-      marginBottom: 0
-    },
-
-    ".tool-call-header": {
-      display: "flex",
-      alignItems: "center",
-      gap: theme.spacing(1),
-      lineHeight: 1.25,
-      padding: theme.spacing(1, 1.5)
-    },
-
-    ".tool-call-header.expandable": {
-      cursor: "pointer",
-      userSelect: "none",
-      transition: MOTION.background,
-      "&:hover": {
-        background: theme.vars.palette.action.selected
-      },
-      "&:focus-visible": {
-        outline: `2px solid ${theme.vars.palette.primary.main}`,
-        outlineOffset: -2
-      }
-    },
-
-    ".tool-call-name": {
-      fontSize: "var(--fontSizeSmall)",
-      fontWeight: 500,
-      color: theme.vars.palette.text.primary,
-      whiteSpace: "nowrap"
-    },
-
-    ".tool-message": {
-      fontSize: "var(--fontSizeSmall)",
-      color: theme.vars.palette.text.secondary
-    },
-
-    ".media-prediction-inline": {
-      padding: theme.spacing(0, 1.5, 1, 1.5)
-    },
-
-    ".expand-icon": {
-      transition: MOTION.transform,
-      color: theme.vars.palette.text.disabled,
-      fontSize: 16
-    },
-
-    ".expand-icon.expanded": {
-      transform: "rotate(180deg)"
-    },
-
     ".tool-section-header": {
-      minHeight: theme.spacing(6)
+      minHeight: theme.spacing(SPACING.xxl)
     },
 
     ".tool-section-title": {
       color: theme.vars.palette.text.disabled,
       display: "block",
-      marginBottom: theme.spacing(0.5)
+      marginBottom: theme.spacing(SPACING.xs)
     },
 
     ".tool-section-header .tool-section-title": {
       marginBottom: 0
+    },
+
+    ".media-prediction-inline": {
+      padding: theme.spacing(SPACING.none, SPACING.none, SPACING.xs)
     },
 
     ".pretty-json": {

--- a/web/src/styles/mobile.css
+++ b/web/src/styles/mobile.css
@@ -446,16 +446,16 @@
     width: 90% !important;
   }
 
-  .mobile .chat-messages-list .tool-call-card {
+  .mobile .chat-messages-list .tool-row {
     font-size: 0.875em !important;
   }
 
-  .mobile .chat-messages-list .tool-call-header {
+  .mobile .chat-messages-list .tool-row-header {
     padding: var(--spacing-micro) var(--spacing-sm) !important;
     gap: var(--spacing-xs) !important;
   }
 
-  .mobile .chat-messages-list .tool-message {
+  .mobile .chat-messages-list .media-prediction-label {
     font-size: var(--fontSizeSmall) !important;
   }
 


### PR DESCRIPTION
## What changed

Tool calls in chat were a stack of bordered cards — each with a colored icon tile and a snake_case tool name — wrapped in a "Tool execution chain" section header, a hairline rule, and an "N/M completed" summary bar. Four calls produced four boxes and three pieces of chrome around them. They are now rows on a rail: a monochrome glyph, a hairline running to the next row, a verb phrase for what happened, and the thing it happened to in mono — "Opened page `finance.yahoo.com/quote/META/`", "Ran 2 searches", "Read `src/analysis/meta.ts`". A new `toolCallPhrase` module supplies the phrasing, falling back to the tool's own formatted name, with the LLM-authored `message` still winning when there is one; its keyword matching runs over whole name segments rather than substrings, so `cat` inside `frobnicate` is no longer read as a file read. A run of same-tool calls renders one of two ways, decided by `toolCallRunDisplay`: rows sitting flush against each other with no hairline between them when every call names a location worth reading, or one counted row that expands, otherwise. The section header and summary bar collapse into a single footer — "Worked for 1.2s", "Working · 2/4" — which also folds the rows away. Arguments, code, and results stay behind each row, with the chevron that opens them appearing on hover instead of sitting in every row. `ResourceChip` keeps its own accent vocabulary now that the tool glyphs carry none.

## Verification

Rendered the real `MessageView` against a seven-call message through a throwaway jsdom + Playwright harness (since removed) and read the result: rail, connectors, verb phrases, the flush page-open cluster, and the footer aligned with the row labels above it.

- [x] `npm run test:affected` — web/electron/mobile green; `packages/kernel` failed under turbo's parallel load and passes on its own (`npm run test --workspace=packages/kernel` → 73 files, 1018 tests passed), and this diff touches only `web/src`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run dev:nodetool -- harness gate --base HEAD~1` — `11 changed file(s) touch 1 surface(s): web-editor`, `0 selfcheck(s) to run`. Scoped to this branch's own commit: the branch sits on merged history, so `--base main` selects 567 unrelated files.

`npx jest src/components/chat` in `web/`: 31 suites, 257 tests passed. The tool-call suites were rewritten against the new structure, and `toolCallPhrase.test.ts` is new — 16 cases over kind bucketing, detail extraction, phrasing, count labels, and the list-vs-count run policy.

## Agent capabilities

No capability added, and no capability's declared contract changed.

## New checks

No check, rule, or audit added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATUUqHcsrg71tPAgeh1ZdJ